### PR TITLE
feat(cli): --json output for status + run; documented exit-code contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Wiki knowledge base under `wiki/` with index, architecture, state-model, decisions (ADRs), per-stage and per-module pages.
 - CI: GitHub Actions running tests, RuboCop (37signals omakase), Brakeman, and `bundler-audit`.
 - Dependabot configuration (bundler weekly, GitHub Actions weekly).
+- `--json` output mode for `hive status` and `hive run`. Each emits a single JSON document on stdout with a `schema` + `schema_version` header (current: `hive-status` / `hive-run`, version 1).
+- Documented exit-code contract: `Hive::ExitCodes` constants and per-`Hive::Error`-subclass codes mapped through `bin/hive` (0 success, 2 already-initialised, 3 task in `:error`, 4 wrong stage, 64 usage, 70 software, 75 retryable lock contention, 78 config).
+- New `Hive::TaskInErrorState`, `Hive::WrongStage`, `Hive::AlreadyInitialized` exceptions for the new exit-code mappings — all three now actually raised by their corresponding call sites (run.rb on `:error` marker; inbox.rb when `hive run` is invoked on `1-inbox/`; init.rb on a second-init).
+- `Hive::SCHEMA_VERSIONS` registry: single source of truth for the JSON contract version per schema (`hive-status`, `hive-run`).
+- `Hive::Schemas::NextActionKind` closed enum (`EDIT`, `MV`, `RECOVER_STALE`, `NO_OP`, plus `ALL`) shared between the producer (`run.rb`) and the JSON regression tests.
+
+### Changed
+
+- `hive run` exits with code `3` (not `1`) when a stage records a `:error` marker — distinguishes a runner-level failure from an agent-recorded task failure.
+- `hive run` on a `1-inbox/` task now raises `Hive::WrongStage` (exit 4) instead of warning + returning 0, so agent callers can branch on the wrong-stage condition.
+- `hive init` on an already-initialised project raises `Hive::AlreadyInitialized` (exit 2) through the rescue path; behaviour is identical to the previous bare `exit 2` but the contract now flows through one channel.
+- `with_captured_exit` test helper centralised in `test/test_helper.rb` (previously duplicated in **four** integration test files — the `init_test.rb` copy was missed in the first pass).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,37 @@ For security issues, see [SECURITY.md](SECURITY.md) — please do not open a pub
 - All git/gh/claude calls go through the dedicated wrappers in `lib/hive/git_ops.rb`, `lib/hive/worktree.rb`, and `lib/hive/agent.rb`. Don't call `system` or backticks directly.
 - See [`wiki/architecture.md`](wiki/architecture.md) for the layer cake and [`wiki/decisions.md`](wiki/decisions.md) for the active ADRs before proposing structural changes.
 
+## CLI contract for agent callers
+
+Two surface guarantees that programmatic callers can rely on:
+
+### Exit codes
+
+| Code | Meaning | Retry? |
+|------|---------|--------|
+| 0    | success                                             | n/a       |
+| 1    | generic failure (unclassified)                      | no        |
+| 2    | `hive init` ran on an already-initialised project   | no        |
+| 3    | task is in `:error` marker state (agent recorded a failure) | no — investigate task.md |
+| 4    | wrong stage (`hive run` on inert `1-inbox/`)        | no — `mv` first |
+| 64   | usage error (bad slug, malformed task path)         | no        |
+| 70   | internal failure (git, worktree, agent, stage)      | maybe — inspect logs |
+| 75   | retryable: lock contention                          | **yes**   |
+| 78   | bad config (project or global)                      | no        |
+
+Codes are surfaced via `Hive::Error` subclasses; `bin/hive` rescues them and exits with the contract code. Constants live in `Hive::ExitCodes`.
+
+### `--json` output
+
+Both `hive status` and `hive run` accept `--json`. Each emits a single JSON document on stdout with a `schema` + `schema_version` header so future evolution is explicit.
+
+```bash
+hive status --json | jq '.projects[].tasks[] | select(.marker == "execute_waiting")'
+hive run /path/to/task --json | jq '.next_action'
+```
+
+`schema_version` will only bump when an existing key changes shape or is removed — adding new keys is non-breaking. Pin and assert the version in your wrapper if you depend on the contract.
+
 ## Tests
 
 - `test/fixtures/fake-claude` and `test/fixtures/fake-gh` are bash scripts that stand in for real binaries during tests. Pointed at via `HIVE_CLAUDE_BIN` / `PATH`.

--- a/lib/hive.rb
+++ b/lib/hive.rb
@@ -2,17 +2,136 @@ module Hive
   VERSION = "0.1.0".freeze
   MIN_CLAUDE_VERSION = "2.1.118".freeze
 
-  class Error < StandardError
-    def exit_code
-      1
+  module Schemas
+    # JSON schema versions for the agent-callable contracts emitted by the
+    # CLI. Bump a value here when an existing key's shape changes or is
+    # removed; adding new keys is non-breaking and does NOT require a bump.
+    # Single source of truth so the two emit sites can't drift.
+    SCHEMA_VERSIONS = {
+      "hive-status" => 1,
+      "hive-run" => 1
+    }.freeze
+
+    # Closed enum of `next_action.kind` values emitted by `hive run --json`.
+    # `ALL` is self-derived from the constants in this module so adding a
+    # new kind without updating ALL is impossible.
+    #
+    # Adding a new kind is non-breaking by contract: callers MUST treat
+    # unknown kinds as forward-compatible no-ops. Renaming or removing a
+    # value requires a SCHEMA_VERSIONS["hive-run"] bump.
+    module NextActionKind
+      EDIT          = "edit".freeze
+      MV            = "mv".freeze
+      RECOVER_STALE = "recover_stale".freeze
+      NO_OP         = "no_op".freeze
+      # Self-derived: every constant in this module other than ALL itself.
+      # Defined last so the `constants` lookup runs after every value-bearing
+      # constant is in place but before ALL is added.
+      ALL = constants.map { |c| const_get(c) }.freeze
     end
   end
 
