### PR TITLE
fix(tui): accept `### Q{n} answer.` as an answer heading

### DIFF
--- a/lib/hive/tui/brainstorm_answers.rb
+++ b/lib/hive/tui/brainstorm_answers.rb
@@ -5,8 +5,15 @@ module Hive
   module Tui
     # Pure markdown-parsing predicate over a brainstorm.md state file.
     # Returns true only when the latest `## Round N` block has every
-    # `### Qn` paired with a non-empty `### An`, mirroring the contract
-    # in `templates/brainstorm_prompt.md.erb`.
+    # numbered question paired with a non-empty numbered answer.
+    #
+    # Heading-form tolerance:
+    #   The canonical contract in `templates/brainstorm_prompt.md.erb`
+    #   uses `### Q{n}.` for questions and `### A{n}.` for answers,
+    #   but the `/compound-engineering:ce-brainstorm` skill (which the
+    #   prompt invokes for Round 2+) emits `### Q{n} answer.` instead
+    #   of `### A{n}.`. Both forms are accepted as answers so the
+    #   parser does not refuse on legitimate agent output.
     #
     # Conservative on ambiguity:
     # - duplicate Q/A numbers within the same round → not complete
@@ -23,12 +30,15 @@ module Hive
     module BrainstormAnswers
       module_function
 
-      ROUND_HEADING = /\A {0,3}##\s+Round\s+(\d+)\b/i.freeze
-      QA_HEADING    = /\A {0,3}###\s+([QA])(\d+)\b/i.freeze
-      ANSWER_HEAD_PREFIX = /\A {0,3}###\s+A\d+\s*\.?\s*/i.freeze
-      H2_HEADING    = /\A {0,3}##\s+/.freeze
-      FENCE_LINE    = /\A {0,3}(```|~~~)/.freeze
-      HTML_COMMENT  = /<!--.*?-->/m.freeze
+      ROUND_HEADING       = /\A {0,3}##\s+Round\s+(\d+)\b/i.freeze
+      ANSWER_HEAD_LONG    = /\A {0,3}###\s+Q(\d+)\s+answer\b/i.freeze
+      ANSWER_HEAD_SHORT   = /\A {0,3}###\s+A(\d+)\b/i.freeze
+      QUESTION_HEAD       = /\A {0,3}###\s+Q(\d+)\b/i.freeze
+      QA_HEADING_ANY      = /\A {0,3}###\s+(?:Q\d+\s+answer|[QA]\d+)\b/i.freeze
+      ANSWER_HEAD_PREFIX  = /\A {0,3}###\s+(?:A\d+\s*\.?|Q\d+\s+answer\s*\.?)\s*/i.freeze
+      H2_HEADING          = /\A {0,3}##\s+/.freeze
+      FENCE_LINE          = /\A {0,3}(```|~~~)/.freeze
+      HTML_COMMENT        = /<!--.*?-->/m.freeze
 
       # Public entrypoint. Reads `path`, returns true iff the latest
       # round in the file has every numbered question paired with a
@@ -47,8 +57,7 @@ module Hive
         round_start = latest_round_start(lines, live)
         return false if round_start.nil?
 
-        questions, q_dup = numbered_headings(lines, live, round_start + 1, "Q")
-        answers,   a_dup = numbered_headings(lines, live, round_start + 1, "A")
+        questions, answers, q_dup, a_dup = numbered_headings(lines, live, round_start + 1)
         return false if q_dup || a_dup
         return false if questions.empty? || answers.empty?
         return false unless questions.keys.sort == answers.keys.sort
@@ -108,30 +117,53 @@ module Hive
       end
       private_class_method :latest_round_start
 
-      # Walk forward from `start_idx` collecting `### Qn` or `### An`
-      # heading line indices keyed by their digit. Returns
-      # `[Hash{String => Integer}, duplicates_seen?]`. Stops at the
-      # next `## ` (sibling round) so headings from later rounds do
-      # not bleed into the current round's coverage check.
-      def numbered_headings(lines, live, start_idx, prefix)
-        headings = {}
-        duplicates = false
+      # Walk the round body once, collecting numbered question and
+      # answer heading line indices keyed by digit. Returns
+      # `[questions, answers, q_dup, a_dup]`. Stops at the next `## `
+      # (sibling round) so headings from later rounds do not bleed
+      # into the current round's coverage check.
+      #
+      # Recognized answer forms (both yield the same numeric key):
+      #   `### A{n}`            (canonical, per brainstorm template)
+      #   `### Q{n} answer`     (ce-brainstorm skill output for Round 2+)
+      #
+      # Order of `classify_qa_heading` checks matters: the long form
+      # `Q{n} answer` must be tested before the plain `Q{n}` so a
+      # legitimate answer heading is not double-matched as a question.
+      def numbered_headings(lines, live, start_idx)
+        questions = {}
+        answers = {}
+        q_dup = false
+        a_dup = false
         (start_idx...lines.length).each do |idx|
           next unless live[idx]
           line = lines[idx]
           break if line.match?(H2_HEADING)
