### PR TITLE
docs(readme): lead with TUI and agent-driven CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,30 +4,51 @@
 
 # Hive
 
-Hive is a multi-agent orchestrator that ships software ideas from rough note to pull request through a folder-as-agent pipeline.
+Hive turns a rough software idea into a merge-ready pull request through a multi-agent pipeline you can watch as it works. You sketch an idea in a few sentences, open the `hive tui` dashboard, and watch the work move forward: brainstorm pins down what you actually want, plan fixes the approach, execute writes the code, review hardens it, and finalize ships the PR. You can step in at any stage with a normal editor — every artefact is a markdown file in a stage folder, inspectable and editable by you or by another agent.
 
-Each task is a directory. The directory's stage folder is the task state, so moving a folder forward is the approval gesture and every artefact stays inspectable with normal filesystem tools. Compound engineering is the practice of making each step's output strong enough for the next step to run autonomously: brainstorm fixes the requirements, plan fixes the approach, execute writes code, review hardens it, and PR stages ship it.
+The mental model is folders. Every task is a directory; the folder's location is the task state. Moving a task from `2-brainstorm/` to `3-plan/` is the approval gesture, and every stage writes a durable artefact the next stage can trust. That practice — making each step's output strong enough for the next one to run autonomously — is called *compound engineering*. It's how Hive carries work from rough idea to merged PR while letting humans drop in on their own terms instead of a chat thread's.
 
 ```text
 1-inbox  ->  2-brainstorm  ->  3-plan  ->  4-execute  ->  5-open-pr  ->  6-review  ->  7-finalize  ->  8-done
 capture       refine           design      build          draft PR       harden        publish         archive
 ```
 
-Read the model in depth in [docs/concepts.md](docs/concepts.md).
+Read the model in depth in [docs/concepts.md](docs/concepts.md) — folder-as-agent, the marker protocol that lets stages negotiate handoff, the eight stages in detail, and the trade-offs that come with making everything a file.
 
