### PR TITLE
fix(tui): format agent log tail

### DIFF
--- a/lib/hive/tui/bubble_model.rb
+++ b/lib/hive/tui/bubble_model.rb
@@ -979,7 +979,7 @@ module Hive
         end
 
         def lines(count)
-          @tail.lines(count)
+          Hive::Tui::LogTail::Formatter.format_lines(@tail.lines(count))
         end
       end
 
@@ -1296,7 +1296,7 @@ module Hive
       end
 
       def footer_hint
-        "[Tab] switch  [Enter] open  [n] new  [/] filter  [?] help  [q] quit"
+        "[Tab] switch  [Enter] action  [n] new  [/] filter  [?] help  [q] quit"
       end
 
       # Compute pane widths and join horizontally. Left pane is clamped

--- a/lib/hive/tui/log_tail.rb
+++ b/lib/hive/tui/log_tail.rb
@@ -1,4 +1,5 @@
 require "fileutils"
+require "json"
 require "hive"
 require "hive/tui/debug"
 
@@ -20,6 +21,115 @@ module Hive
     # keystrokes on the same loop, so the buffer stays fresh without
     # the synchronisation footprint of a worker thread.
     module LogTail
+      module Formatter
+        STREAM_LINE = /\A\[stream\]\s+(\S+)\s+(.+)\z/
+        HIVE_LINE = /\A\[hive\]\s+(\S+)\s+(.+)\z/
+        ID_WIDTH = 12
+
+        module_function
+
+        def format(line)
+          text = line.to_s
+
+          if (match = STREAM_LINE.match(text))
+            return format_stream(match[1], match[2], fallback: text)
+          end
+
+          if (match = HIVE_LINE.match(text))
+            return "#{time_label(match[1])} hive #{match[2]}"
+          end
+
+          text
+        end
+
+        def format_lines(lines)
+          lines.map { |line| format(line) }
+        end
+
+        def format_stream(timestamp, payload, fallback:)
+          doc = JSON.parse(payload)
+          return fallback unless doc.is_a?(Hash)
+
+          case doc["type"]
+          when "system" then format_system(timestamp, doc)
+          when "assistant" then format_assistant(timestamp, doc)
+          when "user" then format_user(timestamp, doc)
+          else
+            parts = [ time_label(timestamp), doc["type"].to_s ]
+            append_id(parts, "task", doc["task_id"])
+            append_id(parts, "tool", doc["tool_use_id"])
+            parts.join(" ")
+          end
+        rescue JSON::ParserError, TypeError
+          fallback
+        end
+
+        def format_system(timestamp, doc)
+          parts = [ time_label(timestamp), "system" ]
+          parts << doc["subtype"].to_s if present?(doc["subtype"])
+          append_id(parts, "task", doc["task_id"])
+          append_id(parts, "tool", doc["tool_use_id"])
+          parts.join(" ")
+        end
+
+        def format_assistant(timestamp, doc)
+          message = hash_or_empty(doc["message"])
+          parts = [ time_label(timestamp), "assistant" ]
+          parts << message["model"].to_s if present?(message["model"])
+          append_id(parts, "msg", message["id"])
+          append_content_summary(parts, message["content"])
+          parts.join(" ")
+        end
+
+        def format_user(timestamp, doc)
+          message = hash_or_empty(doc["message"])
+          role = present?(message["role"]) ? message["role"].to_s : "user"
+          parts = [ time_label(timestamp), role ]
+          append_id(parts, "msg", message["id"])
+          append_id(parts, "tool", first_content_value(message["content"], "tool_use_id"))
+          append_content_summary(parts, message["content"])
+          parts.join(" ")
+        end
+
+        def append_content_summary(parts, content)
+          return unless content.is_a?(Array)
+
+          types = content.filter_map { |entry| entry["type"] if entry.is_a?(Hash) }.uniq
+          parts << "content=#{types.join(',')}" unless types.empty?
+        end
+
+        def first_content_value(content, key)
+          return nil unless content.is_a?(Array)
+
+          entry = content.find { |item| item.is_a?(Hash) && present?(item[key]) }
+          entry&.fetch(key)
+        end
+
+        def append_id(parts, label, value)
+          return unless present?(value)
+
+          parts << "#{label}=#{compact_id(value)}"
+        end
+
+        def compact_id(value)
+          text = value.to_s
+          text.length > ID_WIDTH ? text[0, ID_WIDTH] : text
+        end
+
+        def time_label(timestamp)
+          text = timestamp.to_s
+          text.length >= 19 ? text[11, 8] : text
+        end
+
+        def hash_or_empty(value)
+          value.is_a?(Hash) ? value : {}
+        end
+
+        def present?(value)
+          !value.nil? && !value.to_s.empty?
+        end
+      end
+
       module FileResolver
         module_function
 

--- a/test/unit/tui/bubble_model_test.rb
+++ b/test/unit/tui/bubble_model_test.rb
@@ -339,6 +339,8 @@ class HiveTuiBubbleModelTest < Minitest::Test
     assert_includes out, "fix-cache-x",   "right pane task row must render"
     assert_includes out, "Tasks ·",       "tasks pane title must render"
     assert_includes out, "[Tab] switch",  "default footer hints must appear"
