### PR TITLE
fix(daemon): auto-advance ready plans

### DIFF
--- a/docs/solutions/architecture-patterns/daemon-plan-approval-policy-exception-2026-05-15.md
+++ b/docs/solutions/architecture-patterns/daemon-plan-approval-policy-exception-2026-05-15.md
@@ -1,0 +1,97 @@
+---
+title: Daemon plan-approval policy exception — auto-dispatch plan WAITING rows for daemon-enabled projects
+date: 2026-05-15
+category: architecture-patterns
+module: Hive::Daemon
+problem_type: architecture_pattern
+component: dispatcher
+severity: high
+applies_when:
+  - Building a background dispatcher that classifies status rows into dispatch decisions
+  - A subset of "WAITING" states are actually "approval pauses" (durable consent already given out-of-band) rather than Q&A waits requiring user input
+  - The dispatcher must satisfy a downstream "terminal-marker gate" that refuses to advance while a WAITING marker is in place
+  - The same dispatch decision is also surfaced through a manual UI (TUI, CLI) which already handles the case correctly
+tags:
+  - daemon
+  - dispatcher
+  - policy
+  - state-machine
+  - hive-pipeline
+  - marker-flip
+  - workflow-verb
+  - approval-pause
+---
+
+# Daemon plan-approval policy exception
+
+## Context
+
+`Hive::Daemon` (ADR-024) auto-advances tasks through the pipeline so an operator-enabled project marches `inbox → brainstorm → plan → execute → review → open-pr → finalize → done` without per-stage approval gestures. The daemon's source of truth is `hive status --json` — each task row carries an `action` field (`ready_to_*`, `needs_input`, etc.) and a `suggested_command` populated by `Hive::TaskAction`. `Hive::Daemon::Policy.decide` classifies each row into one of `:dispatch / :poll_for_merge / :wait_for_debounce / :record_baseline / :skip`.
+
+Originally `Policy.decide` treated every `needs_input` row identically: apply an mtime baseline + debounce so the daemon dispatches only after the operator visibly edits the state file. This makes sense for brainstorm answers, execute questions, and review decisions — all are Q&A waits where the agent needs typed input. But it produced a stuck-state bug for plan-stage rows.
+
+## Symptom
+
+A generated plan would sit in `3-plan` with `<!-- WAITING -->` and TUI status "Needs your input" indefinitely. The daemon log showed `event: skipped` every 30s with `in_flight: 0`. Manually running `hive run --json` on the row flipped the marker to `<!-- COMPLETE -->`, after which the daemon immediately dispatched `hive develop ... --from 3-plan` on its next tick.
+
+Symptom signature for future debugging:
+- `hive status --json` reports the row as `stage: "3-plan", action: "needs_input", marker: "waiting"`
+- The state file's mtime is days-old
+- Daemon log shows continuous `event: skipped` with no `event: dispatched`
+- Operator did nothing wrong — they generated a plan, expected the daemon to take it forward
+
+## Root cause
+
+`plan_waiting` semantically isn't a Q&A wait. The plan stage emits `<!-- WAITING -->` when the plan document is ready for human review, not because the agent needs typed input. In the manual TUI flow, the operator reads `plan.md`, decides "yes ship this", and presses `d` (develop) — the TUI then transparently flips the marker `:waiting → :complete` and dispatches `hive develop`. For daemon-enabled projects, the durable consent is `daemon.enabled: true` (set at `hive init`); the operator's "yes ship this" was given when they enrolled the project. There is no per-task approval gesture needed.
+
+The Policy treating every `needs_input` row uniformly meant the daemon waited forever for an operator gesture that, by the project's own consent model, was already given.
+
+## Fix
+
+Two coupled changes, both required:
+
+1. **Carve out `plan_approval?` in `Policy.decide`.** The predicate matches `action == "needs_input" && stage == "3-plan"` (literal stage equality — `Hive::Stages::DIRS` is a closed enum with exactly one plan stage). When true, `Policy.decide` returns `:dispatch` directly, bypassing the mtime debounce. Other `needs_input` stages (brainstorm/execute/review) keep the existing edit-resume path.
+
+2. **`Hive::Daemon::PlanApproval.prepare`** at dispatch time. The row's `suggested_command` is `hive plan ... --from 3-plan` (per `TaskAction`, which is correct for the manual TUI's `p` re-run flow but wrong for daemon auto-advance). The dispatcher cannot just dispatch the raw command — it would re-run the plan stage, leaving the marker at `:waiting`, producing a 60s-cadence re-dispatch loop. The fix is to:
+   - Rewrite the command: `hive plan ...` → `hive develop ...` via Shellwords round-trip.
+   - Flip the marker `:waiting → :complete` via `Hive::Markers.set`. This is required so the workflow verb's terminal-marker gate (`Hive::Commands::Approve::VALID_TERMINAL_MARKERS = %i[complete execute_complete review_complete]`) accepts the advance — `hive develop --from 3-plan` against a `:waiting` marker raises `Hive::WrongStage` (exit 4) and the daemon would loop on the gate refusal instead of the agent re-run.
+
+**Load-bearing ordering:** validate the command shape BEFORE flipping the marker. If a malformed `suggested_command` is dispatched and the marker has already been flipped to `:complete`, the row strands at "approved" with no follow-up dispatch — operationally worse than the original loop because the operator sees a green-looking row that never moves. `PlanApproval.prepare` raises `ArgumentError` on a malformed command without touching the marker; `Dispatcher` routes the row to `:skipped reason: "plan_approval_invalid"` and the marker stays at `:waiting` for inspection.
+
+## Why this composes with the TUI's pattern
+
+The TUI's `BubbleModel#dispatch_develop_for` / `#develop_command_from_plan` / `#finalize_plan_marker` already implements exactly the same two-step pattern for its `:advance_to_develop` keybinding (diagnosed in `i-want-to-be-able-260507-7682` / `now-we-run-claude-codex-260508-3b8f` bug reports). The daemon fix EXTRACTS this pattern into a callable module (`Hive::Daemon::PlanApproval`) rather than duplicating it inline. The TUI's helper stays scoped to its message layer; the daemon's helper is callable from outside the TUI. Same load-bearing invariants in both places (validate command before flipping marker, raise on non-`:waiting`/`:complete` markers).
+
+If a future surface (CLI verb, MCP tool, webhook) ever needs the same advance-plan-as-daemon-eligible behavior, it should call `Hive::Daemon::PlanApproval.prepare` and not re-derive the logic.
+
+## Logging contract
+
+`Dispatcher#dispatch_command` emits `:dispatched` with a `trigger:` field set to `"plan_approval"` (vs `"advance"` for `ready_to_*` actions). An operator or agent reading `daemon.log` can distinguish plan-approval auto-advances from regular advance-action dispatches without re-implementing `Policy.decide`. The Logger validates event NAME against a closed enum but per-event fields are open (`**attrs`), so adding `trigger:` is non-breaking for consumers.
+
+## Testing
+
+The bug was masked in the original PR's dispatcher test because it stubbed `command: "hive develop slug --from 3-plan"` — the production string would have been `"hive plan slug --from 3-plan"`. Test rewritten to:
+- Create a real tmpfile with `<!-- WAITING -->` marker
+- Pass the production `hive plan ...` string as `suggested_command`
+- Assert the spawned command is the rewritten `hive develop ...` form
+- Assert the marker on disk is `:complete` after the tick
+- Assert `:dispatched` event fired with `trigger: "plan_approval"`
+
+Plus dedicated `test/unit/daemon/plan_approval_test.rb` (10 cases) covers every branch of `PlanApproval.prepare` and `.rewrite_to_develop` directly so a refactor breaking one arm surfaces in the focused file rather than in noisier dispatcher tests.
+
+**General lesson on test mocks:** when a unit test stubs a value the production code computes through another module, the test passes regardless of whether the producer matches. Whenever feasible, drive the test through the real producer (here: real `TaskAction#command` output) or assert the producer's output matches the stub in a separate test. The PR-#83 mask cost a full review cycle to surface.
+
+## Negative cases (do NOT auto-approve)
+
+`plan_approval?` is deliberately narrow:
+
+- Triage WAITING (`6-review` / `:review_waiting`) requires the user to tick `[x]` on findings — a genuine Q&A gate. Do NOT extend the carve-out here.
+- Brainstorm WAITING (`2-brainstorm` / `:waiting`) holds questions the brainstorm agent asked. Daemon must wait for typed answers; mtime debounce stays.
+- Execute WAITING (`4-execute` / `:execute_waiting`) is the agent asking the user something or surfacing a recoverable state. Same — keep debounce.
+
+The asymmetry is genuine: only plan WAITING represents a finished artefact waiting for an approval signal that the daemon's enrollment already gave.
+
+## Related solutions
+
+- `docs/solutions/architecture-patterns/background-spawn-and-signal-aware-marker-healing-2026-04-28.md` — supervisor-not-owner pattern. Establishes the precedent that a specific marker signature can be treated as "automation can resolve this without a human touching the file." Plan-approval is the same shape applied at the Policy level.
+- ADR-024 in `wiki/decisions.md` — daemon automation-first; the gate is "user input required." The plan-approval exception is ADR-024 amended: plan WAITING is NOT a user-input gate when consent is given out-of-band via `daemon.enabled: true`.

