### PR TITLE
refactor(tui): drop unnecessary public_send around Bubbletea.exec

### DIFF
--- a/lib/hive/tui/subprocess.rb
+++ b/lib/hive/tui/subprocess.rb
@@ -139,7 +139,7 @@ module Hive
       def foreground_takeover_command(callable)
         Bubbletea.sequence(
           Bubbletea.exit_alt_screen,
-          Bubbletea.public_send(:exec, callable),
+          Bubbletea.exec(callable),
           Bubbletea.enter_alt_screen
         )
       end


### PR DESCRIPTION
## Summary

Follow-up cleanup from the ce-code-review on PR #26. The `public_send(:exec, callable)` form on `lib/hive/tui/subprocess.rb:142` predates the foreground-takeover wrapper extraction and was never required — `Bubbletea.exec` is a public module method on bubbletea-ruby 0.1.4 (`commands.rb:136`, exposed via `module_function`). Calling it directly removes a layer of indirection that gives a future reader pause.

Behavior is byte-identical: both forms construct the same `Bubbletea::ExecCommand`. The existing wrapper-shape test in `test/integration/tui_subprocess_test.rb` and the end-to-end coverage in `test/unit/tui/bubble_model_test.rb:540` both pin the resulting class identity, which is unchanged.

## Test Plan

- `bundle exec rubocop lib/hive/tui/subprocess.rb` — clean
- `bundle exec ruby -Itest -Ilib test/integration/tui_subprocess_test.rb` — 20 runs, 47 assertions, 0 failures
- `bundle exec ruby -Itest -Ilib test/unit/tui/bubble_model_test.rb` — 72 runs, 193 assertions, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)