### PR TITLE
ci(release): add verify-release.sh end-to-end behavior check

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -13,11 +13,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: bash -n install.sh
+      - run: bash -n packaging/verify-release.sh
       - name: Shellcheck
         uses: ludeeus/action-shellcheck@00b27aa7cb85167568cb48a3838b75f4265f2bca
         with:
           scandir: '.'
-          additional_files: install.sh
+          additional_files: |
+            install.sh
+            packaging/verify-release.sh
       - run: bash install.sh --dry-run --version=v0.1.0
 
   macos-dry-run:
@@ -96,6 +99,41 @@ jobs:
           grep -q '^bash$' "$XDG_DATA_HOME/hive/install-channel"
           test -x "$XDG_BIN_HOME/hive"
           "$XDG_BIN_HOME/hive" --version
+
+  verify-release:
+    name: verify-release.sh (end-to-end behavior)
+    runs-on: ubuntu-24.04
+    # Same gate as full-smoke: only runs against a real published
+    # release. Skips on PRs that predate the pinned release. The
+    # script feature-detects post-pin subcommands (e.g., `daemon
+    # install` shipped post-v0.1.0) and skips their assertions when
+    # the released binary doesn't have them yet.
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+      - name: Check pinned release exists
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HIVE_VERSION: v0.1.0
+        run: |
+          if gh release view "$HIVE_VERSION" --repo ivankuznetsov/hive >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "verify-release skipped: ${HIVE_VERSION} is not published yet" >&2
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Install jq (for envelope assertions)
+        if: ${{ steps.release.outputs.exists == 'true' }}
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq jq
+      - name: Run verify-release.sh
+        if: ${{ steps.release.outputs.exists == 'true' }}
+        env:
+          HIVE_VERSION: v0.1.0
+        run: |
+          bash packaging/verify-release.sh --version="$HIVE_VERSION"
 
   installer-fixtures:
     name: install.sh fixture regressions

--- a/packaging/verify-release.sh
+++ b/packaging/verify-release.sh
@@ -16,8 +16,7 @@
 #                               [--keep-prefix] [--no-uninstall]
 #
 # Defaults:
-#   --version    : whatever bin/hive --version reports if run in-repo,
-#                  else v0.1.0
+#   --version    : v0.1.0 (override to verify a different release)
 #   --prefix     : mktemp -d hive-verify-XXXXXX (deleted on success
 #                  unless --keep-prefix)
 #   --keep-prefix: keep the tmp prefix after success (useful when
@@ -29,7 +28,7 @@
 #   0   all verifications passed
 #   1   a verification step failed (script preserves the tmp prefix)
 #   2   bad arguments
-#   3   prerequisite missing (curl, gh, ruby, jq)
+#   3   prerequisite missing (curl, ruby, jq, git)
 
 set -euo pipefail
 
@@ -40,18 +39,19 @@ PREFIX=""
 KEEP_PREFIX=0
 RUN_UNINSTALL=1
 
+# Argument dialect matches install.sh: --flag=value only. Drops the
+# space-separated form so two release-ceremony scripts share one
+# parser convention.
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --version=*) HIVE_VERSION="${1#*=}"; shift ;;
-    --version)   HIVE_VERSION="$2"; shift 2 ;;
     --prefix=*)  PREFIX="${1#*=}"; shift ;;
-    --prefix)    PREFIX="$2"; shift 2 ;;
     --keep-prefix) KEEP_PREFIX=1; shift ;;
     --no-uninstall) RUN_UNINSTALL=0; shift ;;
     -h|--help)
       sed -n '3,29p' "$0"
       exit 0 ;;
-    *) echo "verify-release: unknown argument: $1" >&2; exit 2 ;;
+    *) echo "verify-release: unknown argument: $1 (try --help)" >&2; exit 2 ;;
   esac
 done
 
@@ -68,7 +68,7 @@ INSTALL_SH="$REPO_ROOT/install.sh"
 
 # ─── prerequisites ───────────────────────────────────────────────────
 
-for cmd in curl ruby jq; do
+for cmd in curl ruby jq git; do
   command -v "$cmd" >/dev/null 2>&1 || {
     echo "verify-release: missing prerequisite: $cmd" >&2
     exit 3
@@ -83,6 +83,16 @@ if [[ -z "$PREFIX" ]]; then
 else
   CREATED_PREFIX=0
   mkdir -p "$PREFIX"
+fi
+
+# Capture the real user's HOME BEFORE overwriting it — the leak
+# detector at the end of the script needs to scan the real home,
+# not the sandboxed one. Done this way (capture into HOME_BEFORE)
+# rather than via getent so macOS works too (getent doesn't exist).
+HOME_BEFORE="${HOME:-}"
+if [[ -z "$HOME_BEFORE" ]]; then
+  echo "verify-release: \$HOME is unset; leak detection cannot run" >&2
+  exit 3
 fi
 
 # Everything hive writes (config, cache, state, bin, data, daemon
@@ -103,6 +113,13 @@ export HOME="$PREFIX/home"
 mkdir -p "$XDG_BIN_HOME" "$XDG_DATA_HOME" "$XDG_CONFIG_HOME" \
          "$XDG_STATE_HOME" "$XDG_CACHE_HOME" "$HIVE_HOME" "$HOME"
 
+# Sentinel file for leak detection: anchor `find -newer` on a file
+# whose mtime never moves, not on $PREFIX (whose mtime updates every
+# time a child file is added — which would mask early leaks because
+# the reference timestamp drifts toward end-of-script).
+START_MARKER="$PREFIX/.start-marker"
+: > "$START_MARKER"
+
 # Put the installed binary first on PATH so subsequent `hive` calls
 # resolve to the just-installed artifact, not a host install.
 export PATH="$XDG_BIN_HOME:$PATH"
@@ -111,9 +128,18 @@ PASS_COUNT=0
 FAIL_COUNT=0
 STEP=0
 
-log() { printf '\033[1;36m[verify]\033[0m %s\n' "$*"; }
-ok()  { printf '\033[1;32m  ✓\033[0m %s\n' "$*"; PASS_COUNT=$((PASS_COUNT + 1)); }
-fail() { printf '\033[1;31m  ✗\033[0m %s\n' "$*" >&2; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+# ANSI colors only when stdout is a TTY and NO_COLOR is unset (per
+# no-color.org). CI typically captures stdout non-interactively;
+# emitting raw escape codes there pollutes log parsers.
+if [[ -t 1 ]] && [[ -z "${NO_COLOR:-}" ]]; then
+  C_INFO=$'\033[1;36m'; C_OK=$'\033[1;32m'; C_FAIL=$'\033[1;31m'; C_RESET=$'\033[0m'
+else
+  C_INFO=""; C_OK=""; C_FAIL=""; C_RESET=""
+fi
+
+log() { printf '%s[verify]%s %s\n' "$C_INFO" "$C_RESET" "$*"; }
+ok()  { printf '%s  ✓%s %s\n' "$C_OK" "$C_RESET" "$*"; PASS_COUNT=$((PASS_COUNT + 1)); }
+fail() { printf '%s  ✗%s %s\n' "$C_FAIL" "$C_RESET" "$*" >&2; FAIL_COUNT=$((FAIL_COUNT + 1)); }
 
 cleanup() {
   local exit_code=$?
@@ -137,13 +163,24 @@ step() { STEP=$((STEP + 1)); log "step ${STEP}: $*"; }
 # ─── 1. install ──────────────────────────────────────────────────────
 
 step "install hive ${HIVE_VERSION} into ${PREFIX}"
-if bash "$INSTALL_SH" --version="$HIVE_VERSION" >"$PREFIX/install.log" 2>&1; then
-  ok "install.sh exited 0"
-else
-  cat "$PREFIX/install.log" >&2
-  fail "install.sh failed"
-  exit 1
-fi
+# `timeout 300` bounds the install at 5 minutes. install.sh downloads
+# release tarballs from GitHub via curl/gh; if the CDN stalls (TCP
+# connect succeeds but bytes stop flowing) curl waits on its unbounded
+# default. Without the timeout, verify-release.sh hangs until GHA's
+# 6h job-level cap fires. timeout returns 124 on expiry.
+set +e
+timeout 300 bash "$INSTALL_SH" --version="$HIVE_VERSION" >"$PREFIX/install.log" 2>&1
+INSTALL_RC=$?
+set -e
+case "$INSTALL_RC" in
+  0)   ok "install.sh exited 0" ;;
+  124) cat "$PREFIX/install.log" >&2 2>/dev/null || true
+       fail "install.sh timed out after 300s (network stall or CDN unreachable)"
+       exit 1 ;;
+  *)   cat "$PREFIX/install.log" >&2 2>/dev/null || true
+       fail "install.sh failed (rc=$INSTALL_RC)"
+       exit 1 ;;
+esac
 
 [[ -x "$XDG_BIN_HOME/hive" ]] && ok "binary at \$XDG_BIN_HOME/hive is executable" \
                               || fail "binary missing or not executable at $XDG_BIN_HOME/hive"
