### PR TITLE
fix(daemon): inject Ruby version-manager shim into unit PATH

### DIFF
--- a/examples/systemd/hive-daemon.service
+++ b/examples/systemd/hive-daemon.service
@@ -51,13 +51,24 @@ StartLimitIntervalSec=300
 
 [Service]
 Type=simple
-# `hive daemon` shells out to `hive status --json` once per tick. systemd
-# user services do NOT inherit your interactive shell's PATH, so we set
-# HIVE_BIN to an absolute path (consumed by lib/hive/daemon/status_consumer.rb)
-# and a minimal PATH for any other shell-outs the daemon performs (git, etc.).
-# `hive init` and `hive daemon install` rewrite HIVE_BIN= to the same absolute
-# path used in ExecStart=. If you copy this template verbatim, the default
-# %h/.local/bin/hive is the option-A install location.
+# `hive daemon` shells out to `hive status --json` once per tick.
+# systemd user services do NOT inherit your interactive shell's
+# PATH, so:
+#   1. HIVE_BIN — absolute path to the binary; the daemon reads
+#      this directly (lib/hive/daemon/status_consumer.rb) instead
+#      of resolving "hive" via PATH.
+#   2. PATH — covers (a) any incidental shell-outs the daemon
+#      performs (git, etc.) and (b) the gem's bin/hive wrapper
+#      whose `#!/usr/bin/env ruby` shebang needs to find a Ruby
+#      with the gem's dependencies. `hive daemon install` detects
+#      mise/rbenv/asdf and prepends the matching shim directory
+#      automatically; otherwise the minimal PATH below covers
+#      system-Ruby installs.
+# `hive init` and `hive daemon install` rewrite HIVE_BIN= and
+# Environment=PATH= to match the resolved binary + Ruby manager
+# detected on the host. If you copy this template verbatim, the
+# default %h/.local/bin/hive is the option-A install location and
+# system Ruby is assumed.
 Environment=HIVE_BIN=%h/.local/bin/hive
 Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin
 ExecStart=%h/.local/bin/hive daemon start

--- a/lib/hive/commands/daemon/service_installer.rb
+++ b/lib/hive/commands/daemon/service_installer.rb
@@ -184,6 +184,19 @@ module Hive
           end
         end
 
+        # Per-manager root → shim dir. The keys are checked against
+        # the realpath of the active `ruby` interpreter; the matching
+        # value is the shim directory injected into the unit's
+        # `Environment=PATH=`. All paths use `%h` so systemd expands
+        # them per-user at runtime. chruby and RVM are absent because
+        # they don't use a shim directory — they modify PATH per
+        # shell, which the unit's static Environment= can't replicate.
+        RUBY_SHIM_MANAGERS = {
+          ".local/share/mise" => "%h/.local/share/mise/shims",
+          ".rbenv" => "%h/.rbenv/shims",
+          ".asdf" => "%h/.asdf/shims"
+        }.freeze
+
         def render_systemd
           template = File.read(File.expand_path("../../../../examples/systemd/hive-daemon.service", __dir__))
           # systemd .service files are POSIX-shell-ish — escape the
@@ -193,6 +206,41 @@ module Hive
           template
             .sub(/^ExecStart=.*$/, "ExecStart=#{escaped} daemon start")
             .sub(/^Environment=HIVE_BIN=.*$/, "Environment=HIVE_BIN=#{escaped}")