--- a/lib/hive/daemon/dispatcher.rb
+++ b/lib/hive/daemon/dispatcher.rb
@@ -1,6 +1,7 @@
 require "hive/config"
 require "hive/stages"
 require "hive/daemon/policy"
+require "hive/daemon/plan_approval"
 require "hive/daemon/concurrency_controller"
 require "hive/daemon/child_supervisor"
 require "hive/daemon/status_consumer"
@@ -290,20 +291,42 @@ module Hive
           external_global_count: @external_active_agent_total,
           external_project_count: external_active_agent_count_for(row.project)
         )
-        if gate == :ok
-          dispatch_command(
-            row.suggested_command,
-            project: row.project, slug: row.slug, stage: row.stage,
-            state_file_mtime: row.state_file_mtime,
-            state_file_path: row.state_file,
-            hive_state_path: nil, # supervisor falls back to tmpdir
-            now: now,
-            trigger: trigger
-          )
-        else
+        unless gate == :ok
           @logger.event(:blocked, project: row.project, slug: row.slug,
                                   stage: row.stage, reason: gate.to_s)
+          return
         end
+
+        # Plan-approval rows need a command rewrite + marker flip BEFORE
+        # dispatch because TaskAction emits `hive plan ...` for the
+        # `plan_waiting` row state (correct for the manual TUI's `p`
+        # re-run path) but the daemon wants `hive develop ...` to
+        # advance the stage. The marker also has to flip `:waiting →
+        # :complete` so the workflow verb's terminal-marker gate
+        # (Hive::Commands::Approve::VALID_TERMINAL_MARKERS) accepts the
+        # advance. Both steps live in Hive::Daemon::PlanApproval so the
+        # daemon and the TUI's equivalent helper cannot drift.
+        command = row.suggested_command
+        if trigger == "plan_approval"
+          begin
+            command = PlanApproval.prepare(row.suggested_command, row.state_file)
+          rescue PlanApproval::NotApprovable, ArgumentError => e
+            @logger.event(:skipped, project: row.project, slug: row.slug,
+                                    stage: row.stage, action: row.action,
+                                    reason: "plan_approval_invalid: #{e.message}")
+            return
+          end
+        end
+
+        dispatch_command(
+          command,
+          project: row.project, slug: row.slug, stage: row.stage,
+          state_file_mtime: row.state_file_mtime,
+          state_file_path: row.state_file,
+          hive_state_path: nil, # supervisor falls back to tmpdir
+          now: now,
+          trigger: trigger
+        )
       end
 
       def observe_external_running_rows(rows)

--- a/lib/hive/daemon/dispatcher.rb
+++ b/lib/hive/daemon/dispatcher.rb
@@ -243,6 +243,7 @@ module Hive
 
         decision = Policy.decide(
           action: row.action,
+          stage: row.stage,
           command: row.suggested_command,
           state_file_mtime: row.state_file_mtime,
           last_dispatched_state_file_mtime:

--- a/lib/hive/daemon/dispatcher.rb
+++ b/lib/hive/daemon/dispatcher.rb
@@ -254,7 +254,13 @@ module Hive
 
         case decision
         when :dispatch
-          dispatch_or_block(row, now: now)
+          # Pass through the reason the dispatch fired so the
+          # `:dispatched` logger event can distinguish plan-approval
+          # auto-advance from regular advance-action dispatches. An
+          # agent or operator reading daemon.log can then audit WHICH
+          # policy branch fired without re-implementing Policy.decide.
+          trigger = Policy.plan_approval?(row.action, row.stage) ? "plan_approval" : "advance"
+          dispatch_or_block(row, now: now, trigger: trigger)
         when :wait_for_debounce
           @logger.event(:debouncing, project: row.project, slug: row.slug,
                                      stage: row.stage, mtime: row.state_file_mtime&.utc&.iso8601)
@@ -278,7 +284,7 @@ module Hive
         end
       end
 
-      def dispatch_or_block(row, now:)
+      def dispatch_or_block(row, now:, trigger: "advance")
         gate = @controller.can_dispatch?(
           project: row.project, slug: row.slug, now: now,
           external_global_count: @external_active_agent_total,
@@ -291,7 +297,8 @@ module Hive
             state_file_mtime: row.state_file_mtime,
             state_file_path: row.state_file,
             hive_state_path: nil, # supervisor falls back to tmpdir
-            now: now
+            now: now,
+            trigger: trigger
           )
         else
           @logger.event(:blocked, project: row.project, slug: row.slug,
@@ -367,7 +374,7 @@ module Hive
       end
 
       def dispatch_command(command, project:, slug:, stage:, state_file_mtime:,
-                           state_file_path:, hive_state_path:, now:)
+                           state_file_path:, hive_state_path:, now:, trigger: "advance")
         if @dry_run
           @logger.event(:dry_run, project: project, slug: slug, stage: stage,
                                   command: command)
@@ -384,7 +391,8 @@ module Hive
           command: command, started_at: now, state_file_mtime: state_file_mtime
         )
         @logger.event(:dispatched, pid: pid, project: project, slug: slug,
-                                   stage: stage, command: command, dry_run: @dry_run)
+                                   stage: stage, command: command, trigger: trigger,
+                                   dry_run: @dry_run)
         @dispatched_today += 1
       end
 

