### PR TITLE
fix(status): surface tasks hidden in legacy stage dirs

### DIFF
--- a/lib/hive/commands/migrate.rb
+++ b/lib/hive/commands/migrate.rb
@@ -28,8 +28,10 @@ module Hive
       # Task-folder names follow this slug pattern (see Task::PATH_RE).
       # Any entry under a legacy stage directory that doesn't look like a
       # task slug is left in place — never silently mv'd into the new
-      # stage dir.
-      SLUG_RE = /\A[a-z][a-z0-9-]{0,62}[a-z0-9]\z/
+      # stage dir. Re-exported here for back-compat with existing callers;
+      # `Hive::Stages::SLUG_RE` is the single source of truth shared with
+      # `Hive::Commands::Status#detect_legacy_stage_dirs`.
+      SLUG_RE = Hive::Stages::SLUG_RE
 
       def initialize(project_path = Dir.pwd)
         @project_path = File.expand_path(project_path)
@@ -84,7 +86,7 @@ module Hive
           Dir.children(old_dir).sort.each do |entry|
             # Skip any non-slug entry (including .gitkeep, .DS_Store,
             # stray .lock, etc.). Only task-folder slugs migrate.
-            next unless SLUG_RE.match?(entry)
+            next unless Hive::Stages.task_slug?(entry)
 
             src = File.join(old_dir, entry)
             next unless File.directory?(src)

--- a/lib/hive/commands/status.rb
+++ b/lib/hive/commands/status.rb
@@ -116,19 +116,34 @@ module Hive
           # every row. Schema mandates the field.
           rows = annotate_actions(collect_rows(hive_state), project, project_count, with_diagnostic: true)
           out = base.merge("tasks" => rows.map { |r| task_payload(r) })
-          legacy = detect_legacy_stage_dirs(hive_state)
-          out["legacy_stage_dirs"] = legacy unless legacy.empty?
+          # Always emit `legacy_stage_dirs` (default empty array) so
+          # consumers can branch on `.empty?` without a `key?` probe and
+          # the schema's optional-but-never-undefined contract holds.
+          legacy_stage_dirs = detect_legacy_stage_dirs(hive_state)
+          out["legacy_stage_dirs"] = legacy_stage_dirs
+          # `legacy_migrate_command` is the machine-readable parity of the
+          # text-mode "run `hive migrate`" recovery hint. Agents reading
+          # the JSON envelope get a ready-to-execute command string when
+          # legacy_stage_dirs is non-empty; `null` otherwise. The field is
+          # always present (never absent) — same diagnostic-field
+          # convention as `diagnostic` on tasks. Issue #94.
+          out["legacy_migrate_command"] = legacy_stage_dirs.empty? ? nil : "hive migrate"
           out
         end
       end
 
       # Scan `<hive_state>/stages/` for directories that are NOT in
-      # `Hive::Stages::DIRS` and contain at least one subfolder. Returns
-      # `[{"dir" => name, "task_count" => N}, ...]` sorted by name.
-      # `collect_rows` walks only canonical DIRS, so any stage rename in
-      # `lib/hive/stages.rb` leaves pre-rename tasks unreachable from
-      # every operator surface — this is the detector that turns that
-      # silent gap into a visible warning instead.
+      # `Hive::Stages::DIRS` and contain at least one task-slug-shaped
+      # subfolder. Returns `[{"stage_dir" => name, "task_count" => N},
+      # ...]` sorted by name. `collect_rows` walks only canonical DIRS, so
+      # any stage rename in `lib/hive/stages.rb` leaves pre-rename tasks
+      # unreachable from every operator surface — this is the detector
+      # that turns that silent gap into a visible warning instead. Only
+      # `Hive::Stages.task_slug?` children count toward `task_count` so
+      # stray `logs/`, `.DS_Store`, or `.gitkeep` siblings don't inflate
+      # the number — the same predicate `Hive::Commands::Migrate` uses to
+      # decide what it is allowed to mv, so the count matches what
+      # `hive migrate` would actually move.
       def detect_legacy_stage_dirs(hive_state)
         stages_root = File.join(hive_state, "stages")
         return [] unless File.directory?(stages_root)
@@ -139,11 +154,13 @@ module Hive
           dir = File.join(stages_root, basename)
           next unless File.directory?(dir)
 
-          task_count = Dir.children(dir).count { |child| File.directory?(File.join(dir, child)) }
+          task_count = Dir.children(dir).count do |child|
+            Hive::Stages.task_slug?(child) && File.directory?(File.join(dir, child))
+          end
           next if task_count.zero?
 
-          { "dir" => basename, "task_count" => task_count }
-        end.sort_by { |entry| entry["dir"] }
+          { "stage_dir" => basename, "task_count" => task_count }
+        end.sort_by { |entry| entry["stage_dir"] }
       end
 
       def task_payload(row)
@@ -276,7 +293,7 @@ module Hive
 
       def render_legacy_stage_warning(legacy)
         total = legacy.sum { |entry| entry["task_count"] }
-        dirs = legacy.map { |entry| "#{entry['dir']} (#{entry['task_count']})" }.join(", ")
+        dirs = legacy.map { |entry| "#{entry['stage_dir']} (#{entry['task_count']})" }.join(", ")
         puts "  ⚠ #{total} task#{total == 1 ? '' : 's'} hidden in legacy stage dirs: #{dirs}"
         puts "    run `hive migrate` to move them into the current layout"
       end

--- a/lib/hive/commands/status.rb
+++ b/lib/hive/commands/status.rb
@@ -115,8 +115,35 @@ module Hive
           # external consumers (TUI, daemon, bots) read `diagnostic` off
           # every row. Schema mandates the field.
           rows = annotate_actions(collect_rows(hive_state), project, project_count, with_diagnostic: true)
-          base.merge("tasks" => rows.map { |r| task_payload(r) })
+          out = base.merge("tasks" => rows.map { |r| task_payload(r) })
+          legacy = detect_legacy_stage_dirs(hive_state)
+          out["legacy_stage_dirs"] = legacy unless legacy.empty?
+          out
         end