-  class InvalidTaskPath < Error; end
-  class ConcurrentRunError < Error; end
-  class GitError < Error; end
-  class WorktreeError < Error; end
-  class AgentError < Error; end
-  class ConfigError < Error; end
-  class StageError < Error; end
+  # Process exit-code contract for the `hive` CLI.
+  #
+  # Codes are stable; agent callers can branch on them to decide retry vs
+  # escalate vs propagate. The numeric values follow sysexits(3) where
+  # plausible so wrappers and shells already understand them.
+  #
+  #   0   success
+  #   1   generic failure (anything not classified below)
+  #   2   already-initialized / idempotent reject (`hive init` on existing project)
+  #   3   task is in :error marker state (a stage agent recorded an error)
+  #   4   wrong stage (`hive run` on an inert 1-inbox folder, etc.)
+  #   64  EX_USAGE — invalid argument: bad slug, malformed task path, …
+  #   70  EX_SOFTWARE — internal error: git failure, worktree failure, agent failure, stage runner error
+  #   75  EX_TEMPFAIL — retryable: lock contention (`ConcurrentRunError`)
+  #   78  EX_CONFIG — bad project / global config
+  #
+  # Subclasses below override `exit_code` so any `raise Hive::SomeError` ->
+  # `bin/hive` rescue path produces the right code automatically.
+  module ExitCodes
+    SUCCESS = 0
+    GENERIC = 1
+    ALREADY_INITIALIZED = 2
+    TASK_IN_ERROR = 3
+    WRONG_STAGE = 4
+    USAGE = 64
+    SOFTWARE = 70
+    TEMPFAIL = 75
+    CONFIG = 78
+  end
+
+  class Error < StandardError
+    def exit_code
+      ExitCodes::GENERIC
+    end
+  end
+
+  class InvalidTaskPath < Error
+    def exit_code
+      ExitCodes::USAGE
+    end
+  end
+
+  class ConcurrentRunError < Error
+    def exit_code
+      ExitCodes::TEMPFAIL
+    end
+  end
+
+  class GitError < Error
+    def exit_code
+      ExitCodes::SOFTWARE
+    end
+  end
+
+  class WorktreeError < Error
+    def exit_code
+      ExitCodes::SOFTWARE
+    end
+  end
+
+  class AgentError < Error
+    def exit_code
+      ExitCodes::SOFTWARE
+    end
+  end
+
+  class ConfigError < Error
+    def exit_code
+      ExitCodes::CONFIG
+    end
+  end
+
+  class StageError < Error
+    def exit_code
+      ExitCodes::SOFTWARE
+    end
+  end
+
+  # Raised by `hive run` when the stage's terminal marker is :error. The
+  # runner itself succeeded — the agent recorded a task-level failure.
+  # Distinct from StageError (which signals a runner bug / git failure).
+  class TaskInErrorState < Error
+    def exit_code
+      ExitCodes::TASK_IN_ERROR
+    end
+  end
+
+  # Raised when the user invokes `hive run` on an inert stage (1-inbox).
+  # The folder is in the wrong location for the requested operation.
+  class WrongStage < Error
+    def exit_code
+      ExitCodes::WRONG_STAGE
+    end
+  end
+
+  # Raised by `hive init` when the project is already initialized. The
+  # operation is idempotent at the contract level — code 2 lets a caller
+  # detect "already done" without retrying.
+  class AlreadyInitialized < Error
+    def exit_code
+      ExitCodes::ALREADY_INITIALIZED
+    end
+  end
 end

--- a/lib/hive/cli.rb
+++ b/lib/hive/cli.rb
@@ -6,6 +6,11 @@ module Hive
       true
     end
 
+    # `--json` is honoured by `status` and `run`; other commands accept the
+    # flag silently so an automated caller can pass it uniformly.
+    class_option :json, type: :boolean, default: false,
+                        desc: "emit a single JSON document on stdout (commands that support it)"
+
     desc "init [PROJECT_PATH]", "Bootstrap .hive-state in a project (orphan hive/state branch)"
     option :force, type: :boolean, default: false, desc: "skip clean-tree check"
     def init(project_path = Dir.pwd)
@@ -26,14 +31,14 @@ module Hive
     desc "run FOLDER", "Run the stage agent for the task at FOLDER"
     def run_task(folder)
       require "hive/commands/run"
-      Hive::Commands::Run.new(folder).call
+      Hive::Commands::Run.new(folder, json: options[:json]).call
     end
     map "run" => :run_task
 
     desc "status", "Show all active tasks across registered projects"
     def status
       require "hive/commands/status"
-      Hive::Commands::Status.new.call
+      Hive::Commands::Status.new(json: options[:json]).call
     end
   end
 end

--- a/lib/hive/commands/init.rb
+++ b/lib/hive/commands/init.rb
@@ -17,8 +17,8 @@ module Hive
 
         ops = Hive::GitOps.new(@project_path)
         if ops.hive_state_branch_exists?
-          warn "hive: already initialized; hive/state branch present at #{@project_path}"
-          exit 2
+          raise Hive::AlreadyInitialized,
+                "already initialized; hive/state branch present at #{@project_path}"
         end
 
         ops.hive_state_init

--- a/lib/hive/commands/run.rb
+++ b/lib/hive/commands/run.rb
@@ -1,3 +1,4 @@
+require "json"
 require "hive/config"
 require "hive/task"
 require "hive/markers"
@@ -8,8 +9,9 @@ require "hive/agent"
 module Hive
   module Commands
     class Run
-      def initialize(folder)
+      def initialize(folder, json: false)
         @folder = File.expand_path(folder)
+        @json = json
       end
 
       def call
@@ -60,8 +62,68 @@ module Hive
         end
       end
 
-      def report(task, _result)
+      def report(task, result)
         marker = Hive::Markers.current(task.state_file)
+        if @json
+          report_json(task, result, marker)
+        else
+          report_text(task, result, marker)
+        end
+      end
+
+      # Stable schema for agent / wrapper consumption. The closed set of
+      # `next_action.kind` values is exported as Hive::Schemas::NextActionKind
+      # so producer and tests share a single source of truth.
+      def report_json(task, result, marker)
+        payload = {
+          "schema" => "hive-run",
+          "schema_version" => Hive::Schemas::SCHEMA_VERSIONS.fetch("hive-run"),
+          "slug" => task.slug,
+          "stage" => task.stage_name,
+          "stage_index" => task.stage_index,
+          "folder" => task.folder,
+          "state_file" => task.state_file,
+          "marker" => marker.name.to_s,
+          "attrs" => marker.attrs,
+          "commit_action" => result.is_a?(Hash) ? result[:commit] : nil,
+          "next_action" => json_next_action(task, marker)
+        }
+        # The JSON payload is written to stdout *before* the raise. bin/hive
+        # rescues Hive::Error and calls `exit(e.exit_code)`; Ruby's normal
+        # interpreter shutdown flushes stdout via IO finalizers, so the
+        # caller receives the full JSON document AND a non-zero exit code
+        # (3, TASK_IN_ERROR) as a dual signal.
+        puts JSON.generate(payload)
+        raise Hive::TaskInErrorState, "stage recorded :error (#{marker.attrs.inspect})" if marker.name == :error
+      end
+
+      def json_next_action(task, marker)
+        kind = Hive::Schemas::NextActionKind
+        case marker.name
+        when :waiting, :execute_waiting
+          { "kind" => kind::EDIT, "target" => task.state_file, "rerun_with" => "hive run #{task.folder}" }
+        when :complete
+          next_stage = next_stage_dir(task)
+          if next_stage
+            { "kind" => kind::MV, "from" => task.folder, "to" => "#{next_stage}/" }
+          else
+            { "kind" => kind::NO_OP }
+          end
+        when :execute_complete
+          { "kind" => kind::MV,
+            "from" => task.folder,
+            "to" => "#{File.join(task.hive_state_path, 'stages', '5-pr')}/" }
+        when :execute_stale
+          { "kind" => kind::RECOVER_STALE,
+            "instructions" => "edit reviews/, lower task.md frontmatter pass:, remove EXECUTE_STALE marker, re-run" }
+        when :error
+          { "kind" => kind::NO_OP, "error" => marker.attrs }
+        else
+          { "kind" => kind::NO_OP }
+        end
+      end
+
+      def report_text(task, _result, marker)
         puts "hive: marker=#{marker.name}"
         puts "  state_file: #{task.state_file}"
         case marker.name
