### PR TITLE
chore: gitignore .worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@
 /logs/
 .qmd/
 /.llm-wiki/qmd-cache/
+.worktrees/


### PR DESCRIPTION
## Summary

Add `.worktrees/` to `.gitignore` so local sibling-worktree directories (created by `gh pr checkout`, `git worktree add`, the ce-worktree skill, etc.) stop showing up as untracked in every `git status`.

The hive-task worktrees defined by `wiki/modules/worktree.md` live at `~/Dev/hive.worktrees/<slug>/` — those are outside the repo and unaffected. This entry covers only the developer-local `.worktrees/` directory that some review/dogfood workflows create at the repo root.

## Test plan

- [x] `.gitignore` reads cleanly; no syntax errors
- [x] After merge, `git status` in a checkout that has `.worktrees/` underneath no longer shows the directory as untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)