@@ -161,18 +198,24 @@ INSTALLED_VERSION="$("$XDG_BIN_HOME/hive" --version 2>/dev/null || true)"
 # ─── 2. doctor ───────────────────────────────────────────────────────
 
 step "hive doctor"
-if "$XDG_BIN_HOME/hive" doctor >"$PREFIX/doctor.log" 2>&1; then
-  ok "doctor exited 0"
+set +e
+"$XDG_BIN_HOME/hive" doctor >"$PREFIX/doctor.log" 2>&1
+DOCTOR_RC=$?
+set -e
+# doctor signals "ran and produced a report" by emitting its
+# signature header (a fixed-width status table starting with "stage"
+# / "agent" / "skill" / "status"). A real crash (NoMethodError,
+# LoadError, syntax error) lacks that header. Discriminating on
+# output shape rather than exit code lets the script tolerate
+# doctor's varied non-zero codes (1, 65 EX_DATAERR, 70 SOFTWARE)
+# while still catching genuine crashes.
+if [[ "$DOCTOR_RC" -eq 0 ]]; then
+  ok "doctor exited 0 (all prereqs present)"
+elif grep -qE '^stage[[:space:]]+agent[[:space:]]+skill[[:space:]]+status' "$PREFIX/doctor.log"; then
+  ok "doctor reported issues (rc=$DOCTOR_RC, expected in CI sandbox without LLM CLIs/skills)"
 else
-  # doctor exits non-zero when prereqs are missing. That's expected in
-  # a sandboxed CI env (no gh login, no claude binary). Just verify it
-  # ran without crashing and produced human-readable output.
-  if grep -qE "(claude|gh|git)" "$PREFIX/doctor.log"; then
-    ok "doctor reported missing prerequisites (expected in sandbox)"
-  else
-    cat "$PREFIX/doctor.log" >&2
-    fail "doctor crashed without producing the expected report"
-  fi
+  cat "$PREFIX/doctor.log" >&2 2>/dev/null || true
+  fail "doctor exited unexpectedly (rc=$DOCTOR_RC) — output lacks the signature report header, likely a crash"
 fi
 
 # ─── 3. scratch project: init + new + status ─────────────────────────
@@ -207,15 +250,30 @@ PROJECT_NAME="$(basename "$PROJECT")"
 STATUS_JSON="$PREFIX/status.json"
 "$XDG_BIN_HOME/hive" status --json >"$STATUS_JSON" 2>"$PREFIX/status.err" \
   && ok "hive status --json exited 0" \
-  || { cat "$PREFIX/status.err" >&2; fail "hive status --json failed"; }
+  || { cat "$PREFIX/status.err" >&2 2>/dev/null || true; fail "hive status --json failed"; }
 
-# Validate envelope basics: schema name + version + at least one task.
-SCHEMA="$(jq -r '.schema // empty' "$STATUS_JSON")"
-TASK_COUNT="$(jq -r '[.projects[].tasks[]] | length' "$STATUS_JSON")"
+# Validate envelope shape: schema name, then probe the new task's
+# stage/marker/action so a regression that creates the row in the
+# wrong stage (or with the wrong marker / wrong action key) fails
+# loudly. jq calls are made defensive with `|| true` so a malformed
+# envelope produces a clean fail line instead of aborting the script
+# mid-step under set -e.
+SCHEMA="$(jq -r '.schema // empty' "$STATUS_JSON" 2>/dev/null || true)"
+TASK_COUNT="$(jq -r '[.projects[].tasks[]] | length' "$STATUS_JSON" 2>/dev/null || echo 0)"
+NEW_TASK_STAGE="$(jq -r '[.projects[].tasks[]][0].stage // empty' "$STATUS_JSON" 2>/dev/null || true)"
+NEW_TASK_MARKER="$(jq -r '[.projects[].tasks[]][0].marker // empty' "$STATUS_JSON" 2>/dev/null || true)"
+NEW_TASK_ACTION="$(jq -r '[.projects[].tasks[]][0].action // empty' "$STATUS_JSON" 2>/dev/null || true)"
+
 [[ "$SCHEMA" == "hive-status" ]] && ok "status envelope schema=hive-status" \
-                                 || fail "status envelope schema is $SCHEMA, want hive-status"
-[[ "${TASK_COUNT:-0}" -ge 1 ]] && ok "status envelope reports ≥1 task" \
-                               || fail "status envelope reports 0 tasks after `hive new`"
+                                 || fail "status envelope schema is '$SCHEMA', want hive-status"
+[[ "${TASK_COUNT:-0}" -ge 1 ]] && ok "status envelope reports >=1 task" \
+                               || fail "status envelope reports 0 tasks after 'hive new'"
+[[ "$NEW_TASK_STAGE" == "1-inbox" ]] && ok "new task at stage=1-inbox" \
+                                     || fail "new task at stage='$NEW_TASK_STAGE', want 1-inbox"
+[[ "$NEW_TASK_MARKER" == "waiting" ]] && ok "new task marker=waiting" \
+                                      || fail "new task marker='$NEW_TASK_MARKER', want waiting"
+[[ "$NEW_TASK_ACTION" == "ready_to_brainstorm" ]] && ok "new task action=ready_to_brainstorm" \
+                                                  || fail "new task action='$NEW_TASK_ACTION', want ready_to_brainstorm"
 
 # ─── 4. daemon install --json envelope ───────────────────────────────
 
@@ -223,14 +281,31 @@ TASK_COUNT="$(jq -r '[.projects[].tasks[]] | length' "$STATUS_JSON")"
 # often lack systemd-user, and even where it's available, starting a
 # real daemon inside this script is out of scope).
 
-# Feature-detect the `daemon install` subcommand. Pre-PR-#113
-# releases listed only start/stop/status/reload/tail/enable/disable.
-# When the pinned release predates the feature, gracefully skip the
-# envelope block instead of falsely failing the verification — the
-# script's job is to verify the artifact's own behavior, not to
-# require features the artifact doesn't ship.
-DAEMON_SUBS="$("$XDG_BIN_HOME/hive" help daemon 2>&1 || true)"
-if grep -qE "^[[:space:]]*install\b" <<<"$DAEMON_SUBS"; then
+# Feature-detect the `daemon install` subcommand by listing the
+# binary's VALID_SUBCOMMANDS via the unknown-subcommand error path.
+# Calling `hive daemon <impossible-token>` triggers Thor's reflection
+# and prints "expected: start, stop, status, reload, tail, ..." which
+# we grep for the literal token "install". This is more robust than:
+#   - `hive daemon install --help` (Thor falls back to parent help
+#     with rc=0 when the subcommand doesn't exist, masking the gap)
+#   - `hive help daemon` (Thor reflows long_desc into wrapped prose
+#     where "install" can appear mid-line)
+# Pre-PR-#113 releases list start/stop/status/reload/tail/enable/disable
+# only. Releases that ship the subcommand list "install" in the
+# "expected:" enumeration. Gracefully skip the envelope block when
+# the artifact doesn't ship the feature — the script's job is to
+# verify the artifact's own behavior, not to require features it
+# doesn't ship.
+DAEMON_PROBE_ERR="$PREFIX/daemon-probe.err"
+set +e
+"$XDG_BIN_HOME/hive" daemon __verify_release_probe_nonexistent_subcommand__ \
+  >/dev/null 2>"$DAEMON_PROBE_ERR"
+set -e
+DAEMON_INSTALL_AVAILABLE=0
+if grep -qE 'expected:[^)]*\binstall\b' "$DAEMON_PROBE_ERR" 2>/dev/null; then
+  DAEMON_INSTALL_AVAILABLE=1
+fi
+if [[ "$DAEMON_INSTALL_AVAILABLE" -eq 1 ]]; then
   step "daemon install --json (dry verification of envelope shape)"
   DAEMON_INSTALL_JSON="$PREFIX/daemon-install.json"
 
@@ -329,20 +404,27 @@ fi
 # real ~/.config/systemd/user/.
 
 step "leak detection: nothing written outside the tmp prefix"
