### PR TITLE
Fix finalize missing PR metadata diagnostic

### DIFF
--- a/lib/hive/bot/handlers/callback_handlers.rb
+++ b/lib/hive/bot/handlers/callback_handlers.rb
@@ -54,9 +54,10 @@ module Hive
         def clear_and_retry(data)
           _prefix, project, slug, stage, marker = split_callback(data, 5)
           verb = retry_verb_for_stage(stage)
-          commands = [
-            [ "hive", "markers", "clear", slug, "--name", marker.upcase, "--project", project, "--json" ]
-          ]
+          commands = []
+          unless marker.to_s.casecmp("none").zero?
+            commands << [ "hive", "markers", "clear", slug, "--name", marker.upcase, "--project", project, "--json" ]
+          end
           commands << [ "hive", verb, slug, "--from", stage, "--project", project, "--json" ] if verb
           @result_class.new(action: :dispatch_commands, project: project, slug: slug, commands: commands)
         end

--- a/lib/hive/bot/notification_builders.rb
+++ b/lib/hive/bot/notification_builders.rb
@@ -133,6 +133,12 @@ module Hive
               [ button("Open laptop", "open_laptop:#{row.project}:#{row.slug}") ],
               details_row
             ]
+          elsif markerless_retry_recovery?(row)
+            [
+              [ button("Retry", "clear_retry:#{row.project}:#{row.slug}:#{row.stage}:NONE") ],
+              [ button("Open laptop", "open_laptop:#{row.project}:#{row.slug}") ],
+              details_row
+            ]
           else
             [
               [ button("Clear and retry", "clear_retry:#{row.project}:#{row.slug}:#{row.stage}:#{row.marker}") ],
@@ -155,9 +161,26 @@ module Hive
 
       def open_laptop_only_recovery?(row)
         attrs = row.attrs.to_h.transform_keys(&:to_s)
-        row.marker.to_s == "review_error" &&
-          attrs["phase"] == "fix" &&
-          attrs["reason"] == "fix_tampered"
+        diagnostic_manual_fix?(row) ||
+          row.marker.to_s == "review_error" &&
+            attrs["phase"] == "fix" &&
+            attrs["reason"] == "fix_tampered"
+      end
+
+      def markerless_retry_recovery?(row)
+        row.marker.to_s == "none" && diagnostic_suggested_action(row)["kind"].to_s == "retry"
+      end
+
+      def diagnostic_manual_fix?(row)
+        diagnostic_suggested_action(row)["kind"].to_s == "manual_fix"
+      end
+
+      def diagnostic_suggested_action(row)
+        diagnostic = row.diagnostic
+        return {} unless diagnostic.is_a?(Hash)
+
+        suggested = diagnostic["suggested_next_action"]
+        suggested.is_a?(Hash) ? suggested : {}
       end
 
       def header(row)

--- a/lib/hive/stages/finalize.rb
+++ b/lib/hive/stages/finalize.rb
@@ -28,7 +28,8 @@ module Hive
         pointer = worktree_pointer_or_exit(task)
         worktree_path = pointer.fetch("path")
         branch = pointer["branch"] || task.slug
-        pr_url = pr_url_or_exit(task)
+        pr_url, pr_error = pr_url_or_error(task)
+        return pr_error if pr_error
 
         # Authenticate first so an auth-related push failure surfaces
         # as a clear "gh not authenticated" hard-fail (Plan R5)
@@ -106,18 +107,24 @@ module Hive
         pointer
       end
 
-      def pr_url_or_exit(task)
+      def pr_url_or_error(task)
         pr_md = File.join(task.folder, "pr.md")
         unless File.exist?(pr_md)
           warn "hive: finalize entered without 5-open-pr's pr.md; re-create via hive run on a 5-open-pr task or move back"
-          exit 1
+          Hive::Markers.set(task.state_file, :error,
+                            reason: "missing_pr_md",
+                            detail: "finalize requires pr.md from 5-open-pr")
+          return [ nil, { commit: "finalize_missing_pr_md", status: :error } ]
         end
 
         url = Hive::Gh.pr_frontmatter(pr_md)["pr_url"]
-        return url unless url.to_s.empty?
+        return [ url, nil ] unless url.to_s.empty?
 
         warn "hive: finalize entered with pr.md missing pr_url; move back to 5-open-pr or repair pr.md"
-        exit 1
+        Hive::Markers.set(task.state_file, :error,
+                          reason: "missing_pr_url",
+                          detail: "finalize requires pr_url frontmatter from 5-open-pr")
+        [ nil, { commit: "finalize_missing_pr_url", status: :error } ]
       end
 
       def verify_state!(task, worktree_path, branch, cfg)

--- a/lib/hive/task_action.rb
+++ b/lib/hive/task_action.rb
@@ -275,10 +275,18 @@ module Hive
     end
 
     def finalize_action
-      return ACTIONS.fetch(:finalize_complete) if marker.name == :complete
       return ACTIONS.fetch(:error) if finalize_missing_pr_md?
+      return finalize_complete_action if marker.name == :complete
 
       ACTIONS.fetch(:finalize_waiting)
+    end
+
+    def finalize_complete_action
+      return ACTIONS.fetch(:error) if finalize_missing_pr_url?
+      return ACTIONS.fetch(:error) if finalize_pr_url_mismatch?
+      return ACTIONS.fetch(:finalize_complete) if marker.attrs["is_draft"].to_s == "false"
+
+      ACTIONS.fetch(:review_complete)
     end
 
     public
@@ -287,7 +295,7 @@ module Hive
       return nil unless diagnostic_action?
 
       artifacts = diagnostic_artifacts.select { |path| safe_diagnostic_artifact?(path) }
-      primary = artifacts.first
+      primary = incomplete_plan_artifact? ? nil : artifacts.first
       updated_at = diagnostic_updated_at(primary)
       detail = primary ? artifact_detail(primary) : marker_detail
       generator = diagnostic_generated_by(primary)
@@ -329,7 +337,7 @@ module Hive
     end
 
     def diagnostic_artifacts
-      return generic_error_artifacts if incomplete_plan_artifact?
+      return latest_log_artifacts if incomplete_plan_artifact?
 
       case marker.name
       when :review_error
@@ -487,6 +495,8 @@ module Hive
     def marker_summary
       return "PLAN_MISSING_OUTPUT" if incomplete_plan_artifact?
       return "FINALIZE_MISSING_PR_MD" if finalize_missing_pr_md?
+      return "FINALIZE_MISSING_PR_URL" if finalize_missing_pr_url?
+      return "FINALIZE_PR_URL_MISMATCH" if finalize_pr_url_mismatch?
 
       attrs = marker.attrs.map { |key, value| "#{key}=#{value}" }.join(" ")
       marker_name = marker.name.to_s.upcase
@@ -507,6 +517,22 @@ module Hive
           "FINALIZE_MISSING_PR_MD",
           "Finalize cannot run because #{task.state_file} is missing.",
           "Move the task back to 5-open-pr or recreate pr.md with pr_url frontmatter."
+        ].join("\n")
+      end
+
+      if finalize_missing_pr_url?
+        return [
+          "FINALIZE_MISSING_PR_URL",
+          "Finalize cannot archive because #{task.state_file} is missing pr_url metadata.",
+          "Repair pr.md or move the task back to 5-open-pr so the PR metadata can be recreated."
+        ].join("\n")
+      end
+
+      if finalize_pr_url_mismatch?
+        return [
+          "FINALIZE_PR_URL_MISMATCH",
+          "Finalize cannot archive because the COMPLETE marker pr_url does not match pr.md frontmatter.",
+          "Rerun finalize or repair pr.md so both PR URLs match."
         ].join("\n")
       end
 
