### PR TITLE
feat(tui): auto-continue on plan stage (revise vs advance)

### DIFF
--- a/lib/hive/tui/bubble_model.rb
+++ b/lib/hive/tui/bubble_model.rb
@@ -1,4 +1,5 @@
 require "bubbletea"
+require "digest"
 require "shellwords"
 require "hive"
 require "hive/markers"
@@ -640,8 +641,10 @@ module Hive
         argv = editor_argv
         callable = lambda do
           before_mtime = file_mtime(path)
+          before_hash = file_content_hash(path)
           exit_code = run_editor(argv, path)
           after_mtime = file_mtime(path)
+          after_hash = file_content_hash(path)
           # Wipe whatever the editor left on the main screen before
           # bubbletea re-enters alt-screen. Alt-screen *should* hide
           # the main buffer regardless, but on some terminals the
@@ -649,12 +652,16 @@ module Hive
           # output is still being painted. Mirror of the pre-spawn
           # clear in `clear_terminal_for_takeover`.
           clear_terminal_for_takeover
-          # Both samples must be non-nil to claim a change. A transient
-          # ENOENT/EACCES between samples turns `file_mtime` into nil and
-          # the asymmetric `nil != Float` would otherwise register as a
-          # bogus save.
+          # mtime answers "did the user save at all" (cheap, used as
+          # the InputEditorExited `changed:` flag). Hash answers "did
+          # the user actually change content" (precise, used by
+          # plan-stage auto-advance to distinguish 'approved as-is'
+          # from 'added feedback'). mtime samples must both be non-nil
+          # to claim a change — a transient ENOENT/EACCES otherwise
+          # produces a bogus `nil != Float` true.
           changed = !before_mtime.nil? && !after_mtime.nil? && before_mtime != after_mtime
-          input_editor_exit_messages(row, path, exit_code, changed).each do |message|
+          content_changed = !before_hash.nil? && !after_hash.nil? && before_hash != after_hash
+          input_editor_exit_messages(row, path, exit_code, changed, content_changed).each do |message|
             @dispatch.call(message)
           end
         end
@@ -732,7 +739,14 @@ module Hive
 
       # Returns the messages to dispatch after the editor exits.
       # Manual path:               [InputEditorExited].
-      # Auto-continue success:     [InputEditorExited, DispatchCommand].
+      # Auto-continue (re-run):    [InputEditorExited, DispatchCommand]
+      #                            for `:proceed` (brainstorm complete)
+      #                            and `:revise_plan` (user added plan
+      #                            feedback). Both re-run the same
+      #                            stage agent via `row.suggested_command`.
+      # Auto-advance (next stage): [InputEditorExited, DispatchCommand]
+      #                            for `:advance_to_develop` (plan
+      #                            approved as-is — no content changes).
       # Auto-continue suppressed:  [InputEditorExited] OR
       #                            [InputEditorExited, Flash(reason)] for
       #                            race / data-anomaly cases the user
@@ -743,20 +757,22 @@ module Hive
       # `ArgumentError` raised by `Shellwords.split` on a malformed
       # `suggested_command` without swallowing constructor errors from
       # `InputEditorExited.new` (which lives outside the begin/rescue).
-      def input_editor_exit_messages(row, path, exit_code, changed)
+      def input_editor_exit_messages(row, path, exit_code, changed, content_changed)
         exited = Hive::Tui::Messages::InputEditorExited.new(
           slug: row.slug,
           exit_code: exit_code,
           changed: changed
         )
 
-        case auto_continue_outcome(row, path, exit_code, changed)
-        when :proceed
+        case auto_continue_outcome(row, path, exit_code, changed, content_changed)
+        when :proceed, :revise_plan
           dispatch_messages_for(row, exited)
+        when :advance_to_develop
+          dispatch_develop_for(row, exited)
         when :empty_command
           [ exited, suppression_flash(row, "no suggested command on row") ]
         when :marker_changed
-          [ exited, suppression_flash(row, "brainstorm marker changed during edit") ]
+          [ exited, suppression_flash(row, "marker changed during edit") ]
         else # :silent — expected refusals (parser incomplete, exit nonzero, unchanged, off-stage)
           [ exited ]
         end
