### PR TITLE
fix(doctor): claude/codex bare-name verifiers fall back to plugin caches

### DIFF
--- a/lib/hive/skill_check.rb
+++ b/lib/hive/skill_check.rb
@@ -66,6 +66,20 @@ module Hive
       #     2. <project>/.claude/skills/<name>/SKILL.md    (project skill)
       #     3. ~/.claude/commands/<name>.md                (user slash command)
       #     4. ~/.claude/skills/<name>/SKILL.md            (user skill)
+      #     5. ~/.claude/plugins/cache/*/*/*/skills/<name>/SKILL.md
+      #     6. ~/.claude/plugins/cache/*/*/*/commands/<name>.md
+      #     7. ~/.claude/plugins/marketplaces/*/plugins/*/skills/<name>/SKILL.md
+      #     8. ~/.claude/plugins/marketplaces/*/plugins/*/commands/<name>.md
+      #
+      # Steps 5–8 are the plugin-fallback paths: claude resolves a bare
+      # `/foo` invocation against any installed plugin's skill named
+      # `foo` (in addition to user-level commands/skills). A user who
+      # ran `claude plugin install some-marketplace` to bring in
+      # `compound-engineering` and then writes `skill: ce-code-review`
+      # in their hive config expects `/ce-code-review` to resolve
+      # against the plugin's skill, even though the bare invocation
+      # has no explicit `<plugin>:` prefix. The fallback matches that
+      # runtime behaviour.
       def verify(invocation, project_root: nil)
         inv = Hive::SkillCheck.parse(invocation)
         home = ENV["HOME"] || Dir.home
@@ -95,6 +109,13 @@ module Hive
           end
           paths << File.join(home, ".claude/commands/#{inv.name}.md")
           paths << File.join(home, ".claude/skills/#{inv.name}/SKILL.md")
+          # Plugin-fallback for bare invocations: claude's runtime
+          # resolves `/foo` against any installed plugin's skill named
+          # `foo` (in addition to user-level commands/skills).
+          paths.concat(Dir[File.join(home, ".claude/plugins/cache/*/*/*/skills/#{inv.name}/SKILL.md")])
+          paths.concat(Dir[File.join(home, ".claude/plugins/cache/*/*/*/commands/#{inv.name}.md")])
+          paths.concat(Dir[File.join(home, ".claude/plugins/marketplaces/*/plugins/*/skills/#{inv.name}/SKILL.md")])
+          paths.concat(Dir[File.join(home, ".claude/plugins/marketplaces/*/plugins/*/commands/#{inv.name}.md")])
           paths
         end
       end
@@ -107,10 +128,12 @@ module Hive
             "Install via `claude plugin install <marketplace>` for the marketplace " \
             "that ships #{inv.plugin}."
         else
-          "claude: /#{inv.name} not found under ~/.claude/{commands,skills}/ " \
-            "(or <project>/.claude/...). Install as a user-level slash command " \
-            "(write ~/.claude/commands/#{inv.name}.md) or as a skill " \
-            "(write ~/.claude/skills/#{inv.name}/SKILL.md)."
+          "claude: /#{inv.name} not found under ~/.claude/{commands,skills}/, any " \
+            "installed plugin's skills/<name>/ or commands/<name>.md, or " \
+            "<project>/.claude/.... Install as a user-level slash command " \
+            "(write ~/.claude/commands/#{inv.name}.md), as a user skill " \
+            "(write ~/.claude/skills/#{inv.name}/SKILL.md), or via " \
+            "`claude plugin install <marketplace>` for a plugin that ships #{inv.name}."
         end
       end
     end
@@ -125,6 +148,7 @@ module Hive
       #   /<name>
       #     1. ~/.codex/skills/<name>/SKILL.md
       #     2. ~/.codex/skills/.system/<name>/SKILL.md
+      #     3. ~/.codex/plugins/cache/*/*/*/skills/<name>/SKILL.md (plugin fallback)
       def verify(invocation, project_root: nil)
         inv = Hive::SkillCheck.parse(invocation)
         home = ENV["HOME"] || Dir.home
