### PR TITLE
feat(worktree): new branches start from origin/<default> after a quick fetch

### DIFF
--- a/lib/hive/worktree.rb
+++ b/lib/hive/worktree.rb
@@ -35,10 +35,21 @@ module Hive
 
       _, _, exists = Open3.capture3("git", "-C", @project_root,
                                     "show-ref", "--verify", "refs/heads/#{branch_name}")
-      args = if exists.success?
-               [ "worktree", "add", path, branch_name ]
+      if exists.success?
+        args = [ "worktree", "add", path, branch_name ]
       else
-               [ "worktree", "add", path, "-b", branch_name, default_branch ]
+        # Branch new worktrees from `origin/<default>` (after a quick
+        # fetch) instead of local `<default>` so a stale or
+        # behind-origin local default doesn't silently produce a
+        # worktree missing the latest upstream commits. Auto-rebase
+        # (PR #69) handles drift in long-running worktrees; this
+        # handles drift at creation time. Fail-soft: if there is no
+        # `origin` remote, or the fetch fails (network down, auth),
+        # fall back to the local default with a stderr warning.
+        # Never touches local `<default>` — preserves any unpushed
+        # commits the user has there.
+        base = freshest_base(default_branch)
+        args = [ "worktree", "add", path, "-b", branch_name, base ]
       end
       out, err, status = Open3.capture3("git", "-C", @project_root, *args)
       unless status.success?
@@ -53,6 +64,35 @@ module Hive
       raise WorktreeError, "git worktree remove failed: #{err.strip.empty? ? out : err}" unless status.success?
 
       :removed
+    end
+
+    # Decide what to base a new worktree branch on. Prefer
+    # `origin/<default>` after a quick fetch so the worktree starts
+    # at upstream's current tip. Fall back to local `<default>` on:
+    #   - no `origin` remote configured (early-stage repos, forks
+    #     without an upstream)
+    #   - fetch failure (network down, auth missing, dead remote)
+    # The fetch uses the same non-interactive env as
+    # `GitOps#fetch_default_branch` (PR #69) so credential prompts
+    # cannot hang the worktree-creation path.
+    def freshest_base(default_branch)
+      _, _, has_origin = Open3.capture3("git", "-C", @project_root,
+                                        "config", "remote.origin.url")
+      return default_branch unless has_origin.success?
+
+      env = {
+        "GIT_TERMINAL_PROMPT" => "0",
+        "GIT_SSH_COMMAND" => "ssh -oBatchMode=yes -oConnectTimeout=10"
+      }
+      _, err, status = Open3.capture3(env, "git", "-C", @project_root,
+                                      "fetch", "origin", default_branch)
+      unless status.success?
+        warn "[hive] worktree base: fetch origin #{default_branch} failed " \
+             "(#{err.strip[0, 200]}); branching from local #{default_branch}"
+        return default_branch
+      end
+
+      "origin/#{default_branch}"
     end
 
     def list_worktree_paths

--- a/test/unit/worktree_test.rb
+++ b/test/unit/worktree_test.rb
@@ -87,6 +87,10 @@ class WorktreeTest < Minitest::Test
       scratch = Dir.mktmpdir("origin-pusher")
       begin
         run!("git", "clone", origin_dir, scratch)
+        # CI runners don't have global git identity; configure
+        # locally so the commit lands without prompting.
+        run!("git", "-C", scratch, "config", "user.email", "test@example.com")
+        run!("git", "-C", scratch, "config", "user.name", "Test")
         File.write(File.join(scratch, "from-origin.txt"), "advanced\n")
         run!("git", "-C", scratch, "add", ".")
         run!("git", "-C", scratch, "commit", "-m", "origin-advance", "--quiet")

--- a/test/unit/worktree_test.rb
+++ b/test/unit/worktree_test.rb
@@ -71,6 +71,81 @@ class WorktreeTest < Minitest::Test
     end
   end
 
