### PR TITLE
feat(llm-wiki): bootstrap subsystem for per-project managed wiki context

### DIFF
--- a/lib/hive/cli.rb
+++ b/lib/hive/cli.rb
@@ -30,7 +30,9 @@ module Hive
       Initialises hive in PROJECT_PATH (defaults to the current directory):
       creates the orphan `hive/state` branch, attaches it as a worktree at
       `<project>/.hive-state/`, scaffolds stage folders, ignores
-      `.hive-state/` on master, and registers the project globally.
+      `.hive-state/` on master, bootstraps managed llm-wiki project
+      context with Codex as the headless wiki refresher, and registers
+      the project globally.
 
       On a TTY, init asks the operator five questions before writing
       anything to disk:

--- a/lib/hive/commands/doctor.rb
+++ b/lib/hive/commands/doctor.rb
@@ -163,7 +163,8 @@ module Hive
 
       def check_stage(stage)
         agent_name = (@config.dig(stage, "agent") || "claude").to_s
-        skill = @config.dig(stage, "skill") || Hive::Config::DEFAULTS.dig(stage, "skill")
+        configured_skill = @config.dig(stage, "skill")
+        skill = Hive::Config.stage_skill(@config, stage)
         profile = Hive::AgentProfiles.lookup(agent_name.to_sym)
         invocation = profile.format_skill_invocation(skill)
 
@@ -173,7 +174,7 @@ module Hive
           stage: stage,
           label: stage,
           agent: agent_name,
-          configured_skill: skill.to_s,
+          configured_skill: (configured_skill || skill).to_s,
           skill: invocation,
           status: status.to_s,
           message: message

--- a/lib/hive/commands/init.rb
+++ b/lib/hive/commands/init.rb
@@ -3,6 +3,7 @@ require "fileutils"
 require "stringio"
 require "hive/config"
 require "hive/git_ops"
+require "hive/llm_wiki_bootstrap"
 require "hive/commands/init/prompts"
 require "hive/commands/doctor"
 require "hive/commands/daemon/service_installer"
@@ -42,6 +43,9 @@ module Hive
         ops.hive_state_init
         write_per_project_config(ops, answers: answers)
         ops.add_hive_state_to_master_gitignore!
+        Hive::LlmWikiBootstrap.install!(@project_path, post_commit_hook: false, scheduler: false)
+        ops.commit_llm_wiki_bootstrap!
+        Hive::LlmWikiBootstrap.install_runtime_hooks!(@project_path)
 
         entry = Hive::Config.register_project(name: File.basename(@project_path), path: @project_path)
 

--- a/lib/hive/config.rb
+++ b/lib/hive/config.rb
@@ -50,15 +50,11 @@ module Hive
       # DEFAULTS itself, to avoid silently flipping the implementer for old
       # projects on next load.
       # The `skill` field per stage names the slash-command the agent
-      # is told to invoke inside its prompt. Hive ships expecting both
-      # llm-wiki (`/plan`) and compound-engineering (`/compound-
-      # engineering:ce-*`) to be installed alongside the agent CLI:
-      # - `plan` defaults to `/plan` (llm-wiki's wiki-research-first
-      #   wrapper that delegates into the CE planning workflow).
-      # - `brainstorm` defaults to `/compound-engineering:ce-brainstorm`
-      #   (no llm-wiki equivalent today; flip this here if one lands).
-      # Per-project overrides via `<stage>.skill` in config.yml pick a
-      # different skill without touching templates/.
+      # is told to invoke inside its prompt. Per-project overrides via
+      # `<stage>.skill` in config.yml pick a different skill without
+      # touching templates/. When the field is absent, stage runners use
+      # `stage_skill` below so agent-specific defaults can follow each
+      # CLI's installed skill names.
       "brainstorm" => {
         "agent" => "claude",
         "skill" => "/compound-engineering:ce-brainstorm",
@@ -66,7 +62,12 @@ module Hive
       },
       "plan" => {
         "agent" => "claude",
-        "skill" => "/plan"
+        "skill_by_agent" => {
+          "claude" => "/plan",
+          "codex" => "/llm-wiki:wiki-plan",
+          "pi" => "/llm-wiki:wiki-plan",
+          "default" => "/llm-wiki:wiki-plan"
+        }
       },
       "execute" => { "agent" => "claude" },
       "open_pr" => { "agent" => "claude" },
@@ -212,6 +213,12 @@ module Hive
       %w[review browser_test agent]
     ].freeze
 
+    # `/plan` was Hive's original wiki-first planning alias. It remains the
+    # Claude default because Claude supports user-level slash commands. Codex
+    # and Pi receive llm-wiki's canonical skill name unless a project chooses
+    # a non-legacy override.
+    LEGACY_WIKI_PLAN_ALIAS = "/plan"
+
     module_function
 
     def hive_home
@@ -240,6 +247,32 @@ module Hive
       merged = merge_defaults(data).merge("project_root" => project_root)
       validate!(merged, candidate)
       merged
+    end
+
+    def stage_skill(cfg, stage)
+      stage_cfg = cfg.fetch(stage, {})
+      agent_name = (stage_cfg["agent"] || DEFAULTS.dig(stage, "agent") || "claude").to_s
+      configured_skill = stage_cfg["skill"]
+
+      return configured_skill if configured_skill && !legacy_wiki_plan_alias_for_non_claude?(stage, agent_name, configured_skill)
+
+      skills_by_agent = {}
+      default_skills_by_agent = DEFAULTS.dig(stage, "skill_by_agent")
+      skills_by_agent.merge!(default_skills_by_agent) if default_skills_by_agent.is_a?(Hash)
+      configured_skills_by_agent = stage_cfg["skill_by_agent"]
+      skills_by_agent.merge!(configured_skills_by_agent) if configured_skills_by_agent.is_a?(Hash)
+
+      if !skills_by_agent.empty?
+        skills_by_agent[agent_name] || skills_by_agent["default"] || configured_skill
+      else
+        configured_skill || DEFAULTS.dig(stage, "skill")
+      end
+    end
+
+    def legacy_wiki_plan_alias_for_non_claude?(stage, agent_name, skill)
+      stage == "plan" &&
+        agent_name != "claude" &&
+        skill.to_s == LEGACY_WIKI_PLAN_ALIAS
     end
 
     # Surface a misconfigured HIVE_HOME loudly on READ paths only.
@@ -562,6 +595,7 @@ module Hive
     # ever fails validation.
     def validate!(cfg, source_path)
       validate_hash_shaped_keys!(cfg, source_path)
+      validate_stage_skill_by_agent!(cfg, source_path)
       validate_reviewers!(cfg, source_path)
       validate_role_agent_names!(cfg, source_path)
       validate_brainstorm_runtime!(cfg, source_path)
@@ -602,6 +636,27 @@ module Hive
               "#{key} in #{describe_source(source_path)} must be a Hash; " \
               "got #{value.inspect} (#{value.class}). Either remove the key " \
               "(defaults will apply) or supply `#{key}: { ... }` with the right shape."
+      end
+    end
+
+    def validate_stage_skill_by_agent!(cfg, source_path)
+      %w[brainstorm plan].each do |stage|
+        value = cfg.dig(stage, "skill_by_agent")
+        next if value.nil?
+
+        unless value.is_a?(Hash)
+          raise ConfigError,
+                "#{stage}.skill_by_agent in #{describe_source(source_path)} must be a Hash; " \
+                "got #{value.inspect} (#{value.class})"
+        end
+
+        value.each do |agent, skill|
+          unless skill.is_a?(String) || skill.is_a?(Symbol)
+            raise ConfigError,
+                  "#{stage}.skill_by_agent.#{agent} in #{describe_source(source_path)} must be a String; " \
+                  "got #{skill.inspect} (#{skill.class})"
+          end
+        end
       end
     end
 

--- a/lib/hive/git_ops.rb
+++ b/lib/hive/git_ops.rb
@@ -132,6 +132,33 @@ module Hive
       :added
     end
 
+    def commit_llm_wiki_bootstrap!
+      paths = %w[
+        .llm-wiki/config.json
+        .llm-wiki/refresh-wiki.sh
+        .llm-wiki/post-commit-refresh.sh
+        .claude/settings.json
+        AGENTS.md
+        CLAUDE.md
+        wiki/index.md
+        wiki/log.md
+        wiki/gaps.md
+        wiki/architecture.md
+        wiki/decisions.md
+        wiki/dependencies.md
+        raw/notes/.gitkeep
+      ]
+      existing = paths.select { |path| File.exist?(File.join(@project_root, path)) }
+      return :nothing_to_commit if existing.empty?
+
+      run_git!("-C", @project_root, "add", "--", *existing)
+      _, _, status = Open3.capture3("git", "-C", @project_root, "diff", "--cached", "--quiet")
+      return :nothing_to_commit if status.success?
+
+      run_git!("-C", @project_root, "commit", "-m", "chore: initialize llm-wiki")
+      :committed
+    end
+
     # Scoped add: only stage files under stages/<stage_name>/<slug>/ and the
     # logs/ directory so a crashed prior run's leftover staging cannot cross-
     # contaminate this commit's message.