-          next unless (m = line.match(QA_HEADING))
-          next unless m[1].casecmp?(prefix)
 
-          if headings.key?(m[2])
-            duplicates = true
+          kind, num = classify_qa_heading(line)
+          next if kind.nil?
+
+          target = kind == :q ? questions : answers
+          if target.key?(num)
+            kind == :q ? q_dup = true : a_dup = true
           else
-            headings[m[2]] = idx
+            target[num] = idx
           end
         end
-        [ headings, duplicates ]
+        [ questions, answers, q_dup, a_dup ]
       end
       private_class_method :numbered_headings
+
+      def classify_qa_heading(line)
+        if (m = line.match(ANSWER_HEAD_LONG))
+          [ :a, m[1] ]
+        elsif (m = line.match(ANSWER_HEAD_SHORT))
+          [ :a, m[1] ]
+        elsif (m = line.match(QUESTION_HEAD))
+          [ :q, m[1] ]
+        end
+      end
+      private_class_method :classify_qa_heading
 
       # An answer is filled when the heading line plus the body up to
       # the next Q/A or `## ` heading contains at least one
@@ -158,7 +190,7 @@ module Hive
         (start_idx...lines.length).find do |idx|
           next false unless live[idx]
 
-          lines[idx].match?(QA_HEADING) || lines[idx].match?(H2_HEADING)
+          lines[idx].match?(QA_HEADING_ANY) || lines[idx].match?(H2_HEADING)
         end
       end
       private_class_method :next_section_break

--- a/test/unit/tui/brainstorm_answers_test.rb
+++ b/test/unit/tui/brainstorm_answers_test.rb
@@ -44,6 +44,114 @@ class HiveTuiBrainstormAnswersTest < Minitest::Test
     end
   end
 
+  # ---- Heading-form tolerance: `### Q{n} answer.` ----
+
+  def test_q_n_answer_heading_recognized_as_answer
+    # The /compound-engineering:ce-brainstorm skill emits
+    # `### Q{n} answer.` instead of `### A{n}.` for Round 2+. The
+    # parser must accept both forms or it would refuse on legitimate
+    # agent output.
+    with_tmp_dir do |dir|
+      path = write_md(dir, <<~MD)
+        ## Round 2
+        ### Q1. X API access — concrete path for v1
+        Question text on multiple lines.
+        ### Q1 answer.
+        Pricing is now pay per use.
+        ### Q2. What does LLM enrichment do?
+        ### Q2 answer.
+        Just summary, tags, link expansion.
+      MD
+
+      assert_equal true, Hive::Tui::BrainstormAnswers.complete?(path)
+    end
+  end
+
+  def test_q_n_answer_with_inline_text_recognized
+    with_tmp_dir do |dir|
+      path = write_md(dir, <<~MD)
+        ## Round 1
+        ### Q1. Cadence?
+        ### Q1 answer. Daily cron.
+      MD
+
+      assert_equal true, Hive::Tui::BrainstormAnswers.complete?(path)
+    end
+  end
+
+  def test_mixed_a_n_and_q_n_answer_within_same_round
+    # Defensive: an agent that emits a mix of forms in a single round
+    # should still count each as the appropriate answer.
+    with_tmp_dir do |dir|
+      path = write_md(dir, <<~MD)
+        ## Round 1
+        ### Q1. First?
+        ### A1. yes
+        ### Q2. Second?
+        ### Q2 answer. also yes
+      MD
+
+      assert_equal true, Hive::Tui::BrainstormAnswers.complete?(path)
+    end
+  end
+
+  def test_duplicate_answer_across_a_and_q_n_answer_forms_refuses
+    # Both `### A1.` and `### Q1 answer.` populate the answer slot
+    # for digit "1"; a round with both is malformed and must refuse
+    # to auto-continue.
+    with_tmp_dir do |dir|
+      path = write_md(dir, <<~MD)
+        ## Round 1
+        ### Q1. Scope?
+        ### A1. one
+        ### Q1 answer. two
+      MD
+
+      assert_equal false, Hive::Tui::BrainstormAnswers.complete?(path)
+    end
+  end
+
+  def test_q_n_answer_with_empty_body_returns_false
+    with_tmp_dir do |dir|
+      path = write_md(dir, <<~MD)
+        ## Round 1
+        ### Q1. Scope?
+        ### Q1 answer.
+      MD
+
+      assert_equal false, Hive::Tui::BrainstormAnswers.complete?(path)
+    end
+  end
+
+  def test_real_xbookmark_round_2_fixture_parses_complete
+    # Captures the exact heading shapes observed in the wild
+    # (xbookmark brainstorm.md): Round 1 used `### A{n}.` and Round 2
+    # used `### Q{n} answer.`. Latest-round-by-N selects Round 2; the
+    # parser must classify each `Q{n} answer.` heading as an answer.
+    with_tmp_dir do |dir|
+      path = write_md(dir, <<~MD)
+        # Brainstorm — xbookmark
+
+        ## Round 1
+        ### Q1. How will the service authenticate to X?
+        ### A1.
+        Use API for my own account.
+
+        ## Round 2
+        ### Q1. X API access — concrete path for v1
+        Long question text spanning multiple lines.
+        ### Q1 answer.
+        pricing is now pay per use.
+        ### Q2. What does LLM enrichment do?
+        ### Q2 answer.
+        summary, tags, link expansion.
+        <!-- WAITING -->
+      MD
+
+      assert_equal true, Hive::Tui::BrainstormAnswers.complete?(path)
+    end
+  end
+
   # ---- Empty / missing structure ----
 
   def test_no_round_heading_returns_false


