### PR TITLE
feat(init): styled summary with TTY-gated colors

### DIFF
--- a/lib/hive/commands/init.rb
+++ b/lib/hive/commands/init.rb
@@ -27,11 +27,26 @@ module Hive
 
         entry = Hive::Config.register_project(name: File.basename(@project_path), path: @project_path)
 
-        puts "hive: initialized #{entry['name']} at #{@project_path}"
-        puts "  default_branch: #{ops.default_branch}"
-        puts "  hive_state_path: #{ops.hive_state_path}"
-        puts "  worktree_root: #{worktree_root}"
-        puts "next: hive new #{entry['name']} '<short task description>'"
+        print_summary(entry: entry, ops: ops)
+      end
+
+      def print_summary(entry:, ops:)
+        c = Palette.for($stdout)
+        name = entry["name"]
+        rows = [
+          [ "project",        @project_path ],
+          [ "default branch", ops.default_branch ],
+          [ "hive state",     ops.hive_state_path ],
+          [ "worktree root",  worktree_root ]
+        ]
+        label_width = rows.map { |k, _| k.length }.max
+
+        $stdout.puts "#{c.green('✔')} #{c.bold('hive: initialized')} #{c.bold_cyan(name)}"
+        rows.each do |label, value|
+          $stdout.puts "  #{c.dim(label.ljust(label_width))}  #{value}"
+        end
+        $stdout.puts
+        $stdout.puts "#{c.cyan('→')} #{c.bold('next:')} hive new #{name} '<short task description>'"
       end
 
       def validate_git_repo!
@@ -83,6 +98,37 @@ module Hive
 
       def worktree_root
         File.expand_path("~/Dev/#{File.basename(@project_path)}.worktrees")
+      end
+
+      # Minimal ANSI palette for one-shot CLI summaries. Honors
+      # NO_COLOR and falls back to plain text on non-tty IO so piped
+      # callers (CI, `hive init … | tee …`) get clean output.
+      class Palette
+        CODES = {
+          reset: "\e[0m",
+          bold: "\e[1m",
+          dim: "\e[2m",
+          green: "\e[32m",
+          cyan: "\e[36m",
+          bold_cyan: "\e[1;36m"
+        }.freeze
+
+        def self.for(io)
+          color = io.respond_to?(:tty?) && io.tty? && (ENV["NO_COLOR"].nil? || ENV["NO_COLOR"].empty?)
+          new(color: color)
+        end
+
+        def initialize(color:)
+          @color = color
+        end
+
+        CODES.each_key do |name|
+          next if name == :reset
+
+          define_method(name) do |text|
+            @color ? "#{CODES[name]}#{text}#{CODES[:reset]}" : text.to_s
+          end
+        end
       end
 
       class ProjectConfigBinding

--- a/test/integration/init_test.rb
+++ b/test/integration/init_test.rb
@@ -7,7 +7,20 @@ class InitTest < Minitest::Test
   def test_initializes_project_with_orphan_branch_and_global_registration
     with_tmp_global_config do
       with_tmp_git_repo do |dir|