--- a/lib/hive/llm_wiki_bootstrap.rb
+++ b/lib/hive/llm_wiki_bootstrap.rb
@@ -1,0 +1,142 @@
+require "fileutils"
+require "json"
+
+require "hive/llm_wiki_bootstrap/context"
+require "hive/llm_wiki_bootstrap/pages"
+require "hive/llm_wiki_bootstrap/scheduler"
+require "hive/llm_wiki_bootstrap/scripts"
+
+module Hive
+  module LlmWikiBootstrap
+    HEADLESS_AGENT = "codex".freeze
+    CONTEXT_AGENTS = %w[claude codex pi].freeze
+
+    MANAGED_BEGIN = "<!-- BEGIN LLM WIKI -->".freeze
+    MANAGED_END = "<!-- END LLM WIKI -->".freeze
+    POST_COMMIT_BEGIN = "# BEGIN LLM WIKI POST-COMMIT".freeze
+    POST_COMMIT_END = "# END LLM WIKI POST-COMMIT".freeze
+    SESSION_HOOK_MARKER = "LLM WIKI SESSION START".freeze
+
+    module_function
+
+    def install!(project_root, post_commit_hook: true, scheduler: true)
+      project_root = File.expand_path(project_root)
+      FileUtils.mkdir_p(File.join(project_root, ".llm-wiki"))
+
+      ensure_config(project_root)
+      ensure_project_wiki(project_root)
+      Context.install(project_root)
+      ensure_refresh_scripts(project_root)
+      ensure_post_commit_hook(project_root) if post_commit_hook
+      Scheduler.install(project_root) if scheduler
+    end
+
+    def install_runtime_hooks!(project_root)
+      project_root = File.expand_path(project_root)
+      ensure_post_commit_hook(project_root)
+      Scheduler.install(project_root)
+    end
+
+    def ensure_config(project_root)
+      path = File.join(project_root, ".llm-wiki", "config.json")
+      payload = read_json_hash(path).merge(
+        "headless_agent" => HEADLESS_AGENT,
+        "context_agents" => CONTEXT_AGENTS,
+        "created_by" => "hive"
+      )
+      main_wiki_path = payload["main_wiki_path"] || detect_main_wiki_path(project_root)
+      if main_wiki_path
+        payload["main_wiki_path"] = main_wiki_path
+      else
+        payload.delete("main_wiki_path")
+      end
+
+      write_file(path, "#{JSON.pretty_generate(payload)}\n")
+    end
+
+    def read_json_hash(path)
+      return {} unless File.exist?(path)
+
+      parsed = JSON.parse(File.read(path))
+      parsed.is_a?(Hash) ? parsed : {}
+    rescue JSON::ParserError
+      {}
+    end
+
+    def detect_main_wiki_path(project_root)
+      candidates = [
+        File.expand_path("~/wikis/master/wiki"),
+        File.expand_path("~/wikis/main/wiki"),
+        File.expand_path("../wikis/master/wiki", project_root),
+        File.expand_path("../wikis/main/wiki", project_root)
+      ]
+      candidates.find { |path| File.directory?(path) }
+    end
+
+    def ensure_project_wiki(project_root)
+      FileUtils.mkdir_p(File.join(project_root, "wiki"))
+      FileUtils.mkdir_p(File.join(project_root, "raw", "notes"))
+      write_once(File.join(project_root, "raw", "notes", ".gitkeep"), "")
+      write_once(File.join(project_root, "wiki", "index.md"), Pages.index)
+      write_once(File.join(project_root, "wiki", "log.md"), Pages.log)
+      write_once(File.join(project_root, "wiki", "gaps.md"), Pages.gaps)
+      write_once(File.join(project_root, "wiki", "architecture.md"), Pages.architecture)
+      write_once(File.join(project_root, "wiki", "decisions.md"), Pages.decisions)
+      write_once(File.join(project_root, "wiki", "dependencies.md"), Pages.dependencies)
+    end
+
+    def write_once(path, content)
+      return if File.exist?(path)
+
+      write_file(path, content)
+    end
+
+    def ensure_refresh_scripts(project_root)
+      llm_wiki_dir = File.join(project_root, ".llm-wiki")
+      refresh_path = File.join(llm_wiki_dir, "refresh-wiki.sh")
+      post_commit_path = File.join(llm_wiki_dir, "post-commit-refresh.sh")
+
+      write_file(refresh_path, Scripts.refresh_wiki)
+      write_file(post_commit_path, Scripts.post_commit_refresh(File.basename(project_root)))
+      File.chmod(0o755, refresh_path)
+      File.chmod(0o755, post_commit_path)
+    end
+
+    def ensure_post_commit_hook(project_root)
+      hook_path = File.join(project_root, ".git", "hooks", "post-commit")
+      block = <<~BASH.strip
+        #{POST_COMMIT_BEGIN}
+        if [ "${HIVE_SKIP_LLM_WIKI_POST_COMMIT:-}" != "1" ] && [ -x ".llm-wiki/post-commit-refresh.sh" ]; then
+          ".llm-wiki/post-commit-refresh.sh" >/dev/null 2>&1 &
+        fi
+        #{POST_COMMIT_END}
+      BASH
+      existing = File.exist?(hook_path) ? File.read(hook_path) : "#!/usr/bin/env bash\n"
+      write_file(hook_path, managed_content(existing, POST_COMMIT_BEGIN, POST_COMMIT_END, block))
+      File.chmod(File.stat(hook_path).mode | 0o111, hook_path)
+    end
+
+    def project_slug(project_root)
+      Scheduler.project_slug(project_root)
+    end
+
+    def replace_block(path, begin_marker, end_marker, block)
+      existing = File.exist?(path) ? File.read(path) : ""
+      write_file(path, managed_content(existing, begin_marker, end_marker, block))
+    end
+
+    def managed_content(existing, begin_marker, end_marker, block)
+      pattern = /#{Regexp.escape(begin_marker)}.*?#{Regexp.escape(end_marker)}\n?/m
+      return existing.sub(pattern, "#{block}\n") if existing.match?(pattern)
+
+      separator = existing.empty? || existing.end_with?("\n") ? "" : "\n"
+      blank_line = existing.empty? ? "" : "\n"
+      "#{existing}#{separator}#{blank_line}#{block}\n"
+    end
+
+    def write_file(path, content)
+      FileUtils.mkdir_p(File.dirname(path))
+      File.write(path, content)
+    end
+  end
+end

--- a/lib/hive/llm_wiki_bootstrap/context.rb
+++ b/lib/hive/llm_wiki_bootstrap/context.rb
@@ -1,0 +1,104 @@
+require "json"
+require "fileutils"
+require "shellwords"
+
+module Hive
+  module LlmWikiBootstrap
+    module Context
+      module_function
+
+      def install(project_root)
+        ensure_context_files(project_root)
+        ensure_claude_session_start_hook(project_root)
+      end
+
+      def ensure_context_files(project_root)
+        block = context_block
+        %w[CLAUDE.md AGENTS.md].each do |filename|
+          path = File.join(project_root, filename)
+          Hive::LlmWikiBootstrap.replace_block(path, MANAGED_BEGIN, MANAGED_END, block)
+        end
+      end
+
+      def context_block
+        <<~MARKDOWN.strip
+          #{MANAGED_BEGIN}
+          ## LLM Wiki
+
+          This project has a managed LLM wiki. Treat it as required project context.
+
+          - Project wiki: `wiki/`
+          - Index: `wiki/index.md`
+          - Change log: `wiki/log.md`
+          - Known gaps: `wiki/gaps.md`
+          - Raw notes: `raw/notes/`
+
+          Before planning, implementation, review, or debugging:
+
+          1. Read `wiki/index.md`.
+          2. Search the project wiki with `qmd search "<topic>"` when QMD is available, or `rg "<topic>" wiki/` otherwise.
+          3. Use `qmd query "<topic>"` only when local model generation is acceptable; if it hangs or errors, fall back to `qmd search` or `rg`.
+          4. If `.llm-wiki/config.json` has `main_wiki_path`, search that main wiki too.
+          5. Use `/llm-wiki:wiki-plan` for planning-stage work when available.
+
+          When code behavior, architecture, commands, or dependencies change:
+
+          1. Update affected wiki pages.
+          2. Append `wiki/log.md`.
+          3. Record uncertainty in `wiki/gaps.md`.
+
+          Headless wiki refresh is managed by `.llm-wiki/refresh-wiki.sh` and
+          `.llm-wiki/post-commit-refresh.sh`. Codex is the configured headless wiki agent.
+          #{MANAGED_END}
+        MARKDOWN
+      end
+
+      def ensure_claude_session_start_hook(project_root)
+        settings_path = File.join(project_root, ".claude", "settings.json")
+        FileUtils.mkdir_p(File.dirname(settings_path))
+        settings = Hive::LlmWikiBootstrap.read_json_hash(settings_path)
+        hooks = settings["hooks"].is_a?(Hash) ? settings["hooks"] : {}
+        session_hooks = Array(hooks["SessionStart"]).filter_map { |entry| cleaned_session_hook(entry) }
+
+        session_hooks << {
+          "matcher" => "*",
+          "hooks" => [
+            {
+              "type" => "command",
+              "command" => session_start_command
+            }
+          ]
+        }
+
+        hooks["SessionStart"] = session_hooks
+        settings["hooks"] = hooks
+        Hive::LlmWikiBootstrap.write_file(settings_path, "#{JSON.pretty_generate(settings)}\n")
+      end
+
+      def cleaned_session_hook(entry)
+        return nil unless entry.is_a?(Hash)
+
+        hook_entries = Array(entry["hooks"]).reject do |hook|
+          hook.is_a?(Hash) && hook["command"].to_s.include?(SESSION_HOOK_MARKER)
+        end
+        return nil if hook_entries.empty? && entry["matcher"].to_s.empty?
+
+        entry.merge("hooks" => hook_entries)
+      end
+
+      def session_start_command
+        script = <<~SH.strip
+          if [ -f wiki/index.md ]; then
+            printf '\\n[llm-wiki index]\\n'
+            sed -n '1,160p' wiki/index.md
+          fi
+          if [ -f wiki/log.md ]; then
+            printf '\\n[llm-wiki recent log]\\n'
+            sed -n '1,80p' wiki/log.md
+          fi
+        SH
+        "bash -lc #{Shellwords.escape(script)} # #{SESSION_HOOK_MARKER}"
+      end
+    end
+  end
+end

--- a/lib/hive/llm_wiki_bootstrap/pages.rb
+++ b/lib/hive/llm_wiki_bootstrap/pages.rb
@@ -1,0 +1,75 @@
+module Hive
+  module LlmWikiBootstrap
+    module Pages
+      module_function
+
+      def index
+        <<~MARKDOWN
+          # Project Wiki
+
+          This wiki is maintained for coding agents. Read it before planning,
+          implementation, review, or debugging work, and update it when project facts
+          change.
+
+          ## Core Pages
+
+          - [[architecture]] - system shape, runtime flows, and important modules.
+          - [[decisions]] - durable design decisions and tradeoffs.
+          - [[dependencies]] - runtime, development, and service dependencies.
+          - [[gaps]] - missing, uncertain, or stale wiki coverage.
+
+          ## Update Protocol
+
+          - Update affected pages when code behavior, architecture, commands, or
+            dependencies change.
+          - Append [[log]] after every wiki update.
+          - Record uncertainty in [[gaps]] instead of inventing facts.
+        MARKDOWN
+      end
+
+      def log
+        <<~MARKDOWN
+          # Wiki Changelog
+
+          Append-only log of meaningful wiki updates.
+        MARKDOWN
+      end
+
+      def gaps
+        <<~MARKDOWN
+          # Wiki Gaps
+
+          | Area | Gap | Notes |
+          |------|-----|-------|
+        MARKDOWN
+      end
+
+      def architecture
+        <<~MARKDOWN
+          # Architecture
+
+          Initial placeholder. Replace with the project's current structure, key flows,
+          and module responsibilities.
+        MARKDOWN
+      end
+
+      def decisions
+        <<~MARKDOWN
+          # Decisions
+
+          Record durable technical decisions here with date, context, decision, and
+          consequence.
+        MARKDOWN
+      end
+
+      def dependencies
+        <<~MARKDOWN
+          # Dependencies
+
+          Initial placeholder. Summarize runtime dependencies, development tools, and
+          external services when they are confirmed.
+        MARKDOWN
+      end
+    end
+  end
+end