@@ -770,35 +786,95 @@ module Hive
         [ exited, suppression_flash(row, "malformed suggested command") ]
       end
 
+      # Build a `hive develop <slug> ...` dispatch by swapping the verb
+      # in the row's plan-stage `suggested_command`. Preserves
+      # `--project` / `--from` flags so the develop spawn keeps the
+      # same idempotency lever the plan command had.
+      def dispatch_develop_for(row, exited)
+        dispatch = develop_command_from_plan(row.suggested_command)
+        [ exited, dispatch ]
+      rescue ArgumentError => e
+        Hive::Tui::Debug.log("input_editor", "advance-to-develop skipped for #{row.slug}: #{e.message}")
+        [ exited, suppression_flash(row, "couldn't build develop command") ]
+      end
+
+      def develop_command_from_plan(suggested_command)
+        argv = Shellwords.split(suggested_command.to_s)
+        unless argv.length >= 3 && argv[0] == "hive" && argv[1] == "plan"
+          raise ArgumentError, "expected `hive plan ...`, got #{suggested_command.inspect}"
+        end
+
+        argv[1] = "develop"
+        Hive::Tui::Messages::DispatchCommand.new(argv: argv, verb: "develop")
+      end
+
       def suppression_flash(row, reason)
         Hive::Tui::Messages::Flash.new(text: "auto-continue skipped for #{row.slug}: #{reason}")
       end
 
       # Returns one of:
-      #   :proceed         — fire DispatchCommand
-      #   :silent          — refuse, common-case (user can self-diagnose)
-      #   :empty_command   — refuse, surface to user (data anomaly)
-      #   :marker_changed  — refuse, surface to user (race with another actor)
-      def auto_continue_outcome(row, path, exit_code, changed)
-        return :silent unless exit_code == 0 && changed
+      #   :proceed             — fire DispatchCommand for brainstorm re-run
+      #   :revise_plan         — fire DispatchCommand for plan re-run (user added feedback)
+      #   :advance_to_develop  — fire DispatchCommand for `hive develop` (plan approved as-is)
+      #   :silent              — refuse, common-case (user can self-diagnose)
+      #   :empty_command       — refuse, surface to user (data anomaly)
+      #   :marker_changed      — refuse, surface to user (race with another actor)
+      #
+      # `changed` is mtime-based ("did the user save at all"); `content_changed`
+      # is hash-based ("did content actually differ"). Brainstorm gates on
+      # `changed` (parser then decides). Plan needs `content_changed` to
+      # distinguish "approved by saving without edits" (advance) from
+      # "added feedback" (revise).
+      def auto_continue_outcome(row, path, exit_code, changed, content_changed)
+        return :silent unless exit_code == 0
         return :silent unless row.action_key == "needs_input"
-        return :silent unless row.stage.to_s == "2-brainstorm"
+
+        case row.stage.to_s
+        when "2-brainstorm"
+          brainstorm_outcome(row, path, changed)
+        when "3-plan"
+          plan_outcome(row, path, exit_code, changed, content_changed)
+        else
+          :silent
+        end
+      end
+
+      def brainstorm_outcome(row, path, changed)
+        return :silent unless changed
         return :empty_command if row.suggested_command.to_s.empty?
-        return :marker_changed unless current_brainstorm_input_marker?(path)
+        return :marker_changed unless marker_still_open_for_input?(path)
         return :silent unless Hive::Tui::BrainstormAnswers.complete?(path)
 
         :proceed
       end
 
+      def plan_outcome(row, path, exit_code, _changed, content_changed)
+        # The only safety gate is a clean editor exit. By design, an
+        # exit-0 close on a `:waiting` plan row is a "user is done"
+        # signal even when nothing was edited — see PR description on
+        # advance-on-clean-exit. Aborts (SIGINT/130) take the manual
+        # path so a half-typed plan isn't accidentally advanced.
+        return :silent unless exit_code == 0
+        return :marker_changed unless marker_still_open_for_input?(path)
+
+        if content_changed
+          return :empty_command if row.suggested_command.to_s.empty?
+
+          :revise_plan
+        else
+          :advance_to_develop
+        end
+      end
+
       # Re-reads the on-disk marker after the editor exits to defend
       # against a race where another actor (a sibling `hive` process,