@@ -150,6 +174,10 @@ module Hive
           end
           paths << File.join(home, ".codex/skills/#{inv.name}/SKILL.md")
           paths << File.join(home, ".codex/skills/.system/#{inv.name}/SKILL.md")
+          # Plugin fallback: codex resolves `/foo` against any installed
+          # plugin's skill named `foo` in addition to user-level
+          # ~/.codex/skills/. Mirrors claude's behaviour.
+          paths.concat(Dir[File.join(home, ".codex/plugins/cache/*/*/*/skills/#{inv.name}/SKILL.md")])
           paths
         end
       end
@@ -161,10 +189,11 @@ module Hive
             "Install via `codex plugin install <marketplace>` for the marketplace " \
             "that ships #{inv.plugin}."
         else
-          "codex: /#{inv.name} not found under ~/.codex/skills/ or skills/.system/. " \
-            "Codex has no user-level slash-command directory; either install a " \
-            "skill named #{inv.name.inspect} or override the stage's skill in " \
-            "config.yml (e.g. `plan.skill: /compound-engineering:ce-plan`)."
+          "codex: /#{inv.name} not found under ~/.codex/skills/, ~/.codex/skills/.system/, " \
+            "or any installed plugin's skills/<name>/SKILL.md. Codex has no user-level " \
+            "slash-command directory; either install a skill named #{inv.name.inspect}, " \
+            "install a plugin that ships it, or override the stage's skill in config.yml " \
+            "(e.g. `plan.skill: /compound-engineering:ce-plan`)."
         end
       end
     end

--- a/test/unit/skill_check_test.rb
+++ b/test/unit/skill_check_test.rb
@@ -105,6 +105,42 @@ class HiveSkillCheckClaudeTest < Minitest::Test
       status, msg = Hive::SkillCheck::Claude.verify("/nonexistent-skill")
       assert_equal :missing, status
       assert_match(/not found under ~\/\.claude\/\{commands,skills\}/, msg)
+      assert_match(/installed plugin/, msg, "hint mentions plugin fallback path")
+    end
+  end
+
+  def test_present_via_plugin_cache_for_bare_invocation
+    # Claude resolves `/foo` against any installed plugin's skill
+    # named `foo` (in addition to user-level commands/skills). A user
+    # who ran `claude plugin install some-marketplace` to bring in
+    # `compound-engineering` and writes `skill: ce-code-review` in
+    # config expects `/ce-code-review` to resolve against the plugin
+    # — even though there's no explicit `<plugin>:` prefix.
+    with_fake_home do |home|
+      write_file("#{home}/.claude/plugins/cache/every-marketplace/compound-engineering/3.0.1/skills/ce-code-review/SKILL.md")
+      status, msg = Hive::SkillCheck::Claude.verify("/ce-code-review")
+      assert_equal :present, status
+      assert_match(%r{cache/every-marketplace/compound-engineering/3\.0\.1/skills/ce-code-review/SKILL.md\z}, msg)
+    end
+  end
+
+  def test_present_via_plugin_marketplace_source_for_bare_invocation
+    with_fake_home do |home|
+      write_file("#{home}/.claude/plugins/marketplaces/some-mp/plugins/compound-engineering/skills/ce-code-review/SKILL.md")
+      status, msg = Hive::SkillCheck::Claude.verify("/ce-code-review")
+      assert_equal :present, status
+      assert_match(%r{plugins/compound-engineering/skills/ce-code-review/SKILL.md\z}, msg)
+    end
+  end
+
+  def test_user_level_command_takes_precedence_over_plugin_fallback
+    with_fake_home do |home|
+      write_file("#{home}/.claude/commands/ce-code-review.md", "user")
+      write_file("#{home}/.claude/plugins/cache/mp/foo/1.0/skills/ce-code-review/SKILL.md", "plugin")
+      status, msg = Hive::SkillCheck::Claude.verify("/ce-code-review")
+      assert_equal :present, status
+      assert_match(%r{commands/ce-code-review\.md\z}, msg,
+        "user-level command must beat the plugin-fallback path")
     end
   end
 