--- a/lib/hive/llm_wiki_bootstrap/scheduler.rb
+++ b/lib/hive/llm_wiki_bootstrap/scheduler.rb
@@ -1,0 +1,74 @@
+require "digest"
+require "fileutils"
+require "rbconfig"
+
+module Hive
+  module LlmWikiBootstrap
+    module Scheduler
+      module_function
+
+      def install(project_root)
+        return if ENV["HIVE_SKIP_LLM_WIKI_SCHEDULER"] == "1"
+        return unless RbConfig::CONFIG["host_os"].include?("linux")
+
+        slug = project_slug(project_root)
+        user_dir = File.expand_path("~/.config/systemd/user")
+        service_name = "llm-wiki-#{slug}.service"
+        timer_name = "llm-wiki-#{slug}.timer"
+        FileUtils.mkdir_p(user_dir)
+        Hive::LlmWikiBootstrap.write_file(File.join(user_dir, service_name), systemd_service(project_root, service_name))
+        Hive::LlmWikiBootstrap.write_file(File.join(user_dir, timer_name), systemd_timer(service_name))
+        enable_timer_symlink(user_dir, timer_name)
+      end
+
+      def enable_timer_symlink(user_dir, timer_name)
+        wants_dir = File.join(user_dir, "timers.target.wants")
+        link_path = File.join(wants_dir, timer_name)
+        FileUtils.mkdir_p(wants_dir)
+        return if File.exist?(link_path) || File.symlink?(link_path)
+
+        File.symlink(File.join("..", timer_name), link_path)
+      end
+
+      def systemd_service(project_root, service_name)
+        <<~UNIT
+          [Unit]
+          Description=Refresh LLM wiki for #{service_name.sub(/\.service\z/, "")}
+
+          [Service]
+          Type=oneshot
+          WorkingDirectory=#{systemd_path(project_root)}
+          ExecStart=#{systemd_path(File.join(project_root, ".llm-wiki", "refresh-wiki.sh"))}
+          TimeoutStartSec=45min
+        UNIT
+      end
+
+      def systemd_timer(service_name)
+        <<~UNIT
+          [Unit]
+          Description=Run #{service_name} daily
+
+          [Timer]
+          OnBootSec=10min
+          OnUnitActiveSec=1d
+          Persistent=true
+          Unit=#{service_name}
+
+          [Install]
+          WantedBy=timers.target
+        UNIT
+      end
+
+      def systemd_path(path)
+        path.gsub("\\", "\\x5c")
+            .gsub(" ", "\\x20")
+            .gsub("\"", "\\x22")
+      end
+
+      def project_slug(project_root)
+        base = File.basename(project_root).gsub(/[^A-Za-z0-9_.-]/, "-")
+        "#{base}-#{Digest::SHA256.hexdigest(project_root)[0, 8]}"
+      end
+    end
+  end
+end

--- a/lib/hive/llm_wiki_bootstrap/scripts.rb
+++ b/lib/hive/llm_wiki_bootstrap/scripts.rb
@@ -1,0 +1,208 @@
+module Hive
+  module LlmWikiBootstrap
+    module Scripts
+      module_function
+
+      def refresh_wiki
+        <<~BASH
+          #!/usr/bin/env bash
+          set -euo pipefail
+
+          project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+          cd "$project_root"
+
+          configure_qmd_environment() {
+            local cache_home="${XDG_CACHE_HOME:-$HOME/.cache}"
+            if ! mkdir -p "$cache_home/qmd" 2>/dev/null || ! touch "$cache_home/qmd/.write-test" 2>/dev/null; then
+              export XDG_CACHE_HOME="$project_root/.llm-wiki/qmd-cache"
+              mkdir -p "$XDG_CACHE_HOME/qmd"
+              export LLM_WIKI_QMD_CACHE_DIR="$XDG_CACHE_HOME/qmd"
+            else
+              rm -f "$cache_home/qmd/.write-test"
+              export LLM_WIKI_QMD_CACHE_DIR="$cache_home/qmd"
+            fi
+          }
+
+          configure_qmd_environment
+
+          run_qmd() {
+            command -v qmd >/dev/null 2>&1 || return 0
+
+            if command -v timeout >/dev/null 2>&1; then
+              timeout "${LLM_WIKI_QMD_TIMEOUT:-900}" qmd "$@"
+            else
+              qmd "$@"
+            fi
+          }
+
+          run_codex() {
+            if command -v timeout >/dev/null 2>&1; then
+              timeout "${LLM_WIKI_CODEX_TIMEOUT:-1800}" codex exec --add-dir "$LLM_WIKI_QMD_CACHE_DIR" -C "$project_root" "$prompt"
+            else
+              codex exec --add-dir "$LLM_WIKI_QMD_CACHE_DIR" -C "$project_root" "$prompt"
+            fi
+          }
+
+          if command -v qmd >/dev/null 2>&1; then
+            run_qmd update >/dev/null 2>&1 || true
+          fi
+
+          prompt="$(cat <<'PROMPT'
+          Refresh this project's LLM wiki.
+          Read .llm-wiki/config.json, AGENTS.md, CLAUDE.md, wiki/index.md, wiki/gaps.md,
+          and recent wiki/log.md entries first.
+          If .llm-wiki/config.json contains main_wiki_path, search that exact path before
+          changing project pages.
+          Also search default main cross-project wiki paths when they exist:
+          ~/wikis/master/wiki/, ~/wikis/main/wiki/, ../wikis/master/wiki/, and
+          ../wikis/main/wiki/.
+          Inspect recent git history and changed source files.
+          Update stale wiki pages, update wiki/index.md when page coverage changes, append
+          wiki/log.md, and record uncertainty in wiki/gaps.md.
+          Do not run qmd update or qmd embed yourself; the wrapper script runs bounded qmd
+          maintenance after this Codex refresh finishes.
+          Do not invent facts.
+          PROMPT
+          )"
+
+          codex_status=0
+          run_codex || codex_status=$?
+
+          run_qmd update >/dev/null 2>&1 || true
+          run_qmd embed --max-docs-per-batch 64 --max-batch-mb 64 >/dev/null 2>&1 || true
+
+          exit "$codex_status"
+        BASH
+      end
+
+      def post_commit_refresh(project_name)
+        <<~BASH
+          #!/usr/bin/env bash
+          set -euo pipefail
+
+          project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+          cd "$project_root"
+
+          configure_qmd_environment() {
+            local cache_home="${XDG_CACHE_HOME:-$HOME/.cache}"
+            if ! mkdir -p "$cache_home/qmd" 2>/dev/null || ! touch "$cache_home/qmd/.write-test" 2>/dev/null; then
+              export XDG_CACHE_HOME="$project_root/.llm-wiki/qmd-cache"
+              mkdir -p "$XDG_CACHE_HOME/qmd"
+              export LLM_WIKI_QMD_CACHE_DIR="$XDG_CACHE_HOME/qmd"
+            else
+              rm -f "$cache_home/qmd/.write-test"
+              export LLM_WIKI_QMD_CACHE_DIR="$cache_home/qmd"
+            fi
+          }
+
+          configure_qmd_environment
+
+          run_qmd() {
+            command -v qmd >/dev/null 2>&1 || return 0
+
+            if command -v timeout >/dev/null 2>&1; then
+              timeout "${LLM_WIKI_QMD_TIMEOUT:-900}" qmd "$@"
+            else
+              qmd "$@"
+            fi
+          }
+
+          log_file="$project_root/.llm-wiki/post-commit-refresh.log"
+          lock_dir="$project_root/.llm-wiki/post-commit-refresh.lock"
+          changed_files="$(git diff-tree --no-commit-id --name-only -r HEAD 2>/dev/null || true)"
+          ran_refresh=0
+
+          [ -n "$changed_files" ] || exit 0
+
+          if ! mkdir "$lock_dir" 2>/dev/null; then
+            exit 0
+          fi
+          trap 'rmdir "$lock_dir"' EXIT
+
+          matches() {
+            printf '%s\\n' "$changed_files" | grep -Eq "$1"
+          }
+
+          run_refresh() {
+            local prompt="$1"
+            ran_refresh=1
+            if command -v timeout >/dev/null 2>&1; then
+              timeout "${LLM_WIKI_CODEX_TIMEOUT:-1800}" codex exec --add-dir "$LLM_WIKI_QMD_CACHE_DIR" -C "$project_root" "$prompt" >>"$log_file" 2>&1 || true
+            else
+              codex exec --add-dir "$LLM_WIKI_QMD_CACHE_DIR" -C "$project_root" "$prompt" >>"$log_file" 2>&1 || true
+            fi
+          }
+
+          if matches '(^|/)(schema\\.rb|structure\\.sql|db/migrate/|migrations/|models/|entities/|prisma/schema\\.prisma)'; then
+            run_refresh "$(cat <<'PROMPT'
+          Refresh this project's LLM wiki data-model coverage after a commit touched schema,
+          migration, model, or entity files. Read AGENTS.md, wiki/index.md,
+          wiki/architecture.md, wiki/dependencies.md, wiki/gaps.md, and recent wiki/log.md
+          entries first. Inspect the committed diff and relevant source files. Update affected
+          wiki pages, update wiki/index.md if page coverage changes, append wiki/log.md, and
+          record uncertainty in wiki/gaps.md. Do not run qmd update or qmd embed yourself; the
+          post-commit wrapper runs bounded qmd maintenance after refreshes finish. Do not
+          invent facts.
+          PROMPT
+          )"
+          fi
+
+          if matches '(^|/)(routes|controllers|handlers|resolvers|src/commands/|lib/.*commands|bin/|README\\.md)'; then
+            run_refresh "$(cat <<'PROMPT'
+          Refresh this project's LLM wiki command and API surface coverage after a commit
+          touched routes, handlers, commands, executable entrypoints, or README content. Read
+          AGENTS.md, wiki/index.md, wiki/architecture.md, wiki/decisions.md, wiki/gaps.md,
+          and recent wiki/log.md entries first. Inspect the committed diff and relevant source
+          files. Update affected wiki pages, update wiki/index.md if page coverage changes,
+          append wiki/log.md, and record uncertainty in wiki/gaps.md. Do not run qmd update or
+          qmd embed yourself; the post-commit wrapper runs bounded qmd maintenance after
+          refreshes finish. Do not invent facts.
+          PROMPT
+          )"
+          fi
+
+          if matches '(^|/)(Gemfile|Gemfile\\.lock|package\\.json|package-lock\\.json|go\\.mod|go\\.sum|Cargo\\.toml|Cargo\\.lock|requirements\\.txt|pyproject\\.toml|poetry\\.lock|composer\\.json|composer\\.lock)$'; then
+            run_refresh "$(cat <<'PROMPT'
+          Refresh this project's LLM wiki dependency coverage after a commit touched dependency
+          files. Read AGENTS.md, wiki/index.md, wiki/dependencies.md, wiki/gaps.md, and recent
+          wiki/log.md entries first. Inspect the committed diff and dependency files. Update
+          wiki/dependencies.md and related pages if facts changed, update wiki/index.md if page
+          coverage changes, append wiki/log.md, and record uncertainty in wiki/gaps.md. Do not
+          run qmd update or qmd embed yourself; the post-commit wrapper runs bounded qmd
+          maintenance after refreshes finish. Do not
+          invent facts.
+          PROMPT
+          )"
+          fi
+
+          if matches '(^|/)(docs/|wiki/|raw/notes/|plans/|todos/)|(^|/)(CHANGELOG\\.md|AGENTS\\.md|CLAUDE\\.md)$'; then
+            run_refresh "$(cat <<'PROMPT'
+          Refresh this project's LLM wiki planning and documentation coverage after a commit
+          touched docs, plans, notes, context files, or the wiki itself. Read AGENTS.md,
+          wiki/index.md, wiki/decisions.md, wiki/gaps.md, and recent wiki/log.md entries first.
+          Inspect the committed diff and relevant source files. Update stale pages, update
+          wiki/index.md if page coverage changes, append wiki/log.md, and record uncertainty in
+          wiki/gaps.md. Do not run qmd update or qmd embed yourself; the post-commit wrapper
+          runs bounded qmd maintenance after refreshes finish. Do not invent facts.
+          PROMPT
+          )"
+          fi
+
+          if [ "$ran_refresh" -eq 1 ]; then
+            if command -v qmd >/dev/null 2>&1; then
+              run_qmd update >>"$log_file" 2>&1 || true
+              run_qmd embed --max-docs-per-batch 64 --max-batch-mb 64 >>"$log_file" 2>&1 || true
+            fi
+
+            for sync_dir in "$HOME/wikis/.sync-needed" "$(dirname "$project_root")/wikis/.sync-needed"; do
+              if [ -d "$(dirname "$sync_dir")" ]; then
+                mkdir -p "$sync_dir"
+                touch "$sync_dir/#{project_name}"
+              fi
+            done
+          fi
+        BASH
+      end
+    end
+  end
+end

