### PR TITLE
test: restore strict coverage on current main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - name: Run minitest suite with merged coverage report
+        env:
+          HIVE_COVERAGE_MIN_LINE: "100"
         run: bundle exec rake coverage
 
   rubocop:

--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ Rake::TestTask.new do |t|
   t.warning = false
 end
 
-desc "Run the default suite with merged stdlib Coverage reporting (set HIVE_COVERAGE_MIN_LINE to enforce a line threshold)"
+desc "Run the default suite with merged stdlib Coverage reporting and a 100% line threshold"
 task :coverage do
   root = File.expand_path(__dir__)
   run_id = "#{Process.pid}-#{SecureRandom.hex(4)}"

--- a/lib/hive/process_kill.rb
+++ b/lib/hive/process_kill.rb
@@ -103,7 +103,7 @@ module Hive
 
     def safe_kill(signal, target)
       Process.kill(signal, target)
-    rescue Errno::ESRCH, Errno::EPERM
+    rescue Errno::ESRCH
       nil
     end
 

--- a/test/integration/init_test.rb
+++ b/test/integration/init_test.rb
@@ -136,6 +136,20 @@ class InitTest < Minitest::Test
     end
   end
 
+  def test_llm_wiki_bootstrap_recovers_from_invalid_existing_config_json
+    with_tmp_git_repo do |dir|
+      FileUtils.mkdir_p(File.join(dir, ".llm-wiki"))
+      File.write(File.join(dir, ".llm-wiki", "config.json"), "not-json")
+
+      Hive::LlmWikiBootstrap.install!(dir, post_commit_hook: false, scheduler: false)
+
+      cfg = JSON.parse(File.read(File.join(dir, ".llm-wiki", "config.json")))
+      assert_equal "codex", cfg.fetch("headless_agent")
+      assert_equal %w[claude codex pi], cfg.fetch("context_agents")
+      assert_equal "hive", cfg.fetch("created_by")
+    end
+  end
+
   def assert_llm_wiki_scheduler_files(home, project_dir)
     skip "systemd user timers are Linux-only" unless RbConfig::CONFIG["host_os"].include?("linux")
 

--- a/test/integration/migrate_test.rb
+++ b/test/integration/migrate_test.rb
@@ -70,6 +70,28 @@ class MigrateTest < Minitest::Test
     end
   end
 
+  def test_migrate_preflight_catches_plan_internal_duplicate_destination
+    with_tmp_global_config do
+      with_tmp_git_repo do |dir|
+        capture_io { Hive::Commands::Init.new(dir).call }
+        stages = File.join(dir, ".hive-state", "stages")
+        slug = "same-finalize-260525-aaaa"
+        FileUtils.mkdir_p(File.join(stages, "6-pr", slug))
+        FileUtils.mkdir_p(File.join(stages, "7-finalize", slug))
+
+        err = assert_raises(Hive::DestinationCollision) do
+          capture_io { Hive::Commands::Migrate.new(dir).call }
+        end
+
+        assert_match(/multiple legacy stages target the same destination/, err.message)
+        assert File.directory?(File.join(stages, "6-pr", slug))
+        assert File.directory?(File.join(stages, "7-finalize", slug))
+        refute File.directory?(File.join(stages, "8-finalize", slug)),
+               "plan-internal duplicate destinations must abort before any mv"
+      end
+    end
+  end
+
   # Mid-loop atomicity (round-1 finding): pre-flight collision check
   # must catch a SECOND-iteration collision BEFORE the first-iteration
   # rename runs. Without this, a successful 5-review→6-review followed
@@ -228,5 +250,127 @@ class MigrateTest < Minitest::Test
                "legacy key must still be removed even when canonical wins"
       end
     end
+  end
+  def test_migrate_warns_with_recovery_command_when_git_commit_fails
+    fake_ops = Object.new
+    fake_ops.define_singleton_method(:run_git!) do |*_args|
+      raise Hive::GitError, "permission denied"
+    end
+    migrate = Hive::Commands::Migrate.new("/tmp/project")
+
+    with_replaced_singleton_method(Hive::GitOps, :new, lambda { |_project_path| fake_ops }) do
+      _out, err = capture_io do
+        migrate.send(:commit_migration, "/tmp/project/.hive-state", [ [ "5-review", "6-review", "demo-260525-aaaa" ] ])
+      end
+
+      assert_includes err, "could not commit them to the hive-state git history"
+      assert_includes err, "git -C /tmp/project/.hive-state add -A"
+      assert_includes err, "hive: migrate stage directories (1 task)"
+    end
+  end
+
+  def test_restart_daemon_uses_systemctl_when_available
+    migrate = Hive::Commands::Migrate.new("/tmp/project")
+    calls = []
+    migrate.define_singleton_method(:read_daemon_pid) { 1234 }
+    migrate.define_singleton_method(:daemon_alive?) { |_pid| true }
+    migrate.define_singleton_method(:systemctl_available?) { true }
+    migrate.define_singleton_method(:system) do |*args, **kwargs|
+      calls << [ args, kwargs ]
+      true
+    end
+
+    out, err = capture_io { migrate.send(:restart_daemon_if_running!) }
+
+    assert_equal [ [ [ "systemctl", "--user", "restart", "hive-daemon" ], { out: File::NULL, err: File::NULL } ] ], calls
+    assert_includes out, "restarted hive-daemon (pid 1234)"
+    assert_empty err
+  end
+
+  def test_restart_daemon_warns_when_systemctl_restart_fails
+    migrate = Hive::Commands::Migrate.new("/tmp/project")
+    migrate.define_singleton_method(:read_daemon_pid) { 1234 }
+    migrate.define_singleton_method(:daemon_alive?) { |_pid| true }
+    migrate.define_singleton_method(:systemctl_available?) { true }
+    migrate.define_singleton_method(:system) { |*_args, **_kwargs| false }
+
+    _out, err = capture_io { migrate.send(:restart_daemon_if_running!) }
+
+    assert_includes err, "systemctl --user restart hive-daemon` failed"
+  end
+
+  def test_restart_daemon_warns_when_systemctl_is_unavailable
+    migrate = Hive::Commands::Migrate.new("/tmp/project")
+    migrate.define_singleton_method(:read_daemon_pid) { 1234 }
+    migrate.define_singleton_method(:daemon_alive?) { |_pid| true }
+    migrate.define_singleton_method(:systemctl_available?) { false }
+
+    _out, err = capture_io { migrate.send(:restart_daemon_if_running!) }
+
+    assert_includes err, "restart it manually so its in-memory stage layout refreshes"
+  end
+
+  def test_read_daemon_pid_accepts_hash_payload
+    with_tmp_dir do |dir|
+      File.write(File.join(dir, ".daemon.pid"), { "pid" => 4321 }.to_yaml)
+      with_env("HIVE_HOME" => dir) do
+        assert_equal 4321, Hive::Commands::Migrate.new("/tmp/project").send(:read_daemon_pid)
+      end
+    end
+  end
+
+  def test_read_daemon_pid_returns_nil_when_pid_file_cannot_be_read
+    with_tmp_dir do |dir|
+      pid_file = File.join(dir, ".daemon.pid")
+      File.write(pid_file, { "pid" => 4321 }.to_yaml)
+      original = File.method(:read)
+      with_env("HIVE_HOME" => dir) do
+        with_replaced_singleton_method(File, :read, lambda { |path, *args, **kwargs|
+          raise Errno::EACCES if path == pid_file
+
+          original.call(path, *args, **kwargs)
+        }) do
+          assert_nil Hive::Commands::Migrate.new("/tmp/project").send(:read_daemon_pid)
+        end
+      end
+    end
+  end
+
+  def test_read_daemon_pid_returns_nil_when_pid_file_stat_fails
+    with_tmp_dir do |dir|
+      pid_file = File.join(dir, ".daemon.pid")
+      File.write(pid_file, { "pid" => 4321 }.to_yaml)
+      original = File.method(:exist?)
+      with_env("HIVE_HOME" => dir) do
+        with_replaced_singleton_method(File, :exist?, lambda { |path|
+          raise Errno::EACCES if path == pid_file
+
+          original.call(path)
+        }) do
+          assert_nil Hive::Commands::Migrate.new("/tmp/project").send(:read_daemon_pid)
+        end
+      end
+    end
+  end
+
+  def test_daemon_alive_classifies_signal_results
+    migrate = Hive::Commands::Migrate.new("/tmp/project")
+
+    with_replaced_singleton_method(Process, :kill, lambda { |_signal, _pid| 1 }) do
+      assert migrate.send(:daemon_alive?, 1234)
+    end
+    with_replaced_singleton_method(Process, :kill, lambda { |_signal, _pid| raise Errno::ESRCH }) do
+      refute migrate.send(:daemon_alive?, 1234)
+    end
+    with_replaced_singleton_method(Process, :kill, lambda { |_signal, _pid| raise Errno::EPERM }) do
+      assert migrate.send(:daemon_alive?, 1234)
+    end
+  end
+
+  def test_systemctl_available_returns_false_when_system_call_cannot_spawn
+    migrate = Hive::Commands::Migrate.new("/tmp/project")
+    migrate.define_singleton_method(:system) { |*_args, **_kwargs| raise Errno::ENOENT }
+
+    refute migrate.send(:systemctl_available?)
   end
 end

--- a/test/integration/stages_base_usage_test.rb
+++ b/test/integration/stages_base_usage_test.rb
@@ -157,4 +157,35 @@ class StagesBaseUsageTest < Minitest::Test
       assert_match(/usage record failed/, err)
     end
   end
+  def test_base_usage_helpers_handle_synthetic_task_shapes
+    project_task = Struct.new(:project_root, :folder).new("/tmp/project-alpha", "/tmp/project-alpha/.hive-state/stages/6-review/slug")
+    folder_task = Struct.new(:folder).new("/tmp/project/.hive-state/stages/6-review/slug")
+    stage_task = Struct.new(:stage_name, :folder).new("6-review", "/tmp/project/.hive-state/stages/6-review/slug")
+
+    assert_equal "project-alpha", Hive::Stages::Base.usage_project_slug(project_task)
+    assert_nil Hive::Stages::Base.usage_project_slug(folder_task)
+    assert_equal "slug", Hive::Stages::Base.usage_task_slug(folder_task)
+    assert_equal "6-review", Hive::Stages::Base.usage_stage_label(stage_task)
+    assert_equal "6-review", Hive::Stages::Base.usage_stage_label(folder_task)
+  end
+
+  def test_record_usage_warns_and_continues_when_usage_db_fails
+    task = Struct.new(:project_name, :slug, :stage_index, :stage_name, :folder).new(
+      "alpha", "slug", 6, "review", "/tmp/slug"
+    )
+    profile = Struct.new(:name).new(:claude)
+
+    _out, err = capture_io do
+      with_replaced_singleton_method(Hive::UsageDb, :record!, ->(**_kwargs) { raise "db locked" }) do
+        assert_nil Hive::Stages::Base.record_usage(
+          task,
+          profile,
+          { usage: { input: 1, output: 2, cached: 3 }, model: "m" },
+          Time.utc(2026, 5, 25)
+        )
+      end
+    end
+
+    assert_match(/usage record failed: db locked/, err)
+  end
 end

