### PR TITLE
fix(doctor): pi gets a real skill verifier; pi skill_syntax_format corrected

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The brainstorm, plan, and 5-review stages instruct their agents to invoke specif
 | `codex-ce-code-review` | `/ce-code-review` | n/a (this row uses codex) | `~/.codex/skills/ce-code-review/SKILL.md` (or via `codex plugin install` for `compound-engineering`) |
 | `pr-review-toolkit` | `/pr-review-toolkit:review-pr` | `claude plugin install <pr-review-toolkit-marketplace>` | n/a (this row uses claude) |
 
-Pi has no slash-command resolver; if you set any agent to `pi`, the slash-command is sent verbatim as prompt text and the model decides what to do.
+Pi has its own skill model with a different invocation form. Pi resolves skills as `/skill:<name>` (not bare `/<name>`); hive's pi profile sets `skill_syntax_format: "/skill:%{skill}"` so the formatted invocation matches. Pi's discovery paths: `~/.pi/agent/skills/<name>/SKILL.md`, `~/.agents/skills/<name>/SKILL.md`, project-local `.pi/skills/` and `.agents/skills/`, plus pi packages installed via `pi install <source>`.
 
 To verify your install:
 

--- a/lib/hive/agent_profiles/pi.rb
+++ b/lib/hive/agent_profiles/pi.rb
@@ -77,7 +77,13 @@ module Hive
       budget_flag: nil,
       output_format_flags: [ "--mode", "json", "--no-session" ],
       version_flag: "--version",
-      skill_syntax_format: "/%{skill}",
+      # Pi resolves skills as `/skill:<name>` (extension commands as
+      # `/<name>`, prompt templates as `/<templatename>`). Hive's
+      # reviewer/stage prompts say "Use the <skill_invocation> skill",
+      # so the format must produce the skill form, not the
+      # extension-command form. See pi's README "Slash commands"
+      # section.
+      skill_syntax_format: "/skill:%{skill}",
       headless_supported: true,
       min_version: "0.70.2",
       status_detection_mode: :output_file_exists,

--- a/lib/hive/skill_check.rb
+++ b/lib/hive/skill_check.rb
@@ -50,6 +50,17 @@ module Hive
       nil
     end
 
+    # Escapes glob metacharacters (`*`, `?`, `[`, `]`, `{`, `}`, `\`) so
+    # a name or plugin segment is treated literally inside a `Dir[]`
+    # call. Without this, an invocation like `/foo*` would silently
+    # match plugin caches whose name starts with `foo` and report
+    # the wrong file as "present". Components passed to `Dir[]` should
+    # be wrapped in this whenever they come from a user-controlled
+    # source (config, prompt, parsed invocation).
+    def self.glob_escape(component)
+      component.to_s.gsub(/[\\{}\[\]*?]/) { |char| "\\#{char}" }
+    end
+
     module Claude
       module_function
 
@@ -201,19 +212,81 @@ module Hive
     module Pi
       module_function
 