--- a/lib/hive/stages/plan.rb
+++ b/lib/hive/stages/plan.rb
@@ -9,8 +9,7 @@ module Hive
         brainstorm_path = File.join(task.folder, "brainstorm.md")
         brainstorm_text = File.exist?(brainstorm_path) ? File.read(brainstorm_path) : ""
         profile = Hive::Stages::Base.stage_profile(cfg, "plan")
-        skill = cfg.dig("plan", "skill") ||
-          Hive::Config::DEFAULTS.dig("plan", "skill")
+        skill = Hive::Config.stage_skill(cfg, "plan")
         prompt = Hive::Stages::Base.render(
           "plan_prompt.md.erb",
           Hive::Stages::Base::TemplateBindings.new(

--- a/templates/project_config.yml.erb
+++ b/templates/project_config.yml.erb
@@ -10,10 +10,10 @@ hive_state_path: .hive-state
 # for development (its edit-mode is more efficient for implementation).
 #
 # `skill` overrides the slash-command the stage's agent invokes inside
-# its prompt. Hive ships expecting llm-wiki (`/plan`) AND
-# compound-engineering (`/compound-engineering:ce-*`) to be installed
-# alongside your agent CLI. Defaults: `plan` → `/plan` (llm-wiki's
-# wiki-research-first Plan wrapper); `brainstorm` →
+# its prompt. Hive ships expecting llm-wiki and compound-engineering to
+# be installed alongside your agent CLI. Plan defaults are agent-aware:
+# claude → `/plan`, codex → `/llm-wiki:wiki-plan`, pi →
+# `/skill:wiki-plan` after profile formatting. Brainstorm defaults to
 # `/compound-engineering:ce-brainstorm`. Override here to pin a
 # different skill per project.
 brainstorm:

--- a/test/integration/init_test.rb
+++ b/test/integration/init_test.rb
@@ -1,8 +1,22 @@
 require "test_helper"
+require "json"
 require "hive/commands/init"
+require "hive/llm_wiki_bootstrap"
 
 class InitTest < Minitest::Test
   include HiveTestHelper
+
+  def with_tmp_home
+    Dir.mktmpdir("hive-home") do |dir|
+      old = ENV["HOME"]
+      ENV["HOME"] = dir
+      begin
+        yield(dir)
+      ensure
+        old.nil? ? ENV.delete("HOME") : ENV["HOME"] = old
+      end
+    end
+  end
 
   def test_initializes_project_with_orphan_branch_and_global_registration
     # `with_tmp_global_config_and_home` overrides HOME alongside
@@ -34,6 +48,7 @@ class InitTest < Minitest::Test
 
         master_log = `git -C #{dir} log --format=%s master`.strip
         assert_includes master_log, "chore: ignore .hive-state worktree"
+        assert_includes master_log, "chore: initialize llm-wiki"
 
         gitignore = File.read(File.join(dir, ".gitignore"))
         assert_includes gitignore, "/.hive-state/"
@@ -46,6 +61,117 @@ class InitTest < Minitest::Test
         global = YAML.safe_load(File.read(File.join(home, "config.yml")))
         assert_equal false, global.dig("daemon", "autostart"),
                      "non-TTY init writes the service unit but does not start it by default"
+      end
+    end
+  end
+
+  def test_initializes_managed_llm_wiki_with_codex_headless_agent_and_scheduler
+    with_tmp_home do |home|
+      ENV.delete("HIVE_SKIP_LLM_WIKI_SCHEDULER")
+      FileUtils.mkdir_p(File.join(home, "wikis", "master", "wiki"))
+
+      with_tmp_global_config do
+        with_tmp_git_repo do |dir|
+          capture_io { Hive::Commands::Init.new(dir).call }
+
+          llm_wiki_config = JSON.parse(File.read(File.join(dir, ".llm-wiki", "config.json")))
+          assert_equal "codex", llm_wiki_config.fetch("headless_agent")
+          assert_equal %w[claude codex pi], llm_wiki_config.fetch("context_agents")
+          assert_equal "hive", llm_wiki_config.fetch("created_by")
+          assert_equal File.join(home, "wikis", "master", "wiki"), llm_wiki_config.fetch("main_wiki_path")
+
+          assert File.exist?(File.join(dir, "wiki", "index.md"))
+          assert File.exist?(File.join(dir, "wiki", "log.md"))
+          assert File.exist?(File.join(dir, "wiki", "gaps.md"))
+          assert File.exist?(File.join(dir, "raw", "notes", ".gitkeep"))
+          tracked = `git -C #{dir} ls-files .llm-wiki/config.json .llm-wiki/refresh-wiki.sh AGENTS.md CLAUDE.md wiki/index.md`
+          assert_includes tracked, ".llm-wiki/config.json"
+          assert_includes tracked, ".llm-wiki/refresh-wiki.sh"
+          assert_includes tracked, "AGENTS.md"
+          assert_includes tracked, "CLAUDE.md"
+          assert_includes tracked, "wiki/index.md"
+
+          agents = File.read(File.join(dir, "AGENTS.md"))
+          claude = File.read(File.join(dir, "CLAUDE.md"))
+          assert_includes agents, "<!-- BEGIN LLM WIKI -->"
+          assert_includes agents, "/llm-wiki:wiki-plan"
+          assert_includes claude, "<!-- BEGIN LLM WIKI -->"
+
+          settings = JSON.parse(File.read(File.join(dir, ".claude", "settings.json")))
+          hook_commands = settings.dig("hooks", "SessionStart").flat_map { |entry| entry.fetch("hooks") }
+                                  .map { |hook| hook.fetch("command") }
+          assert hook_commands.any? { |command| command.include?("wiki/index.md") }
+          assert hook_commands.any? { |command| command.include?("LLM WIKI SESSION START") }
+
+          refresh_script = File.join(dir, ".llm-wiki", "refresh-wiki.sh")
+          post_commit_script = File.join(dir, ".llm-wiki", "post-commit-refresh.sh")
+          assert File.executable?(refresh_script)
+          assert File.executable?(post_commit_script)
+          assert_includes File.read(refresh_script), 'codex exec --add-dir "$LLM_WIKI_QMD_CACHE_DIR" -C "$project_root"'
+          assert_includes File.read(post_commit_script), 'codex exec --add-dir "$LLM_WIKI_QMD_CACHE_DIR" -C "$project_root"'
+          assert_includes File.read(refresh_script), "LLM_WIKI_QMD_CACHE_DIR"
+          assert_includes File.read(post_commit_script), "LLM_WIKI_QMD_CACHE_DIR"
+          assert_includes File.read(refresh_script), ".llm-wiki/qmd-cache"
+          assert_includes File.read(post_commit_script), ".llm-wiki/qmd-cache"
+          assert_includes File.read(refresh_script), "LLM_WIKI_CODEX_TIMEOUT"
+          assert_includes File.read(refresh_script), "LLM_WIKI_QMD_TIMEOUT"
+          assert_includes File.read(refresh_script), "qmd embed --max-docs-per-batch 64 --max-batch-mb 64"
+          assert_includes File.read(refresh_script), "Do not run qmd update or qmd embed yourself"
+          assert_includes File.read(post_commit_script), "LLM_WIKI_CODEX_TIMEOUT"
+          assert_includes File.read(post_commit_script), "LLM_WIKI_QMD_TIMEOUT"
+          assert_includes File.read(post_commit_script), "qmd embed --max-docs-per-batch 64 --max-batch-mb 64"
+          assert_includes File.read(post_commit_script), "Do not run qmd update or qmd embed yourself"
+          refute_includes File.read(refresh_script), "QMD_LLAMA_GPU"
+          refute_includes File.read(post_commit_script), "QMD_LLAMA_GPU"
+          refute_includes File.read(refresh_script), "claude -p"
+          refute_includes File.read(post_commit_script), "claude -p"
+
+          hook = File.read(File.join(dir, ".git", "hooks", "post-commit"))
+          assert_includes hook, "# BEGIN LLM WIKI POST-COMMIT"
+          assert_includes hook, ".llm-wiki/post-commit-refresh.sh"
+
+          assert_llm_wiki_scheduler_files(home, dir)
+        end
+      end
+    ensure
+      ENV["HIVE_SKIP_LLM_WIKI_SCHEDULER"] = "1"
+    end
+  end
+
+  def assert_llm_wiki_scheduler_files(home, project_dir)
+    skip "systemd user timers are Linux-only" unless RbConfig::CONFIG["host_os"].include?("linux")
+
+    slug = Hive::LlmWikiBootstrap.project_slug(project_dir)
+    user_dir = File.join(home, ".config", "systemd", "user")
+    service = File.join(user_dir, "llm-wiki-#{slug}.service")
+    timer = File.join(user_dir, "llm-wiki-#{slug}.timer")
+    wants = File.join(user_dir, "timers.target.wants", "llm-wiki-#{slug}.timer")
+
+    assert File.exist?(service)
+    assert File.exist?(timer)
+    assert File.symlink?(wants)
+    service_contents = File.read(service)
+    assert_includes service_contents, "WorkingDirectory=#{project_dir}"
+    assert_includes service_contents, "ExecStart=#{File.join(project_dir, ".llm-wiki", "refresh-wiki.sh")}"
+    assert_includes service_contents, "TimeoutStartSec=45min"
+    refute_includes service_contents, 'WorkingDirectory="'
+    assert_includes File.read(timer), "OnUnitActiveSec=1d"
+  end
+
+  def test_init_preserves_existing_post_commit_hook_when_adding_managed_wiki_block
+    with_tmp_global_config do
+      with_tmp_git_repo do |dir|
+        hook_path = File.join(dir, ".git", "hooks", "post-commit")
+        File.write(hook_path, "#!/usr/bin/env bash\nprintf 'existing hook\\n'\n")
+        File.chmod(0o755, hook_path)
+
+        capture_io { Hive::Commands::Init.new(dir).call }
+        Hive::LlmWikiBootstrap.install!(dir)
+
+        hook = File.read(hook_path)
+        assert_includes hook, "printf 'existing hook\\n'"
+        assert_equal 1, hook.scan("# BEGIN LLM WIKI POST-COMMIT").length
+        assert_equal 1, hook.scan("# END LLM WIKI POST-COMMIT").length
       end
     end
   end

--- a/test/integration/prompt_injection_test.rb
+++ b/test/integration/prompt_injection_test.rb
@@ -100,7 +100,7 @@ class PromptInjectionTest < Minitest::Test
           task_folder: task.folder,
           brainstorm_text: HOSTILE_IDEA,
           user_supplied_tag: tag,
-          skill_invocation: Hive::Config::DEFAULTS.dig("plan", "skill")
+          skill_invocation: Hive::Config.stage_skill({ "plan" => { "agent" => "claude" } }, "plan")
         )
       )
       assert_includes prompt, "<#{tag} content_type=\"brainstorm_md\">"
