### PR TITLE
fix(tui): require project choice for all-project ideas

### DIFF
--- a/lib/hive/tui/bubble_model.rb
+++ b/lib/hive/tui/bubble_model.rb
@@ -28,6 +28,7 @@ require "hive/tui/views/log_tail"
 require "hive/tui/views/help_overlay"
 require "hive/tui/views/filter_prompt"
 require "hive/tui/views/new_idea_prompt"
+require "hive/tui/views/new_idea_project_picker"
 
 module Hive
   module Tui
@@ -217,9 +218,10 @@ module Hive
         when :grid then compose_two_pane_view
         when :triage then Views::Triage.render(@hive_model)
         when :log_tail then Views::LogTail.render(@hive_model)
-        when :help then Views::HelpOverlay.render(@hive_model)
-        when :filter then compose_filter_view
-        when :new_idea then compose_new_idea_view
+	        when :help then Views::HelpOverlay.render(@hive_model)
+	        when :filter then compose_filter_view
+	        when :new_idea_project then compose_new_idea_project_view
+	        when :new_idea then compose_new_idea_view
         else compose_two_pane_view
         end
       end
@@ -2157,9 +2159,10 @@ module Hive
       #   so the success `puts` lines do NOT corrupt the alt-screen
       #   render.
       #
-      # Project is resolved from `model.scope` (0 = first registered
-      # project per the v2 brainstorm decision; N = nth registered
-      # project). Empty title or no-projects-registered states flash an
+	      # Project is resolved from either the explicit chooser target
+	      # (`new_idea_project_name`, set when `n` starts from ★ All
+	      # projects) or from a concrete project scope. Empty title or
+	      # no-projects-registered states flash an
       # error and return to :grid without spawning a child.
       #
       # Staging cleanup policy: every exit path either runs
@@ -2491,10 +2494,12 @@ module Hive
       # buffer, return to :grid, set a flash. Three call sites in the
       # success/validation branches plus the rescue all funnel through
       # this so the mode/buffer/flash trio always moves together.
