### PR TITLE
test(eval): add Telegram bot evaluation harness

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -77,6 +77,16 @@ namespace :e2e do
   end
 end
 
+namespace :test do
+  Rake::TestTask.new(:eval) do |t|
+    t.libs << "test"
+    t.libs << "lib"
+    t.test_files = FileList["test/eval/**/*_test.rb"]
+    t.warning = false
+    t.description = "Run Telegram bot eval harness tests"
+  end
+end
+
 desc "Run real-subprocess CLI/TUI e2e scenarios"
 task :e2e do
   ruby "bin/hive-e2e", "run"

--- a/Rakefile
+++ b/Rakefile
@@ -81,7 +81,8 @@ namespace :test do
   Rake::TestTask.new(:eval) do |t|
     t.libs << "test"
     t.libs << "lib"
-    t.test_files = FileList["test/eval/**/*_test.rb"]
+    glob = ENV["HIVE_EVAL_SCENARIOS_ONLY"] == "1" ? "test/eval/scenarios/**/*_test.rb" : "test/eval/**/*_test.rb"
+    t.test_files = FileList[glob]
     t.warning = false
     t.description = "Run Telegram bot eval harness tests"
   end

--- a/bin/hive-eval
+++ b/bin/hive-eval
@@ -1,0 +1,51 @@
+#!/usr/bin/env ruby
+
+require "fileutils"
+require "English"
+require "optparse"
+
+root = File.expand_path("..", __dir__)
+options = {
+  report: File.join(root, "tmp", "hive-eval-report.json"),
+  scenario: nil,
+  no_judge: false
+}
+
+OptionParser.new do |parser|
+  parser.banner = "Usage: bin/hive-eval [--scenario NAME] [--report PATH] [--no-judge]"
+  parser.on("--scenario NAME", "Run one scenario by basename, e.g. s1_status") do |value|
+    options[:scenario] = value
+  end
+  parser.on("--report PATH", "Write JSON report to PATH") do |value|
+    options[:report] = value
+  end
+  parser.on("--no-judge", "Skip Codex judge assertions") do
+    options[:no_judge] = true
+  end
+end.parse!
+
+def scenario_path(root, value)
+  return nil if value.nil?
+  return File.expand_path(value, root) if value.end_with?(".rb")
+
+  basename = value.sub(/_test\z/, "")
+  File.join(root, "test", "eval", "scenarios", "#{basename}_test.rb")
+end
+
+env = {
+  "HIVE_EVAL_REPORT" => File.expand_path(options.fetch(:report), root),
+  "HIVE_EVAL_SCENARIOS_ONLY" => "1"
+}
+env["HIVE_EVAL_NO_JUDGE"] = "1" if options[:no_judge]
+
+if (path = scenario_path(root, options[:scenario]))
+  unless File.exist?(path)
+    warn "hive-eval: scenario not found: #{path}"
+    exit 64
+  end
+  env["TEST"] = path
+end
+
+FileUtils.mkdir_p(File.dirname(env.fetch("HIVE_EVAL_REPORT")))
+ok = system(env, "bundle", "exec", "rake", "test:eval", chdir: root)
+exit($CHILD_STATUS&.exitstatus || (ok ? 0 : 1))