+      end
+
+      # Scan `<hive_state>/stages/` for directories that are NOT in
+      # `Hive::Stages::DIRS` and contain at least one subfolder. Returns
+      # `[{"dir" => name, "task_count" => N}, ...]` sorted by name.
+      # `collect_rows` walks only canonical DIRS, so any stage rename in
+      # `lib/hive/stages.rb` leaves pre-rename tasks unreachable from
+      # every operator surface — this is the detector that turns that
+      # silent gap into a visible warning instead.
+      def detect_legacy_stage_dirs(hive_state)
+        stages_root = File.join(hive_state, "stages")
+        return [] unless File.directory?(stages_root)
+
+        Dir.children(stages_root).filter_map do |basename|
+          next if Hive::Stages::DIRS.include?(basename)
+
+          dir = File.join(stages_root, basename)
+          next unless File.directory?(dir)
+
+          task_count = Dir.children(dir).count { |child| File.directory?(File.join(dir, child)) }
+          next if task_count.zero?
+
+          { "dir" => basename, "task_count" => task_count }
+        end.sort_by { |entry| entry["dir"] }
       end
 
       def task_payload(row)
@@ -227,9 +254,11 @@ module Hive
         # I/O that TaskAction#diagnostic performs per red row. JSON path
         # still pays the full cost via project_payload.
         rows = annotate_actions(collect_rows(hive_state), project, project_count, with_diagnostic: false)
+        legacy = detect_legacy_stage_dirs(hive_state)
         puts project["name"]
+        render_legacy_stage_warning(legacy) unless legacy.empty?
         if rows.empty?
-          puts "  no active tasks"
+          puts "  no active tasks" if legacy.empty?
           return
         end
 
@@ -243,6 +272,13 @@ module Hive
             puts "    #{r[:icon]} #{r[:slug].ljust(36)} #{r[:state_label].ljust(24)} #{command} #{r[:age]}"
           end
         end
+      end
+
+      def render_legacy_stage_warning(legacy)
+        total = legacy.sum { |entry| entry["task_count"] }
+        dirs = legacy.map { |entry| "#{entry['dir']} (#{entry['task_count']})" }.join(", ")
+        puts "  ⚠ #{total} task#{total == 1 ? '' : 's'} hidden in legacy stage dirs: #{dirs}"
+        puts "    run `hive migrate` to move them into the current layout"
       end
 
       def collect_rows(hive_state)

--- a/lib/hive/daemon/dispatcher.rb
+++ b/lib/hive/daemon/dispatcher.rb
@@ -57,6 +57,18 @@ module Hive
         # interval without the operator having to send SIGHUP.
         # PR-40 follow-up #2.
         @enabled_cache = {}
+        # Per-tick set of project names whose layout is half-migrated
+        # (non-empty legacy_stage_dirs). Populated at the start of each
+        # tick from StatusConsumer::Result#projects; row dispatch refuses
+        # any row whose project lives in this set. Issue #95.
+        @legacy_layout_projects = {}
+        # Process-lifetime set of project names we've already logged the
+        # "legacy stage dirs detected" warning for, so a half-migrated
+        # project doesn't spam daemon.log on every 30s poll. Cleared on
+        # SIGHUP/reload — operator fixing the layout + reloading will
+        # see the next warning the next time it goes red, but we don't
+        # actively re-emit on every tick. Issue #95.
+        @legacy_layout_logged = {}
       end
 
       # Single tick: reap, fetch, dispatch. Pure dispatcher — no signal
@@ -86,6 +98,12 @@ module Hive
           @logger.event(:tick_end, now: Time.now.utc.iso8601, action: "status_failure")
           return
         end
+        # Rebuild the per-tick set of half-migrated projects from the
+        # status snapshot. Stays empty when the daemon talks to an old
+        # status binary that didn't ship the field (Result#projects
+        # defaults to []) so old binaries stay forward-compatible.
+        # Issue #95.
+        refresh_legacy_layout_projects(result.projects)
         refresh_active_agent_snapshot(result.rows)
 
         observe_external_running_rows(result.rows)
@@ -241,6 +259,7 @@ module Hive
 
       def handle_row(row, now:)
         return unless project_enabled?(row.project)
+        return if @legacy_layout_projects.key?(row.project)
 
         decision = Policy.decide(
           action: row.action,
@@ -433,7 +452,30 @@ module Hive
         @external_active_agent_counts = Hash.new(0)
       end
 
-      def refresh_active_agent_snapshot(rows)
+       # Populate the per-tick "skip this project's rows" set from the
+       # status snapshot's projects[] list. A project counts as legacy if
+       # its `legacy_stage_dirs` array is non-empty (i.e. tasks were left
+       # in a pre-rename stage directory). Advancing a row on top of a
+       # half-migrated layout would silently lose work, so we skip the
+       # whole project until the operator runs `hive migrate`. Logging is
+       # gated by `@legacy_layout_logged` so a half-migrated project
+       # doesn't spam daemon.log every tick — first-sight only.
+       # Issue #95.
+       def refresh_legacy_layout_projects(projects)
+         @legacy_layout_projects = {}
+         Array(projects).each do |project|
+           next unless project.respond_to?(:legacy?) && project.legacy?
+
+           @legacy_layout_projects[project.name] = true
+           next if @legacy_layout_logged[project.name]
+
+           @logger.event(:legacy_layout_detected, project: project.name,
+                                                  stage_dirs: project.legacy_stage_dirs.map { |d| d["stage_dir"] })
+           @legacy_layout_logged[project.name] = true
+         end
+       end
+
+       def refresh_active_agent_snapshot(rows)
         reset_active_agent_snapshot
         rows.each do |row|
           next unless active_agent_row?(row)

--- a/lib/hive/daemon/status_consumer.rb
+++ b/lib/hive/daemon/status_consumer.rb
@@ -13,7 +13,18 @@ module Hive
                        :state_file_mtime, :action, :suggested_command, :claude_pid_alive,
                        :diagnostic,
                        keyword_init: true)