+            .sub(/^Environment=PATH=.*$/, build_path_line)
+        end
+
+        # The unit's Environment=PATH= must let `#!/usr/bin/env ruby`
+        # in the gem's bin/hive wrapper resolve to a Ruby that has
+        # the gem's dependencies installed. On stock Linux that's
+        # /usr/bin/ruby + the system gem store, which works. On
+        # workstations using mise / rbenv / asdf to manage Ruby
+        # versions, the system Ruby has none of the project's gems
+        # and the daemon crashes with `cannot load such file -- thor
+        # (LoadError)` the first time it tries to start.
+        #
+        # Detect the active `ruby` interpreter's path and, if it
+        # lives under a known version manager's installs directory,
+        # prepend the matching shim directory to the baked PATH so
+        # `env ruby` picks up the right interpreter when the daemon
+        # forks. If no manager is detected, the minimal PATH
+        # (sufficient for system-Ruby installs) is preserved.
+        def build_path_line
+          base = %w[%h/.local/bin /usr/local/bin /usr/bin /bin]
+          shim = ruby_shim_dir
+          base.insert(1, shim) if shim
+          "Environment=PATH=#{base.join(':')}"
+        end
+
+        def ruby_shim_dir
+          ruby_path = which("ruby")
+          return nil unless ruby_path
+
+          resolved = File.exist?(ruby_path) ? File.realpath(ruby_path) : ruby_path
+          RUBY_SHIM_MANAGERS.each do |root_segment, shim_template|
+            mgr_root = File.join(@home, root_segment)
+            return shim_template if resolved.start_with?("#{mgr_root}/")
+          end
+          nil
         end
 
         def render_launchd

--- a/test/unit/commands/daemon/service_installer_test.rb
+++ b/test/unit/commands/daemon/service_installer_test.rb
@@ -224,6 +224,100 @@ class DaemonServiceInstallerTest < Minitest::Test
     end
   end
 
