### PR TITLE
fix(tui): suppress render during editor takeover

### DIFF
--- a/lib/hive/tui/paste_aware_runner.rb
+++ b/lib/hive/tui/paste_aware_runner.rb
@@ -55,6 +55,23 @@ module Hive
         end
       end
 
+      # Sequence commands run on a background thread in bubbletea-ruby.
+      # Suppress rendering through foreground takeovers so the main loop
+      # cannot repaint the dashboard onto the editor's screen.
+      def execute_sequence_sync(commands)
+        suppress_render = foreground_takeover_sequence?(commands)
+        @suppress_render_for_foreground_takeover = true if suppress_render
+        super
+      ensure
+        @suppress_render_for_foreground_takeover = false if suppress_render
+      end
+
+      def render
+        return if @suppress_render_for_foreground_takeover
+
+        super
+      end
+
       def process_input
         raw = @program.read_raw_input(@options[:input_timeout])
         messages = raw ? @input_decoder.drain(raw) : @input_decoder.flush
@@ -76,6 +93,12 @@ module Hive
           @input_decoder.reset!
         end
         @last_editable_mode = EDITABLE_MODES.include?(mode) ? mode : nil
+      end
+
+      def foreground_takeover_sequence?(commands)
+        commands.any? { |cmd| cmd.is_a?(Bubbletea::ExitAltScreenCommand) } &&
+          commands.any? { |cmd| cmd.is_a?(Bubbletea::ExecCommand) } &&
+          commands.any? { |cmd| cmd.is_a?(Bubbletea::EnterAltScreenCommand) }
       end
 
       def current_mode

--- a/test/unit/tui/paste_aware_runner_test.rb
+++ b/test/unit/tui/paste_aware_runner_test.rb
@@ -103,7 +103,7 @@ class HiveTuiPasteAwareRunnerTest < Minitest::Test
     observed = []
     commands = [
       Bubbletea.exit_alt_screen,
-      Bubbletea.exec(-> {}),
+      Bubbletea.exec(-> { }),
       Bubbletea.enter_alt_screen
     ]
 

--- a/test/unit/tui/paste_aware_runner_test.rb
+++ b/test/unit/tui/paste_aware_runner_test.rb
@@ -96,4 +96,44 @@ class HiveTuiPasteAwareRunnerTest < Minitest::Test
     assert_equal "\e[", runner.input_decoder.instance_variable_get(:@pending),
                  "latch must not re-fire on subsequent :grid → :grid"
   end
+
+  def test_foreground_takeover_sequence_suppresses_render_until_sequence_finishes
+    runner, = runner_for(initial_mode: :grid)
+    runner.instance_variable_set(:@running, true)
+    observed = []
+    commands = [
+      Bubbletea.exit_alt_screen,
+      Bubbletea.exec(-> {}),
+      Bubbletea.enter_alt_screen
+    ]
+
+    runner.define_singleton_method(:execute_command_sync) do |cmd|
+      observed << [ cmd.class, instance_variable_get(:@suppress_render_for_foreground_takeover) ]
+    end
+
+    runner.__send__(:execute_sequence_sync, commands)
+
+    assert_equal(
+      [
+        [ Bubbletea::ExitAltScreenCommand, true ],
+        [ Bubbletea::ExecCommand, true ],
+        [ Bubbletea::EnterAltScreenCommand, true ]
+      ],
+      observed,
+      "rendering must stay suppressed across exit-alt-screen, editor exec, and re-entry"
+    )
+    refute runner.instance_variable_get(:@suppress_render_for_foreground_takeover),
+           "render suppression must clear after the foreground takeover sequence"
+  end
+
+  def test_render_is_noop_while_foreground_takeover_is_suppressed
+    runner, = runner_for(initial_mode: :grid)
+    runner.instance_variable_set(:@renderer_id, 1)
+    fake_program = Object.new
+    fake_program.define_singleton_method(:render) { |_renderer_id, _view| raise "rendered during takeover" }
+    runner.instance_variable_set(:@program, fake_program)
+    runner.instance_variable_set(:@suppress_render_for_foreground_takeover, true)
+
+    assert_nil runner.__send__(:render)
+  end
 end


### PR DESCRIPTION
## Summary

- suppress Bubbletea rendering while a foreground takeover sequence is active
- prevent the dashboard from repainting into the editor's main-screen buffer between alt-screen exit and editor startup
- add PasteAwareRunner regression coverage for takeover render suppression

## Test plan

- [x] bundle exec rake test — 1288 runs / 4384 assertions / 0 failures