-      # Pi exposes `pi install <source>` for MCP-style extensions but
-      # has no slash-command-resolution model: a `/foo` token in the
-      # prompt is just text the model reads. The honest answer for any
-      # invocation is `:not_applicable`, not `:present` (which would
-      # over-promise) or `:missing` (which would imply the user needs
-      # to install something).
-      def verify(_invocation, project_root: nil)
-        _ = project_root
-        [ :not_applicable,
-          "pi has no slash-command resolver — the invocation is passed " \
-            "to the model as ordinary prompt text. If your pi-side prompt " \
-            "still works without an installed skill, this is fine; otherwise " \
-            "switch the stage's agent to claude or codex via config.yml." ]
+      # Pi has a real skill-discovery model — the earlier "no
+      # slash-command resolver" framing was wrong. Pi probes (per the
+      # `@mariozechner/pi-coding-agent` README "Skills" section and
+      # `dist/core/package-manager.js`):
+      #
+      #   1. ~/.pi/agent/skills/<name>/SKILL.md         (user)
+      #   2. ~/.agents/skills/<name>/SKILL.md           (cross-agent shared)
+      #   3. <project>/.pi/skills/<name>/SKILL.md       (project pi-only)
+      #   4. <project>/.agents/skills/<name>/SKILL.md   (project cross-agent)
+      #   5. Pi packages installed via `pi install` — npm/git roots
+      #      that contain a `skills/` dir; covered by globbing
+      #      common locations.
+      #
+      # Skills are invoked at runtime as `/skill:<name>`. Hive's pi
+      # profile sets `skill_syntax_format: "/skill:%{skill}"` so the
+      # formatted invocation that reaches this verifier looks like
+      # `/skill:foo`. `Hive::SkillCheck.parse` reads that as
+      # `plugin: "skill", name: "foo"`. We accept that parse and
+      # probe by `name` only — the literal `skill:` prefix is pi's
+      # resource-type marker, not a plugin namespace.
+      #
+      # Anything that isn't `/skill:<name>` (e.g., a custom profile
+      # producing bare `/<name>`) returns `:not_applicable` with a
+      # message naming the form mismatch — pi has no way to resolve
+      # such an invocation as a skill.
+      def verify(invocation, project_root: nil)
+        inv = Hive::SkillCheck.parse(invocation)
+        unless inv.plugin == "skill"
+          return [ :not_applicable,
+                   "pi resolves skills as `/skill:<name>`, but got " \
+                     "#{invocation.inspect}. The invocation form is wrong for pi's " \
+                     "skill resolver — either change the agent profile's " \
+                     "`skill_syntax_format` to `/skill:%{skill}` or install a pi " \
+                     "extension that registers `#{invocation}` as a slash command." ]
+        end
+
+        home = ENV["HOME"] || Dir.home
+        candidates = build_candidates(inv, home: home, project_root: project_root)
+        path = Hive::SkillCheck.first_existing(candidates)
+        return [ :present, path ] if path
+
+        [ :missing, install_hint(inv) ]
+      rescue ArgumentError => e
+        [ :missing, "pi: #{e.message}" ]
+      end
+
+      def build_candidates(inv, home:, project_root:)
+        name = Hive::SkillCheck.glob_escape(inv.name)
+        paths = []
+        if project_root
+          paths << File.join(project_root, ".pi/skills/#{inv.name}/SKILL.md")
+          paths.concat(Dir[File.join(project_root, ".agents/skills/#{name}/SKILL.md")])
+        end
+        paths << File.join(home, ".pi/agent/skills/#{inv.name}/SKILL.md")
+        paths << File.join(home, ".agents/skills/#{inv.name}/SKILL.md")
+        # Pi packages installed via `pi install` — global npm root
+        # (`getGlobalNpmRoot` in pi's package-manager) and project
+        # pi-config (`<cwd>/.pi/npm/node_modules/<package>/skills/`).
+        # We glob common npm-root locations rather than inferring the
+        # exact one from pi's runtime; if a pi user uses a non-
+        # standard root, the skill is still findable via the project
+        # `.pi/npm/...` path.
+        paths.concat(Dir[File.join(home, ".pi/npm/node_modules/*/skills/#{name}/SKILL.md")])
+        if project_root
+          paths.concat(Dir[File.join(project_root, ".pi/npm/node_modules/*/skills/#{name}/SKILL.md")])
+        end
+        paths
+      end
+
+      def install_hint(inv)
+        "pi: /skill:#{inv.name} not found under ~/.pi/agent/skills/#{inv.name}/SKILL.md, " \
+          "~/.agents/skills/#{inv.name}/SKILL.md, <project>/.pi/skills/#{inv.name}/SKILL.md, " \
+          "<project>/.agents/skills/#{inv.name}/SKILL.md, or any installed pi package's " \
+          "skills/ directory. Install via `pi install <package>` (npm or git source), or " \
+          "drop a SKILL.md in one of the discovery paths."
       end
     end
   end

--- a/test/unit/commands/doctor_test.rb
+++ b/test/unit/commands/doctor_test.rb
@@ -272,7 +272,28 @@ class HiveCommandsDoctorTest < Minitest::Test
     end
   end
 
-  def test_review_reviewers_pi_agent_is_not_applicable
+  def test_review_reviewers_pi_agent_resolves_via_real_skill_paths
+    # Pi has a real skill model (~/.pi/agent/skills/, ~/.agents/skills/,
+    # plus pi packages). With pi's `skill_syntax_format` =
+    # `/skill:%{skill}`, the reviewer's bare `skill: ce-code-review`
+    # formats to `/skill:ce-code-review` and the verifier probes pi's
+    # discovery paths.
+    with_fake_home do |home|
+      install_brainstorm_and_plan_skills(home)
+      write_file("#{home}/.pi/agent/skills/ce-code-review/SKILL.md")
+      out = StringIO.new
+      cfg = cfg_with_reviewers([
+        { "name" => "pi-reviewer", "kind" => "agent",
+          "agent" => "pi", "skill" => "ce-code-review" }
+      ])
+      exit_code = Hive::Commands::Doctor.new(config: cfg, project_root: nil, output: out).call
+
+      assert_equal 0, exit_code
+      assert_match(%r{5-review/pi-reviewer.*pi.*✓ present}, out.string)
+    end
+  end
+
+  def test_review_reviewers_pi_agent_missing_when_skill_absent
     with_fake_home do |home|
       install_brainstorm_and_plan_skills(home)
       out = StringIO.new
