### PR TITLE
test: close 2 coverage gaps surfaced by post-merge audit of PRs #64/#65/#66

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@
 /test/e2e/runs/*
 !/test/e2e/runs/.gitkeep
 /.hive-state/
+# Local daemon runtime artifacts.
+/.daemon.pid
+/daemon.pid
+/logs/

--- a/test/unit/reviewers/agent_test.rb
+++ b/test/unit/reviewers/agent_test.rb
@@ -580,4 +580,69 @@ class ReviewersAgentTest < Minitest::Test
       FileUtils.rm_rf(log_dir) if log_dir
     end
   end
+
+  # --- Plan-context flow through to spawned subprocess argv ---
+  #
+  # The render_prompt tests (above) verify the prompt STRING is built
+  # correctly. This test closes the integration gap: confirms the
+  # rendered string is actually piped through Agent.run!'s build_cmd
+  # (lib/hive/agent.rb:234 — prompt is the final argv arg) to the
+  # spawned reviewer subprocess. Without this, a refactor that
+  # accidentally dropped the binding from TemplateBindings would not
+  # be caught by the unit tests (which would still build a valid
+  # string in isolation).
+  def test_rendered_prompt_with_plan_context_reaches_spawned_subprocess
+    with_tmp_dir do |dir|
+      ctx = make_ctx(dir)
+      FileUtils.mkdir_p(ctx.task_folder)
+      plan_marker = "ZB7K_PLAN_MARKER_DETECTABLE_STRING"
+      File.write(
+        File.join(ctx.task_folder, "plan.md"),
+        "# Plan\n\n## Goals\n- G1. #{plan_marker} — must reach the reviewer prompt.\n"
+      )
+      reviewer = Hive::Reviewers::Agent.new(make_spec, ctx)
+
+      log_dir = Dir.mktmpdir("fake-claude-argv")
+      ENV["HIVE_FAKE_CLAUDE_LOG_DIR"] = log_dir
+      ENV["HIVE_FAKE_CLAUDE_WRITE_FILE"] = reviewer.output_path
+      ENV["HIVE_FAKE_CLAUDE_WRITE_CONTENT"] = "## High\n- [ ] f: j\n"
+
+      reviewer.run!
+
+      argv = File.read(File.join(log_dir, "fake-claude-argv.log"))
+      assert_includes argv, plan_marker,
+                      "plan.md content must flow through TemplateBindings → ERB → build_cmd → spawned subprocess argv"
+      assert_match(/<user_supplied_[a-f0-9]{16} content_type="plan_md">/, argv,
+                   "ADR-008/019 per-spawn nonce wrapper must reach the spawn — not just the unit-tested string")
+    ensure
+      FileUtils.rm_rf(log_dir) if log_dir
+    end
+  end
+
+  def test_rendered_prompt_without_plan_context_still_reaches_spawned_subprocess
+    # Counterpart: when plan.md is absent, the absent-note must reach
+    # the spawn too — confirms the fallback path isn't accidentally
+    # bypassed by an empty-string-coalesce somewhere in the pipeline.
+    with_tmp_dir do |dir|
+      ctx = make_ctx(dir)
+      FileUtils.mkdir_p(ctx.task_folder)
+      # Deliberately no plan.md.
+      reviewer = Hive::Reviewers::Agent.new(make_spec, ctx)
+
+      log_dir = Dir.mktmpdir("fake-claude-argv")
+      ENV["HIVE_FAKE_CLAUDE_LOG_DIR"] = log_dir
+      ENV["HIVE_FAKE_CLAUDE_WRITE_FILE"] = reviewer.output_path
+      ENV["HIVE_FAKE_CLAUDE_WRITE_CONTENT"] = "## High\n- [ ] f: j\n"
+
+      reviewer.run!
+
+      argv = File.read(File.join(log_dir, "fake-claude-argv.log"))
+      assert_includes argv, "no plan.md found",
+                      "absent-note fallback must also reach the spawned subprocess (not just the rendered string)"
+      refute_match(/<user_supplied_[a-f0-9]{16} content_type="plan_md">/, argv,
+                   "no wrapper tag in the spawn argv when plan.md is absent")
+    ensure
+      FileUtils.rm_rf(log_dir) if log_dir
+    end
+  end
 end

--- a/test/unit/tui/bubble_model_test.rb
+++ b/test/unit/tui/bubble_model_test.rb
@@ -2260,6 +2260,41 @@ class HiveTuiBubbleModelTest < Minitest::Test
     end
   end
 
+  def test_recover_review_stale_max_passes_picks_escalations_by_pass_attr_not_highest_nn_on_disk
+    # The resolver's contract is: open the focal file recorded in the
+    # marker's `pass=N` attr, NOT the highest-NN escalations file on
+    # disk. This matters for tasks that hit REVIEW_STALE at pass=2,
+    # got partially fixed (escalations-03.md, escalations-04.md
+    # leftover from an interrupted re-run), but the operator-visible
+    # marker still records pass=2. A future refactor that switched to
+    # `Dir.glob.max` would silently break this contract — the test
+    # locks it down.
+    with_tmp_dir do |dir|
+      FileUtils.mkdir_p(File.join(dir, "reviews"))
+      File.write(File.join(dir, "reviews", "escalations-01.md"), "## pass-1 findings\n")
+      File.write(File.join(dir, "reviews", "escalations-02.md"), "## pass-2 findings (the recorded pass)\n")
+      File.write(File.join(dir, "reviews", "escalations-03.md"), "## pass-3 findings\n")
+      File.write(File.join(dir, "reviews", "escalations-04.md"), "## pass-4 findings\n")
+
+      row = make_task_row(
+        action_key: "recover_review", slug: "stale-review", stage: "5-review",
+        folder: dir, marker: "review_stale", attrs: { "pass" => "2" }, suggested_command: nil
+      )
+      seen_path = nil
+      @model.define_singleton_method(:editor_argv) { [ "fake-editor" ] }
+      @model.define_singleton_method(:run_editor) do |_argv, path|
+        seen_path = path
+        0
+      end
+
+      _, cmd = @model.update(Hive::Tui::Messages::RecoverReview.new(row: row))
+      cmd.commands.find { |c| c.is_a?(Bubbletea::ExecCommand) }.callable.call
+
+      assert_equal File.join(dir, "reviews", "escalations-02.md"), seen_path,
+                   "resolver must select by attrs[\"pass\"], NOT by highest-NN escalations-*.md on disk"
+    end
+  end
+
   def test_recover_review_stale_max_passes_falls_back_to_reviews_dir
     # Defensive corner: marker claims REVIEW_STALE pass=4 but no
     # pass-4 files exist on disk at all (corrupted state). The


### PR DESCRIPTION
## Summary

Post-merge audit of today's three PRs (an Explore agent cross-checking production code against test files) surfaced 2 real coverage gaps. This PR closes them.

## Gaps closed

### Gap A — multi-escalations disambiguation (was PR #66)

`review_stale_editor_path` contract: select by \`attrs[\"pass\"]\`, NOT by highest-NN \`escalations-*.md\` on disk. Tests only ever created one escalations file at a time — a future refactor that switched to \`Dir.glob.max\` would have passed silently.

**New test:** \`test_recover_review_stale_max_passes_picks_escalations_by_pass_attr_not_highest_nn_on_disk\` — creates \`escalations-01\` through \`escalations-04\` with \`pass=2\` in attrs, asserts \`escalations-02.md\` is selected.

### Gap B — PlanContext stdin→spawn integration (was PR #65)

\`render_prompt\` unit tests verify the prompt **string** is built correctly. No test confirmed the rendered string actually flows through \`Agent.run!\` → \`build_cmd\` → spawned reviewer subprocess argv (prompt is the final argv arg per \`lib/hive/agent.rb:234\`). A refactor that accidentally dropped \`plan_context_section\` from \`TemplateBindings\` would still have passed the unit tests in isolation.

**New tests:** use the existing \`HIVE_FAKE_CLAUDE_LOG_DIR\` + \`fake-claude-argv.log\` harness (mirrors the existing \`test_argv_invokes_claude_with_expected_skill_in_prompt\` pattern):
- \`test_rendered_prompt_with_plan_context_reaches_spawned_subprocess\` — plan.md content reaches the spawn AND the per-spawn \`<user_supplied_<hex>>\` nonce wrapper is present in argv
- \`test_rendered_prompt_without_plan_context_still_reaches_spawned_subprocess\` — counterpart: absent-note fallback reaches the spawn when plan.md is missing

## Cleanup

Adds the daemon runtime artifacts (\`.daemon.pid\` / \`daemon.pid\` / \`logs/\`) to \`.gitignore\` so they stop showing up as \"2 uncommitted changes\" in every \`gh pr create\`.

## Test plan

- [x] \`bundle exec rake test TEST=test/unit/reviewers/agent_test.rb\` — 24 runs / 0 failures (+2 new integration tests)
- [x] \`bundle exec rake test TEST=test/unit/tui/bubble_model_test.rb\` — 173 runs / 0 failures (+1 new disambiguation test)
- [x] \`bundle exec rake test\` — full suite: 1806 runs / 6140 assertions / 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)