### PR TITLE
fix(runtime): correct status and open-pr recovery

### DIFF
--- a/lib/hive/commands/status.rb
+++ b/lib/hive/commands/status.rb
@@ -180,6 +180,12 @@ module Hive
           "age_seconds" => (Time.now - row[:mtime]).to_i,
           "claude_pid" => row[:claude_pid],
           "claude_pid_alive" => row[:claude_pid_alive],
+          # Coerced to boolean so nil never leaks into JSON: live_task_lock is
+          # a tri-state internally (nil = no .lock, true/false = liveness),
+          # but external consumers only need "is the runner still holding it"
+          # and would have to handle JSON null otherwise. Additive field per
+          # the SCHEMA_VERSIONS policy in lib/hive.rb — no version bump.
+          "live_task_lock" => row[:live_task_lock] == true,
           "action" => row[:action_key],
           "action_label" => row[:action_label],
           "suggested_command" => row[:suggested_command],
@@ -487,17 +493,19 @@ module Hive
         true
       end
 
-      def lookup_claude_pid(task)
-        claude_pid_from_lock(task_lock_holder(task))
-      end
-
       def task_lock_holder(task)
         lock_file = File.join(task.folder, ".lock")
         return nil unless File.exist?(lock_file)
 
         data = YAML.safe_load(File.read(lock_file), permitted_classes: [ Time ]) || {}
         data.is_a?(Hash) ? data : nil
-      rescue StandardError
+      rescue StandardError => e
+        # A corrupt or unparseable .lock used to silently drop us into the
+        # "no lock" branch; ops would then see a row classified as ready
+        # despite the disk state showing something was running. Emit a
+        # warn so the inconsistency is visible without changing classifier
+        # semantics (still returning nil).
+        warn "hive: status: failed to read .lock at #{File.join(task.folder, '.lock')}: #{e.class}: #{e.message}"
         nil
       end
 
@@ -509,10 +517,12 @@ module Hive
 
         recorded = holder["process_start_time"]
         live = Hive::Lock.process_start_time(pid)
-        return nil if recorded && live && recorded != live
+        # When recorded is set, a missing or differing live start time means the original process is gone (PID may be reused).
+        return nil if recorded && live != recorded
 
         holder
-      rescue StandardError
+      rescue StandardError => e
+        warn "hive: status: failed to check liveness for lock pid=#{holder['pid'].inspect}: #{e.class}: #{e.message}"
         nil
       end
 

--- a/lib/hive/commands/status.rb
+++ b/lib/hive/commands/status.rb
@@ -237,13 +237,16 @@ module Hive
       # diagnostic=nil and the `--write` path would refuse with "not
       # in a red recovery state."
       def liveness_kwargs_for(task)
-        claude_pid = lookup_claude_pid(task)
+        lock_holder = task_lock_holder(task)
+        live_holder = live_task_lock_holder(lock_holder)
+        claude_pid = claude_pid_from_lock(lock_holder)
         state_file = task.state_file
         mtime = File.exist?(state_file) ? File.mtime(state_file) : nil
         {
           pid_alive: claude_pid ? pid_alive?(claude_pid.to_i) : nil,
           state_file_mtime: mtime,
-          agent_marker_grace_sec: agent_marker_grace_sec_from_config
+          agent_marker_grace_sec: agent_marker_grace_sec_from_config,
+          live_task_lock: !live_holder.nil?
         }
       end
 
@@ -337,8 +340,10 @@ module Hive
             end
             marker = Hive::Markers.current(task.state_file)
             mtime = File.exist?(task.state_file) ? File.mtime(task.state_file) : File.mtime(entry)
-            icon, state_label = decorate(task, marker)
-            claude_pid = lookup_claude_pid(task)
+            lock_holder = task_lock_holder(task)
+            live_holder = live_task_lock_holder(lock_holder)
+            icon, state_label = decorate(task, marker, lock_holder: lock_holder, live_task_lock: !live_holder.nil?)
+            claude_pid = claude_pid_from_lock(lock_holder)
             # Resolve once per row so JSON consumers (bot / daemon / agents)
             # get the absolute worktree path without re-implementing the
             # branch.yml lookup. Pre-execute stages legitimately return
@@ -363,23 +368,27 @@ module Hive
               mtime: mtime,
               age: humanise_age(mtime),
               claude_pid: claude_pid,
-              claude_pid_alive: claude_pid ? pid_alive?(claude_pid.to_i) : nil
+              claude_pid_alive: claude_pid ? pid_alive?(claude_pid.to_i) : nil,
+              live_task_lock: !live_holder.nil?
             }
           end
         end
         rows
       end
 
-      def decorate(task, marker)
+      def decorate(task, marker, lock_holder: nil, live_task_lock: false)
         if marker.name == :agent_working
           # Marker only carries the hive runner PID; the claude subprocess PID
           # is recorded in the per-task .lock file by Hive::Agent.
-          pid = lookup_claude_pid(task) || marker.attrs["pid"]
+          pid = claude_pid_from_lock(lock_holder) || marker.attrs["pid"]
           if pid && pid_alive?(pid.to_i)
             [ "🤖", "agent_working pid=#{pid}" ]
           else
             [ "⚠", "stale lock pid=#{pid}" ]
           end
+        elsif live_task_lock
+          pid = lock_holder && lock_holder["pid"]
+          [ "🤖", pid ? "run_lock pid=#{pid}" : "run_lock" ]
         else
           [ ICON.fetch(marker.name, "·"), label_for(marker) ]
         end
@@ -391,6 +400,7 @@ module Hive
         "Ready to plan",
         "Ready to develop",
         "Needs recovery",
+        "Agent running",
         "Ready to open PR",
         "Ready for review",
         "Ready to collect artifacts",
@@ -413,7 +423,8 @@ module Hive
             stage_collision: slug_counts[row[:slug]] > 1,
             pid_alive: row[:claude_pid_alive],
             state_file_mtime: row[:mtime],
-            agent_marker_grace_sec: grace_sec
+            agent_marker_grace_sec: grace_sec,
+            live_task_lock: row[:live_task_lock]
           )
           row.merge(
             action_key: action.key,
@@ -456,8 +467,12 @@ module Hive
       end
 
       def label_for(marker)
-        attrs = marker.attrs.map { |k, v| "#{k}=#{v}" }.join(" ")
+        attrs = marker.attrs.map { |k, v| "#{k}=#{status_attr_value(v)}" }.join(" ")
         attrs.empty? ? marker.name.to_s : "#{marker.name} #{attrs}"
+      end
+
+      def status_attr_value(value)
+        value.to_s.gsub(/\s+/, " ").strip
       end
 
       def pid_alive?(pid)
@@ -470,13 +485,36 @@ module Hive
       end
 
       def lookup_claude_pid(task)
+        claude_pid_from_lock(task_lock_holder(task))
+      end
+
+      def task_lock_holder(task)
         lock_file = File.join(task.folder, ".lock")
         return nil unless File.exist?(lock_file)
 
-        data = YAML.safe_load(File.read(lock_file)) || {}
-        data.is_a?(Hash) ? data["claude_pid"] : nil
+        data = YAML.safe_load(File.read(lock_file), permitted_classes: [ Time ]) || {}
+        data.is_a?(Hash) ? data : nil
       rescue StandardError
         nil
+      end
+
+      def live_task_lock_holder(holder)
+        return nil unless holder.is_a?(Hash)
+
+        pid = holder["pid"]
+        return nil unless pid.is_a?(Integer) && pid_alive?(pid)
+
+        recorded = holder["process_start_time"]
+        live = Hive::Lock.process_start_time(pid)
+        return nil if recorded && live && recorded != live
+
+        holder
+      rescue StandardError
+        nil
+      end
+
+      def claude_pid_from_lock(holder)
+        holder.is_a?(Hash) ? holder["claude_pid"] : nil
       end
 
       def humanise_age(mtime)

--- a/lib/hive/commands/status.rb
+++ b/lib/hive/commands/status.rb
@@ -517,7 +517,17 @@ module Hive
 
         recorded = holder["process_start_time"]
         live = Hive::Lock.process_start_time(pid)
-        # When recorded is set, a missing or differing live start time means the original process is gone (PID may be reused).
+        # PID-reuse defense: when the lock recorded a start time and the
+        # live counterpart differs (or cannot be read at all), assume the
+        # original process is gone and the PID may have been recycled.
+        # We deliberately lose liveness signal in environments where both
+        # /proc and `ps -o lstart=` are unreadable (e.g. heavily-sandboxed
+        # containers) — see `Hive::Lock.process_start_time` (lib/hive/lock.rb:128-134)
+        # for the nil-return contract. A phantom-live row masking a
+        # recycled PID is the worse failure mode than under-reporting
+        # liveness, so we err toward "stale". Regression coverage:
+        # `test_live_task_lock_with_recorded_but_unreadable_live_start_time_is_stale`
+        # and `test_live_task_lock_with_mismatched_process_start_time_is_treated_as_stale`.
         return nil if recorded && live != recorded
 
         holder

--- a/lib/hive/commands/status.rb
+++ b/lib/hive/commands/status.rb
@@ -383,6 +383,9 @@ module Hive
           pid = claude_pid_from_lock(lock_holder) || marker.attrs["pid"]
           if pid && pid_alive?(pid.to_i)
             [ "🤖", "agent_working pid=#{pid}" ]
+          elsif live_task_lock
+            pid = lock_holder && lock_holder["pid"]
+            [ "🤖", pid ? "run_lock pid=#{pid}" : "run_lock" ]
           else
             [ "⚠", "stale lock pid=#{pid}" ]
           end

--- a/lib/hive/gh.rb
+++ b/lib/hive/gh.rb
@@ -61,22 +61,15 @@ module Hive
       raise Hive::GhError, "git push failed: #{result.stderr.strip.empty? ? result.stdout : result.stderr}"
     end
 
-    # Look up an OPEN pull request for `branch`. Returns:
-    #   - the PR hash when an OPEN PR exists for this branch
-    #   - nil when `gh pr list` succeeds and reports no OPEN PR
+    # Look up all pull requests for `branch`. Returns the raw array from
+    # `gh pr list --state all`; callers decide which states matter.
     # Raises Hive::GhError when `gh pr list` itself fails or returns
     # unparseable JSON — the caller can't safely decide between
-    # "no PR exists" and "remote unavailable" without this signal,
-    # and silently falling through opens a second PR for the same
-    # branch on retry (Plan R5).
+    # "no PR exists" and "remote unavailable" without this signal.
     #
-    # CLOSED/MERGED PRs are explicitly NOT returned: a stale URL
-    # would propagate into pr.md and downstream `gh pr edit` /
-    # `gh pr ready` calls would target a dead PR.
-    #
-    # The returned hash may omit `isDraft` on older/future gh JSON
-    # shapes. Stage code treats a missing key as draft for forward
-    # compatibility; only an explicit false means "already ready".
+    # The returned hashes may omit optional fields on older/future gh JSON
+    # shapes. Stage code treats a missing `isDraft` key as draft for
+    # forward compatibility; only an explicit false means "already ready".
     def lookup_prs_for_branch(worktree_path, branch, cfg: nil)
       # `gh -R` accepts a `owner/repo` slug but not a worktree path;
       # `--repo` likewise. `gh` resolves the remote from cwd's git
@@ -86,7 +79,7 @@ module Hive
       # `-C` flag), not stylistic. Kept here with a comment so the
       # next reader doesn't "fix" it.
       out, err, status = capture3("gh", "pr", "list", "--head", branch,
-                                  "--state", "all", "--json", "url,number,state,isDraft",
+                                  "--state", "all", "--json", "url,number,state,isDraft,headRefName,headRefOid",
                                   chdir: worktree_path, cfg: cfg)
       unless status.success?
         raise Hive::GhError, "`gh pr list` failed for branch #{branch}: #{err.to_s.strip.empty? ? out : err.strip}"
@@ -101,12 +94,17 @@ module Hive
       raise Hive::GhError, "`gh pr list` returned unparseable JSON for branch #{branch}: #{e.message}"
     end
 
+    # Normal open-PR path: return only OPEN pull requests. CLOSED/MERGED
+    # PRs are handled by explicit recovery paths so a stale URL cannot
+    # silently flow into draft-finalization commands.
     def lookup_existing_pr(worktree_path, branch, cfg: nil)
       lookup_prs_for_branch(worktree_path, branch, cfg: cfg).find { |p| p["state"] == "OPEN" }
     end
 
-    def lookup_merged_pr(worktree_path, branch, cfg: nil)
-      lookup_prs_for_branch(worktree_path, branch, cfg: cfg).find { |p| p["state"] == "MERGED" }
+    def lookup_merged_pr(worktree_path, branch, cfg: nil, head_oid: nil)
+      lookup_prs_for_branch(worktree_path, branch, cfg: cfg).find do |p|
+        p["state"] == "MERGED" && (head_oid.nil? || p["headRefOid"].to_s == head_oid.to_s)
+      end
     end
 
     def pr_frontmatter(path)

--- a/lib/hive/gh.rb
+++ b/lib/hive/gh.rb
@@ -77,7 +77,7 @@ module Hive
     # The returned hash may omit `isDraft` on older/future gh JSON
     # shapes. Stage code treats a missing key as draft for forward
     # compatibility; only an explicit false means "already ready".
-    def lookup_existing_pr(worktree_path, branch, cfg: nil)
+    def lookup_prs_for_branch(worktree_path, branch, cfg: nil)
       # `gh -R` accepts a `owner/repo` slug but not a worktree path;
       # `--repo` likewise. `gh` resolves the remote from cwd's git
       # config, so route through chdir. Earlier passes flagged the
@@ -96,9 +96,17 @@ module Hive
       unless list.is_a?(Array)
         raise Hive::GhError, "`gh pr list` returned #{list.class} for branch #{branch}; expected Array"
       end
-      list.find { |p| p["state"] == "OPEN" }
+      list
     rescue JSON::ParserError => e
       raise Hive::GhError, "`gh pr list` returned unparseable JSON for branch #{branch}: #{e.message}"
+    end
+
+    def lookup_existing_pr(worktree_path, branch, cfg: nil)
+      lookup_prs_for_branch(worktree_path, branch, cfg: cfg).find { |p| p["state"] == "OPEN" }
+    end
+
+    def lookup_merged_pr(worktree_path, branch, cfg: nil)
+      lookup_prs_for_branch(worktree_path, branch, cfg: cfg).find { |p| p["state"] == "MERGED" }
     end
 
     def pr_frontmatter(path)

--- a/lib/hive/markers.rb
+++ b/lib/hive/markers.rb
@@ -146,6 +146,11 @@ module Hive
       attrs
     end
 
+    # The three gsubs below are boundary escapes, not data transformations.
+    # `"` -> `'` keeps the outer attr quoting unambiguous for parse_attrs.
+    # `<!--` -> `< !--` and `-->` -> `-- >` prevent attr-value text from
+    # being mistaken for a marker boundary by MARKER_RE. The mapping is
+    # lossy/one-way; readers may see `< !--` in state files and that is intentional.
     def format_attr(value)
       str = value.to_s.gsub('"', "'").gsub("<!--", "< !--").gsub("-->", "-- >")
       str =~ /\s/ ? "\"#{str}\"" : str

--- a/lib/hive/markers.rb
+++ b/lib/hive/markers.rb
@@ -19,8 +19,7 @@ module Hive
       REVIEW_WORKING REVIEW_WAITING REVIEW_CI_STALE
       REVIEW_STALE REVIEW_COMPLETE REVIEW_ERROR
     ].freeze
-    MARKER_RE = /<!--\s*(?<name>WAITING|COMPLETE|AGENT_WORKING|ERROR|MANUAL_STEERING|EXECUTE_WAITING|EXECUTE_COMPLETE|EXECUTE_STALE|REVIEW_WORKING|REVIEW_WAITING|REVIEW_CI_STALE|REVIEW_STALE|REVIEW_COMPLETE|REVIEW_ERROR)(?<attrs>(?:\s+[^<>]*?)?)\s*-->/
-
+    MARKER_RE = /<!--\s*(?<name>WAITING|COMPLETE|AGENT_WORKING|ERROR|MANUAL_STEERING|EXECUTE_WAITING|EXECUTE_COMPLETE|EXECUTE_STALE|REVIEW_WORKING|REVIEW_WAITING|REVIEW_CI_STALE|REVIEW_STALE|REVIEW_COMPLETE|REVIEW_ERROR)(?<attrs>.*?)\s*-->/m
     # Markers whose presence means "this stage is done; the next verb
     # may advance the task". Single source of truth — previously this
     # list was duplicated across `Hive::Commands::StageAction#terminal_marker?`,