+  # Set up `origin` as a bare clone of the dev repo, push master to it,
+  # then advance origin by one commit so local master is one commit
+  # behind origin/master. Returns [dev_dir, worktree_root, origin_dir,
+  # origin_advance_sha] for the test body to assert against.
+  def with_origin_ahead_of_local
+    with_initialized_project do |dir, root|
+      origin_dir = "#{dir}.origin.git"
+      run!("git", "clone", "--bare", dir, origin_dir)
+      run!("git", "-C", dir, "remote", "add", "origin", origin_dir)
+      run!("git", "-C", dir, "fetch", "origin")
+      # Advance origin: clone the bare into a scratch worktree, add a
+      # commit, push back. This simulates someone else pushing to
+      # origin while local master sits still.
+      scratch = Dir.mktmpdir("origin-pusher")
+      begin
+        run!("git", "clone", origin_dir, scratch)
+        File.write(File.join(scratch, "from-origin.txt"), "advanced\n")
+        run!("git", "-C", scratch, "add", ".")
+        run!("git", "-C", scratch, "commit", "-m", "origin-advance", "--quiet")
+        run!("git", "-C", scratch, "push", "origin", "master:master")
+      ensure
+        FileUtils.rm_rf(scratch)
+      end
+      origin_sha = `git -C #{origin_dir} rev-parse master`.strip
+      yield(dir, root, origin_dir, origin_sha)
+    end
+  end
+
+  def test_create_branches_from_origin_default_when_origin_ahead_of_local
+    # Regression for the agent-plugins-was-7-commits-behind incident:
+    # creating a worktree must branch from origin/<default>'s current
+    # tip, not from local <default>. Without the fetch+origin/ base
+    # the new worktree silently misses upstream commits and reviewers
+    # surface them as phantom deletions.
+    with_origin_ahead_of_local do |dir, root, _origin_dir, origin_sha|
+      wt = Hive::Worktree.new(dir, "feat-fresh", worktree_root: root)
+      wt.create!("feat-fresh", default_branch: "master")
+
+      worktree_sha = `git -C #{wt.path} rev-parse HEAD`.strip
+      assert_equal origin_sha, worktree_sha,
+                   "new worktree's HEAD must match origin/master, not stale local master"
+    end
+  end
+
+  def test_create_falls_back_to_local_default_when_no_origin_remote
+    # No `origin` configured — the existing behavior (branch from
+    # local default) is the correct fallback. Must not raise.
+    with_initialized_project do |dir, root|
+      local_sha = `git -C #{dir} rev-parse master`.strip
+      wt = Hive::Worktree.new(dir, "feat-no-remote", worktree_root: root)
+      wt.create!("feat-no-remote", default_branch: "master")
+      worktree_sha = `git -C #{wt.path} rev-parse HEAD`.strip
+      assert_equal local_sha, worktree_sha,
+                   "no-origin fallback: worktree HEAD matches local master"
+    end
+  end
+
+  def test_create_falls_back_to_local_when_fetch_fails
+    # Origin remote configured but unreachable — fetch fails, fallback
+    # to local <default> with a stderr warning. The worktree must
+    # still be created (no raise) so the operator can still work
+    # offline.
+    with_initialized_project do |dir, root|
+      run!("git", "-C", dir, "remote", "add", "origin", "https://nonexistent.invalid/repo.git")
+      local_sha = `git -C #{dir} rev-parse master`.strip
+      wt = Hive::Worktree.new(dir, "feat-no-net", worktree_root: root)
+      _, err = capture_io { wt.create!("feat-no-net", default_branch: "master") }
+      worktree_sha = `git -C #{wt.path} rev-parse HEAD`.strip
+      assert_equal local_sha, worktree_sha,
+                   "fetch-failure fallback: worktree HEAD matches local master"
+      assert_match(/worktree base: fetch origin master failed/, err,
+                   "fetch failure must surface a stderr warning so the operator knows")
+    end
+  end
+
   def test_master_log_clean_after_feature_commits
     with_initialized_project do |dir, root|
       wt = Hive::Worktree.new(dir, "feat-q", worktree_root: root)

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1410,3 +1410,10 @@ One single propagation made: `lib/hive/config.rb:220` corrected a misattribution
 
 **Refreshed pages:**
 - `wiki/stages/review.md` — updated the `pass_completion_status` classification list to document the operator-edit detection branch and added a paragraph explaining how it composes with the TUI's `r` gesture (PR #72).