-REAL_HOME="$(getent passwd "$(id -un)" | cut -d: -f6 2>/dev/null || echo "${HOME_BEFORE:-/dev/null}")"
+# Anchor on HOME_BEFORE (captured at script start, before HOME was
+# overwritten). Drops the getent dependency that didn't work on
+# macOS. The scan list includes the systemd unit + macOS plist
+# paths explicitly — those are the regression class the comment
+# above calls out, and they live OUTSIDE the XDG dirs.
 LEAKS=()
 for path in \
-  "$REAL_HOME/.config/hive" \
-  "$REAL_HOME/.local/state/hive" \
-  "$REAL_HOME/.local/share/hive" \
-  "$REAL_HOME/.cache/hive"
+  "$HOME_BEFORE/.config/hive" \
+  "$HOME_BEFORE/.local/state/hive" \
+  "$HOME_BEFORE/.local/share/hive" \
+  "$HOME_BEFORE/.cache/hive" \
+  "$HOME_BEFORE/.config/systemd/user/hive-daemon.service" \
+  "$HOME_BEFORE/Library/LaunchAgents/local.hive-daemon.plist"
 do
-  # Only flag if the path exists AND its mtime is within the last 5
-  # minutes (matching this script's runtime). Pre-existing dirs from
-  # the user's normal hive install are not leaks; only fresh writes
-  # by this script are.
+  # Flag if the path exists AND has any descendant newer than the
+  # sentinel file ($START_MARKER) created at script start. Using a
+  # sentinel anchor avoids the trap where `find -newer "$PREFIX"`
+  # silently fails to flag early leaks because $PREFIX's own mtime
+  # advances as the script writes child files into it.
   if [[ -e "$path" ]]; then
-    if find "$path" -newer "$PREFIX" -print -quit 2>/dev/null | grep -q .; then
+    if find "$path" -newer "$START_MARKER" -print -quit 2>/dev/null | grep -q .; then
       LEAKS+=("$path")
     fi
   fi

--- a/packaging/verify-release.sh
+++ b/packaging/verify-release.sh
@@ -32,28 +32,60 @@
 
 set -euo pipefail
 
+usage() {
+  cat <<'HELP'
+verify-release.sh — end-to-end verification of a published hive release.
+
+USAGE:
+  packaging/verify-release.sh [--version=vX.Y.Z] [--prefix=/path]
+                              [--keep-prefix] [--no-uninstall]
+                              [--report=json]
+
+DEFAULTS:
+  --version       v0.1.0 (override to verify a different release)
+  --prefix        mktemp -d hive-verify-XXXXXX (deleted on success
+                  unless --keep-prefix; failures always preserve it)
+
+FLAGS:
+  --keep-prefix   keep the tmp prefix after success (debugging)
+  --no-uninstall  skip the uninstall step (poke at installed state)
+  --report=json   emit a hive-verify-release.v1 JSON envelope on
+                  stdout at end-of-run; human prose redirected to
+                  stderr. Without this flag, output is human-only.
+
+EXIT CODES:
+  0   all verifications passed
+  1   a verification step failed (script preserves the tmp prefix)
+  2   bad arguments
+  3   prerequisite missing (curl, ruby, jq, git)
+HELP
+}
+
 # ─── argument parsing ────────────────────────────────────────────────
 
 HIVE_VERSION=""
 PREFIX=""
 KEEP_PREFIX=0
 RUN_UNINSTALL=1
+REPORT_FORMAT="text"
 
-# Argument dialect matches install.sh: --flag=value only. Drops the
-# space-separated form so two release-ceremony scripts share one
-# parser convention.
+# Argument dialect matches install.sh: --flag=value only.
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --version=*) HIVE_VERSION="${1#*=}"; shift ;;
-    --prefix=*)  PREFIX="${1#*=}"; shift ;;
-    --keep-prefix) KEEP_PREFIX=1; shift ;;
+    --version=*)    HIVE_VERSION="${1#*=}"; shift ;;
+    --prefix=*)     PREFIX="${1#*=}"; shift ;;
+    --keep-prefix)  KEEP_PREFIX=1; shift ;;
     --no-uninstall) RUN_UNINSTALL=0; shift ;;
-    -h|--help)
-      sed -n '3,29p' "$0"
-      exit 0 ;;
+    --report=*)     REPORT_FORMAT="${1#*=}"; shift ;;
+    -h|--help)      usage; exit 0 ;;
     *) echo "verify-release: unknown argument: $1 (try --help)" >&2; exit 2 ;;
   esac
 done
+
+case "$REPORT_FORMAT" in
+  text|json) ;;
+  *) echo "verify-release: invalid --report value: $REPORT_FORMAT (want: text|json)" >&2; exit 2 ;;
+esac
 
 if [[ -z "$HIVE_VERSION" ]]; then
   HIVE_VERSION="v0.1.0"
@@ -128,18 +160,53 @@ PASS_COUNT=0
 FAIL_COUNT=0
 STEP=0
 
-# ANSI colors only when stdout is a TTY and NO_COLOR is unset (per
-# no-color.org). CI typically captures stdout non-interactively;
-# emitting raw escape codes there pollutes log parsers.
-if [[ -t 1 ]] && [[ -z "${NO_COLOR:-}" ]]; then
+# Output routing: --report=json puts every human line on stderr
+# (FD 2) and reserves stdout (FD 1) for the single JSON envelope
+# emitted at end-of-run. Default (--report=text) puts log/ok on
+# stdout and fail on stderr, like a normal CLI tool. FD 3 is the
+# "human prose" sink — log/ok write to it; fail keeps writing to
+# stderr regardless so failure markers always reach the operator.
+if [[ "$REPORT_FORMAT" == "json" ]]; then
+  exec 3>&2
+else
+  exec 3>&1
+fi
+
+# ANSI colors only when the prose sink is a TTY and NO_COLOR is unset
+# (per no-color.org). CI typically captures non-interactively so
+# emitting raw escape codes pollutes log parsers.
+if { [[ "$REPORT_FORMAT" == "text" ]] && [[ -t 1 ]]; } \
+   || { [[ "$REPORT_FORMAT" == "json" ]] && [[ -t 2 ]]; } \
+   && [[ -z "${NO_COLOR:-}" ]]; then
   C_INFO=$'\033[1;36m'; C_OK=$'\033[1;32m'; C_FAIL=$'\033[1;31m'; C_RESET=$'\033[0m'
 else
   C_INFO=""; C_OK=""; C_FAIL=""; C_RESET=""
 fi
 
-log() { printf '%s[verify]%s %s\n' "$C_INFO" "$C_RESET" "$*"; }
-ok()  { printf '%s  ✓%s %s\n' "$C_OK" "$C_RESET" "$*"; PASS_COUNT=$((PASS_COUNT + 1)); }
+log() { printf '%s[verify]%s %s\n' "$C_INFO" "$C_RESET" "$*" >&3; }
+ok()  { printf '%s  ✓%s %s\n' "$C_OK" "$C_RESET" "$*" >&3; PASS_COUNT=$((PASS_COUNT + 1)); }
 fail() { printf '%s  ✗%s %s\n' "$C_FAIL" "$C_RESET" "$*" >&2; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+
+# Per-step pass/fail bookkeeping for the JSON envelope. Each call to
+# `step` finalises the prior step's record using the delta in
+# PASS_COUNT/FAIL_COUNT, then snapshots the counters for the new
+# step. STEP_RECORDS is an array of JSON-line strings.
+STEP_RECORDS=()
+CURRENT_STEP_NAME=""
+LAST_PASS_SNAPSHOT=0
+LAST_FAIL_SNAPSHOT=0
+
+finalize_current_step() {
+  if [[ -n "$CURRENT_STEP_NAME" ]]; then
+    local p=$((PASS_COUNT - LAST_PASS_SNAPSHOT))
+    local f=$((FAIL_COUNT - LAST_FAIL_SNAPSHOT))
+    STEP_RECORDS+=("$(jq -cn \
+      --arg name "$CURRENT_STEP_NAME" \
+      --argjson passed "$p" \
+      --argjson failed "$f" \
+      '{name: $name, passed: $passed, failed: $failed}')")
+  fi
+}
 
 cleanup() {
   local exit_code=$?
@@ -158,7 +225,40 @@ cleanup() {
 }
 trap cleanup EXIT
 
-step() { STEP=$((STEP + 1)); log "step ${STEP}: $*"; }
+step() {
+  finalize_current_step
+  STEP=$((STEP + 1))
+  CURRENT_STEP_NAME="$*"
+  LAST_PASS_SNAPSHOT=$PASS_COUNT
+  LAST_FAIL_SNAPSHOT=$FAIL_COUNT
+  log "step ${STEP}: $*"
+}
+
+# Emit the hive-verify-release.v1 envelope on stdout. Single JSON
+# document; per-step records carry pass/fail counts. Shape pinned so
+# automation can branch on .ok and inspect .steps[] without parsing
+# the human prose stream on stderr.
+emit_json_envelope() {
+  finalize_current_step
+  local steps_json
+  steps_json="[$(IFS=,; printf '%s' "${STEP_RECORDS[*]-}")]"
+  jq -cn \
+    --arg version "$HIVE_VERSION" \
+    --arg prefix "$PREFIX" \
+    --argjson passed "$PASS_COUNT" \
+    --argjson failed "$FAIL_COUNT" \
+    --argjson steps "$steps_json" \
+    '{
+      schema: "hive-verify-release",
+      schema_version: 1,
+      ok: ($failed == 0),
+      version: $version,
+      prefix: $prefix,
+      passed: $passed,
+      failed: $failed,
+      steps: $steps
+    }'
+}
 
 # ─── 1. install ──────────────────────────────────────────────────────
 
@@ -339,27 +439,70 @@ if [[ "$DAEMON_INSTALL_AVAILABLE" -eq 1 ]]; then
     *)  fail "daemon install exited unexpectedly rc=$INSTALL_RC" ;;
   esac
 