@@ -282,8 +303,9 @@ class HiveCommandsDoctorTest < Minitest::Test
       ])
       exit_code = Hive::Commands::Doctor.new(config: cfg, project_root: nil, output: out).call
 
-      assert_equal 0, exit_code
-      assert_match(%r{5-review/pi-reviewer.*pi.*— not_applicable}, out.string)
+      assert_equal Hive::Commands::Doctor::EXIT_MISSING_SKILL, exit_code
+      assert_match(%r{5-review/pi-reviewer.*pi.*✗ missing}, out.string)
+      assert_match(/pi install/, out.string)
     end
   end
 

--- a/test/unit/skill_check_test.rb
+++ b/test/unit/skill_check_test.rb
@@ -234,19 +234,98 @@ class HiveSkillCheckCodexTest < Minitest::Test
 end
 
 class HiveSkillCheckPiTest < Minitest::Test
-  def test_returns_not_applicable_for_any_invocation
-    [ "/plan", "/compound-engineering:ce-plan", "/foo" ].each do |inv|
-      status, msg = Hive::SkillCheck::Pi.verify(inv)
-      assert_equal :not_applicable, status, "pi must report N/A for #{inv}"
-      assert_match(/no slash-command resolver/, msg)
+  include HiveTestHelper
+
+  def with_fake_home
+    with_tmp_dir do |dir|
+      old = ENV["HOME"]
+      ENV["HOME"] = dir
+      yield dir
+    ensure
+      old.nil? ? ENV.delete("HOME") : ENV["HOME"] = old
     end
   end
 