@@ -148,7 +147,7 @@ module Hive
     end
 
     def format_attr(value)
-      str = value.to_s
+      str = value.to_s.gsub('"', "'").gsub("-->", "-- >")
       str =~ /\s/ ? "\"#{str}\"" : str
     end
 

--- a/lib/hive/markers.rb
+++ b/lib/hive/markers.rb
@@ -19,7 +19,7 @@ module Hive
       REVIEW_WORKING REVIEW_WAITING REVIEW_CI_STALE
       REVIEW_STALE REVIEW_COMPLETE REVIEW_ERROR
     ].freeze
-    MARKER_RE = /<!--\s*(?<name>WAITING|COMPLETE|AGENT_WORKING|ERROR|MANUAL_STEERING|EXECUTE_WAITING|EXECUTE_COMPLETE|EXECUTE_STALE|REVIEW_WORKING|REVIEW_WAITING|REVIEW_CI_STALE|REVIEW_STALE|REVIEW_COMPLETE|REVIEW_ERROR)(?<attrs>.*?)\s*-->/m
+    MARKER_RE = /<!--\s*(?<name>WAITING|COMPLETE|AGENT_WORKING|ERROR|MANUAL_STEERING|EXECUTE_WAITING|EXECUTE_COMPLETE|EXECUTE_STALE|REVIEW_WORKING|REVIEW_WAITING|REVIEW_CI_STALE|REVIEW_STALE|REVIEW_COMPLETE|REVIEW_ERROR)(?=\s|-->)(?<attrs>(?:(?!<!--).)*?)\s*-->/m
     # Markers whose presence means "this stage is done; the next verb
     # may advance the task". Single source of truth — previously this
     # list was duplicated across `Hive::Commands::StageAction#terminal_marker?`,
@@ -147,7 +147,7 @@ module Hive
     end
 
     def format_attr(value)
-      str = value.to_s.gsub('"', "'").gsub("-->", "-- >")
+      str = value.to_s.gsub('"', "'").gsub("<!--", "< !--").gsub("-->", "-- >")
       str =~ /\s/ ? "\"#{str}\"" : str
     end
 

--- a/lib/hive/stages/open_pr.rb
+++ b/lib/hive/stages/open_pr.rb
@@ -28,6 +28,12 @@ module Hive
         # match the local HEAD so a stale OPEN PR on a re-pushed branch
         # is not silently adopted; the merged-arm has carried that check
         # since the merged-recovery fix.
+        #
+        # Note: `Hive::Gh.lookup_existing_pr` and `lookup_merged_pr` are
+        # still exported on the Gh module because callers like
+        # `validate_complete_marker` (below) invoke them directly. The
+        # de-duplication above only collapses the two-call pattern *inside*
+        # `run!` — the helpers remain available for other call sites.
         prs = Hive::Gh.lookup_prs_for_branch(worktree_path, branch, cfg: cfg)
         head_oid = local_head_oid(worktree_path)
         existing = prs.find do |pr|
@@ -261,8 +267,11 @@ module Hive
       end
 
       def local_head_oid(worktree_path)
-        out, _err, status = Open3.capture3("git", "-C", worktree_path, "rev-parse", "HEAD")
-        return nil unless status.success?
+        out, err, status = Open3.capture3("git", "-C", worktree_path, "rev-parse", "HEAD")
+        unless status.success?
+          warn "hive: open_pr: failed to read worktree HEAD at #{worktree_path}: #{err.to_s.strip}"
+          return nil
+        end
 
         out.strip.empty? ? nil : out.strip
       end
@@ -317,6 +326,13 @@ module Hive
       # used here mirrors what those stages would emit on their own happy
       # path so downstream consumers (Workflows, status) see one consistent
       # terminal shape.
+      #
+      # Cross-references for the short-circuit hand-off:
+      # - `lib/hive/stages/review.rb` (~:102 case-when on `marker.name`,
+      #   `:review_complete` branch) — observes the REVIEW_COMPLETE marker
+      #   we land here on task.md and returns early without spawning.
+      # - `lib/hive/stages/artifacts.rb` (~:14 `:complete` short-circuit
+      #   guard) — observes the COMPLETE marker we land here on artifact.md.
       def write_merged_downstream_markers(task)
         review_state_file = File.join(task.folder, Hive::Task::STATE_FILES.fetch("review"))
         File.write(review_state_file, <<~MD)

--- a/lib/hive/stages/open_pr.rb
+++ b/lib/hive/stages/open_pr.rb
@@ -31,7 +31,8 @@ module Hive
           return { commit: "open_pr_already_open", status: :complete }
         end
 
-        merged = Hive::Gh.lookup_merged_pr(worktree_path, branch, cfg: cfg)
+        head_oid = local_head_oid(worktree_path)
+        merged = head_oid && Hive::Gh.lookup_merged_pr(worktree_path, branch, cfg: cfg, head_oid: head_oid)
         if merged
           write_merged_pr_md(task, merged)
           marker = Hive::Markers.current(task.state_file)
@@ -214,6 +215,13 @@ module Hive
         end
 
         nil
+      end
+
+      def local_head_oid(worktree_path)
+        out, _err, status = Open3.capture3("git", "-C", worktree_path, "rev-parse", "HEAD")
+        return nil unless status.success?
+
+        out.strip.empty? ? nil : out.strip
       end
 
       def write_pr_md(task, existing, idempotent: false)

--- a/lib/hive/stages/open_pr.rb
+++ b/lib/hive/stages/open_pr.rb
@@ -31,6 +31,19 @@ module Hive
           return { commit: "open_pr_already_open", status: :complete }
         end
 
+        merged = Hive::Gh.lookup_merged_pr(worktree_path, branch, cfg: cfg)
+        if merged
+          write_merged_pr_md(task, merged)
+          marker = Hive::Markers.current(task.state_file)
+          scan = Hive::Gh.scan_pr_for_secrets(state_file: task.state_file,
+                                              pr_url: marker.attrs["pr_url"],
+                                              cfg: cfg)
+          return handle_secret_scan_result(task, marker.attrs["pr_url"], scan, "open_pr") if scan.fetch_failed || scan.hits.any?
+
+          write_merged_summary(task, merged)
+          return { commit: "open_pr_already_merged", status: :complete }
+        end
+
         Hive::Gh.push_branch!(worktree_path, branch, cfg: cfg)
 
         prompt = render_prompt(task, worktree_path, branch)
@@ -225,6 +238,46 @@ module Hive
           #{task.folder}
 
           <!-- COMPLETE pr_url=#{pr_url} is_draft=#{is_draft}#{suffix} -->
+        MD
+      end
+
+      def write_merged_pr_md(task, existing)
+        pr_url = existing["url"].to_s
+        pr_number = existing["number"]
+        if pr_url.empty?
+          warn "hive: `gh pr list` returned a merged PR with an empty url; refusing to write pr.md"
+          exit 1
+        end
+        File.write(task.state_file, <<~MD)
+          ---
+          pr_url: #{pr_url}
+          pr_number: #{pr_number}
+          ---
+
+          ## Summary
+          PR already merged for this task.
+
+          ## Linked task
+          #{task.folder}
+
+          <!-- COMPLETE pr_url=#{pr_url} is_draft=false merged=true -->
+        MD
+      end
+
+      def write_merged_summary(task, existing)
+        pr_url = existing["url"].to_s
+        pr_number = existing["number"]
+        File.write(File.join(task.folder, "summary.md"), <<~MD)
+          ## Summary
+          PR ##{pr_number} was already merged before Hive finished the open-pr stage.
+
+          PR: #{pr_url}
+
+          ## Review
+          Hive recovered the task from a stale open-pr state after confirming the PR is merged on GitHub.
+
+          ## Open Escalations
+          None.
         MD
       end
 

--- a/lib/hive/stages/open_pr.rb
+++ b/lib/hive/stages/open_pr.rb
@@ -5,6 +5,7 @@ require "hive/protected_files"
 require "hive/secret_patterns"
 require "hive/claude_launcher"
 require "hive/stages/base"
+require "hive/task"
 require "hive/worktree"
 
 module Hive
@@ -19,7 +20,19 @@ module Hive
 
         Hive::Gh.ensure_authenticated!(cfg)
 
-        existing = Hive::Gh.lookup_existing_pr(worktree_path, branch, cfg: cfg)
+        # Single `gh pr list` round-trip per stage entry. Earlier passes
+        # called `lookup_existing_pr` and `lookup_merged_pr` separately,
+        # each shelling out to `gh pr list --state all` — two network
+        # hits with identical filter args. Pull the list once and branch
+        # in-process. The OPEN-arm filter ALSO requires headRefOid to
+        # match the local HEAD so a stale OPEN PR on a re-pushed branch
+        # is not silently adopted; the merged-arm has carried that check
+        # since the merged-recovery fix.
+        prs = Hive::Gh.lookup_prs_for_branch(worktree_path, branch, cfg: cfg)
+        head_oid = local_head_oid(worktree_path)
+        existing = prs.find do |pr|
+          pr["state"] == "OPEN" && (head_oid.nil? || pr["headRefOid"].to_s == head_oid.to_s)
+        end
         if existing
           write_pr_md(task, existing, idempotent: true)
           marker = Hive::Markers.current(task.state_file)
@@ -31,8 +44,7 @@ module Hive
           return { commit: "open_pr_already_open", status: :complete }
         end
 
-        head_oid = local_head_oid(worktree_path)
-        merged = head_oid && Hive::Gh.lookup_merged_pr(worktree_path, branch, cfg: cfg, head_oid: head_oid)
+        merged = head_oid && prs.find { |pr| pr["state"] == "MERGED" && pr["headRefOid"].to_s == head_oid.to_s }
         if merged
           write_merged_pr_md(task, merged)
           marker = Hive::Markers.current(task.state_file)
@@ -41,6 +53,7 @@ module Hive
                                               cfg: cfg)
           return handle_secret_scan_result(task, marker.attrs["pr_url"], scan, "open_pr") if scan.fetch_failed || scan.hits.any?
 
+          write_merged_downstream_markers(task)
           write_merged_summary(task, merged)
           return { commit: "open_pr_already_merged", status: :complete }
         end
@@ -233,20 +246,13 @@ module Hive
         end
         is_draft = existing["isDraft"] == false ? "false" : "true"
         suffix = idempotent ? " idempotent=true" : ""
-        File.write(task.state_file, <<~MD)
-          ---
-          pr_url: #{pr_url}
-          pr_number: #{pr_number}
-          ---
-
-          ## Summary
-          PR already open for this task.
-
-          ## Linked task
-          #{task.folder}
-
-          <!-- COMPLETE pr_url=#{pr_url} is_draft=#{is_draft}#{suffix} -->
-        MD
+        File.write(task.state_file, pr_md_body(
+          pr_url: pr_url,
+          pr_number: pr_number,
+          summary_text: "PR already open for this task.",
+          task_folder: task.folder,
+          marker_text: "<!-- COMPLETE pr_url=#{pr_url} is_draft=#{is_draft}#{suffix} -->"
+        ))
       end
 
       def write_merged_pr_md(task, existing)
@@ -256,19 +262,62 @@ module Hive
           warn "hive: `gh pr list` returned a merged PR with an empty url; refusing to write pr.md"
           exit 1
         end
-        File.write(task.state_file, <<~MD)
+        File.write(task.state_file, pr_md_body(
+          pr_url: pr_url,
+          pr_number: pr_number,
+          summary_text: "PR already merged for this task.",
+          task_folder: task.folder,
+          marker_text: "<!-- COMPLETE pr_url=#{pr_url} is_draft=false merged=true -->"
+        ))
+      end
+
+      # Shared body for pr.md emitted by both the already-open and merged-
+      # recovery arms. Same frontmatter + Summary + Linked task layout; the
+      # caller supplies the human-readable summary text and the trailing
+      # marker. Extracted in fix #149 so the two heredocs cannot drift.
+      def pr_md_body(pr_url:, pr_number:, summary_text:, task_folder:, marker_text:)
+        <<~MD
           ---
           pr_url: #{pr_url}
           pr_number: #{pr_number}
           ---
 
           ## Summary
-          PR already merged for this task.
+          #{summary_text}
 
           ## Linked task
-          #{task.folder}
+          #{task_folder}
 
-          <!-- COMPLETE pr_url=#{pr_url} is_draft=false merged=true -->
+          #{marker_text}
+        MD
+      end
+
+      # Merged-recovery short-circuits 6-review and 7-artifacts so we don't
+      # rerun reviewers / collect artifacts against an already-merged PR.
+      # Without these markers, a user advancing the folder to 6-review
+      # would see `Hive::Stages::Review.run!` ignore the absent task.md
+      # terminal marker and re-spawn reviewers + CI against the merged PR.
+      # Same logic for 7-artifacts and its artifact.md. The COMPLETE marker
+      # used here mirrors what those stages would emit on their own happy
+      # path so downstream consumers (Workflows, status) see one consistent
+      # terminal shape.
+      def write_merged_downstream_markers(task)
+        review_state_file = File.join(task.folder, Hive::Task::STATE_FILES.fetch("review"))
+        File.write(review_state_file, <<~MD)
+          # Review skipped — PR merged before open-pr finished
+
+          The PR for this task was merged on GitHub before the open-pr stage
+          completed. The 6-review and 7-artifacts loops would otherwise re-run
+          against the merged PR; this terminal marker short-circuits them.
+
+          <!-- REVIEW_COMPLETE pass=0 browser=skipped merged=true -->
+        MD
+
+        artifact_state_file = File.join(task.folder, Hive::Task::STATE_FILES.fetch("artifacts"))
+        File.write(artifact_state_file, <<~MD)
+          # Artifacts skipped — PR merged before open-pr finished
+
+          <!-- COMPLETE merged=true -->
         MD
       end
 

--- a/lib/hive/stages/open_pr.rb
+++ b/lib/hive/stages/open_pr.rb
@@ -46,14 +46,44 @@ module Hive
 
         merged = head_oid && prs.find { |pr| pr["state"] == "MERGED" && pr["headRefOid"].to_s == head_oid.to_s }
         if merged
-          write_merged_pr_md(task, merged)
-          marker = Hive::Markers.current(task.state_file)
-          scan = Hive::Gh.scan_pr_for_secrets(state_file: task.state_file,
-                                              pr_url: marker.attrs["pr_url"],
-                                              cfg: cfg)
-          return handle_secret_scan_result(task, marker.attrs["pr_url"], scan, "open_pr") if scan.fetch_failed || scan.hits.any?
+          pr_url = merged["url"].to_s
+          if pr_url.empty?
+            warn "hive: `gh pr list` returned a merged PR with an empty url; refusing to recover"
+            exit 1
+          end
 
+          # Write pr.md body upfront WITHOUT a terminal marker so
+          # `scan_pr_for_secrets` (which `File.read`s state_file) has content
+          # to scan. The COMPLETE marker is the commit point below — keeping
+          # it last means any mid-sequence failure leaves pr.md non-terminal
+          # and recovery re-enters on the next `hive run` instead of
+          # advancing into a half-written cascade.
+          File.write(task.state_file, pr_md_body(
+            pr_url: pr_url,
+            pr_number: merged["number"],
+            summary_text: "PR already merged for this task.",
+            task_folder: task.folder,
+            marker_text: ""
+          ))
+
+          scan = Hive::Gh.scan_pr_for_secrets(state_file: task.state_file,
+                                              pr_url: pr_url,
+                                              cfg: cfg)
+          return handle_secret_scan_result(task, pr_url, scan, "open_pr") if scan.fetch_failed || scan.hits.any?
+
+          # Downstream short-circuit markers BEFORE the open-pr terminal
+          # marker. They only become observable once the folder is advanced
+          # past 5-open-pr, so writing them first is safe — and if either
+          # File.write raises, pr.md is still non-terminal so the next run
+          # re-enters the recovery path instead of advancing.
           write_merged_downstream_markers(task)
