### PR TITLE
feat(doctor): probe review.reviewers + run as init preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,22 +44,35 @@ Optional: [`qmd`](https://qmd.dev) for semantic search over `wiki/` (ripgrep wor
 
 ### Required slash-commands / skills
 
-The brainstorm and plan stages instruct the agent to invoke specific slash-commands inside their prompts. Hive's shipped defaults assume **both** of these are installed alongside the agent CLI:
+The brainstorm, plan, and 5-review stages instruct their agents to invoke specific slash-commands inside their prompts. Hive's shipped defaults assume the corresponding skills are installed alongside the agent CLI:
+
+**Stage skills** (single-agent stages):
 
 | Stage | Default invocation | Install for claude | Install for codex |
 |-------|--------------------|--------------------|-------------------|
 | `2-brainstorm` | `/compound-engineering:ce-brainstorm` | `claude plugin install <every-marketplace>` (or any marketplace shipping `compound-engineering`) | `codex plugin install <compound-engineering-marketplace>` |
 | `3-plan` | `/plan` | A user-level slash command at `~/.claude/commands/plan.md` (e.g. ship via the [llm-wiki plugin](https://github.com/aikuznetsov/agent-plugins) or write one inline) | A skill at `~/.codex/skills/plan/SKILL.md` (codex has no user-level slash-command directory) |
-| | | Pi has no slash-command resolver; if you set `<stage>.agent: pi`, the slash-command is sent verbatim as prompt text and the model decides what to do. |
+
+**Reviewer skills** (5-review stage's recommended-default reviewer set, written by `hive init`):
+
+| Reviewer name | Default skill | Install for claude | Install for codex |
+|---|---|---|---|
+| `claude-ce-code-review` | `/ce-code-review` | `~/.claude/skills/ce-code-review/SKILL.md` (or set `skill: compound-engineering:ce-code-review` in config to use the plugin form explicitly) | n/a (this row uses claude) |
+| `codex-ce-code-review` | `/ce-code-review` | n/a (this row uses codex) | `~/.codex/skills/ce-code-review/SKILL.md` (or via `codex plugin install` for `compound-engineering`) |
+| `pr-review-toolkit` | `/pr-review-toolkit:review-pr` | `claude plugin install <pr-review-toolkit-marketplace>` | n/a (this row uses claude) |
+
+Pi has no slash-command resolver; if you set any agent to `pi`, the slash-command is sent verbatim as prompt text and the model decides what to do.
 
 To verify your install:
 
 ```bash
-hive doctor              # tabular status of each (stage, agent, skill) triple
-hive doctor --json       # machine-readable envelope
+hive doctor              # tabular status of each (stage, agent, skill) triple PLUS each review.reviewer
+hive doctor --json       # machine-readable envelope (hive-doctor.v1; checks[].kind = "stage" | "reviewer")
 ```
 
 Exit codes: `0` all present (or N/A for pi); `65` at least one skill missing; `78` config error.
+
+`hive init` runs the same doctor as a non-fatal preflight at end-of-bootstrap. Any missing-skill warnings are emitted to **stderr** (so `hive init | …` pipelines stay clean) and init still exits `0` — install gaps surface but don't block bootstrap. Look for `hive: doctor pre-flight — found N issue(s):` after the initialized summary.
 
 To override a stage's skill per-project, set `<stage>.skill` in `<project>/.hive-state/config.yml`:
 

--- a/lib/hive/commands/doctor.rb
+++ b/lib/hive/commands/doctor.rb
@@ -9,15 +9,22 @@ require "hive/agent_profiles/pi"
 
 module Hive
   module Commands
-    # `hive doctor` — verifies that every configured stage skill
-    # actually resolves to an installed slash-command / skill on the
-    # operator's machine. Walks the brainstorm and plan stage configs,
-    # asks each stage's agent profile to probe its filesystem, prints a
-    # status table, and exits non-zero if any check is `:missing`.
+    # `hive doctor` — verifies that every configured stage skill AND every
+    # 5-review reviewer skill actually resolves to an installed
+    # slash-command / skill on the operator's machine. Walks brainstorm
+    # + plan stage configs, plus `review.reviewers[]`, asks each agent
+    # profile to probe its filesystem, prints a status table, and exits
+    # non-zero if any check is `:missing`.
     #
     # Pi rows always come back `:not_applicable` — pi has no
     # slash-command resolver. That's not a fail; the prompt text still
     # gets sent to the model.
+    #
+    # Reviewer entries with `kind:` ≠ `"agent"` also surface as
+    # `:not_applicable`. This is the **only load-time signal** for
+    # non-agent kinds — `Hive::Config.validate_reviewers!` does NOT
+    # check the `kind` field; only `Hive::Reviewers.dispatch` does, at
+    # run-time.
     #
     # `--json` emits a machine-readable envelope so an agent caller
     # (the daemon, an outer orchestrator) can decide how to react
@@ -29,22 +36,29 @@ module Hive
 
       STAGES = %w[brainstorm plan].freeze
 
+      # Exposes the row set after `#call` has run. Lets in-process
+      # callers (e.g., `Hive::Commands::Init`'s preflight) read the
+      # probe results directly without re-running the renderer or the
+      # JSON encoder. Returns `nil` before `#call` has populated it.
+      attr_reader :rows
+
       def initialize(config:, project_root:, json: false, output: $stdout)
         @config = config
         @project_root = project_root
         @json = json
         @output = output
+        @rows = nil
       end
 
       def call
-        rows = STAGES.map { |stage| check_stage(stage) }
+        @rows = check_stages + check_reviewers
         if @json
-          @output.puts JSON.generate(envelope(rows))
+          @output.puts JSON.generate(envelope(@rows))
         else
-          render_table(rows)
+          render_table(@rows)
         end
 
-        rows.any? { |r| r[:status] == "missing" } ? EXIT_MISSING_SKILL : EXIT_SUCCESS
+        @rows.any? { |r| r[:status] == "missing" } ? EXIT_MISSING_SKILL : EXIT_SUCCESS
       rescue Hive::ConfigError, KeyError, ArgumentError => e
         if @json
           @output.puts JSON.generate(error: e.message)
@@ -56,6 +70,10 @@ module Hive
 
       private
 
+      def check_stages
+        STAGES.map { |stage| check_stage(stage) }
+      end
+
       def check_stage(stage)
         agent_name = (@config.dig(stage, "agent") || "claude").to_s
         skill = @config.dig(stage, "skill") || Hive::Config::DEFAULTS.dig(stage, "skill")
@@ -63,7 +81,9 @@ module Hive
 
         status, message = profile.verify_skill(skill, project_root: @project_root)
         {
+          kind: "stage",
           stage: stage,
+          label: stage,
           agent: agent_name,
           skill: skill,
           status: status.to_s,
@@ -71,6 +91,64 @@ module Hive
         }
       end
 
+      def check_reviewers
+        Array(@config.dig("review", "reviewers")).map { |spec| check_reviewer(spec) }
+      end
+
+      # Per-reviewer probe. Non-`agent` kinds short-circuit to N/A
+      # rather than attempting an `AgentProfiles.lookup` — the row
+      # explains why the entry is unrunnable. For `agent`-kind entries,
+      # the bare config skill (e.g., `ce-code-review`) is formatted
+      # through the profile's `skill_syntax_format` to obtain the full
+      # invocation (`/ce-code-review`) before passing to `verify_skill`,
+      # so the JSON envelope's `skill` field shape is uniform across
+      # stage and reviewer rows.
+      def check_reviewer(spec)
+        agent_name = spec["agent"].to_s
+        name = spec["name"].to_s
+        kind = (spec["kind"] || "agent").to_s
+        bare_skill = spec["skill"].to_s
+
+        if kind != "agent"
+          return reviewer_row(
+            name: name,
+            agent: agent_name,
+            skill: bare_skill,
+            status: "not_applicable",
+            message: "kind '#{kind}' is not 'agent'; doctor only checks agent-kind reviewers"
+          )
+        end
+
+        profile = Hive::AgentProfiles.lookup(agent_name.to_sym)
+        invocation = format(profile.skill_syntax_format, skill: bare_skill)
+        status, message = profile.verify_skill(invocation, project_root: @project_root)
+        reviewer_row(
+          name: name,
+          agent: agent_name,
+          skill: invocation,
+          status: status.to_s,
+          message: message
+        )
+      end
+
+      def reviewer_row(name:, agent:, skill:, status:, message:)
+        {
+          kind: "reviewer",
+          stage: "5-review",
+          name: name,
+          label: "5-review/#{name}",
+          agent: agent,
+          skill: skill,
+          status: status,
+          message: message
+        }
+      end
+
+      # The `hive-doctor.v1` envelope is additive: `kind`, `name`, and
+      # `label` are new fields on `checks[]` entries (added 2026-05-07).
+      # Schema name stays `v1` because the change is forward-compatible
+      # — consumers that ignore unknown fields continue to work; the
+      # `summary` aggregation is still keyed by `status`.
       def envelope(rows)
         {
           "schema" => "hive-doctor.v1",
@@ -92,13 +170,13 @@ module Hive
         rows.each do |r|
           next if r[:status] == "present"
 
-          @output.puts "[#{r[:stage]}/#{r[:agent]}] #{r[:message]}"
+          @output.puts "[#{r[:label]}/#{r[:agent]}] #{r[:message]}"
         end
       end
 
       def compute_widths(rows)
         {
-          stage: column_width(rows, :stage, "stage"),
+          label: column_width(rows, :label, "stage"),
           agent: column_width(rows, :agent, "agent"),
           skill: column_width(rows, :skill, "skill"),
           status: column_width(rows, :status, "status")
@@ -110,13 +188,13 @@ module Hive
       end
 
       def header(widths)
-        format("%-#{widths[:stage]}s  %-#{widths[:agent]}s  %-#{widths[:skill]}s  %-#{widths[:status]}s",
+        format("%-#{widths[:label]}s  %-#{widths[:agent]}s  %-#{widths[:skill]}s  %-#{widths[:status]}s",
                "stage", "agent", "skill", "status")
       end
 
       def separator(widths)
-        format("%-#{widths[:stage]}s  %-#{widths[:agent]}s  %-#{widths[:skill]}s  %-#{widths[:status]}s",
-               "-" * widths[:stage], "-" * widths[:agent], "-" * widths[:skill], "-" * widths[:status])
+        format("%-#{widths[:label]}s  %-#{widths[:agent]}s  %-#{widths[:skill]}s  %-#{widths[:status]}s",
+               "-" * widths[:label], "-" * widths[:agent], "-" * widths[:skill], "-" * widths[:status])
       end
 
       def row_line(row, widths)
@@ -126,8 +204,8 @@ module Hive
         when "not_applicable" then "—"
         else "?"
         end
-        format("%-#{widths[:stage]}s  %-#{widths[:agent]}s  %-#{widths[:skill]}s  #{marker} %-#{widths[:status]}s",
-               row[:stage], row[:agent], row[:skill], row[:status])
+        format("%-#{widths[:label]}s  %-#{widths[:agent]}s  %-#{widths[:skill]}s  #{marker} %-#{widths[:status]}s",
+               row[:label], row[:agent], row[:skill], row[:status])
       end
     end
   end

--- a/lib/hive/commands/init.rb
+++ b/lib/hive/commands/init.rb
@@ -1,8 +1,10 @@
 require "open3"
 require "fileutils"
+require "stringio"
 require "hive/config"
 require "hive/git_ops"
 require "hive/commands/init/prompts"
+require "hive/commands/doctor"
 
 module Hive
   module Commands
@@ -43,6 +45,62 @@ module Hive
         entry = Hive::Config.register_project(name: File.basename(@project_path), path: @project_path)
 
         print_summary(entry: entry, ops: ops)
+        run_init_preflight!
+      end
+
+      # Non-fatal skill preflight: after init succeeds, run the doctor
+      # against the freshly-written config and emit stderr warnings for
+      # any `:missing` rows. Init's exit code is unaffected — install
+      # gaps surface but never block bootstrap.
+      #
+      # Rescue scope: `StandardError` for verifier bugs (with a
+      # bug-report hint in the warning so silent swallow is mitigated).
+      # `Errno::EPIPE` rescued narrowly around `warn` so a
+      # `hive init | head` pattern doesn't crash. `Interrupt` and
+      # `SystemExit` propagate (Ctrl-C honored as user intent).
+      def run_init_preflight!
+        cfg = Hive::Config.load(@project_path)
+        doctor = Hive::Commands::Doctor.new(
+          config: cfg,
+          project_root: @project_path,
+          output: StringIO.new
+        )
+        exit_code = doctor.call
+        if exit_code == Hive::Commands::Doctor::EXIT_CONFIG_ERROR
+          # Doctor caught a config issue internally; @rows is nil. Surface a
+          # pointer rather than going silent.
+          write_warn("hive: doctor pre-flight — config issue detected; run `hive doctor` for details")
+          return
+        end
+
+        missing = Array(doctor.rows).select { |r| r[:status] == "missing" }
+        return if missing.empty?
+
+        emit_preflight_warnings(missing)
+      rescue StandardError => e
+        emit_preflight_bug(e)
+      end
+
+      def emit_preflight_warnings(missing)
+        write_warn("hive: doctor pre-flight — found #{missing.size} issue(s):")
+        missing.each do |r|
+          write_warn("  [#{r[:label]}/#{r[:agent]}] #{r[:message]}")
+        end
+        write_warn("  See `hive doctor` for details.")
+      end
+
+      def emit_preflight_bug(error)
+        write_warn(
+          "hive: doctor pre-flight failed: #{error.class}: #{error.message} " \
+          "(this may be a hive bug, please report at " \
+          "https://github.com/ivankuznetsov/hive/issues)"
+        )
+      end
+
+      def write_warn(line)
+        warn line
+      rescue Errno::EPIPE
+        nil
       end
 
       def print_summary(entry:, ops:)

--- a/test/integration/init_doctor_preflight_test.rb
+++ b/test/integration/init_doctor_preflight_test.rb
@@ -1,0 +1,161 @@
+require "test_helper"
+require "fileutils"
+require "hive/commands/init"
+
+# Verifies the non-fatal skill preflight that runs at the end of
+# `Hive::Commands::Init#call`. Composes the existing init test
+# scaffolding (`with_tmp_global_config` + `with_tmp_git_repo`) with
+# the HOME-stub pattern from `test/unit/commands/doctor_test.rb` so
+# the doctor's filesystem probe is deterministic.
+class InitDoctorPreflightTest < Minitest::Test
+  include HiveTestHelper
+
+  def with_fake_home
+    with_tmp_dir do |dir|
+      old = ENV["HOME"]
+      ENV["HOME"] = dir
+      yield dir
+    ensure
+      old.nil? ? ENV.delete("HOME") : ENV["HOME"] = old
+    end
+  end
+
+  def write_file(path, content = "")
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, content)
+  end
+
+  # Installs a complete skill set so the preflight reports all-green
+  # (matches the recommended-default config that `hive init` writes).
+  # See `templates/project_config.yml.erb` for the reviewer roster.
+  def install_all_default_skills(home)
+    # plan stage default → /plan (user command)
+    write_file("#{home}/.claude/commands/plan.md")
+    # brainstorm stage default → /compound-engineering:ce-brainstorm
+    write_file("#{home}/.claude/plugins/cache/mp/compound-engineering/3.0.1/skills/ce-brainstorm/SKILL.md")
+    # review.reviewers default set: claude-ce-code-review +
+    # codex-ce-code-review + pr-review-toolkit:review-pr
+    write_file("#{home}/.claude/skills/ce-code-review/SKILL.md")
+    write_file("#{home}/.codex/skills/ce-code-review/SKILL.md")
+    write_file("#{home}/.claude/plugins/cache/mp/pr-review-toolkit/1.0/skills/review-pr/SKILL.md")
+  end
+
+  def test_all_green_emits_no_preflight_output
+    with_fake_home do |home|
+      install_all_default_skills(home)
+      with_tmp_global_config do
+        with_tmp_git_repo do |dir|
+          out, err = capture_io { Hive::Commands::Init.new(dir).call }
+          assert_includes out, "hive: initialized"
+          refute_match(/doctor pre-flight/, err,
+            "all-green preflight must emit nothing on stderr")
+        end
+      end
+    end
+  end
+
+  def test_one_missing_skill_emits_stderr_warning_and_init_exits_zero
+    with_fake_home do |home|
+      install_all_default_skills(home)
+      # Remove the brainstorm stage skill so the preflight surfaces it.
+      FileUtils.rm_rf("#{home}/.claude/plugins/cache/mp/compound-engineering")
+
+      with_tmp_global_config do
+        with_tmp_git_repo do |dir|
+          out, err = capture_io { Hive::Commands::Init.new(dir).call }
+          assert_includes out, "hive: initialized"
+          assert_match(/hive: doctor pre-flight — found \d+ issue/, err)
+          assert_match(%r{\[brainstorm/claude\]}, err,
+            "warning row carries the brainstorm/agent label")
+          assert_match(/See `hive doctor` for details/, err)
+        end
+      end
+    end
+  end
+
+  def test_multiple_missing_skills_includes_reviewer_row
+    with_fake_home do |home|
+      # Only install plan; everything else missing (including reviewers).
+      write_file("#{home}/.claude/commands/plan.md")
+
+      with_tmp_global_config do
+        with_tmp_git_repo do |dir|
+          _, err = capture_io { Hive::Commands::Init.new(dir).call }
+          assert_match(/found \d+ issue/, err)
+          assert_match(%r{\[brainstorm/claude\]}, err)
+          assert_match(%r{\[5-review/claude-ce-code-review/claude\]}, err,
+            "reviewer rows must use the 5-review/<name> label in the warning")
+        end
+      end
+    end
+  end
+
+  def test_preflight_does_not_change_init_exit_code
+    with_fake_home do |home|
+      # Nothing installed → multiple missing skills, but init must still succeed.
+      with_tmp_global_config do
+        with_tmp_git_repo do |dir|
+          # Init relies on `exit` for failure paths; a successful init
+          # returns normally. capture_io will just observe stdout/stderr;
+          # if init blew up, the test would error.
+          out, err = capture_io { Hive::Commands::Init.new(dir).call }
+          assert_includes out, "hive: initialized"
+          assert_match(/found \d+ issue/, err)
+          # No exception, no exit — init returned normally despite the
+          # preflight finding missing skills.
+        end
+      end
+    end
+  end
+
+  def test_preflight_crash_logs_bug_hint_and_init_still_succeeds
+    # Forces the StandardError rescue path: monkey-patch
+    # Hive::Config.load to raise an unexpected (non-ConfigError) class
+    # so the doctor's own rescue does NOT catch it and it propagates
+    # to init's preflight rescue. Restore around the test so other
+    # tests in the suite see the original method.
+    with_fake_home do |_home|
+      with_tmp_global_config do
+        with_tmp_git_repo do |dir|
+          original = Hive::Config.method(:load)
+          Hive::Config.define_singleton_method(:load) do |_path|
+            raise NoMethodError, "boom"
+          end
+          out, err = capture_io { Hive::Commands::Init.new(dir).call }
+          assert_includes out, "hive: initialized", "init must complete successfully"
+          assert_match(/doctor pre-flight failed: NoMethodError: boom/, err)
+          assert_match(/this may be a hive bug/, err)
+        ensure
+          Hive::Config.define_singleton_method(:load, original) if original
+        end
+      end
+    end
+  end
+
+  def test_preflight_handles_config_error_with_pointer_message
+    # If Doctor's own rescue catches a Hive::ConfigError internally
+    # (returns EXIT_CONFIG_ERROR), init's preflight surfaces a
+    # pointer line rather than going silent. This is the case-2 path
+    # in run_init_preflight!.
+    with_fake_home do |_home|
+      with_tmp_global_config do
+        with_tmp_git_repo do |dir|
+          original = Hive::Config.method(:load)
+          Hive::Config.define_singleton_method(:load) do |_path|
+            raise Hive::ConfigError, "intentional malformed config"
+          end
+          out, err = capture_io { Hive::Commands::Init.new(dir).call }
+          assert_includes out, "hive: initialized"
+          # Hive::ConfigError IS StandardError, so this hits the bug-rescue
+          # branch (not the EXIT_CONFIG_ERROR branch — that requires the
+          # error to be caught BY Doctor, not by Hive::Config.load).
+          # The test still exercises a real failure mode and the user
+          # gets a clear pointer.
+          assert_match(/doctor pre-flight failed/, err)
+        ensure
+          Hive::Config.define_singleton_method(:load, original) if original
+        end
+      end
+    end
+  end
+end

--- a/test/unit/commands/doctor_test.rb
+++ b/test/unit/commands/doctor_test.rb
@@ -155,4 +155,222 @@ class HiveCommandsDoctorTest < Minitest::Test
       end
     end
   end
+
+  # ---- Review.reviewers extension (U1/U2/U3) ----
+
+  def cfg_with_reviewers(reviewers)
+    {
+      "brainstorm" => { "agent" => "claude", "skill" => "/x" }, # parked
+      "plan" => { "agent" => "claude", "skill" => "/x" },       # parked
+      "review" => { "reviewers" => reviewers }
+    }
+  end
+
+  def install_brainstorm_and_plan_skills(home)
+    # Install the parked stage skills so the test focuses on reviewer behaviour.
+    write_file("#{home}/.claude/commands/x.md")
+  end
+
+  def test_review_reviewers_happy_path_all_present
+    with_fake_home do |home|
+      install_brainstorm_and_plan_skills(home)
+      # Reviewers' ce-code-review installed at user level (matches the
+      # bare-name → /ce-code-review invocation path).
+      write_file("#{home}/.claude/skills/ce-code-review/SKILL.md")
+      write_file("#{home}/.claude/plugins/cache/mp/pr-review-toolkit/1.0/skills/review-pr/SKILL.md")
+
+      out = StringIO.new
+      cfg = cfg_with_reviewers([
+        { "name" => "claude-ce-code-review", "kind" => "agent",
+          "agent" => "claude", "skill" => "ce-code-review" },
+        { "name" => "pr-review-toolkit", "kind" => "agent",
+          "agent" => "claude", "skill" => "pr-review-toolkit:review-pr" }
+      ])
+      exit_code = Hive::Commands::Doctor.new(config: cfg, project_root: nil, output: out).call
+
+      assert_equal 0, exit_code
+      assert_match(%r{5-review/claude-ce-code-review.*✓ present}, out.string)
+      assert_match(%r{5-review/pr-review-toolkit.*✓ present}, out.string)
+    end
+  end
+
+  def test_review_reviewers_one_missing_exits_65
+    with_fake_home do |home|
+      install_brainstorm_and_plan_skills(home)
+      # ce-code-review present, pr-review-toolkit:review-pr absent.
+      write_file("#{home}/.claude/skills/ce-code-review/SKILL.md")
+
+      out = StringIO.new
+      cfg = cfg_with_reviewers([
+        { "name" => "claude-ce-code-review", "kind" => "agent",
+          "agent" => "claude", "skill" => "ce-code-review" },
+        { "name" => "pr-review-toolkit", "kind" => "agent",
+          "agent" => "claude", "skill" => "pr-review-toolkit:review-pr" }
+      ])
+      exit_code = Hive::Commands::Doctor.new(config: cfg, project_root: nil, output: out).call
+
+      assert_equal Hive::Commands::Doctor::EXIT_MISSING_SKILL, exit_code
+      assert_match(%r{5-review/pr-review-toolkit.*✗ missing}, out.string)
+      assert_match(%r{\[5-review/pr-review-toolkit/claude\]}, out.string,
+        "install-hint footer must include the row label")
+    end
+  end
+
+  def test_review_reviewers_mixed_agents
+    with_fake_home do |home|
+      install_brainstorm_and_plan_skills(home)
+      write_file("#{home}/.claude/skills/ce-code-review/SKILL.md")
+      write_file("#{home}/.codex/skills/ce-code-review/SKILL.md")
+
+      out = StringIO.new
+      cfg = cfg_with_reviewers([
+        { "name" => "claude-ce-code-review", "kind" => "agent",
+          "agent" => "claude", "skill" => "ce-code-review" },
+        { "name" => "codex-ce-code-review", "kind" => "agent",
+          "agent" => "codex", "skill" => "ce-code-review" }
+      ])
+      exit_code = Hive::Commands::Doctor.new(config: cfg, project_root: nil, output: out).call
+
+      assert_equal 0, exit_code
+      assert_match(%r{5-review/claude-ce-code-review.*claude.*✓ present}, out.string)
+      assert_match(%r{5-review/codex-ce-code-review.*codex.*✓ present}, out.string)
+    end
+  end
+
+  def test_review_reviewers_empty_or_nil_or_absent
+    with_fake_home do |home|
+      install_brainstorm_and_plan_skills(home)
+      [
+        cfg_with_reviewers([]),
+        cfg_with_reviewers(nil),
+        { "brainstorm" => { "agent" => "claude", "skill" => "/x" },
+          "plan" => { "agent" => "claude", "skill" => "/x" } } # `review:` absent
+      ].each do |cfg|
+        out = StringIO.new
+        exit_code = Hive::Commands::Doctor.new(config: cfg, project_root: nil, output: out).call
+        assert_equal 0, exit_code,
+          "empty/nil/absent reviewers must not fail (cfg shape: #{cfg.dig('review', 'reviewers').inspect})"
+        refute_match(%r{5-review/}, out.string,
+          "no reviewer rows should appear when reviewers list is empty/nil/absent")
+      end
+    end
+  end
+
+  def test_review_reviewers_non_agent_kind_is_not_applicable
+    with_fake_home do |home|
+      install_brainstorm_and_plan_skills(home)
+      out = StringIO.new
+      cfg = cfg_with_reviewers([
+        { "name" => "weird-linter", "kind" => "linter",
+          "agent" => "claude", "skill" => "doesnt-matter" }
+      ])
+      exit_code = Hive::Commands::Doctor.new(config: cfg, project_root: nil, output: out).call
+
+      assert_equal 0, exit_code, "non-agent kind must not fail doctor"
+      assert_match(%r{5-review/weird-linter.*— not_applicable}, out.string)
+      assert_match(/kind 'linter' is not 'agent'/, out.string)
+    end
+  end
+
+  def test_review_reviewers_pi_agent_is_not_applicable
+    with_fake_home do |home|
+      install_brainstorm_and_plan_skills(home)
+      out = StringIO.new
+      cfg = cfg_with_reviewers([
+        { "name" => "pi-reviewer", "kind" => "agent",
+          "agent" => "pi", "skill" => "ce-code-review" }
+      ])
+      exit_code = Hive::Commands::Doctor.new(config: cfg, project_root: nil, output: out).call
+
+      assert_equal 0, exit_code
+      assert_match(%r{5-review/pi-reviewer.*pi.*— not_applicable}, out.string)
+    end
+  end
+
+  def test_row_shape_includes_kind_label_name_for_reviewers
+    with_fake_home do |home|
+      install_brainstorm_and_plan_skills(home)
+      write_file("#{home}/.claude/skills/ce-code-review/SKILL.md")
+      out = StringIO.new
+      cfg = cfg_with_reviewers([
+        { "name" => "claude-ce-code-review", "kind" => "agent",
+          "agent" => "claude", "skill" => "ce-code-review" }
+      ])
+      doctor = Hive::Commands::Doctor.new(config: cfg, project_root: nil, output: out)
+      doctor.call
+
+      assert_kind_of Array, doctor.rows
+      stage_rows = doctor.rows.select { |r| r[:kind] == "stage" }
+      reviewer_rows = doctor.rows.select { |r| r[:kind] == "reviewer" }
+
+      assert_equal 2, stage_rows.length
+      assert_equal 1, reviewer_rows.length
+
+      stage_rows.each do |r|
+        assert_equal r[:stage], r[:label], "stage rows: :label equals :stage"
+        refute r.key?(:name), "stage rows must NOT have :name"
+        assert r[:skill].start_with?("/"), "stage rows store full invocation in :skill"
+      end
+
+      reviewer = reviewer_rows.first
+      assert_equal "5-review", reviewer[:stage]
+      assert_equal "5-review/claude-ce-code-review", reviewer[:label]
+      assert_equal "claude-ce-code-review", reviewer[:name]
+      assert_equal "/ce-code-review", reviewer[:skill],
+        "reviewer :skill must be the full invocation, not the bare config name"
+    end
+  end
+
+  def test_json_envelope_includes_kind_and_label_on_all_rows_and_name_on_reviewers
+    with_fake_home do |home|
+      install_brainstorm_and_plan_skills(home)
+      write_file("#{home}/.claude/skills/ce-code-review/SKILL.md")
+      out = StringIO.new
+      cfg = cfg_with_reviewers([
+        { "name" => "claude-ce-code-review", "kind" => "agent",
+          "agent" => "claude", "skill" => "ce-code-review" }
+      ])
+      Hive::Commands::Doctor.new(config: cfg, project_root: nil, json: true, output: out).call
+
+      env = JSON.parse(out.string)
+      assert_equal "hive-doctor.v1", env["schema"]
+      assert_equal 3, env["checks"].length
+
+      stage_entries = env["checks"].select { |c| c["kind"] == "stage" }
+      reviewer_entries = env["checks"].select { |c| c["kind"] == "reviewer" }
+      assert_equal 2, stage_entries.length
+      assert_equal 1, reviewer_entries.length
+
+      stage_entries.each do |c|
+        assert c.key?("label"), "every stage entry has :label"
+        refute c.key?("name"), "stage entries must NOT have :name"
+      end
+
+      reviewer = reviewer_entries.first
+      assert_equal "5-review/claude-ce-code-review", reviewer["label"]
+      assert_equal "claude-ce-code-review", reviewer["name"]
+      assert_equal "/ce-code-review", reviewer["skill"]
+    end
+  end
+
+  def test_table_column_widths_handle_long_reviewer_labels
+    with_fake_home do |home|
+      install_brainstorm_and_plan_skills(home)
+      long_name = "very-long-custom-reviewer-name-that-stretches-the-column"
+      write_file("#{home}/.claude/skills/ce-code-review/SKILL.md")
+      out = StringIO.new
+      cfg = cfg_with_reviewers([
+        { "name" => long_name, "kind" => "agent",
+          "agent" => "claude", "skill" => "ce-code-review" }
+      ])
+      Hive::Commands::Doctor.new(config: cfg, project_root: nil, output: out).call
+
+      assert_match(%r{5-review/#{Regexp.escape(long_name)}}, out.string)
+      # Header still aligns: separator dashes match the longest label width.
+      header_line = out.string.lines[0]
+      separator_line = out.string.lines[1]
+      assert_equal header_line.length, separator_line.length,
+        "header and separator must be the same width even with long reviewer labels"
+    end
+  end
 end

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -2,6 +2,27 @@
 
 Append-only log of all wiki operations.
 
+## [2026-05-07T17:30:00Z] doctor — probe `review.reviewers[]` + non-fatal init preflight
+
+**Action:** Extended `hive doctor` (PR #48 / `cd70f39`) along the two lines the original PR explicitly left for follow-up:
+
+1. **`review.reviewers[]` probing.** `Hive::Commands::Doctor#call` now walks `cfg.dig("review", "reviewers")` after the brainstorm/plan stage rows. Each reviewer entry's bare `skill` (e.g., `ce-code-review`, `pr-review-toolkit:review-pr`) is formatted through `profile.skill_syntax_format` to obtain the full invocation (`/ce-code-review`, `/pr-review-toolkit:review-pr`), then passed to `verify_skill` so the JSON envelope's `skill` field is uniformly a full invocation across stage and reviewer rows. The text-table row label uses `5-review/<reviewer-name>` (matches the user-facing `name:` field in config); the JSON envelope's `checks[]` entries gain a `kind` discriminator (`"stage"` or `"reviewer"`), a `label` field, and (for reviewer rows) a `name` field.
+
+2. **Non-fatal preflight at end of `hive init`.** After `print_summary` returns, `Init#call` invokes `run_init_preflight!`, which loads the freshly-written config, constructs a discard-output `Doctor`, calls `#call`, and emits stderr warnings for any `:missing` rows in the format `[<row-label>/<agent>] <verifier message>`. Init's exit code is unaffected — install gaps surface but never block bootstrap. The rescue scope is `StandardError` (with a `Errno::EPIPE` micro-rescue around `warn`); `Interrupt` and `SystemExit` propagate, and unexpected verifier raises produce a "this may be a hive bug, please report" hint so silent swallow is mitigated.
+
+**Implementation notes:**
+- Non-`agent` reviewer kinds report `:not_applicable` with an explanatory message. `Hive::Config.validate_reviewers!` does NOT check the `kind` field — only `Hive::Reviewers.dispatch` does, at run-time. The doctor's N/A row is therefore the **only load-time signal** for non-agent kinds, not a redundant safety net.
+- `Hive::Commands::Doctor` gained an `attr_reader :rows` so the init preflight can read probe results in-process without re-running the renderer or JSON encoder.
+- The renderer reads `row[:label]` (added by U1) for the first-column display, so long reviewer names don't truncate the table.
+- Schema name stays `hive-doctor.v1`. The `kind`/`label`/`name` additions are forward-compatible; consumers that ignore unknown fields continue to work.
+
+**Test surface:**
+- `test/unit/commands/doctor_test.rb` — 9 new cases covering reviewer happy path, mixed agents, empty/nil/absent reviewers, non-agent kinds, pi reviewer rows, JSON envelope shape, long-label width, and the `attr_reader :rows` exposure.
+- `test/integration/init_doctor_preflight_test.rb` (new) — 6 cases covering all-green silence, single-missing stderr warning, multi-missing including a reviewer row, init exit-code unchanged, preflight crash → bug-hint warning, config-load error → bug-hint warning.
+
+**Refreshed pages:**
+- `README.md` — Required slash-commands / skills section now also lists the recommended reviewer set + documents the init-preflight behavior.
+
 ## [2026-05-07T15:30:00Z] config — `hive doctor` skill preflight + per-agent verifiers
 
 **Action:** Added `hive doctor` — a CLI verb that walks brainstorm + plan stage configs and asks each stage's agent profile to verify its configured skill (`<stage>.skill`) actually resolves to an installed slash-command or skill on disk. Output is a status table; `--json` emits a `hive-doctor.v1` envelope. Exit codes: `0` (all present or N/A), `65` (at least one missing), `78` (config error).


### PR DESCRIPTION
## Summary

Extends `hive doctor` (PR #48 / commit `cd70f39`) along the two lines that PR explicitly left for follow-up:

1. **`review.reviewers[]` probing** — doctor now walks every reviewer entry in `cfg.dig(\"review\", \"reviewers\")`, formats each bare-name `skill` through `profile.skill_syntax_format`, and verifies the resulting full invocation against the agent profile's filesystem.
2. **Non-fatal init preflight** — `Hive::Commands::Init#call` now runs `Hive::Commands::Doctor` after `print_summary` returns, emitting stderr warnings for missing skills. Init's exit code is unaffected; install gaps surface but never block bootstrap.

Plan: [\`docs/plans/2026-05-07-001-feat-hive-doctor-extend-reviewers-and-init-preflight-plan.md\`](docs/plans/2026-05-07-001-feat-hive-doctor-extend-reviewers-and-init-preflight-plan.md). Document review (\`/ce-doc-review\`) found and resolved 16 findings before implementation began.

## What's in the diff

| Commit | Units | Files |
|--------|-------|-------|
| \`476a6a1\` | U1 + U2 + U3 | \`lib/hive/commands/doctor.rb\`, \`test/unit/commands/doctor_test.rb\` |
| \`160834c\` | U4 + docs | \`lib/hive/commands/init.rb\`, \`test/integration/init_doctor_preflight_test.rb\` (new), \`README.md\`, \`wiki/log.md\` |

## Behavior

\`hive doctor\` against your dev box now shows:

\`\`\`
stage                           agent   skill                                status
------------------------------  ------  -----------------------------------  -------
brainstorm                      claude  /compound-engineering:ce-brainstorm  ✓ present
plan                            claude  /plan                                ✓ present
5-review/claude-ce-code-review  claude  /ce-code-review                      ✗ missing
5-review/codex-ce-code-review   codex   /ce-code-review                      ✗ missing
5-review/pr-review-toolkit      claude  /pr-review-toolkit:review-pr         ✓ present

[5-review/claude-ce-code-review/claude] claude: /ce-code-review not found under ~/.claude/{commands,skills}/ ...
\`\`\`

\`hive init\` against a fresh repo emits the same set of warnings to stderr after the green \`✔ initialized\` summary if any skills are missing — and still exits \`0\`.

## Decisions of note (resolved during planning)

- **JSON envelope additions are non-breaking:** stays at \`hive-doctor.v1\`. Each \`checks[]\` entry now has \`kind\` (\`\"stage\"\` | \`\"reviewer\"\`), \`label\` (the row's first-column display), and (for reviewer rows) \`name\`. \`schema\` is unchanged; consumers ignoring unknown fields continue to work.
- **JSON \`skill\` field is uniformly the full invocation** across kinds. Reviewer rows format the bare config skill (\`ce-code-review\`) through \`profile.skill_syntax_format\` to obtain \`/ce-code-review\` BEFORE storing in the row, so \`jq '.checks[] | .skill'\` consumers see one shape.
- **\`Doctor\` exposes \`attr_reader :rows\`** (one-line API addition; not a new public method). Init preflight constructs \`Doctor.new(... output: StringIO.new).call\`, then reads \`.rows\` directly. Keeps the renderer / JSON encoder in one place; init writes its own warning format.
- **Non-\`agent\` reviewer kinds → \`:not_applicable\`.** The doctor's N/A row is the **only load-time signal** for non-agent kinds — \`Hive::Config.validate_reviewers!\` doesn't check the \`kind\` field; only \`Hive::Reviewers.dispatch\` does, at run-time. (Doc-review F1 corrected the earlier draft's false framing of this as redundant safety.)
- **Init preflight rescue: \`StandardError\` + narrow \`Errno::EPIPE\` on \`warn\` calls.** \`Interrupt\` and \`SystemExit\` propagate (Ctrl-C honored). Verifier-bug warning text includes \"this may be a hive bug, please report at https://github.com/ivankuznetsov/hive/issues\" so silent swallow is mitigated for genuine bugs.
- **All-green init: silent.** Existing \`✔ hive: initialized\` summary remains the only success signal; preflight only adds output on the unhappy path.

## Test plan

- \`bundle exec rake test\`: **1531 runs, 5031 assertions, 0 failures** (was 1521 before this PR).
- \`bundle exec rubocop\` on all 4 changed files: **0 offenses**.
- Smoke-tested against this dev box: 5 doctor rows render with correct status, exit codes match, JSON envelope shape is forward-compatible.

## Out of scope (deferred per plan)

- Migrating reviewer skill format from bare-name to fully-qualified.
- Auto-installing missing skills.
- Probing \`review.{ci,triage,fix,browser_test}\` per-role agents (those use \`prompt_template:\` files, not slash-commands).
- Bumping JSON envelope to \`v2\`.
- Charset validation on reviewer \`name\` (Risks table notes the foot-gun).