@@ -296,7 +296,7 @@ class PromptInjectionTest < Minitest::Test
           task_folder: task.folder,
           brainstorm_text: "",
           user_supplied_tag: tag,
-          skill_invocation: Hive::Config::DEFAULTS.dig("plan", "skill")
+          skill_invocation: Hive::Config.stage_skill({ "plan" => { "agent" => "claude" } }, "plan")
         )
       )
       assert_includes prompt, "use the `/plan` skill",
@@ -328,13 +328,16 @@ class PromptInjectionTest < Minitest::Test
   end
 
   def test_default_skill_values_match_shipped_invocations
-    # Pins the DEFAULTS so a refactor that drops the skill key (or
+    # Pins the DEFAULTS so a refactor that drops the skill defaults (or
     # changes the shipped skill name) trips this test. Hive ships
-    # expecting both llm-wiki (`/plan`) and compound-engineering
-    # (`/compound-engineering:ce-*`) to be installed.
+    # expecting both llm-wiki and compound-engineering to be installed.
     assert_equal "/compound-engineering:ce-brainstorm",
       Hive::Config::DEFAULTS.dig("brainstorm", "skill")
     assert_equal "/plan",
-      Hive::Config::DEFAULTS.dig("plan", "skill")
+      Hive::Config::DEFAULTS.dig("plan", "skill_by_agent", "claude")
+    assert_equal "/llm-wiki:wiki-plan",
+      Hive::Config::DEFAULTS.dig("plan", "skill_by_agent", "codex")
+    assert_equal "/llm-wiki:wiki-plan",
+      Hive::Config::DEFAULTS.dig("plan", "skill_by_agent", "pi")
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,6 +15,10 @@ module HiveTestStdinIsolation
   # interactive path inject their own tty-flagged StringIO explicitly.
   def before_setup
     @hive_original_stdin = $stdin
+    @hive_original_skip_llm_wiki_scheduler = ENV["HIVE_SKIP_LLM_WIKI_SCHEDULER"]
+    @hive_original_skip_llm_wiki_post_commit = ENV["HIVE_SKIP_LLM_WIKI_POST_COMMIT"]
+    ENV["HIVE_SKIP_LLM_WIKI_SCHEDULER"] = "1"
+    ENV["HIVE_SKIP_LLM_WIKI_POST_COMMIT"] = "1"
     $stdin = StringIO.new
     super
   end
@@ -22,6 +26,20 @@ module HiveTestStdinIsolation
   def after_teardown
     super
   ensure
+    if defined?(@hive_original_skip_llm_wiki_scheduler)
+      if @hive_original_skip_llm_wiki_scheduler.nil?
+        ENV.delete("HIVE_SKIP_LLM_WIKI_SCHEDULER")
+      else
+        ENV["HIVE_SKIP_LLM_WIKI_SCHEDULER"] = @hive_original_skip_llm_wiki_scheduler
+      end
+    end
+    if defined?(@hive_original_skip_llm_wiki_post_commit)
+      if @hive_original_skip_llm_wiki_post_commit.nil?
+        ENV.delete("HIVE_SKIP_LLM_WIKI_POST_COMMIT")
+      else
+        ENV["HIVE_SKIP_LLM_WIKI_POST_COMMIT"] = @hive_original_skip_llm_wiki_post_commit
+      end
+    end
     $stdin = @hive_original_stdin if defined?(@hive_original_stdin)
   end
 end

--- a/test/unit/commands/doctor_test.rb
+++ b/test/unit/commands/doctor_test.rb
@@ -89,7 +89,7 @@ class HiveCommandsDoctorTest < Minitest::Test
   def test_pi_stage_uses_profile_skill_format_and_resolves
     with_fake_home do |home|
       write_file("#{home}/.pi/agent/skills/ce-brainstorm/SKILL.md")
-      write_file("#{home}/.pi/agent/skills/plan/SKILL.md")
+      write_file("#{home}/.pi/agent/skills/wiki-plan/SKILL.md")
       out = StringIO.new
       cfg = {
         "brainstorm" => { "agent" => "pi" },
@@ -102,7 +102,7 @@ class HiveCommandsDoctorTest < Minitest::Test
       ).call
       assert_equal 0, exit_code
       assert_match(%r{brainstorm.*pi.*/skill:ce-brainstorm.*✓ present}, out.string)
-      assert_match(%r{plan.*pi.*/skill:plan.*✓ present}, out.string)
+      assert_match(%r{plan.*pi.*/skill:wiki-plan.*✓ present}, out.string)
     end
   end
 
@@ -120,7 +120,47 @@ class HiveCommandsDoctorTest < Minitest::Test
         output: out
       ).call
       assert_equal Hive::Commands::Doctor::EXIT_MISSING_SKILL, exit_code
-      assert_match(%r{plan.*pi.*/skill:plan.*✗ missing}, out.string)
+      assert_match(%r{plan.*pi.*/skill:wiki-plan.*✗ missing}, out.string)
+    end
+  end
+
+  def test_codex_plan_stage_uses_llm_wiki_plugin_skill_by_default
+    with_fake_home do |home|
+      write_file("#{home}/.codex/plugins/cache/mp/llm-wiki/0.1.7/skills/wiki-plan/SKILL.md")
+      write_file("#{home}/.codex/plugins/cache/mp/compound-engineering/3.8.1/skills/ce-brainstorm/SKILL.md")
+      out = StringIO.new
+      cfg = {
+        "brainstorm" => { "agent" => "codex" },
+        "plan" => { "agent" => "codex" }
+      }
+      exit_code = Hive::Commands::Doctor.new(
+        config: cfg,
+        project_root: nil,
+        output: out
+      ).call
+
+      assert_equal 0, exit_code
+      assert_match(%r{plan.*codex.*/llm-wiki:wiki-plan.*✓ present}, out.string)
+    end
+  end
+
+  def test_codex_plan_stage_maps_legacy_plan_alias_to_llm_wiki
+    with_fake_home do |home|
+      write_file("#{home}/.codex/plugins/cache/mp/llm-wiki/0.1.7/skills/wiki-plan/SKILL.md")
+      write_file("#{home}/.codex/plugins/cache/mp/compound-engineering/3.8.1/skills/ce-brainstorm/SKILL.md")
+      out = StringIO.new
+      cfg = {
+        "brainstorm" => { "agent" => "codex" },
+        "plan" => { "agent" => "codex", "skill" => "/plan" }
+      }
+      exit_code = Hive::Commands::Doctor.new(
+        config: cfg,
+        project_root: nil,
+        output: out
+      ).call
+
+      assert_equal 0, exit_code
+      assert_match(%r{plan.*codex.*/llm-wiki:wiki-plan.*✓ present}, out.string)
     end
   end
 
@@ -153,7 +193,7 @@ class HiveCommandsDoctorTest < Minitest::Test
   def test_uses_config_defaults_when_skill_key_unset
     with_fake_home do |home|
       # No `skill:` key in config; doctor falls back to DEFAULTS
-      # ("/compound-engineering:ce-brainstorm" and "/plan").
+      # ("/compound-engineering:ce-brainstorm" and Claude's "/plan").
       write_file("#{home}/.claude/plugins/cache/mp/compound-engineering/3.0.1/skills/ce-brainstorm/SKILL.md")
       write_file("#{home}/.claude/commands/plan.md")
       out = StringIO.new

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -124,6 +124,40 @@ class ConfigTest < Minitest::Test
     end
   end
 
