### PR TITLE
fix(daemon): propagate live_task_lock through healer and dispatcher

### DIFF
--- a/lib/hive/daemon/dispatcher.rb
+++ b/lib/hive/daemon/dispatcher.rb
@@ -416,8 +416,7 @@ module Hive
       def observe_external_running_rows(rows)
         per_project = Hash.new(0)
         rows.each do |row|
-          next unless row.action == "agent_running"
-          next if row.claude_pid_alive == false
+          next unless externally_running?(row)
           next if @controller.running_task?(project: row.project, slug: row.slug)
 
           per_project[row.project] += 1
@@ -568,8 +567,26 @@ module Hive
       end
 
       def active_agent_row?(row)
-        row.action == Hive::Schemas::TaskActionKind::AGENT_RUNNING &&
-          row.claude_pid_alive == true
+        externally_running?(row)
+      end
+
+      # A row counts as externally running when `Hive::TaskAction` has
+      # classified it as `agent_running` AND we have positive evidence
+      # that the run is in flight — either the .lock recorded a live
+      # claude_pid, OR `Hive::Commands::Status` verified the .lock
+      # holder PID + process_start_time still match (`live_task_lock`).
+      # Both the dispatcher's global concurrency counter
+      # (`@external_active_agent_total`) and the controller's per-project
+      # counter (`set_external_running_counts`) use this predicate so
+      # they agree on which rows count against the cap. Issue #144
+      # narrowed the predicate from "claude_pid_alive != false" (which
+      # over-counted rows with no liveness signal) and broadened the
+      # strict "claude_pid_alive == true" path (which silently dropped
+      # live_task_lock-only rows during the pre-claude window).
+      def externally_running?(row)
+        return false unless row.action == Hive::Schemas::TaskActionKind::AGENT_RUNNING
+
+        row.claude_pid_alive == true || row.live_task_lock == true
       end
 
       def external_active_agent_count_for(project)

--- a/lib/hive/daemon/stale_agent_healer.rb
+++ b/lib/hive/daemon/stale_agent_healer.rb
@@ -28,6 +28,10 @@ module Hive
     # Skip cases:
     #   - controller.running_task? returns true (an in-process dispatch
     #     is live; do not race it)
+    #   - row.live_task_lock is true (an externally-spawned `hive run` is
+    #     holding the per-task .lock with a verified PID + start-time
+    #     match; the runner is still inside the task even if its
+    #     claude_pid is not yet recorded — do not race it). Issue #144.
     #   - project's legacy_stage_dirs is non-empty (we never touch markers
     #     in a half-migrated layout — the dispatcher already refuses to
     #     advance these)
@@ -64,6 +68,11 @@ module Hive
           next unless row.marker.to_s == "agent_working"
           next if legacy_layout_projects.include?(row.project)
           next if @controller.running_task?(project: row.project, slug: row.slug)
+          # Externally-spawned `hive run` is holding the per-task .lock;
+          # claude_pid_alive may still be nil because the runner has not
+          # written its claude_pid yet (auto-rebase, etc.). Healing here
+          # would race the live runner. Issue #144.
+          next if row.live_task_lock == true
 
           reason = classify_stale(row, now: now)
           next unless reason

--- a/lib/hive/daemon/status_consumer.rb
+++ b/lib/hive/daemon/status_consumer.rb
@@ -9,9 +9,16 @@ module Hive
     # as a structured `{ok: false}` rather than raising, so a transient
     # status hiccup doesn't crash the daemon.
     class StatusConsumer
+      # `live_task_lock` is the per-task `.lock`-holder-alive signal
+      # `Hive::Commands::Status` derives from a PID + process_start_time
+      # match. It is true while a `hive run` invocation is actively inside
+      # the task — including pre-stage work like auto-rebase — even before
+      # the runner has written its claude_pid to the lock. The daemon
+      # healer and dispatcher both need this so they don't race the runner
+      # during the pre-claude window (issue #144).
       Row = Struct.new(:project, :slug, :stage, :marker, :folder, :state_file,
                        :state_file_mtime, :action, :suggested_command, :claude_pid_alive,
-                       :diagnostic,
+                       :live_task_lock, :diagnostic,
                        keyword_init: true)
       # Aggregated per-project legacy-layout signal lifted out of each
       # project payload's `legacy_stage_dirs` array. The dispatcher uses
@@ -86,6 +93,7 @@ module Hive
               action: task["action"],
               suggested_command: task["suggested_command"],
               claude_pid_alive: task["claude_pid_alive"],
+              live_task_lock: task["live_task_lock"] == true,
               diagnostic: task["diagnostic"]
             )
           end