@@ -76,7 +138,7 @@ module Hive
           puts "  next: edit reviews/, lower task.md frontmatter pass:, remove EXECUTE_STALE marker, re-run"
         when :error
           warn "  status: ERROR (#{marker.attrs.inspect})"
-          exit 1
+          raise Hive::TaskInErrorState, "stage recorded :error (#{marker.attrs.inspect})"
         end
       end
 

--- a/lib/hive/commands/status.rb
+++ b/lib/hive/commands/status.rb
@@ -1,3 +1,4 @@
+require "json"
 require "time"
 require "hive/config"
 require "hive/task"
@@ -19,8 +20,17 @@ module Hive
       }.freeze
       STAGE_ORDER = %w[1-inbox 2-brainstorm 3-plan 4-execute 5-pr 6-done].freeze
 
+      def initialize(json: false)
+        @json = json
+      end
+
       def call
         projects = Hive::Config.registered_projects
+        if @json
+          puts JSON.generate(json_payload(projects))
+          return
+        end
+
         if projects.empty?
           puts "(no projects registered; run `hive init <path>`)"
           return
@@ -29,6 +39,51 @@ module Hive
         projects.each do |project|
           render_project(project)
         end
+      end
+
+      # Stable schema for agent / wrapper consumption. Adding new keys is
+      # non-breaking; removing or renaming keys must bump a documented
+      # version. `tasks[].marker` is the lowercased symbol name as a string;
+      # `tasks[].attrs` is the marker's attribute map.
+      def json_payload(projects)
+        {
+          "schema" => "hive-status",
+          "schema_version" => Hive::Schemas::SCHEMA_VERSIONS.fetch("hive-status"),
+          "generated_at" => Time.now.utc.iso8601,
+          "projects" => projects.map { |p| project_payload(p) }
+        }
+      end
+
+      def project_payload(project)
+        path = project["path"]
+        hive_state = project["hive_state_path"]
+        base = {
+          "name" => project["name"],
+          "path" => path,
+          "hive_state_path" => hive_state
+        }
+        if !File.directory?(path)
+          base.merge("error" => "missing_project_path", "tasks" => [])
+        elsif !File.directory?(hive_state)
+          base.merge("error" => "not_initialised", "tasks" => [])
+        else
+          base.merge("tasks" => collect_rows(hive_state).map { |r| task_payload(r) })
+        end
+      end
+
+      def task_payload(row)
+        {
+          "stage" => row[:stage],
+          "slug" => row[:slug],
+          "folder" => row[:folder],
+          "state_file" => row[:state_file],
+          "marker" => row[:marker_name].to_s,
+          "attrs" => row[:marker_attrs],
+          "mtime" => row[:mtime].utc.iso8601,
+          "age_seconds" => (Time.now - row[:mtime]).to_i,
+          "claude_pid" => row[:claude_pid],
+          "claude_pid_alive" => row[:claude_pid_alive]
+        }
       end
 
       def render_project(project)
@@ -79,13 +134,20 @@ module Hive
             marker = Hive::Markers.current(task.state_file)
             mtime = File.exist?(task.state_file) ? File.mtime(task.state_file) : File.mtime(entry)
             icon, state_label = decorate(task, marker)
+            claude_pid = lookup_claude_pid(task)
             rows << {
               stage: stage,
               slug: slug,
+              folder: entry,
+              state_file: task.state_file,
+              marker_name: marker.name,
+              marker_attrs: marker.attrs,
               icon: icon,
               state_label: state_label,
               mtime: mtime,
-              age: humanise_age(mtime)
+              age: humanise_age(mtime),
+              claude_pid: claude_pid,
+              claude_pid_alive: claude_pid ? pid_alive?(claude_pid.to_i) : nil
             }
           end
         end

--- a/lib/hive/stages/inbox.rb
+++ b/lib/hive/stages/inbox.rb
@@ -3,12 +3,15 @@ module Hive
     module Inbox
       module_function
 
+      # 1-inbox is an inert capture zone — the user must `mv` the task into
+      # 2-brainstorm before any agent will run on it. Raising WrongStage
+      # gives agent callers a distinct exit code (4) so they can branch on
+      # "wrong stage" without parsing stderr.
       def run!(task, _cfg)
         target = File.join(task.hive_state_path, "stages", "2-brainstorm")
-        warn "hive: 1-inbox/ is an inert capture zone. To start work:"
-        warn "  mv #{task.folder} #{target}/"
-        warn "  hive run #{File.join(target, task.slug)}"
-        { commit: nil, status: :inert }
+        raise Hive::WrongStage,
+              "1-inbox/ is an inert capture zone. To start work: " \
+              "mv #{task.folder} #{target}/ && hive run #{File.join(target, task.slug)}"
       end
     end
   end

