### PR TITLE
feat(tui): simplify red-status detail to Recover + Open in agent

### DIFF
--- a/docs/solutions/architecture-patterns/red-status-diagnose-then-act-2026-05-16.md
+++ b/docs/solutions/architecture-patterns/red-status-diagnose-then-act-2026-05-16.md
@@ -105,12 +105,13 @@ For ambiguous red rows, grid Enter should open a detail view, not immediately mu
 1. Why is this red?
 2. What can Hive do next?
 
-Then offer explicit actions:
+Then offer a deliberately narrow, unified action surface:
 
-- `Enter`: existing autofix/retry path.
-- `f`: open worktree in `$EDITOR` for manual fix.
-- `R`: refresh diagnosis via the headless command.
+- `Enter`: run the automated recovery for this row, then close the detail screen. Rows with no auto-recovery recipe surface a refusal flash that names the manual fallback ("Open in agent") and still close — the operator's binary gesture should never strand them on a stale view.
+- `o`: open the task in the project's configured development agent (the same takeover path the grid `s` key uses), then close the detail screen as the TUI suspends.
 - `q`/`Esc`: return.
+
+Two actions beat three because every additional gesture demands a justification on the screen. Refreshing diagnosis is a shell-level affordance (`hive status --diagnose <slug> --write`) rather than a TUI keybinding — the detail screen is for "act on what we already know", and the headless diagnosis command is for "ask the agent to look again." Separating them keeps the in-TUI action surface boring and predictable.
 
 Preserve direct paths for deterministic states where a detail view would add friction:
 

--- a/lib/hive/task_action.rb
+++ b/lib/hive/task_action.rb
@@ -439,14 +439,13 @@ module Hive
     # The diagnostic shape exists for ALL three recovery action keys per
     # ADR-027 and wiki/commands/status.md — recover_review, error, AND
     # recover_execute (EXECUTE_STALE). The TUI's red_status_detail view
-    # renders all three; recover_execute deliberately omits the [Enter]
-    # autofix affordance because EXECUTE_STALE has no auto-retry recipe
-    # (see red_status_detail.rb#FOOTER_NO_ENTER and
-    # suggested_next_action_payload below — manual_fix / command:null).
-    # Bot, daemon, and external `--json` consumers also rely on this
-    # field for EXECUTE_STALE rows the autofix path cannot resolve;
-    # emitting nil would defeat the diagnose-then-act feature for one
-    # of the three red states it covers.
+    # renders all three under a unified [Enter] Recover / [o] Open in
+    # agent contract; recover_execute rows surface the Risk-#3 mitigation
+    # flash when [Enter] Recover is pressed (no auto-retry recipe), then
+    # the screen closes. Bot, daemon, and external `--json` consumers
+    # also rely on this field for EXECUTE_STALE rows the autofix path
+    # cannot resolve; emitting nil would defeat the diagnose-then-act
+    # feature for one of the three red states it covers.
     def diagnostic_action?
       %w[recover_execute recover_review error].include?(key.to_s)
     end

--- a/lib/hive/tui/bubble_model.rb
+++ b/lib/hive/tui/bubble_model.rb
@@ -368,12 +368,14 @@ module Hive
           dispatch_command(message)
         when Hive::Tui::Messages::OpenLogTail
           open_log_tail(message.row)
+        when Hive::Tui::Messages::OpenRedStatusDetail
+          open_red_status_detail(message)
         when Hive::Tui::Messages::RecoverReview
           recover_review(message.row, force: message.force)
         when Hive::Tui::Messages::RecoverError
           recover_error(message.row)
         when Hive::Tui::Messages::RedStatusAutofix
-          red_status_autofix_from_detail(message.row)
+          dispatch_red_status_autofix_then_close_detail(message.row)
         when Hive::Tui::Messages::OpenInputEditor
           open_input_editor(message.row)
         when Hive::Tui::Messages::OpenTaskFolder
@@ -381,7 +383,7 @@ module Hive
         when Hive::Tui::Messages::OpenIdeaPreview
           open_idea_preview(message.row)
         when Hive::Tui::Messages::OpenInAgent
-          open_in_agent_from_detail(message.row)
+          dispatch_open_in_agent_then_close_detail(message.row)
         when Hive::Tui::Messages::AgentSteerExited
           archive_steer(message)
         when Hive::Tui::Messages::OpenSummary
@@ -861,8 +863,12 @@ module Hive
       # Wrap red_status_autofix so the detail screen closes after the
       # keypress (Recover refusal flash still surfaces — the operator's
       # gesture was binary, leaving them on the screen contradicts the
-      # plan's "screen closes after the keypress" requirement).
-      def red_status_autofix_from_detail(row)
+      # plan's "screen closes after the keypress" requirement). The
+      # wrapper is also reached from grid mode (Enter routes
+      # `RedStatusAutofix` through `handle_side_effect`) — the close
+      # branch is mode-guarded so grid-mode invocations are a no-op
+      # pass-through.
+      def dispatch_red_status_autofix_then_close_detail(row)
         model, cmd = red_status_autofix(row)
         close_red_status_detail_on_dispatch(model, cmd)
       end
@@ -871,7 +877,9 @@ module Hive
       # (success and refusal alike). The takeover Cmd is preserved so
       # the foreground takeover still suspends the TUI; on return the
       # operator lands on the grid rather than a stale detail view.
-      def open_in_agent_from_detail(row)
+      # Reached from grid mode (`s` key) and detail mode (`o` key); the
+      # close branch is mode-guarded so grid-mode `s` is unchanged.
+      def dispatch_open_in_agent_then_close_detail(row)
         model, cmd = open_in_agent(row)
         close_red_status_detail_on_dispatch(model, cmd)
       end
@@ -881,9 +889,8 @@ module Hive
         return [ model, cmd ] unless model.mode == :red_status_detail
 
         closed = model.with(mode: :grid, red_status_detail_state: nil)
-        snap = closed.snapshot
-        if snap
-          visible = snap.scope_to_project_index(closed.scope).filter_by_slug(closed.filter)
+        visible = Hive::Tui::Update.visible_snapshot(closed)
+        if visible
           cursor = Hive::Tui::Update.reclamp_cursor(visible, closed.cursor)
           closed = closed.with(cursor: cursor)
         end
@@ -895,7 +902,7 @@ module Hive
         return [ flashed("Hive has no automatic recovery for this state — try Open in agent"), nil ] if command.nil?
 
         if command.match?(/[;&|]/)
-          return [ flashed("diagnostic retry command is not directly dispatchable; use the shell command from details"), nil ]
+          return [ flashed("diagnostic retry command is not directly dispatchable; run it from a shell or use Open in agent"), nil ]
         end
 
         argv = Shellwords.split(command)
@@ -1511,6 +1518,38 @@ module Hive
           aliases: false
         ) || {}
         parsed.is_a?(Hash) ? parsed : {}
+      end
+
+      # Resolve the configured development-agent label for the detail
+      # screen, then delegate to Update so the model transition stays in
+      # the pure MVU layer. Lives here (not in Update or the view) so
+      # the no-I/O Update contract is preserved and the view stays a
+      # pure projection. Rescue list is intentionally broad — a corrupt
+      # project config (chmod 000, hand-edited YAML aliases, dangling
+      # path) must never crash the bubbletea runner when the user opens
+      # the detail screen; fall back to the canonical "your project's
+      # development agent" label instead. Plan Risk #4.
+      def open_red_status_detail(message)
+        label = resolve_agent_label(message.row)
+        new_message = Hive::Tui::Messages::OpenRedStatusDetail.new(
+          row: message.row,
+          agent_label: label
+        )
+        new_model, _cmd = Hive::Tui::Update.apply(@hive_model, new_message)
+        [ new_model, nil ]
+      end
+
+      def resolve_agent_label(row)
+        task = Hive::Task.new(row.folder.to_s)
+        cfg = Hive::Config.load(task.project_root)
+        agent_name = cfg.dig("execute", "agent") || "claude"
+        profile = Hive::AgentProfiles.lookup(agent_name, cfg: cfg)
+        basename = File.basename(profile.bin.to_s)
+        basename.empty? ? Hive::Tui::Model::RedStatusDetailState::AGENT_FALLBACK : basename
+      rescue Hive::ConfigError, Hive::AgentProfiles::UnknownAgent,
+             Hive::AgentError, Hive::InvalidTaskPath,
+             Psych::Exception, SystemCallError, IOError
+        Hive::Tui::Model::RedStatusDetailState::AGENT_FALLBACK
       end
 
       def open_in_agent(row)

--- a/lib/hive/tui/bubble_model.rb
+++ b/lib/hive/tui/bubble_model.rb
@@ -138,10 +138,9 @@ module Hive
         # in the spawn-thread's `ensure` so retries unblock once the
         # first pass settles. Reuses @healed_folders_mutex so all
         # background-thread bookkeeping fields (@healed_folders,
-        # @heal_threads, @review_recovery_inflight, @error_recovery_inflight,
-        # @diagnosis_inflight) share a single lock.
+        # @heal_threads, @review_recovery_inflight,
+        # @error_recovery_inflight) share a single lock.
         @error_recovery_inflight = Set.new
-        @diagnosis_inflight = Set.new
         # Once-per-session latch (reset in #stage_image on success).
         @clipboard_tool_hint_shown = false
         # Consecutive `wl-paste`/`xclip` timeouts: a single timeout
@@ -374,11 +373,7 @@ module Hive
         when Hive::Tui::Messages::RecoverError
           recover_error(message.row)
         when Hive::Tui::Messages::RedStatusAutofix
-          red_status_autofix(message.row)
-        when Hive::Tui::Messages::OpenManualFix
-          open_manual_fix(message.row)
-        when Hive::Tui::Messages::RefreshRedStatusDiagnosis
-          refresh_red_status_diagnosis(message.row)
+          red_status_autofix_from_detail(message.row)
         when Hive::Tui::Messages::OpenInputEditor
           open_input_editor(message.row)
         when Hive::Tui::Messages::OpenTaskFolder
@@ -386,7 +381,7 @@ module Hive
         when Hive::Tui::Messages::OpenIdeaPreview
           open_idea_preview(message.row)
         when Hive::Tui::Messages::OpenInAgent
-          open_in_agent(message.row)
+          open_in_agent_from_detail(message.row)
         when Hive::Tui::Messages::AgentSteerExited
           archive_steer(message)
         when Hive::Tui::Messages::OpenSummary
@@ -667,37 +662,12 @@ module Hive
       # `Update.apply_subprocess_exited` keeps its existing default
       # flash behavior.
       def diagnose_subprocess_exit(msg)
-        if msg.verb.to_s == "status"
-          # Evict EXACTLY the completing folder (passed through by
-          # refresh_red_status_diagnosis's dispatcher wrap). Clearing
-          # the whole Set on every status exit cascaded across rows:
-          # a finish on folder A wiped B's inflight slot while B was
-          # still running, letting a second R-press on B spawn a
-          # duplicate agent.
-          evict_diagnosis_attempt(msg.folder) if msg.folder
-          model = clear_detail_refreshing(@hive_model)
-          if msg.exit_code.to_i.zero?
-            return [ model.with(flash: "red-status diagnosis refreshed", flash_set_at: Time.now), nil ]
-          end
-
-          diagnostic = Hive::Tui::Subprocess.diagnose_recent_failure(msg.verb)
-          text = diagnostic || "`status --diagnose` exited #{msg.exit_code} — tail #{Hive::Tui::Subprocess.log_path}"
-          return [ model.with(flash: text, flash_set_at: Time.now), nil ]
-        end
-
         return nil if msg.exit_code.nil? || msg.exit_code.zero?
 
         diagnostic = Hive::Tui::Subprocess.diagnose_recent_failure(msg.verb)
         return nil if diagnostic.nil?
 
         [ @hive_model.with(flash: diagnostic, flash_set_at: Time.now), nil ]
-      end
-
-      def clear_detail_refreshing(model)
-        state = model.red_status_detail_state
-        return model if state.nil?
-
-        model.with(red_status_detail_state: state.with(refreshing: false))
       end
 
       # Scan a fresh snapshot for tasks whose `:error` marker came from
@@ -884,13 +854,45 @@ module Hive
         when "error"
           recover_error(row)
         else
-          [ flashed("no autofix action available for #{row.slug}"), nil ]
+          [ flashed("Hive has no automatic recovery for this state — try Open in agent"), nil ]
         end
+      end
+
+      # Wrap red_status_autofix so the detail screen closes after the
+      # keypress (Recover refusal flash still surfaces — the operator's
+      # gesture was binary, leaving them on the screen contradicts the
+      # plan's "screen closes after the keypress" requirement).
+      def red_status_autofix_from_detail(row)
+        model, cmd = red_status_autofix(row)
+        close_red_status_detail_on_dispatch(model, cmd)
+      end
+
+      # Wrap open_in_agent so the detail screen closes on dispatch
+      # (success and refusal alike). The takeover Cmd is preserved so
+      # the foreground takeover still suspends the TUI; on return the
+      # operator lands on the grid rather than a stale detail view.
+      def open_in_agent_from_detail(row)
+        model, cmd = open_in_agent(row)
+        close_red_status_detail_on_dispatch(model, cmd)
+      end
+
+      def close_red_status_detail_on_dispatch(model, cmd)
+        return [ model, cmd ] unless model
+        return [ model, cmd ] unless model.mode == :red_status_detail
+
+        closed = model.with(mode: :grid, red_status_detail_state: nil)
+        snap = closed.snapshot
+        if snap
+          visible = snap.scope_to_project_index(closed.scope).filter_by_slug(closed.filter)
+          cursor = Hive::Tui::Update.reclamp_cursor(visible, closed.cursor)
+          closed = closed.with(cursor: cursor)
+        end
+        [ closed, cmd ]
       end
 
       def dispatch_diagnostic_retry(row)
         command = diagnostic_retry_command(row)
-        return [ flashed("no autofix action available for #{row.slug}"), nil ] if command.nil?
+        return [ flashed("Hive has no automatic recovery for this state — try Open in agent"), nil ] if command.nil?
 
         if command.match?(/[;&|]/)
           return [ flashed("diagnostic retry command is not directly dispatchable; use the shell command from details"), nil ]
@@ -926,141 +928,6 @@ module Hive
         Hive::TaskAction.max_passes_review_stale_with_escalations?(
           folder: row.folder, marker_name: row.marker, attrs: row.attrs
         )
-      end
-
-      # Returns true if a per-row autofix (recover_review / recover_error)
-      # is currently in flight. Used by refresh_red_status_diagnosis to
-      # refuse R-press while autofix is running — the autofix path
-      # acquires the per-task lock via `hive run`, and a parallel
-      # diagnose would either fail at the flock or write an artifact that
-      # describes pre-autofix state. See PR #84 review row 13.
-      def autofix_in_flight?(row)
-        @healed_folders_mutex.synchronize do
-          @review_recovery_inflight.include?(row.folder) ||
-            @error_recovery_inflight.include?(row.folder)
-        end
-      rescue StandardError
-        false
-      end
-
-      def register_diagnosis_attempt(folder)
-        @healed_folders_mutex.synchronize do
-          return false if @diagnosis_inflight.include?(folder)
-
-          @diagnosis_inflight.add(folder)
-          true
-        end
-      end
-
-      def evict_diagnosis_attempt(folder)
-        @healed_folders_mutex.synchronize { @diagnosis_inflight.delete(folder) }
-      end
-
-      def refresh_red_status_diagnosis(row)
-        return [ flashed("diagnosis unavailable: task folder missing"), nil ] if row.folder.to_s.empty?
-        # Refuse to spawn a second diagnose if autofix is already running
-        # against this row — the autofix path acquires the per-task lock
-        # via `hive run` and a parallel diagnose would either fail at the
-        # flock or write an artifact that describes pre-autofix state.
-        # Surface the operator-visible reason rather than a generic
-        # "in progress" flash so the operator knows which gesture to
-        # wait on. See PR #84 review row 13.
-        if row.action_key.to_s == "agent_running" || autofix_in_flight?(row)
-          return [ flashed("autofix already running for #{row.slug}; wait or press q to abort"), nil ]
-        end
-        return [ flashed("diagnosis already in progress for #{row.slug}"), nil ] unless register_diagnosis_attempt(row.folder)
-
-        argv = [ "hive", "status", "--diagnose", row.slug ]
-        argv += [ "--project", row.project_name ] if row.project_name.to_s != ""
-        # Disambiguate when the same slug lives in multiple stages of the
-        # same project (TaskResolver raises AmbiguousSlug otherwise).
-        argv += [ "--stage", row.stage ] if row.stage.to_s != ""
-        argv << "--write"
-        # An explicit operator R-press signals "show me a fresh verdict";
-        # the idempotency short-circuit (cache hit on matching
-        # marker_signature) would otherwise return the previous artifact
-        # silently and the TUI would flash "refreshed" without any
-        # new agent run. --force bypasses the short-circuit. See PR #84
-        # review row 8.
-        argv << "--force"
-
-        folder = row.folder
-        # Wrap the dispatcher so the SubprocessExited message arriving
-        # from the reaper Thread carries the originating folder. This
-        # is what lets diagnose_subprocess_exit evict EXACTLY the
-        # completing folder from @diagnosis_inflight; without the wrap
-        # we either evicted the whole Set (cross-task cascade letting
-        # duplicates through) or we'd need the SubprocessRegistry to
-        # track per-pid folders.
-        wrapped_dispatch = lambda do |msg|
-          if msg.is_a?(Hive::Tui::Messages::SubprocessExited)
-            msg = Hive::Tui::Messages::SubprocessExited.new(
-              verb: msg.verb, exit_code: msg.exit_code, folder: folder
-            )
-          end
-          @dispatch.call(msg)
-        end
-
-        Hive::Tui::Subprocess.dispatch_background(argv, dispatch: wrapped_dispatch)
-        state = @hive_model.red_status_detail_state
-        # Pressing R is an explicit operator acknowledgement of the
-        # current marker_signature — re-baseline so a subsequent
-        # snapshot-poll marker rotation re-fires the "marker changed"
-        # flash. See PR #84 review finding #7.
-        next_state =
-          if state
-            state.with(refreshing: true,
-                       acknowledged_marker_signature: state.marker_signature)
-          end
-        model = next_state ? @hive_model.with(red_status_detail_state: next_state) : @hive_model
-        [ model.with(flash: "refreshing diagnosis for #{row.slug}", flash_set_at: Time.now), nil ]
-      rescue SystemCallError, IOError, Hive::Tui::Subprocess::TimeoutError => e
-        evict_diagnosis_attempt(folder)
-        [ flashed("diagnosis failed to start: #{Hive::Tui::Text.sanitize(e.message)[0, 120]}"), nil ]
-      end
-
-      def open_manual_fix(row)
-        path = manual_fix_path(row)
-        return [ flashed("worktree not found for #{row.slug}: #{manual_fix_candidate(row)}"), nil ] if path.empty?
-
-        argv = editor_argv
-        callable = lambda do
-          run_editor(argv, path)
-          clear_terminal_for_takeover
-        end
-
-        cmd = Hive::Tui::Subprocess.foreground_takeover_command(callable)
-        [
-          @hive_model.with(
-            flash: "opening worktree for #{row.slug} in #{File.basename(argv.first)}",
-            flash_set_at: Time.now
-          ),
-          cmd
-        ]
-      rescue ArgumentError => e
-        [ flashed("editor command invalid: #{e.message}"), nil ]
-      end
-
-      def manual_fix_path(row)
-        candidate = manual_fix_candidate(row)
-        return "" if candidate.to_s.empty?
-
-        File.directory?(candidate) ? candidate : ""
-      end
-
-      def manual_fix_candidate(row)
-        task = Hive::Task.new(row.folder.to_s)
-        task.worktree_path.to_s
-      rescue Hive::InvalidTaskPath, Hive::ConfigError, Hive::WorktreeError,
-             SystemCallError, Psych::SyntaxError, Psych::DisallowedClass => e
-        # Narrow rescue: only the classes Task#worktree_path may
-        # legitimately raise via the config-load + worktree-yml path.
-        # The previous Hive::Error umbrella swallowed every Hive-namespaced
-        # error to ""; future subclasses would silently inherit the
-        # collapse. Log via Debug so the operator-visible "worktree not
-        # found" flash still has a breadcrumb in the debug log.
-        Hive::Tui::Debug.log("manual_fix_candidate", "#{row.slug}: #{e.class.name}: #{e.message}") if defined?(Hive::Tui::Debug)
-        ""
       end
 
       # Enter-driven review recovery. Review-stage recovery markers are