--- a/test/unit/daemon/dispatcher_test.rb
+++ b/test/unit/daemon/dispatcher_test.rb
@@ -139,15 +139,16 @@ class HiveDaemonDispatcherTest < Minitest::Test
 
   def row(project: "p1", slug: "s1", stage: "1-inbox", marker: "waiting",
           action: "ready_to_brainstorm", command: "hive brainstorm s1",
-          mtime: T0 - 600, claude_pid_alive: nil, state_file: nil,
-          folder: nil)
+          mtime: T0 - 600, claude_pid_alive: nil, live_task_lock: nil,
+          state_file: nil, folder: nil)
     folder ||= make_existing_row_folder(project: project, stage: stage, slug: slug)
     Row.new(
       project: project, slug: slug, stage: stage, marker: marker,
       folder: folder,
       state_file: state_file || File.join(folder, "idea.md"),
       state_file_mtime: mtime, action: action,
-      suggested_command: command, claude_pid_alive: claude_pid_alive
+      suggested_command: command, claude_pid_alive: claude_pid_alive,
+      live_task_lock: live_task_lock
     )
   end
 
@@ -563,6 +564,27 @@ class HiveDaemonDispatcherTest < Minitest::Test
     assert_equal 0, sup.spawned.size
     blocked = logger.events.find { |(n, attrs)| n == :blocked && attrs[:slug] == "ready" }
     refute_nil blocked, "visible running agents must consume capacity after daemon restart"
+    assert_equal "global_cap", blocked[1][:reason]
+  end
+
+  # Issue #144: a row whose only liveness signal is `live_task_lock`
+  # (runner is in the pre-claude_pid window — auto-rebase or other
+  # pre-stage work) must consume capacity, otherwise the daemon will
+  # dispatch more work and breach the global cap.
+  def test_live_task_lock_only_row_counts_toward_global_cap
+    rows = [
+      row(slug: "rebasing", action: "agent_running", command: nil, mtime: T0 - 60,
+          claude_pid_alive: nil, live_task_lock: true),
+      row(slug: "ready", action: "ready_to_plan", command: "hive plan ready --from 2-brainstorm")
+    ]
+    dispatcher, sup, ctrl, logger, _mw = make_dispatcher(rows: rows)
+    ctrl.instance_variable_set(:@max_concurrent_runs, 1)
+
+    dispatcher.tick(now: T0)
+
+    assert_equal 0, sup.spawned.size
+    blocked = logger.events.find { |(n, attrs)| n == :blocked && attrs[:slug] == "ready" }
+    refute_nil blocked, "live_task_lock=true row must consume a global cap slot"
     assert_equal "global_cap", blocked[1][:reason]
   end
 

--- a/test/unit/daemon/stale_agent_healer_test.rb
+++ b/test/unit/daemon/stale_agent_healer_test.rb
@@ -62,13 +62,13 @@ class HiveDaemonStaleAgentHealerTest < Minitest::Test
   # on-disk marker name), not row.action, so we use the production-
   # accurate combo by default. Tests can override via the action: kwarg.
   def make_row(state_file, pid_alive:, mtime: NOW - 1000, project: "p", slug: "s", stage: "4-execute",
-               marker: "agent_working", action: "error")
+               marker: "agent_working", action: "error", live_task_lock: nil)
     Row.new(
       project: project, slug: slug, stage: stage,
       marker: marker, folder: File.dirname(state_file), state_file: state_file,
       state_file_mtime: mtime,
       action: action, suggested_command: nil,
-      claude_pid_alive: pid_alive, diagnostic: nil
+      claude_pid_alive: pid_alive, live_task_lock: live_task_lock, diagnostic: nil
     )
   end
 
@@ -116,6 +116,23 @@ class HiveDaemonStaleAgentHealerTest < Minitest::Test
       heal([ row ])
 
       refute @logger.events.any? { |name, _| name == :marker_healed }
+      assert_match(/AGENT_WORKING/, File.read(state_file))
+    end
+  end
+
+  # Issue #144: an externally-spawned `hive run` may hold the per-task
+  # .lock with a verified PID + process_start_time match while it does
+  # pre-stage work (e.g. auto-rebase) — the marker is still AGENT_WORKING
+  # and claude_pid_alive is still nil because the runner has not written
+  # its claude_pid yet. Without the live_task_lock skip, the healer
+  # races the live runner once mtime exceeds grace.
+  def test_skips_row_with_live_task_lock_even_when_grace_exceeded
+    with_marker_file do |state_file|
+      row = make_row(state_file, pid_alive: nil, mtime: NOW - 600, live_task_lock: true)
+      heal([ row ])
+
+      refute @logger.events.any? { |name, _| name == :marker_healed },
+             "live_task_lock=true must pre-empt grace-exceeded heal so the healer does not race the live runner; events: #{@logger.events.inspect}"
       assert_match(/AGENT_WORKING/, File.read(state_file))
     end
   end

