### PR TITLE
feat(doctor): hive doctor — verify each stage's skill is installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,37 @@ ln -s ~/Dev/hive/bin/hive ~/.local/bin/hive   # or add bin/ to PATH
 | Tool | Min version | Why |
 |------|-------------|-----|
 | Ruby | 3.4 | the runtime |
-| `claude` CLI | 2.1.118 | every active stage; verified at runtime |
+| `claude` CLI | 2.1.118 | every active stage by default; verified at runtime |
 | `gh` CLI | recent | `6-pr` stage (`gh pr create`); must be authenticated |
 | `git` | 2.40 | worktrees, orphan branches |
 
 Optional: [`qmd`](https://qmd.dev) for semantic search over `wiki/` (ripgrep works as fallback).
+
+### Required slash-commands / skills
+
+The brainstorm and plan stages instruct the agent to invoke specific slash-commands inside their prompts. Hive's shipped defaults assume **both** of these are installed alongside the agent CLI:
+
+| Stage | Default invocation | Install for claude | Install for codex |
+|-------|--------------------|--------------------|-------------------|
+| `2-brainstorm` | `/compound-engineering:ce-brainstorm` | `claude plugin install <every-marketplace>` (or any marketplace shipping `compound-engineering`) | `codex plugin install <compound-engineering-marketplace>` |
+| `3-plan` | `/plan` | A user-level slash command at `~/.claude/commands/plan.md` (e.g. ship via the [llm-wiki plugin](https://github.com/aikuznetsov/agent-plugins) or write one inline) | A skill at `~/.codex/skills/plan/SKILL.md` (codex has no user-level slash-command directory) |
+| | | Pi has no slash-command resolver; if you set `<stage>.agent: pi`, the slash-command is sent verbatim as prompt text and the model decides what to do. |
+
+To verify your install:
+
+```bash
+hive doctor              # tabular status of each (stage, agent, skill) triple
+hive doctor --json       # machine-readable envelope
+```
+
+Exit codes: `0` all present (or N/A for pi); `65` at least one skill missing; `78` config error.
+
+To override a stage's skill per-project, set `<stage>.skill` in `<project>/.hive-state/config.yml`:
+
+```yaml
+plan:
+  skill: /compound-engineering:ce-plan   # opt out of /plan, use the CE skill directly
+```
 
 ## Quickstart
 

--- a/lib/hive/agent_profile.rb
+++ b/lib/hive/agent_profile.rb
@@ -83,7 +83,8 @@ module Hive
                    output_format_flags: [],
                    headless_supported: true, min_version: nil,
                    status_detection_mode: :output_file_exists,
-                   preflight: nil)
+                   preflight: nil,
+                   skill_verifier: nil)
       unless STATUS_DETECTION_MODES.include?(status_detection_mode)
         raise ArgumentError,
               "unknown status_detection_mode: #{status_detection_mode.inspect}; " \
@@ -104,8 +105,26 @@ module Hive
       @min_version = min_version
       @status_detection_mode = status_detection_mode
       @preflight = preflight
+      @skill_verifier = skill_verifier
 
       freeze
+    end
+
+    # Verifies whether `invocation` (e.g. "/plan",
+    # "/compound-engineering:ce-plan") resolves to a real on-disk
+    # skill/command for this agent. Profiles supply a callable via the
+    # `skill_verifier:` constructor kwarg (typically one of the
+    # `Hive::SkillCheck::*` modules). When no verifier is supplied the
+    # default is `[:not_applicable, ...]` — the honest answer for an
+    # agent with no slash-command-resolution model.
+    #
+    # `project_root` lets profiles probe project-level overrides
+    # (`<repo>/.claude/skills/...` etc.); it may be nil for global
+    # checks.
+    def verify_skill(invocation, project_root: nil)
+      return [ :not_applicable, "no skill verifier configured for this profile" ] unless @skill_verifier
+
+      @skill_verifier.call(invocation, project_root: project_root)
     end
 
     # Resolved binary path: env override (if env_bin_override_key set and
@@ -236,7 +255,8 @@ module Hive
         headless_supported: @headless_supported,
         min_version: @min_version,
         status_detection_mode: @status_detection_mode,
-        preflight: @preflight
+        preflight: @preflight,
+        skill_verifier: @skill_verifier
       }
     end
 

--- a/lib/hive/agent_profiles/claude.rb
+++ b/lib/hive/agent_profiles/claude.rb
@@ -1,4 +1,5 @@
 require "hive/agent_profile"
+require "hive/skill_check"
 
 module Hive
   module AgentProfiles
@@ -25,7 +26,8 @@ module Hive
       skill_syntax_format: "/%{skill}",
       headless_supported: true,
       min_version: Hive::MIN_CLAUDE_VERSION,
-      status_detection_mode: :state_file_marker
+      status_detection_mode: :state_file_marker,
+      skill_verifier: Hive::SkillCheck::Claude.method(:verify)
     )
 
     register(:claude, CLAUDE)

--- a/lib/hive/agent_profiles/codex.rb
+++ b/lib/hive/agent_profiles/codex.rb
@@ -1,4 +1,5 @@
 require "hive/agent_profile"
+require "hive/skill_check"
 
 module Hive
   module AgentProfiles
@@ -28,7 +29,8 @@ module Hive
       skill_syntax_format: "/%{skill}",
       headless_supported: true,
       min_version: "0.125.0",
