### PR TITLE
chore: enable managed llm-wiki

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@
 /.daemon.pid
 /daemon.pid
 /logs/
+.qmd/
+/.llm-wiki/qmd-cache/

--- a/.llm-wiki/config.json
+++ b/.llm-wiki/config.json
@@ -1,0 +1,10 @@
+{
+  "headless_agent": "codex",
+  "context_agents": [
+    "claude",
+    "codex",
+    "pi"
+  ],
+  "main_wiki_path": "/home/asterio/wikis/master/wiki",
+  "created_by": "codex"
+}

--- a/.llm-wiki/post-commit-refresh.sh
+++ b/.llm-wiki/post-commit-refresh.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$project_root"
+
+configure_qmd_environment() {
+  local cache_home="${XDG_CACHE_HOME:-$HOME/.cache}"
+  if ! mkdir -p "$cache_home/qmd" 2>/dev/null || ! touch "$cache_home/qmd/.write-test" 2>/dev/null; then
+    export XDG_CACHE_HOME="$project_root/.llm-wiki/qmd-cache"
+    mkdir -p "$XDG_CACHE_HOME/qmd"
+  else
+    rm -f "$cache_home/qmd/.write-test"
+  fi
+}
+
+configure_qmd_environment
+
+run_qmd() {
+  command -v qmd >/dev/null 2>&1 || return 0
+
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "${LLM_WIKI_QMD_TIMEOUT:-900}" qmd "$@"
+  else
+    qmd "$@"
+  fi
+}
+
+log_file="$project_root/.llm-wiki/post-commit-refresh.log"
+lock_dir="$project_root/.llm-wiki/post-commit-refresh.lock"
+changed_files="$(git diff-tree --no-commit-id --name-only -r HEAD 2>/dev/null || true)"
+ran_refresh=0
+
+[ -n "$changed_files" ] || exit 0
+
+if ! mkdir "$lock_dir" 2>/dev/null; then
+  exit 0
+fi
+trap 'rmdir "$lock_dir"' EXIT
+
+matches() {
+  printf '%s\n' "$changed_files" | grep -Eq "$1"
+}
+
+run_refresh() {
+  local prompt="$1"
+  ran_refresh=1
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "${LLM_WIKI_CODEX_TIMEOUT:-1800}" codex exec -C "$project_root" "$prompt" >>"$log_file" 2>&1 || true
+  else
+    codex exec -C "$project_root" "$prompt" >>"$log_file" 2>&1 || true
+  fi
+}
+
+if matches '(^|/)(schema\.rb|structure\.sql|db/migrate/|migrations/|models/|entities/|prisma/schema\.prisma)'; then
+  run_refresh "$(cat <<'PROMPT'
+Refresh this project's LLM wiki data-model coverage after a commit touched schema,
+migration, model, or entity files. Read AGENTS.md, wiki/index.md,
+wiki/architecture.md, wiki/dependencies.md, wiki/gaps.md, and recent wiki/log.md
+entries first. Inspect the committed diff and relevant source files. Update affected
+wiki pages, update wiki/index.md if page coverage changes, append wiki/log.md, and
+record uncertainty in wiki/gaps.md. Do not run qmd update or qmd embed yourself; the
+post-commit wrapper runs bounded qmd maintenance after refreshes finish. Do not
+invent facts.
+PROMPT
+)"
+fi
+
+if matches '(^|/)(routes|controllers|handlers|resolvers|src/commands/|lib/.*commands|bin/|README\.md)'; then
+  run_refresh "$(cat <<'PROMPT'
+Refresh this project's LLM wiki command and API surface coverage after a commit
+touched routes, handlers, commands, executable entrypoints, or README content. Read
+AGENTS.md, wiki/index.md, wiki/architecture.md, wiki/decisions.md, wiki/gaps.md,
+and recent wiki/log.md entries first. Inspect the committed diff and relevant source
+files. Update affected wiki pages, update wiki/index.md if page coverage changes,
+append wiki/log.md, and record uncertainty in wiki/gaps.md. Do not run qmd update or
+qmd embed yourself; the post-commit wrapper runs bounded qmd maintenance after
+refreshes finish. Do not invent facts.
+PROMPT
+)"
+fi
+
+if matches '(^|/)(Gemfile|Gemfile\.lock|package\.json|package-lock\.json|go\.mod|go\.sum|Cargo\.toml|Cargo\.lock|requirements\.txt|pyproject\.toml|poetry\.lock|composer\.json|composer\.lock)$'; then
+  run_refresh "$(cat <<'PROMPT'
+Refresh this project's LLM wiki dependency coverage after a commit touched dependency
+files. Read AGENTS.md, wiki/index.md, wiki/dependencies.md, wiki/gaps.md, and recent
+wiki/log.md entries first. Inspect the committed diff and dependency files. Update
+wiki/dependencies.md and related pages if facts changed, update wiki/index.md if page
+coverage changes, append wiki/log.md, and record uncertainty in wiki/gaps.md. Do not
+run qmd update or qmd embed yourself; the post-commit wrapper runs bounded qmd
+maintenance after refreshes finish. Do not
+invent facts.
+PROMPT
+)"
+fi
+
+if matches '(^|/)(docs/|wiki/|raw/notes/|plans/|todos/)|(^|/)(CHANGELOG\.md|AGENTS\.md|CLAUDE\.md)$'; then
+  run_refresh "$(cat <<'PROMPT'
+Refresh this project's LLM wiki planning and documentation coverage after a commit
+touched docs, plans, notes, context files, or the wiki itself. Read AGENTS.md,
+wiki/index.md, wiki/decisions.md, wiki/gaps.md, and recent wiki/log.md entries first.
+Inspect the committed diff and relevant source files. Update stale pages, update
+wiki/index.md if page coverage changes, append wiki/log.md, and record uncertainty in
+wiki/gaps.md. Do not run qmd update or qmd embed yourself; the post-commit wrapper
+runs bounded qmd maintenance after refreshes finish. Do not invent facts.
+PROMPT
+)"
+fi
+
+if [ "$ran_refresh" -eq 1 ]; then
+  if command -v qmd >/dev/null 2>&1; then
+    run_qmd update >>"$log_file" 2>&1 || true
+    run_qmd embed --max-docs-per-batch 64 --max-batch-mb 64 >>"$log_file" 2>&1 || true
+  fi
+
+  for sync_dir in "$HOME/wikis/.sync-needed" "$(dirname "$project_root")/wikis/.sync-needed"; do
+    if [ -d "$(dirname "$sync_dir")" ]; then
+      mkdir -p "$sync_dir"
+      touch "$sync_dir/hive"
+    fi
+  done
+fi