-      # an editor on a sync mount) advanced the brainstorm to
+      # an editor on a sync mount) advanced the stage to
       # `:agent_working`, `:complete`, or `:error` while the long-lived
       # editor was open. The captured `row.marker` is from the snapshot
       # taken when Enter was pressed; only the freshly-read marker
       # reflects current truth. `:none` is permitted because the first
-      # round may have no marker yet on a fresh brainstorm.md.
-      def current_brainstorm_input_marker?(path)
+      # round of a fresh brainstorm/plan may have no marker yet.
+      def marker_still_open_for_input?(path)
         marker = Hive::Markers.current(path)
         marker.name == :waiting || marker.name == :none
       rescue SystemCallError, IOError => e
@@ -862,6 +938,18 @@ module Hive
       def file_mtime(path)
         File.mtime(path).to_f
       rescue Errno::ENOENT, Errno::EACCES
+        nil
+      end
+
+      # Content fingerprint used by the plan-stage auto-continue gate
+      # to distinguish "user saved without editing" (advance to next
+      # stage) from "user added feedback" (revise plan). SHA1 is
+      # cryptographically weak but plenty for change detection on a
+      # local file the user just edited; `Digest::SHA1.file` does a
+      # single read and never raises on bytes (no encoding work).
+      def file_content_hash(path)
+        Digest::SHA1.file(path).hexdigest
+      rescue SystemCallError, IOError
         nil
       end
 

--- a/test/unit/tui/bubble_model_test.rb
+++ b/test/unit/tui/bubble_model_test.rb
@@ -1199,18 +1199,20 @@ class HiveTuiBubbleModelTest < Minitest::Test
     end
   end
 
-  def test_open_input_editor_does_not_auto_dispatch_non_brainstorm_rows
+  def test_open_input_editor_does_not_auto_dispatch_non_auto_stages
+    # Stages other than 2-brainstorm and 3-plan have no auto-continue
+    # path; they must always take the manual InputEditorExited route.
     with_tmp_dir do |dir|
-      plan_md = File.join(dir, "plan.md")
-      File.write(plan_md, <<~MD)
+      task_md = File.join(dir, "task.md")
+      File.write(task_md, <<~MD)
         ## Round 1
         ### Q1. Scope?
-        ### A1. Complete-looking, but this is not brainstorm.
+        ### A1. Complete-looking, but this stage has no auto-continue.
       MD
       row = make_task_row(
-        stage: "3-plan",
-        state_file: plan_md,
-        suggested_command: "hive plan some-slug --from 3-plan"
+        stage: "4-execute",
+        state_file: task_md,
+        suggested_command: "hive develop some-slug --from 4-execute"
       )
       mtimes = [ 30.0, 31.0 ]
       @model.define_singleton_method(:editor_argv) { [ "fake-editor" ] }
@@ -1223,6 +1225,190 @@ class HiveTuiBubbleModelTest < Minitest::Test
       assert_equal 1, @messages.length
       assert_kind_of Hive::Tui::Messages::InputEditorExited, @messages.first
       assert_empty mtimes
