### PR TITLE
ci(install-smoke): set up Ruby 3.4 before real release install

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -68,6 +68,9 @@ jobs:
     # but predate a published release.
     steps:
       - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
       - name: Check pinned release exists
         id: release
         env:


### PR DESCRIPTION
## Summary

The `install.sh full install smoke (against real release)` job has been failing on every CI run since the workflow landed, with:

```
hive install: Ruby 3.4+ required; found 3.2.3
```

Stock `ubuntu-24.04` ships Ruby 3.2; `install.sh` enforces a Ruby 3.4+ gate at the start of the real install path (`install.sh:214`), explicitly skipped under `--dry-run` (`install.sh:199-200`), which is why every other job in this workflow passes.

The `installer-fixtures` job in the same file already runs `ruby/setup-ruby@v1` with `ruby-version: "3.4"` for the same reason. This PR mirrors that step into `full-smoke`.

Branch protection doesn't currently require this check, so PRs still merged with it red, but the check is now actionable instead of permanently broken.

## Test plan

- This PR's own `install.sh full install smoke (against real release)` run is the smoke.
- YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(...)"`).
- Other jobs in this workflow are unchanged and should stay green.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)