@@ -608,8 +634,9 @@ module Hive
     # external consumers don't have to re-derive the next move from
     # marker shape alone. `kind` mirrors the operator gesture:
     #   - "retry" — Enter-in-detail-view runs the existing recover_review
-    #     / recover_error path (clear marker + re-run); `command` is the
-    #     copy-paste shell form.
+    #     / recover_error path, or a markerless synthetic-error direct
+    #     rerun such as PLAN_MISSING_OUTPUT; `command` is the copy-
+    #     paste shell form.
     #   - "manual_fix" — max_passes-hit REVIEW_STALE; the operator must
     #     edit `reviews/escalations-NN.md` before retry. command stays
     #     null because there's nothing safe to dispatch.
@@ -618,6 +645,18 @@ module Hive
     #     through retry or manual_fix.
     def suggested_next_action_payload
       return nil unless diagnostic_action?
+
+      if incomplete_plan_artifact?
+        return { "kind" => "retry", "command" => workflow_command("plan") }
+      end
+
+      if finalize_missing_pr_md? || finalize_missing_metadata_error?
+        return { "kind" => "manual_fix", "command" => nil }
+      end
+
+      if finalize_missing_pr_url? || finalize_pr_url_mismatch?
+        return { "kind" => "manual_fix", "command" => nil }
+      end
 
       if max_passes_review_stale_with_escalations?
         return { "kind" => "manual_fix", "command" => nil }
@@ -693,6 +732,13 @@ module Hive
       []
     end
 
+    def workflow_command(verb)
+      parts = [ "hive", verb, task.slug ]
+      parts.concat([ "--project", project_name ]) if project_name && @project_count > 1
+      parts.concat([ "--from", stage_dir ])
+      parts.shelljoin
+    end
+
     def safe_mtime(path)
       return nil if path.nil? || path.to_s.empty?
 
@@ -766,11 +812,57 @@ module Hive
         !File.exist?(task.state_file)
     end
 
+    def finalize_missing_pr_url?
+      task.stage_name == "finalize" &&
+        marker.name == :complete &&
+        task.state_file.to_s.end_with?("/pr.md") &&
+        frontmatter_pr_url.empty?
+    end
+
+    def finalize_pr_url_mismatch?
+      task.stage_name == "finalize" &&
+        marker.name == :complete &&
+        task.state_file.to_s.end_with?("/pr.md") &&
+        !frontmatter_pr_url.empty? &&
+        marker.attrs["pr_url"].to_s != frontmatter_pr_url
+    end
+
+    def finalize_missing_metadata_error?
+      task.stage_name == "finalize" &&
+        marker.name == :error &&
+        %w[missing_pr_md missing_pr_url].include?(marker.attrs["reason"].to_s)
+    end
+
+    def frontmatter_pr_url
+      @frontmatter_pr_url ||= begin
+        parsed = state_file_frontmatter
+        parsed.fetch("pr_url", "").to_s
+      end
+    end
+
+    def state_file_frontmatter
+      return {} unless File.exist?(task.state_file)
+
+      content = File.read(task.state_file)
+      match = content.match(/\A---\s*\n(.*?)\n---\s*\n/m)
+      return {} unless match
+
+      parsed = YAML.safe_load(match[1]) || {}
+      parsed.is_a?(Hash) ? parsed.transform_keys(&:to_s) : {}
+    rescue Psych::Exception, SystemCallError
+      {}
+    end
+
     def incomplete_plan_artifact?
       task.stage_name == "plan" &&
         marker.name == :none &&
         task.state_file.to_s.end_with?("/plan.md") &&
-        (!File.exist?(task.state_file) || File.zero?(task.state_file))
+        ((File.exist?(task.state_file) && File.zero?(task.state_file)) ||
+          (!File.exist?(task.state_file) && plan_run_started?))
+    end
+
+    def plan_run_started?
+      log_dirs.any? { |dir| Dir[File.join(dir, "plan-*.log")].any? }
     end
 
     # Workflow verbs (brainstorm/plan/develop/pr/archive) use --from for

--- a/lib/hive/task_action.rb
+++ b/lib/hive/task_action.rb
@@ -211,7 +211,7 @@ module Hive
       when "brainstorm"
         marker.name == :complete ? ACTIONS.fetch(:brainstorm_complete) : ACTIONS.fetch(:brainstorm_waiting)
       when "plan"
-        marker.name == :complete ? ACTIONS.fetch(:plan_complete) : ACTIONS.fetch(:plan_waiting)
+        plan_action
       when "execute"
         execute_action
       when "open-pr"
@@ -219,7 +219,7 @@ module Hive
       when "review"
         review_action
       when "finalize"
-        marker.name == :complete ? ACTIONS.fetch(:finalize_complete) : ACTIONS.fetch(:finalize_waiting)
+        finalize_action
       when "done"
         ACTIONS.fetch(:done)
       else
@@ -265,6 +265,20 @@ module Hive
       else
         ACTIONS.fetch(:execute_waiting)
       end