+  def test_stage_skill_uses_agent_specific_plan_defaults
+    assert_equal "/plan",
+      Hive::Config.stage_skill({ "plan" => { "agent" => "claude" } }, "plan")
+    assert_equal "/llm-wiki:wiki-plan",
+      Hive::Config.stage_skill({ "plan" => { "agent" => "codex" } }, "plan")
+    assert_equal "/llm-wiki:wiki-plan",
+      Hive::Config.stage_skill({ "plan" => { "agent" => "pi" } }, "plan")
+  end
+
+  def test_stage_skill_maps_legacy_plan_alias_for_non_claude_agents
+    cfg = { "plan" => { "agent" => "codex", "skill" => "/plan" } }
+
+    assert_equal "/llm-wiki:wiki-plan", Hive::Config.stage_skill(cfg, "plan")
+  end
+
+  def test_stage_skill_keeps_non_legacy_plan_override
+    cfg = { "plan" => { "agent" => "codex", "skill" => "/compound-engineering:ce-plan" } }
+
+    assert_equal "/compound-engineering:ce-plan", Hive::Config.stage_skill(cfg, "plan")
+  end
+
+  def test_load_rejects_non_hash_stage_skill_by_agent
+    with_tmp_dir do |dir|
+      FileUtils.mkdir_p(File.join(dir, ".hive-state"))
+      File.write(File.join(dir, ".hive-state", "config.yml"), <<~YAML)
+        plan:
+          skill_by_agent: wiki-plan
+      YAML
+
+      err = assert_raises(Hive::ConfigError) { Hive::Config.load(dir) }
+      assert_match(/plan\.skill_by_agent.*must be a Hash/, err.message)
+    end
+  end
+
   def test_load_raises_when_stage_agent_is_unknown_profile
     with_tmp_dir do |dir|
       FileUtils.mkdir_p(File.join(dir, ".hive-state"))

--- a/test/unit/stages/skill_invocation_format_test.rb
+++ b/test/unit/stages/skill_invocation_format_test.rb
@@ -58,8 +58,48 @@ class HiveStagesSkillInvocationFormatTest < Minitest::Test
       with_stubbed_spawn do |captured|
         Hive::Stages::Plan.run!(task, { "plan" => { "agent" => "pi" } })
 
-        assert_includes captured.first[:prompt], "/skill:plan"
+        assert_includes captured.first[:prompt], "/skill:wiki-plan"
         assert_equal :pi, captured.first[:kwargs][:profile].name
+      end
+    end
+  end
+
+  def test_plan_formats_default_skill_for_codex_profile
+    with_tmp_dir do |project|
+      task_dir = File.join(project, ".hive-state", "stages", "3-plan", "demo")
+      FileUtils.mkdir_p(task_dir)
+      File.write(File.join(task_dir, "brainstorm.md"), "brainstorm\n")
+      task = TaskStub.new(
+        project_root: project,
+        folder: task_dir,
+        state_file: File.join(task_dir, "plan.md")
+      )
+
+      with_stubbed_spawn do |captured|
+        Hive::Stages::Plan.run!(task, { "plan" => { "agent" => "codex" } })
+
+        assert_includes captured.first[:prompt], "/llm-wiki:wiki-plan"
+        assert_equal :codex, captured.first[:kwargs][:profile].name
+      end
+    end
+  end
+
+  def test_plan_maps_legacy_plan_alias_for_codex_profile
+    with_tmp_dir do |project|
+      task_dir = File.join(project, ".hive-state", "stages", "3-plan", "demo")
+      FileUtils.mkdir_p(task_dir)
+      File.write(File.join(task_dir, "brainstorm.md"), "brainstorm\n")
+      task = TaskStub.new(
+        project_root: project,
+        folder: task_dir,
+        state_file: File.join(task_dir, "plan.md")
+      )
+
+      with_stubbed_spawn do |captured|
+        Hive::Stages::Plan.run!(task, { "plan" => { "agent" => "codex", "skill" => "/plan" } })
+
+        assert_includes captured.first[:prompt], "/llm-wiki:wiki-plan"
+        assert_equal :codex, captured.first[:kwargs][:profile].name
       end
     end
   end

--- a/wiki/cli.md
+++ b/wiki/cli.md
@@ -17,7 +17,7 @@ tags: [cli, api]
 
 | Command | Synopsis | Routes to | Page |
 |---------|----------|-----------|------|
-| `hive init [PROJECT_PATH]` | Bootstrap `.hive-state` orphan branch + worktree in a git project | `Hive::Commands::Init` | [[commands/init]] |
+| `hive init [PROJECT_PATH]` | Bootstrap `.hive-state` orphan branch + worktree plus managed llm-wiki context in a git project | `Hive::Commands::Init` | [[commands/init]] |
 | `hive new PROJECT TEXT...` | Create a task in `1-inbox/` of a registered project | `Hive::Commands::New` | [[commands/new]] |
 | `hive status [--diagnose SLUG [--write [--force]] [--project NAME] [--stage STAGE]]` | Action-grouped task list across registered projects. With `--diagnose <slug>`, prints the bounded diagnostic for one task (schema `hive-status-diagnose`). Add `--write` to spawn the configured execute `AgentProfile` and atomically write `<task>/diagnostics/red-status.md` (no lock, no marker mutation; `--force` bypasses the `marker_signature` idempotency short-circuit; green rows are rejected). | `Hive::Commands::Status` (delegates write path to `Hive::DiagnosisAgent`) | [[commands/status]] |
 | `hive tui` | Live, keystroke-driven Charm bubbletea + lipgloss dashboard over `hive status` (human-only; rejects `--json`) | `Hive::Tui` | [[commands/tui]] |

--- a/wiki/commands/doctor.md
+++ b/wiki/commands/doctor.md
@@ -7,7 +7,7 @@ updated: 2026-05-14
 tags: [command, preflight, skills, tmux]
 ---
 
-**TLDR**: `hive doctor` walks `brainstorm` + `plan` stage configs **and** every entry in `review.reviewers[]`, asking each agent profile to verify its configured skill (e.g. `/plan`, `/compound-engineering:ce-brainstorm`, `/ce-code-review`, `/skill:plan`) actually resolves to an installed slash-command or skill on disk. Prints a status table; `--json` emits a `hive-doctor.v1` envelope. Also runs **non-fatally** at the end of `hive init` as a preflight: missing skills surface as stderr warnings, but `init` exit code is unaffected.
+**TLDR**: `hive doctor` walks `brainstorm` + `plan` stage configs **and** every entry in `review.reviewers[]`, asking each agent profile to verify its configured skill (e.g. `/plan`, `/llm-wiki:wiki-plan`, `/compound-engineering:ce-brainstorm`, `/ce-code-review`, `/skill:wiki-plan`) actually resolves to an installed slash-command or skill on disk. Prints a status table; `--json` emits a `hive-doctor.v1` envelope. Also runs **non-fatally** at the end of `hive init` as a preflight: missing skills surface as stderr warnings, but `init` exit code is unaffected.
 
 ## Usage
 
@@ -29,7 +29,7 @@ Run from a hive-initialized project (loads `<project>/.hive-state/config.yml`).
 
 `Doctor#call` builds two row kinds and concatenates them:
 
-- **`kind: "stage"`** — one row per entry in `STAGES = %w[brainstorm plan]`. `label = stage`. Reads `cfg.dig(stage, "agent")` (default `"claude"`) and `cfg.dig(stage, "skill")` (falling back to `Hive::Config::DEFAULTS.dig(stage, "skill")`). The configured skill is routed through `profile.format_skill_invocation(skill)` before verification, so a pi stage receives `/skill:<name>` even when the user wrote `/<name>` in config.
+- **`kind: "stage"`** — one row per entry in `STAGES = %w[brainstorm plan]`. `label = stage`. Reads `cfg.dig(stage, "agent")` (default `"claude"`) and resolves the skill via `Hive::Config.stage_skill`. Plan defaults are agent-aware: Claude keeps the legacy `/plan` alias, Codex gets `/llm-wiki:wiki-plan`, and Pi gets `/skill:wiki-plan` after profile formatting. A legacy `plan.skill: /plan` config is also mapped to llm-wiki's canonical `wiki-plan` skill for Codex/Pi. The resolved skill is routed through `profile.format_skill_invocation(skill)` before verification.
 - **`kind: "reviewer"`** — one row per entry in `cfg.dig("review", "reviewers")`. `label = "6-review/<name>"`. Reads `agent`, `name`, `kind` (default `"agent"`), and `skill`. The bare config skill is formatted through `profile.format_skill_invocation` to obtain the full invocation before passing to `verify_skill`, so the JSON envelope's `skill` field is uniform across stage and reviewer rows.
 
 Reviewer entries with `kind != "agent"` short-circuit to `:not_applicable` with a "kind '<X>' is not 'agent'; doctor only checks agent-kind reviewers" message. **This is the only load-time signal for non-agent kinds** — `Hive::Config.validate_reviewers!` does not validate `kind`; only `Hive::Reviewers.dispatch` does, at run-time.
@@ -61,7 +61,7 @@ A new agent profile becomes "doctorable" by registering a `Hive::SkillCheck::*` 
   "schema": "hive-doctor.v1",
   "checks": [
     {"kind": "stage", "stage": "brainstorm", "label": "brainstorm", "agent": "claude", "configured_skill": "/compound-engineering:ce-brainstorm", "skill": "/compound-engineering:ce-brainstorm", "status": "present", "message": "..."},
-    {"kind": "stage", "stage": "plan", "label": "plan", "agent": "pi", "configured_skill": "/plan", "skill": "/skill:plan", "status": "present", "message": "..."},
+    {"kind": "stage", "stage": "plan", "label": "plan", "agent": "pi", "configured_skill": "/llm-wiki:wiki-plan", "skill": "/skill:wiki-plan", "status": "present", "message": "..."},
     {"kind": "reviewer", "stage": "6-review", "name": "claude-ce-code-review", "label": "6-review/claude-ce-code-review", "agent": "claude", "configured_skill": "ce-code-review", "skill": "/ce-code-review", "status": "missing", "message": "..."}
   ],
   "summary": {"missing": 1, "present": 2, "not_applicable": 0}
@@ -71,7 +71,8 @@ A new agent profile becomes "doctorable" by registering a `Hive::SkillCheck::*` 
 Field history (all additive — schema name stays `v1`):
 
 - 2026-05-07: `kind`, `name`, `label` added on `checks[]`.
-- 2026-05-07: `configured_skill` added on `checks[]`. Carries the raw config-supplied value alongside `skill`, which carries the profile-aware formatted invocation. Pi stage rows are the most affected — a configured `/plan` shows `configured_skill: "/plan"` and `skill: "/skill:plan"`; consumers that need to round-trip back to the operator's config should read `configured_skill`, not `skill`.
+- 2026-05-07: `configured_skill` added on `checks[]`. Carries the raw config-supplied value alongside `skill`, which carries the profile-aware formatted invocation. Pi stage rows are the most affected; consumers that need to round-trip back to the operator's config should read `configured_skill`, not `skill`.
+- 2026-05-14: plan-stage defaults became agent-aware. Codex and Pi now resolve the llm-wiki `wiki-plan` skill directly instead of requiring a local `plan` alias.
 
 ## Init preflight (non-fatal)
 