--- a/lib/hive/daemon/plan_approval.rb
+++ b/lib/hive/daemon/plan_approval.rb
@@ -1,0 +1,79 @@
+require "shellwords"
+require "hive/markers"
+
+module Hive
+  module Daemon
+    # Rewrite a `hive plan ...` command into `hive develop ...` and
+    # flip the plan-stage `:waiting` marker to `:complete` so the
+    # daemon's plan-approval auto-dispatch can satisfy the workflow
+    # verb's terminal-marker gate (`Hive::Commands::Approve::
+    # VALID_TERMINAL_MARKERS`). Without this, the daemon would
+    # dispatch `hive plan ...` (which loops; the plan stage does
+    # not transition `:waiting` on its own re-run) or dispatch
+    # `hive develop ...` against a `:waiting` marker (which raises
+    # `Hive::WrongStage` and exits 4 every tick).
+    #
+    # Mirrors the TUI's two-step pattern in
+    # `Hive::Tui::BubbleModel#dispatch_develop_for` /
+    # `#develop_command_from_plan` / `#finalize_plan_marker`. The
+    # TUI helper stays scoped to its message layer; this module is
+    # the daemon-callable equivalent. Both share the same load-bearing
+    # safety property (validate command shape BEFORE flipping the
+    # marker so a malformed row leaves the marker at `:waiting` for
+    # operator inspection rather than stranding it at `:complete`
+    # with no follow-up dispatch).
+    module PlanApproval
+      module_function
+
+      class NotApprovable < StandardError; end
+
+      # Prepare a plan-stage row for daemon auto-dispatch.
+      #
+      # Returns the rewritten develop command string. Side effect:
+      # if the marker is `:waiting`, flips it to `:complete` on disk.
+      # If the marker is already `:complete` (a race with manual
+      # operator action), leaves it alone and returns the rewritten
+      # command. For any other marker, raises `NotApprovable` so the
+      # caller can route the row to `:skip` instead of relying on the
+      # workflow verb's `WrongStage` check as the failure boundary.
+      #
+      # @param suggested_command [String] the `hive plan ...` command
+      #   from the row's `suggested_command`
+      # @param state_file [String] absolute path to the row's state
+      #   file (e.g. `.../3-plan/<slug>/plan.md`)
+      # @return [String] the rewritten `hive develop ...` command
+      # @raise [ArgumentError] when `suggested_command` is not a
+      #   well-formed `hive plan ...` invocation
+      # @raise [NotApprovable] when the marker is neither `:waiting`
+      #   nor `:complete`
+      def prepare(suggested_command, state_file)
+        develop_command = rewrite_to_develop(suggested_command)
+
+        marker = Hive::Markers.current(state_file)
+        case marker.name
+        when :waiting
+          Hive::Markers.set(state_file, :complete)
+        when :complete
+          # Already approved by something else (manual operator
+          # action, prior tick race). The dispatch is still valid.
+        else
+          raise NotApprovable,
+                "marker=#{marker.name.inspect}; plan-approval auto-dispatch requires :waiting or :complete"
+        end
+
+        develop_command
+      end
+
+      def rewrite_to_develop(suggested_command)
+        argv = Shellwords.split(suggested_command.to_s)
+        unless argv.length >= 3 && argv[0] == "hive" && argv[1] == "plan"
+          raise ArgumentError,
+                "plan-approval auto-dispatch expects `hive plan ...`, got #{suggested_command.inspect}"
+        end
+
+        argv[1] = "develop"
+        Shellwords.join(argv)
+      end
+    end
+  end
+end

--- a/lib/hive/daemon/policy.rb
+++ b/lib/hive/daemon/policy.rb
@@ -98,7 +98,18 @@ module Hive
       def decide(action:, stage: nil, command:, state_file_mtime:, last_dispatched_state_file_mtime:,
                  now:, edit_debounce_sec: 30)
         return :skip if action.nil?
-        return :skip if (advance?(action) || edit_resume?(action)) && (command.nil? || command.empty?)
+        # Three branches dispatch the row's command verbatim (advance,
+        # plan_approval) or via the edit-resume path (edit_resume).
+        # All three need nil/empty-command protection. The guard
+        # lists plan_approval? explicitly even though today's
+        # plan_approval? rows are always edit_resume? rows too
+        # (`needs_input`); a future refactor extending plan_approval?
+        # to a non-edit_resume action would otherwise silently lose
+        # this coverage. PR #83 code review finding #3.
+        if (advance?(action) || edit_resume?(action) || plan_approval?(action, stage)) &&
+           (command.nil? || command.empty?)
+          return :skip
+        end
 
         if advance?(action) || plan_approval?(action, stage)
           :dispatch
@@ -127,8 +138,18 @@ module Hive
         EDIT_RESUME_ACTIONS.include?(action)
       end
 
+      # Literal `"3-plan"` equality matches every other stage-identity
+      # check in the codebase (e.g., `bubble_model.rb:1833 when "3-plan"`
+      # and `Hive::Stages::DIRS` membership). Earlier drafts used
+      # `/\A\d+-plan\z/` but the regex matched any digit-prefixed plan
+      # stage; today's `Hive::Stages::DIRS` is a closed 8-entry enum
+      # with exactly one plan stage, so the regex implied a forward-flex
+      # that didn't exist and a hypothetical `1-plan`/`5-plan` would
+      # silently inherit auto-approval. PR #83 code review finding #4
+      # (cross-corroborated by reliability + testing + maintainability +
+      # project-standards reviewers).
       def plan_approval?(action, stage)
-        action == "needs_input" && stage.to_s.match?(/\A\d+-plan\z/)
+        action == "needs_input" && stage == "3-plan"
       end
 
       def decide_edit(state_file_mtime:, last_dispatched:, now:, debounce_sec:)

--- a/lib/hive/daemon/policy.rb
+++ b/lib/hive/daemon/policy.rb
@@ -19,11 +19,15 @@ module Hive
     # will fail loudly with `Hive::WrongStage` (exit 4) at the workflow-
     # verb level rather than silently advancing past a human gate.
     #
-    # The only non-marker-driven decision is the `:edit` debounce: when
-    # the task is in a `:waiting` state, the daemon dispatches only if
-    # the state-file mtime is strictly newer than the last observed
-    # mtime AND `now - mtime >= edit_debounce_sec` (so a partial
-    # mid-save draft doesn't trigger an early dispatch).
+    # The only non-marker-driven decisions are:
+    # - plan approval rows (`3-plan` + `needs_input`) are auto-dispatched
+    #   for daemon-enabled projects. The durable consent is enabling the
+    #   daemon; a generated plan should not sit forever waiting for an
+    #   editor open/close gesture.
+    # - true edit waits dispatch only if the state-file mtime is strictly
+    #   newer than the last observed mtime AND `now - mtime >=
+    #   edit_debounce_sec` (so a partial mid-save draft doesn't trigger
+    #   an early dispatch).
     #
     # First-sight policy on `kind: edit`: the daemon sees a `_WAITING`
     # task with no prior observation. We CANNOT distinguish "agent just
@@ -75,6 +79,7 @@ module Hive
       # Decide what to do with one task row.
       #
       # @param action [String] the `tasks[].action` value from hive-status JSON
+      # @param stage [String, nil] the `tasks[].stage` value (e.g. "3-plan")
       # @param command [String, nil] the `suggested_command` for the row (may be nil)
       # @param state_file_mtime [Time, nil] mtime of the task's state file
       # @param last_dispatched_state_file_mtime [Time, nil] mtime captured at the
@@ -90,12 +95,12 @@ module Hive
       # the dispatcher does NOT spawn a child, but it MUST call
       # ConcurrencyController#observe_state_file_mtime so the next tick
       # has a baseline to compare against.