+    end
+
+    def plan_action
+      return ACTIONS.fetch(:plan_complete) if marker.name == :complete
+      return ACTIONS.fetch(:error) if incomplete_plan_artifact?
+
+      ACTIONS.fetch(:plan_waiting)
+    end
+
+    def finalize_action
+      return ACTIONS.fetch(:finalize_complete) if marker.name == :complete
+      return ACTIONS.fetch(:error) if finalize_missing_pr_md?
+
+      ACTIONS.fetch(:finalize_waiting)
     end
 
     public
@@ -315,6 +329,8 @@ module Hive
     end
 
     def diagnostic_artifacts
+      return generic_error_artifacts if incomplete_plan_artifact?
+
       case marker.name
       when :review_error
         fresh_diagnosis_artifact + review_error_artifacts
@@ -469,12 +485,31 @@ module Hive
     end
 
     def marker_summary
+      return "PLAN_MISSING_OUTPUT" if incomplete_plan_artifact?
+      return "FINALIZE_MISSING_PR_MD" if finalize_missing_pr_md?
+
       attrs = marker.attrs.map { |key, value| "#{key}=#{value}" }.join(" ")
       marker_name = marker.name.to_s.upcase
       attrs.empty? ? marker_name : "#{marker_name} #{attrs}"
     end
 
     def marker_detail
+      if incomplete_plan_artifact?
+        return [
+          "PLAN_MISSING_OUTPUT",
+          "Plan is incomplete because #{task.state_file} is missing or empty.",
+          "Rerun the plan stage to regenerate plan.md."
+        ].join("\n")
+      end
+
+      if finalize_missing_pr_md?
+        return [
+          "FINALIZE_MISSING_PR_MD",
+          "Finalize cannot run because #{task.state_file} is missing.",
+          "Move the task back to 5-open-pr or recreate pr.md with pr_url frontmatter."
+        ].join("\n")
+      end
+
       lines = [ marker_summary ]
       lines << "No diagnostic artifact was found under #{task.folder}."
       lines.join("\n")
@@ -722,6 +757,20 @@ module Hive
       task.stage_name == "execute" &&
         marker.name == :execute_waiting &&
         marker.attrs["findings_count"].to_i <= 0
+    end
+
+    def finalize_missing_pr_md?
+      task.stage_name == "finalize" &&
+        marker.name == :none &&
+        task.state_file.to_s.end_with?("/pr.md") &&
+        !File.exist?(task.state_file)
+    end
+
+    def incomplete_plan_artifact?
+      task.stage_name == "plan" &&
+        marker.name == :none &&
+        task.state_file.to_s.end_with?("/plan.md") &&
+        (!File.exist?(task.state_file) || File.zero?(task.state_file))
     end
 
     # Workflow verbs (brainstorm/plan/develop/pr/archive) use --from for

--- a/lib/hive/tui/bubble_model.rb
+++ b/lib/hive/tui/bubble_model.rb
@@ -873,6 +873,10 @@ module Hive
       end
 
       def red_status_autofix(row)
+        if row.action_key.to_s == "error" && row.marker.to_s != "error"
+          return dispatch_diagnostic_retry(row)
+        end
+
         case row.action_key.to_s
         when "recover_review"
           recover_review(row, force: red_status_autofix_force?(row))
@@ -881,6 +885,31 @@ module Hive
         else
           [ flashed("no autofix action available for #{row.slug}"), nil ]
         end
+      end
+
+      def dispatch_diagnostic_retry(row)
+        command = diagnostic_retry_command(row)
+        return [ flashed("no autofix action available for #{row.slug}"), nil ] if command.nil?
+
+        if command.match?(/[;&|]/)
+          return [ flashed("diagnostic retry command is not directly dispatchable; use the shell command from details"), nil ]
+        end
+
+        argv = Shellwords.split(command)
+        return [ flashed("diagnostic retry command is empty"), nil ] if argv.empty?
+
+        dispatch_command(Hive::Tui::Messages::DispatchCommand.new(argv: argv, verb: argv[1]))
+      rescue ArgumentError => e
+        [ flashed("diagnostic retry command is malformed: #{Hive::Tui::Text.sanitize(e.message)[0, 80]}"), nil ]
+      end
+
+      def diagnostic_retry_command(row)
+        suggested = row.diagnostic && row.diagnostic["suggested_next_action"]
+        return nil unless suggested.is_a?(Hash)
+        return nil unless suggested["kind"].to_s == "retry"
+
+        command = suggested["command"].to_s.strip
+        command.empty? ? nil : command
       end
 
       # The `r` grid-mode gesture (PR #72) sets force: true ONLY for

--- a/lib/hive/tui/views/red_status_detail.rb
+++ b/lib/hive/tui/views/red_status_detail.rb
@@ -20,7 +20,7 @@ module Hive
         module_function
 
         def footer_for(row)
-          row && row.action_key.to_s == "recover_execute" ? FOOTER_NO_ENTER : FOOTER
+          auto_action_available?(row) ? FOOTER : FOOTER_NO_ENTER
         end
 
         def render(model)
@@ -70,7 +70,13 @@ module Hive
           when "recover_review"
             "A: Enter runs the existing review recovery path. f opens the worktree in $EDITOR without clearing the marker."
           when "error"
-            "A: Enter clears the ERROR marker and reruns the task. f opens the worktree in $EDITOR without clearing the marker."
+            if diagnostic_retry_command(row)
+              "A: Enter reruns the suggested recovery command. f opens the task folder in $EDITOR without changing state."
+            elsif manual_fix?(row)
+              "A: No autofix available. Press f to open the task folder in $EDITOR and repair the missing state."
+            else
+              "A: Enter clears the ERROR marker and reruns the task. f opens the worktree in $EDITOR without clearing the marker."
+            end
           when "recover_execute"
             # EXECUTE_STALE has no auto-retry recipe — the operator must
             # edit findings or lower the pass counter before re-running.
@@ -80,6 +86,30 @@ module Hive
           else
             "A: This row has no autofix action in the detail view."
           end
+        end
+
+        def auto_action_available?(row)
+          return false if row.nil?
+          return true if row.action_key.to_s == "recover_review"
+          return false if row.action_key.to_s == "recover_execute"
+          return true if row.action_key.to_s == "error" && diagnostic_retry_command(row)
+          return true if row.action_key.to_s == "error" && row.marker.to_s == "error"
+
+          false
+        end
+
+        def diagnostic_retry_command(row)
+          suggested = row&.diagnostic && row.diagnostic["suggested_next_action"]
+          return nil unless suggested.is_a?(Hash)
+          return nil unless suggested["kind"].to_s == "retry"
+
+          command = suggested["command"].to_s.strip
+          command.empty? ? nil : command
+        end
+
+        def manual_fix?(row)
+          suggested = row&.diagnostic && row.diagnostic["suggested_next_action"]
+          suggested.is_a?(Hash) && suggested["kind"].to_s == "manual_fix"
         end
 
         def artifact_lines(row, width)