+
+## [2026-05-14T15:00:00Z] worktree — new branches always start from origin/<default> after a quick fetch
+
+**Action:** Closed the gap exposed by the agent-plugins-was-7-commits-behind incident. `Worktree#create!`'s new-branch path previously ran `git worktree add <path> -b <slug> <local_default>` — the new branch started wherever local `<default>` happened to be, which on a stale checkout was N commits behind `origin/<default>`. Reviewers in 5-review then surfaced every missing upstream commit as a phantom deletion (same failure mode as the i-want-to-be-able-260507-7682 incident PR #69 was built to handle, just at a different point in the pipeline). PR #69's auto-rebase pre-step keeps drift fresh in *existing* worktrees; this commit handles drift at *creation*. New private helper `freshest_base(default_branch)` returns `"origin/<default>"` after a successful `git fetch origin <default>` (non-interactive env, same shape as `GitOps#fetch_default_branch`); falls back to `default_branch` with a stderr warning when there is no `origin` remote or the fetch fails. Local `<default>` is never touched — any unpushed commits there are preserved. Tests: +3 in `worktree_test.rb` (origin-ahead-of-local case verifies worktree HEAD matches `origin/master` not local `master`; no-origin fallback still works; fetch-failure fallback emits a stderr warning AND still creates the worktree so offline operators are not blocked).
+
+**Refreshed pages:**
+- `wiki/modules/worktree.md` — added the `freshest_base` subsection under `create!`, naming the incident, citing PR #69 (drift in existing vs. new worktrees), and documenting the fetch env + fail-soft fallback.

--- a/wiki/modules/worktree.md
+++ b/wiki/modules/worktree.md
@@ -41,10 +41,22 @@ If passed explicitly, that's used. Otherwise:
 1. `mkdir -p` the parent of `path`.
 2. Probe `git show-ref --verify refs/heads/<branch_name>`:
    - If it exists, run `git worktree add <path> <branch_name>` (attach to existing branch).
-   - If not, run `git worktree add <path> -b <branch_name> <default_branch>` (create new branch off default).
+   - If not, **resolve the freshest base** via `freshest_base(default_branch)` (see below), then run `git worktree add <path> -b <branch_name> <base>`.
 3. On non-zero exit, raise `Hive::WorktreeError` with the captured stderr.
 
 This handles re-attaching to a previously-created branch (e.g. after manually deleting a worktree) without losing history.
+
+### `freshest_base(default_branch)` — origin-first base resolution
+
+New branches always start at `origin/<default>` (after a quick fetch) rather than local `<default>`. The reason is concrete: a contributor who hasn't pulled in a while has a stale local default — `git worktree add -b <slug> <local_default>` would silently produce a worktree missing every upstream commit, and reviewers in 5-review would surface those missing commits as phantom deletions (this was the agent-plugins-was-7-commits-behind incident). Auto-rebase (PR #69) handles drift in long-running worktrees; this handles drift at *creation* time.
+
+The helper:
+1. Checks `git config remote.origin.url` — if no `origin` is configured (early-stage repos, internal forks without upstream), return `default_branch` (local fallback). No fetch attempted.
+2. Runs `git fetch origin <default_branch>` with non-interactive env (`GIT_TERMINAL_PROMPT=0`, `GIT_SSH_COMMAND="ssh -oBatchMode=yes -oConnectTimeout=10"` — same shape as `GitOps#fetch_default_branch`) so credential prompts cannot hang worktree creation.
+3. On fetch failure (network down, auth missing, dead remote), warn to stderr (`[hive] worktree base: fetch origin <default> failed (<err>); branching from local <default>`) and return `default_branch` (fall back). The worktree is still created so the operator can keep working offline.
+4. On fetch success, return `"origin/#{default_branch}"`.
+
+Local `<default>` is never modified — any unpushed commits there are preserved. Only the new feature branch's starting point is affected.
 
 ## `remove!`
 


### PR DESCRIPTION
## Summary

- `Worktree#create!` now branches new feature branches from `origin/<default>` (after a quick fetch) instead of local `<default>`
- Fail-soft: no `origin` configured → fall back to local; fetch fails (network/auth) → warn + fall back to local
- Local `<default>` is never touched — any unpushed commits the operator has stay where they are
- Composes with PR #69's auto-rebase: #69 handles drift in existing worktrees, this handles drift at *creation*

## Why

The agent-plugins repo had local `main` 7 commits behind `origin/main`. When `hive develop` created a worktree, the new branch started at stale local main — silently missing 7 upstream commits. Once 5-review ran, reviewers diff'd against \`origin/main\` and surfaced those 7 missing commits as "phantom deletions" — the exact failure mode that drove the i-want-to-be-able-260507-7682 task to REVIEW_STALE pass=4 and triggered PR #69.

PR #69 fixed it for *existing* worktrees (auto-rebase pre-step on every `hive run`). This PR fixes it at *creation* time so new worktrees never start stale in the first place.

## Test plan

- [x] +3 cases in `worktree_test.rb`: origin-ahead-of-local (worktree HEAD matches origin, not stale local); no-origin fallback (existing behavior preserved); fetch-failure fallback (warns to stderr AND still creates the worktree so offline operators are not blocked)
- [x] Full suite: 1899 runs / 6369 assertions / 0 failures
- [x] rubocop clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)