--- a/lib/hive/tui/help.rb
+++ b/lib/hive/tui/help.rb
@@ -51,11 +51,10 @@ module Hive
         { mode: :log_tail, key: "q",   action: :back, description: "back to grid" },
         { mode: :log_tail, key: "Esc", action: :back, description: "back to grid" },
         # Red-status detail mode.
-        { mode: :red_status_detail, key: "Enter", action: :autofix, description: "autofix / retry using the existing recovery handler" },
-        { mode: :red_status_detail, key: "f",     action: :manual_fix, description: "open the task worktree in $EDITOR without clearing markers" },
-        { mode: :red_status_detail, key: "R",     action: :refresh_diagnosis, description: "run headless status diagnosis and write the durable diagnostic artifact" },
-        { mode: :red_status_detail, key: "q",     action: :back, description: "back to grid" },
-        { mode: :red_status_detail, key: "Esc",   action: :back, description: "back to grid" },
+        { mode: :red_status_detail, key: "Enter", action: :recover,       description: "run hive's automated recovery for this task and close this screen" },
+        { mode: :red_status_detail, key: "o",     action: :open_in_agent, description: "open this task in the project's development agent and close this screen" },
+        { mode: :red_status_detail, key: "q",     action: :back,          description: "close this screen and return to the grid" },
+        { mode: :red_status_detail, key: "Esc",   action: :back,          description: "close this screen and return to the grid" },
         # Filter prompt mode.
         { mode: :filter, key: "Enter", action: :commit_filter, description: "commit typed filter" },
         { mode: :filter, key: "Esc",   action: :cancel_filter, description: "discard typed buffer and return to grid (any committed filter is preserved)" },

--- a/lib/hive/tui/key_map.rb
+++ b/lib/hive/tui/key_map.rb
@@ -2,6 +2,7 @@ require "shellwords"
 require "hive/markers"
 require "hive/tui/snapshot"
 require "hive/tui/messages"
+require "hive/tui/views/red_status_detail"
 require "hive/workflows"
 
 module Hive
@@ -233,13 +234,13 @@ module Hive
           attrs = row.attrs || {}
           !KILL_CLASS_EXIT_CODES.include?(attrs["exit_code"].to_s)
         when "recover_execute"
-          # EXECUTE_STALE rows expose the same diagnostic payload in
-          # JSON but historically lacked a detail view. Opening the
-          # view lets operators read the bounded summary + artifact
-          # tail and refresh the diagnosis with `R`. The autofix
-          # action is intentionally a no-op for these rows (they
-          # require a manual fix); see PR #84 review finding #10 and
-          # task_action.rb#suggested_next_action_payload.
+          # EXECUTE_STALE rows route through the detail screen so the
+          # operator sees the diagnosis + the two unified actions
+          # ([Enter] Recover always flashes when no auto-recovery
+          # recipe exists; [o] Open in agent is the manual fallback).
+          # See plan Unit 1: the screen always advertises both actions
+          # regardless of action_key, and refusals are surfaced via a
+          # flash that names the manual fallback.
           true
         else
           false
@@ -308,18 +309,29 @@ module Hive
         return Messages::BACK if ESCAPE_KEYS.include?(key) || key == "q"
         return Messages::RedStatusAutofix.new(row: row) if ENTER_KEYS.include?(key) && row
         return Messages::OpenInAgent.new(row: row) if key == "o" && row
-        hint = "press Enter to recover, o to open in agent, Esc to close"
-        return Messages::Flash.new(text: hint) if key == "s"
+        # The grid-mode steer key is `s`; in detail mode the equivalent
+        # action is bound to `o`. Surface an explicit nudge rather than
+        # the generic refusal so a muscle-memory drift fires a
+        # diagnosable signal instead of a silent NOOP.
+        return Messages::Flash.new(text: "press o for Open in agent") if key == "s"
+        # `f` (manual fix) and `R` (refresh diagnosis) were the previous
+        # detail-mode bindings; flash the refusal so muscle-memory drift
+        # surfaces the new contract rather than silently noop-ing.
+        return Messages::Flash.new(text: red_status_detail_hint) if key == "f" || key == "R"
         # Grid-mode verb keys (b/p/d/r/P/F/a) silently no-oping in the
         # detail view conflicts with the muscle memory documented in
         # wiki/commands/tui.md — notably `r` is the in-grid force-retry
         # gesture (PR #72). Flash an explicit refusal instead so the
         # operator sees the mode boundary.
         if VERB_KEYS.key?(key)
-          return Messages::Flash.new(text: hint)
+          return Messages::Flash.new(text: red_status_detail_hint)
         end
 
         Messages::NOOP
+      end
+
+      def red_status_detail_hint
+        Hive::Tui::Views::RedStatusDetail::ACTION_KEYS.map { |k| k[:hint] }.join(", ")
       end
 
       # Filter-prompt mode keystrokes. Update consumes the FilterChar*

--- a/lib/hive/tui/key_map.rb
+++ b/lib/hive/tui/key_map.rb
@@ -2,7 +2,7 @@ require "shellwords"
 require "hive/markers"
 require "hive/tui/snapshot"
 require "hive/tui/messages"
-require "hive/tui/views/red_status_detail"
+require "hive/tui/red_status_detail_keys"
 require "hive/workflows"
 
 module Hive
@@ -54,11 +54,13 @@ module Hive
       # `error` is intentionally absent — Enter on an error-state row
       # is routed by `error_message` (clear the ERROR marker + re-run
       # for non-kill-class failures; OpenLogTail while a kill-class
-      # auto-heal is in flight). The dual routing lives in the
-      # `enter_message` -> `error_message` branch below.
+      # auto-heal is in flight). `recover_execute` is also intentionally
+      # absent — Enter on those rows routes through `red_detail_row?` to
+      # the detail screen before ever reaching this lookup. The dual
+      # routing lives in the `enter_message` -> `error_message` branch
+      # below.
       ENTER_FLASH_MESSAGES = {
-        "archived" => "task is archived; no further action",
-        "recover_execute" => "task needs recovery — open the worktree to re-prioritise"
+        "archived" => "task is archived; no further action"
       }.freeze
 
       # @api private
@@ -331,7 +333,7 @@ module Hive
       end
 
       def red_status_detail_hint
-        Hive::Tui::Views::RedStatusDetail::ACTION_KEYS.map { |k| k[:hint] }.join(", ")
+        Hive::Tui::RedStatusDetailKeys::ACTION_KEYS.map { |k| k[:hint] }.join(", ")
       end
 
       # Filter-prompt mode keystrokes. Update consumes the FilterChar*

--- a/lib/hive/tui/key_map.rb
+++ b/lib/hive/tui/key_map.rb
@@ -307,15 +307,16 @@ module Hive
       def red_status_detail_message(key:, row:)
         return Messages::BACK if ESCAPE_KEYS.include?(key) || key == "q"
         return Messages::RedStatusAutofix.new(row: row) if ENTER_KEYS.include?(key) && row
-        return Messages::OpenManualFix.new(row: row) if key == "f" && row
-        return Messages::RefreshRedStatusDiagnosis.new(row: row) if key == "R" && row
+        return Messages::OpenInAgent.new(row: row) if key == "o" && row
+        hint = "press Enter to recover, o to open in agent, Esc to close"
+        return Messages::Flash.new(text: hint) if key == "s"
         # Grid-mode verb keys (b/p/d/r/P/F/a) silently no-oping in the
         # detail view conflicts with the muscle memory documented in
         # wiki/commands/tui.md — notably `r` is the in-grid force-retry
         # gesture (PR #72). Flash an explicit refusal instead so the
         # operator sees the mode boundary.
         if VERB_KEYS.key?(key)
-          return Messages::Flash.new(text: "verb keys are grid-mode only — Esc to return")
+          return Messages::Flash.new(text: hint)
         end
 
         Messages::NOOP

--- a/lib/hive/tui/messages.rb
+++ b/lib/hive/tui/messages.rb
@@ -43,15 +43,7 @@ module Hive
       # POSIX-shell-convention status (0 success; 128+signo for signal
       # kills; 127 command-not-found).
       #
-      # `folder` is optional — reserved for dispatchers that wrap
-      # @dispatch to thread per-row context through the reaper Thread.
-      # No active callers today; default nil keeps every workflow-verb
-      # and takeover-command spawn unchanged.
-      SubprocessExited = Data.define(:verb, :exit_code, :folder) do
-        def initialize(verb:, exit_code:, folder: nil)
-          super
-        end
-      end
+      SubprocessExited = Data.define(:verb, :exit_code)
 
       # Cooperative shutdown signal — set by the SIGHUP trap (via
       # `runner.send`) and by `q`-keystroke dispatch in grid mode.
@@ -158,8 +150,14 @@ module Hive
       RecoverError = Data.define(:row)
 
       # Enter on a gated red row — open the diagnosis/action view
-      # without clearing markers or dispatching recovery.
-      OpenRedStatusDetail = Data.define(:row)
+      # without clearing markers or dispatching recovery. `agent_label`
+      # is the resolved development-agent name, resolved by BubbleModel
+      # before dispatch so the no-I/O Update layer never reads disk.
+      OpenRedStatusDetail = Data.define(:row, :agent_label) do
+        def initialize(row:, agent_label: nil)
+          super
+        end
+      end
 
       # Enter inside the red-status detail view — run the same
       # recovery handler the grid row used to run directly.

--- a/lib/hive/tui/messages.rb
+++ b/lib/hive/tui/messages.rb
@@ -43,12 +43,10 @@ module Hive
       # POSIX-shell-convention status (0 success; 128+signo for signal
       # kills; 127 command-not-found).
       #
-      # `folder` is optional — present only when the dispatcher wrapped
-      # @dispatch to thread per-row context through the reaper Thread
-      # (today: `refresh_red_status_diagnosis`, so the diagnose-subprocess
-      # exit handler can evict the right slot from @diagnosis_inflight).
-      # Default nil keeps every existing call site (workflow-verb spawns,
-      # takeover-command spawns) unchanged.
+      # `folder` is optional — reserved for dispatchers that wrap
+      # @dispatch to thread per-row context through the reaper Thread.
+      # No active callers today; default nil keeps every workflow-verb
+      # and takeover-command spawn unchanged.
       SubprocessExited = Data.define(:verb, :exit_code, :folder) do
         def initialize(verb:, exit_code:, folder: nil)
           super
@@ -166,14 +164,6 @@ module Hive
       # Enter inside the red-status detail view — run the same
       # recovery handler the grid row used to run directly.
       RedStatusAutofix = Data.define(:row)
-
-      # `f` inside the red-status detail view — open the task worktree
-      # in $EDITOR for manual edits. This never clears markers.
-      OpenManualFix = Data.define(:row)
-
-      # `R` inside the red-status detail view — ask Hive to refresh the
-      # durable headless diagnosis artifact for this row.
-      RefreshRedStatusDiagnosis = Data.define(:row)
 
       # Enter on a `needs_input` row — suspend the TUI and open the
       # row's input target in the user's editor so they can answer or

--- a/lib/hive/tui/model.rb
+++ b/lib/hive/tui/model.rb
@@ -86,8 +86,14 @@ module Hive
       end
     end
 
-    Model::RedStatusDetailState = Data.define(:row, :marker_signature, :agent_label) do
-      def initialize(row:, marker_signature:, agent_label: nil)
+    Model::RedStatusDetailState = Data.define(:row, :agent_label)
+    # Single source of truth for the "no resolved label" copy. The
+    # resolver in BubbleModel falls back to this string when project
+    # config / agent lookup fails, so the view can render `agent_label`
+    # directly without re-applying a render-time `|| AGENT_FALLBACK`.
+    Model::RedStatusDetailState::AGENT_FALLBACK = "your project's development agent".freeze
+    class Model::RedStatusDetailState
+      def initialize(row:, agent_label: AGENT_FALLBACK)
         super
       end
     end

--- a/lib/hive/tui/model.rb
+++ b/lib/hive/tui/model.rb
@@ -86,15 +86,8 @@ module Hive
       end
     end
 
-    Model::RedStatusDetailState = Data.define(:row, :marker_signature, :acknowledged_marker_signature, :refreshing) do
-      # `marker_signature` is the most-recently observed value from the
-      # row's diagnostic; it follows the producer in real time.
-      # `acknowledged_marker_signature` is only updated on operator
-      # actions (open detail view, press R, dispatch autofix) so a
-      # marker that rotates multiple times between polls still fires
-      # the "marker changed" flash once per acknowledgement window
-      # rather than only on the first poll. See PR #84 review #7.
-      def initialize(row:, marker_signature:, acknowledged_marker_signature: marker_signature, refreshing: false)
+    Model::RedStatusDetailState = Data.define(:row, :marker_signature, :agent_label) do
+      def initialize(row:, marker_signature:, agent_label: nil)
         super
       end
     end

--- a/lib/hive/tui/red_status_detail_keys.rb
+++ b/lib/hive/tui/red_status_detail_keys.rb
@@ -1,0 +1,19 @@
+module Hive
+  module Tui
+    # Shared key list for the red-status detail screen — referenced by
+    # the view (footer) and KeyMap (refusal-flash hint). Single source
+    # so a key rename in one surface cannot drift away from the other.
+    # Lives outside the view module so KeyMap (an input-layer concern)
+    # doesn't have to require a view (an output-layer concern) just to
+    # read shared key-binding data.
+    module RedStatusDetailKeys
+      ACTION_KEYS = [
+        { footer: "[Enter] Recover",   hint: "press Enter to recover" },
+        { footer: "[o] Open in agent", hint: "o to open in agent" },
+        { footer: "[Esc] back",        hint: "Esc or q to close" }
+      ].each(&:freeze).freeze
+
+      FOOTER = ACTION_KEYS.map { |k| k[:footer] }.join("   ").freeze
+    end
+  end
+end

--- a/lib/hive/tui/update.rb
+++ b/lib/hive/tui/update.rb
@@ -1,9 +1,7 @@
-require "digest"
 require "hive"
 require "hive/tui/model"
 require "hive/tui/messages"
 require "hive/tui/subprocess"
-require "hive/tui/views/red_status_detail"
 
 module Hive
   module Tui
@@ -182,8 +180,7 @@ module Hive
           )
         end
 
-        signature = red_status_marker_signature(row)
-        model.with(red_status_detail_state: state.with(row: row, marker_signature: signature))
+        model.with(red_status_detail_state: state.with(row: row))
       end
 
       # Close the red-status detail view and return to grid. Recompute