-      Result = Struct.new(:ok, :rows, :error, keyword_init: true)
+      # Aggregated per-project legacy-layout signal lifted out of each
+      # project payload's `legacy_stage_dirs` array. The dispatcher uses
+      # this to skip dispatching ANY task for a half-migrated project —
+      # advancing on top of a renamed stage dir would silently lose work.
+      # `legacy_stage_dirs` is the project payload's array verbatim (empty
+      # when the project is clean). Issue #95.
+      ProjectInfo = Struct.new(:name, :legacy_stage_dirs, keyword_init: true) do
+        def legacy?
+          !Array(legacy_stage_dirs).empty?
+        end
+      end
+      Result = Struct.new(:ok, :rows, :projects, :error, keyword_init: true)
 
       def initialize(hive_bin: ENV.fetch("HIVE_BIN", "hive"),
                      extra_env: {})
@@ -24,18 +35,20 @@ module Hive
       def fetch
         out, err, status = Open3.capture3(@extra_env, @hive_bin, "status", "--json")
         unless status.success?
-          return Result.new(ok: false, rows: [],
+          return Result.new(ok: false, rows: [], projects: [],
                             error: "hive status exited #{status.exitstatus}: #{err.strip}")
         end
 
         doc = JSON.parse(out)
         validate_envelope!(doc)
         rows = extract_rows(doc)
-        Result.new(ok: true, rows: rows, error: nil)
+        projects = extract_projects(doc)
+        Result.new(ok: true, rows: rows, projects: projects, error: nil)
       rescue JSON::ParserError => e
-        Result.new(ok: false, rows: [], error: "malformed JSON from hive status: #{e.message}")
+        Result.new(ok: false, rows: [], projects: [],
+                   error: "malformed JSON from hive status: #{e.message}")
       rescue StandardError => e
-        Result.new(ok: false, rows: [], error: "#{e.class}: #{e.message}")
+        Result.new(ok: false, rows: [], projects: [], error: "#{e.class}: #{e.message}")
       end
 
       private
@@ -78,6 +91,20 @@ module Hive
           end
         end
         rows
+      end
+
+      # Surface per-project payload-level signal (legacy_stage_dirs) so
+      # the dispatcher can gate dispatch on a project being in a clean
+      # layout, without re-walking the JSON. Skips error projects (same
+      # filter as extract_rows) so the projects list is in 1:1
+      # correspondence with dispatchable projects. Issue #95.
+      def extract_projects(doc)
+        Array(doc["projects"]).reject { |p| p["error"] }.map do |project_doc|
+          ProjectInfo.new(
+            name: project_doc["name"],
+            legacy_stage_dirs: Array(project_doc["legacy_stage_dirs"])
+          )
+        end
       end
 
       def parse_mtime(iso_string, state_file_path)

--- a/lib/hive/stages.rb
+++ b/lib/hive/stages.rb
@@ -16,7 +16,21 @@ module Hive
     NAMES = DIRS.map { |d| d.split("-", 2).last }.freeze
     SHORT_TO_FULL = DIRS.each_with_object({}) { |d, h| h[d.split("-", 2).last] = d }.freeze
 
+    # Slug shape for task-folder names (see Task::PATH_RE / Migrate::SLUG_RE).
+    # Single source of truth so the legacy-stage detector in
+    # `Hive::Commands::Status` and the `Hive::Commands::Migrate` walker stay
+    # in lockstep — both must treat the same set of entries as task folders.
+    SLUG_RE = /\A[a-z][a-z0-9-]{0,62}[a-z0-9]\z/
+
     module_function
+
+    # True iff `name` is a task-folder slug (per `SLUG_RE`). Used by Status
+    # to count only task subfolders inside a legacy stage dir (skipping
+    # `.gitkeep`, `logs/`, `.DS_Store`, etc.) and by Migrate to decide
+    # which entries it is allowed to mv.
+    def task_slug?(name)
+      SLUG_RE.match?(name.to_s)
+    end
 
     # Directory for the stage *after* the one whose numeric prefix is `idx`.
     # Returns nil when `idx` is past the final stage's prefix or when no

--- a/lib/hive/tui/snapshot.rb
+++ b/lib/hive/tui/snapshot.rb
@@ -14,7 +14,24 @@ module Hive
     class Snapshot
       # `error` is nil for healthy projects and the JSON's "error" string
       # ("missing_project_path" / "not_initialised") otherwise.
-      ProjectView = Data.define(:name, :path, :hive_state_path, :error, :rows)
+      # `legacy_stage_dirs` carries the JSON's `legacy_stage_dirs` array
+      # verbatim ([] when the project is clean) so the renderer can flag
+      # projects with task folders stuck under a renamed stage directory
+      # without re-walking the filesystem. `legacy_migrate_command`
+      # carries the JSON's `legacy_migrate_command` string verbatim
+      # ("hive migrate" when legacy_stage_dirs is non-empty; nil
+      # otherwise) — agent-facing parity of the text recovery hint.
+      ProjectView = Data.define(:name, :path, :hive_state_path, :error, :rows,
+                                :legacy_stage_dirs, :legacy_migrate_command) do
+        # `legacy_stage_dirs` defaults to `[]` and `legacy_migrate_command`
+        # to nil so existing test factories (predating the fields) can keep
+        # building ProjectView with the original 5-keyword shape.
+        # Production callers in this file always pass them explicitly.
+        def initialize(legacy_stage_dirs: [].freeze, legacy_migrate_command: nil, **rest)
+          super(legacy_stage_dirs: legacy_stage_dirs,
+                legacy_migrate_command: legacy_migrate_command, **rest)
+        end
+      end
 
       # Mirrors `Hive::Commands::Status#task_payload` 1:1 plus a
       # `project_name` back-reference so a flat row list stays attributable
@@ -88,7 +105,9 @@ module Hive
           path: payload["path"],
           hive_state_path: payload["hive_state_path"],
           error: payload["error"],
-          rows: sorted.freeze
+          rows: sorted.freeze,
+          legacy_stage_dirs: Array(payload["legacy_stage_dirs"]).freeze,
+          legacy_migrate_command: payload["legacy_migrate_command"]
         ).freeze
       end
 
@@ -136,7 +155,9 @@ module Hive
             path: project.path,
             hive_state_path: project.hive_state_path,
             error: project.error,
-            rows: matched.freeze
+            rows: matched.freeze,
+            legacy_stage_dirs: project.legacy_stage_dirs,
+            legacy_migrate_command: project.legacy_migrate_command
           ).freeze
         end
         self.class.new(generated_at: @generated_at, projects: filtered)

