### PR TITLE
fix(bot): start telegram bot in the background

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,57 @@ You see a left pane listing your registered projects (with `★ All projects` on
 
 Workflow keystrokes are non-blocking: dispatching `b` (brainstorm) on one task while another task's agent is still running is fine — both processes run in their own pgroup and the dashboard keeps polling. See [wiki/commands/tui.md](wiki/commands/tui.md) for the full layout, red-status detail, log tail, the new-idea composer with image paste, and the keybinding map per mode.
 
+## Manage Hive From Telegram in 2 Minutes
+
+Hive can notify you, show the queue, and accept approvals from Telegram. It uses long polling, so there is no webhook, public URL, or tunnel to configure.
+
+1. Create a bot with `@BotFather`.
+
+   Send `/newbot`, choose a display name, then choose a username ending in `bot`. BotFather gives you a token like `123456789:ABCdef...`. Keep it secret.
+
+2. Message your bot once.
+
+   Open the new bot chat and send `/start` or `hi`. Telegram only exposes your chat id after you have messaged the bot.
+
+3. Get your numeric chat id.
+
+   ```bash
+   export HIVE_TELEGRAM_BOT_TOKEN='paste-token-from-botfather'
+
+   curl -s "https://api.telegram.org/bot${HIVE_TELEGRAM_BOT_TOKEN}/getUpdates" |
+     ruby -rjson -e 'data = JSON.parse(STDIN.read); ids = data.fetch("result", []).filter_map { |u| (u["message"] || u["edited_message"] || u.dig("callback_query", "message"))&.dig("chat", "id") }; abort("No chat id yet: send your bot a fresh message and retry") if ids.empty?; puts ids.last'
+   ```
+
+   Use this number, not your `@username`.
+
+4. Allow that chat in Hive.
+
+   Add the bot block to `~/.config/hive/config.yml`, preserving any existing `registered_projects:` entries:
+
+   ```yaml
+   bot:
+     enabled: true
+     chat_id_allowlist:
+       - 123456789
+   ```
+
+5. Start Hive bot.
+
+   ```bash
+   hive bot start
+   hive bot status --json
+   ```
+
+Now send `/help`, `/status`, or `/queue` in Telegram. Useful local commands:
+
+```bash
+hive bot tail        # follow ~/.local/state/hive/logs/bot.log
+hive bot reload      # pick up allowlist/config changes
+hive bot stop        # stop the background bot
+```
+
+If the bot stays silent, check `hive bot tail`, confirm the allowlist contains the numeric chat id, and send a fresh Telegram message before rerunning `getUpdates`. A Telegram `404 Not Found` usually means the token is missing or mistyped. If a token leaks, rotate it in `@BotFather` with `/revoke` and restart `hive bot`.
+
 ## Drive Hive From Your Coding Agent
 
 Hive's other primary surface is a coding agent — Claude Code, Codex, Gemini, Pi, or anything that can read terminal output and run shell commands. You describe intent in natural language ("brainstorm the bookmark service idea", "run review on the failing task and report the findings"), the agent translates that into `hive <verb>` calls, and you watch the result in the TUI or read the markdown artefacts directly. Every workflow verb supports `--json` and emits a typed envelope (schemas under [schemas/](schemas/), contract in [docs/cli.md#json-output](docs/cli.md#json-output)), so agent-side parsing is structured rather than scraped.

--- a/examples/launchd/hive-bot.plist
+++ b/examples/launchd/hive-bot.plist
@@ -10,6 +10,7 @@
     <string>/Users/asterio/Dev/hive/bin/hive</string>
     <string>bot</string>
     <string>start</string>
+    <string>--foreground</string>
   </array>
   <key>EnvironmentVariables</key>
   <dict>

--- a/examples/systemd/hive-bot.service
+++ b/examples/systemd/hive-bot.service
@@ -8,7 +8,7 @@ Type=simple
 WorkingDirectory=%h/Dev/hive
 Environment=HIVE_HOME=%h/Dev/hive
 Environment=HIVE_TELEGRAM_BOT_TOKEN=replace-with-botfather-token
-ExecStart=%h/Dev/hive/bin/hive bot start
+ExecStart=%h/Dev/hive/bin/hive bot start --foreground
 ExecStop=%h/Dev/hive/bin/hive bot stop
 Restart=on-failure
 RestartSec=10

--- a/lib/hive/cli.rb
+++ b/lib/hive/cli.rb
@@ -657,8 +657,8 @@ module Hive
     desc "bot SUBCOMMAND", "Manage the Telegram bot (start / stop / status / reload / tail)"
     long_desc <<~DESC
       Subcommands:
-        start [--detach] [--dry-run]      Run the Telegram long-poll bot.
-                                          Without --detach, runs in foreground.
+        start [--foreground] [--dry-run]  Run the Telegram long-poll bot in the background.
+                                          Use --foreground for systemd/launchd/debugging.
         stop [--json]                     Send SIGTERM to the running bot.
                                           --json emits hive-bot-stop.v1.
         status [--json]                   Show running / not-running.
@@ -667,7 +667,7 @@ module Hive
                                           --json emits hive-bot-reload.v1.
         tail                              Stream bot.log.
 
-      The bot reads the global `bot:` block from ~/Dev/hive/config.yml.
+      The bot reads the global `bot:` block from ~/.config/hive/config.yml.
       Its Telegram token comes only from HIVE_TELEGRAM_BOT_TOKEN. Incoming
       updates from chat IDs outside bot.chat_id_allowlist are ignored.
 
@@ -675,14 +675,22 @@ module Hive
       70 internal error; 75 TEMPFAIL when start finds a live bot; 78 CONFIG
       when runtime config or HIVE_TELEGRAM_BOT_TOKEN is missing.
     DESC
-    option :detach, type: :boolean, default: false, desc: "fork to background after start"
+    option :foreground, type: :boolean, default: false,
+                        desc: "run in the foreground instead of backgrounding"
+    option :detach, type: :boolean, default: false, hide: true,
+                    desc: "deprecated; start already backgrounds by default"
     option :dry_run, type: :boolean, default: false,
                      desc: "log/send would-be actions without spawning child commands"
     def bot(subcommand = nil)
       require "hive/commands/bot"
+      if options[:foreground] && options[:detach]
+        raise Hive::InvalidTaskPath,
+              "hive bot start: --detach is the default; do not combine it with --foreground"
+      end
+
       Hive::Commands::Bot.new(
         subcommand,
-        detach: options[:detach],
+        foreground: options[:foreground],
         dry_run: options[:dry_run],
         json: options[:json]
       ).call

--- a/lib/hive/commands/bot.rb
+++ b/lib/hive/commands/bot.rb
@@ -13,10 +13,10 @@ module Hive
     class Bot
       VALID_SUBCOMMANDS = %w[start stop status reload tail].freeze
 
-      def initialize(subcommand, detach: false, dry_run: false, json: false,
+      def initialize(subcommand, detach: nil, foreground: false, dry_run: false, json: false,
                      hive_home: Hive::Paths.state_home)
         @subcommand = subcommand
-        @detach = detach
+        @foreground = foreground || detach == false
         @dry_run = dry_run
         @json = json
         @hive_home = hive_home
@@ -66,7 +66,7 @@ module Hive
                                              holder: { pid: existing_pid }, lock_path: pid_file)
         end
 
-        Process.daemon(true, true) if @detach
+        Process.daemon(true, true) unless @foreground
         lock_file.rewind
         lock_file.truncate(0)
         lock_file.write({ "pid" => Process.pid, "started_at" => Time.now.utc.iso8601 }.to_yaml)

--- a/lib/hive/config.rb
+++ b/lib/hive/config.rb
@@ -164,7 +164,7 @@ module Hive
       },
       # Global Telegram bot settings. The bot is an operator surface
       # across every registered project, so runtime code loads these