-  # If install reported success (rc=0), exercise --force on the existing
-  # unit and assert the .bak rotation contract.
-  if [[ "$INSTALL_RC" -eq 0 ]]; then
-    step "daemon install --force --json (verify .bak rotation)"
+  # Force-upgrade test runs UNCONDITIONALLY by planting a known
+  # canary unit at the target path. The atomic-write contract
+  # (write + rotate-to-timestamped-.bak) runs BEFORE the systemctl
+  # restart inside install_linux! / install_macos!, so even on CI
+  # hosts where the restart call fails (no user systemd session),
+  # the .bak file MUST be on disk with the canary content and the
+  # main unit file MUST contain the new template. Previously this
+  # block was gated on `INSTALL_RC -eq 0` (first install succeeded),
+  # which is structurally false on ubuntu-24.04 runners → the .bak
+  # rotation contract had zero CI coverage.
+  UNIT_PATH=""
+  case "$(uname -s)" in
+    Linux)  UNIT_PATH="$HOME/.config/systemd/user/hive-daemon.service" ;;
+    Darwin) UNIT_PATH="$HOME/Library/LaunchAgents/local.hive-daemon.plist" ;;
+  esac
+  if [[ -n "$UNIT_PATH" ]]; then
+    step "daemon install --force --json (verify .bak rotation, unconditional)"
+    CANARY='# verify-release canary — drifted user-customised unit content'
+    mkdir -p "$(dirname "$UNIT_PATH")"
+    printf '%s\n' "$CANARY" > "$UNIT_PATH"
+
     set +e
     "$XDG_BIN_HOME/hive" daemon install --force --json \
       >"$PREFIX/daemon-install-force.json" 2>"$PREFIX/daemon-install-force.err"
     FORCE_RC=$?
     set -e
     FORCE_OUTCOME="$(jq -r '.outcome // empty' "$PREFIX/daemon-install-force.json" 2>/dev/null || true)"
-    if [[ "$FORCE_RC" -eq 0 ]] && [[ "$FORCE_OUTCOME" == "upgraded" || "$FORCE_OUTCOME" == "unchanged" ]]; then
-      ok "daemon install --force outcome=$FORCE_OUTCOME"
-      if [[ "$FORCE_OUTCOME" == "upgraded" ]]; then
-        BACKUPS="$(find "$HOME/.config/systemd/user" -maxdepth 1 -name 'hive-daemon.service.bak-*' 2>/dev/null | wc -l)"
-        [[ "$BACKUPS" -ge 1 ]] && ok "timestamped .bak present after --force" \
-                               || fail "force-upgrade reported but no .bak-<timestamp> file written"
+
+    # Atomic-write contract: regardless of whether the service-manager
+    # call (systemctl restart / launchctl load) ultimately succeeded,
+    # the unit file was rewritten BEFORE that call and the previous
+    # content was rotated to a timestamped .bak.
+    BACKUPS=( "$UNIT_PATH".bak-* )
+    if [[ -e "${BACKUPS[0]}" ]]; then
+      ok "timestamped .bak written before service-manager call (count=${#BACKUPS[@]})"
+      # Pin: the .bak must contain the canary content we planted.
+      if grep -qxF "$CANARY" "${BACKUPS[0]}" 2>/dev/null; then
+        ok "backup preserves prior unit content verbatim"
+      else
+        fail "backup at ${BACKUPS[0]} does not contain the canary content"
       fi
     else
-      cat "$PREFIX/daemon-install-force.json" "$PREFIX/daemon-install-force.err" >&2
-      fail "daemon install --force unexpected outcome (rc=$FORCE_RC, outcome=$FORCE_OUTCOME)"
+      fail "no .bak-<timestamp> file written despite --force against drifted unit"
     fi
+
+    # New content must have landed on disk regardless of outcome
+    # (atomic write happens before the systemctl/launchctl call).
+    if ! grep -qxF "$CANARY" "$UNIT_PATH" 2>/dev/null; then
+      ok "main unit file rewritten with new template (canary content gone)"
+    else
+      fail "main unit at $UNIT_PATH still contains the canary content"
+    fi
+
+    # The outcome enum is contextual: outcome=upgraded means
+    # service-manager succeeded too; outcome=failed means the write
+    # happened but the restart didn't. Both are acceptable here —
+    # we already validated the disk-level contract above. Reject only
+    # truly bad shapes.
+    case "$FORCE_OUTCOME" in
+      upgraded) ok "force outcome=upgraded (write + service-manager both succeeded)" ;;
+      failed)   ok "force outcome=failed (write succeeded; service-manager rejected, expected on CI without user systemd)" ;;
+      *) cat "$PREFIX/daemon-install-force.json" "$PREFIX/daemon-install-force.err" >&2
+         fail "force outcome='$FORCE_OUTCOME' (rc=$FORCE_RC) — want upgraded or failed" ;;
+    esac
   fi
 else
   log "step: daemon install — SKIPPED (pinned release predates the subcommand)"
@@ -440,6 +583,9 @@ fi
 # ─── summary ─────────────────────────────────────────────────────────
 
 log "summary: $PASS_COUNT passed, $FAIL_COUNT failed"
+if [[ "$REPORT_FORMAT" == "json" ]]; then
+  emit_json_envelope
+fi
 if [[ $FAIL_COUNT -gt 0 ]]; then
   log "logs preserved at: $PREFIX"
   exit 1

--- a/packaging/verify-release.sh
+++ b/packaging/verify-release.sh
@@ -282,18 +282,26 @@ case "$INSTALL_RC" in
        exit 1 ;;
 esac
 
-[[ -x "$XDG_BIN_HOME/hive" ]] && ok "binary at \$XDG_BIN_HOME/hive is executable" \
-                              || fail "binary missing or not executable at $XDG_BIN_HOME/hive"
+if [[ -x "$XDG_BIN_HOME/hive" ]]; then
+  ok "binary at \$XDG_BIN_HOME/hive is executable"
+else
+  fail "binary missing or not executable at $XDG_BIN_HOME/hive"
+fi
 
 INSTALLED_VERSION="$("$XDG_BIN_HOME/hive" --version 2>/dev/null || true)"
-[[ -n "$INSTALLED_VERSION" ]] && ok "hive --version: $INSTALLED_VERSION" \
-                              || fail "hive --version returned empty / failed"
+if [[ -n "$INSTALLED_VERSION" ]]; then
+  ok "hive --version: $INSTALLED_VERSION"
+else
+  fail "hive --version returned empty / failed"
+fi
 
 # install.sh writes an install-channel sidecar so `hive update` knows
 # how the binary was installed. Pin its presence.
-[[ -s "$XDG_DATA_HOME/hive/install-channel" ]] \
-  && ok "install-channel sidecar exists" \
-  || fail "install-channel sidecar missing at $XDG_DATA_HOME/hive/install-channel"
+if [[ -s "$XDG_DATA_HOME/hive/install-channel" ]]; then
+  ok "install-channel sidecar exists"
+else
+  fail "install-channel sidecar missing at $XDG_DATA_HOME/hive/install-channel"
+fi
 
 # ─── 2. doctor ───────────────────────────────────────────────────────
 
@@ -336,21 +344,29 @@ else
   fail "hive init failed"
 fi
 
-[[ -d "$PROJECT/.hive-state/stages/1-inbox" ]] \
-  && ok ".hive-state/stages/1-inbox/ created" \
-  || fail ".hive-state/stages/1-inbox/ missing after init"
+if [[ -d "$PROJECT/.hive-state/stages/1-inbox" ]]; then
+  ok ".hive-state/stages/1-inbox/ created"
+else
+  fail ".hive-state/stages/1-inbox/ missing after init"
+fi
 
 step "new task + status --json"
 PROJECT_NAME="$(basename "$PROJECT")"
