### PR TITLE
fix(test): isolate uninstall HIVE_HOME-collapse test from real ~/.local/bin

### DIFF
--- a/test/unit/commands/uninstall_test.rb
+++ b/test/unit/commands/uninstall_test.rb
@@ -63,28 +63,31 @@ class UninstallCommandTest < Minitest::Test
   end
 
   def test_hive_home_collapse_skips_config_cache_and_state_deletes
-    with_tmp_dir do |dir|
-      old = ENV["HIVE_HOME"]
-      begin
-        ENV["HIVE_HOME"] = File.join(dir, "collapsed")
-        FileUtils.mkdir_p(ENV.fetch("HIVE_HOME"))
-        File.write(Hive::Config.global_config_path, { "registered_projects" => [] }.to_yaml)
-        FileUtils.mkdir_p(File.join(Hive::Paths.state_home, "projects", "work"))
+    # `with_xdg_home` (not the bare `with_tmp_dir`) is load-bearing here:
+    # `Hive::Paths.bin_home` intentionally ignores HIVE_HOME, so without
+    # the HOME / XDG_BIN_HOME isolation that `with_xdg_home` sets up,
+    # `Uninstall#remove_user_symlinks` would resolve `bin_home` to the
+    # real `~/.local/bin/` and unlink the user's actual hive/hv
+    # symlinks during `rake test`. Every other Uninstall test in this
+    # file uses `with_xdg_home` for that reason; this one is the lone
+    # path that needs to override HIVE_HOME after entering the sandbox.
+    with_xdg_home do |dir|
+      ENV["HIVE_HOME"] = File.join(dir, "collapsed")
+      FileUtils.mkdir_p(ENV.fetch("HIVE_HOME"))
+      File.write(Hive::Config.global_config_path, { "registered_projects" => [] }.to_yaml)
+      FileUtils.mkdir_p(File.join(Hive::Paths.state_home, "projects", "work"))
 
-        out = StringIO.new
-        Hive::Commands::Uninstall.new(
-          purge: true,
-          output: out,
-          runner: ->(_argv) { true },
-          host_os: "freebsd"
-        ).call
+      out = StringIO.new
+      Hive::Commands::Uninstall.new(
+        purge: true,
+        output: out,
+        runner: ->(_argv) { true },
+        host_os: "freebsd"
+      ).call
 
-        assert File.exist?(Hive::Paths.config_home)
-        assert File.exist?(File.join(Hive::Paths.state_home, "projects", "work"))
-        assert_match(/HIVE_HOME collapses/, out.string)
-      ensure
-        old.nil? ? ENV.delete("HIVE_HOME") : ENV["HIVE_HOME"] = old
-      end
+      assert File.exist?(Hive::Paths.config_home)
+      assert File.exist?(File.join(Hive::Paths.state_home, "projects", "work"))
+      assert_match(/HIVE_HOME collapses/, out.string)
     end
   end
 


### PR DESCRIPTION
## Bug

\`test/unit/commands/uninstall_test.rb#test_hive_home_collapse_skips_config_cache_and_state_deletes\` was deleting real user files during a routine \`bundle exec rake test\` run. Today it nuked my dev-clone \`~/.local/bin/hive\` symlink mid-session; I noticed because the running daemon's restart attempt failed with \`cannot load such file -- thor\` (the symlink was gone, so \`%h/.local/bin/hive\` couldn't be exec'd).

## Why it leaks

\`Hive::Paths.bin_home\` deliberately ignores \`HIVE_HOME\` — the comment on the method spells it out:

\`\`\`ruby
# bin_home intentionally ignores HIVE_HOME — install.sh places
# the \`hive\`/\`hv\` symlinks under XDG_BIN_HOME (or ~/.local/bin),
# regardless of how config/data/state/cache are collapsed via the
# test override.
def bin_home
  File.expand_path(env_or_blank("XDG_BIN_HOME") || File.join(home, ".local/bin"))
end
\`\`\`

\`home\` reads \`ENV["HOME"]\` dynamically. The other Uninstall tests use \`with_xdg_home\`, which sets \`ENV["HOME"]\` to a tmp dir AND deletes \`XDG_BIN_HOME\` — that makes \`bin_home\` resolve to \`$tmp/home/.local/bin\` (safe). This one test alone used \`with_tmp_dir\` + a manual \`HIVE_HOME\` export and did not touch HOME, so \`bin_home\` resolved to the real \`~/.local/bin/\` and \`Uninstall#remove_user_symlinks\` happily \`File.unlink\`'d the user's real \`hive\` and \`hv\`.

## Fix

Use the existing \`with_xdg_home\` helper. It already snapshots+restores all the relevant env vars (HOME, HIVE_HOME, XDG_*), so the explicit begin/ensure dance for HIVE_HOME is no longer needed either. Set \`HIVE_HOME\` inside the block to exercise the same code path the original test was after.

Added a comment on the test explaining why the helper choice is load-bearing, so the next person to refactor doesn't fall back to \`with_tmp_dir\`.

## Test plan

- [x] \`bundle exec ruby -Ilib -Itest test/unit/commands/uninstall_test.rb\` — 8 runs, 23 assertions, 0 failures.
- [x] After the full run, \`~/.local/bin/hive\` symlink still exists. Before the fix, the same run deleted it.
- [ ] CI on this PR: rake test / rubocop / brakeman / bundler-audit.

## Follow-up consideration (not in this PR)

The bug is now isolated at the test layer, but \`Hive::Paths.bin_home\` is still surprising from a production-code standpoint: a deliberate "ignore HIVE_HOME" carve-out is the kind of decision that bites future test authors who forget about it. A defensive option is to teach \`bin_home\` to also honor \`HIVE_HOME\` (with a clearly documented "production install.sh never sets HIVE_HOME" caveat). Not doing it here — too easy to break install/update channel resolution, and the test fix is the minimal scope this incident requires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)