--- a/lib/hive/bot/notification_builders.rb
+++ b/lib/hive/bot/notification_builders.rb
@@ -84,7 +84,9 @@ module Hive
 
       def brainstorm_waiting(row)
         Notification.new(
-          text: header(row) + "\nBrainstorm questions are waiting.",
+          text: header(row) + "\n" \
+                "Brainstorm questions are waiting. " \
+                "Tap Answer in chat or reply with /answer #{row.slug} to provide input.",
           keyboard: [
             [ button("Answer in chat", "answer:#{row.project}:#{row.slug}") ],
             [ button("Ask Codex", "path_a_yes:#{row.project}:#{row.slug}") ],

--- a/test/eval/eval_helper.rb
+++ b/test/eval/eval_helper.rb
@@ -1,0 +1,3 @@
+require "test_helper"
+
+Dir[File.expand_path("support/**/*.rb", __dir__)].sort.each { |path| require path }

--- a/test/eval/eval_helper.rb
+++ b/test/eval/eval_helper.rb
@@ -1,3 +1,6 @@
 require "test_helper"
 
-Dir[File.expand_path("support/**/*.rb", __dir__)].sort.each { |path| require path }
+Dir[File.expand_path("support/**/*.rb", __dir__)]
+  .reject { |path| path.end_with?("_test.rb") }
+  .sort
+  .each { |path| require path }

--- a/test/eval/scenarios/s1_status_test.rb
+++ b/test/eval/scenarios/s1_status_test.rb
@@ -1,0 +1,36 @@
+require "eval/eval_helper"
+
+class HiveEvalS1StatusTest < Minitest::Test
+  include Hive::Eval::ScenarioSupport
+
+  RUBRIC = "Pass when the reply identifies blocking/actionable tasks, avoids progress noise, " \
+           "and uses no more than two filler sentences."
+
+  def test_status_query_sends_single_status_response
+    given_project(name: "hive")
+    rows = [
+      status_row(slug: "needs-human", action: "needs_input", marker: "waiting"),
+      status_row(slug: "running-agent", action: "agent_running", marker: "agent_working")
+    ]
+    harness.status_watcher.queue(rows: rows)
+
+    when_user_sends("/status")
+
+    assert_sent_count 1
+    status = assert_sent_one(reason: "status_response")
+    assert_all_messages_typed
+    refute_proactive_status_response
+    assert_judge_rubric_passes(rubric: RUBRIC, text: status.message.text)
+  end
+
+  def test_status_rows_without_user_request_do_not_emit_status_response
+    given_project(name: "hive")
+
+    when_agent_emits(rows: [
+      status_row(slug: "running-agent", action: "agent_running", marker: "agent_working")
+    ])
+
+    assert_sent_count 0
+    assert_no_message_with_reason("status_response")
+  end
+end

--- a/test/eval/scenarios/s2_agent_question_test.rb
+++ b/test/eval/scenarios/s2_agent_question_test.rb
@@ -1,0 +1,45 @@
+require "eval/eval_helper"
+require "hive/bot/brainstorm_parser"
+
+class HiveEvalS2AgentQuestionTest < Minitest::Test
+  include Hive::Eval::ScenarioSupport
+
+  RUBRIC = "Pass when the bot clearly asks for user input, names the affected task, " \
+           "and does not include unrelated status chatter."
+
+  def test_agent_question_is_answered_and_written_to_brainstorm
+    given_project(name: "hive")
+    brainstorm_path = given_brainstorm(slug: "question-a")
+
+    when_agent_emits(rows: [
+      status_row(slug: "question-a", action: "needs_input", marker: "waiting")
+    ])
+
+    question = assert_sent_one(reason: "agent_blocked_question")
+    assert_judge_rubric_passes(rubric: RUBRIC, text: question.message.text)
+
+    when_user_taps("answer:hive:question-a")
+    persona = Hive::Eval::CodexPersona.new(
+      role_prompt: "You are a concise operator answering a Hive brainstorm question. " \
+                   "Give a direct answer in one sentence."
+    )
+    answer = persona.respond(bot_message: harness.last_sent.text)
+    when_user_sends(answer)
+
+    answers = Hive::Bot::BrainstormParser.parse(brainstorm_path).map(&:answer)
+    assert_equal [ answer ], answers
+    assert_equal 1, harness.logger.count_named(:answer_written)
+    assert_all_messages_typed
+  end
+
+  def test_empty_answer_does_not_surface_fatal_error
+    given_project(name: "hive")
+    given_brainstorm(slug: "question-empty")
+
+    when_user_sends("/answer question-empty")
+    when_user_sends(Hive::Eval::ScriptedPersona.new(replies: [ "" ]).respond(bot_message: harness.last_sent.text))
+
+    assert_no_message_with_reason("fatal_error")
+    assert_all_messages_typed
+  end
+end

--- a/test/eval/scenarios/s3_noise_test.rb
+++ b/test/eval/scenarios/s3_noise_test.rb
@@ -1,0 +1,36 @@
+require "eval/eval_helper"
+
+class HiveEvalS3NoiseTest < Minitest::Test
+  include Hive::Eval::ScenarioSupport
+
+  def test_simulated_night_obeys_signal_not_noise_contract
+    given_project(name: "hive")
+
+    50.times do |tick|
+      rows = noisy_rows(tick)
+      when_agent_emits(rows: rows)
+      when_clock_advances(60)
+    end
+
+    assert_all_messages_typed
+    assert_no_duplicates(window_sec: 300)
+    refute_proactive_status_response
+    assert_proactive_rule
+  end
+
+  private
+
+  def noisy_rows(tick)
+    rows = 6.times.map do |idx|
+      status_row(slug: "running-#{idx}", action: "agent_running", marker: "agent_working")
+    end
+    rows << status_row(slug: "same-question", action: "needs_input", marker: "waiting")
+    rows << status_row(slug: "same-question", action: "needs_input", marker: "waiting")
+    rows << status_row(slug: "debug-row", action: "debug", marker: "debug")
+    if (tick % 10).zero?
+      rows << status_row(slug: "finished-#{tick}", stage: "7-artifacts",
+                         action: "ready_to_finalize", marker: "complete")
+    end
+    rows
+  end
+end

--- a/test/eval/scenarios/s4_button_test.rb
+++ b/test/eval/scenarios/s4_button_test.rb
@@ -1,0 +1,31 @@
+require "eval/eval_helper"
+
+class HiveEvalS4ButtonTest < Minitest::Test
+  include Hive::Eval::ScenarioSupport
+
+  def test_inline_approve_button_dispatches_expected_command
+    given_project(name: "hive")
+
+    when_agent_emits(rows: [
+      status_row(slug: "ship-a", stage: "7-artifacts", action: "ready_to_finalize", marker: "complete")
+    ])
+    button = harness.last_sent.reply_markup.flatten.find { |candidate| candidate[:text] == "Approve" }
+
+    when_user_taps(button.fetch(:callback_data))
+
+    assert_equal [ "hive", "finalize", "ship-a", "--from", "7-artifacts",
+                   "--project", "hive", "--json" ], harness.child_supervisor.commands.last
+    assert_match(/Queued command pid=/, harness.last_sent.text)
+    assert_all_messages_typed
+    assert_no_duplicates(window_sec: 300)
+  end
+
+  def test_unknown_callback_does_not_crash_or_emit_unclassified_message
+    given_project(name: "hive")
+
+    when_user_taps("unknown:callback:data")
+
+    assert_sent_count 1
+    assert_all_messages_typed
+  end
+end

--- a/test/eval/scenarios/s5_stuck_test.rb
+++ b/test/eval/scenarios/s5_stuck_test.rb
@@ -1,0 +1,37 @@
+require "eval/eval_helper"
+
+class HiveEvalS5StuckTest < Minitest::Test
+  include Hive::Eval::ScenarioSupport
+
+  def test_silent_agent_after_question_does_not_create_message_storm
+    given_project(name: "hive")
+
+    when_agent_emits(rows: [
+      status_row(slug: "question-a", action: "needs_input", marker: "waiting")
+    ])
+    30.times do
+      when_clock_advances(60)
+      when_agent_emits(rows: [])
+    end
+
+    assert_sent_count 1
+    assert_sent_one(reason: "agent_blocked_question")
+    assert_all_messages_typed
+    assert_proactive_rule
+    assert_no_duplicates(window_sec: 300)
+  end
+
+  def test_idle_running_ticks_emit_no_messages
+    given_project(name: "hive")
+
+    30.times do |idx|
+      when_agent_emits(rows: [
+        status_row(slug: "running-#{idx}", action: "agent_running", marker: "agent_working")
+      ])
+      when_clock_advances(60)
+    end
+
+    assert_sent_count 0
+    assert_all_messages_typed
+  end
+end

--- a/test/eval/support/capturing_logger.rb
+++ b/test/eval/support/capturing_logger.rb
@@ -1,0 +1,37 @@
+require "hive/bot/logger"
+
+module Hive
+  module Eval
+    class CapturingLogger
+      Event = Struct.new(:name, :attrs, :t, keyword_init: true)
+
+      attr_reader :events
+
+      def initialize(now: -> { Time.now })
+        @now = now
+        @events = []
+      end
+
+      def event(name, **attrs)
+        @events << Event.new(name: name.to_sym, attrs: attrs.transform_keys(&:to_sym), t: @now.call)
+      end
+
+      def events_named(name)
+        @events.select { |event| event.name == name.to_sym }
+      end
+
+      def events_with(name, **attr_subset)
+        expected = attr_subset.transform_keys(&:to_sym)
+        events_named(name).select do |event|
+          expected.all? { |key, value| event.attrs[key] == value }
+        end
+      end
+
+      def count_named(name)
+        events_named(name).length
+      end
+
+      def close; end
+    end
+  end
+end

--- a/test/eval/support/capturing_logger_test.rb
+++ b/test/eval/support/capturing_logger_test.rb
@@ -1,0 +1,34 @@
+require "eval/eval_helper"
+
+class HiveEvalCapturingLoggerTest < Minitest::Test
+  def test_captures_events_in_order_with_attrs
+    logger = Hive::Eval::CapturingLogger.new(now: -> { Time.utc(2026, 5, 24, 8, 0, 0) })
+
+    logger.event(:notification_sent, project: "hive", slug: "slug-a", marker: "waiting")
+    logger.event(:send_failure, chat_id: 12345, error_class: "Boom")
+    logger.event(:answer_written, slug: "slug-a", question_n: 1)
+
+    assert_equal %i[notification_sent send_failure answer_written], logger.events.map(&:name)
+    assert_equal 1, logger.count_named(:send_failure)
+    assert_equal [ "slug-a" ], logger.events_with(:answer_written, question_n: 1).map { |event| event.attrs[:slug] }
+  end
+
+  def test_harness_uses_capturing_logger_for_real_supervisor_events
+    harness = Hive::Eval::Harness.new
+    row = Hive::Bot::StatusWatcher::Row.new(
+      project: "hive",
+      slug: "need-answer",
+      stage: "2-brainstorm",
+      marker: "waiting",
+      attrs: {},
+      action: "needs_input",
+      action_label: "needs input"
+    )
+    harness.status_watcher.queue(rows: [ row ])
+
+    harness.when_user_sends("/status")
+
+    assert_equal 1, harness.logger.count_named(:update_received)
+    assert_equal "slash_status", harness.logger.events_named(:update_received).first.attrs[:intent]
+  end
+end

--- a/test/eval/support/cli_capture.rb
+++ b/test/eval/support/cli_capture.rb
@@ -1,0 +1,164 @@
+require "json"
+require "time"
+require "hive/bot/child_supervisor"
+
+module Hive
+  module Eval
+    class FakeChildSupervisor
+      ANYTHING = Object.new.freeze
+
+      Dispatch = Struct.new(
+        :pid,
+        :command_argv,
+        :cwd,
+        :chat_id,
+        :update_id,
+        :project,
+        :slug,
+        :stdout,
+        :stderr,
+        :exit_status,
+        :json_envelope,
+        keyword_init: true
+      )
+
+      Response = Struct.new(:pattern, :stdout, :stderr, :exit_status, :json_envelope, keyword_init: true)
+
+      attr_reader :dispatches
+
+      def initialize(logger: nil, now: -> { Time.now })
+        @logger = logger
+        @now = now
+        @responses = []
+        @dispatches = []
+        @completed = {}
+        @unreaped = []
+        @next_pid = 20_000
+      end
+
+      def self.anything
+        ANYTHING
+      end
+
+      def respond_to(command_pattern)
+        ResponseBuilder.new(self, command_pattern)
+      end
+
+      def add_response(pattern:, stdout: "", stderr: "", exit_status: 0, json_envelope: nil)
+        @responses << Response.new(
+          pattern: pattern,
+          stdout: stdout,
+          stderr: stderr,
+          exit_status: exit_status,
+          json_envelope: json_envelope
+        )
+      end
+
+      def dispatch(command_argv:, cwd:, chat_id:, update_id:, project: nil, slug: nil)
+        response = response_for(command_argv)
+        @next_pid += 1
+        dispatch = Dispatch.new(
+          pid: @next_pid,
+          command_argv: Array(command_argv),
+          cwd: cwd,
+          chat_id: chat_id,
+          update_id: update_id,
+          project: project,
+          slug: slug,
+          stdout: response.stdout,
+          stderr: response.stderr,
+          exit_status: response.exit_status,
+          json_envelope: response.json_envelope || parse_json_envelope(response.stdout)
+        )
+        @dispatches << dispatch
+        @logger&.event(:dispatched_command, pid: dispatch.pid, project: project,
+                                            slug: slug, command: dispatch.command_argv.join(" "),
+                                            dry_run: false, update_id: update_id)
+        remember_exit(dispatch)
+        dispatch.pid
+      end
+
+      def commands
+        @dispatches.map(&:command_argv)
+      end
+
+      def completed_exit(pid)
+        @completed[pid]
+      end
+
+      def reap_all
+        @unreaped.shift(@unreaped.length)
+      end
+
+      def terminate_all(grace_sec:); end
+
+      def in_flight_count
+        0
+      end
+
+      private
+
+      def response_for(argv)
+        @responses.find { |response| command_matches?(response.pattern, argv) } ||
+          Response.new(pattern: [], stdout: "", stderr: "", exit_status: 0, json_envelope: nil)
+      end
+
+      def command_matches?(pattern, argv)
+        pattern = Array(pattern)
+        argv = Array(argv)
+        return false unless pattern.length == argv.length
+
+        pattern.zip(argv).all? do |expected, actual|
+          expected.equal?(ANYTHING) || expected === actual
+        end
+      end
+
+      def parse_json_envelope(stdout)
+        line = stdout.to_s.lines.reverse.find { |candidate| candidate.strip.start_with?("{") }
+        line ? JSON.parse(line) : nil
+      rescue JSON::ParserError
+        nil
+      end
+
+      def remember_exit(dispatch)
+        child = Hive::Bot::ChildSupervisor::ChildExit.new(
+          pid: dispatch.pid,
+          exit_code: dispatch.exit_status,
+          project: dispatch.project,
+          slug: dispatch.slug,
+          command_argv: dispatch.command_argv,
+          chat_id: dispatch.chat_id,
+          update_id: dispatch.update_id,
+          started_at: @now.call,
+          finished_at: @now.call,
+          log_path: nil,
+          json_envelope: dispatch.json_envelope
+        )
+        @completed[dispatch.pid] = child
+        @unreaped << child
+        @logger&.event(:command_completed, pid: dispatch.pid, exit_code: dispatch.exit_status,
+                                           project: dispatch.project, slug: dispatch.slug,
+                                           update_id: dispatch.update_id,
+                                           envelope_ok: dispatch.json_envelope&.dig("ok"),
+                                           error_kind: dispatch.json_envelope&.dig("error_kind"))
+      end
+
+      class ResponseBuilder
+        def initialize(supervisor, pattern)
+          @supervisor = supervisor
+          @pattern = pattern
+        end
+
+        def with_stdout(stdout, stderr: "", exit_status: 0, json_envelope: nil)
+          @supervisor.add_response(
+            pattern: @pattern,
+            stdout: stdout,
+            stderr: stderr,
+            exit_status: exit_status,
+            json_envelope: json_envelope
+          )
+        end
+      end
+    end
+  end
+end

--- a/test/eval/support/cli_capture_test.rb
+++ b/test/eval/support/cli_capture_test.rb
@@ -1,0 +1,35 @@
+require "eval/eval_helper"
+
+class HiveEvalCliCaptureTest < Minitest::Test
+  def test_fake_child_supervisor_captures_command_and_configured_stdout
+    child = Hive::Eval::FakeChildSupervisor.new
+    envelope = { "schema" => "hive-status", "ok" => true }
+    child.respond_to([ "hive", "run", Hive::Eval::FakeChildSupervisor.anything, "--json" ])
+         .with_stdout(JSON.generate(envelope), exit_status: 0)
+
+    pid = child.dispatch(
+      command_argv: [ "hive", "run", "slug-a", "--json" ],
+      cwd: "/tmp/project",
+      chat_id: 12345,
+      update_id: 7,
+      project: "hive",
+      slug: "slug-a"
+    )
+
+    dispatch = child.dispatches.fetch(0)
+    assert_equal [ "hive", "run", "slug-a", "--json" ], dispatch.command_argv
+    assert_equal JSON.generate(envelope), dispatch.stdout
+    assert_equal 0, child.completed_exit(pid).exit_code
+    assert_equal envelope, child.completed_exit(pid).json_envelope
+  end
+
+  def test_harness_callback_dispatch_is_captured
+    harness = Hive::Eval::Harness.new
+
+    harness.when_user_taps("approve:plan:hive:slug-a:2-brainstorm")
+
+    assert_equal [ "hive", "plan", "slug-a", "--from", "2-brainstorm",
+                   "--project", "hive", "--json" ], harness.child_supervisor.commands.last
+    assert_equal "Queued command pid=20001", harness.last_sent.text
+  end
+end

--- a/test/eval/support/codex_judge.rb
+++ b/test/eval/support/codex_judge.rb
@@ -1,0 +1,92 @@
+require "json"
+require "open3"
+require "timeout"
+
+module Hive
+  module Eval
+    class CodexJudge
+      Verdict = Struct.new(:pass, :score, :reason, :transcript, :model_used, :skipped, keyword_init: true)
+
+      def initialize(rubric:, command: ENV.fetch("HIVE_CODEX_BIN", "codex"), timeout_sec: 120)
+        @rubric = rubric
+        @command = command
+        @timeout_sec = timeout_sec
+      end
+
+      def verdict(text:)
+        stdout, stderr, status = capture(prompt(text))
+        transcript = [ stdout, stderr ].reject(&:empty?).join("\n")
+        unless status.success?
+          return Verdict.new(pass: false, score: 0,
+                             reason: "judge_invocation_failed: #{stderr.to_s.strip[0, 500]}",
+                             transcript: transcript, model_used: @command, skipped: false)
+        end
+
+        doc = parse_verdict(stdout)
+        Verdict.new(
+          pass: doc.fetch("pass") == true,
+          score: Integer(doc.fetch("score")),
+          reason: doc.fetch("reason").to_s,
+          transcript: transcript,
+          model_used: @command,
+          skipped: false
+        )
+      rescue Timeout::Error
+        Verdict.new(pass: false, score: 0, reason: "judge_invocation_failed: timeout",
+                    transcript: "", model_used: @command, skipped: false)
+      rescue StandardError => e
+        Verdict.new(pass: false, score: 0,
+                    reason: "judge_parse_failed: #{e.class}: #{e.message}",
+                    transcript: transcript.to_s, model_used: @command, skipped: false)
+      end
+
+      private
+
+      def capture(prompt)
+        Timeout.timeout(@timeout_sec) do
+          Open3.capture3(@command, "exec", "--json", prompt)
+        end
+      end
+
+      def prompt(text)
+        <<~PROMPT
+          You are evaluating whether a Telegram bot's reply meets the rubric below.
+
+          Rubric:
+          #{@rubric}
+
+          Reply to evaluate:
+          #{text}
+
+          Respond with a JSON object only:
+          {"pass": true|false, "score": 0-5, "reason": "..."}
+        PROMPT
+      end
+
+      def parse_verdict(stdout)
+        agent_texts = stdout.to_s.lines.filter_map do |line|
+          parse_json_line(line)&.dig("item", "text")
+        end
+        candidate = agent_texts.last || stdout
+        JSON.parse(extract_json_object(candidate))
+      end
+
+      def parse_json_line(line)
+        JSON.parse(line)
+      rescue JSON::ParserError
+        nil
+      end
+
+      def extract_json_object(text)
+        body = text.to_s.strip
+        body = body.delete_prefix("```json").delete_prefix("```").delete_suffix("```").strip
+        return body if body.start_with?("{") && body.end_with?("}")
+
+        match = body.match(/\{.*\}/m)
+        raise JSON::ParserError, "no JSON object in judge output" unless match
+
+        match[0]
+      end
+    end
+  end
+end

--- a/test/eval/support/codex_judge_test.rb
+++ b/test/eval/support/codex_judge_test.rb
@@ -1,0 +1,20 @@
+require "eval/eval_helper"
+
+class HiveEvalCodexJudgeTest < Minitest::Test
+  def test_judge_passes_clear_good_reply
+    rubric = "Pass only when the reply mentions tasks and uses no more than two sentences."
+    verdict = Hive::Eval::CodexJudge.new(rubric: rubric).verdict(text: "Two tasks need input. No other work is blocked.")
+
+    assert verdict.pass, "expected judge pass, got #{verdict.inspect}"
+    assert_operator verdict.score, :>=, 3
+    refute_empty verdict.transcript
+  end
+
+  def test_judge_fails_empty_reply
+    rubric = "Pass only when the reply mentions tasks and uses no more than two sentences."
+    verdict = Hive::Eval::CodexJudge.new(rubric: rubric).verdict(text: "")
+
+    refute verdict.pass, "expected judge failure, got #{verdict.inspect}"
+    refute_empty verdict.transcript
+  end
+end

--- a/test/eval/support/contract_assertions.rb
+++ b/test/eval/support/contract_assertions.rb
@@ -1,0 +1,100 @@
+require_relative "reason_classifier"
+
+module Hive
+  module Eval
+    module ContractAssertions
+      def classified_messages
+        Hive::Eval::ReasonClassifier.new(
+          messages: harness.sent,
+          log_events: harness.logger.respond_to?(:events) ? harness.logger.events : []
+        ).classify_all
+      end
+
+      def assert_all_messages_typed
+        bad = classified_messages.reject { |entry| Hive::Eval::ReasonClassifier::ALLOW_LIST.include?(entry.reason) }
+        passed = bad.empty?
+        record_eval_assertion(kind: "all_messages_typed", expected: Hive::Eval::ReasonClassifier::ALLOW_LIST,
+                              actual: bad.map { |entry| assertion_detail(entry) }, passed: passed)
+        assert passed, "unclassified Telegram messages:\n#{bad.map { |entry| assertion_detail(entry) }.join("\n")}"
+      end
+
+      def assert_proactive_rule
+        bad = classified_messages.select do |entry|
+          entry.proactive && !%w[agent_blocked_question fatal_error].include?(entry.reason)
+        end
+        passed = bad.empty?
+        record_eval_assertion(kind: "proactive_rule",
+                              expected: "proactive reasons limited to agent_blocked_question,fatal_error",
+                              actual: bad.map { |entry| assertion_detail(entry) },
+                              passed: passed)
+        assert passed, "proactive messages violated allow-list:\n#{bad.map { |entry| assertion_detail(entry) }.join("\n")}"
+      end
+
+      def assert_no_duplicates(window_sec:)
+        duplicates = duplicate_classifications(window_sec: window_sec)
+        passed = duplicates.empty?
+        record_eval_assertion(kind: "dedupe", expected: "no same reason+payload within #{window_sec}s",
+                              actual: duplicates.map { |entry| assertion_detail(entry) }, passed: passed)
+        assert passed, "duplicate Telegram payloads within #{window_sec}s:\n" \
+                       "#{duplicates.map { |entry| assertion_detail(entry) }.join("\n")}"
+      end
+
+      def assert_sent_one(reason:)
+        matches = classified_messages.select { |entry| entry.reason == reason.to_s }
+        record_eval_assertion(kind: "sent_one", reason: reason.to_s, expected: 1,
+                              actual: matches.length, passed: matches.length == 1)
+        assert_equal 1, matches.length,
+                     "expected exactly one #{reason} message, got #{matches.length}: " \
+                     "#{classified_messages.map { |entry| [ entry.reason, entry.message.text ] }.inspect}"
+        matches.first
+      end
+
+      def assert_no_message_with_reason(reason)
+        matches = classified_messages.select { |entry| entry.reason == reason.to_s }
+        record_eval_assertion(kind: "no_message_with_reason", reason: reason.to_s, expected: 0,
+                              actual: matches.length, passed: matches.empty?)
+        assert_empty matches, "expected no #{reason} messages, got #{matches.map { |entry| entry.message.text }.inspect}"
+      end
+
+      def refute_proactive_status_response
+        matches = classified_messages.select { |entry| entry.proactive && entry.reason == "status_response" }
+        record_eval_assertion(kind: "no_proactive_status_response", expected: 0,
+                              actual: matches.length, passed: matches.empty?)
+        assert_empty matches, "status_response must be pull-only: #{matches.map { |entry| entry.message.text }.inspect}"
+      end
+
+      private
+
+      def duplicate_classifications(window_sec:)
+        seen = Hash.new { |hash, key| hash[key] = [] }
+        duplicates = []
+        classified_messages.sort_by { |entry| entry.message.t }.each do |entry|
+          key = [ entry.reason, entry.message.fingerprint ]
+          cutoff = entry.message.t - window_sec
+          seen[key].select! { |old| old.message.t >= cutoff }
+          duplicates << entry unless seen[key].empty?
+          seen[key] << entry
+        end
+        duplicates
+      end
+
+      def assertion_detail(entry)
+        row = entry.message.row
+        row_detail = row ? " row=#{row.project}/#{row.slug} action=#{row.action} marker=#{row.marker}" : ""
+        "reason=#{entry.reason} proactive=#{entry.proactive} detail=#{entry.detail}#{row_detail} text=#{entry.message.text.inspect}"
+      end
+
+      def record_eval_assertion(kind:, expected:, actual:, passed:, reason: nil)
+        return unless respond_to?(:eval_assertions)
+
+        eval_assertions << {
+          kind: kind,
+          reason: reason,
+          expected: expected,
+          actual: actual,
+          passed: passed
+        }
+      end
+    end
+  end
+end

--- a/test/eval/support/fake_telegram.rb
+++ b/test/eval/support/fake_telegram.rb
@@ -1,0 +1,130 @@
+require "digest"
+require "json"
+require "hive/bot/telegram"
+
+module Hive
+  module Eval
+    class FakeTelegram
+      DEFAULT_CHAT_ID = 12345
+      DEFAULT_USER_ID = 12345
+
+      Sent = Struct.new(
+        :chat_id,
+        :text,
+        :reply_markup,
+        :parse_mode,
+        :t,
+        :fingerprint,
+        :source,
+        :row,
+        :intent,
+        :child,
+        keyword_init: true
+      )
+      Edit = Struct.new(:chat_id, :message_id, :reply_markup, :t, keyword_init: true)
+      CallbackAnswer = Struct.new(:callback_query_id, :text, :show_alert, :t, keyword_init: true)
+
+      attr_reader :sent, :edits, :answered_callbacks
+
+      def initialize(now: -> { Time.now })
+        @now = now
+        @sent = []
+        @edits = []
+        @answered_callbacks = []
+        @updates = []
+      end
+
+      def send_message(chat_id:, text:, reply_markup: nil, parse_mode: nil)
+        @sent << Sent.new(
+          chat_id: chat_id,
+          text: text.to_s,
+          reply_markup: reply_markup,
+          parse_mode: parse_mode,
+          t: @now.call,
+          fingerprint: self.class.payload_fingerprint(text: text, reply_markup: reply_markup)
+        )
+        { "message_id" => @sent.length }
+      end
+
+      def edit_message_reply_markup(chat_id:, message_id:, reply_markup: nil)
+        @edits << Edit.new(
+          chat_id: chat_id,
+          message_id: message_id,
+          reply_markup: reply_markup,
+          t: @now.call
+        )
+        true
+      end
+
+      def answer_callback_query(callback_query_id:, text: nil, show_alert: false)
+        @answered_callbacks << CallbackAnswer.new(
+          callback_query_id: callback_query_id,
+          text: text,
+          show_alert: show_alert,
+          t: @now.call
+        )
+        true
+      end
+
+      def poll_updates(timeout:, since_update_id:)
+        selected, remaining = @updates.partition do |update|
+          since_update_id.nil? || update.update_id >= since_update_id
+        end
+        @updates = remaining
+        selected
+      end
+
+      def inject_update(text:, update_id:, chat_id: DEFAULT_CHAT_ID, from_id: DEFAULT_USER_ID,
+                        message_id: update_id, reply_to_text: nil)
+        update = Hive::Bot::Telegram::Update.new(
+          update_id: update_id,
+          chat_id: chat_id,
+          from_id: from_id,
+          message_id: message_id,
+          text: text,
+          reply_to_text: reply_to_text
+        )
+        @updates << update
+        update
+      end
+
+      def tap_button(callback_data:, update_id:, chat_id: DEFAULT_CHAT_ID,
+                     from_id: DEFAULT_USER_ID, message_id: nil)
+        update = Hive::Bot::Telegram::Update.new(
+          update_id: update_id,
+          chat_id: chat_id,
+          from_id: from_id,
+          message_id: message_id || @sent.length,
+          callback_data: callback_data
+        )
+        @updates << update
+        update
+      end
+
+      def messages_with_keyboard
+        @sent.select { |message| !Array(message.reply_markup).empty? }
+      end
+
+      def self.payload_fingerprint(text:, reply_markup:)
+        Digest::SHA256.hexdigest(JSON.generate([ text.to_s, canonical_reply_markup(reply_markup) ]))
+      end
+
+      def self.canonical_reply_markup(reply_markup)
+        case reply_markup
+        when nil
+          nil
+        when Array
+          reply_markup.map { |row| canonical_reply_markup(row) }
+        when Hash
+          reply_markup.transform_keys(&:to_s).sort.to_h
+        else
+          if reply_markup.respond_to?(:to_h)
+            canonical_reply_markup(reply_markup.to_h)
+          else
+            reply_markup.to_s
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/eval/support/fake_telegram_test.rb
+++ b/test/eval/support/fake_telegram_test.rb
@@ -1,0 +1,30 @@
+require "eval/eval_helper"
+
+class HiveEvalFakeTelegramTest < Minitest::Test
+  def test_records_sent_payloads_and_fingerprints
+    telegram = Hive::Eval::FakeTelegram.new(now: -> { Time.utc(2026, 5, 24, 8, 0, 0) })
+    keyboard = [ [ { text: "Approve", callback_data: "approve:plan:hive:slug:2-brainstorm" } ] ]
+
+    telegram.send_message(chat_id: 12345, text: "Ready", reply_markup: keyboard, parse_mode: :markdown)
+
+    sent = telegram.sent.fetch(0)
+    assert_equal 12345, sent.chat_id
+    assert_equal "Ready", sent.text
+    assert_equal keyboard, sent.reply_markup
+    assert_equal :markdown, sent.parse_mode
+    assert_match(/\A[0-9a-f]{64}\z/, sent.fingerprint)
+  end
+
+  def test_queues_text_and_callback_updates
+    telegram = Hive::Eval::FakeTelegram.new
+    telegram.inject_update(text: "/status", update_id: 10)
+    telegram.tap_button(callback_data: "details:hive:slug", update_id: 11, message_id: 3)
+
+    updates = telegram.poll_updates(timeout: 0, since_update_id: 10)
+
+    assert_equal [ 10, 11 ], updates.map(&:update_id)
+    assert_equal "/status", updates.first.text
+    assert_equal "details:hive:slug", updates.last.callback_data
+    assert_equal 3, updates.last.message_id
+  end
+end

--- a/test/eval/support/harness.rb
+++ b/test/eval/support/harness.rb
@@ -1,0 +1,200 @@
+require "time"
+require "tmpdir"
+require "hive/config"
+require "hive/bot/conversation_store"
+require "hive/bot/notification_dispatcher"
+require "hive/bot/router"
+require "hive/bot/status_watcher"
+require "hive/bot/supervisor"
+
+module Hive
+  module Eval
+    class Harness
+      attr_reader :telegram, :logger, :status_watcher, :child_supervisor, :supervisor, :router
+
+      def initialize(bot_config: nil, telegram: nil, logger: nil, status_watcher: nil,
+                     child_supervisor: nil, notification_dispatcher: nil,
+                     conversation_store: nil, now: Time.utc(2026, 5, 24, 8, 0, 0))
+        @now = now
+        @bot_config = default_bot_config.merge(bot_config || {})
+        @telegram = telegram || Hive::Eval::FakeTelegram.new(now: -> { current_time })
+        @logger = logger || NullLogger.new
+        @status_watcher = status_watcher || QueueStatusWatcher.new
+        @child_supervisor = child_supervisor || NullChildSupervisor.new
+        @conversation_store = conversation_store ||
+          Hive::Bot::ConversationStore.new(ttl_sec: @bot_config.fetch("conversation_ttl_sec"))
+        @router = Hive::Bot::Router.new(
+          bot_config: @bot_config,
+          logger: @logger,
+          conversation_store: @conversation_store
+        )
+        @notification_dispatcher = notification_dispatcher ||
+          Hive::Bot::NotificationDispatcher.new(
+            telegram: @telegram,
+            logger: @logger,
+            bot_config: @bot_config,
+            daemon_enabled: ->(_project) { false },
+            now: -> { current_time }
+          )
+        @supervisor = Hive::Bot::Supervisor.new(
+          config: @bot_config,
+          token: "eval-token",
+          logger: @logger,
+          telegram: @telegram,
+          status_watcher: @status_watcher,
+          notification_dispatcher: @notification_dispatcher,
+          router: @router,
+          child_supervisor: @child_supervisor,
+          conversation_store: @conversation_store,
+          dry_run: false
+        )
+      end
+
+      def sent
+        @telegram.sent
+      end
+
+      def last_sent
+        sent.last
+      end
+
+      def process(update)
+        intent = classify(update)
+        before = sent.length
+        @supervisor.process_update(update)
+        annotate_new_messages(before, source: :handler, intent: intent)
+      end
+
+      def when_user_sends(text, update_id: next_update_id, reply_to_text: nil)
+        update = @telegram.inject_update(text: text, update_id: update_id,
+                                         reply_to_text: reply_to_text)
+        process(update)
+        update
+      end
+
+      def when_user_taps(callback_data, update_id: next_update_id, message_id: nil)
+        update = @telegram.tap_button(callback_data: callback_data, update_id: update_id,
+                                      message_id: message_id)
+        process(update)
+        update
+      end
+
+      def status_tick!(rows:)
+        before = sent.length
+        @status_watcher.queue(rows: rows) if @status_watcher.respond_to?(:queue)
+        result = @supervisor.status_tick
+        annotate_status_messages(before, rows)
+        result
+      end
+
+      def reap_children
+        before = sent.length
+        @supervisor.reap_children
+        annotate_new_messages(before, source: :child)
+      end
+
+      def advance(seconds)
+        @now += seconds
+      end
+
+      def current_time
+        @now
+      end
+
+      private
+
+      def default_bot_config
+        {
+          "chat_id_allowlist" => [ Hive::Eval::FakeTelegram::DEFAULT_CHAT_ID ],
+          "conversation_ttl_sec" => 3600,
+          "long_poll_timeout_sec" => 25,
+          "poll_interval_sec" => 30,
+          "notification_dedupe_window_sec" => 300,
+          "shutdown_grace_sec" => 1,
+          "last_seen_state_file" => nil,
+          "clear_retry_grace_sec" => 1,
+          "codex_budget_usd" => 1,
+          "codex_timeout_sec" => 120,
+          "log_file" => File.join(Dir.tmpdir, "hive-eval-bot.log"),
+          "log_max_bytes" => 10_485_760,
+          "log_max_files" => 5
+        }
+      end
+
+      def classify(update)
+        @router.classify(update)
+      rescue StandardError
+        :unknown
+      end
+
+      def next_update_id
+        @next_update_id ||= 0
+        @next_update_id += 1
+      end
+
+      def annotate_new_messages(before, source:, intent: nil)
+        sent[before..]&.each do |message|
+          message.source = source
+          message.intent = intent if intent
+        end
+      end
+
+      def annotate_status_messages(before, rows)
+        new_messages = sent[before..] || []
+        unmatched_rows = rows.dup
+        new_messages.each do |message|
+          row_idx = unmatched_rows.index do |row|
+            notification = Hive::Bot::NotificationBuilders.build(row)
+            notification && notification.text == message.text
+          end
+          row = row_idx ? unmatched_rows.delete_at(row_idx) : nil
+          message.source = :status_row
+          message.row = row
+        end
+      end
+
+      class NullLogger
+        def event(_name, **_attrs); end
+        def close; end
+      end
+
+      class QueueStatusWatcher
+        def initialize
+          @queued = []
+        end
+
+        def queue(rows:)
+          @queued << rows
+        end
+
+        def fetch
+          Hive::Bot::StatusWatcher::Result.new(ok: true, rows: @queued.shift || [], error: nil)
+        end
+      end
+
+      class NullChildSupervisor
+        attr_reader :commands
+
+        def initialize
+          @commands = []
+          @next_pid = 10_000
+        end
+
+        def dispatch(command_argv:, **opts)
+          @commands << { command_argv: command_argv, opts: opts }
+          @next_pid += 1
+        end
+
+        def reap_all
+          []
+        end
+
+        def terminate_all(grace_sec:); end
+
+        def in_flight_count
+          0
+        end
+      end
+    end
+  end
+end

--- a/test/eval/support/harness.rb
+++ b/test/eval/support/harness.rb
@@ -20,7 +20,8 @@ module Hive
         @telegram = telegram || Hive::Eval::FakeTelegram.new(now: -> { current_time })
         @logger = logger || Hive::Eval::CapturingLogger.new(now: -> { current_time })
         @status_watcher = status_watcher || QueueStatusWatcher.new
-        @child_supervisor = child_supervisor || NullChildSupervisor.new
+        @child_supervisor = child_supervisor ||
+          Hive::Eval::FakeChildSupervisor.new(logger: @logger, now: -> { current_time })
         @conversation_store = conversation_store ||
           Hive::Bot::ConversationStore.new(ttl_sec: @bot_config.fetch("conversation_ttl_sec"))
         @router = Hive::Bot::Router.new(
@@ -167,29 +168,6 @@ module Hive
         end
       end
 
-      class NullChildSupervisor
-        attr_reader :commands
-
-        def initialize
-          @commands = []
-          @next_pid = 10_000
-        end
-
-        def dispatch(command_argv:, **opts)
-          @commands << { command_argv: command_argv, opts: opts }
-          @next_pid += 1
-        end
-
-        def reap_all
-          []
-        end
-
-        def terminate_all(grace_sec:); end
-
-        def in_flight_count
-          0
-        end
-      end
     end
   end
 end

--- a/test/eval/support/harness.rb
+++ b/test/eval/support/harness.rb
@@ -6,6 +6,7 @@ require "hive/bot/notification_dispatcher"
 require "hive/bot/router"
 require "hive/bot/status_watcher"
 require "hive/bot/supervisor"
+require_relative "programmable_status_watcher"
 
 module Hive
   module Eval
@@ -19,7 +20,7 @@ module Hive
         @bot_config = default_bot_config.merge(bot_config || {})
         @telegram = telegram || Hive::Eval::FakeTelegram.new(now: -> { current_time })
         @logger = logger || Hive::Eval::CapturingLogger.new(now: -> { current_time })
-        @status_watcher = status_watcher || QueueStatusWatcher.new
+        @status_watcher = status_watcher || Hive::Eval::ProgrammableStatusWatcher.new
         @child_supervisor = child_supervisor ||
           Hive::Eval::FakeChildSupervisor.new(logger: @logger, now: -> { current_time })
         @conversation_store = conversation_store ||
@@ -151,20 +152,6 @@ module Hive
           row = row_idx ? unmatched_rows.delete_at(row_idx) : nil
           message.source = :status_row
           message.row = row
-        end
-      end
-
-      class QueueStatusWatcher
-        def initialize
-          @queued = []
-        end
-
-        def queue(rows:)
-          @queued << rows
-        end
-
-        def fetch
-          Hive::Bot::StatusWatcher::Result.new(ok: true, rows: @queued.shift || [], error: nil)
         end
       end
 

--- a/test/eval/support/harness.rb
+++ b/test/eval/support/harness.rb
@@ -154,7 +154,6 @@ module Hive
           message.row = row
         end
       end
-
     end
   end
 end

--- a/test/eval/support/harness.rb
+++ b/test/eval/support/harness.rb
@@ -18,7 +18,7 @@ module Hive
         @now = now
         @bot_config = default_bot_config.merge(bot_config || {})
         @telegram = telegram || Hive::Eval::FakeTelegram.new(now: -> { current_time })
-        @logger = logger || NullLogger.new
+        @logger = logger || Hive::Eval::CapturingLogger.new(now: -> { current_time })
         @status_watcher = status_watcher || QueueStatusWatcher.new
         @child_supervisor = child_supervisor || NullChildSupervisor.new
         @conversation_store = conversation_store ||
@@ -151,11 +151,6 @@ module Hive
           message.source = :status_row
           message.row = row
         end
-      end
-
-      class NullLogger
-        def event(_name, **_attrs); end
-        def close; end
       end
 
       class QueueStatusWatcher

--- a/test/eval/support/personas.rb
+++ b/test/eval/support/personas.rb
@@ -1,0 +1,82 @@
+require "json"
+require "open3"
+require "timeout"
+
+module Hive
+  module Eval
+    class ScriptedPersona
+      def initialize(replies:)
+        @replies = replies.dup
+      end
+
+      def respond(bot_message:)
+        raise "scripted persona has no replies left for #{bot_message.inspect}" if @replies.empty?
+
+        @replies.shift
+      end
+    end
+
+    class CodexPersona
+      def initialize(role_prompt:, command: ENV.fetch("HIVE_CODEX_BIN", "codex"), timeout_sec: 120)
+        @role_prompt = role_prompt
+        @command = command
+        @timeout_sec = timeout_sec
+      end
+
+      def respond(bot_message:)
+        stdout, stderr, status = capture(prompt(bot_message))
+        raise "codex persona failed: #{stderr.strip}" unless status.success?
+
+        reply = parse_reply(stdout)
+        raise "codex persona returned an empty reply" if reply.strip.empty?
+
+        reply
+      end
+
+      private
+
+      def capture(prompt)
+        Timeout.timeout(@timeout_sec) do
+          Open3.capture3(@command, "exec", "--json", prompt)
+        end
+      end
+
+      def prompt(bot_message)
+        <<~PROMPT
+          #{@role_prompt}
+
+          Bot message:
+          #{bot_message}
+
+          Reply as the Telegram user. Respond with a JSON object only:
+          {"reply": "..."}
+        PROMPT
+      end
+
+      def parse_reply(stdout)
+        agent_text = stdout.to_s.lines.filter_map do |line|
+          parse_json_line(line)&.dig("item", "text")
+        end.last
+        doc = JSON.parse(extract_json_object(agent_text || stdout))
+        doc.fetch("reply").to_s
+      end
+
+      def parse_json_line(line)
+        JSON.parse(line)
+      rescue JSON::ParserError
+        nil
+      end
+
+      def extract_json_object(text)
+        body = text.to_s.strip
+        body = body.delete_prefix("```json").delete_prefix("```").delete_suffix("```").strip
+        return body if body.start_with?("{") && body.end_with?("}")
+
+        match = body.match(/\{.*\}/m)
+        raise JSON::ParserError, "no JSON object in persona output" unless match
+
+        match[0]
+      end
+    end
+  end
+end

--- a/test/eval/support/personas_test.rb
+++ b/test/eval/support/personas_test.rb
@@ -1,0 +1,33 @@
+require "eval/eval_helper"
+
+class HiveEvalPersonasTest < Minitest::Test
+  def test_scripted_persona_returns_replies_in_order
+    persona = Hive::Eval::ScriptedPersona.new(replies: [ "yes", "no" ])
+
+    assert_equal "yes", persona.respond(bot_message: "First?")
+    assert_equal "no", persona.respond(bot_message: "Second?")
+    assert_raises(RuntimeError) { persona.respond(bot_message: "Third?") }
+  end
+
+  def test_codex_persona_returns_non_empty_reply
+    persona = Hive::Eval::CodexPersona.new(
+      role_prompt: "You are a terse user answering a bot question. Keep the reply under six words."
+    )
+
+    reply = persona.respond(bot_message: "Should Hive continue?")
+
+    refute_empty reply.strip
+  end
+
+  def test_programmable_status_watcher_returns_queued_batches_then_empty
+    watcher = Hive::Eval::ProgrammableStatusWatcher.new
+    first = [ Hive::Bot::StatusWatcher::Row.new(project: "hive", slug: "a", action: "needs_input") ]
+    second = [ Hive::Bot::StatusWatcher::Row.new(project: "hive", slug: "b", action: "agent_running") ]
+    watcher.queue(rows: first)
+    watcher.queue(rows: second)
+
+    assert_equal first, watcher.fetch.rows
+    assert_equal second, watcher.fetch.rows
+    assert_empty watcher.fetch.rows
+  end
+end

--- a/test/eval/support/programmable_status_watcher.rb
+++ b/test/eval/support/programmable_status_watcher.rb
@@ -1,0 +1,19 @@
+require "hive/bot/status_watcher"
+
+module Hive
+  module Eval
+    class ProgrammableStatusWatcher
+      def initialize
+        @queued = []
+      end
+
+      def queue(rows:)
+        @queued << rows
+      end
+
+      def fetch
+        Hive::Bot::StatusWatcher::Result.new(ok: true, rows: @queued.shift || [], error: nil)
+      end
+    end
+  end
+end

--- a/test/eval/support/reason_classifier.rb
+++ b/test/eval/support/reason_classifier.rb
@@ -1,0 +1,145 @@
+require "digest"
+require "json"
+require "hive/bot/notification_builders"
+
+module Hive
+  module Eval
+    class ReasonClassifier
+      ALLOW_LIST = %w[
+        agent_blocked_question
+        status_response
+        task_finished
+        fatal_error
+      ].freeze
+      UNCLASSIFIED = "UNCLASSIFIED"
+
+      Classification = Struct.new(:message, :reason, :proactive, :detail, keyword_init: true)
+
+      ERROR_MARKERS = %w[
+        error
+        review_error
+        review_stale
+        review_ci_stale
+        execute_stale
+      ].freeze
+
+      STATUS_INTENTS = %i[
+        slash_status
+        slash_queue
+        callback_show_details
+        callback_refresh_diagnose
+        slash_help
+        slash_idea
+        callback_idea_project_pick
+        callback_idea_project_new
+        callback_open_laptop
+        callback_reject
+        unknown
+      ].freeze
+
+      COMMAND_ACK_INTENTS = %i[
+        slash_approve
+        slash_done
+        callback_approve
+        callback_clear_and_retry
+        callback_findings_accept_all
+        callback_findings_reject_all
+      ].freeze
+
+      ANSWER_INTENTS = %i[
+        slash_answer
+        callback_answer
+        callback_path_a_yes
+        callback_path_a_just_type
+        callback_codex_write_draft
+        callback_codex_edit
+        callback_codex_cancel
+        free_text_answer
+      ].freeze
+
+      def initialize(messages:, log_events: [])
+        @messages = messages
+        @log_events = log_events
+      end
+
+      def classify_all
+        @messages.map { |message| classify(message) }
+      end
+
+      def classify(message)
+        if message.row
+          reason, detail = classify_row(message.row)
+          return classification(message, reason, proactive: true, detail: detail)
+        end
+
+        if message.source == :handler && message.intent
+          reason, detail = classify_handler(message.intent, message.text)
+          return classification(message, reason, proactive: false, detail: detail)
+        end
+
+        if message.source == :child
+          reason = message.child&.exit_code.to_i.zero? ? "task_finished" : "fatal_error"
+          return classification(message, reason, proactive: false, detail: "child_exit")
+        end
+
+        reason, detail = classify_text(message.text)
+        classification(message, reason, proactive: false, detail: detail)
+      end
+
+      private
+
+      def classification(message, reason, proactive:, detail:)
+        Classification.new(
+          message: message,
+          reason: reason || UNCLASSIFIED,
+          proactive: proactive,
+          detail: detail
+        )
+      end
+
+      def classify_row(row)
+        action = row.action.to_s
+        marker = row.marker.to_s
+        if action == "error" || ERROR_MARKERS.include?(marker)
+          return [ "fatal_error", "row action=#{action.inspect} marker=#{marker.inspect}" ]
+        end
+
+        if Hive::Bot::NotificationBuilders::INPUT_ACTIONS.include?(action)
+          return [ "agent_blocked_question", "row action=#{action.inspect} marker=#{marker.inspect}" ]
+        end
+
+        if Hive::Bot::NotificationBuilders::READY_ACTIONS.include?(action)
+          return [ "task_finished", "row action=#{action.inspect} marker=#{marker.inspect}" ]
+        end
+
+        [ UNCLASSIFIED, "no row mapping for action=#{action.inspect} marker=#{marker.inspect}" ]
+      end
+
+      def classify_handler(intent, text)
+        intent = intent.to_sym
+        return [ "status_response", "handler intent=#{intent}" ] if STATUS_INTENTS.include?(intent)
+        return [ "status_response", "handler command ack intent=#{intent}" ] if COMMAND_ACK_INTENTS.include?(intent)
+        return [ classify_answer_text(text), "handler answer intent=#{intent}" ] if ANSWER_INTENTS.include?(intent)
+
+        [ UNCLASSIFIED, "no handler mapping for intent=#{intent}" ]
+      end
+
+      def classify_answer_text(text)
+        body = text.to_s
+        return "fatal_error" if body.match?(/failed|not found|already answered|lock|confused/i)
+        return "agent_blocked_question" if body.match?(/Answer mode started|Send the answer|Codex draft/i)
+
+        "status_response"
+      end
+
+      def classify_text(text)
+        body = text.to_s
+        return [ "task_finished", "text fallback" ] if body.match?(/Command completed|Already advanced/i)
+        return [ "fatal_error", "text fallback" ] if body.match?(/failed|error|confused|Try again|Stopped/i)
+        return [ "status_response", "text fallback" ] if body.match?(/active task|No active Hive tasks|Action:/i)
+
+        [ UNCLASSIFIED, "no text fallback" ]
+      end
+    end
+  end
+end

--- a/test/eval/support/reason_classifier_test.rb
+++ b/test/eval/support/reason_classifier_test.rb
@@ -1,0 +1,66 @@
+require "eval/eval_helper"
+
+class HiveEvalReasonClassifierTest < Minitest::Test
+  include Hive::Eval::ScenarioSupport
+
+  def test_classifies_row_based_notifications
+    question = message_for(row: status_row(action: "needs_input", marker: "waiting"))
+    ready = message_for(row: status_row(action: "ready_to_finalize", marker: "complete"))
+    fatal = message_for(row: status_row(action: "error", marker: "review_error"))
+
+    reasons = classify(question, ready, fatal).map(&:reason)
+
+    assert_equal %w[agent_blocked_question task_finished fatal_error], reasons
+  end
+
+  def test_classifies_handler_replies
+    status = message_for(source: :handler, intent: :slash_status, text: "1 active task")
+    answer = message_for(source: :handler, intent: :callback_answer, text: "Answer mode started for slug-a.")
+    ack = message_for(source: :handler, intent: :callback_approve, text: "Queued command pid=20001")
+
+    reasons = classify(status, answer, ack).map(&:reason)
+
+    assert_equal %w[status_response agent_blocked_question status_response], reasons
+  end
+
+  def test_contract_reports_unclassified_messages
+    harness.telegram.send_message(chat_id: 12345, text: "heartbeat: still alive")
+
+    error = assert_raises(Minitest::Assertion) { assert_all_messages_typed }
+
+    assert_match(/UNCLASSIFIED/, error.message)
+    assert_match(/heartbeat/, error.message)
+  end
+
+  def test_contract_detects_duplicate_reason_payload_within_window
+    2.times do
+      harness.telegram.send_message(chat_id: 12345, text: "1 active task")
+      harness.sent.last.source = :handler
+      harness.sent.last.intent = :slash_status
+    end
+
+    error = assert_raises(Minitest::Assertion) { assert_no_duplicates(window_sec: 300) }
+
+    assert_match(/duplicate Telegram payloads/, error.message)
+  end
+
+  private
+
+  def classify(*messages)
+    Hive::Eval::ReasonClassifier.new(messages: messages).classify_all
+  end
+
+  def message_for(text: "message", row: nil, source: :status_row, intent: nil)
+    Hive::Eval::FakeTelegram::Sent.new(
+      chat_id: 12345,
+      text: text,
+      reply_markup: nil,
+      parse_mode: nil,
+      t: Time.utc(2026, 5, 24, 8, 0, 0),
+      fingerprint: Hive::Eval::FakeTelegram.payload_fingerprint(text: text, reply_markup: nil),
+      source: source,
+      row: row,
+      intent: intent
+    )
+  end
+end

--- a/test/eval/support/reporter.rb
+++ b/test/eval/support/reporter.rb
@@ -1,0 +1,97 @@
+require "json"
+require "fileutils"
+require "time"
+
+module Hive
+  module Eval
+    module ReportStore
+      module_function
+
+      def enabled?
+        !ENV["HIVE_EVAL_REPORT"].to_s.empty?
+      end
+
+      def entries
+        @entries ||= []
+      end
+
+      def record(test)
+        return unless enabled?
+
+        harness = test.instance_variable_get(:@harness)
+        entries << {
+          scenario_name: "#{test.class}##{test.name}",
+          file: source_location_for(test),
+          status: test.failures.empty? ? "pass" : "fail",
+          failures: test.failures.map { |failure| failure.message.to_s },
+          assertions: test.respond_to?(:eval_assertions) ? test.eval_assertions : [],
+          captured_messages: captured_messages(harness),
+          captured_log_events: captured_log_events(harness),
+          duration_ms: duration_ms(test)
+        }
+      end
+
+      def write!
+        return unless enabled?
+
+        path = ENV.fetch("HIVE_EVAL_REPORT")
+        FileUtils.mkdir_p(File.dirname(path))
+        File.write(path, JSON.pretty_generate({
+          schema: "hive-eval-report",
+          schema_version: 1,
+          generated_at: Time.now.utc.iso8601,
+          scenarios: entries
+        }))
+      end
+
+      def source_location_for(test)
+        test.class.instance_method(test.name).source_location&.first
+      rescue NameError
+        nil
+      end
+
+      def duration_ms(test)
+        started = test.instance_variable_get(:@hive_eval_started_at)
+        return nil unless started
+
+        ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - started) * 1000).round
+      end
+
+      def captured_messages(harness)
+        return [] unless harness
+
+        classifications = Hive::Eval::ReasonClassifier.new(
+          messages: harness.sent,
+          log_events: harness.logger.respond_to?(:events) ? harness.logger.events : []
+        ).classify_all
+        classifications.map do |entry|
+          message = entry.message
+          {
+            text: message.text,
+            chat_id: message.chat_id,
+            reason: entry.reason,
+            proactive: entry.proactive,
+            detail: entry.detail,
+            fingerprint: message.fingerprint,
+            reply_markup: Hive::Eval::FakeTelegram.canonical_reply_markup(message.reply_markup),
+            t: message.t&.utc&.iso8601
+          }
+        end
+      end
+
+      def captured_log_events(harness)
+        return [] unless harness&.logger&.respond_to?(:events)
+
+        harness.logger.events.map do |event|
+          {
+            event: event.name.to_s,
+            attrs: event.attrs,
+            t: event.t&.utc&.iso8601
+          }
+        end
+      end
+    end
+  end
+end
+
+Minitest.after_run { Hive::Eval::ReportStore.write! } if defined?(Minitest)

--- a/test/eval/support/reporter_test.rb
+++ b/test/eval/support/reporter_test.rb
@@ -1,0 +1,39 @@
+require "eval/eval_helper"
+require "json"
+require "open3"
+
+class HiveEvalReporterTest < Minitest::Test
+  def test_cli_writes_report_for_passing_scenario
+    Dir.mktmpdir("hive-eval-report") do |dir|
+      report = File.join(dir, "s1.json")
+
+      _out, err, status = Open3.capture3(
+        { "HIVE_EVAL_NO_JUDGE" => "1" },
+        "bin/hive-eval", "--scenario", "s1_status", "--no-judge", "--report", report
+      )
+
+      assert status.success?, err
+      doc = JSON.parse(File.read(report))
+      assert_equal "hive-eval-report", doc.fetch("schema")
+      assert_equal 2, doc.fetch("scenarios").length
+      assert doc.fetch("scenarios").all? { |entry| entry.fetch("status") == "pass" }
+    end
+  end
+
+  def test_cli_reports_failing_scenario_and_exits_nonzero
+    Dir.mktmpdir("hive-eval-report") do |dir|
+      report = File.join(dir, "s3.json")
+
+      _out, _err, status = Open3.capture3(
+        "bin/hive-eval", "--scenario", "s3_noise", "--no-judge", "--report", report
+      )
+
+      refute status.success?, "scenario 3 is expected to fail against the current bot"
+      doc = JSON.parse(File.read(report))
+      entry = doc.fetch("scenarios").fetch(0)
+      assert_equal "fail", entry.fetch("status")
+      assert_match(/proactive messages violated allow-list/, entry.fetch("failures").join("\n"))
+      assert entry.fetch("captured_messages").any? { |message| message.fetch("reason") == "task_finished" }
+    end
+  end
+end

--- a/test/eval/support/scaffold_test.rb
+++ b/test/eval/support/scaffold_test.rb
@@ -1,0 +1,17 @@
+require "eval/eval_helper"
+
+class HiveEvalScaffoldTest < Minitest::Test
+  include Hive::Eval::ScenarioSupport
+
+  def test_scenario_support_drives_status_query
+    given_project(name: "hive")
+    row = status_row(slug: "question-a")
+    harness.status_watcher.queue(rows: [ row ])
+
+    when_user_sends("/status")
+
+    assert_sent_count 1
+    assert_match(/1 active task/, harness.last_sent.text)
+    assert_match(/hive\/question-a/, harness.last_sent.text)
+  end
+end

--- a/test/eval/support/scenario.rb
+++ b/test/eval/support/scenario.rb
@@ -12,6 +12,7 @@ module Hive
 
       def before_setup
         super
+        @hive_eval_started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         @hive_eval_old_env = {
           "HIVE_HOME" => ENV["HIVE_HOME"]
         }
@@ -23,6 +24,7 @@ module Hive
       end
 
       def after_teardown
+        Hive::Eval::ReportStore.record(self) if defined?(Hive::Eval::ReportStore)
         FileUtils.rm_rf(@scenario_home) if @scenario_home
         @hive_eval_old_env&.each do |key, value|
           value.nil? ? ENV.delete(key) : ENV[key] = value
@@ -104,17 +106,17 @@ module Hive
 
       def assert_judge_rubric_passes(rubric:, text:)
         verdict = if ENV["HIVE_EVAL_NO_JUDGE"] == "1"
-                    Hive::Eval::CodexJudge::Verdict.new(
-                      pass: true,
-                      score: nil,
-                      reason: "skipped by --no-judge",
-                      transcript: "",
-                      model_used: nil,
-                      skipped: true
-                    )
-                  else
-                    Hive::Eval::CodexJudge.new(rubric: rubric).verdict(text: text)
-                  end
+          Hive::Eval::CodexJudge::Verdict.new(
+            pass: true,
+            score: nil,
+            reason: "skipped by --no-judge",
+            transcript: "",
+            model_used: nil,
+            skipped: true
+          )
+        else
+          Hive::Eval::CodexJudge.new(rubric: rubric).verdict(text: text)
+        end
         eval_assertions << {
           kind: "judge",
           reason: "rubric",

--- a/test/eval/support/scenario.rb
+++ b/test/eval/support/scenario.rb
@@ -13,12 +13,10 @@ module Hive
       def before_setup
         super
         @hive_eval_old_env = {
-          "HIVE_HOME" => ENV["HIVE_HOME"],
-          "HOME" => ENV["HOME"]
+          "HIVE_HOME" => ENV["HIVE_HOME"]
         }
         @scenario_home = Dir.mktmpdir("hive-eval")
         ENV["HIVE_HOME"] = @scenario_home
-        ENV["HOME"] = @scenario_home
         @hive_eval_projects = []
         @hive_eval_assertions = []
         write_global_config

--- a/test/eval/support/scenario.rb
+++ b/test/eval/support/scenario.rb
@@ -1,0 +1,140 @@
+require "json"
+require "tmpdir"
+require "yaml"
+require "hive/bot/status_watcher"
+
+module Hive
+  module Eval
+    module ScenarioSupport
+      DEFAULT_PROJECT = "hive"
+
+      def before_setup
+        super
+        @hive_eval_old_env = {
+          "HIVE_HOME" => ENV["HIVE_HOME"],
+          "HOME" => ENV["HOME"]
+        }
+        @scenario_home = Dir.mktmpdir("hive-eval")
+        ENV["HIVE_HOME"] = @scenario_home
+        ENV["HOME"] = @scenario_home
+        @hive_eval_projects = []
+        @hive_eval_assertions = []
+        write_global_config
+      end
+
+      def after_teardown
+        FileUtils.rm_rf(@scenario_home) if @scenario_home
+        @hive_eval_old_env&.each do |key, value|
+          value.nil? ? ENV.delete(key) : ENV[key] = value
+        end
+        super
+      end
+
+      def scenario_home
+        @scenario_home
+      end
+
+      def harness
+        @harness ||= Hive::Eval::Harness.new
+      end
+
+      def given_project(name: DEFAULT_PROJECT, path: nil, daemon_enabled: false)
+        project_path = path || File.join(scenario_home, name)
+        hive_state_path = File.join(project_path, ".hive-state")
+        FileUtils.mkdir_p(File.join(hive_state_path, "stages"))
+        File.write(File.join(hive_state_path, "config.yml"), {
+          "daemon" => { "enabled" => daemon_enabled }
+        }.to_yaml)
+        @hive_eval_projects << {
+          "name" => name,
+          "path" => project_path,
+          "hive_state_path" => hive_state_path
+        }
+        write_global_config
+        project_path
+      end
+
+      def given_brainstorm(project: DEFAULT_PROJECT, slug:, content: nil)
+        project_entry = @hive_eval_projects.find { |entry| entry["name"] == project } ||
+          raise("project #{project.inspect} has not been registered")
+        path = File.join(project_entry.fetch("hive_state_path"), "stages", "2-brainstorm", slug, "brainstorm.md")
+        FileUtils.mkdir_p(File.dirname(path))
+        File.write(path, content || default_brainstorm_content)
+        path
+      end
+
+      def status_row(project: DEFAULT_PROJECT, slug: "task-a", stage: "2-brainstorm",
+                     marker: "waiting", attrs: {}, action: "needs_input",
+                     action_label: nil, diagnostic: nil)
+        Hive::Bot::StatusWatcher::Row.new(
+          project: project,
+          project_path: project_path(project),
+          hive_state_path: hive_state_path(project),
+          slug: slug,
+          stage: stage,
+          marker: marker,
+          attrs: attrs,
+          action: action,
+          action_label: action_label || action.tr("_", " "),
+          diagnostic: diagnostic
+        )
+      end
+
+      def when_user_sends(text, **opts)
+        harness.when_user_sends(text, **opts)
+      end
+
+      def when_user_taps(callback_data, **opts)
+        harness.when_user_taps(callback_data, **opts)
+      end
+
+      def when_agent_emits(rows:)
+        harness.status_tick!(rows: rows)
+      end
+
+      def when_clock_advances(seconds)
+        harness.advance(seconds)
+      end
+
+      def assert_sent_count(count)
+        assert_equal count, harness.sent.length,
+                     "expected #{count} sent Telegram payloads, got #{harness.sent.length}: " \
+                     "#{harness.sent.map(&:text).inspect}"
+      end
+
+      def eval_assertions
+        @hive_eval_assertions
+      end
+
+      private
+
+      def write_global_config
+        FileUtils.mkdir_p(scenario_home)
+        File.write(File.join(scenario_home, "config.yml"), {
+          "registered_projects" => @hive_eval_projects,
+          "bot" => { "chat_id_allowlist" => [ Hive::Eval::FakeTelegram::DEFAULT_CHAT_ID ] }
+        }.to_yaml)
+      end
+
+      def project_path(project)
+        @hive_eval_projects.find { |entry| entry["name"] == project }&.fetch("path", nil)
+      end
+
+      def hive_state_path(project)
+        @hive_eval_projects.find { |entry| entry["name"] == project }&.fetch("hive_state_path", nil)
+      end
+
+      def default_brainstorm_content
+        <<~MARKDOWN
+          ## Round 1
+
+          ### Q1. What should Hive do next?
+
+          ### A1.
+
+          <!-- WAITING -->
+        MARKDOWN
+      end
+    end
+  end
+end

--- a/test/eval/support/scenario.rb
+++ b/test/eval/support/scenario.rb
@@ -6,6 +6,8 @@ require "hive/bot/status_watcher"
 module Hive
   module Eval
     module ScenarioSupport
+      include Hive::Eval::ContractAssertions if defined?(Hive::Eval::ContractAssertions)
+
       DEFAULT_PROJECT = "hive"
 
       def before_setup

--- a/test/eval/support/scenario.rb
+++ b/test/eval/support/scenario.rb
@@ -104,6 +104,31 @@ module Hive
                      "#{harness.sent.map(&:text).inspect}"
       end
 
+      def assert_judge_rubric_passes(rubric:, text:)
+        verdict = if ENV["HIVE_EVAL_NO_JUDGE"] == "1"
+                    Hive::Eval::CodexJudge::Verdict.new(
+                      pass: true,
+                      score: nil,
+                      reason: "skipped by --no-judge",
+                      transcript: "",
+                      model_used: nil,
+                      skipped: true
+                    )
+                  else
+                    Hive::Eval::CodexJudge.new(rubric: rubric).verdict(text: text)
+                  end
+        eval_assertions << {
+          kind: "judge",
+          reason: "rubric",
+          expected: rubric,
+          actual: { pass: verdict.pass, score: verdict.score, reason: verdict.reason, skipped: verdict.skipped },
+          passed: verdict.pass,
+          judge_transcript: verdict.transcript
+        }
+        assert verdict.pass, "judge failed: score=#{verdict.score.inspect} reason=#{verdict.reason}"
+        verdict
+      end
+
       def eval_assertions
         @hive_eval_assertions
       end

--- a/test/unit/bot/notification_builders_test.rb
+++ b/test/unit/bot/notification_builders_test.rb
@@ -86,6 +86,8 @@ class HiveBotNotificationBuildersTest < Minitest::Test
     )
 
     assert_match(/Brainstorm questions/, notification.text)
+    assert_match(/provide input/, notification.text)
+    assert_match(%r{/answer slug-260514-abcd}, notification.text)
     assert_equal "Answer in chat", notification.keyboard.first.first[:text]
     assert_equal "Ask Codex", notification.keyboard[1].first[:text]
   end

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -8,6 +8,14 @@ Append-only log of all wiki operations.
 
 **Refreshed pages:** None - docs-only release note plus this changelog entry.
 
+## [2026-05-24T15:40:00Z] testing - Telegram bot eval harness
+
+**Action:** Added an opt-in `test/eval/` suite and `bin/hive-eval` runner for the Telegram bot. The harness drives the real `Hive::Bot::Supervisor` through fake Telegram/status/child-process boundaries, captures structured bot logs, classifies every outbound payload into the v1 typed-reason contract, and writes JSON reports for agent consumption. Scenario `s3_noise` is intentionally baseline-failing today because proactive ready/finished notifications are classified as `task_finished`, while the v1 contract permits only `agent_blocked_question` and `fatal_error` proactively.
+
+**Refreshed pages:**
+- [[testing]] - documented `rake test:eval`, `bin/hive-eval`, JSON reporting, `--no-judge`, and the expected S3 failure.
+- [[modules/bot]] - documented that the eval harness is test-only and does not change production bot behavior.
+
 ## [2026-05-23T18:00:00Z] claude.mode — tmux envelope parity + daemon-headless callout
 
 **Action:** Hardened the `claude.mode: tmux` path after PR review. `Hive::ClaudeLauncher` now emits the same envelope shape as the headless `claude -p` runner so consumers (status/daemon/bot) see identical `{status, error_message, ...}` regardless of mode; the obsolete `HIVE_BRAINSTORM_TMUX_*` env knobs were removed (config is the single source). CLAUDE.md gained an explicit callout that daemon/service hosts that cannot run tmux must set `claude.mode: headless`. G3+G5 tests expand per-stage `allowed_tools` and tmux session-name coverage so reviewers/finalize don't drift from the launcher contract.

--- a/wiki/modules/bot.md
+++ b/wiki/modules/bot.md
@@ -57,6 +57,10 @@ inserts the literal confirmed text. Two devices racing the same question
 therefore produce one answer and one "already answered" reply, not a
 merged or overwritten block.
 
+## Eval harness
+
+`test/eval/` exercises this module through the same supervisor entrypoints production uses, with only Telegram and child-process I/O replaced by in-process fakes. The harness classifies outbound messages into the eval contract reasons (`agent_blocked_question`, `status_response`, `task_finished`, `fatal_error`) from observable status rows, handler intents, and child exits. That mapping stays test-only; production bot payloads are unchanged.
+
 ## Backlinks
 
 - [[commands/bot]]

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -7,7 +7,7 @@ updated: 2026-05-24
 tags: [test, minitest, fixtures]
 ---
 
-**TLDR**: Minitest for unit/integration coverage, plus an opt-in outer e2e layer. `test/unit/` covers modules, `test/integration/` covers command/stage behaviour in-process, and `test/e2e/` drives the real `bin/hive` subprocess plus tmux for TUI scenarios.
+**TLDR**: Minitest for unit/integration coverage, plus opt-in outer e2e and eval layers. `test/unit/` covers modules, `test/integration/` covers command/stage behaviour in-process, `test/e2e/` drives the real `bin/hive` subprocess plus tmux for TUI scenarios, and `test/eval/` evaluates the Telegram bot signal contract.
 
 ## Run all
 
@@ -91,6 +91,19 @@ bin/hive-e2e run
 ```
 
 The six starter scenarios copy `test/e2e/sample-project/` into a per-run sandbox, set `HIVE_HOME` to a run-local directory, and call the real `bin/hive` as a subprocess. `SandboxEnv` routes both Claude and Codex profile binaries to `test/fixtures/fake-claude`; scenarios that exercise `4-execute` with the default Codex profile must ask the fixture to create a real worktree commit, or execute will correctly stop at `EXECUTE_WAITING reason=no_worktree_changes`. TUI scenarios use private tmux sockets (`hive-e2e-<run-id>`) so they never touch the operator's daily tmux server.
+
+## Eval suite (`test/eval/`)
+
+The Telegram bot eval harness is opt-in and separate from the default suite:
+
+```bash
+bundle exec rake test:eval
+bin/hive-eval --scenario s1_status --no-judge --report /tmp/hive-eval.json
+```
+
+`test/eval/support/` provides an in-process fake Telegram transport, a programmable status watcher, a CLI child-supervisor capture, a scenario DSL, typed-reason contract assertions, scripted/Codex personas, and a Codex prose judge. Scenario files live under `test/eval/scenarios/` and drive the real `Hive::Bot::Supervisor#process_update` / `#status_tick` entrypoints without changing production bot behavior.
+
+`bin/hive-eval` runs only scenario files, writes a `hive-eval-report` JSON document with per-scenario assertions/messages/log events, and exits non-zero on scenario failure. `--no-judge` is the explicit structural-only mode; otherwise Codex judge/persona calls are real subprocess calls. Scenario `s3_noise` is intentionally baseline-failing today: it demonstrates that proactive ready/finished notifications violate the v1 signal contract where only `agent_blocked_question` and `fatal_error` may be proactive.
 
 ## Lint
 


### PR DESCRIPTION
## Summary

The Telegram bot ships dozens of outbound message shapes with no way to verify that users only receive signal (agent questions, status replies, task completions, fatal errors) and not noise (heartbeats, debug rows, duplicates, proactive status spam). This PR adds a Minitest-based eval harness under `test/eval/` that drives the real `Hive::Bot::Supervisor` through an in-process fake Telegram transport, captures every outgoing payload and every structured log event, and asserts a typed-reason contract on every message that would have reached the user.

Five scenarios are wired (S1 status query, S2 agent-in-the-loop Q&A, S3 noise suppression, S4 inline keyboard tap, S5 stuck agent). Scenario 3 is **expected to fail today** against the noisy bot, and that failure is the deliverable. It produces a specific, actionable diff between captured messages and the typed-reason allow-list, motivating the follow-up bot work.

No production code changed. The supervisor's existing constructor injection points (`telegram:`, `logger:`, `status_watcher:`, `notification_dispatcher:`, `child_supervisor:`) were already sufficient.

## How it fits together

```mermaid
flowchart TB
  Scenario["Scenario S1 to S5"] -->|inject_update / tap_button| Harness
  Harness -->|drives| Supervisor["Hive::Bot::Supervisor (real)"]
  Supervisor -->|sendMessage / edit| FakeTelegram
  Supervisor -->|events| CapturingLogger
  Supervisor -->|subprocess argv| CliCapture["FakeChildSupervisor"]
  Harness -->|status_tick rows| Dispatcher["NotificationDispatcher (real)"]
  Dispatcher --> FakeTelegram
  FakeTelegram --> ReasonClassifier
  CapturingLogger --> ReasonClassifier
  ReasonClassifier --> ContractAssertions
  CodexJudge -->|prose verdicts| ContractAssertions
  ContractAssertions --> Reporter["JSON Reporter"]
```

## Design decisions

| Decision | Rationale |
|---|---|
| Fake the Telegram transport, not the bot's own LLM calls | Project rule: no mocks for AI service APIs. Only the I/O boundary is faked; OpenRouter and Codex run for real when scenarios trigger them. |
| Typed reasons derived in the harness, not added to the bot | Today the bot has no typed-reason concept. The classifier reads `row.action` + `row.marker` + handler intent and maps to `{agent_blocked_question, status_response, task_finished, fatal_error}`. When mapping fails, the message is `UNCLASSIFIED` and the assertion fails. Surfacing the gap is the point. |
| S3 is allowed to fail | The harness is "done" when scenario 3 surfaces today's noise problem clearly, not when all five are green. |
| Codex headless as the prose judge | Reuses the `Open3.capture3("codex", "exec", "--json", prompt)` shape already in `lib/hive/agent_profiles/codex.rb`. Used only for `status_response` and `agent_blocked_question` rubrics; structural assertions stay deterministic and judge-free. |
| Virtual clock owned by the harness | Dedup windows are time-based; threading `now:` into `NotificationDispatcher` makes window-expiry deterministic. |

## Running it

```bash
bundle exec rake test:eval           # full suite
bin/hive-eval --scenario s3_noise    # one scenario, JSON report at tmp/hive-eval-report.json
bin/hive-eval --no-judge             # structural only, skip Codex
```

`bin/hive-eval` exits non-zero on any failure so a wrapper can parse the JSON report. The default `rake test` target is unchanged; eval runs are opt-in.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Opus 4.7 (1M context)](https://img.shields.io/badge/Opus_4.7_(1M_context)-D97757?logo=claude&logoColor=white)