### PR TITLE
feat(tui): full-screen info panel and footer hint for [i]

### DIFF
--- a/lib/hive/tui/bubble_model.rb
+++ b/lib/hive/tui/bubble_model.rb
@@ -2886,7 +2886,12 @@ module Hive
 
       def compose_idea_preview_view
         usable = [ @hive_model.cols.to_i - 1, 1 ].max
-        compose_two_pane_view(footer: prompt_footer(Views::IdeaPreview.render(@hive_model, width: usable), usable))
+        panel_height = [ @hive_model.rows.to_i - 1, 1 ].max
+        Lipgloss.join_vertical(
+          Lipgloss::TOP,
+          Views::IdeaPreview.render(@hive_model, width: usable, height: panel_height),
+          default_footer(usable)
+        )
       end
 
       # New-idea mode: same composition; footer = the inline prompt with

--- a/lib/hive/tui/bubble_model.rb
+++ b/lib/hive/tui/bubble_model.rb
@@ -3017,7 +3017,7 @@ module Hive
       end
 
       def footer_hint
-        "[Tab] switch  [Enter] action  [n] new  [/] filter  [?] help  [q] quit"
+        "[Tab] switch  [Enter] action  [n] new  [/] filter  [?] help  [i] info  [q] quit"
       end
 
       # Compute pane widths and join horizontally. Left pane is clamped

--- a/lib/hive/tui/bubble_model.rb
+++ b/lib/hive/tui/bubble_model.rb
@@ -72,10 +72,7 @@ module Hive
       # lives on `Hive::Markers::KILL_CLASS_EXIT_CODES` so KeyMap's
       # Enter-routing predicate and this auto-healer never drift.
       KILL_CLASS_EXIT_CODES = Hive::Markers::KILL_CLASS_EXIT_CODES
-      # Read window for the 4-execute info-panel log tail (see `tail_capped`
-      # ~1700 lines below). Sized for ~32 lines of recent agent output —
-      # enough operator context for the no-scroll panel without letting
-      # large logs dominate render-time memory.
+      # Sized for ~32 lines of recent agent output — bounds render-time memory on large logs.
       INFO_PANEL_EXECUTE_TAIL_BYTES = 4 * 1024
       # Lowercase snapshot-row marker keys → uppercase CLI marker names
       # accepted by `hive markers clear --name`. Mirrors the upcase
@@ -1547,7 +1544,7 @@ module Hive
           @hive_model.with(mode: :idea_preview, info_panel_state: state),
           nil
         ]
-      rescue Errno::ENOENT, Errno::EACCES, Psych::Exception
+      rescue Errno::ENOENT, Errno::EACCES, Errno::EISDIR, Errno::ENOTDIR, Errno::ENAMETOOLONG, Encoding::InvalidByteSequenceError, Psych::Exception
         [ flashed("could not read idea for #{row.slug}"), nil ]
       end
 
@@ -1564,15 +1561,7 @@ module Hive
         parsed.is_a?(Hash) ? parsed : {}
       end
 
-      # `created_at` is rendered as-is when the frontmatter carries a
-      # plain scalar (so a non-UTC `+03:00` timezone survives verbatim
-      # for the operator). The fallbacks cover edge cases the scalar
-      # parser can't represent — block scalars (`|` / `>`) or YAML-typed
-      # values that already parsed to a Time/Date — by formatting from
-      # `data`, which has been through `YAML.safe_load`. Time values are
-      # normalized to UTC iso8601 since a typed Time has lost the
-      # original literal; non-UTC offsets must come through the
-      # verbatim path above to be preserved.
+      # Verbatim plain scalar preserves non-UTC offsets; YAML-typed fallback normalizes Time to UTC iso8601.
       def idea_created_at(contents, data)
         raw = frontmatter_scalar(contents, "created_at")
         return raw unless raw.to_s.empty?
@@ -1582,57 +1571,38 @@ module Hive
         return value.utc.iso8601 if value.is_a?(Time)
         return value.iso8601 if value.respond_to?(:iso8601)
 
-        value.to_s
+        value.to_s.strip
       end
 
-      # Tightly-scoped scalar extractor used only by `idea_created_at`
-      # so a non-UTC timestamp (e.g. `+03:00`) survives the
-      # YAML.safe_load round-trip verbatim. Intentionally narrow: it
-      # only handles plain and matched-quote scalars on a single line.
-      # Block scalars (`|` / `>`), multi-line strings, escaped quote
-      # sequences, and YAML tags fall through to `nil`, which sends
-      # `idea_created_at` to its typed-value fallback path. Do not
-      # extend this for general use — for anything beyond `created_at`
-      # verbatim preservation, read from the already-parsed
-      # `idea_frontmatter` hash.
+      # Narrow plain/matched-quote scalar extractor — block scalars and multi-line strings return nil.
       def frontmatter_scalar(contents, key)
         match = contents.match(/\A---[ \t]*\r?\n(.*?)\r?\n---[ \t]*(?:\r?\n|\z)/m)
         return nil unless match
 
         match[1].lines.each do |line|