--- a/lib/hive/tui/views/projects_pane.rb
+++ b/lib/hive/tui/views/projects_pane.rb
@@ -89,8 +89,18 @@ module Hive
         # this, broken projects are visually identical to healthy ones
         # and the user only finds out by trying to dispatch and seeing
         # `hive brainstorm` exit 70.
+        #
+        # A clean-pathed project that nevertheless carries
+        # `legacy_stage_dirs` (task folders under a renamed stage)
+        # gets the same `⚠` prefix and a short "legacy dirs — run
+        # hive migrate" hint, so the operator notices the migration
+        # nudge in the same scan they use for missing/needs-init.
         def project_label(project)
-          return project.name.to_s if project.error.nil?
+          if project.error.nil?
+            return project.name.to_s if Array(project.legacy_stage_dirs).empty?
+
+            return "⚠ #{project.name} (legacy dirs — run hive migrate)"
+          end
 
           short = case project.error
           when "missing_project_path" then "missing"

--- a/schemas/hive-status.v2.json
+++ b/schemas/hive-status.v2.json
@@ -148,6 +148,22 @@
           "items": {
             "$ref": "#/$defs/Task"
           }
+        },
+        "legacy_stage_dirs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["stage_dir", "task_count"],
+            "properties": {
+              "stage_dir": { "type": "string" },
+              "task_count": { "type": "integer", "minimum": 1 }
+            }
+          }
+        },
+        "legacy_migrate_command": {
+          "description": "Machine-readable parity of the text-mode `hive migrate` recovery hint. \"hive migrate\" when `legacy_stage_dirs` is non-empty; `null` when the project is clean. Always present (never absent) — the same diagnostic-field-always-present convention `diagnostic` uses on Task.",
+          "type": ["string", "null"]
         }
       }
     },

--- a/test/integration/status_legacy_layout_test.rb
+++ b/test/integration/status_legacy_layout_test.rb
@@ -19,6 +19,9 @@ class StatusLegacyLayoutTest < Minitest::Test
     with_tmp_global_config do
       with_tmp_git_repo do |dir|
         capture_io { Hive::Commands::Init.new(dir).call }
+        # Seed in non-alphabetical creation order so the sort_by in
+        # `detect_legacy_stage_dirs` has something to sort. The
+        # output must be alphabetical by `stage_dir`.
         seed_legacy_task(dir, "6-pr", "stuck-on-old-layout-260516-aaaa")
         seed_legacy_task(dir, "5-review", "also-stuck-260516-bbbb")
         seed_legacy_task(dir, "5-review", "second-old-260516-cccc")
@@ -28,9 +31,19 @@ class StatusLegacyLayoutTest < Minitest::Test
 
         legacy = project["legacy_stage_dirs"]
         refute_nil legacy, "project payload must expose a legacy_stage_dirs field"
-        by_dir = legacy.to_h { |entry| [ entry["dir"], entry["task_count"] ] }
+        by_dir = legacy.to_h { |entry| [ entry["stage_dir"], entry["task_count"] ] }
         assert_equal 1, by_dir["6-pr"], "6-pr should report its one hidden task"
         assert_equal 2, by_dir["5-review"], "5-review should report both hidden tasks"
+        assert_equal legacy.map { |e| e["stage_dir"] }.sort,
+                     legacy.map { |e| e["stage_dir"] },
+                     "legacy_stage_dirs must be sorted alphabetically by stage_dir"
+        # Machine-readable parity of the text "run `hive migrate`"
+        # recovery hint. Agents reading the JSON envelope must get a
+        # ready-to-execute command string whenever legacy_stage_dirs is
+        # non-empty; see issue #94.
+        assert_equal "hive migrate", project["legacy_migrate_command"],
+                     "legacy_migrate_command must surface the recovery command when " \
+                     "legacy_stage_dirs is non-empty"
       end
     end
   end
@@ -44,19 +57,42 @@ class StatusLegacyLayoutTest < Minitest::Test
         out, _err = capture_io { Hive::Commands::Status.new.call }
         assert_includes out, "6-pr", "warning must name the legacy directory"
         assert_includes out, "hive migrate", "warning must point at the fix command"
+        assert_match(/1 task hidden in legacy stage dirs/, out,
+                     "singular form of the warning must be used for one hidden task")
       end
     end
   end
 
-  def test_legacy_stage_dirs_field_absent_when_layout_is_clean
+  def test_text_output_pluralises_warning_when_multiple_hidden
+    with_tmp_global_config do
+      with_tmp_git_repo do |dir|
+        capture_io { Hive::Commands::Init.new(dir).call }
+        seed_legacy_task(dir, "6-pr", "stuck-one-260516-aaaa")
+        seed_legacy_task(dir, "6-pr", "stuck-two-260516-bbbb")
+
+        out, _err = capture_io { Hive::Commands::Status.new.call }
+        assert_match(/2 tasks hidden in legacy stage dirs/, out,
+                     "plural form of the warning must be used for multiple hidden tasks")
+      end
+    end
+  end
+
+  def test_legacy_stage_dirs_field_is_empty_array_when_layout_is_clean
     with_tmp_global_config do
       with_tmp_git_repo do |dir|
         capture_io { Hive::Commands::Init.new(dir).call }
 
         payload = Hive::Commands::Status.new.json_payload(Hive::Config.registered_projects)
         project = payload.fetch("projects").first
-        refute project.key?("legacy_stage_dirs"),
-               "clean projects must not carry the legacy_stage_dirs field"
+        assert_equal [], project["legacy_stage_dirs"],
+                     "clean projects must emit legacy_stage_dirs as an empty array"
+        # The diagnostic-field-always-present convention: `legacy_migrate_command`
+        # must be `null` (not absent) when the project is clean, so agent
+        # consumers can branch on the field without a `key?` probe. Issue #94.
+        assert project.key?("legacy_migrate_command"),
+               "legacy_migrate_command key must always be present"
+        assert_nil project["legacy_migrate_command"],
+                   "clean projects must emit legacy_migrate_command as nil"
       end
     end
   end
@@ -73,8 +109,73 @@ class StatusLegacyLayoutTest < Minitest::Test
 
         payload = Hive::Commands::Status.new.json_payload(Hive::Config.registered_projects)
         project = payload.fetch("projects").first