--- a/wiki/commands/init.md
+++ b/wiki/commands/init.md
@@ -3,11 +3,11 @@ title: hive init
 type: command
 source: lib/hive/commands/init.rb
 created: 2026-04-25
-updated: 2026-05-19
-tags: [command, bootstrap, git, prompts]
+updated: 2026-05-22
+tags: [command, bootstrap, git, prompts, llm-wiki]
 ---
 
-**TLDR**: `hive init [PATH]` bootstraps a project for hive: creates the orphan `hive/state` branch, attaches it as a worktree at `<project>/.hive-state/`, scaffolds stage folders, asks the operator (on TTY) which agents to use for planning / development / review, which Claude brainstorm runtime to use, and what budget+timeout sanity caps to set, scaffolds `config.yml` from those answers, ignores `.hive-state/` in master, and registers the project globally.
+**TLDR**: `hive init [PATH]` bootstraps a project for hive: creates the orphan `hive/state` branch, attaches it as a worktree at `<project>/.hive-state/`, scaffolds stage folders, asks the operator (on TTY) which agents to use for planning / development / review, which Claude brainstorm runtime to use, and what budget+timeout sanity caps to set, scaffolds `config.yml` from those answers, ignores `.hive-state/` in master, initializes managed llm-wiki context with Codex as the headless wiki refresher, and registers the project globally.
 
 ## Usage
 
@@ -39,8 +39,16 @@ hive init [PROJECT_PATH] [--force]
    - Initial commit `hive: bootstrap` on `hive/state`.
 5. **Render `<path>/.hive-state/config.yml`** from `templates/project_config.yml.erb`, threading the answers hash from step 3 through `ProjectConfigBinding`. Skipped if the file already exists.
 6. **Ignore `.hive-state/` on master** via `GitOps#add_hive_state_to_master_gitignore!`: appends `/.hive-state/` to `.gitignore` (idempotent), then commits `chore: ignore .hive-state worktree` on master.
-7. **Register globally** via `Hive::Config.register_project(name: basename(path), path: path)`, writing into `~/Dev/hive/config.yml`.
-8. Print summary: project name, default branch, hive-state path, worktree root, and a `next:` line with the `hive new ...` invocation.
+7. **Bootstrap managed llm-wiki files** via `Hive::LlmWikiBootstrap.install!(post_commit_hook: false, scheduler: false)`:
+   - `.llm-wiki/config.json` with `headless_agent: "codex"`, `context_agents: ["claude", "codex", "pi"]`, `created_by: "hive"`, and a detected `main_wiki_path` when one exists.
+   - `.llm-wiki/refresh-wiki.sh` and `.llm-wiki/post-commit-refresh.sh`, both Codex-owned and run with `codex exec --add-dir <qmd-cache> -C <project>`. Both scripts keep qmd's normal GPU auto-detection and fall back to `.llm-wiki/qmd-cache` when the normal qmd cache is not writable.
+   - `wiki/index.md`, `wiki/log.md`, `wiki/gaps.md`, `wiki/architecture.md`, `wiki/decisions.md`, `wiki/dependencies.md`, and `raw/notes/.gitkeep`.
+   - Managed LLM WIKI blocks in `AGENTS.md` and `CLAUDE.md`, plus `.claude/settings.json` with a managed `SessionStart` hook that prints `wiki/index.md` and recent `wiki/log.md`.
+8. **Commit llm-wiki bootstrap files** via `GitOps#commit_llm_wiki_bootstrap!`, committing tracked project context as `chore: initialize llm-wiki` so future Hive worktrees inherit wiki context.
+9. **Install runtime wiki hooks** via `Hive::LlmWikiBootstrap.install_runtime_hooks!`: adds/replaces only the managed block in `.git/hooks/post-commit`, writes Linux user systemd service/timer files for daily refresh, and enables the timer through `timers.target.wants`.
+10. **Register globally** via `Hive::Config.register_project(name: basename(path), path: path)`, writing into `~/Dev/hive/config.yml`.
+11. Print summary: project name, default branch, hive-state path, worktree root, and a `next:` line with the `hive new ...` invocation.
+12. Run the non-fatal `hive doctor` skill preflight; missing skills warn on stderr without failing init.
 
 ## Prompt flow (ADR-023)
 
@@ -94,7 +102,7 @@ This branch is what the orphan worktree is initially based on, and what feature 
 
 ## Tests
 
-- `test/integration/init_test.rb` covers all five preconditions, the `--force` path, the idempotent double-init, the rendered template's stage-agent/runtime blocks, the bumped-generous limits, the dropped `execute_review` key, and the U5 piped-input + abort + already-initialized-guard scenarios.
+- `test/integration/init_test.rb` covers all five preconditions, the `--force` path, the idempotent double-init, the rendered template's stage-agent/runtime blocks, the bumped-generous limits, the dropped `execute_review` key, managed llm-wiki bootstrap/scheduler/hooks, and the U5 piped-input + abort + already-initialized-guard scenarios.
 - `test/unit/commands/init/prompts_test.rb` covers the prompt module in isolation: happy paths, edge re-prompts, the Claude-only brainstorm runtime prompt, the non-TTY summary contract, and the testability invariant.
 
 ## Backlinks

--- a/wiki/decisions.md
+++ b/wiki/decisions.md
@@ -91,8 +91,8 @@ tags: [decisions, adr]
 
 **Status:** Active
 **Context:** Hive commits on every `hive run` shouldn't pollute master's history or trigger CI.
-**Decision:** All hive commits go to `hive/state` (the orphan branch). Only one hive-driven commit ever lands on master: the initial `chore: ignore .hive-state worktree` from `hive init`. Master's CI workflows trigger on `master`/`main` pushes only, so `hive/state` commits never trigger CI; no `[skip ci]` flag needed.
-**Consequences:** `git log master` is clean. Feature worktrees branch from master and contain no hive artefacts. User can `git pull` master without conflicts.
+**Decision:** All task-state commits go to `hive/state` (the orphan branch). `hive init` may make project-setup commits on master/default branch: `chore: ignore .hive-state worktree` and `chore: initialize llm-wiki`. Runtime task movement, agent outputs, reviews, and markers stay on `hive/state`, so normal `hive run` activity never triggers master/main CI workflows.
+**Consequences:** Feature worktrees branch from master and inherit tracked project context such as `AGENTS.md`, `CLAUDE.md`, `.llm-wiki/`, and `wiki/`, while mutable Hive task state remains isolated on `hive/state`. User can `git pull` master without task-state conflicts.
 
 ## ADR-010: One commit per `hive run`, skipped if diff is empty
 