@@ -697,15 +694,19 @@ module Hive
         model.with(mode: :filter, filter_buffer: model.filter.to_s)
       end
 
+      # Agent-label resolution lives in BubbleModel (filesystem/config
+      # I/O); when reached without a pre-built state, fall through with
+      # `RedStatusDetailState`'s default `AGENT_FALLBACK`. The
+      # `agent_label:` field on `OpenRedStatusDetail` lets the caller
+      # plumb a resolved label through without touching disk from Update.
       def apply_open_red_status_detail(model, msg)
-        model.with(
-          mode: :red_status_detail,
-          red_status_detail_state: Model::RedStatusDetailState.new(
-            row: msg.row,
-            marker_signature: red_status_marker_signature(msg.row),
-            agent_label: Hive::Tui::Views::RedStatusDetail.resolve_agent_label(msg.row)
-          )
-        )
+        label = msg.respond_to?(:agent_label) ? msg.agent_label : nil
+        state = if label && !label.to_s.empty?
+          Model::RedStatusDetailState.new(row: msg.row, agent_label: label)
+        else
+          Model::RedStatusDetailState.new(row: msg.row)
+        end
+        model.with(mode: :red_status_detail, red_status_detail_state: state)
       end
 
       # Esc / `q` from a sub-mode returns to grid. Clears tail_state on
@@ -760,31 +761,6 @@ module Hive
 
       def red_status_row?(row)
         %w[recover_review recover_execute error].include?(row.action_key.to_s)
-      end
-
-      # Read the canonical marker_signature off the diagnostic payload
-      # rather than recomputing locally. TaskAction#marker_signature is
-      # the producer (the SHA256-hex value emitted into the status JSON
-      # and into the diagnostics/red-status.md artifact frontmatter); the
-      # TUI is a consumer. Recomputing here with a different algorithm
-      # (the prior `\\0`-joined raw concat) meant the freshness compare
-      # could never match the hex stored in row.diagnostic, so the
-      # "marker changed since you opened this view" banner fired on
-      # every poll regardless of marker state.
-      #
-      # Fallback (rarely hit): when row.diagnostic is nil — e.g., the
-      # row is no longer red, or the JSON producer's schema_version
-      # predates the field — fall back to a deterministic local digest
-      # so the live-update gate still compares against a stable value
-      # across snapshots. The local digest is namespaced with a
-      # "no-diag:" prefix so it cannot collide with a real signature.
-      def red_status_marker_signature(row)
-        sig = row.diagnostic && row.diagnostic["marker_signature"]
-        return sig.to_s if sig && !sig.to_s.empty?
-
-        attrs = (row.attrs || {}).sort_by { |key, _value| key.to_s }
-                                 .map { |key, value| "#{key}=#{value}" }
-        "no-diag:" + Digest::SHA256.hexdigest(([ row.marker.to_s ] + attrs).join("\n"))
       end
 
       def next_non_empty_project_idx(visible, start_idx)

--- a/lib/hive/tui/update.rb
+++ b/lib/hive/tui/update.rb
@@ -3,6 +3,7 @@ require "hive"
 require "hive/tui/model"
 require "hive/tui/messages"
 require "hive/tui/subprocess"
+require "hive/tui/views/red_status_detail"
 
 module Hive
   module Tui
@@ -182,27 +183,7 @@ module Hive
         end
 
         signature = red_status_marker_signature(row)
-        # Preserve the operator-visible "Refreshing diagnosis..." flag
-        # across snapshot polls. The 1Hz poll lands while a headless
-        # diagnose subprocess can run up to 600s; the indicator must
-        # survive snapshots and only clear on SubprocessExited (see
-        # BubbleModel#diagnose_subprocess_exit).
-        #
-        # marker_signature follows the live row; acknowledged_marker_signature
-        # only moves on explicit operator actions. Comparing against the
-        # acknowledged value means a second marker rotation still flashes
-        # the "marker changed" warning even when the first rotation
-        # already updated state.marker_signature. See PR #84 review #7.
-        next_state = state.with(row: row, marker_signature: signature)
-        if signature != state.acknowledged_marker_signature
-          return model.with(
-            red_status_detail_state: next_state,
-            flash: "marker changed since you opened this view — refresh (R)",
-            flash_set_at: Time.now
-          )
-        end
-
-        model.with(red_status_detail_state: next_state)
+        model.with(red_status_detail_state: state.with(row: row, marker_signature: signature))
       end
 
       # Close the red-status detail view and return to grid. Recompute
@@ -721,7 +702,8 @@ module Hive
           mode: :red_status_detail,
           red_status_detail_state: Model::RedStatusDetailState.new(
             row: msg.row,
-            marker_signature: red_status_marker_signature(msg.row)
+            marker_signature: red_status_marker_signature(msg.row),
+            agent_label: Hive::Tui::Views::RedStatusDetail.resolve_agent_label(msg.row)
           )
         )
       end

--- a/lib/hive/tui/views/red_status_detail.rb
+++ b/lib/hive/tui/views/red_status_detail.rb
@@ -1,8 +1,6 @@
 require "lipgloss"
-require "hive"
-require "hive/agent_profiles"
-require "hive/config"
-require "hive/task"
+require "hive/tui/model"
+require "hive/tui/red_status_detail_keys"
 require "hive/tui/styles"
 require "hive/tui/text"
 require "hive/tui/views/format"
@@ -11,23 +9,24 @@ module Hive
   module Tui
     module Views
       module RedStatusDetail
-        # Shared key list — referenced by both the footer and the
-        # KeyMap hint flash. Single source so a key rename in one
-        # surface cannot drift away from the other.
-        ACTION_KEYS = [
-          { footer: "[Enter] Recover",      hint: "press Enter to recover" },
-          { footer: "[o] Open in agent",    hint: "o to open in agent" },
-          { footer: "[Esc] back",           hint: "Esc / q to close" }
-        ].freeze
-        FOOTER = ACTION_KEYS.map { |k| k[:footer] }.join("   ").freeze
-        AGENT_FALLBACK = "your project's development agent".freeze
+        # Shared single-source-of-truth for the detail screen's action
+        # key list lives in `Hive::Tui::RedStatusDetailKeys` so both
+        # this view (footer) and `KeyMap` (refusal-flash hint) read the
+        # same data without the view module exposing rendering surface.
+        ACTION_KEYS = Hive::Tui::RedStatusDetailKeys::ACTION_KEYS
+        FOOTER = Hive::Tui::RedStatusDetailKeys::FOOTER
+        # Re-export so external readers (tests, KeyMap) can pin against
+        # the canonical fallback string without depending on Model
+        # internals.
+        AGENT_FALLBACK = Hive::Tui::Model::RedStatusDetailState::AGENT_FALLBACK
 
         # Detect a `TaskAction#marker_summary`-style string (uppercase
-        # marker name optionally followed by attr key=value pairs) that
-        # leaked into diagnostic["summary"] from an older artifact. The
-        # detail screen must never echo debug copy — fall back to the
-        # plain-English placeholder instead. See plan Unit 1.
-        MARKER_SUMMARY_PATTERN = /\A[A-Z][A-Z0-9_]+(?:\s+[a-z_]+=\S+)*\z/
+        # marker name followed by at least one `key=value` attr pair)
+        # that leaked into diagnostic["summary"] from an older artifact.
+        # Requires the attrs portion so a legitimate bare upper-case
+        # verdict like `ABORTED` or a real sentence is not mistakenly
+        # treated as debug copy. See plan Unit 1.
+        MARKER_SUMMARY_PATTERN = /\A[A-Z][A-Z0-9_]+(?:\s+[a-z_]+=\S+)+\z/
 
         module_function
 
@@ -40,7 +39,7 @@ module Hive
           bordered = model.cols.to_i >= 40
           inner_width = bordered ? [ outer_width - 2, 1 ].max : outer_width
           body_height = [ model.rows.to_i - 4, 1 ].max
-          footer_line = Styles::HINT.render(truncate(FOOTER, inner_width))
+          footer_lines = footer_lines_for(inner_width)
 
           body_lines = []
           body_lines << Styles::HEADER.render(truncate("Task needs attention · #{safe(row.slug)}", inner_width))
@@ -50,26 +49,49 @@ module Hive
           body_lines.concat(wrapped("Why: #{summary_text(row)}", inner_width))
           body_lines << ""
           body_lines << Styles::HEADER.render(truncate("Actions", inner_width))
-          # Unified affordance: [Enter] Recover is always shown
-          # regardless of row.action_key. Rows with no automatic
-          # recovery recipe (e.g., recover_execute / EXECUTE_STALE)
-          # flash the Risk-#3 mitigation text and close the screen,
-          # rather than hiding the affordance and stranding the
-          # operator on a "now what?" view.
           body_lines << truncate("[Enter] Recover — re-run hive's automated recovery for this task", inner_width)
-          body_lines << truncate("[o]     Open in agent — launch #{state.agent_label || AGENT_FALLBACK} in the task worktree", inner_width)
+          body_lines << truncate("[o]     Open in agent — launch #{state.agent_label} in the task worktree", inner_width)
 
-          # Reserve the footer line outside the body_height trim so a
-          # short terminal or a long wrapped "Why" block can never
-          # clip the only on-screen reference for the action keys.
-          inner_body_height = [ body_height - 2, 1 ].max
+          flash_line = flash_line_for(model, inner_width)
+
+          # Reserve the footer (and optional flash) lines outside the
+          # body_height trim so a short terminal or long wrapped "Why"
+          # block can never clip the only on-screen reference for the
+          # action keys.
+          reserved = footer_lines.size + 1 # footer + leading blank
+          reserved += 1 if flash_line
+          inner_body_height = [ body_height - reserved, 1 ].max
           visible = body_lines.first(inner_body_height)
           visible << ""
-          visible << footer_line
+          visible << flash_line if flash_line
+          visible.concat(footer_lines)
           body = Lipgloss.join_vertical(Lipgloss::TOP, *visible)
           return body unless bordered
 
           Styles::PANE_FOCUSED_BORDER.width(inner_width).render(body)
+        end
+
+        def footer_lines_for(inner_width)
+          return [ Styles::HINT.render(FOOTER) ] if FOOTER.length <= inner_width
+
+          # Narrow terminals: stack one key per line so a `[Esc] back`
+          # affordance never gets truncated off the end of a single
+          # joined footer line.
+          ACTION_KEYS.map { |entry| Styles::HINT.render(truncate(entry[:footer], inner_width)) }
+        end
+
+        # Surface `model.flash` on the detail screen so a refusal flash
+        # fired by KeyMap (e.g., `s` muscle-memory drift) is observable
+        # without backing out to the grid. Without this, the explicit-
+        # refusal contract documented in `red_status_detail_message` is
+        # invisible until the operator dismisses the screen.
+        def flash_line_for(model, inner_width)
+          return nil unless model.respond_to?(:flash_active?) && model.flash_active?
+
+          text = safe(model.flash.to_s).strip
+          return nil if text.empty?
+
+          Styles::HINT.render(truncate(text, inner_width))
         end
 
         def summary_text(row)
@@ -85,22 +107,6 @@ module Hive
 
         def missing_summary_fallback
           "Hive does not have a diagnosis yet — try Open in agent to inspect."
-        end
-
-        # Called by `Update.apply_open_red_status_detail` so the resolved
-        # label is cached on RedStatusDetailState at open time — render
-        # stays a pure projection and the per-frame Hive::Config.load
-        # cost only fires once per screen open. Plan Risk #4.
-        def resolve_agent_label(row)
-          task = Hive::Task.new(row.folder.to_s)
-          cfg = Hive::Config.load(task.project_root)
-          agent_name = cfg.dig("execute", "agent") || "claude"
-          profile = Hive::AgentProfiles.lookup(agent_name, cfg: cfg)
-          basename = File.basename(profile.bin.to_s)
-          basename.empty? ? AGENT_FALLBACK : basename
-        rescue Hive::ConfigError, Hive::AgentProfiles::UnknownAgent,
-               Hive::AgentError, Hive::InvalidTaskPath, Psych::SyntaxError
-          AGENT_FALLBACK
         end
 
         def wrapped(text, width)

--- a/lib/hive/tui/views/red_status_detail.rb
+++ b/lib/hive/tui/views/red_status_detail.rb
@@ -1,4 +1,7 @@
 require "lipgloss"
+require "hive/agent_profiles"
+require "hive/config"
+require "hive/task"
 require "hive/tui/styles"
 require "hive/tui/text"
 require "hive/tui/views/format"
@@ -7,123 +10,57 @@ module Hive
   module Tui
     module Views
       module RedStatusDetail
-        # Default footer for rows whose Enter has a meaningful action
-        # (recover_review / error → autofix path).
-        FOOTER = "[Enter] autofix / retry  [f] manual fix ($EDITOR)  [R] refresh diagnosis  [q] back".freeze
-        # recover_execute (EXECUTE_STALE) rows have NO Enter affordance —
-        # there is no auto-retry recipe (the operator must edit findings
-        # or lower the pass counter). Advertising [Enter] would set up an
-        # expectation that the no-op Enter then breaks. Drop the affordance
-        # and keep [f]/[R]/[q]. See PR #84 review row 25.
-        FOOTER_NO_ENTER = "[f] manual fix ($EDITOR)  [R] refresh diagnosis  [q] back".freeze
+        FOOTER = "[Enter] Recover   [o] Open in agent   [Esc] back".freeze
+        AGENT_FALLBACK = "your project's development agent".freeze
 
         module_function
-
-        def footer_for(row)
-          auto_action_available?(row) ? FOOTER : FOOTER_NO_ENTER
-        end
 
         def render(model)
           state = model.red_status_detail_state
           return "" if state.nil?
 
           row = state.row
-          width = [ model.cols.to_i - 1, 1 ].max
-          body_height = [ model.rows.to_i - 2, 1 ].max
+          outer_width = [ model.cols.to_i - 2, 1 ].max
+          bordered = outer_width >= 40
+          inner_width = bordered ? [ outer_width - 2, 1 ].max : outer_width
+          body_height = [ model.rows.to_i - 4, 1 ].max
           lines = []
-          lines << Styles::HEADER.render(truncate("Red status · #{safe(row.slug)}", width))
+          lines << Styles::HEADER.render(truncate("Task needs attention · #{safe(row.slug)}", inner_width))
           lines << ""
-          lines << truncate("Project: #{safe(row.project_name)}", width)
-          lines << truncate("Stage: #{safe(row.stage)}", width)
-          lines << truncate("Marker: #{safe(row.marker)} #{attrs_text(row)}".strip, width)
-          lines << truncate("Status: #{safe(row.action_label)}", width)
+          lines << truncate("Project: #{safe(row.project_name)}", inner_width)
+          lines << truncate("Stage: #{safe(row.stage)}", inner_width)
+          lines.concat(wrapped("Why: #{summary_text(row)}", inner_width))
           lines << ""
-          lines.concat(question_answer_lines(row, width))
+          lines << Styles::HEADER.render(truncate("Actions", inner_width))
+          lines << truncate("[Enter] Recover — re-run hive's automated recovery for this task", inner_width)
+          lines << truncate("[o]     Open in agent — launch #{agent_label(row)} in the task worktree", inner_width)
           lines << ""
-          lines.concat(artifact_lines(row, width))
-          lines << Styles::HINT.render(truncate("Refreshing diagnosis...", width)) if state.refreshing
+          lines << Styles::HINT.render(truncate(FOOTER, inner_width))
 
           visible = lines.first(body_height)
-          footer = Styles::CURSOR_HIGHLIGHT.render(truncate(footer_for(row), width))
-          Lipgloss.join_vertical(Lipgloss::TOP, *visible, footer)
+          body = Lipgloss.join_vertical(Lipgloss::TOP, *visible)
+          return body unless bordered
+
+          Styles::PANE_FOCUSED_BORDER.width(inner_width).render(body)
         end
 
-        def question_answer_lines(row, width)
+        def summary_text(row)
           diagnostic = row.diagnostic || {}
-          summary = safe(diagnostic["summary"])
-          detail = safe(diagnostic["detail"])
-          summary = "No local diagnostic is available yet." if summary.empty?
-          detail = "Press R to ask the configured development agent for a fresh diagnosis." if detail.empty?
+          summary = safe(diagnostic["summary"]).strip
+          return summary unless summary.empty?
 
-          [
-            Styles::HEADER.render(truncate("Q: Why is this red?", width)),
-            *wrapped("A: #{summary}", width),
-            *wrapped(detail, width),
-            "",
-            Styles::HEADER.render(truncate("Q: What can Hive do next?", width)),
-            *wrapped(action_answer(row), width)
-          ]
+          "Hive does not have a diagnosis yet — try Open in agent to inspect."
         end
 