--- a/test/fixtures/fake-gh
+++ b/test/fixtures/fake-gh
@@ -8,6 +8,7 @@ ARGV_LOG="${LOG_DIR}/fake-gh-argv.log"
 {
   echo "---"
   date -u +"%Y-%m-%dT%H:%M:%SZ"
+  printf 'cwd=%s\n' "$PWD"
   for a in "$@"; do
     printf 'arg=%s\n' "$a"
   done

--- a/test/integration/init_test.rb
+++ b/test/integration/init_test.rb
@@ -30,7 +30,7 @@ class InitTest < Minitest::Test
   def test_rejects_non_git_repo
     with_tmp_global_config do
       with_tmp_dir do |dir|
-        _, err, status = capture_io_and_exit { Hive::Commands::Init.new(dir).call }
+        _, err, status = with_captured_exit { Hive::Commands::Init.new(dir).call }
         assert_equal 1, status
         assert_includes err, "not a git repository"
       end
@@ -42,7 +42,7 @@ class InitTest < Minitest::Test
       with_tmp_git_repo do |dir|
         # Modify a tracked file to make the tree dirty (untracked files alone don't fail).
         File.write(File.join(dir, "README.md"), "modified\n")
-        _, err, status = capture_io_and_exit { Hive::Commands::Init.new(dir).call }
+        _, err, status = with_captured_exit { Hive::Commands::Init.new(dir).call }
         assert_equal 1, status
         assert_includes err, "uncommitted modifications"
       end
@@ -71,33 +71,15 @@ class InitTest < Minitest::Test
     end
   end
 
-  def test_double_init_idempotent_exit_2
+  def test_double_init_raises_already_initialized_with_exit_2
     with_tmp_global_config do
       with_tmp_git_repo do |dir|
         capture_io { Hive::Commands::Init.new(dir).call }
-        _, err, status = capture_io_and_exit { Hive::Commands::Init.new(dir).call }
-        assert_equal 2, status
+        _, err, status = with_captured_exit { Hive::Commands::Init.new(dir).call }
+        assert_equal Hive::ExitCodes::ALREADY_INITIALIZED, status,
+                     "second init must raise Hive::AlreadyInitialized (exit 2), not bare exit"
         assert_includes err, "already initialized"
       end
     end
-  end
-
-  def capture_io_and_exit
-    out_pipe = StringIO.new
-    err_pipe = StringIO.new
-    real_stdout = $stdout
-    real_stderr = $stderr
-    $stdout = out_pipe
-    $stderr = err_pipe
-    status = 0
-    begin
-      yield
-    rescue SystemExit => e
-      status = e.status
-    ensure
-      $stdout = real_stdout
-      $stderr = real_stderr
-    end
-    [ out_pipe.string, err_pipe.string, status ]
   end
 end

--- a/test/integration/json_output_test.rb
+++ b/test/integration/json_output_test.rb
@@ -1,0 +1,194 @@
+require "test_helper"
+require "json"
+require "hive/commands/init"
+require "hive/commands/new"
+require "hive/commands/run"
+require "hive/commands/status"
+
+# Pin the agent-callable JSON contracts emitted by `hive status --json` and
+# `hive run --json`. Schema versions are checked explicitly so a future
+# breaking change to either payload fails this test instead of silently
+# breaking downstream parsers.
+class JsonOutputTest < Minitest::Test
+  include HiveTestHelper
+
+  FAKE_BIN = File.expand_path("../fixtures/fake-claude", __dir__)
+
+  def setup
+    @prev_bin = ENV["HIVE_CLAUDE_BIN"]
+    ENV["HIVE_CLAUDE_BIN"] = FAKE_BIN
+  end
+
+  def teardown
+    ENV["HIVE_CLAUDE_BIN"] = @prev_bin
+    %w[HIVE_FAKE_CLAUDE_OUTPUT HIVE_FAKE_CLAUDE_EXIT
+       HIVE_FAKE_CLAUDE_WRITE_FILE HIVE_FAKE_CLAUDE_WRITE_CONTENT].each { |k| ENV.delete(k) }
+  end
+
+  def test_status_json_is_a_single_parseable_document_with_schema_header
+    with_tmp_global_config do
+      out, _err = capture_io { Hive::Commands::Status.new(json: true).call }
+      assert_equal 1, out.lines.count, "JSON output must be a single line on stdout (no stray puts)"
+      payload = JSON.parse(out)
+      assert_equal "hive-status", payload["schema"]
+      assert_equal 1, payload["schema_version"]
+      assert_equal [], payload["projects"], "empty registry must surface as projects:[]"
+      assert payload["generated_at"].match?(/\A\d{4}-\d{2}-\d{2}T/), "generated_at must be ISO-8601"
+    end
+  end
+
+  def test_status_json_emits_task_records_with_stable_keys
+    with_tmp_global_config do
+      with_tmp_git_repo do |dir|
+        capture_io { Hive::Commands::Init.new(dir).call }
+        project = File.basename(dir)
+        capture_io { Hive::Commands::New.new(project, "json status probe").call }
+
+        out, _err = capture_io { Hive::Commands::Status.new(json: true).call }
+        payload = JSON.parse(out)
+        proj = payload["projects"].find { |p| p["name"] == project }
+        refute_nil proj, "registered project should appear in JSON output"
+        task = proj["tasks"].first
+        refute_nil task
+
+        %w[stage slug folder state_file marker attrs mtime age_seconds claude_pid claude_pid_alive]
+          .each { |k| assert task.key?(k), "JSON task record must include '#{k}'" }
+        assert_equal "1-inbox", task["stage"]
+        assert_equal "waiting", task["marker"], "fresh idea.md is in WAITING state"
+        assert_kind_of Integer, task["age_seconds"]
+        assert_nil task["claude_pid"], "no claude_pid until an agent has run"
+      end
+    end
+  end
+
+  def test_run_json_emits_marker_and_next_action
+    with_tmp_global_config do
+      with_tmp_git_repo do |dir|
+        capture_io { Hive::Commands::Init.new(dir).call }
+        capture_io { Hive::Commands::New.new(File.basename(dir), "json run probe").call }
+        slug = File.basename(Dir[File.join(dir, ".hive-state", "stages", "1-inbox", "*")].first)
+        brainstorm_dir = File.join(dir, ".hive-state", "stages", "2-brainstorm", slug)
+        FileUtils.mkdir_p(File.dirname(brainstorm_dir))
+        FileUtils.mv(File.join(dir, ".hive-state", "stages", "1-inbox", slug), brainstorm_dir)
+
+        # Fake claude writes a WAITING brainstorm.md so report() sees that marker.
+        ENV["HIVE_FAKE_CLAUDE_WRITE_FILE"] = File.join(brainstorm_dir, "brainstorm.md")
+        ENV["HIVE_FAKE_CLAUDE_WRITE_CONTENT"] = "## Round 1\n### Q1.\n### A1.\n<!-- WAITING -->\n"
+
+        out, _err = capture_io { Hive::Commands::Run.new(brainstorm_dir, json: true).call }
+        assert_equal 1, out.lines.count, "JSON output must be a single line on stdout (no stray puts)"
+        payload = JSON.parse(out)
+        assert_equal "hive-run", payload["schema"]
+        assert_equal 1, payload["schema_version"]
+        assert_equal "brainstorm", payload["stage"]
+        assert_equal 2, payload["stage_index"]
+        assert_equal slug, payload["slug"]
+        assert_equal "waiting", payload["marker"]
+
+        next_action = payload["next_action"]
+        refute_nil next_action
+        assert_equal "edit", next_action["kind"]
+        assert next_action["target"].end_with?("/brainstorm.md")
+        assert_includes next_action["rerun_with"], "hive run"
+      end
+    end
+  end
+
+  def test_run_json_on_complete_marker_returns_mv_next_action
+    with_tmp_global_config do
+      with_tmp_git_repo do |dir|
+        capture_io { Hive::Commands::Init.new(dir).call }
+        capture_io { Hive::Commands::New.new(File.basename(dir), "json complete probe").call }
+        slug = File.basename(Dir[File.join(dir, ".hive-state", "stages", "1-inbox", "*")].first)
+        brainstorm_dir = File.join(dir, ".hive-state", "stages", "2-brainstorm", slug)
+        FileUtils.mkdir_p(File.dirname(brainstorm_dir))
+        FileUtils.mv(File.join(dir, ".hive-state", "stages", "1-inbox", slug), brainstorm_dir)
+
+        ENV["HIVE_FAKE_CLAUDE_WRITE_FILE"] = File.join(brainstorm_dir, "brainstorm.md")
+        ENV["HIVE_FAKE_CLAUDE_WRITE_CONTENT"] = "## Requirements\n- foo\n<!-- COMPLETE -->\n"
+
+        out, _err = capture_io { Hive::Commands::Run.new(brainstorm_dir, json: true).call }
+        payload = JSON.parse(out)
+        assert_equal "complete", payload["marker"]
+        assert_equal Hive::Schemas::NextActionKind::MV, payload["next_action"]["kind"]
+        assert payload["next_action"]["to"].end_with?("3-plan/")
+      end
+    end
+  end
+
+  # Pin the JSON-mode :error contract: a dual signal where the JSON document
+  # carries the marker + attrs AND the process exits with TASK_IN_ERROR (3).
+  # A future refactor that drops the post-puts raise (or wraps it in a
+  # rescue) would silently regress to exit 0; this test catches that.
+  def test_run_json_on_error_marker_emits_no_op_and_exits_three
+    with_tmp_global_config do
+      with_tmp_git_repo do |dir|
+        capture_io { Hive::Commands::Init.new(dir).call }
+        capture_io { Hive::Commands::New.new(File.basename(dir), "json error probe").call }
+        slug = File.basename(Dir[File.join(dir, ".hive-state", "stages", "1-inbox", "*")].first)
+        brainstorm_dir = File.join(dir, ".hive-state", "stages", "2-brainstorm", slug)
+        FileUtils.mkdir_p(File.dirname(brainstorm_dir))
+        FileUtils.mv(File.join(dir, ".hive-state", "stages", "1-inbox", slug), brainstorm_dir)
+
+        ENV["HIVE_FAKE_CLAUDE_EXIT"] = "1" # forces Agent#handle_exit to set :error
+
+        out, _err, status = with_captured_exit { Hive::Commands::Run.new(brainstorm_dir, json: true).call }
+        assert_equal Hive::ExitCodes::TASK_IN_ERROR, status,
+                     "JSON mode must still exit 3 on :error (the JSON document is emitted before the raise)"
+
+        payload = JSON.parse(out)
+        assert_equal "error", payload["marker"]
+        assert_equal Hive::Schemas::NextActionKind::NO_OP, payload["next_action"]["kind"]
+        assert_equal "exit_code", payload["attrs"]["reason"]
+        assert_equal "exit_code", payload["next_action"]["error"]["reason"]
+      end
+    end
+  end
+
+  # Defensive pin: every emitted next_action.kind must be in the closed
+  # NextActionKind::ALL set. Drives THREE distinct producer arms (waiting,
+  # complete, error) so a typo in any one of them is caught — the round-1
+  # version of this test only exercised :waiting.
+  def test_every_emitted_next_action_kind_is_in_the_closed_enum
+    fixtures = [
+      { content: "## Round 1\n<!-- WAITING -->\n",
+        env: {},
+        expected_kind: Hive::Schemas::NextActionKind::EDIT },
+      { content: "## Requirements\n- foo\n<!-- COMPLETE -->\n",
+        env: {},
+        expected_kind: Hive::Schemas::NextActionKind::MV },
+      { content: nil,                       # exit 1 → :error marker
+        env: { "HIVE_FAKE_CLAUDE_EXIT" => "1" },
+        expected_kind: Hive::Schemas::NextActionKind::NO_OP }
+    ]
+
+    fixtures.each_with_index do |fixture, i|
+      with_tmp_global_config do
+        with_tmp_git_repo do |dir|
+          capture_io { Hive::Commands::Init.new(dir).call }
+          capture_io { Hive::Commands::New.new(File.basename(dir), "kind probe #{i}").call }
+          slug = File.basename(Dir[File.join(dir, ".hive-state", "stages", "1-inbox", "*")].first)
+          brainstorm_dir = File.join(dir, ".hive-state", "stages", "2-brainstorm", slug)
+          FileUtils.mkdir_p(File.dirname(brainstorm_dir))
+          FileUtils.mv(File.join(dir, ".hive-state", "stages", "1-inbox", slug), brainstorm_dir)
+
+          fixture[:env].each { |k, v| ENV[k] = v }
+          if fixture[:content]
+            ENV["HIVE_FAKE_CLAUDE_WRITE_FILE"] = File.join(brainstorm_dir, "brainstorm.md")
+            ENV["HIVE_FAKE_CLAUDE_WRITE_CONTENT"] = fixture[:content]
+          end
+
+          out, _err, _status = with_captured_exit do
+            Hive::Commands::Run.new(brainstorm_dir, json: true).call
+          end
+          payload = JSON.parse(out)
+          kind = payload["next_action"]["kind"]
+          assert_includes Hive::Schemas::NextActionKind::ALL, kind,
+                          "fixture #{i}: kind=#{kind.inspect} is outside the closed NextActionKind enum"
+          assert_equal fixture[:expected_kind], kind,
+                       "fixture #{i}: producer arm emitted unexpected kind"
+        end
+      end
+    end
+  end
+end

--- a/test/integration/new_test.rb
+++ b/test/integration/new_test.rb
@@ -126,23 +126,4 @@ class NewTest < Minitest::Test
       end
     end
   end
-
-  def with_captured_exit
-    out_pipe = StringIO.new
-    err_pipe = StringIO.new
-    real_stdout = $stdout
-    real_stderr = $stderr
-    $stdout = out_pipe
-    $stderr = err_pipe
-    status = 0
-    begin
-      yield
-    rescue SystemExit => e
-      status = e.status
-    ensure
-      $stdout = real_stdout
-      $stderr = real_stderr
-    end
-    [ out_pipe.string, err_pipe.string, status ]
-  end
 end

--- a/test/integration/run_brainstorm_test.rb
+++ b/test/integration/run_brainstorm_test.rb
@@ -70,7 +70,7 @@ class RunBrainstormTest < Minitest::Test
     end
   end
 
-  def test_inbox_stage_refuses_to_run_agent
+  def test_inbox_stage_raises_wrong_stage_with_exit_4
     with_tmp_global_config do
       with_tmp_git_repo do |dir|
         capture_io do
@@ -78,7 +78,9 @@ class RunBrainstormTest < Minitest::Test
           Hive::Commands::New.new(File.basename(dir), "no run inbox").call
         end
         inbox_task = Dir[File.join(dir, ".hive-state", "stages", "1-inbox", "*")].first
-        _, err = capture_io { Hive::Commands::Run.new(inbox_task).call }
+        _, err, status = with_captured_exit { Hive::Commands::Run.new(inbox_task).call }
+        assert_equal Hive::ExitCodes::WRONG_STAGE, status,
+                     "1-inbox is inert; running it must raise WrongStage (exit 4)"
         assert_includes err, "1-inbox/ is an inert capture zone"
       end
     end

--- a/test/integration/run_execute_test.rb
+++ b/test/integration/run_execute_test.rb
@@ -212,7 +212,8 @@ class RunExecuteTest < Minitest::Test
         ENV["HIVE_EXEC_DRIVER_FINDINGS"] = "1"
         ENV["HIVE_EXEC_DRIVER_TAMPER"] = "1"
         _, _, status = with_captured_exit { Hive::Commands::Run.new(folder).call }
-        assert_equal 1, status
+        assert_equal Hive::ExitCodes::TASK_IN_ERROR, status,
+                     "marker :error must map to TASK_IN_ERROR (3)"
 
         marker = Hive::Markers.current(File.join(folder, "task.md"))
         assert_equal :error, marker.name
@@ -246,7 +247,8 @@ class RunExecuteTest < Minitest::Test
         File.chmod(0o755, @driver_bin)
 
         _, _, status = with_captured_exit { Hive::Commands::Run.new(folder).call }
-        assert_equal 1, status, "Run.report must exit 1 when execute records :error"
+        assert_equal Hive::ExitCodes::TASK_IN_ERROR, status,
+                     "Run.report must exit 3 (TASK_IN_ERROR) when execute records :error"
 
         marker = Hive::Markers.current(File.join(folder, "task.md"))
         assert_equal :error, marker.name,
@@ -284,7 +286,8 @@ class RunExecuteTest < Minitest::Test
         File.chmod(0o755, @driver_bin)
 
         _, _, status = with_captured_exit { Hive::Commands::Run.new(folder).call }
-        assert_equal 1, status, "Run.report must exit 1 when execute records :error"
+        assert_equal Hive::ExitCodes::TASK_IN_ERROR, status,
+                     "Run.report must exit 3 (TASK_IN_ERROR) when execute records :error"
 
         marker = Hive::Markers.current(File.join(folder, "task.md"))
         assert_equal :error, marker.name,
@@ -312,24 +315,5 @@ class RunExecuteTest < Minitest::Test
         assert_includes err, "plan.md missing"
       end
     end
-  end
-
-  def with_captured_exit
-    out_pipe = StringIO.new
-    err_pipe = StringIO.new
-    real_out = $stdout
-    real_err = $stderr
-    $stdout = out_pipe
-    $stderr = err_pipe
-    status = 0
-    begin
-      yield
-    rescue SystemExit => e
-      status = e.status
-    ensure
-      $stdout = real_out
-      $stderr = real_err
-    end
-    [ out_pipe.string, err_pipe.string, status ]
   end
 end

--- a/test/integration/run_pr_test.rb
+++ b/test/integration/run_pr_test.rb
@@ -23,7 +23,8 @@ class RunPrTest < Minitest::Test
     FileUtils.rm_rf(@gh_dir) if @gh_dir
     Array(@worktree_paths).each { |p| FileUtils.rm_rf(p) }
     %w[HIVE_FAKE_CLAUDE_WRITE_FILE HIVE_FAKE_CLAUDE_WRITE_CONTENT
-       HIVE_FAKE_GH_PR_EXISTS HIVE_FAKE_GH_CREATE_EXIT].each { |k| ENV.delete(k) }
+       HIVE_FAKE_GH_PR_EXISTS HIVE_FAKE_GH_CREATE_EXIT
+       HIVE_FAKE_GH_LOG_DIR].each { |k| ENV.delete(k) }
   end
 
   def setup_pr_task(dir)