@@ -175,6 +211,16 @@ class HiveSkillCheckCodexTest < Minitest::Test
       status, msg = Hive::SkillCheck::Codex.verify("/no-such-skill")
       assert_equal :missing, status
       assert_match(/no user-level slash-command directory/, msg)
+      assert_match(/install a plugin that ships it/, msg, "hint mentions plugin fallback path")
+    end
+  end
+
+  def test_codex_present_via_plugin_cache_for_bare_invocation
+    with_fake_home do |home|
+      write_file("#{home}/.codex/plugins/cache/some-mp/compound-engineering/3.7.0/skills/ce-code-review/SKILL.md")
+      status, msg = Hive::SkillCheck::Codex.verify("/ce-code-review")
+      assert_equal :present, status
+      assert_match(%r{compound-engineering/3\.7\.0/skills/ce-code-review/SKILL.md\z}, msg)
     end
   end
 


### PR DESCRIPTION
## Summary

`Hive::SkillCheck::Claude.verify(\"/foo\")` and `Hive::SkillCheck::Codex.verify(\"/foo\")` previously checked only user-level commands/skills paths. A user who ran `claude plugin install some-marketplace` to bring in `compound-engineering` and writes `skill: ce-code-review` in hive's `review.reviewers` config expects `/ce-code-review` to resolve against the plugin's skill at runtime — even though the bare invocation has no explicit `<plugin>:` prefix. Claude's slash-command resolver does exactly that, so the doctor's strict check produced a **false-positive `:missing`** on a real installed-and-working setup.

This was reported on PR #51's smoke-test against the dev box: \`/ce-code-review\` reported missing even though \`claude plugin install\` had installed it via \`compound-engineering\`. Reproducible by running \`hive doctor\` against any project whose review.reviewers config uses bare-name skills shipped via a plugin (the recommended-default config that \`hive init\` writes).

## Search-order extension for bare `/<name>` invocations

| Agent | Existing paths | New fallback paths |
|-------|----------------|--------------------|
| **claude** | `<project>/.claude/{commands,skills}/...`, `~/.claude/{commands,skills}/...` | `~/.claude/plugins/cache/*/*/*/{skills/<name>/SKILL.md, commands/<name>.md}` AND `~/.claude/plugins/marketplaces/*/plugins/*/{skills/<name>/SKILL.md, commands/<name>.md}` |
| **codex** | `<project>/.codex/skills/...`, `~/.codex/skills/...`, `~/.codex/skills/.system/...` | `~/.codex/plugins/cache/*/*/*/skills/<name>/SKILL.md` |

User-level paths still take precedence over plugin fallback — an explicit user-level shadow keeps working (verified by `test_user_level_command_takes_precedence_over_plugin_fallback`).

## Install-hint copy update

- **claude** bare miss: \"…or via `claude plugin install <marketplace>` for a plugin that ships `<name>`.\"
- **codex** bare miss: \"…install a plugin that ships it…\"

## Tests (+4 cases, +12 assertions)

- Claude bare invocation resolves via plugin cache layout
- Claude bare invocation resolves via marketplace source layout
- Claude user-level command takes precedence over plugin fallback
- Codex bare invocation resolves via plugin cache

## Test plan

- [x] `bundle exec rake test`: 1535 runs, 5047 assertions, 0 failures (was 1531/5031 on the merged main).
- [x] `bundle exec rubocop` on `lib/hive/skill_check.rb` and `test/unit/skill_check_test.rb`: 0 offenses.
- [x] Smoke-tested against this dev box — `hive doctor` now reports all 5 rows as `✓ present` (was 2 missing for `/ce-code-review` against claude and codex agents).

## Out of scope

- Validating that a bare-named skill in the plugin cache is actually invocable at runtime (we trust claude's resolver did the work; the doctor checks file presence, not runtime resolution success).
- Disambiguating between multiple plugins that ship a skill with the same name. The verifier returns the first match; if a user has two plugins each with a `/foo` skill, claude's runtime decides which wins, and hive isn't in that loop.