--- a/test/unit/daemon/status_consumer_test.rb
+++ b/test/unit/daemon/status_consumer_test.rb
@@ -80,6 +80,33 @@ class HiveDaemonStatusConsumerTest < Minitest::Test
     end
   end
 
+  # Issue #144: the daemon healer and dispatcher use `row.live_task_lock`
+  # to recognise a live `hive run` during the pre-claude_pid window. Pin
+  # the parse of the JSON key here so a regression in `task_payload`
+  # (Hive::Commands::Status) or the Row struct surfaces as a structured
+  # test failure rather than a silent classification change downstream.
+  def test_parses_live_task_lock_field_and_coerces_to_strict_boolean
+    task_true = task_row(slug: "live-runner").merge("live_task_lock" => true)
+    task_false = task_row(slug: "no-runner").merge("live_task_lock" => false)
+    task_missing = task_row(slug: "legacy-payload")
+    payload = make_envelope(projects: [ {
+      "name" => "p", "path" => "/tmp/p", "hive_state_path" => "/tmp/p/.h",
+      "tasks" => [ task_true, task_false, task_missing ]
+    } ])
+    with_fake_status(JSON.generate(payload)) do |bin|
+      consumer = Hive::Daemon::StatusConsumer.new(hive_bin: bin)
+      result = consumer.fetch
+      assert result.ok
+      rows = result.rows.each_with_object({}) { |r, h| h[r.slug] = r }
+      assert_equal true, rows.fetch("live-runner").live_task_lock,
+                   "explicit true must propagate"
+      assert_equal false, rows.fetch("no-runner").live_task_lock,
+                   "explicit false must propagate"
+      assert_equal false, rows.fetch("legacy-payload").live_task_lock,
+                   "missing key must coerce to false, not nil — downstream callers compare with ==true"
+    end
+  end
+
   def test_parses_multiple_projects_and_tasks
     payload = make_envelope(projects: [
       {


### PR DESCRIPTION
## Summary

Closes #144.

PR #138 made `live_task_lock` visible in `hive status --json` so external consumers can detect an in-flight `hive run` even before the runner has attached its `claude_pid` (auto-rebase or other pre-stage work). The daemon's `StaleAgentHealer` and `Dispatcher` both classify the same payload but were not updated, leaving two concrete races:

1. **Healer raced the live runner.** `classify_stale` keyed off `claude_pid_alive` alone — a live runner holding the `.lock` with no claude_pid yet + grace-exceeded `AGENT_WORKING` mtime classified as `agent_orphaned`, and the healer overwrote the marker with ERROR over the running runner.
2. **Dispatcher undercounted the global cap.** `observe_external_running_rows` skipped only `claude_pid_alive == false` (counting nil-pid rows), while `active_agent_row?` required `claude_pid_alive == true` strictly. A row with `action=agent_running` + `claude_pid_alive=nil` was in one counter, not the other, so the global cap could be breached by live_task_lock-only rows.

## Changes

- `StatusConsumer::Row` carries an additive `:live_task_lock` field. `build_row` coerces `task["live_task_lock"]` to a strict boolean so legacy payloads omitting the key parse as `false` (downstream compares with `== true`).
- `StaleAgentHealer#heal` adds a `live_task_lock == true` skip before `classify_stale` runs. Docstring updated.
- `Dispatcher` unifies both counters behind one `externally_running?` predicate: `action == AGENT_RUNNING && (claude_pid_alive == true || live_task_lock == true)`. Both the global cap and the per-project counter now use it. The old loose `claude_pid_alive != false` arm (which optimistically counted rows with **no** liveness signal at all) is removed — those phantoms are a transient state the healer rewrites to ERROR within the grace window anyway.

## Tests

- `test_parses_live_task_lock_field_and_coerces_to_strict_boolean` — JSON-parse contract: explicit true/false propagate; missing key → false.
- `test_skips_row_with_live_task_lock_even_when_grace_exceeded` — healer no longer races a live runner.
- `test_live_task_lock_only_row_counts_toward_global_cap` — pre-claude_pid live runner consumes a slot.
- Full suite: 3490 runs, 12521 assertions, 0 failures, 0 errors, 2 skips.
- Coverage gate: passed (100.00%).
- Rubocop: 6 files, 0 offenses.

## Test plan

- [x] `bundle exec rake test`
- [x] `bundle exec rake coverage`
- [x] `bundle exec rubocop` (changed files)
- [ ] CI green