+  # ── Ruby version-manager shim detection (PR #113 follow-up) ────────────
+  # The gem's bin/hive uses `#!/usr/bin/env ruby`. The unit's baked
+  # PATH must include the active Ruby manager's shim dir so the
+  # shebang resolves to a Ruby with the gem's dependencies, not
+  # system Ruby (which on a mise/rbenv/asdf workstation has none of
+  # them and crashes with `cannot load such file -- thor (LoadError)`).
+
+  # Build an installer that fakes `which("ruby")` to point at a
+  # path under one of the manager directories, mimicking what the
+  # operator's interactive shell would resolve.
+  def installer_with_ruby_at(dir, ruby_relative)
+    hive = File.join(dir, "bin", "hive")
+    FileUtils.mkdir_p(File.dirname(hive))
+    File.write(hive, "#!/bin/sh\n")
+    FileUtils.chmod(0755, hive)
+    ruby_path = File.join(dir, ruby_relative)
+    FileUtils.mkdir_p(File.dirname(ruby_path))
+    File.write(ruby_path, "#!/bin/sh\n")
+    FileUtils.chmod(0755, ruby_path)
+    installer = Hive::Commands::Daemon::ServiceInstaller.new(
+      host_os: "linux", home: dir, binary_path: hive, systemctl_available: false
+    )
+    installer.define_singleton_method(:which) do |name|
+      name == "ruby" ? ruby_path : nil
+    end
+    installer
+  end
+
+  def assert_unit_path_includes(dir, shim_template, msg)
+    unit_body = File.read(File.join(dir, ".config/systemd/user/hive-daemon.service"))
+    path_line = unit_body.lines.find { |l| l.start_with?("Environment=PATH=") }
+    refute_nil path_line, "no Environment=PATH= line"
+    assert_includes path_line, shim_template, msg
+  end
+
+  def test_path_includes_mise_shims_when_ruby_resolves_under_mise
+    with_tmp_dir do |dir|
+      installer = installer_with_ruby_at(dir, ".local/share/mise/installs/ruby/3.4.7/bin/ruby")
+      installer.install!(autostart: false)
+      assert_unit_path_includes(dir, "%h/.local/share/mise/shims",
+        "mise-managed Ruby must inject %h/.local/share/mise/shims into PATH or the daemon's `env ruby` falls through to system Ruby which lacks gem deps")
+    end
+  end
+
+  def test_path_includes_rbenv_shims_when_ruby_resolves_under_rbenv
+    with_tmp_dir do |dir|
+      installer = installer_with_ruby_at(dir, ".rbenv/versions/3.4.7/bin/ruby")
+      installer.install!(autostart: false)
+      assert_unit_path_includes(dir, "%h/.rbenv/shims",
+        "rbenv-managed Ruby must inject %h/.rbenv/shims into PATH")
+    end
+  end
+
+  def test_path_includes_asdf_shims_when_ruby_resolves_under_asdf
+    with_tmp_dir do |dir|
+      installer = installer_with_ruby_at(dir, ".asdf/installs/ruby/3.4.7/bin/ruby")
+      installer.install!(autostart: false)
+      assert_unit_path_includes(dir, "%h/.asdf/shims",
+        "asdf-managed Ruby must inject %h/.asdf/shims into PATH")
+    end
+  end
+
+  def test_path_stays_minimal_when_ruby_is_system_install
+    with_tmp_dir do |dir|
+      installer = installer_with_ruby_at(dir, "usr/bin/ruby")
+      installer.install!(autostart: false)
+      unit_body = File.read(File.join(dir, ".config/systemd/user/hive-daemon.service"))
+      path_line = unit_body.lines.find { |l| l.start_with?("Environment=PATH=") }.strip
+      assert_equal "Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin", path_line,
+        "system Ruby installs use the minimal PATH; no manager shim should be injected"
+    end
+  end
+
+  def test_path_stays_minimal_when_ruby_not_on_path
+    # The which("ruby") probe returning nil mirrors a host that
+    # doesn't have ruby on PATH at install time. The installer
+    # should emit the minimal PATH and let the operator deal with
+    # the missing prereq via `hive doctor`.
+    with_tmp_dir do |dir|
+      hive = File.join(dir, "bin", "hive")
+      FileUtils.mkdir_p(File.dirname(hive))
+      File.write(hive, "#!/bin/sh\n")
+      FileUtils.chmod(0755, hive)
+      installer = Hive::Commands::Daemon::ServiceInstaller.new(
+        host_os: "linux", home: dir, binary_path: hive, systemctl_available: false
+      )
+      installer.define_singleton_method(:which) { |_| nil }
+      installer.install!(autostart: false)
+      unit_body = File.read(File.join(dir, ".config/systemd/user/hive-daemon.service"))
+      path_line = unit_body.lines.find { |l| l.start_with?("Environment=PATH=") }.strip
+      assert_equal "Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin", path_line
+    end
+  end
+
   def test_linux_hive_bin_matches_exec_start_for_realpath_binary
     with_tmp_dir do |dir|
       real_hive = File.join(dir, "bin", "hive")

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1755,3 +1755,16 @@ Key contracts:
 
 **Refreshed pages:**
 - `wiki/operating.md` — added a Release Verification section documenting the script's usage, exit codes, and JSON envelope.