-      def reset_to_grid_with_flash(text)
-        @hive_model.with(
-          mode: :grid,
-          new_idea_buffer: "",
+	      def reset_to_grid_with_flash(text)
+	        @hive_model.with(
+	          mode: :grid,
+	          new_idea_project_name: nil,
+	          new_idea_project_cursor: 0,
+	          new_idea_buffer: "",
           new_idea_cursor: 0,
           new_idea_attachments: [],
           new_idea_staging_dir: nil,
@@ -2514,12 +2519,21 @@ module Hive
       # so the operator sees the actual cause rather than a generic
       # "no projects" message that doesn't match what they see in the
       # left pane (which shows the project, just broken).
-      def new_idea_resolution_flash(model)
-        snap = model.snapshot
-        return "no projects — run `hive init <path>` first" if snap.nil? || snap.projects.empty?
+	      def new_idea_resolution_flash(model)
+	        snap = model.snapshot
+	        return "no projects — run `hive init <path>` first" if snap.nil? || snap.projects.empty?
 
-        if model.scope.between?(1, snap.projects.size)
-          project = snap.projects[model.scope - 1]
+	        chosen = model.respond_to?(:new_idea_project_name) ? model.new_idea_project_name.to_s : ""
+	        unless chosen.empty?
+	          project = snap.projects.find { |p| p.name == chosen }
+	          if project&.error
+	            return "project #{project.name.inspect} is #{project.error.gsub('_', ' ')} — choose another project or re-init it"
+	          end
+	          return "project #{chosen.inspect} is not available — choose another project" if project.nil?
+	        end
+
+	        if model.scope.between?(1, snap.projects.size)
+	          project = snap.projects[model.scope - 1]
           if project.error
             return "project #{project.name.inspect} is #{project.error.gsub('_', ' ')} — re-init, press X to drop, or `hive forget`"
           end
@@ -2569,10 +2583,17 @@ module Hive
       # Width clamps the prompt so long titles don't overflow the
       # terminal — the visible buffer slides to keep the cursor on
       # screen (see Views::NewIdeaPrompt.render).
-      def compose_new_idea_view
-        usable = [ @hive_model.cols.to_i - 1, 1 ].max
-        compose_two_pane_view(footer: prompt_footer(Views::NewIdeaPrompt.render(@hive_model, width: usable), usable))
-      end
+	      def compose_new_idea_view
+	        usable = [ @hive_model.cols.to_i - 1, 1 ].max
+	        compose_two_pane_view(footer: prompt_footer(Views::NewIdeaPrompt.render(@hive_model, width: usable), usable))
+	      end
+
+	      def compose_new_idea_project_view
+	        usable = [ @hive_model.cols.to_i - 1, 1 ].max
+	        compose_two_pane_view(
+	          footer: prompt_footer(Views::NewIdeaProjectPicker.render(@hive_model, width: usable), usable)
+	        )
+	      end
 
       # Stack an active flash above the prompt strip so error states
       # raised inside `:new_idea` / `:filter` mode (paste truncated,

--- a/lib/hive/tui/bubble_model.rb
+++ b/lib/hive/tui/bubble_model.rb
@@ -218,10 +218,10 @@ module Hive
         when :grid then compose_two_pane_view
         when :triage then Views::Triage.render(@hive_model)
         when :log_tail then Views::LogTail.render(@hive_model)
-	        when :help then Views::HelpOverlay.render(@hive_model)
-	        when :filter then compose_filter_view
-	        when :new_idea_project then compose_new_idea_project_view
-	        when :new_idea then compose_new_idea_view
+        when :help then Views::HelpOverlay.render(@hive_model)
+        when :filter then compose_filter_view
+        when :new_idea_project then compose_new_idea_project_view
+        when :new_idea then compose_new_idea_view
         else compose_two_pane_view
         end
       end
@@ -2159,10 +2159,10 @@ module Hive
       #   so the success `puts` lines do NOT corrupt the alt-screen
       #   render.
       #
-	      # Project is resolved from either the explicit chooser target
-	      # (`new_idea_project_name`, set when `n` starts from ★ All
-	      # projects) or from a concrete project scope. Empty title or
-	      # no-projects-registered states flash an
+      # Project is resolved from either the explicit chooser target
+      # (`new_idea_project_name`, set when `n` starts from ★ All
+      # projects) or from a concrete project scope. Empty title or
+      # no-projects-registered states flash an
       # error and return to :grid without spawning a child.
       #
       # Staging cleanup policy: every exit path either runs
@@ -2494,12 +2494,12 @@ module Hive
       # buffer, return to :grid, set a flash. Three call sites in the
       # success/validation branches plus the rescue all funnel through
       # this so the mode/buffer/flash trio always moves together.
-	      def reset_to_grid_with_flash(text)
-	        @hive_model.with(
-	          mode: :grid,
-	          new_idea_project_name: nil,
-	          new_idea_project_cursor: 0,
-	          new_idea_buffer: "",
+      def reset_to_grid_with_flash(text)
+        @hive_model.with(
+          mode: :grid,
+          new_idea_project_name: nil,
+          new_idea_project_cursor: 0,
+          new_idea_buffer: "",
           new_idea_cursor: 0,
           new_idea_attachments: [],
           new_idea_staging_dir: nil,
@@ -2519,21 +2519,21 @@ module Hive
       # so the operator sees the actual cause rather than a generic
       # "no projects" message that doesn't match what they see in the
       # left pane (which shows the project, just broken).
-	      def new_idea_resolution_flash(model)
-	        snap = model.snapshot
-	        return "no projects — run `hive init <path>` first" if snap.nil? || snap.projects.empty?
+      def new_idea_resolution_flash(model)
+        snap = model.snapshot
+        return "no projects — run `hive init <path>` first" if snap.nil? || snap.projects.empty?
 
-	        chosen = model.respond_to?(:new_idea_project_name) ? model.new_idea_project_name.to_s : ""
-	        unless chosen.empty?
-	          project = snap.projects.find { |p| p.name == chosen }
-	          if project&.error
-	            return "project #{project.name.inspect} is #{project.error.gsub('_', ' ')} — choose another project or re-init it"
-	          end
-	          return "project #{chosen.inspect} is not available — choose another project" if project.nil?
-	        end
+        chosen = model.new_idea_project_name.to_s
+        unless chosen.empty?
+          project = snap.projects.find { |p| p.name == chosen }
+          if project&.error
+            return "project #{project.name.inspect} is #{project.error.gsub('_', ' ')} — choose another project or re-init it"
+          end
+          return "project #{chosen.inspect} is not available — choose another project" if project.nil?
+        end
 
-	        if model.scope.between?(1, snap.projects.size)
-	          project = snap.projects[model.scope - 1]
+        if model.scope.between?(1, snap.projects.size)
+          project = snap.projects[model.scope - 1]
           if project.error
             return "project #{project.name.inspect} is #{project.error.gsub('_', ' ')} — re-init, press X to drop, or `hive forget`"
           end
@@ -2583,17 +2583,17 @@ module Hive
       # Width clamps the prompt so long titles don't overflow the
       # terminal — the visible buffer slides to keep the cursor on
       # screen (see Views::NewIdeaPrompt.render).
-	      def compose_new_idea_view
-	        usable = [ @hive_model.cols.to_i - 1, 1 ].max
-	        compose_two_pane_view(footer: prompt_footer(Views::NewIdeaPrompt.render(@hive_model, width: usable), usable))
-	      end
+      def compose_new_idea_view
+        usable = [ @hive_model.cols.to_i - 1, 1 ].max
+        compose_two_pane_view(footer: prompt_footer(Views::NewIdeaPrompt.render(@hive_model, width: usable), usable))
+      end
 
-	      def compose_new_idea_project_view
-	        usable = [ @hive_model.cols.to_i - 1, 1 ].max
-	        compose_two_pane_view(
-	          footer: prompt_footer(Views::NewIdeaProjectPicker.render(@hive_model, width: usable), usable)
-	        )
-	      end
+      def compose_new_idea_project_view
+        usable = [ @hive_model.cols.to_i - 1, 1 ].max
+        compose_two_pane_view(
+          footer: prompt_footer(Views::NewIdeaProjectPicker.render(@hive_model, width: usable), usable)
+        )
+      end
 
       # Stack an active flash above the prompt strip so error states
       # raised inside `:new_idea` / `:filter` mode (paste truncated,

--- a/lib/hive/tui/bubble_model.rb
+++ b/lib/hive/tui/bubble_model.rb
@@ -2196,6 +2196,26 @@ module Hive
         project = Hive::Tui::Views::NewIdeaPrompt.resolve_project_name(@hive_model)
         if project.nil?
           flash = new_idea_resolution_flash(@hive_model)
+          # If the operator had picked a concrete project via the picker
+          # and it later went stale (snapshot poll dropped it or marked
+          # it unhealthy), bounce back to the picker with the typed
+          # buffer preserved — the flash advises "choose another
+          # project", and Esc still cleanly discards everything. The
+          # plain "no-projects" / "no scope" cases (no chosen name in
+          # play) fall through to `reset_to_grid_with_flash` because
+          # there's nothing to re-pick.
+          chosen = @hive_model.new_idea_project_name.to_s
+          if !chosen.empty? && @hive_model.scope.zero?
+            return [
+              @hive_model.with(
+                mode: :new_idea_project,
+                new_idea_project_name: nil,
+                flash: flash,
+                flash_set_at: Time.now
+              ),
+              nil
+            ]
+          end
           # `reset_to_grid_with_flash` clears `new_idea_staging_dir`
           # on the model; clean the on-disk dir first so orphaned
           # files don't leak after we drop the reference.
@@ -2278,6 +2298,22 @@ module Hive
         if project.nil?
           preserve_staging = true
           flash = new_idea_resolution_flash(@hive_model)
+          # Mirror the plain-text path: if the operator's picked project
+          # went stale mid-compose, bounce back to the picker so they
+          # can re-pick without losing the staged images. The flash
+          # tells them what happened; Esc still cleans everything.
+          chosen = @hive_model.new_idea_project_name.to_s
+          if !chosen.empty? && @hive_model.scope.zero?
+            return [
+              @hive_model.with(
+                mode: :new_idea_project,
+                new_idea_project_name: nil,
+                flash: flash,
+                flash_set_at: Time.now
+              ),
+              nil
+            ]
+          end
           return [ @hive_model.with(flash: flash, flash_set_at: Time.now), nil ]
         end
 
@@ -2512,8 +2548,12 @@ module Hive
       end
 
       # Build a flash for the case where new-idea resolution returned
-      # nil. Distinguishes three reasons:
+      # nil. Distinguishes five reasons:
       # - no registered projects at all → "run `hive init <path>`"
+      # - chosen project (via picker) now unhealthy → name the error +
+      #   "choose another project" (caller bounces back to picker)
+      # - chosen project name no longer present in snapshot → "is not
+      #   available" + "choose another project" (caller bounces back)
       # - explicit scope onto an unhealthy project → name the error
       # - scope=0 (★ All) but every registered project is unhealthy
       # so the operator sees the actual cause rather than a generic
@@ -2596,11 +2636,12 @@ module Hive
       end
 
       # Stack an active flash above the prompt strip so error states
-      # raised inside `:new_idea` / `:filter` mode (paste truncated,
-      # title too long, decoder overflow, paste timed out) reach the
-      # operator. Without this the flash sets `model.flash` but the
-      # prompt-mode views replace `default_footer` entirely, so the
-      # flash never renders.
+      # raised inside any prompt mode (`:new_idea`, `:new_idea_project`,
+      # `:filter`) — paste truncated, title too long, decoder overflow,
+      # paste timed out, waiting-for-snapshot, no-healthy-projects —
+      # reach the operator. Without this the flash sets `model.flash`
+      # but the prompt-mode views replace `default_footer` entirely, so
+      # the flash never renders.
       def prompt_footer(prompt_strip, usable_width)
         flash = active_flash_line(usable_width)
         flash ? "#{flash}\n#{prompt_strip}" : prompt_strip

--- a/lib/hive/tui/help.rb
+++ b/lib/hive/tui/help.rb
@@ -38,7 +38,7 @@ module Hive
         { mode: :grid, key: "Right",     action: :pane_focus_right,   description: "jump focus to the tasks pane" },
         { mode: :grid, key: "Enter",     action: :open_contextual,    description: "left pane: focus right. right pane: open contextual mode: input editor on `needs_input` (completed brainstorm answers auto-run), triage on `review_findings`, log tail on `agent_running` (and on `error` rows still in a kill-class auto-heal window), recover + rerun on review-recovery and non-kill-class `error` rows, browse focal escalations file on `review_stale` max_passes-hit rows; ready rows still dispatch the suggested command" },
         { mode: :grid, key: "o",         action: :open_task_folder,   description: "open the focused task's folder in $EDITOR (read-only browse — no workflow dispatch, distinct from Enter and the verb keys)" },
-        { mode: :grid, key: "n",         action: :new_idea,           description: "open the new-idea prompt; submitting runs `hive new <project> \"<title>\"`" },
+        { mode: :grid, key: "n",         action: :new_idea,           description: "open the new-idea prompt; from ★ All projects, choose a target project first" },
         { mode: :grid, key: "/",         action: :filter,             description: "open filter prompt" },
         { mode: :grid, key: "1-9",       action: :project_scope,      description: "scope to the Nth registered project" },
         { mode: :grid, key: "0",         action: :project_scope,      description: "clear project scope (★ All projects)" },
@@ -60,6 +60,10 @@ module Hive
         { mode: :filter, key: "Enter", action: :commit_filter, description: "commit typed filter" },
         { mode: :filter, key: "Esc",   action: :cancel_filter, description: "discard typed buffer and return to grid (any committed filter is preserved)" },
         # New-idea prompt mode (v2).
+        { mode: :new_idea_project, key: "j/k",   action: :project_cursor, description: "move through projects for the new idea" },
+        { mode: :new_idea_project, key: "Enter", action: :choose_project,  description: "choose the highlighted project and continue to the title prompt" },
+        { mode: :new_idea_project, key: "Esc",   action: :cancel_new_idea, description: "cancel and return to grid" },
+
         { mode: :new_idea, key: "Enter", action: :submit_new_idea, description: "submit — runs `hive new <project> \"<title>\"` against the project shown in the prompt label" },
         { mode: :new_idea, key: "Esc",   action: :cancel_new_idea, description: "cancel and return to grid; the typed buffer is discarded" }
       ].each(&:freeze).freeze

--- a/lib/hive/tui/help.rb
+++ b/lib/hive/tui/help.rb
@@ -60,9 +60,11 @@ module Hive
         { mode: :filter, key: "Enter", action: :commit_filter, description: "commit typed filter" },
         { mode: :filter, key: "Esc",   action: :cancel_filter, description: "discard typed buffer and return to grid (any committed filter is preserved)" },
         # New-idea prompt mode (v2).
-        { mode: :new_idea_project, key: "j/k",   action: :project_cursor, description: "move through projects for the new idea" },
-        { mode: :new_idea_project, key: "Enter", action: :choose_project,  description: "choose the highlighted project and continue to the title prompt" },
-        { mode: :new_idea_project, key: "Esc",   action: :cancel_new_idea, description: "cancel and return to grid" },
+        { mode: :new_idea_project, key: "j/k",     action: :project_cursor,  description: "move through projects for the new idea" },
+        { mode: :new_idea_project, key: "Up/Down", action: :project_cursor,  description: "move through projects (arrow keys)" },
+        { mode: :new_idea_project, key: "Enter",   action: :choose_project,  description: "choose the highlighted project and continue to the title prompt" },
+        { mode: :new_idea_project, key: "Esc",     action: :cancel_new_idea, description: "cancel and return to grid" },
+        { mode: :new_idea_project, key: "q",       action: :cancel_new_idea, description: "cancel and return to grid (alias for Esc)" },
 
         { mode: :new_idea, key: "Enter", action: :submit_new_idea, description: "submit — runs `hive new <project> \"<title>\"` against the project shown in the prompt label" },
         { mode: :new_idea, key: "Esc",   action: :cancel_new_idea, description: "cancel and return to grid; the typed buffer is discarded" }

--- a/lib/hive/tui/key_map.rb
+++ b/lib/hive/tui/key_map.rb
@@ -83,8 +83,8 @@ module Hive
         when :log_tail then log_tail_message(key: key, row: row)
         when :filter then filter_message(key: key, row: row)
         when :help then help_message(key: key, row: row)
-	        when :new_idea_project then new_idea_project_message(key: key, row: row)
-	        when :new_idea then new_idea_message(key: key, row: row)
+        when :new_idea_project then new_idea_project_message(key: key, row: row)
+        when :new_idea then new_idea_message(key: key, row: row)
         else raise ArgumentError, "unknown mode: #{mode.inspect}"
         end
       end
@@ -319,9 +319,9 @@ module Hive
       # symbol from BubbleModel#bubble_key_to_keymap, so it must be
       # mapped explicitly to a literal space — without this branch,
       # multi-word titles like "rss feeds" would land as "rssfeeds".
-	      def new_idea_message(key:, row:) # rubocop:disable Lint/UnusedMethodArgument
-	        return Messages::NEW_IDEA_CANCELLED if ESCAPE_KEYS.include?(key)
-	        return Messages::NEW_IDEA_SUBMITTED if ENTER_KEYS.include?(key)
+      def new_idea_message(key:, row:) # rubocop:disable Lint/UnusedMethodArgument
+        return Messages::NEW_IDEA_CANCELLED if ESCAPE_KEYS.include?(key)
+        return Messages::NEW_IDEA_SUBMITTED if ENTER_KEYS.include?(key)
         return Messages::NEW_IDEA_CHAR_DELETED if key == :key_backspace
         return Messages::NEW_IDEA_CHAR_DELETED_FORWARD if key == :key_delete
         return Messages::NEW_IDEA_CURSOR_LEFT if key == :key_left
@@ -331,22 +331,22 @@ module Hive
         return Messages::NewIdeaTextInserted.new(text: " ") if key == :space
         return Messages::NewIdeaTextInserted.new(text: key) if printable_filter_char?(key)
 
-	        Messages::NOOP
-	      end
+        Messages::NOOP
+      end
 
-	      # Project chooser shown before the title prompt when `n` starts
-	      # from ★ All projects. Keep the key surface intentionally narrow:
-	      # choose with Enter, move with j/k or arrows, cancel with Esc/q.
-	      def new_idea_project_message(key:, row:) # rubocop:disable Lint/UnusedMethodArgument
-	        return Messages::NEW_IDEA_CANCELLED if ESCAPE_KEYS.include?(key) || key == "q"
-	        return Messages::NEW_IDEA_PROJECT_SELECTED if ENTER_KEYS.include?(key)
-	        return Messages::NEW_IDEA_PROJECT_CURSOR_DOWN if DOWN_KEYS.include?(key)
-	        return Messages::NEW_IDEA_PROJECT_CURSOR_UP if UP_KEYS.include?(key)
+      # Project chooser shown before the title prompt when `n` starts
+      # from ★ All projects. Keep the key surface intentionally narrow:
+      # choose with Enter, move with j/k or arrows, cancel with Esc/q.
+      def new_idea_project_message(key:, row:) # rubocop:disable Lint/UnusedMethodArgument
+        return Messages::NEW_IDEA_CANCELLED if ESCAPE_KEYS.include?(key) || key == "q"
+        return Messages::NEW_IDEA_PROJECT_SELECTED if ENTER_KEYS.include?(key)
+        return Messages::NEW_IDEA_PROJECT_CURSOR_DOWN if DOWN_KEYS.include?(key)
+        return Messages::NEW_IDEA_PROJECT_CURSOR_UP if UP_KEYS.include?(key)
 
-	        Messages::NOOP
-	      end
+        Messages::NOOP
+      end
 
-	      # Shared DispatchCommand builder. `argv[1]` is the workflow verb
+      # Shared DispatchCommand builder. `argv[1]` is the workflow verb
       # (`brainstorm`/`plan`/`develop`/`review`/`pr`/`archive`); cached
       # at construction time so SubprocessExited can flash by verb name.
       def dispatch_command_for(suggested_command)

--- a/lib/hive/tui/key_map.rb
+++ b/lib/hive/tui/key_map.rb
@@ -83,7 +83,8 @@ module Hive
         when :log_tail then log_tail_message(key: key, row: row)
         when :filter then filter_message(key: key, row: row)
         when :help then help_message(key: key, row: row)
-        when :new_idea then new_idea_message(key: key, row: row)
+	        when :new_idea_project then new_idea_project_message(key: key, row: row)
+	        when :new_idea then new_idea_message(key: key, row: row)
         else raise ArgumentError, "unknown mode: #{mode.inspect}"
         end
       end
@@ -318,9 +319,9 @@ module Hive
       # symbol from BubbleModel#bubble_key_to_keymap, so it must be
       # mapped explicitly to a literal space — without this branch,
       # multi-word titles like "rss feeds" would land as "rssfeeds".
-      def new_idea_message(key:, row:) # rubocop:disable Lint/UnusedMethodArgument
-        return Messages::NEW_IDEA_CANCELLED if ESCAPE_KEYS.include?(key)
-        return Messages::NEW_IDEA_SUBMITTED if ENTER_KEYS.include?(key)
+	      def new_idea_message(key:, row:) # rubocop:disable Lint/UnusedMethodArgument
+	        return Messages::NEW_IDEA_CANCELLED if ESCAPE_KEYS.include?(key)
+	        return Messages::NEW_IDEA_SUBMITTED if ENTER_KEYS.include?(key)
         return Messages::NEW_IDEA_CHAR_DELETED if key == :key_backspace
         return Messages::NEW_IDEA_CHAR_DELETED_FORWARD if key == :key_delete
         return Messages::NEW_IDEA_CURSOR_LEFT if key == :key_left
@@ -330,10 +331,22 @@ module Hive
         return Messages::NewIdeaTextInserted.new(text: " ") if key == :space
         return Messages::NewIdeaTextInserted.new(text: key) if printable_filter_char?(key)
 
-        Messages::NOOP
-      end
+	        Messages::NOOP
+	      end
 
-      # Shared DispatchCommand builder. `argv[1]` is the workflow verb
+	      # Project chooser shown before the title prompt when `n` starts
+	      # from ★ All projects. Keep the key surface intentionally narrow:
+	      # choose with Enter, move with j/k or arrows, cancel with Esc/q.
+	      def new_idea_project_message(key:, row:) # rubocop:disable Lint/UnusedMethodArgument
+	        return Messages::NEW_IDEA_CANCELLED if ESCAPE_KEYS.include?(key) || key == "q"
+	        return Messages::NEW_IDEA_PROJECT_SELECTED if ENTER_KEYS.include?(key)
+	        return Messages::NEW_IDEA_PROJECT_CURSOR_DOWN if DOWN_KEYS.include?(key)
+	        return Messages::NEW_IDEA_PROJECT_CURSOR_UP if UP_KEYS.include?(key)
+
+	        Messages::NOOP
+	      end
+
+	      # Shared DispatchCommand builder. `argv[1]` is the workflow verb
       # (`brainstorm`/`plan`/`develop`/`review`/`pr`/`archive`); cached
       # at construction time so SubprocessExited can flash by verb name.
       def dispatch_command_for(suggested_command)

--- a/lib/hive/tui/messages.rb
+++ b/lib/hive/tui/messages.rb
@@ -257,23 +257,23 @@ module Hive
       # Mirror the FilterChar* shape so Update can be unit-tested against
       # the full message set without dependency on view code.
 
-	      # `n` from :grid — open the inline new-idea prompt, or a project
-	      # picker first when scope is ★ All projects.
-	      OpenNewIdeaPrompt = Class.new
-	      OPEN_NEW_IDEA_PROMPT = OpenNewIdeaPrompt.new.freeze
+      # `n` from :grid — open the inline new-idea prompt, or a project
+      # picker first when scope is ★ All projects.
+      OpenNewIdeaPrompt = Class.new
+      OPEN_NEW_IDEA_PROMPT = OpenNewIdeaPrompt.new.freeze
 
-	      # Project picker cursor movement for the pre-new-idea selection
-	      # shown when the operator starts from ★ All projects.
-	      NewIdeaProjectCursorDown = Class.new
-	      NEW_IDEA_PROJECT_CURSOR_DOWN = NewIdeaProjectCursorDown.new.freeze
+      # Project picker cursor movement for the pre-new-idea selection
+      # shown when the operator starts from ★ All projects.
+      NewIdeaProjectCursorDown = Class.new
+      NEW_IDEA_PROJECT_CURSOR_DOWN = NewIdeaProjectCursorDown.new.freeze
 
-	      NewIdeaProjectCursorUp = Class.new
-	      NEW_IDEA_PROJECT_CURSOR_UP = NewIdeaProjectCursorUp.new.freeze
+      NewIdeaProjectCursorUp = Class.new
+      NEW_IDEA_PROJECT_CURSOR_UP = NewIdeaProjectCursorUp.new.freeze
 
-	      # Enter in the project picker — lock the highlighted project as
-	      # the target and continue into the normal new-idea prompt.
-	      NewIdeaProjectSelected = Class.new
-	      NEW_IDEA_PROJECT_SELECTED = NewIdeaProjectSelected.new.freeze
+      # Enter in the project picker — lock the highlighted project as
+      # the target and continue into the normal new-idea prompt.
+      NewIdeaProjectSelected = Class.new
+      NEW_IDEA_PROJECT_SELECTED = NewIdeaProjectSelected.new.freeze
 
       # User inserted text into the new-idea buffer at the cursor. This
       # is the primary path for both printable characters and paste.

--- a/lib/hive/tui/messages.rb
+++ b/lib/hive/tui/messages.rb
@@ -257,9 +257,23 @@ module Hive
       # Mirror the FilterChar* shape so Update can be unit-tested against
       # the full message set without dependency on view code.
 
-      # `n` from :grid — open the inline new-idea prompt (mode → :new_idea).
-      OpenNewIdeaPrompt = Class.new
-      OPEN_NEW_IDEA_PROMPT = OpenNewIdeaPrompt.new.freeze
+	      # `n` from :grid — open the inline new-idea prompt, or a project
+	      # picker first when scope is ★ All projects.
+	      OpenNewIdeaPrompt = Class.new
+	      OPEN_NEW_IDEA_PROMPT = OpenNewIdeaPrompt.new.freeze
+
+	      # Project picker cursor movement for the pre-new-idea selection
+	      # shown when the operator starts from ★ All projects.
+	      NewIdeaProjectCursorDown = Class.new
+	      NEW_IDEA_PROJECT_CURSOR_DOWN = NewIdeaProjectCursorDown.new.freeze
+
+	      NewIdeaProjectCursorUp = Class.new
+	      NEW_IDEA_PROJECT_CURSOR_UP = NewIdeaProjectCursorUp.new.freeze
+
+	      # Enter in the project picker — lock the highlighted project as
+	      # the target and continue into the normal new-idea prompt.
+	      NewIdeaProjectSelected = Class.new
+	      NEW_IDEA_PROJECT_SELECTED = NewIdeaProjectSelected.new.freeze
 
       # User inserted text into the new-idea buffer at the cursor. This
       # is the primary path for both printable characters and paste.

--- a/lib/hive/tui/model.rb
+++ b/lib/hive/tui/model.rb
@@ -27,7 +27,9 @@ module Hive
       :filter_buffer,    # String — typed text in :filter mode
       :scope,            # Integer — 0 means all projects; 1..N selects Nth
       :pane_focus,       # Symbol: :left | :right (v2 two-pane layout)
-      :new_idea_buffer,  # String — typed text in :new_idea mode
+	      :new_idea_project_name, # String or nil — explicit target chosen from ★ All
+	      :new_idea_project_cursor, # Integer — selection cursor in :new_idea_project mode
+	      :new_idea_buffer,  # String — typed text in :new_idea mode
       :new_idea_cursor,  # Integer — character index within new_idea_buffer
       :new_idea_attachments, # Array<Model::Attachment> — staged image refs for :new_idea
       :new_idea_staging_dir, # String or nil — temp dir holding staged image files
@@ -97,7 +99,9 @@ module Hive
           filter_buffer: "",
           scope: 0,
           pane_focus: :right,
-          new_idea_buffer: "",
+	          new_idea_project_name: nil,
+	          new_idea_project_cursor: 0,
+	          new_idea_buffer: "",
           new_idea_cursor: 0,
           new_idea_attachments: [],
           new_idea_staging_dir: nil,

--- a/lib/hive/tui/model.rb
+++ b/lib/hive/tui/model.rb
@@ -20,16 +20,16 @@ module Hive
     # Lifted out of the Data.define block because Ruby's Data.define
     # block-scope doesn't bind constants to the resulting class.
     Model = Data.define(
-      :mode,             # Symbol: :grid / :triage / :log_tail / :filter / :help / :new_idea
+      :mode,             # Symbol: :grid / :triage / :log_tail / :filter / :help / :new_idea_project / :new_idea
       :snapshot,         # Hive::Tui::Snapshot (or nil before first poll)
       :cursor,           # [project_idx, row_idx] (or nil for empty grid)
       :filter,           # String or nil — committed substring filter
       :filter_buffer,    # String — typed text in :filter mode
       :scope,            # Integer — 0 means all projects; 1..N selects Nth
       :pane_focus,       # Symbol: :left | :right (v2 two-pane layout)
-	      :new_idea_project_name, # String or nil — explicit target chosen from ★ All
-	      :new_idea_project_cursor, # Integer — selection cursor in :new_idea_project mode
-	      :new_idea_buffer,  # String — typed text in :new_idea mode
+      :new_idea_project_name, # String or nil — explicit target chosen from ★ All
+      :new_idea_project_cursor, # Integer — selection cursor in :new_idea_project mode
+      :new_idea_buffer,  # String — typed text in :new_idea mode
       :new_idea_cursor,  # Integer — character index within new_idea_buffer
       :new_idea_attachments, # Array<Model::Attachment> — staged image refs for :new_idea
       :new_idea_staging_dir, # String or nil — temp dir holding staged image files
@@ -99,9 +99,9 @@ module Hive
           filter_buffer: "",
           scope: 0,
           pane_focus: :right,
-	          new_idea_project_name: nil,
-	          new_idea_project_cursor: 0,
-	          new_idea_buffer: "",
+          new_idea_project_name: nil,
+          new_idea_project_cursor: 0,
+          new_idea_buffer: "",
           new_idea_cursor: 0,
           new_idea_attachments: [],
           new_idea_staging_dir: nil,

--- a/lib/hive/tui/update.rb
+++ b/lib/hive/tui/update.rb
@@ -83,16 +83,16 @@ module Hive
           [ apply_pane_focus_toggled(model), nil ]
         when Messages::PaneFocusChanged
           [ apply_pane_focus_changed(model, message), nil ]
-	        when Messages::OpenNewIdeaPrompt
-	          [ apply_open_new_idea_prompt(model), nil ]
-	        when Messages::NewIdeaProjectCursorDown
-	          [ apply_new_idea_project_cursor_down(model), nil ]
-	        when Messages::NewIdeaProjectCursorUp
-	          [ apply_new_idea_project_cursor_up(model), nil ]
-	        when Messages::NewIdeaProjectSelected
-	          [ apply_new_idea_project_selected(model), nil ]
-	        when Messages::NewIdeaTextInserted
-	          [ apply_new_idea_text_inserted(model, message), nil ]
+        when Messages::OpenNewIdeaPrompt
+          [ apply_open_new_idea_prompt(model), nil ]
+        when Messages::NewIdeaProjectCursorDown
+          [ apply_new_idea_project_cursor_down(model), nil ]
+        when Messages::NewIdeaProjectCursorUp
+          [ apply_new_idea_project_cursor_up(model), nil ]
+        when Messages::NewIdeaProjectSelected
+          [ apply_new_idea_project_selected(model), nil ]
+        when Messages::NewIdeaTextInserted
+          [ apply_new_idea_text_inserted(model, message), nil ]
         when Messages::NewIdeaImageAttached
           [ apply_new_idea_image_attached(model, message), nil ]
         when Messages::NewIdeaCursorLeft
@@ -418,50 +418,50 @@ module Hive
       # `reset_to_grid_with_flash` carries the same clearing shape
       # plus a flash payload.
 
-	      def apply_open_new_idea_prompt(model)
-	        mode = model.scope.zero? && new_idea_project_choices(model).any? ? :new_idea_project : :new_idea
+      def apply_open_new_idea_prompt(model)
+        mode = model.scope.zero? ? :new_idea_project : :new_idea
 
-	        model.with(
-	          mode: mode,
-	          new_idea_project_name: nil,
-	          new_idea_project_cursor: 0,
-	          new_idea_buffer: "",
-	          new_idea_cursor: 0,
-	          new_idea_attachments: [],
+        model.with(
+          mode: mode,
+          new_idea_project_name: nil,
+          new_idea_project_cursor: 0,
+          new_idea_buffer: "",
+          new_idea_cursor: 0,
+          new_idea_attachments: [],
           new_idea_staging_dir: nil,
           new_idea_staging_tmp_root: nil,
           new_idea_attachment_counter: 0,
-	          new_idea_broken_labels: []
-	        )
-	      end
+          new_idea_broken_labels: []
+        )
+      end
 
-	      def apply_new_idea_project_cursor_down(model)
-	        choices = new_idea_project_choices(model)
-	        return model if choices.empty?
+      def apply_new_idea_project_cursor_down(model)
+        choices = new_idea_project_choices(model)
+        return model if choices.empty?
 
-	        cursor = [ model.new_idea_project_cursor.to_i + 1, choices.size - 1 ].min
-	        model.with(new_idea_project_cursor: cursor)
-	      end
+        cursor = [ model.new_idea_project_cursor.to_i + 1, choices.size - 1 ].min
+        model.with(new_idea_project_cursor: cursor)
+      end
 
-	      def apply_new_idea_project_cursor_up(model)
-	        choices = new_idea_project_choices(model)
-	        return model if choices.empty?
+      def apply_new_idea_project_cursor_up(model)
+        choices = new_idea_project_choices(model)
+        return model if choices.empty?
 
-	        cursor = [ model.new_idea_project_cursor.to_i - 1, 0 ].max
-	        model.with(new_idea_project_cursor: cursor)
-	      end
+        cursor = [ model.new_idea_project_cursor.to_i - 1, 0 ].max
+        model.with(new_idea_project_cursor: cursor)
+      end
 
-	      def apply_new_idea_project_selected(model)
-	        choices = new_idea_project_choices(model)
-	        project = choices[model.new_idea_project_cursor.to_i.clamp(0, [ choices.size - 1, 0 ].max)]
-	        return model.with(mode: :new_idea, new_idea_project_name: nil) if project.nil?
+      def apply_new_idea_project_selected(model)
+        choices = new_idea_project_choices(model)
+        project = choices[model.new_idea_project_cursor.to_i.clamp(0, [ choices.size - 1, 0 ].max)]
+        return model if project.nil?
 
-	        model.with(
-	          mode: :new_idea,
-	          new_idea_project_name: project.name,
-	          new_idea_project_cursor: model.new_idea_project_cursor.to_i.clamp(0, choices.size - 1)
-	        )
-	      end
+        model.with(
+          mode: :new_idea,
+          new_idea_project_name: project.name,
+          new_idea_project_cursor: model.new_idea_project_cursor.to_i.clamp(0, choices.size - 1)
+        )
+      end
 
       def apply_new_idea_text_inserted(model, msg)
         insert_new_idea_text(model, msg.text.to_s)
@@ -552,13 +552,13 @@ module Hive
         model.with(new_idea_attachments: kept)
       end
 
-	      def apply_new_idea_cancelled(model)
-	        model.with(
-	          mode: :grid,
-	          new_idea_project_name: nil,
-	          new_idea_project_cursor: 0,
-	          new_idea_buffer: "",
-	          new_idea_cursor: 0,
+      def apply_new_idea_cancelled(model)
+        model.with(
+          mode: :grid,
+          new_idea_project_name: nil,
+          new_idea_project_cursor: 0,
+          new_idea_buffer: "",
+          new_idea_cursor: 0,
           new_idea_attachments: [],
           new_idea_staging_dir: nil,
           new_idea_staging_tmp_root: nil,
@@ -667,17 +667,17 @@ module Hive
         case model.mode
         when :triage then model.with(mode: :grid, triage_state: nil)
         when :log_tail then model.with(mode: :grid, tail_state: nil)
-	        when :help, :filter then model.with(mode: :grid)
-	        when :new_idea_project then apply_new_idea_cancelled(model)
-	        else model
-	        end
-	      end
+        when :help, :filter then model.with(mode: :grid)
+        when :new_idea_project then apply_new_idea_cancelled(model)
+        else model
+        end
+      end
 
-	      def new_idea_project_choices(model)
-	        Array(model.snapshot&.projects).select { |project| project.error.nil? }
-	      end
+      def new_idea_project_choices(model)
+        Array(model.snapshot&.projects).select { |project| project.error.nil? }
+      end
 
-	      # `n == 0` clears scope (all projects). Out-of-range still flips
+      # `n == 0` clears scope (all projects). Out-of-range still flips
       # the scope (Snapshot returns an empty-projects view); cursor
       # resets to the first non-empty project or nil if the scoped grid
       # is empty.

--- a/lib/hive/tui/update.rb
+++ b/lib/hive/tui/update.rb
@@ -83,10 +83,16 @@ module Hive
           [ apply_pane_focus_toggled(model), nil ]
         when Messages::PaneFocusChanged
           [ apply_pane_focus_changed(model, message), nil ]
-        when Messages::OpenNewIdeaPrompt
-          [ apply_open_new_idea_prompt(model), nil ]
-        when Messages::NewIdeaTextInserted
-          [ apply_new_idea_text_inserted(model, message), nil ]
+	        when Messages::OpenNewIdeaPrompt
+	          [ apply_open_new_idea_prompt(model), nil ]
+	        when Messages::NewIdeaProjectCursorDown
+	          [ apply_new_idea_project_cursor_down(model), nil ]
+	        when Messages::NewIdeaProjectCursorUp
+	          [ apply_new_idea_project_cursor_up(model), nil ]
+	        when Messages::NewIdeaProjectSelected
+	          [ apply_new_idea_project_selected(model), nil ]
+	        when Messages::NewIdeaTextInserted
+	          [ apply_new_idea_text_inserted(model, message), nil ]
         when Messages::NewIdeaImageAttached
           [ apply_new_idea_image_attached(model, message), nil ]
         when Messages::NewIdeaCursorLeft
@@ -412,18 +418,50 @@ module Hive
       # `reset_to_grid_with_flash` carries the same clearing shape
       # plus a flash payload.
 
-      def apply_open_new_idea_prompt(model)
-        model.with(
-          mode: :new_idea,
-          new_idea_buffer: "",
-          new_idea_cursor: 0,
-          new_idea_attachments: [],
+	      def apply_open_new_idea_prompt(model)
+	        mode = model.scope.zero? && new_idea_project_choices(model).any? ? :new_idea_project : :new_idea
+
+	        model.with(
+	          mode: mode,
+	          new_idea_project_name: nil,
+	          new_idea_project_cursor: 0,
+	          new_idea_buffer: "",
+	          new_idea_cursor: 0,
+	          new_idea_attachments: [],
           new_idea_staging_dir: nil,
           new_idea_staging_tmp_root: nil,
           new_idea_attachment_counter: 0,
-          new_idea_broken_labels: []
-        )
-      end
+	          new_idea_broken_labels: []
+	        )
+	      end
+
+	      def apply_new_idea_project_cursor_down(model)
+	        choices = new_idea_project_choices(model)
+	        return model if choices.empty?
+
+	        cursor = [ model.new_idea_project_cursor.to_i + 1, choices.size - 1 ].min
+	        model.with(new_idea_project_cursor: cursor)
+	      end
+
+	      def apply_new_idea_project_cursor_up(model)
+	        choices = new_idea_project_choices(model)
+	        return model if choices.empty?
+
+	        cursor = [ model.new_idea_project_cursor.to_i - 1, 0 ].max
+	        model.with(new_idea_project_cursor: cursor)
+	      end
+
+	      def apply_new_idea_project_selected(model)
+	        choices = new_idea_project_choices(model)
+	        project = choices[model.new_idea_project_cursor.to_i.clamp(0, [ choices.size - 1, 0 ].max)]
+	        return model.with(mode: :new_idea, new_idea_project_name: nil) if project.nil?
+
+	        model.with(
+	          mode: :new_idea,
+	          new_idea_project_name: project.name,
+	          new_idea_project_cursor: model.new_idea_project_cursor.to_i.clamp(0, choices.size - 1)
+	        )
+	      end
 
       def apply_new_idea_text_inserted(model, msg)
         insert_new_idea_text(model, msg.text.to_s)
@@ -514,11 +552,13 @@ module Hive
         model.with(new_idea_attachments: kept)
       end
 
-      def apply_new_idea_cancelled(model)
-        model.with(
-          mode: :grid,
-          new_idea_buffer: "",
-          new_idea_cursor: 0,
+	      def apply_new_idea_cancelled(model)
+	        model.with(
+	          mode: :grid,
+	          new_idea_project_name: nil,
+	          new_idea_project_cursor: 0,
+	          new_idea_buffer: "",
+	          new_idea_cursor: 0,
           new_idea_attachments: [],
           new_idea_staging_dir: nil,
           new_idea_staging_tmp_root: nil,
@@ -627,12 +667,17 @@ module Hive
         case model.mode
         when :triage then model.with(mode: :grid, triage_state: nil)
         when :log_tail then model.with(mode: :grid, tail_state: nil)
-        when :help, :filter then model.with(mode: :grid)
-        else model
-        end
-      end
+	        when :help, :filter then model.with(mode: :grid)
+	        when :new_idea_project then apply_new_idea_cancelled(model)
+	        else model
+	        end
+	      end
 
-      # `n == 0` clears scope (all projects). Out-of-range still flips
+	      def new_idea_project_choices(model)
+	        Array(model.snapshot&.projects).select { |project| project.error.nil? }
+	      end
+
+	      # `n == 0` clears scope (all projects). Out-of-range still flips
       # the scope (Snapshot returns an empty-projects view); cursor
       # resets to the first non-empty project or nil if the scoped grid
       # is empty.

--- a/lib/hive/tui/update.rb
+++ b/lib/hive/tui/update.rb
@@ -452,8 +452,20 @@ module Hive
       end
 
       def apply_new_idea_project_selected(model)
+        # Enter pressed in the picker while no snapshot has arrived yet,
+        # or every project in the snapshot is unhealthy. Acknowledge the
+        # keystroke with a flash instead of silently swallowing it — the
+        # alternative makes the picker feel frozen.
+        if model.snapshot.nil?
+          return model.with(flash: "waiting for snapshot — Esc cancels", flash_set_at: Time.now)
+        end
+
         choices = new_idea_project_choices(model)
-        project = choices[model.new_idea_project_cursor.to_i.clamp(0, [ choices.size - 1, 0 ].max)]
+        if choices.empty?
+          return model.with(flash: "no healthy projects — Esc cancels", flash_set_at: Time.now)
+        end
+
+        project = choices[model.new_idea_project_cursor.to_i.clamp(0, choices.size - 1)]
         return model if project.nil?
 
         model.with(

--- a/lib/hive/tui/views/new_idea_project_picker.rb
+++ b/lib/hive/tui/views/new_idea_project_picker.rb
@@ -1,0 +1,54 @@
+require "hive/tui/styles"
+require "hive/tui/views/format"
+
+module Hive
+  module Tui
+    module Views
+      # Bottom prompt shown when the operator starts a new idea from
+      # `★ All projects`. Creating a task has to target one concrete project,
+      # so this picker makes that choice explicit before the title composer.
+      module NewIdeaProjectPicker
+        MAX_VISIBLE_PROJECTS = 6
+
+        module_function
+
+        def render(model, width: model.cols.to_i)
+          projects = choices(model)
+          return Styles::FLASH.render("No healthy projects available") if projects.empty?
+
+          cursor = model.new_idea_project_cursor.to_i.clamp(0, projects.size - 1)
+          visible, first_idx = visible_projects(projects, cursor)
+          rows = [ "Choose project for new idea:" ]
+          visible.each_with_index do |project, idx|
+            absolute_idx = first_idx + idx
+            prefix = absolute_idx == cursor ? "> " : "  "
+            line = "#{prefix}#{project.name}"
+            rows << (absolute_idx == cursor ? Styles::CURSOR_HIGHLIGHT.render(line) : line)
+          end
+          rows << Styles::HINT.render("Enter choose  Esc cancel")
+
+          rows.map { |line| truncate(line, width) }.join("\n")
+        end
+
+        def choices(model)
+          Array(model.snapshot&.projects).select { |project| project.error.nil? }
+        end
+
+        def visible_projects(projects, cursor)
+          return [ projects, 0 ] if projects.size <= MAX_VISIBLE_PROJECTS
+
+          start = [ cursor - MAX_VISIBLE_PROJECTS + 1, 0 ].max
+          start = [ start, projects.size - MAX_VISIBLE_PROJECTS ].min
+          [ projects[start, MAX_VISIBLE_PROJECTS], start ]
+        end
+
+        def truncate(line, width)
+          usable = width.to_i
+          return line if usable <= 0
+
+          Views::Format.truncate(line, usable)
+        end
+      end
+    end
+  end
+end

--- a/lib/hive/tui/views/new_idea_project_picker.rb
+++ b/lib/hive/tui/views/new_idea_project_picker.rb
@@ -13,21 +13,30 @@ module Hive
         module_function
 
         def render(model, width: model.cols.to_i)
-          return Styles::HINT.render("Loading projects...") if model.snapshot.nil?
-
-          projects = choices(model)
-          return Styles::FLASH.render("No healthy projects available") if projects.empty?
-
-          cursor = model.new_idea_project_cursor.to_i.clamp(0, projects.size - 1)
-          visible, first_idx = visible_projects(projects, cursor)
           rows = [ "Choose project for new idea:" ]
-          visible.each_with_index do |project, idx|
-            absolute_idx = first_idx + idx
-            prefix = absolute_idx == cursor ? "> " : "  "
-            line = "#{prefix}#{project.name}"
-            rows << (absolute_idx == cursor ? Styles::CURSOR_HIGHLIGHT.render(line) : line)
+          projects = nil
+          if model.snapshot.nil?
+            rows << Styles::HINT.render("Loading projects...")
+          else
+            projects = choices(model)
+            if projects.empty?
+              rows << Styles::FLASH.render("No healthy projects available")
+            else
+              cursor = model.new_idea_project_cursor.to_i.clamp(0, projects.size - 1)
+              visible, first_idx = visible_projects(projects, cursor)
+              visible.each_with_index do |project, idx|
+                absolute_idx = first_idx + idx
+                prefix = absolute_idx == cursor ? "> " : "  "
+                line = "#{prefix}#{project.name}"
+                rows << (absolute_idx == cursor ? Styles::CURSOR_HIGHLIGHT.render(line) : line)
+              end
+            end
           end
-          rows << Styles::HINT.render("Enter choose  Esc cancel")
+          # Always anchor the operator with at least an Esc-cancel hint —
+          # loading + no-healthy-projects states used to render with no
+          # exit affordance, making the mode look frozen.
+          hint = projects && !projects.empty? ? "Enter choose  Esc cancel" : "Esc cancel"
+          rows << Styles::HINT.render(hint)
 
           rows.map { |line| truncate(line, width) }.join("\n")
         end

--- a/lib/hive/tui/views/new_idea_project_picker.rb
+++ b/lib/hive/tui/views/new_idea_project_picker.rb
@@ -13,6 +13,8 @@ module Hive
         module_function
 
         def render(model, width: model.cols.to_i)
+          return Styles::HINT.render("Loading projects...") if model.snapshot.nil?
+
           projects = choices(model)
           return Styles::FLASH.render("No healthy projects available") if projects.empty?
 

--- a/lib/hive/tui/views/new_idea_prompt.rb
+++ b/lib/hive/tui/views/new_idea_prompt.rb
@@ -12,10 +12,12 @@ module Hive
       # the resulting `hive new <project> "<title>"` will land in before
       # pressing Enter.
       #
-      # Project resolution for the label:
-      # - `model.scope == 0` (★ All projects) → first registered project,
-      #   prefixed with `★→` so the operator sees the implicit fallback.
-      # - `model.scope == n` → the nth registered project.
+	      # Project resolution for the label:
+	      # - `model.new_idea_project_name` → explicit target chosen from the
+	      #   project picker opened by ★ All projects.
+	      # - `model.scope == 0` (★ All projects) → unresolved; the picker
+	      #   must choose a project before this prompt can submit.
+	      # - `model.scope == n` → the nth registered project.
       # - No registered projects → `(no projects)`; submission flashes an
       #   error in U6's BubbleModel handler instead of dispatching.
       module NewIdeaPrompt
@@ -199,28 +201,32 @@ module Hive
 
         # Resolve which project an idea would land in. Pure read of the
         # snapshot; never raises (falls through to "(no projects)").
-        def project_label(model)
-          name = resolve_project_name(model)
-          return "(no projects)" if name.nil?
-          return "★→#{name}" if model.scope.zero?
+	      def project_label(model)
+	        name = resolve_project_name(model)
+	        if name.nil?
+	          projects = Array(model.snapshot&.projects)
+	          return "(choose project)" if model.scope.zero? && projects.any? { |p| p.error.nil? }
 
-          name
-        end
+	          return "(no projects)"
+	        end
 
-        def resolve_project_name(model)
-          snap = model.snapshot
-          return nil if snap.nil? || snap.projects.empty?
+	        name
+	      end
 
-          if model.scope.zero?
-            # ★ All projects fallback: pick the first project that
-            # is HEALTHY. Skipping projects with `error:` (missing
-            # path / not initialised) prevents `hive new` from
-            # exploding inside the dispatched subprocess against a
-            # stale registration whose directory no longer exists.
-            healthy = snap.projects.find { |p| p.error.nil? }
-            return healthy&.name
-          end
-          return nil unless model.scope.between?(1, snap.projects.size)
+	      def resolve_project_name(model)
+	        snap = model.snapshot
+	        return nil if snap.nil? || snap.projects.empty?
+
+	        chosen = model.respond_to?(:new_idea_project_name) ? model.new_idea_project_name.to_s : ""
+	        unless chosen.empty?
+	          project = snap.projects.find { |p| p.name == chosen }
+	          return project.name if project && project.error.nil?
+
+	          return nil
+	        end
+
+	        return nil if model.scope.zero?
+	        return nil unless model.scope.between?(1, snap.projects.size)
 
           project = snap.projects[model.scope - 1]
           # An explicit scope onto an unhealthy project also returns

--- a/lib/hive/tui/views/new_idea_prompt.rb
+++ b/lib/hive/tui/views/new_idea_prompt.rb
@@ -12,12 +12,12 @@ module Hive
       # the resulting `hive new <project> "<title>"` will land in before
       # pressing Enter.
       #
-	      # Project resolution for the label:
-	      # - `model.new_idea_project_name` → explicit target chosen from the
-	      #   project picker opened by ★ All projects.
-	      # - `model.scope == 0` (★ All projects) → unresolved; the picker
-	      #   must choose a project before this prompt can submit.
-	      # - `model.scope == n` → the nth registered project.
+      # Project resolution for the label:
+      # - `model.new_idea_project_name` → explicit target chosen from the
+      #   project picker opened by ★ All projects.
+      # - `model.scope == 0` (★ All projects) → unresolved; the picker
+      #   must choose a project before this prompt can submit.
+      # - `model.scope == n` → the nth registered project.
       # - No registered projects → `(no projects)`; submission flashes an
       #   error in U6's BubbleModel handler instead of dispatching.
       module NewIdeaPrompt
@@ -201,32 +201,32 @@ module Hive
 
         # Resolve which project an idea would land in. Pure read of the
         # snapshot; never raises (falls through to "(no projects)").
-	      def project_label(model)
-	        name = resolve_project_name(model)
-	        if name.nil?
-	          projects = Array(model.snapshot&.projects)
-	          return "(choose project)" if model.scope.zero? && projects.any? { |p| p.error.nil? }
+      def project_label(model)
+        name = resolve_project_name(model)
+        if name.nil?
+          projects = Array(model.snapshot&.projects)
+          return "(choose project)" if model.scope.zero? && projects.any? { |p| p.error.nil? }
 
-	          return "(no projects)"
-	        end
+          return "(no projects)"
+        end
 
-	        name
-	      end
+        name
+      end
 
-	      def resolve_project_name(model)
-	        snap = model.snapshot
-	        return nil if snap.nil? || snap.projects.empty?
+      def resolve_project_name(model)
+        snap = model.snapshot
+        return nil if snap.nil? || snap.projects.empty?
 
-	        chosen = model.respond_to?(:new_idea_project_name) ? model.new_idea_project_name.to_s : ""
-	        unless chosen.empty?
-	          project = snap.projects.find { |p| p.name == chosen }
-	          return project.name if project && project.error.nil?
+        chosen = model.new_idea_project_name.to_s
+        unless chosen.empty?
+          project = snap.projects.find { |p| p.name == chosen }
+          return project.name if project && project.error.nil?
 
-	          return nil
-	        end
+          return nil
+        end
 
-	        return nil if model.scope.zero?
-	        return nil unless model.scope.between?(1, snap.projects.size)
+        return nil if model.scope.zero?
+        return nil unless model.scope.between?(1, snap.projects.size)
 
           project = snap.projects[model.scope - 1]
           # An explicit scope onto an unhealthy project also returns

--- a/lib/hive/tui/views/new_idea_prompt.rb
+++ b/lib/hive/tui/views/new_idea_prompt.rb
@@ -201,39 +201,40 @@ module Hive
 
         # Resolve which project an idea would land in. Pure read of the
         # snapshot; never raises (falls through to "(no projects)").
-      def project_label(model)
-        name = resolve_project_name(model)
-        if name.nil?
-          projects = Array(model.snapshot&.projects)
-          return "(choose project)" if model.scope.zero? && projects.any? { |p| p.error.nil? }
+        def project_label(model)
+          name = resolve_project_name(model)
+          if name.nil?
+            projects = Array(model.snapshot&.projects)
+            return "(choose project)" if model.scope.zero? && projects.any? { |p| p.error.nil? }
 
-          return "(no projects)"
+            return "(no projects)"
+          end
+
+          name
         end
 
-        name
-      end
+        def resolve_project_name(model)
+          snap = model.snapshot
+          return nil if snap.nil? || snap.projects.empty?
 
-      def resolve_project_name(model)
-        snap = model.snapshot
-        return nil if snap.nil? || snap.projects.empty?
+          chosen = model.new_idea_project_name.to_s
+          unless chosen.empty?
+            project = snap.projects.find { |p| p.name == chosen }
+            return project.name if project && project.error.nil?
 
-        chosen = model.new_idea_project_name.to_s
-        unless chosen.empty?
-          project = snap.projects.find { |p| p.name == chosen }
-          return project.name if project && project.error.nil?
+            return nil
+          end
 
-          return nil
-        end
-
-        return nil if model.scope.zero?
-        return nil unless model.scope.between?(1, snap.projects.size)
+          return nil if model.scope.zero?
+          return nil unless model.scope.between?(1, snap.projects.size)
 
           project = snap.projects[model.scope - 1]
-          # An explicit scope onto an unhealthy project also returns
-          # nil — submit_new_idea then flashes "no projects" rather
-          # than dispatching against a doomed directory. The TUI's
-          # left pane still shows the project (with its name) so the
-          # operator can navigate elsewhere.
+          # An explicit scope onto an unhealthy project also returns nil;
+          # `submit_new_idea` then surfaces the per-project recovery hint
+          # produced by `BubbleModel#new_idea_resolution_flash` rather than
+          # dispatching against a doomed directory. The TUI's left pane
+          # still shows the project (with its name) so the operator can
+          # navigate elsewhere.
           return nil if project.error
 
           project.name

--- a/test/e2e/scenarios/tui_new_idea_editing.yml
+++ b/test/e2e/scenarios/tui_new_idea_editing.yml
@@ -13,6 +13,11 @@ steps:
   - kind: tui_keys
     keys: "n"
   - kind: tui_expect
+    anchor: "Choose project for new idea"
+    timeout: 3
+  - kind: tui_keys
+    keys: "Enter"
+  - kind: tui_expect
     anchor: "New idea"
     timeout: 3
 

--- a/test/integration/tui_new_idea_attachments_smoke_test.rb
+++ b/test/integration/tui_new_idea_attachments_smoke_test.rb
@@ -81,15 +81,15 @@ class TuiNewIdeaAttachmentsSmokeTest < Minitest::Test
           buffer = read_until(reader, deadline_seconds: 10.0) { |buf| buf.include?(project_prefix) }
           assert_includes buffer, project_prefix
 
-	          writer.write("n")
-	          writer.flush
-	          buffer = read_until(reader, deadline_seconds: 5.0) { |buf| buf.include?("Choose project for new idea") }
-	          assert_includes buffer, "Choose project for new idea"
+          writer.write("n")
+          writer.flush
+          buffer = read_until(reader, deadline_seconds: 5.0) { |buf| buf.include?("Choose project for new idea") }
+          assert_includes buffer, "Choose project for new idea"
 
-	          writer.write("\r")
-	          writer.flush
-	          buffer = read_until(reader, deadline_seconds: 5.0) { |buf| buf.include?("New idea") }
-	          assert_includes buffer, "New idea"
+          writer.write("\r")
+          writer.flush
+          buffer = read_until(reader, deadline_seconds: 5.0) { |buf| buf.include?("New idea") }
+          assert_includes buffer, "New idea"
 
           writer.write("bug here ")
           writer.write("\e[200~\e[201~")

--- a/test/integration/tui_new_idea_attachments_smoke_test.rb
+++ b/test/integration/tui_new_idea_attachments_smoke_test.rb
@@ -81,10 +81,15 @@ class TuiNewIdeaAttachmentsSmokeTest < Minitest::Test
           buffer = read_until(reader, deadline_seconds: 10.0) { |buf| buf.include?(project_prefix) }
           assert_includes buffer, project_prefix
 
-          writer.write("n")
-          writer.flush
-          buffer = read_until(reader, deadline_seconds: 5.0) { |buf| buf.include?("New idea") }
-          assert_includes buffer, "New idea"
+	          writer.write("n")
+	          writer.flush
+	          buffer = read_until(reader, deadline_seconds: 5.0) { |buf| buf.include?("Choose project for new idea") }
+	          assert_includes buffer, "Choose project for new idea"
+
+	          writer.write("\r")
+	          writer.flush
+	          buffer = read_until(reader, deadline_seconds: 5.0) { |buf| buf.include?("New idea") }
+	          assert_includes buffer, "New idea"
 
           writer.write("bug here ")
           writer.write("\e[200~\e[201~")

--- a/test/integration/tui_new_idea_attachments_test.rb
+++ b/test/integration/tui_new_idea_attachments_test.rb
@@ -20,11 +20,11 @@ class TuiNewIdeaAttachmentsTest < Minitest::Test
   def model_for(project:, buffer:, attachments:, staging_dir:)
     Hive::Tui::BubbleModel.new(
       hive_model: Hive::Tui::Model.initial.with(
-	        mode: :new_idea,
-	        snapshot: snapshot_for(project),
-	        scope: 0,
-	        new_idea_project_name: project,
-	        new_idea_buffer: buffer,
+        mode: :new_idea,
+        snapshot: snapshot_for(project),
+        scope: 0,
+        new_idea_project_name: project,
+        new_idea_buffer: buffer,
         new_idea_cursor: buffer.length,
         new_idea_attachments: attachments,
         new_idea_staging_dir: staging_dir

--- a/test/integration/tui_new_idea_attachments_test.rb
+++ b/test/integration/tui_new_idea_attachments_test.rb
@@ -20,10 +20,11 @@ class TuiNewIdeaAttachmentsTest < Minitest::Test
   def model_for(project:, buffer:, attachments:, staging_dir:)
     Hive::Tui::BubbleModel.new(
       hive_model: Hive::Tui::Model.initial.with(
-        mode: :new_idea,
-        snapshot: snapshot_for(project),
-        scope: 0,
-        new_idea_buffer: buffer,
+	        mode: :new_idea,
+	        snapshot: snapshot_for(project),
+	        scope: 0,
+	        new_idea_project_name: project,
+	        new_idea_buffer: buffer,
         new_idea_cursor: buffer.length,
         new_idea_attachments: attachments,
         new_idea_staging_dir: staging_dir

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -35,8 +35,17 @@ FAKE_GH_FIXTURE = File.expand_path("fixtures/fake-gh", __dir__).freeze
 FAKE_CLAUDE_FIXTURE = File.expand_path("fixtures/fake-claude", __dir__).freeze
 
 module HiveTestHelper
-  def with_tmp_dir(&block)
-    Dir.mktmpdir("hive-test", &block)
+  # Tests run real `git` inside the tmpdir; pack-objects renames internal
+  # state like `bitmap-ref-tips_*` between scan and unlink, so `Dir.mktmpdir`'s
+  # built-in cleanup (which uses `FileUtils.remove_entry`) intermittently
+  # raises `Errno::ENOENT` under CI load. Replace the block form with an
+  # explicit ensure that uses `FileUtils.rm_rf`, which tolerates concurrent
+  # disappearance instead of raising.
+  def with_tmp_dir
+    dir = Dir.mktmpdir("hive-test")
+    yield dir
+  ensure
+    FileUtils.rm_rf(dir) if dir
   end
 
   def with_tmp_git_repo
@@ -60,15 +69,18 @@ module HiveTestHelper
   end
 
   def with_tmp_global_config
-    Dir.mktmpdir("hive-global") do |dir|
-      old = ENV["HIVE_HOME"]
-      ENV["HIVE_HOME"] = dir
-      File.write(File.join(dir, "config.yml"), { "registered_projects" => [] }.to_yaml)
-      begin
-        yield(dir)
-      ensure
-        ENV["HIVE_HOME"] = old
-      end
+    dir = Dir.mktmpdir("hive-global")
+    old = ENV["HIVE_HOME"]
+    ENV["HIVE_HOME"] = dir
+    File.write(File.join(dir, "config.yml"), { "registered_projects" => [] }.to_yaml)
+    begin
+      yield(dir)
+    ensure
+      ENV["HIVE_HOME"] = old
+      # Same race-tolerant cleanup as `with_tmp_dir`: tests inside this
+      # tmpdir invoke `hive`/git subprocesses that can leave the tree
+      # mid-rename.
+      FileUtils.rm_rf(dir)
     end
   end
 

--- a/test/unit/tui/bubble_model_test.rb
+++ b/test/unit/tui/bubble_model_test.rb
@@ -943,6 +943,12 @@ class HiveTuiBubbleModelTest < Minitest::Test
     assert_equal 0, spawn_count, "must NOT dispatch when the chosen project went unhealthy under us"
     assert_match(/"beta".*not initialised.*choose another project/i, @model.hive_model.flash.to_s,
                  "flash must name the chosen project, the specific error, and steer to a new pick")
+    assert_equal :new_idea_project, @model.hive_model.mode,
+                 "must bounce back to the picker so operator can re-pick without retyping"
+    assert_nil @model.hive_model.new_idea_project_name,
+               "stale project name must be cleared on bounce"
+    assert_equal "an idea", @model.hive_model.new_idea_buffer,
+                 "typed buffer must survive the bounce so the re-pick doesn't cost retyping"
   end
 
   # new_idea_project_name points to a name no longer in the snapshot
@@ -969,6 +975,12 @@ class HiveTuiBubbleModelTest < Minitest::Test
     assert_equal 0, spawn_count, "must NOT dispatch when the chosen project disappeared from snapshot"
     assert_match(/"ghost".*not available.*choose another project/i, @model.hive_model.flash.to_s,
                  "flash must say the chosen name is not available and steer to a new pick")
+    assert_equal :new_idea_project, @model.hive_model.mode,
+                 "must bounce back to the picker so operator can re-pick without retyping"
+    assert_nil @model.hive_model.new_idea_project_name,
+               "stale project name must be cleared on bounce"
+    assert_equal "an idea", @model.hive_model.new_idea_buffer,
+                 "typed buffer must survive the bounce so the re-pick doesn't cost retyping"
   end
 
   def test_new_idea_submission_with_no_projects_flashes_and_does_not_dispatch
@@ -1045,11 +1057,11 @@ class HiveTuiBubbleModelTest < Minitest::Test
       "projects" => [ { "name" => "hive", "tasks" => [] } ]
     )
     @model = Hive::Tui::BubbleModel.new(
-          hive_model: Hive::Tui::Model.initial.with(
-            mode: :new_idea,
-            snapshot: snap,
-            new_idea_project_name: "ghost",
-            new_idea_buffer: "see [image1]",
+      hive_model: Hive::Tui::Model.initial.with(
+        mode: :new_idea,
+        snapshot: snap,
+        new_idea_project_name: "hive",
+        new_idea_buffer: "see [image1]",
         new_idea_cursor: 12
       ),
       dispatch: @dispatch

--- a/test/unit/tui/bubble_model_test.rb
+++ b/test/unit/tui/bubble_model_test.rb
@@ -917,6 +917,60 @@ class HiveTuiBubbleModelTest < Minitest::Test
                  "mixed-error set must point at re-init or per-name `hive forget`")
   end
 
+  # new_idea_project_name points to a project that exists in the
+  # snapshot but has an error — the picker chose it before the snapshot
+  # poll dropped its health. Submission must flash the per-project error
+  # + "choose another project" rather than dispatch against a broken project.
+  def test_new_idea_submission_with_chosen_project_now_unhealthy_flashes_choose_another
+    snap = Hive::Tui::Snapshot.from_payload(
+      "generated_at" => "2026-05-06",
+      "projects" => [
+        { "name" => "alpha", "tasks" => [] },
+        { "name" => "beta", "error" => "not_initialised", "tasks" => [] }
+      ]
+    )
+    @model = Hive::Tui::BubbleModel.new(
+      hive_model: Hive::Tui::Model.initial.with(
+        mode: :new_idea, snapshot: snap, scope: 0,
+        new_idea_project_name: "beta", new_idea_buffer: "an idea"
+      ),
+      dispatch: @dispatch
+    )
+    spawn_count = 0
+    with_run_quiet_stub(->(_argv) { spawn_count += 1; [ 0, "", "" ] }) do
+      @model.update(Hive::Tui::Messages::NEW_IDEA_SUBMITTED)
+    end
+    assert_equal 0, spawn_count, "must NOT dispatch when the chosen project went unhealthy under us"
+    assert_match(/"beta".*not initialised.*choose another project/i, @model.hive_model.flash.to_s,
+                 "flash must name the chosen project, the specific error, and steer to a new pick")
+  end
+
+  # new_idea_project_name points to a name no longer in the snapshot
+  # (project was removed between picker selection and submit). Submission
+  # must flash "is not available — choose another".
+  def test_new_idea_submission_with_chosen_project_missing_from_snapshot_flashes_unavailable
+    snap = Hive::Tui::Snapshot.from_payload(
+      "generated_at" => "2026-05-06",
+      "projects" => [
+        { "name" => "alpha", "tasks" => [] }
+      ]
+    )
+    @model = Hive::Tui::BubbleModel.new(
+      hive_model: Hive::Tui::Model.initial.with(
+        mode: :new_idea, snapshot: snap, scope: 0,
+        new_idea_project_name: "ghost", new_idea_buffer: "an idea"
+      ),
+      dispatch: @dispatch
+    )
+    spawn_count = 0
+    with_run_quiet_stub(->(_argv) { spawn_count += 1; [ 0, "", "" ] }) do
+      @model.update(Hive::Tui::Messages::NEW_IDEA_SUBMITTED)
+    end
+    assert_equal 0, spawn_count, "must NOT dispatch when the chosen project disappeared from snapshot"
+    assert_match(/"ghost".*not available.*choose another project/i, @model.hive_model.flash.to_s,
+                 "flash must say the chosen name is not available and steer to a new pick")
+  end
+
   def test_new_idea_submission_with_no_projects_flashes_and_does_not_dispatch
     snap = Hive::Tui::Snapshot.from_payload(
       "generated_at" => "2026-05-01", "projects" => []
@@ -948,9 +1002,9 @@ class HiveTuiBubbleModelTest < Minitest::Test
       "projects" => [ { "name" => "hive", "tasks" => [] } ]
     )
     @model = Hive::Tui::BubbleModel.new(
-	      hive_model: Hive::Tui::Model.initial.with(
-	        mode: :new_idea, snapshot: snap, new_idea_project_name: "hive",
-	        new_idea_buffer: "rss feeds"
+      hive_model: Hive::Tui::Model.initial.with(
+        mode: :new_idea, snapshot: snap, new_idea_project_name: "hive",
+        new_idea_buffer: "rss feeds"
       ),
       dispatch: @dispatch
     )
@@ -971,9 +1025,9 @@ class HiveTuiBubbleModelTest < Minitest::Test
       "projects" => [ { "name" => "hive", "tasks" => [] } ]
     )
     @model = Hive::Tui::BubbleModel.new(
-	      hive_model: Hive::Tui::Model.initial.with(
-	        mode: :new_idea, snapshot: snap, new_idea_project_name: "hive",
-	        new_idea_buffer: "an idea"
+      hive_model: Hive::Tui::Model.initial.with(
+        mode: :new_idea, snapshot: snap, new_idea_project_name: "hive",
+        new_idea_buffer: "an idea"
       ),
       dispatch: @dispatch
     )
@@ -991,11 +1045,11 @@ class HiveTuiBubbleModelTest < Minitest::Test
       "projects" => [ { "name" => "hive", "tasks" => [] } ]
     )
     @model = Hive::Tui::BubbleModel.new(
-	          hive_model: Hive::Tui::Model.initial.with(
-	            mode: :new_idea,
-	            snapshot: snap,
-	            new_idea_project_name: "ghost",
-	            new_idea_buffer: "see [image1]",
+          hive_model: Hive::Tui::Model.initial.with(
+            mode: :new_idea,
+            snapshot: snap,
+            new_idea_project_name: "ghost",
+            new_idea_buffer: "see [image1]",
         new_idea_cursor: 12
       ),
       dispatch: @dispatch
@@ -1086,10 +1140,10 @@ class HiveTuiBubbleModelTest < Minitest::Test
         )
         @model = Hive::Tui::BubbleModel.new(
           hive_model: Hive::Tui::Model.initial.with(
-	            mode: :new_idea,
-	            snapshot: snap,
-	            new_idea_project_name: "ghost",
-	            new_idea_buffer: "see [image1]",
+            mode: :new_idea,
+            snapshot: snap,
+            new_idea_project_name: "ghost",
+            new_idea_buffer: "see [image1]",
             new_idea_cursor: 12,
             new_idea_attachments: [ attachment ],
             new_idea_staging_dir: staging_dir
@@ -1128,11 +1182,11 @@ class HiveTuiBubbleModelTest < Minitest::Test
       ext: "png"
     )
     @model = Hive::Tui::BubbleModel.new(
-	      hive_model: Hive::Tui::Model.initial.with(
-	        mode: :new_idea,
-	        snapshot: snap,
-	        new_idea_project_name: "hive",
-	        new_idea_buffer: "title [image1]",
+      hive_model: Hive::Tui::Model.initial.with(
+        mode: :new_idea,
+        snapshot: snap,
+        new_idea_project_name: "hive",
+        new_idea_buffer: "title [image1]",
         new_idea_cursor: 14,
         new_idea_attachments: [ attachment ],
         new_idea_staging_dir: staging_dir

--- a/test/unit/tui/bubble_model_test.rb
+++ b/test/unit/tui/bubble_model_test.rb
@@ -575,7 +575,8 @@ class HiveTuiBubbleModelTest < Minitest::Test
     )
     @model = Hive::Tui::BubbleModel.new(
       hive_model: Hive::Tui::Model.initial.with(
-        mode: :new_idea, snapshot: snap, scope: 0, new_idea_buffer: "rss feeds"
+        mode: :new_idea, snapshot: snap, scope: 0,
+        new_idea_project_name: "hive", new_idea_buffer: "rss feeds"
       ),
       dispatch: @dispatch
     )
@@ -947,8 +948,9 @@ class HiveTuiBubbleModelTest < Minitest::Test
       "projects" => [ { "name" => "hive", "tasks" => [] } ]
     )
     @model = Hive::Tui::BubbleModel.new(
-      hive_model: Hive::Tui::Model.initial.with(
-        mode: :new_idea, snapshot: snap, new_idea_buffer: "rss feeds"
+	      hive_model: Hive::Tui::Model.initial.with(
+	        mode: :new_idea, snapshot: snap, new_idea_project_name: "hive",
+	        new_idea_buffer: "rss feeds"
       ),
       dispatch: @dispatch
     )
@@ -969,8 +971,9 @@ class HiveTuiBubbleModelTest < Minitest::Test
       "projects" => [ { "name" => "hive", "tasks" => [] } ]
     )
     @model = Hive::Tui::BubbleModel.new(
-      hive_model: Hive::Tui::Model.initial.with(
-        mode: :new_idea, snapshot: snap, new_idea_buffer: "an idea"
+	      hive_model: Hive::Tui::Model.initial.with(
+	        mode: :new_idea, snapshot: snap, new_idea_project_name: "hive",
+	        new_idea_buffer: "an idea"
       ),
       dispatch: @dispatch
     )
@@ -988,10 +991,11 @@ class HiveTuiBubbleModelTest < Minitest::Test
       "projects" => [ { "name" => "hive", "tasks" => [] } ]
     )
     @model = Hive::Tui::BubbleModel.new(
-      hive_model: Hive::Tui::Model.initial.with(
-        mode: :new_idea,
-        snapshot: snap,
-        new_idea_buffer: "see [image1]",
+	          hive_model: Hive::Tui::Model.initial.with(
+	            mode: :new_idea,
+	            snapshot: snap,
+	            new_idea_project_name: "ghost",
+	            new_idea_buffer: "see [image1]",
         new_idea_cursor: 12
       ),
       dispatch: @dispatch
@@ -1082,9 +1086,10 @@ class HiveTuiBubbleModelTest < Minitest::Test
         )
         @model = Hive::Tui::BubbleModel.new(
           hive_model: Hive::Tui::Model.initial.with(
-            mode: :new_idea,
-            snapshot: snap,
-            new_idea_buffer: "see [image1]",
+	            mode: :new_idea,
+	            snapshot: snap,
+	            new_idea_project_name: "ghost",
+	            new_idea_buffer: "see [image1]",
             new_idea_cursor: 12,
             new_idea_attachments: [ attachment ],
             new_idea_staging_dir: staging_dir
@@ -1123,10 +1128,11 @@ class HiveTuiBubbleModelTest < Minitest::Test
       ext: "png"
     )
     @model = Hive::Tui::BubbleModel.new(
-      hive_model: Hive::Tui::Model.initial.with(
-        mode: :new_idea,
-        snapshot: snap,
-        new_idea_buffer: "title [image1]",
+	      hive_model: Hive::Tui::Model.initial.with(
+	        mode: :new_idea,
+	        snapshot: snap,
+	        new_idea_project_name: "hive",
+	        new_idea_buffer: "title [image1]",
         new_idea_cursor: 14,
         new_idea_attachments: [ attachment ],
         new_idea_staging_dir: staging_dir

--- a/test/unit/tui/help_test.rb
+++ b/test/unit/tui/help_test.rb
@@ -62,7 +62,7 @@ class TuiHelpTest < Minitest::Test
   end
 
   def test_modes_are_drawn_from_a_known_set
-    expected_modes = %i[grid triage log_tail filter new_idea].to_set
+	    expected_modes = %i[grid triage log_tail filter new_idea_project new_idea].to_set
     actual_modes = Hive::Tui::Help::BINDINGS.map { |b| b[:mode] }.to_set
     extra = actual_modes - expected_modes
     assert_empty extra, "unexpected modes in BINDINGS: #{extra.inspect}"

--- a/test/unit/tui/help_test.rb
+++ b/test/unit/tui/help_test.rb
@@ -62,7 +62,7 @@ class TuiHelpTest < Minitest::Test
   end
 
   def test_modes_are_drawn_from_a_known_set
-	    expected_modes = %i[grid triage log_tail filter new_idea_project new_idea].to_set
+    expected_modes = %i[grid triage log_tail filter new_idea_project new_idea].to_set
     actual_modes = Hive::Tui::Help::BINDINGS.map { |b| b[:mode] }.to_set
     extra = actual_modes - expected_modes
     assert_empty extra, "unexpected modes in BINDINGS: #{extra.inspect}"

--- a/test/unit/tui/key_map_test.rb
+++ b/test/unit/tui/key_map_test.rb
@@ -255,24 +255,24 @@ class TuiKeyMapMessageForTest < Minitest::Test
   # SPACE key, but printable_filter_char? returns false for symbols.
   # Without an explicit branch, multi-word titles like "rss feeds"
   # would land as "rssfeeds" in the buffer.
-	  def test_new_idea_space_symbol_appends_literal_space
-	    msg = Hive::Tui::KeyMap.message_for(mode: :new_idea, key: :space, row: nil)
-	    assert_kind_of Hive::Tui::Messages::NewIdeaTextInserted, msg
-	    assert_equal " ", msg.text
-	  end
+  def test_new_idea_space_symbol_appends_literal_space
+    msg = Hive::Tui::KeyMap.message_for(mode: :new_idea, key: :space, row: nil)
+    assert_kind_of Hive::Tui::Messages::NewIdeaTextInserted, msg
+    assert_equal " ", msg.text
+  end
 
-	  def test_new_idea_project_picker_keys_choose_move_and_cancel
-	    assert_same Hive::Tui::Messages::NEW_IDEA_PROJECT_SELECTED,
-	      Hive::Tui::KeyMap.message_for(mode: :new_idea_project, key: :key_enter, row: nil)
-	    assert_same Hive::Tui::Messages::NEW_IDEA_PROJECT_CURSOR_DOWN,
-	      Hive::Tui::KeyMap.message_for(mode: :new_idea_project, key: "j", row: nil)
-	    assert_same Hive::Tui::Messages::NEW_IDEA_PROJECT_CURSOR_UP,
-	      Hive::Tui::KeyMap.message_for(mode: :new_idea_project, key: :key_up, row: nil)
-	    assert_same Hive::Tui::Messages::NEW_IDEA_CANCELLED,
-	      Hive::Tui::KeyMap.message_for(mode: :new_idea_project, key: "q", row: nil)
-	  end
+  def test_new_idea_project_picker_keys_choose_move_and_cancel
+    assert_same Hive::Tui::Messages::NEW_IDEA_PROJECT_SELECTED,
+      Hive::Tui::KeyMap.message_for(mode: :new_idea_project, key: :key_enter, row: nil)
+    assert_same Hive::Tui::Messages::NEW_IDEA_PROJECT_CURSOR_DOWN,
+      Hive::Tui::KeyMap.message_for(mode: :new_idea_project, key: "j", row: nil)
+    assert_same Hive::Tui::Messages::NEW_IDEA_PROJECT_CURSOR_UP,
+      Hive::Tui::KeyMap.message_for(mode: :new_idea_project, key: :key_up, row: nil)
+    assert_same Hive::Tui::Messages::NEW_IDEA_CANCELLED,
+      Hive::Tui::KeyMap.message_for(mode: :new_idea_project, key: "q", row: nil)
+  end
 
-	  # Same regression for filter mode — slug filters with spaces like
+  # Same regression for filter mode — slug filters with spaces like
   # "rss feeds" must work too.
   def test_filter_space_symbol_appends_literal_space
     msg = Hive::Tui::KeyMap.message_for(mode: :filter, key: :space, row: nil)

--- a/test/unit/tui/key_map_test.rb
+++ b/test/unit/tui/key_map_test.rb
@@ -255,13 +255,24 @@ class TuiKeyMapMessageForTest < Minitest::Test
   # SPACE key, but printable_filter_char? returns false for symbols.
   # Without an explicit branch, multi-word titles like "rss feeds"
   # would land as "rssfeeds" in the buffer.
-  def test_new_idea_space_symbol_appends_literal_space
-    msg = Hive::Tui::KeyMap.message_for(mode: :new_idea, key: :space, row: nil)
-    assert_kind_of Hive::Tui::Messages::NewIdeaTextInserted, msg
-    assert_equal " ", msg.text
-  end
+	  def test_new_idea_space_symbol_appends_literal_space
+	    msg = Hive::Tui::KeyMap.message_for(mode: :new_idea, key: :space, row: nil)
+	    assert_kind_of Hive::Tui::Messages::NewIdeaTextInserted, msg
+	    assert_equal " ", msg.text
+	  end
 
-  # Same regression for filter mode — slug filters with spaces like
+	  def test_new_idea_project_picker_keys_choose_move_and_cancel
+	    assert_same Hive::Tui::Messages::NEW_IDEA_PROJECT_SELECTED,
+	      Hive::Tui::KeyMap.message_for(mode: :new_idea_project, key: :key_enter, row: nil)
+	    assert_same Hive::Tui::Messages::NEW_IDEA_PROJECT_CURSOR_DOWN,
+	      Hive::Tui::KeyMap.message_for(mode: :new_idea_project, key: "j", row: nil)
+	    assert_same Hive::Tui::Messages::NEW_IDEA_PROJECT_CURSOR_UP,
+	      Hive::Tui::KeyMap.message_for(mode: :new_idea_project, key: :key_up, row: nil)
+	    assert_same Hive::Tui::Messages::NEW_IDEA_CANCELLED,
+	      Hive::Tui::KeyMap.message_for(mode: :new_idea_project, key: "q", row: nil)
+	  end
+
+	  # Same regression for filter mode — slug filters with spaces like
   # "rss feeds" must work too.
   def test_filter_space_symbol_appends_literal_space
     msg = Hive::Tui::KeyMap.message_for(mode: :filter, key: :space, row: nil)

--- a/test/unit/tui/messages_test.rb
+++ b/test/unit/tui/messages_test.rb
@@ -185,11 +185,11 @@ class HiveTuiMessagesTest < Minitest::Test
     assert Hive::Tui::Messages::NEW_IDEA_CURSOR_HOME.frozen?
     assert Hive::Tui::Messages::NEW_IDEA_CURSOR_END.frozen?
     assert Hive::Tui::Messages::NEW_IDEA_CHAR_DELETED.frozen?
-	    assert Hive::Tui::Messages::NEW_IDEA_CHAR_DELETED_FORWARD.frozen?
-	    assert Hive::Tui::Messages::NEW_IDEA_PROJECT_CURSOR_DOWN.frozen?
-	    assert Hive::Tui::Messages::NEW_IDEA_PROJECT_CURSOR_UP.frozen?
-	    assert Hive::Tui::Messages::NEW_IDEA_PROJECT_SELECTED.frozen?
-	    assert Hive::Tui::Messages::NEW_IDEA_SUBMITTED.frozen?
+    assert Hive::Tui::Messages::NEW_IDEA_CHAR_DELETED_FORWARD.frozen?
+    assert Hive::Tui::Messages::NEW_IDEA_PROJECT_CURSOR_DOWN.frozen?
+    assert Hive::Tui::Messages::NEW_IDEA_PROJECT_CURSOR_UP.frozen?
+    assert Hive::Tui::Messages::NEW_IDEA_PROJECT_SELECTED.frozen?
+    assert Hive::Tui::Messages::NEW_IDEA_SUBMITTED.frozen?
     assert Hive::Tui::Messages::NEW_IDEA_CANCELLED.frozen?
   end
 
@@ -204,15 +204,15 @@ class HiveTuiMessagesTest < Minitest::Test
                    Hive::Tui::Messages::NEW_IDEA_CURSOR_END
     assert_kind_of Hive::Tui::Messages::NewIdeaCharDeleted,
                    Hive::Tui::Messages::NEW_IDEA_CHAR_DELETED
-	    assert_kind_of Hive::Tui::Messages::NewIdeaCharDeletedForward,
-	                   Hive::Tui::Messages::NEW_IDEA_CHAR_DELETED_FORWARD
-	    assert_kind_of Hive::Tui::Messages::NewIdeaProjectCursorDown,
-	                   Hive::Tui::Messages::NEW_IDEA_PROJECT_CURSOR_DOWN
-	    assert_kind_of Hive::Tui::Messages::NewIdeaProjectCursorUp,
-	                   Hive::Tui::Messages::NEW_IDEA_PROJECT_CURSOR_UP
-	    assert_kind_of Hive::Tui::Messages::NewIdeaProjectSelected,
-	                   Hive::Tui::Messages::NEW_IDEA_PROJECT_SELECTED
-	    assert_kind_of Hive::Tui::Messages::NewIdeaSubmitted,
+    assert_kind_of Hive::Tui::Messages::NewIdeaCharDeletedForward,
+                   Hive::Tui::Messages::NEW_IDEA_CHAR_DELETED_FORWARD
+    assert_kind_of Hive::Tui::Messages::NewIdeaProjectCursorDown,
+                   Hive::Tui::Messages::NEW_IDEA_PROJECT_CURSOR_DOWN
+    assert_kind_of Hive::Tui::Messages::NewIdeaProjectCursorUp,
+                   Hive::Tui::Messages::NEW_IDEA_PROJECT_CURSOR_UP
+    assert_kind_of Hive::Tui::Messages::NewIdeaProjectSelected,
+                   Hive::Tui::Messages::NEW_IDEA_PROJECT_SELECTED
+    assert_kind_of Hive::Tui::Messages::NewIdeaSubmitted,
                    Hive::Tui::Messages::NEW_IDEA_SUBMITTED
     assert_kind_of Hive::Tui::Messages::NewIdeaCancelled,
                    Hive::Tui::Messages::NEW_IDEA_CANCELLED

--- a/test/unit/tui/messages_test.rb
+++ b/test/unit/tui/messages_test.rb
@@ -185,8 +185,11 @@ class HiveTuiMessagesTest < Minitest::Test
     assert Hive::Tui::Messages::NEW_IDEA_CURSOR_HOME.frozen?
     assert Hive::Tui::Messages::NEW_IDEA_CURSOR_END.frozen?
     assert Hive::Tui::Messages::NEW_IDEA_CHAR_DELETED.frozen?
-    assert Hive::Tui::Messages::NEW_IDEA_CHAR_DELETED_FORWARD.frozen?
-    assert Hive::Tui::Messages::NEW_IDEA_SUBMITTED.frozen?
+	    assert Hive::Tui::Messages::NEW_IDEA_CHAR_DELETED_FORWARD.frozen?
+	    assert Hive::Tui::Messages::NEW_IDEA_PROJECT_CURSOR_DOWN.frozen?
+	    assert Hive::Tui::Messages::NEW_IDEA_PROJECT_CURSOR_UP.frozen?
+	    assert Hive::Tui::Messages::NEW_IDEA_PROJECT_SELECTED.frozen?
+	    assert Hive::Tui::Messages::NEW_IDEA_SUBMITTED.frozen?
     assert Hive::Tui::Messages::NEW_IDEA_CANCELLED.frozen?
   end
 
@@ -201,9 +204,15 @@ class HiveTuiMessagesTest < Minitest::Test
                    Hive::Tui::Messages::NEW_IDEA_CURSOR_END
     assert_kind_of Hive::Tui::Messages::NewIdeaCharDeleted,
                    Hive::Tui::Messages::NEW_IDEA_CHAR_DELETED
-    assert_kind_of Hive::Tui::Messages::NewIdeaCharDeletedForward,
-                   Hive::Tui::Messages::NEW_IDEA_CHAR_DELETED_FORWARD
-    assert_kind_of Hive::Tui::Messages::NewIdeaSubmitted,
+	    assert_kind_of Hive::Tui::Messages::NewIdeaCharDeletedForward,
+	                   Hive::Tui::Messages::NEW_IDEA_CHAR_DELETED_FORWARD
+	    assert_kind_of Hive::Tui::Messages::NewIdeaProjectCursorDown,
+	                   Hive::Tui::Messages::NEW_IDEA_PROJECT_CURSOR_DOWN
+	    assert_kind_of Hive::Tui::Messages::NewIdeaProjectCursorUp,
+	                   Hive::Tui::Messages::NEW_IDEA_PROJECT_CURSOR_UP
+	    assert_kind_of Hive::Tui::Messages::NewIdeaProjectSelected,
+	                   Hive::Tui::Messages::NEW_IDEA_PROJECT_SELECTED
+	    assert_kind_of Hive::Tui::Messages::NewIdeaSubmitted,
                    Hive::Tui::Messages::NEW_IDEA_SUBMITTED
     assert_kind_of Hive::Tui::Messages::NewIdeaCancelled,
                    Hive::Tui::Messages::NEW_IDEA_CANCELLED

--- a/test/unit/tui/model_test.rb
+++ b/test/unit/tui/model_test.rb
@@ -16,11 +16,11 @@ class HiveTuiModelTest < Minitest::Test
     model = Hive::Tui::Model.initial
     assert_nil model.snapshot
     assert_nil model.filter
-	    assert_equal "", model.filter_buffer
-	    assert_equal 0, model.scope
-	    assert_nil model.new_idea_project_name
-	    assert_equal 0, model.new_idea_project_cursor
-	    assert_equal "", model.new_idea_buffer
+    assert_equal "", model.filter_buffer
+    assert_equal 0, model.scope
+    assert_nil model.new_idea_project_name
+    assert_equal 0, model.new_idea_project_cursor
+    assert_equal "", model.new_idea_buffer
     assert_equal 0, model.new_idea_cursor
     assert_equal [], model.new_idea_attachments
     assert_nil model.new_idea_staging_dir
@@ -113,9 +113,9 @@ class HiveTuiModelTest < Minitest::Test
 
   def test_model_carries_all_documented_fields
     # Schema-pinning test: catch accidental field renames or removals.
-	    expected = %i[mode snapshot cursor filter filter_buffer scope pane_focus new_idea_project_name
-	                  new_idea_project_cursor new_idea_buffer new_idea_cursor
-	                  new_idea_attachments new_idea_staging_dir new_idea_staging_tmp_root new_idea_attachment_counter
+    expected = %i[mode snapshot cursor filter filter_buffer scope pane_focus new_idea_project_name
+                  new_idea_project_cursor new_idea_buffer new_idea_cursor
+                  new_idea_attachments new_idea_staging_dir new_idea_staging_tmp_root new_idea_attachment_counter
                   new_idea_broken_labels flash flash_set_at triage_state tail_state cols rows last_error]
     assert_equal expected, Hive::Tui::Model.members
   end

--- a/test/unit/tui/model_test.rb
+++ b/test/unit/tui/model_test.rb
@@ -16,9 +16,11 @@ class HiveTuiModelTest < Minitest::Test
     model = Hive::Tui::Model.initial
     assert_nil model.snapshot
     assert_nil model.filter
-    assert_equal "", model.filter_buffer
-    assert_equal 0, model.scope
-    assert_equal "", model.new_idea_buffer
+	    assert_equal "", model.filter_buffer
+	    assert_equal 0, model.scope
+	    assert_nil model.new_idea_project_name
+	    assert_equal 0, model.new_idea_project_cursor
+	    assert_equal "", model.new_idea_buffer
     assert_equal 0, model.new_idea_cursor
     assert_equal [], model.new_idea_attachments
     assert_nil model.new_idea_staging_dir
@@ -111,8 +113,9 @@ class HiveTuiModelTest < Minitest::Test
 
   def test_model_carries_all_documented_fields
     # Schema-pinning test: catch accidental field renames or removals.
-    expected = %i[mode snapshot cursor filter filter_buffer scope pane_focus new_idea_buffer new_idea_cursor
-                  new_idea_attachments new_idea_staging_dir new_idea_staging_tmp_root new_idea_attachment_counter
+	    expected = %i[mode snapshot cursor filter filter_buffer scope pane_focus new_idea_project_name
+	                  new_idea_project_cursor new_idea_buffer new_idea_cursor
+	                  new_idea_attachments new_idea_staging_dir new_idea_staging_tmp_root new_idea_attachment_counter
                   new_idea_broken_labels flash flash_set_at triage_state tail_state cols rows last_error]
     assert_equal expected, Hive::Tui::Model.members
   end

--- a/test/unit/tui/update_test.rb
+++ b/test/unit/tui/update_test.rb
@@ -626,11 +626,31 @@ class HiveTuiUpdateTest < Minitest::Test
     assert_equal 0, new_model.scope
   end
 
-  def test_new_idea_project_picker_enter_without_choices_stays_in_picker
+  def test_new_idea_project_picker_enter_without_snapshot_flashes_waiting
     starting = model.with(mode: :new_idea_project, snapshot: nil, scope: 0)
     new_model, _cmd = Hive::Tui::Update.apply(starting, Hive::Tui::Messages::NEW_IDEA_PROJECT_SELECTED)
-    assert_equal :new_idea_project, new_model.mode
+    assert_equal :new_idea_project, new_model.mode,
+                 "Enter on a nil-snapshot picker must stay in picker (not advance silently)"
     assert_nil new_model.new_idea_project_name
+    assert_match(/waiting for snapshot/i, new_model.flash.to_s,
+                 "Enter on a loading picker must acknowledge the keystroke via flash so the mode does not appear frozen")
+  end
+
+  def test_new_idea_project_picker_enter_when_all_unhealthy_flashes_no_healthy
+    snap = Hive::Tui::Snapshot.from_payload(
+      "generated_at" => "2026-05-19",
+      "projects" => [
+        { "name" => "broken-a", "error" => "missing_project_path", "tasks" => [] },
+        { "name" => "broken-b", "error" => "not_initialised", "tasks" => [] }
+      ]
+    )
+    starting = model.with(mode: :new_idea_project, snapshot: snap, scope: 0)
+    new_model, _cmd = Hive::Tui::Update.apply(starting, Hive::Tui::Messages::NEW_IDEA_PROJECT_SELECTED)
+    assert_equal :new_idea_project, new_model.mode,
+                 "Enter against an all-unhealthy snapshot must stay in picker (not advance to composer with nil project)"
+    assert_nil new_model.new_idea_project_name
+    assert_match(/no healthy projects/i, new_model.flash.to_s,
+                 "must acknowledge the keystroke and explain why selection is impossible")
   end
 
   def test_new_idea_project_picker_skips_unhealthy_projects

--- a/test/unit/tui/update_test.rb
+++ b/test/unit/tui/update_test.rb
@@ -569,6 +569,8 @@ class HiveTuiUpdateTest < Minitest::Test
     )
     starting = model.with(
       mode: :grid,
+      snapshot: snap_with_two_projects_three_rows_each,
+      scope: 1,
       new_idea_project_name: "old-project",
       new_idea_project_cursor: 2,
       new_idea_buffer: "leftover-text",
@@ -596,6 +598,14 @@ class HiveTuiUpdateTest < Minitest::Test
     assert_equal 0, new_model.new_idea_project_cursor
   end
 
+  def test_open_new_idea_from_all_projects_before_snapshot_opens_project_picker
+    starting = model.with(snapshot: nil, scope: 0)
+    new_model, _cmd = Hive::Tui::Update.apply(starting, Hive::Tui::Messages::OPEN_NEW_IDEA_PROMPT)
+    assert_equal :new_idea_project, new_model.mode
+    assert_nil new_model.new_idea_project_name
+    assert_equal 0, new_model.new_idea_project_cursor
+  end
+
   def test_open_new_idea_from_explicit_scope_opens_title_prompt
     starting = model.with(snapshot: snap_with_two_projects_three_rows_each, scope: 2)
     new_model, _cmd = Hive::Tui::Update.apply(starting, Hive::Tui::Messages::OPEN_NEW_IDEA_PROMPT)
@@ -614,6 +624,13 @@ class HiveTuiUpdateTest < Minitest::Test
     assert_equal :new_idea, new_model.mode
     assert_equal "beta", new_model.new_idea_project_name
     assert_equal 0, new_model.scope
+  end
+
+  def test_new_idea_project_picker_enter_without_choices_stays_in_picker
+    starting = model.with(mode: :new_idea_project, snapshot: nil, scope: 0)
+    new_model, _cmd = Hive::Tui::Update.apply(starting, Hive::Tui::Messages::NEW_IDEA_PROJECT_SELECTED)
+    assert_equal :new_idea_project, new_model.mode
+    assert_nil new_model.new_idea_project_name
   end
 
   def test_new_idea_project_picker_skips_unhealthy_projects

--- a/test/unit/tui/update_test.rb
+++ b/test/unit/tui/update_test.rb
@@ -569,6 +569,8 @@ class HiveTuiUpdateTest < Minitest::Test
     )
     starting = model.with(
       mode: :grid,
+      new_idea_project_name: "old-project",
+      new_idea_project_cursor: 2,
       new_idea_buffer: "leftover-text",
       new_idea_cursor: 4,
       new_idea_attachments: [ attachment ],
@@ -577,11 +579,57 @@ class HiveTuiUpdateTest < Minitest::Test
     )
     new_model, _cmd = Hive::Tui::Update.apply(starting, Hive::Tui::Messages::OPEN_NEW_IDEA_PROMPT)
     assert_equal :new_idea, new_model.mode
+    assert_nil new_model.new_idea_project_name
+    assert_equal 0, new_model.new_idea_project_cursor
     assert_equal "", new_model.new_idea_buffer
     assert_equal 0, new_model.new_idea_cursor
     assert_equal [], new_model.new_idea_attachments
     assert_nil new_model.new_idea_staging_dir
     assert_nil new_model.new_idea_staging_tmp_root
+  end
+
+  def test_open_new_idea_from_all_projects_opens_project_picker
+    starting = model.with(snapshot: snap_with_two_projects_three_rows_each, scope: 0)
+    new_model, _cmd = Hive::Tui::Update.apply(starting, Hive::Tui::Messages::OPEN_NEW_IDEA_PROMPT)
+    assert_equal :new_idea_project, new_model.mode
+    assert_nil new_model.new_idea_project_name
+    assert_equal 0, new_model.new_idea_project_cursor
+  end
+
+  def test_open_new_idea_from_explicit_scope_opens_title_prompt
+    starting = model.with(snapshot: snap_with_two_projects_three_rows_each, scope: 2)
+    new_model, _cmd = Hive::Tui::Update.apply(starting, Hive::Tui::Messages::OPEN_NEW_IDEA_PROMPT)
+    assert_equal :new_idea, new_model.mode
+    assert_nil new_model.new_idea_project_name
+  end
+
+  def test_new_idea_project_picker_selects_project_without_changing_scope
+    starting = model.with(
+      mode: :new_idea_project,
+      snapshot: snap_with_two_projects_three_rows_each,
+      scope: 0,
+      new_idea_project_cursor: 1
+    )
+    new_model, _cmd = Hive::Tui::Update.apply(starting, Hive::Tui::Messages::NEW_IDEA_PROJECT_SELECTED)
+    assert_equal :new_idea, new_model.mode
+    assert_equal "beta", new_model.new_idea_project_name
+    assert_equal 0, new_model.scope
+  end
+
+  def test_new_idea_project_picker_skips_unhealthy_projects
+    snap = Hive::Tui::Snapshot.from_payload(
+      "generated_at" => "2026-05-17",
+      "projects" => [
+        { "name" => "broken", "error" => "missing_project_path", "tasks" => [] },
+        { "name" => "hive", "tasks" => [] },
+        { "name" => "writero", "tasks" => [] }
+      ]
+    )
+    starting = model.with(mode: :new_idea_project, snapshot: snap, new_idea_project_cursor: 0)
+    down, _cmd = Hive::Tui::Update.apply(starting, Hive::Tui::Messages::NEW_IDEA_PROJECT_CURSOR_DOWN)
+    assert_equal 1, down.new_idea_project_cursor
+    selected, _cmd = Hive::Tui::Update.apply(down, Hive::Tui::Messages::NEW_IDEA_PROJECT_SELECTED)
+    assert_equal "writero", selected.new_idea_project_name
   end
 
   def test_new_idea_text_inserted_in_empty_buffer_advances_cursor
@@ -847,6 +895,8 @@ class HiveTuiUpdateTest < Minitest::Test
     )
     starting = model.with(
       mode: :new_idea,
+      new_idea_project_name: "hive",
+      new_idea_project_cursor: 1,
       new_idea_buffer: "rss feeds",
       new_idea_cursor: 4,
       new_idea_attachments: [ attachment ],
@@ -855,6 +905,8 @@ class HiveTuiUpdateTest < Minitest::Test
     )
     new_model, _cmd = Hive::Tui::Update.apply(starting, Hive::Tui::Messages::NEW_IDEA_CANCELLED)
     assert_equal :grid, new_model.mode
+    assert_nil new_model.new_idea_project_name
+    assert_equal 0, new_model.new_idea_project_cursor
     assert_equal "", new_model.new_idea_buffer
     assert_equal 0, new_model.new_idea_cursor
     assert_equal [], new_model.new_idea_attachments

--- a/test/unit/tui/views/new_idea_project_picker_test.rb
+++ b/test/unit/tui/views/new_idea_project_picker_test.rb
@@ -1,0 +1,51 @@
+require "test_helper"
+require "hive/tui/model"
+require "hive/tui/snapshot"
+require "hive/tui/views/new_idea_project_picker"
+
+class HiveTuiViewsNewIdeaProjectPickerTest < Minitest::Test
+  include HiveTestHelper
+
+  def snapshot
+    Hive::Tui::Snapshot.from_payload(
+      "generated_at" => "2026-05-17T00:00:00Z",
+      "projects" => [
+        { "name" => "broken", "error" => "missing_project_path", "tasks" => [] },
+        { "name" => "hive", "tasks" => [] },
+        { "name" => "writero", "tasks" => [] }
+      ]
+    )
+  end
+
+  def test_render_lists_healthy_projects_and_highlights_cursor
+    model = Hive::Tui::Model.initial.with(
+      mode: :new_idea_project,
+      snapshot: snapshot,
+      new_idea_project_cursor: 1
+    )
+
+    out = Hive::Tui::Views::NewIdeaProjectPicker.render(model, width: 80)
+
+    assert_includes out, "Choose project for new idea:"
+    assert_includes out, "hive"
+    assert_includes out, "> writero"
+    refute_includes out, "broken"
+  end
+
+  def test_choices_skip_unhealthy_projects
+    model = Hive::Tui::Model.initial.with(snapshot: snapshot)
+
+    assert_equal %w[hive writero],
+      Hive::Tui::Views::NewIdeaProjectPicker.choices(model).map(&:name)
+  end
+
+  def test_empty_choices_render_clear_message
+    snap = Hive::Tui::Snapshot.from_payload(
+      "generated_at" => "2026-05-17T00:00:00Z",
+      "projects" => [ { "name" => "broken", "error" => "missing_project_path", "tasks" => [] } ]
+    )
+    model = Hive::Tui::Model.initial.with(mode: :new_idea_project, snapshot: snap)
+
+    assert_includes Hive::Tui::Views::NewIdeaProjectPicker.render(model), "No healthy projects"
+  end
+end

--- a/test/unit/tui/views/new_idea_project_picker_test.rb
+++ b/test/unit/tui/views/new_idea_project_picker_test.rb
@@ -48,4 +48,10 @@ class HiveTuiViewsNewIdeaProjectPickerTest < Minitest::Test
 
     assert_includes Hive::Tui::Views::NewIdeaProjectPicker.render(model), "No healthy projects"
   end
+
+  def test_nil_snapshot_renders_loading_message
+    model = Hive::Tui::Model.initial.with(mode: :new_idea_project, snapshot: nil)
+
+    assert_includes Hive::Tui::Views::NewIdeaProjectPicker.render(model), "Loading projects"
+  end
 end

--- a/test/unit/tui/views/new_idea_prompt_test.rb
+++ b/test/unit/tui/views/new_idea_prompt_test.rb
@@ -25,25 +25,25 @@ class HiveTuiViewsNewIdeaPromptTest < Minitest::Test
     )
   end
 
-	  def test_renders_prompt_label_with_chosen_project
-	    model = Hive::Tui::Model.initial.with(
-	      mode: :new_idea, snapshot: make_snapshot(%w[hive myapp]),
-	      scope: 0, new_idea_project_name: "hive", new_idea_buffer: "rss feeds"
-	    )
-	    out = Hive::Tui::Views::NewIdeaPrompt.render(model)
-	    assert_includes out, "New idea (project="
-	    assert_includes out, "hive", "chosen project must be shown before submission"
-	    assert_includes out, "rss feeds", "buffer text must surface verbatim"
-	  end
+  def test_renders_prompt_label_with_chosen_project
+    model = Hive::Tui::Model.initial.with(
+      mode: :new_idea, snapshot: make_snapshot(%w[hive myapp]),
+      scope: 0, new_idea_project_name: "hive", new_idea_buffer: "rss feeds"
+    )
+    out = Hive::Tui::Views::NewIdeaPrompt.render(model)
+    assert_includes out, "New idea (project="
+    assert_includes out, "hive", "chosen project must be shown before submission"
+    assert_includes out, "rss feeds", "buffer text must surface verbatim"
+  end
 
-	  def test_label_indicates_unresolved_project_when_scope_zero
-	    model = Hive::Tui::Model.initial.with(
-	      mode: :new_idea, snapshot: make_snapshot(%w[hive myapp]),
-	      scope: 0
-	    )
-	    out = Hive::Tui::Views::NewIdeaPrompt.render(model)
-	    assert_includes out, "(choose project)",
-	                    "scope=0 must not silently label or submit to the first project"
+  def test_label_indicates_unresolved_project_when_scope_zero
+    model = Hive::Tui::Model.initial.with(
+      mode: :new_idea, snapshot: make_snapshot(%w[hive myapp]),
+      scope: 0
+    )
+    out = Hive::Tui::Views::NewIdeaPrompt.render(model)
+    assert_includes out, "(choose project)",
+                    "scope=0 must not silently label or submit to the first project"
   end
 
   def test_label_uses_explicit_project_when_scope_n
@@ -51,9 +51,9 @@ class HiveTuiViewsNewIdeaPromptTest < Minitest::Test
       mode: :new_idea, snapshot: make_snapshot(%w[hive myapp]),
       scope: 2
     )
-	    out = Hive::Tui::Views::NewIdeaPrompt.render(model)
-	    assert_includes out, "myapp"
-	    refute_includes out, "choose project", "explicit scope must NOT look unresolved"
+    out = Hive::Tui::Views::NewIdeaPrompt.render(model)
+    assert_includes out, "myapp"
+    refute_includes out, "choose project", "explicit scope must NOT look unresolved"
   end
 
   def test_label_handles_nil_snapshot
@@ -120,9 +120,9 @@ class HiveTuiViewsNewIdeaPromptTest < Minitest::Test
   def test_project_label_returns_plain_name_when_scope_n
     model = Hive::Tui::Model.initial.with(
       snapshot: make_snapshot(%w[hive myapp]), scope: 2
-	    )
-	    assert_equal "myapp", Hive::Tui::Views::NewIdeaPrompt.project_label(model),
-	                 "explicit scope must NOT look unresolved"
+    )
+    assert_equal "myapp", Hive::Tui::Views::NewIdeaPrompt.project_label(model),
+                 "explicit scope must NOT look unresolved"
   end
 
   def test_project_label_handles_no_projects_gracefully
@@ -138,9 +138,9 @@ class HiveTuiViewsNewIdeaPromptTest < Minitest::Test
 
   def test_long_buffer_slides_to_show_tail_within_cols
     long = ("a" * 60) + ("z" * 60) # 120 chars
-	    model = Hive::Tui::Model.initial.with(
-	      mode: :new_idea, snapshot: make_snapshot(%w[hive]),
-	      scope: 0, new_idea_project_name: "hive", new_idea_buffer: long, new_idea_cursor: long.length, cols: 50
+    model = Hive::Tui::Model.initial.with(
+      mode: :new_idea, snapshot: make_snapshot(%w[hive]),
+      scope: 0, new_idea_project_name: "hive", new_idea_buffer: long, new_idea_cursor: long.length, cols: 50
     )
     out = Hive::Tui::Views::NewIdeaPrompt.render(model)
     refute_includes out, ("a" * 60),
@@ -150,9 +150,9 @@ class HiveTuiViewsNewIdeaPromptTest < Minitest::Test
   end
 
   def test_buffer_within_cols_renders_in_full
-	    model = Hive::Tui::Model.initial.with(
-	      mode: :new_idea, snapshot: make_snapshot(%w[hive]),
-	      scope: 0, new_idea_project_name: "hive", new_idea_buffer: "rss feeds", cols: 100
+    model = Hive::Tui::Model.initial.with(
+      mode: :new_idea, snapshot: make_snapshot(%w[hive]),
+      scope: 0, new_idea_project_name: "hive", new_idea_buffer: "rss feeds", cols: 100
     )
     out = Hive::Tui::Views::NewIdeaPrompt.render(model)
     assert_includes out, "rss feeds", "short buffer must render verbatim"
@@ -160,11 +160,11 @@ class HiveTuiViewsNewIdeaPromptTest < Minitest::Test
 
   def test_render_shows_single_staged_image_count
     model = Hive::Tui::Model.initial.with(
-	      mode: :new_idea,
-	      snapshot: make_snapshot(%w[hive]),
-	      scope: 0,
-	      new_idea_project_name: "hive",
-	      new_idea_buffer: "hi [image1]",
+      mode: :new_idea,
+      snapshot: make_snapshot(%w[hive]),
+      scope: 0,
+      new_idea_project_name: "hive",
+      new_idea_buffer: "hi [image1]",
       new_idea_cursor: "hi [image1]".length,
       new_idea_attachments: [ attachment("image1") ],
       cols: 100
@@ -177,11 +177,11 @@ class HiveTuiViewsNewIdeaPromptTest < Minitest::Test
 
   def test_render_shows_plural_staged_image_count
     model = Hive::Tui::Model.initial.with(
-	      mode: :new_idea,
-	      snapshot: make_snapshot(%w[hive]),
-	      scope: 0,
-	      new_idea_project_name: "hive",
-	      new_idea_buffer: "[image1][image2][image3]",
+      mode: :new_idea,
+      snapshot: make_snapshot(%w[hive]),
+      scope: 0,
+      new_idea_project_name: "hive",
+      new_idea_buffer: "[image1][image2][image3]",
       new_idea_cursor: 24,
       new_idea_attachments: [ attachment("image1"), attachment("image2"), attachment("image3") ],
       cols: 100
@@ -194,11 +194,11 @@ class HiveTuiViewsNewIdeaPromptTest < Minitest::Test
 
   def test_render_suppresses_staged_image_count_on_narrow_terminal
     model = Hive::Tui::Model.initial.with(
-	      mode: :new_idea,
-	      snapshot: make_snapshot(%w[hive]),
-	      scope: 0,
-	      new_idea_project_name: "hive",
-	      new_idea_buffer: "hi [image1]",
+      mode: :new_idea,
+      snapshot: make_snapshot(%w[hive]),
+      scope: 0,
+      new_idea_project_name: "hive",
+      new_idea_buffer: "hi [image1]",
       new_idea_cursor: "hi [image1]".length,
       new_idea_attachments: [ attachment("image1") ],
       cols: 28
@@ -212,11 +212,11 @@ class HiveTuiViewsNewIdeaPromptTest < Minitest::Test
 
   def test_render_omits_staged_image_count_when_no_attachments
     model = Hive::Tui::Model.initial.with(
-	      mode: :new_idea,
-	      snapshot: make_snapshot(%w[hive]),
-	      scope: 0,
-	      new_idea_project_name: "hive",
-	      new_idea_buffer: "hi",
+      mode: :new_idea,
+      snapshot: make_snapshot(%w[hive]),
+      scope: 0,
+      new_idea_project_name: "hive",
+      new_idea_buffer: "hi",
       new_idea_attachments: [],
       cols: 100
     )
@@ -238,11 +238,11 @@ class HiveTuiViewsNewIdeaPromptTest < Minitest::Test
 
   def test_render_preserves_broken_placeholder_text
     model = Hive::Tui::Model.initial.with(
-	      mode: :new_idea,
-	      snapshot: make_snapshot(%w[hive]),
-	      scope: 0,
-	      new_idea_project_name: "hive",
-	      new_idea_buffer: "see [image1]",
+      mode: :new_idea,
+      snapshot: make_snapshot(%w[hive]),
+      scope: 0,
+      new_idea_project_name: "hive",
+      new_idea_buffer: "see [image1]",
       new_idea_cursor: "see [image1]".length,
       new_idea_broken_labels: [ "image1" ],
       cols: 100
@@ -254,9 +254,9 @@ class HiveTuiViewsNewIdeaPromptTest < Minitest::Test
   end
 
   def test_explicit_width_kwarg_clamps_independently_of_cols
-	    model = Hive::Tui::Model.initial.with(
-	      mode: :new_idea, snapshot: make_snapshot(%w[hive]),
-	      scope: 0, new_idea_project_name: "hive", new_idea_buffer: "x" * 80, cols: 200
+    model = Hive::Tui::Model.initial.with(
+      mode: :new_idea, snapshot: make_snapshot(%w[hive]),
+      scope: 0, new_idea_project_name: "hive", new_idea_buffer: "x" * 80, cols: 200
     )
     out = Hive::Tui::Views::NewIdeaPrompt.render(model, width: 30)
     refute_match(/x{80}/, out, "width: kwarg must clamp regardless of model.cols")
@@ -266,9 +266,9 @@ class HiveTuiViewsNewIdeaPromptTest < Minitest::Test
 
   def test_long_buffer_wraps_across_multiple_rows
     long = "abcdef" * 30 # 180 chars
-	    model = Hive::Tui::Model.initial.with(
-	      mode: :new_idea, snapshot: make_snapshot(%w[hive]),
-	      scope: 0, new_idea_project_name: "hive", new_idea_buffer: long, cols: 80
+    model = Hive::Tui::Model.initial.with(
+      mode: :new_idea, snapshot: make_snapshot(%w[hive]),
+      scope: 0, new_idea_project_name: "hive", new_idea_buffer: long, cols: 80
     )
     out = Hive::Tui::Views::NewIdeaPrompt.render(model)
     assert out.lines.count > 1, "180-char buffer at cols=80 must wrap onto multiple rows"
@@ -280,13 +280,13 @@ class HiveTuiViewsNewIdeaPromptTest < Minitest::Test
   end
 
   def test_continuation_rows_align_to_label_column
-	    model = Hive::Tui::Model.initial.with(
-	      mode: :new_idea, snapshot: make_snapshot(%w[hive]),
-	      scope: 0, new_idea_project_name: "hive", new_idea_buffer: "a" * 200, cols: 80
+    model = Hive::Tui::Model.initial.with(
+      mode: :new_idea, snapshot: make_snapshot(%w[hive]),
+      scope: 0, new_idea_project_name: "hive", new_idea_buffer: "a" * 200, cols: 80
     )
     out = Hive::Tui::Views::NewIdeaPrompt.render(model)
     rows = out.lines.map { |l| l.chomp.gsub(/\e\[[\d;]*m/, "") }
-	    label_col = "New idea (project=hive): ".length
+    label_col = "New idea (project=hive): ".length
     rows[1..].each do |row|
       assert row.start_with?(" " * label_col),
              "continuation row must start with label-width padding (got #{row.inspect})"
@@ -294,9 +294,9 @@ class HiveTuiViewsNewIdeaPromptTest < Minitest::Test
   end
 
   def test_buffer_within_first_row_capacity_renders_single_line
-	    model = Hive::Tui::Model.initial.with(
-	      mode: :new_idea, snapshot: make_snapshot(%w[hive]),
-	      scope: 0, new_idea_project_name: "hive", new_idea_buffer: "rss", cols: 80
+    model = Hive::Tui::Model.initial.with(
+      mode: :new_idea, snapshot: make_snapshot(%w[hive]),
+      scope: 0, new_idea_project_name: "hive", new_idea_buffer: "rss", cols: 80
     )
     out = Hive::Tui::Views::NewIdeaPrompt.render(model)
     assert_equal 1, out.lines.count, "short buffer must NOT wrap"
@@ -305,9 +305,9 @@ class HiveTuiViewsNewIdeaPromptTest < Minitest::Test
   def test_extreme_overflow_caps_at_max_visible_rows
     # Buffer big enough to wrap to 20+ rows; renderer caps at
     # MAX_VISIBLE_ROWS so the prompt doesn't push the panes off-screen.
-	    model = Hive::Tui::Model.initial.with(
-	      mode: :new_idea, snapshot: make_snapshot(%w[hive]),
-	      scope: 0, new_idea_project_name: "hive", new_idea_buffer: "x" * 2000, cols: 80
+    model = Hive::Tui::Model.initial.with(
+      mode: :new_idea, snapshot: make_snapshot(%w[hive]),
+      scope: 0, new_idea_project_name: "hive", new_idea_buffer: "x" * 2000, cols: 80
     )
     out = Hive::Tui::Views::NewIdeaPrompt.render(model)
     assert_operator out.lines.count, :<=, Hive::Tui::Views::NewIdeaPrompt::MAX_VISIBLE_ROWS
@@ -357,10 +357,10 @@ class HiveTuiViewsNewIdeaPromptTest < Minitest::Test
 
   def test_wrapped_render_keeps_cursor_row_visible
     buffer = "abcdefghij" * 10
-	    model = Hive::Tui::Model.initial.with(
-	      mode: :new_idea, snapshot: make_snapshot(%w[hive]),
-	      scope: 0, new_idea_project_name: "hive", new_idea_buffer: buffer, new_idea_cursor: 4, cols: 45
-	    )
+    model = Hive::Tui::Model.initial.with(
+      mode: :new_idea, snapshot: make_snapshot(%w[hive]),
+      scope: 0, new_idea_project_name: "hive", new_idea_buffer: buffer, new_idea_cursor: 4, cols: 45
+    )
     out = Hive::Tui::Views::NewIdeaPrompt.render(model)
 
     assert_includes out, "abcd", "cursor near the start should keep the start of the buffer visible"
@@ -369,17 +369,17 @@ class HiveTuiViewsNewIdeaPromptTest < Minitest::Test
 
   # ---- Unhealthy-project resolution ----
 
-	  def test_resolve_project_name_refuses_unhealthy_chosen_project
-	    snap = Hive::Tui::Snapshot.from_payload(
-	      "generated_at" => "2026-05-04",
-	      "projects" => [
-	        { "name" => "broken", "error" => "missing_project_path", "tasks" => [] },
-	        { "name" => "alpha", "tasks" => [] }
-	      ]
-	    )
-	    model = Hive::Tui::Model.initial.with(snapshot: snap, scope: 0, new_idea_project_name: "broken")
-	    assert_nil Hive::Tui::Views::NewIdeaPrompt.resolve_project_name(model),
-	               "chosen project must be revalidated against the latest snapshot before dispatch"
+  def test_resolve_project_name_refuses_unhealthy_chosen_project
+    snap = Hive::Tui::Snapshot.from_payload(
+      "generated_at" => "2026-05-04",
+      "projects" => [
+        { "name" => "broken", "error" => "missing_project_path", "tasks" => [] },
+        { "name" => "alpha", "tasks" => [] }
+      ]
+    )
+    model = Hive::Tui::Model.initial.with(snapshot: snap, scope: 0, new_idea_project_name: "broken")
+    assert_nil Hive::Tui::Views::NewIdeaPrompt.resolve_project_name(model),
+               "chosen project must be revalidated against the latest snapshot before dispatch"
   end
 
   def test_resolve_project_name_returns_nil_when_explicit_scope_is_unhealthy

--- a/test/unit/tui/views/new_idea_prompt_test.rb
+++ b/test/unit/tui/views/new_idea_prompt_test.rb
@@ -25,25 +25,25 @@ class HiveTuiViewsNewIdeaPromptTest < Minitest::Test
     )
   end
 
-  def test_renders_prompt_label_with_resolved_project
-    model = Hive::Tui::Model.initial.with(
-      mode: :new_idea, snapshot: make_snapshot(%w[hive myapp]),
-      scope: 0, new_idea_buffer: "rss feeds"
-    )
-    out = Hive::Tui::Views::NewIdeaPrompt.render(model)
-    assert_includes out, "New idea (project="
-    assert_includes out, "hive", "★ All scope must resolve to first registered project"
-    assert_includes out, "rss feeds", "buffer text must surface verbatim"
-  end
+	  def test_renders_prompt_label_with_chosen_project
+	    model = Hive::Tui::Model.initial.with(
+	      mode: :new_idea, snapshot: make_snapshot(%w[hive myapp]),
+	      scope: 0, new_idea_project_name: "hive", new_idea_buffer: "rss feeds"
+	    )
+	    out = Hive::Tui::Views::NewIdeaPrompt.render(model)
+	    assert_includes out, "New idea (project="
+	    assert_includes out, "hive", "chosen project must be shown before submission"
+	    assert_includes out, "rss feeds", "buffer text must surface verbatim"
+	  end
 
-  def test_label_indicates_star_fallback_when_scope_zero
-    model = Hive::Tui::Model.initial.with(
-      mode: :new_idea, snapshot: make_snapshot(%w[hive myapp]),
-      scope: 0
-    )
-    out = Hive::Tui::Views::NewIdeaPrompt.render(model)
-    assert_includes out, "★→hive",
-                    "scope=0 should be labeled with ★→<first> so the operator sees the fallback"
+	  def test_label_indicates_unresolved_project_when_scope_zero
+	    model = Hive::Tui::Model.initial.with(
+	      mode: :new_idea, snapshot: make_snapshot(%w[hive myapp]),
+	      scope: 0
+	    )
+	    out = Hive::Tui::Views::NewIdeaPrompt.render(model)
+	    assert_includes out, "(choose project)",
+	                    "scope=0 must not silently label or submit to the first project"
   end
 
   def test_label_uses_explicit_project_when_scope_n
@@ -51,9 +51,9 @@ class HiveTuiViewsNewIdeaPromptTest < Minitest::Test
       mode: :new_idea, snapshot: make_snapshot(%w[hive myapp]),
       scope: 2
     )
-    out = Hive::Tui::Views::NewIdeaPrompt.render(model)
-    assert_includes out, "myapp"
-    refute_includes out, "★→", "explicit scope must NOT carry the ★→ fallback prefix"
+	    out = Hive::Tui::Views::NewIdeaPrompt.render(model)
+	    assert_includes out, "myapp"
+	    refute_includes out, "choose project", "explicit scope must NOT look unresolved"
   end
 
   def test_label_handles_nil_snapshot
@@ -75,11 +75,18 @@ class HiveTuiViewsNewIdeaPromptTest < Minitest::Test
     assert_nil Hive::Tui::Views::NewIdeaPrompt.resolve_project_name(model)
   end
 
-  def test_resolve_project_name_returns_first_project_when_scope_zero
+  def test_resolve_project_name_returns_nil_when_scope_zero_without_choice
     model = Hive::Tui::Model.initial.with(
       snapshot: make_snapshot(%w[alpha beta]), scope: 0
     )
-    assert_equal "alpha", Hive::Tui::Views::NewIdeaPrompt.resolve_project_name(model)
+    assert_nil Hive::Tui::Views::NewIdeaPrompt.resolve_project_name(model)
+  end
+
+  def test_resolve_project_name_returns_chosen_project_under_scope_zero
+    model = Hive::Tui::Model.initial.with(
+      snapshot: make_snapshot(%w[alpha beta]), scope: 0, new_idea_project_name: "beta"
+    )
+    assert_equal "beta", Hive::Tui::Views::NewIdeaPrompt.resolve_project_name(model)
   end
 
   def test_resolve_project_name_returns_nth_project_when_scope_n
@@ -98,24 +105,24 @@ class HiveTuiViewsNewIdeaPromptTest < Minitest::Test
 
   # ---- project_label decoration logic ----
   # The render path covers these transitively, but a direct test pins
-  # the ★→ fallback marker, the explicit-scope path, and the empty-
+  # the unresolved ★ All marker, the explicit-scope path, and the empty-
   # snapshot placeholder so a regression in the decoration logic
   # surfaces independently of the prompt layout.
 
-  def test_project_label_marks_star_fallback_with_arrow_prefix
+  def test_project_label_marks_scope_zero_without_choice
     model = Hive::Tui::Model.initial.with(
       snapshot: make_snapshot(%w[hive myapp]), scope: 0
     )
-    assert_equal "★→hive", Hive::Tui::Views::NewIdeaPrompt.project_label(model),
-                 "scope=0 fallback must be visually distinguished from explicit selection"
+    assert_equal "(choose project)", Hive::Tui::Views::NewIdeaPrompt.project_label(model),
+                 "scope=0 must ask for a concrete target instead of falling back"
   end
 
   def test_project_label_returns_plain_name_when_scope_n
     model = Hive::Tui::Model.initial.with(
       snapshot: make_snapshot(%w[hive myapp]), scope: 2
-    )
-    assert_equal "myapp", Hive::Tui::Views::NewIdeaPrompt.project_label(model),
-                 "explicit scope must NOT carry the ★→ fallback marker"
+	    )
+	    assert_equal "myapp", Hive::Tui::Views::NewIdeaPrompt.project_label(model),
+	                 "explicit scope must NOT look unresolved"
   end
 
   def test_project_label_handles_no_projects_gracefully
@@ -131,9 +138,9 @@ class HiveTuiViewsNewIdeaPromptTest < Minitest::Test
 
   def test_long_buffer_slides_to_show_tail_within_cols
     long = ("a" * 60) + ("z" * 60) # 120 chars
-    model = Hive::Tui::Model.initial.with(
-      mode: :new_idea, snapshot: make_snapshot(%w[hive]),
-      scope: 0, new_idea_buffer: long, new_idea_cursor: long.length, cols: 50
+	    model = Hive::Tui::Model.initial.with(
+	      mode: :new_idea, snapshot: make_snapshot(%w[hive]),
+	      scope: 0, new_idea_project_name: "hive", new_idea_buffer: long, new_idea_cursor: long.length, cols: 50
     )
     out = Hive::Tui::Views::NewIdeaPrompt.render(model)
     refute_includes out, ("a" * 60),
@@ -143,9 +150,9 @@ class HiveTuiViewsNewIdeaPromptTest < Minitest::Test
   end
 
   def test_buffer_within_cols_renders_in_full
-    model = Hive::Tui::Model.initial.with(
-      mode: :new_idea, snapshot: make_snapshot(%w[hive]),
-      scope: 0, new_idea_buffer: "rss feeds", cols: 100
+	    model = Hive::Tui::Model.initial.with(
+	      mode: :new_idea, snapshot: make_snapshot(%w[hive]),
+	      scope: 0, new_idea_project_name: "hive", new_idea_buffer: "rss feeds", cols: 100
     )
     out = Hive::Tui::Views::NewIdeaPrompt.render(model)
     assert_includes out, "rss feeds", "short buffer must render verbatim"
@@ -153,10 +160,11 @@ class HiveTuiViewsNewIdeaPromptTest < Minitest::Test
 
   def test_render_shows_single_staged_image_count
     model = Hive::Tui::Model.initial.with(
-      mode: :new_idea,
-      snapshot: make_snapshot(%w[hive]),
-      scope: 0,
-      new_idea_buffer: "hi [image1]",
+	      mode: :new_idea,
+	      snapshot: make_snapshot(%w[hive]),
+	      scope: 0,
+	      new_idea_project_name: "hive",
+	      new_idea_buffer: "hi [image1]",
       new_idea_cursor: "hi [image1]".length,
       new_idea_attachments: [ attachment("image1") ],
       cols: 100
@@ -169,10 +177,11 @@ class HiveTuiViewsNewIdeaPromptTest < Minitest::Test
 
   def test_render_shows_plural_staged_image_count
     model = Hive::Tui::Model.initial.with(
-      mode: :new_idea,
-      snapshot: make_snapshot(%w[hive]),
-      scope: 0,
-      new_idea_buffer: "[image1][image2][image3]",
+	      mode: :new_idea,
+	      snapshot: make_snapshot(%w[hive]),
+	      scope: 0,
+	      new_idea_project_name: "hive",
+	      new_idea_buffer: "[image1][image2][image3]",
       new_idea_cursor: 24,
       new_idea_attachments: [ attachment("image1"), attachment("image2"), attachment("image3") ],
       cols: 100
@@ -185,10 +194,11 @@ class HiveTuiViewsNewIdeaPromptTest < Minitest::Test
 
   def test_render_suppresses_staged_image_count_on_narrow_terminal
     model = Hive::Tui::Model.initial.with(
-      mode: :new_idea,
-      snapshot: make_snapshot(%w[hive]),
-      scope: 0,
-      new_idea_buffer: "hi [image1]",
+	      mode: :new_idea,
+	      snapshot: make_snapshot(%w[hive]),
+	      scope: 0,
+	      new_idea_project_name: "hive",
+	      new_idea_buffer: "hi [image1]",
       new_idea_cursor: "hi [image1]".length,
       new_idea_attachments: [ attachment("image1") ],
       cols: 28
@@ -202,10 +212,11 @@ class HiveTuiViewsNewIdeaPromptTest < Minitest::Test
 
   def test_render_omits_staged_image_count_when_no_attachments
     model = Hive::Tui::Model.initial.with(
-      mode: :new_idea,
-      snapshot: make_snapshot(%w[hive]),
-      scope: 0,
-      new_idea_buffer: "hi",
+	      mode: :new_idea,
+	      snapshot: make_snapshot(%w[hive]),
+	      scope: 0,
+	      new_idea_project_name: "hive",
+	      new_idea_buffer: "hi",
       new_idea_attachments: [],
       cols: 100
     )
@@ -227,10 +238,11 @@ class HiveTuiViewsNewIdeaPromptTest < Minitest::Test
 
   def test_render_preserves_broken_placeholder_text
     model = Hive::Tui::Model.initial.with(
-      mode: :new_idea,
-      snapshot: make_snapshot(%w[hive]),
-      scope: 0,
-      new_idea_buffer: "see [image1]",
+	      mode: :new_idea,
+	      snapshot: make_snapshot(%w[hive]),
+	      scope: 0,
+	      new_idea_project_name: "hive",
+	      new_idea_buffer: "see [image1]",
       new_idea_cursor: "see [image1]".length,
       new_idea_broken_labels: [ "image1" ],
       cols: 100
@@ -242,9 +254,9 @@ class HiveTuiViewsNewIdeaPromptTest < Minitest::Test
   end
 
   def test_explicit_width_kwarg_clamps_independently_of_cols
-    model = Hive::Tui::Model.initial.with(
-      mode: :new_idea, snapshot: make_snapshot(%w[hive]),
-      scope: 0, new_idea_buffer: "x" * 80, cols: 200
+	    model = Hive::Tui::Model.initial.with(
+	      mode: :new_idea, snapshot: make_snapshot(%w[hive]),
+	      scope: 0, new_idea_project_name: "hive", new_idea_buffer: "x" * 80, cols: 200
     )
     out = Hive::Tui::Views::NewIdeaPrompt.render(model, width: 30)
     refute_match(/x{80}/, out, "width: kwarg must clamp regardless of model.cols")
@@ -254,9 +266,9 @@ class HiveTuiViewsNewIdeaPromptTest < Minitest::Test
 
   def test_long_buffer_wraps_across_multiple_rows
     long = "abcdef" * 30 # 180 chars
-    model = Hive::Tui::Model.initial.with(
-      mode: :new_idea, snapshot: make_snapshot(%w[hive]),
-      scope: 0, new_idea_buffer: long, cols: 80
+	    model = Hive::Tui::Model.initial.with(
+	      mode: :new_idea, snapshot: make_snapshot(%w[hive]),
+	      scope: 0, new_idea_project_name: "hive", new_idea_buffer: long, cols: 80
     )
     out = Hive::Tui::Views::NewIdeaPrompt.render(model)
     assert out.lines.count > 1, "180-char buffer at cols=80 must wrap onto multiple rows"
@@ -268,13 +280,13 @@ class HiveTuiViewsNewIdeaPromptTest < Minitest::Test
   end
 
   def test_continuation_rows_align_to_label_column
-    model = Hive::Tui::Model.initial.with(
-      mode: :new_idea, snapshot: make_snapshot(%w[hive]),
-      scope: 0, new_idea_buffer: "a" * 200, cols: 80
+	    model = Hive::Tui::Model.initial.with(
+	      mode: :new_idea, snapshot: make_snapshot(%w[hive]),
+	      scope: 0, new_idea_project_name: "hive", new_idea_buffer: "a" * 200, cols: 80
     )
     out = Hive::Tui::Views::NewIdeaPrompt.render(model)
     rows = out.lines.map { |l| l.chomp.gsub(/\e\[[\d;]*m/, "") }
-    label_col = "New idea (project=★→hive): ".length
+	    label_col = "New idea (project=hive): ".length
     rows[1..].each do |row|
       assert row.start_with?(" " * label_col),
              "continuation row must start with label-width padding (got #{row.inspect})"
@@ -282,9 +294,9 @@ class HiveTuiViewsNewIdeaPromptTest < Minitest::Test
   end
 
   def test_buffer_within_first_row_capacity_renders_single_line
-    model = Hive::Tui::Model.initial.with(
-      mode: :new_idea, snapshot: make_snapshot(%w[hive]),
-      scope: 0, new_idea_buffer: "rss", cols: 80
+	    model = Hive::Tui::Model.initial.with(
+	      mode: :new_idea, snapshot: make_snapshot(%w[hive]),
+	      scope: 0, new_idea_project_name: "hive", new_idea_buffer: "rss", cols: 80
     )
     out = Hive::Tui::Views::NewIdeaPrompt.render(model)
     assert_equal 1, out.lines.count, "short buffer must NOT wrap"
@@ -293,9 +305,9 @@ class HiveTuiViewsNewIdeaPromptTest < Minitest::Test
   def test_extreme_overflow_caps_at_max_visible_rows
     # Buffer big enough to wrap to 20+ rows; renderer caps at
     # MAX_VISIBLE_ROWS so the prompt doesn't push the panes off-screen.
-    model = Hive::Tui::Model.initial.with(
-      mode: :new_idea, snapshot: make_snapshot(%w[hive]),
-      scope: 0, new_idea_buffer: "x" * 2000, cols: 80
+	    model = Hive::Tui::Model.initial.with(
+	      mode: :new_idea, snapshot: make_snapshot(%w[hive]),
+	      scope: 0, new_idea_project_name: "hive", new_idea_buffer: "x" * 2000, cols: 80
     )
     out = Hive::Tui::Views::NewIdeaPrompt.render(model)
     assert_operator out.lines.count, :<=, Hive::Tui::Views::NewIdeaPrompt::MAX_VISIBLE_ROWS
@@ -345,10 +357,10 @@ class HiveTuiViewsNewIdeaPromptTest < Minitest::Test
 
   def test_wrapped_render_keeps_cursor_row_visible
     buffer = "abcdefghij" * 10
-    model = Hive::Tui::Model.initial.with(
-      mode: :new_idea, snapshot: make_snapshot(%w[hive]),
-      scope: 0, new_idea_buffer: buffer, new_idea_cursor: 4, cols: 45
-    )
+	    model = Hive::Tui::Model.initial.with(
+	      mode: :new_idea, snapshot: make_snapshot(%w[hive]),
+	      scope: 0, new_idea_project_name: "hive", new_idea_buffer: buffer, new_idea_cursor: 4, cols: 45
+	    )
     out = Hive::Tui::Views::NewIdeaPrompt.render(model)
 
     assert_includes out, "abcd", "cursor near the start should keep the start of the buffer visible"
@@ -357,17 +369,17 @@ class HiveTuiViewsNewIdeaPromptTest < Minitest::Test
 
   # ---- Unhealthy-project resolution ----
 
-  def test_resolve_project_name_skips_unhealthy_projects_under_star_all
-    snap = Hive::Tui::Snapshot.from_payload(
-      "generated_at" => "2026-05-04",
-      "projects" => [
-        { "name" => "broken", "error" => "missing_project_path", "tasks" => [] },
-        { "name" => "alpha", "tasks" => [] }
-      ]
-    )
-    model = Hive::Tui::Model.initial.with(snapshot: snap, scope: 0)
-    assert_equal "alpha", Hive::Tui::Views::NewIdeaPrompt.resolve_project_name(model),
-                 "★ All fallback must skip projects with `error:` and pick the first HEALTHY one"
+	  def test_resolve_project_name_refuses_unhealthy_chosen_project
+	    snap = Hive::Tui::Snapshot.from_payload(
+	      "generated_at" => "2026-05-04",
+	      "projects" => [
+	        { "name" => "broken", "error" => "missing_project_path", "tasks" => [] },
+	        { "name" => "alpha", "tasks" => [] }
+	      ]
+	    )
+	    model = Hive::Tui::Model.initial.with(snapshot: snap, scope: 0, new_idea_project_name: "broken")
+	    assert_nil Hive::Tui::Views::NewIdeaPrompt.resolve_project_name(model),
+	               "chosen project must be revalidated against the latest snapshot before dispatch"
   end
 
   def test_resolve_project_name_returns_nil_when_explicit_scope_is_unhealthy

--- a/wiki/commands/tui.md
+++ b/wiki/commands/tui.md
@@ -43,7 +43,8 @@ Pane focus is keyboard-only; the focused pane border is bright cyan, the inactiv
 | Agent log tail | `Enter` on an `agent_running` row | `q` / `Esc` |
 | Input editor | `Enter` on a `needs_input` row | editor exit; completed brainstorm answers auto-continue; plan rows auto-advance to `develop` (or auto-revise if user added feedback) |
 | Filter prompt | `/` | `Esc` (cancels typed buffer; any committed filter is preserved) / `Enter` (commits) |
-| New idea prompt | `n` | `Esc` (cancels) / `Enter` (submits `hive new <project> "<title>"`) |
+| New idea project picker | `n` from `★ All projects` scope | `Esc` / `q` (cancels) / `Enter` (selects and advances to title prompt) |
+| New idea prompt | `n` (single-project scope), or after picker selection (all-projects scope) | `Esc` (cancels) / `Enter` (submits `hive new <project> "<title>"`) |
 | Help overlay | `?` | any key |
 
 ## Keybindings (default mode)
@@ -77,7 +78,7 @@ In findings-triage mode `a` and `r` rebind to *bulk accept* and *bulk reject* (a
 
 ## New Idea Prompt Editing
 
-The `n` prompt is a cursor-aware single-line title editor. When the dashboard scope is `★ All projects`, `n` first opens a concrete project picker (`j`/`k` or arrows to move, `Enter` to choose, `Esc` to cancel) so task capture never silently lands in the first registered project. After a project is chosen, printable typing inserts at the title cursor; `←` / `→` move within the title; `Home` / `End` and `Ctrl+A` / `Ctrl+E` jump to the start/end; `Backspace` deletes before the cursor; `Delete` deletes under the cursor. Paste is accepted as either ordinary terminal text chunks or bracketed paste; CR/LF/TAB in pasted payloads are normalized to spaces because `hive new` takes a single title. The prompt keeps a conservative 4 KiB title buffer cap and flashes `title too long` instead of accepting oversized clipboard dumps.
+The `n` prompt is a cursor-aware single-line title editor. When the dashboard scope is `★ All projects`, `n` first opens a concrete project picker (`j`/`k` or arrows to move, `Enter` to choose, `Esc` to cancel) so task capture never silently lands in the first registered project; if the first status snapshot has not arrived yet, the picker stays open in a loading state until projects are available. After a project is chosen, printable typing inserts at the title cursor; `←` / `→` move within the title; `Home` / `End` and `Ctrl+A` / `Ctrl+E` jump to the start/end; `Backspace` deletes before the cursor; `Delete` deletes under the cursor. Paste is accepted as either ordinary terminal text chunks or bracketed paste; CR/LF/TAB in pasted payloads are normalized to spaces because `hive new` takes a single title. The prompt keeps a conservative 4 KiB title buffer cap and flashes `title too long` instead of accepting oversized clipboard dumps.
 
 ### Image paste
 

--- a/wiki/commands/tui.md
+++ b/wiki/commands/tui.md
@@ -3,7 +3,7 @@ title: hive tui
 type: command
 source: lib/hive/tui.rb
 created: 2026-04-27
-updated: 2026-05-13T23:00:00Z
+updated: 2026-05-19T00:00:00Z
 tags: [command, tui, observability, interactive]
 ---
 

--- a/wiki/commands/tui.md
+++ b/wiki/commands/tui.md
@@ -64,7 +64,7 @@ Pane focus is keyboard-only; the focused pane border is bright cyan, the inactiv
 | `a` | run `hive archive` |
 | `Enter` | from left pane: focus right pane. From right pane: perform the row's contextual action: input editor on `needs_input` (completed brainstorm answer rounds auto-run; plan rows auto-advance to `develop` or auto-revise on user feedback), triage on `review_findings`, log tail on `agent_running` (and on `error` rows still in a kill-class auto-heal window), recover + rerun on review-recovery and non-kill-class `error` rows; ready rows still dispatch the suggested command |
 | `o` | open the focused row's hive-state task folder in `$VISUAL` / `$EDITOR` / `vi` for read-only browsing — no marker change, no workflow dispatch. Distinct from `Enter` (workflow-contextual) and the verb keys (subprocess dispatch). Useful for revisiting investigation outputs in `8-done` (or any stage). |
-| `n` | open the new-idea prompt; submitting runs `hive new <project> "<title>"` against the project selected in the left pane (`★ All` falls back to the first registered project) |
+| `n` | open the new-idea flow; if scope is `★ All projects`, first show a project picker, then submit with `hive new <project> "<title>"` against the chosen concrete project |
 | `/` | open filter prompt |
 | `1`–`9` | scope the right pane to the Nth registered project (mirrors selection in the left pane) |
 | `0` | scope back to `★ All projects` |
@@ -77,7 +77,7 @@ In findings-triage mode `a` and `r` rebind to *bulk accept* and *bulk reject* (a
 
 ## New Idea Prompt Editing
 
-The `n` prompt is a cursor-aware single-line title editor. Printable typing inserts at the cursor; `←` / `→` move within the title; `Home` / `End` and `Ctrl+A` / `Ctrl+E` jump to the start/end; `Backspace` deletes before the cursor; `Delete` deletes under the cursor. Paste is accepted as either ordinary terminal text chunks or bracketed paste; CR/LF/TAB in pasted payloads are normalized to spaces because `hive new` takes a single title. The prompt keeps a conservative 4 KiB title buffer cap and flashes `title too long` instead of accepting oversized clipboard dumps.
+The `n` prompt is a cursor-aware single-line title editor. When the dashboard scope is `★ All projects`, `n` first opens a concrete project picker (`j`/`k` or arrows to move, `Enter` to choose, `Esc` to cancel) so task capture never silently lands in the first registered project. After a project is chosen, printable typing inserts at the title cursor; `←` / `→` move within the title; `Home` / `End` and `Ctrl+A` / `Ctrl+E` jump to the start/end; `Backspace` deletes before the cursor; `Delete` deletes under the cursor. Paste is accepted as either ordinary terminal text chunks or bracketed paste; CR/LF/TAB in pasted payloads are normalized to spaces because `hive new` takes a single title. The prompt keeps a conservative 4 KiB title buffer cap and flashes `title too long` instead of accepting oversized clipboard dumps.
 
 ### Image paste
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -2,6 +2,13 @@
 
 Append-only log of all wiki operations.
 
+## [2026-05-19T00:00:00Z] tui — keep All projects idea picker open while loading
+
+**Action:** Documented the follow-up behavior that `n` from `★ All projects` enters the concrete project picker even before the first status snapshot arrives. The picker now uses a loading state instead of falling through to the title composer without a selected project.
+
+**Refreshed pages:**
+- [[commands/tui]] — clarified the picker loading state before projects are available.
+
 ## [2026-05-17T00:55:00Z] tui — require project choice for new ideas from All projects
 
 **Action:** Updated the TUI new-idea behavior so `n` from `★ All projects` opens a concrete project picker before the title composer. The old implicit first-registered-project fallback could land ideas in the wrong repo while the header still read All projects. The chosen project is carried only for that new idea, so the dashboard can remain scoped to All while `hive new <project> "<title>"` targets the explicit selection.

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -2,6 +2,13 @@
 
 Append-only log of all wiki operations.
 
+## [2026-05-17T00:55:00Z] tui — require project choice for new ideas from All projects
+
+**Action:** Updated the TUI new-idea behavior so `n` from `★ All projects` opens a concrete project picker before the title composer. The old implicit first-registered-project fallback could land ideas in the wrong repo while the header still read All projects. The chosen project is carried only for that new idea, so the dashboard can remain scoped to All while `hive new <project> "<title>"` targets the explicit selection.
+
+**Refreshed pages:**
+- [[commands/tui]] — documented the project picker and removed the old `★ All` first-project fallback wording.
+
 ## [2026-05-14T23:30:00Z] brainstorm — tmux interactive runtime (U1–U8)
 
 **Action:** Documented the new interactive tmux runtime for 2-brainstorm. The stage can now spawn the agent inside a detached tmux session (U3) via the `Stages::BrainstormTmux` runner, with U2's interactive Claude wrapper, U4's stop-hook install, U5's tmux sentinel fallback, U7's hardened preflight/teardown, and U8's operator notes. `lib/hive/tmux_runner.rb` (U1) is the shared runtime primitive. Selection is gated by a per-project config flag (U6) surfaced through `templates/project_config.yml.erb`. `hive doctor` (U7) preflights `tmux` availability + version and reports stale brainstorm sessions; the brainstorm stage cleans them up on completion. Wiki refresh in b67096c updated the brainstorm stage, doctor command, and state-model pages.


### PR DESCRIPTION
## Summary

New ideas created from `★ All projects` now stop for an explicit project choice instead of inheriting the first healthy project from the snapshot. The picker keeps the dashboard scoped to All projects while storing the selected project only for the composer, so submission still validates the target against the current project list.

The new TUI mode has dedicated key handling for selection, movement, and cancellation, plus help text, wiki notes, and coverage for picker rendering, selected-project submission, cancellation, attachments, and the e2e editing scenario.

## Test Plan

- [x] `bundle exec rake test` (`2232 runs, 7566 assertions, 0 failures, 0 errors, 1 skips`)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