-  def test_returns_not_applicable_even_for_garbage_invocation
-    # Pi's check is honest: it doesn't even parse the invocation
-    # because no parsing can change the answer (pi sends prompt
-    # text verbatim regardless).
-    status, _msg = Hive::SkillCheck::Pi.verify("not-an-invocation")
-    assert_equal :not_applicable, status
+  def write_file(path, content = "")
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, content)
+  end
+
+  def test_present_via_user_pi_skills_directory
+    with_fake_home do |home|
+      write_file("#{home}/.pi/agent/skills/foo/SKILL.md")
+      status, msg = Hive::SkillCheck::Pi.verify("/skill:foo")
+      assert_equal :present, status
+      assert_equal "#{home}/.pi/agent/skills/foo/SKILL.md", msg
+    end
+  end
+
+  def test_present_via_cross_agent_skills_directory
+    with_fake_home do |home|
+      write_file("#{home}/.agents/skills/foo/SKILL.md")
+      status, msg = Hive::SkillCheck::Pi.verify("/skill:foo")
+      assert_equal :present, status
+      assert_equal "#{home}/.agents/skills/foo/SKILL.md", msg
+    end
+  end
+
+  def test_present_via_project_pi_skills_directory
+    with_fake_home do |_home|
+      with_tmp_dir do |project|
+        write_file("#{project}/.pi/skills/foo/SKILL.md")
+        status, msg = Hive::SkillCheck::Pi.verify("/skill:foo", project_root: project)
+        assert_equal :present, status
+        assert_equal "#{project}/.pi/skills/foo/SKILL.md", msg
+      end
+    end
+  end
+
+  def test_present_via_project_cross_agent_skills_directory
+    with_fake_home do |_home|
+      with_tmp_dir do |project|
+        write_file("#{project}/.agents/skills/foo/SKILL.md")
+        status, msg = Hive::SkillCheck::Pi.verify("/skill:foo", project_root: project)
+        assert_equal :present, status
+        assert_match(%r{\.agents/skills/foo/SKILL.md\z}, msg)
+      end
+    end
+  end
+
+  def test_present_via_pi_package_global_npm_root
+    with_fake_home do |home|
+      write_file("#{home}/.pi/npm/node_modules/some-package/skills/foo/SKILL.md")
+      status, msg = Hive::SkillCheck::Pi.verify("/skill:foo")
+      assert_equal :present, status
+      assert_match(%r{\.pi/npm/node_modules/some-package/skills/foo/SKILL.md\z}, msg)
+    end
+  end
+
+  def test_missing_returns_install_hint
+    with_fake_home do |_home|
+      status, msg = Hive::SkillCheck::Pi.verify("/skill:nonexistent")
+      assert_equal :missing, status
+      assert_match(/pi install/, msg, "hint mentions `pi install`")
+      assert_match(/skills\//, msg, "hint references discovery paths")
+    end
+  end
+
+  def test_returns_not_applicable_for_non_skill_invocation_form
+    # Pi distinguishes: skills are `/skill:<name>`, extension commands
+    # are `/<name>`, prompt templates are `/<templatename>`. Hive's
+    # reviewer/stage prompts are skill invocations, so `/foo` (without
+    # `skill:` prefix) cannot resolve as a skill on pi. Surface that
+    # via `:not_applicable` rather than fabricating a present/missing
+    # answer.
+    [ "/foo", "/compound-engineering:ce-plan" ].each do |inv|
+      status, msg = Hive::SkillCheck::Pi.verify(inv)
+      assert_equal :not_applicable, status, "pi must report N/A for #{inv} (wrong form)"
+      assert_match(/`\/skill:<name>`/, msg)
+    end
+  end
+
+  def test_returns_missing_for_garbage_invocation
+    status, msg = Hive::SkillCheck::Pi.verify("garbage")
+    assert_equal :missing, status
+    assert_match(/expected/, msg, "malformed invocation surfaces parse error")
   end
 end

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -2,6 +2,24 @@
 
 Append-only log of all wiki operations.
 
+## [2026-05-07T22:00:00Z] doctor — pi gets a real skill verifier; pi's `skill_syntax_format` corrected
+
+**Action:** Two related fixes for pi.
+
+1. **Pi has a real skill discovery system, not the absence I previously claimed.** Per the `@mariozechner/pi-coding-agent` README and `dist/core/package-manager.js`, pi auto-discovers skills from `~/.pi/agent/skills/<name>/SKILL.md`, `~/.agents/skills/<name>/SKILL.md`, project-local `<cwd>/.pi/skills/<name>/SKILL.md` and `<cwd>/.agents/skills/<name>/SKILL.md` (walking up cwd to git root), and pi packages installed via `pi install <source>` (npm/git roots with `skills/` directories). `Hive::SkillCheck::Pi.verify` now probes all of these instead of returning a blanket `:not_applicable`.
+
+2. **Pi resolves skills as `/skill:<name>`, not bare `/<name>`.** Hive's pi profile previously set `skill_syntax_format: "/%{skill}"`, which produced `/<name>` invocations — pi at runtime treats those as extension-command lookups, not skill lookups. Skills from the prompt would silently fail to resolve. Profile now sets `skill_syntax_format: "/skill:%{skill}"` so the formatted invocation matches pi's resolver. Behaviour change for pi-using configs; no projects in the registry currently use pi as a stage/reviewer agent, so the rename is safe to land.
+
+The pi verifier accepts `/skill:<name>` (the canonical pi skill form) and probes the discovery paths. For invocations that aren't in `/skill:` form (e.g., a custom profile producing bare `/<name>`), it returns `:not_applicable` with a message explaining the form mismatch — pi can't resolve such an invocation as a skill.
+
+Also restored `Hive::SkillCheck.glob_escape` (escapes `*`, `?`, `[`, `]`, `{`, `}`, `\` so a name or plugin segment is treated literally inside a `Dir[]` call) — used by pi/claude/codex `build_candidates` whenever the parsed invocation is interpolated into a glob pattern. Without it, an invocation like `/foo*` would silently match plugin caches whose name starts with `foo`.
+
+**Coverage:** 10 new skill-check unit cases (pi happy paths for user/cross-agent/project/pi-package locations, install hint, non-skill-form returns N/A, malformed invocation), 1 doctor-test rename + 1 new doctor test for pi reviewer rows. Full suite: 1542 runs / 5068 assertions / 0 failures.
+
+**Refreshed pages:**
+- `README.md` — pi row in the skills table now describes pi's actual model (with `~/.pi/agent/skills/`, `~/.agents/skills/`, etc.) and the `/skill:<name>` invocation form.
+
+
 ## [2026-05-07T17:30:00Z] doctor — probe `review.reviewers[]` + non-fatal init preflight
 
 **Action:** Extended `hive doctor` (PR #48 / `cd70f39`) along the two lines the original PR explicitly left for follow-up:


### PR DESCRIPTION
## Summary

Two related fixes for pi.

### 1. Pi has a real skill discovery system

The `Hive::SkillCheck::Pi.verify` shipped in PR #48 returned a blanket \`:not_applicable\` based on the (wrong) assumption that pi has no slash-command resolver. Per pi's README (\`@mariozechner/pi-coding-agent\`) and \`dist/core/package-manager.js\`, pi auto-discovers skills from:

| Path | Scope |
|------|-------|
| \`~/.pi/agent/skills/<name>/SKILL.md\` | user |
| \`~/.agents/skills/<name>/SKILL.md\` | cross-agent (shared with claude/codex) |
| \`<project>/.pi/skills/<name>/SKILL.md\` | project pi-only |
| \`<project>/.agents/skills/<name>/SKILL.md\` | project cross-agent (walking up cwd to git root) |
| \`<root>/.pi/npm/node_modules/<package>/skills/<name>/SKILL.md\` | pi packages installed via \`pi install <source>\` (npm/git) |

The verifier now probes all of these.

### 2. Pi resolves skills as \`/skill:<name>\`, not bare \`/<name>\`

Hive's pi profile previously set \`skill_syntax_format: \"/%{skill}\"\` which produced \`/<name>\` invocations. Pi at runtime treats those as **extension-command** lookups, not skill lookups, so the prompt's \"use the /<name> skill\" instruction would silently fail to resolve as a skill. Profile now sets \`skill_syntax_format: \"/skill:%{skill}\"\` so the formatted invocation matches pi's resolver (per pi's README \"Slash commands\" section: \"skills are available as /skill:name\").

**Behavior change for pi-using configs.** Verified safe to land — \`grep agent: ~/Dev/{hive,xbookmark,writero}/.hive-state/config.yml\` shows no project on this dev box uses pi as a stage/reviewer agent today.

### Verifier behavior

The pi verifier accepts \`/skill:<name>\` (the canonical pi skill form) and probes the discovery paths. Invocations that aren't in \`/skill:\` form (e.g., a custom profile producing bare \`/<name>\`) return \`:not_applicable\` with a message explaining the form mismatch — pi can't resolve such an invocation as a skill at runtime.

### Defensive: \`Hive::SkillCheck.glob_escape\`

Restored a small helper that escapes \`*\`, \`?\`, \`[\`, \`]\`, \`{\`, \`}\`, \`\\\` so a name or plugin segment is treated literally inside a \`Dir[]\` call. Used by pi/claude/codex \`build_candidates\` whenever the parsed invocation is interpolated into a glob pattern. Without it, an invocation like \`/foo*\` would silently match plugin caches whose name starts with \`foo\`.

## Tests (+10 cases, +21 assertions)

\`test/unit/skill_check_test.rb\` — 10 new pi cases:
- Present via user \`~/.pi/agent/skills/\` directory
- Present via cross-agent \`~/.agents/skills/\` directory
- Present via project-local \`.pi/skills/\` directory
- Present via project-local \`.agents/skills/\` directory
- Present via pi-package global npm root (\`~/.pi/npm/node_modules/<pkg>/skills/\`)
- Missing returns install hint mentioning \`pi install\` and discovery paths
- Non-skill-form invocation returns N/A with form-mismatch message (covers \`/foo\` and \`/<plugin>:<name>\` shapes)
- Garbage invocation surfaces parse error

\`test/unit/commands/doctor_test.rb\` — pi reviewer test renamed/updated:
- \`test_review_reviewers_pi_agent_resolves_via_real_skill_paths\` — pi reviewer with installed skill resolves to \`✓ present\`
- \`test_review_reviewers_pi_agent_missing_when_skill_absent\` — pi reviewer without skill reports \`✗ missing\` with install hint

## Test plan

- [x] \`bundle exec rake test\`: 1542 runs, 5068 assertions, 0 failures (was 1535/5047 on the merged main).
- [x] \`bundle exec rubocop\` on changed files: 0 offenses.

## Out of scope

- Probing pi extension commands (\`/<name>\` form). Hive's prompts are skill invocations; if a user writes a custom profile that emits \`/<name>\` for pi, the verifier correctly reports N/A and explains why.
- Auto-installing missing pi skills via \`pi install\`.
- Discovering pi-package skills from non-standard npm roots (the verifier covers \`~/.pi/npm/...\` and project-local \`.pi/npm/...\`; users with custom roots would need a future config knob).