--- a/test/support/coverage.rb
+++ b/test/support/coverage.rb
@@ -4,7 +4,7 @@ require "json"
 require "time"
 
 module HiveTestCoverage
-  DEFAULT_MIN_LINE_PERCENT = 0.0
+  DEFAULT_MIN_LINE_PERCENT = 100.0
 
   module_function
 

--- a/test/support/coverage.rb
+++ b/test/support/coverage.rb
@@ -78,13 +78,27 @@ module HiveTestCoverage
 
     # Bundler evaluates the gemspec before RUBYOPT coverage boots, and the
     # gemspec requires lib/hive.rb for Hive::VERSION. Reload only the entrypoint
-    # under coverage so the unloaded-file gate can stay strict. $VERBOSE = false
-    # suppresses "already initialized constant" warnings only; real warnings
-    # (deprecation, circular require) still print.
+    # under coverage so the unloaded-file gate can stay strict. Filter just the
+    # expected constant redefinition warnings; ordinary warnings still print.
     $VERBOSE = false
-    load path
+    without_constant_redefinition_warnings { load path }
   ensure
     $VERBOSE = old_verbose
+  end
+
+  def without_constant_redefinition_warnings
+    original_warn = Warning.method(:warn)
+    Warning.define_singleton_method(:warn) do |message, **kwargs|
+      text = message.to_s
+      if text.include?("already initialized constant") || text.include?("previous definition of")
+        nil
+      else
+        original_warn.call(message, **kwargs)
+      end
+    end
+    yield
+  ensure
+    Warning.define_singleton_method(:warn, original_warn) if original_warn
   end
 
   def dump_process_result!
@@ -401,7 +415,7 @@ module HiveTestCoverage
   end
 
   def coverage_ok?(report)
-    numeric_value(report, :line_percent) >= minimum_line_percent &&
+    line_percent_for(report) >= minimum_line_percent &&
       Array(value(report, :unloaded_files)).empty? &&
       Array(value(report, :result_errors)).empty?
   end
@@ -417,7 +431,7 @@ module HiveTestCoverage
     line_covered = numeric_value(report, :line_covered)
     line_total = numeric_value(report, :line_total)
     minimum = minimum_line_percent
-    line_percent = numeric_value(report, :line_percent)
+    line_percent = line_percent_for(report)
     if line_percent < minimum
       lines << format(
         "line coverage %.2f%% (%d/%d) below minimum %.2f%%",
@@ -514,6 +528,13 @@ module HiveTestCoverage
 
   def numeric_value(hash, key)
     value(hash, key).to_f
+  end
+
+  def line_percent_for(report)
+    explicit = value(report, :line_percent)
+    return explicit.to_f unless explicit.nil?
+
+    percent(numeric_value(report, :line_covered), numeric_value(report, :line_total))
   end
 
   def percent(covered, total)

--- a/test/unit/agent_profile_test.rb
+++ b/test/unit/agent_profile_test.rb
@@ -180,4 +180,9 @@ class AgentProfileTest < Minitest::Test
     overridden = profile.with_overrides("bin" => "/x")
     assert overridden.frozen?
   end
+  def test_usage_extractor_errors_are_ignored
+    profile = make_profile(usage_extractor: ->(_event) { raise "bad usage payload" })
+
+    assert_nil profile.extract_usage_event({ "type" => "result" })
+  end
 end

--- a/test/unit/agent_test.rb
+++ b/test/unit/agent_test.rb
@@ -543,4 +543,11 @@ class AgentTest < Minitest::Test
       ))
     end
   end
+  def test_event_stage_falls_back_to_parent_folder_for_synthetic_task_without_stage_name
+    task = Struct.new(:folder).new("/tmp/project/.hive-state/stages/6-review/synthetic")
+    agent = Hive::Agent.allocate
+    agent.instance_variable_set(:@task, task)
+
+    assert_equal "6-review", agent.send(:event_stage)
+  end
 end

--- a/test/unit/claude_launcher_test.rb
+++ b/test/unit/claude_launcher_test.rb
@@ -301,4 +301,191 @@ class ClaudeLauncherTest < Minitest::Test
       mod.define_singleton_method(method_name, original_unbound_or_method)
     end
   end
+
+  public
+
+  def test_prepare_claude_session_fails_when_session_disappears_before_ready
+    runner = Struct.new(:name) do
+      def session_exists? = false
+    end.new("gone-session")
+
+    err = assert_raises(Hive::AgentError) do
+      Hive::ClaudeLauncher.prepare_claude_session!(runner)
+    end
+
+    assert_match(/terminated before becoming ready/, err.message)
+  end
+
+  def test_wait_for_status_dispatches_exit_output_and_unknown_modes
+    with_tmp_task do |task|
+      runner = Struct.new(:tail) do
+        def capture_pane_tail(bytes:) = tail
+      end.new("Claude Code\n❯")
+      output = File.join(task.folder, "expected.md")
+      File.write(output, "done")
+      File.write(Hive::ClaudeLauncher.done_path(task), "done")
+
+      output_result = Hive::ClaudeLauncher.wait_for_status(
+        task, runner, 1, :output_file_exists, output, "reviewer"
+      )
+      assert_equal :ok, output_result.fetch(:status)
+      assert_equal "reviewer", output_result.fetch(:log_label)
+
+      done_result = Hive::ClaudeLauncher.wait_for_status(
+        task, runner, 1, :exit_code_only, output, "ci"
+      )
+      assert_equal :ok, done_result.fetch(:status)
+      assert_equal "ci", done_result.fetch(:log_label)
+
+      assert_raises(ArgumentError) do
+        Hive::ClaudeLauncher.wait_for_status(task, runner, 1, :mystery, output, "x")
+      end
+    end
+  end
+
+  def test_wait_for_expected_output_accepts_ready_prompt_without_done_file
+    with_tmp_task do |task|
+      output = File.join(task.folder, "result.md")
+      File.write(output, "review findings")
+      runner = Struct.new(:tail) do
+        def capture_pane_tail(bytes:) = tail
+      end.new("Claude Code v2\n❯")
+
+      result = Hive::ClaudeLauncher.wait_for_expected_output(task, runner, 1, output, "review")
+
+      assert_equal({ status: :ok, log_label: "review" }, result)
+    end
+  end
+
+  def test_wait_for_expected_output_reports_repeated_tmux_errors
+    with_tmp_task do |task|
+      output = File.join(task.folder, "result.md")
+      File.write(output, "review findings")
+      runner = Struct.new(:name) do
+        def capture_pane_tail(bytes:)
+          raise Hive::TmuxError, "pane unreadable"
+        end
+      end.new("broken")
+
+      with_replaced_singleton_method(Hive::ClaudeLauncher, :sleep, ->(_seconds) { }) do
+        result = Hive::ClaudeLauncher.wait_for_expected_output(task, runner, 10, output, "review")
+        assert_equal :error, result.fetch(:status)
+        assert_match(/tmux_pane_unreadable: pane unreadable/, result.fetch(:error_message))
+      end
+    end
+  end
+
+  def test_wait_for_expected_output_times_out_when_file_missing
+    with_tmp_task do |task|
+      runner = Struct.new(:tail) do
+        def capture_pane_tail(bytes:) = tail
+      end.new("")
+      output = File.join(task.folder, "missing.md")
+
+      result = Hive::ClaudeLauncher.wait_for_expected_output(task, runner, 0, output, "review")
+
+      assert_equal :timeout, result.fetch(:status)
+      assert_match(/missing or empty/, result.fetch(:error_message))
+    end
+  end
+
+  def test_wait_for_done_signal_uses_result_json_status_and_timeout
+    with_tmp_task do |task|
+      File.write(Hive::ClaudeLauncher.done_path(task), "done")
+      File.write(Hive::ClaudeLauncher.result_path(task), JSON.generate("status" => "failed"))
+
+      failed = Hive::ClaudeLauncher.wait_for_done_signal(task, nil, 1, "ci")
+      assert_equal :failed, failed.fetch(:status)
+      assert_match(/failed/, failed.fetch(:error_message))
+    end
+
+    with_tmp_task do |task|
+      timeout = Hive::ClaudeLauncher.wait_for_done_signal(task, nil, 0, "ci")
+      assert_equal :timeout, timeout.fetch(:status)
+      assert_match(/stop hook did not signal/, timeout.fetch(:error_message))
+    end
+  end
+
+  def test_read_result_json_status_handles_all_fallback_shapes
+    with_tmp_task do |task|
+      assert_nil Hive::ClaudeLauncher.read_result_json_status(task)
+
+      FileUtils.touch(Hive::ClaudeLauncher.result_path(task))
+      assert_nil Hive::ClaudeLauncher.read_result_json_status(task)
+
+      File.write(Hive::ClaudeLauncher.result_path(task), JSON.generate("status" => "success"))
+      assert_equal :ok, Hive::ClaudeLauncher.read_result_json_status(task)
+
+      File.write(Hive::ClaudeLauncher.result_path(task), JSON.generate("status" => ""))
+      assert_nil Hive::ClaudeLauncher.read_result_json_status(task)
+
+      File.write(Hive::ClaudeLauncher.result_path(task), JSON.generate("status" => "cancelled"))
+      assert_equal :cancelled, Hive::ClaudeLauncher.read_result_json_status(task)
+
+      File.write(Hive::ClaudeLauncher.result_path(task), JSON.generate([ "not", "a", "hash" ]))
+      assert_nil Hive::ClaudeLauncher.read_result_json_status(task)
+
+      File.write(Hive::ClaudeLauncher.result_path(task), "{")
+      assert_nil Hive::ClaudeLauncher.read_result_json_status(task)
+    end
+  end
+
+  def test_wait_for_terminal_marker_preserves_pane_unreadable_error_on_timeout
+    with_tmp_task do |task|
+      Hive::Markers.set(task.state_file, :error, reason: "tmux_pane_unreadable", message: "pane gone")
+      runner = Struct.new(:tail) do
+        def capture_pane_tail(bytes:) = tail
+      end.new("")
+
+      marker = Hive::ClaudeLauncher.wait_for_terminal_marker(task, runner, 0)
+
+      assert_equal :error, marker.name
+      assert_equal "tmux_pane_unreadable", marker.attrs.fetch("reason")
+    end
+  end
+
+  def test_signal_cleanup_helpers_ignore_unlink_races
+    with_tmp_task do |task|
+      File.write(Hive::ClaudeLauncher.result_path(task), "{}")
+      result_path = Hive::ClaudeLauncher.result_path(task)
+      with_replaced_singleton_method(File, :delete, lambda { |path|
+        raise Errno::ENOENT if path == result_path
+        true
+      }) do
+        assert_nil Hive::ClaudeLauncher.reset_signal_files(task)
+      end
+    end
+
+    with_tmp_task do |task|
+      output = File.join(task.folder, "expected.md")
+      File.write(output, "x")
+      with_replaced_singleton_method(File, :delete, ->(_path) { raise Errno::ENOENT }) do
+        assert_nil Hive::ClaudeLauncher.cleanup_expected_output(output)
+      end
+    end
+  end
+
+  def test_cleanup_scratch_ignores_directory_races
+    with_tmp_task do |task|
+      scratch = File.join(task.folder, ".claude", "settings.json")
+      FileUtils.mkdir_p(File.dirname(scratch))
+      File.write(scratch, "{}")
+
+      with_replaced_singleton_method(Dir, :rmdir, ->(_dir) { raise Errno::ENOTEMPTY }) do
+        assert_nil Hive::ClaudeLauncher.cleanup_scratch(scratch)
+      end
+    end
+  end
+
+  def test_safe_with_log_mentions_task_folder_when_available
+    task = Struct.new(:folder).new("/tmp/example-task")
+
+    _out, err = capture_io do
+      result = Hive::ClaudeLauncher.safe_with_log(task, "cleanup") { raise "boom" }
+      assert_nil result
+    end
+
+    assert_match(/example-task/, err)
+    assert_match(/cleanup/, err)
+  end
 end