-        def action_answer(row)
-          case row.action_key.to_s
-          when "recover_review"
-            "A: Enter runs the existing review recovery path. f opens the worktree in $EDITOR without clearing the marker."
-          when "error"
-            if diagnostic_retry_command(row)
-              "A: Enter reruns the suggested recovery command. f opens the task folder in $EDITOR without changing state."
-            elsif manual_fix?(row)
-              "A: No autofix available. Press f to open the task folder in $EDITOR and repair the missing state."
-            else
-              "A: Enter clears the ERROR marker and reruns the task. f opens the worktree in $EDITOR without clearing the marker."
-            end
-          when "recover_execute"
-            # EXECUTE_STALE has no auto-retry recipe — the operator must
-            # edit findings or lower the pass counter before re-running.
-            # The footer drops the [Enter] affordance for this row; mirror
-            # the contract in the answer so the operator knows why.
-            "A: No autofix available. Edit findings or lower the pass counter; press f to open the worktree in $EDITOR, then re-run."
-          else
-            "A: This row has no autofix action in the detail view."
-          end
-        end
-
-        def auto_action_available?(row)
-          return false if row.nil?
-          return true if row.action_key.to_s == "recover_review"
-          return false if row.action_key.to_s == "recover_execute"
-          return true if row.action_key.to_s == "error" && diagnostic_retry_command(row)
-          return true if row.action_key.to_s == "error" && row.marker.to_s == "error"
-
-          false
-        end
-
-        def diagnostic_retry_command(row)
-          suggested = row&.diagnostic && row.diagnostic["suggested_next_action"]
-          return nil unless suggested.is_a?(Hash)
-          return nil unless suggested["kind"].to_s == "retry"
-
-          command = suggested["command"].to_s.strip
-          command.empty? ? nil : command
-        end
-
-        def manual_fix?(row)
-          suggested = row&.diagnostic && row.diagnostic["suggested_next_action"]
-          suggested.is_a?(Hash) && suggested["kind"].to_s == "manual_fix"
-        end
-
-        def artifact_lines(row, width)
-          diagnostic = row.diagnostic || {}
-          paths = Array(diagnostic["artifact_paths"])
-          return [ Styles::HINT.render(truncate("Artifacts: none", width)) ] if paths.empty?
-
-          lines = [ Styles::HEADER.render(truncate("Artifacts", width)) ]
-          paths.each { |path| lines << truncate("- #{safe(path)}", width) }
-          lines
-        end
-
-        def attrs_text(row)
-          (row.attrs || {}).map { |key, value| "#{safe(key)}=#{safe(value)}" }.join(" ")
+        def agent_label(row)
+          task = Hive::Task.new(row.folder.to_s)
+          cfg = Hive::Config.load(task.project_root)
+          agent_name = cfg.dig("execute", "agent") || "claude"
+          profile = Hive::AgentProfiles.lookup(agent_name, cfg: cfg)
+          File.basename(profile.bin.to_s)
+        rescue Hive::ConfigError, Hive::AgentProfiles::UnknownAgent,
+               Hive::AgentError, Hive::InvalidTaskPath, SystemCallError, IOError
+          AGENT_FALLBACK
         end
 
         def wrapped(text, width)

--- a/lib/hive/tui/views/red_status_detail.rb
+++ b/lib/hive/tui/views/red_status_detail.rb
@@ -1,4 +1,5 @@
 require "lipgloss"
+require "hive"
 require "hive/agent_profiles"
 require "hive/config"
 require "hive/task"
@@ -10,8 +11,23 @@ module Hive
   module Tui
     module Views
       module RedStatusDetail
-        FOOTER = "[Enter] Recover   [o] Open in agent   [Esc] back".freeze
+        # Shared key list — referenced by both the footer and the
+        # KeyMap hint flash. Single source so a key rename in one
+        # surface cannot drift away from the other.
+        ACTION_KEYS = [
+          { footer: "[Enter] Recover",      hint: "press Enter to recover" },
+          { footer: "[o] Open in agent",    hint: "o to open in agent" },
+          { footer: "[Esc] back",           hint: "Esc / q to close" }
+        ].freeze
+        FOOTER = ACTION_KEYS.map { |k| k[:footer] }.join("   ").freeze
         AGENT_FALLBACK = "your project's development agent".freeze
+
+        # Detect a `TaskAction#marker_summary`-style string (uppercase
+        # marker name optionally followed by attr key=value pairs) that
+        # leaked into diagnostic["summary"] from an older artifact. The
+        # detail screen must never echo debug copy — fall back to the
+        # plain-English placeholder instead. See plan Unit 1.
+        MARKER_SUMMARY_PATTERN = /\A[A-Z][A-Z0-9_]+(?:\s+[a-z_]+=\S+)*\z/
 
         module_function
 
@@ -21,23 +37,35 @@ module Hive
 
           row = state.row
           outer_width = [ model.cols.to_i - 2, 1 ].max
-          bordered = outer_width >= 40
+          bordered = model.cols.to_i >= 40
           inner_width = bordered ? [ outer_width - 2, 1 ].max : outer_width
           body_height = [ model.rows.to_i - 4, 1 ].max
-          lines = []
-          lines << Styles::HEADER.render(truncate("Task needs attention · #{safe(row.slug)}", inner_width))
-          lines << ""
-          lines << truncate("Project: #{safe(row.project_name)}", inner_width)
-          lines << truncate("Stage: #{safe(row.stage)}", inner_width)
-          lines.concat(wrapped("Why: #{summary_text(row)}", inner_width))
-          lines << ""
-          lines << Styles::HEADER.render(truncate("Actions", inner_width))
-          lines << truncate("[Enter] Recover — re-run hive's automated recovery for this task", inner_width)
-          lines << truncate("[o]     Open in agent — launch #{agent_label(row)} in the task worktree", inner_width)
-          lines << ""
-          lines << Styles::HINT.render(truncate(FOOTER, inner_width))
+          footer_line = Styles::HINT.render(truncate(FOOTER, inner_width))
 
-          visible = lines.first(body_height)
+          body_lines = []
+          body_lines << Styles::HEADER.render(truncate("Task needs attention · #{safe(row.slug)}", inner_width))
+          body_lines << ""
+          body_lines << truncate("Project: #{safe(row.project_name)}", inner_width)
+          body_lines << truncate("Stage: #{safe(row.stage)}", inner_width)
+          body_lines.concat(wrapped("Why: #{summary_text(row)}", inner_width))
+          body_lines << ""
+          body_lines << Styles::HEADER.render(truncate("Actions", inner_width))
+          # Unified affordance: [Enter] Recover is always shown
+          # regardless of row.action_key. Rows with no automatic
+          # recovery recipe (e.g., recover_execute / EXECUTE_STALE)
+          # flash the Risk-#3 mitigation text and close the screen,
+          # rather than hiding the affordance and stranding the
+          # operator on a "now what?" view.
+          body_lines << truncate("[Enter] Recover — re-run hive's automated recovery for this task", inner_width)
+          body_lines << truncate("[o]     Open in agent — launch #{state.agent_label || AGENT_FALLBACK} in the task worktree", inner_width)
+
+          # Reserve the footer line outside the body_height trim so a
+          # short terminal or a long wrapped "Why" block can never
+          # clip the only on-screen reference for the action keys.
+          inner_body_height = [ body_height - 2, 1 ].max
+          visible = body_lines.first(inner_body_height)
+          visible << ""
+          visible << footer_line
           body = Lipgloss.join_vertical(Lipgloss::TOP, *visible)
           return body unless bordered
 
@@ -47,19 +75,31 @@ module Hive
         def summary_text(row)
           diagnostic = row.diagnostic || {}
           summary = safe(diagnostic["summary"]).strip
-          return summary unless summary.empty?
+          return missing_summary_fallback if summary.empty?
+          # marker_summary leaked from TaskAction: strip and use the
+          # plain-English fallback rather than dump debug copy.
+          return missing_summary_fallback if summary.match?(MARKER_SUMMARY_PATTERN)
 
+          summary
+        end
+
+        def missing_summary_fallback
           "Hive does not have a diagnosis yet — try Open in agent to inspect."
         end
 
-        def agent_label(row)
+        # Called by `Update.apply_open_red_status_detail` so the resolved
+        # label is cached on RedStatusDetailState at open time — render
+        # stays a pure projection and the per-frame Hive::Config.load
+        # cost only fires once per screen open. Plan Risk #4.
+        def resolve_agent_label(row)
           task = Hive::Task.new(row.folder.to_s)
           cfg = Hive::Config.load(task.project_root)
           agent_name = cfg.dig("execute", "agent") || "claude"
           profile = Hive::AgentProfiles.lookup(agent_name, cfg: cfg)
-          File.basename(profile.bin.to_s)
+          basename = File.basename(profile.bin.to_s)
+          basename.empty? ? AGENT_FALLBACK : basename
         rescue Hive::ConfigError, Hive::AgentProfiles::UnknownAgent,
-               Hive::AgentError, Hive::InvalidTaskPath, SystemCallError, IOError
+               Hive::AgentError, Hive::InvalidTaskPath, Psych::SyntaxError
           AGENT_FALLBACK
         end
 

--- a/test/unit/tui/bubble_model_test.rb
+++ b/test/unit/tui/bubble_model_test.rb
@@ -2222,6 +2222,63 @@ class HiveTuiBubbleModelTest < Minitest::Test
                  "no-recipe refusal must nudge operator toward the manual fallback")
   end
 
+  def test_red_status_autofix_from_detail_mode_closes_screen_on_recovery_success
+    # Happy-path pin for plan Unit 4: a recoverable recover_review row
+    # dispatched from :red_status_detail must flip the mode back to
+    # :grid and clear red_status_detail_state — same close-on-dispatch
+    # contract as the no-recipe refusal branch, with the synchronous
+    # "clearing…" flash still surfacing.
+    folder = "/tmp/hive/recover-detail"
+    row = make_task_row(
+      action_key: "recover_review", action_label: "Needs recovery",
+      slug: "recover-detail", stage: "6-review", folder: folder,
+      marker: "review_error", attrs: {}, suggested_command: nil
+    )
+    state = Hive::Tui::Model::RedStatusDetailState.new(row: row)
+    @model = Hive::Tui::BubbleModel.new(
+      hive_model: Hive::Tui::Model.initial.with(mode: :red_status_detail, red_status_detail_state: state),
+      dispatch: @dispatch
+    )
+
+    with_run_quiet_stub(->(_argv) { [ 0, "", "" ] }) do
+      with_dispatch_background_stub(->(_argv, **_kwargs) { nil }) do
+        @model.update(Hive::Tui::Messages::RedStatusAutofix.new(row: row))
+        @model.wait_for_background_threads
+      end
+    end
+
+    assert_equal :grid, @model.hive_model.mode
+    assert_nil @model.hive_model.red_status_detail_state
+    assert_match(/clearing/, @model.hive_model.flash.to_s)
+  end
+
+  def test_close_red_status_detail_on_dispatch_passes_through_in_grid_mode
+    # `dispatch_*_then_close_detail` wrappers also fire from grid mode
+    # (RedStatusAutofix from grid Enter, OpenInAgent from grid `s`).
+    # Pin the mode-guarded early-return so a grid-mode dispatch never
+    # rewrites cursor / scope / filter through the close branch.
+    row = make_task_row(
+      action_key: "recover_review", action_label: "Needs recovery",
+      slug: "grid-row", stage: "6-review", folder: "/tmp/hive/grid-row",
+      marker: "review_error", attrs: {}, suggested_command: nil
+    )
+    starting = @model.hive_model.with(mode: :grid, cursor: [ 0, 0 ], scope: 0, filter: "foo")
+    @model = Hive::Tui::BubbleModel.new(hive_model: starting, dispatch: @dispatch)
+
+    with_run_quiet_stub(->(_argv) { [ 0, "", "" ] }) do
+      with_dispatch_background_stub(->(_argv, **_kwargs) { nil }) do
+        @model.update(Hive::Tui::Messages::RedStatusAutofix.new(row: row))
+        @model.wait_for_background_threads
+      end
+    end
+
+    assert_equal :grid, @model.hive_model.mode, "grid-mode autofix must leave mode unchanged"
+    assert_nil @model.hive_model.red_status_detail_state
+    assert_equal [ 0, 0 ], @model.hive_model.cursor, "cursor must be preserved on grid-mode pass-through"
+    assert_equal 0, @model.hive_model.scope
+    assert_equal "foo", @model.hive_model.filter
+  end
+
   def test_red_status_autofix_from_detail_mode_closes_screen_on_no_recipe
     # Pressing Enter from :red_status_detail on a row with no automatic
     # recovery still closes the screen — the operator's gesture was
@@ -2238,7 +2295,7 @@ class HiveTuiBubbleModelTest < Minitest::Test
       attrs: {},
       suggested_command: nil
     )