-        refute project.key?("legacy_stage_dirs"),
-               "an empty legacy stage dir must not raise a false positive"
+        assert_equal [], project["legacy_stage_dirs"],
+                     "an empty legacy stage dir must produce an empty legacy_stage_dirs array, not a false positive"
+      end
+    end
+  end
+
+  # `task_count` must only include slug-shaped children — stray sibling
+  # directories with non-slug names (a `.logs` dot-folder, an
+  # underscore-named scratch dir) must not inflate the number,
+  # otherwise the operator sees a count that doesn't match what
+  # `hive migrate` would actually move. (Note: bare `logs` happens to
+  # match the slug regex — the test uses `.logs` and `scratch_dir` so
+  # the gate it pins is `Hive::Stages.task_slug?`, not "any name with
+  # letters in it".)
+  def test_task_count_excludes_non_slug_subdirs
+    with_tmp_global_config do
+      with_tmp_git_repo do |dir|
+        capture_io { Hive::Commands::Init.new(dir).call }
+        seed_legacy_task(dir, "6-pr", "real-task-260516-aaaa")
+        # Dot-prefixed name fails the leading `[a-z]` anchor.
+        FileUtils.mkdir_p(File.join(dir, ".hive-state", "stages", "6-pr", ".logs"))
+        # Underscore is outside the `[a-z0-9-]` charset.
+        FileUtils.mkdir_p(File.join(dir, ".hive-state", "stages", "6-pr", "scratch_dir"))
+
+        payload = Hive::Commands::Status.new.json_payload(Hive::Config.registered_projects)
+        project = payload.fetch("projects").first
+        legacy = project["legacy_stage_dirs"]
+        by_dir = legacy.to_h { |entry| [ entry["stage_dir"], entry["task_count"] ] }
+        assert_equal 1, by_dir["6-pr"],
+                     "non-slug subdirs (.logs, scratch_dir) must not inflate task_count"
+      end
+    end
+  end
+
+  def test_text_warns_under_project_header_when_rows_and_legacy_both_exist
+    with_tmp_global_config do
+      with_tmp_git_repo do |dir|
+        capture_io { Hive::Commands::Init.new(dir).call }
+        # Canonical task in 4-execute (visible) AND legacy task in 6-pr (hidden).
+        seed_legacy_task(dir, "4-execute", "real-260516-aaaa")
+        seed_legacy_task(dir, "6-pr", "stuck-260516-bbbb")
+
+        out, _err = capture_io { Hive::Commands::Status.new.call }
+        assert_match(/hidden in legacy stage dirs/, out,
+                     "warning must appear even when canonical rows are also present")
+        assert_includes out, "real-260516-aaaa",
+                        "canonical task row must still render under its action label"
+        refute_includes out, "no active tasks",
+                        "the no-active-tasks placeholder must not appear when rows are present"
+      end
+    end
+  end
+
+  # A stray file (not a directory) directly under `stages/` must not
+  # raise — the detector should ignore non-directories.
+  def test_non_directory_in_stages_root_is_ignored
+    with_tmp_global_config do
+      with_tmp_git_repo do |dir|
+        capture_io { Hive::Commands::Init.new(dir).call }
+        File.write(File.join(dir, ".hive-state", "stages", ".DS_Store"), "")
+
+        payload = nil
+        # Must not crash on the non-directory child.
+        payload = Hive::Commands::Status.new.json_payload(Hive::Config.registered_projects)
+        project = payload.fetch("projects").first
+        assert_equal [], project["legacy_stage_dirs"],
+                     "stray non-directory entries in stages/ must be silently ignored"
       end
     end
   end

--- a/test/integration/status_legacy_layout_test.rb
+++ b/test/integration/status_legacy_layout_test.rb
@@ -1,0 +1,89 @@
+require "test_helper"
+require "hive/commands/init"
+require "hive/commands/status"
+
+# Reproduces the regression where a stage rename in `Hive::Stages::DIRS`
+# silently makes pre-rename tasks invisible to `hive status` and the TUI.
+# `Status#collect_rows` walks only canonical stages, so a task left in a
+# legacy stage directory (e.g. `6-pr/` from the pre-PR-first layout)
+# becomes unreachable from every operator surface until the operator
+# happens to run `hive migrate`.
+#
+# These tests assert that Status surfaces the legacy directories in both
+# JSON and text output so the operator gets a visible nudge instead of a
+# silent truncation.
+class StatusLegacyLayoutTest < Minitest::Test
+  include HiveTestHelper
+
+  def test_json_payload_surfaces_legacy_stage_dirs_with_task_counts
+    with_tmp_global_config do
+      with_tmp_git_repo do |dir|
+        capture_io { Hive::Commands::Init.new(dir).call }
+        seed_legacy_task(dir, "6-pr", "stuck-on-old-layout-260516-aaaa")
+        seed_legacy_task(dir, "5-review", "also-stuck-260516-bbbb")
+        seed_legacy_task(dir, "5-review", "second-old-260516-cccc")
+
+        payload = Hive::Commands::Status.new.json_payload(Hive::Config.registered_projects)
+        project = payload.fetch("projects").first
+
+        legacy = project["legacy_stage_dirs"]
+        refute_nil legacy, "project payload must expose a legacy_stage_dirs field"
+        by_dir = legacy.to_h { |entry| [ entry["dir"], entry["task_count"] ] }
+        assert_equal 1, by_dir["6-pr"], "6-pr should report its one hidden task"
+        assert_equal 2, by_dir["5-review"], "5-review should report both hidden tasks"
+      end
+    end
+  end
+
+  def test_text_output_warns_when_legacy_stage_dirs_exist
+    with_tmp_global_config do
+      with_tmp_git_repo do |dir|
+        capture_io { Hive::Commands::Init.new(dir).call }
+        seed_legacy_task(dir, "6-pr", "stuck-on-old-layout-260516-aaaa")
+
+        out, _err = capture_io { Hive::Commands::Status.new.call }
+        assert_includes out, "6-pr", "warning must name the legacy directory"
+        assert_includes out, "hive migrate", "warning must point at the fix command"
+      end
+    end
+  end
+
+  def test_legacy_stage_dirs_field_absent_when_layout_is_clean
+    with_tmp_global_config do
+      with_tmp_git_repo do |dir|
+        capture_io { Hive::Commands::Init.new(dir).call }
+
+        payload = Hive::Commands::Status.new.json_payload(Hive::Config.registered_projects)
+        project = payload.fetch("projects").first
+        refute project.key?("legacy_stage_dirs"),
+               "clean projects must not carry the legacy_stage_dirs field"
+      end
+    end
+  end
+
+  def test_empty_legacy_stage_dir_is_not_reported
+    with_tmp_global_config do
+      with_tmp_git_repo do |dir|
+        capture_io { Hive::Commands::Init.new(dir).call }
+        # Stage dir exists but holds no task subfolders — `hive init` may
+        # leave behind a `.gitkeep` from a prior layout. Only stage dirs
+        # that actually shadow live state should trigger the warning.
+        FileUtils.mkdir_p(File.join(dir, ".hive-state", "stages", "6-pr"))
+        File.write(File.join(dir, ".hive-state", "stages", "6-pr", ".gitkeep"), "")
+
+        payload = Hive::Commands::Status.new.json_payload(Hive::Config.registered_projects)
+        project = payload.fetch("projects").first
+        refute project.key?("legacy_stage_dirs"),
+               "an empty legacy stage dir must not raise a false positive"
+      end
+    end
+  end
+
+  private
+
+  def seed_legacy_task(project_dir, stage, slug)
+    folder = File.join(project_dir, ".hive-state", "stages", stage, slug)
+    FileUtils.mkdir_p(folder)
+    File.write(File.join(folder, "task.md"), "x\n")
+  end
+end