-## Install
+## Quickstart
+
+Hive is driven through a terminal dashboard (`hive tui`) that polls every task in every registered project once a second and dispatches stage commands on a single keystroke. New users should start there. If you have not installed Hive yet, jump to [Install](#install) below and come back.
+
+Attach Hive to a project and open the dashboard:
 
 ```bash
-git clone https://github.com/ivankuznetsov/hive ~/Dev/hive && cd ~/Dev/hive && bundle install && mkdir -p ~/.local/bin && ln -sf ~/Dev/hive/bin/hive ~/.local/bin/hive
+cd ~/Dev/your-project
+hive init .                     # creates .hive-state/ and registers the project globally
+hive tui                        # opens the two-pane dashboard
 ```
 
-If `~/.local/bin` is not on `PATH`, put the symlink in a directory that is. The `-sf` form will overwrite an existing `hive` at the target path; run `command -v hive` first if you already have one installed and don't want to clobber it.
+You see a left pane listing your registered projects (with `★ All projects` on top) and a right pane showing tasks as a compact table — icon, slug, stage, status, age. From there everything is keystrokes:
 
-Requires Ruby 3.4, git >= 2.40, `claude` >= 2.1.118, `codex` >= 0.125.0 for the default execute agent, and authenticated `gh`. See [docs/getting-started.md](docs/getting-started.md) for the first run.
+| Key | What it does |
+|---|---|
+| `n` | Capture a new idea. The prompt accepts plain text, pasted screenshots, and dragged image paths. |
+| `Enter` | Drive the highlighted task's next action — open its input file for brainstorm/plan/review answers, tail its agent log, or run the suggested recovery on a red row. |
+| `b` / `p` / `d` / `P` / `r` / `F` / `a` | Run brainstorm / plan / develop / open-PR / review / finalize / archive on the highlighted task. |
+| `o` | Open the task's `.hive-state/stages/<n>-<stage>/<slug>/` folder in your editor for read-only browsing. |
+| `/` | Filter the visible rows. |
+| `Tab` / `Shift+Tab` | Toggle focus between the projects pane and the tasks pane. |
+| `?` | Help overlay. |
+| `q` | Quit. |
 
-## Install As A Prompt
+Workflow keystrokes are non-blocking: dispatching `b` (brainstorm) on one task while another task's agent is still running is fine — both processes run in their own pgroup and the dashboard keeps polling. See [wiki/commands/tui.md](wiki/commands/tui.md) for the full layout, every mode (findings triage, red-status detail, log tail, new-idea composer with image paste), and the keybinding map per mode.
 
-Paste this into Claude Code or Codex when you want the agent to install Hive for you:
+## Drive Hive From Your Coding Agent
+
+Hive's other primary surface is a coding agent — Claude Code, Codex, Gemini, Pi, or anything that can read terminal output and run shell commands. You describe intent in natural language ("brainstorm the bookmark service idea", "run review on the failing task and report the findings"), the agent translates that into `hive <verb>` calls, and you watch the result in the TUI or read the markdown artefacts directly. Every workflow verb supports `--json` and emits a typed envelope (schemas under [schemas/](schemas/), contract in [docs/cli.md#json-output](docs/cli.md#json-output)), so agent-side parsing is structured rather than scraped.
+
+### Install Hive via an agent
+
+Paste this into Claude Code, Codex, or another agent CLI when you want it to install Hive for you. The block has explicit stop-conditions so the agent halts before clobbering existing state.
 
 ```text
 Install Hive from the canonical GitHub source into ~/Dev/hive and put the hive binary on PATH.
@@ -52,32 +73,52 @@ hive --version
 Report the installed version and the path returned by `command -v hive`.
 ```
 
-## Quickstart
+### Operate Hive day-to-day via an agent
 
-Replace `your-project` with the registry name you pick at `hive init`. `hive new` prints the slug to use in the next commands; `hive status` also lists it.
+Once Hive is installed, you can hand any of the workflow verbs to an agent. Useful prompt shapes:
+
+- *Capture an idea:* `Run hive new your-project "<title>" and report the slug it printed.`
+- *Triage what's waiting:* `Run hive status --json and tell me which tasks are waiting for me (any row whose action_key is needs_input or review_findings).`
+- *Drive a task through one stage:* `Run hive review <slug> --json and summarize the resulting envelope, including any waiting markers.`
+- *Watch a long-running task:* `Run hive status --json --project <name> every 30 seconds and stop when the task at <slug> reaches a needs_input or completed action_key.`
+
+The `--json` envelope is stable across versions (schemas live under [schemas/](schemas/)), so agent prompts can rely on field shapes without scraping. `hive tui` is intentionally human-only and rejects `--json` — use the CLI verbs and `hive status --json` for programmatic use.
+
+## Install
+
+Requires Ruby 3.4, git ≥ 2.40, an authenticated `claude` ≥ 2.1.118, `codex` ≥ 0.125.0 for the default execute agent, and an authenticated `gh`. See [docs/getting-started.md#prerequisites](docs/getting-started.md#prerequisites) for the full prerequisite list and the first-run walkthrough.
 
 ```bash
-cd ~/Dev/your-project
-hive init .                                      # attach .hive-state to this repo
-hive new your-project "add tag autocomplete"     # create 1-inbox/<slug>/idea.md (prints <slug>)
-hive status                                      # see the next useful action
-hive brainstorm <slug>                           # write brainstorm.md, then answer questions inline
-hive plan <slug>                                 # write or refine plan.md
-hive develop <slug>                              # create the feature worktree and implementation commit
-hive open-pr <slug>                              # push the branch and open a draft PR
-hive review <slug>                               # run CI, reviewers, triage, fixes, and browser test
-hive finalize <slug>                             # refresh the PR body and mark it ready
-hive archive <slug>                              # after 7-finalize completes, move the task to 8-done
+git clone https://github.com/ivankuznetsov/hive ~/Dev/hive
+cd ~/Dev/hive
+bundle install
+mkdir -p ~/.local/bin
+ln -sf ~/Dev/hive/bin/hive ~/.local/bin/hive
 ```
 
-Walk through the same shape on a fresh project in [docs/getting-started.md](docs/getting-started.md), or read the replay of the completed xbookmark task in [docs/recipes.md#xbookmark-end-to-end](docs/recipes.md#xbookmark-end-to-end).
+If `~/.local/bin` is not on `PATH`, put the symlink in a directory that is. The `-sf` form overwrites an existing `hive` at the target path; run `command -v hive` first if you already have one installed and don't want to clobber it. Verify the install with `hive --version` and `hive doctor`.
+
+## Power-User / Scripting CLI
+
+The TUI is the recommended human interface and an agent-driven CLI is the recommended automation surface, but every workflow verb is also available directly on `bin/hive` for scripting, debugging, and recovery. Each verb supports `--json` and returns a typed envelope, so wrapper scripts get structured output.
+
+| Group | Verbs | What it's for |
+|---|---|---|
+| Workflow | `hive new`, `hive brainstorm`, `hive plan`, `hive develop`, `hive open-pr`, `hive review`, `hive finalize`, `hive archive`, `hive run`, `hive approve` | Drive a single stage of a single task by hand. `--from <stage>` lets you re-run a stage in place. See [docs/cli.md#day-to-day-workflow](docs/cli.md#day-to-day-workflow). |
+| Findings triage | `hive findings`, `hive accept-finding`, `hive reject-finding` | Inspect GFM-checkbox findings from the latest review pass and tick which ones should feed the next fix pass. See [docs/cli.md#findings-triage](docs/cli.md#findings-triage). |
+| Daemon | `hive daemon enable/start/status/tail/stop/disable` | Run the per-project daemon that polls `hive status --json` and auto-dispatches workflow verbs for tasks that can advance. Opt-in; read [wiki/operating.md](wiki/operating.md) before going live. See [docs/cli.md#daemon](docs/cli.md#daemon). |
+| Diagnostics | `hive status`, `hive doctor`, `hive rebase-status`, `hive markers clear`, `hive metrics rollback-rate` | Inspect task state, validate configured stage/reviewer skills, check whether the next run would auto-rebase, clear a recovery marker by name, or report fix-agent rollback rate. See [docs/cli.md#diagnostics](docs/cli.md#diagnostics). |
+| Registry | `hive init`, `hive forget`, `hive prune`, `hive migrate`, `hive tree` | Attach Hive to a project, remove projects from the global registry, prune missing paths, rename old stage folders, or print the Thor command tree. See [docs/cli.md#lower-level-surface](docs/cli.md#lower-level-surface). |
+
+Full per-command reference, every flag, every envelope field, and every exit code lives in [docs/cli.md](docs/cli.md).
 
 ## Documentation
 
-- [docs/getting-started.md](docs/getting-started.md): five-minute first run against a real project.
-- [docs/concepts.md](docs/concepts.md): folder-as-agent, the eight stages, and compound engineering.
-- [docs/architecture.md](docs/architecture.md): how stages, agents, files, config, and worktrees compose.
-- [docs/cli.md](docs/cli.md): current command surface from `bin/hive`.
-- [docs/recipes.md](docs/recipes.md): concrete workflows, including the xbookmark dogfood replay.
-- [docs/faq.md](docs/faq.md): troubleshooting and design questions.
-- [wiki/index.md](wiki/index.md): deeper engineering reference maintained by the LLM wiki.
+- **[docs/concepts.md](docs/concepts.md)** — The conceptual deep-dive: folder-as-agent, the eight stages in detail, the marker protocol that lets stages negotiate handoff, and what compound engineering looks like in practice. Read this when you want to understand *why* Hive is shaped the way it is, or before extending a stage and needing to know what the artefact contract is.
+- **[docs/getting-started.md](docs/getting-started.md)** — A five-minute first-run walkthrough against a real project, from prerequisites through capturing an idea, watching brainstorm work, and promoting to plan. Read this on day one; come back if you ever forget the `hive init` → `hive new` → `hive brainstorm` shape.
+- **[wiki/commands/tui.md](wiki/commands/tui.md)** — The TUI deep reference: the two-pane layout, every mode (findings triage, red-status detail, log tail, new-idea composer with image paste), the per-mode keybinding map, the terminal-hostility contract (resize, SIGTSTP, SIGHUP, non-tty rejection), and the subprocess-dispatch model. Read this when the TUI does something surprising or you want the full keystroke surface.
+- **[docs/architecture.md](docs/architecture.md)** — The user-facing architecture: the three trees (project checkout, `.hive-state/` orphan branch, feature worktree), the storage layout `hive init` creates, and how stages, agents, configs, and worktrees compose. Read this when you want to know where files live and which process owns what.
+- **[docs/cli.md](docs/cli.md)** — The full command surface exposed by `bin/hive`: every verb, every flag, every `--json` envelope contract, and every exit code. Read this when you're scripting Hive or wiring it into an agent that needs the full CLI map.
+- **[docs/recipes.md](docs/recipes.md)** — Concrete end-to-end workflows, including the xbookmark dogfood replay (linked to the real PR and a committed transcript of the run). Read this when you want to see what a complete idea-to-PR run looks like before trying it yourself.
+- **[docs/faq.md](docs/faq.md)** — Troubleshooting and design-rationale answers: why folders instead of a database, why per-stage subprocesses instead of a long-running orchestrator, why commit `.hive-state/` to an orphan branch, why opt-in daemon, why no built-in web UI. Read this when you hit a surprise or want to know "why is it like this?".
+- **[wiki/index.md](wiki/index.md)** — The catalog of the LLM-maintained engineering wiki under `wiki/`, which is the deepest source of reference material for every command, module, and stage. Read this when the user-facing docs above don't have the depth you need.

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -2,6 +2,13 @@
 
 Append-only log of all wiki operations.
 
+## [2026-05-20T00:00:00Z] README rewritten with TUI-first framing
+
+**Action:** Restructured `README.md` so the user-facing entry point is the `hive tui` dashboard, the second-tier entry point is "Drive Hive From Your Coding Agent" (folding in the existing install-prompt block plus day-to-day operate-via-agent guidance), and direct CLI use is demoted to a Power-User / Scripting CLI summary that links out to `docs/cli.md` instead of duplicating the per-command table. The hero now explains what Hive does and the folder-as-agent + compound-engineering mental model before any install line. The Documentation section replaces bare bullet links with 1–3 sentence prose descriptions per linked doc.
+
+**Refreshed pages:**
+- None — README sits outside `wiki/`. This entry logs the rewrite for traceability with the rest of the docs surface.
+
 ## [2026-05-19T22:22:00Z] plan — missing output surfaces as error
 
 **Action:** Documented the recovery hardening for `3-plan` rows whose agent is interrupted before producing `plan.md`. Markerless plan rows with a zero-byte `plan.md`, or a missing `plan.md` after a `plan-*.log` proves the plan run started, now classify as `Error` with `PLAN_MISSING_OUTPUT`, so the TUI does not open an empty editor buffer as if user input were required. Freshly promoted `3-plan` folders with no plan output yet remain runnable as `Needs your input`; `PLAN_MISSING_OUTPUT` recovery reruns `hive plan ... --from 3-plan` directly because there is no `ERROR` marker to clear.


### PR DESCRIPTION
## Summary

The previous README walked a reader straight from one-line pitch to a `git clone` install line to a Quickstart that was nine `hive <verb>` lines in a row. That ordering hides how Hive is actually used: humans drive it through `hive tui` (the Charm two-pane dashboard), autonomous coding agents drive the CLI on the user's behalf, and direct CLI use is the scripting / recovery surface — not the front door. The Documentation section's bare bullet links also gave readers no way to pick the right doc without opening every link.

This PR rewrites `README.md` end-to-end:

- **Hero** explains what Hive does and the folder-as-agent + compound-engineering mental model before any install line, so a reader who never scrolls past the first screen knows what Hive is for.
- **Quickstart** now starts with `hive init . && hive tui` and a user-facing keystroke table (`n`, `Enter`, `b/p/d/P/r/F/a`, `o`, `/`, `Tab`, `?`, `q`) — not the verb chain.
- **Drive Hive From Your Coding Agent** is a new top-level section. It folds the existing "Install As A Prompt" block in (verbatim — same commands, same stop-conditions) and adds a sibling "Operate Hive day-to-day via an agent" subsection with concrete prompt shapes for capturing ideas, triaging waiting tasks, driving a stage, and watching a long-running task. References `--json` envelope + `schemas/` so agent-side parsing is structured.
- **Install** moves below the TUI and agent-driven sections, trimmed to prereqs + the canonical install commands (prereq versions cross-checked against `docs/getting-started.md`).
- **Power-User / Scripting CLI** is a new section: a compact grouped table (Workflow / Findings triage / Daemon / Diagnostics / Registry) with one-sentence purposes and anchor links into `docs/cli.md` instead of duplicating the per-command table.
- **Documentation** section: each link now has a 1–3 sentence prose description naming what's in the doc, who it's for, and when to open it. Adds `wiki/commands/tui.md` to the list.

Net effect: 83 lines → 124 lines, every internal link verified, no behavioral change.

## Test plan

- [x] Every internal link in the new README resolves (17 paths, all under `docs/`, `wiki/`, or `schemas/`).
- [x] Every anchor fragment resolves to an actual `## ` header in the target file (`docs/cli.md#json-output`, `#day-to-day-workflow`, `#findings-triage`, `#daemon`, `#diagnostics`, `#lower-level-surface`, `docs/getting-started.md#prerequisites`).
- [x] `hive --version` reports `0.1.0` against the existing install (binary unchanged).
- [ ] TUI boot smoke (`hive init . && hive tui`) not run from the rewrite branch — TUI requires a tty. Worth a manual eyeball before merging.
- [x] `wiki/log.md` updated with a `2026-05-20` entry per project convention.

## Plan

`~/Dev/hive-private/docs/plans/2026-05-20-001-feat-readme-tui-first-rewrite-plan.md` (private repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)