+    assert_includes out, "[Enter] action", "Enter footer hint must describe contextual behavior"
+    refute_includes out, "[Enter] open",   "Enter is not only an open action"
   end
 
   def test_grid_mode_collapses_to_single_pane_below_min_cols

--- a/test/unit/tui/log_tail_test.rb
+++ b/test/unit/tui/log_tail_test.rb
@@ -17,6 +17,56 @@ class TuiLogTailTest < Minitest::Test
     end
   end
 
+  # ---------- Formatter ----------
+
+  def test_formatter_compacts_stream_json_system_events
+    payload = {
+      "type" => "system", "subtype" => "task_progress",
+      "task_id" => "a0ac6000829a0b140", "tool_use_id" => "toolu_abcdef"
+    }
+    line = "[stream] 2026-05-07T14:37:13Z #{JSON.generate(payload)}"
+
+    assert_equal "14:37:13 system task_progress task=a0ac6000829a tool=toolu_abcdef",
+                 Hive::Tui::LogTail::Formatter.format(line)
+  end
+
+  def test_formatter_compacts_stream_json_assistant_events
+    payload = {
+      "type" => "assistant",
+      "message" => { "model" => "claude-opus-4-7", "id" => "msg_abcdefghi" }
+    }
+    line = "[stream] 2026-05-07T14:37:13Z #{JSON.generate(payload)}"
+
+    assert_equal "14:37:13 assistant claude-opus-4-7 msg=msg_abcdefgh",
+                 Hive::Tui::LogTail::Formatter.format(line)
+  end
+
+  def test_formatter_compacts_stream_json_user_tool_results
+    payload = {
+      "type" => "user",
+      "message" => {
+        "role" => "user",
+        "content" => [ { "type" => "tool_result", "tool_use_id" => "toolu_abc123" } ]
+      }
+    }
+    line = "[stream] 2026-05-07T14:37:13Z #{JSON.generate(payload)}"
+
+    assert_equal "14:37:13 user tool=toolu_abc123 content=tool_result",
+                 Hive::Tui::LogTail::Formatter.format(line)
+  end
+
+  def test_formatter_leaves_unparseable_stream_lines_raw
+    line = "[stream] 2026-05-07T14:37:13Z not-json"
+
+    assert_equal line, Hive::Tui::LogTail::Formatter.format(line)
+  end
+
+  def test_formatter_leaves_non_hash_json_stream_lines_raw
+    line = "[stream] 2026-05-07T14:37:13Z []"
+
+    assert_equal line, Hive::Tui::LogTail::Formatter.format(line)
+  end
+
   # ---------- FileResolver ----------
 
   def test_latest_returns_file_with_newest_mtime

--- a/wiki/commands/tui.md
+++ b/wiki/commands/tui.md
@@ -28,7 +28,7 @@ The legacy curses backend was removed in plan #003 U11. `HIVE_TUI_BACKEND=curses
 │  myapp     │  ⚠  oauth-…       5-review      Review findings     1h │
 │  appcrawl       │                                                        │
 ├─────────────────┴────────────────────────────────────────────────────────┤
-│ Footer: [Tab] switch  [Enter] open  [n] new  [/] filter  [?] help  [q]  │
+│ Footer: [Tab] switch  [Enter] action  [n] new  [/] filter  [?] help  [q]│
 └──────────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -61,7 +61,7 @@ Pane focus is keyboard-only; the focused pane border is bright cyan, the inactiv
 | `r` | run `hive review` |
 | `P` | run `hive pr` (capital so it doesn't collide with `plan`) |
 | `a` | run `hive archive` |
-| `Enter` | from left pane: focus right pane. From right pane: open the row's contextual mode: input editor on `needs_input` (completed brainstorm answer rounds auto-run; plan rows auto-advance to `develop` or auto-revise on user feedback), triage on `review_findings`, log tail on `agent_running` / `error`; ready rows still dispatch the suggested command |
+| `Enter` | from left pane: focus right pane. From right pane: perform the row's contextual action: input editor on `needs_input` (completed brainstorm answer rounds auto-run; plan rows auto-advance to `develop` or auto-revise on user feedback), triage on `review_findings`, log tail on `agent_running` / `error`; ready rows still dispatch the suggested command |
 | `n` | open the new-idea prompt; submitting runs `hive new <project> "<title>"` against the project selected in the left pane (`★ All` falls back to the first registered project) |
 | `/` | open filter prompt |
 | `1`–`9` | scope the right pane to the Nth registered project (mirrors selection in the left pane) |


### PR DESCRIPTION
## Summary
- format raw agent stream-json lines in the TUI log-tail view
- keep raw log files unchanged on disk
- rename the footer hint from [Enter] open to [Enter] action

## Tests
- bundle exec ruby -Itest -Ilib test/unit/tui/log_tail_test.rb
- bundle exec ruby -Itest -Ilib test/unit/tui/bubble_model_test.rb
- bundle exec ruby -Itest -Ilib test/unit/tui/views/log_tail_test.rb
- bundle exec rubocop lib/hive/tui/log_tail.rb lib/hive/tui/bubble_model.rb test/unit/tui/log_tail_test.rb test/unit/tui/bubble_model_test.rb