### PR TITLE
fix(release): isolate GEM_PATH during smoke install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,9 +39,11 @@ jobs:
           gem_file="$(ls hive-cli-*.gem | head -n 1)"
           [[ -s "$gem_file" ]] || { echo "no hive-cli-*.gem in workspace" >&2; exit 1; }
           sandbox="$(mktemp -d)/gem-sandbox"
-          GEM_HOME="$sandbox" gem install "$gem_file" \
-            --no-document \
+          mkdir -p "$sandbox"
+          GEM_HOME="$sandbox" GEM_PATH="$sandbox" gem install "$gem_file" \
+            --install-dir "$sandbox" \
             --bindir "$sandbox/bin" \
+            --no-document \
             --source https://rubygems.org
           GEM_HOME="$sandbox" GEM_PATH="$sandbox" "$sandbox/bin/hive" --version
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
First v0.1.0 retag against the rubygem-pivot main failed at the build-job smoke step:

```
Could not find 'bigdecimal' (>= 3.0) among 75 total gem(s)
```

The smoke step's `gem install` saw the runner's bundler-cached transitive deps on the default `GEM_PATH` and considered them satisfied, so it didn't fetch them into the sandbox. The post-install `hive --version` then ran with `GEM_PATH` clamped to the sandbox where those deps weren't installed.

Fix: clamp `GEM_PATH` to the sandbox during install too, plus pass `--install-dir` explicitly. One-line behavior change.

This mirrors what `install.sh` does on a user's machine — same root cause, same fix shape.

## Test plan

- [ ] CI on this PR (the release build path itself isn't tested by PR CI; the install-smoke fixtures already exercise the install.sh `gem install` path).
- [ ] After merge: retag v0.1.0 against the new main, watch release.yml.