--- a/wiki/gaps.md
+++ b/wiki/gaps.md
@@ -3,7 +3,7 @@ title: Gaps
 type: gaps
 source: wiki/* vs lib/, templates/, test/
 created: 2026-04-25
-updated: 2026-05-20
+updated: 2026-05-22
 tags: [gap, todo]
 ---
 
@@ -23,6 +23,7 @@ tags: [gap, todo]
 | `lib/hive/worktree.rb` | ✓ [[modules/worktree]] |
 | `lib/hive/git_ops.rb` | ✓ [[modules/git_ops]] |
 | `lib/hive/agent.rb` | ✓ [[modules/agent]] |
+| `lib/hive/llm_wiki_bootstrap*.rb` | ✓ [[commands/init]] |
 | `lib/hive/commands/init.rb` | ✓ [[commands/init]] |
 | `lib/hive/commands/new.rb` | ✓ [[commands/new]] |
 | `lib/hive/commands/run.rb` | ✓ [[commands/run]] |

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -168,6 +168,16 @@ Skipped per product direction: schema versioning #5 (product unreleased, in-plac
 - [[commands/doctor]] — tmux preflight and stale-session reporting.
 - [[state-model]] — `brainstorm.runtime` config flag.
 
+## [2026-05-14T17:30:00Z] commands/init — managed llm-wiki bootstrap during project setup
+
+**Action:** `hive init` now initializes managed llm-wiki project context directly. New `Hive::LlmWikiBootstrap` writes `.llm-wiki/config.json` with Codex as `headless_agent`, creates project wiki starter pages plus `raw/notes/`, writes managed LLM WIKI blocks into `AGENTS.md` and `CLAUDE.md`, and writes `.claude/settings.json` with a managed `SessionStart` hook that surfaces `wiki/index.md` and recent `wiki/log.md`. The refresh scripts are Codex-owned (`codex exec --add-dir <qmd-cache> -C <project>`), preserve qmd's GPU auto-detection, grant the maintenance agent qmd cache write access, and fall back to `.llm-wiki/qmd-cache` when the normal qmd cache is not writable. The post-commit hook is installed only after the bootstrap files are committed so init's own `chore: initialize llm-wiki` commit does not immediately launch a refresh. Linux init also writes daily user-systemd service/timer files and enables the timer symlink. Tests cover managed config shape, committed context files, scheduler files, hook preservation, qmd cache fallback, and no legacy `claude -p` refresh path.
+
+**Refreshed pages:**
+- [[commands/init]] — init steps now include managed llm-wiki files, the committed bootstrap context, runtime hook installation, and the doctor preflight.
+- [[modules/git_ops]] — documents the `commit_llm_wiki_bootstrap!` project-setup commit and why it runs before post-commit hook installation.
+- [[decisions]] — ADR-009 now distinguishes task-state commits from one-time project-setup commits required for feature worktrees to inherit wiki context.
+- [[cli]], [[index]], and [[gaps]] — command/source summaries now note the llm-wiki initialization surface.
+
 ## [2026-05-14T17:17:00Z] review — clarify live review-pass config and stale recovery docs
 
 **Action:** Follow-up from code review on the review/daemon default PR. Removed the stale top-level `max_review_passes` key from `Config::DEFAULTS`, the project config template, README, and wiki examples so `review.max_passes` is the only documented live review-loop cap. Replaced the README troubleshooting row that still described max review pass exhaustion as `EXECUTE_STALE` with the current `REVIEW_STALE` / `hive markers clear ... --name REVIEW_STALE` recovery flow. Clarified daemon docs that `max_concurrent_per_project` is a per-project burst cap; setting it below the global cap is what enforces cross-project fairness.
@@ -175,6 +185,14 @@ Skipped per product direction: schema versioning #5 (product unreleased, in-plac
 **Refreshed pages:**
 - [[commands/daemon]] — concurrency table wording now matches the 5/5 default.
 - [[modules/config]] and [[state-model]] — config examples only expose `review.max_passes`.
+
+## [2026-05-14T16:45:00Z] plan — agent-aware llm-wiki planning defaults for Codex and Pi
+
+**Action:** Changed 3-plan skill resolution from one literal default (`/plan`) to `Hive::Config.stage_skill`, which keeps Claude on the legacy `/plan` wiki-first alias while using llm-wiki's canonical `/llm-wiki:wiki-plan` skill for Codex and Pi. Pi's agent profile formats that to `/skill:wiki-plan`. Existing configs that still say `plan.skill: /plan` now map to `wiki-plan` for Codex/Pi, so switching `plan.agent` no longer requires a local Codex or Pi `plan` alias. Non-legacy stage overrides, such as `/compound-engineering:ce-plan`, still win. `hive doctor` now verifies the resolved agent-aware planning skill, and tests cover Codex defaults, Pi defaults, and the legacy alias mapping.
+
+**Refreshed pages:**
+- [[stages/plan]] — plan stage now documents `Hive::Config.stage_skill`, agent-aware llm-wiki defaults, task-folder-only isolation, and current plan budget/timeout defaults.
+- [[commands/doctor]] — doctor rows now document the resolved Codex/Pi `wiki-plan` invocation instead of the old `/skill:plan` example.
 
 ## [2026-05-14T15:20:40Z] review — lower default review loop cap to 2 passes
 

--- a/wiki/modules/git_ops.md
+++ b/wiki/modules/git_ops.md
@@ -7,7 +7,7 @@ updated: 2026-05-22T13:30:00Z
 tags: [git, init, commit]
 ---
 
-**TLDR**: Project-scoped git operations: detect default branch, inspect HEAD/branch/worktree status, bootstrap the orphan `hive/state` worktree at `<project>/.hive-state/`, append `/.hive-state/` to master's `.gitignore`, and run `git add && git commit` inside the hive-state worktree.
+**TLDR**: Project-scoped git operations: detect default branch, inspect HEAD/branch/worktree status, bootstrap the orphan `hive/state` worktree at `<project>/.hive-state/`, append `/.hive-state/` to master's `.gitignore`, commit managed llm-wiki bootstrap files during `hive init`, and run `git add && git commit` inside the hive-state worktree.
 
 ## Constants
 
@@ -68,7 +68,22 @@ Appends `/.hive-state/` to `<project>/.gitignore` (idempotent: returns `:already
 1. `git -C <project> add .gitignore`.
 2. `git -C <project> commit -m "chore: ignore .hive-state worktree"`.
 
-This is the *only* commit Hive ever makes on master. After this, all hive activity goes to `hive/state`.
+This is one of the project-setup commits Hive may make on master/default branch. Runtime task activity still goes to `hive/state`.
+
+## `commit_llm_wiki_bootstrap!`
+
+Stages the managed llm-wiki context paths written by `Hive::LlmWikiBootstrap`:
+
+- `.llm-wiki/config.json`
+- `.llm-wiki/refresh-wiki.sh`
+- `.llm-wiki/post-commit-refresh.sh`
+- `.claude/settings.json`
+- `AGENTS.md`
+- `CLAUDE.md`
+- `wiki/{index,log,gaps,architecture,decisions,dependencies}.md`
+- `raw/notes/.gitkeep`
+
+If staging produces a diff, commits `chore: initialize llm-wiki`; otherwise returns `:nothing_to_commit`. `hive init` calls this before installing the runtime post-commit hook so the bootstrap commit does not launch a wiki refresh immediately.
 
 ## `hive_commit(stage_name:, slug:, action:)`
 

--- a/wiki/stages/plan.md
+++ b/wiki/stages/plan.md
@@ -3,22 +3,23 @@ title: 3-plan stage
 type: stage
 source: lib/hive/stages/plan.rb, templates/plan_prompt.md.erb
 created: 2026-04-25
-updated: 2026-05-19
-tags: [stage, plan, ce-plan]
+updated: 2026-05-22
+tags: [stage, plan, llm-wiki, ce-plan]
 ---
 
-**TLDR**: Agent reads `brainstorm.md`, runs `/compound-engineering:ce-plan` to generate a structured `plan.md`, and waits for human review/edits via `<!-- WAITING -->` until ready (`<!-- COMPLETE -->`).
+**TLDR**: Agent reads `brainstorm.md`, runs Hive's configured wiki-first planning skill to generate a structured `plan.md`, and waits for human review/edits via `<!-- WAITING -->` until ready (`<!-- COMPLETE -->`). The default is agent-aware: Claude uses `/plan`, Codex uses `/llm-wiki:wiki-plan`, and Pi receives `/skill:wiki-plan` after profile formatting.
 
 ## Setup
 
 - **State file**: `plan.md`.
-- **Prompt**: `templates/plan_prompt.md.erb`, rendered with `project_name`, `task_folder`, `brainstorm_text`. Brainstorm content is wrapped in `<user_supplied content_type="brainstorm_md">…</user_supplied>`.
-- **Agent invocation**: `cwd = task.folder`, `--add-dir <project_root>`, `log_label = "plan"`.
-- **Budgets**: `cfg["budget_usd"]["plan"]` (default 20), `cfg["timeout_sec"]["plan"]` (default 600).
+- **Prompt**: `templates/plan_prompt.md.erb`, rendered with `project_name`, `task_folder`, `brainstorm_text`, `user_supplied_tag`, and `skill_invocation`. Brainstorm content is wrapped in a nonce-tagged user-supplied block.
+- **Skill resolution**: `Hive::Config.stage_skill(cfg, "plan")` picks a project override when present. If the legacy `plan.skill: /plan` alias is used with Codex or Pi, Hive maps it to llm-wiki's canonical `wiki-plan` skill.
+- **Agent invocation**: `cwd = task.folder`, `add_dirs = [task.folder]`, `log_label = "plan"`.
+- **Budgets**: `cfg["budget_usd"]["plan"]` (default 100), `cfg["timeout_sec"]["plan"]` (default 3600).
 
 ## Agent behaviour (per `templates/plan_prompt.md.erb`)
 
-1. If `plan.md` does not exist, use the `/compound-engineering:ce-plan` skill to generate the plan with required sections:
+1. If `plan.md` does not exist, use the configured wiki-first planning skill to generate the plan with required sections:
    - `## Overview`
    - `## Requirements Trace`
    - `## Scope Boundaries`


### PR DESCRIPTION
## Summary

Introduces `Hive::LlmWikiBootstrap` — a project-setup subsystem that, on `hive init`, writes a managed `.llm-wiki/` directory plus the supporting context files (`AGENTS.md`, `CLAUDE.md`, `.claude/settings.json` session-start hook, refresh scripts, optional systemd-user timer) so every agent invocation inside the project sees the same wiki-grounded context.

Lands as a single squash-candidate commit rebased onto current `main`. Branch had been sitting uncommitted in a worktree since 2026-05-14; this brings it through the review path with the snapshot's intent preserved.

## What's new

**`Hive::LlmWikiBootstrap` (5 new files, ~17 KB total)**

- `lib/hive/llm_wiki_bootstrap.rb` — top-level `install!` entrypoint, idempotent.
- `lib/hive/llm_wiki_bootstrap/context.rb` — managed `LLM WIKI` block writer for `AGENTS.md` / `CLAUDE.md` and `.claude/settings.json` `SessionStart` hook.
- `lib/hive/llm_wiki_bootstrap/pages.rb` — initial wiki page scaffolding (`wiki/index.md`, `wiki/log.md`, `raw/notes/`).
- `lib/hive/llm_wiki_bootstrap/scheduler.rb` — Linux user-systemd service + timer for the daily wiki refresh.
- `lib/hive/llm_wiki_bootstrap/scripts.rb` — Codex-owned `refresh-wiki.sh` and `post-commit-refresh.sh` with qmd cache fallback and GPU auto-detection preserved.

**Supporting wiring**

- `Hive::Config` grows the `skill_by_agent` block and `Hive::Config.stage_skill` resolver so `plan.skill` resolution is agent-aware (Claude `/plan`, Codex `/llm-wiki:wiki-plan`, Pi `/skill:wiki-plan`). Legacy `plan.skill: /plan` is mapped to `wiki-plan` for non-Claude agents (+75 lines in `lib/hive/config.rb`).
- `hive init` calls `LlmWikiBootstrap.install!` after the standard scaffolding, then commits the bootstrap files via a `chore: initialize llm-wiki` commit BEFORE installing the post-commit hook so init's own commit doesn't immediately trigger a refresh.
- `hive doctor` verifies the resolved per-agent planning skill.
- `Hive::Stages::{Brainstorm,Plan}` and `Hive::GitOps` thread the new skill resolution and the `commit_llm_wiki_bootstrap!` helper.

**Tests**

- Integration: `init_test.rb` covers managed config shape, committed context files, scheduler files, hook preservation, qmd cache fallback, no legacy `claude -p` refresh path.
- Unit: `config_test.rb` pins the three `Hive::Config.stage_skill` paths (default per agent, legacy alias mapping, non-legacy override) and the `skill_by_agent` shape validator.
- Existing `doctor_test`, `skill_invocation_format_test`, `prompt_injection_test`, and shared `test_helper` extended.

**Documentation (the substantial wiki update)**

- `wiki/commands/init.md` documents the new managed-bootstrap step.
- `wiki/commands/doctor.md` documents the agent-aware `stage_skill` resolution.
- `wiki/stages/plan.md` describes Claude/Codex/Pi defaults.
- `wiki/modules/git_ops.md` documents `commit_llm_wiki_bootstrap!`.
- `wiki/log.md` gets two dated entries describing the change (chronologically interleaved with the existing 2026-05-14 entries).
- `wiki/decisions.md`, `wiki/gaps.md`, `wiki/index.md`, `wiki/cli.md` and `README.md` get cross-reference updates.

## History note

The branch base was `e6458e5` (2026-05-14, 35 commits behind main at rebase time). The original branch's only commit (`9324199 chore: tune daemon and review defaults`) was dropped during rebase because every default it set (max_review_passes, max_concurrent_runs, max_concurrent_per_project) already matches main's current values, so its diff was pure churn against the merged result. The single snapshot commit on top is what this PR proposes.

## Test plan

- [ ] CI's `rake test (Ruby 3.4)` (local run: 2534 runs / 8910 assertions / 0 failures; one environmental `tmux kill-session` error unrelated to this PR's diff).
- [ ] `hive doctor` against a freshly-`hive init`ed sandbox returns the new agent-aware plan-skill rows.
- [ ] After merge: verify `.llm-wiki/` is created in projects when `hive init` runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)