+
+## [2026-05-22T14:30:00Z] daemon — auto-detect Ruby manager shim in unit's PATH
+
+**Action:** Fixed a release-blocking daemon failure on workstations running mise / rbenv / asdf to manage Ruby. PR #113 baked `Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin` into the unit, which is sufficient for system-Ruby hosts but causes `bin/hive`'s `#!/usr/bin/env ruby` shebang to resolve to `/usr/bin/ruby` — which has none of the gem's dependencies on a version-manager-driven workstation. The daemon then crashes on every restart with `cannot load such file -- thor (LoadError)` and systemd hits `StartLimitBurst=3 / Result=start-limit-hit`.
+
+`ServiceInstaller#render_systemd` now detects the active Ruby interpreter via `which("ruby")`, walks the realpath against a known-manager set (mise's `~/.local/share/mise`, rbenv's `~/.rbenv`, asdf's `~/.asdf`), and prepends the matching `*/shims` directory to the unit's `Environment=PATH=` so `env ruby` resolves to the manager's shim → the right version with the right gemset. System-Ruby and "no ruby on PATH" cases fall through to the existing minimal PATH unchanged.
+
+chruby and RVM are intentionally not handled — they modify PATH per-shell and don't expose a stable shim directory the unit can hard-code at install time.
+
+**Why CI didn't catch it:** install-smoke's `full-smoke` job runs `hive --version` directly (not through systemd) using `ruby/setup-ruby@v1` which puts Ruby on PATH. `verify-release.sh` from PR #118 validates the install envelope but doesn't actually start the daemon and let it run a tick. Both pass against a release that crashes on the user's actual workstation. Worth a follow-up: integration coverage that exercises the daemon start path against multiple Ruby-manager fixtures.
+
+**Refreshed pages:**
+- `examples/systemd/hive-daemon.service` — extended the inline comment to explain why both `HIVE_BIN=` and `Environment=PATH=` are installer-managed (the PATH now carries Ruby-manager shim discovery on top of the minimal shell-out coverage).


### PR DESCRIPTION
## Summary

PR #113 baked `Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin` into the systemd unit so the daemon could find `hive`. Sufficient for system-Ruby hosts. On mise / rbenv / asdf workstations, the gem's `bin/hive` uses `#!/usr/bin/env ruby` → that PATH makes `env ruby` resolve to `/usr/bin/ruby`, which has none of the gem's dependencies → daemon crashes every restart with `cannot load such file -- thor (LoadError)` → systemd hits `StartLimitBurst=3` → unit goes `failed`.

`ServiceInstaller#render_systemd` now detects the active Ruby interpreter (`which("ruby")` + realpath walk against known-manager roots) and prepends the matching `*/shims` directory to the baked `Environment=PATH=`. System-Ruby and "no ruby on PATH" cases fall through to the existing minimal PATH unchanged — backward compatible.

Detected managers:

| Manager | Detection (installs path) | Injected shim path |
|---|---|---|
| mise | `~/.local/share/mise/...` | `%h/.local/share/mise/shims` |
| rbenv | `~/.rbenv/...` | `%h/.rbenv/shims` |
| asdf | `~/.asdf/...` | `%h/.asdf/shims` |

chruby and RVM are intentionally out of scope — they modify PATH per-shell and don't expose a stable shim directory the unit can hard-code.

## Why CI didn't catch this

- `install-smoke full-smoke` runs `hive --version` directly (not through systemd) using `ruby/setup-ruby@v1`. The test process has Ruby on PATH; the unit's environ is never exercised.
- `verify-release.sh` (PR #118) validates the install envelope but doesn't actually start the daemon. The LoadError fires only when systemd forks the daemon process.

Worth a follow-up: integration coverage that actually starts the daemon against a fixture install and asserts it ticks cleanly. Out of scope here.

## Test plan

- [x] `bundle exec rake test`: 22 tests pass (5 new), 0 failures, 0 errors
- [x] Rubocop clean on touched files
- [x] Verified locally: my own workstation (mise-managed Ruby 3.4.7) was wedged in exactly this failure mode before this fix; manually patching the unit with `%h/.local/share/mise/shims` got the daemon ticking. The installer change automates that patch.
- [ ] CI green

## Test coverage

| Scenario | Asserts |
|---|---|
| `which("ruby")` returns `~/.local/share/mise/installs/ruby/3.4.7/bin/ruby` | Unit PATH includes `%h/.local/share/mise/shims` |
| `which("ruby")` returns `~/.rbenv/versions/3.4.7/bin/ruby` | Unit PATH includes `%h/.rbenv/shims` |
| `which("ruby")` returns `~/.asdf/installs/ruby/3.4.7/bin/ruby` | Unit PATH includes `%h/.asdf/shims` |
| `which("ruby")` returns `/usr/bin/ruby` | Unit PATH is the minimal default unchanged |
| `which("ruby")` returns nil | Unit PATH is the minimal default unchanged |

## Recovery for users hit by this in production

Users running PR #113's installer on a Ruby-managed workstation can upgrade with:

```bash
hive daemon install --force
```

The new template detects their Ruby manager and bakes the right shim path. The old unit moves to `<path>.bak-<timestamp>` per the existing rotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)