-"$XDG_BIN_HOME/hive" new "$PROJECT_NAME" "verify release smoke task" \
-  >"$PREFIX/new.log" 2>&1 \
-  && ok "hive new exited 0" \
-  || { cat "$PREFIX/new.log" >&2; fail "hive new failed"; }
+if "$XDG_BIN_HOME/hive" new "$PROJECT_NAME" "verify release smoke task" \
+     >"$PREFIX/new.log" 2>&1; then
+  ok "hive new exited 0"
+else
+  cat "$PREFIX/new.log" >&2 2>/dev/null || true
+  fail "hive new failed"
+fi
 
 STATUS_JSON="$PREFIX/status.json"
-"$XDG_BIN_HOME/hive" status --json >"$STATUS_JSON" 2>"$PREFIX/status.err" \
-  && ok "hive status --json exited 0" \
-  || { cat "$PREFIX/status.err" >&2 2>/dev/null || true; fail "hive status --json failed"; }
+if "$XDG_BIN_HOME/hive" status --json >"$STATUS_JSON" 2>"$PREFIX/status.err"; then
+  ok "hive status --json exited 0"
+else
+  cat "$PREFIX/status.err" >&2 2>/dev/null || true
+  fail "hive status --json failed"
+fi
 
 # Validate envelope shape: schema name, then probe the new task's
 # stage/marker/action so a regression that creates the row in the
@@ -364,16 +380,20 @@ NEW_TASK_STAGE="$(jq -r '[.projects[].tasks[]][0].stage // empty' "$STATUS_JSON"
 NEW_TASK_MARKER="$(jq -r '[.projects[].tasks[]][0].marker // empty' "$STATUS_JSON" 2>/dev/null || true)"
 NEW_TASK_ACTION="$(jq -r '[.projects[].tasks[]][0].action // empty' "$STATUS_JSON" 2>/dev/null || true)"
 
-[[ "$SCHEMA" == "hive-status" ]] && ok "status envelope schema=hive-status" \
-                                 || fail "status envelope schema is '$SCHEMA', want hive-status"
-[[ "${TASK_COUNT:-0}" -ge 1 ]] && ok "status envelope reports >=1 task" \
-                               || fail "status envelope reports 0 tasks after 'hive new'"
-[[ "$NEW_TASK_STAGE" == "1-inbox" ]] && ok "new task at stage=1-inbox" \
-                                     || fail "new task at stage='$NEW_TASK_STAGE', want 1-inbox"
-[[ "$NEW_TASK_MARKER" == "waiting" ]] && ok "new task marker=waiting" \
-                                      || fail "new task marker='$NEW_TASK_MARKER', want waiting"
-[[ "$NEW_TASK_ACTION" == "ready_to_brainstorm" ]] && ok "new task action=ready_to_brainstorm" \
-                                                  || fail "new task action='$NEW_TASK_ACTION', want ready_to_brainstorm"
+if [[ "$SCHEMA" == "hive-status" ]]; then ok "status envelope schema=hive-status"
+else fail "status envelope schema is '$SCHEMA', want hive-status"; fi
+
+if [[ "${TASK_COUNT:-0}" -ge 1 ]]; then ok "status envelope reports >=1 task"
+else fail "status envelope reports 0 tasks after 'hive new'"; fi
+
+if [[ "$NEW_TASK_STAGE" == "1-inbox" ]]; then ok "new task at stage=1-inbox"
+else fail "new task at stage='$NEW_TASK_STAGE', want 1-inbox"; fi
+
+if [[ "$NEW_TASK_MARKER" == "waiting" ]]; then ok "new task marker=waiting"
+else fail "new task marker='$NEW_TASK_MARKER', want waiting"; fi
+
+if [[ "$NEW_TASK_ACTION" == "ready_to_brainstorm" ]]; then ok "new task action=ready_to_brainstorm"
+else fail "new task action='$NEW_TASK_ACTION', want ready_to_brainstorm"; fi
 
 # ─── 4. daemon install --json envelope ───────────────────────────────
 
@@ -428,14 +448,27 @@ if [[ "$DAEMON_INSTALL_AVAILABLE" -eq 1 ]]; then
   fi
 
   case "$INSTALL_RC" in
-    0)  [[ "$DAEMON_OK" == "true" ]] && ok "daemon install success: outcome=$DAEMON_OUTCOME (rc=0)" \
-                                      || fail "rc=0 but ok=$DAEMON_OK" ;;
-    64) [[ "$DAEMON_OK" == "false" ]] && [[ "$DAEMON_OUTCOME" == "drifted" ]] \
-          && ok "daemon install drift (rc=64, outcome=drifted) — retryable with --force" \
-          || fail "rc=64 but envelope shape unexpected (ok=$DAEMON_OK, outcome=$DAEMON_OUTCOME)" ;;
-    70) [[ "$DAEMON_OK" == "false" ]] && [[ "$DAEMON_OUTCOME" == "failed" ]] \
-          && ok "daemon install failure (rc=70, outcome=failed) — expected without systemd-user" \
-          || fail "rc=70 but envelope shape unexpected (ok=$DAEMON_OK, outcome=$DAEMON_OUTCOME)" ;;
+    0)
+      if [[ "$DAEMON_OK" == "true" ]]; then
+        ok "daemon install success: outcome=$DAEMON_OUTCOME (rc=0)"
+      else
+        fail "rc=0 but ok=$DAEMON_OK"
+      fi
+      ;;
+    64)
+      if [[ "$DAEMON_OK" == "false" ]] && [[ "$DAEMON_OUTCOME" == "drifted" ]]; then
+        ok "daemon install drift (rc=64, outcome=drifted) — retryable with --force"
+      else
+        fail "rc=64 but envelope shape unexpected (ok=$DAEMON_OK, outcome=$DAEMON_OUTCOME)"
+      fi
+      ;;
+    70)
+      if [[ "$DAEMON_OK" == "false" ]] && [[ "$DAEMON_OUTCOME" == "failed" ]]; then
+        ok "daemon install failure (rc=70, outcome=failed) — expected without systemd-user"
+      else
+        fail "rc=70 but envelope shape unexpected (ok=$DAEMON_OK, outcome=$DAEMON_OUTCOME)"
+      fi
+      ;;
     *)  fail "daemon install exited unexpectedly rc=$INSTALL_RC" ;;
   esac
 
@@ -512,23 +545,43 @@ fi
 
 if [[ $RUN_UNINSTALL -eq 1 ]]; then
   step "hive uninstall"
+  # Snapshot daemon-unit state before uninstall so the post-condition
+  # check below knows whether removal was a meaningful assertion at
+  # all. On CI runners without user systemd, uninstall.rb correctly
+  # bails out of the systemctl --user disable path and leaves the
+  # unit file in place — the operator is expected to clean up
+  # manually in that case. We mirror that contract here: only assert
+  # "removed" when uninstall could actually remove it.
+  UNIT_SYSTEMD="$HOME/.config/systemd/user/hive-daemon.service"
+  UNIT_LAUNCHD="$HOME/Library/LaunchAgents/local.hive-daemon.plist"
+  UNIT_PRESENT_BEFORE=0
+  [[ -f "$UNIT_SYSTEMD" ]] && UNIT_PRESENT_BEFORE=1
+  [[ -f "$UNIT_LAUNCHD" ]] && UNIT_PRESENT_BEFORE=1
+
   # `hive uninstall` is interactive (prompts before purging state).
   # Pipe empty stdin so it takes the default (no purge) path.
   if echo "" | "$XDG_BIN_HOME/hive" uninstall >"$PREFIX/uninstall.log" 2>&1; then
     ok "uninstall exited 0"
   else
-    cat "$PREFIX/uninstall.log" >&2
+    cat "$PREFIX/uninstall.log" >&2 2>/dev/null || true
     fail "uninstall failed"
   fi
 
   # Per uninstall.rb, it removes the daemon unit and user config/cache
