### PR TITLE
chore: grant llm-wiki refresh qmd cache access

### DIFF
--- a/.llm-wiki/post-commit-refresh.sh
+++ b/.llm-wiki/post-commit-refresh.sh
@@ -9,8 +9,10 @@ configure_qmd_environment() {
   if ! mkdir -p "$cache_home/qmd" 2>/dev/null || ! touch "$cache_home/qmd/.write-test" 2>/dev/null; then
     export XDG_CACHE_HOME="$project_root/.llm-wiki/qmd-cache"
     mkdir -p "$XDG_CACHE_HOME/qmd"
+    export LLM_WIKI_QMD_CACHE_DIR="$XDG_CACHE_HOME/qmd"
   else
     rm -f "$cache_home/qmd/.write-test"
+    export LLM_WIKI_QMD_CACHE_DIR="$cache_home/qmd"
   fi
 }
 
@@ -46,9 +48,9 @@ run_refresh() {
   local prompt="$1"
   ran_refresh=1
   if command -v timeout >/dev/null 2>&1; then
-    timeout "${LLM_WIKI_CODEX_TIMEOUT:-1800}" codex exec -C "$project_root" "$prompt" >>"$log_file" 2>&1 || true
+    timeout "${LLM_WIKI_CODEX_TIMEOUT:-1800}" codex exec --add-dir "$LLM_WIKI_QMD_CACHE_DIR" -C "$project_root" "$prompt" >>"$log_file" 2>&1 || true
   else
-    codex exec -C "$project_root" "$prompt" >>"$log_file" 2>&1 || true
+    codex exec --add-dir "$LLM_WIKI_QMD_CACHE_DIR" -C "$project_root" "$prompt" >>"$log_file" 2>&1 || true
   fi
 }
 

--- a/.llm-wiki/refresh-wiki.sh
+++ b/.llm-wiki/refresh-wiki.sh
@@ -9,8 +9,10 @@ configure_qmd_environment() {
   if ! mkdir -p "$cache_home/qmd" 2>/dev/null || ! touch "$cache_home/qmd/.write-test" 2>/dev/null; then
     export XDG_CACHE_HOME="$project_root/.llm-wiki/qmd-cache"
     mkdir -p "$XDG_CACHE_HOME/qmd"
+    export LLM_WIKI_QMD_CACHE_DIR="$XDG_CACHE_HOME/qmd"
   else
     rm -f "$cache_home/qmd/.write-test"
+    export LLM_WIKI_QMD_CACHE_DIR="$cache_home/qmd"
   fi
 }
 
@@ -28,9 +30,9 @@ run_qmd() {
 
 run_codex() {
   if command -v timeout >/dev/null 2>&1; then
-    timeout "${LLM_WIKI_CODEX_TIMEOUT:-1800}" codex exec -C "$project_root" "$prompt"
+    timeout "${LLM_WIKI_CODEX_TIMEOUT:-1800}" codex exec --add-dir "$LLM_WIKI_QMD_CACHE_DIR" -C "$project_root" "$prompt"
   else
-    codex exec -C "$project_root" "$prompt"
+    codex exec --add-dir "$LLM_WIKI_QMD_CACHE_DIR" -C "$project_root" "$prompt"
   fi
 }
 

--- a/wiki/gaps.md
+++ b/wiki/gaps.md
@@ -70,5 +70,5 @@ tags: [gap, todo]
 ## Resolved Bootstrap Validation
 
 - 2026-05-14: Managed llm-wiki config, agent context, post-commit hook, and daily systemd timer were validated for `hive`.
-- 2026-05-14: `qmd update`, `qmd embed`, and collection-scoped `qmd search` passed for `hive`. QMD tries GPU first and falls back to CPU on this host because Vulkan headers are missing.
-- 2026-05-14: `qmd query` can still be slow under the sandboxed local-model path; use `qmd search` for maintenance checks and fall back to `rg` when semantic generation is too slow.
+- 2026-05-15: `qmd status` reports Vulkan GPU offload on AMD Radeon 890M Graphics (RADV STRIX1) after installing the Arch Vulkan stack.
+- 2026-05-15: `qmd query "llm wiki managed bootstrap" -c hive --no-rerank -n 3` completed with local Vulkan-backed generation; sandboxed agent sessions still need qmd cache write access via `--add-dir` or host-side maintenance hooks.

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1449,7 +1449,7 @@ One single propagation made: `lib/hive/config.rb:220` corrected a misattribution
 **Action:** Validated managed llm-wiki bootstrap and scheduled maintenance after Hive registry bootstrap.
 **Headless agent:** Codex (`.llm-wiki/config.json` has `headless_agent: "codex"`).
 **Context:** `AGENTS.md` and `CLAUDE.md` contain the managed LLM WIKI block; Claude `SessionStart` prints `wiki/index.md` and recent `wiki/log.md`.
-**QMD:** `qmd 2.1.0` collection update, embed, and `qmd search` succeeded for this collection after the scheduled refresh test. QMD attempted GPU first and fell back to CPU because Vulkan headers are missing.
+**QMD:** `qmd 2.1.0` collection update, embed, and `qmd search` succeeded for this collection after the scheduled refresh test. Follow-up verification on 2026-05-15 confirmed `qmd status` uses Vulkan GPU offload on AMD Radeon 890M Graphics (RADV STRIX1), and `qmd query "llm wiki managed bootstrap" -c hive --no-rerank -n 3` completes with local GPU-backed generation.
 **Scheduler:** `llm-wiki-hive-e2088c70.timer` is enabled and active under `systemctl --user`; next run is scheduled for 2026-05-15 18:03:41 BST.
 **Maintenance scripts:** `.llm-wiki/refresh-wiki.sh` and `.llm-wiki/post-commit-refresh.sh` use bounded Codex and qmd timeouts and tell headless Codex not to run `qmd update` or `qmd embed` itself.
 **Source:** `systemctl --user list-timers`, `qmd update`, `qmd embed`, and collection-scoped `qmd search`.


### PR DESCRIPTION
Updates managed llm-wiki maintenance scripts so Codex refresh runs receive qmd cache write access via --add-dir, without disabling sandboxing. Also refreshes Hive's qmd verification notes now that local Vulkan GPU offload is working.