+    end
+  end
+
+  # ---- Plan-stage auto-continue (3-plan) ----
+
+  def test_open_input_editor_advances_to_develop_when_plan_unchanged
+    # User opens plan.md, saves without changes → auto-advance to
+    # `hive develop`. The marker on disk is still `<!-- WAITING -->`
+    # (the agent thinks it has questions); the user is overriding by
+    # saving without editing.
+    with_tmp_dir do |dir|
+      plan_md = File.join(dir, "plan.md")
+      File.write(plan_md, <<~MD)
+        # Plan
+        Some content the agent wrote.
+        <!-- WAITING -->
+      MD
+      row = make_task_row(
+        stage: "3-plan",
+        state_file: plan_md,
+        suggested_command: "hive plan some-slug --from 3-plan"
+      )
+      @model.define_singleton_method(:editor_argv) { [ "fake-editor" ] }
+      # Editor is a no-op: opens, returns 0, file untouched (real
+      # File.mtime / File.read drive the comparison).
+      @model.define_singleton_method(:run_editor) { |_argv, _path| 0 }
+
+      _, cmd = @model.update(Hive::Tui::Messages::OpenInputEditor.new(row: row))
+      cmd.commands.find { |c| c.is_a?(Bubbletea::ExecCommand) }.callable.call
+
+      assert_equal 2, @messages.length,
+        "unchanged plan must dispatch [InputEditorExited, DispatchCommand for develop]"
+      assert_kind_of Hive::Tui::Messages::InputEditorExited, @messages[0]
+      assert_kind_of Hive::Tui::Messages::DispatchCommand, @messages[1]
+      assert_equal "develop", @messages[1].verb
+      assert_equal(
+        [ "hive", "develop", "some-slug", "--from", "3-plan" ],
+        @messages[1].argv
+      )
+    end
+  end
+
+  def test_open_input_editor_revises_plan_when_user_added_feedback
+    # User adds inline feedback in the plan; auto-continue dispatches
+    # the row's existing `hive plan ... --from 3-plan` so the agent
+    # reads the comment and revises.
+    with_tmp_dir do |dir|
+      plan_md = File.join(dir, "plan.md")
+      File.write(plan_md, "# Plan\nOriginal content.\n<!-- WAITING -->\n")
+      row = make_task_row(
+        stage: "3-plan",
+        state_file: plan_md,
+        suggested_command: "hive plan some-slug --from 3-plan"
+      )
+      @model.define_singleton_method(:editor_argv) { [ "fake-editor" ] }
+      # Stub editor: writes a comment line into the plan, simulating
+      # the user's `:wq` after typing.
+      @model.define_singleton_method(:run_editor) do |_argv, path|
+        File.write(path, "# Plan\nOriginal content.\nUser feedback here.\n<!-- WAITING -->\n")
+        0
+      end
+
+      _, cmd = @model.update(Hive::Tui::Messages::OpenInputEditor.new(row: row))
+      cmd.commands.find { |c| c.is_a?(Bubbletea::ExecCommand) }.callable.call
+
+      assert_equal 2, @messages.length,
+        "edited plan must dispatch [InputEditorExited, DispatchCommand for plan re-run]"
+      assert_kind_of Hive::Tui::Messages::InputEditorExited, @messages[0]
+      assert_equal true, @messages[0].changed
+      assert_kind_of Hive::Tui::Messages::DispatchCommand, @messages[1]
+      assert_equal "plan", @messages[1].verb
+      assert_equal(
+        [ "hive", "plan", "some-slug", "--from", "3-plan" ],
+        @messages[1].argv
+      )
+    end
+  end
+
+  def test_open_input_editor_no_plan_action_when_marker_changed_to_complete
+    # Race: another actor advanced the plan to `<!-- COMPLETE -->`
+    # while the editor was open. Even if the user added content, do
+    # not auto-anything — surface a suppression flash so the user
+    # knows the captured row was stale.
+    with_tmp_dir do |dir|
+      plan_md = File.join(dir, "plan.md")
+      File.write(plan_md, "# Plan\nFinalised by another actor.\n<!-- COMPLETE -->\n")
+      row = make_task_row(
+        stage: "3-plan",
+        state_file: plan_md,
+        marker: "waiting", # row attr is stale; production reads marker from disk
+        suggested_command: "hive plan some-slug --from 3-plan"
+      )
+      @model.define_singleton_method(:editor_argv) { [ "fake-editor" ] }
+      @model.define_singleton_method(:run_editor) do |_argv, path|
+        File.write(path, "# Plan\nFinalised by another actor.\nuser-added.\n<!-- COMPLETE -->\n")
+        0
+      end
+
+      _, cmd = @model.update(Hive::Tui::Messages::OpenInputEditor.new(row: row))
+      cmd.commands.find { |c| c.is_a?(Bubbletea::ExecCommand) }.callable.call
+
+      assert_equal 2, @messages.length
+      assert_kind_of Hive::Tui::Messages::InputEditorExited, @messages[0]
+      assert_kind_of Hive::Tui::Messages::Flash, @messages[1]
+      assert_match(/marker changed during edit/, @messages[1].text)
+      refute(@messages.any? { |m| m.is_a?(Hive::Tui::Messages::DispatchCommand) },
+        "marker race must NOT auto-dispatch")
+    end
+  end
+
+  def test_open_input_editor_plan_stays_silent_when_editor_aborted
+    # SIGINT during edit on a plan row: take no auto action either way.
+    with_tmp_dir do |dir|
+      plan_md = File.join(dir, "plan.md")
+      File.write(plan_md, "# Plan\nContent.\n<!-- WAITING -->\n")
+      row = make_task_row(
+        stage: "3-plan",
+        state_file: plan_md,
+        suggested_command: "hive plan some-slug --from 3-plan"
+      )
+      @model.define_singleton_method(:editor_argv) { [ "fake-editor" ] }
+      @model.define_singleton_method(:run_editor) { |_argv, _path| 130 } # SIGINT
+
+      _, cmd = @model.update(Hive::Tui::Messages::OpenInputEditor.new(row: row))
+      cmd.commands.find { |c| c.is_a?(Bubbletea::ExecCommand) }.callable.call
+
+      assert_equal 1, @messages.length
+      assert_kind_of Hive::Tui::Messages::InputEditorExited, @messages.first
+      assert_equal 130, @messages.first.exit_code
+    end
+  end
+
+  def test_open_input_editor_plan_with_malformed_suggested_command_falls_back_on_revise
+    # User added feedback (revise path) but suggested_command is
+    # malformed. Suppression flash keeps the user informed; no
+    # DispatchCommand fires.
+    with_tmp_dir do |dir|
+      plan_md = File.join(dir, "plan.md")
+      File.write(plan_md, "# Plan\nOriginal.\n<!-- WAITING -->\n")
+      row = make_task_row(
+        stage: "3-plan",
+        state_file: plan_md,
+        # Unbalanced quote → Shellwords.split raises ArgumentError.
+        suggested_command: %q(hive plan slug --note 'unclosed)
+      )
+      @model.define_singleton_method(:editor_argv) { [ "fake-editor" ] }
+      @model.define_singleton_method(:run_editor) do |_argv, path|
+        File.write(path, "# Plan\nOriginal.\nUser added.\n<!-- WAITING -->\n")
+        0
+      end
+
+      _, cmd = @model.update(Hive::Tui::Messages::OpenInputEditor.new(row: row))
+      cmd.commands.find { |c| c.is_a?(Bubbletea::ExecCommand) }.callable.call
+
+      assert_equal 2, @messages.length
+      assert_kind_of Hive::Tui::Messages::InputEditorExited, @messages[0]
+      assert_kind_of Hive::Tui::Messages::Flash, @messages[1]
+      assert_match(/malformed suggested command/, @messages[1].text)
+    end
+  end
+
+  def test_open_input_editor_plan_advance_falls_back_when_command_is_not_hive_plan
+    # `develop_command_from_plan` requires the suggested_command to
+    # start with `hive plan`. If the row is misconfigured (e.g. row
+    # builder bug), surface a suppression flash instead of crashing.
+    with_tmp_dir do |dir|
+      plan_md = File.join(dir, "plan.md")
+      File.write(plan_md, "# Plan\nUntouched.\n<!-- WAITING -->\n")
+      row = make_task_row(
+        stage: "3-plan",
+        state_file: plan_md,
+        # Missing `plan` verb — develop_command_from_plan must refuse.
+        suggested_command: "hive develop some-slug --from 3-plan"
+      )
+      @model.define_singleton_method(:editor_argv) { [ "fake-editor" ] }
+      @model.define_singleton_method(:run_editor) { |_argv, _path| 0 }
+
+      _, cmd = @model.update(Hive::Tui::Messages::OpenInputEditor.new(row: row))
+      cmd.commands.find { |c| c.is_a?(Bubbletea::ExecCommand) }.callable.call
+
+      assert_kind_of Hive::Tui::Messages::Flash, @messages[1]
+      assert_match(/couldn't build develop command/, @messages[1].text)
+      refute(@messages.any? { |m| m.is_a?(Hive::Tui::Messages::DispatchCommand) },
+        "misconfigured suggested_command must NOT spawn anything")
     end
   end
 

--- a/wiki/commands/tui.md
+++ b/wiki/commands/tui.md
@@ -41,7 +41,7 @@ Pane focus is keyboard-only; the focused pane border is bright cyan, the inactiv
 | Two-pane dashboard (default) | boot | `q` |
 | Findings triage | `Enter` on a `review_findings` row | `Esc` |
 | Agent log tail | `Enter` on an `agent_running` row | `q` / `Esc` |
-| Input editor | `Enter` on a `needs_input` row | editor exit; completed brainstorm answers auto-continue |
+| Input editor | `Enter` on a `needs_input` row | editor exit; completed brainstorm answers auto-continue; plan rows auto-advance to `develop` (or auto-revise if user added feedback) |
 | Filter prompt | `/` | `Esc` (cancels typed buffer; any committed filter is preserved) / `Enter` (commits) |
 | New idea prompt | `n` | `Esc` (cancels) / `Enter` (submits `hive new <project> "<title>"`) |
 | Help overlay | `?` | any key |
@@ -61,7 +61,7 @@ Pane focus is keyboard-only; the focused pane border is bright cyan, the inactiv
 | `r` | run `hive review` |
 | `P` | run `hive pr` (capital so it doesn't collide with `plan`) |
 | `a` | run `hive archive` |
-| `Enter` | from left pane: focus right pane. From right pane: open the row's contextual mode: input editor on `needs_input` (completed brainstorm answer rounds auto-run), triage on `review_findings`, log tail on `agent_running` / `error`; ready rows still dispatch the suggested command |
+| `Enter` | from left pane: focus right pane. From right pane: open the row's contextual mode: input editor on `needs_input` (completed brainstorm answer rounds auto-run; plan rows auto-advance to `develop` or auto-revise on user feedback), triage on `review_findings`, log tail on `agent_running` / `error`; ready rows still dispatch the suggested command |
 | `n` | open the new-idea prompt; submitting runs `hive new <project> "<title>"` against the project selected in the left pane (`★ All` falls back to the first registered project) |
 | `/` | open filter prompt |
 | `1`–`9` | scope the right pane to the Nth registered project (mirrors selection in the left pane) |

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -2,6 +2,22 @@
 
 Append-only log of all wiki operations.
 
+## [2026-05-07T12:00:00Z] tui — auto-continue on plan stage (revise vs advance)
+
+**Action:** Extended the editor-takeover auto-continue path from `2-brainstorm` to `3-plan`. The brainstorm path is unchanged. The plan path adds two outcomes the brainstorm flow does not have: `:revise_plan` (user added inline feedback in the editor — re-run `hive plan ... --from 3-plan`) and `:advance_to_develop` (user saved without changes — interpret as approval, dispatch `hive develop ... --from 3-plan` to start the next stage). Detection is content-hash-based (SHA1 of the file before vs. after the editor session) — mtime is too unreliable across editors for the "saved without edits" semantics.
+
+The only safety gate on the plan path is a clean editor exit: `exit_code == 0`. SIGINT (`130`) and other non-zero exits stay manual. The on-disk marker is re-read after the editor exits; if a sibling actor flipped the marker to `:complete` / `:agent_working` / `:error` during a long edit, the row falls back to the manual path with a `Messages::Flash` saying `auto-continue skipped for <slug>: marker changed during edit`.
+
+The `current_brainstorm_input_marker?` helper was renamed to `marker_still_open_for_input?` since both stages key off the same `:waiting` / `:none` test. The `auto_continue_outcome` predicate became a stage-dispatch (`brainstorm_outcome` / `plan_outcome` / fall-through `:silent`).
+
+`develop_command_from_plan` builds the advance argv by swapping `plan` for `develop` in the row's `suggested_command`, preserving `--project` / `--from` flags so the develop spawn keeps the same idempotency lever.
+
+Coverage: 6 new BubbleModel integration tests for the plan path (advance-on-unchanged, revise-on-edit, marker race to `:complete`, SIGINT abort stays manual, malformed `suggested_command` rescue branch, advance falls back when `suggested_command` is not `hive plan ...`). All 1479 tests pass; rubocop clean.
+
+**Refreshed pages:**
+- `wiki/commands/tui.md` — Subprocess dispatch section names the plan-stage auto-continue alongside brainstorm; Modes table notes "completed plans auto-advance, edited plans auto-revise."
+
+
 ## [2026-05-06T23:00:00Z] tui — surface auto-continue suppression reasons + tighten rescues
 
 **Action:** Made the brainstorm auto-continue path observable instead of silently degrading to the generic post-save flash. `auto_continue_after_edit?` was replaced by `auto_continue_outcome`, which returns one of `:proceed`, `:silent`, `:empty_command`, or `:marker_changed`. The race / data-anomaly cases (`:empty_command`, `:marker_changed`, plus the rescue path on a malformed `suggested_command`) now dispatch a follow-up `Messages::Flash` like `auto-continue skipped for <slug>: brainstorm marker changed during edit`, so a user whose mental model is "I filled in answers, expected `hive brainstorm` to auto-fire" can actually see why it didn't. Expected-refusal cases (`exit_code != 0`, mtime unchanged, off-stage, parser says incomplete) stay silent — those are self-evident.


### PR DESCRIPTION
Replacement for #44 (closed — got stuck with non-recomputing mergeability state after a force-push following an upstream rebase).

## Summary

Extends the editor-takeover auto-continue path from `2-brainstorm` (PR #38, #42) to `3-plan`. Closes the user-reported gap where saving inline feedback in `plan.md` left the row stuck at "Needs your input" with no signal to advance.

## Plan-stage outcomes

| Editor exit state | Outcome | Dispatched |
|-------------------|---------|------------|
| Content changed during edit | `:revise_plan` | `hive plan <slug> --from 3-plan` |
| Content unchanged | `:advance_to_develop` | `hive develop <slug> --from 3-plan` |
| Marker raced mid-edit | `:marker_changed` | none + suppression flash |
| Editor exit ≠ 0 | `:silent` | none (manual path) |

**Detection** is content-hash-based (SHA1 of `plan.md` before vs. after the editor session). mtime is unreliable across editors for the "saved without edits = approve" semantics.

**Safety gate** is just `exit_code == 0`. SIGINT (130) and other non-zero exits stay manual.

## Refactors

- `auto_continue_after_edit?` → `auto_continue_outcome` that dispatches on `row.stage`.
- `current_brainstorm_input_marker?` → `marker_still_open_for_input?` (both stages share the `:waiting` / `:none` check).
- Editor callable samples both mtime and SHA1 hash before / after `run_editor`.
- `develop_command_from_plan(suggested_command)` swaps `plan` for `develop`, preserving `--project` / `--from`.

## Tests (+6 cases, +29 assertions)

- `test_open_input_editor_advances_to_develop_when_plan_unchanged`
- `test_open_input_editor_revises_plan_when_user_added_feedback`
- `test_open_input_editor_no_plan_action_when_marker_changed_to_complete`
- `test_open_input_editor_plan_stays_silent_when_editor_aborted` (SIGINT)
- `test_open_input_editor_plan_with_malformed_suggested_command_falls_back_on_revise`
- `test_open_input_editor_plan_advance_falls_back_when_command_is_not_hive_plan`
- Renamed the old "non-brainstorm rows" test to use a `4-execute` fixture.

## Test plan

- [x] `bundle exec rake test`: 1479 runs, 4829 assertions, 0 failures.
- [x] `bundle exec rubocop lib/hive/tui/bubble_model.rb test/unit/tui/bubble_model_test.rb`: 0 offenses.