--- a/test/unit/claude_launcher_test.rb
+++ b/test/unit/claude_launcher_test.rb
@@ -323,22 +323,29 @@ class ClaudeLauncherTest < Minitest::Test
       end.new("Claude Code\n❯")
       output = File.join(task.folder, "expected.md")
       File.write(output, "done")
-      File.write(Hive::ClaudeLauncher.done_path(task), "done")
 
       output_result = Hive::ClaudeLauncher.wait_for_status(
-        task, runner, 1, :output_file_exists, output, "reviewer"
+        task, runner, 0, :output_file_exists, output, "reviewer"
       )
       assert_equal :ok, output_result.fetch(:status)
       assert_equal "reviewer", output_result.fetch(:log_label)
+    end
+
+    with_tmp_task do |task|
+      runner = Struct.new(:tail) do
+        def capture_pane_tail(bytes:) = tail
+      end.new("")
+      missing_output = File.join(task.folder, "missing.md")
+      File.write(Hive::ClaudeLauncher.done_path(task), "done")
 
       done_result = Hive::ClaudeLauncher.wait_for_status(
-        task, runner, 1, :exit_code_only, output, "ci"
+        task, runner, 0, :exit_code_only, missing_output, "ci"
       )
       assert_equal :ok, done_result.fetch(:status)
       assert_equal "ci", done_result.fetch(:log_label)
 
       assert_raises(ArgumentError) do
-        Hive::ClaudeLauncher.wait_for_status(task, runner, 1, :mystery, output, "x")
+        Hive::ClaudeLauncher.wait_for_status(task, runner, 0, :mystery, missing_output, "x")
       end
     end
   end

--- a/test/unit/cli_test.rb
+++ b/test/unit/cli_test.rb
@@ -133,6 +133,7 @@ class HiveCliTest < Minitest::Test
       "open-pr" => "open-pr",
       "pr" => "open-pr",
       "review" => "review",
+      "artifacts" => "artifacts",
       "finalize" => "finalize",
       "archive" => "archive"
     }
@@ -202,6 +203,16 @@ class HiveCliTest < Minitest::Test
       assert_equal [ "rollback-rate" ], calls.first.fetch(:args)
       assert_equal({ days: 30, project: "proj", json: true }, calls.first.fetch(:kwargs))
     end
+  end
+
+
+  def test_bot_rejects_foreground_and_detach_together
+    _out, err, status = with_captured_exit do
+      Hive::CLI.start([ "bot", "start", "--foreground", "--detach" ])
+    end
+
+    assert_equal Hive::ExitCodes::USAGE, status
+    assert_match(/do not combine it with --foreground/, err)
   end
 
   def test_daemon_argv_errors_emit_json_envelopes_before_raising

--- a/test/unit/commands/doctor_test.rb
+++ b/test/unit/commands/doctor_test.rb
@@ -658,4 +658,33 @@ class HiveCommandsDoctorTest < Minitest::Test
     assert_match(/✗ version_too_old/, old_line)
     assert_match(/\? mystery/, unknown_line)
   end
+  def test_legacy_runtime_warning_reports_unreadable_config_yml
+    with_fake_home do |home|
+      install_brainstorm_and_plan_skills(home)
+      with_tmp_dir do |project|
+        FileUtils.mkdir_p(File.join(project, ".hive-state"))
+        File.write(File.join(project, ".hive-state", "config.yml"), "brainstorm: [broken\n")
+        out = StringIO.new
+        cfg = base_config(
+          "brainstorm" => { "agent" => "claude", "skill" => "/x" },
+          "plan" => { "agent" => "claude", "skill" => "/x" }
+        )
+
+        exit_code = Hive::Commands::Doctor.new(config: cfg, project_root: project, output: out).call
+
+        assert_equal 0, exit_code
+        assert_match(/could not parse \.hive-state\/config\.yml/, out.string)
+      end
+    end
+  end
+
+  def test_legacy_runtime_probe_ignores_invalid_yaml_when_called_directly
+    with_tmp_dir do |project|
+      FileUtils.mkdir_p(File.join(project, ".hive-state"))
+      File.write(File.join(project, ".hive-state", "config.yml"), "brainstorm: [broken\n")
+      doctor = Hive::Commands::Doctor.new(config: base_config, project_root: project)
+
+      refute doctor.send(:legacy_brainstorm_runtime_present?)
+    end
+  end
 end

--- a/test/unit/commands/drop_test.rb
+++ b/test/unit/commands/drop_test.rb
@@ -562,4 +562,97 @@ class DropCommandTest < Minitest::Test
              "dirty worktree must be removed via the --force retry path"
     end
   end
+  def test_drop_prints_human_success_without_json
+    with_drop_project do |dir, ops, project|
+      slug = "plain-drop-260525-aaaa"
+      folder = create_task(dir, "3-plan", slug)
+      commit_hive_state(ops, "3-plan", slug)
+
+      out, _err = capture_io do
+        Hive::Commands::Drop.new(slug, project: project).call
+      end
+
+      assert_includes out, "dropped #{slug} from #{project} (3-plan)"
+      refute File.directory?(folder)
+    end
+  end
+
+  def test_drop_ignores_corrupt_lock_payload_as_no_pid
+    with_drop_project do |dir, ops, project|
+      slug = "bad-lock-260525-aaaa"
+      folder = create_task(dir, "4-execute", slug)
+      File.write(File.join(folder, ".lock"), "pid: [unterminated\n")
+      commit_hive_state(ops, "4-execute", slug)
+
+      out, _err = capture_io do
+        Hive::Commands::Drop.new(slug, project: project, json: true).call
+      end
+      payload = JSON.parse(out)
+
+      assert_equal true, payload["ok"]
+      assert_equal "no_pid", payload["agent_kill_skipped_reason"]
+    end
+  end
+
+  def test_collect_stage_folders_collapses_concurrent_unlink
+    with_drop_project do |dir, _ops, _project|
+      slug = "gone-during-realpath-260525-aaaa"
+      folder = create_task(dir, "3-plan", slug)
+      original = File.method(:realpath)
+
+      with_replaced_singleton_method(File, :realpath, lambda { |path, *args, **kwargs|
+        raise Errno::ENOENT if path == folder
+
+        original.call(path, *args, **kwargs)
+      }) do
+        drop = Hive::Commands::Drop.new(slug)
+        assert_equal [], drop.send(:collect_stage_folders, File.join(dir, ".hive-state"), slug, [ "3-plan" ])
+      end
+    end
+  end
+
+  def test_marker_for_returns_none_for_malformed_task_folder
+    state = Hive::Commands::Drop.new("bad-folder-260525-aaaa").send(:marker_for, "/tmp/not-a-hive-task")
+
+    assert_equal :none, state.name
+    assert_equal({}, state.attrs)
+  end
+
+  def test_remove_one_worktree_treats_already_removed_path_as_false
+    drop = Hive::Commands::Drop.new("missing-wt-260525-aaaa")
+    path = File.join(Dir.tmpdir, "hive-missing-worktree-#{Process.pid}")
+    FileUtils.rm_rf(path)
+    fake_wt = Object.new
+    fake_wt.define_singleton_method(:remove!) { |path:| raise Hive::WorktreeError, "git worktree remove failed: #{path}" }
+    fake_wt.define_singleton_method(:remove_force!) { |path:| raise Hive::WorktreeError, "force failed: #{path}" }
+
+    refute drop.send(:remove_one_worktree, fake_wt, path, registered_paths: [ path ])
+  end
+
+  def test_remove_one_worktree_reraises_force_error_when_path_still_exists
+    drop = Hive::Commands::Drop.new("dirty-wt-260525-aaaa")
+    Dir.mktmpdir("hive-force-wt-") do |path|
+      fake_wt = Object.new
+      fake_wt.define_singleton_method(:remove!) { |path:| raise Hive::WorktreeError, "git worktree remove failed: #{path}" }
+      fake_wt.define_singleton_method(:remove_force!) { |path:| raise Hive::WorktreeError, "force failed: #{path}" }
+
+      err = assert_raises(Hive::WorktreeError) do
+        drop.send(:remove_one_worktree, fake_wt, path, registered_paths: [ path ])
+      end
+      assert_match(/force failed/, err.message)
+    end
+  end
+
+  def test_drop_error_kind_maps_typed_operational_errors
+    drop = Hive::Commands::Drop.new("kind-260525-aaaa")
+
+    assert_equal Hive::Schemas::DropErrorKind::CONFIG,
+                 drop.send(:error_kind_for, Hive::ConfigError.new("bad config"))
+    assert_equal Hive::Schemas::DropErrorKind::GIT,
+                 drop.send(:error_kind_for, Hive::GitError.new("git failed"))
+    assert_equal Hive::Schemas::DropErrorKind::WORKTREE,
+                 drop.send(:error_kind_for, Hive::WorktreeError.new("worktree failed"))
+    assert_equal Hive::Schemas::DropErrorKind::INTERNAL,
+                 drop.send(:error_kind_for, Hive::InternalError.new("boom"))
+  end
 end

--- a/test/unit/commands/init/prompts_test.rb
+++ b/test/unit/commands/init/prompts_test.rb
@@ -653,4 +653,9 @@ class InitPromptsTest < Minitest::Test
     assert_match(/claude/, err.message)
     assert_match(/codex/, err.message)
   end
+  def test_resolve_claude_mode_choice_rejects_numeric_out_of_range
+    prompts, _output = make_prompts(interactive_input)
+
+    assert_nil prompts.send(:resolve_claude_mode_choice, "99")
+  end
 end

--- a/test/unit/commands/status_test.rb
+++ b/test/unit/commands/status_test.rb
@@ -345,6 +345,16 @@ class CommandsStatusTest < Minitest::Test
       assert_equal true, cmd.send(:pid_alive?, 12_345)
     end
 
+    holder = { "pid" => 12_345, "process_start_time" => "recorded" }
+    cmd.define_singleton_method(:pid_alive?) { |_pid| true }
+    with_replaced_singleton_method(Hive::Lock, :process_start_time, ->(_pid) { raise RuntimeError, "blocked" }) do
+      _out, err = capture_io do
+        assert_nil cmd.send(:live_task_lock_holder, holder)
+      end
+      assert_includes err, "hive: status: failed to check liveness"
+      assert_includes err, "RuntimeError: blocked"
+    end
+
     with_replaced_singleton_method(Hive::Config, :load_global_daemon, -> { { "agent_marker_grace_sec" => "not-int" } }) do
       _out, err = capture_io do
         assert_equal Hive::TaskAction::DEFAULT_AGENT_MARKER_GRACE_SEC,

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -219,6 +219,20 @@ class ConfigTest < Minitest::Test
     end
   end
 