-      def decide(action:, command:, state_file_mtime:, last_dispatched_state_file_mtime:,
+      def decide(action:, stage: nil, command:, state_file_mtime:, last_dispatched_state_file_mtime:,
                  now:, edit_debounce_sec: 30)
         return :skip if action.nil?
         return :skip if (advance?(action) || edit_resume?(action)) && (command.nil? || command.empty?)
 
-        if advance?(action)
+        if advance?(action) || plan_approval?(action, stage)
           :dispatch
         elsif action == MERGE_WAIT_ACTION
           :poll_for_merge
@@ -120,6 +125,10 @@ module Hive
 
       def edit_resume?(action)
         EDIT_RESUME_ACTIONS.include?(action)
+      end
+
+      def plan_approval?(action, stage)
+        action == "needs_input" && stage.to_s.match?(/\A\d+-plan\z/)
       end
 
       def decide_edit(state_file_mtime:, last_dispatched:, now:, debounce_sec:)

--- a/test/unit/daemon/dispatcher_test.rb
+++ b/test/unit/daemon/dispatcher_test.rb
@@ -283,6 +283,19 @@ class HiveDaemonDispatcherTest < Minitest::Test
     refute_nil skipped, "must log :skipped reason: baseline_recorded"
   end
 
+  def test_plan_needs_input_first_sight_dispatches_without_baseline
+    rows = [ row(stage: "3-plan", action: "needs_input", marker: "waiting",
+                 command: "hive develop s1 --from 3-plan",
+                 mtime: T0 - 600) ]
+    dispatcher, sup, ctrl, logger, _mw = make_dispatcher(rows: rows)
+    dispatcher.tick(now: T0)
+    assert_equal 1, sup.spawned.size
+    assert_equal "hive develop s1 --from 3-plan", sup.spawned.first[:command]
+    assert_equal T0 - 600,
+                 ctrl.last_dispatched_state_file_mtime_for(project: "p1", slug: "s1")
+    refute logger.events.any? { |(n, a)| n == :skipped && a[:reason] == "baseline_recorded" }
+  end
+
   def test_edit_action_after_baseline_user_edit_dispatches
     rows = [ row(action: "needs_input", marker: "waiting",
                  command: "hive brainstorm s1 --from 2-brainstorm",

--- a/test/unit/daemon/dispatcher_test.rb
+++ b/test/unit/daemon/dispatcher_test.rb
@@ -294,6 +294,15 @@ class HiveDaemonDispatcherTest < Minitest::Test
     assert_equal T0 - 600,
                  ctrl.last_dispatched_state_file_mtime_for(project: "p1", slug: "s1")
     refute logger.events.any? { |(n, a)| n == :skipped && a[:reason] == "baseline_recorded" }
+    # The :dispatched audit event must fire — every other dispatch
+    # test asserts this; a regression dropping the log line would
+    # otherwise pass silently.
+    assert events_include?(logger, :dispatched)
+    # The trigger field distinguishes plan-approval auto-advance from
+    # regular advance-action dispatch so daemon.log readers do not
+    # have to re-implement Policy.decide to audit the source.
+    dispatched_event = logger.events.find { |(n, _a)| n == :dispatched }
+    assert_equal "plan_approval", dispatched_event[1][:trigger]
   end
 
   def test_edit_action_after_baseline_user_edit_dispatches

--- a/test/unit/daemon/dispatcher_test.rb
+++ b/test/unit/daemon/dispatcher_test.rb
@@ -1,4 +1,6 @@
 require "test_helper"
+require "tmpdir"
+require "hive/markers"
 require "hive/daemon/dispatcher"
 require "hive/daemon/concurrency_controller"
 require "hive/daemon/logger"
@@ -122,11 +124,11 @@ class HiveDaemonDispatcherTest < Minitest::Test
 
   def row(project: "p1", slug: "s1", stage: "1-inbox", marker: "waiting",
           action: "ready_to_brainstorm", command: "hive brainstorm s1",
-          mtime: T0 - 600, claude_pid_alive: nil)
+          mtime: T0 - 600, claude_pid_alive: nil, state_file: nil)
     Row.new(
       project: project, slug: slug, stage: stage, marker: marker,
       folder: "/tmp/#{project}/#{stage}/#{slug}",
-      state_file: "/tmp/#{project}/#{stage}/#{slug}/idea.md",
+      state_file: state_file || "/tmp/#{project}/#{stage}/#{slug}/idea.md",
       state_file_mtime: mtime, action: action,
       suggested_command: command, claude_pid_alive: claude_pid_alive
     )
@@ -284,25 +286,101 @@ class HiveDaemonDispatcherTest < Minitest::Test
   end
 
   def test_plan_needs_input_first_sight_dispatches_without_baseline
-    rows = [ row(stage: "3-plan", action: "needs_input", marker: "waiting",
-                 command: "hive develop s1 --from 3-plan",
-                 mtime: T0 - 600) ]
-    dispatcher, sup, ctrl, logger, _mw = make_dispatcher(rows: rows)
-    dispatcher.tick(now: T0)
-    assert_equal 1, sup.spawned.size
-    assert_equal "hive develop s1 --from 3-plan", sup.spawned.first[:command]
-    assert_equal T0 - 600,
-                 ctrl.last_dispatched_state_file_mtime_for(project: "p1", slug: "s1")
-    refute logger.events.any? { |(n, a)| n == :skipped && a[:reason] == "baseline_recorded" }
-    # The :dispatched audit event must fire — every other dispatch
-    # test asserts this; a regression dropping the log line would
-    # otherwise pass silently.
-    assert events_include?(logger, :dispatched)
-    # The trigger field distinguishes plan-approval auto-advance from
-    # regular advance-action dispatch so daemon.log readers do not
-    # have to re-implement Policy.decide to audit the source.
-    dispatched_event = logger.events.find { |(n, _a)| n == :dispatched }
-    assert_equal "plan_approval", dispatched_event[1][:trigger]
+    # End-to-end fix for PR #83's P0: the production command for a
+    # `plan_waiting` row is `hive plan ...` (per TaskAction; see the
+    # `plan_waiting` entry in lib/hive/task_action.rb). The daemon
+    # rewrites it to `hive develop ...` AND flips the `:waiting`
+    # marker to `:complete` before dispatch so the workflow verb's
+    # terminal-marker gate (VALID_TERMINAL_MARKERS) accepts the
+    # advance. Both steps live in Hive::Daemon::PlanApproval.
+    Dir.mktmpdir("dispatcher-plan-approval") do |dir|
+      state_file = File.join(dir, "plan.md")
+      File.write(state_file, "# plan\n\n<!-- WAITING -->\n")
+
+      rows = [ row(stage: "3-plan", action: "needs_input", marker: "waiting",
+                   command: "hive plan s1 --from 3-plan",
+                   mtime: T0 - 600, state_file: state_file) ]
+      dispatcher, sup, ctrl, logger, _mw = make_dispatcher(rows: rows)
+      dispatcher.tick(now: T0)
+
+      # Dispatched the rewritten command (develop, not plan).
+      assert_equal 1, sup.spawned.size
+      assert_equal "hive develop s1 --from 3-plan", sup.spawned.first[:command],
+                   "PlanApproval must rewrite `hive plan ...` to `hive develop ...`"
+
+      # Marker flipped to :complete on disk so `hive develop --from
+      # 3-plan` will be accepted by VALID_TERMINAL_MARKERS on the
+      # spawned child.
+      assert_equal :complete, Hive::Markers.current(state_file).name,
+                   "plan-approval auto-dispatch must flip :waiting → :complete"
+
+      # Baseline mtime recorded so subsequent ticks have something
+      # to compare against (and don't re-record a baseline).
+      assert_equal T0 - 600,
+                   ctrl.last_dispatched_state_file_mtime_for(project: "p1", slug: "s1")
+      refute logger.events.any? { |(n, a)| n == :skipped && a[:reason] == "baseline_recorded" }
+
+      # Audit event fired with the trigger field set so log readers
+      # can distinguish plan-approval dispatches from advance-action
+      # dispatches without re-implementing Policy.decide.
+      assert events_include?(logger, :dispatched)
+      dispatched_event = logger.events.find { |(n, _a)| n == :dispatched }
+      assert_equal "plan_approval", dispatched_event[1][:trigger]
+    end
+  end
+
+  def test_plan_needs_input_skips_when_marker_is_not_waiting_or_complete
+    # PlanApproval.prepare raises NotApprovable for any marker that
+    # isn't :waiting or :complete (e.g., :error). The dispatcher must
+    # log :skipped and NOT spawn — the workflow verb's WrongStage
+    # check would refuse the advance anyway, but failing in Policy is
+    # noisier than failing in PlanApproval, so we route to :skip
+    # before dispatch.
+    Dir.mktmpdir("dispatcher-plan-approval-error") do |dir|
+      state_file = File.join(dir, "plan.md")
+      File.write(state_file, "# plan\n\n<!-- ERROR reason=plan_failed -->\n")
+
+      rows = [ row(stage: "3-plan", action: "needs_input", marker: "waiting",
+                   command: "hive plan s1 --from 3-plan",
+                   mtime: T0 - 600, state_file: state_file) ]
+      dispatcher, sup, _ctrl, logger, _mw = make_dispatcher(rows: rows)
+      dispatcher.tick(now: T0)
+
+      assert_equal 0, sup.spawned.size, "must not spawn when marker isn't :waiting/:complete"
+      skip_event = logger.events.find do |(n, a)|
+        n == :skipped && a[:reason].to_s.start_with?("plan_approval_invalid")
+      end
+      refute_nil skip_event,
+                 "must log :skipped reason: plan_approval_invalid (got events: #{logger.events.map(&:first).inspect})"
+    end
+  end
+
+  def test_plan_needs_input_with_malformed_command_skips
+    # If the suggested_command is not a well-formed `hive plan ...`
+    # invocation (e.g., a stale TaskAction emission or a malformed
+    # status JSON row), PlanApproval raises ArgumentError; dispatcher
+    # routes to :skip with a reason field instead of spawning a
+    # garbage subprocess.
+    Dir.mktmpdir("dispatcher-plan-approval-malformed") do |dir|
+      state_file = File.join(dir, "plan.md")
+      File.write(state_file, "# plan\n\n<!-- WAITING -->\n")
+
+      rows = [ row(stage: "3-plan", action: "needs_input", marker: "waiting",
+                   command: "hive review s1 --from 3-plan",
+                   mtime: T0 - 600, state_file: state_file) ]
+      dispatcher, sup, _ctrl, logger, _mw = make_dispatcher(rows: rows)
+      dispatcher.tick(now: T0)
+
+      assert_equal 0, sup.spawned.size
+      skip_event = logger.events.find do |(n, a)|
+        n == :skipped && a[:reason].to_s.start_with?("plan_approval_invalid")
+      end
+      refute_nil skip_event
+      # Marker NOT flipped — malformed command must leave the
+      # marker at :waiting so an operator can inspect.
+      assert_equal :waiting, Hive::Markers.current(state_file).name,
+                   "malformed command must not flip the marker"
+    end
   end
 
   def test_edit_action_after_baseline_user_edit_dispatches

--- a/test/unit/daemon/plan_approval_test.rb
+++ b/test/unit/daemon/plan_approval_test.rb
@@ -1,0 +1,112 @@
+require "test_helper"
+require "tmpdir"
+require "hive/markers"
+require "hive/daemon/plan_approval"
+
+# Unit coverage for the shared helper that the dispatcher's
+# plan-approval auto-dispatch path relies on. The dispatcher tests
+# exercise the end-to-end flow; these tests pin each branch of
+# PlanApproval#prepare individually so a refactor that breaks one
+# arm surfaces in this file rather than in a noisier integration
+# failure.
+class HiveDaemonPlanApprovalTest < Minitest::Test
+  PA = Hive::Daemon::PlanApproval
+
+  def with_state_file(marker_line)
+    Dir.mktmpdir("plan-approval-test") do |dir|
+      path = File.join(dir, "plan.md")
+      File.write(path, "# plan\n\n#{marker_line}\n")
+      yield path
+    end
+  end
+
+  # ---- rewrite_to_develop ----
+
+  def test_rewrite_to_develop_swaps_verb
+    assert_equal "hive develop slug --from 3-plan",
+                 PA.rewrite_to_develop("hive plan slug --from 3-plan")
+  end
+
+  def test_rewrite_to_develop_preserves_quoting_on_complex_slugs
+    # Shellwords round-trips quoted args safely so a slug with
+    # special characters (unlikely but possible per the slug
+    # regex) doesn't get mangled.
+    cmd = "hive plan slug-with-dash --from 3-plan --project demo"
+    assert_equal "hive develop slug-with-dash --from 3-plan --project demo",
+                 PA.rewrite_to_develop(cmd)
+  end
+
+  def test_rewrite_to_develop_rejects_non_plan_verb
+    err = assert_raises(ArgumentError) do
+      PA.rewrite_to_develop("hive review slug --from 3-plan")
+    end
+    assert_match(/expects `hive plan/, err.message)
+  end
+
+  def test_rewrite_to_develop_rejects_empty_command
+    assert_raises(ArgumentError) { PA.rewrite_to_develop("") }
+    assert_raises(ArgumentError) { PA.rewrite_to_develop(nil) }
+  end
+
+  def test_rewrite_to_develop_rejects_command_with_only_two_argv_elements
+    # `hive plan` alone (no slug) is malformed for our purposes.
+    assert_raises(ArgumentError) { PA.rewrite_to_develop("hive plan") }
+  end
+
+  # ---- prepare (full flow) ----
+
+  def test_prepare_flips_waiting_marker_to_complete_and_returns_develop_command
+    with_state_file("<!-- WAITING -->") do |path|
+      cmd = PA.prepare("hive plan slug --from 3-plan", path)
+      assert_equal "hive develop slug --from 3-plan", cmd
+      assert_equal :complete, Hive::Markers.current(path).name
+    end
+  end
+
+  def test_prepare_leaves_complete_marker_alone_and_still_returns_develop_command
+    # Idempotent for the race where a manual operator action (or a
+    # prior tick) already flipped the marker between the status read
+    # and dispatch. The dispatch is still valid; we just don't
+    # re-flip.
+    with_state_file("<!-- COMPLETE -->") do |path|
+      cmd = PA.prepare("hive plan slug --from 3-plan", path)
+      assert_equal "hive develop slug --from 3-plan", cmd
+      assert_equal :complete, Hive::Markers.current(path).name
+    end
+  end
+
+  def test_prepare_raises_not_approvable_for_error_marker
+    with_state_file("<!-- ERROR reason=plan_failed -->") do |path|
+      err = assert_raises(PA::NotApprovable) do
+        PA.prepare("hive plan slug --from 3-plan", path)
+      end
+      assert_match(/marker=:error/, err.message)
+      # Marker NOT touched.
+      assert_equal :error, Hive::Markers.current(path).name
+    end
+  end
+
+  def test_prepare_raises_not_approvable_for_agent_working_marker
+    with_state_file("<!-- AGENT_WORKING pid=12345 -->") do |path|
+      assert_raises(PA::NotApprovable) do
+        PA.prepare("hive plan slug --from 3-plan", path)
+      end
+    end
+  end
+
+  def test_prepare_validates_command_BEFORE_flipping_marker
+    # Load-bearing: if the suggested_command is malformed and we
+    # flipped the marker first, the row would land at :complete
+    # with no follow-up dispatch — worse than the original failure
+    # because the operator sees an "approved" plan that never
+    # advances. Validate command FIRST so the failure path leaves
+    # the marker untouched at :waiting for inspection.
+    with_state_file("<!-- WAITING -->") do |path|
+      assert_raises(ArgumentError) do
+        PA.prepare("hive review slug --from 3-plan", path)
+      end
+      assert_equal :waiting, Hive::Markers.current(path).name,
+                   "command validation must happen before marker flip"
+    end
+  end
+end

--- a/test/unit/daemon/policy_test.rb
+++ b/test/unit/daemon/policy_test.rb
@@ -233,6 +233,73 @@ class HiveDaemonPolicyTest < Minitest::Test
     assert_equal :skip, decide(action: "ready_to_plan", command: "")
   end
 
+  def test_plan_approval_matches_only_literal_3_plan_stage
+    # PR #83 code review finding #4 (cross-corroborated by 4
+    # reviewers): the earlier `/\A\d+-plan\z/` regex matched any
+    # digit-prefixed plan stage. Only `"3-plan"` exists in
+    # `Hive::Stages::DIRS`, so any other `N-plan` value coming
+    # through the status surface (typo, future renumbering,
+    # hostile injection) should take the standard mtime-debounce
+    # path, NOT auto-dispatch. With `stage: nil` and a non-nil
+    # mtime + nil last_dispatched, the brainstorm-shaped behavior
+    # is :record_baseline.
+    assert_equal :record_baseline,
+                 decide(action: "needs_input", stage: "1-plan",
+                        command: "hive plan slug-a --from 1-plan",
+                        state_file_mtime: T0 - 60,
+                        last_dispatched_state_file_mtime: nil)
+    assert_equal :record_baseline,
+                 decide(action: "needs_input", stage: "13-plan",
+                        command: "hive plan slug-a --from 13-plan",
+                        state_file_mtime: T0 - 60,
+                        last_dispatched_state_file_mtime: nil)
+    # Positive control: real "3-plan" still auto-dispatches.
+    assert_equal :dispatch,
+                 decide(action: "needs_input", stage: "3-plan",
+                        command: "hive plan slug-a --from 3-plan",
+                        state_file_mtime: T0 - 60,
+                        last_dispatched_state_file_mtime: nil)
+  end
+
+  def test_plan_approval_dispatches_on_subsequent_tick_with_unchanged_mtime
+    # PR #83 code review finding #8: pin the contrast between the
+    # brainstorm-path (same-mtime returns :skip because user hasn't
+    # edited since last dispatch) and the plan-path (must still
+    # return :dispatch because plan_approval? fires BEFORE
+    # decide_edit). A refactor reordering the branches in
+    # Policy#decide would silently break second-and-later ticks
+    # while every existing test still passes.
+    same_mtime = T0 - 600
+    # Brainstorm-stage control: same mtime + non-nil last_dispatched
+    # → :skip via decide_edit's "mtime hasn't moved" branch.
+    assert_equal :skip,
+                 decide(action: "needs_input", stage: "2-brainstorm",
+                        command: "hive brainstorm slug-a --from 2-brainstorm",
+                        state_file_mtime: same_mtime,
+                        last_dispatched_state_file_mtime: same_mtime),
+                 "brainstorm path: unchanged mtime since last dispatch → :skip (sanity)"
+    # Plan-stage: plan_approval? fires first, returns :dispatch
+    # regardless of mtime state. This is what makes the auto-advance
+    # work — the brainstorm rule does not apply.
+    assert_equal :dispatch,
+                 decide(action: "needs_input", stage: "3-plan",
+                        command: "hive plan slug-a --from 3-plan",
+                        state_file_mtime: same_mtime,
+                        last_dispatched_state_file_mtime: same_mtime),
+                 "plan path: plan_approval? fires before decide_edit; subsequent ticks must still :dispatch"
+  end
+
+  def test_plan_approval_with_nil_or_empty_command_skips
+    # PR #83 code review finding #3: the nil-command guard must
+    # explicitly cover plan_approval? rows, not rely on the
+    # accidental overlap with edit_resume? (`needs_input` is in
+    # both sets today, but a future refactor extending plan_approval?
+    # to a non-edit_resume action would silently lose this coverage
+    # and a malformed status row would dispatch a nil command).
+    assert_equal :skip, decide(action: "needs_input", stage: "3-plan", command: nil)
+    assert_equal :skip, decide(action: "needs_input", stage: "3-plan", command: "")
+  end
+
   private
 
   def decide(action:, command:, stage: nil, state_file_mtime: nil,

--- a/test/unit/daemon/policy_test.rb
+++ b/test/unit/daemon/policy_test.rb
@@ -65,6 +65,18 @@ class HiveDaemonPolicyTest < Minitest::Test
                                           last_dispatched_state_file_mtime: nil)
   end
 
+  def test_plan_needs_input_dispatches_without_mtime_edit
+    # Plan-stage WAITING is an approval pause, not a request for fresh
+    # typed answers. In daemon-enabled projects, enabling the daemon is
+    # the approval gesture, so the generated plan should advance to
+    # develop without requiring a user to open and close the file.
+    assert_equal :dispatch, decide(action: "needs_input",
+                                   stage: "3-plan",
+                                   command: "hive develop slug-a --from 3-plan",
+                                   state_file_mtime: T0 - 600,
+                                   last_dispatched_state_file_mtime: nil)
+  end
+
   def test_needs_input_first_sight_with_fresh_mtime_records_baseline
     # First-sight always records baseline regardless of mtime age.
     assert_equal :record_baseline, decide(action: "needs_input",
@@ -223,10 +235,11 @@ class HiveDaemonPolicyTest < Minitest::Test
 
   private
 
-  def decide(action:, command:, state_file_mtime: nil,
+  def decide(action:, command:, stage: nil, state_file_mtime: nil,
              last_dispatched_state_file_mtime: nil, now: T0, edit_debounce_sec: 30)
     Hive::Daemon::Policy.decide(
       action: action,
+      stage: stage,
       command: command,
       state_file_mtime: state_file_mtime,
       last_dispatched_state_file_mtime: last_dispatched_state_file_mtime,

--- a/wiki/commands/daemon.md
+++ b/wiki/commands/daemon.md
@@ -3,7 +3,7 @@ title: hive daemon
 type: command
 source: lib/hive/commands/daemon.rb, lib/hive/daemon/*
 created: 2026-05-06
-updated: 2026-05-08
+updated: 2026-05-15
 tags: [command, daemon, automation, json]
 ---
 
@@ -53,7 +53,8 @@ value) and routes:
 | `ready_for_review`    | Dispatch `hive review <slug> --from 5-open-pr` (5→6) |
 | `ready_to_finalize`   | Dispatch `hive finalize <slug> --from 6-review` (6→7) |
 | `ready_to_archive`    | **Hand off to PrMergeWatcher**: poll `gh pr view` until `MERGED`, then dispatch `hive archive <slug> --from 7-finalize` (7→8) |
-| `needs_input`         | Dispatch only if state-file mtime moved AND `daemon.edit_debounce_sec` elapsed since last edit. The debounce guards mid-save partial drafts. |
+| `needs_input` at `3-plan` | **Auto-dispatch immediately.** Plan-stage `:waiting` is an approval pause, not a Q&A wait — `daemon.enabled: true` is the durable consent. `Hive::Daemon::PlanApproval.prepare` rewrites the row's `hive plan ...` command to `hive develop ...` and flips the `:waiting` marker to `:complete` before dispatch so the workflow verb's terminal-marker gate (`VALID_TERMINAL_MARKERS`) accepts the advance. Logged as `:dispatched` with `trigger: "plan_approval"`. |
+| `needs_input` (any other stage) | Dispatch only if state-file mtime moved AND `daemon.edit_debounce_sec` elapsed since last edit. The debounce guards mid-save partial drafts. Brainstorm/execute/review WAITING represent actual user-authored answers; auto-dispatch without an edit would either spam the agent or skip real user input. |
 | `review_findings`     | Same as `needs_input` (legacy 4-execute findings; rare post-ADR-014). |
 | `recover_execute`, `recover_review` | Skip — recovery markers are explicit human-input gates. |
 | `agent_running`       | Skip — task is in flight; per-task `.lock` would block double-spawn anyway. |

--- a/wiki/decisions.md
+++ b/wiki/decisions.md
@@ -205,6 +205,12 @@ Meanwhile the system grew its own load-bearing safety net: `hive approve` (`wiki
   3. **Recovery waits** (`:execute_stale`, `:review_stale`, `:review_ci_stale`, `:review_error`, `:error`) — these markers EXIST to demand human intervention; skipping them is correct.
   4. **External-state waits** — 7-finalize/`:complete` whose PR is open on GitHub. Daemon polls `gh pr view --json state` and auto-archives on `MERGED`. The merge itself remains a human gesture (the green button on GitHub); the daemon detects the merge and removes the bookkeeping burden.
 
+`3-plan`/`:waiting` is not a Q&A wait. It is the plan-approval pause
+used by the manual TUI/editor flow. For daemon-enabled projects,
+`daemon.enabled: true` is already the durable approval gesture, so the
+daemon auto-dispatches the row's `hive develop ... --from 3-plan`
+command instead of waiting for an editor open/close or mtime change.
+
 The human approval gesture for the daemon is **enabling it at `hive init`** (TTY prompt, default `Y`, per ADR-023 onboarding pattern). Per-project `daemon.enabled: true` is the explicit, durable consent. Legacy projects already on disk (configs without the `daemon:` key) fall back to `Config::DEFAULTS`'s per-project default of `false` — same "don't silently flip legacy" pattern ADR-023 used for stage agents.
 
 **Relationship to ADR-004:**

--- a/wiki/decisions.md
+++ b/wiki/decisions.md
@@ -3,7 +3,7 @@ title: Architectural Decisions
 type: decisions
 source: code + author's local planning notes (not committed)
 created: 2026-04-25
-updated: 2026-05-14
+updated: 2026-05-15
 tags: [decisions, adr]
 ---
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1458,28 +1458,6 @@ One single propagation made: `lib/hive/config.rb:220` corrected a misattribution
 **Refreshed pages:**
 - `wiki/commands/tui.md` — updated the "max_passes hit with completed passes" paragraph to document the Enter-vs-`r` gesture split and the `force:` flag's role in `BubbleModel#recover_review`.
 
-## [2026-05-15T15:55:00Z] daemon — plan WAITING rows auto-advance for daemon-enabled projects
-
-**Action:** Fixed the daemon scheduler treating every `needs_input` row
-as a user-edit wait. The symptom was a generated plan sitting in
-`3-plan` with `<!-- WAITING -->` and "Needs your input" while the daemon
-logged `skipped` every tick with `in_flight=0`; manually running
-`hive run --json` flipped the marker to `complete`, after which the
-daemon immediately dispatched `hive develop ... --from 3-plan`.
-Root cause: `Hive::Daemon::Policy` only saw `action=needs_input`, so it
-applied the mtime-baseline/debounce path meant for brainstorm answers,
-execute questions, and review decisions. `Policy.decide` now accepts
-the status row's `stage`; `3-plan` + `needs_input` dispatches
-immediately because a plan WAITING marker is an approval pause, not a
-Q&A file. Other `needs_input` stages keep the existing edit debounce.
-Tests: added policy and dispatcher pins for first-sight plan WAITING
-dispatch while preserving first-sight brainstorm baseline behavior.
-
-**Refreshed pages:**
-- `wiki/modules/daemon.md` — documents the stage-aware policy exception.
-- `wiki/decisions.md` — ADR-024 now calls out `3-plan`/`:waiting` as
-  daemon-auto-approved by `daemon.enabled: true`.
-
 ## [2026-05-14T14:00:00Z] review — operator-edit detection retries pass N's fix when escalations-NN.md is edited after fix-success-NN.md
 
 **Action:** Closed the recovery hole that made `r`-press on a max_passes-hit REVIEW_STALE row visually re-run hive but immediately re-write `REVIEW_STALE pass=N` without anything happening. Root cause: `Stages::Review#pass_completion_status` returned `:complete` whenever `fix-success-NN.md` existed, regardless of whether the operator had edited `escalations-NN.md` afterwards. `next_pass_for` then advanced to N+1, the loop body saw `pass > max_passes` and set REVIEW_STALE pass=N — same state, no progress. Fix: `pass_completion_status` now returns `:fix_incomplete` instead of `:complete` when `mtime(escalations-NN.md) > mtime(fix-success-NN.md)`, which keeps `next_pass_for` on pass N and routes the loop through the existing Phase-4-retry-only path (skips reviewers + triage, re-runs fix against the operator's current `[x]` marks). New helper `operator_edited_escalations_after_fix?` swallows `SystemCallError` / `IOError` so a transient stat failure fails-closed (no surprise retries). The comparison is strict `>` not `>=` so back-to-back same-second writes don't spuriously trigger retries. The TUI's `r` gesture from PR #72 is now actually useful for the max_passes-exhausted shape: Enter to open `escalations-NN.md`, edit, save, `r` to retry — Phase 4 re-runs with the edits as authoritative input, no max_passes bump required. Tests: +4 in `run_reviewers_test.rb` (post-fix newer-fix-success still :complete, operator edit flips to :fix_incomplete, equal mtimes stay :complete, stat failure fails closed) plus an end-to-end pin via `next_pass_for` returning N (not N+1) when escalations is newer.
@@ -1520,3 +1498,25 @@ dispatch while preserving first-sight brainstorm baseline behavior.
 
 **Refreshed pages:**
 - `wiki/stages/index.md`, `wiki/stages/open-pr.md`, `wiki/stages/review.md`, `wiki/stages/finalize.md`, `wiki/state-model.md`, `wiki/architecture.md`, `wiki/commands/stage_action.md`, `wiki/commands/run.md`, `wiki/decisions.md`.
+
+## [2026-05-15T15:55:00Z] daemon — plan WAITING rows auto-advance for daemon-enabled projects
+
+**Action:** Fixed the daemon scheduler treating every `needs_input` row
+as a user-edit wait. The symptom was a generated plan sitting in
+`3-plan` with `<!-- WAITING -->` and "Needs your input" while the daemon
+logged `skipped` every tick with `in_flight=0`; manually running
+`hive run --json` flipped the marker to `complete`, after which the
+daemon immediately dispatched `hive develop ... --from 3-plan`.
+Root cause: `Hive::Daemon::Policy` only saw `action=needs_input`, so it
+applied the mtime-baseline/debounce path meant for brainstorm answers,
+execute questions, and review decisions. `Policy.decide` now accepts
+the status row's `stage`; `3-plan` + `needs_input` dispatches
+immediately because a plan WAITING marker is an approval pause, not a
+Q&A file. Other `needs_input` stages keep the existing edit debounce.
+Tests: added policy and dispatcher pins for first-sight plan WAITING
+dispatch while preserving first-sight brainstorm baseline behavior.
+
+**Refreshed pages:**
+- `wiki/modules/daemon.md` — documents the stage-aware policy exception.
+- `wiki/decisions.md` — ADR-024 now calls out `3-plan`/`:waiting` as
+  daemon-auto-approved by `daemon.enabled: true`.

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1458,6 +1458,28 @@ One single propagation made: `lib/hive/config.rb:220` corrected a misattribution
 **Refreshed pages:**
 - `wiki/commands/tui.md` — updated the "max_passes hit with completed passes" paragraph to document the Enter-vs-`r` gesture split and the `force:` flag's role in `BubbleModel#recover_review`.
 
+## [2026-05-15T15:55:00Z] daemon — plan WAITING rows auto-advance for daemon-enabled projects
+
+**Action:** Fixed the daemon scheduler treating every `needs_input` row
+as a user-edit wait. The symptom was a generated plan sitting in
+`3-plan` with `<!-- WAITING -->` and "Needs your input" while the daemon
+logged `skipped` every tick with `in_flight=0`; manually running
+`hive run --json` flipped the marker to `complete`, after which the
+daemon immediately dispatched `hive develop ... --from 3-plan`.
+Root cause: `Hive::Daemon::Policy` only saw `action=needs_input`, so it
+applied the mtime-baseline/debounce path meant for brainstorm answers,
+execute questions, and review decisions. `Policy.decide` now accepts
+the status row's `stage`; `3-plan` + `needs_input` dispatches
+immediately because a plan WAITING marker is an approval pause, not a
+Q&A file. Other `needs_input` stages keep the existing edit debounce.
+Tests: added policy and dispatcher pins for first-sight plan WAITING
+dispatch while preserving first-sight brainstorm baseline behavior.
+
+**Refreshed pages:**
+- `wiki/modules/daemon.md` — documents the stage-aware policy exception.
+- `wiki/decisions.md` — ADR-024 now calls out `3-plan`/`:waiting` as
+  daemon-auto-approved by `daemon.enabled: true`.
+
 ## [2026-05-14T14:00:00Z] review — operator-edit detection retries pass N's fix when escalations-NN.md is edited after fix-success-NN.md
 
 **Action:** Closed the recovery hole that made `r`-press on a max_passes-hit REVIEW_STALE row visually re-run hive but immediately re-write `REVIEW_STALE pass=N` without anything happening. Root cause: `Stages::Review#pass_completion_status` returned `:complete` whenever `fix-success-NN.md` existed, regardless of whether the operator had edited `escalations-NN.md` afterwards. `next_pass_for` then advanced to N+1, the loop body saw `pass > max_passes` and set REVIEW_STALE pass=N — same state, no progress. Fix: `pass_completion_status` now returns `:fix_incomplete` instead of `:complete` when `mtime(escalations-NN.md) > mtime(fix-success-NN.md)`, which keeps `next_pass_for` on pass N and routes the loop through the existing Phase-4-retry-only path (skips reviewers + triage, re-runs fix against the operator's current `[x]` marks). New helper `operator_edited_escalations_after_fix?` swallows `SystemCallError` / `IOError` so a transient stat failure fails-closed (no surprise retries). The comparison is strict `>` not `>=` so back-to-back same-second writes don't spuriously trigger retries. The TUI's `r` gesture from PR #72 is now actually useful for the max_passes-exhausted shape: Enter to open `escalations-NN.md`, edit, save, `r` to retry — Phase 4 re-runs with the edits as authoritative input, no max_passes bump required. Tests: +4 in `run_reviewers_test.rb` (post-fix newer-fix-success still :complete, operator edit flips to :fix_incomplete, equal mtimes stay :complete, stat failure fails closed) plus an end-to-end pin via `next_pass_for` returning N (not N+1) when escalations is newer.

--- a/wiki/modules/daemon.md
+++ b/wiki/modules/daemon.md
@@ -3,7 +3,7 @@ title: Hive::Daemon
 type: module
 source: lib/hive/daemon/
 created: 2026-05-06
-updated: 2026-05-06
+updated: 2026-05-15
 tags: [daemon, module, automation, dispatcher]
 ---
 
@@ -17,7 +17,7 @@ decisions are unit-testable without forking.
 
 | Module | File | Purpose |
 |--------|------|---------|
-| `Hive::Daemon::Policy` | `lib/hive/daemon/policy.rb` | Pure switch over `Hive::Schemas::TaskActionKind` + mtime debounce → `:dispatch` / `:poll_for_merge` / `:wait_for_debounce` / `:skip`. Source of truth for "should this row fire a child?". |
+| `Hive::Daemon::Policy` | `lib/hive/daemon/policy.rb` | Pure switch over `Hive::Schemas::TaskActionKind`, stage context, and mtime debounce → `:dispatch` / `:poll_for_merge` / `:wait_for_debounce` / `:skip`. Source of truth for "should this row fire a child?". |
 | `Hive::Daemon::ConcurrencyController` | `lib/hive/daemon/concurrency_controller.rb` | In-memory budget gate: caps (global / per-project / per-day rate), cooldowns, transient backoff schedule, quarantine, dropped projects, last-dispatched mtime tracking. |
 | `Hive::Daemon::StatusConsumer` | `lib/hive/daemon/status_consumer.rb` | Wraps `Open3.capture3("hive status --json")`; returns typed `Row` records. Validates schema version; surfaces parse failures as `Result(ok: false)`. |
 | `Hive::Daemon::ChildSupervisor` | `lib/hive/daemon/child_supervisor.rb` | Spawns `hive ...` subprocesses with `pgroup: true`; reaps via `Process.wait(-1, WNOHANG)`; parses JSON envelopes from child stdout; supports `terminate_all(grace_sec:)` with TERM→KILL escalation. |
@@ -57,6 +57,15 @@ folders, never touches per-task `.lock` files directly. Any
 misclassification at the `Policy` level surfaces as `Hive::WrongStage`
 (exit 4) at the workflow-verb level, not as a silent advance past a
 human gate. See ADR-024.
+
+`3-plan`/`needs_input` is the policy exception to the generic
+edit-resume debounce. A generated plan in `WAITING` is an approval
+pause, not a Q&A file waiting for typed answers. For daemon-enabled
+projects the durable approval gesture is `daemon.enabled: true`, so the
+policy dispatches the row's `hive develop ... --from 3-plan` command
+immediately. Brainstorm, execute, and review `needs_input` rows still
+use mtime-baseline + debounce because those states represent actual
+user-authored answers or review decisions.
 
 ## Backlinks
 


### PR DESCRIPTION
## Summary
- treat 3-plan needs_input rows as daemon-approved plan waits and dispatch develop immediately
- keep brainstorm/execute/review needs_input rows on the existing mtime debounce path
- document the daemon policy exception in the wiki

## Verification
- bundle exec ruby -Itest test/unit/daemon/policy_test.rb
- bundle exec ruby -Itest test/unit/daemon/dispatcher_test.rb
- bundle exec ruby -Itest test/unit/daemon/concurrency_controller_test.rb
- bundle exec ruby -Itest test/unit/daemon/status_consumer_test.rb
- bundle exec ruby -Itest test/integration/daemon_command_test.rb
- bundle exec rake test
- bundle exec rubocop --parallel --format github