--- a/test/unit/commands/migrate_renames_consistency_test.rb
+++ b/test/unit/commands/migrate_renames_consistency_test.rb
@@ -1,0 +1,34 @@
+require "test_helper"
+require "hive/commands/migrate"
+require "hive/stages"
+
+# Guards the invariant that connects two files: any future stage rename in
+# `lib/hive/stages.rb` must also be reflected in `Migrate::STAGE_RENAMES`.
+# These checks would have caught the off-by-one mistake of mapping
+# `6-pr → 5-open-pr` (which lost task state because `5-open-pr` is the
+# pre-PR stage, not the post-PR stage) when the PR-first pipeline shipped.
+class MigrateRenamesConsistencyTest < Minitest::Test
+  def test_every_rename_target_is_a_current_stage_directory
+    renames = Hive::Commands::Migrate::STAGE_RENAMES
+    unknown = renames.values.uniq - Hive::Stages::DIRS
+    assert_empty unknown,
+                 "Migrate::STAGE_RENAMES has targets that are not in Hive::Stages::DIRS " \
+                 "(#{unknown.inspect}); update lib/hive/commands/migrate.rb when stage names change"
+  end
+
+  def test_no_rename_key_is_also_a_current_stage_directory
+    renames = Hive::Commands::Migrate::STAGE_RENAMES
+    overlap = renames.keys & Hive::Stages::DIRS
+    assert_empty overlap,
+                 "Migrate::STAGE_RENAMES has keys that are still canonical stage names " \
+                 "(#{overlap.inspect}); a legacy key cannot be both legacy and current"
+  end
+
+  def test_no_rename_key_is_also_a_rename_target
+    renames = Hive::Commands::Migrate::STAGE_RENAMES
+    chain = renames.keys & renames.values
+    assert_empty chain,
+                 "Migrate::STAGE_RENAMES has keys that are also values (#{chain.inspect}); " \
+                 "chained renames would migrate twice or land on a legacy name"
+  end
+end

--- a/test/unit/schema_files_test.rb
+++ b/test/unit/schema_files_test.rb
@@ -207,6 +207,100 @@ class SchemaFilesTest < Minitest::Test
            "schema must reject error_kind values outside StatusErrorKind::ALL"
   end
 
+  # Round-trip: a SuccessPayload with `legacy_stage_dirs` populated must
+  # validate against the published schema. Without this, an additive
+  # field could land in the producer (Hive::Commands::Status#project_payload)
+  # without the schema declaring it — and `additionalProperties: false`
+  # on the Project def would reject the payload at runtime for external
+  # consumers (TUI, daemon, bots).
+  def test_hive_status_success_payload_with_legacy_stage_dirs_validates_against_published_schema
+    schemer = JSONSchemer.schema(JSON.parse(File.read(Hive::Schemas.schema_path("hive-status"))))
+    payload = {
+      "schema" => "hive-status",
+      "schema_version" => 2,
+      "ok" => true,
+      "generated_at" => "2026-05-19T00:00:00Z",
+      "projects" => [
+        {
+          "name" => "alpha",
+          "path" => "/tmp/alpha",
+          "hive_state_path" => "/tmp/alpha/.hive-state",
+          "tasks" => [],
+          "legacy_stage_dirs" => [
+            { "stage_dir" => "5-review", "task_count" => 2 },
+            { "stage_dir" => "6-pr",     "task_count" => 1 }
+          ],
+          # Machine-readable recovery hint; siblings legacy_stage_dirs.
+          # Issue #94.
+          "legacy_migrate_command" => "hive migrate"
+        },
+        {
+          # Clean project: explicit empty array still validates, and
+          # legacy_migrate_command is explicitly null.
+          "name" => "beta",
+          "path" => "/tmp/beta",
+          "hive_state_path" => "/tmp/beta/.hive-state",
+          "tasks" => [],
+          "legacy_stage_dirs" => [],
+          "legacy_migrate_command" => nil
+        }
+      ]
+    }
+    errors = schemer.validate(payload).map { |e| e["error"] }
+    assert_empty errors,
+                 "hive-status SuccessPayload with legacy_stage_dirs must validate " \
+                 "(errors: #{errors.inspect})"
+  end
+
+  # `legacy_migrate_command` accepts either "hive migrate" (when
+  # legacy_stage_dirs is non-empty) or `null` (when clean); any other
+  # JSON type (e.g. a boolean or a number) must be rejected. Issue #94.
+  def test_hive_status_legacy_migrate_command_rejects_non_string_non_null
+    schemer = JSONSchemer.schema(JSON.parse(File.read(Hive::Schemas.schema_path("hive-status"))))
+    payload = {
+      "schema" => "hive-status",
+      "schema_version" => 2,
+      "ok" => true,
+      "generated_at" => "2026-05-19T00:00:00Z",
+      "projects" => [
+        {
+          "name" => "alpha",
+          "path" => "/tmp/alpha",
+          "hive_state_path" => "/tmp/alpha/.hive-state",
+          "tasks" => [],
+          "legacy_stage_dirs" => [],
+          "legacy_migrate_command" => false # not a string and not null
+        }
+      ]
+    }
+    refute schemer.valid?(payload),
+           "legacy_migrate_command must reject values that aren't string-or-null"
+  end
+
+  # Negative case: a legacy_stage_dirs entry missing `stage_dir` or with
+  # `task_count` below the schema minimum must be rejected — pins
+  # additionalProperties: false on the entry shape.
+  def test_hive_status_legacy_stage_dirs_entry_shape_is_enforced
+    schemer = JSONSchemer.schema(JSON.parse(File.read(Hive::Schemas.schema_path("hive-status"))))
+    base = {
+      "schema" => "hive-status",
+      "schema_version" => 2,
+      "ok" => true,
+      "generated_at" => "2026-05-19T00:00:00Z",
+      "projects" => [
+        {
+          "name" => "alpha",
+          "path" => "/tmp/alpha",
+          "hive_state_path" => "/tmp/alpha/.hive-state",
+          "tasks" => [],
+          "legacy_stage_dirs" => [ { "stage_dir" => "6-pr" } ] # missing task_count
+        }
+      ]
+    }
+    refute schemer.valid?(base),
+           "legacy_stage_dirs entry without task_count must be rejected"
+  end
+
   # ── hive-status-diagnose ───────────────────────────────────────────────
 
   def test_hive_status_diagnose_schema_file_exists_and_is_valid_json