+  def test_load_rejects_non_string_stage_skill_by_agent_value
+    with_tmp_dir do |dir|
+      FileUtils.mkdir_p(File.join(dir, ".hive-state"))
+      File.write(File.join(dir, ".hive-state", "config.yml"), <<~YAML)
+        plan:
+          skill_by_agent:
+            codex: 42
+      YAML
+
+      err = assert_raises(Hive::ConfigError) { Hive::Config.load(dir) }
+      assert_match(/plan\.skill_by_agent\.codex.*must be a String/, err.message)
+    end
+  end
+
   def test_load_raises_when_stage_agent_is_unknown_profile
     with_tmp_dir do |dir|
       FileUtils.mkdir_p(File.join(dir, ".hive-state"))

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -1833,4 +1833,12 @@ class ConfigTest < Minitest::Test
       assert_match(/rebase.*must be a Hash/, err.message)
     end
   end
+  def test_claude_mode_rejects_unknown_value
+    err = assert_raises(Hive::ConfigError) do
+      Hive::Config.claude_mode("claude" => { "mode" => "warm_pool" })
+    end
+
+    assert_match(/claude\.mode must be one of/, err.message)
+    assert_match(/warm_pool/, err.message)
+  end
 end

--- a/test/unit/coverage_test.rb
+++ b/test/unit/coverage_test.rb
@@ -82,6 +82,33 @@ class HiveTestCoverageTest < Minitest::Test
     end
   end
 