+
+          # Commit point. Once this terminal marker lands, the open-pr stage
+          # is "done" from the state-machine's perspective. write_merged_summary
+          # is documentation only; its failure does not corrupt state.
+          Hive::Markers.set(task.state_file, :complete,
+                            pr_url: pr_url, is_draft: "false", merged: "true")
+
           write_merged_summary(task, merged)
           return { commit: "open_pr_already_merged", status: :complete }
         end
@@ -255,26 +285,12 @@ module Hive
         ))
       end
 
-      def write_merged_pr_md(task, existing)
-        pr_url = existing["url"].to_s
-        pr_number = existing["number"]
-        if pr_url.empty?
-          warn "hive: `gh pr list` returned a merged PR with an empty url; refusing to write pr.md"
-          exit 1
-        end
-        File.write(task.state_file, pr_md_body(
-          pr_url: pr_url,
-          pr_number: pr_number,
-          summary_text: "PR already merged for this task.",
-          task_folder: task.folder,
-          marker_text: "<!-- COMPLETE pr_url=#{pr_url} is_draft=false merged=true -->"
-        ))
-      end
-
-      # Shared body for pr.md emitted by both the already-open and merged-
-      # recovery arms. Same frontmatter + Summary + Linked task layout; the
-      # caller supplies the human-readable summary text and the trailing
-      # marker. Extracted in fix #149 so the two heredocs cannot drift.
+      # Shared body for pr.md. The already-open arm passes a baked-in
+      # COMPLETE marker via `marker_text:`; the merged-recovery arm passes
+      # an empty `marker_text:` and commits the COMPLETE marker via
+      # `Hive::Markers.set` after downstream short-circuit markers land
+      # (so a partial failure leaves pr.md non-terminal — see the
+      # commit-point comment in `run!`).
       def pr_md_body(pr_url:, pr_number:, summary_text:, task_folder:, marker_text:)
         <<~MD
           ---

--- a/lib/hive/task_action.rb
+++ b/lib/hive/task_action.rb
@@ -183,7 +183,8 @@ module Hive
 
     def initialize(task, marker, project_name: nil, project_count: 1, stage_collision: false,
                    pid_alive: nil, state_file_mtime: nil,
-                   agent_marker_grace_sec: DEFAULT_AGENT_MARKER_GRACE_SEC)
+                   agent_marker_grace_sec: DEFAULT_AGENT_MARKER_GRACE_SEC,
+                   live_task_lock: false)
       @task = task
       @marker = marker
       @project_name = project_name
@@ -192,6 +193,7 @@ module Hive
       @pid_alive = pid_alive
       @state_file_mtime = state_file_mtime
       @agent_marker_grace_sec = agent_marker_grace_sec
+      @live_task_lock = live_task_lock
     end
 
     def self.for(task, marker, **)
@@ -236,6 +238,12 @@ module Hive
     private
 
     def action
+      # A live task lock means `hive run` is already inside this task,
+      # including pre-stage work such as auto-rebase. It must pre-empt
+      # marker-derived workflow advice; otherwise status can offer a
+      # duplicate runnable command that immediately hits ConcurrentRunError.
+      return ACTIONS.fetch(:agent_running) if @live_task_lock
+
       # `:agent_working` overrides every (stage, marker) pair — a live
       # agent run on the task pre-empts whatever workflow advice the
       # state-machine would otherwise produce. When liveness signal is

--- a/lib/hive/tui/snapshot.rb
+++ b/lib/hive/tui/snapshot.rb
@@ -55,14 +55,18 @@ module Hive
         :action_label,
         :suggested_command,
         :next_action,
-        :diagnostic
+        :diagnostic,
+        :live_task_lock
       ) do
         # worktree_path defaults to nil so existing test factories that
         # predate PR #84 finding #8 can keep their existing Row.new
         # calls; production code in build_row always passes the value
         # explicitly. New tests should pass it explicitly too.
-        def initialize(worktree_path: nil, **rest)
-          super(worktree_path: worktree_path, **rest)
+        # live_task_lock defaults to false so older JSON payloads (and
+        # tests written before issue #144) keep classifying correctly;
+        # production payloads always emit the boolean explicitly.
+        def initialize(worktree_path: nil, live_task_lock: false, **rest)
+          super(worktree_path: worktree_path, live_task_lock: live_task_lock, **rest)
         end
       end
 
@@ -130,7 +134,8 @@ module Hive
           action_label: payload["action_label"],
           suggested_command: payload["suggested_command"],
           next_action: payload["next_action"],
-          diagnostic: payload["diagnostic"]
+          diagnostic: payload["diagnostic"],
+          live_task_lock: payload["live_task_lock"] == true
         ).freeze
       end
 

--- a/lib/hive/tui/views/usage_footer.rb
+++ b/lib/hive/tui/views/usage_footer.rb
@@ -8,7 +8,6 @@ module Hive
         BUCKET_LABELS = {
           today: "today",
           "7d": "7d",
-          "30d": "30d",
           all: "all"
         }.freeze
 
@@ -25,7 +24,7 @@ module Hive
           parts = BUCKET_LABELS.map do |bucket, label|
             "#{label} #{format_usage(buckets.fetch(bucket, zero_usage))}"
           end
-          "tokens — #{parts.join(' • ')}"
+          parts.join(" • ") + " • tokens"
         end
 
         def format_usage(usage)

--- a/schemas/hive-status.v2.json
+++ b/schemas/hive-status.v2.json
@@ -182,6 +182,7 @@
         "age_seconds",
         "claude_pid",
         "claude_pid_alive",
+        "live_task_lock",
         "action",
         "action_label",
         "suggested_command",
@@ -263,6 +264,10 @@
             "boolean",
             "null"
           ]
+        },
+        "live_task_lock": {
+          "description": "True when the task's .lock file points at a process that is still running (PID alive + start time matches). False when the lock is absent, the PID is dead, or PID reuse was detected. Coerced from nil/true/false to a strict boolean so external consumers (TUI, bots) never see JSON null.",
+          "type": "boolean"
         },
         "action": {
           "type": "string",

--- a/test/fixtures/fake-gh
+++ b/test/fixtures/fake-gh
@@ -58,11 +58,15 @@ case "${1:-}" in
           isdraft="${HIVE_FAKE_GH_PR_ISDRAFT:-true}"
           url="${HIVE_FAKE_GH_PR_EXISTS_URL:-https://example.com/pr/9}"
           num="${HIVE_FAKE_GH_PR_EXISTS_NUMBER:-9}"
-          printf '[{"url":"%s","number":%s,"state":"%s","isDraft":%s}]\n' "$url" "$num" "$state" "$isdraft"
+          head_oid="${HIVE_FAKE_GH_HEAD_REF_OID:-fake-head-oid}"
+          head_name="${HIVE_FAKE_GH_HEAD_REF_NAME:-fake-head}"
+          printf '[{"url":"%s","number":%s,"state":"%s","isDraft":%s,"headRefOid":"%s","headRefName":"%s"}]\n' "$url" "$num" "$state" "$isdraft" "$head_oid" "$head_name"
         elif [[ -n "${HIVE_FAKE_GH_PR_EXISTS:-}" ]]; then
           state="${HIVE_FAKE_GH_PR_STATE:-OPEN}"
           isdraft="${HIVE_FAKE_GH_PR_ISDRAFT:-true}"
-          printf '[{"url":"https://example.com/pr/1","number":1,"state":"%s","isDraft":%s}]\n' "$state" "$isdraft"
+          head_oid="${HIVE_FAKE_GH_HEAD_REF_OID:-fake-head-oid}"
+          head_name="${HIVE_FAKE_GH_HEAD_REF_NAME:-fake-head}"
+          printf '[{"url":"https://example.com/pr/1","number":1,"state":"%s","isDraft":%s,"headRefOid":"%s","headRefName":"%s"}]\n' "$state" "$isdraft" "$head_oid" "$head_name"
         else
           printf '[]\n'
         fi

--- a/test/integration/run_open_pr_test.rb
+++ b/test/integration/run_open_pr_test.rb
@@ -28,6 +28,7 @@ class RunOpenPrTest < Minitest::Test
         HIVE_FAKE_GH_PR_BODY HIVE_FAKE_GH_PR_STATE
         HIVE_FAKE_GH_PR_ISDRAFT HIVE_FAKE_GH_READY_STDERR
         HIVE_FAKE_GH_PR_EXISTS_FILE HIVE_FAKE_GH_PR_EXISTS_URL HIVE_FAKE_GH_PR_EXISTS_NUMBER
+        HIVE_FAKE_GH_HEAD_REF_OID
       ].each { |k| ENV.delete(k) }
     end
 
@@ -40,6 +41,9 @@ class RunOpenPrTest < Minitest::Test
           run!("git", "-C", worktree_path, "push", "-u", "origin", slug, "--quiet")
           ENV["HIVE_FAKE_GH_PR_EXISTS"] = "1"
           ENV["HIVE_FAKE_GH_PR_ISDRAFT"] = "false"
+          # PR #138 fix #146: pin fake-gh's headRefOid to local HEAD so
+          # the already-open short-circuit triggers under the new filter.
+          ENV["HIVE_FAKE_GH_HEAD_REF_OID"] = run!("git", "-C", worktree_path, "rev-parse", "HEAD").strip
 
           capture_io { Hive::Commands::Run.new(task_dir).call }
           pr_md = File.join(task_dir, "pr.md")
@@ -126,6 +130,11 @@ class RunOpenPrTest < Minitest::Test
         task_dir, worktree_path = setup_open_pr_task(dir)
         stub_push(worktree_path)
         ENV["HIVE_FAKE_GH_PR_EXISTS"] = "1"
+        # PR #138 fix #146: open-pr now requires headRefOid to match the
+        # local HEAD before adopting an OPEN PR as already-open. Pin
+        # fake-gh's reported headRefOid to the worktree's current HEAD
+        # so the idempotent short-circuit still triggers.
+        ENV["HIVE_FAKE_GH_HEAD_REF_OID"] = run!("git", "-C", worktree_path, "rev-parse", "HEAD").strip
         # Set a tripwire content the fake-claude WOULD write if invoked —
         # the test then asserts pr.md does NOT have it.
         ENV["HIVE_FAKE_CLAUDE_WRITE_FILE"] = File.join(task_dir, "pr.md")

--- a/test/integration/tui_usage_footer_test.rb
+++ b/test/integration/tui_usage_footer_test.rb
@@ -71,8 +71,9 @@ class TuiUsageFooterTest < Minitest::Test
 
       out = bubble.send(:default_footer, 180)
 
-      assert_includes out, "tokens"
       assert_includes out, "today 1.5k/100/0"
+      assert_includes out, " • all 1.5k/100/0 • tokens"
+      refute_includes out, "30d"
       assert_includes out, "[Tab] switch"
     end
   end

--- a/test/unit/commands/status_test.rb
+++ b/test/unit/commands/status_test.rb
@@ -27,6 +27,37 @@ class CommandsStatusTest < Minitest::Test
     end
   end
 
+  def test_json_payload_emits_live_task_lock_as_strict_boolean
+    # Fix #144 regression guard: external consumers (TUI, daemon, bots)
+    # rely on `live_task_lock` to render the runner badge without
+    # re-parsing the .lock file. Must be a strict boolean — never null —
+    # even when the underlying classifier returned nil (no .lock file).
+    with_tmp_dir do |project_root|
+      hive_state = File.join(project_root, ".hive-state")
+      live_folder = File.join(hive_state, "stages", "4-execute", "live-task-260525-aaaa")
+      idle_folder = File.join(hive_state, "stages", "4-execute", "idle-task-260525-bbbb")
+      FileUtils.mkdir_p(live_folder)
+      FileUtils.mkdir_p(idle_folder)
+      File.write(File.join(live_folder, "task.md"), "<!-- EXECUTE_COMPLETE -->\n")
+      File.write(File.join(live_folder, ".lock"), YAML.dump(
+        "pid" => Process.pid,
+        "process_start_time" => Hive::Lock.process_start_time(Process.pid)
+      ))
+      File.write(File.join(idle_folder, "task.md"), "<!-- EXECUTE_COMPLETE -->\n")
+
+      payload = Hive::Commands::Status.new.json_payload([
+        { "name" => "demo", "path" => project_root, "hive_state_path" => hive_state }
+      ])
+      tasks = payload.fetch("projects").first.fetch("tasks")
+      live = tasks.find { |t| t.fetch("slug") == "live-task-260525-aaaa" }
+      idle = tasks.find { |t| t.fetch("slug") == "idle-task-260525-bbbb" }
+
+      assert_equal true, live.fetch("live_task_lock")
+      assert_equal false, idle.fetch("live_task_lock"),
+                   "rows without a .lock must serialise as false, never nil"
+    end
+  end
+
   def test_call_rejects_empty_diagnose_and_write_without_diagnose
     error = assert_raises(Hive::Error) { Hive::Commands::Status.new(diagnose: "  ").call }
     assert_match(/--diagnose requires a non-empty task slug/, error.message)
@@ -191,6 +222,96 @@ class CommandsStatusTest < Minitest::Test
     end
   end
 
+  def test_live_task_lock_with_recorded_but_unreadable_live_start_time_is_stale
+    # PID-reuse defense: a .lock written with a recorded process_start_time
+    # whose live counterpart can no longer be read (containerised /proc,
+    # PID has since exited and the kernel reused it) must be treated as
+    # stale. Otherwise we'd misclassify a freshly-reused PID as live.
+    with_tmp_dir do |project_root|
+      hive_state = File.join(project_root, ".hive-state")
+      folder = File.join(hive_state, "stages", "4-execute", "phantom-task-260525-abcd")
+      FileUtils.mkdir_p(folder)
+      File.write(File.join(folder, "task.md"), "<!-- EXECUTE_COMPLETE -->\n")
+      File.write(File.join(folder, ".lock"), YAML.dump(
+        "pid" => Process.pid,
+        "process_start_time" => "recorded-but-unreadable-now",
+        "slug" => "phantom-task-260525-abcd",
+        "stage" => "execute"
+      ))
+
+      cmd = Hive::Commands::Status.new
+      rows = nil
+      with_replaced_singleton_method(Hive::Lock, :process_start_time, ->(_pid) { nil }) do
+        rows = cmd.send(:annotate_actions,
+                        cmd.send(:collect_rows, hive_state),
+                        { "name" => "demo" },
+                        1,
+                        with_diagnostic: false)
+      end
+      row = rows.find { |candidate| candidate[:slug] == "phantom-task-260525-abcd" }
+
+      assert_equal false, row.fetch(:live_task_lock),
+                   "recorded start time + nil live start time must be classified as stale (PID may have been reused)"
+    end
+  end
+
+  def test_live_task_lock_with_legacy_lock_omitting_process_start_time_is_live
+    # Backwards-compat: .lock files written before the start-time guard
+    # was introduced have no `process_start_time` key. Treat those as
+    # live when the PID is alive — the alternative (treating legacy locks
+    # as stale) would auto-classify in-flight runs from older hive
+    # versions as recoverable, racing the daemon's auto-heal.
+    with_tmp_dir do |project_root|
+      hive_state = File.join(project_root, ".hive-state")
+      folder = File.join(hive_state, "stages", "4-execute", "legacy-task-260525-abcd")
+      FileUtils.mkdir_p(folder)
+      File.write(File.join(folder, "task.md"), "<!-- EXECUTE_COMPLETE -->\n")
+      File.write(File.join(folder, ".lock"), YAML.dump(
+        "pid" => Process.pid,
+        "slug" => "legacy-task-260525-abcd",
+        "stage" => "execute"
+      ))
+
+      cmd = Hive::Commands::Status.new
+      rows = cmd.send(:annotate_actions,
+                      cmd.send(:collect_rows, hive_state),
+                      { "name" => "demo" },
+                      1,
+                      with_diagnostic: false)
+      row = rows.find { |candidate| candidate[:slug] == "legacy-task-260525-abcd" }
+
+      assert_equal true, row.fetch(:live_task_lock),
+                   "legacy lock without process_start_time must stay live while PID is alive"
+      assert_equal "agent_running", row.fetch(:action_key)
+    end
+  end
+
+  def test_live_task_lock_with_mismatched_process_start_time_is_treated_as_stale
+    with_tmp_dir do |project_root|
+      hive_state = File.join(project_root, ".hive-state")
+      folder = File.join(hive_state, "stages", "4-execute", "executing-task-260524-abcd")
+      FileUtils.mkdir_p(folder)
+      File.write(File.join(folder, "task.md"), "<!-- EXECUTE_COMPLETE -->\n")
+      File.write(File.join(folder, ".lock"), YAML.dump(
+        "pid" => Process.pid,
+        "process_start_time" => "wrong-start-1234",
+        "slug" => "executing-task-260524-abcd",
+        "stage" => "execute"
+      ))
+
+      cmd = Hive::Commands::Status.new
+      rows = cmd.send(:annotate_actions,
+                      cmd.send(:collect_rows, hive_state),
+                      { "name" => "demo" },
+                      1,
+                      with_diagnostic: false)
+      row = rows.find { |candidate| candidate[:slug] == "executing-task-260524-abcd" }
+
+      assert_equal false, row.fetch(:live_task_lock)
+      assert_equal "ready_to_open_pr", row.fetch(:action_key)
+    end
+  end
+
   def test_render_project_skips_empty_action_label_groups
     with_tmp_dir do |project_root|
       hive_state = File.join(project_root, ".hive-state")