### PR DESCRIPTION
## Summary

The brainstorm auto-continue parser was refusing to fire on legitimate Round 2+ output because the `/compound-engineering:ce-brainstorm` skill emits `### Q{n} answer.` instead of the canonical `### A{n}.`. The parser's `\b`-anchored regex matched both `### Q1.` AND `### Q1 answer.` as Q1, so a Round 2 with the alternate form looked like a round full of duplicate Qs and zero As → refused.

Reproducible against `~/Dev/xbookmark/.hive-state/stages/2-brainstorm/i-want-to-create-a-260504-1253/brainstorm.md` — Round 1 used `### A{n}.`, Round 2 used `### Q{n} answer.`. With this fix, the parser correctly classifies all 7 `Q{n} answer.` headings as answers and auto-continue fires.

## Heading classification rules

| Line | Classified as |
|------|---------------|
| `### Q{n}.` (or `### Q{n}` not followed by ` answer`) | question |
| `### A{n}.` | answer |
| `### Q{n} answer.` | answer (alternate form) |

`classify_qa_heading` checks `ANSWER_HEAD_LONG` (`Q{n} answer`) before `QUESTION_HEAD` (plain `Q{n}`), so the alternate answer form does not get double-matched as a question.

## Other changes

- `numbered_headings` refactored to a single pass that returns `[questions, answers, q_dup, a_dup]` instead of two prefix-keyed passes.
- `ANSWER_HEAD_PREFIX` widened to strip both canonical and alternate prefixes so inline answer text (`### Q1 answer. text...`) is read as body content.
- `next_section_break` uses the combined `QA_HEADING_ANY` regex.
- Module-level docstring documents the heading-form tolerance and why both forms exist.

## Tests

6 new unit tests in `test/unit/tui/brainstorm_answers_test.rb`:

- `test_q_n_answer_heading_recognized_as_answer` — basic alternate form
- `test_q_n_answer_with_inline_text_recognized` — `### Q1 answer. inline`
- `test_mixed_a_n_and_q_n_answer_within_same_round` — defensive
- `test_duplicate_answer_across_a_and_q_n_answer_forms_refuses` — `### A1.` + `### Q1 answer.` collide on slot 1
- `test_q_n_answer_with_empty_body_returns_false`
- `test_real_xbookmark_round_2_fixture_parses_complete` — wild-shape regression mirror

## Test plan

- [x] `bundle exec ruby -Itest -Ilib test/unit/tui/brainstorm_answers_test.rb` (31 runs, 32 assertions)
- [x] `bundle exec rake test` (1473 runs, 4800 assertions, 0 failures)
- [x] `bundle exec rubocop lib/hive/tui/brainstorm_answers.rb test/unit/tui/brainstorm_answers_test.rb` (0 offenses)
- [x] Verified `Hive::Tui::BrainstormAnswers.complete?` returns `true` against the xbookmark Round 2 fixture that originally reproduced the bug.

## Follow-up considerations

- Could pin the agent to `### A{n}.` in the brainstorm prompt template (option 2 from the diagnosis), but parser tolerance is more robust against future skill drift. This PR takes the parser-tolerance route.