### PR TITLE
docs(wiki): rescue stranded wiki edits from PR #23 worktree

### DIFF
--- a/wiki/commands/init.md
+++ b/wiki/commands/init.md
@@ -28,7 +28,9 @@ hive init [PROJECT_PATH] [--force]
 
 1. **Validate** — `validate_git_repo!` then `validate_clean_tree!` (skipped under `--force`).
 2. **Already-initialized guard** — if `hive/state` exists, raise `Hive::AlreadyInitialized` (exit 2). Runs **before** the prompt so a re-run never asks the user anything.
-3. **Collect prompt answers** — `Hive::Commands::Init::Prompts.new(input: $stdin, output: $stderr, summary_io: $stdout).collect`. Prompt UI (intro / menus / re-prompts / confirmation) goes to **stderr**; the non-TTY one-line summary goes to **stdout** so scripted callers can `summary=$(hive init)` cleanly. On TTY this opens the interactive flow described below; on non-TTY (CI, pipes, test harness) it short-circuits to recommended defaults. Aborting the prompt (`n` at confirmation) exits **64** (`Hive::ExitCodes::USAGE`, distinct from generic crashes at 1) with **zero disk side effects** — no orphan branch, no worktree, no master gitignore commit.
+3. **Collect prompt answers** — `Hive::Commands::Init::Prompts.new(input: $stdin, output: $stderr, summary_io: $stdout).collect`. Prompt UI (intro / menus / re-prompts / confirmation) goes to **stderr**; the non-TTY one-line summary goes to **stdout** so scripted callers can `summary=$(hive init)` cleanly. On TTY this opens the interactive flow described below; on non-TTY (CI, pipes, test harness) it short-circuits to recommended defaults. Two abort paths exit **64** (`Hive::ExitCodes::USAGE`, distinct from generic crashes at 1) with **zero disk side effects** — no orphan branch, no worktree, no master gitignore commit:
+   - Operator answers `n` at the final confirmation prompt.
+   - Input stream closes mid-flow (Ctrl-D / EOF / disconnected pipe). `Prompts#read_line` distinguishes `nil` (closed stream) from `""` (blank line for default) and raises `Aborted`. Treating EOF as a blank confirmation would silently write disk state with whatever was already collected.
 4. **Create orphan worktree** via `Hive::GitOps#hive_state_init` (`lib/hive/git_ops.rb:34`):
    - `git worktree add --no-checkout --detach <path>/.hive-state <default_branch>`
    - `git -C .hive-state checkout --orphan hive/state`

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -90,6 +90,15 @@ Coverage: 23-test unit suite directly against the new module (real fixtures on d
 
 **Refreshed pages:** none. `wiki/commands/tui.md` still describes `takeover_command` accurately as the public surface for `interactive: true` verbs; the new helper is an internal building block with one caller today and no immediate user-facing change to surface. Worth refreshing if/when a second caller lands (the `interactive: true` escape hatch is the most likely vector — a future interactive `gh pr create` prompt or a manual review verb), at which point `wiki/commands/tui.md`'s "Subprocess dispatch" section can name `foreground_takeover_command` as the shared primitive and `takeover_command` as one caller of it.
 
+## [2026-05-04T20:00:00Z] state-model trigger fired on init/config polish — wiki note only
+
+**Action:** Commit `93bcc18` (polish: comment drifts, validator coverage, construction guards) touched `lib/hive/commands/init.rb`, `lib/hive/commands/init/prompts.rb`, and `lib/hive/config.rb`. Reviewed every diff hunk: all changes are factual-accuracy comment fixes, table-driven validator-coverage tests, `Hash#fetch`-instead-of-`[]` defense-in-depth in `Prompts#default_budgets/timeouts`, and `Prompts#initialize` ArgumentError guards (empty registry / missing recommended defaults). The state-model surface (`Hive::Task`, `Hive::Markers`, `Hive::Config` schema/DEFAULTS, `Hive::Lock`, `Hive::Worktree`, `Hive::Metrics`) is unchanged — no marker added/removed, no DEFAULTS shape change, no validation rule change, no template field change.
+
+One single propagation made: `lib/hive/config.rb:220` corrected a misattribution ("review.reviewers Array semantic per ADR-018" — ADR-018 is about per-CLI isolation, not array merge). The same misattribution appeared at `wiki/modules/config.md:90` and is now corrected to match the code comment.
+
+**Refreshed pages:**
+- `wiki/modules/config.md` — Recursive deep-merge bullet on Array semantics no longer cites ADR-018; rationale ("per-element merge has ambiguous semantics for ordered lists") matches the code comment verbatim.
+
 ## [2026-05-04T19:10:44Z] tui — new-idea editing and paste support
 
 **Action:** Added cursor-aware editing to the `hive tui` new-idea prompt: Left/Right, Home/End, Ctrl+A/Ctrl+E, Backspace, Delete, insertion at cursor, wrapped cursor rendering, paste normalization, and a conservative 4 KiB title-buffer cap with a `title too long` flash. The terminal input path now uses a Hive-owned `PasteAwareRunner` over `Program#read_raw_input` so complete raw chunks are drained instead of losing bytes through bubbletea-ruby 0.1.4's one-event `poll_event` path. Copy remains terminal/OS-owned; Hive handles paste bytes only.

--- a/wiki/modules/config.md
+++ b/wiki/modules/config.md
@@ -91,7 +91,7 @@ Closes doc-review F3 (P0). The previous implementation was a **single-level** `H
 Rules:
 
 - **Hash + Hash** → recurse, key-by-key.
-- **Array** (any depth) → replace wholesale. Explicit semantic for `review.reviewers` per ADR-018 (see [[state-model]]); generalises to all Array-typed settings — per-element merge has ambiguous semantics for ordered lists.
+- **Array** (any depth) → replace wholesale. Per-element merge has ambiguous semantics for ordered lists (e.g. `review.reviewers`), so all Array-typed settings replace wholesale. (Earlier wiki/code comments misattributed this to ADR-018, which is actually the per-CLI-isolation trust-model amendment — unrelated.)
 - **Scalar / nil / type mismatch** → override wins.
 
 ## Validation (`Config.validate!`)


### PR DESCRIPTION
## Summary

Three doc-only wiki edits sat uncommitted in the `.worktrees/feat/hive-init-interactive-prompts` checkout after PR #23 was squash-merged. Bringing them onto main so they aren't lost when that worktree gets cleaned up.

## Changes

- `wiki/commands/init.md` — documents the EOF / closed-stream abort path in `Prompts#read_line` (raises `Aborted`; treats `nil`-from-stream distinctly from empty-line default).
- `wiki/log.md` — adds the `[2026-05-04T20:00:00Z]` entry covering commit `93bcc18` (polish: comment drifts, validator coverage, construction guards) and the ADR-018-misattribution propagation. Inserted at the right reverse-chronological position.
- `wiki/modules/config.md` — corrects the Array deep-merge bullet to drop the ADR-018 misattribution (ADR-018 is about per-CLI isolation, not array semantics).

## Test plan

- [x] `git diff --stat` matches the stranded patch exactly (3 files, 13 insertions, 2 deletions).
- [x] No code changes; doc-only.