@@ -70,6 +71,29 @@ class RunPrTest < Minitest::Test
     end
   end
 
+  def test_existing_pr_lookup_runs_in_worktree
+    with_tmp_global_config do
+      with_tmp_git_repo do |dir|
+        pr_dir, worktree_path = setup_pr_task(dir)
+        stub_push(worktree_path)
+        log_dir = Dir.mktmpdir("fake-gh-log")
+        ENV["HIVE_FAKE_GH_LOG_DIR"] = log_dir
+        ENV["HIVE_FAKE_GH_PR_EXISTS"] = "1"
+
+        Dir.chdir("/") do
+          capture_io { Hive::Commands::Run.new(pr_dir).call }
+        end
+
+        argv_log = File.read(File.join(log_dir, "fake-gh-argv.log"))
+        pr_list_call = argv_log.split("---").find { |entry| entry.include?("arg=list") }
+        assert pr_list_call, "expected fake gh to receive a pr list call"
+        assert_includes pr_list_call, "cwd=#{worktree_path}\n"
+      ensure
+        FileUtils.rm_rf(log_dir) if log_dir
+      end
+    end
+  end
+
   def test_pr_runner_invokes_agent_when_pr_missing
     with_tmp_global_config do
       with_tmp_git_repo do |dir|
@@ -105,24 +129,5 @@ class RunPrTest < Minitest::Test
         assert_includes err, "no worktree pointer"
       end
     end