+  def test_reload_preloaded_entrypoint_filters_constant_redefinition_warnings_only
+    with_tmp_dir do |dir|
+      lib = File.join(dir, "lib")
+      FileUtils.mkdir_p(lib)
+      path = File.join(lib, "hive.rb")
+      File.write(path, <<~RUBY)
+        module CoverageReloadProbe
+          VALUE = 1
+        end
+        warn "real reload warning"
+      RUBY
+
+      _out, _err = capture_io { load path }
+      $LOADED_FEATURES << path
+      with_coverage_config(root: dir) do
+        _out, err = capture_io { HiveTestCoverage.send(:reload_preloaded_entrypoint!) }
+
+        assert_includes err, "real reload warning"
+        refute_includes err, "already initialized constant"
+        refute_includes err, "previous definition of VALUE"
+      end
+    ensure
+      $LOADED_FEATURES.delete(path) if path
+      Object.send(:remove_const, :CoverageReloadProbe) if Object.const_defined?(:CoverageReloadProbe)
+    end
+  end
+
   def test_coverage_gate_accepts_string_keyed_json_report
     report = {
       "line_total" => 3,

--- a/test/unit/coverage_test.rb
+++ b/test/unit/coverage_test.rb
@@ -120,6 +120,18 @@ class HiveTestCoverageTest < Minitest::Test
     assert HiveTestCoverage.coverage_ok?(report)
   end
 
+  def test_coverage_gate_defaults_to_full_line_coverage
+    report = {
+      "line_total" => 4,
+      "line_covered" => 3,
+      "line_percent" => 75.0,
+      "unloaded_files" => [],
+      "result_errors" => []
+    }
+
+    refute HiveTestCoverage.coverage_ok?(report)
+    assert_includes HiveTestCoverage.failure_message(report), "below minimum 100.00%"
+  end
 
   def test_coverage_gate_honors_min_line_threshold_env
     report = {

--- a/test/unit/current_main_coverage_gap_test.rb
+++ b/test/unit/current_main_coverage_gap_test.rb
@@ -1,0 +1,461 @@
+require "test_helper"
+require "json"
+require "hive/task"
+require "hive/stages/artifacts"
+require "hive/stages/finalize"
+require "hive/stages/review"
+require "hive/stages/review/browser_test"
+require "hive/stages/review/ci_fix"
+require "hive/stages/review/triage"
+require "hive/reviewers/agent"
+require "hive/tui/bubble_model"
+require "hive/tui/messages"
+require "hive/tui/red_status_detail_layout"
+require "hive/tui/update"
+require "hive/tui/views/idea_preview"
+require "hive/tui/views/red_status_detail"
+
+class CurrentMainCoverageGapTest < Minitest::Test
+  include HiveTestHelper
+
+  FakeProfile = Struct.new(:name) do
+    def format_skill_invocation(skill)
+      "/#{skill}"
+    end
+  end
+
+  FakeTask = Struct.new(
+    :folder, :worktree_path, :project_root, :state_file, :slug,
+    :stage_index, :stage_name, keyword_init: true
+  ) do
+    def log_dir
+      File.join(folder, "logs")
+    end
+  end
+
+  FakeHandle = Struct.new(:calls) do
+    def send_and_wait!(**kwargs)
+      calls << kwargs
+      File.write(kwargs.fetch(:expected_output), "ok\n")
+      { status: :ok }
+    end
+  end
+
+  def row(stage: "6-review", slug: "red-task", folder: "/tmp/red-task", diagnostic: nil)
+    Hive::Tui::Snapshot::Row.new(
+      project_name: "alpha", stage: stage, slug: slug, folder: folder,
+      state_file: File.join(folder.to_s, "task.md"), marker: "review_error",
+      attrs: { "phase" => "fix", "pass" => "1" }, mtime: nil, age_seconds: 0,
+      claude_pid: nil, claude_pid_alive: nil, action_key: "recover_review",
+      action_label: "Needs recovery", suggested_command: nil, next_action: nil,
+      diagnostic: diagnostic
+    )
+  end
+
+  def task_folder(root, stage: "6-review", slug: "gap-task")
+    folder = File.join(root, ".hive-state", "stages", stage, slug)
+    FileUtils.mkdir_p(File.join(folder, "reviews"))
+    folder
+  end
+
+  def review_ctx(root, folder, pass: 1)
+    Hive::Stages::Review::Context.new(
+      worktree_path: root,
+      task_folder: folder,
+      default_branch: "main",
+      pass: pass
+    )
+  end
+
+  def fake_task(root, folder, worktree: root)
+    FakeTask.new(
+      folder: folder,
+      worktree_path: worktree,
+      project_root: root,
+      state_file: File.join(folder, "task.md"),
+      slug: File.basename(folder),
+      stage_index: 6,
+      stage_name: "review"
+    )
+  end
+
+  def with_fake_profile(profile = FakeProfile.new(:codex))
+    with_replaced_singleton_method(Hive::AgentProfiles, :lookup, ->(*_args, **_kwargs) { profile }) do
+      yield profile
+    end
+  end
+
+  def with_spawn_agent_capture(calls, result = { status: :ok })
+    with_replaced_singleton_method(Hive::Stages::Base, :spawn_agent, lambda { |task, **kwargs|
+      calls << [ task, kwargs ]
+      FileUtils.mkdir_p(File.dirname(kwargs[:expected_output])) if kwargs[:expected_output]
+      File.write(kwargs[:expected_output], JSON.generate(status: "passed", summary: "ok", details: "", duration_sec: 1)) if kwargs[:expected_output]&.end_with?(".json")
+      File.write(kwargs[:expected_output], "# Escalations\n") if kwargs[:expected_output]&.end_with?(".md")
+      result
+    }) do
+      yield
+    end
+  end
+
+  def snapshot_with(rows)
+    project = Hive::Tui::Snapshot::ProjectView.new(
+      name: "alpha", path: "/alpha", hive_state_path: "/alpha/.hive-state",
+      error: nil, rows: rows.freeze
+    ).freeze
+    Hive::Tui::Snapshot.new(generated_at: nil, projects: [ project ])
+  end
+
+  def test_claude_launcher_wait_for_done_signal_handles_success_after_poll
+    with_tmp_dir do |dir|
+      task = Struct.new(:folder).new(dir)
+      done = File.join(dir, ".done")
+      calls = 0
+      sleeps = []
+      base = Time.utc(2026, 5, 25, 12, 0, 0)
+      times = [ base, base, base ]
+      original_exist = File.method(:exist?)
+
+      with_replaced_singleton_method(Time, :now, -> { times.shift || base }) do
+        with_replaced_singleton_method(File, :exist?, lambda { |path|
+          if path == done
+            calls += 1
+            calls > 1
+          else
+            original_exist.call(path)
+          end
+        }) do
+          with_replaced_singleton_method(Hive::ClaudeLauncher, :read_result_json_status, ->(_task) { :ok }) do
+            with_replaced_singleton_method(Hive::ClaudeLauncher, :sleep, ->(seconds) { sleeps << seconds }) do
+              result = Hive::ClaudeLauncher.wait_for_done_signal(task, nil, 5, "review")
+
+              assert_equal({ status: :ok, log_label: "review" }, result)
+              assert_equal [ 0.5 ], sleeps
+            end
+          end
+        end
+      end
+    end
+  end
+
+  def test_stage_non_claude_dispatchers_use_generic_spawn_agent
+    with_tmp_dir do |root|
+      folder = task_folder(root)
+      task = fake_task(root, folder)
+      File.write(task.state_file, "")
+      calls = []
+      profile = FakeProfile.new(:codex)
+
+      with_spawn_agent_capture(calls) do
+        Hive::Stages::Artifacts.spawn_artifacts_agent(task, { "budget_usd" => {}, "timeout_sec" => {} }, "collect", profile)
+        Hive::Stages::Finalize.spawn_finalize_agent(task, { "budget_usd" => {}, "timeout_sec" => {} }, "final", profile, root)
+      end
+
+      assert_equal 2, calls.length
+      assert_equal %w[artifacts finalize], calls.map { |_task, kwargs| kwargs[:log_label] }
+      assert_equal "error", Hive::Stages::Artifacts.action_for(:error)
+      assert_equal "custom", Hive::Stages::Artifacts.action_for(:custom)
+    end
+  end
+
+  def test_review_substages_use_generic_spawn_agent_for_non_claude_profiles
+    with_tmp_dir do |root|
+      folder = task_folder(root)
+      File.write(File.join(folder, "reviews", "codex-ce-code-review-01.md"), "## Finding\n- [ ] fix this\n")
+      ctx = review_ctx(root, folder)
+      cfg = {
+        "review" => {
+          "browser_test" => { "enabled" => true, "agent" => "codex", "max_attempts" => 1, "prompt_template" => "browser_test_prompt.md.erb" },
+          "triage" => { "agent" => "codex", "bias" => "courageous" },
+          "ci" => { "agent" => "codex", "prompt_template" => "ci_fix_prompt.md.erb" }
+        },
+        "budget_usd" => {},
+        "timeout_sec" => {}
+      }
+      calls = []
+
+      with_fake_profile(FakeProfile.new(:codex)) do
+        with_spawn_agent_capture(calls) do
+          browser = Hive::Stages::Review::BrowserTest.run_attempt(cfg: cfg, ctx: ctx, attempt: 1)
+          triage = Hive::Stages::Review::Triage.run!(cfg: cfg, ctx: ctx)
+          ci = Hive::Stages::Review::CiFix.spawn_fix_agent(
+            cfg: cfg,
+            ctx: ctx,
+            command: "bin/test",
+            attempt: 1,
+            max_attempts: 2,
+            captured_output: "red"
+          )
+
+          assert_equal :passed, browser[:status]
+          assert_equal :ok, triage.status
+          assert_equal({ status: :ok }, ci)
+        end
+      end
+
+      assert_equal [
+        "review-browser-pass01-attempt01",
+        "review-triage-pass01",
+        "review-ci-fix-attempt01"
+      ], calls.map { |_task, kwargs| kwargs[:log_label] }
+    end
+  end
+
+  def test_review_fix_and_reviewer_shared_session_edge_paths
+    with_tmp_dir do |root|
+      folder = task_folder(root)
+      ctx = review_ctx(root, folder)
+      File.write(File.join(folder, "task.md"), "Task\n")
+      calls = []
+
+      with_fake_profile(FakeProfile.new(:codex)) do
+        with_spawn_agent_capture(calls) do
+          Hive::Stages::Review.spawn_fix_agent(
+            fake_task(root, folder),
+            { "review" => { "fix" => { "agent" => "codex", "prompt_template" => "fix_prompt.md.erb" } }, "budget_usd" => {}, "timeout_sec" => {} },
+            ctx,
+            accepted: [ "finding" ]
+          )
+        end
+      end
+      assert_equal "review-fix-pass01", calls.last.last[:log_label]
+
+      spec = {
+        "name" => "codex-ce-code-review",
+        "output_basename" => "codex-ce-code-review",
+        "agent" => "claude",
+        "skill" => "ce-code-review",
+        "prompt_template" => "reviewer_claude_ce_code_review.md.erb",
+        "max_attempts" => 1,
+        "timeout_sec" => 30
+      }
+      handle = FakeHandle.new([])
+
+      with_fake_profile(FakeProfile.new(:claude)) do
+        result = Hive::Reviewers::Agent.new(spec, ctx, cfg: {}).run_in_session!(handle: handle)
+
+        assert_equal :ok, result.status
+        assert_equal 1, handle.calls.length
+        assert_equal "review-codex-ce-code-review-pass01", handle.calls.first[:log_label]
+      end
+    end
+  end
+
+  def test_base_marker_and_spawn_defensive_branches
+    with_tmp_dir do |root|
+      folder = task_folder(root, stage: "2-brainstorm")
+      task = fake_task(root, folder)
+      task.stage_index = 2
+      task.stage_name = "brainstorm"
+
+      with_replaced_singleton_method(Hive::Events, :emit, ->(**_kwargs) { raise Errno::EACCES, "blocked" }) do
+        assert_nil Hive::Stages::Base.emit_rescue_close(task, nil, "boom")
+      end
+
+      marker = Struct.new(:name, :attrs).new(:review_error, {})
+      assert_equal "review_error", Hive::Stages::Base.marker_event_message(marker)
+
+      error = assert_raises(Hive::AgentError) do
+        Hive::Stages::Base.spawn_claude!(
+          task,
+          {},
+          prompt: "prompt",
+          max_budget_usd: 1,
+          timeout_sec: 1,
+          session_name: "session",
+          profile: FakeProfile.new(:codex)
+        )
+      end
+      assert_includes error.message, "only supports the claude profile"
+    end
+  end
+
+  def test_review_run_maps_tmux_unavailable_agent_error
+    with_tmp_dir do |root|
+      folder = task_folder(root)
+      worktree = File.join(root, "worktree")
+      FileUtils.mkdir_p(worktree)
+      task = Hive::Task.new(folder)
+      File.write(task.state_file, "")
+      File.write(task.worktree_yml_path, { "path" => worktree }.to_yaml)
+
+      with_replaced_singleton_method(Hive::Stages::Review, :canonical_worktree_root, ->(_task, _cfg) { root }) do
+        with_replaced_singleton_method(Hive::Worktree, :read_pointer, ->(_folder) { { "path" => worktree } }) do
+          with_replaced_singleton_method(Hive::Worktree, :validate_pointer_path, ->(_path, _root) { true }) do
+            with_replaced_singleton_method(Hive::Stages::Review, :reviewer_compare_ref, ->(_cfg, _ops) { "main" }) do
+              with_replaced_singleton_method(Hive::Stages::Review::CiFix, :run!, ->(**_kwargs) { raise Hive::AgentError, "tmux binary not runnable: tmux" }) do
+                result = Hive::Stages::Review.run!(task, { "review" => {}, "claude" => { "mode" => "tmux" } })
+
+                assert_equal({ commit: "review_error_tmux_unavailable", status: :review_error }, result)
+                marker = Hive::Markers.current(task.state_file)
+                assert_equal :review_error, marker.name
+                assert_equal "tmux_unavailable", marker.attrs["reason"]
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+
+  def test_review_helper_error_paths_return_structured_results
+    with_tmp_dir do |root|
+      folder = task_folder(root)
+      ctx = review_ctx(root, folder)
+      task = fake_task(root, folder)
+
+      Hive::Stages::Review.instance_variable_set(:@open_phase_event, {
+        task: task,
+        slug: task.slug,
+        label: "phase=ci pass=01",
+        stage: "6-review"
+      })
+      with_replaced_singleton_method(Hive::Events, :emit, ->(**_kwargs) { raise Errno::EACCES, "blocked" }) do
+        assert_nil Hive::Stages::Review.close_phase_event!
+      end
+
+      assert_equal :wall_clock_exceeded,
+                   Hive::Stages::Review.run_reviewer_spec({}, ctx, { "name" => "late" }, nil,
+                                                           started_at: Time.now - 10,
+                                                           max_wall_clock_sec: 1)
+
+      adapter = Struct.new(:output_path) do
+        def run!(deadline: nil)
+          raise Hive::AgentError, "quota exhausted"
+        end
+      end.new(File.join(folder, "reviews", "quota-01.md"))
+      spec = { "name" => "quota" }
+      with_replaced_singleton_method(Hive::Reviewers, :dispatch, ->(_spec, _ctx, cfg:) { adapter }) do
+        result = Hive::Stages::Review.run_reviewer_spec({}, ctx, spec, nil)
+
+        assert_equal :error, result.status
+        assert_includes result.error_message, "quota exhausted"
+      end
+    end
+  end
+
+  def test_tui_update_scroll_and_token_stats_edge_branches
+    model = Hive::Tui::Model.initial(cols: 100, rows: 24)
+    red_state = Hive::Tui::Model::RedStatusDetailState.new(
+      row: row,
+      log_lines: (1..20).map { |i| "line-#{i}" },
+      log_scroll_offset: 0
+    )
+
+    skipped, = Hive::Tui::Update.apply(model, Hive::Tui::Messages::RedStatusDetailScroll.new(direction: :up, amount: 1))
+    assert_same model, skipped
+
+    state_nil = model.with(red_status_detail_state: nil)
+    assert_equal 0, Hive::Tui::Update.red_status_detail_log_capacity(state_nil)
+
+    crowded = model.with(
+      mode: :red_status_detail,
+      rows: 6,
+      red_status_detail_state: red_state
+    )
+    assert_equal 0, Hive::Tui::Update.red_status_detail_log_capacity(crowded)
+    unchanged, = Hive::Tui::Update.apply(crowded, Hive::Tui::Messages::RedStatusDetailScroll.new(direction: :up, amount: 1))
+    assert_same crowded, unchanged
+
+    unknown, = Hive::Tui::Update.apply(
+      model.with(mode: :red_status_detail, red_status_detail_state: red_state.with(log_scroll_offset: 2)),
+      Hive::Tui::Messages::RedStatusDetailScroll.new(direction: :sideways, amount: 1)
+    )
+    assert_equal 2, unknown.red_status_detail_state.log_scroll_offset
+
+    assert_same model, Hive::Tui::Update.apply(model, Hive::Tui::Messages::TokenStatsScopeChanged.new(direction: :sideways)).first
+
+    token_all = model.with(mode: :token_stats, token_stats_state: Hive::Tui::Model::TokenStatsState.new(scope_level: :all))
+    assert_equal :all, Hive::Tui::Update.apply(token_all, Hive::Tui::Messages::TokenStatsScopeChanged.new(direction: :sideways)).first.token_stats_state.scope_level
+    assert_equal :all, Hive::Tui::Update.apply(token_all, Hive::Tui::Messages::TokenStatsScopeChanged.new(direction: :out)).first.token_stats_state.scope_level
+    assert_equal :all, Hive::Tui::Update.apply(token_all, Hive::Tui::Messages::TokenStatsSelectionMoved.new(direction: :next)).first.token_stats_state.scope_level
+
+    token_task = model.with(mode: :token_stats, token_stats_state: Hive::Tui::Model::TokenStatsState.new(scope_level: :task, project_slug: "alpha", task_slug: "one"))
+    assert_equal :task, Hive::Tui::Update.apply(token_task, Hive::Tui::Messages::TokenStatsScopeChanged.new(direction: :in)).first.token_stats_state.scope_level
+  end
+
+  def test_bubble_model_token_stats_and_log_edge_branches
+    dispatch = ->(_message) { }
+    selected_row = row(slug: "task-one")
+    bubble = Hive::Tui::BubbleModel.new(
+      hive_model: Hive::Tui::Model.initial.with(
+        snapshot: snapshot_with([ selected_row ]),
+        cursor: [ 0, 0 ],
+        pane_focus: :left,
+        scope: 1
+      ),
+      dispatch: dispatch
+    )
+
+    project_state = bubble.send(:token_stats_state_for_current_scope)
+    assert_equal :project, project_state.scope_level
+    assert_equal({ project_slug: "alpha" }, bubble.send(:token_stats_scope, project_state))
+
+    all_bubble = Hive::Tui::BubbleModel.new(hive_model: Hive::Tui::Model.initial.with(snapshot: nil), dispatch: dispatch)
+    all_state = all_bubble.send(:token_stats_state_for_current_scope)
+    assert_equal :all, all_state.scope_level
+    assert_equal({}, all_bubble.send(:token_stats_scope, all_state))
+    assert_nil all_bubble.send(:frontmatter_scalar, "---\nname: demo\n---\n", "created_at")
+
+    with_tmp_dir do |root|
+      folder = task_folder(root, stage: "4-execute", slug: "log-task")
+      log_dir = File.join(root, ".hive-state", "logs", "log-task")
+      FileUtils.mkdir_p(log_dir)
+      log_path = File.join(log_dir, "execute-test.log")
+      File.write(log_path, "hello\n")
+      log_row = row(stage: "4-execute", slug: "log-task", folder: folder)
+
+      with_replaced_singleton_method(File, :mtime, ->(_path) { raise Errno::ENOENT, "gone" }) do
+        assert_equal log_path, bubble.send(:latest_log_matching, log_row) { true }
+      end
+
+      with_replaced_singleton_method(Dir, :glob, ->(_pattern) { raise Errno::EACCES, "blocked" }) do
+        assert_nil bubble.send(:latest_log_matching, log_row) { true }
+      end
+
+      invalid_row = row(folder: File.join(root, "not-a-task"))
+      assert_nil bubble.send(:task_log_dir_for, invalid_row)
+
+      with_replaced_singleton_method(bubble, :read_capped, ->(_path) { raise Errno::EACCES, "blocked" }) do
+        assert_nil bubble.send(:stage_extra_for, row(stage: "2-brainstorm", folder: folder))
+      end
+
+      fake_file = Object.new
+      fake_file.define_singleton_method(:seek) { |_offset, _whence| raise Errno::EINVAL, "short" }
+      fake_file.define_singleton_method(:rewind) { raise Errno::ESPIPE, "pipe" }
+      original_open = File.method(:open)
+      with_replaced_singleton_method(File, :open, lambda { |path, *args, &block|
+        path == log_path ? block.call(fake_file) : original_open.call(path, *args, &block)
+      }) do
+        assert_nil bubble.send(:tail_capped, log_path)
+      end
+
+      with_replaced_singleton_method(File, :open, lambda { |path, *_args, &_block|
+        raise Errno::ENXIO, "blocked" if path == log_path
+      }) do
+        assert_nil bubble.send(:tail_capped, log_path)
+      end
+    end
+  end
+
+  def test_tui_view_edge_branches
+    artifact_row = row(diagnostic: { "artifact_paths" => %w[a b c d e f] })
+    assert_equal 8, Hive::Tui::RedStatusDetailLayout.artifact_row_count(artifact_row)
+
+    assert_equal "status…\e[0m", Hive::Tui::Views::IdeaPreview.with_ellipsis("status  \e[0m")
+    assert_equal "already…\e[0m", Hive::Tui::Views::IdeaPreview.with_ellipsis("already…\e[0m")
+
+    state = Hive::Tui::Model::InfoPanelState.new(
+      slug: "done",
+      stage: "8-finalize",
+      created_at: nil,
+      original_text: "text",
+      folder_path: "/tmp/task",
+      latest_log_path: nil,
+      stage_extra: "details"
+    )
+    assert_equal "details", Hive::Tui::Views::IdeaPreview.extra_title(state)
+
+    header = Hive::Tui::Views::RedStatusDetail.header_line("RED · ", "alpha/6-review", "slug", "/tmp/path", 3)
+    assert_operator header.length, :<=, 3
+  end
+end

--- a/test/unit/daemon/child_supervisor_test.rb
+++ b/test/unit/daemon/child_supervisor_test.rb
@@ -247,6 +247,64 @@ class HiveDaemonChildSupervisorTest < Minitest::Test
     assert_equal 1, reap_calls
   end
 
+  def test_terminate_all_wait_loop_reaps_before_deadline
+    sup = make
+    sup.instance_variable_set(:@running, {
+      123 => { project: "p1", slug: "a", stage: "6-review", command: "hive run a" }
+    })
+    reap_calls = 0
+    kills = []
+
+    sup.define_singleton_method(:collect_pgids) { [] }
+    sup.define_singleton_method(:safe_kill) { |signal, target| kills << [ signal, target ] }
+    sup.define_singleton_method(:reap_all) do
+      reap_calls += 1
+      if reap_calls == 1
+        [ Object.new ]
+      else
+        instance_variable_get(:@running).clear
+        []
+      end
+    end
+
+    sup.terminate_all(grace_sec: 1)
+
+    assert_equal 2, reap_calls
+    assert_empty kills
+    assert_equal 0, sup.in_flight_count
+  end
+
+  def test_collect_pgids_deduplicates_and_ignores_exited_children
+    sup = make
+    sup.instance_variable_set(:@running, {
+      111 => { project: "p1", slug: "a", stage: "6-review", command: "hive run a" },
+      222 => { project: "p1", slug: "b", stage: "6-review", command: "hive run b" },
+      333 => { project: "p1", slug: "gone", stage: "6-review", command: "hive run gone" }
+    })
+
+    with_replaced_singleton_method(Process, :getpgid, lambda { |pid|
+      raise Errno::ESRCH if pid == 333
+
+      42
+    }) do
+      assert_equal [ 42 ], sup.send(:collect_pgids)
+    end
+  end
+
+  def test_safe_kill_sends_signal_to_target
+    sup = make
+    calls = []
+
+    with_replaced_singleton_method(Process, :kill, lambda { |signal, target|
+      calls << [ signal, target ]
+      1
+    }) do
+      assert_equal 1, sup.send(:safe_kill, :TERM, -123)
+    end
+
+    assert_equal [ [ :TERM, -123 ] ], calls
+  end
+
   def test_terminate_all_signals_running_children
     skip "skipping signal test under CI containers" if ENV["CI"] == "true"
 

--- a/test/unit/daemon/dispatcher_test.rb
+++ b/test/unit/daemon/dispatcher_test.rb
@@ -278,6 +278,23 @@ class HiveDaemonDispatcherTest < Minitest::Test
     assert_equal "hive archive s1 --from 8-finalize --project p1 --json", sup.spawned.first[:command]
   end
 
+  def test_merge_watcher_dropped_entries_are_logged
+    dispatcher, _sup, _ctrl, logger, mw = make_dispatcher(rows: [], with_merge_watcher: true)
+    mw.next_dropped = [ {
+      project: "p1", slug: "s1", pr_url: "https://example.com/pull/1",
+      failure_count: 3, last_error: "gh api failed"
+    } ]
+
+    dispatcher.tick(now: T0)
+
+    event = logger.events.find { |(name, _attrs)| name == :merge_watcher_dropped }
+    refute_nil event
+    assert_equal({
+      project: "p1", slug: "s1", pr_url: "https://example.com/pull/1",
+      failure_count: 3, last_error: "gh api failed"
+    }, event[1])
+  end
+
   def test_merged_pr_archive_skips_when_project_disabled_after_enqueue
     # PR-40 review P2 #4: a project disabled between merge-watch
     # enqueue and the merge-completion tick must NOT be archived.

--- a/test/unit/events_test.rb
+++ b/test/unit/events_test.rb
@@ -130,4 +130,65 @@ class EventsTest < Minitest::Test
       lines.each { |line| assert_kind_of Hash, JSON.parse(line) }
     end
   end
+  def test_truncate_message_preserves_utf8_boundary_and_suffix
+    message = "ø" * Hive::Events::MAX_MESSAGE_BYTES
+
+    truncated = Hive::Events.truncate_message(message)
+
+    assert truncated.valid_encoding?
+    assert truncated.end_with?(Hive::Events::MESSAGE_TRUNCATION_SUFFIX)
+    assert_operator truncated.bytesize, :<=, Hive::Events::MAX_MESSAGE_BYTES
+  end
+
+  def test_render_status_body_handles_empty_event_list
+    body = Hive::Events.render_status_body(
+      {
+        "slug" => "empty-events",
+        "stage" => "2-brainstorm",
+        "ts" => "2026-05-25T00:00:00Z",
+        "event_type" => "stage_enter",
+        "message" => nil
+      },
+      []
+    )
+
+    assert_includes body, "- (no events yet)"
+    assert_includes body, "Current agent: #{Hive::Events::EM_DASH}"
+  end
+
+  def test_read_recent_events_skips_malformed_lines_and_handles_read_errors
+    with_tmp_dir do |dir|
+      path = File.join(dir, "events.jsonl")
+      File.write(path, "not-json\n#{JSON.generate('event_type' => 'stage_enter')}\n")
+
+      events = Hive::Events.read_recent_events(path, 10)
+      assert_equal [ "stage_enter" ], events.map { |event| event.fetch("event_type") }
+
+      with_replaced_singleton_method(File, :open, ->(*_args) { raise Errno::EACCES }) do
+        assert_equal [], Hive::Events.read_recent_events(path, 10)
+      end
+    end
+  end
+
+  def test_write_atomic_tolerates_fsync_unsupported
+    with_tmp_dir do |dir|
+      path = File.join(dir, "status.md")
+      original_open = File.method(:open)
+      File.define_singleton_method(:open) do |*args, **kwargs, &block|
+        if block && args.first.to_s.include?(".status.md.tmp")
+          original_open.call(*args, **kwargs) do |file|
+            file.define_singleton_method(:fsync) { raise Errno::EINVAL }
+            block.call(file)
+          end
+        else
+          original_open.call(*args, **kwargs, &block)
+        end
+      end
+
+      Hive::Events.write_atomic(path, "body\n")
+      assert_equal "body\n", File.read(path)
+    ensure
+      File.define_singleton_method(:open, original_open) if original_open
+    end
+  end
 end

--- a/test/unit/git_ops_test.rb
+++ b/test/unit/git_ops_test.rb
@@ -457,6 +457,17 @@ class GitOpsTest < Minitest::Test
     end
   end
 
+  def test_delete_branch_raises_for_unexpected_git_failure
+    dir = Dir.mktmpdir("hive-missing-git-root-")
+    FileUtils.rm_rf(dir)
+    ops = Hive::GitOps.new(dir)
+
+    err = assert_raises(Hive::GitError) do
+      ops.delete_branch!("still-fatal-260525")
+    end
+    assert_match(/branch -D still-fatal-260525 failed/, err.message)
+  end
+
   def test_delete_branch_returns_false_when_branch_already_gone
     with_tmp_git_repo do |dir|
       ops = Hive::GitOps.new(dir)

--- a/test/unit/process_kill_test.rb
+++ b/test/unit/process_kill_test.rb
@@ -8,6 +8,7 @@ require "hive/lock"
 # permission_denied, kill_failed) so a regression in any of them
 # fails here instead of letting drop signal a foreign PID silently.
 class ProcessKillTest < Minitest::Test
+  include HiveTestHelper
   def test_terminate_process_refuses_pid_zero_as_invalid
     result = Hive::ProcessKill.terminate_process(0)
     assert_equal 0, result.pid
@@ -109,6 +110,123 @@ class ProcessKillTest < Minitest::Test
       end
     end
   end
+
+  def test_pid_alive_treats_permission_denied_as_alive
+    with_replaced_singleton_method(Process, :kill, lambda { |_signal, _pid| raise Errno::EPERM }) do
+      assert Hive::ProcessKill.pid_alive?(1234)
+    end
+  end
+
+  def test_process_start_time_returns_nil_for_malformed_pid
+    assert_nil Hive::ProcessKill.process_start_time("not-a-pid")
+  end
+
+  def test_terminate_process_escalates_to_kill_when_term_does_not_stop_process
+    alive_sequence = [ true, true, false ]
+    signals = []
+    with_replaced_singleton_method(Hive::ProcessKill, :pid_alive?, lambda { |_pid| alive_sequence.shift }) do
+      with_replaced_singleton_method(Hive::ProcessKill, :safe_kill, lambda { |signal, pid| signals << [ signal, pid ] }) do
+        with_replaced_singleton_method(Hive::ProcessKill, :wait_until_dead, lambda { |_pid, _seconds| false }) do
+          result = Hive::ProcessKill.terminate_process(1234, grace_seconds: 0)
+
+          assert_equal [ [ "TERM", 1234 ], [ "KILL", 1234 ] ], signals
+          assert result.killed
+          assert_nil result.skipped_reason
+        end
+      end
+    end
+  end
+
+  def test_terminate_process_reports_permission_denied_when_signal_fails
+    with_replaced_singleton_method(Hive::ProcessKill, :pid_alive?, lambda { |_pid| true }) do
+      with_replaced_singleton_method(Hive::ProcessKill, :safe_kill, lambda { |_signal, _pid| raise Errno::EPERM }) do
+        result = Hive::ProcessKill.terminate_process(1234, grace_seconds: 0)
+
+        refute result.killed
+        assert_equal "permission_denied", result.skipped_reason
+      end
+    end
+  end
+
+  def test_terminate_process_group_pid_reuse_guard_when_start_time_does_not_match
+    with_process_start_time_stub("live-start-time") do
+      result = Hive::ProcessKill.terminate_process_group(
+        Process.pid, recorded_start_time: "different-recorded-time"
+      )
+
+      refute result.killed
+      assert_equal "pid_reuse_guard", result.skipped_reason
+    end
+  end
+
+  def test_terminate_process_group_returns_invalid_pid_for_nil_argument
+    result = Hive::ProcessKill.terminate_process_group(nil)
+
+    assert_nil result.pid
+    refute result.killed
+    assert_equal "invalid_pid", result.skipped_reason
+  end
+
+  def test_terminate_process_group_escalates_to_kill_when_term_does_not_stop_process
+    alive_sequence = [ true, true, false ]
+    signals = []
+    with_replaced_singleton_method(Hive::ProcessKill, :pid_alive?, lambda { |_pid| alive_sequence.shift }) do
+      with_replaced_singleton_method(Process, :getpgid, lambda { |pid| pid }) do
+        with_replaced_singleton_method(Hive::ProcessKill, :safe_kill, lambda { |signal, target| signals << [ signal, target ] }) do
+          with_replaced_singleton_method(Hive::ProcessKill, :wait_until_dead, lambda { |_pid, _seconds| false }) do
+            result = Hive::ProcessKill.terminate_process_group(1234, grace_seconds: 0)
+
+            assert_equal [ [ "TERM", -1234 ], [ "KILL", -1234 ] ], signals
+            assert result.killed
+            assert_nil result.skipped_reason
+          end
+        end
+      end
+    end
+  end
+
+  def test_terminate_process_group_reports_not_alive_when_group_disappears
+    with_replaced_singleton_method(Hive::ProcessKill, :pid_alive?, lambda { |_pid| true }) do
+      with_replaced_singleton_method(Process, :getpgid, lambda { |_pid| raise Errno::ESRCH }) do
+        result = Hive::ProcessKill.terminate_process_group(1234, grace_seconds: 0)
+
+        refute result.killed
+        assert_equal "not_alive", result.skipped_reason
+      end
+    end
+  end
+
+  def test_terminate_process_group_reports_permission_denied_when_signal_fails
+    with_replaced_singleton_method(Hive::ProcessKill, :pid_alive?, lambda { |_pid| true }) do
+      with_replaced_singleton_method(Process, :getpgid, lambda { |pid| pid }) do
+        with_replaced_singleton_method(Hive::ProcessKill, :safe_kill, lambda { |_signal, _target| raise Errno::EPERM }) do
+          result = Hive::ProcessKill.terminate_process_group(1234, grace_seconds: 0)
+
+          refute result.killed
+          assert_equal "permission_denied", result.skipped_reason
+        end
+      end
+    end
+  end
+
+  def test_safe_kill_ignores_missing_or_forbidden_targets
+    with_replaced_singleton_method(Process, :kill, lambda { |_signal, _target| raise Errno::ESRCH }) do
+      assert_nil Hive::ProcessKill.safe_kill("TERM", 1234)
+    end
+  end
+
+  def test_wait_until_dead_checks_final_state_after_deadline
+    with_replaced_singleton_method(Hive::ProcessKill, :reap_if_child_exited, lambda { |_pid| false }) do
+      with_replaced_singleton_method(Hive::ProcessKill, :pid_alive?, lambda { |_pid| false }) do
+        assert Hive::ProcessKill.wait_until_dead(1234, 0)
+      end
+    end
+  end
+
+  def test_reap_if_child_exited_returns_false_for_non_child
+    refute Hive::ProcessKill.reap_if_child_exited(999_999)
+  end
+
 
   private
 

--- a/test/unit/process_kill_test.rb
+++ b/test/unit/process_kill_test.rb
@@ -209,9 +209,15 @@ class ProcessKillTest < Minitest::Test
     end
   end
 
-  def test_safe_kill_ignores_missing_or_forbidden_targets
+  def test_safe_kill_ignores_missing_targets
     with_replaced_singleton_method(Process, :kill, lambda { |_signal, _target| raise Errno::ESRCH }) do
       assert_nil Hive::ProcessKill.safe_kill("TERM", 1234)
+    end
+  end
+
+  def test_safe_kill_propagates_permission_denied
+    with_replaced_singleton_method(Process, :kill, lambda { |_signal, _target| raise Errno::EPERM }) do
+      assert_raises(Errno::EPERM) { Hive::ProcessKill.safe_kill("TERM", 1234) }
     end
   end
 

--- a/test/unit/reviewers/agent_test.rb
+++ b/test/unit/reviewers/agent_test.rb
@@ -665,4 +665,17 @@ class ReviewersAgentTest < Minitest::Test
       FileUtils.rm_rf(log_dir) if log_dir
     end
   end
+  def test_run_in_shared_session_rejects_non_claude_profile
+    with_tmp_dir do |dir|
+      ctx = make_ctx(dir)
+      FileUtils.mkdir_p(ctx.task_folder)
+      reviewer = Hive::Reviewers::Agent.new(make_spec("agent" => "codex"), ctx)
+
+      err = assert_raises(Hive::AgentError) do
+        reviewer.run_in_session!(handle: Object.new)
+      end
+
+      assert_match(/shared Claude reviewer session cannot run :codex/, err.message)
+    end
+  end
 end

--- a/test/unit/stages/brainstorm_tmux_sentinel_test.rb
+++ b/test/unit/stages/brainstorm_tmux_sentinel_test.rb
@@ -421,4 +421,113 @@ class BrainstormTmuxSentinelTest < Minitest::Test
       yield Hive::Task.new(folder)
     end
   end
+
+  public
+
+  def test_brainstorm_tmux_run_uses_claude_launcher_and_returns_marker_action
+    with_tmp_task_folder do |task|
+      cfg = {
+        "budget_usd" => { "brainstorm" => 12 },
+        "timeout_sec" => { "brainstorm" => 34 }
+      }
+      profile = Struct.new(:name).new(:claude)
+      captured = nil
+      lookup_call = nil
+      render_call = nil
+
+      with_claude_launcher_stubs(
+        launch!: ->(**kwargs) {
+          captured = kwargs
+          Hive::Markers.set(task.state_file, :complete)
+          { status: :complete }
+        }
+      ) do
+        with_replaced_singleton_method(Hive::AgentProfiles, :lookup, ->(name, cfg:) {
+          lookup_call = [ name, cfg ]
+          profile
+        }) do
+          with_replaced_singleton_method(Hive::Stages::Brainstorm, :render_prompt, ->(render_task, render_cfg, profile:) {
+            render_call = [ render_task, render_cfg, profile ]
+            "brainstorm prompt"
+          }) do
+            result = Hive::Stages::BrainstormTmux.run!(task, cfg)
+
+            assert_equal({ commit: "complete", status: :complete }, result)
+          end
+        end
+      end
+
+      assert_equal [ :claude, cfg ], lookup_call
+      assert_equal [ task, cfg, profile ], render_call
+      assert_equal task, captured.fetch(:task)
+      assert_equal "brainstorm prompt", captured.fetch(:prompt)
+      assert_equal [ task.folder ], captured.fetch(:add_dirs)
+      assert_equal task.folder, captured.fetch(:cwd)
+      assert_equal 12, captured.fetch(:max_budget_usd)
+      assert_equal 34, captured.fetch(:timeout_sec)
+      assert_equal "brainstorm", captured.fetch(:log_label)
+      assert_equal :state_file_marker, captured.fetch(:status_mode)
+      assert_equal Hive::ClaudeLauncher::PLANNER_ALLOWED_TOOLS, captured.fetch(:allowed_tools)
+    end
+  end
+
+  def test_brainstorm_tmux_delegates_remaining_helpers_to_claude_launcher
+    task = Struct.new(:folder, :slug).new("/tmp/task", "task-slug")
+    runner = Object.new
+    profile = Struct.new(:bin).new("claude")
+    marker = Object.new
+    calls = []
+
+    with_claude_launcher_stubs(
+      parse_tmux_version: ->(output) { calls << [ :parse, output ]; "3.6" },
+      version_tuple: ->(version) { calls << [ :tuple, version ]; [ 3, 6 ] },
+      tmux_bin: -> { calls << [ :tmux_bin ]; "tmux-custom" },
+      wrapper_command: ->(**kwargs) { calls << [ :wrapper, kwargs ]; [ "wrapper" ] },
+      claude_trust_prompt?: ->(pane) { calls << [ :trust, pane ]; true },
+      claude_ready_prompt?: ->(pane) { calls << [ :ready, pane ]; false },
+      wait_for_terminal_marker: ->(t, r, timeout) { calls << [ :wait_marker, t, r, timeout ]; marker },
+      record_claude_pid: ->(t, r) { calls << [ :pid, t, r ]; nil },
+      sweep_orphan_processes: ->(t) { calls << [ :sweep, t ]; nil },
+      orphan_sweep_pattern: ->(t) { calls << [ :pattern, t ]; "pattern" },
+      poll_interval: -> { calls << [ :poll ]; 0.1 },
+      sentinel_poll_interval: -> { calls << [ :sentinel ]; 0.2 },
+      claude_ready_wait_timeout: -> { calls << [ :ready_timeout ]; 3 },
+      session_ready_wait_timeout: -> { calls << [ :session_timeout ]; 4 },
+      pid_ready_wait_timeout: -> { calls << [ :pid_timeout ]; 5 },
+      cleanup_done: ->(t) { calls << [ :cleanup_done, t ]; nil }
+    ) do
+      assert_equal "3.6", Hive::Stages::BrainstormTmux.parse_tmux_version("tmux 3.6")
+      assert_equal [ 3, 6 ], Hive::Stages::BrainstormTmux.version_tuple("3.6")
+      assert_equal "tmux-custom", Hive::Stages::BrainstormTmux.tmux_bin
+      assert_equal [ "wrapper" ], Hive::Stages::BrainstormTmux.wrapper_command(task, profile)
+      assert Hive::Stages::BrainstormTmux.claude_trust_prompt?("pane")
+      refute Hive::Stages::BrainstormTmux.claude_ready_prompt?("pane")
+      assert_same marker, Hive::Stages::BrainstormTmux.wait_for_terminal_marker(task, runner, 9)
+      assert_nil Hive::Stages::BrainstormTmux.record_claude_pid(task, runner)
+      assert_nil Hive::Stages::BrainstormTmux.sweep_orphan_processes(task)
+      assert_equal "pattern", Hive::Stages::BrainstormTmux.orphan_sweep_pattern(task)
+      assert_equal 0.1, Hive::Stages::BrainstormTmux.poll_interval
+      assert_equal 0.2, Hive::Stages::BrainstormTmux.sentinel_poll_interval
+      assert_equal 3, Hive::Stages::BrainstormTmux.claude_ready_wait_timeout
+      assert_equal 4, Hive::Stages::BrainstormTmux.session_ready_wait_timeout
+      assert_equal 5, Hive::Stages::BrainstormTmux.pid_ready_wait_timeout
+      assert_nil Hive::Stages::BrainstormTmux.cleanup_done(task)
+    end
+
+    assert_includes calls, [ :parse, "tmux 3.6" ]
+    assert calls.any? { |entry| entry.first == :wrapper && entry.last[:allowed_tools] == Hive::ClaudeLauncher::PLANNER_ALLOWED_TOOLS }
+    assert_includes calls, [ :wait_marker, task, runner, 9 ]
+  end
+
+  def with_claude_launcher_stubs(replacements)
+    originals = replacements.keys.to_h { |name| [ name, Hive::ClaudeLauncher.method(name) ] }
+    replacements.each do |name, replacement|
+      Hive::ClaudeLauncher.define_singleton_method(name, &replacement)
+    end
+    yield
+  ensure
+    originals&.each do |name, original|
+      Hive::ClaudeLauncher.define_singleton_method(name, original)
+    end
+  end
 end

--- a/test/unit/stages/open_pr_test.rb
+++ b/test/unit/stages/open_pr_test.rb
@@ -104,6 +104,33 @@ class HiveStagesOpenPrTest < Minitest::Test
     end
   end
 
+  def test_run_refuses_merged_pr_recovery_with_empty_url
+    with_tmp_dir do |root|
+      task = make_task(root)
+      with_tmp_git_repo do |worktree|
+        head_oid = run!("git", "-C", worktree, "rev-parse", "HEAD").strip
+        write_pointer(task, worktree)
+        merged = {
+          "url" => "",
+          "number" => 134,
+          "state" => "MERGED",
+          "isDraft" => false,
+          "headRefOid" => head_oid
+        }
+
+        with_basic_open_pr_run_stubs(merged_pr: merged) do
+          _out, err, status = with_captured_exit do
+            Hive::Stages::OpenPr.run!(task, cfg)
+          end
+
+          assert_equal 1, status
+          assert_match(/merged PR with an empty url/, err)
+          refute File.exist?(task.state_file)
+        end
+      end
+    end
+  end
+
   def test_run_recovers_when_branch_pr_is_already_merged
     with_tmp_dir do |root|
       task = make_task(root)

--- a/test/unit/tui/bubble_model_test.rb
+++ b/test/unit/tui/bubble_model_test.rb
@@ -2825,6 +2825,39 @@ class HiveTuiBubbleModelTest < Minitest::Test
                  "no-recipe refusal must nudge operator toward the manual fallback")
   end
 
+  def test_open_red_status_detail_resolves_agent_label_from_task_project_config
+    with_tmp_dir do |dir|
+      slug = "red-detail-260525-aaaa"
+      folder = File.join(dir, ".hive-state", "stages", "4-execute", slug)
+      FileUtils.mkdir_p(folder)
+      File.write(File.join(dir, ".hive-state", "config.yml"), { "execute" => { "agent" => "codex" } }.to_yaml)
+      File.write(File.join(folder, "task.md"), "# task\n<!-- ERROR -->\n")
+      row = make_task_row(
+        action_key: "error", action_label: "Error", slug: slug, stage: "4-execute",
+        folder: folder, marker: "error", attrs: { "reason" => "exit_code" }, suggested_command: nil
+      )
+
+      @model.update(Hive::Tui::Messages::OpenRedStatusDetail.new(row: row))
+
+      assert_equal :red_status_detail, @model.hive_model.mode
+      assert_equal "codex", @model.hive_model.red_status_detail_state.agent_label
+      assert_same row, @model.hive_model.red_status_detail_state.row
+    end
+  end
+
+  def test_open_red_status_detail_uses_fallback_agent_label_for_malformed_folder
+    row = make_task_row(
+      action_key: "error", action_label: "Error", slug: "bad-folder", stage: "4-execute",
+      folder: "/tmp/not-a-hive-task", marker: "error", attrs: {}, suggested_command: nil
+    )
+
+    @model.update(Hive::Tui::Messages::OpenRedStatusDetail.new(row: row))
+
+    assert_equal :red_status_detail, @model.hive_model.mode
+    assert_equal Hive::Tui::Model::RedStatusDetailState::AGENT_FALLBACK,
+                 @model.hive_model.red_status_detail_state.agent_label
+  end
+
   def test_red_status_autofix_from_detail_mode_closes_screen_on_recovery_success
     # Happy-path pin for plan Unit 4: a recoverable recover_review row
     # dispatched from :red_status_detail must flip the mode back to
@@ -2853,6 +2886,35 @@ class HiveTuiBubbleModelTest < Minitest::Test
     assert_equal :grid, @model.hive_model.mode
     assert_nil @model.hive_model.red_status_detail_state
     assert_match(/clearing/, @model.hive_model.flash.to_s)
+  end
+
+  def test_close_red_status_detail_on_dispatch_reclamps_cursor_when_snapshot_visible
+    row = make_task_row(
+      action_key: "recover_review", action_label: "Needs recovery",
+      slug: "visible-row", stage: "6-review", folder: "/tmp/hive/visible-row",
+      marker: "review_error", attrs: {}, suggested_command: nil
+    )
+    snapshot = Hive::Tui::Snapshot.new(
+      generated_at: "now",
+      projects: [ Hive::Tui::Snapshot::ProjectView.new(
+        name: "demo", path: "/tmp/demo", hive_state_path: "/tmp/demo/.hive-state",
+        error: nil, rows: [ row ]
+      ) ]
+    )
+    state = Hive::Tui::Model::RedStatusDetailState.new(row: row)
+    starting = Hive::Tui::Model.initial.with(
+      mode: :red_status_detail,
+      red_status_detail_state: state,
+      snapshot: snapshot,
+      cursor: [ 0, 99 ]
+    )
+
+    closed, cmd = @model.send(:close_red_status_detail_on_dispatch, starting, nil)
+
+    assert_nil cmd
+    assert_equal :grid, closed.mode
+    assert_nil closed.red_status_detail_state
+    assert_equal [ 0, 0 ], closed.cursor
   end
 
   def test_close_red_status_detail_on_dispatch_passes_through_in_grid_mode

--- a/test/unit/tui/views/token_stats_test.rb
+++ b/test/unit/tui/views/token_stats_test.rb
@@ -41,4 +41,16 @@ class HiveTuiViewsTokenStatsTest < Minitest::Test
     assert_includes out, "scope: empty"
     assert_includes out, "0/0/0"
   end
+  def test_column_widths_shrink_usage_columns_for_narrow_inner_width
+    rows = [
+      Hive::Tui::Views::TokenStats::HEADER,
+      [ "claude", "123456789", "123456789", "123456789", "123456789" ]
+    ]
+
+    widths = Hive::Tui::Views::TokenStats.column_widths(rows, 24)
+
+    assert_equal 6, widths.first
+    assert_operator widths[1], :<, 9
+    assert_operator widths[1..].min, :>=, 6
+  end
 end

--- a/test/unit/usage_db_test.rb
+++ b/test/unit/usage_db_test.rb
@@ -141,4 +141,20 @@ class UsageDbTest < Minitest::Test
       assert_equal({ input: 3, output: 3, cached: 3 }, usage_at(aggregate, :claude, :all))
     end
   end
+  def test_aggregate_with_broken_path_warns_and_returns_zero_tree
+    with_tmp_dir do |dir|
+      Hive::UsageDb.path = dir
+
+      _out, err = capture_io do
+        aggregate = Hive::UsageDb.aggregate(scope: {}, now: Time.utc(2026, 5, 24, 12))
+        assert_equal({ input: 0, output: 0, cached: 0 }, usage_at(aggregate, :claude, :all))
+      end
+
+      assert_match(/usage aggregate failed/, err)
+    end
+  end
+
+  def test_iso8601_returns_original_text_when_parse_fails
+    assert_equal "not-a-time", Hive::UsageDb.iso8601("not-a-time")
+  end
 end

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -2,6 +2,13 @@
 
 Append-only log of all wiki operations.
 
+## [2026-05-25T00:00:00Z] testing - default 100 percent coverage gate
+
+**Action:** Made `bundle exec rake coverage` enforce 100% line coverage by default, with CI also exporting `HIVE_COVERAGE_MIN_LINE=100` explicitly. Added unit coverage for the default threshold and updated the ProcessKill permission-denied tests to exercise production-reachable `EPERM` behavior.
+
+**Refreshed pages:**
+- [[testing]] - documented the default 100% coverage threshold and the override role of `HIVE_COVERAGE_MIN_LINE`.
+
 ## [2026-05-24T16:46:47Z] release notes - final verified PR merge batch
 
 **Action:** Refreshed `docs/notes/2026-05-24-verified-pr-merge-notes.md` after #134 and #135 merged. The note now covers the full ordered #121-first pass through #135, includes the docs checkpoint #136, records the PR #135 CI flake fix and verification evidence, and updates the line-change scoreboard/fun stats.

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -3,7 +3,7 @@ title: Testing
 type: reference
 source: test/, Rakefile, .rubocop.yml
 created: 2026-04-25
-updated: 2026-05-24
+updated: 2026-05-25
 tags: [test, minitest, fixtures]
 ---
 
@@ -23,7 +23,7 @@ bundle exec rake coverage
 
 The coverage task uses Ruby's stdlib `Coverage` API. It starts line and branch coverage in the parent test process and prepends `RUBYOPT=-Itest -rhive_coverage_boot` so Ruby subprocess tests dump their own result files under a per-run `coverage/.resultset/<run-id>/` directory. The final merged report is written to `coverage/coverage.json` and prints the lowest-covered source files plus uncovered line numbers.
 
-`bundle exec rake coverage` is the CI coverage-report path. It fails when an executable source file was never loaded or when a subprocess result file cannot be read. Set `HIVE_COVERAGE_MIN_LINE` (for example `100`) to enforce a minimum line-coverage percentage.
+`bundle exec rake coverage` is the CI coverage-report path. It fails when an executable source file was never loaded, when a subprocess result file cannot be read, or when line coverage drops below the default 100% threshold. Set `HIVE_COVERAGE_MIN_LINE` to a different numeric percentage only when intentionally loosening or tightening that gate.
 
 In CI (`CI=true`), tests that exercise backgrounding commands must force a foreground path (for example `foreground: true`) or stub daemonization. Otherwise the test process can daemonize before Minitest `after_run` writes `coverage/coverage.json`, leaving the parent coverage task with a missing report while child output keeps streaming. Coverage also reloads `lib/hive.rb`, so self-derived enum constants must exclude `:ALL` to stay reload-safe.
 


### PR DESCRIPTION
## Summary
Strict coverage is back to 100% on current `main`. The branch closes the drift from newly uncovered defensive paths while keeping the coverage gate itself more tolerant of report-shape and reload-warning noise.

## Stage Notes
| Stage | Commit | What changed |
| --- | --- | --- |
| Coverage harness | `0f420afc` | Coverage reporting now reads string-keyed JSON totals and reloads preloaded sources without constant-redefinition warning spam. |
| Initial gap closure | `02e72139` | Added focused tests for CLI/config/git/process/migration/drop/dispatcher/init/TUI paths that were uncovered after the mainline changes. |
| Current-main closure | `fc9c78be` | Covered the remaining launcher, stage dispatch, review error, TUI detail/token, events, and usage edge branches needed for a clean 100% gate. |

## Verification
- `env HIVE_COVERAGE_MIN_LINE=100 bundle exec rake coverage` - passed, `100.00% (15317/15317)`, `3459` runs, `12378` assertions, `0` failures, `0` errors, `2` skips.
- `bundle exec rubocop` - passed, no offenses.
- `bundle exec ruby -Itest -Ilib test/unit/current_main_coverage_gap_test.rb` - passed, `10` runs, `54` assertions.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)