-      # from ~/Dev/hive/config.yml via load_global_bot. The token lives
+      # from the global config via load_global_bot. The token lives
       # only in HIVE_TELEGRAM_BOT_TOKEN and is never persisted.
       "bot" => {
         "enabled" => false,
@@ -396,7 +396,7 @@ module Hive
       merged
     end
 
-    # Load and validate the global `bot` block from ~/Dev/hive/config.yml.
+    # Load and validate the global `bot` block from the XDG config path.
     # `require_runtime: true` is used by `hive bot start` so the opt-in
     # credentials fail loudly there without making read-only commands like
     # `hive status` require a Telegram token.

--- a/test/integration/bot/bot_lifecycle_test.rb
+++ b/test/integration/bot/bot_lifecycle_test.rb
@@ -72,13 +72,40 @@ class HiveBotLifecycleTest < Minitest::Test
     end
   end
 
-  def test_start_creates_pid_file_lockable_and_log_directory
+  def test_start_backgrounds_by_default
+    with_bot_home do
+      ENV["HIVE_TELEGRAM_BOT_TOKEN"] = "test-token"
+      daemon_args = []
+      fake_supervisor = Class.new do
+        def run_forever
+          raise StopIteration, "stop after startup"
+        end
+      end
+      original_daemon = Process.method(:daemon)
+      original_supervisor_new = Hive::Bot::Supervisor.method(:new)
+
+      Process.define_singleton_method(:daemon) { |*args| daemon_args << args }
+      Hive::Bot::Supervisor.define_singleton_method(:new) { |**_kwargs| fake_supervisor.new }
+
+      assert_raises(StopIteration) do
+        Hive::Commands::Bot.new("start", dry_run: true).send(:start_bot)
+      end
+
+      assert_equal [ [ true, true ] ], daemon_args
+    ensure
+      Process.define_singleton_method(:daemon, original_daemon) if original_daemon
+      Hive::Bot::Supervisor.define_singleton_method(:new, original_supervisor_new) if original_supervisor_new
+      ENV.delete("HIVE_TELEGRAM_BOT_TOKEN")
+    end
+  end
+
+  def test_start_foreground_creates_pid_file_lockable_and_log_directory
     with_bot_home do |home|
       ENV["HIVE_TELEGRAM_BOT_TOKEN"] = "test-token"
       pid_path = File.join(home, ".bot.pid")
       log_dir = File.join(home, "logs")
 
-      cmd = Hive::Commands::Bot.new("start", dry_run: true)
+      cmd = Hive::Commands::Bot.new("start", foreground: true, dry_run: true)
 
       pid = fork do
         cmd.send(:start_bot)

--- a/wiki/commands/bot.md
+++ b/wiki/commands/bot.md
@@ -16,7 +16,7 @@ use. It is a subprocess caller, not a second approval engine.
 ## Subcommands
 
 ```
-hive bot start [--detach] [--dry-run]
+hive bot start [--foreground] [--dry-run]
 hive bot stop [--json]
 hive bot status [--json]
 hive bot reload [--json]
@@ -25,11 +25,11 @@ hive bot tail
 
 | Subcommand | Behavior |
 |-----------|----------|
-| `start` | Loads `bot:` from `~/Dev/hive/config.yml`, requires `HIVE_TELEGRAM_BOT_TOKEN`, writes `~/Dev/hive/.bot.pid`, then starts the long-poll/status/reaper supervisor. With `--detach`, daemonizes. With `--dry-run`, outbound Telegram parsing still works but child `hive ...` dispatches are reported rather than spawned. A second live bot exits `75 (TEMPFAIL)`. |
+| `start` | Loads `bot:` from the global config, requires `HIVE_TELEGRAM_BOT_TOKEN`, writes the bot PID file, then starts the long-poll/status/reaper supervisor. By default it daemonizes so the shell prompt returns immediately. With `--foreground`, it stays attached for systemd, launchd, or debugging. With `--dry-run`, inbound Telegram parsing and notifications still run but child `hive ...` dispatches are reported rather than spawned. A second live bot exits `75 (TEMPFAIL)`. |
 | `stop` | Sends `SIGTERM` to the PID file's process and waits up to `bot.shutdown_grace_sec`, then escalates to `SIGKILL`. Idempotent when no bot is running. With `--json`, emits `hive-bot-stop.v1`. |
 | `status` | Reports running/not-running and exits `0` when running, `1` when not. With `--json`, emits `hive-bot-status.v1` with `running`, `pid`, `uptime_sec`, `pid_file`, and `log_file`. |
 | `reload` | Sends `SIGHUP`; the supervisor reloads config at the next loop boundary while preserving in-flight children and conversations. With `--json`, emits `hive-bot-reload.v1`. |
-| `tail` | Streams `~/Dev/hive/logs/bot.log`; exits 1 if the log does not exist. |
+| `tail` | Streams `~/.local/state/hive/logs/bot.log`; exits 1 if the log does not exist. |
 
 ## Commands in Telegram
 
@@ -67,9 +67,9 @@ bot:
   poll_interval_sec: 30
   long_poll_timeout_sec: 25
   notification_dedupe_window_sec: 300
-  pid_file: ~/Dev/hive/.bot.pid
-  log_file: ~/Dev/hive/logs/bot.log
-  last_seen_state_file: ~/Dev/hive/.bot.last_seen_update_id
+  pid_file: ~/.local/state/hive/.bot.pid
+  log_file: ~/.local/state/hive/logs/bot.log
+  last_seen_state_file: ~/.local/state/hive/.bot.last_seen_update_id
 ```
 
 `HIVE_TELEGRAM_BOT_TOKEN` is the only supported token source. Missing
@@ -79,7 +79,7 @@ silently.
 
 ## Structured log
 
-`~/Dev/hive/logs/bot.log` is one JSON document per line with schema
+`~/.local/state/hive/logs/bot.log` is one JSON document per line with schema
 `hive-bot-log.v1`. The event enum is closed in
 `Hive::Bot::Logger::EVENTS`; unknown events raise at the call site.
 Events include `bot_started`, `poll_failure`, `update_received`,
@@ -90,7 +90,7 @@ Events include `bot_started`, `poll_failure`, `update_received`,
 
 | Subcommand | Code | Condition |
 |------------|------|-----------|
-| `start` | 0 | Foreground bot exits cleanly |
+| `start` | 0 | Background bot started, or foreground bot exited cleanly |
 | `start` | 75 | Another bot is already running |
 | `start` | 78 | Token/allowlist/config is missing or malformed |
 | `stop` | 0 | Always, including not-running |

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -2,6 +2,12 @@
 
 Append-only log of all wiki operations.
 
+## [2026-05-23T09:20:00Z] bot - default start backgrounds for manual use
+
+**Action:** Simplified Telegram onboarding by making `hive bot start` background the bot by default. `--foreground` is now the explicit mode for systemd, launchd, and terminal debugging; legacy `--detach` remains accepted as a no-op compatibility flag because backgrounding is already the default. README now includes a short BotFather -> numeric chat id -> allowlist -> `hive bot start` path based on the OpenClaw-style quick onboarding pattern.
+
+**Refreshed pages:** [[commands/bot]], [[modules/bot]], [[operating]], [[state-model]].
+
 ## [2026-05-22T13:30:00Z] rebase / review — close three post-merge follow-up gaps from PR #104 review
 
 **Action:** Documented three follow-up fixes after the initial PR #104 review pass surfaced sharper failure modes than the first round caught.

--- a/wiki/modules/bot.md
+++ b/wiki/modules/bot.md
@@ -36,9 +36,9 @@ and subprocess I/O.
 
 ```
 hive bot start
-  └─ Hive::Commands::Bot
+  └─ Hive::Commands::Bot (daemonizes unless --foreground)
        ├─ validates global bot config + HIVE_TELEGRAM_BOT_TOKEN
-       ├─ writes ~/Dev/hive/.bot.pid
+       ├─ writes ~/.local/state/hive/.bot.pid
        └─ Hive::Bot::Supervisor.run_forever
             ├─ poll loop: Telegram.getUpdates → Router → handler descriptors
             ├─ status loop: hive status --json → NotificationDispatcher

--- a/wiki/operating.md
+++ b/wiki/operating.md
@@ -345,11 +345,10 @@ Runtime token:
 ```bash
 export HIVE_TELEGRAM_BOT_TOKEN=123456:token-from-botfather
 hive bot start --dry-run
+hive bot status
 ```
 
-`--dry-run` is useful for first shakedown: inbound command parsing and
-status notifications run, but state-changing child commands are not
-spawned. The bot log is `~/.local/state/hive/logs/bot.log`:
+`hive bot start` backgrounds by default so the shell prompt returns immediately. `--dry-run` is useful for first shakedown: inbound command parsing and status notifications run, but state-changing child commands are not spawned. Use `hive bot start --foreground --dry-run` when you want to watch the process under a terminal or process supervisor. The bot log is `~/.local/state/hive/logs/bot.log`:
 
 ```bash
 jq -r '.event' ~/.local/state/hive/logs/bot.log | sort | uniq -c
@@ -380,8 +379,9 @@ $EDITOR ~/Library/LaunchAgents/hive-bot.plist     # set token / paths
 launchctl load ~/Library/LaunchAgents/hive-bot.plist
 ```
 
-The sample files run `hive bot start` in the foreground and let the
-host supervisor restart on failure. `hive bot stop` remains the manual
+The sample files run `hive bot start --foreground` and let the
+host supervisor restart on failure. Plain `hive bot start` backgrounds
+for manual use. `hive bot stop` remains the manual
 drain path when you are not using systemd/launchd.
 
 ## Day-2 operations

--- a/wiki/state-model.md
+++ b/wiki/state-model.md
@@ -161,18 +161,18 @@ bot:
   codex_budget_usd: 1
   codex_timeout_sec: 120
   shutdown_grace_sec: 60
-  pid_file: ~/Dev/hive/.bot.pid
-  log_file: ~/Dev/hive/logs/bot.log
+  pid_file: ~/.local/state/hive/.bot.pid
+  log_file: ~/.local/state/hive/logs/bot.log
   log_max_bytes: 10485760
   log_max_files: 5
-  last_seen_state_file: ~/Dev/hive/.bot.last_seen_update_id
+  last_seen_state_file: ~/.local/state/hive/.bot.last_seen_update_id
 ```
 
 Managed by `Hive::Config.register_project` (`lib/hive/config.rb:79`); deregistered by `unregister_project` (one row, by name) and `prune_missing_projects!` (every row whose `path` is missing OR whose shape is invalid). `HIVE_HOME` env var overrides the default `~/Dev/hive`.
 
 Loader tolerance (`Config.registered_projects` / `load_global_config`): a non-Hash row, a row missing `name`, or a row whose `path` isn't a String is *skipped silently* instead of raising — a single hand-edit accident can no longer brick `status`/`forget`/`prune`/TUI. `Psych::Exception` (any malformed YAML — syntax, disallowed-class, alias-not-enabled) plus `Errno::EACCES`/`EISDIR` are rewrapped as `ConfigError` (exit 78); `chmod 000 ~/Dev/hive/config.yml` no longer leaks as exit-70 InternalError. `prune` is the cleanup verb for invalid rows surfaced this way (predicate `Config.droppable_registry_entry?` covers both missing-path and invalid-shape; `valid_registry_entry?` is the shared shape gate). All writes go through `write_global_config!` so the read/write classification is symmetric and a future flock upgrade (Issue #31) lands in one place. See [[commands/forget]] · [[commands/prune]] · [[modules/config]]. All writers (`register_project`, `unregister_project`, `prune_missing_projects!`) go through `Hive::Config.write_global_config!`, which rewraps `Errno::EACCES`/`EROFS`/`ENOSPC` as `Hive::ConfigError` (exit 78). The reader (`load_global_config`) likewise rewraps `Psych::SyntaxError` AND `Errno::EACCES`/`EISDIR` to `ConfigError` so a `chmod 000` on `~/Dev/hive/config.yml` surfaces as exit 78, not exit 70. Name matching in `unregister_project` is `to_s`-symmetric so a hand-edited Integer `name:` in YAML still resolves. `forget`/`prune` `--json` envelopes use `Hive::Schemas::EnvelopeEmitter` (`lib/hive.rb`) and `File.expand_path` raw `path` / `hive_state_path` to honor the schemas' "Absolute path" contract regardless of how the registry row was hand-edited.
 
-`bot:` is a global operator-surface block, not a per-project enrollment knob. `Config.load_global_bot(require_runtime: true)` merges it over `Config.global_bot_defaults`, validates integer chat IDs, poll bounds, and path strings, then requires both a non-empty allowlist and `HIVE_TELEGRAM_BOT_TOKEN` before `hive bot start` can run. Runtime files are global: `~/Dev/hive/.bot.pid` for the single-instance lock, `~/Dev/hive/logs/bot.log` for structured JSON lines, and `~/Dev/hive/.bot.last_seen_update_id` for Telegram reconnect summaries.
+`bot:` is a global operator-surface block, not a per-project enrollment knob. `Config.load_global_bot(require_runtime: true)` merges it over `Config.global_bot_defaults`, validates integer chat IDs, poll bounds, and path strings, then requires both a non-empty allowlist and `HIVE_TELEGRAM_BOT_TOKEN` before `hive bot start` can run. Runtime files are global under `~/.local/state/hive/`: `.bot.pid` for the single-instance lock, `logs/bot.log` for structured JSON lines, and `.bot.last_seen_update_id` for Telegram reconnect summaries.
 
 ### Per-project: `<project>/.hive-state/config.yml`
 


### PR DESCRIPTION
## Summary

Telegram bot onboarding no longer asks people to remember `--detach`: `hive bot start` now returns the shell prompt and leaves the bot running in the background. Supervisors and debugging sessions can opt into attached execution with `--foreground`, while legacy `--detach` invocations remain accepted but hidden from help.

The README now has a two-minute BotFather -> first message -> numeric chat id -> allowlist -> `hive bot start` path based on the live setup we just worked through. The systemd and launchd examples use `--foreground`, and the bot docs now point at the current XDG config and log paths.

## Testing

- `bundle exec ruby -Itest test/integration/bot/bot_lifecycle_test.rb`
- `bundle exec rubocop lib/hive/commands/bot.rb lib/hive/cli.rb test/integration/bot/bot_lifecycle_test.rb`
- `ruby -Ilib bin/hive help bot`
- `ruby -Ilib bin/hive bot start --foreground --detach` exits `64` with the expected conflict message

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/Codex-000000)