-  # but leaves project .hive-state/ in place by default. Verify the
-  # daemon unit is gone from the sandboxed HOME.
-  if [[ ! -f "$HOME/.config/systemd/user/hive-daemon.service" ]] \
-       && [[ ! -f "$HOME/Library/LaunchAgents/local.hive-daemon.plist" ]]; then
+  # but leaves project .hive-state/ in place by default. The unit
+  # removal is contingent on the service manager being reachable
+  # (`systemctl --user disable --now hive-daemon` on Linux,
+  # `launchctl unload` on macOS) — uninstall bails out with a
+  # warning if the call fails. Match that behavior in the assertion.
+  if [[ "$UNIT_PRESENT_BEFORE" -eq 0 ]]; then
+    ok "daemon unit removal: not applicable (no unit was installed)"
+  elif [[ ! -f "$UNIT_SYSTEMD" ]] && [[ ! -f "$UNIT_LAUNCHD" ]]; then
     ok "daemon unit removed from sandboxed HOME"
+  elif grep -qE "systemctl --user disable failed|launchctl unload failed" \
+         "$PREFIX/uninstall.log" 2>/dev/null; then
+    ok "daemon unit removal skipped (service manager unreachable, expected on CI without user systemd; uninstall.log warned correctly)"
   else
-    fail "uninstall left a daemon unit behind"
+    fail "uninstall left a daemon unit behind without warning"
   fi
 fi
 