--- a/test/integration/run_finalize_test.rb
+++ b/test/integration/run_finalize_test.rb
@@ -133,6 +133,7 @@ class RunFinalizeTest < Minitest::Test
       with_tmp_git_repo do |dir|
         task_dir, _worktree_path, _pr_md = setup_finalize_task(dir)
         FileUtils.rm_f(File.join(task_dir, "pr.md"))
+        ENV["HIVE_FAKE_GH_AUTH_EXIT"] = "1"
 
         _out, err, status = with_captured_exit { Hive::Commands::Run.new(task_dir).call }
 
@@ -141,6 +142,8 @@ class RunFinalizeTest < Minitest::Test
         marker = Hive::Markers.current(File.join(task_dir, "pr.md"))
         assert_equal :error, marker.name
         assert_equal "missing_pr_md", marker.attrs["reason"]
+        assert_equal "", gh_argv_log,
+                     "missing pr.md must short-circuit before gh auth, push, or agent spawn"
       end
     end
   end
@@ -159,6 +162,7 @@ class RunFinalizeTest < Minitest::Test
 
           <!-- COMPLETE is_draft=true -->
         MD
+        ENV["HIVE_FAKE_GH_AUTH_EXIT"] = "1"
 
         _out, err, status = with_captured_exit { Hive::Commands::Run.new(task_dir).call }
 
@@ -167,6 +171,8 @@ class RunFinalizeTest < Minitest::Test
         marker = Hive::Markers.current(pr_md)
         assert_equal :error, marker.name
         assert_equal "missing_pr_url", marker.attrs["reason"]
+        assert_equal "", gh_argv_log,
+                     "missing pr_url must short-circuit before gh auth, push, or agent spawn"
       end
     end
   end

--- a/test/integration/run_finalize_test.rb
+++ b/test/integration/run_finalize_test.rb
@@ -136,8 +136,37 @@ class RunFinalizeTest < Minitest::Test
 
         _out, err, status = with_captured_exit { Hive::Commands::Run.new(task_dir).call }
 
-        assert_equal 1, status
+        assert_equal Hive::ExitCodes::TASK_IN_ERROR, status
         assert_includes err, "finalize entered without 5-open-pr"
+        marker = Hive::Markers.current(File.join(task_dir, "pr.md"))
+        assert_equal :error, marker.name
+        assert_equal "missing_pr_md", marker.attrs["reason"]
+      end
+    end
+  end
+
+  def test_finalize_requires_pr_url
+    with_tmp_global_config do
+      with_tmp_git_repo do |dir|
+        task_dir, _worktree_path, pr_md = setup_finalize_task(dir)
+        File.write(pr_md, <<~MD)
+          ---
+          pr_number: 9
+          ---
+
+          ## Summary
+          draft
+
+          <!-- COMPLETE is_draft=true -->
+        MD
+
+        _out, err, status = with_captured_exit { Hive::Commands::Run.new(task_dir).call }
+
+        assert_equal Hive::ExitCodes::TASK_IN_ERROR, status
+        assert_includes err, "finalize entered with pr.md missing pr_url"
+        marker = Hive::Markers.current(pr_md)
+        assert_equal :error, marker.name
+        assert_equal "missing_pr_url", marker.attrs["reason"]
       end
     end
   end

--- a/test/unit/bot/callback_handlers_test.rb
+++ b/test/unit/bot/callback_handlers_test.rb
@@ -96,6 +96,20 @@ class HiveBotCallbackHandlersTest < Minitest::Test
     )
   end
 
+  def test_clear_and_retry_none_marker_skips_marker_clear_and_runs_stage
+    result = @handlers.handle(
+      :callback_clear_and_retry,
+      update("clear_retry:alpha:plan-task-260519-abcd:3-plan:NONE")
+    )
+
+    assert_equal :dispatch_commands, result.action
+    assert_equal(
+      [ [ "hive", "plan", "plan-task-260519-abcd", "--from", "3-plan", "--project", "alpha", "--json" ] ],
+      result.commands,
+      "markerless synthetic errors must retry the stage directly instead of clearing a non-existent ERROR marker"
+    )
+  end
+
   def test_refresh_diagnose_rejects_malformed_callback_data
     # Defense against malformed callback round-trips. Any non-3-part
     # callback (legacy data, manual postback fuzzing) should fall back

--- a/test/unit/bot/notification_builders_test.rb
+++ b/test/unit/bot/notification_builders_test.rb
@@ -5,7 +5,8 @@ require "hive/bot/notification_builders"
 class HiveBotNotificationBuildersTest < Minitest::Test
   Row = Hive::Bot::StatusWatcher::Row
 
-  def row(action:, marker:, attrs: {}, slug: "slug-260514-abcd", stage: "2-brainstorm")
+  def row(action:, marker:, attrs: {}, slug: "slug-260514-abcd", stage: "2-brainstorm",
+          diagnostic: nil)
     Row.new(
       project: "hive",
       slug: slug,
@@ -15,7 +16,8 @@ class HiveBotNotificationBuildersTest < Minitest::Test
       folder: "/tmp/#{slug}",
       action: action,
       action_label: "label",
-      suggested_command: nil
+      suggested_command: nil,
+      diagnostic: diagnostic
     )
   end
 
@@ -113,6 +115,41 @@ class HiveBotNotificationBuildersTest < Minitest::Test
     # keystroke — issue #91. Order is locked so a future keyboard
     # tweak cannot accidentally drop or duplicate the button.
     assert_equal [ "Clear and retry", "Open laptop", "Show details", "Refresh diagnosis" ], labels
