### PR TITLE
fix(daemon): count live agents toward dispatch caps

### DIFF
--- a/lib/hive/daemon/child_supervisor.rb
+++ b/lib/hive/daemon/child_supervisor.rb
@@ -2,6 +2,7 @@ require "fileutils"
 require "json"
 require "shellwords"
 require "time"
+require "tmpdir"
 
 module Hive
   module Daemon

--- a/lib/hive/daemon/concurrency_controller.rb
+++ b/lib/hive/daemon/concurrency_controller.rb
@@ -53,17 +53,27 @@ module Hive
       end
 
       # Predicate: can the daemon spawn a child for (project, slug) now?
+      #
+      # `external_*_count` is the dispatcher's per-tick snapshot of
+      # active agent rows already visible in `hive status --json` but not
+      # owned by this controller. That lets a daemon restart respect
+      # work already in flight while keeping waiting rows (`needs_input`,
+      # `review_findings`, recovery states, etc.) out of the cap.
       # Returns one of :ok | :global_cap | :project_cap | :daily_cap |
       #   :cooldown | :quarantined | :project_dropped
-      def can_dispatch?(project:, slug:, now: Time.now)
+      def can_dispatch?(project:, slug:, now: Time.now,
+                        external_global_count: 0, external_project_count: 0)
         return :project_dropped if @dropped_projects.include?(project)
         return :quarantined     if @quarantine.include?([ project, slug ])
 
         cooldown_expiry = @cooldown_until[[ project, slug ]]
         return :cooldown if cooldown_expiry && cooldown_expiry > now
 
-        return :global_cap  if @running.size >= @max_concurrent_runs
-        return :project_cap if running_count_for(project) >= @max_concurrent_per_project
+        active_global_count = @running.size + external_global_count
+        active_project_count = running_count_for(project) + external_project_count
+
+        return :global_cap  if active_global_count >= @max_concurrent_runs
+        return :project_cap if active_project_count >= @max_concurrent_per_project
         return :daily_cap   if daily_count_for(project, now) >= @max_runs_per_day_per_project
 
         :ok
@@ -171,6 +181,12 @@ module Hive
 
       def running_pids
         @running.keys
+      end
+
+      def running_task?(project:, slug:)
+        @running.any? do |_pid, entry|
+          entry[:project] == project && entry[:slug] == slug
+        end
       end
 
       def in_flight_count

--- a/lib/hive/daemon/dispatcher.rb
+++ b/lib/hive/daemon/dispatcher.rb
@@ -48,6 +48,7 @@ module Hive
         @started_at = nil
         @last_tick_at = nil
         @dispatched_today = 0
+        reset_active_agent_snapshot
         # Per-tick enable cache. Populated lazily within one tick so
         # each row-handler call does at most one `Config.load(project_root)`
         # per project, and cleared at the start of every tick so YAML
@@ -69,6 +70,7 @@ module Hive
         # lifetime and the only way to honour a disable was SIGHUP.
         @enabled_cache.clear
         @logger.event(:tick_begin, now: now.utc.iso8601)
+        reset_active_agent_snapshot
 
         # 1. Reap completed children, update controller, log decisions
         reap_completed(now: now)
@@ -83,6 +85,7 @@ module Hive
           @logger.event(:tick_end, now: Time.now.utc.iso8601, action: "status_failure")
           return
         end
+        refresh_active_agent_snapshot(result.rows)
 
         # 3. PrMergeWatcher tick (if present): check pending merges
         # first. Archive dispatches MUST flow through the same enable +
@@ -273,7 +276,11 @@ module Hive
       end
 
       def dispatch_or_block(row, now:)