--- a/.llm-wiki/refresh-wiki.sh
+++ b/.llm-wiki/refresh-wiki.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$project_root"
+
+configure_qmd_environment() {
+  local cache_home="${XDG_CACHE_HOME:-$HOME/.cache}"
+  if ! mkdir -p "$cache_home/qmd" 2>/dev/null || ! touch "$cache_home/qmd/.write-test" 2>/dev/null; then
+    export XDG_CACHE_HOME="$project_root/.llm-wiki/qmd-cache"
+    mkdir -p "$XDG_CACHE_HOME/qmd"
+  else
+    rm -f "$cache_home/qmd/.write-test"
+  fi
+}
+
+configure_qmd_environment
+
+run_qmd() {
+  command -v qmd >/dev/null 2>&1 || return 0
+
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "${LLM_WIKI_QMD_TIMEOUT:-900}" qmd "$@"
+  else
+    qmd "$@"
+  fi
+}
+
+run_codex() {
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "${LLM_WIKI_CODEX_TIMEOUT:-1800}" codex exec -C "$project_root" "$prompt"
+  else
+    codex exec -C "$project_root" "$prompt"
+  fi
+}
+
+if command -v qmd >/dev/null 2>&1; then
+  run_qmd update >/dev/null 2>&1 || true
+fi
+
+prompt="$(cat <<'PROMPT'
+Refresh this project's LLM wiki.
+Read .llm-wiki/config.json, AGENTS.md, CLAUDE.md, wiki/index.md, wiki/gaps.md,
+and recent wiki/log.md entries first.
+If .llm-wiki/config.json contains main_wiki_path, search that exact path before
+changing project pages.
+Also search default main cross-project wiki paths when they exist:
+~/wikis/master/wiki/, ~/wikis/main/wiki/, ../wikis/master/wiki/, and
+../wikis/main/wiki/.
+Inspect recent git history and changed source files.
+Update stale wiki pages, update wiki/index.md when page coverage changes, append
+wiki/log.md, and record uncertainty in wiki/gaps.md.
+Do not run qmd update or qmd embed yourself; the wrapper script runs bounded qmd
+maintenance after this Codex refresh finishes.
+Do not invent facts.
+PROMPT
+)"
+
+codex_status=0
+run_codex || codex_status=$?
+
+run_qmd update >/dev/null 2>&1 || true
+run_qmd embed --max-docs-per-batch 64 --max-batch-mb 64 >/dev/null 2>&1 || true
+
+exit "$codex_status"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+<!-- BEGIN LLM WIKI -->
+## Wiki
+
+This project has an LLM-maintained knowledge base in `wiki/`.
+
+- `wiki/` — project knowledge pages maintained by the agent
+- `wiki/index.md` — catalog of all pages
+- `wiki/log.md` — append-only changelog
+- `wiki/gaps.md` — known gaps and open questions
+- `raw/notes/` — manually added reference material
+
+Always check `wiki/` before answering questions about this project's architecture, patterns, or decisions.
+
+When you learn something new about the project or make a decision:
+1. Create or update the relevant page in `wiki/`
+2. Update `wiki/index.md` if a new page was created
+3. Append an entry to `wiki/log.md`
+
+Never hallucinate. Ground everything in code or existing wiki pages. If unsure, note it in `wiki/gaps.md`.
+
+Use `[[page-name]]` backlinks between wiki pages.
+
+Query protocol:
+1. Read `.llm-wiki/config.json` when it exists.
+2. Run `qmd search "<topic>"` when QMD is available. Use `qmd query "<topic>"` only when local model generation is acceptable; if it hangs or errors, fall back to `qmd search` or `rg`.
+3. Fall back to `rg "<topic>" wiki/`.
+4. Check the configured `main_wiki_path` before making architectural decisions when it exists.
+5. Also check default main cross-project wiki paths when they exist:
+   - `~/wikis/master/wiki/`
+   - `~/wikis/main/wiki/`
+   - `<parent-of-project>/wikis/master/wiki/`
+   - `<parent-of-project>/wikis/main/wiki/`
+<!-- END LLM WIKI -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,3 +34,37 @@ Before making architectural decisions, check ~/wikis/master/wiki/ for existing p
 ## Documented Solutions
 
 `docs/solutions/` — documented solutions to past problems (bugs, architecture patterns, conventions, workflow learnings), organized by category with YAML frontmatter (`module`, `tags`, `problem_type`). Relevant when implementing or debugging in documented areas.