+  end
+
+  def test_markerless_retry_recovery_uses_retry_button_without_clear_copy
+    diagnostic = {
+      "summary" => "PLAN_MISSING_OUTPUT",
+      "suggested_next_action" => {
+        "kind" => "retry",
+        "command" => "hive plan slug-260514-abcd --from 3-plan"
+      }
+    }
+    notification = Hive::Bot::NotificationBuilders.build(
+      row(action: "error", marker: "none", stage: "3-plan", diagnostic: diagnostic)
+    )
+
+    labels = notification.keyboard.flatten.map { |button| button[:text] }
+    assert_equal [ "Retry", "Open laptop", "Show details", "Refresh diagnosis" ], labels
+    assert_equal "clear_retry:hive:slug-260514-abcd:3-plan:NONE",
+                 notification.keyboard.first.first[:callback_data]
+  end
+
+  def test_manual_fix_recovery_omits_clear_and_retry_button
+    diagnostic = {
+      "summary" => "FINALIZE_MISSING_PR_MD",
+      "suggested_next_action" => {
+        "kind" => "manual_fix",
+        "command" => nil
+      }
+    }
+    notification = Hive::Bot::NotificationBuilders.build(
+      row(action: "error", marker: "error", stage: "7-finalize", diagnostic: diagnostic)
+    )
+
+    labels = notification.keyboard.flatten.map { |button| button[:text] }
+    refute_includes labels, "Clear and retry"
+    assert_equal [ "Open laptop", "Show details", "Refresh diagnosis" ], labels
   end
 
   def test_fix_tampered_recovery_falls_back_to_laptop

--- a/test/unit/task_action_test.rb
+++ b/test/unit/task_action_test.rb
@@ -1,5 +1,6 @@
 require "test_helper"
 require "fileutils"
+require "hive/task"
 require "hive/task_action"
 require "hive/markers"
 
@@ -49,6 +50,33 @@ class TaskActionTest < Minitest::Test
   def test_plan_complete_is_ready_to_develop
     task = fake_task(stage_name: "plan", stage_index: 3)
     assert_equal "ready_to_develop", Hive::TaskAction.for(task, marker(:complete)).key
+  end
+
+  def test_plan_missing_or_empty_output_is_error_not_needs_input
+    Dir.mktmpdir("task-action-plan") do |dir|
+      folder = File.join(dir, ".hive-state", "stages", "3-plan", "demo-260426-aaaa")
+      FileUtils.mkdir_p(folder)
+      task = FakeTask.new(
+        stage_name: "plan",
+        stage_index: 3,
+        slug: "demo-260426-aaaa",
+        project_root: dir,
+        project_name: File.basename(dir),
+        folder: folder,
+        state_file: File.join(folder, "plan.md")
+      )
+
+      missing = Hive::TaskAction.for(task, marker(:none))
+      assert_equal "error", missing.key
+      assert_nil missing.command
+      assert_match(/Plan is incomplete because .*plan\.md is missing or empty/, missing.diagnostic["detail"])
+
+      File.write(task.state_file, "")
+      empty = Hive::TaskAction.for(task, marker(:none))
+      assert_equal "error", empty.key
+      assert_nil empty.command
+      assert_match(/PLAN_MISSING_OUTPUT/, empty.diagnostic["summary"])
+    end
   end
 
   def test_execute_complete_is_ready_to_open_pr
@@ -131,6 +159,29 @@ class TaskActionTest < Minitest::Test
   def test_finalize_complete_is_ready_to_archive
     task = fake_task(stage_name: "finalize", stage_index: 7)
     assert_equal "ready_to_archive", Hive::TaskAction.for(task, marker(:complete)).key
+  end
+
+  def test_finalize_missing_pr_md_is_error_not_needs_input
+    Dir.mktmpdir("task-action-finalize") do |dir|
+      folder = File.join(dir, ".hive-state", "stages", "7-finalize", "demo-260426-aaaa")
+      FileUtils.mkdir_p(folder)
+      task = FakeTask.new(
+        stage_name: "finalize",
+        stage_index: 7,
+        slug: "demo-260426-aaaa",
+        project_root: dir,
+        project_name: File.basename(dir),
+        folder: folder,
+        state_file: File.join(folder, "pr.md")
+      )
+
+      action = Hive::TaskAction.for(task, marker(:none))
+
+      assert_equal "error", action.key
+      assert_equal "Error", action.label
+      assert_nil action.command
+      assert_match(/Finalize cannot run because .*pr\.md is missing/, action.diagnostic["detail"])
+    end
   end
 
   def test_done_is_archived_with_no_command

--- a/test/unit/task_action_test.rb
+++ b/test/unit/task_action_test.rb
@@ -56,26 +56,32 @@ class TaskActionTest < Minitest::Test
     Dir.mktmpdir("task-action-plan") do |dir|
       folder = File.join(dir, ".hive-state", "stages", "3-plan", "demo-260426-aaaa")
       FileUtils.mkdir_p(folder)
-      task = FakeTask.new(
-        stage_name: "plan",
-        stage_index: 3,
-        slug: "demo-260426-aaaa",
-        project_root: dir,
-        project_name: File.basename(dir),
-        folder: folder,
-        state_file: File.join(folder, "plan.md")
-      )
+      task = Hive::Task.new(folder)
 
       missing = Hive::TaskAction.for(task, marker(:none))
-      assert_equal "error", missing.key
-      assert_nil missing.command
-      assert_match(/Plan is incomplete because .*plan\.md is missing or empty/, missing.diagnostic["detail"])
+      assert_equal "needs_input", missing.key,
+                   "freshly approved plan-stage folders start without plan.md and must remain runnable"
+      assert_equal "hive plan demo-260426-aaaa --from 3-plan", missing.command
 
+      FileUtils.mkdir_p(File.join(dir, ".hive-state", "logs", task.slug))
+      File.write(File.join(dir, ".hive-state", "logs", task.slug, "plan-20260519T221007Z.log"), "spawned\n")
+      interrupted = Hive::TaskAction.for(task, marker(:none))
+      assert_equal "error", interrupted.key
+      assert_nil interrupted.command
+      assert_match(/Plan is incomplete because .*plan\.md is missing or empty/,
+                   interrupted.diagnostic["detail"])
+
+      FileUtils.rm_rf(File.join(dir, ".hive-state", "logs", task.slug))
       File.write(task.state_file, "")
       empty = Hive::TaskAction.for(task, marker(:none))
       assert_equal "error", empty.key
       assert_nil empty.command
       assert_match(/PLAN_MISSING_OUTPUT/, empty.diagnostic["summary"])
+      assert_match(/Rerun the plan stage to regenerate plan\.md/, empty.diagnostic["detail"])
+      assert_equal "marker", empty.diagnostic["source"]
+      assert_equal "retry", empty.diagnostic.fetch("suggested_next_action").fetch("kind")
+      assert_equal "hive plan demo-260426-aaaa --from 3-plan",
+                   empty.diagnostic.fetch("suggested_next_action").fetch("command")
     end
   end
 