-      status_detection_mode: :output_file_exists
+      status_detection_mode: :output_file_exists,
+      skill_verifier: Hive::SkillCheck::Codex.method(:verify)
     )
 
     register(:codex, CODEX)

--- a/lib/hive/agent_profiles/pi.rb
+++ b/lib/hive/agent_profiles/pi.rb
@@ -1,4 +1,5 @@
 require "hive/agent_profile"
+require "hive/skill_check"
 
 module Hive
   module AgentProfiles
@@ -80,7 +81,8 @@ module Hive
       headless_supported: true,
       min_version: "0.70.2",
       status_detection_mode: :output_file_exists,
-      preflight: PI_PREFLIGHT
+      preflight: PI_PREFLIGHT,
+      skill_verifier: Hive::SkillCheck::Pi.method(:verify)
     )
 
     register(:pi, PI)

--- a/lib/hive/cli.rb
+++ b/lib/hive/cli.rb
@@ -120,6 +120,47 @@ module Hive
       Hive::Commands::Prune.new(dry_run: options[:dry_run], json: options[:json]).call
     end
 
+    desc "doctor", "Verify each stage's configured skill is installed for its agent"
+    long_desc <<~DESC
+      Walks the brainstorm and plan stage configs and asks the
+      configured agent profile (claude / codex / pi) to probe whether
+      its skill (`<stage>.skill` in config.yml) actually resolves to
+      an installed slash-command or skill on disk.
+
+      Hive ships expecting both llm-wiki (`/plan`) and
+      compound-engineering (`/compound-engineering:ce-*`) to be
+      installed alongside your agent CLI. `hive doctor` is the
+      preflight that catches a missing install before a stage spawns
+      and the agent reports `skill not found` mid-run.
+
+      Per-agent search rules:
+      - claude: `~/.claude/{commands/<name>.md, skills/<name>/SKILL.md}`
+        for plain `/<name>`; `~/.claude/plugins/marketplaces/<plug>*/skills/...`
+        for `/<plug>:<name>`. Project-level paths checked too.
+      - codex: `~/.codex/skills/<name>/SKILL.md` (and `.system/`) for
+        plain; `~/.codex/plugins/cache/*/<plug>/*/skills/...` for
+        plug-namespaced.
+      - pi: always `:not_applicable` — pi has no slash-command
+        resolver; the prompt is sent verbatim.
+
+      Exit codes: 0 all checks present or N/A; 65 at least one missing
+      skill; 78 config error.
+
+      Examples:
+
+        hive doctor                       # tabular output
+        hive doctor --json                # machine-readable envelope
+    DESC
+    def doctor
+      require "hive/commands/doctor"
+      cfg = Hive::Config.load(Dir.pwd)
+      exit Hive::Commands::Doctor.new(
+        config: cfg,
+        project_root: Dir.pwd,
+        json: options[:json]
+      ).call
+    end
+
     desc "new PROJECT TEXT", "Create a new task in 1-inbox of PROJECT"
     def new_task(project, *text_parts)
       require "hive/commands/new"

--- a/lib/hive/commands/doctor.rb
+++ b/lib/hive/commands/doctor.rb
@@ -1,0 +1,134 @@
+require "json"
+
+require "hive"
+require "hive/config"
+require "hive/agent_profiles"
+require "hive/agent_profiles/claude"
+require "hive/agent_profiles/codex"
+require "hive/agent_profiles/pi"
+
+module Hive
+  module Commands
+    # `hive doctor` — verifies that every configured stage skill
+    # actually resolves to an installed slash-command / skill on the
+    # operator's machine. Walks the brainstorm and plan stage configs,
+    # asks each stage's agent profile to probe its filesystem, prints a
+    # status table, and exits non-zero if any check is `:missing`.
+    #
+    # Pi rows always come back `:not_applicable` — pi has no
+    # slash-command resolver. That's not a fail; the prompt text still
+    # gets sent to the model.
+    #
+    # `--json` emits a machine-readable envelope so an agent caller
+    # (the daemon, an outer orchestrator) can decide how to react
+    # without scraping the human-readable table.
+    class Doctor
+      EXIT_SUCCESS = 0
+      EXIT_MISSING_SKILL = 65
+      EXIT_CONFIG_ERROR = 78
+
+      STAGES = %w[brainstorm plan].freeze
+
+      def initialize(config:, project_root:, json: false, output: $stdout)
+        @config = config
+        @project_root = project_root
+        @json = json
+        @output = output
+      end
+
+      def call
+        rows = STAGES.map { |stage| check_stage(stage) }
+        if @json
+          @output.puts JSON.generate(envelope(rows))
+        else
+          render_table(rows)
+        end
+
+        rows.any? { |r| r[:status] == "missing" } ? EXIT_MISSING_SKILL : EXIT_SUCCESS
+      rescue Hive::ConfigError, KeyError, ArgumentError => e
+        if @json
+          @output.puts JSON.generate(error: e.message)
+        else
+          @output.puts "hive doctor: #{e.message}"
+        end
+        EXIT_CONFIG_ERROR
+      end
+
+      private
+
+      def check_stage(stage)
+        agent_name = (@config.dig(stage, "agent") || "claude").to_s
+        skill = @config.dig(stage, "skill") || Hive::Config::DEFAULTS.dig(stage, "skill")
+        profile = Hive::AgentProfiles.lookup(agent_name.to_sym)
+
+        status, message = profile.verify_skill(skill, project_root: @project_root)
+        {
+          stage: stage,
+          agent: agent_name,
+          skill: skill,
+          status: status.to_s,
+          message: message
+        }
+      end
+
+      def envelope(rows)
+        {
+          "schema" => "hive-doctor.v1",
+          "checks" => rows,
+          "summary" => {
+            "missing" => rows.count { |r| r[:status] == "missing" },
+            "present" => rows.count { |r| r[:status] == "present" },
+            "not_applicable" => rows.count { |r| r[:status] == "not_applicable" }
+          }
+        }
+      end
+
+      def render_table(rows)
+        widths = compute_widths(rows)
+        @output.puts header(widths)
+        @output.puts separator(widths)
+        rows.each { |r| @output.puts row_line(r, widths) }
+        @output.puts
+        rows.each do |r|
+          next if r[:status] == "present"
+
+          @output.puts "[#{r[:stage]}/#{r[:agent]}] #{r[:message]}"
+        end
+      end
+
+      def compute_widths(rows)
+        {
+          stage: column_width(rows, :stage, "stage"),
+          agent: column_width(rows, :agent, "agent"),
+          skill: column_width(rows, :skill, "skill"),
+          status: column_width(rows, :status, "status")
+        }
+      end
+
+      def column_width(rows, key, header)
+        ([ header.length ] + rows.map { |r| r[key].to_s.length }).max
+      end
+
+      def header(widths)
+        format("%-#{widths[:stage]}s  %-#{widths[:agent]}s  %-#{widths[:skill]}s  %-#{widths[:status]}s",
+               "stage", "agent", "skill", "status")
+      end
+
+      def separator(widths)
+        format("%-#{widths[:stage]}s  %-#{widths[:agent]}s  %-#{widths[:skill]}s  %-#{widths[:status]}s",
+               "-" * widths[:stage], "-" * widths[:agent], "-" * widths[:skill], "-" * widths[:status])
+      end
+
+      def row_line(row, widths)
+        marker = case row[:status]
+        when "present" then "✓"
+        when "missing" then "✗"
+        when "not_applicable" then "—"
+        else "?"
+        end
+        format("%-#{widths[:stage]}s  %-#{widths[:agent]}s  %-#{widths[:skill]}s  #{marker} %-#{widths[:status]}s",
+               row[:stage], row[:agent], row[:skill], row[:status])
+      end
+    end
+  end
+end