+
+<!-- BEGIN LLM WIKI -->
+## Wiki
+
+This project has an LLM-maintained knowledge base in `wiki/`.
+
+- `wiki/` — project knowledge pages maintained by the agent
+- `wiki/index.md` — catalog of all pages
+- `wiki/log.md` — append-only changelog
+- `wiki/gaps.md` — known gaps and open questions
+- `raw/notes/` — manually added reference material
+
+Always check `wiki/` before answering questions about this project's architecture, patterns, or decisions.
+
+When you learn something new about the project or make a decision:
+1. Create or update the relevant page in `wiki/`
+2. Update `wiki/index.md` if a new page was created
+3. Append an entry to `wiki/log.md`
+
+Never hallucinate. Ground everything in code or existing wiki pages. If unsure, note it in `wiki/gaps.md`.
+
+Use `[[page-name]]` backlinks between wiki pages.
+
+Query protocol:
+1. Read `.llm-wiki/config.json` when it exists.
+2. Run `qmd search "<topic>"` when QMD is available. Use `qmd query "<topic>"` only when local model generation is acceptable; if it hangs or errors, fall back to `qmd search` or `rg`.
+3. Fall back to `rg "<topic>" wiki/`.
+4. Check the configured `main_wiki_path` before making architectural decisions when it exists.
+5. Also check default main cross-project wiki paths when they exist:
+   - `~/wikis/master/wiki/`
+   - `~/wikis/main/wiki/`
+   - `<parent-of-project>/wikis/master/wiki/`
+   - `<parent-of-project>/wikis/main/wiki/`
+<!-- END LLM WIKI -->