@@ -157,8 +163,75 @@ class TaskActionTest < Minitest::Test
   end
 
   def test_finalize_complete_is_ready_to_archive
-    task = fake_task(stage_name: "finalize", stage_index: 7)
-    assert_equal "ready_to_archive", Hive::TaskAction.for(task, marker(:complete)).key
+    Dir.mktmpdir("task-action-finalize") do |dir|
+      folder = File.join(dir, ".hive-state", "stages", "7-finalize", "demo-260426-aaaa")
+      FileUtils.mkdir_p(folder)
+      task = FakeTask.new(
+        stage_name: "finalize",
+        stage_index: 7,
+        slug: "demo-260426-aaaa",
+        project_root: dir,
+        project_name: File.basename(dir),
+        folder: folder,
+        state_file: File.join(folder, "pr.md")
+      )
+      File.write(task.state_file, <<~MD)
+        ---
+        pr_url: https://example.com/pr/9
+        ---
+
+        <!-- COMPLETE pr_url=https://example.com/pr/9 is_draft=false -->
+      MD
+
+      assert_equal "ready_to_archive",
+                   Hive::TaskAction.for(
+                     task,
+                     marker(:complete, "pr_url" => "https://example.com/pr/9", "is_draft" => "false")
+                   ).key
+    end
+  end
+
+  def test_finalize_complete_requires_final_pr_metadata_before_archive
+    Dir.mktmpdir("task-action-finalize") do |dir|
+      folder = File.join(dir, ".hive-state", "stages", "7-finalize", "demo-260426-aaaa")
+      FileUtils.mkdir_p(folder)
+      task = FakeTask.new(
+        stage_name: "finalize",
+        stage_index: 7,
+        slug: "demo-260426-aaaa",
+        project_root: dir,
+        project_name: File.basename(dir),
+        folder: folder,
+        state_file: File.join(folder, "pr.md")
+      )
+
+      File.write(task.state_file, "<!-- COMPLETE is_draft=false -->\n")
+      missing_url = Hive::TaskAction.for(task, marker(:complete, "is_draft" => "false"))
+      assert_equal "error", missing_url.key
+      assert_match(/FINALIZE_MISSING_PR_URL/, missing_url.diagnostic["summary"])
+
+      File.write(task.state_file, <<~MD)
+        ---
+        pr_url: https://example.com/pr/9
+        ---
+
+        <!-- COMPLETE pr_url=https://example.com/pr/other is_draft=false -->
+      MD
+      mismatch = Hive::TaskAction.for(
+        task,
+        marker(:complete, "pr_url" => "https://example.com/pr/other", "is_draft" => "false")
+      )
+      assert_equal "error", mismatch.key
+      assert_match(/FINALIZE_PR_URL_MISMATCH/, mismatch.diagnostic["summary"])
+
+      open_pr_marker = Hive::TaskAction.for(
+        task,
+        marker(:complete, "pr_url" => "https://example.com/pr/9", "is_draft" => "true")
+      )
+      assert_equal "ready_to_finalize", open_pr_marker.key,
+                   "open-pr's is_draft=true COMPLETE marker must not look archive-ready"
+      assert_equal "hive finalize demo-260426-aaaa --from 7-finalize", open_pr_marker.command
+    end
   end
 
   def test_finalize_missing_pr_md_is_error_not_needs_input
@@ -181,6 +254,30 @@ class TaskActionTest < Minitest::Test
       assert_equal "Error", action.label
       assert_nil action.command
       assert_match(/Finalize cannot run because .*pr\.md is missing/, action.diagnostic["detail"])
+    end
+  end
+
+  def test_finalize_missing_metadata_error_is_manual_fix_not_retry
+    Dir.mktmpdir("task-action-finalize") do |dir|
+      folder = File.join(dir, ".hive-state", "stages", "7-finalize", "demo-260426-aaaa")
+      FileUtils.mkdir_p(folder)
+      task = FakeTask.new(
+        stage_name: "finalize",
+        stage_index: 7,
+        slug: "demo-260426-aaaa",
+        project_root: dir,
+        project_name: File.basename(dir),
+        folder: folder,
+        state_file: File.join(folder, "pr.md")
+      )
+
+      %w[missing_pr_md missing_pr_url].each do |reason|
+        diagnostic = Hive::TaskAction.for(task, marker(:error, "reason" => reason)).diagnostic
+        suggested = diagnostic.fetch("suggested_next_action")
+
+        assert_equal "manual_fix", suggested.fetch("kind"), "reason=#{reason}"
+        assert_nil suggested["command"], "reason=#{reason}"
+      end
     end
   end
 

--- a/test/unit/tui/bubble_model_test.rb
+++ b/test/unit/tui/bubble_model_test.rb
@@ -2241,6 +2241,67 @@ class HiveTuiBubbleModelTest < Minitest::Test
     assert_match(/running.*hive run/, final_flash, "async flash must announce the rerun")
   end
 