-  end
-
-  def with_captured_exit
-    out_pipe = StringIO.new
-    err_pipe = StringIO.new
-    real_out = $stdout
-    real_err = $stderr
-    $stdout = out_pipe
-    $stderr = err_pipe
-    status = 0
-    begin
-      yield
-    rescue SystemExit => e
-      status = e.status
-    ensure
-      $stdout = real_out
-      $stderr = real_err
-    end
-    [ out_pipe.string, err_pipe.string, status ]
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -45,4 +45,30 @@ module HiveTestHelper
       end
     end
   end
+
+  # Run a block that may either call `exit N` directly or `raise Hive::Error`.
+  # Captures stdout/stderr and returns [out, err, exit_code]. Mirrors what
+  # `bin/hive` does in production: a raised Hive::Error is mapped to its
+  # exit_code and its message is sent to stderr as `hive: <message>`.
+  def with_captured_exit
+    out_pipe = StringIO.new
+    err_pipe = StringIO.new
+    real_stdout = $stdout
+    real_stderr = $stderr
+    $stdout = out_pipe
+    $stderr = err_pipe
+    status = 0
+    begin
+      yield
+    rescue SystemExit => e
+      status = e.status
+    rescue Hive::Error => e
+      err_pipe.puts "hive: #{e.message}"
+      status = e.exit_code
+    ensure
+      $stdout = real_stdout
+      $stderr = real_stderr
+    end
+    [ out_pipe.string, err_pipe.string, status ]
+  end
 end

--- a/test/unit/exit_codes_test.rb
+++ b/test/unit/exit_codes_test.rb
@@ -1,0 +1,44 @@
+require "test_helper"
+
+# Pin the exit-code contract. Each Hive::Error subclass owns a stable code
+# that automated callers depend on. Changing one of these values is a
+# breaking change for the CLI contract.
+class ExitCodesTest < Minitest::Test
+  def test_exit_code_constants_are_stable
+    assert_equal 0,  Hive::ExitCodes::SUCCESS
+    assert_equal 1,  Hive::ExitCodes::GENERIC
+    assert_equal 2,  Hive::ExitCodes::ALREADY_INITIALIZED
+    assert_equal 3,  Hive::ExitCodes::TASK_IN_ERROR
+    assert_equal 4,  Hive::ExitCodes::WRONG_STAGE
+    assert_equal 64, Hive::ExitCodes::USAGE
+    assert_equal 70, Hive::ExitCodes::SOFTWARE
+    assert_equal 75, Hive::ExitCodes::TEMPFAIL
+    assert_equal 78, Hive::ExitCodes::CONFIG
+  end
+
+  def test_error_subclasses_map_to_their_contract_code
+    assert_equal Hive::ExitCodes::GENERIC,             Hive::Error.new("x").exit_code
+    assert_equal Hive::ExitCodes::USAGE,               Hive::InvalidTaskPath.new("x").exit_code
+    assert_equal Hive::ExitCodes::TEMPFAIL,            Hive::ConcurrentRunError.new("x").exit_code
+    assert_equal Hive::ExitCodes::SOFTWARE,            Hive::GitError.new("x").exit_code
+    assert_equal Hive::ExitCodes::SOFTWARE,            Hive::WorktreeError.new("x").exit_code
+    assert_equal Hive::ExitCodes::SOFTWARE,            Hive::AgentError.new("x").exit_code
+    assert_equal Hive::ExitCodes::CONFIG,              Hive::ConfigError.new("x").exit_code
+    assert_equal Hive::ExitCodes::SOFTWARE,            Hive::StageError.new("x").exit_code
+    assert_equal Hive::ExitCodes::TASK_IN_ERROR,       Hive::TaskInErrorState.new("x").exit_code
+    assert_equal Hive::ExitCodes::WRONG_STAGE,         Hive::WrongStage.new("x").exit_code
+    assert_equal Hive::ExitCodes::ALREADY_INITIALIZED, Hive::AlreadyInitialized.new("x").exit_code
+  end
+
+  # The `schema_version` emit sites in run.rb / status.rb call
+  # SCHEMA_VERSIONS.fetch("hive-run") / .fetch("hive-status") with literal
+  # strings. Pin both keys so a rename of either constant key without
+  # updating the call sites fails at test time, not at runtime as a
+  # cryptic KeyError out of a real `hive run`.
+  def test_schema_versions_keys_match_emit_sites
+    assert Hive::Schemas::SCHEMA_VERSIONS.key?("hive-status"),
+           "Hive::Commands::Status emits payload['schema'] = 'hive-status' and fetches the version by that key"
+    assert Hive::Schemas::SCHEMA_VERSIONS.key?("hive-run"),
+           "Hive::Commands::Run emits payload['schema'] = 'hive-run' and fetches the version by that key"
+  end
+end