-    state = Hive::Tui::Model::RedStatusDetailState.new(row: row, marker_signature: "execute_stale")
+    state = Hive::Tui::Model::RedStatusDetailState.new(row: row)
     @model = Hive::Tui::BubbleModel.new(
       hive_model: Hive::Tui::Model.initial.with(mode: :red_status_detail, red_status_detail_state: state),
       dispatch: @dispatch
@@ -3277,6 +3334,32 @@ class HiveTuiBubbleModelTest < Minitest::Test
     end
   end
 
+  def test_open_in_agent_from_detail_mode_closes_screen_on_success
+    # Happy-path pin for plan Unit 5: pressing `o` from
+    # :red_status_detail on a healthy task (worktree present, profile
+    # resolves) returns a non-nil takeover Cmd alongside a model whose
+    # mode is :grid and red_status_detail_state cleared. The takeover
+    # Cmd is preserved so the foreground suspend still fires; the
+    # close-on-dispatch contract guarantees the operator lands back on
+    # the grid after the agent exits.
+    with_manual_task_context do |_project_root, _hive_state, _folder, _state_file, _worktree_path, row|
+      profile = ManualProfileStub.new(bin: "codex", add_dir_flag: "--add-dir")
+      state = Hive::Tui::Model::RedStatusDetailState.new(row: row)
+      @model = Hive::Tui::BubbleModel.new(
+        hive_model: Hive::Tui::Model.initial.with(mode: :red_status_detail, red_status_detail_state: state),
+        dispatch: @dispatch
+      )
+
+      with_agent_profile_lookup_stub(->(_name, cfg:) { profile }) do
+        _, cmd = @model.update(Hive::Tui::Messages::OpenInAgent.new(row: row))
+
+        refute_nil cmd, "happy path must return a foreground-takeover Cmd"
+        assert_equal :grid, @model.hive_model.mode
+        assert_nil @model.hive_model.red_status_detail_state
+      end
+    end
+  end
+
   def test_open_in_agent_from_detail_mode_closes_screen_on_refusal
     # Pressing `o` from :red_status_detail closes the screen even
     # when the refusal branch fires (no worktree) — the operator
@@ -3284,7 +3367,7 @@ class HiveTuiBubbleModelTest < Minitest::Test
     # detail view. See plan Unit 5.
     with_manual_task_context(stage: "3-plan", worktree: false) do |_project_root, _hive_state, _folder, state_file, _worktree_path, row|
       profile = ManualProfileStub.new(bin: "codex", add_dir_flag: "--add-dir")
-      state = Hive::Tui::Model::RedStatusDetailState.new(row: row, marker_signature: "x")
+      state = Hive::Tui::Model::RedStatusDetailState.new(row: row)
       @model = Hive::Tui::BubbleModel.new(
         hive_model: Hive::Tui::Model.initial.with(mode: :red_status_detail, red_status_detail_state: state),
         dispatch: @dispatch
@@ -4840,6 +4923,34 @@ class HiveTuiBubbleModelTest < Minitest::Test
   def test_zero_exit_does_not_flash_diagnostic
     @model.update(Hive::Tui::Messages::SubprocessExited.new(verb: "pr", exit_code: 0))
     assert_nil @model.hive_model.flash, "zero exit must not flash anything (success path is silent)"
+  end
+
+  def test_verb_status_zero_exit_is_silent
+    # The previous `verb == "status"` special case (handled the
+    # `hive status --diagnose --write` background spawn fired by the
+    # removed [R] refresh-diagnosis binding) is gone. Replacement
+    # behavior: status verb falls through to the standard zero-exit
+    # short-circuit and emits no flash.
+    @model.update(Hive::Tui::Messages::SubprocessExited.new(verb: "status", exit_code: 0))
+    assert_nil @model.hive_model.flash,
+               "zero-exit status verb must be silent (no diagnose-failure flash)"
+  end
+
+  def test_verb_status_nonzero_exit_falls_through_to_default_flash
+    with_isolated_subprocess_log do |log_path|
+      write_log_section(
+        log_path,
+        argv: %w[hive status --diagnose hello --write],
+        stderr: "some unknown error nobody patterns against",
+        exit_code: 1
+      )
+
+      @model.update(Hive::Tui::Messages::SubprocessExited.new(verb: "status", exit_code: 1))
+
+      flash = @model.hive_model.flash.to_s
+      assert_match(/exited 1/, flash, "non-zero status verb without specific diagnostic falls back to generic flash")
+      assert_match(/tail/, flash)
+    end
   end
 
   # Last-resort safety net: an unhandled exception escaping

--- a/test/unit/tui/bubble_model_test.rb
+++ b/test/unit/tui/bubble_model_test.rb
@@ -601,214 +601,6 @@ class HiveTuiBubbleModelTest < Minitest::Test
     Hive::Tui::Subprocess.define_singleton_method(:dispatch_background, sentinel) if sentinel
   end
 
-  def test_refresh_red_status_diagnosis_dispatches_status_diagnose_and_dedups
-    row = make_task_row(
-      action_key: "error",
-      action_label: "Error",
-      marker: "error",
-      attrs: { "reason" => "exit_code", "exit_code" => "1" },
-      suggested_command: nil
-    )
-    state = Hive::Tui::Model::RedStatusDetailState.new(row: row, marker_signature: "error")
-    @model = Hive::Tui::BubbleModel.new(
-      hive_model: Hive::Tui::Model.initial.with(mode: :red_status_detail, red_status_detail_state: state),
-      dispatch: @dispatch
-    )
-
-    calls = []
-    with_dispatch_background_stub(->(argv, **_kwargs) { calls << argv; nil }) do
-      @model.update(Hive::Tui::Messages::RefreshRedStatusDiagnosis.new(row: row))
-      @model.update(Hive::Tui::Messages::RefreshRedStatusDiagnosis.new(row: row))
-    end
-
-    # --stage disambiguates when the same slug exists in multiple stages
-    # of the same project. TaskResolver raises AmbiguousSlug otherwise,
-    # which the operator sees as "diagnosis failed to start" — silently
-    # losing the refresh signal.
-    #
-    # --force is appended on the R-press path so the CLI's
-    # marker_signature idempotency short-circuit (silent cache reuse)
-    # does NOT fire. Without --force, R-press would flash "refreshed"
-    # while no new agent ran (PR #84 review row 8).
-    expected = [ "hive", "status", "--diagnose", row.slug,
-                 "--project", row.project_name, "--stage", row.stage,
-                 "--write", "--force" ]
-    assert_equal [ expected ], calls
-    assert @model.hive_model.red_status_detail_state.refreshing
-    assert_match(/already in progress/, @model.hive_model.flash)
-  end
-
-  def test_refresh_red_status_diagnosis_short_circuits_when_autofix_inflight
-    # If a recover_review autofix is already running for the row, R-press
-    # must refuse rather than spawn a parallel diagnose. The autofix path
-    # holds the per-task `hive run` lock; a parallel diagnose would fail
-    # at the flock or describe pre-autofix state. See PR #84 review row 13.
-    row = make_task_row(
-      action_key: "recover_review",
-      action_label: "Needs recovery",
-      marker: "review_error",
-      attrs: { "phase" => "fix", "pass" => "1" },
-      suggested_command: nil
-    )
-    @model = Hive::Tui::BubbleModel.new(
-      hive_model: Hive::Tui::Model.initial,
-      dispatch: @dispatch
-    )
-    # Simulate an in-flight autofix by claiming the recovery slot.
-    inflight = @model.instance_variable_get(:@review_recovery_inflight)
-    inflight.add(row.folder)
-
-    calls = []
-    with_dispatch_background_stub(->(argv, **_kwargs) { calls << argv; nil }) do
-      @model.update(Hive::Tui::Messages::RefreshRedStatusDiagnosis.new(row: row))
-    end
-
-    assert_empty calls,
-                 "diagnose must not dispatch when autofix is already running"
-    assert_match(/autofix already running/i, @model.hive_model.flash)
-  end
-
-  def test_refresh_red_status_diagnosis_short_circuits_when_error_autofix_inflight
-    row = make_task_row(
-      action_key: "error",
-      action_label: "Error",
-      marker: "error",
-      attrs: { "exit_code" => "70" },
-      suggested_command: nil
-    )
-    @model = Hive::Tui::BubbleModel.new(
-      hive_model: Hive::Tui::Model.initial,
-      dispatch: @dispatch
-    )
-    inflight = @model.instance_variable_get(:@error_recovery_inflight)
-    inflight.add(row.folder)
-
-    calls = []
-    with_dispatch_background_stub(->(argv, **_kwargs) { calls << argv; nil }) do
-      @model.update(Hive::Tui::Messages::RefreshRedStatusDiagnosis.new(row: row))
-    end
-
-    assert_empty calls,
-                 "diagnose must not dispatch when error autofix is already running"
-    assert_match(/autofix already running/i, @model.hive_model.flash)
-  end
-
-  def test_refresh_red_status_diagnosis_short_circuits_on_agent_running_row
-    # action_key=='agent_running' means the row is currently being
-    # processed by a workflow agent (claude/codex). Same refuse-then-flash
-    # contract as the autofix-inflight branch.
-    row = make_task_row(
-      action_key: "agent_running",
-      action_label: "Agent running",
-      marker: "agent_working",
-      attrs: { "pid" => "12345" },
-      suggested_command: nil
-    )
-    @model = Hive::Tui::BubbleModel.new(
-      hive_model: Hive::Tui::Model.initial,
-      dispatch: @dispatch
-    )
-    calls = []
-    with_dispatch_background_stub(->(argv, **_kwargs) { calls << argv; nil }) do
-      @model.update(Hive::Tui::Messages::RefreshRedStatusDiagnosis.new(row: row))
-    end
-
-    assert_empty calls,
-                 "diagnose must not dispatch when action_key is agent_running"
-    assert_match(/autofix already running/i, @model.hive_model.flash)
-  end
-
-  def test_diagnose_subprocess_exit_success_flashes_and_evicts_inflight
-    # success case: exit_code zero → "refreshed" flash, slot evicted so
-    # a subsequent R-press can run. See PR #84 review row 14.
-    row = make_task_row(
-      action_key: "error",
-      action_label: "Error",
-      marker: "error",
-      attrs: {},
-      suggested_command: nil
-    )
-    state = Hive::Tui::Model::RedStatusDetailState.new(row: row, marker_signature: "sig", refreshing: true)
-    @model = Hive::Tui::BubbleModel.new(
-      hive_model: Hive::Tui::Model.initial.with(mode: :red_status_detail, red_status_detail_state: state),
-      dispatch: @dispatch
-    )
-    inflight = @model.instance_variable_get(:@diagnosis_inflight)
-    inflight.add(row.folder)
-
-    @model.update(
-      Hive::Tui::Messages::SubprocessExited.new(verb: "status", exit_code: 0, folder: row.folder)
-    )
-
-    refute_includes inflight, row.folder,
-                    "successful diagnose exit must evict the inflight slot"
-    assert_match(/refreshed/, @model.hive_model.flash)
-    refute @model.hive_model.red_status_detail_state.refreshing,
-           "refreshing flag must clear on subprocess exit"
-  end
-
-  def test_diagnose_subprocess_exit_failure_flashes_and_evicts_inflight
-    # failure case: non-zero exit → operator-actionable failure flash
-    # AND the slot is evicted so a retry is possible.
-    row = make_task_row(
-      action_key: "error",
-      action_label: "Error",
-      marker: "error",
-      attrs: {},
-      suggested_command: nil
-    )
-    state = Hive::Tui::Model::RedStatusDetailState.new(row: row, marker_signature: "sig", refreshing: true)
-    @model = Hive::Tui::BubbleModel.new(
-      hive_model: Hive::Tui::Model.initial.with(mode: :red_status_detail, red_status_detail_state: state),
-      dispatch: @dispatch
-    )
-    inflight = @model.instance_variable_get(:@diagnosis_inflight)
-    inflight.add(row.folder)
-
-    @model.update(
-      Hive::Tui::Messages::SubprocessExited.new(verb: "status", exit_code: 1, folder: row.folder)
-    )
-
-    refute_includes inflight, row.folder,
-                    "failed diagnose exit must STILL evict the inflight slot (retry must be possible)"
-    refute @model.hive_model.red_status_detail_state.refreshing,
-           "refreshing flag must clear on subprocess exit (even on failure)"
-    refute_nil @model.hive_model.flash
-  end
-
-  def test_open_manual_fix_opens_task_worktree_without_changing_marker
-    require "tmpdir"
-    Dir.mktmpdir do |project_root|
-      slug = "manual-fix-260516-aaaa"
-      folder = File.join(project_root, ".hive-state", "stages", "6-review", slug)
-      worktree = File.join(project_root, "worktrees", slug)
-      FileUtils.mkdir_p(folder)
-      FileUtils.mkdir_p(worktree)
-      marker_path = File.join(folder, "task.md")
-      marker_body = "<!-- REVIEW_ERROR phase=fix pass=1 -->\n"
-      File.write(marker_path, marker_body)
-      File.write(File.join(folder, "worktree.yml"), { "path" => worktree }.to_yaml)
-      row = make_task_row(
-        action_key: "error",
-        action_label: "Error",
-        stage: "6-review",
-        slug: slug,
-        folder: folder,
-        state_file: marker_path,
-        marker: "error",
-        attrs: { "reason" => "exit_code", "exit_code" => "1" },
-        suggested_command: nil
-      )
-      @model.define_singleton_method(:editor_argv) { [ "fake-editor" ] }
-
-      _model, cmd = @model.update(Hive::Tui::Messages::OpenManualFix.new(row: row))
-
-      refute_nil cmd
-      assert_match(/opening worktree/, @model.hive_model.flash)
-      assert_equal marker_body, File.read(marker_path)
-    end
-  end
-
   def with_run_takeover_stub(stub_proc)
     sentinel = Hive::Tui::Subprocess.method(:run_takeover_child_sync)
     Hive::Tui::Subprocess.define_singleton_method(:run_takeover_child_sync, &stub_proc)
@@ -2425,7 +2217,39 @@ class HiveTuiBubbleModelTest < Minitest::Test
     end
 
     assert_equal 0, clear_count
-    assert_match(/no autofix action available/, @model.hive_model.flash)
+    assert_match(/no automatic recovery/i, @model.hive_model.flash)
+    assert_match(/Open in agent/, @model.hive_model.flash,
+                 "no-recipe refusal must nudge operator toward the manual fallback")
+  end
+
+  def test_red_status_autofix_from_detail_mode_closes_screen_on_no_recipe
+    # Pressing Enter from :red_status_detail on a row with no automatic
+    # recovery still closes the screen — the operator's gesture was
+    # binary, leaving them stranded contradicts the plan's
+    # "screen closes after the keypress" requirement. The Risk #3
+    # mitigation flash names "Open in agent" so the next action is
+    # obvious from the same flash. See plan Unit 4.
+    row = make_task_row(
+      action_key: "recover_execute",
+      action_label: "Needs recovery",
+      slug: "execute-stale-row",
+      stage: "4-execute",
+      marker: "execute_stale",
+      attrs: {},
+      suggested_command: nil
+    )
+    state = Hive::Tui::Model::RedStatusDetailState.new(row: row, marker_signature: "execute_stale")
+    @model = Hive::Tui::BubbleModel.new(
+      hive_model: Hive::Tui::Model.initial.with(mode: :red_status_detail, red_status_detail_state: state),
+      dispatch: @dispatch
+    )
+
+    @model.update(Hive::Tui::Messages::RedStatusAutofix.new(row: row))
+
+    assert_equal :grid, @model.hive_model.mode
+    assert_nil @model.hive_model.red_status_detail_state
+    assert_match(/no automatic recovery/i, @model.hive_model.flash)
+    assert_match(/Open in agent/, @model.hive_model.flash)
   end
 
   def test_recover_error_does_not_rerun_when_marker_clear_fails
@@ -3447,6 +3271,31 @@ class HiveTuiBubbleModelTest < Minitest::Test
         _, cmd = @model.update(Hive::Tui::Messages::OpenInAgent.new(row: row))
 
         assert_nil cmd
+        assert_match(/no worktree for manual-task/, @model.hive_model.flash)
+        assert_equal :none, Hive::Markers.current(state_file).name
+      end
+    end
+  end
+
+  def test_open_in_agent_from_detail_mode_closes_screen_on_refusal
+    # Pressing `o` from :red_status_detail closes the screen even
+    # when the refusal branch fires (no worktree) — the operator
+    # should land back on the grid, not stay stranded on the stale
+    # detail view. See plan Unit 5.
+    with_manual_task_context(stage: "3-plan", worktree: false) do |_project_root, _hive_state, _folder, state_file, _worktree_path, row|
+      profile = ManualProfileStub.new(bin: "codex", add_dir_flag: "--add-dir")
+      state = Hive::Tui::Model::RedStatusDetailState.new(row: row, marker_signature: "x")
+      @model = Hive::Tui::BubbleModel.new(
+        hive_model: Hive::Tui::Model.initial.with(mode: :red_status_detail, red_status_detail_state: state),
+        dispatch: @dispatch
+      )
+
+      with_agent_profile_lookup_stub(->(_name, cfg:) { profile }) do
+        _, cmd = @model.update(Hive::Tui::Messages::OpenInAgent.new(row: row))
+
+        assert_nil cmd
+        assert_equal :grid, @model.hive_model.mode
+        assert_nil @model.hive_model.red_status_detail_state
         assert_match(/no worktree for manual-task/, @model.hive_model.flash)
         assert_equal :none, Hive::Markers.current(state_file).name
       end

--- a/test/unit/tui/help_test.rb
+++ b/test/unit/tui/help_test.rb
@@ -82,6 +82,29 @@ class TuiHelpTest < Minitest::Test
     assert_match(/MANUAL_STEERING/, entry[:description])
   end
 
+  def test_red_status_detail_mode_pins_two_action_contract
+    # Pin the operator-visible contract for red_status_detail mode:
+    # exactly Enter / o / q / Esc — and the removed [f] / [R] bindings
+    # must NOT come back without an explicit help-overlay update.
+    entries = Hive::Tui::Help::BINDINGS.select { |b| b[:mode] == :red_status_detail }
+    keys = entries.map { |b| b[:key] }
+
+    assert_equal %w[Enter o q Esc].sort, keys.sort,
+                 "red_status_detail mode must expose exactly Enter / o / q / Esc"
+
+    enter = entries.find { |b| b[:key] == "Enter" }
+    assert_equal :recover, enter[:action]
+    o_key = entries.find { |b| b[:key] == "o" }
+    assert_equal :open_in_agent, o_key[:action]
+    %w[Esc q].each do |k|
+      back = entries.find { |b| b[:key] == k }
+      assert_equal :back, back[:action], "#{k} in red_status_detail must close the screen"
+    end
+
+    refute_includes keys, "f", "removed [f] manual-fix binding must not return"
+    refute_includes keys, "R", "removed [R] refresh-diagnosis binding must not return"
+  end
+
   def test_capital_p_is_open_pr_lowercase_p_is_plan
     grid = Hive::Tui::Help::BINDINGS.select { |b| b[:mode] == :grid }
     by_key = grid.each_with_object({}) { |b, h| h[b[:key]] = b[:action] }

--- a/test/unit/tui/key_map_test.rb
+++ b/test/unit/tui/key_map_test.rb
@@ -711,10 +711,14 @@ class TuiKeyMapMessageForTest < Minitest::Test
     assert_same Hive::Tui::Messages::BACK,
       Hive::Tui::KeyMap.message_for(mode: :red_status_detail, key: :key_escape, row: row)
 
-    assert_same Hive::Tui::Messages::NOOP,
-      Hive::Tui::KeyMap.message_for(mode: :red_status_detail, key: "f", row: row)
-    assert_same Hive::Tui::Messages::NOOP,
-      Hive::Tui::KeyMap.message_for(mode: :red_status_detail, key: "R", row: row)
+    # `f` (old manual-fix) and `R` (old refresh-diagnosis) flash a
+    # refusal hint rather than silently NOOP so a muscle-memory drift
+    # surfaces the new contract instead of returning no signal.
+    f_msg = Hive::Tui::KeyMap.message_for(mode: :red_status_detail, key: "f", row: row)
+    assert_kind_of Hive::Tui::Messages::Flash, f_msg
+
+    r_msg = Hive::Tui::KeyMap.message_for(mode: :red_status_detail, key: "R", row: row)
+    assert_kind_of Hive::Tui::Messages::Flash, r_msg
   end
 
   def test_red_status_detail_s_key_flashes_use_o_hint

--- a/test/unit/tui/key_map_test.rb
+++ b/test/unit/tui/key_map_test.rb
@@ -698,16 +698,34 @@ class TuiKeyMapMessageForTest < Minitest::Test
     assert_same row, msg.row
   end
 
-  def test_red_status_detail_keys_route_to_manual_refresh_and_back
+  def test_red_status_detail_keys_route_to_recover_open_in_agent_and_back
     row = make_row(action_key: "error", action_label: "Error",
                    marker: "error", attrs: {}, suggested_command: nil)
 
-    assert_kind_of Hive::Tui::Messages::OpenManualFix,
-      Hive::Tui::KeyMap.message_for(mode: :red_status_detail, key: "f", row: row)
-    assert_kind_of Hive::Tui::Messages::RefreshRedStatusDiagnosis,
-      Hive::Tui::KeyMap.message_for(mode: :red_status_detail, key: "R", row: row)
+    open_msg = Hive::Tui::KeyMap.message_for(mode: :red_status_detail, key: "o", row: row)
+    assert_kind_of Hive::Tui::Messages::OpenInAgent, open_msg
+    assert_same row, open_msg.row
+
     assert_same Hive::Tui::Messages::BACK,
       Hive::Tui::KeyMap.message_for(mode: :red_status_detail, key: "q", row: row)
+    assert_same Hive::Tui::Messages::BACK,
+      Hive::Tui::KeyMap.message_for(mode: :red_status_detail, key: :key_escape, row: row)
+
+    assert_same Hive::Tui::Messages::NOOP,
+      Hive::Tui::KeyMap.message_for(mode: :red_status_detail, key: "f", row: row)
+    assert_same Hive::Tui::Messages::NOOP,
+      Hive::Tui::KeyMap.message_for(mode: :red_status_detail, key: "R", row: row)
+  end
+
+  def test_red_status_detail_s_key_flashes_use_o_hint
+    row = make_row(action_key: "error", action_label: "Error",
+                   marker: "error", attrs: {}, suggested_command: nil)
+
+    msg = Hive::Tui::KeyMap.message_for(mode: :red_status_detail, key: "s", row: row)
+
+    assert_kind_of Hive::Tui::Messages::Flash, msg
+    assert_match(/\bo\b/, msg.text)
+    assert_match(/open in agent/i, msg.text)
   end
 
   def test_enter_on_needs_input_opens_input_editor_when_command_present

--- a/test/unit/tui/key_map_test.rb
+++ b/test/unit/tui/key_map_test.rb
@@ -728,8 +728,11 @@ class TuiKeyMapMessageForTest < Minitest::Test
     msg = Hive::Tui::KeyMap.message_for(mode: :red_status_detail, key: "s", row: row)
 
     assert_kind_of Hive::Tui::Messages::Flash, msg
-    assert_match(/\bo\b/, msg.text)
-    assert_match(/open in agent/i, msg.text)
+    # Pin the exact s-key copy so the s-key-specific nudge stays
+    # divergent from the generic f/R refusal — a regression that
+    # collapses both into `red_status_detail_hint` would slip through a
+    # looser `/\bo\b/` match.
+    assert_equal "press o for Open in agent", msg.text
   end
 
   def test_enter_on_needs_input_opens_input_editor_when_command_present

--- a/test/unit/tui/messages_test.rb
+++ b/test/unit/tui/messages_test.rb
@@ -115,8 +115,6 @@ class HiveTuiMessagesTest < Minitest::Test
     row = Object.new
     assert_same row, Hive::Tui::Messages::OpenRedStatusDetail.new(row: row).row
     assert_same row, Hive::Tui::Messages::RedStatusAutofix.new(row: row).row
-    assert_same row, Hive::Tui::Messages::OpenManualFix.new(row: row).row
-    assert_same row, Hive::Tui::Messages::RefreshRedStatusDiagnosis.new(row: row).row
   end
 
   def test_terminate_requested_singleton

--- a/test/unit/tui/update_test.rb
+++ b/test/unit/tui/update_test.rb
@@ -169,7 +169,12 @@ class HiveTuiUpdateTest < Minitest::Test
     assert_match(/recovered/, new_model.flash)
   end
 
-  def test_snapshot_arrived_updates_red_detail_when_marker_signature_changes
+  def test_snapshot_arrived_updates_red_detail_row_without_flash
+    # The red-status detail screen now exposes only two actions; the
+    # "marker changed — refresh (R)" flash relied on R-press which is
+    # no longer in the keymap. A snapshot poll while the screen is
+    # open quietly updates the cached row so the operator sees fresh
+    # diagnosis the next time they re-open the screen.
     row = red_detail_row
     starting = model.with(
       mode: :red_status_detail,
@@ -187,39 +192,7 @@ class HiveTuiUpdateTest < Minitest::Test
 
     assert_equal :red_status_detail, new_model.mode
     assert_same changed, new_model.red_status_detail_state.row
-    assert_match(/marker changed/, new_model.flash)
-  end
-
-  def test_snapshot_arrived_fires_flash_again_on_second_marker_rotation
-    # The "marker changed" flash must fire on EVERY rotation that
-    # hasn't been operator-acknowledged. Previously the state
-    # rebased marker_signature on every poll, so a second rotation
-    # between polls was silently swallowed and the operator never
-    # saw the warning. See PR #84 review finding #7.
-    row = red_detail_row
-    initial_sig = Hive::Tui::Update.red_status_marker_signature(row)
-    starting = model.with(
-      mode: :red_status_detail,
-      red_status_detail_state: Hive::Tui::Model::RedStatusDetailState.new(
-        row: row,
-        marker_signature: initial_sig
-      )
-    )
-
-    rotated_once = red_detail_row(attrs: { "phase" => "triage", "pass" => "2" })
-    after_first, _cmd = Hive::Tui::Update.apply(
-      starting,
-      Hive::Tui::Messages::SnapshotArrived.new(snapshot: snapshot_with_rows(rotated_once))
-    )
-    assert_match(/marker changed/, after_first.flash, "first rotation must flash")
-
-    rotated_twice = red_detail_row(attrs: { "phase" => "fix", "pass" => "3" })
-    after_second, _cmd = Hive::Tui::Update.apply(
-      after_first.with(flash: nil, flash_set_at: nil),
-      Hive::Tui::Messages::SnapshotArrived.new(snapshot: snapshot_with_rows(rotated_twice))
-    )
-    assert_match(/marker changed/, after_second.flash,
-                 "second rotation without operator acknowledgement must also flash")
+    assert_nil new_model.flash
   end
 
   # ---------- PollFailed ----------

--- a/test/unit/tui/update_test.rb
+++ b/test/unit/tui/update_test.rb
@@ -120,42 +120,43 @@ class HiveTuiUpdateTest < Minitest::Test
       "first snapshot must seed cursor at first visible row instead of leaving it nil"
   end
 
-  def test_open_red_status_detail_enters_mode_with_marker_signature
-    # Pin the canonical contract: when row.diagnostic carries a
-    # marker_signature (the producer-side SHA256 hex from
-    # TaskAction#marker_signature), the TUI reads that value verbatim
-    # so producer + consumer can never drift. Without diagnostic on the
-    # row, Update falls back to a locally-computed hash so the
-    # freshness gate still detects rotation across snapshots.
-    sig = Digest::SHA256.hexdigest("review_error\npass=1\nphase=fix")
-    row = red_detail_row(diagnostic: {
-      "summary" => "REVIEW_ERROR", "detail" => "failed", "marker_signature" => sig
-    })
-    new_model, cmd = Hive::Tui::Update.apply(model, Hive::Tui::Messages::OpenRedStatusDetail.new(row: row))
+  def test_open_red_status_detail_enters_mode_with_agent_label
+    # Pin the unified contract: opening the detail screen flips the
+    # model into :red_status_detail and constructs a state with the
+    # supplied row. The resolved agent_label flows in via the message
+    # (BubbleModel#resolve_agent_label populates it before delegating
+    # to Update.apply) so Update never reads the filesystem.
+    row = red_detail_row(diagnostic: { "summary" => "REVIEW_ERROR" })
+    new_model, cmd = Hive::Tui::Update.apply(
+      model,
+      Hive::Tui::Messages::OpenRedStatusDetail.new(row: row, agent_label: "codex")
+    )
 
     assert_nil cmd
     assert_equal :red_status_detail, new_model.mode
     assert_same row, new_model.red_status_detail_state.row
-    assert_equal sig, new_model.red_status_detail_state.marker_signature,
-                 "TUI must read the canonical marker_signature off row.diagnostic"
+    assert_equal "codex", new_model.red_status_detail_state.agent_label
   end
 
-  def test_red_status_marker_signature_falls_back_when_diagnostic_absent
+  def test_open_red_status_detail_defaults_agent_label_when_missing
+    # No resolver result (BubbleModel rescued a corrupt config) — the
+    # state falls back to RedStatusDetailState::AGENT_FALLBACK so the
+    # view never has to apply a render-time fallback.
     row = red_detail_row(diagnostic: nil)
-    sig = Hive::Tui::Update.red_status_marker_signature(row)
+    new_model, _cmd = Hive::Tui::Update.apply(
+      model,
+      Hive::Tui::Messages::OpenRedStatusDetail.new(row: row, agent_label: nil)
+    )
 
-    assert_match(/\Ano-diag:[0-9a-f]{64}\z/, sig,
-                 "missing diagnostic must produce a deterministic locally-namespaced digest")
+    assert_equal Hive::Tui::Model::RedStatusDetailState::AGENT_FALLBACK,
+                 new_model.red_status_detail_state.agent_label
   end
 
   def test_snapshot_arrived_closes_red_detail_when_row_recovers
     row = red_detail_row
     starting = model.with(
       mode: :red_status_detail,
-      red_status_detail_state: Hive::Tui::Model::RedStatusDetailState.new(
-        row: row,
-        marker_signature: Hive::Tui::Update.red_status_marker_signature(row)
-      )
+      red_status_detail_state: Hive::Tui::Model::RedStatusDetailState.new(row: row)
     )
     recovered = red_detail_row(marker: "review_complete", attrs: {}, action_key: "ready_to_artifacts")
 
@@ -178,10 +179,7 @@ class HiveTuiUpdateTest < Minitest::Test
     row = red_detail_row
     starting = model.with(
       mode: :red_status_detail,
-      red_status_detail_state: Hive::Tui::Model::RedStatusDetailState.new(
-        row: row,
-        marker_signature: Hive::Tui::Update.red_status_marker_signature(row)
-      )
+      red_status_detail_state: Hive::Tui::Model::RedStatusDetailState.new(row: row)
     )
     changed = red_detail_row(attrs: { "phase" => "triage", "pass" => "2" })
 

--- a/test/unit/tui/views/red_status_detail_test.rb
+++ b/test/unit/tui/views/red_status_detail_test.rb
@@ -4,8 +4,6 @@ require "hive/tui/snapshot"
 require "hive/tui/views/red_status_detail"
 
 class HiveTuiViewsRedStatusDetailTest < Minitest::Test
-  ProfileStub = Struct.new(:bin, keyword_init: true)
-
   def row(diagnostic: nil, action_key: "recover_review", stage: "6-review",
           marker: "review_error", attrs: { "phase" => "fix", "pass" => "2" },
           folder: "/tmp/demo/.hive-state/stages/6-review/red-task")
@@ -19,28 +17,17 @@ class HiveTuiViewsRedStatusDetailTest < Minitest::Test
     )
   end
 
-  def model_for(row)
+  # The agent label is cached on RedStatusDetailState at open time
+  # (Update.apply_open_red_status_detail), so the view never does
+  # per-frame disk I/O. Tests pass the precomputed label directly,
+  # matching how production opens the screen.
+  def model_for(row, cols: 100, rows: 24, agent_label: "codex")
     state = Hive::Tui::Model::RedStatusDetailState.new(
       row: row,
-      marker_signature: "review_error"
+      marker_signature: "review_error",
+      agent_label: agent_label
     )
-    Hive::Tui::Model.initial.with(mode: :red_status_detail, red_status_detail_state: state, cols: 100, rows: 24)
-  end
-
-  def with_config_load_stub(stub_proc)
-    sentinel = Hive::Config.method(:load)
-    Hive::Config.define_singleton_method(:load, &stub_proc)
-    yield
-  ensure
-    Hive::Config.define_singleton_method(:load, sentinel) if sentinel
-  end
-
-  def with_agent_profile_lookup_stub(stub_proc)
-    sentinel = Hive::AgentProfiles.method(:lookup)
-    Hive::AgentProfiles.define_singleton_method(:lookup, &stub_proc)
-    yield
-  ensure
-    Hive::AgentProfiles.define_singleton_method(:lookup, sentinel) if sentinel
+    Hive::Tui::Model.initial.with(mode: :red_status_detail, red_status_detail_state: state, cols: cols, rows: rows)
   end
 
   def test_renders_user_facing_summary_with_two_actions
@@ -48,12 +35,7 @@ class HiveTuiViewsRedStatusDetailTest < Minitest::Test
       "summary" => "The review fixer stopped before tests completed."
     }
 
-    output = nil
-    with_config_load_stub(->(_project_root) { { "execute" => { "agent" => "codex" } } }) do
-      with_agent_profile_lookup_stub(->(_name, cfg:) { ProfileStub.new(bin: "/usr/local/bin/codex") }) do
-        output = Hive::Tui::Views::RedStatusDetail.render(model_for(row(diagnostic: diagnostic)))
-      end
-    end
+    output = Hive::Tui::Views::RedStatusDetail.render(model_for(row(diagnostic: diagnostic)))
 
     assert_includes output, "Task needs attention"
     assert_includes output, "red-task"
@@ -67,6 +49,7 @@ class HiveTuiViewsRedStatusDetailTest < Minitest::Test
     assert_includes output, "[o]"
     assert_includes output, "[Esc] back"
     refute_includes output, "marker_signature"
+    refute_includes output, "Marker:"
     refute_includes output, "$EDITOR"
     refute_includes output, "manual fix"
     refute_includes output, "autofix"
@@ -91,17 +74,17 @@ class HiveTuiViewsRedStatusDetailTest < Minitest::Test
     assert_includes output, "bad"
   end
 
-  def test_falls_back_when_dev_agent_lookup_fails
-    output = nil
-    with_config_load_stub(->(_project_root) { raise Hive::ConfigError, "broken config" }) do
-      output = Hive::Tui::Views::RedStatusDetail.render(model_for(row))
-    end
+  def test_falls_back_when_agent_label_is_missing
+    # Caller resolution failure surfaces as a nil agent_label on
+    # RedStatusDetailState (the rescue in resolve_agent_label is
+    # exercised in test_resolve_agent_label_*).
+    output = Hive::Tui::Views::RedStatusDetail.render(model_for(row, agent_label: nil))
 
     assert_includes output, "Open in agent"
     assert_includes output, "your project's development agent"
   end
 
-  def test_recover_execute_rows_still_show_only_two_actions
+  def test_recover_execute_rows_still_show_two_actions_with_enter_affordance
     output = Hive::Tui::Views::RedStatusDetail.render(
       model_for(
         row(
@@ -114,17 +97,121 @@ class HiveTuiViewsRedStatusDetailTest < Minitest::Test
       )
     )
 
+    # The unified contract: [Enter] Recover always shown regardless of
+    # action_key. recover_execute rows route refusals through the
+    # bubble_model flash so the operator's binary gesture never leaves
+    # them stranded on the detail screen.
     assert_includes output, "[Enter] Recover"
-    assert_includes output, "[o] Open in agent"
+    assert_includes output, "[o]     Open in agent"
     refute_includes output, "[f] manual fix"
     refute_includes output, "[R] refresh diagnosis"
     refute_includes output, "EXECUTE_STALE"
+  end
+
+  def test_recover_review_row_shows_enter_affordance
+    # Positive pin for the unified [Enter] Recover contract — paired
+    # with test_recover_execute_rows_still_show_two_actions_with_enter_affordance
+    # so a future split-by-action_key regression breaks both tests.
+    output = Hive::Tui::Views::RedStatusDetail.render(model_for(row))
+
+    assert_includes output, "[Enter] Recover"
+    assert_includes output, "[o]     Open in agent"
   end
 
   def test_missing_diagnostic_uses_plain_english_fallback
     output = Hive::Tui::Views::RedStatusDetail.render(model_for(row(diagnostic: nil)))
 
     assert_includes output, "Hive does not have a diagnosis yet"
-    refute_includes output, "marker"
+    refute_includes output, "marker_signature"
+    refute_includes output, "Marker:"
+  end
+
+  def test_marker_summary_string_falls_back_to_plain_english
+    # Older artifacts can leak `TaskAction#marker_summary`-shaped strings
+    # ("REVIEW_ERROR phase=fix pass=2") into diagnostic["summary"]. The
+    # detail screen must detect that shape and use the plain-English
+    # fallback rather than dump debug copy.
+    diagnostic = { "summary" => "REVIEW_ERROR phase=fix pass=2" }
+    output = Hive::Tui::Views::RedStatusDetail.render(model_for(row(diagnostic: diagnostic)))
+
+    assert_includes output, "Hive does not have a diagnosis yet"
+    refute_includes output, "REVIEW_ERROR"
+    refute_includes output, "phase=fix"
+    refute_includes output, "pass=2"
+  end
+
+  def test_renders_without_border_on_narrow_terminals
+    # Below the 40-col threshold the border is skipped so the body
+    # gets the full inner width. Plan Risk #5 — the dual-path render
+    # exists precisely to keep the screen legible on narrow terminals.
+    output = Hive::Tui::Views::RedStatusDetail.render(model_for(row, cols: 30, rows: 20))
+
+    refute_includes output, "╭", "narrow terminals must skip the box-drawing border"
+    refute_includes output, "╰"
+    assert_includes output, "Task needs attention"
+    assert_includes output, "[Enter] Recover"
+  end
+
+  def test_renders_with_border_on_wide_terminals
+    # Above the threshold the rounded border wraps the body. Pin the
+    # box-drawing corners so a style swap that drops the border would
+    # break the test rather than silently regress.
+    output = Hive::Tui::Views::RedStatusDetail.render(model_for(row, cols: 80, rows: 24))
+
+    assert_includes output, "╭", "wide terminals must render the rounded border"
+    assert_includes output, "╰"
+    assert_includes output, "[Enter] Recover"
+  end
+
+  def test_footer_survives_short_rows_and_long_summaries
+    # With body_height too small to fit every body line, the footer
+    # must still render — it is the only on-screen reference for the
+    # action keys. Reserve test pins the "footer outside truncation"
+    # invariant called out in the review.
+    diagnostic = {
+      "summary" => "A " * 400
+    }
+    output = Hive::Tui::Views::RedStatusDetail.render(model_for(row(diagnostic: diagnostic), cols: 80, rows: 8))
+
+    assert_includes output, "[Enter] Recover   [o] Open in agent   [Esc] back",
+                    "the action-keys footer must always be on screen even when the body is truncated"
+  end
+
+  def test_resolve_agent_label_blank_bin_uses_fallback
+    profile = Struct.new(:bin).new("")
+    label = nil
+    with_singleton_method_stub(Hive::Config, :load, ->(_root) { { "execute" => { "agent" => "claude" } } }) do
+      with_singleton_method_stub(Hive::AgentProfiles, :lookup, ->(_name, cfg:) { profile }) do
+        label = Hive::Tui::Views::RedStatusDetail.resolve_agent_label(row)
+      end
+    end
+
+    assert_equal Hive::Tui::Views::RedStatusDetail::AGENT_FALLBACK, label
+  end
+
+  def test_resolve_agent_label_falls_back_on_psych_error
+    # Malformed YAML raises Psych::SyntaxError from Config.load. The
+    # resolver must catch it so an unhealthy config can't crash the
+    # detail-screen open path. See plan Risk #4 / codex review row.
+    label = nil
+    with_singleton_method_stub(Hive::Config, :load, ->(_root) { raise Psych::SyntaxError.new("config.yml", 1, 1, 0, "bad", "context") }) do
+      label = Hive::Tui::Views::RedStatusDetail.resolve_agent_label(row)
+    end
+
+    assert_equal Hive::Tui::Views::RedStatusDetail::AGENT_FALLBACK, label
+  end
+
+  private
+
+  # Module-singleton stub with original-method restore. Used only by
+  # the two resolve_agent_label tests above; the render-path tests
+  # avoid stubbing module singletons entirely because the agent label
+  # is now cached on RedStatusDetailState at open time.
+  def with_singleton_method_stub(target, name, stub_proc)
+    original = target.method(name)
+    target.define_singleton_method(name, &stub_proc)
+    yield
+  ensure
+    target.define_singleton_method(name, original) if original
   end
 end

--- a/test/unit/tui/views/red_status_detail_test.rb
+++ b/test/unit/tui/views/red_status_detail_test.rb
@@ -18,13 +18,13 @@ class HiveTuiViewsRedStatusDetailTest < Minitest::Test
   end
 
   # The agent label is cached on RedStatusDetailState at open time
-  # (Update.apply_open_red_status_detail), so the view never does
-  # per-frame disk I/O. Tests pass the precomputed label directly,
-  # matching how production opens the screen.
+  # (BubbleModel#resolve_agent_label populates it before delegating to
+  # Update.apply), so the view never does per-frame disk I/O. Tests
+  # pass the precomputed label directly, matching how production opens
+  # the screen.
   def model_for(row, cols: 100, rows: 24, agent_label: "codex")
     state = Hive::Tui::Model::RedStatusDetailState.new(
       row: row,
-      marker_signature: "review_error",
       agent_label: agent_label
     )
     Hive::Tui::Model.initial.with(mode: :red_status_detail, red_status_detail_state: state, cols: cols, rows: rows)
@@ -75,13 +75,16 @@ class HiveTuiViewsRedStatusDetailTest < Minitest::Test
   end
 
   def test_falls_back_when_agent_label_is_missing
-    # Caller resolution failure surfaces as a nil agent_label on
-    # RedStatusDetailState (the rescue in resolve_agent_label is
-    # exercised in test_resolve_agent_label_*).
-    output = Hive::Tui::Views::RedStatusDetail.render(model_for(row, agent_label: nil))
+    # Caller resolution failure surfaces as the canonical AGENT_FALLBACK
+    # label on RedStatusDetailState (the rescue in BubbleModel
+    # #resolve_agent_label is exercised in bubble_model_test.rb). Pin
+    # via the constant so a future rewording of the fallback copy stays
+    # in one place.
+    fallback = Hive::Tui::Model::RedStatusDetailState::AGENT_FALLBACK
+    output = Hive::Tui::Views::RedStatusDetail.render(model_for(row, agent_label: fallback))
 
     assert_includes output, "Open in agent"
-    assert_includes output, "your project's development agent"
+    assert_includes output, fallback
   end
 
   def test_recover_execute_rows_still_show_two_actions_with_enter_affordance
@@ -140,6 +143,28 @@ class HiveTuiViewsRedStatusDetailTest < Minitest::Test
     refute_includes output, "pass=2"
   end
 
+  def test_marker_summary_pattern_passes_through_bare_uppercase_verdict
+    # `ABORTED` looks like the leading-token portion of a marker_summary
+    # but has no `key=value` attrs — the tightened regex requires at
+    # least one attrs token, so a legitimate bare upper-case verdict
+    # must survive unmodified.
+    diagnostic = { "summary" => "ABORTED" }
+    output = Hive::Tui::Views::RedStatusDetail.render(model_for(row(diagnostic: diagnostic)))
+
+    assert_includes output, "ABORTED"
+    refute_includes output, "Hive does not have a diagnosis yet"
+  end
+
+  def test_marker_summary_pattern_passes_through_legitimate_sentence
+    # A normal human-readable sentence shares no shape with the
+    # marker_summary pattern and must render verbatim.
+    diagnostic = { "summary" => "Build failed: out of memory" }
+    output = Hive::Tui::Views::RedStatusDetail.render(model_for(row(diagnostic: diagnostic)))
+
+    assert_includes output, "Build failed: out of memory"
+    refute_includes output, "Hive does not have a diagnosis yet"
+  end
+
   def test_renders_without_border_on_narrow_terminals
     # Below the 40-col threshold the border is skipped so the body
     # gets the full inner width. Plan Risk #5 — the dual-path render
@@ -177,41 +202,37 @@ class HiveTuiViewsRedStatusDetailTest < Minitest::Test
                     "the action-keys footer must always be on screen even when the body is truncated"
   end
 
-  def test_resolve_agent_label_blank_bin_uses_fallback
-    profile = Struct.new(:bin).new("")
-    label = nil
-    with_singleton_method_stub(Hive::Config, :load, ->(_root) { { "execute" => { "agent" => "claude" } } }) do
-      with_singleton_method_stub(Hive::AgentProfiles, :lookup, ->(_name, cfg:) { profile }) do
-        label = Hive::Tui::Views::RedStatusDetail.resolve_agent_label(row)
-      end
-    end
+  def test_footer_stacks_per_key_on_very_narrow_terminals
+    # At rows=6 the body is trimmed and at cols=40 the joined FOOTER
+    # (~52 chars) won't fit on one line — `truncate` would drop the
+    # tail and hide `[Esc] back`. The stacked-footer branch puts one
+    # key per line so every affordance stays visible.
+    output = Hive::Tui::Views::RedStatusDetail.render(model_for(row, cols: 40, rows: 12))
 
-    assert_equal Hive::Tui::Views::RedStatusDetail::AGENT_FALLBACK, label
+    assert_includes output, "[Enter] Recover",
+                    "narrow terminals must keep [Enter] Recover visible"
+    assert_includes output, "[o] Open in agent",
+                    "narrow terminals must keep [o] Open in agent visible"
+    assert_includes output, "[Esc] back",
+                    "narrow terminals must keep [Esc] back visible — the only documented dismiss affordance"
   end
 
-  def test_resolve_agent_label_falls_back_on_psych_error
-    # Malformed YAML raises Psych::SyntaxError from Config.load. The
-    # resolver must catch it so an unhealthy config can't crash the
-    # detail-screen open path. See plan Risk #4 / codex review row.
-    label = nil
-    with_singleton_method_stub(Hive::Config, :load, ->(_root) { raise Psych::SyntaxError.new("config.yml", 1, 1, 0, "bad", "context") }) do
-      label = Hive::Tui::Views::RedStatusDetail.resolve_agent_label(row)
-    end
+  def test_renders_flash_on_detail_screen
+    # KeyMap fires `Messages::Flash` for refusal keystrokes (e.g.,
+    # `s`/`f`/`R` muscle-memory drift in :red_status_detail). The flash
+    # must be visible without backing out to the grid — otherwise the
+    # documented refusal contract is invisible until dismiss.
+    state = Hive::Tui::Model::RedStatusDetailState.new(row: row, agent_label: "codex")
+    model = Hive::Tui::Model.initial.with(
+      mode: :red_status_detail,
+      red_status_detail_state: state,
+      cols: 100, rows: 24,
+      flash: "press o for Open in agent",
+      flash_set_at: Time.now
+    )
+    output = Hive::Tui::Views::RedStatusDetail.render(model)
 
-    assert_equal Hive::Tui::Views::RedStatusDetail::AGENT_FALLBACK, label
-  end
-
-  private
-
-  # Module-singleton stub with original-method restore. Used only by
-  # the two resolve_agent_label tests above; the render-path tests
-  # avoid stubbing module singletons entirely because the agent label
-  # is now cached on RedStatusDetailState at open time.
-  def with_singleton_method_stub(target, name, stub_proc)
-    original = target.method(name)
-    target.define_singleton_method(name, &stub_proc)
-    yield
-  ensure
-    target.define_singleton_method(name, original) if original
+    assert_includes output, "press o for Open in agent",
+                    "active flash must surface on the detail screen so refusal hints are observable"
   end
 end

--- a/test/unit/tui/views/red_status_detail_test.rb
+++ b/test/unit/tui/views/red_status_detail_test.rb
@@ -4,13 +4,17 @@ require "hive/tui/snapshot"
 require "hive/tui/views/red_status_detail"
 
 class HiveTuiViewsRedStatusDetailTest < Minitest::Test
-  def row(diagnostic: nil)
+  ProfileStub = Struct.new(:bin, keyword_init: true)
+
+  def row(diagnostic: nil, action_key: "recover_review", stage: "6-review",
+          marker: "review_error", attrs: { "phase" => "fix", "pass" => "2" },
+          folder: "/tmp/demo/.hive-state/stages/6-review/red-task")
     Hive::Tui::Snapshot::Row.new(
-      project_name: "alpha", stage: "6-review", slug: "red-task", folder: "/tmp/red-task",
-      state_file: "/tmp/red-task/task.md", marker: "review_error",
-      attrs: { "phase" => "fix", "pass" => "2" }, mtime: nil, age_seconds: 0,
+      project_name: "alpha", stage: stage, slug: "red-task", folder: folder,
+      state_file: File.join(folder, "task.md"), marker: marker,
+      attrs: attrs, mtime: nil, age_seconds: 0,
       claude_pid: nil, claude_pid_alive: nil,
-      action_key: "recover_review", action_label: "Needs recovery",
+      action_key: action_key, action_label: "Needs recovery",
       suggested_command: nil, next_action: nil, diagnostic: diagnostic
     )
   end
@@ -23,26 +27,61 @@ class HiveTuiViewsRedStatusDetailTest < Minitest::Test
     Hive::Tui::Model.initial.with(mode: :red_status_detail, red_status_detail_state: state, cols: 100, rows: 24)
   end
 
-  def test_renders_q_and_a_diagnosis_and_actions
+  def with_config_load_stub(stub_proc)
+    sentinel = Hive::Config.method(:load)
+    Hive::Config.define_singleton_method(:load, &stub_proc)
+    yield
+  ensure
+    Hive::Config.define_singleton_method(:load, sentinel) if sentinel
+  end
+
+  def with_agent_profile_lookup_stub(stub_proc)
+    sentinel = Hive::AgentProfiles.method(:lookup)
+    Hive::AgentProfiles.define_singleton_method(:lookup, &stub_proc)
+    yield
+  ensure
+    Hive::AgentProfiles.define_singleton_method(:lookup, sentinel) if sentinel
+  end
+
+  def test_renders_user_facing_summary_with_two_actions
     diagnostic = {
-      "summary" => "REVIEW_ERROR phase=fix pass=2",
-      "detail" => "Fix agent failed before tests completed.",
-      "artifact_paths" => [ "/tmp/red-task/reviews/errors-02.md" ]
+      "summary" => "The review fixer stopped before tests completed."
     }
 
-    output = Hive::Tui::Views::RedStatusDetail.render(model_for(row(diagnostic: diagnostic)))
+    output = nil
+    with_config_load_stub(->(_project_root) { { "execute" => { "agent" => "codex" } } }) do
+      with_agent_profile_lookup_stub(->(_name, cfg:) { ProfileStub.new(bin: "/usr/local/bin/codex") }) do
+        output = Hive::Tui::Views::RedStatusDetail.render(model_for(row(diagnostic: diagnostic)))
+      end
+    end
 
-    assert_includes output, "Q: Why is this red?"
-    assert_includes output, "REVIEW_ERROR phase=fix pass=2"
-    assert_includes output, "Q: What can Hive do next?"
-    assert_includes output, "/tmp/red-task/reviews/errors-02.md"
-    assert_includes output, "[Enter] autofix / retry"
+    assert_includes output, "Task needs attention"
+    assert_includes output, "red-task"
+    assert_includes output, "Project: alpha"
+    assert_includes output, "Stage: 6-review"
+    assert_includes output, "The review fixer stopped before tests completed."
+    assert_includes output, "Recover"
+    assert_includes output, "Open in agent"
+    assert_includes output, "codex"
+    assert_includes output, "[Enter]"
+    assert_includes output, "[o]"
+    assert_includes output, "[Esc] back"
+    refute_includes output, "marker_signature"
+    refute_includes output, "$EDITOR"
+    refute_includes output, "manual fix"
+    refute_includes output, "autofix"
+    refute_includes output, "recover_review"
+    refute_includes output, "recover_execute"
+    refute_includes output, "EXECUTE_STALE"
+    refute_includes output, "phase=fix"
+    refute_includes output, "pass=2"
+    refute_includes output, "Q: Why is this red?"
+    refute_includes output, "Q: What can Hive do next?"
   end
 
   def test_sanitizes_ansi_sequences_from_diagnostic_text
     diagnostic = {
       "summary" => "\e[31mbad\e[0m",
-      "detail" => "detail\e[2J",
       "artifact_paths" => []
     }
 
@@ -52,82 +91,40 @@ class HiveTuiViewsRedStatusDetailTest < Minitest::Test
     assert_includes output, "bad"
   end
 
-  # Footer is row-dependent: recover_review / error rows advertise
-  # [Enter] autofix; recover_execute rows DO NOT (Enter would be a no-op
-  # because EXECUTE_STALE has no auto-retry recipe). Pinning both
-  # branches so the footer cannot regress to advertising a non-op.
-  # See PR #84 review row 25.
-  def test_footer_includes_enter_affordance_for_recover_review_rows
-    output = Hive::Tui::Views::RedStatusDetail.render(model_for(row))
-    assert_includes output, "[Enter] autofix / retry",
-                    "recover_review rows must keep the [Enter] affordance"
+  def test_falls_back_when_dev_agent_lookup_fails
+    output = nil
+    with_config_load_stub(->(_project_root) { raise Hive::ConfigError, "broken config" }) do
+      output = Hive::Tui::Views::RedStatusDetail.render(model_for(row))
+    end
+
+    assert_includes output, "Open in agent"
+    assert_includes output, "your project's development agent"
   end
 
-  def test_footer_omits_enter_affordance_for_recover_execute_rows
-    execute_row = Hive::Tui::Snapshot::Row.new(
-      project_name: "alpha", stage: "4-execute", slug: "stale-task",
-      folder: "/tmp/stale-task", state_file: "/tmp/stale-task/task.md",
-      marker: "execute_stale", attrs: { "pass" => "3" }, mtime: nil,
-      age_seconds: 0, claude_pid: nil, claude_pid_alive: nil,
-      action_key: "recover_execute", action_label: "Needs recovery",
-      suggested_command: nil, next_action: nil, diagnostic: nil
+  def test_recover_execute_rows_still_show_only_two_actions
+    output = Hive::Tui::Views::RedStatusDetail.render(
+      model_for(
+        row(
+          action_key: "recover_execute",
+          stage: "4-execute",
+          marker: "execute_stale",
+          attrs: { "pass" => "3" },
+          folder: "/tmp/demo/.hive-state/stages/4-execute/red-task"
+        )
+      )
     )
 
-    output = Hive::Tui::Views::RedStatusDetail.render(model_for(execute_row))
-
-    refute_includes output, "[Enter] autofix / retry",
-                    "recover_execute rows MUST NOT advertise [Enter] (Enter is a no-op for EXECUTE_STALE)"
-    assert_includes output, "[f] manual fix",
-                    "recover_execute rows must keep the manual-fix affordance"
-    assert_includes output, "[R] refresh diagnosis",
-                    "recover_execute rows must keep the refresh affordance"
-    assert_includes output, "[q] back",
-                    "recover_execute rows must keep the back affordance"
+    assert_includes output, "[Enter] Recover"
+    assert_includes output, "[o] Open in agent"
+    refute_includes output, "[f] manual fix"
+    refute_includes output, "[R] refresh diagnosis"
+    refute_includes output, "EXECUTE_STALE"
   end
 
-  def test_markerless_retry_error_keeps_enter_affordance
-    diagnostic = {
-      "summary" => "PLAN_MISSING_OUTPUT",
-      "suggested_next_action" => {
-        "kind" => "retry",
-        "command" => "hive plan red-task --from 3-plan"
-      }
-    }
-    retry_row = Hive::Tui::Snapshot::Row.new(
-      project_name: "alpha", stage: "3-plan", slug: "red-task",
-      folder: "/tmp/red-task", state_file: "/tmp/red-task/plan.md",
-      marker: "none", attrs: {}, mtime: nil,
-      age_seconds: 0, claude_pid: nil, claude_pid_alive: nil,
-      action_key: "error", action_label: "Error",
-      suggested_command: nil, next_action: nil, diagnostic: diagnostic
-    )
+  def test_missing_diagnostic_uses_plain_english_fallback
+    output = Hive::Tui::Views::RedStatusDetail.render(model_for(row(diagnostic: nil)))
 
-    output = Hive::Tui::Views::RedStatusDetail.render(model_for(retry_row))
-
-    assert_includes output, "[Enter] autofix / retry"
-    assert_includes output, "Enter reruns the suggested recovery command"
-  end
-
-  def test_manual_fix_error_omits_enter_affordance
-    diagnostic = {
-      "summary" => "FINALIZE_MISSING_PR_MD",
-      "suggested_next_action" => {
-        "kind" => "manual_fix",
-        "command" => nil
-      }
-    }
-    manual_row = Hive::Tui::Snapshot::Row.new(
-      project_name: "alpha", stage: "8-finalize", slug: "red-task",
-      folder: "/tmp/red-task", state_file: "/tmp/red-task/pr.md",
-      marker: "none", attrs: {}, mtime: nil,
-      age_seconds: 0, claude_pid: nil, claude_pid_alive: nil,
-      action_key: "error", action_label: "Error",
-      suggested_command: nil, next_action: nil, diagnostic: diagnostic
-    )
-
-    output = Hive::Tui::Views::RedStatusDetail.render(model_for(manual_row))
-
-    refute_includes output, "[Enter] autofix / retry"
-    assert_includes output, "No autofix available"
+    assert_includes output, "Hive does not have a diagnosis yet"
+    refute_includes output, "marker"
   end
 end

--- a/wiki/commands/tui.md
+++ b/wiki/commands/tui.md
@@ -75,7 +75,7 @@ Pane focus is keyboard-only; the focused pane border is bright cyan, the inactiv
 | `q` | quit (default mode) |
 | `Esc` | back to default mode (any sub-mode) |
 
-Findings triage is no longer an in-TUI mode. Use `hive findings`, `hive accept-finding`, and `hive reject-finding` directly from a shell or coding agent; legacy `EXECUTE_WAITING findings_count` rows surface as `recover_execute` and point at `hive findings` from status JSON (see [[commands/findings]]). In red-status detail mode, `Enter` runs the existing autofix/retry path, `f` opens the task worktree in `$VISUAL` / `$EDITOR` / `vi`, `R` runs `hive status --diagnose <slug> --project <project> --write` in the background, and `q` / `Esc` returns to the grid. The help overlay groups bindings by mode for the disambiguation.
+Findings triage is no longer an in-TUI mode. Use `hive findings`, `hive accept-finding`, and `hive reject-finding` directly from a shell or coding agent; legacy `EXECUTE_WAITING findings_count` rows surface as `recover_execute` and point at `hive findings` from status JSON (see [[commands/findings]]). In red-status detail mode, `Enter` runs hive's automated recovery for the task and closes the detail screen (rows with no auto-recovery recipe surface a refusal flash that names `Open in agent` as the manual fallback before closing), `o` opens the task in the project's configured development agent and closes the detail screen, and `q` / `Esc` returns to the grid. The help overlay groups bindings by mode for the disambiguation.
 
 ## New Idea Prompt Editing
 
@@ -155,9 +155,9 @@ Red rows still show the concrete marker details in the grid status column, but s
 - `Q: What can Hive do next?` names the available action.
 - `Artifacts` lists the exact files Hive used to explain the row.
 
-The goal is "auto-fix first, ask only when needed." `Enter` inside the detail view invokes the same recovery path that grid Enter used to call directly. `f` opens the task worktree in the configured editor without clearing markers, for the "open worktree in development agent/fix manually" path. `R` asks the configured development agent for a fresh diagnosis by dispatching `hive status --diagnose <slug> --project <project> --write`; once the next snapshot lands, the view refreshes from `diagnostics/red-status.md` if its marker signature matches the current marker.
+The goal is "auto-fix first, ask only when needed." `Enter` inside the detail view runs the same recovery path that grid Enter used to call directly and closes the screen on dispatch (success or refusal); rows with no automatic recovery recipe surface a refusal flash naming `Open in agent` and still close the screen so the operator's binary gesture never strands them on a stale view. `o` invokes the manual-steering takeover — same path as grid `s` — and closes the detail screen as the agent suspends the TUI; on agent exit the operator lands back on the grid rather than a stale detail view.
 
-Snapshot polling keeps the view honest. If the row disappears, the detail view closes with `<slug> no longer in this project`. If the row recovers to a non-red action, it closes with `<slug> recovered - status updated`. If the marker changes under the open view, the row refreshes in place and the footer prompts the user to refresh diagnosis with `R`.
+Snapshot polling keeps the view honest. If the row disappears, the detail view closes with `<slug> no longer in this project`. If the row recovers to a non-red action, it closes with `<slug> recovered - status updated`. If the marker changes under the open view, the cached row updates in place silently — the next time the operator re-opens the screen they see the fresh diagnosis.
 
 The grid still preserves the established direct paths where the right answer is already known:
 

--- a/wiki/decisions.md
+++ b/wiki/decisions.md
@@ -310,7 +310,7 @@ The TUI applies "auto-fix first, manual only when needed." Grid Enter opens red-
 1. Why is this red?
 2. What can Hive do next?
 
-Then it offers three explicit gestures: `Enter` for the existing autofix/retry path, `f` for manual worktree editing, and `R` for fresh headless diagnosis. Existing deterministic paths stay direct: wall-clock review stale retries, max-passes review stale with an escalations file opens that file for browse/edit, and kill-class errors open the log tail while auto-heal runs.
+Then it offers a unified two-action contract: `Enter` runs hive's automated recovery for the task and closes the screen (rows without an auto-recovery recipe surface a refusal flash naming `Open in agent` as the manual fallback and still close so the operator's binary gesture never strands them on a stale view), and `o` opens the task in the project's configured development agent (same path as grid `s`) and closes the screen as the TUI suspends. `q` / `Esc` returns to the grid. Existing deterministic paths stay direct: wall-clock review stale retries, max-passes review stale with an escalations file opens that file for browse/edit, and kill-class errors open the log tail while auto-heal runs. The previous `f` / `R` bindings (manual worktree editor + headless diagnosis refresh) were removed alongside `RedStatusDetailState#marker_signature` — refreshing a diagnosis is a `hive status --diagnose <slug> --write` shell affordance now.
 
 **Consequences:**
 - Operators see the concrete artifact/log/marker explanation before retrying.

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -14,6 +14,23 @@ Append-only log of all wiki operations.
 
 **Refreshed pages:** [[commands/bot]], [[modules/bot]], [[operating]], [[state-model]].
 
+## [2026-05-23T00:00:00Z] tui — red-status detail screen simplified to a two-action contract
+
+**Action:** Documented the simplification of the red-status detail screen to a unified two-action contract. The previous `[f] manual fix` and `[R] refresh diagnosis` bindings are removed; the screen now exposes only `[Enter] Recover` (re-runs hive's automated recovery and closes the screen — rows with no auto-recovery recipe surface a refusal flash naming `Open in agent`) and `[o] Open in agent` (suspends the TUI into the configured development agent — same path as grid `s` — and closes the detail screen). `q` / `Esc` returns to the grid.
+
+The supporting cleanup:
+
+1. **`RedStatusDetailState#marker_signature` is gone.** The freshness gate it served (the "marker changed since you opened this view — refresh (R)" banner) was removed when `R` was dropped; the field was being written on every snapshot poll but never read. Update no longer recomputes a per-snapshot signature.
+2. **`refresh_red_status_diagnosis` and its `@diagnosis_inflight` dedup set were removed from `BubbleModel`.** No `R` keystroke routes here anymore.
+3. **Agent-label resolution moved out of `Views::RedStatusDetail` and `Update.apply`.** It now lives in `BubbleModel#resolve_agent_label`, called from a side-effect handler before delegating to `Update.apply`. The view is a pure projection again; Update stays no-I/O. Rescue list was widened to `Psych::Exception`, `SystemCallError`, and `IOError` so a corrupt project config (chmod 000, hand-edited `!ruby/object:` tag, dangling path) falls back to the canonical `your project's development agent` label instead of crashing the TUI on Enter.
+4. **`Hive::Tui::RedStatusDetailKeys`** is the new shared module for the detail-screen key list — referenced by both the view (footer rendering) and `KeyMap` (refusal-flash hint copy) so a future key rename in one surface cannot drift away from the other.
+
+**Refreshed pages:**
+- `wiki/commands/tui.md` — updated red-status detail mode docs to the new two-action contract.
+- `wiki/modules/diagnosis_agent.md` — removed the TUI `R` key entry-point reference; only `hive status --diagnose <slug> --write` remains as the consumer.
+- `wiki/decisions.md` ADR-027 — replaced the three-gesture (`Enter` / `f` / `R`) action surface with the new unified two-action contract.
+- `docs/solutions/architecture-patterns/red-status-diagnose-then-act-2026-05-16.md` — pattern doc Section 5 reflects the two-action contract; refresh-via-headless-agent is now documented as a CLI-only affordance.
+
 ## [2026-05-22T13:30:00Z] rebase / review — close three post-merge follow-up gaps from PR #104 review
 
 **Action:** Documented three follow-up fixes after the initial PR #104 review pass surfaced sharper failure modes than the first round caught.

--- a/wiki/modules/diagnosis_agent.md
+++ b/wiki/modules/diagnosis_agent.md
@@ -7,7 +7,7 @@ updated: 2026-05-19
 tags: [module, status, diagnostic, agent, recovery]
 ---
 
-**TLDR**: Headless one-shot spawn of the project's configured execute AgentProfile (claude / codex / pi) whose sole purpose is producing a human-readable verdict on a red task's marker state. Writes the result to `<task.folder>/diagnostics/red-status.md`, which `Hive::TaskAction#diagnostic` then prefers over its local bounded extraction. Invoked by `hive status --diagnose <slug> --write` (CLI) and by the TUI red-status detail view's `R` key.
+**TLDR**: Headless one-shot spawn of the project's configured execute AgentProfile (claude / codex / pi) whose sole purpose is producing a human-readable verdict on a red task's marker state. Writes the result to `<task.folder>/diagnostics/red-status.md`, which `Hive::TaskAction#diagnostic` then prefers over its local bounded extraction. Invoked by `hive status --diagnose <slug> --write` (CLI). The previous TUI `R`-key entry point was removed when the red-status detail screen was simplified to the two-action `[Enter] Recover` / `[o] Open in agent` contract; refreshing a diagnosis is now a shell-only affordance.
 
 ## Public surface
 
@@ -60,7 +60,6 @@ diagnosed_at: <ISO 8601 UTC timestamp>
 | File | Use |
 |------|-----|
 | `lib/hive/commands/status.rb` | `diagnose_call` invokes `DiagnosisAgent.run!` when `--write` is passed and emits the resulting path under the `hive-status-diagnose` schema's `SuccessPayload.path`. |
-| `lib/hive/tui/bubble_model.rb` | `refresh_red_status_diagnosis` shells out to `hive status --diagnose <slug> --write --force` via `Hive::Tui::Subprocess.dispatch_background`; the spawn ultimately re-enters this module. Per-folder dedup via `@diagnosis_inflight` prevents duplicate budget burn from held-down `R` keys within a single TUI session. |
 | `lib/hive/task_action.rb` | `#diagnostic` reads the artifact `red-status.md` and prefers its body over the local fallback when `marker_signature` matches the current marker (`fresh_diagnosis_artifact`). |
 
 ## Backlinks
@@ -69,5 +68,4 @@ diagnosed_at: <ISO 8601 UTC timestamp>
 - [[modules/agent_profile]] — the AgentProfile this module spawns (execute-stage profile)
 - [[modules/secret_patterns]] — redaction patterns applied to the agent body before write
 - [[commands/status]] — `--diagnose --write` entry point
-- [[commands/tui]] — TUI `R` keybinding entry point
 - [[decisions]] ADR-019 (nonce-wrapped prompts), ADR-025 (required-and-nullable envelopes), ADR-027 (diagnose-then-act, automation outside the lock)


### PR DESCRIPTION
## Summary

The red-status detail screen now leads with what the operator can do, not how hive talks to itself. The previous Q/A layout exposed marker names like `REVIEW_ERROR phase=fix pass=2`, `$EDITOR`, and a four-key footer (`[Enter] autofix / retry  [f] manual fix  [R] refresh diagnosis  [q] back`) whose affordances varied with `action_key`. Every red-status row now shows the same panel: a one-sentence "why", `[Enter] Recover`, and `[o] Open in agent` (which names the project's configured agent, e.g., `claude` or `codex`). After either action, the screen closes and the operator lands back on the grid.

### What changed

- `lib/hive/tui/views/red_status_detail.rb` — one layout for every row: header, project / stage / why lines, two labelled actions, footer. Wrapped in `Styles::PANE_FOCUSED_BORDER` for terminals ≥ 40 cols; narrower terminals fall back to plain text. The footer is reserved outside the body-height trim so the action-keys hint cannot be clipped. The "why" line strips ANSI/control bytes and replaces marker-shape summaries (`REVIEW_ERROR phase=fix pass=2`) with a plain-English fallback.
- `lib/hive/tui/red_status_detail_keys.rb` (new) — single source of truth for the two action keys, shared by the view footer and the KeyMap refusal-flash hint so a key rename can't drift between surfaces.
- `lib/hive/tui/key_map.rb` — `red_status_detail_message` routes `Enter → RedStatusAutofix`, `o → OpenInAgent`, `Esc`/`q → BACK`. The retired `f` and `R` plus the grid-mode `s` and verb keys all flash a hint that points at `o`.
- `lib/hive/tui/bubble_model.rb` — both `RedStatusAutofix` and `OpenInAgent` are wrapped so that, when dispatched from `:red_status_detail`, the screen closes back to `:grid` in the same tick (success, refusal, and "no recipe" all close). For Open-in-agent, the foreground takeover Cmd is still returned, so the suspend/resume cycle ends on the grid. The recover-execute refusal flash now reads "Hive has no automatic recovery for this state — try Open in agent" instead of the bare `no autofix action available`.
- Dead surface removed: `Messages::OpenManualFix`, `Messages::RefreshRedStatusDiagnosis`, the `open_manual_fix` / `refresh_red_status_diagnosis` handlers, the `marker_signature` / `acknowledged_marker_signature` / `refreshing` state, the `recover_execute` ENTER_FLASH_MESSAGES entry, and the `SubprocessExited(folder:)` kwarg.
- Agent label is resolved once at open time in `BubbleModel#open_red_status_detail` (not on every render or inside `Update`), cached on `RedStatusDetailState#agent_label`, and protected by a wide rescue (`Hive::ConfigError`, `Hive::AgentProfiles::UnknownAgent`, `Hive::AgentError`, `Hive::InvalidTaskPath`, `Psych::Exception`, `SystemCallError`) so any bad config falls back to "your project's development agent" without crashing the bubbletea loop.
- Wiki + docs/solutions/ refreshed: `wiki/commands/tui.md`, `wiki/decisions.md` (ADR-027), `wiki/modules/diagnosis_agent.md`, `docs/solutions/architecture-patterns/red-status-diagnose-then-act-2026-05-16.md`, and `wiki/log.md` all now describe the two-action contract; the stale `FOOTER_NO_ENTER` comment in `task_action.rb` was removed.

### Design notes

- `recover_execute` rows now advertise Recover too. Previously the footer dropped `[Enter]` for `EXECUTE_STALE` because there is no auto-retry recipe. The unified surface trades that branch for a flash from `red_status_autofix` when no recipe exists, so the operator's gesture stays "let hive try" and the flash points them at Open in agent.
- `o`, not `s`. Grid-mode already uses `s` to steer the focal row into the dev agent. Reusing `s` here would muddle the mode boundary; `o` reads as "open in" and the `s`-key hint surfaces the rename to anyone with grid-mode muscle memory.
- Close-on-dispatch is gated on the source mode being `:red_status_detail`. Grid-mode `s` (which dispatches the same `OpenInAgent` message) and grid-mode `RedStatusAutofix` both pass through the wrapper unchanged.

## Test plan

- `bin/rake test TEST=test/unit/tui/views/red_status_detail_test.rb` — new copy, agent-label lookup, `ConfigError` fallback, missing-diagnostic fallback, marker-summary suppression, ANSI sanitization, bordered render on wide terminals, plain-text fallback on narrow terminals, footer survival under short rows and long summaries.
- `bin/rake test TEST=test/unit/tui/key_map_test.rb` — pins `o → OpenInAgent`, `Esc`/`q → BACK`, `f`/`R → NOOP`, the `s`-key "press o for Open in agent" hint, and the verb-keys generic hint.
- `bin/rake test TEST=test/unit/tui/bubble_model_test.rb` — pins screen-close on Recover success and refusal from detail mode; close on Open-in-agent success (Cmd still returned) and refusal; grid-mode pass-through of the close wrapper.
- `bin/rake test TEST=test/unit/tui/help_test.rb` — pins the exact `:red_status_detail` BINDINGS (Enter / o / q / Esc) and the absence of `f` / `R`.
- `bin/rake test TEST=test/unit/tui/update_test.rb` and `bin/rake test TEST=test/unit/tui/messages_test.rb` — confirm the removed surface (refresh-diagnosis, OpenManualFix, SubprocessExited.folder) is gone without collateral damage.

## Review summary

Two review passes (claude + codex + pr-review-toolkit) ran against this branch. All High and Medium findings were auto-fixed and all Nit findings were either fixed or resolved with explicit triage notes — see `reviews/` in the task folder for the full audit trail. Highlights:

- Plan Units 3 (help-overlay sweep), 4 (Recover closes the screen), 5 (Open-in-agent closes the screen), and 6 (delete dead surface) were initially missed in pass 1 and landed in pass 2 (commit `1450d12`).
- Plan Risk #4 (cache agent-label at open time, wide rescue list) and Risk #5 (border threshold + footer survival) were addressed in the same pass.
- Pass 2 hardening (commit `1e5354f`) moved the agent-label lookup out of `Update.apply` into `BubbleModel`, extracted `RedStatusDetailKeys` so KeyMap no longer reaches into a view module, tightened `MARKER_SUMMARY_PATTERN` so all-caps verdicts like `ABORTED` aren't suppressed, and aligned wiki + `docs/solutions/` with the new contract.
- Pass 2 tests (commit `4cd1654`) added the plan-mandated happy-path close tests, narrow-terminal regression, footer-truncation regression, and grid-mode pass-through coverage.

## Linked task

- Slug: `red-status-debug-screen-where-260519-4e22`
- Idea: red status debug screen where i'm choosing between recovery and editor not looking very good, we need to make it easy to understand for the user
- Task folder: `.hive-state/stages/8-finalize/red-status-debug-screen-where-260519-4e22/`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_%281M%29-D97757?logo=claude&logoColor=white)