--- a/wiki/commands.md
+++ b/wiki/commands.md
@@ -1,0 +1,15 @@
+---
+title: Interaction Surface
+type: commands
+source: bin/hive, bin/hive-e2e
+created: 2026-05-14
+updated: 2026-05-14
+tags: [commands, api]
+---
+
+**TLDR**: External interaction surface is derived from routes, controllers, commands, and plugin surfaces.
+
+## Source Files
+
+- `bin/hive`
+- `bin/hive-e2e`

--- a/wiki/gaps.md
+++ b/wiki/gaps.md
@@ -66,3 +66,9 @@ tags: [gap, todo]
 - [[active-areas]]
 - [[index]]
 - [[e2e]]
+
+## Resolved Bootstrap Validation
+
+- 2026-05-14: Managed llm-wiki config, agent context, post-commit hook, and daily systemd timer were validated for `hive`.
+- 2026-05-14: `qmd update`, `qmd embed`, and collection-scoped `qmd search` passed for `hive`. QMD tries GPU first and falls back to CPU on this host because Vulkan headers are missing.
+- 2026-05-14: `qmd query` can still be slow under the sandboxed local-model path; use `qmd search` for maintenance checks and fall back to `rg` when semantic generation is too slow.

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -1,81 +1,79 @@
 ---
-title: Hive Wiki Index
+title: hive Wiki
 type: index
-created: 2026-04-25
+source: wiki/**/*.md
+created: 2026-05-14
 updated: 2026-05-14
-tags: [index]
+tags: [index, wiki]
 ---
 
-# hive — Wiki Index
 
-*Auto-generated. Do not edit manually.*
+**TLDR**: Catalog of the LLM-maintained wiki for `hive`.
 
-Folder-as-agent pipeline: a Ruby 3.4 / Thor CLI control plane that drives a seven-stage filesystem state machine (`1-inbox` → `2-brainstorm` → `3-plan` → `4-execute` → `5-review` → `6-pr` → `7-done`) where stage agents run via configurable AgentProfile CLIs (`claude` default, `codex`, `pi`) and `mv` between directories is the only approval gesture.
+Page count: 56
+Updated: 2026-05-14
 
-**Pages**: 51 (excl. `index.md`/`log.md`) · **Date**: 2026-05-14
+## Pages
 