--- a/wiki/cli.md
+++ b/wiki/cli.md
@@ -7,11 +7,11 @@ updated: 2026-04-25
 tags: [cli, api]
 ---
 
-**TLDR**: Hive exposes a Thor-based CLI with four commands: `init`, `new`, `run`, `status`. There is no daemon, no HTTP server, no sockets — the CLI is the entire control surface.
+**TLDR**: Hive exposes a Thor-based CLI with four commands: `init`, `new`, `run`, `status`. There is no daemon, no HTTP server, no sockets — the CLI is the entire control surface. `status` and `run` support `--json` for machine-readable output, and process exit codes are stable per `Hive::ExitCodes` so wrappers can branch deterministically.
 
 ## Entry point
 
-`bin/hive` is a thin runner that loads `lib/hive` and calls `Hive::CLI.start(ARGV)`, catching `Hive::Error` to render `hive: <message>` to stderr with the error's `exit_code` (default 1).
+`bin/hive` is a thin runner that loads `lib/hive` and calls `Hive::CLI.start(ARGV)`, catching `Hive::Error` to render `hive: <message>` to stderr with the error's `exit_code` (default `ExitCodes::GENERIC = 1`).
 
 ## Command table
 
@@ -26,20 +26,37 @@ tags: [cli, api]
 
 - `new_task` is mapped to the user-visible `new` (Thor reserves `new`).
 - `run_task` is mapped to `run`.
-- `init` accepts `--force` (skip clean-tree check); other commands take no flags in MVP.
+- `init` accepts `--force` (skip clean-tree check).
+- `--json` is a `class_option` honoured by `status` and `run`; other commands accept the flag silently so an automated caller can pass it uniformly.
+
+## Exit-code contract (`Hive::ExitCodes`)
+
+| Code | Constant | Meaning | Raised by |
+|------|----------|---------|-----------|
+| 0 | `SUCCESS` | command completed | — |
+| 1 | `GENERIC` | unclassified `Hive::Error` | base `Hive::Error` |
+| 2 | `ALREADY_INITIALIZED` | idempotent reject of `hive init` on existing project | `Hive::AlreadyInitialized` |
+| 3 | `TASK_IN_ERROR` | a stage agent recorded `:error` (runner itself succeeded) | `Hive::TaskInErrorState` |
+| 4 | `WRONG_STAGE` | `hive run` invoked on an inert stage (e.g. `1-inbox`) | `Hive::WrongStage` |
+| 64 | `USAGE` | EX_USAGE — bad slug, malformed task path | `Hive::InvalidTaskPath` |
+| 70 | `SOFTWARE` | EX_SOFTWARE — git, worktree, agent, or stage-runner failure | `GitError`, `WorktreeError`, `AgentError`, `StageError` |
+| 75 | `TEMPFAIL` | EX_TEMPFAIL — retryable lock contention | `Hive::ConcurrentRunError` |
+| 78 | `CONFIG` | EX_CONFIG — bad project / global config | `Hive::ConfigError` |
+
+Codes are stable; bumping a code requires updating `test/unit/exit_codes_test.rb`. See [CONTRIBUTING.md](../CONTRIBUTING.md) "CLI contract for agent callers".
 
 ## Authentication / preconditions
 
 The CLI itself has no auth. Preconditions checked at runtime by individual stage runners:
 
-- `Hive::Agent.check_version!` parses `claude --version` and compares against `Hive::MIN_CLAUDE_VERSION = "2.1.118"` (`lib/hive.rb:3`). Raises `AgentError` if below.
+- `Hive::Agent.check_version!` parses `claude --version` and compares against `Hive::MIN_CLAUDE_VERSION = "2.1.118"`. Raises `AgentError` if below.
 - `Stages::Pr#ensure_gh_authenticated!` runs `gh auth status` and exits 1 with stderr if unauthenticated.
 - `Init#validate_git_repo!` rejects non-git dirs and rejects targets that are themselves worktrees (must run on the main checkout).
 - `Init#validate_clean_tree!` aborts on dirty working tree unless `--force`.
 
 ## Error conventions
 
-`Hive::Error` (`lib/hive.rb:6`) is the root exception. Subclasses define stage-shaped failure modes:
+`Hive::Error` is the root exception. Subclasses define stage-shaped failure modes; each overrides `exit_code` so `bin/hive`'s rescue path produces the contract code automatically.
 
 | Class | Raised by |
 |-------|-----------|
@@ -50,8 +67,11 @@ The CLI itself has no auth. Preconditions checked at runtime by individual stage
 | `Hive::AgentError` | `Agent.check_version!` |
 | `Hive::ConfigError` | `Config.load`/`registered_projects` on shape mismatch |
 | `Hive::StageError` | `Commands::Run#pick_runner` for unknown stage names |
+| `Hive::TaskInErrorState` | `Commands::Run#report` when the stage marker is `:error` |
+| `Hive::WrongStage` | `Stages::Inbox#run!` (running an agent on an inert stage) |
+| `Hive::AlreadyInitialized` | `Commands::Init#call` when `hive/state` branch already exists |
 
-Stage runners use `warn`/`exit N` directly for user-facing errors that aren't bugs (e.g., `plan.md missing` → exit 1; `already initialized` → exit 2). See per-command pages.
+A few stage runners still call `warn`/`exit N` directly for non-bug user errors that don't yet have a typed class — most notably `Init#validate_git_repo!` / `validate_clean_tree!` (exit 1), `Execute#run!` for `plan.md missing` (exit 1), and the `Pr` stage's network/auth abort paths. Migrating these to typed exceptions is tracked as Phase 2 follow-up work.
 
 ## Backlinks
 

--- a/wiki/commands/run.md
+++ b/wiki/commands/run.md
@@ -4,15 +4,15 @@ type: command
 source: lib/hive/commands/run.rb
 created: 2026-04-25
 updated: 2026-04-25
-tags: [command, dispatcher, stages]
+tags: [command, dispatcher, stages, json]
 ---
 