--- a/test/unit/tui/snapshot_test.rb
+++ b/test/unit/tui/snapshot_test.rb
@@ -271,6 +271,55 @@ class TuiSnapshotTest < Minitest::Test
                  "JSON order is the stable secondary sort within a label group"
   end
 
+  # The Snapshot must preserve the JSON's `legacy_stage_dirs` field on
+  # each ProjectView so the renderer can flag projects with task folders
+  # stuck under a renamed stage dir without re-walking the filesystem.
+  def test_from_payload_preserves_legacy_stage_dirs_array
+    legacy_entries = [
+      { "stage_dir" => "5-review", "task_count" => 2 },
+      { "stage_dir" => "6-pr",     "task_count" => 1 }
+    ]
+    payload = sample_payload([
+                               {
+                                 "name" => "alpha",
+                                 "path" => "/tmp/alpha",
+                                 "hive_state_path" => "/tmp/alpha/.hive-state",
+                                 "tasks" => [],
+                                 "legacy_stage_dirs" => legacy_entries,
+                                 "legacy_migrate_command" => "hive migrate"
+                               }
+                             ])
+
+    snapshot = Hive::Tui::Snapshot.from_payload(payload)
+    project = snapshot.projects.first
+    assert_equal legacy_entries, project.legacy_stage_dirs,
+                 "ProjectView must preserve legacy_stage_dirs verbatim"
+    # The machine-readable recovery hint must flow through ProjectView
+    # so non-TUI consumers (and the TUI itself, eventually) can read it
+    # without re-deriving "is this project clean?". Issue #94.
+    assert_equal "hive migrate", project.legacy_migrate_command,
+                 "ProjectView must preserve legacy_migrate_command verbatim"
+  end
+
+  def test_from_payload_defaults_legacy_stage_dirs_to_empty_array_when_key_absent
+    payload = sample_payload([
+                               {
+                                 "name" => "alpha",
+                                 "path" => "/tmp/alpha",
+                                 "hive_state_path" => "/tmp/alpha/.hive-state",
+                                 "tasks" => []
+                                 # no legacy_stage_dirs / legacy_migrate_command keys
+                               }
+                             ])
+
+    snapshot = Hive::Tui::Snapshot.from_payload(payload)
+    project = snapshot.projects.first
+    assert_equal [], project.legacy_stage_dirs,
+                 "missing legacy_stage_dirs key must default to []"
+    assert_nil project.legacy_migrate_command,
+               "missing legacy_migrate_command key must default to nil"
+  end
+
   def test_build_project_view_unknown_action_labels_sort_last_and_preserve_json_order
     known = sample_task(slug: "known-task")
     unknown_one = sample_task(slug: "future-one")

--- a/wiki/commands/status.md
+++ b/wiki/commands/status.md
@@ -4,7 +4,7 @@ type: command
 source: lib/hive/commands/status.rb
 created: 2026-04-25
 updated: 2026-05-19
-tags: [command, status, observability, json, diagnostics]
+tags: [command, status, observability, json, diagnostics, legacy-dirs]
 ---
 
 **TLDR**: `hive status` walks every registered project's `.hive-state/stages/<N>-<name>/<slug>/` directory, reads each task's marker, and prints slugs grouped by the next useful action. Normal status is read-only and takes no args. Pass `--json` for a single machine-readable document on stdout (schema `hive-status`, version per `Hive::SCHEMA_VERSIONS`). Pass `--diagnose <task>` to inspect one red row, and add `--write` only when you want the configured development agent to write `diagnostics/red-status.md`.