@@ -235,9 +356,9 @@ class CommandsStatusTest < Minitest::Test
     with_tmp_dir do |dir|
       task = Struct.new(:folder).new(dir)
       File.write(File.join(dir, ".lock"), "- not\n- a\n- hash\n")
-      assert_nil cmd.send(:lookup_claude_pid, task)
+      assert_nil cmd.send(:claude_pid_from_lock, cmd.send(:task_lock_holder, task))
       File.write(File.join(dir, ".lock"), "[")
-      assert_nil cmd.send(:lookup_claude_pid, task)
+      assert_nil cmd.send(:claude_pid_from_lock, cmd.send(:task_lock_holder, task))
     end
   end
 

--- a/test/unit/commands/status_test.rb
+++ b/test/unit/commands/status_test.rb
@@ -132,6 +132,65 @@ class CommandsStatusTest < Minitest::Test
     end
   end
 
+  def test_agent_working_with_live_runner_lock_is_not_rendered_stale_before_claude_pid
+    with_tmp_dir do |project_root|
+      hive_state = File.join(project_root, ".hive-state")
+      folder = File.join(hive_state, "stages", "5-open-pr", "opening-task-260524-abcd")
+      FileUtils.mkdir_p(folder)
+      File.write(File.join(folder, "pr.md"), "<!-- AGENT_WORKING -->\n")
+      File.write(File.join(folder, ".lock"), YAML.dump(
+        "pid" => Process.pid,
+        "process_start_time" => Hive::Lock.process_start_time(Process.pid),
+        "slug" => "opening-task-260524-abcd",
+        "stage" => "open-pr"
+      ))
+
+      cmd = Hive::Commands::Status.new
+      rows = cmd.send(:annotate_actions,
+                      cmd.send(:collect_rows, hive_state),
+                      { "name" => "demo" },
+                      1,
+                      with_diagnostic: false)
+      row = rows.find { |candidate| candidate[:slug] == "opening-task-260524-abcd" }
+
+      assert_equal :agent_working, row.fetch(:marker_name)
+      assert_equal true, row.fetch(:live_task_lock)
+      assert_nil row.fetch(:claude_pid)
+      assert_equal "agent_running", row.fetch(:action_key)
+      assert_equal "Agent running", row.fetch(:action_label)
+      assert_nil row.fetch(:suggested_command)
+      assert_match(/run_lock pid=#{Process.pid}/, row.fetch(:state_label))
+    end
+  end
+
+  def test_dead_task_lock_does_not_override_marker_derived_action
+    with_tmp_dir do |project_root|
+      hive_state = File.join(project_root, ".hive-state")
+      folder = File.join(hive_state, "stages", "4-execute", "ready-task-260524-abcd")
+      FileUtils.mkdir_p(folder)
+      File.write(File.join(folder, "task.md"), "<!-- EXECUTE_COMPLETE -->\n")
+      File.write(File.join(folder, ".lock"), YAML.dump(
+        "pid" => 12_345,
+        "process_start_time" => "old-start",
+        "slug" => "ready-task-260524-abcd",
+        "stage" => "execute"
+      ))
+
+      cmd = Hive::Commands::Status.new
+      cmd.define_singleton_method(:pid_alive?) { |_pid| false }
+      rows = cmd.send(:annotate_actions,
+                      cmd.send(:collect_rows, hive_state),
+                      { "name" => "demo" },
+                      1,
+                      with_diagnostic: false)
+      row = rows.find { |candidate| candidate[:slug] == "ready-task-260524-abcd" }
+
+      assert_equal false, row.fetch(:live_task_lock)
+      assert_equal "ready_to_open_pr", row.fetch(:action_key)
+      assert_equal "hive open-pr ready-task-260524-abcd --from 4-execute", row.fetch(:suggested_command)
+    end
+  end
+
   def test_render_project_skips_empty_action_label_groups
     with_tmp_dir do |project_root|
       hive_state = File.join(project_root, ".hive-state")

--- a/test/unit/commands/status_test.rb
+++ b/test/unit/commands/status_test.rb
@@ -355,10 +355,23 @@ class CommandsStatusTest < Minitest::Test
 
     with_tmp_dir do |dir|
       task = Struct.new(:folder).new(dir)
+      # Array-shaped (parseable but not a Hash) → silently nil, no warn.
       File.write(File.join(dir, ".lock"), "- not\n- a\n- hash\n")
-      assert_nil cmd.send(:claude_pid_from_lock, cmd.send(:task_lock_holder, task))
+      _out, err = capture_io do
+        assert_nil cmd.send(:claude_pid_from_lock, cmd.send(:task_lock_holder, task))
+      end
+      assert_equal "", err,
+                   "a parseable non-Hash .lock must not trigger the corrupt-lock warn"
+
+      # Malformed YAML → rescue path, must emit warn so the degraded
+      # classification ("no lock" despite something being on disk) is
+      # observable in operator output.
       File.write(File.join(dir, ".lock"), "[")
-      assert_nil cmd.send(:claude_pid_from_lock, cmd.send(:task_lock_holder, task))
+      _out, err = capture_io do
+        assert_nil cmd.send(:claude_pid_from_lock, cmd.send(:task_lock_holder, task))
+      end
+      assert_includes err, "hive: status: failed to read .lock"
+      assert_includes err, "Psych"
     end
   end
 

--- a/test/unit/commands/status_test.rb
+++ b/test/unit/commands/status_test.rb
@@ -102,6 +102,36 @@ class CommandsStatusTest < Minitest::Test
     end
   end
 
+  def test_live_task_lock_overrides_marker_derived_action
+    with_tmp_dir do |project_root|
+      hive_state = File.join(project_root, ".hive-state")
+      folder = File.join(hive_state, "stages", "6-review", "reviewing-task-260524-abcd")
+      FileUtils.mkdir_p(folder)
+      File.write(File.join(folder, "task.md"), "<!-- EXECUTE_COMPLETE -->\n")
+      File.write(File.join(folder, ".lock"), YAML.dump(
+        "pid" => Process.pid,
+        "process_start_time" => Hive::Lock.process_start_time(Process.pid),
+        "slug" => "reviewing-task-260524-abcd",
+        "stage" => "review"
+      ))
+
+      cmd = Hive::Commands::Status.new
+      rows = cmd.send(:annotate_actions,
+                      cmd.send(:collect_rows, hive_state),
+                      { "name" => "demo" },
+                      1,
+                      with_diagnostic: false)
+      row = rows.find { |candidate| candidate[:slug] == "reviewing-task-260524-abcd" }
+
+      assert_equal :execute_complete, row.fetch(:marker_name)
+      assert_equal true, row.fetch(:live_task_lock)
+      assert_equal "agent_running", row.fetch(:action_key)
+      assert_equal "Agent running", row.fetch(:action_label)
+      assert_nil row.fetch(:suggested_command)
+      assert_match(/run_lock pid=#{Process.pid}/, row.fetch(:state_label))
+    end
+  end
+
   def test_render_project_skips_empty_action_label_groups
     with_tmp_dir do |project_root|
       hive_state = File.join(project_root, ".hive-state")
@@ -126,6 +156,8 @@ class CommandsStatusTest < Minitest::Test
     assert_equal [], cmd.send(:detect_legacy_stage_dirs, "/tmp/no-such-hive-state")
     assert_match(/h ago/, cmd.send(:humanise_age, Time.now - 7_200))
     assert_match(/d ago/, cmd.send(:humanise_age, Time.now - 172_800))
+    marker = Hive::Markers::State.new(name: :error, attrs: { "detail" => "line 1\nline 2" }, raw: nil)
+    assert_equal "error detail=line 1 line 2", cmd.send(:label_for, marker)
     assert_equal Hive::Schemas::StatusErrorKind::ERROR,
                  cmd.send(:error_kind_for, Hive::Error.new("generic"))
 

--- a/test/unit/gh_test.rb
+++ b/test/unit/gh_test.rb
@@ -169,12 +169,30 @@ class GhUnitTest < Minitest::Test
   def test_lookup_existing_pr_skips_closed_and_merged
     # Plan correctness: even when a CLOSED/MERGED PR exists for the
     # branch, lookup_existing_pr returns nil so the caller does not
-    # propagate a stale URL into pr.md.
+    # propagate a stale URL into normal open-PR downstream handling.
     with_tmp_git_repo do |dir|
       ENV["HIVE_FAKE_GH_PR_EXISTS"] = "1"
       ENV["HIVE_FAKE_GH_PR_STATE"] = "CLOSED"
       assert_nil Hive::Gh.lookup_existing_pr(dir, "feat-x-260424-aaaa"),
                  "CLOSED PR must not be returned"
+
+      ENV["HIVE_FAKE_GH_PR_STATE"] = "MERGED"
+      assert_nil Hive::Gh.lookup_existing_pr(dir, "feat-x-260424-aaaa"),
+                 "MERGED PR must not be returned by normal open lookup"
+    ensure
+      ENV.delete("HIVE_FAKE_GH_PR_EXISTS")
+      ENV.delete("HIVE_FAKE_GH_PR_STATE")
+    end
+  end
+
+  def test_lookup_merged_pr_returns_merged_pr
+    with_tmp_git_repo do |dir|
+      ENV["HIVE_FAKE_GH_PR_EXISTS"] = "1"
+      ENV["HIVE_FAKE_GH_PR_STATE"] = "MERGED"
+
+      pr = Hive::Gh.lookup_merged_pr(dir, "feat-x-260424-aaaa")
+      assert_equal "MERGED", pr.fetch("state")
+      assert_equal "https://example.com/pr/1", pr.fetch("url")
     ensure
       ENV.delete("HIVE_FAKE_GH_PR_EXISTS")
       ENV.delete("HIVE_FAKE_GH_PR_STATE")

--- a/test/unit/gh_test.rb
+++ b/test/unit/gh_test.rb
@@ -199,6 +199,23 @@ class GhUnitTest < Minitest::Test
     end
   end
 
+  def test_lookup_merged_pr_can_filter_by_head_oid
+    with_tmp_git_repo do |dir|
+      ENV["HIVE_FAKE_GH_LIST_JSON"] = <<~JSON
+        [
+          {"url":"https://example.com/pr/old","number":1,"state":"MERGED","isDraft":false,"headRefOid":"old"},
+          {"url":"https://example.com/pr/current","number":2,"state":"MERGED","isDraft":false,"headRefOid":"current"}
+        ]
+      JSON
+
+      pr = Hive::Gh.lookup_merged_pr(dir, "feat-x-260424-aaaa", head_oid: "current")
+      assert_equal "https://example.com/pr/current", pr.fetch("url")
+      assert_nil Hive::Gh.lookup_merged_pr(dir, "feat-x-260424-aaaa", head_oid: "missing")
+    ensure
+      ENV.delete("HIVE_FAKE_GH_LIST_JSON")
+    end
+  end
+
   # --- push_branch returns PushResult, push_branch! hard-fails ---------
 
   def test_push_branch_returns_push_result_on_failure

--- a/test/unit/markers_test.rb
+++ b/test/unit/markers_test.rb
@@ -41,6 +41,33 @@ class MarkersTest < Minitest::Test
     end
   end
 
+  def test_rejects_marker_names_that_only_prefix_known_names
+    with_tmp_dir do |dir|
+      file = File.join(dir, "x.md")
+      File.write(file, "<!-- COMPLETED -->\n<!-- ERROR_DETAIL reason=boom -->\n<!-- REVIEW_COMPLETE_SUFFIX -->\n")
+
+      state = Hive::Markers.current(file)
+
+      assert_equal :none, state.name
+      assert_empty state.attrs
+    end
+  end
+
+  def test_ignores_unterminated_marker_before_later_valid_marker
+    with_tmp_dir do |dir|
+      file = File.join(dir, "x.md")
+      File.write(file, <<~MD)
+        <!-- ERROR reason="unterminated
+        <!-- COMPLETE -->
+      MD
+
+      state = Hive::Markers.current(file)
+
+      assert_equal :complete, state.name
+      assert_empty state.attrs
+    end
+  end
+
   def test_parses_git_error_detail_with_branch_arrow
     with_tmp_dir do |dir|
       file = File.join(dir, "x.md")
@@ -58,16 +85,16 @@ class MarkersTest < Minitest::Test
     end
   end
 
-  def test_set_sanitizes_quotes_and_comment_close_in_attr_values
+  def test_set_sanitizes_quotes_and_comment_delimiters_in_attr_values
     with_tmp_dir do |dir|
       file = File.join(dir, "x.md")
-      Hive::Markers.set(file, :error, reason: "boom", detail: 'bad "quoted" --> payload')
+      Hive::Markers.set(file, :error, reason: "boom", detail: 'bad "quoted" <!-- marker --> payload')
 
       state = Hive::Markers.current(file)
 
       assert_equal :error, state.name
       assert_equal "boom", state.attrs["reason"]
-      assert_equal "bad 'quoted' -- > payload", state.attrs["detail"]
+      assert_equal "bad 'quoted' < !-- marker -- > payload", state.attrs["detail"]
     end
   end
 

--- a/test/unit/markers_test.rb
+++ b/test/unit/markers_test.rb
@@ -41,6 +41,36 @@ class MarkersTest < Minitest::Test
     end
   end
 
+  def test_parses_git_error_detail_with_branch_arrow
+    with_tmp_dir do |dir|
+      file = File.join(dir, "x.md")
+      File.write(file, <<~MD)
+        <!-- ERROR reason=unpushed_commits detail="To https://github.com/example/repo.git
+         ! [rejected]          branch-a -> branch-a (non-fast-forward)
+        error: failed to push some refs to 'origin'" -->
+      MD
+
+      state = Hive::Markers.current(file)
+
+      assert_equal :error, state.name
+      assert_equal "unpushed_commits", state.attrs["reason"]
+      assert_includes state.attrs.fetch("detail"), "branch-a -> branch-a"
+    end
+  end
+
+  def test_set_sanitizes_quotes_and_comment_close_in_attr_values
+    with_tmp_dir do |dir|
+      file = File.join(dir, "x.md")
+      Hive::Markers.set(file, :error, reason: "boom", detail: 'bad "quoted" --> payload')
+
+      state = Hive::Markers.current(file)
+
+      assert_equal :error, state.name
+      assert_equal "boom", state.attrs["reason"]
+      assert_equal "bad 'quoted' -- > payload", state.attrs["detail"]
+    end
+  end
+
   def test_set_appends_marker_to_empty_file
     with_tmp_dir do |dir|
       file = File.join(dir, "x.md")

--- a/test/unit/stages/open_pr_test.rb
+++ b/test/unit/stages/open_pr_test.rb
@@ -61,7 +61,11 @@ class HiveStagesOpenPrTest < Minitest::Test
         with_replaced_singleton_method(Hive::ProtectedFiles, :snapshot, ->(_folder) { Object.new }) do
           with_replaced_singleton_method(Hive::ProtectedFiles, :diff, ->(_before, _after) { [ "worktree.yml" ] }) do
             with_replaced_singleton_method(Hive::Stages::Base, :spawn_agent, ->(*_args, **_kwargs) { }) do
-              result = Hive::Stages::OpenPr.run!(task, cfg)
+              # capture_io swallows the expected `local_head_oid` warn —
+              # this test uses a plain dir, not a git repo, so the new
+              # rev-parse warn fires by design. Keep it out of test output.
+              result = nil
+              capture_io { result = Hive::Stages::OpenPr.run!(task, cfg) }
 
               marker = Hive::Markers.current(task.state_file)
               assert_equal({ commit: "open_pr_tampered", status: :error }, result)
@@ -88,7 +92,8 @@ class HiveStagesOpenPrTest < Minitest::Test
             with_replaced_singleton_method(Hive::Stages::Base, :spawn_agent, lambda { |_task, **_kwargs|
               Hive::Markers.set(task.state_file, :review_waiting, reason: "human")
             }) do
-              result = Hive::Stages::OpenPr.run!(task, cfg)
+              result = nil
+              capture_io { result = Hive::Stages::OpenPr.run!(task, cfg) }
 
               assert_equal({ commit: nil, status: :review_waiting }, result)
               assert_equal :review_waiting, Hive::Markers.current(task.state_file).name
@@ -137,10 +142,14 @@ class HiveStagesOpenPrTest < Minitest::Test
                 # Fix #142: merged recovery also lands terminal markers on
                 # the downstream stage state files so 6-review and 7-artifacts
                 # short-circuit instead of re-running against a merged PR.
-                review_file = File.join(task.folder, "task.md")
-                artifact_file = File.join(task.folder, "artifact.md")
-                assert File.exist?(review_file), "task.md (6-review state file) must be written"
-                assert File.exist?(artifact_file), "artifact.md (7-artifacts state file) must be written"
+                # Look up the file names via Hive::Task::STATE_FILES (the
+                # same source production uses) so a future rename in
+                # lib/hive/task.rb breaks this assertion instead of letting
+                # the test silently pass while production diverges.
+                review_file = File.join(task.folder, Hive::Task::STATE_FILES.fetch("review"))
+                artifact_file = File.join(task.folder, Hive::Task::STATE_FILES.fetch("artifacts"))
+                assert File.exist?(review_file), "review state file must be written"
+                assert File.exist?(artifact_file), "artifacts state file must be written"
                 review_marker = Hive::Markers.current(review_file)
                 assert_equal :review_complete, review_marker.name
                 assert_equal "true", review_marker.attrs.fetch("merged")
@@ -327,6 +336,135 @@ class HiveStagesOpenPrTest < Minitest::Test
                 end
               end
             end
+          end
+        end
+      end
+    end
+  end
+
+  def test_run_ignores_open_pr_when_head_oid_does_not_match_local_head
+    # Symmetric coverage to test_run_ignores_merged_pr_when_head_oid_does_not_match_local_head.
+    # If a future cleanup pass drops the OPEN-arm headRefOid filter (assuming
+    # `gh pr list --head <branch>` is "good enough" on its own), a stale OPEN
+    # PR on a re-pushed branch could silently be adopted — this test catches
+    # that regression.
+    with_tmp_dir do |root|
+      task = make_task(root)
+      with_tmp_git_repo do |worktree|
+        write_pointer(task, worktree)
+        local_head = run!("git", "-C", worktree, "rev-parse", "HEAD").strip
+        # Stale OPEN PR on the same branch but a different HEAD — must NOT
+        # short-circuit into `open_pr_already_open`.
+        stale_open = {
+          "url" => "https://example.com/pr/stale-open",
+          "number" => 200,
+          "state" => "OPEN",
+          "isDraft" => true,
+          "headRefOid" => "0" * 40
+        }
+        new_pr = {
+          "url" => "https://example.com/pr/fresh",
+          "number" => 201,
+          "state" => "OPEN",
+          "isDraft" => true,
+          "headRefOid" => local_head
+        }
+        list_calls = 0
+        pushed = false
+        scan = Scan.new(fetch_failed: false, fetch_error: nil, hits: [])
+
+        with_replaced_singleton_method(Hive::Gh, :ensure_authenticated!, ->(_cfg) { }) do
+          with_replaced_singleton_method(Hive::Gh, :lookup_prs_for_branch, lambda { |_worktree_path, _branch, cfg:|
+            list_calls += 1
+            list_calls == 1 ? [ stale_open ] : [ new_pr ]
+          }) do
+            with_replaced_singleton_method(Hive::Gh, :push_branch!, ->(_worktree_path, _branch, cfg:) { pushed = true }) do
+              with_replaced_singleton_method(Hive::Gh, :scan_pr_for_secrets, ->(state_file:, pr_url:, cfg:) { scan }) do
+                with_replaced_singleton_method(Hive::Stages::Base, :stage_profile, ->(_cfg, _stage) { :profile }) do
+                  with_replaced_singleton_method(Hive::Stages::Base, :render, ->(_template, _bindings) { "prompt" }) do
+                    with_replaced_singleton_method(Hive::ProtectedFiles, :snapshot, ->(_folder) { Object.new }) do
+                      with_replaced_singleton_method(Hive::ProtectedFiles, :diff, ->(_before, _after) { [] }) do
+                        with_replaced_singleton_method(Hive::Gh, :lookup_existing_pr, lambda { |_worktree, _branch, cfg:| new_pr }) do
+                          with_replaced_singleton_method(Hive::Stages::Base, :spawn_agent, lambda { |spawned_task, **_kwargs|
+                            Hive::Markers.set(spawned_task.state_file, :complete,
+                                              pr_url: new_pr.fetch("url"), is_draft: "true")
+                          }) do
+                            result = Hive::Stages::OpenPr.run!(task, cfg)
+
+                            assert_equal({ commit: "pr_opened_draft", status: :complete }, result)
+                            assert pushed, "stale OPEN PR with mismatched headRefOid must not skip the normal push/create path"
+                            marker = Hive::Markers.current(task.state_file)
+                            assert_equal :complete, marker.name
+                            assert_equal "https://example.com/pr/fresh", marker.attrs.fetch("pr_url"),
+                                         "the freshly-opened PR's url must land on the marker, not the stale OPEN PR's"
+                          end
+                        end
+                      end
+                    end
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+
+  def test_run_lands_error_when_open_pr_recovery_secret_scan_fetch_fails
+    with_tmp_dir do |root|
+      task = make_task(root)
+      with_tmp_git_repo do |worktree|
+        head_oid = run!("git", "-C", worktree, "rev-parse", "HEAD").strip
+        write_pointer(task, worktree)
+        existing = {
+          "url" => "https://example.com/pr/300",
+          "number" => 300,
+          "state" => "OPEN",
+          "isDraft" => true,
+          "headRefOid" => head_oid
+        }
+        fetch_failed = Scan.new(fetch_failed: true, fetch_error: "simulated", hits: [])
+
+        with_basic_open_pr_run_stubs(existing_pr: existing, scan: fetch_failed) do
+          result = Hive::Stages::OpenPr.run!(task, cfg)
+
+          assert_equal({ commit: "open_pr_secret_scan_failed", status: :error }, result)
+          marker = Hive::Markers.current(task.state_file)
+          assert_equal :error, marker.name
+          assert_equal "secret_scan_fetch_failed", marker.attrs.fetch("reason")
+          assert_equal "simulated", marker.attrs.fetch("detail")
+        end
+      end
+    end
+  end
+
+  def test_run_lands_error_when_open_pr_recovery_secret_scan_hits
+    with_tmp_dir do |root|
+      task = make_task(root)
+      with_tmp_git_repo do |worktree|
+        head_oid = run!("git", "-C", worktree, "rev-parse", "HEAD").strip
+        write_pointer(task, worktree)
+        existing = {
+          "url" => "https://example.com/pr/301",
+          "number" => 301,
+          "state" => "OPEN",
+          "isDraft" => true,
+          "headRefOid" => head_oid
+        }
+        hit_scan = Scan.new(fetch_failed: false, fetch_error: nil, hits: [ { name: :aws_key } ])
+        remediated = []
+
+        with_basic_open_pr_run_stubs(existing_pr: existing, scan: hit_scan) do
+          with_replaced_singleton_method(Hive::Stages::OpenPr, :remediate_secret_leak!, ->(url) { remediated << url }) do
+            result = Hive::Stages::OpenPr.run!(task, cfg)
+
+            assert_equal({ commit: "open_pr_secret_blocked", status: :error }, result)
+            marker = Hive::Markers.current(task.state_file)
+            assert_equal :error, marker.name
+            assert_equal "secret_in_pr_body", marker.attrs.fetch("reason")
+            assert_equal "aws_key", marker.attrs.fetch("patterns")
+            assert_equal [ "https://example.com/pr/301" ], remediated
           end
         end
       end

--- a/test/unit/stages/open_pr_test.rb
+++ b/test/unit/stages/open_pr_test.rb
@@ -224,6 +224,48 @@ class HiveStagesOpenPrTest < Minitest::Test
     end
   end
 
+  # If a write between the scan success and the COMPLETE marker raises
+  # (ENOSPC, EROFS, SIGTERM mid-write), pr.md must NOT be left with a
+  # terminal :complete marker — otherwise the open-pr stage looks done
+  # on disk while task.md / artifact.md are missing, and the user
+  # advancing the folder will cascade exactly the way the merged-recovery
+  # path was designed to prevent.
+  def test_merged_recovery_leaves_pr_md_non_terminal_when_downstream_markers_fail
+    with_tmp_dir do |root|
+      task = make_task(root)
+      with_tmp_git_repo do |worktree|
+        head_oid = run!("git", "-C", worktree, "rev-parse", "HEAD").strip
+        write_pointer(task, worktree)
+        merged = {
+          "url" => "https://example.com/pr/200",
+          "number" => 200,
+          "state" => "MERGED",
+          "isDraft" => false,
+          "headRefOid" => head_oid
+        }
+        clean_scan = Scan.new(fetch_failed: false, fetch_error: nil, hits: [])
+
+        with_basic_open_pr_run_stubs(merged_pr: merged, scan: clean_scan) do
+          with_replaced_singleton_method(Hive::Stages::OpenPr, :write_merged_downstream_markers, ->(_t) { raise Errno::ENOSPC, "simulated disk full" }) do
+            assert_raises(Errno::ENOSPC) { Hive::Stages::OpenPr.run!(task, cfg) }
+
+            marker = Hive::Markers.current(task.state_file)
+            refute_equal :complete, marker.name,
+                         "pr.md must NOT carry a terminal :complete marker after a downstream-markers write fails"
+            refute File.exist?(File.join(task.folder, "task.md")),
+                   "task.md should not exist when downstream-markers helper raised before writing it"
+            refute File.exist?(File.join(task.folder, "artifact.md")),
+                   "artifact.md should not exist when downstream-markers helper raised before writing it"
+            refute File.exist?(File.join(task.folder, "summary.md")),
+                   "summary.md should not exist when downstream-markers helper raised"
+            assert_includes File.read(task.state_file), "PR already merged for this task.",
+                            "pr.md body should still be written so a re-run finds expected content"
+          end
+        end
+      end
+    end
+  end
+
   def test_run_ignores_merged_pr_when_head_oid_does_not_match_local_head
     with_tmp_dir do |root|
       task = make_task(root)

--- a/test/unit/stages/open_pr_test.rb
+++ b/test/unit/stages/open_pr_test.rb
@@ -27,14 +27,16 @@ class HiveStagesOpenPrTest < Minitest::Test
     { "budget_usd" => {}, "timeout_sec" => {} }
   end
 
-  def with_basic_open_pr_run_stubs(existing_pr: nil, scan: Scan.new(fetch_failed: false, fetch_error: nil, hits: []), &block)
+  def with_basic_open_pr_run_stubs(existing_pr: nil, merged_pr: nil, scan: Scan.new(fetch_failed: false, fetch_error: nil, hits: []), &block)
     with_replaced_singleton_method(Hive::Gh, :ensure_authenticated!, ->(_cfg) { }) do
       with_replaced_singleton_method(Hive::Gh, :lookup_existing_pr, ->(_worktree_path, _branch, cfg:) { existing_pr }) do
-        with_replaced_singleton_method(Hive::Gh, :push_branch!, ->(_worktree_path, _branch, cfg:) { }) do
-          with_replaced_singleton_method(Hive::Gh, :scan_pr_for_secrets, ->(state_file:, pr_url:, cfg:) { scan }) do
-            with_replaced_singleton_method(Hive::Stages::Base, :stage_profile, ->(_cfg, _stage) { :profile }) do
-              with_replaced_singleton_method(Hive::Stages::Base, :render, ->(_template, _bindings) { "prompt" }) do
-                yield
+        with_replaced_singleton_method(Hive::Gh, :lookup_merged_pr, ->(_worktree_path, _branch, cfg:) { merged_pr }) do
+          with_replaced_singleton_method(Hive::Gh, :push_branch!, ->(_worktree_path, _branch, cfg:) { }) do
+            with_replaced_singleton_method(Hive::Gh, :scan_pr_for_secrets, ->(state_file:, pr_url:, cfg:) { scan }) do
+              with_replaced_singleton_method(Hive::Stages::Base, :stage_profile, ->(_cfg, _stage) { :profile }) do
+                with_replaced_singleton_method(Hive::Stages::Base, :render, ->(_template, _bindings) { "prompt" }) do
+                  yield
+                end
               end
             end
           end
@@ -85,6 +87,43 @@ class HiveStagesOpenPrTest < Minitest::Test
 
               assert_equal({ commit: nil, status: :review_waiting }, result)
               assert_equal :review_waiting, Hive::Markers.current(task.state_file).name
+            end
+          end
+        end
+      end
+    end
+  end
+
+  def test_run_recovers_when_branch_pr_is_already_merged
+    with_tmp_dir do |root|
+      task = make_task(root)
+      worktree = File.join(root, "worktree")
+      FileUtils.mkdir_p(worktree)
+      write_pointer(task, worktree)
+      merged = {
+        "url" => "https://example.com/pr/134",
+        "number" => 134,
+        "state" => "MERGED",
+        "isDraft" => false
+      }
+      scan = Scan.new(fetch_failed: false, fetch_error: nil, hits: [])
+
+      with_replaced_singleton_method(Hive::Gh, :ensure_authenticated!, ->(_cfg) { }) do
+        with_replaced_singleton_method(Hive::Gh, :lookup_existing_pr, ->(_worktree_path, _branch, cfg:) { nil }) do
+          with_replaced_singleton_method(Hive::Gh, :lookup_merged_pr, ->(_worktree_path, _branch, cfg:) { merged }) do
+            with_replaced_singleton_method(Hive::Gh, :push_branch!, ->(_worktree_path, _branch, cfg:) { flunk "merged recovery must not push" }) do
+              with_replaced_singleton_method(Hive::Gh, :scan_pr_for_secrets, ->(state_file:, pr_url:, cfg:) { scan }) do
+                result = Hive::Stages::OpenPr.run!(task, cfg)
+
+                assert_equal({ commit: "open_pr_already_merged", status: :complete }, result)
+                marker = Hive::Markers.current(task.state_file)
+                assert_equal :complete, marker.name
+                assert_equal "https://example.com/pr/134", marker.attrs.fetch("pr_url")
+                assert_equal "false", marker.attrs.fetch("is_draft")
+                assert_equal "true", marker.attrs.fetch("merged")
+                assert_includes File.read(task.state_file), "PR already merged for this task."
+                assert_includes File.read(File.join(task.folder, "summary.md")), "PR #134 was already merged"
+              end
             end
           end
         end

--- a/test/unit/stages/open_pr_test.rb
+++ b/test/unit/stages/open_pr_test.rb
@@ -30,7 +30,7 @@ class HiveStagesOpenPrTest < Minitest::Test
   def with_basic_open_pr_run_stubs(existing_pr: nil, merged_pr: nil, scan: Scan.new(fetch_failed: false, fetch_error: nil, hits: []), &block)
     with_replaced_singleton_method(Hive::Gh, :ensure_authenticated!, ->(_cfg) { }) do
       with_replaced_singleton_method(Hive::Gh, :lookup_existing_pr, ->(_worktree_path, _branch, cfg:) { existing_pr }) do
-        with_replaced_singleton_method(Hive::Gh, :lookup_merged_pr, ->(_worktree_path, _branch, cfg:) { merged_pr }) do
+        with_replaced_singleton_method(Hive::Gh, :lookup_merged_pr, ->(_worktree_path, _branch, cfg:, head_oid: nil) { merged_pr }) do
           with_replaced_singleton_method(Hive::Gh, :push_branch!, ->(_worktree_path, _branch, cfg:) { }) do
             with_replaced_singleton_method(Hive::Gh, :scan_pr_for_secrets, ->(state_file:, pr_url:, cfg:) { scan }) do
               with_replaced_singleton_method(Hive::Stages::Base, :stage_profile, ->(_cfg, _stage) { :profile }) do
@@ -97,32 +97,109 @@ class HiveStagesOpenPrTest < Minitest::Test
   def test_run_recovers_when_branch_pr_is_already_merged
     with_tmp_dir do |root|
       task = make_task(root)
-      worktree = File.join(root, "worktree")
-      FileUtils.mkdir_p(worktree)
-      write_pointer(task, worktree)
-      merged = {
-        "url" => "https://example.com/pr/134",
-        "number" => 134,
-        "state" => "MERGED",
-        "isDraft" => false
-      }
-      scan = Scan.new(fetch_failed: false, fetch_error: nil, hits: [])
+      with_tmp_git_repo do |worktree|
+        head_oid = run!("git", "-C", worktree, "rev-parse", "HEAD").strip
+        write_pointer(task, worktree)
+        merged = {
+          "url" => "https://example.com/pr/134",
+          "number" => 134,
+          "state" => "MERGED",
+          "isDraft" => false,
+          "headRefOid" => head_oid
+        }
+        scan = Scan.new(fetch_failed: false, fetch_error: nil, hits: [])
+        scanned = []
+        received_head_oid = nil
 
-      with_replaced_singleton_method(Hive::Gh, :ensure_authenticated!, ->(_cfg) { }) do
-        with_replaced_singleton_method(Hive::Gh, :lookup_existing_pr, ->(_worktree_path, _branch, cfg:) { nil }) do
-          with_replaced_singleton_method(Hive::Gh, :lookup_merged_pr, ->(_worktree_path, _branch, cfg:) { merged }) do
-            with_replaced_singleton_method(Hive::Gh, :push_branch!, ->(_worktree_path, _branch, cfg:) { flunk "merged recovery must not push" }) do
-              with_replaced_singleton_method(Hive::Gh, :scan_pr_for_secrets, ->(state_file:, pr_url:, cfg:) { scan }) do
-                result = Hive::Stages::OpenPr.run!(task, cfg)
+        with_replaced_singleton_method(Hive::Gh, :ensure_authenticated!, ->(_cfg) { }) do
+          with_replaced_singleton_method(Hive::Gh, :lookup_existing_pr, ->(_worktree_path, _branch, cfg:) { nil }) do
+            with_replaced_singleton_method(Hive::Gh, :lookup_merged_pr, lambda { |_worktree_path, _branch, cfg:, head_oid: nil|
+              received_head_oid = head_oid
+              merged
+            }) do
+              with_replaced_singleton_method(Hive::Gh, :push_branch!, ->(_worktree_path, _branch, cfg:) { flunk "merged recovery must not push" }) do
+                with_replaced_singleton_method(Hive::Gh, :scan_pr_for_secrets, lambda { |state_file:, pr_url:, cfg:|
+                  scanned << [ state_file, pr_url ]
+                  scan
+                }) do
+                  result = Hive::Stages::OpenPr.run!(task, cfg)
 
-                assert_equal({ commit: "open_pr_already_merged", status: :complete }, result)
-                marker = Hive::Markers.current(task.state_file)
-                assert_equal :complete, marker.name
-                assert_equal "https://example.com/pr/134", marker.attrs.fetch("pr_url")
-                assert_equal "false", marker.attrs.fetch("is_draft")
-                assert_equal "true", marker.attrs.fetch("merged")
-                assert_includes File.read(task.state_file), "PR already merged for this task."
-                assert_includes File.read(File.join(task.folder, "summary.md")), "PR #134 was already merged"
+                  assert_equal({ commit: "open_pr_already_merged", status: :complete }, result)
+                  assert_equal head_oid, received_head_oid
+                  assert_equal [[ task.state_file, "https://example.com/pr/134" ]], scanned
+                  marker = Hive::Markers.current(task.state_file)
+                  assert_equal :complete, marker.name
+                  assert_equal "https://example.com/pr/134", marker.attrs.fetch("pr_url")
+                  assert_equal "false", marker.attrs.fetch("is_draft")
+                  assert_equal "true", marker.attrs.fetch("merged")
+                  assert_includes File.read(task.state_file), "PR already merged for this task."
+                  assert_includes File.read(File.join(task.folder, "summary.md")), "PR #134 was already merged"
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+
+  def test_run_ignores_merged_pr_when_head_oid_does_not_match_local_head
+    with_tmp_dir do |root|
+      task = make_task(root)
+      with_tmp_git_repo do |worktree|
+        local_head = run!("git", "-C", worktree, "rev-parse", "HEAD").strip
+        write_pointer(task, worktree)
+        old_merged = {
+          "url" => "https://example.com/pr/old",
+          "number" => 133,
+          "state" => "MERGED",
+          "isDraft" => false,
+          "headRefOid" => "0" * 40
+        }
+        new_pr = {
+          "url" => "https://example.com/pr/new",
+          "number" => 135,
+          "state" => "OPEN",
+          "isDraft" => true
+        }
+        existing_calls = 0
+        pushed = false
+        received_head_oid = nil
+        scan = Scan.new(fetch_failed: false, fetch_error: nil, hits: [])
+
+        with_replaced_singleton_method(Hive::Gh, :ensure_authenticated!, ->(_cfg) { }) do
+          with_replaced_singleton_method(Hive::Gh, :lookup_existing_pr, lambda { |_worktree_path, _branch, cfg:|
+            existing_calls += 1
+            existing_calls == 1 ? nil : new_pr
+          }) do
+            with_replaced_singleton_method(Hive::Gh, :lookup_merged_pr, lambda { |_worktree_path, _branch, cfg:, head_oid: nil|
+              received_head_oid = head_oid
+              old_merged.fetch("headRefOid") == head_oid ? old_merged : nil
+            }) do
+              with_replaced_singleton_method(Hive::Gh, :push_branch!, ->(_worktree_path, _branch, cfg:) { pushed = true }) do
+                with_replaced_singleton_method(Hive::Gh, :scan_pr_for_secrets, ->(state_file:, pr_url:, cfg:) { scan }) do
+                  with_replaced_singleton_method(Hive::Stages::Base, :stage_profile, ->(_cfg, _stage) { :profile }) do
+                    with_replaced_singleton_method(Hive::Stages::Base, :render, ->(_template, _bindings) { "prompt" }) do
+                      with_replaced_singleton_method(Hive::ProtectedFiles, :snapshot, ->(_folder) { Object.new }) do
+                        with_replaced_singleton_method(Hive::ProtectedFiles, :diff, ->(_before, _after) { [] }) do
+                          with_replaced_singleton_method(Hive::Stages::Base, :spawn_agent, lambda { |spawned_task, **_kwargs|
+                            Hive::Markers.set(spawned_task.state_file, :complete,
+                                              pr_url: new_pr.fetch("url"), is_draft: "true")
+                          }) do
+                            result = Hive::Stages::OpenPr.run!(task, cfg)
+
+                            assert_equal({ commit: "pr_opened_draft", status: :complete }, result)
+                            assert_equal local_head, received_head_oid
+                            assert pushed, "mismatched historical merged PR must not skip the normal push/create path"
+                            refute File.exist?(File.join(task.folder, "summary.md"))
+                            marker = Hive::Markers.current(task.state_file)
+                            assert_equal "https://example.com/pr/new", marker.attrs.fetch("pr_url")
+                          end
+                        end
+                      end
+                    end
+                  end
+                end
               end
             end
           end

--- a/test/unit/stages/open_pr_test.rb
+++ b/test/unit/stages/open_pr_test.rb
@@ -28,15 +28,20 @@ class HiveStagesOpenPrTest < Minitest::Test
   end
 
   def with_basic_open_pr_run_stubs(existing_pr: nil, merged_pr: nil, scan: Scan.new(fetch_failed: false, fetch_error: nil, hits: []), &block)
+    # With PR #138 fix #145, run! calls `lookup_prs_for_branch` ONCE and
+    # filters in-process. The legacy `existing_pr` / `merged_pr` kwargs
+    # are preserved for caller ergonomics: we compose the canonical
+    # `gh pr list` array from them.
+    prs = []
+    prs << existing_pr.merge("state" => existing_pr["state"] || "OPEN") if existing_pr
+    prs << merged_pr.merge("state" => merged_pr["state"] || "MERGED") if merged_pr
     with_replaced_singleton_method(Hive::Gh, :ensure_authenticated!, ->(_cfg) { }) do
-      with_replaced_singleton_method(Hive::Gh, :lookup_existing_pr, ->(_worktree_path, _branch, cfg:) { existing_pr }) do
-        with_replaced_singleton_method(Hive::Gh, :lookup_merged_pr, ->(_worktree_path, _branch, cfg:, head_oid: nil) { merged_pr }) do
-          with_replaced_singleton_method(Hive::Gh, :push_branch!, ->(_worktree_path, _branch, cfg:) { }) do
-            with_replaced_singleton_method(Hive::Gh, :scan_pr_for_secrets, ->(state_file:, pr_url:, cfg:) { scan }) do
-              with_replaced_singleton_method(Hive::Stages::Base, :stage_profile, ->(_cfg, _stage) { :profile }) do
-                with_replaced_singleton_method(Hive::Stages::Base, :render, ->(_template, _bindings) { "prompt" }) do
-                  yield
-                end
+      with_replaced_singleton_method(Hive::Gh, :lookup_prs_for_branch, ->(_worktree_path, _branch, cfg:) { prs }) do
+        with_replaced_singleton_method(Hive::Gh, :push_branch!, ->(_worktree_path, _branch, cfg:) { }) do
+          with_replaced_singleton_method(Hive::Gh, :scan_pr_for_secrets, ->(state_file:, pr_url:, cfg:) { scan }) do
+            with_replaced_singleton_method(Hive::Stages::Base, :stage_profile, ->(_cfg, _stage) { :profile }) do
+              with_replaced_singleton_method(Hive::Stages::Base, :render, ->(_template, _bindings) { "prompt" }) do
+                yield
               end
             end
           end
@@ -109,34 +114,110 @@ class HiveStagesOpenPrTest < Minitest::Test
         }
         scan = Scan.new(fetch_failed: false, fetch_error: nil, hits: [])
         scanned = []
-        received_head_oid = nil
 
         with_replaced_singleton_method(Hive::Gh, :ensure_authenticated!, ->(_cfg) { }) do
-          with_replaced_singleton_method(Hive::Gh, :lookup_existing_pr, ->(_worktree_path, _branch, cfg:) { nil }) do
-            with_replaced_singleton_method(Hive::Gh, :lookup_merged_pr, lambda { |_worktree_path, _branch, cfg:, head_oid: nil|
-              received_head_oid = head_oid
-              merged
-            }) do
-              with_replaced_singleton_method(Hive::Gh, :push_branch!, ->(_worktree_path, _branch, cfg:) { flunk "merged recovery must not push" }) do
-                with_replaced_singleton_method(Hive::Gh, :scan_pr_for_secrets, lambda { |state_file:, pr_url:, cfg:|
-                  scanned << [ state_file, pr_url ]
-                  scan
-                }) do
-                  result = Hive::Stages::OpenPr.run!(task, cfg)
+          with_replaced_singleton_method(Hive::Gh, :lookup_prs_for_branch, ->(_worktree_path, _branch, cfg:) { [ merged ] }) do
+            with_replaced_singleton_method(Hive::Gh, :push_branch!, ->(_worktree_path, _branch, cfg:) { flunk "merged recovery must not push" }) do
+              with_replaced_singleton_method(Hive::Gh, :scan_pr_for_secrets, lambda { |state_file:, pr_url:, cfg:|
+                scanned << [ state_file, pr_url ]
+                scan
+              }) do
+                result = Hive::Stages::OpenPr.run!(task, cfg)
 
-                  assert_equal({ commit: "open_pr_already_merged", status: :complete }, result)
-                  assert_equal head_oid, received_head_oid
-                  assert_equal [[ task.state_file, "https://example.com/pr/134" ]], scanned
-                  marker = Hive::Markers.current(task.state_file)
-                  assert_equal :complete, marker.name
-                  assert_equal "https://example.com/pr/134", marker.attrs.fetch("pr_url")
-                  assert_equal "false", marker.attrs.fetch("is_draft")
-                  assert_equal "true", marker.attrs.fetch("merged")
-                  assert_includes File.read(task.state_file), "PR already merged for this task."
-                  assert_includes File.read(File.join(task.folder, "summary.md")), "PR #134 was already merged"
-                end
+                assert_equal({ commit: "open_pr_already_merged", status: :complete }, result)
+                assert_equal [ [ task.state_file, "https://example.com/pr/134" ] ], scanned
+                marker = Hive::Markers.current(task.state_file)
+                assert_equal :complete, marker.name
+                assert_equal "https://example.com/pr/134", marker.attrs.fetch("pr_url")
+                assert_equal "false", marker.attrs.fetch("is_draft")
+                assert_equal "true", marker.attrs.fetch("merged")
+                assert_includes File.read(task.state_file), "PR already merged for this task."
+                assert_includes File.read(File.join(task.folder, "summary.md")), "PR #134 was already merged"
+
+                # Fix #142: merged recovery also lands terminal markers on
+                # the downstream stage state files so 6-review and 7-artifacts
+                # short-circuit instead of re-running against a merged PR.
+                review_file = File.join(task.folder, "task.md")
+                artifact_file = File.join(task.folder, "artifact.md")
+                assert File.exist?(review_file), "task.md (6-review state file) must be written"
+                assert File.exist?(artifact_file), "artifact.md (7-artifacts state file) must be written"
+                review_marker = Hive::Markers.current(review_file)
+                assert_equal :review_complete, review_marker.name
+                assert_equal "true", review_marker.attrs.fetch("merged")
+                artifact_marker = Hive::Markers.current(artifact_file)
+                assert_equal :complete, artifact_marker.name
+                assert_equal "true", artifact_marker.attrs.fetch("merged")
               end
             end
+          end
+        end
+      end
+    end
+  end
+
+  def test_run_lands_error_when_merged_pr_recovery_secret_scan_fetch_fails
+    with_tmp_dir do |root|
+      task = make_task(root)
+      with_tmp_git_repo do |worktree|
+        head_oid = run!("git", "-C", worktree, "rev-parse", "HEAD").strip
+        write_pointer(task, worktree)
+        merged = {
+          "url" => "https://example.com/pr/144",
+          "number" => 144,
+          "state" => "MERGED",
+          "isDraft" => false,
+          "headRefOid" => head_oid
+        }
+        fetch_failed = Scan.new(fetch_failed: true, fetch_error: "simulated", hits: [])
+
+        with_basic_open_pr_run_stubs(merged_pr: merged, scan: fetch_failed) do
+          result = Hive::Stages::OpenPr.run!(task, cfg)
+
+          assert_equal({ commit: "open_pr_secret_scan_failed", status: :error }, result)
+          marker = Hive::Markers.current(task.state_file)
+          assert_equal :error, marker.name
+          assert_equal "secret_scan_fetch_failed", marker.attrs.fetch("reason")
+          assert_equal "simulated", marker.attrs.fetch("detail")
+          # Downstream markers must NOT be written when the scan failed;
+          # the task should land in :error, not advance through merged
+          # recovery's downstream short-circuit.
+          refute File.exist?(File.join(task.folder, "task.md")),
+                 "task.md must not be written when merged-recovery scan fetch fails"
+          refute File.exist?(File.join(task.folder, "artifact.md")),
+                 "artifact.md must not be written when merged-recovery scan fetch fails"
+        end
+      end
+    end
+  end
+
+  def test_run_lands_error_when_merged_pr_recovery_secret_scan_hits
+    with_tmp_dir do |root|
+      task = make_task(root)
+      with_tmp_git_repo do |worktree|
+        head_oid = run!("git", "-C", worktree, "rev-parse", "HEAD").strip
+        write_pointer(task, worktree)
+        merged = {
+          "url" => "https://example.com/pr/145",
+          "number" => 145,
+          "state" => "MERGED",
+          "isDraft" => false,
+          "headRefOid" => head_oid
+        }
+        hit_scan = Scan.new(fetch_failed: false, fetch_error: nil, hits: [ { name: :aws_key } ])
+        remediated = []
+
+        with_basic_open_pr_run_stubs(merged_pr: merged, scan: hit_scan) do
+          with_replaced_singleton_method(Hive::Stages::OpenPr, :remediate_secret_leak!, ->(url) { remediated << url }) do
+            result = Hive::Stages::OpenPr.run!(task, cfg)
+
+            assert_equal({ commit: "open_pr_secret_blocked", status: :error }, result)
+            marker = Hive::Markers.current(task.state_file)
+            assert_equal :error, marker.name
+            assert_equal "secret_in_pr_body", marker.attrs.fetch("reason")
+            assert_equal "aws_key", marker.attrs.fetch("patterns")
+            assert_equal [ "https://example.com/pr/145" ], remediated
+            refute File.exist?(File.join(task.folder, "task.md"))
+            refute File.exist?(File.join(task.folder, "artifact.md"))
           end
         end
       end
@@ -147,8 +228,13 @@ class HiveStagesOpenPrTest < Minitest::Test
     with_tmp_dir do |root|
       task = make_task(root)
       with_tmp_git_repo do |worktree|
-        local_head = run!("git", "-C", worktree, "rev-parse", "HEAD").strip
         write_pointer(task, worktree)
+        local_head = run!("git", "-C", worktree, "rev-parse", "HEAD").strip
+        # Historical merged PR on the same branch but a different HEAD —
+        # must NOT be adopted as recovery. validate_complete_marker re-uses
+        # `lookup_existing_pr` (still public) to confirm the freshly-opened
+        # PR matches the marker; that helper still pulls from the same
+        # `gh pr list` fixture via `lookup_prs_for_branch`.
         old_merged = {
           "url" => "https://example.com/pr/old",
           "number" => 133,
@@ -160,41 +246,38 @@ class HiveStagesOpenPrTest < Minitest::Test
           "url" => "https://example.com/pr/new",
           "number" => 135,
           "state" => "OPEN",
-          "isDraft" => true
+          "isDraft" => true,
+          "headRefOid" => local_head
         }
-        existing_calls = 0
+        list_calls = 0
         pushed = false
-        received_head_oid = nil
         scan = Scan.new(fetch_failed: false, fetch_error: nil, hits: [])
 
         with_replaced_singleton_method(Hive::Gh, :ensure_authenticated!, ->(_cfg) { }) do
-          with_replaced_singleton_method(Hive::Gh, :lookup_existing_pr, lambda { |_worktree_path, _branch, cfg:|
-            existing_calls += 1
-            existing_calls == 1 ? nil : new_pr
+          with_replaced_singleton_method(Hive::Gh, :lookup_prs_for_branch, lambda { |_worktree_path, _branch, cfg:|
+            list_calls += 1
+            # First call: only the stale historical merged PR exists.
+            # Subsequent call (validate_complete_marker): the new OPEN PR
+            # has been published by the simulated agent below.
+            list_calls == 1 ? [ old_merged ] : [ new_pr ]
           }) do
-            with_replaced_singleton_method(Hive::Gh, :lookup_merged_pr, lambda { |_worktree_path, _branch, cfg:, head_oid: nil|
-              received_head_oid = head_oid
-              old_merged.fetch("headRefOid") == head_oid ? old_merged : nil
-            }) do
-              with_replaced_singleton_method(Hive::Gh, :push_branch!, ->(_worktree_path, _branch, cfg:) { pushed = true }) do
-                with_replaced_singleton_method(Hive::Gh, :scan_pr_for_secrets, ->(state_file:, pr_url:, cfg:) { scan }) do
-                  with_replaced_singleton_method(Hive::Stages::Base, :stage_profile, ->(_cfg, _stage) { :profile }) do
-                    with_replaced_singleton_method(Hive::Stages::Base, :render, ->(_template, _bindings) { "prompt" }) do
-                      with_replaced_singleton_method(Hive::ProtectedFiles, :snapshot, ->(_folder) { Object.new }) do
-                        with_replaced_singleton_method(Hive::ProtectedFiles, :diff, ->(_before, _after) { [] }) do
-                          with_replaced_singleton_method(Hive::Stages::Base, :spawn_agent, lambda { |spawned_task, **_kwargs|
-                            Hive::Markers.set(spawned_task.state_file, :complete,
-                                              pr_url: new_pr.fetch("url"), is_draft: "true")
-                          }) do
-                            result = Hive::Stages::OpenPr.run!(task, cfg)
+            with_replaced_singleton_method(Hive::Gh, :push_branch!, ->(_worktree_path, _branch, cfg:) { pushed = true }) do
+              with_replaced_singleton_method(Hive::Gh, :scan_pr_for_secrets, ->(state_file:, pr_url:, cfg:) { scan }) do
+                with_replaced_singleton_method(Hive::Stages::Base, :stage_profile, ->(_cfg, _stage) { :profile }) do
+                  with_replaced_singleton_method(Hive::Stages::Base, :render, ->(_template, _bindings) { "prompt" }) do
+                    with_replaced_singleton_method(Hive::ProtectedFiles, :snapshot, ->(_folder) { Object.new }) do
+                      with_replaced_singleton_method(Hive::ProtectedFiles, :diff, ->(_before, _after) { [] }) do
+                        with_replaced_singleton_method(Hive::Stages::Base, :spawn_agent, lambda { |spawned_task, **_kwargs|
+                          Hive::Markers.set(spawned_task.state_file, :complete,
+                                            pr_url: new_pr.fetch("url"), is_draft: "true")
+                        }) do
+                          result = Hive::Stages::OpenPr.run!(task, cfg)
 
-                            assert_equal({ commit: "pr_opened_draft", status: :complete }, result)
-                            assert_equal local_head, received_head_oid
-                            assert pushed, "mismatched historical merged PR must not skip the normal push/create path"
-                            refute File.exist?(File.join(task.folder, "summary.md"))
-                            marker = Hive::Markers.current(task.state_file)
-                            assert_equal "https://example.com/pr/new", marker.attrs.fetch("pr_url")
-                          end
+                          assert_equal({ commit: "pr_opened_draft", status: :complete }, result)
+                          assert pushed, "mismatched historical merged PR must not skip the normal push/create path"
+                          refute File.exist?(File.join(task.folder, "summary.md"))
+                          marker = Hive::Markers.current(task.state_file)
+                          assert_equal "https://example.com/pr/new", marker.attrs.fetch("pr_url")
                         end
                       end
                     end

--- a/test/unit/task_action_test.rb
+++ b/test/unit/task_action_test.rb
@@ -131,6 +131,15 @@ class TaskActionTest < Minitest::Test
     assert_match(/\Ahive review demo-260426-aaaa --from 6-review\z/, action.command)
   end
 
+  def test_live_task_lock_overrides_review_ready_marker
+    task = fake_task(stage_name: "review", stage_index: 6)
+    action = Hive::TaskAction.for(task, marker(:execute_complete), live_task_lock: true)
+
+    assert_equal "agent_running", action.key
+    assert_equal "Agent running", action.label
+    assert_nil action.command
+  end
+
   def test_review_waiting_is_needs_input
     task = fake_task(stage_name: "review", stage_index: 6)
     action = Hive::TaskAction.for(task, marker(:review_waiting, "pass" => "2"))

--- a/test/unit/tui/views/usage_footer_test.rb
+++ b/test/unit/tui/views/usage_footer_test.rb
@@ -20,7 +20,8 @@ class HiveTuiViewsUsageFooterTest < Minitest::Test
       width: 120
     )
 
-    assert_equal "tokens — today 0/0/0 • 7d 0/0/0 • 30d 0/0/0 • all 0/0/0", out
+    assert_equal "today 0/0/0 • 7d 0/0/0 • all 0/0/0 • tokens", out
+    refute_includes out, "30d"
   end
 
   def test_formats_k_and_m_units
@@ -38,6 +39,6 @@ class HiveTuiViewsUsageFooterTest < Minitest::Test
     )
 
     assert_operator out.length, :<=, 30
-    assert_match(/\A(tokens|token)/, out)
+    assert_match(/\Atoday /, out)
   end
 end

--- a/wiki/commands/status.md
+++ b/wiki/commands/status.md
@@ -3,7 +3,7 @@ title: hive status
 type: command
 source: lib/hive/commands/status.rb
 created: 2026-04-25
-updated: 2026-05-24
+updated: 2026-05-25
 tags: [command, status, observability, json, diagnostics, legacy-dirs]
 ---
 
@@ -46,10 +46,10 @@ The `legacy_stage_dirs` field is an additive, non-breaking extension of `urn:hiv
 | `·` | `:none` (no marker yet, e.g. fresh `1-inbox` capture before WAITING was added) |
 | `⏸` | `:waiting`, `:execute_waiting`, `:review_waiting` |
 | `✓` | `:complete`, `:execute_complete`, `:review_complete` |
-| `🤖` | `:agent_working` with a live PID, `:review_working`, or a live per-task `.lock` holder before a working marker is written |
+| `🤖` | `:agent_working` with a live PID, `:review_working`, or a live per-task `.lock` holder before a Claude PID is recorded |
 | `⚠` | `:execute_stale`, `:review_ci_stale`, `:review_stale`, `:review_error`, `:error`, or `:agent_working` with a dead PID |
 
-`decorate` special-cases `:agent_working`: reads `claude_pid` from the per-task `.lock` (or fallback marker `pid`) and runs `Process.kill(0, pid)` to decide between 🤖 and ⚠ "stale lock". It also renders a live non-marker `.lock` as `🤖 run_lock pid=<pid>`; this is internal display state, not an added JSON field.
+`decorate` special-cases `:agent_working`: reads `claude_pid` from the per-task `.lock` (or fallback marker `pid`) and runs `Process.kill(0, pid)` to decide between 🤖 and ⚠ "stale lock". If the task lock is live but the Claude PID is not attached yet, status renders `🤖 run_lock pid=<pid>` instead of a stale warning. This is internal display state, not an added JSON field.
 
 ## Rendering rules
 

--- a/wiki/commands/status.md
+++ b/wiki/commands/status.md
@@ -3,7 +3,7 @@ title: hive status
 type: command
 source: lib/hive/commands/status.rb
 created: 2026-04-25
-updated: 2026-05-20
+updated: 2026-05-24
 tags: [command, status, observability, json, diagnostics, legacy-dirs]
 ---
 
@@ -17,8 +17,8 @@ tags: [command, status, observability, json, diagnostics, legacy-dirs]
     ⏸ add-inbox-filter-260424-7a3b   waiting                  hive brainstorm add-inbox-filter-260424-7a3b 2h ago
   Ready to develop
     ✓ refactor-auth-260423-1c2d      complete                 hive develop refactor-auth-260423-1c2d 1d ago
-  Needs your input
-    🤖 add-cache-260424-9a8b          agent_working pid=1234   hive develop add-cache-260424-9a8b 5m ago
+  Agent running
+    🤖 add-cache-260424-9a8b          agent_working pid=1234   - 5m ago
 ```
 
 `hive status` prints one block per project. Action buckets without active tasks are skipped. Within a bucket, rows are sorted by state-file mtime (newest first). Raw stage and folder remain available in `--json`. JSON rows also include `next_action`; it is usually `null`, but `EXECUTE_WAITING reason=...` rows carry the same structured recovery target that `hive run --json` emits. Every JSON row also includes `diagnostic`; it is `null` for ordinary rows and a bounded red-row payload for `recover_execute`, `recover_review`, and `error` rows.
@@ -46,10 +46,10 @@ The `legacy_stage_dirs` field is an additive, non-breaking extension of `urn:hiv
 | `·` | `:none` (no marker yet, e.g. fresh `1-inbox` capture before WAITING was added) |
 | `⏸` | `:waiting`, `:execute_waiting`, `:review_waiting` |
 | `✓` | `:complete`, `:execute_complete`, `:review_complete` |
-| `🤖` | `:agent_working` with a live PID, `:review_working` |
+| `🤖` | `:agent_working` with a live PID, `:review_working`, or a live per-task `.lock` holder before a working marker is written |
 | `⚠` | `:execute_stale`, `:review_ci_stale`, `:review_stale`, `:review_error`, `:error`, or `:agent_working` with a dead PID |
 
-`decorate` (`lib/hive/commands/status.rb:95`) special-cases `:agent_working`: reads `claude_pid` (or fallback `pid`) from the marker attrs and runs `Process.kill(0, pid)` to decide between 🤖 and ⚠ "stale lock".
+`decorate` special-cases `:agent_working`: reads `claude_pid` from the per-task `.lock` (or fallback marker `pid`) and runs `Process.kill(0, pid)` to decide between 🤖 and ⚠ "stale lock". It also renders a live non-marker `.lock` as `🤖 run_lock pid=<pid>`; this is internal display state, not an added JSON field.
 
 ## Rendering rules
 
@@ -57,7 +57,7 @@ The `legacy_stage_dirs` field is an additive, non-breaking extension of `urn:hiv
 - Project path missing → `"<name>: missing project path <path>"`.
 - `.hive-state` missing → `"<name>: not initialised (no .hive-state)"`.
 - Action bucket with no tasks → header omitted entirely.
-- Slug is left-padded to 36 chars; state label to 24 chars; then the suggested command and humanised age.
+- Slug is left-padded to 36 chars; state label to 24 chars; then the suggested command and humanised age. Marker attr values in the state label collapse internal whitespace so multi-line stderr details do not break the table.
 
 `humanise_age` thresholds: `<60s → Ns ago`, `<3600s → Nm ago`, `<86400s → Nh ago`, else `Nd ago`.
 
@@ -65,7 +65,7 @@ The `legacy_stage_dirs` field is an additive, non-breaking extension of `urn:hiv
 
 For each stage in `Hive::Stages::DIRS = %w[1-inbox 2-brainstorm 3-plan 4-execute 5-open-pr 6-review 7-artifacts 8-finalize 9-done]` (single source of truth — see [[modules/stages]]), `collect_rows` globs `<hive_state>/stages/<stage>/*` directories. Each is parsed via `Hive::Task.new(entry)`; non-conforming directories (no slug match) are silently skipped via `rescue InvalidTaskPath`. Marker is read with `Hive::Markers.current(task.state_file)`; mtime falls back to the directory mtime if the state file doesn't exist yet.
 
-Rows are then classified by `Hive::TaskAction`, which emits an action key, label, suggested command, and optional row-local `next_action` such as `kind=edit target=<worktree>` for dirty execute worktrees or `kind=run` for `missing_research_output`. If one project has the same slug in multiple stages, workflow commands include `--from <stage>` and generic findings commands include `--stage <stage>`.
+Rows are then classified by `Hive::TaskAction`, which emits an action key, label, suggested command, and optional row-local `next_action` such as `kind=edit target=<worktree>` for dirty execute worktrees or `kind=run` for `missing_research_output`. `collect_rows` also reads each task `.lock`, verifies the holder PID and recorded process start time through `Hive::Lock`, and passes `live_task_lock: true` to `TaskAction` while `hive run` is active even if the stage has not written an `AGENT_WORKING` or `REVIEW_WORKING` marker yet. If one project has the same slug in multiple stages, workflow commands include `--from <stage>` and generic findings commands include `--stage <stage>`.
 
 ## Red-row diagnostics
 
@@ -108,6 +108,7 @@ Normal `status` and `status --diagnose` without `--write` do not mutate filesyst
 ## Tests
 
 - `test/integration/status_test.rb` — empty registry, action grouping, suggested commands, stale-lock decoration.
+- `test/unit/commands/status_test.rb` — status row collection, legacy dir warnings, and live task-lock action override.
 - `test/unit/commands/status_diagnose_test.rb` — local diagnose JSON and agent-written artifact refresh.
 - `test/unit/task_action_test.rb` — diagnostic extraction, redaction, artifact selection, marker fallback, non-red nil.
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1950,3 +1950,19 @@ chruby and RVM are intentionally not handled — they modify PATH per-shell and 
 - [[stages/artifacts]]
 - [[state-model]]
 - [[decisions]]
+
+## [2026-05-24T21:05:40Z] status — marker attrs and live task locks
+
+**Action:** Fixed status classification for two runtime edge cases: marker parsing now tolerates Git stderr attrs containing `>` such as `branch -> branch`, and status treats a live per-task `.lock` as `Agent running` even before a working marker is written. This prevents finalize errors from appearing as "Needs your input" and prevents pre-review rebase work from appearing as runnable review work.
+
+**Refreshed pages:**
+- [[modules/markers]]
+- [[modules/task_action]]
+- [[commands/status]]
+
+## [2026-05-25T07:34:24Z] tui — compact token footer
+
+**Action:** Updated the grid-mode token footer to show only `today`, `7d`, and `all`, with the `tokens` label at the end of the compact legend instead of the beginning. The full `T` token matrix still exposes `30d`.
+
+**Refreshed pages:**
+- [[token-usage]]

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1966,3 +1966,12 @@ chruby and RVM are intentionally not handled — they modify PATH per-shell and 
 
 **Refreshed pages:**
 - [[token-usage]]
+
+## [2026-05-25T08:18:06Z] review follow-up — marker parsing and open-pr recovery
+
+**Action:** Tightened marker parsing around marker-name boundaries and nested comment starts, clarified live-lock status rendering before a Claude PID is attached, and made 5-open-pr merged-PR recovery require a `headRefOid` match with the current local worktree HEAD.
+
+**Refreshed pages:**
+- [[modules/markers]]
+- [[commands/status]]
+- [[stages/open-pr]]

--- a/wiki/modules/markers.md
+++ b/wiki/modules/markers.md
@@ -3,7 +3,7 @@ title: Hive::Markers
 type: module
 source: lib/hive/markers.rb
 created: 2026-04-25
-updated: 2026-05-13
+updated: 2026-05-24
 tags: [marker, protocol, flock]
 ---
 
@@ -35,7 +35,7 @@ Allowlist: see `KNOWN_NAMES` in `lib/hive/markers.rb` (twelve names total — si
 
 `KILL_CLASS_EXIT_CODES = %w[130 137 143]` — POSIX signal exit codes (SIGINT/SIGKILL/SIGTERM). When an `ERROR` marker's `exit_code` attr is in this list the task was interrupted, not broken. Single source of truth shared by `Hive::Tui::BubbleModel#auto_heal_kill_class_errors` (auto-clears them) and `Hive::Tui::KeyMap.error_message` (routes Enter to OpenLogTail instead of RecoverError so Enter doesn't race the auto-healer for the markers-lock).
 
-Regex: `MARKER_RE` enumerates every name in `KNOWN_NAMES`. Adding a marker name requires updating BOTH the list AND the regex alternation (they are two sources of truth).
+Regex: `MARKER_RE` enumerates every name in `KNOWN_NAMES` and captures attrs until the terminating `-->`, so quoted error details may contain `>` (for example Git stderr `branch -> branch`) and newlines. Adding a marker name requires updating BOTH the list AND the regex alternation (they are two sources of truth).
 
 ### EXECUTE_* attribute schemas
 
@@ -75,17 +75,17 @@ State = Struct.new(:name, :attrs, :raw, keyword_init: true)
 ## `set(path, name, attrs = {})`
 
 - `name` is upcased; raises `ArgumentError` if not in `KNOWN_NAMES`.
-- Builds the marker text via `build_marker`. Attribute values containing whitespace get double-quoted.
+- Builds the marker text via `build_marker`. Attribute values containing whitespace get double-quoted. Double quotes are normalized to single quotes and `-->` is rewritten to `-- >` so generated attrs cannot terminate the HTML comment early.
 - Opens the file with `RDWR | CREAT, 0o644`, takes `LOCK_EX`, reads the full body, replaces the *last* marker via `replace_last_marker`, or appends if none. Truncates and rewrites in place.
 - This locking is what makes concurrent writes from `Hive::Agent` (during a run) and `Markers.set` (from tests or recovery) safe.
 
 ## `parse_attrs`
 
-Parses the attribute string into a Hash. Format: `key=value` pairs, optional double-quoted values for whitespace-containing payloads. Regex: `/(\w[\w-]*)=("[^"]*"|\S+)/`.
+Parses the attribute string into a Hash. Format: `key=value` pairs, optional double-quoted values for whitespace-containing payloads. Quoted values may span newlines and may contain `>` characters; parsing stops at the closing quote, not at branch-arrow text. Regex: `/(\w[\w-]*)=("[^"]*"|\S+)/`.
 
 ## Tests
 
-- `test/unit/markers_test.rb` — round-trip set/get, attribute quoting, last-marker semantics, missing-file handling.
+- `test/unit/markers_test.rb` — round-trip set/get, attribute quoting/sanitization, last-marker semantics, missing-file handling, and Git stderr attrs containing `branch -> branch`.
 
 ## Used by
 

--- a/wiki/modules/markers.md
+++ b/wiki/modules/markers.md
@@ -3,7 +3,7 @@ title: Hive::Markers
 type: module
 source: lib/hive/markers.rb
 created: 2026-04-25
-updated: 2026-05-24
+updated: 2026-05-25
 tags: [marker, protocol, flock]
 ---
 
@@ -31,11 +31,11 @@ tags: [marker, protocol, flock]
 <!-- REVIEW_ERROR phase=reviewers reason=all_failed -->          # terminal — agent-level failure
 ```
 
-Allowlist: see `KNOWN_NAMES` in `lib/hive/markers.rb` (twelve names total — six pre-U3, six REVIEW_* added in U3).
+Allowlist: see `KNOWN_NAMES` in `lib/hive/markers.rb`.
 
 `KILL_CLASS_EXIT_CODES = %w[130 137 143]` — POSIX signal exit codes (SIGINT/SIGKILL/SIGTERM). When an `ERROR` marker's `exit_code` attr is in this list the task was interrupted, not broken. Single source of truth shared by `Hive::Tui::BubbleModel#auto_heal_kill_class_errors` (auto-clears them) and `Hive::Tui::KeyMap.error_message` (routes Enter to OpenLogTail instead of RecoverError so Enter doesn't race the auto-healer for the markers-lock).
 
-Regex: `MARKER_RE` enumerates every name in `KNOWN_NAMES` and captures attrs until the terminating `-->`, so quoted error details may contain `>` (for example Git stderr `branch -> branch`) and newlines. Adding a marker name requires updating BOTH the list AND the regex alternation (they are two sources of truth).
+Regex: `MARKER_RE` enumerates every name in `KNOWN_NAMES`, requires a marker-name boundary, and captures attrs until the terminating `-->` without crossing another `<!--`. Quoted error details may contain `>` (for example Git stderr `branch -> branch`) and newlines. Adding a marker name requires updating BOTH the list AND the regex alternation (they are two sources of truth).
 
 ### EXECUTE_* attribute schemas
 
@@ -75,7 +75,7 @@ State = Struct.new(:name, :attrs, :raw, keyword_init: true)
 ## `set(path, name, attrs = {})`
 
 - `name` is upcased; raises `ArgumentError` if not in `KNOWN_NAMES`.
-- Builds the marker text via `build_marker`. Attribute values containing whitespace get double-quoted. Double quotes are normalized to single quotes and `-->` is rewritten to `-- >` so generated attrs cannot terminate the HTML comment early.
+- Builds the marker text via `build_marker`. Attribute values containing whitespace get double-quoted. Double quotes are normalized to single quotes, `<!--` is rewritten to `< !--`, and `-->` is rewritten to `-- >` so generated attrs cannot confuse HTML-comment marker boundaries.
 - Opens the file with `RDWR | CREAT, 0o644`, takes `LOCK_EX`, reads the full body, replaces the *last* marker via `replace_last_marker`, or appends if none. Truncates and rewrites in place.
 - This locking is what makes concurrent writes from `Hive::Agent` (during a run) and `Markers.set` (from tests or recovery) safe.
 

--- a/wiki/modules/task_action.md
+++ b/wiki/modules/task_action.md
@@ -3,7 +3,7 @@ title: Hive::TaskAction
 type: module
 source: lib/hive/task_action.rb
 created: 2026-04-26
-updated: 2026-05-22
+updated: 2026-05-24
 tags: [module, status, action, classifier, diagnostic]
 ---
 
@@ -12,7 +12,7 @@ tags: [module, status, action, classifier, diagnostic]
 ## Public surface
 
 ```ruby
-action = Hive::TaskAction.for(task, marker, project_name: nil, project_count: 1, stage_collision: false)
+action = Hive::TaskAction.for(task, marker, project_name: nil, project_count: 1, stage_collision: false, live_task_lock: false)
 action.key         # closed enum string per Hive::Schemas::TaskActionKind
 action.label       # human label, e.g. "Ready to plan"
 action.command     # copy-paste shell command, or nil
@@ -64,8 +64,9 @@ Entries are keyed by an internal symbol that's resolved via `(stage_name, marker
 
 ## Marker carve-outs
 
-Two markers short-circuit the per-stage dispatch:
+Runtime liveness can short-circuit per-stage dispatch before marker lookup:
 
+- **`live_task_lock: true`** → `agent_running` (label "Agent running", command nil). `Hive::Commands::Status` sets this when a task `.lock` holder PID is alive and its recorded process start time still matches. This covers pre-marker work inside `hive run`, such as auto-rebase before `REVIEW_WORKING` is written, so status and the TUI do not offer a duplicate runnable command that would immediately hit `ConcurrentRunError`.
 - **`:agent_working`** → `agent_running` (label "Agent running", command nil) when the agent is actually alive. A `hive run` is in flight; surfacing a workflow command would send the user (or an agent retry loop) straight into `ConcurrentRunError`. **Stale carve-out:** when the caller passes `pid_alive:` and `state_file_mtime:` kwargs and either (a) `pid_alive` is `false` (the per-task `.lock` recorded a `claude_pid` that's now dead), or (b) `pid_alive` is `nil` (no `.lock` claude_pid), the marker has no `pid` attr, and the state-file mtime is older than `agent_marker_grace_sec` (default 300s; threaded from `daemon.agent_marker_grace_sec` by `Hive::Commands::Status`), the action is reclassified as `:error` with a synthesized diagnostic (summary describes "agent process not alive" / "agent never attached"; detail explains the daemon will heal the on-disk marker within ~30s). This makes the row a recoverable red status immediately, without waiting for the daemon's `StaleAgentHealer` to rewrite the marker on disk.
 - **`:error`** → always `error`. The stage agent recorded a failure; recovery is manual (edit reviews/, lower frontmatter pass:, remove EXECUTE_STALE marker, etc.). The healer-written subset (`reason=agent_died` / `reason=agent_orphaned`) recovers via the standard `hive markers clear <slug> --name ERROR` flow once the on-disk rewrite lands.
 

--- a/wiki/stages/open-pr.md
+++ b/wiki/stages/open-pr.md
@@ -3,7 +3,7 @@ title: 5-open-pr stage
 type: stage
 source: lib/hive/stages/open_pr.rb, templates/open_pr_prompt.md.erb
 created: 2026-05-13
-updated: 2026-05-13
+updated: 2026-05-25
 tags: [stage, pr, github]
 ---
 
@@ -17,18 +17,20 @@ tags: [stage, pr, github]
 
 ## Steps performed (`Stages::OpenPr.run!`)
 
-1. Check for an existing PR for the branch with `gh pr list --head <branch> --state all`.
-2. If one exists, write `pr.md` with `idempotent=true` and `is_draft=true` and finish without spawning an agent.
-3. Push the branch with `git push -u origin <branch>`.
-4. Render `templates/open_pr_prompt.md.erb` with the plan and execute output wrapped in a per-spawn `<user_supplied>` nonce.
-5. Spawn the open-pr agent in the worktree. The prompt invokes `compound-engineering:ce-commit-push-pr`, requires `gh pr create --draft`, forbids another push, and requires `pr.md` frontmatter with `pr_url` / `pr_number`.
-6. Secret-scan the resulting `pr.md` and PR body before returning success.
+1. Check pull requests for the branch with `gh pr list --head <branch> --state all`.
+2. If an OPEN PR exists, write `pr.md` with `idempotent=true`, secret-scan it, and finish without spawning an agent.
+3. If a MERGED PR exists for the current local `HEAD` (`headRefOid` match), write `pr.md` with `merged=true`, secret-scan it, write `summary.md`, and finish without spawning an agent.
+4. Push the branch with `git push -u origin <branch>`.
+5. Render `templates/open_pr_prompt.md.erb` with the plan and execute output wrapped in a per-spawn `<user_supplied>` nonce.
+6. Spawn the open-pr agent in the worktree. The prompt invokes `compound-engineering:ce-commit-push-pr`, requires `gh pr create --draft`, forbids another push, and requires `pr.md` frontmatter with `pr_url` / `pr_number`.
+7. Secret-scan the resulting `pr.md` and PR body before returning success.
 
 ## Marker → commit action
 
 - `:complete` → `pr_opened_draft`.
-- Existing PR → `open_pr_already_open`.
-- Secret scan failure → `ERROR reason=secret_in_pr_body`.
+- Existing OPEN PR → `open_pr_already_open` with `idempotent=true`.
+- Existing MERGED PR for local HEAD → `open_pr_already_merged` with `merged=true` and `summary.md` written.
+- Secret scan failure → `ERROR reason=secret_in_pr_body` or `ERROR reason=secret_scan_fetch_failed`.
 
 ## Backlinks
 

--- a/wiki/token-usage.md
+++ b/wiki/token-usage.md
@@ -3,7 +3,7 @@ title: Token Usage Stats
 type: observability
 source: lib/hive/usage_db.rb, lib/hive/agent_profiles/usage_extractors.rb, lib/hive/tui/views/token_stats.rb
 created: 2026-05-24
-updated: 2026-05-24
+updated: 2026-05-25
 tags: [observability, tui, sqlite, agent]
 ---
 

--- a/wiki/token-usage.md
+++ b/wiki/token-usage.md
@@ -69,10 +69,10 @@ The scope hash accepts `project_slug:` and `task_slug:` filters. `task_slug` is 
 
 ## TUI Surfaces
 
-`hive tui` shows a usage footer in grid mode:
+`hive tui` shows a compact usage footer in grid mode. The compact footer intentionally omits the `30d` bucket; use the full `T` matrix for that window:
 
 ```text
-tokens — today 1.2M/400k/200k • 7d ... • 30d ... • all ...
+today 1.2M/400k/200k • 7d ... • all ... • tokens
 ```
 
 The tuple is `input/output/cached`. Units use `k` and `M` with compact one-decimal formatting. Footer scope follows the current selection:


### PR DESCRIPTION
## Summary

Runtime status now tells the truth while Hive is doing background work: live task locks surface as `Agent running` instead of actionable rows, and marker parsing no longer turns malformed HTML comments or Git stderr into false terminal states.

Open-pr recovery is also safer. Hive can recover already-open and already-merged branch PRs, but a merged PR only counts when GitHub's `headRefOid` matches the current worktree HEAD, so a reused branch name cannot make new work look already merged.

The compact TUI token footer now stays focused on `today`, `7d`, and `all`, with the `tokens` label at the end of the legend.

## Tests

- `bundle exec ruby -Itest -Ilib test/unit/markers_test.rb`
- `bundle exec ruby -Itest -Ilib test/unit/commands/status_test.rb`
- `bundle exec ruby -Itest -Ilib test/unit/gh_test.rb`
- `bundle exec ruby -Itest -Ilib test/unit/stages/open_pr_test.rb`
- `bundle exec ruby -Itest -Ilib test/unit/task_action_test.rb`
- `bundle exec ruby -Itest -Ilib test/integration/run_open_pr_test.rb`
- `test/unit/tui/views/usage_footer_test.rb`
- `test/integration/tui_usage_footer_test.rb`
- `test/unit/tui/views/token_stats_test.rb`
- `test/unit/tui/bubble_model_test.rb`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