-        capture_io { Hive::Commands::Init.new(dir).call }
+        out, _err = capture_io { Hive::Commands::Init.new(dir).call }
+
+        # Summary content contract — agents and humans both rely on these tokens
+        # surviving future refactors of print_summary's layout.
+        name = File.basename(dir)
+        assert_includes out, "hive: initialized"
+        assert_includes out, name
+        assert_includes out, dir
+        assert_includes out, "next: hive new #{name}"
+
+        # capture_io yields a non-tty StringIO; ANSI must be suppressed there
+        # so piped/CI output stays clean. Load-bearing safety property of the
+        # styled summary.
+        refute_match(/\e\[/, out, "ANSI escapes must not appear in non-tty output")
 
         assert File.directory?(File.join(dir, ".hive-state", "stages", "1-inbox"))
         assert File.exist?(File.join(dir, ".hive-state", "config.yml"))

--- a/test/unit/init_palette_test.rb
+++ b/test/unit/init_palette_test.rb
@@ -1,0 +1,66 @@
+require "test_helper"
+require "hive/commands/init"
+
+class InitPaletteTest < Minitest::Test
+  Palette = Hive::Commands::Init::Palette
+
+  def test_color_disabled_returns_plain_text
+    p = Palette.new(color: false)
+    assert_equal "x", p.green("x")
+    assert_equal "x", p.cyan("x")
+    assert_equal "x", p.bold("x")
+    assert_equal "x", p.dim("x")
+    assert_equal "x", p.bold_cyan("x")
+  end
+
+  def test_color_enabled_wraps_with_ansi_codes
+    p = Palette.new(color: true)
+    assert_equal "\e[32mx\e[0m",   p.green("x")
+    assert_equal "\e[36mx\e[0m",   p.cyan("x")
+    assert_equal "\e[1mx\e[0m",    p.bold("x")
+    assert_equal "\e[2mx\e[0m",    p.dim("x")
+    assert_equal "\e[1;36mx\e[0m", p.bold_cyan("x")
+  end
+
+  def test_for_disables_color_on_non_tty_io
+    p = Palette.for(StringIO.new)
+    assert_equal "x", p.green("x")
+  end
+
+  def test_for_enables_color_on_tty_io_when_no_color_unset
+    with_no_color(nil) do
+      p = Palette.for(tty_io)
+      assert_equal "\e[32mx\e[0m", p.green("x")
+    end
+  end
+
+  def test_for_treats_empty_no_color_as_unset
+    with_no_color("") do
+      p = Palette.for(tty_io)
+      assert_equal "\e[32mx\e[0m", p.green("x")
+    end
+  end
+
+  def test_for_disables_color_when_no_color_set
+    with_no_color("1") do
+      p = Palette.for(tty_io)
+      assert_equal "x", p.green("x")
+    end
+  end
+
+  private
+
+  def tty_io
+    Class.new do
+      def tty?; true; end
+    end.new
+  end
+
+  def with_no_color(value)
+    prior = ENV["NO_COLOR"]
+    ENV["NO_COLOR"] = value
+    yield
+  ensure
+    ENV["NO_COLOR"] = prior
+  end
+end

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -2,6 +2,12 @@
 
 Append-only log of all wiki operations.
 
+## [2026-05-04T11:50:00Z] commands/init — beautified summary
+
+**Action:** Replaced the plain key:value summary printed at the end of `hive init` with a styled summary: green ✔ + bold heading + bold-cyan project name, dim labels in an aligned two-column block, and a cyan `→ next:` prompt. Colors are emitted only when `$stdout.tty?` and `NO_COLOR` is unset/empty, so piped/CI output stays plain. Field labels are now spaced (`default branch`, `hive state`, `worktree root`) instead of underscore-cased. Implementation lives in a nested `Hive::Commands::Init::Palette` so it can be lifted out if other commands want the same treatment.
+
+**Refreshed pages:** none (the existing summary description in `wiki/commands/init.md` already describes it at a level that survives the cosmetic change).
+
 ## [2026-05-01T15:00:00Z] tui — v2 two-pane redesign
 
 **Action:** Replaced v1's single-column action-grouped `Views::Grid` with a two-pane composition: `Views::ProjectsPane` (left, project list with `★ All projects` virtual entry) and `Views::TasksPane` (right, 5-column compact table — icon · slug · stage · status · age). `Views::Grid` and its tests were deleted in the same PR — no `HIVE_TUI_LAYOUT=v1` escape hatch. Pane focus is keyboard-only via `Tab` / `Shift+Tab` / `h` / `l`. `j` / `k` route by `model.pane_focus`: left-pane navigation drives `model.scope`; right-pane navigation drives the row cursor. New `n` keystroke opens an inline new-idea prompt that dispatches `hive new <project> "<title>"` via `Subprocess.run_quiet!` (project resolved from left-pane selection; `★ All` falls back to the first registered project, label shows `★→<name>` so the resolved target is visible). Below 70 cols the project pane is suppressed and the tasks pane occupies the full width. Visual style refresh: rounded borders, focused/dim border distinction (cyan/faint), refined action-key palette (magenta=agent_running, red=error, blue=ready_*, green=archived, yellow=needs_input/review_findings).


### PR DESCRIPTION
## Summary

`hive init` now prints a styled summary instead of a flat key:value block.

**TTY output**
```
✔ hive: initialized xbookmark
  project         /home/asterio/Dev/xbookmark
  default branch  main
  hive state      /home/asterio/Dev/xbookmark/.hive-state
  worktree root   /home/asterio/Dev/xbookmark.worktrees

→ next: hive new xbookmark '<short task description>'
```

- ✔ green, heading bold, project name bold-cyan
- aligned two-column body with dim labels
- cyan `→ next:` prompt

**Piped / CI output** is identical text with all ANSI stripped — gated on `$stdout.tty?` + `NO_COLOR`. The `hive:` prefix is preserved so log/grep workflows are unaffected.

ANSI codes live in a small nested `Hive::Commands::Init::Palette` (`lib/hive/commands/init.rb`). It can be lifted out later if other commands want the same treatment; deliberately kept inline for now.

## Test plan

- [x] `bundle exec rake test` — 1072 runs / 3662 assertions, 0 failures
- [x] `bundle exec rubocop lib/hive/commands/init.rb` — clean
- [x] Dogfood under `script` (TTY path) — colors render
- [x] Dogfood with stdout piped to `cat -A` — no ANSI escapes in output