--- a/packaging/verify-release.sh
+++ b/packaging/verify-release.sh
@@ -1,0 +1,365 @@
+#!/usr/bin/env bash
+#
+# verify-release.sh — end-to-end verification that a published hive
+# release artifact installs cleanly, exposes the expected command
+# surface, walks a task through one stage transition, and uninstalls
+# without leaking state outside its tmp prefix.
+#
+# Complements .github/workflows/install-smoke.yml. The CI smoke verifies
+# install SHAPE (binary lands, sidecar files written, `hive --version`
+# works). This script verifies BEHAVIOR — that the installed binary
+# actually runs `init` / `status` / `daemon install` / `uninstall` and
+# produces the right JSON envelopes against the published schemas.
+#
+# Usage:
+#   packaging/verify-release.sh [--version=vX.Y.Z] [--prefix=/path]
+#                               [--keep-prefix] [--no-uninstall]
+#
+# Defaults:
+#   --version    : whatever bin/hive --version reports if run in-repo,
+#                  else v0.1.0
+#   --prefix     : mktemp -d hive-verify-XXXXXX (deleted on success
+#                  unless --keep-prefix)
+#   --keep-prefix: keep the tmp prefix after success (useful when
+#                  debugging; failures always preserve it)
+#   --no-uninstall: skip the uninstall step (useful when you want to
+#                  poke at the installed state after the test runs)
+#
+# Exit codes:
+#   0   all verifications passed
+#   1   a verification step failed (script preserves the tmp prefix)
+#   2   bad arguments
+#   3   prerequisite missing (curl, gh, ruby, jq)
+
+set -euo pipefail
+
+# ─── argument parsing ────────────────────────────────────────────────
+
+HIVE_VERSION=""
+PREFIX=""
+KEEP_PREFIX=0
+RUN_UNINSTALL=1
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version=*) HIVE_VERSION="${1#*=}"; shift ;;
+    --version)   HIVE_VERSION="$2"; shift 2 ;;
+    --prefix=*)  PREFIX="${1#*=}"; shift ;;
+    --prefix)    PREFIX="$2"; shift 2 ;;
+    --keep-prefix) KEEP_PREFIX=1; shift ;;
+    --no-uninstall) RUN_UNINSTALL=0; shift ;;
+    -h|--help)
+      sed -n '3,29p' "$0"
+      exit 0 ;;
+    *) echo "verify-release: unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$HIVE_VERSION" ]]; then
+  HIVE_VERSION="v0.1.0"
+fi
+
+# Anchor on the repo's own install.sh, not whatever the user has on
+# PATH. Resolve relative to this script's location so the script can
+# be run from anywhere.
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+INSTALL_SH="$REPO_ROOT/install.sh"
+[[ -f "$INSTALL_SH" ]] || { echo "verify-release: install.sh not found at $INSTALL_SH" >&2; exit 3; }
+
+# ─── prerequisites ───────────────────────────────────────────────────
+
+for cmd in curl ruby jq; do
+  command -v "$cmd" >/dev/null 2>&1 || {
+    echo "verify-release: missing prerequisite: $cmd" >&2
+    exit 3
+  }
+done
+
+# ─── prefix setup ────────────────────────────────────────────────────
+
+if [[ -z "$PREFIX" ]]; then
+  PREFIX="$(mktemp -d -t hive-verify-XXXXXX)"
+  CREATED_PREFIX=1
+else
+  CREATED_PREFIX=0
+  mkdir -p "$PREFIX"
+fi
+
+# Everything hive writes (config, cache, state, bin, data, daemon
+# unit) is scoped inside $PREFIX via XDG and HIVE_HOME. `install.sh`
+# honors XDG_BIN_HOME / XDG_DATA_HOME / XDG_CONFIG_HOME / XDG_STATE_HOME
+# / XDG_CACHE_HOME. We DO NOT mock HOME — install.sh writes the
+# systemd unit to ~/.config/systemd/user/, and that path is not XDG-
+# overridable. To keep this side-effect inside the prefix on Linux,
+# we run with `HOME=$PREFIX/home` so systemctl --user reads its config
+# from there.
+export XDG_BIN_HOME="$PREFIX/bin"
+export XDG_DATA_HOME="$PREFIX/data"
+export XDG_CONFIG_HOME="$PREFIX/config"
+export XDG_STATE_HOME="$PREFIX/state"
+export XDG_CACHE_HOME="$PREFIX/cache"
+export HIVE_HOME="$PREFIX/hive-home"
+export HOME="$PREFIX/home"
+mkdir -p "$XDG_BIN_HOME" "$XDG_DATA_HOME" "$XDG_CONFIG_HOME" \
+         "$XDG_STATE_HOME" "$XDG_CACHE_HOME" "$HIVE_HOME" "$HOME"
+
+# Put the installed binary first on PATH so subsequent `hive` calls
+# resolve to the just-installed artifact, not a host install.
+export PATH="$XDG_BIN_HOME:$PATH"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+STEP=0
+
+log() { printf '\033[1;36m[verify]\033[0m %s\n' "$*"; }
+ok()  { printf '\033[1;32m  ✓\033[0m %s\n' "$*"; PASS_COUNT=$((PASS_COUNT + 1)); }
+fail() { printf '\033[1;31m  ✗\033[0m %s\n' "$*" >&2; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+
+cleanup() {
+  local exit_code=$?
+  if [[ $exit_code -ne 0 ]] || [[ $FAIL_COUNT -gt 0 ]]; then
+    log "preserving tmp prefix for inspection: $PREFIX"
+    return
+  fi
+  if [[ $KEEP_PREFIX -eq 1 ]]; then
+    log "keeping tmp prefix per --keep-prefix: $PREFIX"
+    return
+  fi
+  if [[ $CREATED_PREFIX -eq 1 ]]; then
+    log "tearing down tmp prefix: $PREFIX"
+    rm -rf "$PREFIX"
+  fi
+}
+trap cleanup EXIT
+
+step() { STEP=$((STEP + 1)); log "step ${STEP}: $*"; }
+
+# ─── 1. install ──────────────────────────────────────────────────────
+
+step "install hive ${HIVE_VERSION} into ${PREFIX}"
+if bash "$INSTALL_SH" --version="$HIVE_VERSION" >"$PREFIX/install.log" 2>&1; then
+  ok "install.sh exited 0"
+else
+  cat "$PREFIX/install.log" >&2
+  fail "install.sh failed"
+  exit 1
+fi
+
+[[ -x "$XDG_BIN_HOME/hive" ]] && ok "binary at \$XDG_BIN_HOME/hive is executable" \
+                              || fail "binary missing or not executable at $XDG_BIN_HOME/hive"
+
+INSTALLED_VERSION="$("$XDG_BIN_HOME/hive" --version 2>/dev/null || true)"
+[[ -n "$INSTALLED_VERSION" ]] && ok "hive --version: $INSTALLED_VERSION" \
+                              || fail "hive --version returned empty / failed"
+
+# install.sh writes an install-channel sidecar so `hive update` knows
+# how the binary was installed. Pin its presence.
+[[ -s "$XDG_DATA_HOME/hive/install-channel" ]] \
+  && ok "install-channel sidecar exists" \
+  || fail "install-channel sidecar missing at $XDG_DATA_HOME/hive/install-channel"
+
+# ─── 2. doctor ───────────────────────────────────────────────────────
+
+step "hive doctor"
+if "$XDG_BIN_HOME/hive" doctor >"$PREFIX/doctor.log" 2>&1; then
+  ok "doctor exited 0"
+else
+  # doctor exits non-zero when prereqs are missing. That's expected in
+  # a sandboxed CI env (no gh login, no claude binary). Just verify it
+  # ran without crashing and produced human-readable output.
+  if grep -qE "(claude|gh|git)" "$PREFIX/doctor.log"; then
+    ok "doctor reported missing prerequisites (expected in sandbox)"
+  else
+    cat "$PREFIX/doctor.log" >&2
+    fail "doctor crashed without producing the expected report"
+  fi
+fi
+
+# ─── 3. scratch project: init + new + status ─────────────────────────
+
+step "init scratch project"
+PROJECT="$PREFIX/scratch-project"
+mkdir -p "$PROJECT"
+( cd "$PROJECT" \
+    && git init -q -b main \
+    && git config user.email "verify@example.invalid" \
+    && git config user.name  "Verify" \
+    && git commit -q --allow-empty -m "init" )
+
+if "$XDG_BIN_HOME/hive" init "$PROJECT" >"$PREFIX/init.log" 2>&1; then
+  ok "hive init exited 0"
+else
+  cat "$PREFIX/init.log" >&2
+  fail "hive init failed"
+fi
+
+[[ -d "$PROJECT/.hive-state/stages/1-inbox" ]] \
+  && ok ".hive-state/stages/1-inbox/ created" \
+  || fail ".hive-state/stages/1-inbox/ missing after init"
+
+step "new task + status --json"
+PROJECT_NAME="$(basename "$PROJECT")"
+"$XDG_BIN_HOME/hive" new "$PROJECT_NAME" "verify release smoke task" \
+  >"$PREFIX/new.log" 2>&1 \
+  && ok "hive new exited 0" \
+  || { cat "$PREFIX/new.log" >&2; fail "hive new failed"; }
+
+STATUS_JSON="$PREFIX/status.json"
+"$XDG_BIN_HOME/hive" status --json >"$STATUS_JSON" 2>"$PREFIX/status.err" \
+  && ok "hive status --json exited 0" \
+  || { cat "$PREFIX/status.err" >&2; fail "hive status --json failed"; }
+
+# Validate envelope basics: schema name + version + at least one task.
+SCHEMA="$(jq -r '.schema // empty' "$STATUS_JSON")"
+TASK_COUNT="$(jq -r '[.projects[].tasks[]] | length' "$STATUS_JSON")"
+[[ "$SCHEMA" == "hive-status" ]] && ok "status envelope schema=hive-status" \
+                                 || fail "status envelope schema is $SCHEMA, want hive-status"
+[[ "${TASK_COUNT:-0}" -ge 1 ]] && ok "status envelope reports ≥1 task" \
+                               || fail "status envelope reports 0 tasks after `hive new`"
+
+# ─── 4. daemon install --json envelope ───────────────────────────────
+
+# Only validate the envelope; don't start a real daemon (CI runners
+# often lack systemd-user, and even where it's available, starting a
+# real daemon inside this script is out of scope).
+
+# Feature-detect the `daemon install` subcommand. Pre-PR-#113
+# releases listed only start/stop/status/reload/tail/enable/disable.
+# When the pinned release predates the feature, gracefully skip the
+# envelope block instead of falsely failing the verification — the
+# script's job is to verify the artifact's own behavior, not to
+# require features the artifact doesn't ship.
+DAEMON_SUBS="$("$XDG_BIN_HOME/hive" help daemon 2>&1 || true)"
+if grep -qE "^[[:space:]]*install\b" <<<"$DAEMON_SUBS"; then
+  step "daemon install --json (dry verification of envelope shape)"
+  DAEMON_INSTALL_JSON="$PREFIX/daemon-install.json"
+
+  # First call: fresh install. May exit 0 (success) or 70 (systemctl
+  # unavailable). Either way, the envelope must validate.
+  set +e
+  "$XDG_BIN_HOME/hive" daemon install --json >"$DAEMON_INSTALL_JSON" 2>"$PREFIX/daemon-install.err"
+  INSTALL_RC=$?
+  set -e
+
+  DAEMON_SCHEMA="$(jq -r '.schema // empty' "$DAEMON_INSTALL_JSON" 2>/dev/null || true)"
+  DAEMON_OK="$(jq -r '.ok // empty' "$DAEMON_INSTALL_JSON" 2>/dev/null || true)"
+  DAEMON_OUTCOME="$(jq -r '.outcome // empty' "$DAEMON_INSTALL_JSON" 2>/dev/null || true)"
+
+  if [[ "$DAEMON_SCHEMA" == "hive-daemon-install" ]]; then
+    ok "daemon install envelope schema=hive-daemon-install"
+  else
+    cat "$DAEMON_INSTALL_JSON" "$PREFIX/daemon-install.err" >&2
+    fail "daemon install envelope schema is '$DAEMON_SCHEMA', want hive-daemon-install"
+  fi
+
+  case "$INSTALL_RC" in
+    0)  [[ "$DAEMON_OK" == "true" ]] && ok "daemon install success: outcome=$DAEMON_OUTCOME (rc=0)" \
+                                      || fail "rc=0 but ok=$DAEMON_OK" ;;
+    64) [[ "$DAEMON_OK" == "false" ]] && [[ "$DAEMON_OUTCOME" == "drifted" ]] \
+          && ok "daemon install drift (rc=64, outcome=drifted) — retryable with --force" \
+          || fail "rc=64 but envelope shape unexpected (ok=$DAEMON_OK, outcome=$DAEMON_OUTCOME)" ;;
+    70) [[ "$DAEMON_OK" == "false" ]] && [[ "$DAEMON_OUTCOME" == "failed" ]] \
+          && ok "daemon install failure (rc=70, outcome=failed) — expected without systemd-user" \
+          || fail "rc=70 but envelope shape unexpected (ok=$DAEMON_OK, outcome=$DAEMON_OUTCOME)" ;;
+    *)  fail "daemon install exited unexpectedly rc=$INSTALL_RC" ;;
+  esac
+
+  # If install reported success (rc=0), exercise --force on the existing
+  # unit and assert the .bak rotation contract.
+  if [[ "$INSTALL_RC" -eq 0 ]]; then
+    step "daemon install --force --json (verify .bak rotation)"
+    set +e
+    "$XDG_BIN_HOME/hive" daemon install --force --json \
+      >"$PREFIX/daemon-install-force.json" 2>"$PREFIX/daemon-install-force.err"
+    FORCE_RC=$?
+    set -e
+    FORCE_OUTCOME="$(jq -r '.outcome // empty' "$PREFIX/daemon-install-force.json" 2>/dev/null || true)"
+    if [[ "$FORCE_RC" -eq 0 ]] && [[ "$FORCE_OUTCOME" == "upgraded" || "$FORCE_OUTCOME" == "unchanged" ]]; then
+      ok "daemon install --force outcome=$FORCE_OUTCOME"
+      if [[ "$FORCE_OUTCOME" == "upgraded" ]]; then
+        BACKUPS="$(find "$HOME/.config/systemd/user" -maxdepth 1 -name 'hive-daemon.service.bak-*' 2>/dev/null | wc -l)"
+        [[ "$BACKUPS" -ge 1 ]] && ok "timestamped .bak present after --force" \
+                               || fail "force-upgrade reported but no .bak-<timestamp> file written"
+      fi
+    else
+      cat "$PREFIX/daemon-install-force.json" "$PREFIX/daemon-install-force.err" >&2
+      fail "daemon install --force unexpected outcome (rc=$FORCE_RC, outcome=$FORCE_OUTCOME)"
+    fi
+  fi
+else
+  log "step: daemon install — SKIPPED (pinned release predates the subcommand)"
+fi
+
+# ─── 5. uninstall ────────────────────────────────────────────────────
+
+if [[ $RUN_UNINSTALL -eq 1 ]]; then
+  step "hive uninstall"
+  # `hive uninstall` is interactive (prompts before purging state).
+  # Pipe empty stdin so it takes the default (no purge) path.
+  if echo "" | "$XDG_BIN_HOME/hive" uninstall >"$PREFIX/uninstall.log" 2>&1; then
+    ok "uninstall exited 0"
+  else
+    cat "$PREFIX/uninstall.log" >&2
+    fail "uninstall failed"
+  fi
+
+  # Per uninstall.rb, it removes the daemon unit and user config/cache
+  # but leaves project .hive-state/ in place by default. Verify the
+  # daemon unit is gone from the sandboxed HOME.
+  if [[ ! -f "$HOME/.config/systemd/user/hive-daemon.service" ]] \
+       && [[ ! -f "$HOME/Library/LaunchAgents/local.hive-daemon.plist" ]]; then
+    ok "daemon unit removed from sandboxed HOME"
+  else
+    fail "uninstall left a daemon unit behind"
+  fi
+fi
+
+# ─── 6. leak detection ───────────────────────────────────────────────
+
+# Verify that nothing the install/test sequence wrote leaked outside
+# the prefix. We anchor on the real (un-mocked) user's HOME — but
+# since this script always sets HOME=$PREFIX/home, the script's own
+# process should not have written to the real $HOME at all. Detect
+# any post-script state under the real user's HIVE_HOME / XDG paths
+# that wasn't there before.
+#
+# This catches: a code path that bypasses XDG/HIVE_HOME indirection
+# and reads/writes Dir.home directly. Specifically guards against
+# regressions like the daemon unit accidentally landing under the
+# real ~/.config/systemd/user/.
+
+step "leak detection: nothing written outside the tmp prefix"
+REAL_HOME="$(getent passwd "$(id -un)" | cut -d: -f6 2>/dev/null || echo "${HOME_BEFORE:-/dev/null}")"
+LEAKS=()
+for path in \
+  "$REAL_HOME/.config/hive" \
+  "$REAL_HOME/.local/state/hive" \
+  "$REAL_HOME/.local/share/hive" \
+  "$REAL_HOME/.cache/hive"
+do
+  # Only flag if the path exists AND its mtime is within the last 5
+  # minutes (matching this script's runtime). Pre-existing dirs from
+  # the user's normal hive install are not leaks; only fresh writes
+  # by this script are.
+  if [[ -e "$path" ]]; then
+    if find "$path" -newer "$PREFIX" -print -quit 2>/dev/null | grep -q .; then
+      LEAKS+=("$path")
+    fi
+  fi
+done
+if [[ ${#LEAKS[@]} -eq 0 ]]; then
+  ok "no leaks outside $PREFIX"
+else
+  for leak in "${LEAKS[@]}"; do
+    fail "leaked write at $leak (within last script runtime)"
+  done
+fi
+
+# ─── summary ─────────────────────────────────────────────────────────
+
+log "summary: $PASS_COUNT passed, $FAIL_COUNT failed"
+if [[ $FAIL_COUNT -gt 0 ]]; then
+  log "logs preserved at: $PREFIX"
+  exit 1
+fi
+log "release ${HIVE_VERSION} verified ✓"

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1739,3 +1739,19 @@ dispatch while preserving first-sight brainstorm baseline behavior.
 - `wiki/commands/daemon.md` — added `install [--force]` to the subcommands table.
 - `wiki/modules/daemon.md` — corrected the load-bearing "daemon never writes markers" claim; documented the healer's narrow carve-out (heals, never advances) and the new log events.
 - `wiki/modules/task_action.md` — updated the `:agent_working` carve-out to cover the new stale-classification branch and the synthetic diagnostic.
+
+## [2026-05-22T13:30:00Z] release — packaging/verify-release.sh end-to-end behavior check
+
+**Action:** Added `packaging/verify-release.sh` and a matching `verify-release` job in `install-smoke.yml`. The existing install-smoke jobs verify install SHAPE (binary lands, sidecar files written, `hive --version` works). The new script verifies BEHAVIOR — that the installed release artifact actually runs `init` / `status --json` / `daemon install --json` / `uninstall` and produces the right JSON envelopes (PR #118).
+
+Key contracts:
+
+- Isolates everything inside an XDG/HIVE_HOME/HOME tmp prefix. Captures `HOME_BEFORE` BEFORE overwriting `HOME` so the leak detector can scan the real user's home on macOS too (getent doesn't exist there).
+- Sentinel file (`$PREFIX/.start-marker`) anchors `find -newer` for leak detection so the reference timestamp doesn't drift forward as the script writes child files into $PREFIX.
+- Feature-detects post-`v0.1.0` subcommands (`daemon install`) by listing `VALID_SUBCOMMANDS` via the unknown-subcommand error path — robust against Thor's wrapped long_desc.
+- Force-upgrade test plants a canary unit and asserts the `.bak-<timestamp>` rotation regardless of whether the service-manager call succeeded (the atomic write happens BEFORE systemctl/launchctl is invoked), so the .bak contract has CI coverage even on hosts without user systemd.
+- `--report=json` flag emits a `hive-verify-release.v1` envelope on stdout (`{ok, version, prefix, passed, failed, steps[]}`) with human prose redirected to stderr, for programmatic consumption.
+- Doctor crash discrimination keys off doctor's signature report header (`stage / agent / skill / status`), not arbitrary log content — tolerates rc=1/65/70 while still catching genuine Ruby uncaught-exception crashes.
+
+**Refreshed pages:**
+- `wiki/operating.md` — added a Release Verification section documenting the script's usage, exit codes, and JSON envelope.

--- a/wiki/operating.md
+++ b/wiki/operating.md
@@ -103,6 +103,45 @@ still succeeds without it:
 | Codex | `codex plugin install ivankuznetsov/hive-skills` |
 | Pi | `pi install ivankuznetsov/hive-skills` |
 
+## Release verification
+
+The release ceremony exercises the published artifact end-to-end via
+[`packaging/verify-release.sh`](../packaging/verify-release.sh). The
+script installs a published release into an isolated XDG/HIVE_HOME/HOME
+tmp prefix, walks the command surface (`hive --version`, `hive doctor`,
+`hive init`, `hive new`, `hive status --json`, `hive daemon install
+[--force] --json`, `hive uninstall`), validates JSON envelopes against
+the published schemas, and asserts no state leaks outside the prefix.
+
+Local usage:
+
+```bash
+packaging/verify-release.sh --version=v0.1.0
+packaging/verify-release.sh --version=v0.1.0 --report=json | jq .ok
+```
+
+Exit codes:
+
+- `0` — all verifications passed; tmp prefix removed
+- `1` — a verification step failed; tmp prefix preserved at the
+  path printed in the trailing `[verify] logs preserved at` line
+- `2` — bad arguments
+- `3` — prerequisite missing (`curl`, `ruby`, `jq`, `git`)
+
+`--report=json` emits a single `hive-verify-release.v1` envelope on
+stdout (with human prose redirected to stderr) for programmatic
+consumption: `{schema, schema_version, ok, version, prefix, passed,
+failed, steps[]}` where each step is `{name, passed, failed}`.
+
+In CI, the `verify-release` job in
+[`.github/workflows/install-smoke.yml`](../.github/workflows/install-smoke.yml)
+runs this script against the pinned `HIVE_VERSION` whenever the
+matching GitHub Release exists. The script feature-detects
+post-pin subcommands (e.g., `daemon install` shipped in PR #113) and
+gracefully skips assertions the released binary doesn't support — so
+the script keeps providing value during the gap between when a feature
+lands on main and when the next release tag is cut.
+
 ## Prerequisites
 
 Once per workstation:


### PR DESCRIPTION
## Summary

Adds `packaging/verify-release.sh` and a matching `verify-release` CI job in `install-smoke.yml`. Together they verify the actual command surface of a published release artifact end-to-end:

- install.sh against the pinned release into an isolated XDG/HIVE_HOME/HOME tmp prefix
- `hive --version`, `hive doctor`
- `hive init` on a scratch git repo
- `hive new` + `hive status --json` round-trip + envelope schema check
- `hive daemon install [--force] --json` envelope + exit-code/outcome pairing (feature-detected: skipped when the pin predates the subcommand)
- `hive uninstall` (no-purge), assert daemon unit removed from sandboxed HOME
- leak detection: scan the real user's XDG/HIVE_HOME paths for writes within script runtime — catches regressions that bypass XDG indirection

## Why this matters

Existing install-smoke jobs verify install SHAPE — binary lands, sidecar files written, `hive --version` works. They don't exercise behavior: a release where `hive init` or `hive status --json` regresses would still pass. This script fills that gap with a single end-to-end walk.

## Design notes

- Same release gate as `full-smoke`: only runs when the pinned `HIVE_VERSION` tag actually exists. PRs that predate the pinned release see the job skip.
- Feature-detected: post-`v0.1.0` subcommands (e.g., `daemon install` from PR #113) are skipped when the released binary doesn't have them yet. Once the pin advances to a release that includes them, the assertions kick in automatically.
- HOME is sandboxed too (not just XDG) so the systemd unit `hive daemon install` writes lands inside the prefix, not in the real `~/.config/systemd/user/`.
- Local dry-run against v0.1.0: 14 passed, 0 failed, tmp prefix torn down clean.

## Test plan

- [x] `bash -n packaging/verify-release.sh` — syntax clean
- [x] Local dry-run against v0.1.0 (14/14 pass, daemon block correctly skipped)
- [ ] CI green on this PR
- [ ] When the next release lands (post-PR #113), the daemon-install assertions activate automatically — verify by bumping the pinned `HIVE_VERSION` in the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)