@@ -22,6 +22,22 @@ tags: [command, status, observability, json, diagnostics]
 ```
 
 `hive status` prints one block per project. Action buckets without active tasks are skipped. Within a bucket, rows are sorted by state-file mtime (newest first). Raw stage and folder remain available in `--json`. JSON rows also include `next_action`; it is usually `null`, but `EXECUTE_WAITING reason=...` rows carry the same structured recovery target that `hive run --json` emits. Every JSON row also includes `diagnostic`; it is `null` for ordinary rows and a bounded red-row payload for `recover_execute`, `recover_review`, and `error` rows.
+
+## Legacy stage directories (`legacy_stage_dirs`)
+
+Every Project entry in `hive status --json` carries a `legacy_stage_dirs` array — `[]` for healthy projects, otherwise a list of `{ "stage_dir": "<name>", "task_count": <N> }` entries (sorted alphabetically by `stage_dir`). The field is populated by `Status#detect_legacy_stage_dirs`, which scans `<hive_state>/stages/` for directories that are **not** in `Hive::Stages::DIRS` and contain at least one slug-shaped task subfolder (per `Hive::Stages.task_slug?`, the same predicate `hive migrate` uses to decide which entries it is allowed to mv — so the count reflects what `hive migrate` would actually move). Stray non-slug siblings (`logs/`, `.gitkeep`, `.DS_Store`) are ignored.
+
+When the field is non-empty, the text output prints a warning under the project header:
+
+```
+<project_name>
+  ⚠ 2 tasks hidden in legacy stage dirs: 5-review (1), 6-pr (1)
+    run `hive migrate` to move them into the current layout
+```
+
+The warning is singular for one hidden task (`1 task hidden`) and plural otherwise. The TUI projects pane mirrors the warning by prefixing the affected project's name with `⚠` and the short hint `legacy dirs — run hive migrate`. Running `hive migrate` moves the slugs into the canonical stage directory listed in `Hive::Commands::Migrate::STAGE_RENAMES`, and after the next status poll the warning disappears.
+
+The `legacy_stage_dirs` field is an additive, non-breaking extension of `urn:hive:schema:status:v2` (see [[schemas]] and the policy comment in `lib/hive.rb` — additive optional fields do **not** bump `SCHEMA_VERSIONS["hive-status"]`).
 
 ## Icon legend (`Status::ICON`, `lib/hive/commands/status.rb:11`)
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -2,6 +2,13 @@
 
 Append-only log of all wiki operations.
 
+## [2026-05-19T16:00:00Z] status — surface legacy stage dirs in JSON + text + TUI (PR #93)
+
+**Action:** `hive status` now detects task folders left behind by a stage rename in `Hive::Stages::DIRS` and surfaces them on every operator surface, instead of silently truncating them out of view. `Status#detect_legacy_stage_dirs` scans `<hive_state>/stages/` for directories outside `Hive::Stages::DIRS` containing slug-shaped subfolders (per the new `Hive::Stages.task_slug?` predicate — single source of truth shared with `Hive::Commands::Migrate`, so the count matches what `hive migrate` would actually move). The JSON payload's `Project` entry now always carries an additive `legacy_stage_dirs` array (`[]` when clean, otherwise `[{stage_dir, task_count}, ...]` sorted alphabetically). Text output prints a `⚠ N task(s) hidden in legacy stage dirs: ...` warning + `run hive migrate` hint under the project header; the TUI projects pane prefixes the affected project with `⚠` and a `legacy dirs — run hive migrate` hint by extending `ProjectView` with the new field. Schema `urn:hive:schema:status:v2` gains the optional `legacy_stage_dirs` property on `Project` without bumping `SCHEMA_VERSIONS["hive-status"]` (additive-optional policy in `lib/hive.rb`, precedent in PR #69's `rebase` block).
+
+**Refreshed pages:**
+- [[commands/status]] — new "Legacy stage directories" section documenting JSON shape, text warning, TUI hint, and the schema additive-field rationale.
+
 ## [2026-05-19T12:41:25Z] review — PR #84 follow-up contract hardening
 
 **Action:** Documented the follow-up PR #84 fixes that tightened the red-status diagnostic contract after code review. Bot diagnose callbacks now carry `--stage`, refresh uses `--force`, and child completion replies render the `hive-status-diagnose` envelope instead of a generic completion message. `DiagnosisAgent` now validates worktree pointers before `chdir`, bounds inherited-stdio timeout hangs, redacts failed-agent stderr, and refuses custom execute profiles whose `generated_by` value is outside `Hive::Schemas::DIAGNOSTIC_GENERATORS`. `TaskAction` now rejects symlink-escaped diagnostic artifacts before tailing them.


### PR DESCRIPTION
## Summary

When a stage rename lands in `Hive::Stages::DIRS` (the PR-first pipeline did `6-pr → 7-finalize`, `5-review → 6-review`, `7-done → 8-done`), `Status#collect_rows` silently stops walking the old directories. Tasks left behind become unreachable from `hive status`, the TUI, and every downstream consumer until the operator happens to run `hive migrate` — the existing migration command shipped in #78 but nothing pointed operators at it. Five real projects on my machine had 13 tasks invisible for four days before the gap surfaced.

This PR:
- Adds `Status#detect_legacy_stage_dirs` — scans `<hive_state>/stages/` for directories not in `Stages::DIRS` that contain at least one task subfolder.
- Surfaces them as a new `legacy_stage_dirs` field in the JSON payload (absent when clean) and a one-line warning under the project header in text output:

  > ⚠ 13 tasks hidden in legacy stage dirs: 5-review (3), 6-pr (3), 7-done (7)
  >   run \`hive migrate\` to move them into the current layout

- Adds two regression-prevention test files:
  - **`migrate_renames_consistency_test.rb`** (unit, no I/O): asserts every value in `Migrate::STAGE_RENAMES` lives in `Stages::DIRS`, no key is also a canonical stage, no key is also a target. The next time someone renames a stage and forgets to wire it through migrate, this fails.
  - **`status_legacy_layout_test.rb`** (integration): asserts JSON shape, text warning content, absence on clean projects, no false positive on an empty legacy stage dir.

## Why two tests instead of one

The pair catches two distinct failure modes:
- **Code-only**: `migrate_renames_consistency_test` catches a rename in `stages.rb` that's missing or wrong in `migrate.rb`. Pure assertion against module constants.
- **Filesystem-touching**: `status_legacy_layout_test` catches a future regression where Status starts ignoring legacy dirs silently (e.g. someone removes the detector). Uses sandboxed `HIVE_HOME` + tmp git repos.

## Test plan

- [x] `test/unit/commands/migrate_renames_consistency_test.rb` — 3 tests, 6 assertions, pass
- [x] `test/integration/status_legacy_layout_test.rb` — 4 tests, 9 assertions, pass
- [x] `test/integration/status_test.rb`, `status_error_envelope_test.rb`, `migrate_test.rb` — 17 sibling tests, 80 assertions, no regression
- [x] Rubocop clean on the three changed files
- [x] Smoke against my real registry: all 5 projects load, no false-positive `legacy_stage_dirs` (since I migrated them by hand earlier today)

🤖 Generated with [Claude Code](https://claude.com/claude-code)