--- a/lib/hive/skill_check.rb
+++ b/lib/hive/skill_check.rb
@@ -1,0 +1,191 @@
+require "pathname"
+
+module Hive
+  # Per-agent verification that a configured slash-command skill
+  # invocation actually resolves to a file on disk. `Hive::AgentProfile`
+  # delegates to one of `SkillCheck::Claude` / `SkillCheck::Codex` /
+  # `SkillCheck::Pi` so the profile interface stays uniform.
+  #
+  # Each profile-specific module exposes
+  # `verify(invocation, project_root: nil)` returning a 2-element array:
+  #
+  #   [:present, "<resolved path or descriptor>"]
+  #     — invocation maps to a real on-disk file.
+  #
+  #   [:missing, "<install hint>"]
+  #     — invocation is a real shape (`/foo` or `/plug:foo`) but no
+  #       installed file matches it.
+  #
+  #   [:not_applicable, "<why>"]
+  #     — this agent has no slash-command-with-disk-resolution model
+  #       (e.g. pi, which sends the prompt verbatim and treats slash
+  #       text as ordinary characters in the user message).
+  module SkillCheck
+    # Parsed invocation. Either form is accepted:
+    #   /name           -> Invocation.new(plugin: nil, name: "name")
+    #   /plugin:name    -> Invocation.new(plugin: "plugin", name: "name")
+    Invocation = Struct.new(:plugin, :name, keyword_init: true)
+
+    # Raises ArgumentError on malformed input so callers can surface the
+    # error rather than silently treating garbage as a valid skill.
+    def self.parse(invocation)
+      raise ArgumentError, "expected /name or /plugin:name, got nil" if invocation.nil?
+
+      str = invocation.to_s
+      m = str.match(%r{\A/(?:([^:/\s]+):)?([^:/\s]+)\z})
+      raise ArgumentError, "expected /name or /plugin:name, got #{str.inspect}" unless m
+
+      Invocation.new(plugin: m[1], name: m[2])
+    end
+
+    # Helper: returns the first existing path from `candidates`, or nil
+    # if none exist. `Pathname#exist?` follows symlinks — that's the
+    # right behavior for claude's `~/.claude/skills/<name>` symlinks
+    # into `~/.agents/skills/<name>/`.
+    def self.first_existing(candidates)
+      candidates.each do |path|
+        pn = Pathname.new(path)
+        return pn.to_s if pn.exist?
+      end
+      nil
+    end
+
+    module Claude
+      module_function
+
+      # Search order:
+      #   /<plugin>:<name>
+      #     1. ~/.claude/plugins/cache/*/<plugin>/*/skills/<name>/SKILL.md
+      #        (resolved cache layout: <marketplace>/<plugin>/<version>/skills/<name>/)
+      #     2. ~/.claude/plugins/cache/*/<plugin>/*/commands/<name>.md
+      #     3. ~/.claude/plugins/marketplaces/*/plugins/<plugin>/skills/<name>/SKILL.md
+      #        (marketplace source layout: <marketplace>/plugins/<plugin>/skills/<name>/)
+      #     4. ~/.claude/plugins/marketplaces/*/plugins/<plugin>/commands/<name>.md
+      #   /<name>
+      #     1. <project>/.claude/commands/<name>.md       (project slash command)
+      #     2. <project>/.claude/skills/<name>/SKILL.md    (project skill)
+      #     3. ~/.claude/commands/<name>.md                (user slash command)
+      #     4. ~/.claude/skills/<name>/SKILL.md            (user skill)
+      def verify(invocation, project_root: nil)
+        inv = Hive::SkillCheck.parse(invocation)
+        home = ENV["HOME"] || Dir.home
+        candidates = build_candidates(inv, home: home, project_root: project_root)
+        path = Hive::SkillCheck.first_existing(candidates)
+        return [ :present, path ] if path
+
+        [ :missing, install_hint(inv) ]
+      rescue ArgumentError => e
+        [ :missing, "claude: #{e.message}" ]
+      end
+
+      def build_candidates(inv, home:, project_root:)
+        if inv.plugin
+          # Cache layout: <marketplace>/<plugin>/<version>/skills/<name>/SKILL.md
+          cache_skill_glob = File.join(home, ".claude/plugins/cache/*", inv.plugin, "*", "skills", inv.name, "SKILL.md")
+          cache_cmd_glob   = File.join(home, ".claude/plugins/cache/*", inv.plugin, "*", "commands", "#{inv.name}.md")
+          # Marketplace source layout: <marketplace>/plugins/<plugin>/skills/<name>/SKILL.md
+          mp_skill_glob = File.join(home, ".claude/plugins/marketplaces/*/plugins", inv.plugin, "skills", inv.name, "SKILL.md")
+          mp_cmd_glob   = File.join(home, ".claude/plugins/marketplaces/*/plugins", inv.plugin, "commands", "#{inv.name}.md")
+          (Dir[cache_skill_glob] + Dir[cache_cmd_glob] + Dir[mp_skill_glob] + Dir[mp_cmd_glob])
+        else
+          paths = []
+          if project_root
+            paths << File.join(project_root, ".claude/commands/#{inv.name}.md")
+            paths << File.join(project_root, ".claude/skills/#{inv.name}/SKILL.md")
+          end
+          paths << File.join(home, ".claude/commands/#{inv.name}.md")
+          paths << File.join(home, ".claude/skills/#{inv.name}/SKILL.md")
+          paths
+        end
+      end
+
+      def install_hint(inv)
+        if inv.plugin
+          "claude: /#{inv.plugin}:#{inv.name} not found under " \
+            "~/.claude/plugins/cache/*/#{inv.plugin}/*/skills/ or " \
+            "~/.claude/plugins/marketplaces/*/plugins/#{inv.plugin}/skills/. " \
+            "Install via `claude plugin install <marketplace>` for the marketplace " \
+            "that ships #{inv.plugin}."
+        else
+          "claude: /#{inv.name} not found under ~/.claude/{commands,skills}/ " \
+            "(or <project>/.claude/...). Install as a user-level slash command " \
+            "(write ~/.claude/commands/#{inv.name}.md) or as a skill " \
+            "(write ~/.claude/skills/#{inv.name}/SKILL.md)."
+        end
+      end
+    end
+
+    module Codex
+      module_function
+
+      # Search order:
+      #   /<plugin>:<name>
+      #     1. ~/.codex/plugins/cache/*<plugin>*/<plugin>*/*/skills/<name>/SKILL.md
+      #        (cache layout is <marketplace>/<plugin>/<version>/skills/<name>/)
+      #   /<name>
+      #     1. ~/.codex/skills/<name>/SKILL.md
+      #     2. ~/.codex/skills/.system/<name>/SKILL.md
+      def verify(invocation, project_root: nil)
+        inv = Hive::SkillCheck.parse(invocation)
+        home = ENV["HOME"] || Dir.home
+        candidates = build_candidates(inv, home: home, project_root: project_root)
+        path = Hive::SkillCheck.first_existing(candidates)
+        return [ :present, path ] if path
+
+        [ :missing, install_hint(inv) ]
+      rescue ArgumentError => e
+        [ :missing, "codex: #{e.message}" ]
+      end
+
+      def build_candidates(inv, home:, project_root:)
+        if inv.plugin
+          # Cache layout produced by `codex plugin install`:
+          # ~/.codex/plugins/cache/<owner>-<marketplace>/<plugin>/<version>/skills/<name>/SKILL.md
+          glob = File.join(home, ".codex/plugins/cache/*", inv.plugin, "*", "skills", inv.name, "SKILL.md")
+          Dir[glob]
+        else
+          paths = []
+          if project_root
+            paths << File.join(project_root, ".codex/skills/#{inv.name}/SKILL.md")
+          end
+          paths << File.join(home, ".codex/skills/#{inv.name}/SKILL.md")
+          paths << File.join(home, ".codex/skills/.system/#{inv.name}/SKILL.md")
+          paths
+        end
+      end
+
+      def install_hint(inv)
+        if inv.plugin
+          "codex: /#{inv.plugin}:#{inv.name} not found under " \
+            "~/.codex/plugins/cache/*/#{inv.plugin}/*/skills/. " \
+            "Install via `codex plugin install <marketplace>` for the marketplace " \
+            "that ships #{inv.plugin}."
+        else
+          "codex: /#{inv.name} not found under ~/.codex/skills/ or skills/.system/. " \
+            "Codex has no user-level slash-command directory; either install a " \
+            "skill named #{inv.name.inspect} or override the stage's skill in " \
+            "config.yml (e.g. `plan.skill: /compound-engineering:ce-plan`)."
+        end
+      end
+    end
+
+    module Pi
+      module_function
+
+      # Pi exposes `pi install <source>` for MCP-style extensions but
+      # has no slash-command-resolution model: a `/foo` token in the
+      # prompt is just text the model reads. The honest answer for any
+      # invocation is `:not_applicable`, not `:present` (which would
+      # over-promise) or `:missing` (which would imply the user needs
+      # to install something).
+      def verify(_invocation, project_root: nil)
+        _ = project_root
+        [ :not_applicable,
+          "pi has no slash-command resolver — the invocation is passed " \
+            "to the model as ordinary prompt text. If your pi-side prompt " \
+            "still works without an installed skill, this is fine; otherwise " \
+            "switch the stage's agent to claude or codex via config.yml." ]
+      end
+    end
+  end
+end