-        gate = @controller.can_dispatch?(project: row.project, slug: row.slug, now: now)
+        gate = @controller.can_dispatch?(
+          project: row.project, slug: row.slug, now: now,
+          external_global_count: @external_active_agent_total,
+          external_project_count: external_active_agent_count_for(row.project)
+        )
         if gate == :ok
           dispatch_command(
             row.suggested_command,
@@ -306,7 +313,11 @@ module Hive
           return
         end
 
-        gate = @controller.can_dispatch?(project: project, slug: slug, now: now)
+        gate = @controller.can_dispatch?(
+          project: project, slug: slug, now: now,
+          external_global_count: @external_active_agent_total,
+          external_project_count: external_active_agent_count_for(project)
+        )
         if gate == :ok
           dispatch_command(
             archive_dispatch[:command],
@@ -369,6 +380,31 @@ module Hive
                                task_folder: row.folder)
         @logger.event(:merge_watcher_enqueued, project: row.project, slug: row.slug,
                                                folder: row.folder)
+      end
+
+      def reset_active_agent_snapshot
+        @external_active_agent_total = 0
+        @external_active_agent_counts = Hash.new(0)
+      end
+
+      def refresh_active_agent_snapshot(rows)
+        reset_active_agent_snapshot
+        rows.each do |row|
+          next unless active_agent_row?(row)
+          next if @controller.running_task?(project: row.project, slug: row.slug)
+
+          @external_active_agent_total += 1
+          @external_active_agent_counts[row.project] += 1
+        end
+      end
+
+      def active_agent_row?(row)
+        row.action == Hive::Schemas::TaskActionKind::AGENT_RUNNING &&
+          row.claude_pid_alive == true
+      end
+
+      def external_active_agent_count_for(project)
+        @external_active_agent_counts.fetch(project, 0)
       end
 
       def project_enabled?(project_name)

--- a/test/unit/daemon/child_supervisor_test.rb
+++ b/test/unit/daemon/child_supervisor_test.rb
@@ -1,4 +1,6 @@
 require "test_helper"
+require "open3"
+require "rbconfig"
 require "tmpdir"
 require "hive/daemon/child_supervisor"
 
@@ -74,6 +76,33 @@ class HiveDaemonChildSupervisorTest < Minitest::Test
       assert_equal 1, completed.size
       assert_equal 75, completed.first.exit_code
     end
+  end
+
+  def test_spawn_tmpdir_log_fallback_loads_its_own_dependency
+    script = <<~RUBY
+      require "hive/daemon/child_supervisor"
+
+      sup = Hive::Daemon::ChildSupervisor.new(hive_bin: #{FAKE_HIVE.inspect})
+      sup.spawn(
+        command_string: "hive run tmpdir-fallback --exit-code 0",
+        project: "p1",
+        slug: "tmpdir-fallback",
+        stage: "1-inbox"
+      )
+
+      deadline = Time.now + 5
+      completed = []
+      until Time.now > deadline || completed.any?
+        completed.concat(sup.reap_all)
+        sleep 0.05
+      end
+
+      abort "child did not complete" if completed.empty?
+      abort "exit=\#{completed.first.exit_code}" unless completed.first.exit_code == 0
+    RUBY
+
+    _out, err, status = Open3.capture3(RbConfig.ruby, "-Ilib", "-e", script)
+    assert status.success?, err
   end
 
   def test_spawn_two_children_reap_returns_both

--- a/test/unit/daemon/concurrency_controller_test.rb
+++ b/test/unit/daemon/concurrency_controller_test.rb
@@ -46,6 +46,25 @@ class HiveDaemonConcurrencyControllerTest < Minitest::Test
     assert_equal :ok, c.can_dispatch?(project: "p2", slug: "s1", now: T0)
   end
 
+  def test_external_active_agents_count_toward_global_cap
+    c = make(global: 1, per_project: 5)
+    assert_equal :global_cap,
+                 c.can_dispatch?(project: "p1", slug: "s1", now: T0,
+                                  external_global_count: 1)
+  end
+
+  def test_external_active_agents_count_toward_project_cap
+    c = make(global: 5, per_project: 1)
+    assert_equal :project_cap,
+                 c.can_dispatch?(project: "p1", slug: "s1", now: T0,
+                                  external_global_count: 1,
+                                  external_project_count: 1)
+    assert_equal :ok,
+                 c.can_dispatch?(project: "p2", slug: "s1", now: T0,
+                                  external_global_count: 1,
+                                  external_project_count: 0)
+  end
+
   def test_daily_cap_blocks_after_n_dispatches
     c = make(daily: 2)
     dispatch(c, 100, "p1", "s1")
@@ -255,6 +274,16 @@ class HiveDaemonConcurrencyControllerTest < Minitest::Test
     assert_equal 1, c.in_flight_count
     refute_includes c.running_pids, 100
     assert_includes c.running_pids, 101
+  end
+
+  def test_running_task_detects_tracked_project_slug
+    c = make(global: 5, per_project: 5)
+    refute c.running_task?(project: "p1", slug: "s1")
+
+    dispatch(c, 100, "p1", "s1")
+    assert c.running_task?(project: "p1", slug: "s1")
+    refute c.running_task?(project: "p1", slug: "s2")
+    refute c.running_task?(project: "p2", slug: "s1")
   end
 
   def test_completion_for_unknown_pid_is_a_no_op

--- a/test/unit/daemon/dispatcher_test.rb
+++ b/test/unit/daemon/dispatcher_test.rb
@@ -122,13 +122,13 @@ class HiveDaemonDispatcherTest < Minitest::Test
 
   def row(project: "p1", slug: "s1", stage: "1-inbox", marker: "waiting",
           action: "ready_to_brainstorm", command: "hive brainstorm s1",
-          mtime: T0 - 600)
+          mtime: T0 - 600, claude_pid_alive: nil)
     Row.new(
       project: project, slug: slug, stage: stage, marker: marker,
       folder: "/tmp/#{project}/#{stage}/#{slug}",
       state_file: "/tmp/#{project}/#{stage}/#{slug}/idea.md",
       state_file_mtime: mtime, action: action,
-      suggested_command: command, claude_pid_alive: nil
+      suggested_command: command, claude_pid_alive: claude_pid_alive
     )
   end
 
@@ -311,6 +311,63 @@ class HiveDaemonDispatcherTest < Minitest::Test
     blocked = logger.events.find { |(n, attrs)| n == :blocked && attrs[:slug] == "s3" }
     refute_nil blocked, "third dispatch must be :blocked when global cap = 2"
     assert_equal "global_cap", blocked[1][:reason]
+  end
+
+  def test_status_active_agent_row_counts_toward_project_cap
+    rows = [
+      row(slug: "running", stage: "5-review", marker: "review_working",
+          action: "agent_running", command: nil, claude_pid_alive: true),
+      row(slug: "ready", action: "ready_to_plan",
+          command: "hive plan ready --from 2-brainstorm")
+    ]
+    dispatcher, sup, _ctrl, logger, _mw = make_dispatcher(rows: rows)
+    dispatcher.controller.instance_variable_set(:@max_concurrent_per_project, 1)
+
+    dispatcher.tick(now: T0)
+
+    assert_equal 0, sup.spawned.size
+    blocked = logger.events.find { |(n, attrs)| n == :blocked && attrs[:slug] == "ready" }
+    refute_nil blocked, "ready row must block while an active agent is already running"
+    assert_equal "project_cap", blocked[1][:reason]
+  end
+
+  def test_needs_input_rows_do_not_count_toward_project_cap
+    rows = [
+      row(slug: "waiting", stage: "2-brainstorm", action: "needs_input",
+          command: "hive brainstorm waiting --from 2-brainstorm"),
+      row(slug: "ready", action: "ready_to_plan",
+          command: "hive plan ready --from 2-brainstorm")
+    ]
+    dispatcher, sup, _ctrl, logger, _mw = make_dispatcher(rows: rows)
+    dispatcher.controller.instance_variable_set(:@max_concurrent_per_project, 1)
+
+    dispatcher.tick(now: T0)
+
+    assert_equal 1, sup.spawned.size
+    assert_equal "ready", sup.spawned.first[:slug]
+    refute logger.events.any? { |(n, attrs)| n == :blocked && attrs[:slug] == "ready" }
+  end
+
+  def test_status_agent_row_for_daemon_child_is_not_double_counted
+    rows = [
+      row(slug: "running", stage: "5-review", marker: "review_working",
+          action: "agent_running", command: nil, claude_pid_alive: true),
+      row(slug: "ready", action: "ready_to_plan",
+          command: "hive plan ready --from 2-brainstorm")
+    ]
+    dispatcher, sup, ctrl, _logger, _mw = make_dispatcher(rows: rows)
+    dispatcher.controller.instance_variable_set(:@max_concurrent_runs, 2)
+    ctrl.record_dispatch(
+      pid: 999, project: "p1", slug: "running",
+      stage: "5-review", command: "hive review running",
+      started_at: T0, state_file_mtime: T0 - 60
+    )
+
+    dispatcher.tick(now: T0)
+
+    assert_equal 1, sup.spawned.size,
+                 "the status row for a daemon-owned child must not consume a second slot"
+    assert_equal "ready", sup.spawned.first[:slug]
   end
 
   # ── status failure ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Daemon dispatch caps now reflect actual active agent work instead of only children spawned by the current daemon process. Live `agent_running` rows from `hive status --json` count against global and per-project limits, while human-blocked `needs_input` rows stay outside the cap. This also fixes normal daemon runs that fall back to tmpdir-based logs by loading the missing `tmpdir` dependency.

## Test Plan

- `ruby -c lib/hive/daemon/concurrency_controller.rb`
- `ruby -c lib/hive/daemon/dispatcher.rb`
- `bundle exec ruby -Itest -Ilib test/unit/daemon/concurrency_controller_test.rb`
- `bundle exec ruby -Itest -Ilib test/unit/daemon/dispatcher_test.rb`
- `bundle exec ruby -Itest -Ilib test/unit/daemon/child_supervisor_test.rb`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