+  def test_red_status_autofix_dispatches_markerless_diagnostic_retry_without_marker_clear
+    row = make_task_row(
+      action_key: "error",
+      action_label: "Error",
+      slug: "plan-task-260519-abcd",
+      stage: "3-plan",
+      marker: "none",
+      attrs: {},
+      suggested_command: nil
+    )
+    diagnostic = {
+      "summary" => "PLAN_MISSING_OUTPUT",
+      "suggested_next_action" => {
+        "kind" => "retry",
+        "command" => "hive plan plan-task-260519-abcd --from 3-plan"
+      }
+    }
+    row = row.with(diagnostic: diagnostic)
+    clear_count = 0
+    run_argv = nil
+
+    with_run_quiet_stub(->(_argv) { clear_count += 1; [ 0, "", "" ] }) do
+      with_dispatch_background_stub(->(argv, **_kwargs) { run_argv = argv; nil }) do
+        @model.update(Hive::Tui::Messages::RedStatusAutofix.new(row: row))
+      end
+    end
+
+    assert_equal 0, clear_count, "markerless synthetic errors must not try to clear ERROR"
+    assert_equal [ "hive", "plan", "plan-task-260519-abcd", "--from", "3-plan" ], run_argv
+    assert_match(/running.*hive plan.*plan-task-260519-abcd/, @model.hive_model.flash)
+  end
+
+  def test_red_status_autofix_refuses_markerless_manual_fix
+    row = make_task_row(
+      action_key: "error",
+      action_label: "Error",
+      slug: "finalize-task-260519-abcd",
+      stage: "7-finalize",
+      marker: "none",
+      attrs: {},
+      suggested_command: nil
+    )
+    row = row.with(
+      diagnostic: {
+        "summary" => "FINALIZE_MISSING_PR_MD",
+        "suggested_next_action" => {
+          "kind" => "manual_fix",
+          "command" => nil
+        }
+      }
+    )
+    clear_count = 0
+
+    with_run_quiet_stub(->(_argv) { clear_count += 1; [ 0, "", "" ] }) do
+      @model.update(Hive::Tui::Messages::RedStatusAutofix.new(row: row))
+    end
+
+    assert_equal 0, clear_count
+    assert_match(/no autofix action available/, @model.hive_model.flash)
+  end
+
   def test_recover_error_does_not_rerun_when_marker_clear_fails
     row = make_task_row(
       action_key: "error", action_label: "Error",

--- a/test/unit/tui/views/red_status_detail_test.rb
+++ b/test/unit/tui/views/red_status_detail_test.rb
@@ -84,4 +84,50 @@ class HiveTuiViewsRedStatusDetailTest < Minitest::Test
     assert_includes output, "[q] back",
                     "recover_execute rows must keep the back affordance"
   end
+
+  def test_markerless_retry_error_keeps_enter_affordance
+    diagnostic = {
+      "summary" => "PLAN_MISSING_OUTPUT",
+      "suggested_next_action" => {
+        "kind" => "retry",
+        "command" => "hive plan red-task --from 3-plan"
+      }
+    }
+    retry_row = Hive::Tui::Snapshot::Row.new(
+      project_name: "alpha", stage: "3-plan", slug: "red-task",
+      folder: "/tmp/red-task", state_file: "/tmp/red-task/plan.md",
+      marker: "none", attrs: {}, mtime: nil,
+      age_seconds: 0, claude_pid: nil, claude_pid_alive: nil,
+      action_key: "error", action_label: "Error",
+      suggested_command: nil, next_action: nil, diagnostic: diagnostic
+    )
+
+    output = Hive::Tui::Views::RedStatusDetail.render(model_for(retry_row))
+
+    assert_includes output, "[Enter] autofix / retry"
+    assert_includes output, "Enter reruns the suggested recovery command"
+  end
+
+  def test_manual_fix_error_omits_enter_affordance
+    diagnostic = {
+      "summary" => "FINALIZE_MISSING_PR_MD",
+      "suggested_next_action" => {
+        "kind" => "manual_fix",
+        "command" => nil
+      }
+    }
+    manual_row = Hive::Tui::Snapshot::Row.new(
+      project_name: "alpha", stage: "7-finalize", slug: "red-task",
+      folder: "/tmp/red-task", state_file: "/tmp/red-task/pr.md",
+      marker: "none", attrs: {}, mtime: nil,
+      age_seconds: 0, claude_pid: nil, claude_pid_alive: nil,
+      action_key: "error", action_label: "Error",
+      suggested_command: nil, next_action: nil, diagnostic: diagnostic
+    )
+
+    output = Hive::Tui::Views::RedStatusDetail.render(model_for(manual_row))
+
+    refute_includes output, "[Enter] autofix / retry"
+    assert_includes output, "No autofix available"
+  end
 end

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -2,6 +2,20 @@
 
 Append-only log of all wiki operations.
 
+## [2026-05-19T22:22:00Z] plan — missing output surfaces as error
+
+**Action:** Documented the recovery hardening for `3-plan` rows whose agent is interrupted before producing `plan.md`. Markerless plan rows with a missing or zero-byte `plan.md` now classify as `Error` with `PLAN_MISSING_OUTPUT`, so the TUI does not open an empty editor buffer as if user input were required.
+
+**Refreshed pages:**
+- [[stages/plan]] — explains the interrupted-plan missing-output state and rerun path.
+
+## [2026-05-19T22:00:00Z] finalize — missing PR metadata surfaces as error
+
+**Action:** Documented the recovery hardening for `7-finalize` rows missing `pr.md`. `Stages::Finalize` now records `ERROR reason=missing_pr_md` / `missing_pr_url` instead of exiting before the state file exists, and `TaskAction` classifies a markerless `7-finalize` folder without `pr.md` as `Error` so the TUI does not open an empty editor buffer.
+
+**Refreshed pages:**
+- [[stages/finalize]] — preconditions and marker-action table now mention missing PR metadata error markers.
+
 ## [2026-05-19T16:00:00Z] status — surface legacy stage dirs in JSON + text + TUI (PR #93)
 
 **Action:** `hive status` now detects task folders left behind by a stage rename in `Hive::Stages::DIRS` and surfaces them on every operator surface, instead of silently truncating them out of view. `Status#detect_legacy_stage_dirs` scans `<hive_state>/stages/` for directories outside `Hive::Stages::DIRS` containing slug-shaped subfolders (per the new `Hive::Stages.task_slug?` predicate — single source of truth shared with `Hive::Commands::Migrate`, so the count matches what `hive migrate` would actually move). The JSON payload's `Project` entry now always carries an additive `legacy_stage_dirs` array (`[]` when clean, otherwise `[{stage_dir, task_count}, ...]` sorted alphabetically). Text output prints a `⚠ N task(s) hidden in legacy stage dirs: ...` warning + `run hive migrate` hint under the project header; the TUI projects pane prefixes the affected project with `⚠` and a `legacy dirs — run hive migrate` hint by extending `ProjectView` with the new field. Schema `urn:hive:schema:status:v2` gains the optional `legacy_stage_dirs` property on `Project` without bumping `SCHEMA_VERSIONS["hive-status"]` (additive-optional policy in `lib/hive.rb`, precedent in PR #69's `rebase` block).

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -4,7 +4,7 @@ Append-only log of all wiki operations.
 
 ## [2026-05-19T22:22:00Z] plan — missing output surfaces as error
 