--- a/test/unit/commands/doctor_test.rb
+++ b/test/unit/commands/doctor_test.rb
@@ -1,0 +1,158 @@
+require "test_helper"
+require "stringio"
+require "fileutils"
+require "json"
+require "hive/commands/doctor"
+
+class HiveCommandsDoctorTest < Minitest::Test
+  include HiveTestHelper
+
+  def with_fake_home
+    with_tmp_dir do |dir|
+      old = ENV["HOME"]
+      ENV["HOME"] = dir
+      yield dir
+    ensure
+      old.nil? ? ENV.delete("HOME") : ENV["HOME"] = old
+    end
+  end
+
+  def write_file(path, content = "")
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, content)
+  end
+
+  def base_config(overrides = {})
+    {
+      "brainstorm" => { "agent" => "claude" },
+      "plan" => { "agent" => "claude" }
+    }.merge(overrides) { |_k, a, b| a.merge(b) }
+  end
+
+  def test_exit_success_when_all_present
+    with_fake_home do |home|
+      write_file("#{home}/.claude/plugins/cache/mp/compound-engineering/3.0.1/skills/ce-brainstorm/SKILL.md")
+      write_file("#{home}/.claude/commands/plan.md")
+      out = StringIO.new
+      cfg = base_config(
+        "brainstorm" => { "agent" => "claude", "skill" => "/compound-engineering:ce-brainstorm" },
+        "plan" => { "agent" => "claude", "skill" => "/plan" }
+      )
+      exit_code = Hive::Commands::Doctor.new(
+        config: cfg,
+        project_root: nil,
+        output: out
+      ).call
+      assert_equal 0, exit_code
+      assert_match(/✓ present/, out.string)
+      refute_match(/✗ missing/, out.string)
+    end
+  end
+
+  def test_exit_missing_skill_when_one_missing
+    with_fake_home do |home|
+      write_file("#{home}/.claude/commands/plan.md")
+      # ce-brainstorm intentionally absent
+      out = StringIO.new
+      cfg = base_config(
+        "brainstorm" => { "agent" => "claude", "skill" => "/compound-engineering:ce-brainstorm" },
+        "plan" => { "agent" => "claude", "skill" => "/plan" }
+      )
+      exit_code = Hive::Commands::Doctor.new(
+        config: cfg,
+        project_root: nil,
+        output: out
+      ).call
+      assert_equal Hive::Commands::Doctor::EXIT_MISSING_SKILL, exit_code
+      assert_match(/✗ missing/, out.string)
+      assert_match(/claude plugin install/, out.string,
+        "human-readable output must include the install hint for the missing one")
+    end
+  end
+
+  def test_pi_stage_is_not_applicable_and_does_not_fail
+    with_fake_home do |_home|
+      out = StringIO.new
+      cfg = {
+        "brainstorm" => { "agent" => "pi", "skill" => "/anything" },
+        "plan" => { "agent" => "pi", "skill" => "/anything" }
+      }
+      exit_code = Hive::Commands::Doctor.new(
+        config: cfg,
+        project_root: nil,
+        output: out
+      ).call
+      assert_equal 0, exit_code, "pi-only configs must not fail doctor"
+      assert_match(/— not_applicable/, out.string)
+    end
+  end
+
+  def test_json_envelope_shape
+    with_fake_home do |home|
+      write_file("#{home}/.claude/commands/plan.md")
+      out = StringIO.new
+      cfg = base_config(
+        "brainstorm" => { "agent" => "claude", "skill" => "/missing-plug:missing-skill" },
+        "plan" => { "agent" => "claude", "skill" => "/plan" }
+      )
+      exit_code = Hive::Commands::Doctor.new(
+        config: cfg,
+        project_root: nil,
+        json: true,
+        output: out
+      ).call
+      assert_equal Hive::Commands::Doctor::EXIT_MISSING_SKILL, exit_code
+
+      env = JSON.parse(out.string)
+      assert_equal "hive-doctor.v1", env["schema"]
+      assert_equal 2, env["checks"].length
+      assert_equal 1, env["summary"]["missing"]
+      assert_equal 1, env["summary"]["present"]
+      assert(env["checks"].any? { |c| c["stage"] == "plan" && c["status"] == "present" })
+      assert(env["checks"].any? { |c| c["stage"] == "brainstorm" && c["status"] == "missing" })
+    end
+  end
+
+  def test_uses_config_defaults_when_skill_key_unset
+    with_fake_home do |home|
+      # No `skill:` key in config; doctor falls back to DEFAULTS
+      # ("/compound-engineering:ce-brainstorm" and "/plan").
+      write_file("#{home}/.claude/plugins/cache/mp/compound-engineering/3.0.1/skills/ce-brainstorm/SKILL.md")
+      write_file("#{home}/.claude/commands/plan.md")
+      out = StringIO.new
+      cfg = {
+        "brainstorm" => { "agent" => "claude" },
+        "plan" => { "agent" => "claude" }
+      }
+      exit_code = Hive::Commands::Doctor.new(
+        config: cfg,
+        project_root: nil,
+        output: out
+      ).call
+      assert_equal 0, exit_code
+      assert_match(%r{/compound-engineering:ce-brainstorm}, out.string)
+      assert_match(%r{/plan}, out.string)
+    end
+  end
+
+  def test_project_root_affects_claude_plain_invocation_resolution
+    with_fake_home do |_home|
+      # No user-level claude /plan, but project-level present.
+      with_tmp_dir do |project|
+        write_file("#{project}/.claude/commands/plan.md")
+        out = StringIO.new
+        cfg = base_config(
+          "brainstorm" => { "agent" => "pi", "skill" => "/x" }, # parked: pi → N/A
+          "plan" => { "agent" => "claude", "skill" => "/plan" }
+        )
+        exit_code = Hive::Commands::Doctor.new(
+          config: cfg,
+          project_root: project,
+          output: out
+        ).call
+        assert_equal 0, exit_code, "project-level /plan should be detected"
+        assert_match(/✓ present/, out.string)
+      end
+    end
+  end
+end