-          next unless (field = line.match(/\A#{Regexp.escape(key)}:[ \t]*(.*?)[ \t]*(?:#.*)?\r?\n?\z/))
+          next unless (field = line.match(/\A#{Regexp.escape(key)}:[ \t]*(.*?)\r?\n?\z/))
 
-          value = field[1].strip
-          return nil if value.empty? || value == "|" || value == ">"
+          raw = field[1].strip
+          return nil if raw.empty? || raw == "|" || raw == ">"
 
-          quote = value[0]
-          return value[1...-1] if value.length >= 2 && (quote == "\"" || quote == 39.chr) && value[-1] == quote
+          if raw.length >= 2 && [ "\"", "'" ].include?(raw[0])
+            quote = raw[0]
+            closing = raw.index(quote, 1)
+            return closing ? raw[1...closing] : nil
+          end
 
-          return value
+          stripped = raw.sub(/[ \t]+#.*\z/, "").strip
+          return stripped.empty? ? nil : stripped
         end
         nil
       end
 
-      # Returns the most recently modified log file under
-      # `.hive-state/logs/<slug>/` regardless of stage. Used for the
-      # generic `latest log` line in the info panel header — the
-      # 4-execute extra panel uses `latest_execute_log_for` instead so
-      # a stray `plan-*.log` mtime cannot be tailed as "execute log".
-      # The `*.log` glob matches `Hive::Agent#log_path`'s naming
-      # convention (`<log_label>-<ts>.log`); a non-`.log` artefact
-      # dropped into the logs dir is intentionally invisible here so
-      # cron-style sidecar files (`.tmp`, `.rotated`) do not surface as
-      # the operator-visible "latest log" pointer.
+      # Generic latest log used in the header; 4-execute extra uses `latest_execute_log_for` to avoid stray plan-*.log mtimes.
       def latest_log_for(row)
         latest_log_matching(row) { |_path| true }
       end
 
-      # Same shape as `latest_log_for` but restricted to files whose
-      # basename starts with `execute-` (matches the `log_label:
-      # "execute-impl"` convention in `Hive::Stages::Execute`). Keeps
-      # the 4-execute info-panel tail from picking up a freshly-written
-      # `plan-*.log` whose mtime happens to outrank the prior execute
-      # log.
+      # Restricted to `execute-*` basenames so a fresh plan-*.log mtime cannot masquerade as the execute log.
       def latest_execute_log_for(row)
         latest_log_matching(row) { |path| File.basename(path).start_with?("execute-") }
       end
@@ -1655,7 +1625,7 @@ module Hive
         end
 
         with_mtimes.max_by(&:last).first
-      rescue Errno::ENOENT, Errno::EACCES, SystemCallError
+      rescue Errno::ENOENT, Errno::EACCES
         nil
       end
 
@@ -1688,29 +1658,28 @@ module Hive
       def tail_capped(path)
         return nil if path.to_s.empty? || !File.file?(path)
 
-        # The seek is byte-aligned, not line-aligned: the tail's first
-        # rendered line may begin mid-character on a log line. This is
-        # acceptable for the read-only panel — it is documented here so
-        # a future contributor does not "fix" it by adding line-aware
-        # framing that re-introduces a full-file scan on large logs.
+        # Byte-aligned seek — the first rendered line may begin mid-character; do not add line-aware framing.
         text = File.open(path, "rb") do |file|
-          file.seek(-INFO_PANEL_EXECUTE_TAIL_BYTES, IO::SEEK_END)
-          file.read
-        rescue Errno::EINVAL
-          file.rewind
-          file.read
+          begin
+            file.seek(-INFO_PANEL_EXECUTE_TAIL_BYTES, IO::SEEK_END)
+            file.read
+          rescue Errno::EINVAL
+            begin
+              file.rewind
+              file.read
+            rescue Errno::ESPIPE
+              nil
+            end
+          end
         end
+        return nil if text.nil?
+
         scrub_utf8(text)
-      rescue Errno::ENOENT, Errno::EACCES, Errno::EISDIR, Errno::ENXIO
+      rescue Errno::ENOENT, Errno::EACCES, Errno::EISDIR, Errno::ENXIO, Errno::ESPIPE
         nil
       end
 
-      # `force_encoding` mutates in place, so dup first — callers may
-      # pass shared strings now or in the future. Also strips C0 control
-      # bytes (preserving TAB / LF / CR) and DEL so an agent-authored
-      # markdown body or log tail carrying ANSI escape sequences cannot
-      # corrupt the info-panel frame. Lone C1 bytes (0x80-0x9F) are
-      # invalid UTF-8 leads and are already removed by `String#scrub`.
+      # Dup before force_encoding (callers may share); also strips C0/DEL so ANSI escapes cannot corrupt the panel frame.
       def scrub_utf8(text)
         scrubbed = text.to_s.dup.force_encoding(Encoding::UTF_8).scrub
         scrubbed.gsub(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/, "")

--- a/lib/hive/tui/bubble_model.rb
+++ b/lib/hive/tui/bubble_model.rb
@@ -72,6 +72,7 @@ module Hive
       # lives on `Hive::Markers::KILL_CLASS_EXIT_CODES` so KeyMap's
       # Enter-routing predicate and this auto-healer never drift.
       KILL_CLASS_EXIT_CODES = Hive::Markers::KILL_CLASS_EXIT_CODES
+      INFO_PANEL_EXECUTE_TAIL_BYTES = 4 * 1024
       # Lowercase snapshot-row marker keys → uppercase CLI marker names
       # accepted by `hive markers clear --name`. Mirrors the upcase
       # convention in `Hive::Markers::KNOWN_NAMES`. A new recoverable
@@ -1520,18 +1521,30 @@ module Hive
         idea_path = File.join(row.folder, "idea.md")
         return [ flashed("no idea.md for #{row.slug}"), nil ] unless File.exist?(idea_path)
 
-        data = idea_frontmatter(File.read(idea_path))
+        contents = File.read(idea_path)
+        data = idea_frontmatter(contents)
         original_text = data["original_text"].to_s
         if original_text.empty?
           return [ flashed("idea has no original_text for #{row.slug}"), nil ]
         end
 
         capped_text = original_text[0, Hive::Tui::Model::NEW_IDEA_BUFFER_MAX_CHARS]
+        latest_log_path = latest_log_for(row)
+        state = Hive::Tui::Model::InfoPanelState.new(
+          slug: row.slug,
+          stage: row.stage,
+          created_at: idea_created_at(contents, data),
+          original_text: capped_text,
+          folder_path: File.expand_path(row.folder),
+          latest_log_path: latest_log_path,
+          stage_extra: stage_extra_for(row, latest_log_path)
+        )
         [
           @hive_model.with(
             mode: :idea_preview,
             idea_preview_text: capped_text,
-            idea_preview_slug: row.slug
+            idea_preview_slug: row.slug,
+            info_panel_state: state
           ),
           nil
         ]
@@ -1550,6 +1563,105 @@ module Hive
           aliases: false
         ) || {}
         parsed.is_a?(Hash) ? parsed : {}
+      end
+
+      def idea_created_at(contents, data)
+        raw = frontmatter_scalar(contents, "created_at")
+        return raw unless raw.to_s.empty?
+
+        value = data["created_at"]
+        return nil if value.nil?
+        return value.utc.iso8601 if value.is_a?(Time)
+        return value.iso8601 if value.respond_to?(:iso8601)
+
+        value.to_s
+      end
+
+      def frontmatter_scalar(contents, key)
+        match = contents.match(/\A---[ \t]*\r?\n(.*?)\r?\n---[ \t]*(?:\r?\n|\z)/m)
+        return nil unless match
+
+        match[1].lines.each do |line|
+          next unless (field = line.match(/\A#{Regexp.escape(key)}:[ \t]*(.*?)[ \t]*(?:#.*)?\r?\n?\z/))
+
+          value = field[1].strip
+          return nil if value.empty? || value == "|" || value == ">"
+
+          quote = value[0]
+          return value[1...-1] if value.length >= 2 && (quote == "\"" || quote == 39.chr) && value[-1] == quote
+
+          return value
+        end
+        nil
+      end
+
+      def latest_log_for(row)
+        log_dir = task_log_dir_for(row)
+        return nil if log_dir.nil? || !File.directory?(log_dir)
+
+        candidates = Dir.glob(File.join(log_dir, "*.log"))
+        return nil if candidates.empty?
+
+        with_mtimes = candidates.filter_map do |path|
+          [ File.expand_path(path), File.mtime(path) ]
+        rescue Errno::ENOENT
+          nil
+        end
+        if with_mtimes.empty?
+          candidate = candidates.find { |path| File.exist?(path) }
+          return candidate ? File.expand_path(candidate) : nil
+        end
+
+        with_mtimes.max_by(&:last).first
+      rescue Errno::EACCES
+        nil
+      end
+
+      def task_log_dir_for(row)
+        Hive::Task.new(row.folder).log_dir
+      rescue Hive::InvalidTaskPath
+        nil
+      end
+
+      def stage_extra_for(row, latest_log_path)
+        case row.stage.to_s
+        when "2-brainstorm" then read_capped(File.join(row.folder, "brainstorm.md"))
+        when "3-plan" then read_capped(File.join(row.folder, "plan.md"))
+        when "4-execute" then tail_capped(latest_log_path)
+        else nil
+        end
+      rescue Errno::ENOENT, Errno::EACCES
+        nil
+      end
+
+      def read_capped(path)
+        return nil if path.to_s.empty? || !File.exist?(path)
+
+        text = File.open(path, "rb") { |file| file.read(Hive::Tui::Model::NEW_IDEA_BUFFER_MAX_CHARS) }
+        scrub_utf8(text)
+      rescue Errno::ENOENT, Errno::EACCES
+        nil
+      end
+
+      def tail_capped(path)
+        return nil if path.to_s.empty? || !File.exist?(path)
+
+        # 4 KiB is enough recent execute context for the no-scroll panel
+        # without letting large logs dominate render-time memory.
+        text = File.open(path, "rb") do |file|
+          file.seek(-INFO_PANEL_EXECUTE_TAIL_BYTES, IO::SEEK_END)
+          file.read
+        rescue Errno::EINVAL
+          file.rewind
+          file.read
+        end
+        scrub_utf8(text)
+      rescue Errno::ENOENT, Errno::EACCES
+        nil
+      end
+
+      def scrub_utf8(text)
+        text.to_s.force_encoding(Encoding::UTF_8).scrub
       end
 
       def resolve_agent_label(row)

--- a/lib/hive/tui/bubble_model.rb
+++ b/lib/hive/tui/bubble_model.rb
@@ -72,6 +72,10 @@ module Hive
       # lives on `Hive::Markers::KILL_CLASS_EXIT_CODES` so KeyMap's
       # Enter-routing predicate and this auto-healer never drift.
       KILL_CLASS_EXIT_CODES = Hive::Markers::KILL_CLASS_EXIT_CODES
+      # Read window for the 4-execute info-panel log tail (see `tail_capped`
+      # ~1700 lines below). Sized for ~32 lines of recent agent output —
+      # enough operator context for the no-scroll panel without letting
+      # large logs dominate render-time memory.
       INFO_PANEL_EXECUTE_TAIL_BYTES = 4 * 1024
       # Lowercase snapshot-row marker keys → uppercase CLI marker names
       # accepted by `hive markers clear --name`. Mirrors the upcase
@@ -1537,15 +1541,10 @@ module Hive
           original_text: capped_text,
           folder_path: File.expand_path(row.folder),
           latest_log_path: latest_log_path,
-          stage_extra: stage_extra_for(row, latest_log_path)
+          stage_extra: stage_extra_for(row)
         )
         [
-          @hive_model.with(
-            mode: :idea_preview,
-            idea_preview_text: capped_text,
-            idea_preview_slug: row.slug,
-            info_panel_state: state
-          ),
+          @hive_model.with(mode: :idea_preview, info_panel_state: state),
           nil
         ]
       rescue Errno::ENOENT, Errno::EACCES, Psych::Exception
@@ -1565,6 +1564,15 @@ module Hive
         parsed.is_a?(Hash) ? parsed : {}
       end
 
+      # `created_at` is rendered as-is when the frontmatter carries a
+      # plain scalar (so a non-UTC `+03:00` timezone survives verbatim
+      # for the operator). The fallbacks cover edge cases the scalar
+      # parser can't represent — block scalars (`|` / `>`) or YAML-typed
+      # values that already parsed to a Time/Date — by formatting from
+      # `data`, which has been through `YAML.safe_load`. Time values are
+      # normalized to UTC iso8601 since a typed Time has lost the
+      # original literal; non-UTC offsets must come through the
+      # verbatim path above to be preserved.
       def idea_created_at(contents, data)
         raw = frontmatter_scalar(contents, "created_at")
         return raw unless raw.to_s.empty?
@@ -1577,6 +1585,16 @@ module Hive
         value.to_s
       end
 
+      # Tightly-scoped scalar extractor used only by `idea_created_at`
+      # so a non-UTC timestamp (e.g. `+03:00`) survives the
+      # YAML.safe_load round-trip verbatim. Intentionally narrow: it
+      # only handles plain and matched-quote scalars on a single line.
+      # Block scalars (`|` / `>`), multi-line strings, escaped quote
+      # sequences, and YAML tags fall through to `nil`, which sends
+      # `idea_created_at` to its typed-value fallback path. Do not
+      # extend this for general use — for anything beyond `created_at`
+      # verbatim preservation, read from the already-parsed
+      # `idea_frontmatter` hash.
       def frontmatter_scalar(contents, key)
         match = contents.match(/\A---[ \t]*\r?\n(.*?)\r?\n---[ \t]*(?:\r?\n|\z)/m)
         return nil unless match
@@ -1595,25 +1613,49 @@ module Hive
         nil
       end
 
+      # Returns the most recently modified log file under
+      # `.hive-state/logs/<slug>/` regardless of stage. Used for the
+      # generic `latest log` line in the info panel header — the
+      # 4-execute extra panel uses `latest_execute_log_for` instead so
+      # a stray `plan-*.log` mtime cannot be tailed as "execute log".
+      # The `*.log` glob matches `Hive::Agent#log_path`'s naming
+      # convention (`<log_label>-<ts>.log`); a non-`.log` artefact
+      # dropped into the logs dir is intentionally invisible here so
+      # cron-style sidecar files (`.tmp`, `.rotated`) do not surface as
+      # the operator-visible "latest log" pointer.
       def latest_log_for(row)
+        latest_log_matching(row) { |_path| true }
+      end
+
+      # Same shape as `latest_log_for` but restricted to files whose
+      # basename starts with `execute-` (matches the `log_label:
+      # "execute-impl"` convention in `Hive::Stages::Execute`). Keeps
+      # the 4-execute info-panel tail from picking up a freshly-written
+      # `plan-*.log` whose mtime happens to outrank the prior execute
+      # log.
+      def latest_execute_log_for(row)
+        latest_log_matching(row) { |path| File.basename(path).start_with?("execute-") }
+      end
+
+      def latest_log_matching(row)
         log_dir = task_log_dir_for(row)
         return nil if log_dir.nil? || !File.directory?(log_dir)
 
-        candidates = Dir.glob(File.join(log_dir, "*.log"))
+        candidates = Dir.glob(File.join(log_dir, "*.log")).select { |path| yield(path) }
         return nil if candidates.empty?
 
         with_mtimes = candidates.filter_map do |path|
           [ File.expand_path(path), File.mtime(path) ]
-        rescue Errno::ENOENT
+        rescue Errno::ENOENT, Errno::EACCES
           nil
         end
         if with_mtimes.empty?
-          candidate = candidates.find { |path| File.exist?(path) }
+          candidate = candidates.find { |path| File.file?(path) }
           return candidate ? File.expand_path(candidate) : nil
         end
 
         with_mtimes.max_by(&:last).first
-      rescue Errno::EACCES
+      rescue Errno::ENOENT, Errno::EACCES, SystemCallError
         nil
       end
 
@@ -1623,31 +1665,34 @@ module Hive
         nil
       end
 
-      def stage_extra_for(row, latest_log_path)
+      def stage_extra_for(row)
         case row.stage.to_s
         when "2-brainstorm" then read_capped(File.join(row.folder, "brainstorm.md"))
         when "3-plan" then read_capped(File.join(row.folder, "plan.md"))
-        when "4-execute" then tail_capped(latest_log_path)
+        when "4-execute" then tail_capped(latest_execute_log_for(row))
         else nil
         end
-      rescue Errno::ENOENT, Errno::EACCES
+      rescue Errno::ENOENT, Errno::EACCES, Errno::EISDIR, Errno::ENXIO, SystemCallError
         nil
       end
 
       def read_capped(path)
-        return nil if path.to_s.empty? || !File.exist?(path)
+        return nil if path.to_s.empty? || !File.file?(path)
 
         text = File.open(path, "rb") { |file| file.read(Hive::Tui::Model::NEW_IDEA_BUFFER_MAX_CHARS) }
         scrub_utf8(text)
-      rescue Errno::ENOENT, Errno::EACCES
+      rescue Errno::ENOENT, Errno::EACCES, Errno::EISDIR, Errno::ENXIO
         nil
       end
 
       def tail_capped(path)
-        return nil if path.to_s.empty? || !File.exist?(path)
+        return nil if path.to_s.empty? || !File.file?(path)
 
-        # 4 KiB is enough recent execute context for the no-scroll panel
-        # without letting large logs dominate render-time memory.
+        # The seek is byte-aligned, not line-aligned: the tail's first
+        # rendered line may begin mid-character on a log line. This is
+        # acceptable for the read-only panel — it is documented here so
+        # a future contributor does not "fix" it by adding line-aware
+        # framing that re-introduces a full-file scan on large logs.
         text = File.open(path, "rb") do |file|
           file.seek(-INFO_PANEL_EXECUTE_TAIL_BYTES, IO::SEEK_END)
           file.read
@@ -1656,12 +1701,19 @@ module Hive
           file.read
         end
         scrub_utf8(text)
-      rescue Errno::ENOENT, Errno::EACCES
+      rescue Errno::ENOENT, Errno::EACCES, Errno::EISDIR, Errno::ENXIO
         nil
       end
 
+      # `force_encoding` mutates in place, so dup first — callers may
+      # pass shared strings now or in the future. Also strips C0 control
+      # bytes (preserving TAB / LF / CR) and DEL so an agent-authored
+      # markdown body or log tail carrying ANSI escape sequences cannot
+      # corrupt the info-panel frame. Lone C1 bytes (0x80-0x9F) are
+      # invalid UTF-8 leads and are already removed by `String#scrub`.
       def scrub_utf8(text)
-        text.to_s.force_encoding(Encoding::UTF_8).scrub
+        scrubbed = text.to_s.dup.force_encoding(Encoding::UTF_8).scrub
+        scrubbed.gsub(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/, "")
       end
 
       def resolve_agent_label(row)

--- a/lib/hive/tui/help.rb
+++ b/lib/hive/tui/help.rb
@@ -38,7 +38,7 @@ module Hive
         { mode: :grid, key: "Right",     action: :pane_focus_right,   description: "jump focus to the tasks pane" },
         { mode: :grid, key: "Enter",     action: :open_contextual,    description: "left pane: focus right. right pane: open red-status detail on gated red rows; wall_clock REVIEW_STALE keeps direct retry, kill-class ERROR opens log tail, max_passes REVIEW_STALE opens focal escalations; non-red contextual behavior is unchanged" },
         { mode: :grid, key: "o",         action: :open_task_folder,   description: "open the focused task's folder in $EDITOR (read-only browse — no workflow dispatch, distinct from Enter and the verb keys)" },
-        { mode: :grid, key: "i",         action: :open_idea_preview,  description: "preview the original idea text for the focused task in the bottom strip" },
+        { mode: :grid, key: "i",         action: :open_idea_preview,  description: "open the info panel for the focused task (slug, stage, created_at, folder, latest log, original idea, and stage-specific brainstorm.md / plan.md / execute log tail)" },
         { mode: :grid, key: "s",         action: :open_in_agent,      description: "steer the focused task manually — opens the project's configured development agent in the feature worktree with every stage folder for this slug preloaded as context, marks the task MANUAL_STEERING so headless runs skip it, then archives the slug on agent exit" },
         { mode: :grid, key: "n",         action: :new_idea,           description: "open the new-idea prompt; from ★ All projects, choose a target project first; submitting runs `hive new <project> \"<title>\"`" },
         { mode: :grid, key: "/",         action: :filter,             description: "open filter prompt" },
@@ -65,7 +65,9 @@ module Hive
         { mode: :filter, key: "Enter", action: :commit_filter, description: "commit typed filter" },
         { mode: :filter, key: "Esc",   action: :cancel_filter, description: "discard typed buffer and return to grid (any committed filter is preserved)" },
         # Idea preview mode.
-        { mode: :idea_preview, key: "any", action: :back, description: "any key dismisses the preview" },
+        { mode: :idea_preview, key: "q",   action: :back, description: "close the info panel and return to grid" },
+        { mode: :idea_preview, key: "Esc", action: :back, description: "close the info panel and return to grid" },
+        { mode: :idea_preview, key: "i",   action: :back, description: "close the info panel (toggle off — same key that opens it)" },
         # New-idea prompt mode (v2).
         { mode: :new_idea_project, key: "j/k",     action: :project_cursor,  description: "move through projects for the new idea" },
         { mode: :new_idea_project, key: "Up/Down", action: :project_cursor,  description: "move through projects (arrow keys)" },

--- a/lib/hive/tui/key_map.rb
+++ b/lib/hive/tui/key_map.rb
@@ -402,8 +402,7 @@ module Hive
         Messages::BACK
       end
 
-      # Idea preview is read-only and sticky: only explicit close keys
-      # leave the panel so accidental typing does not dismiss it.
+      # Sticky panel: only explicit close keys dismiss, so accidental typing cannot leave it.
       def idea_preview_message(key:, row:) # rubocop:disable Lint/UnusedMethodArgument
         return Messages::BACK if ESCAPE_KEYS.include?(key) || key == "q" || key == "i"
 

--- a/lib/hive/tui/key_map.rb
+++ b/lib/hive/tui/key_map.rb
@@ -402,11 +402,12 @@ module Hive
         Messages::BACK
       end
 
-      # Idea preview is read-only: every key closes it and returns to
-      # grid, whether Bubble Tea emitted a printable String or a
-      # special-key Symbol.
+      # Idea preview is read-only and sticky: only explicit close keys
+      # leave the panel so accidental typing does not dismiss it.
       def idea_preview_message(key:, row:) # rubocop:disable Lint/UnusedMethodArgument
-        Messages::BACK
+        return Messages::BACK if ESCAPE_KEYS.include?(key) || key == "q" || key == "i"
+
+        Messages::NOOP
       end
 
       # New-idea prompt mode — same key shape as `:filter` mode but

--- a/lib/hive/tui/model.rb
+++ b/lib/hive/tui/model.rb
@@ -40,8 +40,6 @@ module Hive
       # asset. Resets only on open / cancel / submit.
       :new_idea_attachment_counter,
       :new_idea_broken_labels, # Array<String> — labels highlighted after rich-submit validation fails
-      :idea_preview_text, # String or nil — deprecated legacy preview text mirror
-      :idea_preview_slug, # String or nil — deprecated legacy preview slug mirror
       :info_panel_state, # Model::InfoPanelState or nil — read-only :idea_preview payload
       :flash,            # String or nil — current status-line message
       :flash_set_at,     # Time or nil — flash decay timestamp
@@ -139,8 +137,6 @@ module Hive
           new_idea_staging_tmp_root: nil,
           new_idea_attachment_counter: 0,
           new_idea_broken_labels: [],
-          idea_preview_text: nil,
-          idea_preview_slug: nil,
           info_panel_state: nil,
           flash: nil,
           flash_set_at: nil,

--- a/lib/hive/tui/model.rb
+++ b/lib/hive/tui/model.rb
@@ -40,8 +40,9 @@ module Hive
       # asset. Resets only on open / cancel / submit.
       :new_idea_attachment_counter,
       :new_idea_broken_labels, # Array<String> — labels highlighted after rich-submit validation fails
-      :idea_preview_text, # String or nil — original_text rendered in :idea_preview mode
-      :idea_preview_slug, # String or nil — slug captured when the preview opened
+      :idea_preview_text, # String or nil — deprecated legacy preview text mirror
+      :idea_preview_slug, # String or nil — deprecated legacy preview slug mirror
+      :info_panel_state, # Model::InfoPanelState or nil — read-only :idea_preview payload
       :flash,            # String or nil — current status-line message
       :flash_set_at,     # Time or nil — flash decay timestamp
       :tail_state,       # Hive::Tui::LogTail::Tail or nil — :log_tail mode only
@@ -85,6 +86,16 @@ module Hive
         )
       end
     end
+
+    Model::InfoPanelState = Data.define(
+      :slug,
+      :stage,
+      :created_at,
+      :original_text,
+      :folder_path,
+      :latest_log_path,
+      :stage_extra
+    )
 
     Model::RedStatusDetailState = Data.define(
       :row,
@@ -130,6 +141,7 @@ module Hive
           new_idea_broken_labels: [],
           idea_preview_text: nil,
           idea_preview_slug: nil,
+          info_panel_state: nil,
           flash: nil,
           flash_set_at: nil,
           tail_state: nil,

--- a/lib/hive/tui/update.rb
+++ b/lib/hive/tui/update.rb
@@ -782,7 +782,8 @@ end
           closed = model.with(mode: :grid, red_status_detail_state: nil)
           visible = visible_snapshot(closed)
           visible.nil? ? closed : closed.with(cursor: reclamp_cursor(visible, closed.cursor))
-        when :idea_preview then model.with(mode: :grid, idea_preview_text: nil, idea_preview_slug: nil)
+        when :idea_preview
+          model.with(mode: :grid, idea_preview_text: nil, idea_preview_slug: nil, info_panel_state: nil)
         when :help, :filter then model.with(mode: :grid)
         when :new_idea_project then apply_new_idea_cancelled(model)
         else model

--- a/lib/hive/tui/update.rb
+++ b/lib/hive/tui/update.rb
@@ -783,7 +783,7 @@ end
           visible = visible_snapshot(closed)
           visible.nil? ? closed : closed.with(cursor: reclamp_cursor(visible, closed.cursor))
         when :idea_preview
-          model.with(mode: :grid, idea_preview_text: nil, idea_preview_slug: nil, info_panel_state: nil)
+          model.with(mode: :grid, info_panel_state: nil)
         when :help, :filter then model.with(mode: :grid)
         when :new_idea_project then apply_new_idea_cancelled(model)
         else model

--- a/lib/hive/tui/views/idea_preview.rb
+++ b/lib/hive/tui/views/idea_preview.rb
@@ -5,16 +5,11 @@ require "hive/tui/views/format"
 module Hive
   module Tui
     module Views
-      # Full-screen, read-only task info panel. All file I/O happens in
-      # BubbleModel when the panel opens; this view only renders the
-      # captured InfoPanelState.
+      # Renders captured InfoPanelState; all file I/O happens in BubbleModel at open time.
       module IdeaPreview
         DISMISS_HINT = "press q / Esc / i to close".freeze
         DIVIDER = "─".freeze
-        # Common label-column width for the `created_at`, `folder`, and
-        # `latest log` rows. Computed from the longest label so a future
-        # rename (e.g. `working_dir` at 11 chars) does not silently
-        # collapse the value-column gap to a single space.
+        # Computed from the longest label so a future rename does not collapse the value gap.
         LABEL_COL = [ "created_at", "folder", "latest log" ].map(&:length).max + 2
 
         module_function
@@ -63,10 +58,13 @@ module Hive
 
         def fit_panel_lines(base, extra, capacity, width)
           return [] if capacity <= 0
-          return truncate_rows(base, capacity, width) if base.length >= capacity
+          return truncate_rows(base, capacity, width) if extra.empty?
 
-          remaining = capacity - base.length
-          base + truncate_rows(extra, remaining, width)
+          # Reserve at least the title block so a long original_text cannot suppress extra entirely.
+          extra_reserve = [ extra.length, 3 ].min
+          base_capacity = [ capacity - extra_reserve, 1 ].max
+          base_rows = truncate_rows(base, base_capacity, width)
+          base_rows + truncate_rows(extra, capacity - base_rows.length, width)
         end
 
         def truncate_rows(rows, capacity, width)
@@ -78,11 +76,7 @@ module Hive
           visible
         end
 
-        # Append the truncation `…` indicator, taking care to insert it
-        # before any trailing ANSI reset escape so a styled line (e.g.
-        # the dim divider rendered via `Styles::HINT.render(DIVIDER * …)`)
-        # keeps the ellipsis inside the same style run. Without this,
-        # the indicator pops outside the dim style on real terminals.
+        # Insert `…` before any trailing ANSI reset so styled lines keep the indicator inside the style run.
         def with_ellipsis(line)
           if (match = line.match(/\A(.*?)(\e\[[\d;]*m)\z/m))
             prefix = match[1].sub(/\s+\z/, "")

--- a/lib/hive/tui/views/idea_preview.rb
+++ b/lib/hive/tui/views/idea_preview.rb
@@ -11,11 +11,16 @@ module Hive
       module IdeaPreview
         DISMISS_HINT = "press q / Esc / i to close".freeze
         DIVIDER = "─".freeze
+        # Common label-column width for the `created_at`, `folder`, and
+        # `latest log` rows. Computed from the longest label so a future
+        # rename (e.g. `working_dir` at 11 chars) does not silently
+        # collapse the value-column gap to a single space.
+        LABEL_COL = [ "created_at", "folder", "latest log" ].map(&:length).max + 2
 
         module_function
 
         def render(model, width: model.cols.to_i, height: model.rows.to_i - 1)
-          state = model.info_panel_state || legacy_state(model)
+          state = model.info_panel_state
           return "" if state.nil?
 
           usable = [ width.to_i, 1 ].max
@@ -47,10 +52,11 @@ module Hive
         def extra_lines(state, width)
           return [] unless present(state.stage_extra)
 
+          title = extra_title(state)
           [
             "",
-            Styles::HINT.render(truncate(extra_title(state), width)),
-            Styles::HINT.render(DIVIDER * [ extra_title(state).length, width ].min),
+            Styles::HINT.render(truncate(title, width)),
+            Styles::HINT.render(DIVIDER * [ title.length, width ].min),
             *wrapped_body(state.stage_extra.to_s, width)
           ]
         end
@@ -72,9 +78,21 @@ module Hive
           visible
         end
 
+        # Append the truncation `…` indicator, taking care to insert it
+        # before any trailing ANSI reset escape so a styled line (e.g.
+        # the dim divider rendered via `Styles::HINT.render(DIVIDER * …)`)
+        # keeps the ellipsis inside the same style run. Without this,
+        # the indicator pops outside the dim style on real terminals.
         def with_ellipsis(line)
-          stripped = line.sub(/\s+\z/, "")
-          stripped.end_with?("…") ? stripped : "#{stripped}…"
+          if (match = line.match(/\A(.*?)(\e\[[\d;]*m)\z/m))
+            prefix = match[1].sub(/\s+\z/, "")
+            return line if prefix.end_with?("…")
+
+            "#{prefix}…#{match[2]}"
+          else
+            stripped = line.sub(/\s+\z/, "")
+            stripped.end_with?("…") ? stripped : "#{stripped}…"
+          end
         end
 
         def header_line(state, width)
@@ -85,7 +103,8 @@ module Hive
         end
 
         def field_line(label, value, width)
-          truncate("#{label}:#{' ' * [ 12 - label.length, 1 ].max}#{value}", width)
+          gap = [ LABEL_COL - label.length, 1 ].max
+          truncate("#{label}:#{' ' * gap}#{value}", width)
         end
 
         def extra_title(state)
@@ -95,23 +114,6 @@ module Hive
           when "4-execute" then "execute log"
           else "details"
           end
-        end
-
-        # Compatibility for the brief transition while BubbleModel still
-        # mirrors the old bottom-strip fields. New callers should set
-        # info_panel_state directly.
-        def legacy_state(model)
-          return nil if model.idea_preview_text.to_s.empty? && model.idea_preview_slug.to_s.empty?
-
-          Hive::Tui::Model::InfoPanelState.new(
-            slug: model.idea_preview_slug,
-            stage: "(unknown)",
-            created_at: nil,
-            original_text: model.idea_preview_text.to_s,
-            folder_path: nil,
-            latest_log_path: nil,
-            stage_extra: nil
-          )
         end
 
         def wrapped_body(text, width)

--- a/lib/hive/tui/views/idea_preview.rb
+++ b/lib/hive/tui/views/idea_preview.rb
@@ -1,32 +1,123 @@
+require "hive/tui/model"
 require "hive/tui/styles"
 require "hive/tui/views/format"
 
 module Hive
   module Tui
     module Views
-      # Bottom-strip preview for a task's source idea.md original_text.
-      # Read-only: KeyMap routes every key in :idea_preview mode back
-      # to grid; this view only renders the captured model fields.
+      # Full-screen, read-only task info panel. All file I/O happens in
+      # BubbleModel when the panel opens; this view only renders the
+      # captured InfoPanelState.
       module IdeaPreview
-        DISMISS_HINT = "press any key to dismiss".freeze
-        MAX_VISIBLE_ROWS = 6
+        DISMISS_HINT = "press q / Esc / i to close".freeze
+        DIVIDER = "─".freeze
 
         module_function
 
-        def render(model, width: model.cols.to_i)
+        def render(model, width: model.cols.to_i, height: model.rows.to_i - 1)
+          state = model.info_panel_state || legacy_state(model)
+          return "" if state.nil?
+
           usable = [ width.to_i, 1 ].max
-          rows = [
-            Styles::HINT.render(truncate("Idea for #{model.idea_preview_slug}:", usable)),
-            *body_rows(model.idea_preview_text.to_s, usable),
-            Styles::HINT.render(truncate(DISMISS_HINT, usable))
-          ]
+          max_rows = [ height.to_i, 1 ].max
+          content_capacity = [ max_rows - 1, 0 ].max
+
+          base = base_lines(state, usable)
+          extra = extra_lines(state, usable)
+          rows = fit_panel_lines(base, extra, content_capacity, usable)
+          rows << "" while rows.length < content_capacity
+          rows << Styles::HINT.render(truncate(DISMISS_HINT.rjust(usable), usable))
           rows.join("\n")
         end
 
-        def body_rows(text, width)
+        def base_lines(state, width)
+          [
+            Styles::HINT.render(truncate(header_line(state, width), width)),
+            Styles::HINT.render(DIVIDER * width),
+            field_line("created_at", present(state.created_at) ? state.created_at : "(unknown)", width),
+            field_line("folder", present(state.folder_path) ? state.folder_path : "(unknown)", width),
+            field_line("latest log", present(state.latest_log_path) ? state.latest_log_path : "(none)", width),
+            "",
+            Styles::HINT.render(truncate("Original idea", width)),
+            Styles::HINT.render(truncate(DIVIDER * "Original idea".length, width)),
+            *wrapped_body(state.original_text.to_s, width)
+          ]
+        end
+
+        def extra_lines(state, width)
+          return [] unless present(state.stage_extra)
+
+          [
+            "",
+            Styles::HINT.render(truncate(extra_title(state), width)),
+            Styles::HINT.render(DIVIDER * [ extra_title(state).length, width ].min),
+            *wrapped_body(state.stage_extra.to_s, width)
+          ]
+        end
+
+        def fit_panel_lines(base, extra, capacity, width)
+          return [] if capacity <= 0
+          return truncate_rows(base, capacity, width) if base.length >= capacity
+
+          remaining = capacity - base.length
+          base + truncate_rows(extra, remaining, width)
+        end
+
+        def truncate_rows(rows, capacity, width)
+          return [] if capacity <= 0
+          return rows if rows.length <= capacity
+
+          visible = rows.first(capacity)
+          visible[-1] = truncate(with_ellipsis(visible[-1].to_s), width)
+          visible
+        end
+
+        def with_ellipsis(line)
+          stripped = line.sub(/\s+\z/, "")
+          stripped.end_with?("…") ? stripped : "#{stripped}…"
+        end
+
+        def header_line(state, width)
+          stage = "[stage: #{state.stage}]"
+          prefix = "Info: #{state.slug}"
+          gap = width - prefix.length - stage.length
+          gap >= 2 ? "#{prefix}#{" " * gap}#{stage}" : "#{prefix}  #{stage}"
+        end
+
+        def field_line(label, value, width)
+          truncate("#{label}:#{' ' * [ 12 - label.length, 1 ].max}#{value}", width)
+        end
+
+        def extra_title(state)
+          case state.stage.to_s
+          when "2-brainstorm" then "brainstorm.md"
+          when "3-plan" then "plan.md"
+          when "4-execute" then "execute log"
+          else "details"
+          end
+        end
+
+        # Compatibility for the brief transition while BubbleModel still
+        # mirrors the old bottom-strip fields. New callers should set
+        # info_panel_state directly.
+        def legacy_state(model)
+          return nil if model.idea_preview_text.to_s.empty? && model.idea_preview_slug.to_s.empty?
+
+          Hive::Tui::Model::InfoPanelState.new(
+            slug: model.idea_preview_slug,
+            stage: "(unknown)",
+            created_at: nil,
+            original_text: model.idea_preview_text.to_s,
+            folder_path: nil,
+            latest_log_path: nil,
+            stage_extra: nil
+          )
+        end
+
+        def wrapped_body(text, width)
           return [] if text.empty?
 
-          wrap_text(text, width).first(MAX_VISIBLE_ROWS).map { |line| truncate(line, width) }
+          wrap_text(text, width).map { |line| truncate(line, width) }
         end
 
         # Intentional local copy of NewIdeaPrompt's simple chunking shape.
@@ -53,6 +144,10 @@ module Hive
 
         def truncate(line, width)
           Views::Format.truncate(line, width.to_i)
+        end
+
+        def present(value)
+          !value.nil? && !value.to_s.empty?
         end
       end
     end

--- a/test/unit/tui/bubble_model_test.rb
+++ b/test/unit/tui/bubble_model_test.rb
@@ -603,28 +603,30 @@ class HiveTuiBubbleModelTest < Minitest::Test
     refute_includes out, "[Enter] open",   "Enter is not only an open action"
   end
 
-  def test_default_footer_hint_omits_o_at_70_col_budget
-    # Plan R6: `[o] open` is included in the footer only if it fits
-    # the 70-col budget without wrapping or pushing primary actions
-    # onto a second line. At 70 cols the current hint string is
-    # already ~69 chars; adding ten more (separator + "[o] open")
-    # would exceed the budget. We rely on the `?` overlay for
-    # discoverability instead. This test pins that decision so a
-    # future contributor doesn't silently re-add the hint and break
-    # 70-col rendering.
+  def test_default_footer_hint_advertises_info_between_help_and_quit
     hint = @model.send(:footer_hint)
-    assert_equal "[Tab] switch  [Enter] action  [n] new  [/] filter  [?] help  [q] quit",
-                 hint,
-                 "footer hint must remain the pre-`o` literal; `o` is documented in `?` only"
+    assert_equal "[Tab] switch  [Enter] action  [n] new  [/] filter  [?] help  [i] info  [q] quit",
+                 hint
+    assert_match(/\[\?\] help  \[i\] info  \[q\] quit/, hint)
     refute_includes hint, "[o] open",
-                    "70-col budget can't absorb `[o] open` alongside primary hints"
-    # Width guard: pin the actual character count so a future contributor
-    # who adds a hint and (correctly) bumps the literal above also has to
-    # acknowledge they're spending bytes against the 70-col budget. If
-    # this assertion fires alongside an updated literal, the contributor
-    # MUST verify default_footer truncation behavior at cols == 70.
-    assert hint.length <= 70,
-           "footer hint must fit the 70-col budget without truncation; got #{hint.length} chars"
+                    "`o` remains discoverable through the help overlay, not the fixed footer"
+  end
+
+  def test_default_footer_renders_full_hint_at_wide_width
+    out = @model.send(:default_footer, 120)
+
+    assert_includes out, "[i] info"
+    assert_includes out, "[q] quit"
+  end
+
+  def test_default_footer_truncates_from_right_at_narrow_width
+    out = @model.send(:default_footer, 76)
+
+    assert_includes out, "[?] help"
+    assert_includes out, "[i] info"
+    assert out.end_with?("…"), "narrow footer should truncate the right edge, got #{out.inspect}"
+    refute_includes out, "[i] inf…",
+                    "76-column truncation should not split the `[i] info` token"
   end
 
   def test_grid_mode_collapses_to_single_pane_below_min_cols

--- a/test/unit/tui/bubble_model_test.rb
+++ b/test/unit/tui/bubble_model_test.rb
@@ -46,17 +46,17 @@ class HiveTuiBubbleModelTest < Minitest::Test
     old_editor.nil? ? ENV.delete("EDITOR") : ENV["EDITOR"] = old_editor
   end
 
-  def write_idea_md(dir, original_text:)
+  def write_idea_md(dir, original_text:, slug: "some-slug", created_at: "2026-05-20T00:00:00Z")
     indented_original = original_text.lines.map { |line| "  #{line.chomp}" }
     body = [
       "---",
-      "slug: some-slug",
-      "created_at: 2026-05-20T00:00:00Z",
+      "slug: #{slug}",
+      "created_at: #{created_at}",
       "original_text: |",
       *indented_original,
       "---",
       "",
-      "# some-slug",
+      "# #{slug}",
       "",
       original_text,
       "",
@@ -86,6 +86,21 @@ class HiveTuiBubbleModelTest < Minitest::Test
     yield(staging_dir, staging_path, attachment)
   ensure
     Hive::Tui::ComposerStaging.cleanup!(staging_dir) if staging_dir && File.exist?(staging_dir)
+  end
+
+  def make_task_folder(root, stage: "2-brainstorm", slug: "some-slug")
+    folder = File.join(root, ".hive-state", "stages", stage, slug)
+    FileUtils.mkdir_p(folder)
+    folder
+  end
+
+  def make_log(root, slug: "some-slug", name: "run.log", text: "log\n", mtime: Time.now)
+    dir = File.join(root, ".hive-state", "logs", slug)
+    FileUtils.mkdir_p(dir)
+    path = File.join(dir, name)
+    File.write(path, text)
+    File.utime(mtime, mtime, path)
+    path
   end
 
   # ---- Construction / init ----
@@ -3674,12 +3689,13 @@ class HiveTuiBubbleModelTest < Minitest::Test
       "OpenTaskFolder must not dispatch any follow-up message — no auto-continue, no InputEditorExited"
   end
 
-  # ---- OpenIdeaPreview → bottom-strip preview (read-only) ----
+  # ---- OpenIdeaPreview → full-screen info panel (read-only) ----
 
-  def test_open_idea_preview_reads_original_text_and_enters_preview_mode
-    with_tmp_dir do |dir|
-      write_idea_md(dir, original_text: "Build task from user note")
-      row = make_task_row(folder: dir, slug: "some-slug")
+  def test_open_idea_preview_reads_inbox_common_fields_without_extra
+    with_tmp_dir do |root|
+      folder = make_task_folder(root, stage: "1-inbox")
+      write_idea_md(folder, original_text: "Build task from user note")
+      row = make_task_row(folder: folder, slug: "some-slug", stage: "1-inbox")
 
       _, cmd = @model.update(Hive::Tui::Messages::OpenIdeaPreview.new(row: row))
 
@@ -3687,6 +3703,103 @@ class HiveTuiBubbleModelTest < Minitest::Test
       assert_equal :idea_preview, @model.hive_model.mode
       assert_equal "Build task from user note", @model.hive_model.idea_preview_text
       assert_equal "some-slug", @model.hive_model.idea_preview_slug
+      state = @model.hive_model.info_panel_state
+      assert_equal "some-slug", state.slug
+      assert_equal "1-inbox", state.stage
+      assert_equal "2026-05-20T00:00:00Z", state.created_at
+      assert_equal "Build task from user note", state.original_text
+      assert_equal File.expand_path(folder), state.folder_path
+      assert_nil state.latest_log_path
+      assert_nil state.stage_extra
+    end
+  end
+
+  def test_open_idea_preview_reads_brainstorm_extra_and_latest_log_path
+    with_tmp_dir do |root|
+      folder = make_task_folder(root, stage: "2-brainstorm")
+      write_idea_md(folder, original_text: "Brainstorm this")
+      File.write(File.join(folder, "brainstorm.md"), "# Brainstorm\nA1")
+      older = make_log(root, name: "old.log", text: "old\n", mtime: Time.at(1_700_000_000))
+      latest = make_log(root, name: "latest.log", text: "latest\n", mtime: Time.at(1_700_000_010))
+      row = make_task_row(folder: folder, slug: "some-slug", stage: "2-brainstorm")
+
+      _, cmd = @model.update(Hive::Tui::Messages::OpenIdeaPreview.new(row: row))
+
+      assert_nil cmd
+      state = @model.hive_model.info_panel_state
+      assert_equal File.expand_path(latest), state.latest_log_path
+      refute_equal File.expand_path(older), state.latest_log_path
+      assert_equal "# Brainstorm\nA1", state.stage_extra
+    end
+  end
+
+  def test_open_idea_preview_brainstorm_extra_missing_is_nil
+    with_tmp_dir do |root|
+      folder = make_task_folder(root, stage: "2-brainstorm")
+      write_idea_md(folder, original_text: "Brainstorm this")
+      row = make_task_row(folder: folder, slug: "some-slug", stage: "2-brainstorm")
+
+      _, cmd = @model.update(Hive::Tui::Messages::OpenIdeaPreview.new(row: row))
+
+      assert_nil cmd
+      assert_equal :idea_preview, @model.hive_model.mode
+      assert_nil @model.hive_model.info_panel_state.stage_extra
+    end
+  end
+
+  def test_open_idea_preview_reads_plan_extra
+    with_tmp_dir do |root|
+      folder = make_task_folder(root, stage: "3-plan")
+      write_idea_md(folder, original_text: "Plan this")
+      File.write(File.join(folder, "plan.md"), "# Plan\nIU1")
+      row = make_task_row(folder: folder, slug: "some-slug", stage: "3-plan")
+
+      _, cmd = @model.update(Hive::Tui::Messages::OpenIdeaPreview.new(row: row))
+
+      assert_nil cmd
+      state = @model.hive_model.info_panel_state
+      assert_equal "3-plan", state.stage
+      assert_equal "# Plan\nIU1", state.stage_extra
+    end
+  end
+
+  def test_open_idea_preview_reads_execute_log_tail
+    with_tmp_dir do |root|
+      folder = make_task_folder(root, stage: "4-execute")
+      write_idea_md(folder, original_text: "Execute this")
+      old_log = make_log(root, name: "execute-old.log", text: "old log\n", mtime: Time.at(1_700_000_000))
+      long_prefix = "prefix-marker\n" + ("x" * (Hive::Tui::BubbleModel::INFO_PANEL_EXECUTE_TAIL_BYTES + 100))
+      latest_log = make_log(
+        root,
+        name: "execute-latest.log",
+        text: "#{long_prefix}\nlatest tail marker\n",
+        mtime: Time.at(1_700_000_020)
+      )
+      row = make_task_row(folder: folder, slug: "some-slug", stage: "4-execute")
+
+      _, cmd = @model.update(Hive::Tui::Messages::OpenIdeaPreview.new(row: row))
+
+      assert_nil cmd
+      state = @model.hive_model.info_panel_state
+      assert_equal File.expand_path(latest_log), state.latest_log_path
+      refute_equal File.expand_path(old_log), state.latest_log_path
+      assert_includes state.stage_extra, "latest tail marker"
+      refute_includes state.stage_extra, "prefix-marker"
+    end
+  end
+
+  def test_open_idea_preview_execute_without_log_has_nil_log_fields
+    with_tmp_dir do |root|
+      folder = make_task_folder(root, stage: "4-execute")
+      write_idea_md(folder, original_text: "Execute this")
+      row = make_task_row(folder: folder, slug: "some-slug", stage: "4-execute")
+
+      _, cmd = @model.update(Hive::Tui::Messages::OpenIdeaPreview.new(row: row))
+
+      assert_nil cmd
+      state = @model.hive_model.info_panel_state
+      assert_nil state.latest_log_path
+      assert_nil state.stage_extra
     end
   end
 
@@ -3701,8 +3814,9 @@ class HiveTuiBubbleModelTest < Minitest::Test
   end
 
   def test_open_idea_preview_flashes_when_idea_md_missing
-    with_tmp_dir do |dir|
-      row = make_task_row(folder: dir)
+    with_tmp_dir do |root|
+      folder = make_task_folder(root, stage: "2-brainstorm")
+      row = make_task_row(folder: folder)
 
       _, cmd = @model.update(Hive::Tui::Messages::OpenIdeaPreview.new(row: row))
 
@@ -3713,9 +3827,10 @@ class HiveTuiBubbleModelTest < Minitest::Test
   end
 
   def test_open_idea_preview_flashes_when_original_text_missing
-    with_tmp_dir do |dir|
-      File.write(File.join(dir, "idea.md"), "---\nslug: some-slug\n---\n")
-      row = make_task_row(folder: dir)
+    with_tmp_dir do |root|
+      folder = make_task_folder(root, stage: "2-brainstorm")
+      File.write(File.join(folder, "idea.md"), "---\nslug: some-slug\n---\n")
+      row = make_task_row(folder: folder)
 
       _, cmd = @model.update(Hive::Tui::Messages::OpenIdeaPreview.new(row: row))
 
@@ -3726,9 +3841,10 @@ class HiveTuiBubbleModelTest < Minitest::Test
   end
 
   def test_open_idea_preview_flashes_on_unreadable_idea_md
-    with_tmp_dir do |dir|
-      File.write(File.join(dir, "idea.md"), "---\noriginal_text: [broken\n---\n")
-      row = make_task_row(folder: dir)
+    with_tmp_dir do |root|
+      folder = make_task_folder(root, stage: "2-brainstorm")
+      File.write(File.join(folder, "idea.md"), "---\noriginal_text: [broken\n---\n")
+      row = make_task_row(folder: folder)
 
       _, cmd = @model.update(Hive::Tui::Messages::OpenIdeaPreview.new(row: row))
 
@@ -3738,25 +3854,56 @@ class HiveTuiBubbleModelTest < Minitest::Test
     end
   end
 
-  def test_open_idea_preview_does_not_dispatch_or_mutate_marker
-    with_tmp_dir do |dir|
-      idea_path = write_idea_md(dir, original_text: "Read only")
-      before = File.read(idea_path)
-      row = make_task_row(folder: dir)
+  def test_open_idea_preview_unreadable_extra_opens_common_fields
+    with_tmp_dir do |root|
+      folder = make_task_folder(root, stage: "2-brainstorm")
+      write_idea_md(folder, original_text: "Read common")
+      extra_path = File.join(folder, "brainstorm.md")
+      File.write(extra_path, "secret\n")
+      File.chmod(0, extra_path)
+      row = make_task_row(folder: folder, slug: "some-slug", stage: "2-brainstorm")
+
+      _, cmd = @model.update(Hive::Tui::Messages::OpenIdeaPreview.new(row: row))
+
+      assert_nil cmd
+      assert_equal :idea_preview, @model.hive_model.mode
+      assert_equal "Read common", @model.hive_model.info_panel_state.original_text
+      assert_nil @model.hive_model.info_panel_state.stage_extra
+    ensure
+      File.chmod(0o600, extra_path) if extra_path && File.exist?(extra_path)
+    end
+  end
+
+  def test_open_idea_preview_does_not_dispatch_or_mutate_files
+    with_tmp_dir do |root|
+      folder = make_task_folder(root, stage: "2-brainstorm")
+      idea_path = write_idea_md(folder, original_text: "Read only")
+      extra_path = File.join(folder, "brainstorm.md")
+      File.write(extra_path, "notes\n")
+      log_path = make_log(root, text: "log\n")
+      before_mtimes = [ idea_path, extra_path, log_path ].to_h { |path| [ path, File.mtime(path) ] }
+      before_contents = [ idea_path, extra_path, log_path ].to_h { |path| [ path, File.read(path) ] }
+      row = make_task_row(folder: folder)
 
       _, cmd = @model.update(Hive::Tui::Messages::OpenIdeaPreview.new(row: row))
 
       assert_nil cmd
       assert_empty @messages
-      assert_equal before, File.read(idea_path)
+      before_mtimes.each do |path, mtime|
+        assert_equal mtime, File.mtime(path), "#{path} mtime changed"
+      end
+      before_contents.each do |path, content|
+        assert_equal content, File.read(path), "#{path} content changed"
+      end
     end
   end
 
   def test_open_idea_preview_truncates_oversized_original_text
-    with_tmp_dir do |dir|
+    with_tmp_dir do |root|
+      folder = make_task_folder(root, stage: "2-brainstorm")
       original = "x" * (Hive::Tui::Model::NEW_IDEA_BUFFER_MAX_CHARS + 20)
-      write_idea_md(dir, original_text: original)
-      row = make_task_row(folder: dir)
+      write_idea_md(folder, original_text: original)
+      row = make_task_row(folder: folder)
 
       _, cmd = @model.update(Hive::Tui::Messages::OpenIdeaPreview.new(row: row))
 
@@ -3764,26 +3911,43 @@ class HiveTuiBubbleModelTest < Minitest::Test
       assert_equal :idea_preview, @model.hive_model.mode
       assert_equal Hive::Tui::Model::NEW_IDEA_BUFFER_MAX_CHARS,
                    @model.hive_model.idea_preview_text.length
+      assert_equal Hive::Tui::Model::NEW_IDEA_BUFFER_MAX_CHARS,
+                   @model.hive_model.info_panel_state.original_text.length
     end
   end
 
-  def test_idea_preview_roundtrip_open_then_any_key_dismisses
-    with_tmp_dir do |dir|
-      write_idea_md(dir, original_text: "Roundtrip idea")
-      row = make_task_row(folder: dir)
+  def test_open_idea_preview_created_at_is_propagated_from_frontmatter
+    with_tmp_dir do |root|
+      folder = make_task_folder(root, stage: "2-brainstorm")
+      write_idea_md(folder, original_text: "Has timestamp", created_at: "2026-05-22T22:40:00Z")
+      row = make_task_row(folder: folder)
+
+      _, cmd = @model.update(Hive::Tui::Messages::OpenIdeaPreview.new(row: row))
+
+      assert_nil cmd
+      assert_equal "2026-05-22T22:40:00Z", @model.hive_model.info_panel_state.created_at
+    end
+  end
+
+  def test_idea_preview_roundtrip_open_then_i_dismisses
+    with_tmp_dir do |root|
+      folder = make_task_folder(root, stage: "2-brainstorm")
+      write_idea_md(folder, original_text: "Roundtrip idea")
+      row = make_task_row(folder: folder)
 
       _, open_cmd = @model.update(Hive::Tui::Messages::OpenIdeaPreview.new(row: row))
 
       assert_nil open_cmd
       assert_equal :idea_preview, @model.hive_model.mode
-      assert_equal "Roundtrip idea", @model.hive_model.idea_preview_text
+      assert_equal "Roundtrip idea", @model.hive_model.info_panel_state.original_text
 
-      _, dismiss_cmd = @model.update(Bubbletea::KeyMessage.new(key_type: 0, runes: [ "x".ord ]))
+      _, dismiss_cmd = @model.update(Bubbletea::KeyMessage.new(key_type: 0, runes: [ "i".ord ]))
 
       assert_nil dismiss_cmd
       assert_equal :grid, @model.hive_model.mode
       assert_nil @model.hive_model.idea_preview_text
       assert_nil @model.hive_model.idea_preview_slug
+      assert_nil @model.hive_model.info_panel_state
       assert_empty @messages
     end
   end

--- a/test/unit/tui/bubble_model_test.rb
+++ b/test/unit/tui/bubble_model_test.rb
@@ -656,6 +656,13 @@ class HiveTuiBubbleModelTest < Minitest::Test
     assert out.end_with?("…"), "narrow footer should truncate the right edge, got #{out.inspect}"
     refute_includes out, "[i] inf…",
                     "76-column truncation should not split the `[i] info` token"
+    # Pin the surviving tail so a future hint change that silently
+    # clipped `[q] quit` away entirely (or replaced it with a different
+    # token at the right edge) trips a meaningful failure instead of
+    # passing on `end_with?("…")` alone. The truncation lands one char
+    # into `[q] quit` so the visible prefix is `[q] ` plus the ellipsis.
+    assert out.end_with?("[q] …"),
+           "76-column truncation should preserve the `[q] ` prefix before the ellipsis, got #{out.inspect}"
   end
 
   def test_grid_mode_collapses_to_single_pane_below_min_cols
@@ -3701,8 +3708,6 @@ class HiveTuiBubbleModelTest < Minitest::Test
 
       assert_nil cmd
       assert_equal :idea_preview, @model.hive_model.mode
-      assert_equal "Build task from user note", @model.hive_model.idea_preview_text
-      assert_equal "some-slug", @model.hive_model.idea_preview_slug
       state = @model.hive_model.info_panel_state
       assert_equal "some-slug", state.slug
       assert_equal "1-inbox", state.stage
@@ -3788,6 +3793,42 @@ class HiveTuiBubbleModelTest < Minitest::Test
     end
   end
 
+  def test_open_idea_preview_execute_tail_filters_to_execute_prefix
+    # 4-execute info-panel tail must select the latest `execute-*.log`
+    # — a newer non-execute log (e.g. `plan-*.log`) shows up in
+    # `latest_log_path` (the generic pointer) but is not tailed in the
+    # `execute log` extra section.
+    with_tmp_dir do |root|
+      folder = make_task_folder(root, stage: "4-execute")
+      write_idea_md(folder, original_text: "Execute prefix test")
+      execute_log = make_log(
+        root,
+        name: "execute-impl-old.log",
+        text: "execute tail marker\n",
+        mtime: Time.at(1_700_000_010)
+      )
+      newer_plan = make_log(
+        root,
+        name: "plan-newer.log",
+        text: "plan tail marker\n",
+        mtime: Time.at(1_700_000_020)
+      )
+      row = make_task_row(folder: folder, slug: "some-slug", stage: "4-execute")
+
+      _, cmd = @model.update(Hive::Tui::Messages::OpenIdeaPreview.new(row: row))
+
+      assert_nil cmd
+      state = @model.hive_model.info_panel_state
+      # `latest_log_path` still reports the absolute newest log, so the
+      # operator sees the freshest pointer even when it isn't the
+      # execute log they are about to tail.
+      assert_equal File.expand_path(newer_plan), state.latest_log_path
+      assert_includes state.stage_extra, "execute tail marker"
+      refute_includes state.stage_extra, "plan tail marker"
+      _ = execute_log
+    end
+  end
+
   def test_open_idea_preview_execute_without_log_has_nil_log_fields
     with_tmp_dir do |root|
       folder = make_task_folder(root, stage: "4-execute")
@@ -3860,8 +3901,17 @@ class HiveTuiBubbleModelTest < Minitest::Test
       write_idea_md(folder, original_text: "Read common")
       extra_path = File.join(folder, "brainstorm.md")
       File.write(extra_path, "secret\n")
-      File.chmod(0, extra_path)
       row = make_task_row(folder: folder, slug: "some-slug", stage: "2-brainstorm")
+
+      # Stub `read_capped` to raise EACCES so the test exercises the
+      # rescue path deterministically. Pre-fix, the test relied on
+      # `File.chmod(0)` which does not block reads as root and breaks
+      # on CI containers that run the suite as root.
+      @model.define_singleton_method(:read_capped) do |path|
+        raise Errno::EACCES if path == extra_path
+
+        nil
+      end
 
       _, cmd = @model.update(Hive::Tui::Messages::OpenIdeaPreview.new(row: row))
 
@@ -3869,8 +3919,6 @@ class HiveTuiBubbleModelTest < Minitest::Test
       assert_equal :idea_preview, @model.hive_model.mode
       assert_equal "Read common", @model.hive_model.info_panel_state.original_text
       assert_nil @model.hive_model.info_panel_state.stage_extra
-    ensure
-      File.chmod(0o600, extra_path) if extra_path && File.exist?(extra_path)
     end
   end
 
@@ -3910,8 +3958,6 @@ class HiveTuiBubbleModelTest < Minitest::Test
       assert_nil cmd
       assert_equal :idea_preview, @model.hive_model.mode
       assert_equal Hive::Tui::Model::NEW_IDEA_BUFFER_MAX_CHARS,
-                   @model.hive_model.idea_preview_text.length
-      assert_equal Hive::Tui::Model::NEW_IDEA_BUFFER_MAX_CHARS,
                    @model.hive_model.info_panel_state.original_text.length
     end
   end
@@ -3926,6 +3972,52 @@ class HiveTuiBubbleModelTest < Minitest::Test
 
       assert_nil cmd
       assert_equal "2026-05-22T22:40:00Z", @model.hive_model.info_panel_state.created_at
+    end
+  end
+
+  def test_open_idea_preview_created_at_preserves_non_utc_timezone_verbatim
+    # Pins the verbatim scalar path: a non-`Z` timestamp must survive
+    # the YAML round-trip exactly as the operator typed it. Without
+    # the `frontmatter_scalar` shortcut, a typed Time would normalize
+    # to UTC and silently strip the `+03:00` offset.
+    with_tmp_dir do |root|
+      folder = make_task_folder(root, stage: "2-brainstorm")
+      write_idea_md(folder, original_text: "TZ idea", created_at: "2026-05-22T22:40:00+03:00")
+      row = make_task_row(folder: folder)
+
+      _, cmd = @model.update(Hive::Tui::Messages::OpenIdeaPreview.new(row: row))
+
+      assert_nil cmd
+      assert_equal "2026-05-22T22:40:00+03:00", @model.hive_model.info_panel_state.created_at
+    end
+  end
+
+  def test_open_idea_preview_created_at_falls_back_to_typed_value
+    # When `frontmatter_scalar` cannot extract a verbatim value (block
+    # scalar, multi-line string, etc.), `idea_created_at` falls back to
+    # the YAML-parsed typed value. Constructs a frontmatter shape the
+    # scalar parser cannot represent and asserts the Time branch
+    # formats to a UTC iso8601 string.
+    with_tmp_dir do |root|
+      folder = make_task_folder(root, stage: "2-brainstorm")
+      File.write(File.join(folder, "idea.md"), <<~MD)
+        ---
+        slug: some-slug
+        created_at: |
+          2026-05-22T22:40:00Z
+        original_text: |
+          Block scalar idea
+        ---
+      MD
+      row = make_task_row(folder: folder)
+
+      _, cmd = @model.update(Hive::Tui::Messages::OpenIdeaPreview.new(row: row))
+
+      assert_nil cmd
+      # YAML parses the block scalar to "2026-05-22T22:40:00Z\n"; the
+      # fallback path returns the trailing-newline-trimmed iso8601 via
+      # `to_s` since the value is not a Time/Date.
+      assert_match(/\A2026-05-22T22:40:00Z/, @model.hive_model.info_panel_state.created_at.to_s)
     end
   end
 
@@ -3945,8 +4037,6 @@ class HiveTuiBubbleModelTest < Minitest::Test
 
       assert_nil dismiss_cmd
       assert_equal :grid, @model.hive_model.mode
-      assert_nil @model.hive_model.idea_preview_text
-      assert_nil @model.hive_model.idea_preview_slug
       assert_nil @model.hive_model.info_panel_state
       assert_empty @messages
     end

--- a/test/unit/tui/bubble_model_test.rb
+++ b/test/unit/tui/bubble_model_test.rb
@@ -345,18 +345,32 @@ class HiveTuiBubbleModelTest < Minitest::Test
     assert_includes out, "/auth"
   end
 
-  def test_view_composes_idea_preview_onto_grid_in_idea_preview_mode
+  def test_view_composes_idea_preview_as_full_frame_with_default_footer
+    state = Hive::Tui::Model::InfoPanelState.new(
+      slug: "some-slug",
+      stage: "2-brainstorm",
+      created_at: "2026-05-22T22:40:00Z",
+      original_text: "original idea",
+      folder_path: "/tmp/.hive-state/stages/2-brainstorm/some-slug",
+      latest_log_path: "/tmp/.hive-state/logs/some-slug/run.log",
+      stage_extra: "brainstorm notes"
+    )
     @model = Hive::Tui::BubbleModel.new(
       hive_model: Hive::Tui::Model.initial.with(
         mode: :idea_preview,
-        idea_preview_slug: "some-slug",
-        idea_preview_text: "original idea"
+        info_panel_state: state,
+        rows: 20,
+        cols: 100
       ),
       dispatch: @dispatch
     )
     out = @model.view
-    assert_includes out, "Idea for some-slug:"
+
+    assert_includes out, "Info: some-slug"
     assert_includes out, "original idea"
+    assert_includes out, "brainstorm notes"
+    assert_includes out, "[i] info"
+    refute_includes out, "Projects"
   end
 
   # Regression: paste-truncated / paste-timeout / overflow flashes

--- a/test/unit/tui/bubble_model_test.rb
+++ b/test/unit/tui/bubble_model_test.rb
@@ -648,6 +648,16 @@ class HiveTuiBubbleModelTest < Minitest::Test
     assert_includes out, "[q] quit"
   end
 
+  def test_default_footer_fits_full_hint_at_exact_boundary_width
+    hint = @model.send(:footer_hint)
+    out = @model.send(:default_footer, hint.length)
+
+    assert_includes out, "[i] info"
+    assert_includes out, "[q] quit"
+    refute out.end_with?("…"),
+           "footer at exact hint width should not truncate, got #{out.inspect}"
+  end
+
   def test_default_footer_truncates_from_right_at_narrow_width
     out = @model.send(:default_footer, 76)
 
@@ -3752,6 +3762,23 @@ class HiveTuiBubbleModelTest < Minitest::Test
     end
   end
 
+  def test_open_idea_preview_unknown_stage_has_no_extra
+    with_tmp_dir do |root|
+      folder = make_task_folder(root, stage: "5-open-pr")
+      write_idea_md(folder, original_text: "PR draft")
+      File.write(File.join(folder, "brainstorm.md"), "# Brainstorm")
+      File.write(File.join(folder, "plan.md"), "# Plan")
+      row = make_task_row(folder: folder, slug: "some-slug", stage: "5-open-pr")
+
+      _, cmd = @model.update(Hive::Tui::Messages::OpenIdeaPreview.new(row: row))
+
+      assert_nil cmd
+      assert_equal :idea_preview, @model.hive_model.mode
+      assert_nil @model.hive_model.info_panel_state.stage_extra,
+                 "unknown stages must fall through to the safe nil default"
+    end
+  end
+
   def test_open_idea_preview_reads_plan_extra
     with_tmp_dir do |root|
       folder = make_task_folder(root, stage: "3-plan")
@@ -3903,17 +3930,19 @@ class HiveTuiBubbleModelTest < Minitest::Test
       File.write(extra_path, "secret\n")
       row = make_task_row(folder: folder, slug: "some-slug", stage: "2-brainstorm")
 
-      # Stub `read_capped` to raise EACCES so the test exercises the
-      # rescue path deterministically. Pre-fix, the test relied on
-      # `File.chmod(0)` which does not block reads as root and breaks
-      # on CI containers that run the suite as root.
-      @model.define_singleton_method(:read_capped) do |path|
-        raise Errno::EACCES if path == extra_path
+      blocked = File.expand_path(extra_path)
+      original_open = File.method(:open)
+      File.define_singleton_method(:open) do |path, *args, **kwargs, &block|
+        raise Errno::EACCES if File.expand_path(path.to_s) == blocked
 
-        nil
+        original_open.call(path, *args, **kwargs, &block)
       end
 
-      _, cmd = @model.update(Hive::Tui::Messages::OpenIdeaPreview.new(row: row))
+      begin
+        _, cmd = @model.update(Hive::Tui::Messages::OpenIdeaPreview.new(row: row))
+      ensure
+        File.define_singleton_method(:open, original_open)
+      end
 
       assert_nil cmd
       assert_equal :idea_preview, @model.hive_model.mode
@@ -3993,11 +4022,6 @@ class HiveTuiBubbleModelTest < Minitest::Test
   end
 
   def test_open_idea_preview_created_at_falls_back_to_typed_value
-    # When `frontmatter_scalar` cannot extract a verbatim value (block
-    # scalar, multi-line string, etc.), `idea_created_at` falls back to
-    # the YAML-parsed typed value. Constructs a frontmatter shape the
-    # scalar parser cannot represent and asserts the Time branch
-    # formats to a UTC iso8601 string.
     with_tmp_dir do |root|
       folder = make_task_folder(root, stage: "2-brainstorm")
       File.write(File.join(folder, "idea.md"), <<~MD)
@@ -4014,11 +4038,29 @@ class HiveTuiBubbleModelTest < Minitest::Test
       _, cmd = @model.update(Hive::Tui::Messages::OpenIdeaPreview.new(row: row))
 
       assert_nil cmd
-      # YAML parses the block scalar to "2026-05-22T22:40:00Z\n"; the
-      # fallback path returns the trailing-newline-trimmed iso8601 via
-      # `to_s` since the value is not a Time/Date.
-      assert_match(/\A2026-05-22T22:40:00Z/, @model.hive_model.info_panel_state.created_at.to_s)
+      # Trailing newline from the `|` block scalar must be stripped so the field grid does not wrap.
+      assert_equal "2026-05-22T22:40:00Z", @model.hive_model.info_panel_state.created_at
     end
+  end
+
+  def test_frontmatter_scalar_preserves_hash_inside_quoted_value
+    contents = <<~MD
+      ---
+      created_at: "2026-05-22 #note"
+      ---
+    MD
+
+    assert_equal "2026-05-22 #note", @model.send(:frontmatter_scalar, contents, "created_at")
+  end
+
+  def test_frontmatter_scalar_strips_trailing_comment_after_whitespace
+    contents = <<~MD
+      ---
+      created_at: 2026-05-22T22:40:00Z  # local capture
+      ---
+    MD
+
+    assert_equal "2026-05-22T22:40:00Z", @model.send(:frontmatter_scalar, contents, "created_at")
   end
 
   def test_idea_preview_roundtrip_open_then_i_dismisses

--- a/test/unit/tui/help_test.rb
+++ b/test/unit/tui/help_test.rb
@@ -158,6 +158,7 @@ class TuiHelpTest < Minitest::Test
 
     refute_nil entry, "expected a grid-mode binding for `i`"
     assert_equal :open_idea_preview, entry[:action]
+    assert_match(/info panel/i, entry[:description])
     assert_match(/original idea/i, entry[:description])
   end
 
@@ -170,11 +171,19 @@ class TuiHelpTest < Minitest::Test
     assert_match(/no undo/i, entry[:description])
   end
 
-  def test_idea_preview_mode_has_a_dismiss_entry
-    entry = Hive::Tui::Help::BINDINGS.find { |b| b[:mode] == :idea_preview && b[:key] == "any" }
+  def test_idea_preview_mode_has_explicit_close_entries
+    entries = Hive::Tui::Help::BINDINGS.select { |b| b[:mode] == :idea_preview }
+    by_key = entries.to_h { |entry| [ entry[:key], entry ] }
 
-    refute_nil entry, "expected an idea-preview dismissal binding"
-    assert_equal :back, entry[:action]
-    assert_match(/dismiss/i, entry[:description])
+    assert_equal %w[Esc i q], by_key.keys.sort
+    %w[q Esc i].each do |key|
+      assert_equal :back, by_key.fetch(key)[:action]
+      assert_match(/close the info panel/i, by_key.fetch(key)[:description])
+    end
+  end
+
+  def test_idea_preview_mode_has_no_any_key_binding
+    refute Hive::Tui::Help::BINDINGS.any? { |b| b[:mode] == :idea_preview && b[:key] == "any" },
+           "idea-preview help must list explicit close keys, not an any-key dismissal"
   end
 end

--- a/test/unit/tui/key_map_test.rb
+++ b/test/unit/tui/key_map_test.rb
@@ -258,10 +258,17 @@ class TuiKeyMapMessageForTest < Minitest::Test
     assert_equal "i", msg.char
   end
 
-  def test_idea_preview_any_key_returns_back
-    [ "i", "x", :key_enter, :key_escape, "q", :space ].each do |key|
+  def test_idea_preview_q_escape_and_i_return_back
+    [ "q", :key_escape, "\e", "i" ].each do |key|
       msg = Hive::Tui::KeyMap.message_for(mode: :idea_preview, key: key, row: nil)
-      assert_same Hive::Tui::Messages::BACK, msg, "#{key.inspect} must dismiss idea preview"
+      assert_same Hive::Tui::Messages::BACK, msg, "#{key.inspect} must close idea preview"
+    end
+  end
+
+  def test_idea_preview_unmapped_keys_are_noop
+    [ "x", :key_enter, :space ].each do |key|
+      msg = Hive::Tui::KeyMap.message_for(mode: :idea_preview, key: key, row: nil)
+      assert_same Hive::Tui::Messages::NOOP, msg, "#{key.inspect} must not close idea preview"
     end
   end
 

--- a/test/unit/tui/model_test.rb
+++ b/test/unit/tui/model_test.rb
@@ -26,8 +26,6 @@ class HiveTuiModelTest < Minitest::Test
     assert_nil model.new_idea_staging_dir
     assert_nil model.new_idea_staging_tmp_root
     assert_equal [], model.new_idea_broken_labels
-    assert_nil model.idea_preview_text
-    assert_nil model.idea_preview_slug
     assert_nil model.info_panel_state
     assert_nil model.flash
     assert_nil model.flash_set_at
@@ -66,20 +64,12 @@ class HiveTuiModelTest < Minitest::Test
     assert_equal 2, b.scope
   end
 
-  def test_with_updates_idea_preview_fields
+  def test_with_updates_info_panel_state
     a = Hive::Tui::Model.initial
     state = info_panel_state(slug: "ship-preview", original_text: "original idea")
-    b = a.with(
-      idea_preview_text: "original idea",
-      idea_preview_slug: "ship-preview",
-      info_panel_state: state
-    )
+    b = a.with(info_panel_state: state)
 
-    assert_nil a.idea_preview_text
-    assert_nil a.idea_preview_slug
     assert_nil a.info_panel_state
-    assert_equal "original idea", b.idea_preview_text
-    assert_equal "ship-preview", b.idea_preview_slug
     assert_equal state, b.info_panel_state
     refute_same a, b
   end
@@ -158,7 +148,7 @@ class HiveTuiModelTest < Minitest::Test
     expected = %i[mode snapshot cursor filter filter_buffer scope pane_focus new_idea_project_name
                   new_idea_project_cursor new_idea_buffer new_idea_cursor
                   new_idea_attachments new_idea_staging_dir new_idea_staging_tmp_root new_idea_attachment_counter
-                  new_idea_broken_labels idea_preview_text idea_preview_slug info_panel_state flash flash_set_at
+                  new_idea_broken_labels info_panel_state flash flash_set_at
                   tail_state red_status_detail_state
                   cols rows last_error]
     assert_equal expected, Hive::Tui::Model.members

--- a/test/unit/tui/model_test.rb
+++ b/test/unit/tui/model_test.rb
@@ -154,6 +154,11 @@ class HiveTuiModelTest < Minitest::Test
     assert_equal expected, Hive::Tui::Model.members
   end
 
+  def test_info_panel_state_carries_all_documented_fields
+    expected = %i[slug stage created_at original_text folder_path latest_log_path stage_extra]
+    assert_equal expected, Hive::Tui::Model::InfoPanelState.members
+  end
+
   def test_pane_focus_can_be_overridden_via_with
     a = Hive::Tui::Model.initial
     b = a.with(pane_focus: :left)

--- a/test/unit/tui/model_test.rb
+++ b/test/unit/tui/model_test.rb
@@ -28,6 +28,7 @@ class HiveTuiModelTest < Minitest::Test
     assert_equal [], model.new_idea_broken_labels
     assert_nil model.idea_preview_text
     assert_nil model.idea_preview_slug
+    assert_nil model.info_panel_state
     assert_nil model.flash
     assert_nil model.flash_set_at
     assert_nil model.tail_state
@@ -67,13 +68,41 @@ class HiveTuiModelTest < Minitest::Test
 
   def test_with_updates_idea_preview_fields
     a = Hive::Tui::Model.initial
-    b = a.with(idea_preview_text: "original idea", idea_preview_slug: "ship-preview")
+    state = info_panel_state(slug: "ship-preview", original_text: "original idea")
+    b = a.with(
+      idea_preview_text: "original idea",
+      idea_preview_slug: "ship-preview",
+      info_panel_state: state
+    )
 
     assert_nil a.idea_preview_text
     assert_nil a.idea_preview_slug
+    assert_nil a.info_panel_state
     assert_equal "original idea", b.idea_preview_text
     assert_equal "ship-preview", b.idea_preview_slug
+    assert_equal state, b.info_panel_state
     refute_same a, b
+  end
+
+  def test_info_panel_state_round_trips_fields_and_is_frozen
+    state = info_panel_state(
+      slug: "slug-a",
+      stage: "4-execute",
+      created_at: "2026-05-22T22:40:00Z",
+      original_text: "ship it",
+      folder_path: "/project/.hive-state/stages/4-execute/slug-a",
+      latest_log_path: "/project/.hive-state/logs/slug-a/execute.log",
+      stage_extra: "tail"
+    )
+
+    assert_equal "slug-a", state.slug
+    assert_equal "4-execute", state.stage
+    assert_equal "2026-05-22T22:40:00Z", state.created_at
+    assert_equal "ship it", state.original_text
+    assert_equal "/project/.hive-state/stages/4-execute/slug-a", state.folder_path
+    assert_equal "/project/.hive-state/logs/slug-a/execute.log", state.latest_log_path
+    assert_equal "tail", state.stage_extra
+    assert state.frozen?
   end
 
   def test_model_is_immutable
@@ -129,7 +158,7 @@ class HiveTuiModelTest < Minitest::Test
     expected = %i[mode snapshot cursor filter filter_buffer scope pane_focus new_idea_project_name
                   new_idea_project_cursor new_idea_buffer new_idea_cursor
                   new_idea_attachments new_idea_staging_dir new_idea_staging_tmp_root new_idea_attachment_counter
-                  new_idea_broken_labels idea_preview_text idea_preview_slug flash flash_set_at
+                  new_idea_broken_labels idea_preview_text idea_preview_slug info_panel_state flash flash_set_at
                   tail_state red_status_detail_state
                   cols rows last_error]
     assert_equal expected, Hive::Tui::Model.members
@@ -186,5 +215,19 @@ class HiveTuiModelTest < Minitest::Test
     assert_nil state.log_path
     assert_equal [], state.log_lines
     assert_equal 0, state.log_scroll_offset
+  end
+
+  def info_panel_state(slug: "some-slug", stage: "2-brainstorm", created_at: nil,
+                       original_text: "Original idea", folder_path: "/tmp/hive/some-slug",
+                       latest_log_path: nil, stage_extra: nil)
+    Hive::Tui::Model::InfoPanelState.new(
+      slug: slug,
+      stage: stage,
+      created_at: created_at,
+      original_text: original_text,
+      folder_path: folder_path,
+      latest_log_path: latest_log_path,
+      stage_extra: stage_extra
+    )
   end
 end

--- a/test/unit/tui/update_test.rb
+++ b/test/unit/tui/update_test.rb
@@ -1338,7 +1338,7 @@ class HiveTuiUpdateTest < Minitest::Test
     assert_equal :grid, new_model.mode
   end
 
-  def test_back_from_idea_preview_clears_text_and_returns_to_grid
+  def test_back_from_idea_preview_clears_state_and_returns_to_grid
     state = Hive::Tui::Model::InfoPanelState.new(
       slug: "some-slug",
       stage: "2-brainstorm",
@@ -1348,17 +1348,10 @@ class HiveTuiUpdateTest < Minitest::Test
       latest_log_path: nil,
       stage_extra: nil
     )
-    starting = model.with(
-      mode: :idea_preview,
-      idea_preview_text: "original idea",
-      idea_preview_slug: "some-slug",
-      info_panel_state: state
-    )
+    starting = model.with(mode: :idea_preview, info_panel_state: state)
     new_model, _cmd = Hive::Tui::Update.apply(starting, Hive::Tui::Messages::BACK)
 
     assert_equal :grid, new_model.mode
-    assert_nil new_model.idea_preview_text
-    assert_nil new_model.idea_preview_slug
     assert_nil new_model.info_panel_state
   end
 

--- a/test/unit/tui/update_test.rb
+++ b/test/unit/tui/update_test.rb
@@ -1339,23 +1339,41 @@ class HiveTuiUpdateTest < Minitest::Test
   end
 
   def test_back_from_idea_preview_clears_text_and_returns_to_grid
+    state = Hive::Tui::Model::InfoPanelState.new(
+      slug: "some-slug",
+      stage: "2-brainstorm",
+      created_at: nil,
+      original_text: "original idea",
+      folder_path: "/tmp/hive/some-slug",
+      latest_log_path: nil,
+      stage_extra: nil
+    )
     starting = model.with(
       mode: :idea_preview,
       idea_preview_text: "original idea",
-      idea_preview_slug: "some-slug"
+      idea_preview_slug: "some-slug",
+      info_panel_state: state
     )
     new_model, _cmd = Hive::Tui::Update.apply(starting, Hive::Tui::Messages::BACK)
 
     assert_equal :grid, new_model.mode
     assert_nil new_model.idea_preview_text
     assert_nil new_model.idea_preview_slug
+    assert_nil new_model.info_panel_state
   end
 
   def test_back_from_idea_preview_preserves_cursor_and_scope
     starting = model.with(
       mode: :idea_preview,
-      idea_preview_text: "original idea",
-      idea_preview_slug: "some-slug",
+      info_panel_state: Hive::Tui::Model::InfoPanelState.new(
+        slug: "some-slug",
+        stage: "2-brainstorm",
+        created_at: nil,
+        original_text: "original idea",
+        folder_path: "/tmp/hive/some-slug",
+        latest_log_path: nil,
+        stage_extra: nil
+      ),
       cursor: [ 1, 2 ],
       scope: 2
     )

--- a/test/unit/tui/views/idea_preview_test.rb
+++ b/test/unit/tui/views/idea_preview_test.rb
@@ -149,4 +149,12 @@ class HiveTuiViewsIdeaPreviewTest < Minitest::Test
     assert_includes out, "…"
     refute_includes out, "extra line 20"
   end
+
+  def test_long_original_text_cannot_suppress_stage_extra_title
+    long_text = (1..40).map { |i| "idea body line #{i}" }.join("\n")
+    out = render(state: info_state(original_text: long_text, stage_extra: "# Brainstorm body"), height: 13)
+
+    assert_includes out, "brainstorm.md",
+                    "stage_extra title block must survive a long original_text per IU3 contract"
+  end
 end

--- a/test/unit/tui/views/idea_preview_test.rb
+++ b/test/unit/tui/views/idea_preview_test.rb
@@ -5,55 +5,148 @@ require "hive/tui/views/idea_preview"
 class HiveTuiViewsIdeaPreviewTest < Minitest::Test
   include HiveTestHelper
 
-  def model_with(text: "Original idea", slug: "some-slug", cols: 80)
-    Hive::Tui::Model.initial.with(
-      mode: :idea_preview,
-      idea_preview_text: text,
-      idea_preview_slug: slug,
-      cols: cols
+  UNSET = Object.new.freeze
+
+  def info_state(stage: "2-brainstorm", slug: "some-slug", created_at: "2026-05-22T22:40:00Z",
+                 original_text: "Original idea", folder_path: UNSET, latest_log_path: UNSET,
+                 stage_extra: nil)
+    folder_path = "/home/asterio/Dev/hive/.hive-state/stages/#{stage}/#{slug}" if folder_path.equal?(UNSET)
+    latest_log_path = "/home/asterio/Dev/hive/.hive-state/logs/#{slug}/run.log" if latest_log_path.equal?(UNSET)
+    Hive::Tui::Model::InfoPanelState.new(
+      slug: slug,
+      stage: stage,
+      created_at: created_at,
+      original_text: original_text,
+      folder_path: folder_path,
+      latest_log_path: latest_log_path,
+      stage_extra: stage_extra
     )
   end
 
-  def render_lines(**kwargs)
-    Hive::Tui::Views::IdeaPreview.render(model_with(**kwargs), width: kwargs.fetch(:cols, 80)).lines(chomp: true)
+  def model_with(state: info_state, cols: 80, rows: 24)
+    Hive::Tui::Model.initial.with(mode: :idea_preview, info_panel_state: state, cols: cols, rows: rows)
   end
 
-  def test_renders_header_with_slug
-    out = Hive::Tui::Views::IdeaPreview.render(model_with(slug: "preview-me"))
-    assert_includes out, "Idea for preview-me:"
+  def render(state: info_state, cols: 80, rows: 24, height: rows - 1)
+    Hive::Tui::Views::IdeaPreview.render(model_with(state: state, cols: cols, rows: rows), width: cols, height: height)
   end
 
-  def test_renders_original_text_verbatim
-    out = Hive::Tui::Views::IdeaPreview.render(model_with(text: "keep [image1] plain"))
+  def rendered_lines(**kwargs)
+    render(**kwargs).lines(chomp: true)
+  end
+
+  def test_returns_empty_string_without_panel_state
+    out = Hive::Tui::Views::IdeaPreview.render(model_with(state: nil))
+
+    assert_equal "", out
+  end
+
+  def test_renders_header_with_slug_and_stage
+    out = render(state: info_state(slug: "preview-me", stage: "2-brainstorm"))
+
+    assert_includes out, "Info: preview-me"
+    assert_includes out, "[stage: 2-brainstorm]"
+  end
+
+  def test_renders_common_fields
+    state = info_state(
+      created_at: "2026-05-22T22:40:00Z",
+      folder_path: "/tmp/project/.hive-state/stages/2-brainstorm/some-slug",
+      latest_log_path: "/tmp/project/.hive-state/logs/some-slug/brainstorm.log"
+    )
+
+    out = render(state: state)
+
+    assert_includes out, "created_at:"
+    assert_includes out, "2026-05-22T22:40:00Z"
+    assert_includes out, "folder:"
+    assert_includes out, "/tmp/project/.hive-state/stages/2-brainstorm/some-slug"
+    assert_includes out, "latest log:"
+    assert_includes out, "/tmp/project/.hive-state/logs/some-slug/brainstorm.log"
+  end
+
+  def test_renders_unknown_common_field_fallbacks
+    out = render(state: info_state(created_at: nil, folder_path: nil, latest_log_path: nil))
+
+    assert_includes out, "created_at:  (unknown)"
+    assert_includes out, "folder:      (unknown)"
+    assert_includes out, "latest log:  (none)"
+  end
+
+  def test_renders_original_idea_section_with_wrapped_text
+    out = render(state: info_state(original_text: "keep [image1] plain\nand wrap"))
+
+    assert_includes out, "Original idea"
     assert_includes out, "keep [image1] plain"
+    assert_includes out, "and wrap"
   end
 
-  def test_renders_dismiss_hint
-    out = Hive::Tui::Views::IdeaPreview.render(model_with)
-    assert out.end_with?(Hive::Tui::Views::IdeaPreview::DISMISS_HINT),
-           "dismiss hint must be the final rendered line"
+  def test_renders_brainstorm_extra_section
+    out = render(state: info_state(stage: "2-brainstorm", stage_extra: "# Brainstorm\nQ1"))
+
+    assert_includes out, "brainstorm.md"
+    assert_includes out, "# Brainstorm"
+    assert_includes out, "Q1"
+  end
+
+  def test_renders_plan_extra_section
+    out = render(state: info_state(stage: "3-plan", stage_extra: "# Plan\nIU1"))
+
+    assert_includes out, "plan.md"
+    assert_includes out, "# Plan"
+    assert_includes out, "IU1"
+  end
+
+  def test_renders_execute_log_extra_section
+    out = render(state: info_state(stage: "4-execute", stage_extra: "line one\nline two"))
+
+    assert_includes out, "execute log"
+    assert_includes out, "line one"
+    assert_includes out, "line two"
+  end
+
+  def test_inbox_without_extra_renders_no_extra_section
+    out = render(state: info_state(stage: "1-inbox", stage_extra: nil))
+
+    refute_includes out, "brainstorm.md"
+    refute_includes out, "plan.md"
+    refute_includes out, "execute log"
+  end
+
+  def test_renders_close_hint_as_final_visible_line
+    lines = rendered_lines(state: info_state)
+
+    assert lines.last.end_with?(Hive::Tui::Views::IdeaPreview::DISMISS_HINT),
+           "close hint must be final rendered line: #{lines.last.inspect}"
   end
 
   def test_truncates_long_lines_to_width
-    lines = render_lines(text: "x" * 80, cols: 20)
+    lines = rendered_lines(
+      state: info_state(
+        slug: "x" * 80,
+        original_text: "y" * 80,
+        folder_path: "/tmp/#{"z" * 80}",
+        latest_log_path: "/tmp/#{"l" * 80}"
+      ),
+      cols: 30,
+      height: 12
+    )
 
-    assert lines.all? { |line| line.length <= 20 },
+    assert lines.all? { |line| line.length <= 30 },
            "all rendered lines must fit width: #{lines.inspect}"
   end
 
-  def test_caps_visible_rows_for_oversized_text
-    text = (1..10).map { |i| "line #{i}" }.join("\n")
-    lines = render_lines(text: text)
-    body_lines = lines[1...-1]
+  def test_truncates_extra_block_before_common_block_when_height_overflows
+    extra = (1..20).map { |i| "extra line #{i}" }.join("\n")
+    out = render(state: info_state(original_text: "common survives", stage_extra: extra), height: 13)
 
-    assert_operator body_lines.length, :<=, Hive::Tui::Views::IdeaPreview::MAX_VISIBLE_ROWS
-  end
-
-  def test_handles_nil_text_gracefully
-    lines = render_lines(text: nil, slug: "nil-text")
-
-    assert_equal 2, lines.length
-    assert_includes lines.first, "Idea for nil-text:"
-    assert_equal Hive::Tui::Views::IdeaPreview::DISMISS_HINT, lines.last
+    assert_includes out, "created_at:"
+    assert_includes out, "folder:"
+    assert_includes out, "latest log:"
+    assert_includes out, "Original idea"
+    assert_includes out, "common survives"
+    assert_includes out, "brainstorm.md"
+    assert_includes out, "…"
+    refute_includes out, "extra line 20"
   end
 end

--- a/wiki/commands/tui.md
+++ b/wiki/commands/tui.md
@@ -28,7 +28,7 @@ The legacy curses backend was removed in plan #003 U11. `HIVE_TUI_BACKEND=curses
 │  myapp          │  ⚠  oauth-…       6-review      Needs recovery      1h │
 │  appcrawl       │                                                        │
 ├─────────────────┴────────────────────────────────────────────────────────┤
-│ Footer: [Tab] switch  [Enter] action  [n] new  [/] filter  [?] help  [q]│
+│ Footer: [Tab] switch  [Enter] action  [n] new  [/] filter  [?] help  [i] info  [q] quit │
 └──────────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -45,6 +45,7 @@ Pane focus is keyboard-only; the focused pane border is bright cyan, the inactiv
 | Filter prompt | `/` | `Esc` (cancels typed buffer; any committed filter is preserved) / `Enter` (commits) |
 | New idea project picker | `n` from `★ All projects` scope | `Esc` / `q` (cancels) / `Enter` (selects and advances to title prompt) |
 | New idea prompt | `n` (single-project scope), or after picker selection (all-projects scope) | `Esc` (cancels) / `Enter` (submits `hive new <project> "<title>"`) |
+| Info panel | `i` on a selected right-pane task | `q` / `Esc` / `i` |
 | Help overlay | `?` | any key |
 
 ## Keybindings (default mode)
@@ -65,6 +66,7 @@ Pane focus is keyboard-only; the focused pane border is bright cyan, the inactiv
 | `a` | run `hive archive` |
 | `Enter` | from left pane: focus right pane. From right pane: perform the row's contextual action: input editor on `needs_input` (completed brainstorm answer rounds auto-run; plan rows auto-advance to `develop` or auto-revise on user feedback), log tail on `agent_running` (and on `error` rows still in a kill-class auto-heal window), red-status detail on selected review-recovery and non-kill-class `error` rows, direct retry/browse for the legacy review-stale exceptions, and suggested-command dispatch for ready rows |
 | `o` | open the focused row's hive-state task folder in `$VISUAL` / `$EDITOR` / `vi` for read-only browsing — no marker change, no workflow dispatch. Distinct from `Enter` (workflow-contextual) and the verb keys (subprocess dispatch). Useful for revisiting investigation outputs in `9-done` (or any stage). |
+| `i` | open the focused row's in-TUI info panel — no editor handoff, no marker change, no workflow dispatch. |
 | `s` | steer the focused task manually: open the configured `execute.agent` in the feature worktree with every existing stage folder for that slug passed as agent context, mark the row `MANUAL_STEERING`, and archive the slug under `archived-manual/` when the agent exits |
 | `n` | open the new-idea flow; if scope is `★ All projects`, first show a project picker, then submit with `hive new <project> "<title>"` against the chosen concrete project |
 | `/` | open filter prompt |
@@ -135,6 +137,8 @@ The takeover handler reuses `Hive::Tui::Subprocess.foreground_takeover_command` 
 
 Pressing `o` from grid mode opens the focused row's task folder in `$EDITOR` for read-only browsing — distinct from `Enter` (workflow-contextual: editor on `needs_input`, log tail on `agent_running`, recover+rerun on review/error recovery rows, etc.) and the verb keys (which dispatch a `hive <verb>` subprocess). `o` mutates no marker, dispatches no workflow, and emits no follow-up `Messages::InputEditorExited` — the editor's exit is the user's last word. Useful for revisiting investigation outputs in `9-done` (or any stage) without dropping to a shell. The handler reuses the same `foreground_takeover_command` machinery `Enter`-on-`needs_input` uses, so terminal handoff is identical; only the after-spawn plumbing differs.
 
+Pressing `i` from grid mode opens a full-screen read-only info panel for the focused task. `BubbleModel#open_idea_preview` reads the task's `idea.md` once, builds `Hive::Tui::Model::InfoPanelState`, and the view renders common identity fields (slug, stage, `created_at`, absolute stage folder, latest `.hive-state/logs/<slug>/*.log` path, and original idea text). Stage extras are plain-text snapshots: `brainstorm.md` for `2-brainstorm`, `plan.md` for `3-plan`, the latest execute-log tail for `4-execute`, and no extra block for `1-inbox`. The panel uses the existing `:idea_preview` mode and `OpenIdeaPreview` / `Back` messages; it mutates no files and spawns no subprocess. Only `q`, `Esc`, or `i` closes it, so accidental unmapped keys are no-ops.
+
 Pressing `s` from grid mode is the manual-steering escape hatch. `KeyMap` emits `Messages::OpenInAgent`, and `BubbleModel` resolves the task's project config, looks up `execute.agent`, verifies the feature worktree exists, then writes `MANUAL_STEERING` to the row's state file before handing the terminal to the configured development agent in that worktree. Existing stage folders for the slug are passed in `Hive::Stages::DIRS` order with the agent profile's add-dir flag, so the agent can read the idea, brainstorm, plan, task, logs, reviews, and later-stage artifacts without the operator copying paths by hand. `MANUAL_STEERING` classifies as `manual_steering` with no suggested command, so `hive run`, the daemon policy, and workflow verb keys skip it. When the interactive agent exits, `Messages::AgentSteerExited` moves the active stage folder to `.hive-state/stages/archived-manual/<slug>/` (or a numeric suffix on collision), which makes the slug disappear from `hive status` and the TUI without treating it as an `9-done` pipeline archive.
 
 Execute-stage waiting rows read `row.next_action` from `hive status --json`: `kind=edit` opens the reason-specific target (`worktree`, `plan.md`, or `task.md`), while `kind=run` dispatches the suggested `hive develop ... --from 4-execute` command directly for recovery states like `missing_research_output` where editing a file cannot clear the gate.
@@ -195,7 +199,7 @@ Note that `REVIEW_STALE reason=wall_clock` deliberately retries even when no rev
 
 - `test/integration/tui_command_test.rb` — Thor help-text registration, `--json` rejection, non-tty boundary check.
 - `test/unit/tui/*_test.rb` — pure-Ruby state machines (`StateSource`, `Snapshot`, `KeyMap`, `GridState`, `LogTail::FileResolver`, `Help`, `Model`, `Messages`, `Update`, `BubbleModel`).
-- `test/unit/tui/views/*_test.rb` — pure-function view tests for every Lipgloss-rendered frame (`ProjectsPane`, `TasksPane`, `LogTail`, `RedStatusDetail`, `HelpOverlay`, `FilterPrompt`, `NewIdeaPrompt`). Layout/text content is pinned; visual styling (color/bold/reverse) is validated by manual dogfood — lipgloss-ruby v0.2.2 strips ANSI in non-tty test environments (gap tracked in `docs/solutions/2026-04-27-charm-bubbletea-api-gaps.md`). Selection / cursor highlight predicates (`ProjectsPane#selected?`, `TasksPane#highlight?`) are exposed for unit-test assertion since the rendered output cannot distinguish them in non-tty.
+- `test/unit/tui/views/*_test.rb` — pure-function view tests for every Lipgloss-rendered frame (`ProjectsPane`, `TasksPane`, `LogTail`, `RedStatusDetail`, `HelpOverlay`, `FilterPrompt`, `IdeaPreview`, `NewIdeaPrompt`). Layout/text content is pinned; visual styling (color/bold/reverse) is validated by manual dogfood — lipgloss-ruby v0.2.2 strips ANSI in non-tty test environments (gap tracked in `docs/solutions/2026-04-27-charm-bubbletea-api-gaps.md`). Selection / cursor highlight predicates (`ProjectsPane#selected?`, `TasksPane#highlight?`) are exposed for unit-test assertion since the rendered output cannot distinguish them in non-tty.
 - `test/integration/tui_subprocess_test.rb` — `Subprocess.takeover_command` / `run_quiet!` against a fake child binary.
 - `test/integration/tui_smoke_test.rb` + `test/integration/tui_smoke_charm_test.rb` — PTY-based boot smokes: `bin/hive tui` paints, the seeded project name appears, `q` exits 0.
 

--- a/wiki/commands/tui.md
+++ b/wiki/commands/tui.md
@@ -28,7 +28,7 @@ The legacy curses backend was removed in plan #003 U11. `HIVE_TUI_BACKEND=curses
 │  myapp          │  ⚠  oauth-…       6-review      Needs recovery      1h │
 │  appcrawl       │                                                        │
 ├─────────────────┴────────────────────────────────────────────────────────┤
-│ Footer: [Tab] switch  [Enter] action  [n] new  [/] filter  [?] help  [i] info  [q] quit │
+│ Footer: [Tab]  [Enter]  [n] new  [/] filter  [?] help  [i] info  [q] quit│
 └──────────────────────────────────────────────────────────────────────────┘
 ```
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -49,6 +49,12 @@ The supporting cleanup:
 - `wiki/modules/diagnosis_agent.md` — removed the TUI `R` key entry-point reference; only `hive status --diagnose <slug> --write` remains as the consumer.
 - `wiki/decisions.md` ADR-027 — replaced the three-gesture (`Enter` / `f` / `R`) action surface with the new unified two-action contract.
 - `docs/solutions/architecture-patterns/red-status-diagnose-then-act-2026-05-16.md` — pattern doc Section 5 reflects the two-action contract; refresh-via-headless-agent is now documented as a CLI-only affordance.
+## [2026-05-22T22:34:07Z] tui — `i` opens a full-screen read-only info panel
+
+**Action:** Documented the upgraded grid-mode `i` affordance. The footer now advertises `[i] info`; `OpenIdeaPreview` still enters `:idea_preview`, but the view is now a full-screen read-only info panel instead of a 6-row bottom strip. The panel renders task identity (slug, stage, `created_at`, absolute stage folder, latest `.hive-state/logs/<slug>/*.log` path, original idea text) plus stage-specific plain-text extras (`brainstorm.md`, `plan.md`, or the latest execute-log tail). It performs one read pass at open time, mutates no files, spawns no subprocess, and closes only on `q`, `Esc`, or `i`; other keys are no-ops.
+
+**Refreshed pages:**
+- [[commands/tui]] — footer, mode table, keybinding table, read-only info-panel behavior, and test surface updated.
 
 ## [2026-05-22T13:30:00Z] rebase / review — close three post-merge follow-up gaps from PR #104 review
 


### PR DESCRIPTION
## Summary

Pressing `i` on a focused task previously opened a 6-row bottom strip of `original_text` that any keystroke dismissed, and the binding was not advertised in the footer. This PR promotes `i` to a discoverable, full-screen, read-only info panel with stage-aware content and an explicit close set.

- **Footer advertises the binding.** `[i] info` is inserted between `[?] help` and `[q] quit` in `BubbleModel#footer_hint`, so the key is discoverable without opening the `?` overlay.
- **Full-screen, read-only panel.** `Hive::Tui::Model::InfoPanelState` carries the panel payload; `Views::IdeaPreview` renders an identity block (slug, stage, `created_at`, absolute stage folder, latest log path, original idea) plus a stage-specific extras block:

  | Stage | Extra content |
  |---|---|
  | `1-inbox` | (no extras) |
  | `2-brainstorm` | `brainstorm.md`, capped |
  | `3-plan` | `plan.md`, capped |
  | `4-execute` | tail of latest `.hive-state/logs/<slug>/execute-*.log` (4 KiB) |

- **Open-time gather, render-time no I/O.** `BubbleModel#open_idea_preview` reads `idea.md` frontmatter once, locates the latest log via `Hive::Task#log_dir`, pulls the stage extra, and packs everything into `InfoPanelState`. The view is a pure function of the captured state.
- **Sticky close-key gating.** `KeyMap#idea_preview_message` returns `BACK` only for `q`, `Esc`, or `i`; every other key is `NOOP`. Accidental typing no longer dismisses the panel.
- **Composition swap.** `compose_idea_preview_view` joins the panel body with `default_footer` directly instead of using `compose_two_pane_view(footer:)`, so the panel owns the body area while the footer hint line stays visible below it.
- **Help reflects the new behaviour.** `Help::BINDINGS` replaces the `key: "any"` row with explicit `q` / `Esc` / `i` entries and rewrites the grid-mode `i` description to enumerate the panel's fields.

The handler is pure read: `File.read` for `idea.md`, `File.open(..., "rb")` for extras, and `File.mtime` for the latest-log scan. No writes, no subprocesses, no markers, no network. Missing or unreadable extras fall through to `nil` and still render a useful identity block; pathological `idea.md` shapes (directory, non-UTF-8 bytes, oversize path) flash `"could not read idea"` instead of crashing the render loop. C0/C1 control bytes in extras are stripped to keep the panel frame intact.

## Test plan

- [x] `bundle exec rake test TEST='test/unit/tui/**/*_test.rb'` — 850 runs / 2860 assertions, green.
  - `bubble_model_test`: per-stage open paths (`1-inbox`, `2-brainstorm`, `3-plan`, `4-execute`), missing/unreadable extras, missing `idea.md`, empty `original_text`, unknown-stage safe fallback, read-only mtime invariant, `default_footer` truncation at cols=80 and cols=76.
  - `views/idea_preview_test`: per-stage layouts, overflow truncation reserves room for the stage-extra block, divider/ellipsis behaviour.
  - `key_map_test`: `q` / `Esc` / `i` → `BACK`; every other key (`x`, `Enter`, arrows…) → `NOOP`.
  - `help_test`: `BINDINGS` contains the three explicit `:idea_preview` close entries and the new grid-mode `i` description; no `key: "any"` row.
  - `model_test` / `update_test`: `InfoPanelState` member order pinned, `apply_back` clears `info_panel_state`, `Model.initial.info_panel_state` is `nil`.
- [x] Full suite `bundle exec rake test` — green after rerunning one unrelated flaky `DiagnosisAgentTest` timeout.
- [x] Manual smoke `bin/hive tui` on a project with cards in each of the four stages — footer shows `[i] info`, panel opens/closes only on `q` / `Esc` / `i`, accidental keys are inert, cursor returns to the originating card.

## Review summary

Two `/ce-code-review` passes plus the `pr-review-toolkit` reviewer ran across the branch. All High and Medium findings were auto-fixed in-tree:

- Restored the daemon-first README quickstart and appended (rather than replaced) the existing `wiki/log.md` entry — an unintended rebase regression.
- Hardened `BubbleModel#open_idea_preview` rescues to cover `Errno::EISDIR` / `Errno::ENOTDIR` / `Errno::ENAMETOOLONG` / `Encoding::InvalidByteSequenceError` so pathological `idea.md` shapes never crash the render loop.
- `latest_log_for` now narrows its outer rescue to `Errno::ENOENT` / `Errno::EACCES` (NFS `EIO` / `EMFILE` no longer silently masquerade as "no log"); the `4-execute` stage extra filters to `execute-*.log` so a stale `plan-*.log` can't masquerade as a fresh execute tail.
- `tail_capped` handles `Errno::ESPIPE` for non-seekable files and `read_capped` / `tail_capped` guard `File.file?` against directory/FIFO shapes.
- `scrub_utf8` strips C0/C1 control bytes (newlines/tabs preserved) so agent-authored markdown can't corrupt the TUI frame.
- `idea_created_at` falls back through `Time#utc.iso8601` and a tightened `frontmatter_scalar` regex (whitespace-anchored `#`-strip), and the fallback string is `.strip`ped so block scalars don't leak a trailing newline into the field grid.
- Deleted the dead `idea_preview_text` / `idea_preview_slug` mirror fields and `Views::IdeaPreview.legacy_state`; `InfoPanelState` is now the single source of truth.
- `field_line` reads its label-column width from a constant computed from the actual labels (no more silent 12→1 collapse for new 12+ char labels).
- `with_ellipsis` runs before styling so the truncation indicator stays inside the dim divider style on a real TTY.
- Test-side: stubbed unreadable-extra coverage at the `File.open` boundary (no longer depends on `chmod 0` semantics that fail under root in CI); added unknown-stage extra and cols=80 footer boundary tests; pinned `InfoPanelState.members` order; tightened the `frontmatter_scalar` comment-strip unit test for quoted-`#` and non-UTC `created_at` cases.
- Comment hygiene: stripped CLAUDE.md-disallowed multi-line docstrings, positional cross-references ("~1700 lines below"), and the history-narrating comment in `bubble_model_test`.

Items deferred with rationale (see review notes): display-width chunking for CJK / emoji, scrolling inside the panel, divider-row ellipsis cosmetics, and review-local `<task>/logs` discovery — all out of plan scope.

## Linked task

- Task slug: `add-i-key-with-legend-260522-ca28`
- Plan + reviews: `/home/asterio/Dev/hive/.hive-state/stages/8-finalize/add-i-key-with-legend-260522-ca28/`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_(1M)-D97757?logo=claude&logoColor=white)
