### PR TITLE
fix(daemon): drop success cooldown from 5min to 1min

### DIFF
--- a/lib/hive/daemon/concurrency_controller.rb
+++ b/lib/hive/daemon/concurrency_controller.rb
@@ -21,7 +21,11 @@ module Hive
     class ConcurrencyController
       # Default cooldown after a SUCCESS exit. Prevents a happy task
       # from re-firing on the next tick before the user sees the result.
-      SUCCESS_COOLDOWN_SEC = 300
+      # 60s gives the operator one full TUI polling cycle to notice the
+      # transition before the daemon advances to the next stage. The
+      # original value (300s) felt too long when watching live — see
+      # commit message for the brainstorm-→-plan handoff incident.
+      SUCCESS_COOLDOWN_SEC = 60
 
       # Transient-failure backoff schedule (seconds). After the Nth
       # consecutive transient failure on the same (project, slug),
@@ -127,9 +131,9 @@ module Hive
       # Record a child completion. Side-effects on cooldown / quarantine
       # / daily-counter depend on exit_code per Hive::ExitCodes:
       #
-      #   0  SUCCESS              → 5 min cooldown
+      #   0  SUCCESS              → 1 min cooldown
       #   3  TASK_IN_ERROR        → no cooldown (marker handles re-entry policy via Policy)
-      #   4  WRONG_STAGE          → 5 min cooldown (race or classifier bug; back off)
+      #   4  WRONG_STAGE          → 1 min cooldown (race or classifier bug; back off)
       #   64 USAGE                → quarantine for daemon lifetime
       #   75 TEMPFAIL             → no cooldown, refund daily-rate slot, allow retry
       #   78 CONFIG               → drop the entire project

--- a/test/unit/daemon/concurrency_controller_test.rb
+++ b/test/unit/daemon/concurrency_controller_test.rb
@@ -93,12 +93,13 @@ class HiveDaemonConcurrencyControllerTest < Minitest::Test
 
   def test_success_triggers_cooldown_for_same_slug
     c = make
+    cd = Hive::Daemon::ConcurrencyController::SUCCESS_COOLDOWN_SEC
     dispatch(c, 100, "p1", "s1")
     c.record_completion(pid: 100, exit_code: Hive::ExitCodes::SUCCESS, completed_at: T0 + 5)
-    assert_equal :cooldown, c.can_dispatch?(project: "p1", slug: "s1", now: T0 + 100)
-    # After cooldown elapses
-    assert_equal :ok, c.can_dispatch?(project: "p1", slug: "s1",
-                                      now: T0 + Hive::Daemon::ConcurrencyController::SUCCESS_COOLDOWN_SEC + 100)
+    # Mid-cooldown: still blocked.
+    assert_equal :cooldown, c.can_dispatch?(project: "p1", slug: "s1", now: T0 + 5 + (cd / 2))
+    # After cooldown elapses.
+    assert_equal :ok, c.can_dispatch?(project: "p1", slug: "s1", now: T0 + 5 + cd + 1)
   end
 
   # ── transient retry → quarantine after schedule exhausted ──────────────


### PR DESCRIPTION
## Summary

- `SUCCESS_COOLDOWN_SEC: 300 → 60`
- Daemon now advances brainstorm → plan → execute etc. with a 1-minute pause between stages instead of 5
- Test updated to express expiry via the constant (`T0 + cd/2`, `T0 + cd + 1`) instead of the hardcoded `T0 + 100` that depended on `cd == 300`

## Why

Watching the TUI live, a task at `2-brainstorm: Ready to plan` was visibly stuck for 5 minutes after the brainstorm child exited at exit 0. The daemon log spammed `event: blocked, reason: cooldown` every 30s until the 300s window cleared. From the operator's seat that reads as "the daemon is broken" even though it's working as designed.

The cooldown's purpose (per its comment) is to "prevent a happy task from re-firing on the next tick before the user sees the result." 60s achieves that — one full TUI poll cycle, long enough to read the transition, short enough that the pipeline feels alive.

This is consistent with ADR-024 (daemon = automation-first, the only gates are points where the system literally needs human input). A successful stage transition is *not* one of those gates; baking in a 5-minute pause translated the operator's enrollment-time consent into an excessive wait.

WRONG_STAGE (exit 4) also reused `SUCCESS_COOLDOWN_SEC` — its backoff is now 60s too. That's fine: WRONG_STAGE means a race or classifier bug, and the primary recovery is fixing the bug, not waiting longer.

## Test plan

- [x] `test/unit/daemon/concurrency_controller_test.rb` — `test_success_triggers_cooldown_for_same_slug` updated; passes
- [x] Full suite: 1887 runs / 6332 assertions / 0 failures
- [x] rubocop clean
- [ ] After merge: restart daemon (`bin/hive daemon stop && bin/hive daemon start`); verify the next ready-to-plan task advances within ≤ 90s of the brainstorm child exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)