--- a/test/unit/skill_check_test.rb
+++ b/test/unit/skill_check_test.rb
@@ -1,0 +1,206 @@
+require "test_helper"
+require "hive/skill_check"
+require "fileutils"
+
+class HiveSkillCheckParseTest < Minitest::Test
+  def test_parses_plain_invocation
+    inv = Hive::SkillCheck.parse("/plan")
+    assert_nil inv.plugin
+    assert_equal "plan", inv.name
+  end
+
+  def test_parses_plugin_namespaced_invocation
+    inv = Hive::SkillCheck.parse("/compound-engineering:ce-plan")
+    assert_equal "compound-engineering", inv.plugin
+    assert_equal "ce-plan", inv.name
+  end
+
+  def test_rejects_nil
+    assert_raises(ArgumentError) { Hive::SkillCheck.parse(nil) }
+  end
+
+  def test_rejects_missing_leading_slash
+    assert_raises(ArgumentError) { Hive::SkillCheck.parse("plan") }
+  end
+
+  def test_rejects_empty_name
+    assert_raises(ArgumentError) { Hive::SkillCheck.parse("/") }
+    assert_raises(ArgumentError) { Hive::SkillCheck.parse("/plug:") }
+  end
+
+  def test_rejects_whitespace
+    assert_raises(ArgumentError) { Hive::SkillCheck.parse("/foo bar") }
+  end
+end
+
+class HiveSkillCheckClaudeTest < Minitest::Test
+  include HiveTestHelper
+
+  def with_fake_home
+    with_tmp_dir do |dir|
+      old = ENV["HOME"]
+      ENV["HOME"] = dir
+      yield dir
+    ensure
+      old.nil? ? ENV.delete("HOME") : ENV["HOME"] = old
+    end
+  end
+
+  def write_file(path, content = "")
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, content)
+  end
+
+  def test_present_via_user_command_directory
+    with_fake_home do |home|
+      write_file("#{home}/.claude/commands/plan.md")
+      status, msg = Hive::SkillCheck::Claude.verify("/plan")
+      assert_equal :present, status
+      assert_equal "#{home}/.claude/commands/plan.md", msg
+    end
+  end
+
+  def test_present_via_user_skill_directory
+    with_fake_home do |home|
+      write_file("#{home}/.claude/skills/wiki-researcher/SKILL.md")
+      status, msg = Hive::SkillCheck::Claude.verify("/wiki-researcher")
+      assert_equal :present, status
+      assert_equal "#{home}/.claude/skills/wiki-researcher/SKILL.md", msg
+    end
+  end
+
+  def test_present_via_project_command_directory_takes_precedence
+    with_fake_home do |home|
+      write_file("#{home}/.claude/commands/plan.md", "user")
+      with_tmp_dir do |project|
+        write_file("#{project}/.claude/commands/plan.md", "project")
+        status, msg = Hive::SkillCheck::Claude.verify("/plan", project_root: project)
+        assert_equal :present, status
+        assert_equal "#{project}/.claude/commands/plan.md", msg,
+          "project-level path must beat the user-level one"
+      end
+    end
+  end
+
+  def test_present_via_plugin_cache_layout
+    with_fake_home do |home|
+      write_file("#{home}/.claude/plugins/cache/every-marketplace/compound-engineering/3.0.1/skills/ce-plan/SKILL.md")
+      status, msg = Hive::SkillCheck::Claude.verify("/compound-engineering:ce-plan")
+      assert_equal :present, status
+      assert_match(%r{cache/every-marketplace/compound-engineering/3.0.1/skills/ce-plan/SKILL.md\z}, msg)
+    end
+  end
+
+  def test_present_via_plugin_marketplace_source_layout
+    with_fake_home do |home|
+      write_file("#{home}/.claude/plugins/marketplaces/some-mp/plugins/compound-engineering/skills/ce-brainstorm/SKILL.md")
+      status, msg = Hive::SkillCheck::Claude.verify("/compound-engineering:ce-brainstorm")
+      assert_equal :present, status
+      assert_match(%r{plugins/compound-engineering/skills/ce-brainstorm/SKILL.md\z}, msg)
+    end
+  end
+
+  def test_missing_returns_install_hint_for_plain_invocation
+    with_fake_home do |_home|
+      status, msg = Hive::SkillCheck::Claude.verify("/nonexistent-skill")
+      assert_equal :missing, status
+      assert_match(/not found under ~\/\.claude\/\{commands,skills\}/, msg)
+    end
+  end
+
+  def test_missing_returns_install_hint_for_plugin_invocation
+    with_fake_home do |_home|
+      status, msg = Hive::SkillCheck::Claude.verify("/no-such-plug:no-such-skill")
+      assert_equal :missing, status
+      assert_match(/claude plugin install/, msg)
+    end
+  end
+
+  def test_malformed_invocation_returns_missing_with_argument_error
+    with_fake_home do |_home|
+      status, msg = Hive::SkillCheck::Claude.verify("garbage")
+      assert_equal :missing, status
+      assert_match(/expected/, msg)
+    end
+  end
+end
+
+class HiveSkillCheckCodexTest < Minitest::Test
+  include HiveTestHelper
+
+  def with_fake_home
+    with_tmp_dir do |dir|
+      old = ENV["HOME"]
+      ENV["HOME"] = dir
+      yield dir
+    ensure
+      old.nil? ? ENV.delete("HOME") : ENV["HOME"] = old
+    end
+  end
+
+  def write_file(path, content = "")
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, content)
+  end
+
+  def test_present_via_user_skill
+    with_fake_home do |home|
+      write_file("#{home}/.codex/skills/plan/SKILL.md")
+      status, msg = Hive::SkillCheck::Codex.verify("/plan")
+      assert_equal :present, status
+      assert_equal "#{home}/.codex/skills/plan/SKILL.md", msg
+    end
+  end
+
+  def test_present_via_system_skill
+    with_fake_home do |home|
+      write_file("#{home}/.codex/skills/.system/imagegen/SKILL.md")
+      status, msg = Hive::SkillCheck::Codex.verify("/imagegen")
+      assert_equal :present, status
+      assert_match(%r{\.system/imagegen/SKILL.md\z}, msg)
+    end
+  end
+
+  def test_present_via_plugin_cache
+    with_fake_home do |home|
+      write_file("#{home}/.codex/plugins/cache/compound-engineering-plugin/compound-engineering/3.6.1/skills/ce-plan/SKILL.md")
+      status, msg = Hive::SkillCheck::Codex.verify("/compound-engineering:ce-plan")
+      assert_equal :present, status
+      assert_match(%r{compound-engineering/3.6.1/skills/ce-plan/SKILL.md\z}, msg)
+    end
+  end
+
+  def test_missing_plain_invocation_with_codex_specific_hint
+    with_fake_home do |_home|
+      status, msg = Hive::SkillCheck::Codex.verify("/no-such-skill")
+      assert_equal :missing, status
+      assert_match(/no user-level slash-command directory/, msg)
+    end
+  end
+
+  def test_missing_plugin_invocation_with_install_hint
+    with_fake_home do |_home|
+      status, msg = Hive::SkillCheck::Codex.verify("/missing-plug:missing-name")
+      assert_equal :missing, status
+      assert_match(/codex plugin install/, msg)
+    end
+  end
+end
+
+class HiveSkillCheckPiTest < Minitest::Test
+  def test_returns_not_applicable_for_any_invocation
+    [ "/plan", "/compound-engineering:ce-plan", "/foo" ].each do |inv|
+      status, msg = Hive::SkillCheck::Pi.verify(inv)
+      assert_equal :not_applicable, status, "pi must report N/A for #{inv}"
+      assert_match(/no slash-command resolver/, msg)
+    end
+  end
+
+  def test_returns_not_applicable_even_for_garbage_invocation
+    # Pi's check is honest: it doesn't even parse the invocation
+    # because no parsing can change the answer (pi sends prompt
+    # text verbatim regardless).
+    status, _msg = Hive::SkillCheck::Pi.verify("not-an-invocation")
+    assert_equal :not_applicable, status
+  end
+end

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -2,6 +2,24 @@
 
 Append-only log of all wiki operations.
 