-## Top level
+- [[active-areas]] — `wiki/active-areas.md`
+- [[architecture]] — `wiki/architecture.md`
+- [[cli]] — `wiki/cli.md`
+- [[commands]] — `wiki/commands.md`
+- [[commands/approve]] — `wiki/commands/approve.md`
+- [[commands/daemon]] — `wiki/commands/daemon.md`
+- [[commands/doctor]] — `wiki/commands/doctor.md`
+- [[commands/findings]] — `wiki/commands/findings.md`
+- [[commands/forget]] — `wiki/commands/forget.md`
+- [[commands/init]] — `wiki/commands/init.md`
+- [[commands/markers]] — `wiki/commands/markers.md`
+- [[commands/new]] — `wiki/commands/new.md`
+- [[commands/prune]] — `wiki/commands/prune.md`
+- [[commands/rebase-status]] — `wiki/commands/rebase-status.md`
+- [[commands/run]] — `wiki/commands/run.md`
+- [[commands/stage_action]] — `wiki/commands/stage_action.md`
+- [[commands/status]] — `wiki/commands/status.md`
+- [[commands/tui]] — `wiki/commands/tui.md`
+- [[decisions]] — `wiki/decisions.md`
+- [[dependencies]] — `wiki/dependencies.md`
+- [[e2e]] — `wiki/e2e.md`
+- [[gaps]] — `wiki/gaps.md`
+- [[index]] — `wiki/index.md`
+- [[log]] — `wiki/log.md`
+- [[modules/agent]] — `wiki/modules/agent.md`
+- [[modules/agent_profile]] — `wiki/modules/agent_profile.md`
+- [[modules/config]] — `wiki/modules/config.md`
+- [[modules/daemon]] — `wiki/modules/daemon.md`
+- [[modules/execute_waiting_action]] — `wiki/modules/execute_waiting_action.md`
+- [[modules/findings]] — `wiki/modules/findings.md`
+- [[modules/git_ops]] — `wiki/modules/git_ops.md`
+- [[modules/lock]] — `wiki/modules/lock.md`
+- [[modules/markers]] — `wiki/modules/markers.md`
+- [[modules/metrics]] — `wiki/modules/metrics.md`
+- [[modules/protected_files]] — `wiki/modules/protected_files.md`
+- [[modules/rebase]] — `wiki/modules/rebase.md`
+- [[modules/reviewers]] — `wiki/modules/reviewers.md`
+- [[modules/secret_patterns]] — `wiki/modules/secret_patterns.md`
+- [[modules/stages]] — `wiki/modules/stages.md`
+- [[modules/task]] — `wiki/modules/task.md`
+- [[modules/task_action]] — `wiki/modules/task_action.md`
+- [[modules/task_resolver]] — `wiki/modules/task_resolver.md`
+- [[modules/workflows]] — `wiki/modules/workflows.md`
+- [[modules/worktree]] — `wiki/modules/worktree.md`
+- [[operating]] — `wiki/operating.md`
+- [[stages/brainstorm]] — `wiki/stages/brainstorm.md`
+- [[stages/done]] — `wiki/stages/done.md`
+- [[stages/execute]] — `wiki/stages/execute.md`
+- [[stages/inbox]] — `wiki/stages/inbox.md`
+- [[stages/index]] — `wiki/stages/index.md`
+- [[stages/plan]] — `wiki/stages/plan.md`
+- [[stages/pr]] — `wiki/stages/pr.md`
+- [[stages/review]] — `wiki/stages/review.md`
+- [[state-model]] — `wiki/state-model.md`
+- [[templates]] — `wiki/templates.md`
+- [[testing]] — `wiki/testing.md`
 
-- [[architecture]] — layer cake, process model, two filesystem trees, agent invocation contract, conventions.
-- [[state-model]] — directory layout, marker grammar, state files, slug rules, configs, frontmatter, lock files, worktree pointer.
-- [[cli]] — top-level CLI surface (entry point, command table, error conventions).
-- [[dependencies]] — runtime gems, dev gems, external CLI deps, Ruby version, stdlib reliance.
-- [[decisions]] — 25 ADRs (ADR-024 covers daemon-mode autonomy; ADR-025 covers the additive-required JSON-envelope policy).
-- [[active-areas]] — what's currently in flight and what's deferred.
-- [[gaps]] — coverage table, open questions, patterns not yet documented.
-- [[templates]] — ERB template catalogue and prompt-injection boundary policy.
-- [[testing]] — minitest layout, fixtures, lint policy.
-- [[e2e]] — outer real-subprocess CLI/TUI e2e suite, scenario DSL, artifact contract.
-- [[operating]] — daemon install + autostart guide for Linux (systemd-user) and macOS (launchd), dry-run shakedown, per-project enrollment, troubleshooting.
+## Maintenance
 