-**TLDR**: `hive run FOLDER` is the dispatcher: parses `FOLDER` into a `Hive::Task`, takes the per-task lock, picks the matching stage runner, executes it, commits any `.hive-state` changes via the per-project commit lock, and reports the resulting marker plus a `next:` hint.
+**TLDR**: `hive run FOLDER` is the dispatcher: parses `FOLDER` into a `Hive::Task`, takes the per-task lock, picks the matching stage runner, executes it, commits any `.hive-state` changes via the per-project commit lock, and reports the resulting marker plus a `next:` hint. With `--json`, emits a single machine-readable document; exit codes are stable per `Hive::ExitCodes` (see [[cli]]).
 
 ## Usage
 
 ```
-hive run <project>/.hive-state/stages/<N>-<stage>/<slug>
+hive run <project>/.hive-state/stages/<N>-<stage>/<slug> [--json]
 ```
 
 `FOLDER` is `File.expand_path`-ed and parsed by `Hive::Task#initialize`; mismatches against `Hive::Task::PATH_RE` raise `InvalidTaskPath`.
@@ -20,7 +20,7 @@ hive run <project>/.hive-state/stages/<N>-<stage>/<slug>
 ## Steps performed (`Commands::Run#call`)
 
 1. Build `Hive::Task.new(folder)` and load merged config via `Hive::Config.load(task.project_root)`.
-2. Acquire the per-task lock via `Hive::Lock.with_task_lock` with payload `{slug:, stage:}`. Concurrent run → `ConcurrentRunError` (exit 1, stderr `hive: another hive run is active`).
+2. Acquire the per-task lock via `Hive::Lock.with_task_lock` with payload `{slug:, stage:}`. Concurrent run → `ConcurrentRunError` (exit 75, `TEMPFAIL`, stderr `hive: another hive run is active`).
 3. `pick_runner(task)` returns one of `Hive::Stages::{Inbox,Brainstorm,Plan,Execute,Pr,Done}.method(:run!)`. Unknown stage → `StageError`.
 4. Call the runner: `runner.call(task, cfg)` → `{commit:, status:}`.
 5. `commit_after`: if `result[:commit]`, take the per-project commit lock and run `GitOps#hive_commit(stage_name: "<N>-<stage>", slug:, action: result[:commit])`.
@@ -34,7 +34,7 @@ hive run <project>/.hive-state/stages/<N>-<stage>/<slug>
 | `:complete` | `next: mv <folder> <hive-state>/stages/<next>/` (resolved by `next_stage_dir`) |
 | `:execute_complete` | `next: mv <folder> <hive-state>/stages/5-pr/` |
 | `:execute_stale` | `next: edit reviews/, lower task.md frontmatter pass:, remove EXECUTE_STALE marker, re-run` |
-| `:error` | stderr `status: ERROR (<attrs>)`, exit 1 |
+| `:error` | raises `Hive::TaskInErrorState` → `bin/hive` rescues → exit 3 (`TASK_IN_ERROR`). JSON mode emits the full payload first, then raises — dual signal. |
 
 `next_stage_dir` increments `task.stage_index`; `6-done` has no `next:`.
 

--- a/wiki/commands/status.md
+++ b/wiki/commands/status.md
@@ -4,10 +4,10 @@ type: command
 source: lib/hive/commands/status.rb
 created: 2026-04-25
 updated: 2026-04-25
-tags: [command, status, observability]
+tags: [command, status, observability, json]
 ---
 
-**TLDR**: `hive status` walks every registered project's `.hive-state/stages/<N>-<name>/<slug>/` directory, reads each task's marker, and prints a grouped, mtime-sorted table. Read-only; takes no args.
+**TLDR**: `hive status` walks every registered project's `.hive-state/stages/<N>-<name>/<slug>/` directory, reads each task's marker, and prints a grouped, mtime-sorted table. Read-only; takes no args. Pass `--json` for a single machine-readable document on stdout (schema `hive-status`, version per `Hive::SCHEMA_VERSIONS`).
 
 ## Output shape
 


### PR DESCRIPTION
## Summary

Adds `--json` output mode for `hive status` and `hive run`, plus a documented exit-code contract that programmatic callers can rely on. First PR of the agent-native CLI bucket on the Phase 2 roadmap.

### `--json` output

Both commands accept `--json` and emit a single JSON document on stdout with `schema` + `schema_version` headers (`hive-status` / `hive-run`, version 1). Adding new keys is non-breaking; removing or changing keys bumps the version.

\`\`\`bash
hive status --json | jq '.projects[].tasks[] | select(.marker == \"execute_waiting\")'
hive run /path/to/task --json | jq '.next_action'
\`\`\`

\`hive run --json\` returns a \`next_action\` object so callers don't have to scrape \"hive: marker=…\" prose.

### Exit-code contract

\`Hive::ExitCodes\` constants + per-\`Hive::Error\`-subclass codes mapped through \`bin/hive\`:

| Code | Meaning | Retryable? |
|------|---------|------------|
| 0    | success                                            | n/a        |
| 1    | generic failure                                    | no         |
| 2    | \`hive init\` on already-initialised project       | no         |
| 3    | task in \`:error\` marker state                    | no         |
| 4    | wrong stage (\`hive run\` on inert \`1-inbox/\`)   | no         |
| 64   | usage / bad slug / malformed task path             | no         |
| 70   | software (git / worktree / agent / stage)          | maybe      |
| 75   | retryable lock contention                          | **yes**    |
| 78   | bad config                                         | no         |

**Behaviour change:** \`hive run\` now returns \`3\` (not \`1\`) when a stage records \`:error\` — distinguishes a runner-level failure from an agent-recorded task failure. Callers that branched on exit 1 should switch to exit 3 (or use the new \`Hive::TaskInErrorState\` semantic).

### Refactors

- \`with_captured_exit\` test helper centralised in \`test/test_helper.rb\`; three duplicated copies removed from integration tests. The helper now catches \`Hive::Error\` and maps to its \`exit_code\`, mirroring \`bin/hive\`.

### Tests

- \`test/unit/exit_codes_test.rb\` pins every constant and every subclass → exit-code mapping. Anyone bumping a code has to update this test.
- \`test/integration/json_output_test.rb\` asserts the JSON payload shape (schema/version, expected keys per record, \`next_action.kind\` values).

100 / 353 assertions, all green. RuboCop clean. Verified live against the existing writero registry: \`hive status --json\` correctly serialises the in-flight \`add-ruby-version-requirement\` task with marker, attrs, mtime, age_seconds, claude_pid, and claude_pid_alive.

## Test plan

- [ ] \`bundle exec rake test\` green (94 → 100, six new in this PR)
- [ ] \`bundle exec rubocop\` clean
- [ ] \`hive status --json | jq .schema\` returns \`\"hive-status\"\`
- [ ] \`hive status --json | jq .projects[0].tasks[0]\` shows the new keys (\`folder\`, \`state_file\`, \`marker\`, \`attrs\`, \`mtime\`, \`age_seconds\`, \`claude_pid\`, \`claude_pid_alive\`)
- [ ] \`hive run <task> --json\` emits a \`next_action\` object
- [ ] \`hive init\` on an already-initialised project still exits 2
- [ ] \`hive run\` on a task whose execute stage recorded \`:error\` now exits **3** (was 1) — this is the breaking-but-narrow behaviour change

## Linked work

First PR of the agent-native CLI bucket on the Phase 2 roadmap. Subsequent PRs in this bucket will land separately:

- \`hive approve <slug> [--to <stage>]\` (replaces shell \`mv\`)
- \`hive findings\` + \`hive accept-finding\` / \`hive reject-finding\`
- \`hive reset-stale\` + \`hive doctor\` + \`hive cleanup\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)