+## [2026-05-07T15:30:00Z] config — `hive doctor` skill preflight + per-agent verifiers
+
+**Action:** Added `hive doctor` — a CLI verb that walks brainstorm + plan stage configs and asks each stage's agent profile to verify its configured skill (`<stage>.skill`) actually resolves to an installed slash-command or skill on disk. Output is a status table; `--json` emits a `hive-doctor.v1` envelope. Exit codes: `0` (all present or N/A), `65` (at least one missing), `78` (config error).
+
+Per-agent search rules encoded in `Hive::SkillCheck::{Claude,Codex,Pi}`:
+
+- **Claude** — for `/<name>`: `<project>/.claude/commands/<name>.md`, `<project>/.claude/skills/<name>/SKILL.md`, `~/.claude/commands/<name>.md`, `~/.claude/skills/<name>/SKILL.md`. For `/<plug>:<name>`: cache layout `~/.claude/plugins/cache/<marketplace>/<plug>/<version>/skills/<name>/SKILL.md` AND marketplace source layout `~/.claude/plugins/marketplaces/<marketplace>/plugins/<plug>/skills/<name>/SKILL.md` (plus `commands/`).
+- **Codex** — for `/<name>`: `~/.codex/skills/<name>/SKILL.md`, `~/.codex/skills/.system/<name>/SKILL.md`. For `/<plug>:<name>`: `~/.codex/plugins/cache/<marketplace>/<plug>/<version>/skills/<name>/SKILL.md`. Note that codex has no user-level slash-command directory like claude's `commands/` — if you need `/plan` on codex, install a SKILL.md.
+- **Pi** — always `:not_applicable`. Pi has no slash-command resolver: a `/foo` token in the prompt is just text the model reads. The honest answer is N/A, not `:missing`.
+
+`AgentProfile` gained a `skill_verifier:` constructor kwarg (defaulting to nil → `:not_applicable`), so adding a fourth profile in the future is "register a `Hive::SkillCheck::*` module and pass its `.method(:verify)`."
+
+README install section updated with per-agent install pointers and the `hive doctor` invocation.
+
+**Refreshed pages:**
+- (none — `hive doctor` is a new CLI surface; existing wiki pages don't reference skill installation.)
+
+
 ## [2026-05-07T14:00:00Z] config — per-stage `skill` override + `/plan` becomes the shipped default
 
 **Action:** Added `brainstorm.skill` and `plan.skill` keys to `Hive::Config::DEFAULTS`. The brainstorm and plan stage prompts now reference `<%= skill_invocation %>` so a per-project `config.yml` override redirects the agent to a different slash-command without touching `templates/`.


### PR DESCRIPTION
## Summary

New `hive doctor` CLI verb that walks the brainstorm and plan stage configs and asks each stage's agent profile to verify its configured skill (`<stage>.skill` from #47) actually resolves to an installed slash-command or skill on disk. Catches a missing install **before** a stage spawns and the agent reports `skill not found` mid-run.

## Per-agent search rules

| Agent | `/<name>` | `/<plugin>:<name>` |
|-------|-----------|--------------------|
| **claude** | `~/.claude/commands/<name>.md`, `~/.claude/skills/<name>/SKILL.md`, project-level `<repo>/.claude/...` | Cache layout `~/.claude/plugins/cache/<mp>/<plug>/<ver>/skills/<name>/SKILL.md` AND marketplace source `~/.claude/plugins/marketplaces/<mp>/plugins/<plug>/skills/<name>/SKILL.md` (plus `commands/` in both) |
| **codex** | `~/.codex/skills/<name>/SKILL.md`, `~/.codex/skills/.system/<name>/SKILL.md` | `~/.codex/plugins/cache/<mp>/<plug>/<ver>/skills/<name>/SKILL.md`. Codex has no user-level slash-command directory; the install hint reflects this. |
| **pi** | always `:not_applicable` — pi has no slash-command resolver; the prompt is sent verbatim. The honest answer, not a stub. |

## Output

```
stage       agent   skill                                status
----------  ------  -----------------------------------  ------
brainstorm  claude  /compound-engineering:ce-brainstorm  ✓ present
plan        claude  /plan                                ✓ present
```

`--json` emits a `hive-doctor.v1` envelope:

```json
{
  "schema": "hive-doctor.v1",
  "checks": [
    {"stage": "brainstorm", "agent": "claude", "skill": "/...:ce-brainstorm", "status": "present", "message": "<path>"},
    {"stage": "plan", "agent": "claude", "skill": "/plan", "status": "present", "message": "<path>"}
  ],
  "summary": {"missing": 0, "present": 2, "not_applicable": 0}
}
```

## Exit codes

| Code | Meaning |
|------|---------|
| `0` | All checks present or `:not_applicable` |
| `65` | At least one `:missing` |
| `78` | Config error |

## Wiring

- `AgentProfile` gained a `skill_verifier:` constructor kwarg (default `nil` → returns `:not_applicable`). Each profile passes the corresponding `Hive::SkillCheck::*.method(:verify)`. Adding a fourth profile is "register a `SkillCheck` module and pass its `method(:verify)`."
- `Hive::Commands::Doctor` reads cfg + stages, dispatches per-profile, prints status.

## Tests (+27 cases, +82 assertions)

`test/unit/skill_check_test.rb` (21 cases):
- `parse()` boundary cases — nil, missing slash, empty name, whitespace, embedded colon in name.
- Claude — user commands, user skills, project-level precedence, cache plugin layout, marketplace source layout, missing-skill hints.
- Codex — user skill, `.system/` skill, plugin cache, plain-invocation hint, plugin-invocation hint.
- Pi — always N/A even on garbage input.

`test/unit/commands/doctor_test.rb` (6 cases):
- Exit `0` all-present.
- Exit `65` one-missing with install hint in output.
- Pi-only configs report N/A and still exit `0`.
- JSON envelope shape.
- DEFAULTS fallback when `<stage>.skill` is unset.
- `project_root` affects claude's plain-invocation lookup.

## README

`Required slash-commands / skills` table added to install section with per-agent install pointers and the `hive doctor` invocation.

## Test plan

- [x] `bundle exec rake test`: 1511 runs, 4931 assertions, 0 failures.
- [x] `bundle exec rubocop` on changed files: 0 offenses.
- [x] Smoke-tested on this dev box — both `/compound-engineering:ce-brainstorm` and `/plan` report present.