-## Commands
-
-- [[commands/init]] — bootstrap orphan branch, attach worktree, register globally.
-- [[commands/new]] — capture an idea, derive a slug, scaffold `idea.md`.
-- [[commands/run]] — dispatcher: lock → auto-rebase pre-step → stage runner → commit → report (`--json` and `--no-rebase` supported).
-- [[commands/rebase-status]] — read-only inspector reporting whether the next `hive run` would attempt an auto-rebase, and how far behind `origin/<default>` the worktree is. Never mutates; never fetches.
-- [[commands/status]] — read-only table of every active task across registered projects (`--json` supported).
-- [[commands/tui]] — live, keystroke-driven curses dashboard over `hive status` (human-only; no JSON).
-- [[commands/approve]] — agent-callable `mv <task> <next-stage>/` with marker validation, ambiguity resolution, and a hive/state commit per move.
-- [[commands/findings]] — `hive findings` / `accept-finding` / `reject-finding`: list and toggle GFM-checkbox findings in `reviews/ce-review-NN.md`.
-- [[commands/stage_action]] — `hive brainstorm` / `plan` / `develop` / `pr` / `archive` workflow verbs (promote-or-run).
-- [[commands/markers]] — `hive markers clear FOLDER --name <NAME>` removes a recovery marker (`REVIEW_STALE` etc.) from `task.md` so an agent can recover from `REVIEW_*_STALE` / `REVIEW_ERROR` without hand-editing.
-- [[commands/forget]] — `hive forget NAME [--json]` drop one named entry from the global registry (inverse of `hive init`). `.hive-state` on disk is not touched.
-- [[commands/prune]] — `hive prune [--dry-run] [--json]` bulk-drop registry entries whose `path` is gone or whose row shape is invalid.
-- [[commands/daemon]] — `hive daemon start|stop|status|reload|tail|enable|disable` auto-advancing dispatcher (ADR-024). Polls `hive status --json` and fires workflow verbs on tasks ready to advance. Per-project enrollment via `hive daemon enable PROJECT` (or `--all`).
-- [[commands/doctor]] — `hive doctor [--json]` per-stage and per-reviewer skill-install preflight (also runs non-fatally at end of `hive init`). Emits `hive-doctor.v1` envelope with `configured_skill` + `skill` per row.
-- `hive metrics rollback-rate [--days N] [--project NAME] [--json]` — fraction of fix-agent commits later reverted, broken down by triage bias / fix phase. See [[cli]] and [[stages/review]].
-
-## Stages
-
-- [[stages/index]] — seven-stage overview.
-- [[stages/inbox]] — inert capture zone.
-- [[stages/brainstorm]] — Q&A round-by-round.
-- [[stages/plan]] — `/compound-engineering:ce-plan` driven plan.
-- [[stages/execute]] — worktree + implementation (impl-only since ADR-014).
-- [[stages/review]] — autonomous review loop: CI-fix → reviewers → triage → fix → guardrail → browser-test.
-- [[stages/pr]] — push branch + `gh pr create` (idempotent).
-- [[stages/done]] — print cleanup commands, stamp COMPLETE.
-
-## Modules
-
-- [[modules/task]] — path parser & value object.
-- [[modules/markers]] — locked HTML-comment marker protocol.
-- [[modules/lock]] — per-task `.lock` + per-project `.commit-lock`.
-- [[modules/worktree]] — git worktree wrapper + path-prefix validation.
-- [[modules/git_ops]] — default-branch detection, hive-state bootstrap, `hive_commit`.
-- [[modules/agent]] — agent CLI subprocess wrapper with timeout/budget/atomic exit-status capture.
-- [[modules/agent_profile]] — per-CLI invocation contract value-object + registry (claude / codex / pi).
-- [[modules/config]] — global + per-project YAML configs with deep-merge defaults.
-- [[modules/stages]] — seven-stage list + helpers; single source of truth for `DIRS` / `NAMES` / `SHORT_TO_FULL`.
-- [[modules/findings]] — parser + writer for `reviews/ce-review-NN.md`; CRLF-safe round-trip toggle.
-- [[modules/task_resolver]] — slug-or-folder TARGET resolution shared by every agent-callable command.
-- [[modules/task_action]] — `(task, marker) → action key/label/command` classifier driving `hive status` and `next_action` emission.
-- [[modules/execute_waiting_action]] — shared `EXECUTE_WAITING reason=...` recovery target builder for run/status/TUI.
-- [[modules/workflows]] — verb→stage SSOT (brainstorm/plan/develop/pr/archive) consumed by every workflow command.
-- [[modules/reviewers]] — Phase 2 reviewer adapter layer (dispatch, Context, Result, Agent, SyntheticTask).
-- [[modules/metrics]] — `hive metrics rollback-rate` library (trailer parsing, revert detection).
-- [[modules/secret_patterns]] — shared regex set for credential/secret detection.
-- [[modules/protected_files]] — SHA-256 snapshot/diff helper for orchestrator-owned files.
-- [[modules/daemon]] — auto-advancing dispatcher (ADR-024): Policy + ConcurrencyController + ChildSupervisor + StatusConsumer + Dispatcher + Logger + PrMergeWatcher.
-- [[modules/rebase]] — auto-rebase orchestrator (`Hive::Rebase.perform`): pre-run guards, fetch with timeout, conflict-resolution agent dispatch (bounded to 5), fail-soft abort, post-rebase `execute_base_head` rewrite. Fail-soft: never raises; returns `Result` with closed-enum `reason`.
+- Managed config: `.llm-wiki/config.json`
+- Headless refresh: `.llm-wiki/refresh-wiki.sh`
+- Post-commit refresh: `.llm-wiki/post-commit-refresh.sh`

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1433,3 +1433,23 @@ One single propagation made: `lib/hive/config.rb:220` corrected a misattribution
 
 **Refreshed pages:**
 - `wiki/modules/worktree.md` — added the `freshest_base` subsection under `create!`, naming the incident, citing PR #69 (drift in existing vs. new worktrees), and documenting the fetch env + fail-soft fallback.