-**Action:** Documented the recovery hardening for `3-plan` rows whose agent is interrupted before producing `plan.md`. Markerless plan rows with a missing or zero-byte `plan.md` now classify as `Error` with `PLAN_MISSING_OUTPUT`, so the TUI does not open an empty editor buffer as if user input were required.
+**Action:** Documented the recovery hardening for `3-plan` rows whose agent is interrupted before producing `plan.md`. Markerless plan rows with a zero-byte `plan.md`, or a missing `plan.md` after a `plan-*.log` proves the plan run started, now classify as `Error` with `PLAN_MISSING_OUTPUT`, so the TUI does not open an empty editor buffer as if user input were required. Freshly promoted `3-plan` folders with no plan output yet remain runnable as `Needs your input`; `PLAN_MISSING_OUTPUT` recovery reruns `hive plan ... --from 3-plan` directly because there is no `ERROR` marker to clear.
 
 **Refreshed pages:**
 - [[stages/plan]] — explains the interrupted-plan missing-output state and rerun path.
@@ -12,6 +12,8 @@ Append-only log of all wiki operations.
 ## [2026-05-19T22:00:00Z] finalize — missing PR metadata surfaces as error
 
 **Action:** Documented the recovery hardening for `7-finalize` rows missing `pr.md`. `Stages::Finalize` now records `ERROR reason=missing_pr_md` / `missing_pr_url` instead of exiting before the state file exists, and `TaskAction` classifies a markerless `7-finalize` folder without `pr.md` as `Error` so the TUI does not open an empty editor buffer.
+
+Status also no longer treats any `7-finalize` `COMPLETE` marker as archive-ready. The marker must carry `is_draft=false` and a `pr_url` matching `pr.md` frontmatter; carried-over `5-open-pr` markers with `is_draft=true` stay ready to finalize, and missing/mismatched PR metadata becomes a red diagnostic.
 
 **Refreshed pages:**
 - [[stages/finalize]] — preconditions and marker-action table now mention missing PR metadata error markers.

--- a/wiki/stages/finalize.md
+++ b/wiki/stages/finalize.md
@@ -12,7 +12,7 @@ tags: [stage, finalize, pr, github]
 ## Preconditions
 
 1. `worktree.yml` must exist and point at a live worktree.
-2. `pr.md` must already exist with `pr_url` frontmatter from 5-open-pr.
+2. `pr.md` must already exist with `pr_url` frontmatter from 5-open-pr; missing PR metadata records `ERROR reason=missing_pr_md` or `ERROR reason=missing_pr_url`.
 3. `gh auth status` must succeed.
 4. The feature worktree must be clean; otherwise the stage writes `<!-- ERROR reason=dirty_worktree -->`.
 5. The branch must be pushed to its upstream. The runner attempts one push before writing `<!-- ERROR reason=unpushed_commits -->`.
@@ -29,7 +29,7 @@ tags: [stage, finalize, pr, github]
 ## Marker → commit action
 
 - `:complete` → `pr_finalized`.
-- Dirty or unpushed state writes an `ERROR` marker and commits the corresponding error state.
+- Missing `pr.md` / missing `pr_url`, dirty worktree, or unpushed state writes an `ERROR` marker and commits the corresponding error state.
 
 ## Backlinks
 

--- a/wiki/stages/finalize.md
+++ b/wiki/stages/finalize.md
@@ -29,6 +29,7 @@ tags: [stage, finalize, pr, github]
 ## Marker → commit action
 
 - `:complete` → `pr_finalized`.
+- Status only treats a `7-finalize` `:complete` marker as archive-ready when it carries `is_draft=false` and a `pr_url` matching `pr.md` frontmatter. A carried-over `5-open-pr` marker with `is_draft=true` remains ready to run finalize, not ready to archive.
 - Missing `pr.md` / missing `pr_url`, dirty worktree, or unpushed state writes an `ERROR` marker and commits the corresponding error state.
 
 ## Backlinks

--- a/wiki/stages/plan.md
+++ b/wiki/stages/plan.md
@@ -30,7 +30,7 @@ tags: [stage, plan, ce-plan]
 
 Agent must not modify any file other than `plan.md`. Must not execute code in the project (execution happens in 4-execute).
 
-If a daemon stop or killed agent leaves `plan.md` missing or zero-byte with no marker, status classifies the row as `Error` with `PLAN_MISSING_OUTPUT` instead of `Needs your input`. That state means the agent never produced a reviewable plan; rerun `hive plan ... --from 3-plan` after clearing the error.
+If a daemon stop or killed agent leaves a zero-byte `plan.md`, or a missing `plan.md` after a `plan-*.log` shows the plan agent started, status classifies the row as `Error` with `PLAN_MISSING_OUTPUT` instead of `Needs your input`. A freshly promoted plan folder with no `plan.md` and no plan-run log still remains `Needs your input` because it is valid and runnable. `PLAN_MISSING_OUTPUT` is a synthetic markerless error, so recovery is a direct rerun: `hive plan ... --from 3-plan`; there is no `ERROR` marker to clear.
 
 ## Marker → commit action mapping (`Stages::Plan.action_for`)
 

--- a/wiki/stages/plan.md
+++ b/wiki/stages/plan.md
@@ -3,7 +3,7 @@ title: 3-plan stage
 type: stage
 source: lib/hive/stages/plan.rb, templates/plan_prompt.md.erb
 created: 2026-04-25
-updated: 2026-04-25
+updated: 2026-05-19
 tags: [stage, plan, ce-plan]
 ---
 
@@ -29,6 +29,8 @@ tags: [stage, plan, ce-plan]
 2. If `plan.md` exists, integrate inline user feedback. End with `<!-- COMPLETE -->` only if no follow-up questions remain; otherwise `<!-- WAITING -->`.
 
 Agent must not modify any file other than `plan.md`. Must not execute code in the project (execution happens in 4-execute).
+
+If a daemon stop or killed agent leaves `plan.md` missing or zero-byte with no marker, status classifies the row as `Error` with `PLAN_MISSING_OUTPUT` instead of `Needs your input`. That state means the agent never produced a reviewable plan; rerun `hive plan ... --from 3-plan` after clearing the error.
 
 ## Marker → commit action mapping (`Stages::Plan.action_for`)
 


### PR DESCRIPTION
## Summary
- record structured finalize errors when pr.md or pr_url is missing
- classify missing finalize PR metadata as Error instead of Needs your input
- classify missing/zero-byte plan.md as Error instead of Needs your input
- document both recovery states and add focused coverage

## Tests
- bundle exec ruby -Itest -Ilib test/integration/run_finalize_test.rb
- bundle exec ruby -Itest -Ilib test/unit/task_action_test.rb
- bundle exec rubocop lib/hive/task_action.rb lib/hive/stages/finalize.rb test/unit/task_action_test.rb test/integration/run_finalize_test.rb