+
+## [2026-05-14T16:53:28Z] bootstrap
+
+**Action:** Managed llm-wiki bootstrap from codebase and Hive registry.
+**Pages created:** wiki/commands.md
+**Pages updated:** wiki/index.md, wiki/log.md, wiki/gaps.md, .llm-wiki/config.json, AGENTS.md, CLAUDE.md, .claude/settings.json
+**QMD:** qmd missing
+**Scheduler:** files written; systemctl enable failed for llm-wiki-hive-e2088c70.timer
+**Post-commit hook:** /home/asterio/Dev/hive/.git/hooks/post-commit
+**Source:** Codebase read + git history
+
+## [2026-05-14T17:26:52Z] llm-wiki validation
+
+**Action:** Validated managed llm-wiki bootstrap and scheduled maintenance after Hive registry bootstrap.
+**Headless agent:** Codex (`.llm-wiki/config.json` has `headless_agent: "codex"`).
+**Context:** `AGENTS.md` and `CLAUDE.md` contain the managed LLM WIKI block; Claude `SessionStart` prints `wiki/index.md` and recent `wiki/log.md`.
+**QMD:** `qmd 2.1.0` collection update, embed, and `qmd search` succeeded for this collection after the scheduled refresh test. QMD attempted GPU first and fell back to CPU because Vulkan headers are missing.
+**Scheduler:** `llm-wiki-hive-e2088c70.timer` is enabled and active under `systemctl --user`; next run is scheduled for 2026-05-15 18:03:41 BST.
+**Maintenance scripts:** `.llm-wiki/refresh-wiki.sh` and `.llm-wiki/post-commit-refresh.sh` use bounded Codex and qmd timeouts and tell headless Codex not to run `qmd update` or `qmd embed` itself.
+**Source:** `systemctl --user list-timers`, `qmd update`, `qmd embed`, and collection-scoped `qmd search`.


### PR DESCRIPTION
Enables managed llm-wiki context, Codex-owned refresh scripts, post-commit maintenance, and refreshed Hive wiki pages.