### PR TITLE
feat(bot): replace recovery alerts with one-button human notifications

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -17,18 +17,10 @@
       "note": "False positive. Open3.capture3 array form in Stages::Finalize#final_commits. base is produced by `git merge-base HEAD origin/<default>` and interpolated into one revspec argv element (`base..HEAD`); no shell ever sees it."
     },
     {
-      "fingerprint": "c95e1a89a496342c7c7f06de67790df2bc46bc538b9ced61c16a703fb42facb5",
-      "note": "False positive. Open3.capture3 array form in BrainstormTmux#sweep_orphan_processes. task.folder is Regexp.escape'd into one pgrep pattern argv element; no shell ever sees it."
-    },
-    {
-      "fingerprint": "5bca07d54019b8f635328009cbc5517d6d7e8f74d12afcb448517a482176d392",
-      "note": "False positive. Open3.capture3 array form in BrainstormTmux#sweep_orphan_processes. task.folder is Regexp.escape'd into one pkill pattern argv element; no shell ever sees it."
-    },
-    {
       "fingerprint": "907f70565e5132a49765208c31e28bbf8433b7819fb85fbc46413a8cb7649f81",
       "note": "False positive. Open3.capture3 array form in GitOps#commits_behind. `ref` is `origin/<default_branch>` constructed inside Hive::Rebase from `cfg.default_branch || git.default_branch` (the latter from `git symbolic-ref refs/remotes/origin/HEAD`). Not attacker-controlled; passed as a single argv element to execve(2)."
     }
   ],
-  "updated": "2026-05-15",
+  "updated": "2026-05-26",
   "brakeman_version": "8.0.4"
 }

--- a/lib/hive/bot/alert_store.rb
+++ b/lib/hive/bot/alert_store.rb
@@ -136,8 +136,16 @@ module Hive
 
         FileUtils.mkdir_p(File.dirname(@path))
         tmp_path = File.join(File.dirname(@path), ".#{File.basename(@path)}.#{$$}.#{Thread.current.object_id}.tmp")
-        File.write(tmp_path, JSON.pretty_generate(@data))
+        File.open(tmp_path, "w") do |f|
+          f.write(JSON.pretty_generate(@data))
+          f.fsync
+        end
         File.rename(tmp_path, @path)
+        begin
+          Dir.open(File.dirname(@path)) { |dir| dir.fsync }
+        rescue StandardError
+          nil
+        end
       ensure
         FileUtils.rm_f(tmp_path) if tmp_path && File.exist?(tmp_path)
       end

--- a/lib/hive/bot/alert_store.rb
+++ b/lib/hive/bot/alert_store.rb
@@ -1,0 +1,166 @@
+require "json"
+require "fileutils"
+require "time"
+
+module Hive
+  module Bot
+    class AlertStore
+      SCHEMA_VERSION = 1
+
+      Entry = Data.define(:first_seen_at, :reminded_at, :row)
+      RowSnapshot = Data.define(:project, :slug, :stage, :marker, :attrs, :action) do
+        def initialize(project:, slug:, stage:, marker:, attrs: {}, action: nil)
+          super
+        end
+      end
+
+      def initialize(path:, logger: nil)
+        @path = path ? File.expand_path(path) : nil
+        @logger = logger
+        @mutex = Mutex.new
+        @data = empty_data
+        load!
+      end
+
+      def each_fingerprint
+        return enum_for(:each_fingerprint) unless block_given?
+
+        synchronize { entries.keys }.each { |fingerprint| yield fingerprint }
+      end
+
+      def add(fingerprint, row, now)
+        synchronize do
+          entries[fingerprint] = {
+            "first_seen_at" => timestamp(now),
+            "reminded_at" => nil,
+            "row" => serialize_row(row)
+          }
+          persist_locked!
+        end
+      end
+
+      def mark_reminded(fingerprint, now)
+        synchronize do
+          entry = entries[fingerprint]
+          next unless entry
+
+          entry["reminded_at"] = timestamp(now)
+          persist_locked!
+        end
+      end
+
+      def remove(fingerprint)
+        synchronize do
+          entry = entries.delete(fingerprint)
+          persist_locked! if entry
+          entry ? row_from_raw(entry["row"]) : nil
+        end
+      end
+
+      def entry(fingerprint)
+        synchronize do
+          raw = entries[fingerprint]
+          raw ? entry_from_raw(raw) : nil
+        end
+      end
+
+      private
+
+      def synchronize(&block)
+        @mutex.synchronize(&block)
+      end
+
+      def load!
+        return unless @path && File.exist?(@path)
+
+        parsed = JSON.parse(File.read(@path))
+        unless parsed.is_a?(Hash) &&
+               parsed["schema_version"] == SCHEMA_VERSION &&
+               parsed["entries"].is_a?(Hash)
+          raise JSON::ParserError, "invalid alert store schema"
+        end
+
+        @data = {
+          "schema_version" => SCHEMA_VERSION,
+          "entries" => parsed["entries"]
+        }
+      rescue JSON::ParserError, TypeError => e
+        corrupt_path = corrupt_path_for(@path)
+        begin
+          File.rename(@path, corrupt_path) if @path && File.exist?(@path)
+        rescue SystemCallError
+          corrupt_path = nil
+        end
+        @logger&.event(:alert_store_corrupt, path: @path, corrupt_path: corrupt_path,
+                                             error_class: e.class.name, message: e.message)
+        @data = empty_data
+      end
+
+      def empty_data
+        { "schema_version" => SCHEMA_VERSION, "entries" => {} }
+      end
+
+      def entries
+        @data["entries"] ||= {}
+      end
+
+      def persist_locked!
+        return unless @path
+
+        FileUtils.mkdir_p(File.dirname(@path))
+        tmp_path = File.join(File.dirname(@path), ".#{File.basename(@path)}.#{$$}.#{Thread.current.object_id}.tmp")
+        File.write(tmp_path, JSON.pretty_generate(@data))
+        File.rename(tmp_path, @path)
+      ensure
+        FileUtils.rm_f(tmp_path) if tmp_path && File.exist?(tmp_path)
+      end
+
+      def serialize_row(row)
+        {
+          "project" => row.project.to_s,
+          "slug" => row.slug.to_s,
+          "stage" => row.stage.to_s,
+          "marker" => row.marker.to_s,
+          "attrs" => row.attrs.to_h.transform_keys(&:to_s),
+          "action" => row.action.to_s
+        }
+      end
+
+      def entry_from_raw(raw)
+        Entry.new(
+          first_seen_at: parse_time(raw["first_seen_at"]),
+          reminded_at: parse_time(raw["reminded_at"]),
+          row: row_from_raw(raw["row"])
+        )
+      end
+
+      def row_from_raw(raw)
+        raw = raw.is_a?(Hash) ? raw : {}
+        RowSnapshot.new(
+          project: raw["project"],
+          slug: raw["slug"],
+          stage: raw["stage"],
+          marker: raw["marker"],
+          attrs: raw["attrs"].is_a?(Hash) ? raw["attrs"] : {},
+          action: raw["action"]
+        )
+      end
+
+      def timestamp(time)
+        time.utc.iso8601
+      end
+
+      def parse_time(value)
+        return nil if value.nil? || value.to_s.empty?
+
+        Time.parse(value.to_s)
+      rescue ArgumentError
+        nil
+      end
+
+      def corrupt_path_for(path)
+        "#{path}.corrupt-#{Time.now.utc.strftime("%Y%m%d%H%M%S")}"
+      end
+    end
+  end
+end

--- a/lib/hive/bot/alert_store.rb
+++ b/lib/hive/bot/alert_store.rb
@@ -7,7 +7,8 @@ module Hive
     class AlertStore
       SCHEMA_VERSION = 1
 
-      Entry = Data.define(:first_seen_at, :reminded_at, :delivered_to, :row)
+      Entry = Data.define(:first_seen_at, :reminded_at, :delivered_to,
+                          :consecutive_failures, :next_attempt_after, :row)
       RowSnapshot = Data.define(:project, :slug, :stage, :marker, :attrs, :action) do
         def initialize(project:, slug:, stage:, marker:, attrs: {}, action: nil)
           super
@@ -34,6 +35,8 @@ module Hive
             "first_seen_at" => timestamp(now),
             "reminded_at" => nil,
             "delivered_to" => normalize_chat_ids(delivered_to),
+            "consecutive_failures" => 0,
+            "next_attempt_after" => nil,
             "row" => serialize_row(row)
           }
           persist_locked!
@@ -50,6 +53,35 @@ module Hive
           return false if additions.empty?
 
           entry["delivered_to"] = existing + additions
+          entry["consecutive_failures"] = 0
+          entry["next_attempt_after"] = nil
+          persist_locked!
+          true
+        end
+      end
+
+      def record_send_failure(fingerprint, now, backoff_for: nil)
+        synchronize do
+          entry = entries[fingerprint]
+          return false unless entry
+
+          failures = entry["consecutive_failures"].to_i + 1
+          delay = backoff_for || backoff_seconds(failures)
+          entry["consecutive_failures"] = failures
+          entry["next_attempt_after"] = timestamp(now + delay)
+          persist_locked!
+          true
+        end
+      end
+
+      def record_send_success(fingerprint)
+        synchronize do
+          entry = entries[fingerprint]
+          return false unless entry
+          return false if entry["consecutive_failures"].to_i.zero? && entry["next_attempt_after"].nil?
+
+          entry["consecutive_failures"] = 0
+          entry["next_attempt_after"] = nil
           persist_locked!
           true
         end
@@ -182,12 +214,24 @@ module Hive
           first_seen_at: parse_time(raw["first_seen_at"]),
           reminded_at: parse_time(raw["reminded_at"]),
           delivered_to: Array(raw["delivered_to"]).map(&:to_s),
+          consecutive_failures: raw["consecutive_failures"].to_i,
+          next_attempt_after: parse_time(raw["next_attempt_after"]),
           row: row_from_raw(raw["row"])
         )
       end
 
       def normalize_chat_ids(chat_ids)
         Array(chat_ids).map(&:to_s).uniq
+      end
+
+      BACKOFF_BASE_SEC = 60
+      BACKOFF_MAX_SEC = 1800
+
+      def backoff_seconds(failures)
+        # 1=60, 2=120, 3=240, 4=480, 5=960, 6=1800, cap 1800
+        exponent = [ failures - 1, 5 ].min
+        delay = BACKOFF_BASE_SEC * (2**exponent)
+        [ delay, BACKOFF_MAX_SEC ].min
       end
 
       def row_from_raw(raw)

--- a/lib/hive/bot/alert_store.rb
+++ b/lib/hive/bot/alert_store.rb
@@ -31,16 +31,18 @@ module Hive
 
       def add(fingerprint, row, now, delivered_to: [])
         synchronize do
-          entries[fingerprint] = {
-            "first_seen_at" => timestamp(now),
-            "reminded_at" => nil,
-            "delivered_to" => normalize_chat_ids(delivered_to),
-            "consecutive_failures" => 0,
-            "next_attempt_after" => nil,
-            "absent_since" => nil,
-            "row" => serialize_row(row)
-          }
-          persist_locked!
+          with_rollback do
+            entries[fingerprint] = {
+              "first_seen_at" => timestamp(now),
+              "reminded_at" => nil,
+              "delivered_to" => normalize_chat_ids(delivered_to),
+              "consecutive_failures" => 0,
+              "next_attempt_after" => nil,
+              "absent_since" => nil,
+              "row" => serialize_row(row)
+            }
+            persist_locked!
+          end
         end
       end
 
@@ -50,8 +52,10 @@ module Hive
           return false unless entry
           return false if entry["absent_since"]
 
-          entry["absent_since"] = timestamp(now)
-          persist_locked!
+          with_rollback do
+            entry["absent_since"] = timestamp(now)
+            persist_locked!
+          end
           true
         end
       end
@@ -62,8 +66,10 @@ module Hive
           return false unless entry
           return false if entry["absent_since"].nil?
 
-          entry["absent_since"] = nil
-          persist_locked!
+          with_rollback do
+            entry["absent_since"] = nil
+            persist_locked!
+          end
           true
         end
       end
@@ -77,10 +83,12 @@ module Hive
           additions = normalize_chat_ids(chat_ids) - existing
           return false if additions.empty?
 
-          entry["delivered_to"] = existing + additions
-          entry["consecutive_failures"] = 0
-          entry["next_attempt_after"] = nil
-          persist_locked!
+          with_rollback do
+            entry["delivered_to"] = existing + additions
+            entry["consecutive_failures"] = 0
+            entry["next_attempt_after"] = nil
+            persist_locked!
+          end
           true
         end
       end
@@ -92,9 +100,11 @@ module Hive
 
           failures = entry["consecutive_failures"].to_i + 1
           delay = backoff_for || backoff_seconds(failures)
-          entry["consecutive_failures"] = failures
-          entry["next_attempt_after"] = timestamp(now + delay)
-          persist_locked!
+          with_rollback do
+            entry["consecutive_failures"] = failures
+            entry["next_attempt_after"] = timestamp(now + delay)
+            persist_locked!
+          end
           true
         end
       end
@@ -105,36 +115,56 @@ module Hive
           return false unless entry
           return false if entry["consecutive_failures"].to_i.zero? && entry["next_attempt_after"].nil?
 
-          entry["consecutive_failures"] = 0
-          entry["next_attempt_after"] = nil
-          persist_locked!
+          with_rollback do
+            entry["consecutive_failures"] = 0
+            entry["next_attempt_after"] = nil
+            persist_locked!
+          end
           true
         end
       end
+
+      private
+
+      def with_rollback
+        snapshot = Marshal.load(Marshal.dump(@data))
+        yield
+      rescue StandardError
+        @data = snapshot
+        raise
+      end
+
+      public
 
       def mark_reminded(fingerprint, now)
         synchronize do
           entry = entries[fingerprint]
           next unless entry
 
-          entry["reminded_at"] = timestamp(now)
-          persist_locked!
+          with_rollback do
+            entry["reminded_at"] = timestamp(now)
+            persist_locked!
+          end
         end
       end
 
       def remove(fingerprint)
         synchronize do
-          entry = entries.delete(fingerprint)
-          persist_locked! if entry
-          entry ? row_from_raw(entry["row"]) : nil
+          entry = entries[fingerprint]
+          next nil unless entry
+
+          with_rollback do
+            entries.delete(fingerprint)
+            persist_locked!
+          end
+          row_from_raw(entry["row"])
         end
       end
 
       def remove_matching(project:, slug:, stage: nil, marker: nil, match_attr: nil)
         attr_key, attr_value = parse_match_attr(match_attr)
         synchronize do
-          before = entries.size
-          entries.delete_if do |_fingerprint, raw|
+          targets = entries.select do |_fingerprint, raw|
             row = row_from_raw(raw.is_a?(Hash) ? raw["row"] : nil)
             next false unless row.project.to_s == project.to_s
             next false unless row.slug.to_s == slug.to_s
@@ -144,9 +174,13 @@ module Hive
 
             true
           end
-          removed = before - entries.size
-          persist_locked! if removed.positive?
-          removed
+          next 0 if targets.empty?
+
+          with_rollback do
+            targets.each_key { |fingerprint| entries.delete(fingerprint) }
+            persist_locked!
+          end
+          targets.size
         end
       end
 

--- a/lib/hive/bot/alert_store.rb
+++ b/lib/hive/bot/alert_store.rb
@@ -8,7 +8,7 @@ module Hive
       SCHEMA_VERSION = 1
 
       Entry = Data.define(:first_seen_at, :reminded_at, :delivered_to,
-                          :consecutive_failures, :next_attempt_after, :row)
+                          :consecutive_failures, :next_attempt_after, :absent_since, :row)
       RowSnapshot = Data.define(:project, :slug, :stage, :marker, :attrs, :action) do
         def initialize(project:, slug:, stage:, marker:, attrs: {}, action: nil)
           super
@@ -37,9 +37,34 @@ module Hive
             "delivered_to" => normalize_chat_ids(delivered_to),
             "consecutive_failures" => 0,
             "next_attempt_after" => nil,
+            "absent_since" => nil,
             "row" => serialize_row(row)
           }
           persist_locked!
+        end
+      end
+
+      def mark_absent(fingerprint, now)
+        synchronize do
+          entry = entries[fingerprint]
+          return false unless entry
+          return false if entry["absent_since"]
+
+          entry["absent_since"] = timestamp(now)
+          persist_locked!
+          true
+        end
+      end
+
+      def mark_present(fingerprint)
+        synchronize do
+          entry = entries[fingerprint]
+          return false unless entry
+          return false if entry["absent_since"].nil?
+
+          entry["absent_since"] = nil
+          persist_locked!
+          true
         end
       end
 
@@ -216,6 +241,7 @@ module Hive
           delivered_to: Array(raw["delivered_to"]).map(&:to_s),
           consecutive_failures: raw["consecutive_failures"].to_i,
           next_attempt_after: parse_time(raw["next_attempt_after"]),
+          absent_since: parse_time(raw["absent_since"]),
           row: row_from_raw(raw["row"])
         )
       end

--- a/lib/hive/bot/alert_store.rb
+++ b/lib/hive/bot/alert_store.rb
@@ -20,6 +20,7 @@ module Hive
         @logger = logger
         @mutex = Mutex.new
         @data = empty_data
+        clean_orphaned_tmp_files!
         load!
       end
 
@@ -204,6 +205,25 @@ module Hive
         return [ nil, nil ] if key.to_s.empty? || value.nil?
 
         [ key.to_s, value.to_s ]
+      end
+
+      # SIGKILL or power loss between File.write(tmp) and File.rename(tmp, @path)
+      # leaves a hidden tmp file in the parent directory. Without periodic
+      # cleanup these accumulate. Sweep on construction: any file matching
+      # the tmp naming convention but not the active path is an orphan.
+      def clean_orphaned_tmp_files!
+        return unless @path
+
+        dir = File.dirname(@path)
+        return unless File.directory?(dir)
+
+        prefix = ".#{File.basename(@path)}."
+        Dir.glob(File.join(dir, "#{prefix}*.tmp")).each do |orphan|
+          FileUtils.rm_f(orphan)
+        end
+      rescue StandardError
+        # Cleanup is best-effort; never let a sweep error block startup.
+        nil
       end
 
       def load!

--- a/lib/hive/bot/alert_store.rb
+++ b/lib/hive/bot/alert_store.rb
@@ -7,7 +7,7 @@ module Hive
     class AlertStore
       SCHEMA_VERSION = 1
 
-      Entry = Data.define(:first_seen_at, :reminded_at, :row)
+      Entry = Data.define(:first_seen_at, :reminded_at, :delivered_to, :row)
       RowSnapshot = Data.define(:project, :slug, :stage, :marker, :attrs, :action) do
         def initialize(project:, slug:, stage:, marker:, attrs: {}, action: nil)
           super
@@ -28,14 +28,30 @@ module Hive
         synchronize { entries.keys }.each { |fingerprint| yield fingerprint }
       end
 
-      def add(fingerprint, row, now)
+      def add(fingerprint, row, now, delivered_to: [])
         synchronize do
           entries[fingerprint] = {
             "first_seen_at" => timestamp(now),
             "reminded_at" => nil,
+            "delivered_to" => normalize_chat_ids(delivered_to),
             "row" => serialize_row(row)
           }
           persist_locked!
+        end
+      end
+
+      def record_delivery(fingerprint, chat_ids)
+        synchronize do
+          entry = entries[fingerprint]
+          return false unless entry
+
+          existing = Array(entry["delivered_to"]).map(&:to_s)
+          additions = normalize_chat_ids(chat_ids) - existing
+          return false if additions.empty?
+
+          entry["delivered_to"] = existing + additions
+          persist_locked!
+          true
         end
       end
 
@@ -165,8 +181,13 @@ module Hive
         Entry.new(
           first_seen_at: parse_time(raw["first_seen_at"]),
           reminded_at: parse_time(raw["reminded_at"]),
+          delivered_to: Array(raw["delivered_to"]).map(&:to_s),
           row: row_from_raw(raw["row"])
         )
+      end
+
+      def normalize_chat_ids(chat_ids)
+        Array(chat_ids).map(&:to_s).uniq
       end
 
       def row_from_raw(raw)

--- a/lib/hive/bot/alert_store.rb
+++ b/lib/hive/bot/alert_store.rb
@@ -73,7 +73,14 @@ module Hive
       def load!
         return unless @path && File.exist?(@path)
 
-        parsed = JSON.parse(File.read(@path))
+        raw = begin
+          File.read(@path)
+        rescue SystemCallError, IOError => e
+          handle_corrupt!(e)
+          return
+        end
+
+        parsed = JSON.parse(raw)
         unless parsed.is_a?(Hash) &&
                parsed["schema_version"] == SCHEMA_VERSION &&
                parsed["entries"].is_a?(Hash)
@@ -85,6 +92,10 @@ module Hive
           "entries" => parsed["entries"]
         }
       rescue JSON::ParserError, TypeError => e
+        handle_corrupt!(e)
+      end
+
+      def handle_corrupt!(error)
         corrupt_path = corrupt_path_for(@path)
         begin
           File.rename(@path, corrupt_path) if @path && File.exist?(@path)
@@ -92,7 +103,7 @@ module Hive
           corrupt_path = nil
         end
         @logger&.event(:alert_store_corrupt, path: @path, corrupt_path: corrupt_path,
-                                             error_class: e.class.name, message: e.message)
+                                             error_class: error.class.name, message: error.message)
         @data = empty_data
       end
 

--- a/lib/hive/bot/alert_store.rb
+++ b/lib/hive/bot/alert_store.rb
@@ -130,14 +130,19 @@ module Hive
         end
       end
 
-      def remove_matching(project:, slug:, stage: nil)
+      def remove_matching(project:, slug:, stage: nil, marker: nil, match_attr: nil)
+        attr_key, attr_value = parse_match_attr(match_attr)
         synchronize do
           before = entries.size
           entries.delete_if do |_fingerprint, raw|
             row = row_from_raw(raw.is_a?(Hash) ? raw["row"] : nil)
-            row.project.to_s == project.to_s &&
-              row.slug.to_s == slug.to_s &&
-              (stage.nil? || row.stage.to_s == stage.to_s)
+            next false unless row.project.to_s == project.to_s
+            next false unless row.slug.to_s == slug.to_s
+            next false unless stage.nil? || row.stage.to_s == stage.to_s
+            next false unless marker.nil? || marker.to_s.empty? || row.marker.to_s.casecmp(marker.to_s).zero?
+            next false if attr_key && row.attrs.to_h.transform_keys(&:to_s)[attr_key].to_s != attr_value.to_s
+
+            true
           end
           removed = before - entries.size
           persist_locked! if removed.positive?
@@ -156,6 +161,15 @@ module Hive
 
       def synchronize(&block)
         @mutex.synchronize(&block)
+      end
+
+      def parse_match_attr(match_attr)
+        return [ nil, nil ] if match_attr.nil? || match_attr.to_s.empty?
+
+        key, value = match_attr.to_s.split("=", 2)
+        return [ nil, nil ] if key.to_s.empty? || value.nil?
+
+        [ key.to_s, value.to_s ]
       end
 
       def load!

--- a/lib/hive/bot/alert_store.rb
+++ b/lib/hive/bot/alert_store.rb
@@ -151,7 +151,11 @@ module Hive
       private
 
       def with_rollback
-        snapshot = Marshal.load(Marshal.dump(@data))
+        # JSON round-trip rather than Marshal: the data is already JSON-
+        # serializable (it's about to be persisted via JSON.pretty_generate),
+        # and JSON has no code-execution attack surface, which keeps brakeman
+        # happy and the deep-clone semantics aligned with the on-disk format.
+        snapshot = ::JSON.parse(::JSON.generate(@data))
         yield
       rescue StandardError
         @data = snapshot

--- a/lib/hive/bot/alert_store.rb
+++ b/lib/hive/bot/alert_store.rb
@@ -57,6 +57,21 @@ module Hive
         end
       end
 
+      def remove_matching(project:, slug:, stage: nil)
+        synchronize do
+          before = entries.size
+          entries.delete_if do |_fingerprint, raw|
+            row = row_from_raw(raw.is_a?(Hash) ? raw["row"] : nil)
+            row.project.to_s == project.to_s &&
+              row.slug.to_s == slug.to_s &&
+              (stage.nil? || row.stage.to_s == stage.to_s)
+          end
+          removed = before - entries.size
+          persist_locked! if removed.positive?
+          removed
+        end
+      end
+
       def entry(fingerprint)
         synchronize do
           raw = entries[fingerprint]
@@ -83,7 +98,8 @@ module Hive
         parsed = JSON.parse(raw)
         unless parsed.is_a?(Hash) &&
                parsed["schema_version"] == SCHEMA_VERSION &&
-               parsed["entries"].is_a?(Hash)
+               parsed["entries"].is_a?(Hash) &&
+               parsed["entries"].all? { |fingerprint, entry| fingerprint.is_a?(String) && entry.is_a?(Hash) }
           raise JSON::ParserError, "invalid alert store schema"
         end
 

--- a/lib/hive/bot/alert_store.rb
+++ b/lib/hive/bot/alert_store.rb
@@ -20,8 +20,31 @@ module Hive
         @logger = logger
         @mutex = Mutex.new
         @data = empty_data
+        # Snapshot whether the persistent file already existed BEFORE load!
+        # so the dispatcher can suppress alerts on the first process_rows
+        # after a fresh install or wiped state file. A previously-running
+        # backlog should not all alert simultaneously on day 1.
+        #
+        # Only "fresh" when there IS a configured path that does not yet
+        # exist on disk. A nil path means the operator is intentionally
+        # running without persistence — every restart is a burst, suppressing
+        # the first tick would just mask real alerts indefinitely.
+        @fresh_install = !@path.nil? && !File.exist?(@path)
         clean_orphaned_tmp_files!
         load!
+      end
+
+      def fresh_install?
+        synchronize { @fresh_install }
+      end
+
+      def mark_seeded!
+        synchronize do
+          next false unless @fresh_install
+
+          @fresh_install = false
+          true
+        end
       end
 
       def each_fingerprint

--- a/lib/hive/bot/handlers/callback_handlers.rb
+++ b/lib/hive/bot/handlers/callback_handlers.rb
@@ -183,11 +183,17 @@ module Hive
             [ "hive", verb, slug, "--all", *stage_argv, "--project", project, "--json" ]
           ]
           commands << retry_argv if retry_argv
+          # The callback only carries (project, slug, stage), not marker — accept/reject
+          # explicitly resolves every finding for the row, so the broad-delete behaviour
+          # (no marker filter) matches operator intent: clear ALL alerts at this (project,
+          # slug, stage) so a recurring same-fingerprint failure re-alerts cleanly.
           @result_class.new(
             action: :dispatch_commands,
             project: project,
             slug: slug,
-            commands: commands
+            commands: commands,
+            alert_reset: alert_reset(project, slug, stage),
+            clear_keyboard: true
           )
         end
 

--- a/lib/hive/bot/handlers/callback_handlers.rb
+++ b/lib/hive/bot/handlers/callback_handlers.rb
@@ -57,7 +57,8 @@ module Hive
           commands = retry_commands(project: project, slug: slug, stage: stage, marker: marker,
                                     match_attr: match_attr)
           @result_class.new(action: :dispatch_commands, project: project, slug: slug, commands: commands,
-                            alert_reset: alert_reset(project, slug, stage), clear_keyboard: true)
+                            alert_reset: alert_reset(project, slug, stage, marker, match_attr),
+                            clear_keyboard: true)
         end
 
         def autofix(data)
@@ -79,7 +80,7 @@ module Hive
             slug: slug,
             commands: retry_commands(project: project, slug: slug, stage: stage, marker: marker,
                                      match_attr: match_attr),
-            alert_reset: alert_reset(project, slug, stage),
+            alert_reset: alert_reset(project, slug, stage, marker, match_attr),
             clear_keyboard: true
           )
         end
@@ -224,8 +225,11 @@ module Hive
           marker.to_s.casecmp("execute_stale").zero?
         end
 
-        def alert_reset(project, slug, stage)
-          { project: project, slug: slug, stage: stage }
+        def alert_reset(project, slug, stage, marker = nil, match_attr = nil)
+          payload = { project: project, slug: slug, stage: stage }
+          payload[:marker] = marker if marker && !marker.to_s.empty?
+          payload[:match_attr] = match_attr if match_attr && !match_attr.to_s.empty?
+          payload
         end
 
         def split_callback(data, expected)

--- a/lib/hive/bot/handlers/callback_handlers.rb
+++ b/lib/hive/bot/handlers/callback_handlers.rb
@@ -53,13 +53,20 @@ module Hive
         end
 
         def clear_and_retry(data)
-          _prefix, project, slug, stage, marker = split_callback(data, 5)
-          commands = retry_commands(project: project, slug: slug, stage: stage, marker: marker)
-          @result_class.new(action: :dispatch_commands, project: project, slug: slug, commands: commands)
+          _prefix, project, slug, stage, marker, match_attr = split_callback(data, [ 5, 6 ])
+          commands = retry_commands(project: project, slug: slug, stage: stage, marker: marker,
+                                    match_attr: match_attr)
+          @result_class.new(action: :dispatch_commands, project: project, slug: slug, commands: commands,
+                            alert_reset: alert_reset(project, slug, stage))
         end
 
         def autofix(data)
-          _prefix, project, slug, stage, marker = split_callback(data, 5)
+          _prefix, project, slug, stage, marker, match_attr = split_callback(data, [ 5, 6 ])
+          if manual_only_marker?(marker)
+            return @result_class.new(action: :reply,
+                                     text: "Hive has no automatic recovery for this state - open it on a laptop.")
+          end
+
           verb = retry_verb_for_stage(stage)
           unless verb
             stage_label = stage.to_s.empty? ? "(empty)" : stage
@@ -70,7 +77,9 @@ module Hive
             action: :dispatch_commands,
             project: project,
             slug: slug,
-            commands: retry_commands(project: project, slug: slug, stage: stage, marker: marker)
+            commands: retry_commands(project: project, slug: slug, stage: stage, marker: marker,
+                                     match_attr: match_attr),
+            alert_reset: alert_reset(project, slug, stage)
           )
         end
 
@@ -193,17 +202,29 @@ module Hive
         # markers skip `hive markers clear` because that name is outside the clear
         # allowlist (markers.rb#ALLOWED_NAMES) and would exit 4. Both branches
         # intentionally diverge from the pre-U7 `clear_and_retry` path.
-        def retry_commands(project:, slug:, stage:, marker:)
+        def retry_commands(project:, slug:, stage:, marker:, match_attr: nil)
           verb = retry_verb_for_stage(stage)
           return [] unless verb
 
           commands = []
           marker_name = marker.to_s
           unless marker_name.casecmp("none").zero? || marker_name.casecmp("agent_working").zero?
-            commands << [ "hive", "markers", "clear", slug, "--name", marker_name.upcase, "--project", project, "--json" ]
+            clear_argv = [ "hive", "markers", "clear", slug, "--name", marker_name.upcase,
+                           "--project", project ]
+            clear_argv += [ "--match-attr", match_attr ] if match_attr.to_s.include?("=")
+            clear_argv << "--json"
+            commands << clear_argv
           end
           commands << [ "hive", verb, slug, "--from", stage, "--project", project, "--json" ]
           commands
+        end
+
+        def manual_only_marker?(marker)
+          marker.to_s.casecmp("execute_stale").zero?
+        end
+
+        def alert_reset(project, slug, stage)
+          { project: project, slug: slug, stage: stage }
         end
 
         def split_callback(data, expected)

--- a/lib/hive/bot/handlers/callback_handlers.rb
+++ b/lib/hive/bot/handlers/callback_handlers.rb
@@ -57,6 +57,11 @@ module Hive
           _prefix, project, slug, stage, marker, match_attr = split_callback(data, [ 5, 6 ])
           commands = retry_commands(project: project, slug: slug, stage: stage, marker: marker,
                                     match_attr: match_attr)
+          if commands.empty?
+            stage_label = stage.to_s.empty? ? "(empty)" : stage
+            return @result_class.new(action: :reply, text: "No retry verb for stage #{stage_label}.")
+          end
+
           @result_class.new(action: :dispatch_commands, project: project, slug: slug, commands: commands,
                             alert_reset: alert_reset(project, slug, stage, marker, match_attr),
                             clear_keyboard: true)

--- a/lib/hive/bot/handlers/callback_handlers.rb
+++ b/lib/hive/bot/handlers/callback_handlers.rb
@@ -1,4 +1,5 @@
 require "hive/workflows"
+require "hive/bot/notification_builders"
 
 module Hive
   module Bot
@@ -222,7 +223,7 @@ module Hive
         end
 
         def manual_only_marker?(marker)
-          marker.to_s.casecmp("execute_stale").zero?
+          Hive::Bot::NotificationBuilders.manual_only?(marker: marker)
         end
 
         def alert_reset(project, slug, stage, marker = nil, match_attr = nil)

--- a/lib/hive/bot/handlers/callback_handlers.rb
+++ b/lib/hive/bot/handlers/callback_handlers.rb
@@ -57,7 +57,7 @@ module Hive
           commands = retry_commands(project: project, slug: slug, stage: stage, marker: marker,
                                     match_attr: match_attr)
           @result_class.new(action: :dispatch_commands, project: project, slug: slug, commands: commands,
-                            alert_reset: alert_reset(project, slug, stage))
+                            alert_reset: alert_reset(project, slug, stage), clear_keyboard: true)
         end
 
         def autofix(data)
@@ -79,7 +79,8 @@ module Hive
             slug: slug,
             commands: retry_commands(project: project, slug: slug, stage: stage, marker: marker,
                                      match_attr: match_attr),
-            alert_reset: alert_reset(project, slug, stage)
+            alert_reset: alert_reset(project, slug, stage),
+            clear_keyboard: true
           )
         end
 

--- a/lib/hive/bot/handlers/callback_handlers.rb
+++ b/lib/hive/bot/handlers/callback_handlers.rb
@@ -18,6 +18,7 @@ module Hive
           case intent
           when :callback_approve then approve(data)
           when :callback_reject then @result_class.new(action: :reply, text: "Left unchanged.")
+          when :callback_autofix then autofix(data)
           when :callback_clear_and_retry then clear_and_retry(data)
           when :callback_open_laptop then @result_class.new(action: :reply, text: "Open laptop for this one.")
           when :callback_show_details then show_details(data)
@@ -53,13 +54,23 @@ module Hive
 
         def clear_and_retry(data)
           _prefix, project, slug, stage, marker = split_callback(data, 5)
-          verb = retry_verb_for_stage(stage)
-          commands = []
-          unless marker.to_s.casecmp("none").zero?
-            commands << [ "hive", "markers", "clear", slug, "--name", marker.upcase, "--project", project, "--json" ]
-          end
-          commands << [ "hive", verb, slug, "--from", stage, "--project", project, "--json" ] if verb
+          commands = retry_commands(project: project, slug: slug, stage: stage, marker: marker)
           @result_class.new(action: :dispatch_commands, project: project, slug: slug, commands: commands)
+        end
+
+        def autofix(data)
+          _prefix, project, slug, stage, marker = split_callback(data, 5)
+          verb = retry_verb_for_stage(stage)
+          unless verb
+            return @result_class.new(action: :reply, text: "No retry verb for stage #{stage}.")
+          end
+
+          @result_class.new(
+            action: :dispatch_commands,
+            project: project,
+            slug: slug,
+            commands: retry_commands(project: project, slug: slug, stage: stage, marker: marker)
+          )
         end
 
         def answer(data)
@@ -168,11 +179,26 @@ module Hive
         end
 
         def retry_verb_for_stage(stage)
+          return nil if stage.to_s == "9-done"
+
           Hive::Workflows.verb_arriving_at(stage) || {
             "4-execute" => "develop",
             "5-review" => "review",
             "6-pr" => "pr"
           }[stage]
+        end
+
+        def retry_commands(project:, slug:, stage:, marker:)
+          verb = retry_verb_for_stage(stage)
+          return [] unless verb
+
+          commands = []
+          marker_name = marker.to_s
+          unless marker_name.casecmp("none").zero? || marker_name.casecmp("agent_working").zero?
+            commands << [ "hive", "markers", "clear", slug, "--name", marker_name.upcase, "--project", project, "--json" ]
+          end
+          commands << [ "hive", verb, slug, "--from", stage, "--project", project, "--json" ]
+          commands
         end
 
         def split_callback(data, expected)

--- a/lib/hive/bot/handlers/callback_handlers.rb
+++ b/lib/hive/bot/handlers/callback_handlers.rb
@@ -188,6 +188,10 @@ module Hive
           }[stage]
         end
 
+        # 9-done returns an empty command list (no retry verb), and AGENT_WORKING
+        # markers skip `hive markers clear` because that name is outside the clear
+        # allowlist (markers.rb#ALLOWED_NAMES) and would exit 4. Both branches
+        # intentionally diverge from the pre-U7 `clear_and_retry` path.
         def retry_commands(project:, slug:, stage:, marker:)
           verb = retry_verb_for_stage(stage)
           return [] unless verb

--- a/lib/hive/bot/handlers/callback_handlers.rb
+++ b/lib/hive/bot/handlers/callback_handlers.rb
@@ -62,7 +62,8 @@ module Hive
           _prefix, project, slug, stage, marker = split_callback(data, 5)
           verb = retry_verb_for_stage(stage)
           unless verb
-            return @result_class.new(action: :reply, text: "No retry verb for stage #{stage}.")
+            stage_label = stage.to_s.empty? ? "(empty)" : stage
+            return @result_class.new(action: :reply, text: "No retry verb for stage #{stage_label}.")
           end
 
           @result_class.new(

--- a/lib/hive/bot/handlers/slash_handlers.rb
+++ b/lib/hive/bot/handlers/slash_handlers.rb
@@ -19,10 +19,12 @@ module Hive
           tokens = rest.split(/\s+/)
           json = !tokens.delete("--json").nil?
           project = tokens.join(" ").strip
-          argv = [ "hive", "status", "--json" ]
-          argv += [ "--project", project ] unless project.empty?
+          # The supervisor's in-process status intercept filters via
+          # Result.project; `hive status --json` itself does not honour a
+          # snapshot-level --project, so the argv stays flag-free to avoid
+          # claiming a filter the subprocess fallback would not enforce.
           @result_class.new(action: :dispatch_then_reply,
-                            command_argv: argv,
+                            command_argv: [ "hive", "status", "--json" ],
                             project: project.empty? ? nil : project,
                             format: json ? :json : nil)
         end

--- a/lib/hive/bot/handlers/slash_handlers.rb
+++ b/lib/hive/bot/handlers/slash_handlers.rb
@@ -15,7 +15,7 @@ module Hive
         end
 
         def status(update)
-          project = update.text.to_s.split(/\s+/, 2)[1].to_s.strip
+          project = update.text.to_s.split(/\s+/)[1].to_s.strip
           argv = [ "hive", "status", "--json" ]
           argv += [ "--project", project ] unless project.empty?
           @result_class.new(action: :dispatch_then_reply,

--- a/lib/hive/bot/handlers/slash_handlers.rb
+++ b/lib/hive/bot/handlers/slash_handlers.rb
@@ -15,12 +15,16 @@ module Hive
         end
 
         def status(update)
-          project = update.text.to_s.split(/\s+/, 2)[1].to_s.strip
+          rest = update.text.to_s.split(/\s+/, 2)[1].to_s.strip
+          tokens = rest.split(/\s+/)
+          json = !tokens.delete("--json").nil?
+          project = tokens.join(" ").strip
           argv = [ "hive", "status", "--json" ]
           argv += [ "--project", project ] unless project.empty?
           @result_class.new(action: :dispatch_then_reply,
                             command_argv: argv,
-                            project: project.empty? ? nil : project)
+                            project: project.empty? ? nil : project,
+                            format: json ? :json : nil)
         end
 
         def queue(_update)

--- a/lib/hive/bot/handlers/slash_handlers.rb
+++ b/lib/hive/bot/handlers/slash_handlers.rb
@@ -14,9 +14,13 @@ module Hive
           @now = now
         end
 
-        def status(_update)
+        def status(update)
+          project = update.text.to_s.split(/\s+/, 2)[1].to_s.strip
+          argv = [ "hive", "status", "--json" ]
+          argv += [ "--project", project ] unless project.empty?
           @result_class.new(action: :dispatch_then_reply,
-                            command_argv: [ "hive", "status", "--json" ])
+                            command_argv: argv,
+                            project: project.empty? ? nil : project)
         end
 
         def queue(_update)
@@ -75,7 +79,7 @@ module Hive
         def help(_update)
           @result_class.new(
             action: :reply,
-            text: "Commands: /status, /queue, /idea <text>, /answer <slug>, /approve <slug>, /done, /help"
+            text: "Commands: /status [project], /queue, /idea <text>, /answer <slug>, /approve <slug>, /done, /help"
           )
         end
 

--- a/lib/hive/bot/handlers/slash_handlers.rb
+++ b/lib/hive/bot/handlers/slash_handlers.rb
@@ -15,7 +15,7 @@ module Hive
         end
 
         def status(update)
-          project = update.text.to_s.split(/\s+/)[1].to_s.strip
+          project = update.text.to_s.split(/\s+/, 2)[1].to_s.strip
           argv = [ "hive", "status", "--json" ]
           argv += [ "--project", project ] unless project.empty?
           @result_class.new(action: :dispatch_then_reply,

--- a/lib/hive/bot/logger.rb
+++ b/lib/hive/bot/logger.rb
@@ -29,6 +29,9 @@ module Hive
         send_failure
         callback_malformed
         pid_file_corrupted
+        unknown_stage_label
+        alert_store_corrupt
+        deprecated_config
         fatal
       ].freeze
 

--- a/lib/hive/bot/logger.rb
+++ b/lib/hive/bot/logger.rb
@@ -17,6 +17,7 @@ module Hive
         notification_sent
         notification_skipped_dedupe
         notification_skipped_backoff
+        fresh_install_seeded
         dispatched_command
         command_completed
         codex_spawned

--- a/lib/hive/bot/logger.rb
+++ b/lib/hive/bot/logger.rb
@@ -16,6 +16,7 @@ module Hive
         update_rejected_unauthorized
         notification_sent
         notification_skipped_dedupe
+        notification_skipped_backoff
         dispatched_command
         command_completed
         codex_spawned

--- a/lib/hive/bot/notification_builders.rb
+++ b/lib/hive/bot/notification_builders.rb
@@ -31,13 +31,13 @@ module Hive
         archived
       ].freeze
 
-      def build(row)
+      def build(row, logger: nil)
         if READY_ACTIONS.include?(row.action)
           stage_approval(row)
         elsif row.action == Hive::Schemas::TaskActionKind::NEEDS_INPUT
           needs_input(row)
         elsif recovery?(row)
-          recovery(row)
+          recovery(row, logger: logger)
         else
           nil
         end
@@ -120,11 +120,11 @@ module Hive
         )
       end
 
-      def recovery(row)
+      def recovery(row, logger: nil)
         retryable = retryable_recovery?(row)
         Notification.new(
           text: [
-            "⚠ #{TitleFormatter.stage_label(row.stage)} stuck — \"#{TitleFormatter.title_from_slug(row.slug)}\"",
+            "⚠ #{TitleFormatter.stage_label(row.stage, logger: logger)} stuck — \"#{TitleFormatter.title_from_slug(row.slug)}\"",
             cause_sentence_for(row),
             retryable ? "Tap Autofix to retry the stage cleanly." :
               "Open this task on a laptop before retrying."

--- a/lib/hive/bot/notification_builders.rb
+++ b/lib/hive/bot/notification_builders.rb
@@ -146,42 +146,6 @@ module Hive
         end
       end
 
-      def open_laptop_only_recovery?(row)
-        attrs = row.attrs.to_h.transform_keys(&:to_s)
-        diagnostic_manual_fix?(row) ||
-          stale_agent_working_pending_heal?(row) ||
-          row.marker.to_s == "review_error" &&
-            attrs["phase"] == "fix" &&
-            attrs["reason"] == "fix_tampered"
-      end
-
-      # Stale AGENT_WORKING that TaskAction has reclassified as :error
-      # but the daemon hasn't yet rewritten on disk. Rendering "Clear
-      # and retry" here would dispatch `hive markers clear --name
-      # AGENT_WORKING`, which is not in the markers-clear allowlist
-      # (lib/hive/commands/markers.rb#ALLOWED_NAMES) and exits 4. Hide
-      # the button; the daemon heals within one tick anyway, after
-      # which the normal ERROR-recovery affordance fires.
-      def stale_agent_working_pending_heal?(row)
-        row.marker.to_s == "agent_working" && row.action.to_s == "error"
-      end
-
-      def markerless_retry_recovery?(row)
-        row.marker.to_s == "none" && diagnostic_suggested_action(row)["kind"].to_s == "retry"
-      end
-
-      def diagnostic_manual_fix?(row)
-        diagnostic_suggested_action(row)["kind"].to_s == "manual_fix"
-      end
-
-      def diagnostic_suggested_action(row)
-        diagnostic = row.diagnostic
-        return {} unless diagnostic.is_a?(Hash)
-
-        suggested = diagnostic["suggested_next_action"]
-        suggested.is_a?(Hash) ? suggested : {}
-      end
-
       def header(row)
         "#{row.project}/#{row.slug} (#{row.stage})"
       end
@@ -194,10 +158,6 @@ module Hive
 
       def details_callback(row)
         callback_with_stage("details", row)
-      end
-
-      def refresh_diagnose_callback(row)
-        callback_with_stage("refresh_diagnose", row)
       end
 
       def callback_with_stage(prefix, row)

--- a/lib/hive/bot/notification_builders.rb
+++ b/lib/hive/bot/notification_builders.rb
@@ -162,7 +162,6 @@ module Hive
         attrs = row.attrs.to_h.transform_keys(&:to_s)
         marker = row.marker.to_s.downcase
         marker == "execute_stale" ||
-          marker == "agent_working" ||
           marker == "review_error" && attrs["phase"] == "fix" && attrs["reason"] == "fix_tampered"
       end
 

--- a/lib/hive/bot/notification_builders.rb
+++ b/lib/hive/bot/notification_builders.rb
@@ -158,11 +158,28 @@ module Hive
         suggested && suggested["kind"].to_s == "retry"
       end
 
+      # Markers that are ALWAYS manual-only regardless of attrs. Adding a new
+      # marker here automatically narrows both the in-row recovery check
+      # (manual_only_recovery?) and the callback-time defensive check
+      # (CallbackHandlers#manual_only_marker?) — they share this constant
+      # through manual_only? below.
+      ALWAYS_MANUAL_MARKERS = %w[execute_stale].freeze
+
+      # Single source of truth for "this state has no auto-recovery".
+      # Pass attrs: nil from callers that only have the marker name
+      # (e.g. callback handlers); pass row.attrs from in-process checks
+      # where the full attrs hash is available.
+      def manual_only?(marker:, attrs: nil)
+        marker = marker.to_s.downcase
+        return true if ALWAYS_MANUAL_MARKERS.include?(marker)
+        return false if attrs.nil?
+
+        attrs = attrs.to_h.transform_keys(&:to_s)
+        marker == "review_error" && attrs["phase"] == "fix" && attrs["reason"] == "fix_tampered"
+      end
+
       def manual_only_recovery?(row)
-        attrs = row.attrs.to_h.transform_keys(&:to_s)
-        marker = row.marker.to_s.downcase
-        marker == "execute_stale" ||
-          marker == "review_error" && attrs["phase"] == "fix" && attrs["reason"] == "fix_tampered"
+        manual_only?(marker: row.marker, attrs: row.attrs)
       end
 
       def suggested_next_action(row)

--- a/lib/hive/bot/notification_builders.rb
+++ b/lib/hive/bot/notification_builders.rb
@@ -193,15 +193,15 @@ module Hive
       def recovery_match_attr(row)
         attrs = row.attrs.to_h.transform_keys(&:to_s)
         keys = case row.marker.to_s.downcase
-               when "review_error", "review_ci_stale"
+        when "review_error", "review_ci_stale"
                  %w[pass phase reason]
-               when "review_stale"
+        when "review_stale"
                  %w[pass reason]
-               when "error"
+        when "error"
                  %w[exit_code]
-               else
+        else
                  []
-               end
+        end
         key = keys.find { |candidate| !attrs[candidate].to_s.empty? }
         key ? "#{key}=#{attrs[key]}" : nil
       end

--- a/lib/hive/bot/notification_builders.rb
+++ b/lib/hive/bot/notification_builders.rb
@@ -1,6 +1,7 @@
 require "digest"
 require "json"
 require "hive"
+require "hive/bot/title_formatter"
 
 module Hive
   module Bot
@@ -44,7 +45,7 @@ module Hive
 
       def fingerprint(row)
         normalized_attrs = row.attrs.to_h.transform_keys(&:to_s).to_a.sort_by(&:first)
-        Digest::SHA256.hexdigest(JSON.generate([ row.project, row.slug, row.marker, normalized_attrs ]))
+        Digest::SHA256.hexdigest(JSON.generate([ row.project, row.slug, row.stage, row.marker, normalized_attrs ]))
       end
 
       def recovery?(row)
@@ -120,45 +121,29 @@ module Hive
       end
 
       def recovery(row)
-        # The "Refresh diagnosis" button is the bot-side parity of the
-        # TUI's R keystroke: dispatches `hive status --diagnose <slug>
-        # --write --force --json` so the configured execute AgentProfile
-        # produces a fresh diagnostic verdict. Pairs with Show details
-        # (which just reads the current verdict). Resolves issue #91.
-        details_row = [
-          button("Show details", details_callback(row)),
-          button("Refresh diagnosis", refresh_diagnose_callback(row))
-        ]
-        keyboard =
-          if open_laptop_only_recovery?(row)
-            [
-              [ button("Open laptop", "open_laptop:#{row.project}:#{row.slug}") ],
-              details_row
-            ]
-          elsif markerless_retry_recovery?(row)
-            [
-              [ button("Retry", "clear_retry:#{row.project}:#{row.slug}:#{row.stage}:NONE") ],
-              [ button("Open laptop", "open_laptop:#{row.project}:#{row.slug}") ],
-              details_row
-            ]
-          else
-            [
-              [ button("Clear and retry", "clear_retry:#{row.project}:#{row.slug}:#{row.stage}:#{row.marker}") ],
-              [ button("Open laptop", "open_laptop:#{row.project}:#{row.slug}") ],
-              details_row
-            ]
-          end
-        # Append the bounded diagnostic summary so the operator sees the
-        # one-line "why is this red" without an extra round-trip through
-        # the Show-details callback. StatusWatcher::Row carries the
-        # diagnostic hash from `hive status --json`; nil when the row is
-        # green or the snapshot pre-dates the schema. See PR #84 review
-        # row 23.
-        text = header(row) + "\nNeeds recovery: #{marker_with_attrs(row)}"
-        if row.diagnostic.is_a?(Hash) && !row.diagnostic["summary"].to_s.empty?
-          text += "\n\n#{row.diagnostic['summary']}"
+        Notification.new(
+          text: [
+            "⚠ #{TitleFormatter.stage_label(row.stage)} stuck — \"#{TitleFormatter.title_from_slug(row.slug)}\"",
+            cause_sentence_for(row),
+            "Tap Autofix to retry the stage cleanly."
+          ].join("\n"),
+          keyboard: [
+            [ button("🔧 Autofix", "autofix:#{row.project}:#{row.slug}:#{row.stage}:#{row.marker}") ]
+          ]
+        )
+      end
+
+      def cause_sentence_for(row)
+        case row.marker.to_s.downcase
+        when "review_error"
+          "The review agent crashed before it could finish."
+        when "execute_stale"
+          "The execute agent stalled before it could finish."
+        when "review_stale", "review_ci_stale"
+          "The review run stalled before it could finish."
+        else
+          "The agent crashed before it could finish."
         end
-        Notification.new(text: text, keyboard: keyboard)
       end
 
       def open_laptop_only_recovery?(row)

--- a/lib/hive/bot/notification_builders.rb
+++ b/lib/hive/bot/notification_builders.rb
@@ -121,16 +121,73 @@ module Hive
       end
 
       def recovery(row)
+        retryable = retryable_recovery?(row)
         Notification.new(
           text: [
             "⚠ #{TitleFormatter.stage_label(row.stage)} stuck — \"#{TitleFormatter.title_from_slug(row.slug)}\"",
             cause_sentence_for(row),
-            "Tap Autofix to retry the stage cleanly."
+            retryable ? "Tap Autofix to retry the stage cleanly." :
+              "Open this task on a laptop before retrying."
           ].join("\n"),
-          keyboard: [
-            [ button("🔧 Autofix", "autofix:#{row.project}:#{row.slug}:#{row.stage}:#{row.marker}") ]
-          ]
+          keyboard: recovery_keyboard(row, retryable: retryable)
         )
+      end
+
+      def recovery_keyboard(row, retryable:)
+        if retryable
+          [ [ button("🔧 Autofix", autofix_callback(row)) ] ]
+        else
+          [
+            [ button("Open laptop", "open_laptop:#{row.project}:#{row.slug}") ],
+            [ button("Show details", details_callback(row)) ]
+          ]
+        end
+      end
+
+      def autofix_callback(row)
+        parts = [ "autofix", row.project, row.slug, row.stage, row.marker ]
+        match_attr = recovery_match_attr(row)
+        parts << match_attr if match_attr
+        parts.join(":")
+      end
+
+      def retryable_recovery?(row)
+        return false if manual_only_recovery?(row)
+
+        suggested = suggested_next_action(row)
+        suggested && suggested["kind"].to_s == "retry"
+      end
+
+      def manual_only_recovery?(row)
+        attrs = row.attrs.to_h.transform_keys(&:to_s)
+        marker = row.marker.to_s.downcase
+        marker == "execute_stale" ||
+          marker == "agent_working" ||
+          marker == "review_error" && attrs["phase"] == "fix" && attrs["reason"] == "fix_tampered"
+      end
+
+      def suggested_next_action(row)
+        diagnostic = row.respond_to?(:diagnostic) ? row.diagnostic : nil
+        return nil unless diagnostic.is_a?(Hash)
+
+        suggested = diagnostic["suggested_next_action"]
+        suggested.is_a?(Hash) ? suggested : nil
+      end
+
+      def recovery_match_attr(row)
+        attrs = row.attrs.to_h.transform_keys(&:to_s)
+        keys = case row.marker.to_s.downcase
+               when "review_error", "review_ci_stale"
+                 %w[pass phase reason]
+               when "review_stale"
+                 %w[pass reason]
+               when "error"
+                 %w[exit_code]
+               else
+                 []
+               end
+        key = keys.find { |candidate| !attrs[candidate].to_s.empty? }
+        key ? "#{key}=#{attrs[key]}" : nil
       end
 
       def cause_sentence_for(row)

--- a/lib/hive/bot/notification_dispatcher.rb
+++ b/lib/hive/bot/notification_dispatcher.rb
@@ -35,7 +35,7 @@ module Hive
         Array(rows).each_with_object({}) do |row, out|
           next if suppress_ready_action?(row)
 
-          notification = NotificationBuilders.build(row)
+          notification = NotificationBuilders.build(row, logger: @logger)
           next unless notification
 
           fingerprint = NotificationBuilders.fingerprint(row)

--- a/lib/hive/bot/notification_dispatcher.rb
+++ b/lib/hive/bot/notification_dispatcher.rb
@@ -24,8 +24,9 @@ module Hive
         process_current(current)
       end
 
-      def reset_task(project:, slug:, stage: nil)
-        @alert_store.remove_matching(project: project, slug: slug, stage: stage)
+      def reset_task(project:, slug:, stage: nil, marker: nil, match_attr: nil)
+        @alert_store.remove_matching(project: project, slug: slug, stage: stage,
+                                     marker: marker, match_attr: match_attr)
       end
 
       private

--- a/lib/hive/bot/notification_dispatcher.rb
+++ b/lib/hive/bot/notification_dispatcher.rb
@@ -57,6 +57,10 @@ module Hive
             end
             next if backoff_active?(entry)
 
+            unless absence_passed_grace?(entry, fingerprint)
+              next
+            end
+
             if send_notification(recovered_message(row)).any?
               @alert_store.remove(fingerprint)
               log_notification_sent(row, recovered: true)
@@ -69,10 +73,25 @@ module Hive
         end
       end
 
+      def absence_passed_grace?(entry, fingerprint)
+        if entry.absent_since.nil?
+          @alert_store.mark_absent(fingerprint, @now.call)
+          return false
+        end
+
+        (@now.call - entry.absent_since) >= recovery_grace_seconds
+      end
+
+      def recovery_grace_seconds
+        @bot_config.fetch("recovery_grace_sec", 60).to_i
+      end
+
       def process_current(current)
         current.each do |fingerprint, payload|
           row = payload.fetch(:row)
           entry = @alert_store.entry(fingerprint)
+          @alert_store.mark_present(fingerprint) if entry && entry.absent_since
+          entry = @alert_store.entry(fingerprint) if entry
           if entry.nil?
             delivered = send_notification(payload.fetch(:notification))
             if delivered.any?

--- a/lib/hive/bot/notification_dispatcher.rb
+++ b/lib/hive/bot/notification_dispatcher.rb
@@ -24,6 +24,10 @@ module Hive
         process_current(current)
       end
 
+      def reset_task(project:, slug:, stage: nil)
+        @alert_store.remove_matching(project: project, slug: slug, stage: stage)
+      end
+
       private
 
       def current_notifications(rows)
@@ -45,7 +49,9 @@ module Hive
           entry = @alert_store.entry(fingerprint)
           row = entry&.row
           if row && NotificationBuilders.recovery?(row)
-            if send_notification(recovered_message(row))
+            if current_recovery_for_same_row?(current, row)
+              @alert_store.remove(fingerprint)
+            elsif send_notification(recovered_message(row))
               @alert_store.remove(fingerprint)
               log_notification_sent(row, recovered: true)
             end
@@ -78,22 +84,35 @@ module Hive
       end
 
       def send_notification(notification)
-        any_sent = false
+        attempted = false
+        all_sent = true
         chat_ids.each do |chat_id|
+          attempted = true
           @telegram.send_message(chat_id: chat_id, text: notification.text,
                                  reply_markup: notification.keyboard)
-          any_sent = true
         rescue StandardError => e
+          all_sent = false
           @logger.event(:send_failure, chat_id: chat_id, error_class: e.class.name, message: e.message)
         end
 
-        any_sent
+        attempted && all_sent
       end
 
       def log_notification_sent(row, reminder: false, recovered: false)
         @logger.event(:notification_sent, project: row.project, slug: row.slug,
                                           marker: row.marker, action: row.action,
                                           reminder: reminder, recovered: recovered)
+      end
+
+      def current_recovery_for_same_row?(current, stored_row)
+        current.values.any? do |payload|
+          row = payload.fetch(:row)
+          NotificationBuilders.recovery?(row) && recovery_identity(row) == recovery_identity(stored_row)
+        end
+      end
+
+      def recovery_identity(row)
+        [ row.project.to_s, row.slug.to_s, row.stage.to_s ]
       end
 
       def reminder_due?(entry, row)

--- a/lib/hive/bot/notification_dispatcher.rb
+++ b/lib/hive/bot/notification_dispatcher.rb
@@ -240,10 +240,15 @@ module Hive
       def reminder_window_label
         seconds = recovery_reminder_window.to_i
         hours = seconds / 3600
-        return "#{hours} h" if hours >= 1 && seconds % 3600 == 0
-
-        minutes = (seconds / 60.0).round
-        "#{minutes} min"
+        remainder_seconds = seconds - (hours * 3600)
+        minutes = (remainder_seconds / 60.0).round
+        if hours >= 1 && minutes.positive?
+          "#{hours} h #{minutes} min"
+        elsif hours >= 1
+          "#{hours} h"
+        else
+          "#{(seconds / 60.0).round} min"
+        end
       end
 
       # ready_to_X notifications are pull-only via /status; never proactive.

--- a/lib/hive/bot/notification_dispatcher.rb
+++ b/lib/hive/bot/notification_dispatcher.rb
@@ -48,12 +48,20 @@ module Hive
 
           entry = @alert_store.entry(fingerprint)
           row = entry&.row
-          if row && NotificationBuilders.recovery?(row)
+          next if row.nil?
+
+          if NotificationBuilders.recovery?(row)
             if current_recovery_for_same_row?(current, row)
               @alert_store.remove(fingerprint)
-            elsif send_notification(recovered_message(row)).any?
+              next
+            end
+            next if backoff_active?(entry)
+
+            if send_notification(recovered_message(row)).any?
               @alert_store.remove(fingerprint)
               log_notification_sent(row, recovered: true)
+            else
+              @alert_store.record_send_failure(fingerprint, @now.call)
             end
           else
             @alert_store.remove(fingerprint)
@@ -67,27 +75,48 @@ module Hive
           entry = @alert_store.entry(fingerprint)
           if entry.nil?
             delivered = send_notification(payload.fetch(:notification))
-            next if delivered.empty?
-
-            @alert_store.add(fingerprint, row, @now.call, delivered_to: delivered)
-            log_notification_sent(row)
+            if delivered.any?
+              @alert_store.add(fingerprint, row, @now.call, delivered_to: delivered)
+              log_notification_sent(row)
+            else
+              # Persist the entry with no delivered chats so the backoff
+              # window applies to subsequent ticks during the outage.
+              @alert_store.add(fingerprint, row, @now.call, delivered_to: [])
+              @alert_store.record_send_failure(fingerprint, @now.call)
+            end
+          elsif backoff_active?(entry)
+            @logger.event(:notification_skipped_backoff, project: row.project, slug: row.slug,
+                                                          marker: row.marker,
+                                                          consecutive_failures: entry.consecutive_failures.to_i)
           elsif (pending = pending_chat_ids(entry)).any?
             newly_delivered = send_notification(payload.fetch(:notification), to: pending)
-            next if newly_delivered.empty?
-
-            @alert_store.record_delivery(fingerprint, newly_delivered)
-            log_notification_sent(row)
+            if newly_delivered.any?
+              @alert_store.record_delivery(fingerprint, newly_delivered)
+              log_notification_sent(row)
+            else
+              @alert_store.record_send_failure(fingerprint, @now.call)
+            end
           elsif reminder_due?(entry, row)
-            next if send_notification(reminder_notification(row)).empty?
-
-            @alert_store.mark_reminded(fingerprint, @now.call)
-            log_notification_sent(row, reminder: true)
+            if send_notification(reminder_notification(row)).any?
+              @alert_store.mark_reminded(fingerprint, @now.call)
+              @alert_store.record_send_success(fingerprint)
+              log_notification_sent(row, reminder: true)
+            else
+              @alert_store.record_send_failure(fingerprint, @now.call)
+            end
           else
             @logger.event(:notification_skipped_dedupe, project: row.project,
                                                          slug: row.slug,
                                                          marker: row.marker)
           end
         end
+      end
+
+      def backoff_active?(entry)
+        next_attempt = entry.next_attempt_after
+        return false unless next_attempt
+
+        @now.call < next_attempt
       end
 
       def pending_chat_ids(entry)

--- a/lib/hive/bot/notification_dispatcher.rb
+++ b/lib/hive/bot/notification_dispatcher.rb
@@ -45,7 +45,10 @@ module Hive
           entry = @alert_store.entry(fingerprint)
           row = entry&.row
           if row && NotificationBuilders.recovery?(row)
-            @alert_store.remove(fingerprint) if send_notification(recovered_message(row))
+            if send_notification(recovered_message(row))
+              @alert_store.remove(fingerprint)
+              log_notification_sent(row, recovered: true)
+            end
           else
             @alert_store.remove(fingerprint)
           end
@@ -87,10 +90,10 @@ module Hive
         any_sent
       end
 
-      def log_notification_sent(row, reminder: false)
+      def log_notification_sent(row, reminder: false, recovered: false)
         @logger.event(:notification_sent, project: row.project, slug: row.slug,
                                           marker: row.marker, action: row.action,
-                                          reminder: reminder)
+                                          reminder: reminder, recovered: recovered)
       end
 
       def reminder_due?(entry, row)
@@ -104,17 +107,26 @@ module Hive
       def reminder_notification(row)
         notification = NotificationBuilders.recovery(row)
         lines = notification.text.lines(chomp: true)
-        lines[0] = "⚠ Still stuck (8 h) — \"#{TitleFormatter.title_from_slug(row.slug)}\" — " \
-                   "#{TitleFormatter.stage_label(row.stage)}"
+        lines[0] = "⚠ Still stuck (#{reminder_window_label}) — \"#{TitleFormatter.title_from_slug(row.slug)}\" — " \
+                   "#{TitleFormatter.stage_label(row.stage, logger: @logger)}"
         NotificationBuilders::Notification.new(text: lines.join("\n"), keyboard: notification.keyboard)
       end
 
       def recovered_message(row)
         NotificationBuilders::Notification.new(
           text: "✅ Recovered: \"#{TitleFormatter.title_from_slug(row.slug)}\" — " \
-                "#{TitleFormatter.stage_label(row.stage)}",
+                "#{TitleFormatter.stage_label(row.stage, logger: @logger)}",
           keyboard: nil
         )
+      end
+
+      def reminder_window_label
+        seconds = recovery_reminder_window.to_i
+        hours = seconds / 3600
+        return "#{hours} h" if hours >= 1 && seconds % 3600 == 0
+
+        minutes = (seconds / 60.0).round
+        "#{minutes} min"
       end
 
       def suppress_ready_action?(row)

--- a/lib/hive/bot/notification_dispatcher.rb
+++ b/lib/hive/bot/notification_dispatcher.rb
@@ -1,47 +1,80 @@
 require "time"
 require "hive/config"
+require "hive/bot/alert_store"
 require "hive/bot/notification_builders"
+require "hive/bot/title_formatter"
 
 module Hive
   module Bot
     class NotificationDispatcher
       def initialize(telegram:, logger:, bot_config:,
-                     daemon_enabled: nil, now: -> { Time.now })
+                     daemon_enabled: nil, now: -> { Time.now },
+                     alert_store: nil)
         @telegram = telegram
         @logger = logger
         @bot_config = bot_config
         @daemon_enabled = daemon_enabled
         @now = now
-        @seen = {}
-        @recent_dispatches = {}
-        @mutex = Mutex.new
+        @alert_store = alert_store || AlertStore.new(path: bot_config["alert_state_file"], logger: logger)
       end
 
       def process_rows(rows)
-        synchronize { prune_seen! }
-        rows.each { |row| process_row(row) }
-      end
-
-      def record_dispatch(project:, slug:, fingerprint: nil)
-        synchronize { @recent_dispatches[fingerprint || [ project, slug ]] = @now.call }
+        current = current_notifications(rows)
+        process_recoveries(current)
+        process_current(current)
       end
 
       private
 
-      def process_row(row)
-        return if suppress_ready_action?(row)
+      def current_notifications(rows)
+        Array(rows).each_with_object({}) do |row, out|
+          next if suppress_ready_action?(row)
 
-        notification = NotificationBuilders.build(row)
-        return unless notification
+          notification = NotificationBuilders.build(row)
+          next unless notification
 
-        fingerprint = NotificationBuilders.fingerprint(row)
-        if synchronize { @seen.key?(fingerprint) || @recent_dispatches.key?(fingerprint) }
-          @logger.event(:notification_skipped_dedupe, project: row.project,
-                                                       slug: row.slug,
-                                                       marker: row.marker)
-          return
+          fingerprint = NotificationBuilders.fingerprint(row)
+          out[fingerprint] ||= { row: row, notification: notification }
         end
+      end
 
+      def process_recoveries(current)
+        @alert_store.each_fingerprint do |fingerprint|
+          next if current.key?(fingerprint)
+
+          entry = @alert_store.entry(fingerprint)
+          row = entry&.row
+          if row && NotificationBuilders.recovery?(row)
+            @alert_store.remove(fingerprint) if send_notification(recovered_message(row))
+          else
+            @alert_store.remove(fingerprint)
+          end
+        end
+      end
+
+      def process_current(current)
+        current.each do |fingerprint, payload|
+          row = payload.fetch(:row)
+          entry = @alert_store.entry(fingerprint)
+          if entry.nil?
+            next unless send_notification(payload.fetch(:notification))
+
+            @alert_store.add(fingerprint, row, @now.call)
+            log_notification_sent(row)
+          elsif reminder_due?(entry, row)
+            next unless send_notification(reminder_notification(row))
+
+            @alert_store.mark_reminded(fingerprint, @now.call)
+            log_notification_sent(row, reminder: true)
+          else
+            @logger.event(:notification_skipped_dedupe, project: row.project,
+                                                         slug: row.slug,
+                                                         marker: row.marker)
+          end
+        end
+      end
+
+      def send_notification(notification)
         any_sent = false
         chat_ids.each do |chat_id|
           @telegram.send_message(chat_id: chat_id, text: notification.text,
@@ -50,15 +83,38 @@ module Hive
         rescue StandardError => e
           @logger.event(:send_failure, chat_id: chat_id, error_class: e.class.name, message: e.message)
         end
-        return unless any_sent
 
-        synchronize { @seen[fingerprint] = @now.call }
-        @logger.event(:notification_sent, project: row.project, slug: row.slug,
-                                          marker: row.marker, action: row.action)
+        any_sent
       end
 
-      def synchronize(&block)
-        @mutex.synchronize(&block)
+      def log_notification_sent(row, reminder: false)
+        @logger.event(:notification_sent, project: row.project, slug: row.slug,
+                                          marker: row.marker, action: row.action,
+                                          reminder: reminder)
+      end
+
+      def reminder_due?(entry, row)
+        return false unless NotificationBuilders.recovery?(row)
+        return false unless entry.first_seen_at
+        return false if entry.reminded_at
+
+        @now.call - entry.first_seen_at >= recovery_reminder_window
+      end
+
+      def reminder_notification(row)
+        notification = NotificationBuilders.recovery(row)
+        lines = notification.text.lines(chomp: true)
+        lines[0] = "⚠ Still stuck (8 h) — \"#{TitleFormatter.title_from_slug(row.slug)}\" — " \
+                   "#{TitleFormatter.stage_label(row.stage)}"
+        NotificationBuilders::Notification.new(text: lines.join("\n"), keyboard: notification.keyboard)
+      end
+
+      def recovered_message(row)
+        NotificationBuilders::Notification.new(
+          text: "✅ Recovered: \"#{TitleFormatter.title_from_slug(row.slug)}\" — " \
+                "#{TitleFormatter.stage_label(row.stage)}",
+          keyboard: nil
+        )
       end
 
       def suppress_ready_action?(row)
@@ -80,18 +136,12 @@ module Hive
         false
       end
 
-      def prune_seen!
-        cutoff = @now.call - dedupe_window
-        @seen.delete_if { |_fingerprint, seen_at| seen_at < cutoff }
-        @recent_dispatches.delete_if { |_key, seen_at| seen_at < cutoff }
-      end
-
       def chat_ids
         Array(@bot_config.fetch("chat_id_allowlist"))
       end
 
-      def dedupe_window
-        @bot_config.fetch("notification_dedupe_window_sec", 300)
+      def recovery_reminder_window
+        @bot_config.fetch("recovery_reminder_window_sec", 28_800)
       end
     end
   end

--- a/lib/hive/bot/notification_dispatcher.rb
+++ b/lib/hive/bot/notification_dispatcher.rb
@@ -7,20 +7,19 @@ require "hive/bot/title_formatter"
 module Hive
   module Bot
     class NotificationDispatcher
-      # daemon_enabled is retained as a no-op keyword so existing callers
-      # don't break. The old gate ("suppress ready_to_X only when the
-      # daemon is enabled for the project") leaked ready_to_X notifications
-      # whenever the daemon was off, which the eval contract classifies as
-      # noise (allow-list is agent_blocked_question / fatal_error only).
-      # ready_to_X is now always pull-only via /status; the operator decides
-      # when to advance.
+      # daemon_enabled is accepted as an unused keyword arg so existing
+      # callers don't break. The old gate ("suppress ready_to_X only when
+      # the daemon is enabled for the project") leaked ready_to_X
+      # notifications whenever the daemon was off, which the eval contract
+      # classifies as noise (allow-list is agent_blocked_question /
+      # fatal_error only). ready_to_X is now always pull-only via /status;
+      # the operator decides when to advance.
       def initialize(telegram:, logger:, bot_config:,
-                     daemon_enabled: nil, now: -> { Time.now },
+                     daemon_enabled: nil, now: -> { Time.now }, # rubocop:disable Lint/UnusedMethodArgument
                      alert_store: nil)
         @telegram = telegram
         @logger = logger
         @bot_config = bot_config
-        _ = daemon_enabled # accepted for backward compatibility, unused
         @now = now
         @alert_store = alert_store || AlertStore.new(path: bot_config["alert_state_file"], logger: logger)
       end
@@ -258,13 +257,6 @@ module Hive
       # operator initiates by pulling /status when ready to advance.
       def suppress_ready_action?(row)
         NotificationBuilders::READY_ACTIONS.include?(row.action)
-      end
-
-      def daemon_enabled_for?(_project)
-        # Retained as no-op for callers that may still subclass or stub it
-        # during the daemon-probe transition. To be removed once the
-        # bot/daemon split lands fully.
-        false
       end
 
       def chat_ids

--- a/lib/hive/bot/notification_dispatcher.rb
+++ b/lib/hive/bot/notification_dispatcher.rb
@@ -107,6 +107,10 @@ module Hive
       def reminder_notification(row)
         notification = NotificationBuilders.recovery(row)
         lines = notification.text.lines(chomp: true)
+        unless lines[0].to_s.start_with?("⚠ ")
+          raise "reminder_notification expected NotificationBuilders.recovery to emit a leading \"⚠ \" headline; " \
+                "got #{lines[0].inspect} — update reminder_notification together with the recovery builder."
+        end
         lines[0] = "⚠ Still stuck (#{reminder_window_label}) — \"#{TitleFormatter.title_from_slug(row.slug)}\" — " \
                    "#{TitleFormatter.stage_label(row.stage, logger: @logger)}"
         NotificationBuilders::Notification.new(text: lines.join("\n"), keyboard: notification.keyboard)

--- a/lib/hive/bot/notification_dispatcher.rb
+++ b/lib/hive/bot/notification_dispatcher.rb
@@ -51,7 +51,7 @@ module Hive
           if row && NotificationBuilders.recovery?(row)
             if current_recovery_for_same_row?(current, row)
               @alert_store.remove(fingerprint)
-            elsif send_notification(recovered_message(row))
+            elsif send_notification(recovered_message(row)).any?
               @alert_store.remove(fingerprint)
               log_notification_sent(row, recovered: true)
             end
@@ -66,12 +66,19 @@ module Hive
           row = payload.fetch(:row)
           entry = @alert_store.entry(fingerprint)
           if entry.nil?
-            next unless send_notification(payload.fetch(:notification))
+            delivered = send_notification(payload.fetch(:notification))
+            next if delivered.empty?
 
-            @alert_store.add(fingerprint, row, @now.call)
+            @alert_store.add(fingerprint, row, @now.call, delivered_to: delivered)
+            log_notification_sent(row)
+          elsif (pending = pending_chat_ids(entry)).any?
+            newly_delivered = send_notification(payload.fetch(:notification), to: pending)
+            next if newly_delivered.empty?
+
+            @alert_store.record_delivery(fingerprint, newly_delivered)
             log_notification_sent(row)
           elsif reminder_due?(entry, row)
-            next unless send_notification(reminder_notification(row))
+            next if send_notification(reminder_notification(row)).empty?
 
             @alert_store.mark_reminded(fingerprint, @now.call)
             log_notification_sent(row, reminder: true)
@@ -83,19 +90,30 @@ module Hive
         end
       end
 
-      def send_notification(notification)
-        attempted = false
-        all_sent = true
-        chat_ids.each do |chat_id|
-          attempted = true
+      def pending_chat_ids(entry)
+        delivered = Array(entry.delivered_to).map(&:to_s)
+        chat_ids.reject { |c| delivered.include?(c.to_s) }
+      end
+
+      def send_notification(notification, to: nil)
+        targets = filter_chats(to)
+        succeeded = []
+        targets.each do |chat_id|
           @telegram.send_message(chat_id: chat_id, text: notification.text,
                                  reply_markup: notification.keyboard)
+          succeeded << chat_id
         rescue StandardError => e
-          all_sent = false
           @logger.event(:send_failure, chat_id: chat_id, error_class: e.class.name, message: e.message)
         end
 
-        attempted && all_sent
+        succeeded
+      end
+
+      def filter_chats(to)
+        return chat_ids if to.nil?
+
+        allow = Array(to).map(&:to_s)
+        chat_ids.select { |c| allow.include?(c.to_s) }
       end
 
       def log_notification_sent(row, reminder: false, recovered: false)

--- a/lib/hive/bot/notification_dispatcher.rb
+++ b/lib/hive/bot/notification_dispatcher.rb
@@ -20,6 +20,11 @@ module Hive
 
       def process_rows(rows)
         current = current_notifications(rows)
+        if @alert_store.fresh_install?
+          seed_silently(current)
+          @alert_store.mark_seeded!
+          return
+        end
         process_recoveries(current)
         process_current(current)
       end
@@ -41,6 +46,21 @@ module Hive
           fingerprint = NotificationBuilders.fingerprint(row)
           out[fingerprint] ||= { row: row, notification: notification }
         end
+      end
+
+      # On a fresh AlertStore (no prior persistent state), pretend every
+      # current notification has already been delivered to every chat in the
+      # allowlist. This populates the store with a baseline so subsequent
+      # ticks only alert on deltas — operators don't see a thunderstorm of
+      # ⚠ alerts on day 1 for failures that pre-date the bot's deployment.
+      def seed_silently(current)
+        return if current.empty?
+
+        chats = chat_ids
+        current.each do |fingerprint, payload|
+          @alert_store.add(fingerprint, payload.fetch(:row), @now.call, delivered_to: chats)
+        end
+        @logger.event(:fresh_install_seeded, fingerprint_count: current.size)
       end
 
       def process_recoveries(current)

--- a/lib/hive/bot/notification_dispatcher.rb
+++ b/lib/hive/bot/notification_dispatcher.rb
@@ -7,13 +7,20 @@ require "hive/bot/title_formatter"
 module Hive
   module Bot
     class NotificationDispatcher
+      # daemon_enabled is retained as a no-op keyword so existing callers
+      # don't break. The old gate ("suppress ready_to_X only when the
+      # daemon is enabled for the project") leaked ready_to_X notifications
+      # whenever the daemon was off, which the eval contract classifies as
+      # noise (allow-list is agent_blocked_question / fatal_error only).
+      # ready_to_X is now always pull-only via /status; the operator decides
+      # when to advance.
       def initialize(telegram:, logger:, bot_config:,
                      daemon_enabled: nil, now: -> { Time.now },
                      alert_store: nil)
         @telegram = telegram
         @logger = logger
         @bot_config = bot_config
-        @daemon_enabled = daemon_enabled
+        _ = daemon_enabled # accepted for backward compatibility, unused
         @now = now
         @alert_store = alert_store || AlertStore.new(path: bot_config["alert_state_file"], logger: logger)
       end
@@ -239,22 +246,19 @@ module Hive
         "#{minutes} min"
       end
 
+      # ready_to_X notifications are pull-only via /status; never proactive.
+      # The eval contract limits proactive messages to agent_blocked_question
+      # (needs_input) and fatal_error (recovery/error). Stage approvals don't
+      # block the operator — they wait for an approve callback, which the
+      # operator initiates by pulling /status when ready to advance.
       def suppress_ready_action?(row)
-        return false unless NotificationBuilders::READY_ACTIONS.include?(row.action)
-
-        daemon_enabled_for?(row.project)
+        NotificationBuilders::READY_ACTIONS.include?(row.action)
       end
 
-      def daemon_enabled_for?(project)
-        return @daemon_enabled.call(project) if @daemon_enabled
-
-        entry = Hive::Config.find_project(project)
-        return false unless entry
-
-        Hive::Config.load(entry["path"]).dig("daemon", "enabled") == true
-      rescue Hive::ConfigError => e
-        @logger.event(:poll_failure, source: "daemon_check", project: project,
-                                      error_class: e.class.name, message: e.message)
+      def daemon_enabled_for?(_project)
+        # Retained as no-op for callers that may still subclass or stub it
+        # during the daemon-probe transition. To be removed once the
+        # bot/daemon split lands fully.
         false
       end
 

--- a/lib/hive/bot/router.rb
+++ b/lib/hive/bot/router.rb
@@ -42,7 +42,7 @@ module Hive
 
       Result = Struct.new(:action, :text, :reply_markup, :command_argv, :commands,
                           :project, :slug, :question_n, :answer_text, :mode,
-                          :intent, :alert_reset, keyword_init: true)
+                          :intent, :alert_reset, :clear_keyboard, keyword_init: true)
 
       ALLOWED_ACTIONS = %i[
         noop reply dispatch_then_reply dispatch_commands start_answer

--- a/lib/hive/bot/router.rb
+++ b/lib/hive/bot/router.rb
@@ -42,7 +42,7 @@ module Hive
 
       Result = Struct.new(:action, :text, :reply_markup, :command_argv, :commands,
                           :project, :slug, :question_n, :answer_text, :mode,
-                          :intent, keyword_init: true)
+                          :intent, :alert_reset, keyword_init: true)
 
       ALLOWED_ACTIONS = %i[
         noop reply dispatch_then_reply dispatch_commands start_answer

--- a/lib/hive/bot/router.rb
+++ b/lib/hive/bot/router.rb
@@ -20,6 +20,7 @@ module Hive
         slash_help
         callback_approve
         callback_reject
+        callback_autofix
         callback_clear_and_retry
         callback_open_laptop
         callback_show_details
@@ -160,6 +161,7 @@ module Hive
         case data
         when /\Aapprove:/ then :callback_approve
         when /\Areject:/ then :callback_reject
+        when /\Aautofix:/ then :callback_autofix
         when /\Aclear_retry:/ then :callback_clear_and_retry
         when /\Aopen_laptop:/ then :callback_open_laptop
         when /\Adetails:/ then :callback_show_details

--- a/lib/hive/bot/router.rb
+++ b/lib/hive/bot/router.rb
@@ -42,7 +42,7 @@ module Hive
 
       Result = Struct.new(:action, :text, :reply_markup, :command_argv, :commands,
                           :project, :slug, :question_n, :answer_text, :mode,
-                          :intent, :alert_reset, :clear_keyboard, keyword_init: true)
+                          :intent, :alert_reset, :clear_keyboard, :format, keyword_init: true)
 
       ALLOWED_ACTIONS = %i[
         noop reply dispatch_then_reply dispatch_commands start_answer

--- a/lib/hive/bot/status_watcher.rb
+++ b/lib/hive/bot/status_watcher.rb
@@ -16,8 +16,8 @@ module Hive
           super
         end
       end
-      Result = Data.define(:ok, :rows, :error) do
-        def initialize(ok:, rows: [], error: nil)
+      Result = Data.define(:ok, :rows, :error, :envelope) do
+        def initialize(ok:, rows: [], error: nil, envelope: nil)
           super
         end
       end
@@ -42,7 +42,7 @@ module Hive
 
         doc = JSON.parse(out)
         validate_envelope!(doc)
-        Result.new(ok: true, rows: extract_rows(doc, now: now), error: nil)
+        Result.new(ok: true, rows: extract_rows(doc, now: now), error: nil, envelope: doc)
       rescue JSON::ParserError => e
         failure("malformed JSON from hive status: #{e.message}")
       rescue StandardError => e

--- a/lib/hive/bot/supervisor.rb
+++ b/lib/hive/bot/supervisor.rb
@@ -229,6 +229,24 @@ module Hive
         @notification_dispatcher.reset_task(project: reset[:project], slug: reset[:slug], stage: reset[:stage])
       end
 
+      def project_filter_miss_text(project, rows)
+        registered = registered_project_names
+        active = rows.map { |row| row.project.to_s }.uniq
+        if registered.include?(project.to_s) || active.include?(project.to_s)
+          "No tasks for project #{project}."
+        else
+          known = (registered + active).uniq.sort
+          known_list = known.empty? ? "(none registered)" : known.join(", ")
+          "Unknown project #{project}. Known: #{known_list}."
+        end
+      end
+
+      def registered_project_names
+        Array(Hive::Config.registered_projects).map { |entry| entry.is_a?(Hash) ? entry["name"].to_s : entry.to_s }
+      rescue StandardError
+        []
+      end
+
       def clear_inline_keyboard(update)
         return unless update.respond_to?(:message_id) && update.message_id && update.chat_id
 
@@ -261,13 +279,22 @@ module Hive
 
       def execute_dispatch(result, update)
         if status_command?(result.command_argv)
-          rows = @status_watcher.fetch.rows
+          fetch_result = @status_watcher.fetch
+          unless fetch_result.ok
+            error = fetch_result.error.to_s.strip
+            error = "unknown error" if error.empty?
+            safe_send_message(chat_id: update.chat_id, text: "hive status unavailable: #{error}")
+            return nil
+          end
+
+          rows = fetch_result.rows
           if result.project && !result.project.to_s.empty?
-            rows = rows.select { |row| row.project == result.project }
-            if rows.empty?
-              safe_send_message(chat_id: update.chat_id, text: "No tasks for project #{result.project}.")
+            filtered = rows.select { |row| row.project == result.project }
+            if filtered.empty?
+              safe_send_message(chat_id: update.chat_id, text: project_filter_miss_text(result.project, rows))
               return nil
             end
+            rows = filtered
           end
           if result.slug
             safe_send_message(chat_id: update.chat_id, text: render_details(rows, result.project, result.slug))

--- a/lib/hive/bot/supervisor.rb
+++ b/lib/hive/bot/supervisor.rb
@@ -13,6 +13,7 @@ require "hive/bot/child_supervisor"
 require "hive/bot/brainstorm_answer_writer"
 require "hive/bot/brainstorm_parser"
 require "hive/bot/codex_conversation"
+require "hive/bot/title_formatter"
 require "hive/task"
 
 module Hive
@@ -236,13 +237,19 @@ module Hive
       end
 
       def execute_dispatch(result, update)
-        if result.command_argv == [ "hive", "status", "--json" ]
+        if status_command?(result.command_argv)
           rows = @status_watcher.fetch.rows
+          if result.project && !result.project.to_s.empty?
+            rows = rows.select { |row| row.project == result.project }
+            if rows.empty?
+              safe_send_message(chat_id: update.chat_id, text: "No tasks for project #{result.project}.")
+              return nil
+            end
+          end
           if result.slug
             safe_send_message(chat_id: update.chat_id, text: render_details(rows, result.project, result.slug))
           else
-            safe_send_message(chat_id: update.chat_id, text: render_queue(rows),
-                              reply_markup: queue_inline_keyboard(rows))
+            safe_send_message(chat_id: update.chat_id, text: render_queue(rows))
           end
           return nil
         end
@@ -497,35 +504,14 @@ module Hive
         return "No active Hive tasks." if actionable.empty?
 
         lines = actionable.first(QUEUE_DISPLAY_CAP).map do |row|
-          "#{row.project}/#{row.slug} #{row.stage} #{row.action_label || row.action} #{row.marker}"
+          "#{Hive::Bot::TitleFormatter.title_from_slug(row.slug)} — " \
+            "#{Hive::Bot::TitleFormatter.stage_label(row.stage, logger: @logger)}"
         end
         header = "#{actionable.size} active task#{actionable.size == 1 ? '' : 's'}"
         if actionable.size > QUEUE_DISPLAY_CAP
           lines << "+ #{actionable.size - QUEUE_DISPLAY_CAP} more tasks (use /status for full list)"
         end
         ([ header ] + lines).join("\n")
-      end
-
-      def queue_inline_keyboard(rows)
-        actionable = actionable_queue_rows(rows).first(QUEUE_DISPLAY_CAP)
-        return nil if actionable.empty?
-
-        actionable.flat_map do |row|
-          notification = Hive::Bot::NotificationBuilders.build(row)
-          buttons = Array(notification&.keyboard).flatten
-          primary = buttons.find { |button| button[:callback_data].to_s !~ /\Aopen_laptop:|details:/ } ||
-            buttons.first ||
-            { text: "Details", callback_data: details_callback_for(row) }
-          [ [ { text: "#{primary[:text]}: #{row.project}/#{row.slug}",
-                callback_data: primary[:callback_data] } ] ]
-        end
-      end
-
-      def details_callback_for(row)
-        parts = [ "details", row.project, row.slug ]
-        stage = row.respond_to?(:stage) ? row.stage.to_s : ""
-        parts << stage unless stage.empty?
-        parts.join(":")
       end
 
       def render_details(rows, project, slug)
@@ -544,6 +530,13 @@ module Hive
 
       def actionable_queue_rows(rows)
         Array(rows).reject { |row| %w[archived agent_running].include?(row.action) }
+      end
+
+      def status_command?(argv)
+        argv = Array(argv)
+        return true if argv == [ "hive", "status", "--json" ]
+
+        argv.length == 5 && argv[0, 3] == [ "hive", "status", "--json" ] && argv[3] == "--project"
       end
 
       def next_unanswered_question_n(brainstorm_path)

--- a/lib/hive/bot/supervisor.rb
+++ b/lib/hive/bot/supervisor.rb
@@ -514,7 +514,7 @@ module Hive
         end
         header = "#{actionable.size} active task#{actionable.size == 1 ? '' : 's'}"
         if actionable.size > QUEUE_DISPLAY_CAP
-          lines << "+ #{actionable.size - QUEUE_DISPLAY_CAP} more tasks (use /status for full list)"
+          lines << "+ #{actionable.size - QUEUE_DISPLAY_CAP} more tasks — open on a laptop for the full list."
         end
         ([ header ] + lines).join("\n")
       end

--- a/lib/hive/bot/supervisor.rb
+++ b/lib/hive/bot/supervisor.rb
@@ -238,17 +238,13 @@ module Hive
       end
 
       def needs_alert_reset?(result)
-        return false unless result.respond_to?(:alert_reset)
-
         reset = result.alert_reset
-        reset && @notification_dispatcher.respond_to?(:reset_task)
+        reset ? true : false
       end
 
       def reset_alert_for_result(result)
-        return unless result.respond_to?(:alert_reset)
-
         reset = result.alert_reset
-        return unless reset && @notification_dispatcher.respond_to?(:reset_task)
+        return unless reset
 
         @notification_dispatcher.reset_task(project: reset[:project], slug: reset[:slug],
                                             stage: reset[:stage], marker: reset[:marker],
@@ -622,10 +618,7 @@ module Hive
       end
 
       def status_command?(argv)
-        argv = Array(argv)
-        return true if argv == [ "hive", "status", "--json" ]
-
-        argv.length == 5 && argv[0, 3] == [ "hive", "status", "--json" ] && argv[3] == "--project"
+        Array(argv) == [ "hive", "status", "--json" ]
       end
 
       def next_unanswered_question_n(brainstorm_path)

--- a/lib/hive/bot/supervisor.rb
+++ b/lib/hive/bot/supervisor.rb
@@ -51,6 +51,7 @@ module Hive
         last_seen = read_last_seen_update_id
         @next_update_id = last_seen ? last_seen + 1 : nil
         @started_at = Time.now
+        emit_deprecated_config_events!
       end
 
       def run_forever
@@ -608,11 +609,18 @@ module Hive
         )
         @conversation_store.update_ttl(@config.fetch("conversation_ttl_sec")) if @conversation_store.respond_to?(:update_ttl)
         @logger.event(:config_reloaded)
+        emit_deprecated_config_events!
         @reload = false
       rescue Hive::ConfigError => e
         @logger.event(:fatal, message: "config reload failed: #{e.message}",
                               keeping_previous: true)
         @reload = false
+      end
+
+      def emit_deprecated_config_events!
+        Hive::Config.deprecated_bot_keys(@config).each do |entry|
+          @logger.event(:deprecated_config, key: entry[:key], replacement: entry[:replacement])
+        end
       end
 
       def install_signal_handlers!

--- a/lib/hive/bot/supervisor.rb
+++ b/lib/hive/bot/supervisor.rb
@@ -689,6 +689,10 @@ module Hive
           bot_config: @config
         )
         @conversation_store.update_ttl(@config.fetch("conversation_ttl_sec")) if @conversation_store.respond_to?(:update_ttl)
+        # Drop the once-per-process unknown-stage-log cache so SIGHUP can
+        # re-surface stage_dir values that the previous instance had
+        # already logged about.
+        Hive::Bot::TitleFormatter.reset_unknown_stage_log_cache!
         @logger.event(:config_reloaded)
         emit_deprecated_config_events!
         @reload = false

--- a/lib/hive/bot/supervisor.rb
+++ b/lib/hive/bot/supervisor.rb
@@ -201,8 +201,9 @@ module Hive
 
       def dispatch_command_sequence(result, update)
         clear_inline_keyboard(update) if result.respond_to?(:clear_keyboard) && result.clear_keyboard
-        reset_alert_for_result(result) unless @dry_run
         commands = Array(result.commands)
+        reset_pending = !@dry_run && needs_alert_reset?(result)
+        failed = false
         commands.each_with_index do |argv, idx|
           per_command = @router.class::Result.new(
             action: :dispatch_then_reply,
@@ -214,10 +215,33 @@ module Hive
           if idx < commands.length - 1 && last_pid
             unless wait_for_child_success(last_pid, deadline: Time.now + (@config.fetch("clear_retry_grace_sec", 30)))
               safe_send_message(chat_id: update.chat_id, text: "Stopped because the previous command failed.")
+              failed = true
               break
+            end
+            # First non-final command (typically `markers clear`) succeeded.
+            # Clear the alert NOW so the row no longer carries a recovery marker
+            # before the retry verb dispatches and before the next status tick.
+            # This closes the race window where reset-before-dispatch would let
+            # process_current re-alert the same fingerprint within seconds of
+            # the Autofix tap.
+            if reset_pending
+              reset_alert_for_result(result)
+              reset_pending = false
             end
           end
         end
+        # Single-command paths (e.g., AGENT_WORKING markers that skip
+        # markers-clear) reach here without ever hitting the between-command
+        # sync point above. Reset the alert post-dispatch — only if we did not
+        # bail out of the loop on a failed precursor.
+        reset_alert_for_result(result) if reset_pending && !failed
+      end
+
+      def needs_alert_reset?(result)
+        return false unless result.respond_to?(:alert_reset)
+
+        reset = result.alert_reset
+        reset && @notification_dispatcher.respond_to?(:reset_task)
       end
 
       def reset_alert_for_result(result)

--- a/lib/hive/bot/supervisor.rb
+++ b/lib/hive/bot/supervisor.rb
@@ -200,6 +200,7 @@ module Hive
       end
 
       def dispatch_command_sequence(result, update)
+        clear_inline_keyboard(update) if result.respond_to?(:clear_keyboard) && result.clear_keyboard
         reset_alert_for_result(result) unless @dry_run
         commands = Array(result.commands)
         commands.each_with_index do |argv, idx|
@@ -226,6 +227,17 @@ module Hive
         return unless reset && @notification_dispatcher.respond_to?(:reset_task)
 
         @notification_dispatcher.reset_task(project: reset[:project], slug: reset[:slug], stage: reset[:stage])
+      end
+
+      def clear_inline_keyboard(update)
+        return unless update.respond_to?(:message_id) && update.message_id && update.chat_id
+
+        @telegram.edit_message_reply_markup(chat_id: update.chat_id, message_id: update.message_id,
+                                            reply_markup: nil)
+      rescue StandardError => e
+        @logger.event(:send_failure, source: "edit_message_reply_markup",
+                                      chat_id: update.chat_id, message_id: update.message_id,
+                                      error_class: e.class.name, message: e.message)
       end
 
       def wait_for_child_success(pid, deadline:)

--- a/lib/hive/bot/supervisor.rb
+++ b/lib/hive/bot/supervisor.rb
@@ -200,6 +200,7 @@ module Hive
       end
 
       def dispatch_command_sequence(result, update)
+        reset_alert_for_result(result) unless @dry_run
         commands = Array(result.commands)
         commands.each_with_index do |argv, idx|
           per_command = @router.class::Result.new(
@@ -216,6 +217,15 @@ module Hive
             end
           end
         end
+      end
+
+      def reset_alert_for_result(result)
+        return unless result.respond_to?(:alert_reset)
+
+        reset = result.alert_reset
+        return unless reset && @notification_dispatcher.respond_to?(:reset_task)
+
+        @notification_dispatcher.reset_task(project: reset[:project], slug: reset[:slug], stage: reset[:stage])
       end
 
       def wait_for_child_success(pid, deadline:)
@@ -462,19 +472,13 @@ module Hive
       def diagnose_reply_for_child(child)
         envelope = child.json_envelope
         return nil unless envelope.is_a?(Hash) && envelope["schema"] == "hive-status-diagnose"
-
         if envelope["ok"] == true
           diagnostic = envelope["diagnostic"].is_a?(Hash) ? envelope["diagnostic"] : {}
-          lines = []
-          summary = diagnostic["summary"].to_s.strip
-          detail = diagnostic["detail"].to_s.strip
-          path = envelope["path"].to_s.strip
-          lines << summary unless summary.empty?
-          lines << detail unless detail.empty? || detail == summary
-          lines << "Path: #{path}" unless path.empty?
-          return lines.join("\n\n") unless lines.empty?
+          slug = envelope["slug"] || child.slug
+          return "No diagnostic available for #{slug}." if diagnostic.empty? && envelope["path"].to_s.strip.empty?
 
-          return "No diagnostic available for #{envelope['slug'] || child.slug}."
+          return "Diagnosis is available for \"#{Hive::Bot::TitleFormatter.title_from_slug(slug)}\". " \
+                 "Open this task on a laptop for full details."
         end
 
         kind = envelope["error_kind"].to_s.strip

--- a/lib/hive/bot/supervisor.rb
+++ b/lib/hive/bot/supervisor.rb
@@ -255,6 +255,19 @@ module Hive
                                             match_attr: reset[:match_attr])
       end
 
+      def render_status_json(envelope, project_filter)
+        return "{}" if envelope.nil?
+
+        if project_filter && !project_filter.to_s.empty?
+          filtered = envelope.merge(
+            "projects" => Array(envelope["projects"]).select { |p| p["name"] == project_filter }
+          )
+          ::JSON.pretty_generate(filtered)
+        else
+          ::JSON.pretty_generate(envelope)
+        end
+      end
+
       def project_filter_miss_text(project, rows)
         registered = registered_project_names
         active = rows.map { |row| row.project.to_s }.uniq
@@ -310,6 +323,12 @@ module Hive
             error = fetch_result.error.to_s.strip
             error = "unknown error" if error.empty?
             safe_send_message(chat_id: update.chat_id, text: "hive status unavailable: #{error}")
+            return nil
+          end
+
+          if result.respond_to?(:format) && result.format == :json
+            safe_send_message(chat_id: update.chat_id,
+                              text: render_status_json(fetch_result.envelope, result.project))
             return nil
           end
 

--- a/lib/hive/bot/supervisor.rb
+++ b/lib/hive/bot/supervisor.rb
@@ -250,7 +250,9 @@ module Hive
         reset = result.alert_reset
         return unless reset && @notification_dispatcher.respond_to?(:reset_task)
 
-        @notification_dispatcher.reset_task(project: reset[:project], slug: reset[:slug], stage: reset[:stage])
+        @notification_dispatcher.reset_task(project: reset[:project], slug: reset[:slug],
+                                            stage: reset[:stage], marker: reset[:marker],
+                                            match_attr: reset[:match_attr])
       end
 
       def project_filter_miss_text(project, rows)

--- a/lib/hive/bot/title_formatter.rb
+++ b/lib/hive/bot/title_formatter.rb
@@ -1,0 +1,52 @@
+module Hive
+  module Bot
+    module TitleFormatter
+      STAGE_LABELS = {
+        "1-inbox" => "Inbox",
+        "2-brainstorm" => "Brainstorm",
+        "3-plan" => "Plan",
+        "4-execute" => "Execute",
+        "5-open-pr" => "Open PR",
+        "6-review" => "Review",
+        "7-artifacts" => "Artifacts",
+        "8-finalize" => "Finalize",
+        "9-done" => "Done"
+      }.freeze
+
+      SLUG_SUFFIX = /-\d{6}-[a-f0-9]{4,}\z/
+      TITLE_LIMIT = 60
+
+      module_function
+
+      def title_from_slug(slug)
+        words = slug.to_s.sub(SLUG_SUFFIX, "").tr("-", " ").strip
+        sentence = words.empty? ? "Task" : words.downcase
+        sentence = sentence[0].upcase + sentence[1..].to_s
+        sentence = sentence[0, TITLE_LIMIT] if sentence.length > TITLE_LIMIT
+        "#{sentence}…"
+      end
+
+      def stage_label(stage_dir, logger: nil)
+        key = stage_dir.to_s
+        label = STAGE_LABELS[key]
+        return label if label
+
+        log_unknown_stage_once(key, logger)
+        fallback = key.sub(/\A\d+-/, "").tr("-", " ").strip
+        fallback = "stage" if fallback.empty?
+        fallback.split(/\s+/).map(&:capitalize).join(" ")
+      end
+
+      def log_unknown_stage_once(key, logger)
+        return unless logger && !unknown_stage_labels.key?(key)
+
+        unknown_stage_labels[key] = true
+        logger.event(:unknown_stage_label, stage: key)
+      end
+
+      def unknown_stage_labels
+        @unknown_stage_labels ||= {}
+      end
+    end
+  end
+end

--- a/lib/hive/bot/title_formatter.rb
+++ b/lib/hive/bot/title_formatter.rb
@@ -20,6 +20,11 @@ module Hive
       ACRONYMS = %w[PR CI CD DB UI UX API URL HTTP].freeze
       ACRONYM_REGEXPS = ACRONYMS.map { |a| [ /\b#{Regexp.escape(a)}\b/i, a ] }.freeze
       UNKNOWN_STAGE_LABELS_LOCK = Monitor.new
+      # Eager-initialize the unknown-label cache so the lookup at log time
+      # is never racing with a lazy-init. Behaviour is unchanged from a
+      # successfully-initialised state; only the construction race goes
+      # away.
+      @unknown_stage_labels = {}
 
       module_function
 
@@ -54,6 +59,16 @@ module Hive
         end
       end
 
+      # Clear the once-per-process log cache so SIGHUP / config reload can
+      # surface new stage_dir values that previously logged. Without this
+      # the cache lives for the bot's lifetime and silently masks stage
+      # additions across `hive bot reload`. Callers MUST hold no other
+      # locks; the synchronize here is the same Monitor protecting the
+      # cache mutation in log_unknown_stage_once.
+      def reset_unknown_stage_log_cache!
+        UNKNOWN_STAGE_LABELS_LOCK.synchronize { unknown_stage_labels.clear }
+      end
+
       def preserve_acronyms(sentence)
         ACRONYM_REGEXPS.each do |pattern, replacement|
           sentence = sentence.gsub(pattern, replacement)
@@ -62,7 +77,7 @@ module Hive
       end
 
       def unknown_stage_labels
-        @unknown_stage_labels ||= {}
+        @unknown_stage_labels
       end
     end
   end

--- a/lib/hive/bot/title_formatter.rb
+++ b/lib/hive/bot/title_formatter.rb
@@ -1,3 +1,5 @@
+require "monitor"
+
 module Hive
   module Bot
     module TitleFormatter
@@ -15,6 +17,8 @@ module Hive
 
       SLUG_SUFFIX = /-\d{6}-[a-f0-9]{4,}\z/
       TITLE_LIMIT = 60
+      ACRONYMS = %w[PR CI CD DB UI UX API URL HTTP].freeze
+      UNKNOWN_STAGE_LABELS_LOCK = Monitor.new
 
       module_function
 
@@ -23,6 +27,7 @@ module Hive
         sentence = words.empty? ? "Task" : words.downcase
         sentence = sentence[0].upcase + sentence[1..].to_s
         sentence = sentence[0, TITLE_LIMIT] if sentence.length > TITLE_LIMIT
+        sentence = preserve_acronyms(sentence)
         "#{sentence}…"
       end
 
@@ -38,10 +43,21 @@ module Hive
       end
 
       def log_unknown_stage_once(key, logger)
-        return unless logger && !unknown_stage_labels.key?(key)
+        return unless logger
 
-        unknown_stage_labels[key] = true
-        logger.event(:unknown_stage_label, stage: key)
+        UNKNOWN_STAGE_LABELS_LOCK.synchronize do
+          return if unknown_stage_labels.key?(key)
+
+          unknown_stage_labels[key] = true
+          logger.event(:unknown_stage_label, stage: key)
+        end
+      end
+
+      def preserve_acronyms(sentence)
+        ACRONYMS.each do |acronym|
+          sentence = sentence.gsub(/\b#{Regexp.escape(acronym.downcase)}\b/, acronym)
+        end
+        sentence
       end
 
       def unknown_stage_labels

--- a/lib/hive/bot/title_formatter.rb
+++ b/lib/hive/bot/title_formatter.rb
@@ -18,6 +18,7 @@ module Hive
       SLUG_SUFFIX = /-\d{6}-[a-f0-9]{4,}\z/
       TITLE_LIMIT = 60
       ACRONYMS = %w[PR CI CD DB UI UX API URL HTTP].freeze
+      ACRONYM_REGEXPS = ACRONYMS.map { |a| [ /\b#{Regexp.escape(a.downcase)}\b/, a ] }.freeze
       UNKNOWN_STAGE_LABELS_LOCK = Monitor.new
 
       module_function
@@ -54,8 +55,8 @@ module Hive
       end
 
       def preserve_acronyms(sentence)
-        ACRONYMS.each do |acronym|
-          sentence = sentence.gsub(/\b#{Regexp.escape(acronym.downcase)}\b/, acronym)
+        ACRONYM_REGEXPS.each do |pattern, replacement|
+          sentence = sentence.gsub(pattern, replacement)
         end
         sentence
       end

--- a/lib/hive/bot/title_formatter.rb
+++ b/lib/hive/bot/title_formatter.rb
@@ -18,7 +18,7 @@ module Hive
       SLUG_SUFFIX = /-\d{6}-[a-f0-9]{4,}\z/
       TITLE_LIMIT = 60
       ACRONYMS = %w[PR CI CD DB UI UX API URL HTTP].freeze
-      ACRONYM_REGEXPS = ACRONYMS.map { |a| [ /\b#{Regexp.escape(a.downcase)}\b/, a ] }.freeze
+      ACRONYM_REGEXPS = ACRONYMS.map { |a| [ /\b#{Regexp.escape(a)}\b/i, a ] }.freeze
       UNKNOWN_STAGE_LABELS_LOCK = Monitor.new
 
       module_function

--- a/lib/hive/config.rb
+++ b/lib/hive/config.rb
@@ -1111,8 +1111,10 @@ module Hive
     ].freeze
 
     def warn_deprecated_bot_dedupe!(bot, source_path)
+      # deprecated_bot_keys already returns the fully-qualified key
+      # ("bot.<name>"), so the warn line does not add its own prefix.
       deprecated_bot_keys(bot).each do |entry|
-        warn "hive: bot.#{entry[:key]} in #{describe_source(source_path)} is deprecated; " \
+        warn "hive: #{entry[:key]} in #{describe_source(source_path)} is deprecated; " \
              "alert lifecycle now uses #{entry[:replacement]}"
       end
     end

--- a/lib/hive/config.rb
+++ b/lib/hive/config.rb
@@ -175,7 +175,11 @@ module Hive
         "poll_interval_sec" => 30,
         "long_poll_timeout_sec" => 25,
         "notification_dedupe_window_sec" => 300,
-        "alert_state_file" => "~/Dev/hive/.bot.alert_state.json",
+        # alert_state_file is intentionally omitted from DEFAULTS — the
+        # path is state_home-derived and resolved at runtime by
+        # `global_bot_defaults` / `Config.load` so a HIVE_HOME / XDG
+        # override propagates correctly. A hardcoded developer-specific
+        # path here would be misleading for direct DEFAULTS readers.
         "recovery_reminder_window_sec" => 28_800,
         "conversation_ttl_sec" => 3600,
         "codex_budget_usd" => 1,
@@ -255,8 +259,23 @@ module Hive
       merged = merge_defaults(data).merge("project_root" => project_root)
       merged[EXPLICIT_CLAUDE_MODE_KEY] = nested_key?(data, "claude", "mode")
       merged[EXPLICIT_BRAINSTORM_RUNTIME_KEY] = nested_key?(data, "brainstorm", "runtime")
+      inject_bot_runtime_path_defaults!(merged)
       validate!(merged, candidate)
       merged
+    end
+
+    # DEFAULTS["bot"] intentionally omits state_home-derived path keys
+    # so direct readers cannot get a stale developer-specific path. We
+    # fill those in here after merge so the consumer-facing cfg always
+    # carries the same path that `global_bot_defaults` would resolve.
+    def inject_bot_runtime_path_defaults!(cfg)
+      # Skip when "bot" is not a Hash — `validate!` runs next and turns
+      # the malformed scalar into a proper ConfigError. Injecting first
+      # would crash with IndexError on String#[]= and lose that signal.
+      bot = cfg["bot"]
+      return unless bot.is_a?(Hash)
+
+      bot["alert_state_file"] ||= File.join(Hive::Paths.state_home, ".bot.alert_state.json")
     end
 
     def claude_mode(cfg)

--- a/lib/hive/config.rb
+++ b/lib/hive/config.rb
@@ -175,6 +175,8 @@ module Hive
         "poll_interval_sec" => 30,
         "long_poll_timeout_sec" => 25,
         "notification_dedupe_window_sec" => 300,
+        "alert_state_file" => "~/Dev/hive/.bot.alert_state.json",
+        "recovery_reminder_window_sec" => 28_800,
         "conversation_ttl_sec" => 3600,
         "codex_budget_usd" => 1,
         "codex_timeout_sec" => 120,
@@ -486,6 +488,7 @@ module Hive
       defaults = deep_dup(DEFAULTS["bot"])
       defaults["pid_file"] = File.join(Hive::Paths.state_home, ".bot.pid")
       defaults["log_file"] = File.join(Hive::Paths.state_home, "logs", "bot.log")
+      defaults["alert_state_file"] = File.join(Hive::Paths.state_home, ".bot.alert_state.json")
       defaults["last_seen_state_file"] = File.join(Hive::Paths.state_home, ".bot.last_seen_update_id")
       defaults
     end
@@ -1002,6 +1005,7 @@ module Hive
       [ "poll_interval_sec", 5, nil ],
       [ "long_poll_timeout_sec", 5, 50 ],
       [ "notification_dedupe_window_sec", 0, nil ],
+      [ "recovery_reminder_window_sec", 3600, 604_800 ],
       [ "conversation_ttl_sec", 60, nil ],
       [ "codex_budget_usd", 0, nil ],
       [ "codex_timeout_sec", 10, nil ],
@@ -1013,6 +1017,7 @@ module Hive
     BOT_PATH_KEYS = %w[
       pid_file
       log_file
+      alert_state_file
       last_seen_state_file
     ].freeze
 
@@ -1028,6 +1033,7 @@ module Hive
       end
 
       validate_bot_allowlist!(bot, source_path)
+      warn_deprecated_bot_dedupe!(bot, source_path)
       validate_bot_numbers!(bot, source_path)
       validate_bot_paths!(bot, source_path)
     end
@@ -1071,6 +1077,15 @@ module Hive
                 "got #{value.inspect} (#{value.class})"
         end
       end
+    end
+
+    def warn_deprecated_bot_dedupe!(bot, source_path)
+      value = bot["notification_dedupe_window_sec"]
+      default = DEFAULTS.dig("bot", "notification_dedupe_window_sec")
+      return if value.nil? || value == default
+
+      warn "hive: bot.notification_dedupe_window_sec in #{describe_source(source_path)} is deprecated; " \
+           "alert lifecycle now uses bot.alert_state_file and bot.recovery_reminder_window_sec"
     end
 
     def validate_bot_paths!(bot, source_path)

--- a/lib/hive/config.rb
+++ b/lib/hive/config.rb
@@ -1088,6 +1088,23 @@ module Hive
            "alert lifecycle now uses bot.alert_state_file and bot.recovery_reminder_window_sec"
     end
 
+    # Returns deprecated bot keys whose value differs from default so callers
+    # (e.g. the bot supervisor) can emit structured :deprecated_config events.
+    def deprecated_bot_keys(bot)
+      return [] unless bot.is_a?(Hash)
+
+      result = []
+      value = bot["notification_dedupe_window_sec"]
+      default = DEFAULTS.dig("bot", "notification_dedupe_window_sec")
+      unless value.nil? || value == default
+        result << {
+          key: "bot.notification_dedupe_window_sec",
+          replacement: "bot.alert_state_file and bot.recovery_reminder_window_sec"
+        }
+      end
+      result
+    end
+
     def validate_bot_paths!(bot, source_path)
       BOT_PATH_KEYS.each do |key|
         value = bot[key]

--- a/lib/hive/config.rb
+++ b/lib/hive/config.rb
@@ -1098,13 +1098,23 @@ module Hive
       end
     end
 
-    def warn_deprecated_bot_dedupe!(bot, source_path)
-      value = bot["notification_dedupe_window_sec"]
-      default = DEFAULTS.dig("bot", "notification_dedupe_window_sec")
-      return if value.nil? || value == default
+    # Single source of truth for deprecated bot keys. Each entry names the
+    # config key, its replacement, and the DEFAULTS path used to suppress
+    # warnings when the user has not actually set anything (or has set the
+    # historical default). Both the load-time `warn` path and the supervisor's
+    # structured :deprecated_config event iterate this list.
+    DEPRECATED_BOT_KEYS = [
+      {
+        key: "notification_dedupe_window_sec",
+        replacement: "bot.alert_state_file and bot.recovery_reminder_window_sec"
+      }
+    ].freeze
 
-      warn "hive: bot.notification_dedupe_window_sec in #{describe_source(source_path)} is deprecated; " \
-           "alert lifecycle now uses bot.alert_state_file and bot.recovery_reminder_window_sec"
+    def warn_deprecated_bot_dedupe!(bot, source_path)
+      deprecated_bot_keys(bot).each do |entry|
+        warn "hive: bot.#{entry[:key]} in #{describe_source(source_path)} is deprecated; " \
+             "alert lifecycle now uses #{entry[:replacement]}"
+      end
     end
 
     # Returns deprecated bot keys whose value differs from default so callers
@@ -1112,16 +1122,13 @@ module Hive
     def deprecated_bot_keys(bot)
       return [] unless bot.is_a?(Hash)
 
-      result = []
-      value = bot["notification_dedupe_window_sec"]
-      default = DEFAULTS.dig("bot", "notification_dedupe_window_sec")
-      unless value.nil? || value == default
-        result << {
-          key: "bot.notification_dedupe_window_sec",
-          replacement: "bot.alert_state_file and bot.recovery_reminder_window_sec"
-        }
+      DEPRECATED_BOT_KEYS.each_with_object([]) do |entry, out|
+        value = bot[entry[:key]]
+        default = DEFAULTS.dig("bot", entry[:key])
+        next if value.nil? || value == default
+
+        out << { key: "bot.#{entry[:key]}", replacement: entry[:replacement] }
       end
-      result
     end
 
     def validate_bot_paths!(bot, source_path)

--- a/lib/hive/config.rb
+++ b/lib/hive/config.rb
@@ -180,6 +180,7 @@ module Hive
         # override propagates correctly. A hardcoded developer-specific
         # path here would be misleading for direct DEFAULTS readers.
         "recovery_reminder_window_sec" => 28_800,
+        "recovery_grace_sec" => 60,
         "conversation_ttl_sec" => 3600,
         "codex_budget_usd" => 1,
         "codex_timeout_sec" => 120,
@@ -1023,6 +1024,7 @@ module Hive
       [ "poll_interval_sec", 5, nil ],
       [ "long_poll_timeout_sec", 5, 50 ],
       [ "recovery_reminder_window_sec", 3600, 604_800 ],
+      [ "recovery_grace_sec", 0, 3600 ],
       [ "conversation_ttl_sec", 60, nil ],
       [ "codex_budget_usd", 0, nil ],
       [ "codex_timeout_sec", 10, nil ],

--- a/lib/hive/config.rb
+++ b/lib/hive/config.rb
@@ -174,7 +174,6 @@ module Hive
         "chat_id_allowlist" => [],
         "poll_interval_sec" => 30,
         "long_poll_timeout_sec" => 25,
-        "notification_dedupe_window_sec" => 300,
         # alert_state_file is intentionally omitted from DEFAULTS — the
         # path is state_home-derived and resolved at runtime by
         # `global_bot_defaults` / `Config.load` so a HIVE_HOME / XDG
@@ -1023,7 +1022,6 @@ module Hive
     BOT_NUMERIC_BOUNDS = [
       [ "poll_interval_sec", 5, nil ],
       [ "long_poll_timeout_sec", 5, 50 ],
-      [ "notification_dedupe_window_sec", 0, nil ],
       [ "recovery_reminder_window_sec", 3600, 604_800 ],
       [ "conversation_ttl_sec", 60, nil ],
       [ "codex_budget_usd", 0, nil ],

--- a/schemas/hive-bot-log.v1.json
+++ b/schemas/hive-bot-log.v1.json
@@ -39,6 +39,9 @@
         "send_failure",
         "callback_malformed",
         "pid_file_corrupted",
+        "unknown_stage_label",
+        "alert_store_corrupt",
+        "deprecated_config",
         "fatal"
       ]
     }

--- a/schemas/hive-bot-log.v1.json
+++ b/schemas/hive-bot-log.v1.json
@@ -26,6 +26,7 @@
         "update_rejected_unauthorized",
         "notification_sent",
         "notification_skipped_dedupe",
+        "notification_skipped_backoff",
         "dispatched_command",
         "command_completed",
         "codex_spawned",

--- a/schemas/hive-bot-log.v1.json
+++ b/schemas/hive-bot-log.v1.json
@@ -27,6 +27,7 @@
         "notification_sent",
         "notification_skipped_dedupe",
         "notification_skipped_backoff",
+        "fresh_install_seeded",
         "dispatched_command",
         "command_completed",
         "codex_spawned",

--- a/schemas/hive-bot-log.v1.json
+++ b/schemas/hive-bot-log.v1.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/ivankuznetsov/hive/blob/main/schemas/hive-bot-log.v1.json",
   "title": "hive bot structured log line (v1)",
-  "description": "One JSON-line event emitted by Hive::Bot::Logger.",
+  "description": "One JSON-line event emitted by Hive::Bot::Logger. v1 follows additive-only evolution: new enum values may be appended to `event` without a SCHEMA_VERSION bump. Breaking changes (removing or renaming an event, changing the value shape of an existing event) require a v2 schema file with $id and `schema_version` bumped.",
   "type": "object",
   "additionalProperties": true,
   "required": ["ts", "schema", "schema_version", "event"],

--- a/templates/hive_config.yml.erb
+++ b/templates/hive_config.yml.erb
@@ -16,7 +16,7 @@ registered_projects: <%= registered_projects.empty? ? "[]" : "" %>
 #   poll_interval_sec: 30
 #   long_poll_timeout_sec: 25
 #   notification_dedupe_window_sec: 300
-#   alert_state_file: ~/Dev/hive/.bot.alert_state.json
+#   alert_state_file: ~/.local/state/hive/.bot.alert_state.json
 #   recovery_reminder_window_sec: 28800
 #   conversation_ttl_sec: 3600
 #   codex_budget_usd: 1

--- a/templates/hive_config.yml.erb
+++ b/templates/hive_config.yml.erb
@@ -15,7 +15,6 @@ registered_projects: <%= registered_projects.empty? ? "[]" : "" %>
 #   chat_id_allowlist: []   # integers only, e.g. [123456789]
 #   poll_interval_sec: 30
 #   long_poll_timeout_sec: 25
-#   notification_dedupe_window_sec: 300
 #   alert_state_file: ~/.local/state/hive/.bot.alert_state.json
 #   recovery_reminder_window_sec: 28800
 #   conversation_ttl_sec: 3600

--- a/templates/hive_config.yml.erb
+++ b/templates/hive_config.yml.erb
@@ -16,6 +16,8 @@ registered_projects: <%= registered_projects.empty? ? "[]" : "" %>
 #   poll_interval_sec: 30
 #   long_poll_timeout_sec: 25
 #   notification_dedupe_window_sec: 300
+#   alert_state_file: ~/Dev/hive/.bot.alert_state.json
+#   recovery_reminder_window_sec: 28800
 #   conversation_ttl_sec: 3600
 #   codex_budget_usd: 1
 #   codex_timeout_sec: 120

--- a/test/eval/scenarios/s4_button_test.rb
+++ b/test/eval/scenarios/s4_button_test.rb
@@ -6,12 +6,18 @@ class HiveEvalS4ButtonTest < Minitest::Test
   def test_inline_approve_button_dispatches_expected_command
     given_project(name: "hive")
 
+    # ready_to_X notifications are pull-only (s3 noise contract: proactive
+    # allow-list is agent_blocked_question / fatal_error only). The
+    # approve callback contract itself is still the contract under test;
+    # construct the callback_data the same way NotificationBuilders would
+    # without depending on a proactive emission.
     when_agent_emits(rows: [
       status_row(slug: "ship-a", stage: "7-artifacts", action: "ready_to_finalize", marker: "complete")
     ])
-    button = harness.last_sent.reply_markup.flatten.find { |candidate| candidate[:text] == "Approve" }
+    refute_proactive_status_response
+    callback_data = "approve:finalize:hive:ship-a:7-artifacts"
 
-    when_user_taps(button.fetch(:callback_data))
+    when_user_taps(callback_data)
 
     assert_equal [ "hive", "finalize", "ship-a", "--from", "7-artifacts",
                    "--project", "hive", "--json" ], harness.child_supervisor.commands.last

--- a/test/integration/bot/scenarios/alert_lifecycle_test.rb
+++ b/test/integration/bot/scenarios/alert_lifecycle_test.rb
@@ -1,0 +1,102 @@
+require "test_helper"
+require "hive/bot/notification_dispatcher"
+require "hive/bot/notification_builders"
+require "hive/bot/status_watcher"
+require "hive/bot/alert_store"
+
+# R13 lifecycle integration: a recovery alert is delivered exactly once,
+# Autofix clears the AlertStore entry, and a subsequent same-fingerprint
+# failure re-alerts. Unit tests cover each step in isolation; this one
+# wires NotificationDispatcher + AlertStore + an AlertStore-backed reset
+# call (the same path the Supervisor invokes when handling an Autofix
+# callback) end-to-end so a future refactor of any single link in the
+# chain cannot silently regress the contract.
+class HiveBotAlertLifecycleIntegrationTest < Minitest::Test
+  include HiveTestHelper
+
+  Row = Hive::Bot::StatusWatcher::Row
+
+  def stuck_row(pass:, attrs_extra: {})
+    Row.new(
+      project: "hive",
+      slug: "stuck-task-260525-abcd",
+      stage: "6-review",
+      marker: "review_error",
+      attrs: { "pass" => pass.to_s, "phase" => "fix" }.merge(attrs_extra),
+      action: "recover_review"
+    )
+  end
+
+  class CapturingTelegram
+    attr_reader :messages
+    def initialize = @messages = []
+    def send_message(chat_id:, text:, reply_markup: nil, parse_mode: :markdown)
+      @messages << { chat_id: chat_id, text: text }
+    end
+  end
+
+  class StubLogger
+    attr_reader :events
+    def initialize = @events = []
+    def event(name, **payload) = @events << [ name, payload ]
+  end
+
+  def test_r13_autofix_clears_alert_then_same_fingerprint_refires
+    with_tmp_dir do |dir|
+      path = File.join(dir, "alerts.json")
+      telegram = CapturingTelegram.new
+      logger = StubLogger.new
+      clock = Time.utc(2026, 5, 25, 10, 0, 0)
+      dispatcher = Hive::Bot::NotificationDispatcher.new(
+        telegram: telegram,
+        logger: logger,
+        bot_config: { "chat_id_allowlist" => [ 42 ], "recovery_reminder_window_sec" => 28_800 },
+        now: -> { clock }
+      )
+      # Manually wire AlertStore so we can drive reset_task without standing up Supervisor.
+      alert_store = Hive::Bot::AlertStore.new(path: path, logger: logger)
+      dispatcher.instance_variable_set(:@alert_store, alert_store)
+
+      row1 = stuck_row(pass: 2)
+
+      # 1. First alert delivers.
+      dispatcher.process_rows([ row1 ])
+      assert_equal 1, telegram.messages.size
+      assert_match(/Review stuck/, telegram.messages.last[:text])
+      assert_equal 1, alert_store.each_fingerprint.to_a.size
+
+      # 2. Same row re-evaluated next tick — dedupe, no new message.
+      clock += 30
+      dispatcher.process_rows([ row1 ])
+      assert_equal 1, telegram.messages.size, "second tick must dedupe; no duplicate ⚠ alert"
+
+      # 3. Operator taps Autofix — Supervisor calls reset_task with the marker fingerprint.
+      dispatcher.reset_task(project: row1.project, slug: row1.slug, stage: row1.stage,
+                            marker: row1.marker)
+      assert_empty alert_store.each_fingerprint.to_a,
+                   "Autofix reset_task must clear the AlertStore entry"
+
+      # 4. The retry stage produces the same fingerprint failure (deterministic crash).
+      #    R13 says the operator must see another alert.
+      clock += 5
+      dispatcher.process_rows([ row1 ])
+      assert_equal 2, telegram.messages.size,
+                   "R13: a same-fingerprint failure after Autofix must re-alert"
+      assert_match(/Review stuck/, telegram.messages.last[:text])
+
+      # 5. Different-marker row at the same stage gets its own alert without
+      #    being deduped by the row1 entry — verifies the marker-scoped fix
+      #    from P2 #7 stays correct end-to-end.
+      row2 = stuck_row(pass: 2, attrs_extra: { "reason" => "stale" })
+      row2_diff_marker = Hive::Bot::StatusWatcher::Row.new(
+        project: row2.project, slug: row2.slug, stage: row2.stage,
+        marker: "review_ci_stale", attrs: row2.attrs.to_h, action: "recover_review"
+      )
+      dispatcher.process_rows([ row1, row2_diff_marker ])
+      # The second tick may or may not produce a new message depending on dedupe,
+      # but the AlertStore must now have two distinct entries.
+      assert_operator alert_store.each_fingerprint.to_a.size, :>=, 2,
+                      "distinct markers must produce distinct AlertStore entries"
+    end
+  end
+end

--- a/test/integration/bot/scenarios/alert_lifecycle_test.rb
+++ b/test/integration/bot/scenarios/alert_lifecycle_test.rb
@@ -55,6 +55,9 @@ class HiveBotAlertLifecycleIntegrationTest < Minitest::Test
       )
       # Manually wire AlertStore so we can drive reset_task without standing up Supervisor.
       alert_store = Hive::Bot::AlertStore.new(path: path, logger: logger)
+      # Skip the fresh-install silent-seed branch; this scenario asserts
+      # the alerting flow for a bot that has run before.
+      alert_store.mark_seeded!
       dispatcher.instance_variable_set(:@alert_store, alert_store)
 
       row1 = stuck_row(pass: 2)

--- a/test/integration/bot/scenarios/s1_brainstorm_test.rb
+++ b/test/integration/bot/scenarios/s1_brainstorm_test.rb
@@ -111,6 +111,8 @@ class HiveBotScenarioBrainstormTest < Minitest::Test
     def send_message(chat_id:, text:, reply_markup: nil, parse_mode: :markdown)
       @messages << { chat_id: chat_id, text: text, reply_markup: reply_markup, parse_mode: parse_mode }
     end
+
+    def edit_message_reply_markup(chat_id:, message_id:, reply_markup: nil); end
   end
 
   class FakeStatusWatcher

--- a/test/integration/bot/scenarios/s3_queue_test.rb
+++ b/test/integration/bot/scenarios/s3_queue_test.rb
@@ -120,6 +120,8 @@ class HiveBotScenarioQueueTest < Minitest::Test
     def send_message(chat_id:, text:, reply_markup: nil, parse_mode: :markdown)
       @messages << { chat_id: chat_id, text: text, reply_markup: reply_markup, parse_mode: parse_mode }
     end
+
+    def edit_message_reply_markup(chat_id:, message_id:, reply_markup: nil); end
   end
 
   class FakeStatusWatcher

--- a/test/integration/bot/scenarios/s3_queue_test.rb
+++ b/test/integration/bot/scenarios/s3_queue_test.rb
@@ -24,7 +24,7 @@ class HiveBotScenarioQueueTest < Minitest::Test
     assert_match(/4 active tasks/, text)
     assert_match(/Brainstorm a… — Brainstorm/, text)
     assert_match(/Review a… — Brainstorm/, text)
-    assert_match(/Pr a… — Brainstorm/, text)
+    assert_match(/PR a… — Brainstorm/, text)
     refute_match(/hive\/brainstorm-a/, text)
     refute_match(/archived-a/, text)
 

--- a/test/integration/bot/scenarios/s3_queue_test.rb
+++ b/test/integration/bot/scenarios/s3_queue_test.rb
@@ -22,14 +22,13 @@ class HiveBotScenarioQueueTest < Minitest::Test
 
     text = telegram.messages.last[:text]
     assert_match(/4 active tasks/, text)
-    assert_match(/hive\/brainstorm-a/, text)
+    assert_match(/Brainstorm a… — Brainstorm/, text)
+    assert_match(/Review a… — Brainstorm/, text)
+    assert_match(/Pr a… — Brainstorm/, text)
+    refute_match(/hive\/brainstorm-a/, text)
     refute_match(/archived-a/, text)
 
-    keyboard = telegram.messages.last[:reply_markup]
-    labels = keyboard.flatten.map { |button| button[:text] }
-    assert labels.any? { |label| label.start_with?("Answer in chat: hive/brainstorm-a") }
-    assert labels.any? { |label| label.start_with?("Accept all: hive/review-a") }
-    assert labels.any? { |label| label.start_with?("Approve: hive/pr-a") }
+    assert_nil telegram.messages.last[:reply_markup]
   end
 
   def test_s3_queue_caps_at_10_rows_and_shows_more_affordance

--- a/test/integration/config_bot_test.rb
+++ b/test/integration/config_bot_test.rb
@@ -25,7 +25,7 @@ class ConfigBotIntegrationTest < Minitest::Test
         with_env("HOME" => home) do
           cfg = Hive::Config.load(project)
 
-          assert_equal File.join(home, "Dev", "hive", ".bot.alert_state.json"),
+          assert_equal File.join(Hive::Paths.state_home, ".bot.alert_state.json"),
                        cfg.dig("bot", "alert_state_file")
           assert_equal 28_800, cfg.dig("bot", "recovery_reminder_window_sec")
         end

--- a/test/integration/config_bot_test.rb
+++ b/test/integration/config_bot_test.rb
@@ -1,7 +1,10 @@
 require "test_helper"
 require "erb"
+require "hive/config"
 
 class ConfigBotIntegrationTest < Minitest::Test
+  include HiveTestHelper
+
   def test_global_config_template_documents_bot_block_and_env_token
     template_path = File.expand_path("../../templates/hive_config.yml.erb", __dir__)
     registered_projects = []
@@ -11,6 +14,44 @@ class ConfigBotIntegrationTest < Minitest::Test
     assert_includes rendered, "bot:"
     assert_includes rendered, "HIVE_TELEGRAM_BOT_TOKEN"
     assert_includes rendered, "chat_id_allowlist"
+    assert_includes rendered, "alert_state_file"
+    assert_includes rendered, "recovery_reminder_window_sec"
     assert_includes rendered, "last_seen_state_file"
+  end
+
+  def test_bot_defaults_include_alert_lifecycle_settings
+    with_tmp_dir do |project|
+      with_tmp_dir do |home|
+        with_env("HOME" => home) do
+          cfg = Hive::Config.load(project)
+
+          assert_equal File.join(home, "Dev", "hive", ".bot.alert_state.json"),
+                       cfg.dig("bot", "alert_state_file")
+          assert_equal 28_800, cfg.dig("bot", "recovery_reminder_window_sec")
+        end
+      end
+    end
+  end
+
+  def test_recovery_reminder_window_is_bounded
+    with_tmp_dir do |project|
+      FileUtils.mkdir_p(File.join(project, ".hive-state"))
+      File.write(File.join(project, ".hive-state", "config.yml"), <<~YAML)
+        bot:
+          recovery_reminder_window_sec: 60
+      YAML
+
+      err = assert_raises(Hive::ConfigError) { Hive::Config.load(project) }
+
+      assert_match(/bot.recovery_reminder_window_sec.*between 3600 and 604800/, err.message)
+    end
+  end
+
+  def test_global_bot_alert_state_file_uses_state_home
+    with_tmp_global_config do |home|
+      cfg = Hive::Config.load_global_bot
+
+      assert_equal File.join(home, ".bot.alert_state.json"), cfg["alert_state_file"]
+    end
   end
 end

--- a/test/unit/bot/alert_store_test.rb
+++ b/test/unit/bot/alert_store_test.rb
@@ -153,6 +153,40 @@ class HiveBotAlertStoreTest < Minitest::Test
     end
   end
 
+  def test_add_persists_delivered_to_chat_ids
+    with_tmp_dir do |dir|
+      path = File.join(dir, "alerts.json")
+      Hive::Bot::AlertStore.new(path: path).add(
+        "fp1", row, Time.utc(2026, 5, 25, 10, 0, 0), delivered_to: [ 12345, 67890 ]
+      )
+
+      reopened = Hive::Bot::AlertStore.new(path: path)
+      assert_equal [ "12345", "67890" ], reopened.entry("fp1").delivered_to
+    end
+  end
+
+  def test_record_delivery_appends_new_chat_ids_only
+    with_tmp_dir do |dir|
+      store = Hive::Bot::AlertStore.new(path: File.join(dir, "alerts.json"))
+      store.add("fp1", row, Time.utc(2026, 5, 25, 10, 0, 0), delivered_to: [ 12345 ])
+
+      assert store.record_delivery("fp1", [ 67890 ]),
+             "record_delivery must return true when chat is newly added"
+      assert_equal [ "12345", "67890" ], store.entry("fp1").delivered_to
+
+      refute store.record_delivery("fp1", [ 12345, 67890 ]),
+             "record_delivery must return false when all chats already delivered"
+    end
+  end
+
+  def test_record_delivery_on_missing_fingerprint_returns_false
+    with_tmp_dir do |dir|
+      store = Hive::Bot::AlertStore.new(path: File.join(dir, "alerts.json"))
+
+      refute store.record_delivery("missing", [ 12345 ])
+    end
+  end
+
   def test_concurrent_add_and_remove_smoke
     with_tmp_dir do |dir|
       store = Hive::Bot::AlertStore.new(path: File.join(dir, "alerts.json"))

--- a/test/unit/bot/alert_store_test.rb
+++ b/test/unit/bot/alert_store_test.rb
@@ -187,6 +187,60 @@ class HiveBotAlertStoreTest < Minitest::Test
     end
   end
 
+  def test_record_send_failure_sets_exponential_backoff
+    with_tmp_dir do |dir|
+      store = Hive::Bot::AlertStore.new(path: File.join(dir, "alerts.json"))
+      now = Time.utc(2026, 5, 25, 10, 0, 0)
+      store.add("fp1", row, now)
+
+      store.record_send_failure("fp1", now)
+      assert_equal 1, store.entry("fp1").consecutive_failures
+      assert_equal now + 60, store.entry("fp1").next_attempt_after
+
+      store.record_send_failure("fp1", now)
+      assert_equal 2, store.entry("fp1").consecutive_failures
+      assert_equal now + 120, store.entry("fp1").next_attempt_after
+
+      4.times { store.record_send_failure("fp1", now) }
+      assert_equal 6, store.entry("fp1").consecutive_failures
+      assert_equal now + 1800, store.entry("fp1").next_attempt_after, "backoff must cap at 1800s"
+    end
+  end
+
+  def test_record_send_success_resets_failures_and_backoff
+    with_tmp_dir do |dir|
+      store = Hive::Bot::AlertStore.new(path: File.join(dir, "alerts.json"))
+      now = Time.utc(2026, 5, 25, 10, 0, 0)
+      store.add("fp1", row, now)
+      store.record_send_failure("fp1", now)
+      assert_equal 1, store.entry("fp1").consecutive_failures
+
+      assert store.record_send_success("fp1"),
+             "record_send_success must return true when state was reset"
+      assert_equal 0, store.entry("fp1").consecutive_failures
+      assert_nil store.entry("fp1").next_attempt_after
+
+      refute store.record_send_success("fp1"),
+             "record_send_success must return false when there is nothing to reset"
+    end
+  end
+
+  def test_record_delivery_resets_failures_and_backoff
+    with_tmp_dir do |dir|
+      store = Hive::Bot::AlertStore.new(path: File.join(dir, "alerts.json"))
+      now = Time.utc(2026, 5, 25, 10, 0, 0)
+      store.add("fp1", row, now, delivered_to: [ 12345 ])
+      store.record_send_failure("fp1", now)
+      assert_equal 1, store.entry("fp1").consecutive_failures
+
+      store.record_delivery("fp1", [ 67890 ])
+
+      assert_equal 0, store.entry("fp1").consecutive_failures,
+                   "successful delivery must reset the failure counter"
+      assert_nil store.entry("fp1").next_attempt_after
+    end
+  end
+
   def test_concurrent_add_and_remove_smoke
     with_tmp_dir do |dir|
       store = Hive::Bot::AlertStore.new(path: File.join(dir, "alerts.json"))

--- a/test/unit/bot/alert_store_test.rb
+++ b/test/unit/bot/alert_store_test.rb
@@ -187,6 +187,43 @@ class HiveBotAlertStoreTest < Minitest::Test
     end
   end
 
+  def test_persist_failure_rolls_back_in_memory_state_on_add
+    with_tmp_dir do |dir|
+      store = Hive::Bot::AlertStore.new(path: File.join(dir, "alerts.json"))
+      # Add one entry successfully so we have a baseline.
+      store.add("fp1", row, Time.utc(2026, 5, 25, 10, 0, 0))
+      assert_equal [ "fp1" ], store.each_fingerprint.to_a
+
+      # Force the next persist to fail.
+      store.define_singleton_method(:persist_locked!) { raise IOError, "disk full" }
+      assert_raises(IOError) do
+        store.add("fp2", row, Time.utc(2026, 5, 25, 10, 0, 5))
+      end
+
+      # In-memory state must NOT contain fp2 — otherwise a restart would
+      # re-alert anything persisted only in memory.
+      assert_equal [ "fp1" ], store.each_fingerprint.to_a,
+                   "failed persist must roll back the in-memory mutation"
+    end
+  end
+
+  def test_persist_failure_rolls_back_remove_matching
+    with_tmp_dir do |dir|
+      store = Hive::Bot::AlertStore.new(path: File.join(dir, "alerts.json"))
+      store.add("fp1", row, Time.utc(2026, 5, 25, 10, 0, 0))
+      store.add("fp2", row(slug: "other-task-260525-abcd"), Time.utc(2026, 5, 25, 10, 0, 5))
+
+      store.define_singleton_method(:persist_locked!) { raise IOError, "disk full" }
+      assert_raises(IOError) do
+        store.remove_matching(project: "hive", slug: "stuck-task-260525-abcd", stage: "6-review")
+      end
+
+      assert_includes store.each_fingerprint.to_a, "fp1",
+                      "remove_matching must roll back deletions on persist failure"
+      assert_includes store.each_fingerprint.to_a, "fp2"
+    end
+  end
+
   def test_remove_matching_with_marker_only_removes_matching_marker
     with_tmp_dir do |dir|
       store = Hive::Bot::AlertStore.new(path: File.join(dir, "alerts.json"))

--- a/test/unit/bot/alert_store_test.rb
+++ b/test/unit/bot/alert_store_test.rb
@@ -7,11 +7,12 @@ class HiveBotAlertStoreTest < Minitest::Test
 
   Row = Hive::Bot::StatusWatcher::Row
 
-  def row(attrs: { "pass" => "1" }, action: "recover_review")
+  def row(attrs: { "pass" => "1" }, action: "recover_review", project: "hive",
+          slug: "stuck-task-260525-abcd", stage: "6-review")
     Row.new(
-      project: "hive",
-      slug: "stuck-task-260525-abcd",
-      stage: "6-review",
+      project: project,
+      slug: slug,
+      stage: stage,
       marker: "review_error",
       attrs: attrs,
       action: action
@@ -103,6 +104,21 @@ class HiveBotAlertStoreTest < Minitest::Test
     end
   end
 
+  def test_shape_invalid_entries_are_treated_as_corrupt
+    with_tmp_dir do |dir|
+      path = File.join(dir, "alerts.json")
+      File.write(path, JSON.generate({ "schema_version" => 1, "entries" => { "fp1" => 1 } }))
+      logger = StubLogger.new
+
+      store = Hive::Bot::AlertStore.new(path: path, logger: logger)
+
+      assert_equal [], store.each_fingerprint.to_a
+      refute File.exist?(path)
+      assert Dir.glob("#{path}.corrupt-*").any?
+      assert_equal :alert_store_corrupt, logger.events.last.first
+    end
+  end
+
   def test_unreadable_file_is_treated_as_corrupt
     with_tmp_dir do |dir|
       path = File.join(dir, "alerts.json")
@@ -118,6 +134,22 @@ class HiveBotAlertStoreTest < Minitest::Test
       assert_equal path, event.last[:path], ":path must match original file path"
     ensure
       File.chmod(0o644, path) if path && File.exist?(path)
+    end
+  end
+
+  def test_remove_matching_removes_matching_rows_only
+    with_tmp_dir do |dir|
+      store = Hive::Bot::AlertStore.new(path: File.join(dir, "alerts.json"))
+      store.add("fp1", row(slug: "target-task-260525-abcd", stage: "6-review"), Time.utc(2026, 5, 25, 10, 0, 0))
+      store.add("fp2", row(slug: "target-task-260525-abcd", stage: "5-open-pr"), Time.utc(2026, 5, 25, 10, 0, 0))
+      store.add("fp3", row(slug: "other-task-260525-abcd", stage: "6-review"), Time.utc(2026, 5, 25, 10, 0, 0))
+
+      removed = store.remove_matching(project: "hive", slug: "target-task-260525-abcd", stage: "6-review")
+
+      assert_equal 1, removed
+      assert_nil store.entry("fp1")
+      assert_equal "target-task-260525-abcd", store.entry("fp2").row.slug
+      assert_equal "other-task-260525-abcd", store.entry("fp3").row.slug
     end
   end
 

--- a/test/unit/bot/alert_store_test.rb
+++ b/test/unit/bot/alert_store_test.rb
@@ -1,0 +1,116 @@
+require "test_helper"
+require "hive/bot/alert_store"
+require "hive/bot/status_watcher"
+
+class HiveBotAlertStoreTest < Minitest::Test
+  include HiveTestHelper
+
+  Row = Hive::Bot::StatusWatcher::Row
+
+  def row(attrs: { "pass" => "1" }, action: "recover_review")
+    Row.new(
+      project: "hive",
+      slug: "stuck-task-260525-abcd",
+      stage: "6-review",
+      marker: "review_error",
+      attrs: attrs,
+      action: action
+    )
+  end
+
+  def test_initial_empty_store
+    with_tmp_dir do |dir|
+      store = Hive::Bot::AlertStore.new(path: File.join(dir, "alerts.json"))
+
+      assert_equal [], store.each_fingerprint.to_a
+      assert_nil store.entry("missing")
+    end
+  end
+
+  def test_add_reads_back_entry
+    with_tmp_dir do |dir|
+      store = Hive::Bot::AlertStore.new(path: File.join(dir, "alerts.json"))
+      now = Time.utc(2026, 5, 25, 10, 0, 0)
+
+      store.add("fp1", row, now)
+
+      assert_equal [ "fp1" ], store.each_fingerprint.to_a
+      entry = store.entry("fp1")
+      assert_equal now, entry.first_seen_at
+      assert_nil entry.reminded_at
+      assert_equal "hive", entry.row.project
+      assert_equal({ "pass" => "1" }, entry.row.attrs)
+    end
+  end
+
+  def test_persists_entries_across_instances
+    with_tmp_dir do |dir|
+      path = File.join(dir, "alerts.json")
+      Hive::Bot::AlertStore.new(path: path).add("fp1", row, Time.utc(2026, 5, 25, 10, 0, 0))
+
+      fresh = Hive::Bot::AlertStore.new(path: path)
+
+      assert_equal [ "fp1" ], fresh.each_fingerprint.to_a
+      assert_equal "stuck-task-260525-abcd", fresh.entry("fp1").row.slug
+    end
+  end
+
+  def test_mark_reminded_and_remove
+    with_tmp_dir do |dir|
+      store = Hive::Bot::AlertStore.new(path: File.join(dir, "alerts.json"))
+      store.add("fp1", row, Time.utc(2026, 5, 25, 10, 0, 0))
+      store.mark_reminded("fp1", Time.utc(2026, 5, 25, 18, 0, 0))
+
+      assert_equal Time.utc(2026, 5, 25, 18, 0, 0), store.entry("fp1").reminded_at
+      removed = store.remove("fp1")
+
+      assert_equal "stuck-task-260525-abcd", removed.slug
+      assert_nil store.entry("fp1")
+    end
+  end
+
+  def test_corrupt_json_is_renamed_and_logged
+    with_tmp_dir do |dir|
+      path = File.join(dir, "alerts.json")
+      File.write(path, "{")
+      logger = StubLogger.new
+
+      store = Hive::Bot::AlertStore.new(path: path, logger: logger)
+
+      assert_equal [], store.each_fingerprint.to_a
+      refute File.exist?(path)
+      assert Dir.glob("#{path}.corrupt-*").any?
+      event = logger.events.last
+      assert_equal :alert_store_corrupt, event.first
+      assert_equal path, event.last[:path]
+    end
+  end
+
+  def test_concurrent_add_and_remove_smoke
+    with_tmp_dir do |dir|
+      store = Hive::Bot::AlertStore.new(path: File.join(dir, "alerts.json"))
+      threads = 10.times.map do |i|
+        Thread.new do
+          fingerprint = "fp#{i}"
+          store.add(fingerprint, row(attrs: { "pass" => i.to_s }), Time.utc(2026, 5, 25, 10, 0, i))
+          store.remove(fingerprint)
+        end
+      end
+      threads.each(&:join)
+
+      assert_equal [], store.each_fingerprint.to_a
+    end
+  end
+
+  class StubLogger
+    attr_reader :events
+
+    def initialize
+      @events = []
+    end
+
+    def event(name, **attrs)
+      @events << [ name, attrs ]
+    end
+  end
+end

--- a/test/unit/bot/alert_store_test.rb
+++ b/test/unit/bot/alert_store_test.rb
@@ -86,6 +86,41 @@ class HiveBotAlertStoreTest < Minitest::Test
     end
   end
 
+  def test_schema_version_mismatch_is_treated_as_corrupt
+    with_tmp_dir do |dir|
+      path = File.join(dir, "alerts.json")
+      File.write(path, JSON.generate({ "schema_version" => 2, "entries" => {} }))
+      logger = StubLogger.new
+
+      store = Hive::Bot::AlertStore.new(path: path, logger: logger)
+
+      assert_equal [], store.each_fingerprint.to_a, "mismatched schema_version must yield empty store"
+      refute File.exist?(path), "original file must be renamed away on schema mismatch"
+      assert Dir.glob("#{path}.corrupt-*").any?, "corrupt-* sibling must exist after schema mismatch"
+      event = logger.events.last
+      assert_equal :alert_store_corrupt, event.first, "logger must receive :alert_store_corrupt event"
+      assert_equal path, event.last[:path], ":path attribute must match the original file path"
+    end
+  end
+
+  def test_unreadable_file_is_treated_as_corrupt
+    with_tmp_dir do |dir|
+      path = File.join(dir, "alerts.json")
+      File.write(path, JSON.generate({ "schema_version" => 1, "entries" => {} }))
+      File.chmod(0o000, path)
+      logger = StubLogger.new
+
+      store = Hive::Bot::AlertStore.new(path: path, logger: logger)
+
+      assert_equal [], store.each_fingerprint.to_a, "unreadable file must yield empty store"
+      event = logger.events.last
+      assert_equal :alert_store_corrupt, event.first, "logger must receive :alert_store_corrupt event"
+      assert_equal path, event.last[:path], ":path must match original file path"
+    ensure
+      File.chmod(0o644, path) if path && File.exist?(path)
+    end
+  end
+
   def test_concurrent_add_and_remove_smoke
     with_tmp_dir do |dir|
       store = Hive::Bot::AlertStore.new(path: File.join(dir, "alerts.json"))

--- a/test/unit/bot/alert_store_test.rb
+++ b/test/unit/bot/alert_store_test.rb
@@ -187,6 +187,44 @@ class HiveBotAlertStoreTest < Minitest::Test
     end
   end
 
+  def test_clean_orphaned_tmp_files_swallows_glob_errors
+    with_tmp_dir do |dir|
+      path = File.join(dir, "alerts.json")
+      original_glob = Dir.method(:glob)
+      Dir.define_singleton_method(:glob) do |*args, **opts|
+        raise IOError, "synthetic glob failure" if args.first.to_s.include?(File.dirname(path))
+
+        original_glob.call(*args, **opts)
+      end
+      Hive::Bot::AlertStore.new(path: path) # must NOT raise — cleanup is best-effort
+    ensure
+      Dir.define_singleton_method(:glob, original_glob) if original_glob
+    end
+  end
+
+  def test_parse_time_returns_nil_for_malformed_persisted_value
+    with_tmp_dir do |dir|
+      path = File.join(dir, "alerts.json")
+      File.write(path, JSON.generate({
+                                       "schema_version" => 1,
+                                       "entries" => {
+                                         "fp1" => {
+                                           "first_seen_at" => "not-a-real-time",
+                                           "reminded_at" => nil,
+                                           "row" => {
+                                             "project" => "hive", "slug" => "a-260525-aaaa", "stage" => "6-review",
+                                             "marker" => "review_error", "attrs" => {}, "action" => "recover_review"
+                                           }
+                                         }
+                                       }
+                                     }))
+      store = Hive::Bot::AlertStore.new(path: path)
+
+      assert_nil store.entry("fp1").first_seen_at,
+                 "malformed first_seen_at must parse to nil rather than raising"
+    end
+  end
+
   def test_constructor_cleans_orphan_tmp_files
     with_tmp_dir do |dir|
       path = File.join(dir, "alerts.json")

--- a/test/unit/bot/alert_store_test.rb
+++ b/test/unit/bot/alert_store_test.rb
@@ -187,6 +187,67 @@ class HiveBotAlertStoreTest < Minitest::Test
     end
   end
 
+  def test_constructor_cleans_orphan_tmp_files
+    with_tmp_dir do |dir|
+      path = File.join(dir, "alerts.json")
+      orphan = File.join(dir, ".alerts.json.99999.deadbeef.tmp")
+      File.write(orphan, "garbage")
+      File.write(path, JSON.generate({ "schema_version" => 1, "entries" => {} }))
+
+      Hive::Bot::AlertStore.new(path: path)
+
+      refute File.exist?(orphan), "orphan tmp file must be cleaned up at construction"
+      assert File.exist?(path), "live alert state file must NOT be touched"
+    end
+  end
+
+  def test_corrupt_rename_failure_starts_empty_without_raising
+    with_tmp_dir do |dir|
+      path = File.join(dir, "alerts.json")
+      # Write a corrupt file then make the parent dir read-only so File.rename
+      # inside handle_corrupt! raises a SystemCallError.
+      File.write(path, "not json")
+      File.chmod(0o500, dir)
+      logger = StubLogger.new
+
+      store = Hive::Bot::AlertStore.new(path: path, logger: logger)
+
+      assert_equal [], store.each_fingerprint.to_a, "store must start empty when rename fails"
+      event = logger.events.find { |e| e.first == :alert_store_corrupt }
+      refute_nil event
+      assert_nil event.last[:corrupt_path],
+                 "corrupt_path must be nil when File.rename could not move the bad file aside"
+    ensure
+      File.chmod(0o700, dir) if dir && File.directory?(dir)
+    end
+  end
+
+  def test_concurrent_contention_on_same_fingerprint_preserves_valid_json
+    with_tmp_dir do |dir|
+      path = File.join(dir, "alerts.json")
+      store = Hive::Bot::AlertStore.new(path: path)
+      now = Time.utc(2026, 5, 25, 10, 0, 0)
+      fingerprint = "shared-fp"
+
+      threads = 20.times.map do |i|
+        Thread.new do
+          if i.even?
+            store.add(fingerprint, row(attrs: { "pass" => i.to_s }), now + i)
+          else
+            store.remove(fingerprint)
+          end
+        end
+      end
+      threads.each(&:join)
+
+      # Final state is unspecified (race), but the on-disk JSON must always
+      # be parseable — every persist_locked! is atomic.
+      content = File.read(path)
+      assert_kind_of Hash, JSON.parse(content),
+                     "on-disk file must remain parseable JSON under contention"
+    end
+  end
+
   def test_persist_failure_rolls_back_in_memory_state_on_add
     with_tmp_dir do |dir|
       store = Hive::Bot::AlertStore.new(path: File.join(dir, "alerts.json"))

--- a/test/unit/bot/alert_store_test.rb
+++ b/test/unit/bot/alert_store_test.rb
@@ -187,6 +187,62 @@ class HiveBotAlertStoreTest < Minitest::Test
     end
   end
 
+  def test_remove_matching_with_marker_only_removes_matching_marker
+    with_tmp_dir do |dir|
+      store = Hive::Bot::AlertStore.new(path: File.join(dir, "alerts.json"))
+      now = Time.utc(2026, 5, 25, 10, 0, 0)
+      store.add("fp1", row(slug: "task", stage: "6-review", attrs: { "pass" => "2" }), now)
+      store.add(
+        "fp2",
+        Row.new(project: "hive", slug: "task", stage: "6-review", marker: "review_ci_stale",
+                attrs: { "pass" => "2" }, action: "recover_review"),
+        now
+      )
+
+      removed = store.remove_matching(project: "hive", slug: "task", stage: "6-review", marker: "review_error")
+
+      assert_equal 1, removed, "only the review_error fingerprint should have been removed"
+      assert_nil store.entry("fp1"), "review_error entry must be cleared"
+      refute_nil store.entry("fp2"), "review_ci_stale entry must remain — different marker, different fingerprint"
+    end
+  end
+
+  def test_remove_matching_with_match_attr_only_removes_matching_attr
+    with_tmp_dir do |dir|
+      store = Hive::Bot::AlertStore.new(path: File.join(dir, "alerts.json"))
+      now = Time.utc(2026, 5, 25, 10, 0, 0)
+      store.add("fp1", row(attrs: { "pass" => "2", "phase" => "fix" }), now)
+      store.add("fp2", row(attrs: { "pass" => "3", "phase" => "fix" }), now)
+
+      removed = store.remove_matching(project: "hive", slug: "stuck-task-260525-abcd", stage: "6-review",
+                                       marker: "review_error", match_attr: "pass=2")
+
+      assert_equal 1, removed, "only the pass=2 entry should be removed"
+      assert_nil store.entry("fp1")
+      refute_nil store.entry("fp2"), "pass=3 entry remains because the match_attr differs"
+    end
+  end
+
+  def test_remove_matching_with_no_marker_filter_still_removes_all_for_tuple
+    # Backward compat: callers that pass project/slug/stage but no marker
+    # should keep the old broad-delete behaviour.
+    with_tmp_dir do |dir|
+      store = Hive::Bot::AlertStore.new(path: File.join(dir, "alerts.json"))
+      now = Time.utc(2026, 5, 25, 10, 0, 0)
+      store.add("fp1", row(attrs: { "pass" => "2" }), now)
+      store.add(
+        "fp2",
+        Row.new(project: "hive", slug: "stuck-task-260525-abcd", stage: "6-review", marker: "review_ci_stale",
+                attrs: {}, action: "recover_review"),
+        now
+      )
+
+      removed = store.remove_matching(project: "hive", slug: "stuck-task-260525-abcd", stage: "6-review")
+
+      assert_equal 2, removed
+    end
+  end
+
   def test_record_send_failure_sets_exponential_backoff
     with_tmp_dir do |dir|
       store = Hive::Bot::AlertStore.new(path: File.join(dir, "alerts.json"))

--- a/test/unit/bot/callback_handlers_test.rb
+++ b/test/unit/bot/callback_handlers_test.rb
@@ -9,7 +9,7 @@ require "hive/bot/handlers/callback_handlers"
 class HiveBotCallbackHandlersTest < Minitest::Test
   Result = Struct.new(:action, :text, :reply_markup, :command_argv, :commands,
                       :project, :slug, :question_n, :answer_text, :mode,
-                      :intent, keyword_init: true)
+                      :intent, :alert_reset, keyword_init: true)
   FakeLogger = Struct.new(:events, keyword_init: true) do
     def event(name, **payload)
       events << { name: name, payload: payload }
@@ -197,6 +197,20 @@ class HiveBotCallbackHandlersTest < Minitest::Test
     )
   end
 
+  def test_clear_and_retry_passes_marker_match_attr_when_present
+    result = @handlers.handle(
+      :callback_clear_and_retry,
+      update("clear_retry:alpha:red-task-260518-cccc:6-review:REVIEW_ERROR:pass=2")
+    )
+
+    assert_equal(
+      [ "hive", "markers", "clear", "red-task-260518-cccc", "--name",
+        "REVIEW_ERROR", "--project", "alpha", "--match-attr", "pass=2", "--json" ],
+      result.commands.first
+    )
+    assert_equal({ project: "alpha", slug: "red-task-260518-cccc", stage: "6-review" }, result.alert_reset)
+  end
+
   def test_clear_and_retry_none_marker_skips_marker_clear_and_runs_stage
     result = @handlers.handle(
       :callback_clear_and_retry,
@@ -214,18 +228,29 @@ class HiveBotCallbackHandlersTest < Minitest::Test
   def test_autofix_marker_dispatches_clear_then_retry
     result = @handlers.handle(
       :callback_autofix,
-      update("autofix:alpha:red-task-260518-cccc:6-review:REVIEW_ERROR")
+      update("autofix:alpha:red-task-260518-cccc:6-review:REVIEW_ERROR:pass=2")
     )
 
     assert_equal :dispatch_commands, result.action
     assert_equal(
       [
         [ "hive", "markers", "clear", "red-task-260518-cccc", "--name",
-          "REVIEW_ERROR", "--project", "alpha", "--json" ],
+          "REVIEW_ERROR", "--project", "alpha", "--match-attr", "pass=2", "--json" ],
         [ "hive", "review", "red-task-260518-cccc", "--from", "6-review", "--project", "alpha", "--json" ]
       ],
       result.commands
     )
+    assert_equal({ project: "alpha", slug: "red-task-260518-cccc", stage: "6-review" }, result.alert_reset)
+  end
+
+  def test_autofix_execute_stale_replies_without_dispatch
+    result = @handlers.handle(
+      :callback_autofix,
+      update("autofix:alpha:exec-task-260519-abcd:4-execute:EXECUTE_STALE")
+    )
+
+    assert_equal :reply, result.action
+    assert_match(/no automatic recovery/i, result.text)
   end
 
   def test_autofix_none_marker_dispatches_retry_only
@@ -238,6 +263,7 @@ class HiveBotCallbackHandlersTest < Minitest::Test
       [ [ "hive", "plan", "plan-task-260519-abcd", "--from", "3-plan", "--project", "alpha", "--json" ] ],
       result.commands
     )
+    assert_equal({ project: "alpha", slug: "plan-task-260519-abcd", stage: "3-plan" }, result.alert_reset)
   end
 
   def test_autofix_agent_working_marker_dispatches_retry_only

--- a/test/unit/bot/callback_handlers_test.rb
+++ b/test/unit/bot/callback_handlers_test.rb
@@ -233,6 +233,19 @@ class HiveBotCallbackHandlersTest < Minitest::Test
     )
   end
 
+  def test_clear_and_retry_replies_when_stage_has_no_retry_verb
+    result = @handlers.handle(
+      :callback_clear_and_retry,
+      update("clear_retry:alpha:done-task-260519-abcd:9-done:REVIEW_ERROR")
+    )
+
+    assert_equal :reply, result.action
+    assert_match(/No retry verb for stage 9-done/, result.text,
+                 "clear_and_retry must short-circuit instead of dispatching zero commands plus an alert_reset")
+    assert_nil result.alert_reset,
+               "with no commands to run, alert_reset must NOT fire (otherwise the alert clears without any retry)"
+  end
+
   def test_autofix_marker_dispatches_clear_then_retry
     result = @handlers.handle(
       :callback_autofix,

--- a/test/unit/bot/callback_handlers_test.rb
+++ b/test/unit/bot/callback_handlers_test.rb
@@ -9,7 +9,7 @@ require "hive/bot/handlers/callback_handlers"
 class HiveBotCallbackHandlersTest < Minitest::Test
   Result = Struct.new(:action, :text, :reply_markup, :command_argv, :commands,
                       :project, :slug, :question_n, :answer_text, :mode,
-                      :intent, :alert_reset, keyword_init: true)
+                      :intent, :alert_reset, :clear_keyboard, keyword_init: true)
   FakeLogger = Struct.new(:events, keyword_init: true) do
     def event(name, **payload)
       events << { name: name, payload: payload }
@@ -241,6 +241,8 @@ class HiveBotCallbackHandlersTest < Minitest::Test
       result.commands
     )
     assert_equal({ project: "alpha", slug: "red-task-260518-cccc", stage: "6-review" }, result.alert_reset)
+    assert_equal true, result.clear_keyboard,
+                 "Autofix must request keyboard removal to prevent double-tap dispatch."
   end
 
   def test_autofix_execute_stale_replies_without_dispatch

--- a/test/unit/bot/callback_handlers_test.rb
+++ b/test/unit/bot/callback_handlers_test.rb
@@ -208,7 +208,8 @@ class HiveBotCallbackHandlersTest < Minitest::Test
         "REVIEW_ERROR", "--project", "alpha", "--match-attr", "pass=2", "--json" ],
       result.commands.first
     )
-    assert_equal({ project: "alpha", slug: "red-task-260518-cccc", stage: "6-review" }, result.alert_reset)
+    assert_equal({ project: "alpha", slug: "red-task-260518-cccc", stage: "6-review",
+                   marker: "REVIEW_ERROR", match_attr: "pass=2" }, result.alert_reset)
   end
 
   def test_clear_and_retry_none_marker_skips_marker_clear_and_runs_stage
@@ -240,7 +241,8 @@ class HiveBotCallbackHandlersTest < Minitest::Test
       ],
       result.commands
     )
-    assert_equal({ project: "alpha", slug: "red-task-260518-cccc", stage: "6-review" }, result.alert_reset)
+    assert_equal({ project: "alpha", slug: "red-task-260518-cccc", stage: "6-review",
+                   marker: "REVIEW_ERROR", match_attr: "pass=2" }, result.alert_reset)
     assert_equal true, result.clear_keyboard,
                  "Autofix must request keyboard removal to prevent double-tap dispatch."
   end
@@ -265,7 +267,11 @@ class HiveBotCallbackHandlersTest < Minitest::Test
       [ [ "hive", "plan", "plan-task-260519-abcd", "--from", "3-plan", "--project", "alpha", "--json" ] ],
       result.commands
     )
-    assert_equal({ project: "alpha", slug: "plan-task-260519-abcd", stage: "3-plan" }, result.alert_reset)
+    # NONE marker is the synthetic markerless retry — alert_reset omits
+    # marker/match_attr fields so the existing broad-delete behaviour
+    # applies (back-compat path).
+    assert_equal({ project: "alpha", slug: "plan-task-260519-abcd", stage: "3-plan",
+                   marker: "NONE" }, result.alert_reset)
   end
 
   def test_autofix_agent_working_marker_dispatches_retry_only

--- a/test/unit/bot/callback_handlers_test.rb
+++ b/test/unit/bot/callback_handlers_test.rb
@@ -211,6 +211,57 @@ class HiveBotCallbackHandlersTest < Minitest::Test
     )
   end
 
+  def test_autofix_marker_dispatches_clear_then_retry
+    result = @handlers.handle(
+      :callback_autofix,
+      update("autofix:alpha:red-task-260518-cccc:6-review:REVIEW_ERROR")
+    )
+
+    assert_equal :dispatch_commands, result.action
+    assert_equal(
+      [
+        [ "hive", "markers", "clear", "red-task-260518-cccc", "--name",
+          "REVIEW_ERROR", "--project", "alpha", "--json" ],
+        [ "hive", "review", "red-task-260518-cccc", "--from", "6-review", "--project", "alpha", "--json" ]
+      ],
+      result.commands
+    )
+  end
+
+  def test_autofix_none_marker_dispatches_retry_only
+    result = @handlers.handle(
+      :callback_autofix,
+      update("autofix:alpha:plan-task-260519-abcd:3-plan:NONE")
+    )
+
+    assert_equal(
+      [ [ "hive", "plan", "plan-task-260519-abcd", "--from", "3-plan", "--project", "alpha", "--json" ] ],
+      result.commands
+    )
+  end
+
+  def test_autofix_agent_working_marker_dispatches_retry_only
+    result = @handlers.handle(
+      :callback_autofix,
+      update("autofix:alpha:exec-task-260519-abcd:4-execute:AGENT_WORKING")
+    )
+
+    assert_equal(
+      [ [ "hive", "develop", "exec-task-260519-abcd", "--from", "4-execute", "--project", "alpha", "--json" ] ],
+      result.commands
+    )
+  end
+
+  def test_autofix_unknown_stage_replies_without_dispatch
+    result = @handlers.handle(
+      :callback_autofix,
+      update("autofix:alpha:done-task-260519-abcd:9-done:ERROR")
+    )
+
+    assert_equal :reply, result.action
+    assert_equal "No retry verb for stage 9-done.", result.text
+  end
+
   def test_refresh_diagnose_rejects_malformed_callback_data
     # Defense against malformed callback round-trips. Any non-3-part
     # callback (legacy data, manual postback fuzzing) should fall back

--- a/test/unit/bot/callback_handlers_test.rb
+++ b/test/unit/bot/callback_handlers_test.rb
@@ -9,7 +9,7 @@ require "hive/bot/handlers/callback_handlers"
 class HiveBotCallbackHandlersTest < Minitest::Test
   Result = Struct.new(:action, :text, :reply_markup, :command_argv, :commands,
                       :project, :slug, :question_n, :answer_text, :mode,
-                      :intent, :alert_reset, :clear_keyboard, keyword_init: true)
+                      :intent, :alert_reset, :clear_keyboard, :format, keyword_init: true)
   FakeLogger = Struct.new(:events, keyword_init: true) do
     def event(name, **payload)
       events << { name: name, payload: payload }

--- a/test/unit/bot/callback_handlers_test.rb
+++ b/test/unit/bot/callback_handlers_test.rb
@@ -111,6 +111,10 @@ class HiveBotCallbackHandlersTest < Minitest::Test
       [ "hive", "accept-finding", "slug", "--all", "--stage", "6-review", "--project", "hive", "--json" ],
       [ "hive", "review", "slug", "--from", "6-review", "--project", "hive", "--json" ]
     ], result.commands
+    assert_equal({ project: "hive", slug: "slug", stage: "6-review" }, result.alert_reset,
+                 "accept-finding must clear the alert so recurring same-fingerprint failures re-alert cleanly")
+    assert_equal true, result.clear_keyboard,
+                 "findings buttons must clear the inline keyboard to prevent double-tap"
   end
 
   def test_findings_reject_all_without_retry_stage_only_toggles_findings
@@ -120,6 +124,9 @@ class HiveBotCallbackHandlersTest < Minitest::Test
     assert_equal [
       [ "hive", "reject-finding", "slug", "--all", "--stage", "unknown-stage", "--project", "hive", "--json" ]
     ], result.commands
+    assert_equal({ project: "hive", slug: "slug", stage: "unknown-stage" }, result.alert_reset,
+                 "reject-finding must clear the alert so a future same-fingerprint failure re-alerts")
+    assert_equal true, result.clear_keyboard
   end
 
   def test_show_details_dispatches_status_diagnose_for_targeted_envelope

--- a/test/unit/bot/callback_handlers_test.rb
+++ b/test/unit/bot/callback_handlers_test.rb
@@ -262,6 +262,17 @@ class HiveBotCallbackHandlersTest < Minitest::Test
     assert_equal "No retry verb for stage 9-done.", result.text
   end
 
+  def test_autofix_empty_stage_reply_labels_stage_as_empty
+    result = @handlers.handle(
+      :callback_autofix,
+      update("autofix:alpha:some-task-260519-abcd::ERROR")
+    )
+
+    assert_equal :reply, result.action
+    assert_equal "No retry verb for stage (empty).", result.text,
+                 "empty stage must be labelled (empty) rather than leaving a blank in the reply"
+  end
+
   def test_refresh_diagnose_rejects_malformed_callback_data
     # Defense against malformed callback round-trips. Any non-3-part
     # callback (legacy data, manual postback fuzzing) should fall back

--- a/test/unit/bot/notification_builders_test.rb
+++ b/test/unit/bot/notification_builders_test.rb
@@ -21,6 +21,14 @@ class HiveBotNotificationBuildersTest < Minitest::Test
     )
   end
 
+  def retry_diagnostic(command: "hive review slug --json")
+    { "suggested_next_action" => { "kind" => "retry", "command" => command } }
+  end
+
+  def manual_diagnostic
+    { "suggested_next_action" => { "kind" => "manual_fix", "command" => nil } }
+  end
+
   def test_ready_to_plan_builds_approval_keyboard
     notification = Hive::Bot::NotificationBuilders.build(
       row(action: "ready_to_plan", marker: "complete")
@@ -136,7 +144,7 @@ class HiveBotNotificationBuildersTest < Minitest::Test
         attrs: { "phase" => "fix", "reason" => "timeout", "exception_class" => "Encoding::CompatibilityError" },
         slug: "we-need-to-improve-this-260522-db23",
         stage: "6-review",
-        diagnostic: { "summary" => "REVIEW_ERROR phase=fix reason=timeout" }
+        diagnostic: retry_diagnostic(command: "hive review we-need-to-improve-this-260522-db23 --json")
       )
     )
 
@@ -154,16 +162,41 @@ class HiveBotNotificationBuildersTest < Minitest::Test
 
   def test_recovery_keyboard_is_single_autofix_button
     notification = Hive::Bot::NotificationBuilders.build(
-      row(action: "recover_review", marker: "review_error",
-          slug: "we-need-to-improve-this-260522-db23", stage: "6-review")
+      row(action: "recover_review", marker: "review_error", attrs: { "pass" => "2" },
+          slug: "we-need-to-improve-this-260522-db23", stage: "6-review",
+          diagnostic: retry_diagnostic)
     )
 
     assert_equal 1, notification.keyboard.length
     assert_equal 1, notification.keyboard.first.length
     button = notification.keyboard.first.first
     assert_equal "🔧 Autofix", button[:text]
-    assert_equal "autofix:hive:we-need-to-improve-this-260522-db23:6-review:review_error",
+    assert_equal "autofix:hive:we-need-to-improve-this-260522-db23:6-review:review_error:pass=2",
                  Hive::Bot::NotificationBuilders.resolve_callback(button[:callback_data])
+  end
+
+  def test_manual_recovery_diagnostic_does_not_offer_autofix
+    notification = Hive::Bot::NotificationBuilders.build(
+      row(action: "recover_execute", marker: "execute_stale", stage: "4-execute",
+          diagnostic: manual_diagnostic)
+    )
+
+    assert_includes notification.text, "Open this task on a laptop before retrying."
+    labels = notification.keyboard.flatten.map { |button| button[:text] }
+    assert_equal [ "Open laptop", "Show details" ], labels
+    refute_includes labels, "🔧 Autofix"
+  end
+
+  def test_fix_tampered_review_error_does_not_offer_autofix
+    notification = Hive::Bot::NotificationBuilders.build(
+      row(action: "recover_review", marker: "review_error",
+          attrs: { "phase" => "fix", "reason" => "fix_tampered" },
+          stage: "6-review", diagnostic: retry_diagnostic)
+    )
+
+    labels = notification.keyboard.flatten.map { |button| button[:text] }
+    refute_includes labels, "🔧 Autofix"
+    assert_includes labels, "Open laptop"
   end
 
   def test_cause_sentence_for_execute_stale

--- a/test/unit/bot/notification_builders_test.rb
+++ b/test/unit/bot/notification_builders_test.rb
@@ -136,6 +136,41 @@ class HiveBotNotificationBuildersTest < Minitest::Test
     assert_includes labels, "Show details"
   end
 
+  def test_review_waiting_non_guardrail_builds_findings_triage_keyboard
+    notification = Hive::Bot::NotificationBuilders.build(
+      row(action: "needs_input", marker: "review_waiting", attrs: { "reason" => "needs_findings" })
+    )
+
+    assert_match(/Review triage is waiting/, notification.text)
+    labels = notification.keyboard.flatten.map { |button| button[:text] }
+    assert_includes labels, "Accept all"
+    assert_includes labels, "Reject all"
+    assert_includes labels, "Show details"
+  end
+
+  def test_recovery_match_attr_review_stale_uses_pass_reason
+    attrs = { "pass" => "3", "reason" => "timeout" }
+    r = row(action: "recover_review", marker: "review_stale", attrs: attrs)
+    autofix = Hive::Bot::NotificationBuilders.autofix_callback(r)
+    assert_match(/:pass=3\z/, autofix,
+                 "review_stale must drive recovery_match_attr toward the pass=<n> key")
+  end
+
+  def test_recovery_match_attr_error_uses_exit_code
+    attrs = { "exit_code" => "137" }
+    r = row(action: "error", marker: "error", attrs: attrs)
+    autofix = Hive::Bot::NotificationBuilders.autofix_callback(r)
+    assert_match(/:exit_code=137\z/, autofix,
+                 "generic `error` marker must drive recovery_match_attr toward exit_code")
+  end
+
+  def test_recovery_match_attr_unknown_marker_omits_match_attr_suffix
+    r = row(action: "recover_execute", marker: "execute_stale", attrs: { "pass" => "1" })
+    autofix = Hive::Bot::NotificationBuilders.autofix_callback(r)
+    refute_match(/=/, autofix.split(":").last.to_s,
+                 "unknown-to-recovery_match_attr markers must produce a no-match_attr callback")
+  end
+
   def test_recovery_marker_builds_plain_language_autofix_notification
     notification = Hive::Bot::NotificationBuilders.build(
       row(

--- a/test/unit/bot/notification_builders_test.rb
+++ b/test/unit/bot/notification_builders_test.rb
@@ -166,6 +166,30 @@ class HiveBotNotificationBuildersTest < Minitest::Test
                  Hive::Bot::NotificationBuilders.resolve_callback(button[:callback_data])
   end
 
+  def test_cause_sentence_for_execute_stale
+    r = row(action: "recover_review", marker: "execute_stale")
+    notification = Hive::Bot::NotificationBuilders.build(r)
+    assert_includes notification.text, "The execute agent stalled before it could finish."
+  end
+
+  def test_cause_sentence_for_review_stale
+    r = row(action: "recover_review", marker: "review_stale")
+    notification = Hive::Bot::NotificationBuilders.build(r)
+    assert_includes notification.text, "The review run stalled before it could finish."
+  end
+
+  def test_cause_sentence_for_review_ci_stale
+    r = row(action: "recover_review", marker: "review_ci_stale")
+    notification = Hive::Bot::NotificationBuilders.build(r)
+    assert_includes notification.text, "The review run stalled before it could finish."
+  end
+
+  def test_cause_sentence_for_unknown_marker_uses_generic_fallback
+    r = row(action: "recover_review", marker: "totally_unknown_marker")
+    notification = Hive::Bot::NotificationBuilders.build(r)
+    assert_includes notification.text, "The agent crashed before it could finish."
+  end
+
   def test_fingerprint_changes_when_marker_attrs_change
     first = row(action: "recover_review", marker: "review_error", attrs: { "pass" => "2" })
     second = row(action: "recover_review", marker: "review_error", attrs: { "pass" => "3" })

--- a/test/unit/bot/notification_builders_test.rb
+++ b/test/unit/bot/notification_builders_test.rb
@@ -128,159 +128,55 @@ class HiveBotNotificationBuildersTest < Minitest::Test
     assert_includes labels, "Show details"
   end
 
-  def test_recovery_marker_builds_full_recovery_keyboard
+  def test_recovery_marker_builds_plain_language_autofix_notification
     notification = Hive::Bot::NotificationBuilders.build(
-      row(action: "recover_review", marker: "review_error", attrs: { "phase" => "fix", "reason" => "timeout" })
+      row(
+        action: "recover_review",
+        marker: "review_error",
+        attrs: { "phase" => "fix", "reason" => "timeout", "exception_class" => "Encoding::CompatibilityError" },
+        slug: "we-need-to-improve-this-260522-db23",
+        stage: "6-review",
+        diagnostic: { "summary" => "REVIEW_ERROR phase=fix reason=timeout" }
+      )
     )
 
-    labels = notification.keyboard.flatten.map { |button| button[:text] }
-    # "Refresh diagnosis" is the bot-side parity of the TUI's R
-    # keystroke — issue #91. Order is locked so a future keyboard
-    # tweak cannot accidentally drop or duplicate the button.
-    assert_equal [ "Clear and retry", "Open laptop", "Show details", "Refresh diagnosis" ], labels
+    assert_includes notification.text, "⚠ Review stuck — \"We need to improve this…\""
+    assert_includes notification.text, "The review agent crashed before it could finish."
+    assert_includes notification.text, "Tap Autofix to retry the stage cleanly."
+    refute_includes notification.text, "phase="
+    refute_includes notification.text, "reason="
+    refute_includes notification.text, "marker"
+    refute_includes notification.text, "exception_class"
+    refute_includes notification.text, "-260522-db23"
+    refute_includes notification.text, "(6-review)"
+    refute_includes notification.text, "Encoding::CompatibilityError"
   end
 
-  def test_markerless_retry_recovery_uses_retry_button_without_clear_copy
-    diagnostic = {
-      "summary" => "PLAN_MISSING_OUTPUT",
-      "suggested_next_action" => {
-        "kind" => "retry",
-        "command" => "hive plan slug-260514-abcd --from 3-plan"
-      }
-    }
-    notification = Hive::Bot::NotificationBuilders.build(
-      row(action: "error", marker: "none", stage: "3-plan", diagnostic: diagnostic)
-    )
-
-    labels = notification.keyboard.flatten.map { |button| button[:text] }
-    assert_equal [ "Retry", "Open laptop", "Show details", "Refresh diagnosis" ], labels
-    assert_equal "clear_retry:hive:slug-260514-abcd:3-plan:NONE",
-                 notification.keyboard.first.first[:callback_data]
-  end
-
-  def test_manual_fix_recovery_omits_clear_and_retry_button
-    diagnostic = {
-      "summary" => "FINALIZE_MISSING_PR_MD",
-      "suggested_next_action" => {
-        "kind" => "manual_fix",
-        "command" => nil
-      }
-    }
-    notification = Hive::Bot::NotificationBuilders.build(
-      row(action: "error", marker: "error", stage: "8-finalize", diagnostic: diagnostic)
-    )
-
-    labels = notification.keyboard.flatten.map { |button| button[:text] }
-    refute_includes labels, "Clear and retry"
-    assert_equal [ "Open laptop", "Show details", "Refresh diagnosis" ], labels
-  end
-
-  def test_fix_tampered_recovery_falls_back_to_laptop
-    notification = Hive::Bot::NotificationBuilders.build(
-      row(action: "recover_review", marker: "review_error", attrs: { "phase" => "fix", "reason" => "fix_tampered" })
-    )
-
-    labels = notification.keyboard.flatten.map { |button| button[:text] }
-    refute_includes labels, "Clear and retry"
-    assert_equal [ "Open laptop", "Show details", "Refresh diagnosis" ], labels
-  end
-
-  def test_stale_agent_working_pending_heal_suppresses_clear_and_retry_button
-    # When TaskAction has reclassified a stale agent_working row to
-    # :error but the daemon hasn't yet rewritten the marker to ERROR
-    # on disk, rendering the default "Clear and retry" button would
-    # dispatch `hive markers clear --name AGENT_WORKING` — which is
-    # not in lib/hive/commands/markers.rb#ALLOWED_NAMES and exits 4.
-    # The bot must instead offer Open laptop only; the daemon's
-    # StaleAgentHealer rewrites the marker within ~30s after which
-    # the normal ERROR recovery affordance fires.
-    notification = Hive::Bot::NotificationBuilders.build(
-      row(action: "error", marker: "agent_working", stage: "4-execute")
-    )
-
-    labels = notification.keyboard.flatten.map { |button| button[:text] }
-    refute_includes labels, "Clear and retry",
-                    "Clear and retry on AGENT_WORKING would dispatch a markers-clear name not in the allowlist"
-    assert_includes labels, "Open laptop",
-                    "Open laptop must remain as a fallback while the daemon heals the marker"
-  end
-
-  def test_refresh_diagnosis_button_carries_callback_with_project_slug_and_stage
-    # The button data must round-trip through the router's callback_intent
-    # regex (\Arefresh_diagnose:/) and split cleanly into
-    # prefix:project:slug:stage for CallbackHandlers#refresh_diagnose.
-    # Pin the exact callback shape.
+  def test_recovery_keyboard_is_single_autofix_button
     notification = Hive::Bot::NotificationBuilders.build(
       row(action: "recover_review", marker: "review_error",
-          attrs: { "phase" => "fix", "reason" => "timeout" })
-    )
-    refresh_btn = notification.keyboard.flatten.find { |b| b[:text] == "Refresh diagnosis" }
-    refute_nil refresh_btn, "Refresh diagnosis button must be present on the recovery keyboard"
-
-    raw = Hive::Bot::NotificationBuilders.resolve_callback(refresh_btn[:callback_data])
-    assert raw.start_with?("refresh_diagnose:"),
-           "Refresh diagnosis callback must use the refresh_diagnose: prefix; got #{raw.inspect}"
-    parts = raw.split(":")
-    assert_equal(
-      [ "refresh_diagnose", "hive", "slug-260514-abcd", "2-brainstorm" ],
-      parts,
-      "callback data must be refresh_diagnose:<project>:<slug>:<stage>"
-    )
-  end
-
-  def test_show_details_button_carries_stage_for_disambiguation
-    notification = Hive::Bot::NotificationBuilders.build(
-      row(action: "recover_review", marker: "review_error",
-          attrs: { "phase" => "fix", "reason" => "timeout" }, stage: "6-review")
-    )
-    details_btn = notification.keyboard.flatten.find { |b| b[:text] == "Show details" }
-
-    assert_equal "details:hive:slug-260514-abcd:6-review",
-                 Hive::Bot::NotificationBuilders.resolve_callback(details_btn[:callback_data])
-  end
-
-  def test_recovery_notification_appends_diagnostic_summary_when_present
-    # Operators reading the bot notification get the "why is this red"
-    # one-liner inline instead of needing to round-trip through Show
-    # details. Mirrors what the TUI red_status_detail view shows at the
-    # top of the screen. See PR #84 review row 23.
-    diag = {
-      "summary" => "REVIEW_ERROR phase=fix pass=2 reason=timeout",
-      "detail" => "agent timed out",
-      "generated_by" => "local"
-    }
-    row_with_diag = row(action: "recover_review", marker: "review_error",
-                        attrs: { "phase" => "fix", "reason" => "timeout" })
-    # Re-construct with diagnostic since the test helper does not pass it.
-    enriched = Row.new(
-      project: row_with_diag.project, slug: row_with_diag.slug,
-      stage: row_with_diag.stage, marker: row_with_diag.marker,
-      attrs: row_with_diag.attrs, folder: row_with_diag.folder,
-      action: row_with_diag.action, action_label: row_with_diag.action_label,
-      suggested_command: row_with_diag.suggested_command,
-      diagnostic: diag
+          slug: "we-need-to-improve-this-260522-db23", stage: "6-review")
     )
 
-    notification = Hive::Bot::NotificationBuilders.build(enriched)
-    assert_includes notification.text, diag["summary"],
-                    "recovery notification must surface diagnostic.summary inline"
-  end
-
-  def test_recovery_notification_omits_diagnostic_when_nil
-    # Pre-schema snapshots / non-red rows return nil diagnostic. The
-    # notification must work without the inline summary — the existing
-    # "Needs recovery: marker attrs" line carries enough operator signal.
-    notification = Hive::Bot::NotificationBuilders.build(
-      row(action: "recover_review", marker: "review_error",
-          attrs: { "phase" => "fix", "reason" => "timeout" })
-    )
-    refute_nil notification
-    assert_match(/Needs recovery/, notification.text)
+    assert_equal 1, notification.keyboard.length
+    assert_equal 1, notification.keyboard.first.length
+    button = notification.keyboard.first.first
+    assert_equal "🔧 Autofix", button[:text]
+    assert_equal "autofix:hive:we-need-to-improve-this-260522-db23:6-review:review_error",
+                 Hive::Bot::NotificationBuilders.resolve_callback(button[:callback_data])
   end
 
   def test_fingerprint_changes_when_marker_attrs_change
     first = row(action: "recover_review", marker: "review_error", attrs: { "pass" => "2" })
     second = row(action: "recover_review", marker: "review_error", attrs: { "pass" => "3" })
+
+    refute_equal Hive::Bot::NotificationBuilders.fingerprint(first),
+                 Hive::Bot::NotificationBuilders.fingerprint(second)
+  end
+
+  def test_fingerprint_changes_when_stage_changes
+    first = row(action: "recover_review", marker: "review_error", attrs: { "pass" => "2" }, stage: "5-open-pr")
+    second = row(action: "recover_review", marker: "review_error", attrs: { "pass" => "2" }, stage: "6-review")
 
     refute_equal Hive::Bot::NotificationBuilders.fingerprint(first),
                  Hive::Bot::NotificationBuilders.fingerprint(second)

--- a/test/unit/bot/notification_dispatcher_test.rb
+++ b/test/unit/bot/notification_dispatcher_test.rb
@@ -90,6 +90,37 @@ class HiveBotNotificationDispatcherTest < Minitest::Test
     end
   end
 
+  def test_recovered_message_send_failure_retries_after_backoff_without_duplicate
+    # Telegram is down when the row first heals — Recovered cannot send.
+    # The entry must stay in the store, backoff must apply, and the next
+    # post-backoff tick must deliver exactly one Recovered message.
+    failing = FlakyTelegram.new
+    with_tmp_dir do |dir|
+      path = File.join(dir, "alerts.json")
+      d = dispatcher(path: path, telegram: failing)
+      d.process_rows([ recovery_row ])
+      # The first tick fails (initial alert), so the entry is persisted with
+      # delivered_to: [] and a 60s backoff. Advance past backoff and past the
+      # absence-grace window before the row disappears.
+      @clock += 61
+      d.process_rows([ recovery_row ])
+      assert_equal 1, failing.messages.size, "initial alert must deliver after backoff"
+
+      # Row heals — process_recoveries enters absence-grace.
+      d.process_rows([])
+      @clock += 61
+      # Now past grace; Telegram is up. Recovered must fire exactly once.
+      d.process_rows([])
+
+      recovered = failing.messages.select { |msg| msg[:text].include?("Recovered") }
+      assert_equal 1, recovered.size,
+                   "Recovered must deliver exactly once after Telegram outage clears"
+      assert_nil Hive::Bot::AlertStore.new(path: path).entry(
+        Hive::Bot::NotificationBuilders.fingerprint(recovery_row)
+      ), "entry must be removed after successful Recovered delivery"
+    end
+  end
+
   def test_transient_row_absence_within_grace_does_not_fire_recovered
     d = dispatcher
     d.process_rows([ recovery_row ])

--- a/test/unit/bot/notification_dispatcher_test.rb
+++ b/test/unit/bot/notification_dispatcher_test.rb
@@ -3,13 +3,15 @@ require "hive/bot/status_watcher"
 require "hive/bot/notification_dispatcher"
 
 class HiveBotNotificationDispatcherTest < Minitest::Test
+  include HiveTestHelper
+
   Row = Hive::Bot::StatusWatcher::Row
 
-  def row(action: "needs_input", marker: "waiting", attrs: {}, slug: "slug-260514-abcd")
+  def row(action: "needs_input", marker: "waiting", attrs: {}, slug: "slug-260514-abcd", stage: "2-brainstorm")
     Row.new(
       project: "hive",
       slug: slug,
-      stage: "2-brainstorm",
+      stage: stage,
       marker: marker,
       attrs: attrs,
       action: action,
@@ -19,12 +21,21 @@ class HiveBotNotificationDispatcherTest < Minitest::Test
     )
   end
 
-  def dispatcher(now: Time.utc(2026, 5, 14, 12, 0, 0), daemon_enabled: ->(_project) { false })
+  def recovery_row(attrs: { "pass" => "1" }, slug: "stuck-task-260525-abcd", stage: "6-review")
+    row(action: "recover_review", marker: "review_error", attrs: attrs, slug: slug, stage: stage)
+  end
+
+  def dispatcher(path: nil, now: Time.utc(2026, 5, 25, 10, 0, 0), daemon_enabled: ->(_project) { false },
+                 telegram: self.telegram)
     @clock = now
     Hive::Bot::NotificationDispatcher.new(
       telegram: telegram,
       logger: logger,
-      bot_config: { "chat_id_allowlist" => [ 12345 ], "notification_dedupe_window_sec" => 300 },
+      bot_config: {
+        "chat_id_allowlist" => [ 12345 ],
+        "alert_state_file" => path,
+        "recovery_reminder_window_sec" => 28_800
+      },
       daemon_enabled: daemon_enabled,
       now: -> { @clock }
     )
@@ -47,7 +58,7 @@ class HiveBotNotificationDispatcherTest < Minitest::Test
     assert_equal :notification_sent, logger.events.last.first
   end
 
-  def test_process_rows_dedupes_same_marker_fingerprint
+  def test_same_row_twice_sends_one_notification
     d = dispatcher
     d.process_rows([ row ])
     d.process_rows([ row ])
@@ -56,12 +67,91 @@ class HiveBotNotificationDispatcherTest < Minitest::Test
     assert_equal :notification_skipped_dedupe, logger.events.last.first
   end
 
+  def test_recovery_row_disappears_sends_recovered_message_and_removes_entry
+    with_tmp_dir do |dir|
+      path = File.join(dir, "alerts.json")
+      d = dispatcher(path: path)
+      d.process_rows([ recovery_row ])
+
+      d.process_rows([])
+
+      assert_equal 2, telegram.messages.size
+      assert_equal "✅ Recovered: \"Stuck task…\" — Review", telegram.messages.last[:text]
+      assert_nil Hive::Bot::AlertStore.new(path: path).entry(
+        Hive::Bot::NotificationBuilders.fingerprint(recovery_row)
+      )
+    end
+  end
+
+  def test_non_recovery_row_disappears_silently_drops_entry
+    with_tmp_dir do |dir|
+      path = File.join(dir, "alerts.json")
+      d = dispatcher(path: path)
+      d.process_rows([ row ])
+
+      d.process_rows([])
+
+      assert_equal 1, telegram.messages.size
+      assert_equal [], Hive::Bot::AlertStore.new(path: path).each_fingerprint.to_a
+    end
+  end
+
+  def test_same_fingerprint_reappears_after_recovery_refires
+    d = dispatcher
+    d.process_rows([ recovery_row ])
+    d.process_rows([])
+    d.process_rows([ recovery_row ])
+
+    assert_equal 3, telegram.messages.size
+    assert_match(/Review stuck/, telegram.messages.first[:text])
+    assert_match(/Recovered/, telegram.messages[1][:text])
+    assert_match(/Review stuck/, telegram.messages.last[:text])
+  end
+
   def test_marker_attr_change_renotifies
     d = dispatcher
-    d.process_rows([ row(action: "recover_review", marker: "review_error", attrs: { "pass" => "2" }) ])
-    d.process_rows([ row(action: "recover_review", marker: "review_error", attrs: { "pass" => "3" }) ])
+    d.process_rows([ recovery_row(attrs: { "pass" => "2" }) ])
+    d.process_rows([ recovery_row(attrs: { "pass" => "3" }) ])
+
+    assert_equal 3, telegram.messages.size
+    assert_match(/Recovered/, telegram.messages[1][:text])
+  end
+
+  def test_eight_hour_reminder_fires_exactly_once
+    d = dispatcher
+    d.process_rows([ recovery_row ])
+    @clock += 28_800
+    d.process_rows([ recovery_row ])
+    @clock += 28_800
+    d.process_rows([ recovery_row ])
 
     assert_equal 2, telegram.messages.size
+    assert_match(/\A⚠ Still stuck \(8 h\) — "Stuck task…" — Review/, telegram.messages.last[:text])
+  end
+
+  def test_restart_simulation_does_not_refire_same_active_row
+    with_tmp_dir do |dir|
+      path = File.join(dir, "alerts.json")
+      dispatcher(path: path).process_rows([ recovery_row ])
+
+      fresh = dispatcher(path: path)
+      fresh.process_rows([ recovery_row ])
+
+      assert_equal 1, telegram.messages.size
+    end
+  end
+
+  def test_corrupt_store_starts_fresh_without_crashing
+    with_tmp_dir do |dir|
+      path = File.join(dir, "alerts.json")
+      File.write(path, "{")
+
+      dispatcher(path: path).process_rows([ recovery_row ])
+
+      assert_equal 1, telegram.messages.size
+      assert_equal :alert_store_corrupt, logger.events.first.first
+      assert Dir.glob("#{path}.corrupt-*").any?
+    end
   end
 
   def test_ready_action_suppressed_when_daemon_enabled
@@ -71,52 +161,16 @@ class HiveBotNotificationDispatcherTest < Minitest::Test
     assert_equal [], telegram.messages
   end
 
-  def test_recent_dispatch_does_not_suppress_unrelated_state_change
-    d = dispatcher
-    d.record_dispatch(project: "hive", slug: "slug-260514-abcd")
-    d.process_rows([ row(action: "needs_input", marker: "waiting") ])
-
-    assert_equal 1, telegram.messages.size,
-                 "post-dispatch state-change notifications must not be suppressed (plan R6)"
-  end
-
-  def test_record_dispatch_with_fingerprint_suppresses_same_fingerprint
-    d = dispatcher
-    target_row = row(action: "needs_input", marker: "waiting")
-    fp = Hive::Bot::NotificationBuilders.fingerprint(target_row)
-    d.record_dispatch(project: "hive", slug: "slug-260514-abcd", fingerprint: fp)
-    d.process_rows([ target_row ])
-
-    assert_equal [], telegram.messages,
-                 "same-fingerprint dispatch should suppress re-notification of the marker that just transitioned"
-  end
-
   def test_multi_chat_fanout_delivers_to_all_allowed_chats
     multi = Hive::Bot::NotificationDispatcher.new(
-      telegram: telegram, logger: logger,
-      bot_config: { "chat_id_allowlist" => [ 12345, 67890 ], "notification_dedupe_window_sec" => 300 }
+      telegram: telegram,
+      logger: logger,
+      bot_config: { "chat_id_allowlist" => [ 12345, 67890 ], "recovery_reminder_window_sec" => 28_800 },
+      now: -> { @clock ||= Time.utc(2026, 5, 25, 10, 0, 0) }
     )
     multi.process_rows([ row ])
 
     assert_equal [ 12345, 67890 ], telegram.messages.map { |msg| msg[:chat_id] }
-  end
-
-  def test_prune_window_lets_repeated_fingerprint_re_notify_after_dedupe_window
-    advancing_clock = Time.utc(2026, 5, 14, 12, 0, 0)
-    clock = -> { advancing_clock }
-    d = Hive::Bot::NotificationDispatcher.new(
-      telegram: telegram, logger: logger,
-      bot_config: { "chat_id_allowlist" => [ 12345 ], "notification_dedupe_window_sec" => 60 },
-      now: clock
-    )
-
-    d.process_rows([ row ])
-    assert_equal 1, telegram.messages.size
-
-    advancing_clock += 120
-    d.process_rows([ row ])
-    assert_equal 2, telegram.messages.size,
-                 "dedupe entry should expire after the window so the same fingerprint re-notifies"
   end
 
   def test_rows_without_notification_are_ignored
@@ -128,12 +182,7 @@ class HiveBotNotificationDispatcherTest < Minitest::Test
 
   def test_send_failures_are_logged_without_marking_seen
     flaky_telegram = FlakyTelegram.new
-    d = Hive::Bot::NotificationDispatcher.new(
-      telegram: flaky_telegram,
-      logger: logger,
-      bot_config: { "chat_id_allowlist" => [ 12345 ], "notification_dedupe_window_sec" => 300 },
-      now: -> { @clock ||= Time.utc(2026, 5, 14, 12, 0, 0) }
-    )
+    d = dispatcher(telegram: flaky_telegram)
 
     d.process_rows([ row ])
 
@@ -168,7 +217,7 @@ class HiveBotNotificationDispatcherTest < Minitest::Test
     loads = []
     with_config_stubs(
       find_project: ->(project) { projects << project; nil },
-      load: ->(path) { loads << path; raise "Config.load should not be called" }
+      load: ->(_path) { loads << path; raise "Config.load should not be called" }
     ) do
       d = dispatcher(daemon_enabled: nil)
       d.process_rows([ row(action: "ready_to_plan", marker: "complete") ])

--- a/test/unit/bot/notification_dispatcher_test.rb
+++ b/test/unit/bot/notification_dispatcher_test.rb
@@ -194,6 +194,39 @@ class HiveBotNotificationDispatcherTest < Minitest::Test
     assert_match(/\A⚠ Still stuck \(8 h\) — "Stuck task…" — Review/, telegram.messages.last[:text])
   end
 
+  def test_reminder_send_failure_applies_backoff
+    # First tick: initial alert succeeds.
+    d = dispatcher
+    d.process_rows([ recovery_row ])
+    assert_equal 1, telegram.messages.size
+
+    # Advance to the 8h reminder boundary and swap in a Telegram that always fails.
+    @clock += 28_800
+    failing = AlwaysFailingTelegram.new
+    failing_dispatcher = Hive::Bot::NotificationDispatcher.new(
+      telegram: failing,
+      logger: logger,
+      bot_config: { "chat_id_allowlist" => [ 12345 ], "recovery_reminder_window_sec" => 28_800 },
+      now: -> { @clock },
+      alert_store: d.instance_variable_get(:@alert_store)
+    )
+    failing_dispatcher.process_rows([ recovery_row ])
+    assert_equal 1, failing.calls, "reminder must attempt one send"
+    refute alert_store_via(failing_dispatcher).entry(
+      Hive::Bot::NotificationBuilders.fingerprint(recovery_row)
+    ).next_attempt_after.nil?, "send failure must schedule a backoff window"
+
+    # Immediately retry: backoff window not yet expired → skip, no extra attempt.
+    failing_dispatcher.process_rows([ recovery_row ])
+    assert_equal 1, failing.calls, "reminder must NOT retry within the backoff window"
+    assert(logger.events.any? { |name, _| name == :notification_skipped_backoff },
+           "skipped reminder retry must emit :notification_skipped_backoff")
+  end
+
+  def alert_store_via(dispatcher)
+    dispatcher.instance_variable_get(:@alert_store)
+  end
+
   def test_ninety_minute_reminder_fires_with_minutes_label
     d = Hive::Bot::NotificationDispatcher.new(
       telegram: telegram,

--- a/test/unit/bot/notification_dispatcher_test.rb
+++ b/test/unit/bot/notification_dispatcher_test.rb
@@ -238,13 +238,39 @@ class HiveBotNotificationDispatcherTest < Minitest::Test
     d.process_rows([ row ])
 
     assert_empty flaky_telegram.messages
-    assert_equal :send_failure, logger.events.last.first
-    assert_equal "IOError", logger.events.last.last[:error_class]
+    assert_equal :send_failure, logger.events.map(&:first).find { |e| e == :send_failure }
+    failure_event = logger.events.find { |e| e.first == :send_failure }
+    assert_equal "IOError", failure_event.last[:error_class]
 
+    @clock += 60
     d.process_rows([ row ])
 
     assert_equal 1, flaky_telegram.messages.size
     assert_equal :notification_sent, logger.events.last.first
+  end
+
+  def test_send_failure_applies_exponential_backoff_skipping_subsequent_ticks
+    flaky_telegram = AlwaysFailingTelegram.new
+    d = dispatcher(telegram: flaky_telegram)
+
+    d.process_rows([ row ])
+    assert_equal 1, flaky_telegram.calls, "first tick must attempt one send"
+
+    # Immediately retry — backoff is 60s, should skip.
+    d.process_rows([ row ])
+    assert_equal 1, flaky_telegram.calls, "second tick within backoff window must skip the send"
+    assert(logger.events.any? { |name, _| name == :notification_skipped_backoff },
+           "skipped tick must emit :notification_skipped_backoff")
+
+    # Advance past first backoff (60s) — try again, still fails, schedules 120s backoff.
+    @clock += 61
+    d.process_rows([ row ])
+    assert_equal 2, flaky_telegram.calls
+
+    # 60s later, still within 120s backoff window — skip.
+    @clock += 60
+    d.process_rows([ row ])
+    assert_equal 2, flaky_telegram.calls
   end
 
   def test_ready_action_uses_config_fallback_when_no_daemon_probe
@@ -321,6 +347,19 @@ class HiveBotNotificationDispatcherTest < Minitest::Test
       end
 
       @messages << { chat_id: chat_id, text: text, reply_markup: reply_markup, parse_mode: parse_mode }
+    end
+  end
+
+  class AlwaysFailingTelegram
+    attr_reader :calls
+
+    def initialize
+      @calls = 0
+    end
+
+    def send_message(chat_id:, text:, reply_markup: nil, parse_mode: :markdown)
+      @calls += 1
+      raise IOError, "delivery failed"
     end
   end
 

--- a/test/unit/bot/notification_dispatcher_test.rb
+++ b/test/unit/bot/notification_dispatcher_test.rb
@@ -73,6 +73,13 @@ class HiveBotNotificationDispatcherTest < Minitest::Test
       d = dispatcher(path: path)
       d.process_rows([ recovery_row ])
 
+      # First absence tick — within grace, no Recovered fires yet.
+      d.process_rows([])
+      assert_equal 1, telegram.messages.size,
+                   "Recovered must not fire while absence is within recovery_grace_sec"
+
+      # Advance past grace and re-evaluate — now Recovered fires.
+      @clock += 61
       d.process_rows([])
 
       assert_equal 2, telegram.messages.size
@@ -81,6 +88,17 @@ class HiveBotNotificationDispatcherTest < Minitest::Test
         Hive::Bot::NotificationBuilders.fingerprint(recovery_row)
       )
     end
+  end
+
+  def test_transient_row_absence_within_grace_does_not_fire_recovered
+    d = dispatcher
+    d.process_rows([ recovery_row ])
+    d.process_rows([])               # tick 2: row absent → mark_absent, no Recovered
+    d.process_rows([ recovery_row ]) # tick 3: row re-appears within grace
+
+    assert_equal 1, telegram.messages.size,
+                 "Transient agent_running flicker must NOT produce a false Recovered + re-stuck pair"
+    refute_match(/Recovered/, telegram.messages.first[:text])
   end
 
   def test_non_recovery_row_disappears_silently_drops_entry
@@ -99,8 +117,10 @@ class HiveBotNotificationDispatcherTest < Minitest::Test
   def test_same_fingerprint_reappears_after_recovery_refires
     d = dispatcher
     d.process_rows([ recovery_row ])
+    d.process_rows([])               # absence tick — within grace
+    @clock += 61                     # past grace, next absent-tick fires Recovered
     d.process_rows([])
-    d.process_rows([ recovery_row ])
+    d.process_rows([ recovery_row ]) # reappears as a fresh alert
 
     assert_equal 3, telegram.messages.size
     assert_match(/Review stuck/, telegram.messages.first[:text])

--- a/test/unit/bot/notification_dispatcher_test.rb
+++ b/test/unit/bot/notification_dispatcher_test.rb
@@ -129,6 +129,26 @@ class HiveBotNotificationDispatcherTest < Minitest::Test
     assert_match(/\A⚠ Still stuck \(8 h\) — "Stuck task…" — Review/, telegram.messages.last[:text])
   end
 
+  def test_ninety_minute_reminder_fires_with_minutes_label
+    d = Hive::Bot::NotificationDispatcher.new(
+      telegram: telegram,
+      logger: logger,
+      bot_config: {
+        "chat_id_allowlist" => [ 12345 ],
+        "recovery_reminder_window_sec" => 5400
+      },
+      now: -> { @clock ||= Time.utc(2026, 5, 25, 10, 0, 0) }
+    )
+    @clock = Time.utc(2026, 5, 25, 10, 0, 0)
+    d.process_rows([ recovery_row ])
+    @clock += 5400
+    d.process_rows([ recovery_row ])
+
+    assert_equal 2, telegram.messages.size, "reminder should fire after 90 min"
+    assert_match(/Still stuck \(90 min\)/, telegram.messages.last[:text],
+                 "reminder label must use minutes form for non-whole-hour windows")
+  end
+
   def test_restart_simulation_does_not_refire_same_active_row
     with_tmp_dir do |dir|
       path = File.join(dir, "alerts.json")

--- a/test/unit/bot/notification_dispatcher_test.rb
+++ b/test/unit/bot/notification_dispatcher_test.rb
@@ -127,6 +127,70 @@ class HiveBotNotificationDispatcherTest < Minitest::Test
     end
   end
 
+  def test_recovered_message_send_failure_records_backoff
+    # Stand up an entry via a working Telegram, then swap the dispatcher
+    # for an always-failing Telegram so process_recoveries lands in the
+    # record_send_failure branch.
+    with_tmp_dir do |dir|
+      path = File.join(dir, "alerts.json")
+      store = Hive::Bot::AlertStore.new(path: path)
+      store.mark_seeded!
+      working = StubTelegram.new
+      d_in = Hive::Bot::NotificationDispatcher.new(
+        telegram: working,
+        logger: logger,
+        bot_config: { "chat_id_allowlist" => [ 12345 ], "recovery_reminder_window_sec" => 28_800 },
+        now: -> { @clock ||= Time.utc(2026, 5, 25, 10, 0, 0) },
+        alert_store: store
+      )
+      @clock = Time.utc(2026, 5, 25, 10, 0, 0)
+      d_in.process_rows([ recovery_row ])
+
+      failing = AlwaysFailingTelegram.new
+      d_out = Hive::Bot::NotificationDispatcher.new(
+        telegram: failing,
+        logger: logger,
+        bot_config: { "chat_id_allowlist" => [ 12345 ], "recovery_reminder_window_sec" => 28_800 },
+        now: -> { @clock },
+        alert_store: store
+      )
+      # Tick 1 absent: mark_absent only, no Recovered attempt yet.
+      d_out.process_rows([])
+      assert_equal 0, failing.calls
+      # Tick 2 absent (past grace): Recovered attempted, send fails.
+      @clock += 61
+      d_out.process_rows([])
+      assert_equal 1, failing.calls
+
+      fingerprint = Hive::Bot::NotificationBuilders.fingerprint(recovery_row)
+      entry = store.entry(fingerprint)
+      refute_nil entry, "failed Recovered must leave the entry intact"
+      refute_nil entry.next_attempt_after,
+                 "Recovered send failure must call record_send_failure to schedule backoff"
+    end
+  end
+
+  def test_reminder_notification_raises_on_unexpected_recovery_headline_shape
+    d = dispatcher
+    # Stub NotificationBuilders.recovery to return text that does not
+    # start with the expected "⚠ " sentinel; reminder_notification must
+    # raise rather than silently mutate the wrong line.
+    original = Hive::Bot::NotificationBuilders.method(:recovery)
+    Hive::Bot::NotificationBuilders.define_singleton_method(:recovery) do |row, **_kwargs|
+      Hive::Bot::NotificationBuilders::Notification.new(
+        text: "different headline\nbody",
+        keyboard: nil
+      )
+    end
+
+    err = assert_raises(RuntimeError) do
+      d.send(:reminder_notification, recovery_row)
+    end
+    assert_match(/reminder_notification expected NotificationBuilders\.recovery/, err.message)
+  ensure
+    Hive::Bot::NotificationBuilders.define_singleton_method(:recovery, original) if original
+  end
+
   def test_fresh_install_silently_seeds_first_tick_and_alerts_only_on_deltas
     with_tmp_dir do |dir|
       path = File.join(dir, "alerts.json")
@@ -295,6 +359,40 @@ class HiveBotNotificationDispatcherTest < Minitest::Test
     assert_equal 2, telegram.messages.size, "reminder should fire after 90 min"
     assert_match(/Still stuck \(1 h 30 min\)/, telegram.messages.last[:text],
                  "reminder label uses combined hours+minutes form for windows that are >= 1h but not whole-hour")
+  end
+
+  def test_dispatcher_uses_default_now_lambda_when_not_provided
+    # Production callers (Supervisor) construct without `now:` and rely
+    # on the default lambda returning Time.now. Exercise the default
+    # so the constructor signature line is covered.
+    d = Hive::Bot::NotificationDispatcher.new(
+      telegram: StubTelegram.new,
+      logger: StubLogger.new,
+      bot_config: { "chat_id_allowlist" => [ 12345 ], "recovery_reminder_window_sec" => 28_800 }
+    )
+    now_lambda = d.instance_variable_get(:@now)
+    refute_nil now_lambda
+    assert_in_delta Time.now.to_f, now_lambda.call.to_f, 1.0,
+                    "default now: lambda must return current time"
+  end
+
+  def test_reminder_label_renders_minutes_form_for_sub_hour_windows
+    # Sub-hour windows aren't normally reachable via config bounds (3600 floor),
+    # but the dispatcher accepts raw bot_config so the minutes form must still
+    # apply if a caller bypasses validation.
+    d = Hive::Bot::NotificationDispatcher.new(
+      telegram: telegram,
+      logger: logger,
+      bot_config: { "chat_id_allowlist" => [ 12345 ], "recovery_reminder_window_sec" => 1800 },
+      now: -> { @clock ||= Time.utc(2026, 5, 25, 10, 0, 0) }
+    )
+    @clock = Time.utc(2026, 5, 25, 10, 0, 0)
+    d.process_rows([ recovery_row ])
+    @clock += 1800
+    d.process_rows([ recovery_row ])
+
+    assert_match(/Still stuck \(30 min\)/, telegram.messages.last[:text],
+                 "sub-1h window uses the bare 'N min' form")
   end
 
   def test_reminder_label_renders_pure_hours_when_whole_hour_window

--- a/test/unit/bot/notification_dispatcher_test.rb
+++ b/test/unit/bot/notification_dispatcher_test.rb
@@ -108,13 +108,27 @@ class HiveBotNotificationDispatcherTest < Minitest::Test
     assert_match(/Review stuck/, telegram.messages.last[:text])
   end
 
-  def test_marker_attr_change_renotifies
+  def test_marker_attr_change_renotifies_without_false_recovered_message
     d = dispatcher
     d.process_rows([ recovery_row(attrs: { "pass" => "2" }) ])
     d.process_rows([ recovery_row(attrs: { "pass" => "3" }) ])
 
-    assert_equal 3, telegram.messages.size
-    assert_match(/Recovered/, telegram.messages[1][:text])
+    assert_equal 2, telegram.messages.size
+    assert_match(/Review stuck/, telegram.messages.first[:text])
+    assert_match(/Review stuck/, telegram.messages.last[:text])
+    refute_match(/Recovered/, telegram.messages.map { |message| message[:text] }.join("\n"))
+  end
+
+  def test_reset_task_allows_same_fingerprint_to_refire
+    d = dispatcher
+    task = recovery_row(attrs: { "pass" => "2" })
+
+    d.process_rows([ task ])
+    d.reset_task(project: "hive", slug: "stuck-task-260525-abcd", stage: "6-review")
+    d.process_rows([ task ])
+
+    assert_equal 2, telegram.messages.size
+    assert telegram.messages.all? { |message| message[:text].include?("Review stuck") }
   end
 
   def test_eight_hour_reminder_fires_exactly_once
@@ -191,6 +205,23 @@ class HiveBotNotificationDispatcherTest < Minitest::Test
     multi.process_rows([ row ])
 
     assert_equal [ 12345, 67890 ], telegram.messages.map { |msg| msg[:chat_id] }
+  end
+
+  def test_partial_multi_chat_failure_does_not_mark_fingerprint_delivered
+    flaky = PartiallyFlakyTelegram.new(fail_chat_id: 67890)
+    multi = Hive::Bot::NotificationDispatcher.new(
+      telegram: flaky,
+      logger: logger,
+      bot_config: { "chat_id_allowlist" => [ 12345, 67890 ], "recovery_reminder_window_sec" => 28_800 },
+      now: -> { @clock ||= Time.utc(2026, 5, 25, 10, 0, 0) }
+    )
+
+    multi.process_rows([ row ])
+    multi.process_rows([ row ])
+
+    assert_equal [ 12345, 67890, 12345, 67890 ], flaky.calls
+    assert_equal [ 12345, 12345, 67890 ], flaky.messages.map { |msg| msg[:chat_id] }
+    assert_equal :notification_sent, logger.events.last.first
   end
 
   def test_rows_without_notification_are_ignored
@@ -286,6 +317,27 @@ class HiveBotNotificationDispatcherTest < Minitest::Test
     def send_message(chat_id:, text:, reply_markup: nil, parse_mode: :markdown)
       if @fail_next
         @fail_next = false
+        raise IOError, "delivery failed"
+      end
+
+      @messages << { chat_id: chat_id, text: text, reply_markup: reply_markup, parse_mode: parse_mode }
+    end
+  end
+
+  class PartiallyFlakyTelegram
+    attr_reader :messages, :calls
+
+    def initialize(fail_chat_id:)
+      @fail_chat_id = fail_chat_id
+      @failed = false
+      @messages = []
+      @calls = []
+    end
+
+    def send_message(chat_id:, text:, reply_markup: nil, parse_mode: :markdown)
+      @calls << chat_id
+      if chat_id == @fail_chat_id && !@failed
+        @failed = true
         raise IOError, "delivery failed"
       end
 

--- a/test/unit/bot/notification_dispatcher_test.rb
+++ b/test/unit/bot/notification_dispatcher_test.rb
@@ -26,9 +26,9 @@ class HiveBotNotificationDispatcherTest < Minitest::Test
   end
 
   def dispatcher(path: nil, now: Time.utc(2026, 5, 25, 10, 0, 0), daemon_enabled: ->(_project) { false },
-                 telegram: self.telegram)
+                 telegram: self.telegram, fresh_install: false)
     @clock = now
-    Hive::Bot::NotificationDispatcher.new(
+    d = Hive::Bot::NotificationDispatcher.new(
       telegram: telegram,
       logger: logger,
       bot_config: {
@@ -39,6 +39,12 @@ class HiveBotNotificationDispatcherTest < Minitest::Test
       daemon_enabled: daemon_enabled,
       now: -> { @clock }
     )
+    # Most tests assert the FIRST tick alerts. The fresh_install
+    # seeding behaviour gets its own focused tests; mark the
+    # AlertStore as already-seeded by default so existing tests
+    # don't need clock-advance wrappers.
+    d.instance_variable_get(:@alert_store).mark_seeded! unless fresh_install
+    d
   end
 
   def telegram
@@ -118,6 +124,50 @@ class HiveBotNotificationDispatcherTest < Minitest::Test
       assert_nil Hive::Bot::AlertStore.new(path: path).entry(
         Hive::Bot::NotificationBuilders.fingerprint(recovery_row)
       ), "entry must be removed after successful Recovered delivery"
+    end
+  end
+
+  def test_fresh_install_silently_seeds_first_tick_and_alerts_only_on_deltas
+    with_tmp_dir do |dir|
+      path = File.join(dir, "alerts.json")
+      refute File.exist?(path), "precondition: alert_state_file must not yet exist"
+
+      d = dispatcher(path: path, fresh_install: true)
+      pre_existing = recovery_row
+      brand_new = recovery_row(slug: "new-stuck-260525-9999")
+
+      # Day 1: existing failure already in the snapshot. Must NOT alert.
+      d.process_rows([ pre_existing ])
+      assert_empty telegram.messages,
+                   "fresh install must not alert on backlog failures from the very first tick"
+      assert(logger.events.any? { |name, _| name == :fresh_install_seeded },
+             ":fresh_install_seeded event must be logged for observability")
+
+      # Day 2: the same pre-existing failure is still around — dedupe applies.
+      @clock += 30
+      d.process_rows([ pre_existing ])
+      assert_empty telegram.messages, "subsequent tick must dedupe seeded entries"
+
+      # Day 3: a NEW failure appears. This one alerts normally.
+      @clock += 30
+      d.process_rows([ pre_existing, brand_new ])
+      assert_equal 1, telegram.messages.size, "only the delta (new failure) must alert"
+      assert_match(/New stuck/, telegram.messages.last[:text])
+    end
+  end
+
+  def test_existing_state_file_does_not_count_as_fresh_install
+    with_tmp_dir do |dir|
+      path = File.join(dir, "alerts.json")
+      # Pre-create an empty but valid state file. This simulates a bot that
+      # has run before but has no entries.
+      File.write(path, JSON.generate({ "schema_version" => 1, "entries" => {} }))
+
+      d = dispatcher(path: path, fresh_install: true)
+      d.process_rows([ recovery_row ])
+
+      assert_equal 1, telegram.messages.size,
+                   "an existing state file (even empty) must NOT trigger silent seeding"
     end
   end
 

--- a/test/unit/bot/notification_dispatcher_test.rb
+++ b/test/unit/bot/notification_dispatcher_test.rb
@@ -207,7 +207,7 @@ class HiveBotNotificationDispatcherTest < Minitest::Test
     assert_equal [ 12345, 67890 ], telegram.messages.map { |msg| msg[:chat_id] }
   end
 
-  def test_partial_multi_chat_failure_does_not_mark_fingerprint_delivered
+  def test_partial_multi_chat_failure_retries_only_undelivered_chats
     flaky = PartiallyFlakyTelegram.new(fail_chat_id: 67890)
     multi = Hive::Bot::NotificationDispatcher.new(
       telegram: flaky,
@@ -219,8 +219,8 @@ class HiveBotNotificationDispatcherTest < Minitest::Test
     multi.process_rows([ row ])
     multi.process_rows([ row ])
 
-    assert_equal [ 12345, 67890, 12345, 67890 ], flaky.calls
-    assert_equal [ 12345, 12345, 67890 ], flaky.messages.map { |msg| msg[:chat_id] }
+    assert_equal [ 12345, 67890, 67890 ], flaky.calls
+    assert_equal [ 12345, 67890 ], flaky.messages.map { |msg| msg[:chat_id] }
     assert_equal :notification_sent, logger.events.last.first
   end
 

--- a/test/unit/bot/notification_dispatcher_test.rb
+++ b/test/unit/bot/notification_dispatcher_test.rb
@@ -293,8 +293,24 @@ class HiveBotNotificationDispatcherTest < Minitest::Test
     d.process_rows([ recovery_row ])
 
     assert_equal 2, telegram.messages.size, "reminder should fire after 90 min"
-    assert_match(/Still stuck \(90 min\)/, telegram.messages.last[:text],
-                 "reminder label must use minutes form for non-whole-hour windows")
+    assert_match(/Still stuck \(1 h 30 min\)/, telegram.messages.last[:text],
+                 "reminder label uses combined hours+minutes form for windows that are >= 1h but not whole-hour")
+  end
+
+  def test_reminder_label_renders_pure_hours_when_whole_hour_window
+    d = Hive::Bot::NotificationDispatcher.new(
+      telegram: telegram,
+      logger: logger,
+      bot_config: { "chat_id_allowlist" => [ 12345 ], "recovery_reminder_window_sec" => 14_400 },
+      now: -> { @clock ||= Time.utc(2026, 5, 25, 10, 0, 0) }
+    )
+    @clock = Time.utc(2026, 5, 25, 10, 0, 0)
+    d.process_rows([ recovery_row ])
+    @clock += 14_400
+    d.process_rows([ recovery_row ])
+
+    assert_match(/Still stuck \(4 h\)/, telegram.messages.last[:text],
+                 "whole-hour window uses bare 'N h' form, no '0 min' suffix")
   end
 
   def test_restart_simulation_does_not_refire_same_active_row

--- a/test/unit/bot/notification_dispatcher_test.rb
+++ b/test/unit/bot/notification_dispatcher_test.rb
@@ -322,11 +322,18 @@ class HiveBotNotificationDispatcherTest < Minitest::Test
     end
   end
 
-  def test_ready_action_suppressed_when_daemon_enabled
-    d = dispatcher(daemon_enabled: ->(_project) { true })
-    d.process_rows([ row(action: "ready_to_plan", marker: "complete") ])
+  def test_ready_actions_are_always_suppressed
+    # ready_to_X notifications are pull-only via /status. The proactive
+    # allow-list (eval contract) is agent_blocked_question / fatal_error
+    # only, so neither a daemon-on project nor a daemon-off project should
+    # ever see a proactive ready_to_X.
+    d = dispatcher
+    Hive::Bot::NotificationBuilders::READY_ACTIONS.each do |action|
+      d.process_rows([ row(action: action, marker: "complete") ])
+    end
 
-    assert_equal [], telegram.messages
+    assert_empty telegram.messages,
+                 "ready_to_X must never produce a proactive Telegram message"
   end
 
   def test_multi_chat_fanout_delivers_to_all_allowed_chats
@@ -407,52 +414,24 @@ class HiveBotNotificationDispatcherTest < Minitest::Test
     assert_equal 2, flaky_telegram.calls
   end
 
-  def test_ready_action_uses_config_fallback_when_no_daemon_probe
-    projects = []
-    loads = []
-    with_config_stubs(
-      find_project: ->(project) { projects << project; { "path" => "/tmp/hive" } },
-      load: ->(path) { loads << path; { "daemon" => { "enabled" => true } } }
-    ) do
-      d = dispatcher(daemon_enabled: nil)
-      d.process_rows([ row(action: "ready_to_plan", marker: "complete") ])
-    end
-
-    assert_empty telegram.messages
-    assert_equal [ "hive" ], projects
-    assert_equal [ "/tmp/hive" ], loads
-  end
-
-  def test_ready_action_not_suppressed_when_project_missing_from_config
+  def test_ready_actions_suppressed_regardless_of_config_or_daemon_state
+    # The daemon-probe gate was removed because ready_to_X is pull-only —
+    # no proactive emission regardless of project config state. These
+    # tests previously pinned the buggy "leak when daemon disabled" path.
     projects = []
     loads = []
     with_config_stubs(
       find_project: ->(project) { projects << project; nil },
-      load: ->(_path) { loads << path; raise "Config.load should not be called" }
+      load: ->(_path) { loads << "loaded"; raise "Config.load should not be called" }
     ) do
-      d = dispatcher(daemon_enabled: nil)
+      d = dispatcher
       d.process_rows([ row(action: "ready_to_plan", marker: "complete") ])
     end
 
-    assert_equal 1, telegram.messages.size
-    assert_equal [ "hive" ], projects
-    assert_empty loads
-  end
-
-  def test_daemon_config_errors_are_logged_and_do_not_suppress_ready_actions
-    with_config_stubs(
-      find_project: ->(_project) { { "path" => "/tmp/hive" } },
-      load: ->(_path) { raise Hive::ConfigError, "bad config" }
-    ) do
-      d = dispatcher(daemon_enabled: nil)
-      d.process_rows([ row(action: "ready_to_plan", marker: "complete") ])
-    end
-
-    assert_equal 1, telegram.messages.size
-    event = logger.events.find { |name, _attrs| name == :poll_failure }
-    assert_equal "daemon_check", event.last[:source]
-    assert_equal "hive", event.last[:project]
-    assert_equal "Hive::ConfigError", event.last[:error_class]
+    assert_empty telegram.messages,
+                 "ready_to_X must be suppressed even when project is missing from config"
+    assert_empty projects, "daemon-probe Config.find_project must no longer be called"
+    assert_empty loads, "daemon-probe Config.load must no longer be called"
   end
 
   def with_config_stubs(find_project:, load:)

--- a/test/unit/bot/router_test.rb
+++ b/test/unit/bot/router_test.rb
@@ -176,6 +176,7 @@ class HiveBotRouterTest < Minitest::Test
   def test_classifies_all_callback_prefixes
     cases = {
       "reject:anything" => :callback_reject,
+      "autofix:hive:slug-260514-abcd:6-review:REVIEW_ERROR" => :callback_autofix,
       "open_laptop:hive:slug-260514-abcd" => :callback_open_laptop,
       "details:hive:slug-260514-abcd" => :callback_show_details,
       "refresh_diagnose:hive:slug-260514-abcd:6-review" => :callback_refresh_diagnose,

--- a/test/unit/bot/slash_handlers_test.rb
+++ b/test/unit/bot/slash_handlers_test.rb
@@ -32,6 +32,14 @@ class HiveBotSlashHandlersTest < Minitest::Test
     assert_equal "hive", result.project
   end
 
+  def test_status_preserves_multi_word_project_names
+    result = @handlers.status(Update.new(text: "/status my project"))
+
+    assert_equal :dispatch_then_reply, result.action
+    assert_equal [ "hive", "status", "--json", "--project", "my project" ], result.command_argv
+    assert_equal "my project", result.project
+  end
+
   def test_help_documents_project_status_argument
     result = @handlers.help(Update.new(text: "/help"))
 

--- a/test/unit/bot/slash_handlers_test.rb
+++ b/test/unit/bot/slash_handlers_test.rb
@@ -4,7 +4,7 @@ require "hive/bot/handlers/slash_handlers"
 class HiveBotSlashHandlersTest < Minitest::Test
   Result = Struct.new(:action, :text, :reply_markup, :command_argv, :commands,
                       :project, :slug, :question_n, :answer_text, :mode,
-                      :intent, keyword_init: true)
+                      :intent, :format, keyword_init: true)
   Update = Struct.new(:text, :chat_id, keyword_init: true)
 
   def setup
@@ -44,5 +44,21 @@ class HiveBotSlashHandlersTest < Minitest::Test
     result = @handlers.help(Update.new(text: "/help"))
 
     assert_includes result.text, "/status [project]"
+  end
+
+  def test_status_with_json_flag_sets_format_json
+    result = @handlers.status(Update.new(text: "/status --json"))
+
+    assert_equal :json, result.format
+    assert_nil result.project, "/status --json without a project must produce a no-project filter"
+    assert_equal [ "hive", "status", "--json" ], result.command_argv
+  end
+
+  def test_status_with_json_flag_and_project_filters_and_sets_format_json
+    result = @handlers.status(Update.new(text: "/status --json hive"))
+
+    assert_equal :json, result.format
+    assert_equal "hive", result.project
+    assert_equal [ "hive", "status", "--json", "--project", "hive" ], result.command_argv
   end
 end

--- a/test/unit/bot/slash_handlers_test.rb
+++ b/test/unit/bot/slash_handlers_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+require "hive/bot/handlers/slash_handlers"
+
+class HiveBotSlashHandlersTest < Minitest::Test
+  Result = Struct.new(:action, :text, :reply_markup, :command_argv, :commands,
+                      :project, :slug, :question_n, :answer_text, :mode,
+                      :intent, keyword_init: true)
+  Update = Struct.new(:text, :chat_id, keyword_init: true)
+
+  def setup
+    @handlers = Hive::Bot::Handlers::SlashHandlers.new(
+      projects_provider: -> { [] },
+      pending_ideas: {},
+      last_project: -> { nil },
+      result_class: Result
+    )
+  end
+
+  def test_status_without_project_dispatches_global_status
+    result = @handlers.status(Update.new(text: "/status"))
+
+    assert_equal :dispatch_then_reply, result.action
+    assert_equal [ "hive", "status", "--json" ], result.command_argv
+    assert_nil result.project
+  end
+
+  def test_status_with_project_dispatches_filtered_status
+    result = @handlers.status(Update.new(text: "/status hive"))
+
+    assert_equal :dispatch_then_reply, result.action
+    assert_equal [ "hive", "status", "--json", "--project", "hive" ], result.command_argv
+    assert_equal "hive", result.project
+  end
+
+  def test_help_documents_project_status_argument
+    result = @handlers.help(Update.new(text: "/help"))
+
+    assert_includes result.text, "/status [project]"
+  end
+end

--- a/test/unit/bot/slash_handlers_test.rb
+++ b/test/unit/bot/slash_handlers_test.rb
@@ -28,7 +28,8 @@ class HiveBotSlashHandlersTest < Minitest::Test
     result = @handlers.status(Update.new(text: "/status hive"))
 
     assert_equal :dispatch_then_reply, result.action
-    assert_equal [ "hive", "status", "--json", "--project", "hive" ], result.command_argv
+    # argv stays flag-free; project filter rides on Result.project
+    assert_equal [ "hive", "status", "--json" ], result.command_argv
     assert_equal "hive", result.project
   end
 
@@ -36,7 +37,7 @@ class HiveBotSlashHandlersTest < Minitest::Test
     result = @handlers.status(Update.new(text: "/status my project"))
 
     assert_equal :dispatch_then_reply, result.action
-    assert_equal [ "hive", "status", "--json", "--project", "my project" ], result.command_argv
+    assert_equal [ "hive", "status", "--json" ], result.command_argv
     assert_equal "my project", result.project
   end
 
@@ -59,6 +60,6 @@ class HiveBotSlashHandlersTest < Minitest::Test
 
     assert_equal :json, result.format
     assert_equal "hive", result.project
-    assert_equal [ "hive", "status", "--json", "--project", "hive" ], result.command_argv
+    assert_equal [ "hive", "status", "--json" ], result.command_argv
   end
 end

--- a/test/unit/bot/supervisor_test.rb
+++ b/test/unit/bot/supervisor_test.rb
@@ -7,7 +7,7 @@ class HiveBotSupervisorTest < Minitest::Test
   ChildExit = Hive::Bot::ChildSupervisor::ChildExit
   Update = Struct.new(:chat_id, :update_id, :message_id, keyword_init: true)
   Row = Struct.new(:project, :slug, :stage, :action, :action_label, :marker, :attrs, keyword_init: true)
-  StatusResult = Struct.new(:ok, :rows, keyword_init: true)
+  StatusResult = Struct.new(:ok, :rows, :error, keyword_init: true)
 
   FakeTelegram = Struct.new(:messages, :raise_on_send, :keyboard_clears, keyword_init: true) do
     def send_message(chat_id:, text:, reply_markup: nil)
@@ -298,7 +298,7 @@ class HiveBotSupervisorTest < Minitest::Test
     assert_nil @telegram.messages.last.fetch(:reply_markup)
   end
 
-  def test_execute_dispatch_reports_no_tasks_for_filtered_project
+  def test_execute_dispatch_reports_unknown_project_with_known_list
     @status_watcher.result = StatusResult.new(ok: true, rows: [ row(project: "hive", slug: "alpha") ])
     result = FakeRouter::Result.new(
       action: :dispatch_then_reply,
@@ -308,7 +308,37 @@ class HiveBotSupervisorTest < Minitest::Test
 
     @supervisor.send(:execute_dispatch, result, Update.new(chat_id: 42, update_id: 10))
 
-    assert_equal "No tasks for project missing.", @telegram.messages.last.fetch(:text)
+    text = @telegram.messages.last.fetch(:text)
+    assert_match(/Unknown project missing/, text)
+    assert_match(/hive/, text)
+  end
+
+  def test_execute_dispatch_reports_no_tasks_for_known_but_empty_project
+    with_registered_projects([ { "name" => "hive" }, { "name" => "other" } ]) do
+      @status_watcher.result = StatusResult.new(ok: true, rows: [ row(project: "hive", slug: "alpha") ])
+      result = FakeRouter::Result.new(
+        action: :dispatch_then_reply,
+        command_argv: [ "hive", "status", "--json", "--project", "other" ],
+        project: "other"
+      )
+
+      @supervisor.send(:execute_dispatch, result, Update.new(chat_id: 42, update_id: 10))
+
+      assert_equal "No tasks for project other.", @telegram.messages.last.fetch(:text)
+    end
+  end
+
+  def test_execute_dispatch_surfaces_status_fetch_failure
+    @status_watcher.result = StatusResult.new(ok: false, rows: [], error: "envelope ok=false: pipeline timeout")
+    result = FakeRouter::Result.new(
+      action: :dispatch_then_reply,
+      command_argv: [ "hive", "status", "--json" ]
+    )
+
+    @supervisor.send(:execute_dispatch, result, Update.new(chat_id: 42, update_id: 10))
+
+    assert_equal "hive status unavailable: envelope ok=false: pipeline timeout",
+                 @telegram.messages.last.fetch(:text)
   end
 
   def test_execute_dispatch_renders_status_details_when_slug_is_present
@@ -911,6 +941,14 @@ class HiveBotSupervisorTest < Minitest::Test
     with_brainstorm_file(content: "## Round 1\n### Q1. Scope?\n### A1.\n") do |path, _project|
       assert_equal 1, @supervisor.send(:next_unanswered_question_n, path)
     end
+  end
+
+  def with_registered_projects(projects)
+    original = Hive::Config.method(:registered_projects)
+    Hive::Config.define_singleton_method(:registered_projects) { projects }
+    yield
+  ensure
+    Hive::Config.define_singleton_method(:registered_projects, original)
   end
 
   def test_interruptible_sleep_sleeps_until_flag_changes

--- a/test/unit/bot/supervisor_test.rb
+++ b/test/unit/bot/supervisor_test.rb
@@ -384,7 +384,7 @@ class HiveBotSupervisorTest < Minitest::Test
     assert_equal "Stopped because the previous command failed.", @telegram.messages.last.fetch(:text)
   end
 
-  def test_dispatch_command_sequence_resets_alert_before_dispatch
+  def test_dispatch_command_sequence_resets_alert_for_single_command
     result = FakeRouter::Result.new(
       action: :dispatch_commands,
       commands: [ [ "hive", "review", "task", "--json" ] ],
@@ -397,6 +397,61 @@ class HiveBotSupervisorTest < Minitest::Test
 
     assert_equal [ { project: "hive", slug: "task", stage: "6-review" } ], @notification_dispatcher.reset_tasks
     assert_equal [ "hive", "review", "task", "--json" ], @child_supervisor.dispatched.first.fetch(:command_argv)
+  end
+
+  def test_dispatch_command_sequence_defers_alert_reset_until_markers_clear_succeeds
+    # markers-clear (pid 200) completes with exit 0; retry verb is fire-and-forget.
+    @child_supervisor.dispatch_pid = 200
+    @child_supervisor.completed[200] = child_exit(exit_code: 0, pid: 200)
+    reset_snapshot_at_dispatch = []
+    notification = @notification_dispatcher
+    dispatched_list = @child_supervisor.dispatched
+    dispatch_pid_value = @child_supervisor.dispatch_pid
+    @child_supervisor.define_singleton_method(:dispatch) do |**kwargs|
+      reset_snapshot_at_dispatch << notification.reset_tasks.dup
+      dispatched_list << kwargs
+      dispatch_pid_value
+    end
+
+    result = FakeRouter::Result.new(
+      action: :dispatch_commands,
+      commands: [
+        [ "hive", "markers", "clear", "task", "--name", "REVIEW_ERROR" ],
+        [ "hive", "review", "task", "--from", "6-review", "--json" ]
+      ],
+      project: "hive",
+      slug: "task",
+      alert_reset: { project: "hive", slug: "task", stage: "6-review" }
+    )
+
+    @supervisor.send(:dispatch_command_sequence, result, Update.new(chat_id: 42, update_id: 12))
+
+    assert_equal 2, @child_supervisor.dispatched.length
+    assert_equal [], reset_snapshot_at_dispatch[0],
+                 "reset_task must NOT have been called when the first command (markers clear) dispatches"
+    assert_equal [ { project: "hive", slug: "task", stage: "6-review" } ], reset_snapshot_at_dispatch[1],
+                 "reset_task must have been called exactly once before the retry verb dispatches"
+    assert_equal [ { project: "hive", slug: "task", stage: "6-review" } ], @notification_dispatcher.reset_tasks
+  end
+
+  def test_dispatch_command_sequence_skips_alert_reset_when_markers_clear_fails
+    @child_supervisor.completed[123] = child_exit(exit_code: 1, pid: 123)
+    result = FakeRouter::Result.new(
+      action: :dispatch_commands,
+      commands: [
+        [ "hive", "markers", "clear", "task" ],
+        [ "hive", "review", "task" ]
+      ],
+      project: "hive",
+      slug: "task",
+      alert_reset: { project: "hive", slug: "task", stage: "6-review" }
+    )
+
+    @supervisor.send(:dispatch_command_sequence, result, Update.new(chat_id: 42, update_id: 12))
+
+    assert_equal 1, @child_supervisor.dispatched.length, "retry verb must not run when markers-clear fails"
+    assert_empty @notification_dispatcher.reset_tasks,
+                 "alert reset must NOT fire when the markers-clear precursor fails"
   end
 
   def test_dispatch_command_sequence_clears_inline_keyboard_when_requested

--- a/test/unit/bot/supervisor_test.rb
+++ b/test/unit/bot/supervisor_test.rb
@@ -5,15 +5,19 @@ class HiveBotSupervisorTest < Minitest::Test
   include HiveTestHelper
 
   ChildExit = Hive::Bot::ChildSupervisor::ChildExit
-  Update = Struct.new(:chat_id, :update_id, keyword_init: true)
+  Update = Struct.new(:chat_id, :update_id, :message_id, keyword_init: true)
   Row = Struct.new(:project, :slug, :stage, :action, :action_label, :marker, :attrs, keyword_init: true)
   StatusResult = Struct.new(:ok, :rows, keyword_init: true)
 
-  FakeTelegram = Struct.new(:messages, :raise_on_send, keyword_init: true) do
+  FakeTelegram = Struct.new(:messages, :raise_on_send, :keyboard_clears, keyword_init: true) do
     def send_message(chat_id:, text:, reply_markup: nil)
       raise raise_on_send if raise_on_send
 
       messages << { chat_id: chat_id, text: text, reply_markup: reply_markup }
+    end
+
+    def edit_message_reply_markup(chat_id:, message_id:, reply_markup: nil)
+      (self.keyboard_clears ||= []) << { chat_id: chat_id, message_id: message_id, reply_markup: reply_markup }
     end
   end
 
@@ -44,7 +48,7 @@ class HiveBotSupervisorTest < Minitest::Test
 
   class FakeRouter
     Result = Struct.new(:action, :text, :reply_markup, :command_argv, :commands, :project, :slug,
-                        :question_n, :answer_text, :mode, :alert_reset, keyword_init: true)
+                        :question_n, :answer_text, :mode, :alert_reset, :clear_keyboard, keyword_init: true)
   end
 
   FakeChildSupervisor = Struct.new(:dispatch_pid, :dispatched, :completed, :reap_batches, keyword_init: true) do
@@ -363,6 +367,37 @@ class HiveBotSupervisorTest < Minitest::Test
 
     assert_equal [ { project: "hive", slug: "task", stage: "6-review" } ], @notification_dispatcher.reset_tasks
     assert_equal [ "hive", "review", "task", "--json" ], @child_supervisor.dispatched.first.fetch(:command_argv)
+  end
+
+  def test_dispatch_command_sequence_clears_inline_keyboard_when_requested
+    result = FakeRouter::Result.new(
+      action: :dispatch_commands,
+      commands: [ [ "hive", "review", "task", "--json" ] ],
+      project: "hive",
+      slug: "task",
+      clear_keyboard: true
+    )
+
+    @supervisor.send(:dispatch_command_sequence, result, Update.new(chat_id: 42, update_id: 12, message_id: 777))
+
+    assert_equal 1, @telegram.keyboard_clears.size, "edit_message_reply_markup must be called once"
+    clear = @telegram.keyboard_clears.first
+    assert_equal 42, clear.fetch(:chat_id)
+    assert_equal 777, clear.fetch(:message_id)
+    assert_nil clear.fetch(:reply_markup), "reply_markup must be nil to remove the inline keyboard"
+  end
+
+  def test_dispatch_command_sequence_does_not_clear_keyboard_without_flag
+    result = FakeRouter::Result.new(
+      action: :dispatch_commands,
+      commands: [ [ "hive", "develop", "task", "--json" ] ],
+      project: "hive",
+      slug: "task"
+    )
+
+    @supervisor.send(:dispatch_command_sequence, result, Update.new(chat_id: 42, update_id: 12, message_id: 777))
+
+    assert_nil @telegram.keyboard_clears, "edit_message_reply_markup must not be called when clear_keyboard is false/nil"
   end
 
   def test_queued_updates_filters_by_last_seen_and_allowlist

--- a/test/unit/bot/supervisor_test.rb
+++ b/test/unit/bot/supervisor_test.rb
@@ -239,8 +239,10 @@ class HiveBotSupervisorTest < Minitest::Test
     text = @supervisor.send(:render_queue, rows)
 
     assert_includes text, "12 active tasks"
-    assert_includes text, "hive/task-0 3-plan Develop COMPLETE"
+    assert_includes text, "Task 0… — Plan"
     assert_includes text, "+ 2 more tasks"
+    refute_includes text, "hive/task-0"
+    refute_includes text, "COMPLETE"
     refute_includes text, "done"
     refute_includes text, "running"
   end
@@ -267,7 +269,37 @@ class HiveBotSupervisorTest < Minitest::Test
     assert_nil pid
     assert_empty @child_supervisor.dispatched
     assert_includes @telegram.messages.last.fetch(:text), "1 active task"
-    refute_nil @telegram.messages.last.fetch(:reply_markup)
+    assert_nil @telegram.messages.last.fetch(:reply_markup)
+  end
+
+  def test_execute_dispatch_filters_status_by_project
+    rows = [ row(project: "hive", slug: "alpha-260525-abcd"), row(project: "other", slug: "beta-260525-abcd") ]
+    @status_watcher.result = StatusResult.new(ok: true, rows: rows)
+    result = FakeRouter::Result.new(
+      action: :dispatch_then_reply,
+      command_argv: [ "hive", "status", "--json", "--project", "other" ],
+      project: "other"
+    )
+
+    @supervisor.send(:execute_dispatch, result, Update.new(chat_id: 42, update_id: 10))
+
+    text = @telegram.messages.last.fetch(:text)
+    assert_includes text, "Beta… — Plan"
+    refute_includes text, "Alpha"
+    assert_nil @telegram.messages.last.fetch(:reply_markup)
+  end
+
+  def test_execute_dispatch_reports_no_tasks_for_filtered_project
+    @status_watcher.result = StatusResult.new(ok: true, rows: [ row(project: "hive", slug: "alpha") ])
+    result = FakeRouter::Result.new(
+      action: :dispatch_then_reply,
+      command_argv: [ "hive", "status", "--json", "--project", "missing" ],
+      project: "missing"
+    )
+
+    @supervisor.send(:execute_dispatch, result, Update.new(chat_id: 42, update_id: 10))
+
+    assert_equal "No tasks for project missing.", @telegram.messages.last.fetch(:text)
   end
 
   def test_execute_dispatch_renders_status_details_when_slug_is_present
@@ -442,14 +474,6 @@ class HiveBotSupervisorTest < Minitest::Test
     ok = @supervisor.send(:wait_for_child_success, 999, deadline: Time.now - 1)
 
     assert_equal false, ok
-  end
-
-  def test_queue_inline_keyboard_falls_back_to_details_callback_with_stage
-    keyboard = @supervisor.send(:queue_inline_keyboard, [ row(action: "unknown", action_label: nil) ])
-
-    button = keyboard.first.first
-    assert_equal "Details: hive/task", button.fetch(:text)
-    assert_equal "details:hive:task:3-plan", button.fetch(:callback_data)
   end
 
   def test_project_and_brainstorm_paths_resolve_registered_project

--- a/test/unit/bot/supervisor_test.rb
+++ b/test/unit/bot/supervisor_test.rb
@@ -523,6 +523,39 @@ class HiveBotSupervisorTest < Minitest::Test
                  "dry_run must not call reset_task even when alert_reset is present"
   end
 
+  def test_clear_inline_keyboard_swallows_telegram_errors
+    @telegram.define_singleton_method(:edit_message_reply_markup) do |*|
+      raise IOError, "telegram offline"
+    end
+    result = FakeRouter::Result.new(
+      action: :dispatch_commands,
+      commands: [ [ "hive", "develop", "task", "--json" ] ],
+      project: "hive",
+      slug: "task",
+      clear_keyboard: true
+    )
+
+    @supervisor.send(:dispatch_command_sequence, result, Update.new(chat_id: 42, update_id: 12, message_id: 777))
+
+    failure = @logger.events.find { |evt| evt[:name] == :send_failure }
+    refute_nil failure, ":send_failure must be logged when edit_message_reply_markup raises"
+    assert_equal "edit_message_reply_markup", failure[:payload][:source]
+    assert_equal 1, @child_supervisor.dispatched.length,
+                 "the command must still dispatch even when keyboard clear fails"
+  end
+
+  def test_registered_project_names_returns_empty_when_config_raises
+    original = Hive::Config.method(:registered_projects)
+    Hive::Config.define_singleton_method(:registered_projects) do
+      raise Hive::ConfigError, "synthetic"
+    end
+
+    assert_equal [], @supervisor.send(:registered_project_names),
+                 "config load errors during registered_project_names must yield []"
+  ensure
+    Hive::Config.define_singleton_method(:registered_projects, original) if original
+  end
+
   def test_dispatch_command_sequence_clears_inline_keyboard_when_requested
     result = FakeRouter::Result.new(
       action: :dispatch_commands,

--- a/test/unit/bot/supervisor_test.rb
+++ b/test/unit/bot/supervisor_test.rb
@@ -287,7 +287,7 @@ class HiveBotSupervisorTest < Minitest::Test
     @status_watcher.result = StatusResult.new(ok: true, rows: rows)
     result = FakeRouter::Result.new(
       action: :dispatch_then_reply,
-      command_argv: [ "hive", "status", "--json", "--project", "other" ],
+      command_argv: [ "hive", "status", "--json" ],
       project: "other"
     )
 
@@ -303,7 +303,7 @@ class HiveBotSupervisorTest < Minitest::Test
     @status_watcher.result = StatusResult.new(ok: true, rows: [ row(project: "hive", slug: "alpha") ])
     result = FakeRouter::Result.new(
       action: :dispatch_then_reply,
-      command_argv: [ "hive", "status", "--json", "--project", "missing" ],
+      command_argv: [ "hive", "status", "--json" ],
       project: "missing"
     )
 
@@ -319,7 +319,7 @@ class HiveBotSupervisorTest < Minitest::Test
       @status_watcher.result = StatusResult.new(ok: true, rows: [ row(project: "hive", slug: "alpha") ])
       result = FakeRouter::Result.new(
         action: :dispatch_then_reply,
-        command_argv: [ "hive", "status", "--json", "--project", "other" ],
+        command_argv: [ "hive", "status", "--json" ],
         project: "other"
       )
 
@@ -366,7 +366,7 @@ class HiveBotSupervisorTest < Minitest::Test
     @status_watcher.result = StatusResult.new(ok: true, rows: [], envelope: envelope)
     result = FakeRouter::Result.new(
       action: :dispatch_then_reply,
-      command_argv: [ "hive", "status", "--json", "--project", "hive" ],
+      command_argv: [ "hive", "status", "--json" ],
       project: "hive",
       format: :json
     )
@@ -505,6 +505,22 @@ class HiveBotSupervisorTest < Minitest::Test
     assert_equal 1, @child_supervisor.dispatched.length, "retry verb must not run when markers-clear fails"
     assert_empty @notification_dispatcher.reset_tasks,
                  "alert reset must NOT fire when the markers-clear precursor fails"
+  end
+
+  def test_dispatch_command_sequence_skips_alert_reset_in_dry_run
+    @supervisor.instance_variable_set(:@dry_run, true)
+    result = FakeRouter::Result.new(
+      action: :dispatch_commands,
+      commands: [ [ "hive", "develop", "task", "--json" ] ],
+      project: "hive",
+      slug: "task",
+      alert_reset: { project: "hive", slug: "task", stage: "4-execute" }
+    )
+
+    @supervisor.send(:dispatch_command_sequence, result, Update.new(chat_id: 42, update_id: 12))
+
+    assert_empty @notification_dispatcher.reset_tasks,
+                 "dry_run must not call reset_task even when alert_reset is present"
   end
 
   def test_dispatch_command_sequence_clears_inline_keyboard_when_requested

--- a/test/unit/bot/supervisor_test.rb
+++ b/test/unit/bot/supervisor_test.rb
@@ -7,7 +7,7 @@ class HiveBotSupervisorTest < Minitest::Test
   ChildExit = Hive::Bot::ChildSupervisor::ChildExit
   Update = Struct.new(:chat_id, :update_id, :message_id, keyword_init: true)
   Row = Struct.new(:project, :slug, :stage, :action, :action_label, :marker, :attrs, keyword_init: true)
-  StatusResult = Struct.new(:ok, :rows, :error, keyword_init: true)
+  StatusResult = Struct.new(:ok, :rows, :error, :envelope, keyword_init: true)
 
   FakeTelegram = Struct.new(:messages, :raise_on_send, :keyboard_clears, keyword_init: true) do
     def send_message(chat_id:, text:, reply_markup: nil)
@@ -48,7 +48,8 @@ class HiveBotSupervisorTest < Minitest::Test
 
   class FakeRouter
     Result = Struct.new(:action, :text, :reply_markup, :command_argv, :commands, :project, :slug,
-                        :question_n, :answer_text, :mode, :alert_reset, :clear_keyboard, keyword_init: true)
+                        :question_n, :answer_text, :mode, :alert_reset, :clear_keyboard, :format,
+                        keyword_init: true)
   end
 
   FakeChildSupervisor = Struct.new(:dispatch_pid, :dispatched, :completed, :reap_batches, keyword_init: true) do
@@ -326,6 +327,55 @@ class HiveBotSupervisorTest < Minitest::Test
 
       assert_equal "No tasks for project other.", @telegram.messages.last.fetch(:text)
     end
+  end
+
+  def test_execute_dispatch_renders_status_envelope_when_format_json
+    envelope = {
+      "schema" => "hive-status",
+      "schema_version" => 1,
+      "ok" => true,
+      "projects" => [
+        { "name" => "hive", "tasks" => [ { "slug" => "alpha" } ] },
+        { "name" => "other", "tasks" => [ { "slug" => "beta" } ] }
+      ]
+    }
+    @status_watcher.result = StatusResult.new(ok: true, rows: [], envelope: envelope)
+    result = FakeRouter::Result.new(
+      action: :dispatch_then_reply,
+      command_argv: [ "hive", "status", "--json" ],
+      format: :json
+    )
+
+    @supervisor.send(:execute_dispatch, result, Update.new(chat_id: 42, update_id: 10))
+
+    text = @telegram.messages.last.fetch(:text)
+    parsed = JSON.parse(text)
+    assert_equal "hive-status", parsed["schema"], "JSON reply must surface the raw envelope"
+    project_names = parsed["projects"].map { |p| p["name"] }
+    assert_equal %w[hive other], project_names
+  end
+
+  def test_execute_dispatch_renders_status_envelope_filtered_by_project_when_format_json
+    envelope = {
+      "schema" => "hive-status",
+      "projects" => [
+        { "name" => "hive", "tasks" => [ { "slug" => "alpha" } ] },
+        { "name" => "other", "tasks" => [ { "slug" => "beta" } ] }
+      ]
+    }
+    @status_watcher.result = StatusResult.new(ok: true, rows: [], envelope: envelope)
+    result = FakeRouter::Result.new(
+      action: :dispatch_then_reply,
+      command_argv: [ "hive", "status", "--json", "--project", "hive" ],
+      project: "hive",
+      format: :json
+    )
+
+    @supervisor.send(:execute_dispatch, result, Update.new(chat_id: 42, update_id: 10))
+
+    parsed = JSON.parse(@telegram.messages.last.fetch(:text))
+    assert_equal [ "hive" ], parsed["projects"].map { |p| p["name"] },
+                 "project filter must drop other projects from the JSON envelope"
   end
 
   def test_execute_dispatch_surfaces_status_fetch_failure

--- a/test/unit/bot/supervisor_test.rb
+++ b/test/unit/bot/supervisor_test.rb
@@ -32,15 +32,19 @@ class HiveBotSupervisorTest < Minitest::Test
   end
 
 
-  FakeNotificationDispatcher = Struct.new(:processed, keyword_init: true) do
+  FakeNotificationDispatcher = Struct.new(:processed, :reset_tasks, keyword_init: true) do
     def process_rows(rows)
       processed << rows
+    end
+
+    def reset_task(**kwargs)
+      reset_tasks << kwargs
     end
   end
 
   class FakeRouter
     Result = Struct.new(:action, :text, :reply_markup, :command_argv, :commands, :project, :slug,
-                        :question_n, :answer_text, :mode, keyword_init: true)
+                        :question_n, :answer_text, :mode, :alert_reset, keyword_init: true)
   end
 
   FakeChildSupervisor = Struct.new(:dispatch_pid, :dispatched, :completed, :reap_batches, keyword_init: true) do
@@ -92,7 +96,7 @@ class HiveBotSupervisorTest < Minitest::Test
     @status_watcher = FakeStatusWatcher.new(result: StatusResult.new(ok: true, rows: []))
     @child_supervisor = FakeChildSupervisor.new(dispatch_pid: 123, dispatched: [], completed: {}, reap_batches: [])
     @conversation_store = FakeConversationStore.new(starts: [], updates: [], states: {}, ttl_updates: [])
-    @notification_dispatcher = FakeNotificationDispatcher.new(processed: [])
+    @notification_dispatcher = FakeNotificationDispatcher.new(processed: [], reset_tasks: [])
     # Drive the real constructor so any future invariant added to
     # Supervisor#initialize is exercised by every test in this file. We
     # inject all collaborators so the constructor's `||=` defaults never
@@ -175,9 +179,10 @@ class HiveBotSupervisorTest < Minitest::Test
     @supervisor.send(:reply_for_child, child_exit(envelope: envelope))
 
     text = @telegram.messages.first.fetch(:text)
-    assert_includes text, "REVIEW_ERROR phase=fix pass=1"
-    assert_includes text, "fix attempt timed out"
-    assert_includes text, "Path: /tmp/red-status.md"
+    assert_equal 'Diagnosis is available for "Red task…". Open this task on a laptop for full details.', text
+    refute_includes text, "REVIEW_ERROR"
+    refute_includes text, "fix attempt timed out"
+    refute_includes text, "/tmp/red-status.md"
     refute_includes text, "Command completed"
   end
 
@@ -343,6 +348,21 @@ class HiveBotSupervisorTest < Minitest::Test
 
     assert_equal 1, @child_supervisor.dispatched.length
     assert_equal "Stopped because the previous command failed.", @telegram.messages.last.fetch(:text)
+  end
+
+  def test_dispatch_command_sequence_resets_alert_before_dispatch
+    result = FakeRouter::Result.new(
+      action: :dispatch_commands,
+      commands: [ [ "hive", "review", "task", "--json" ] ],
+      project: "hive",
+      slug: "task",
+      alert_reset: { project: "hive", slug: "task", stage: "6-review" }
+    )
+
+    @supervisor.send(:dispatch_command_sequence, result, Update.new(chat_id: 42, update_id: 12))
+
+    assert_equal [ { project: "hive", slug: "task", stage: "6-review" } ], @notification_dispatcher.reset_tasks
+    assert_equal [ "hive", "review", "task", "--json" ], @child_supervisor.dispatched.first.fetch(:command_argv)
   end
 
   def test_queued_updates_filters_by_last_seen_and_allowlist

--- a/test/unit/bot/supervisor_test.rb
+++ b/test/unit/bot/supervisor_test.rb
@@ -395,7 +395,8 @@ class HiveBotSupervisorTest < Minitest::Test
 
     @supervisor.send(:dispatch_command_sequence, result, Update.new(chat_id: 42, update_id: 12))
 
-    assert_equal [ { project: "hive", slug: "task", stage: "6-review" } ], @notification_dispatcher.reset_tasks
+    assert_equal [ { project: "hive", slug: "task", stage: "6-review", marker: nil, match_attr: nil } ],
+                 @notification_dispatcher.reset_tasks
     assert_equal [ "hive", "review", "task", "--json" ], @child_supervisor.dispatched.first.fetch(:command_argv)
   end
 
@@ -429,9 +430,11 @@ class HiveBotSupervisorTest < Minitest::Test
     assert_equal 2, @child_supervisor.dispatched.length
     assert_equal [], reset_snapshot_at_dispatch[0],
                  "reset_task must NOT have been called when the first command (markers clear) dispatches"
-    assert_equal [ { project: "hive", slug: "task", stage: "6-review" } ], reset_snapshot_at_dispatch[1],
+    assert_equal [ { project: "hive", slug: "task", stage: "6-review", marker: nil, match_attr: nil } ],
+                 reset_snapshot_at_dispatch[1],
                  "reset_task must have been called exactly once before the retry verb dispatches"
-    assert_equal [ { project: "hive", slug: "task", stage: "6-review" } ], @notification_dispatcher.reset_tasks
+    assert_equal [ { project: "hive", slug: "task", stage: "6-review", marker: nil, match_attr: nil } ],
+                 @notification_dispatcher.reset_tasks
   end
 
   def test_dispatch_command_sequence_skips_alert_reset_when_markers_clear_fails

--- a/test/unit/bot/title_formatter_test.rb
+++ b/test/unit/bot/title_formatter_test.rb
@@ -1,0 +1,47 @@
+require "test_helper"
+require "hive/bot/title_formatter"
+
+class HiveBotTitleFormatterTest < Minitest::Test
+  def test_title_from_slug_strips_generated_suffix_and_sentence_cases
+    assert_equal "We need to improve this…",
+                 Hive::Bot::TitleFormatter.title_from_slug("we-need-to-improve-this-260522-db23")
+    assert_equal "This kind of errors are…",
+                 Hive::Bot::TitleFormatter.title_from_slug("this-kind-of-errors-are-260523-01fa")
+    assert_equal "Task…",
+                 Hive::Bot::TitleFormatter.title_from_slug("task-260424-aaaa")
+    assert_equal "No suffix here…",
+                 Hive::Bot::TitleFormatter.title_from_slug("no-suffix-here")
+  end
+
+  def test_title_from_slug_caps_prefix_at_sixty_characters
+    title = Hive::Bot::TitleFormatter.title_from_slug("#{"a" * 70}-260101-abcd")
+
+    assert_equal "#{"A" + ("a" * 59)}…", title
+  end
+
+  def test_stage_label_uses_known_stage_names
+    assert_equal "Review", Hive::Bot::TitleFormatter.stage_label("6-review")
+    assert_equal "Open PR", Hive::Bot::TitleFormatter.stage_label("5-open-pr")
+  end
+
+  def test_stage_label_falls_back_and_logs_unknown_stage_once
+    logger = StubLogger.new
+
+    assert_equal "Future", Hive::Bot::TitleFormatter.stage_label("99-future", logger: logger)
+    assert_equal "Future", Hive::Bot::TitleFormatter.stage_label("99-future", logger: logger)
+
+    assert_equal [ [ :unknown_stage_label, { stage: "99-future" } ] ], logger.events
+  end
+
+  class StubLogger
+    attr_reader :events
+
+    def initialize
+      @events = []
+    end
+
+    def event(name, **attrs)
+      @events << [ name, attrs ]
+    end
+  end
+end

--- a/test/unit/bot/title_formatter_test.rb
+++ b/test/unit/bot/title_formatter_test.rb
@@ -26,11 +26,25 @@ class HiveBotTitleFormatterTest < Minitest::Test
 
   def test_stage_label_falls_back_and_logs_unknown_stage_once
     logger = StubLogger.new
+    Hive::Bot::TitleFormatter.reset_unknown_stage_log_cache!
 
     assert_equal "Future", Hive::Bot::TitleFormatter.stage_label("99-future", logger: logger)
     assert_equal "Future", Hive::Bot::TitleFormatter.stage_label("99-future", logger: logger)
 
     assert_equal [ [ :unknown_stage_label, { stage: "99-future" } ] ], logger.events
+  end
+
+  def test_reset_unknown_stage_log_cache_re_arms_logging
+    logger = StubLogger.new
+    Hive::Bot::TitleFormatter.reset_unknown_stage_log_cache!
+    Hive::Bot::TitleFormatter.stage_label("88-mystery", logger: logger)
+    Hive::Bot::TitleFormatter.stage_label("88-mystery", logger: logger)
+    assert_equal 1, logger.events.size, "second call must be deduped by the cache"
+
+    Hive::Bot::TitleFormatter.reset_unknown_stage_log_cache!
+    Hive::Bot::TitleFormatter.stage_label("88-mystery", logger: logger)
+    assert_equal 2, logger.events.size,
+                 "after reset, the same unknown stage_dir must log again so SIGHUP / reload surfaces it"
   end
 
   class StubLogger

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -1584,7 +1584,7 @@ class ConfigTest < Minitest::Test
       assert_equal 30, cfg.dig("bot", "poll_interval_sec")
       assert_equal 25, cfg.dig("bot", "long_poll_timeout_sec")
       assert_equal 300, cfg.dig("bot", "notification_dedupe_window_sec")
-      assert_equal File.expand_path("~/Dev/hive/.bot.alert_state.json"), cfg.dig("bot", "alert_state_file")
+      assert_equal File.join(Hive::Paths.state_home, ".bot.alert_state.json"), cfg.dig("bot", "alert_state_file")
       assert_equal 28_800, cfg.dig("bot", "recovery_reminder_window_sec")
       assert_equal 3600, cfg.dig("bot", "conversation_ttl_sec")
       assert_equal 1, cfg.dig("bot", "codex_budget_usd")

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -1583,7 +1583,8 @@ class ConfigTest < Minitest::Test
       assert_equal [], cfg.dig("bot", "chat_id_allowlist")
       assert_equal 30, cfg.dig("bot", "poll_interval_sec")
       assert_equal 25, cfg.dig("bot", "long_poll_timeout_sec")
-      assert_equal 300, cfg.dig("bot", "notification_dedupe_window_sec")
+      assert_nil cfg.dig("bot", "notification_dedupe_window_sec"),
+                 "notification_dedupe_window_sec is deprecated and must be absent from DEFAULTS"
       assert_equal File.join(Hive::Paths.state_home, ".bot.alert_state.json"), cfg.dig("bot", "alert_state_file")
       assert_equal 28_800, cfg.dig("bot", "recovery_reminder_window_sec")
       assert_equal 3600, cfg.dig("bot", "conversation_ttl_sec")
@@ -1843,5 +1844,27 @@ class ConfigTest < Minitest::Test
 
     assert_match(/claude\.mode must be one of/, err.message)
     assert_match(/warm_pool/, err.message)
+  end
+
+  # ── deprecated_bot_keys ──────────────────────────────────────────────────
+
+  def test_deprecated_bot_keys_returns_empty_array_when_bot_is_nil
+    result = Hive::Config.deprecated_bot_keys(nil)
+    assert_equal [], result,
+                   "nil bot config must return empty deprecated list"
+  end
+
+  def test_deprecated_bot_keys_returns_empty_array_when_key_absent
+    result = Hive::Config.deprecated_bot_keys({})
+    assert_equal [], result,
+                   "bot config without notification_dedupe_window_sec must return empty deprecated list"
+  end
+
+  def test_deprecated_bot_keys_flags_non_default_notification_dedupe_window_sec
+    result = Hive::Config.deprecated_bot_keys({ "notification_dedupe_window_sec" => 600 })
+    assert_equal 1, result.size,
+                 "non-default notification_dedupe_window_sec must appear in deprecated list"
+    assert_equal "bot.notification_dedupe_window_sec", result.first[:key]
+    assert_includes result.first[:replacement], "alert_state_file"
   end
 end

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -1867,4 +1867,17 @@ class ConfigTest < Minitest::Test
     assert_equal "bot.notification_dedupe_window_sec", result.first[:key]
     assert_includes result.first[:replacement], "alert_state_file"
   end
+
+  def test_warn_deprecated_bot_dedupe_writes_one_stderr_line_per_deprecated_entry
+    captured = +""
+    Hive::Config.singleton_class.send(:public, :warn_deprecated_bot_dedupe!)
+    $stderr = StringIO.new(captured)
+    Hive::Config.warn_deprecated_bot_dedupe!({ "notification_dedupe_window_sec" => 600 }, "/tmp/hive-config.yml")
+    assert_match(/hive: bot\.notification_dedupe_window_sec.*deprecated.*alert_state_file/,
+                 captured,
+                 "warn_deprecated_bot_dedupe! must emit one stderr line per deprecated key")
+  ensure
+    $stderr = STDERR
+    Hive::Config.singleton_class.send(:private, :warn_deprecated_bot_dedupe!)
+  end
 end

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -1584,6 +1584,8 @@ class ConfigTest < Minitest::Test
       assert_equal 30, cfg.dig("bot", "poll_interval_sec")
       assert_equal 25, cfg.dig("bot", "long_poll_timeout_sec")
       assert_equal 300, cfg.dig("bot", "notification_dedupe_window_sec")
+      assert_equal File.expand_path("~/Dev/hive/.bot.alert_state.json"), cfg.dig("bot", "alert_state_file")
+      assert_equal 28_800, cfg.dig("bot", "recovery_reminder_window_sec")
       assert_equal 3600, cfg.dig("bot", "conversation_ttl_sec")
       assert_equal 1, cfg.dig("bot", "codex_budget_usd")
       assert_equal 120, cfg.dig("bot", "codex_timeout_sec")
@@ -1671,6 +1673,7 @@ class ConfigTest < Minitest::Test
 
       assert_equal File.join(dir, ".bot.pid"), cfg["pid_file"]
       assert_equal File.join(dir, "logs", "bot.log"), cfg["log_file"]
+      assert_equal File.join(dir, ".bot.alert_state.json"), cfg["alert_state_file"]
       assert_equal File.join(dir, ".bot.last_seen_update_id"), cfg["last_seen_state_file"]
     ensure
       ENV["HIVE_HOME"] = old

--- a/wiki/commands/bot.md
+++ b/wiki/commands/bot.md
@@ -78,6 +78,14 @@ bot:
 alert lifecycle dedupe is status-driven and persisted in
 `alert_state_file`.
 
+On a fresh install (or after the operator deletes `alert_state_file`)
+the first status tick **silently seeds** every currently-failing row
+into the store and emits a single `:fresh_install_seeded` log event
+instead of firing an alert per backlog row. Subsequent ticks alert on
+deltas only. To suppress this and force an alert for every active row
+on first start, do not configure `alert_state_file` (running without
+persistence means every restart is a burst — accept the trade-off).
+
 `HIVE_TELEGRAM_BOT_TOKEN` is the only supported token source. Missing
 token or empty allowlist makes `hive bot start` raise `Hive::ConfigError`
 (exit 78). Unknown chat IDs are logged once per bot lifetime and ignored

--- a/wiki/commands/bot.md
+++ b/wiki/commands/bot.md
@@ -35,8 +35,8 @@ hive bot tail
 
 | Slash command | Behavior |
 |--------------|----------|
-| `/status` | Renders the active cross-project queue from `hive status --json`. |
-| `/queue` | Same queue view, focused on actionable waiting/recovery rows. |
+| `/status [project]` | Renders actionable rows from `hive status --json` as `Title... — Stage`; when a project name is supplied, filters to that project. |
+| `/queue` | Same actionable-row view as `/status`, without a project filter. |
 | `/idea <text>` | Shows a project picker. Tapping a project dispatches `hive new <project> <text>`. |
 | `/answer <slug>` | Starts Path B brainstorm answering; each free-text reply writes the current unanswered `### A<N>.` block under the task lock. |
 | `/approve <slug>` | Dispatches `hive approve <slug> --json` for the direct approval surface. Inline approval buttons usually use the workflow verb instead. |
@@ -48,12 +48,12 @@ Free text outside an active answer conversation is rejected with a
 
 ## Inline actions
 
-Notifications and `/queue` rows use callback data that routes to:
+Push notifications use callback data that routes to:
 
 - Stage approvals: `Approve` dispatches `hive brainstorm|plan|develop|review|pr|archive <slug> --from <stage> --project <project> --json`.
 - Brainstorm waits: `Answer in chat` starts the same `/answer` conversation.
 - Review triage: `Accept all` / `Reject all` dispatch `hive accept-finding` or `hive reject-finding` with `--all`.
-- Recovery markers: `Clear and retry` dispatches `hive markers clear ... --name <MARKER> --json`, then dispatches the stage's workflow verb when one exists.
+- Recovery markers: `Autofix` dispatches `hive markers clear ... --name <MARKER> --json` when the marker is clearable, then dispatches the stage's workflow verb when one exists. Legacy `Clear and retry` buttons from older messages still route to the same recovery sequence.
 - `Open laptop` is an explicit no-op reply for disagreements that do not fit the MVP button set.
 
 ## Config
@@ -67,10 +67,16 @@ bot:
   poll_interval_sec: 30
   long_poll_timeout_sec: 25
   notification_dedupe_window_sec: 300
+  alert_state_file: ~/.local/state/hive/.bot.alert_state.json
+  recovery_reminder_window_sec: 28800
   pid_file: ~/.local/state/hive/.bot.pid
   log_file: ~/.local/state/hive/logs/bot.log
   last_seen_state_file: ~/.local/state/hive/.bot.last_seen_update_id
 ```
+
+`notification_dedupe_window_sec` is legacy compatibility surface; current
+alert lifecycle dedupe is status-driven and persisted in
+`alert_state_file`.
 
 `HIVE_TELEGRAM_BOT_TOKEN` is the only supported token source. Missing
 token or empty allowlist makes `hive bot start` raise `Hive::ConfigError`

--- a/wiki/commands/bot.md
+++ b/wiki/commands/bot.md
@@ -35,7 +35,7 @@ hive bot tail
 
 | Slash command | Behavior |
 |--------------|----------|
-| `/status [project]` | Renders actionable rows from `hive status --json` as `Title... — Stage`; when a project name is supplied, filters to that project. |
+| `/status [project]` | Renders actionable rows from `hive status --json` as `Title… — Stage`; when a project name is supplied, filters to that project. |
 | `/queue` | Same actionable-row view as `/status`, without a project filter. |
 | `/idea <text>` | Shows a project picker. Tapping a project dispatches `hive new <project> <text>`. |
 | `/answer <slug>` | Starts Path B brainstorm answering; each free-text reply writes the current unanswered `### A<N>.` block under the task lock. |

--- a/wiki/commands/bot.md
+++ b/wiki/commands/bot.md
@@ -35,7 +35,7 @@ hive bot tail
 
 | Slash command | Behavior |
 |--------------|----------|
-| `/status [project]` | Renders actionable rows from `hive status --json` as `Title… — Stage`; when a project name is supplied, filters to that project. |
+| `/status [--json] [project]` | Renders actionable rows from `hive status --json` as `Title… — Stage`; when a project name is supplied, filters to that project. Pass `--json` to receive the raw `hive-status` envelope instead of human prose (intended for automated callers). |
 | `/queue` | Same actionable-row view as `/status`, without a project filter. |
 | `/idea <text>` | Shows a project picker. Tapping a project dispatches `hive new <project> <text>`. |
 | `/answer <slug>` | Starts Path B brainstorm answering; each free-text reply writes the current unanswered `### A<N>.` block under the task lock. |

--- a/wiki/commands/bot.md
+++ b/wiki/commands/bot.md
@@ -3,7 +3,7 @@ title: hive bot
 type: command
 source: lib/hive/commands/bot.rb, lib/hive/bot/*
 created: 2026-05-14
-updated: 2026-05-14
+updated: 2026-05-25
 tags: [command, bot, telegram, mobile, json]
 ---
 

--- a/wiki/commands/bot.md
+++ b/wiki/commands/bot.md
@@ -53,7 +53,7 @@ Push notifications use callback data that routes to:
 - Stage approvals: `Approve` dispatches `hive brainstorm|plan|develop|review|pr|archive <slug> --from <stage> --project <project> --json`.
 - Brainstorm waits: `Answer in chat` starts the same `/answer` conversation.
 - Review triage: `Accept all` / `Reject all` dispatch `hive accept-finding` or `hive reject-finding` with `--all`.
-- Recovery markers: `Autofix` dispatches `hive markers clear ... --name <MARKER> --json` when the marker is clearable, then dispatches the stage's workflow verb when one exists. Legacy `Clear and retry` buttons from older messages still route to the same recovery sequence.
+- Recovery markers: `Autofix` appears only when the diagnostic suggested action is `retry`. It dispatches `hive markers clear ... --name <MARKER> --match-attr <key=value> --json` when a marker attribute is available, then dispatches the stage's workflow verb when one exists and resets the persisted alert entry for that task. Manual-only recovery states show `Open laptop` / `Show details`; legacy `Clear and retry` buttons from older messages still route to the same guarded recovery sequence.
 - `Open laptop` is an explicit no-op reply for disagreements that do not fit the MVP button set.
 
 ## Config

--- a/wiki/commands/bot.md
+++ b/wiki/commands/bot.md
@@ -35,7 +35,7 @@ hive bot tail
 
 | Slash command | Behavior |
 |--------------|----------|
-| `/status [--json] [project]` | Renders actionable rows from `hive status --json` as `Title… — Stage`; when a project name is supplied, filters to that project. Pass `--json` to receive the raw `hive-status` envelope instead of human prose (intended for automated callers). |
+| `/status [--json] [project]` | Renders actionable rows from `hive status --json` as `Title… — Stage`; when a project name is supplied, filters to that project. Pass `--json` to receive the raw `hive-status` envelope instead of human prose (intended for automated callers). The prose form is intentionally not a versioned contract — automated tooling that needs a stable shape MUST use `--json`, which echoes the `hive-status` envelope schema. |
 | `/queue` | Same actionable-row view as `/status`, without a project filter. |
 | `/idea <text>` | Shows a project picker. Tapping a project dispatches `hive new <project> <text>`. |
 | `/answer <slug>` | Starts Path B brainstorm answering; each free-text reply writes the current unanswered `### A<N>.` block under the task lock. |
@@ -96,6 +96,14 @@ silently.
 `~/.local/state/hive/logs/bot.log` is one JSON document per line with schema
 `hive-bot-log.v1`. The event enum is closed in
 `Hive::Bot::Logger::EVENTS`; unknown events raise at the call site.
+
+The schema evolves additively: new event values may be appended to
+`v1` without changing `schema_version`. Breaking changes (removing an
+event, renaming it, or changing the payload shape of an existing
+event) require a `v2` schema file alongside `v1`, bumped `$id`, and
+synchronized `schema_version` constant. Downstream consumers that pin
+on the `$id` URL must therefore tolerate unknown event values when
+parsing v1; that's the read-side compat invariant.
 Events include `bot_started`, `poll_failure`, `update_received`,
 `notification_sent`, `dispatched_command`, `command_completed`,
 `codex_spawned`, `answer_written`, `reconnect_summary`, and `fatal`.

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1992,7 +1992,7 @@ chruby and RVM are intentionally not handled — they modify PATH per-shell and 
 
 ## [2026-05-25T15:45:00Z] bot — human-readable recovery alerts
 
-**Action:** Replaced bot recovery push alerts with a short human-readable template and a single Autofix button, moved alert dedupe to a persistent status-driven store, added one 8 h reminder per unchanged recovery fingerprint, and made `/status [project]` render clean `Title... — Stage` lines without inline buttons.
+**Action:** Replaced bot recovery push alerts with a short human-readable template and a single Autofix button, moved alert dedupe to a persistent status-driven store, added one 8 h reminder per unchanged recovery fingerprint, and made `/status [project]` render clean `Title… — Stage` lines without inline buttons.
 
 **Refreshed pages:**
 - [[modules/bot]]

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1990,7 +1990,23 @@ chruby and RVM are intentionally not handled — they modify PATH per-shell and 
 - [[commands/status]]
 - [[stages/open-pr]]
 
-<<<<<<< HEAD
+## [2026-05-25T15:45:00Z] bot — human-readable recovery alerts
+
+**Action:** Replaced bot recovery push alerts with a short human-readable template and a single Autofix button, moved alert dedupe to a persistent status-driven store, added one 8 h reminder per unchanged recovery fingerprint, and made `/status [project]` render clean `Title... — Stage` lines without inline buttons.
+
+**Refreshed pages:**
+- [[modules/bot]]
+- [[commands/bot]]
+
+## [2026-05-25T16:40:00Z] bot — guarded Autofix alert lifecycle
+
+**Action:** Guarded recovery Autofix behind retry diagnostics, carried marker match attributes into Telegram retry callbacks, reset persisted alert state before retry dispatch, treated same-task recovery fingerprint changes as superseded instead of recovered, and hardened alert-store/fanout failure handling.
+
+**Refreshed pages:**
+- [[modules/bot]]
+- [[commands/bot]]
+- [[state-model]]
+
 ## [2026-05-25T18:40:00Z] review — auto-commit successful fix-agent edits
 
 **Action:** Changed Phase 4 review recovery so a successful fix agent that leaves dirty worktree files is auto-committed by Hive with the rollback-rate trailers before fix guardrails run, instead of landing repeated `fix_dirty_worktree` errors.
@@ -2013,12 +2029,3 @@ chruby and RVM are intentionally not handled — they modify PATH per-shell and 
 
 **Refreshed pages:**
 - [[stages/review]]
-=======
-## [2026-05-25T15:45:00Z] bot — human-readable recovery alerts
-
-**Action:** Replaced bot recovery push alerts with a short human-readable template and a single Autofix button, moved alert dedupe to a persistent status-driven store, added one 8 h reminder per unchanged recovery fingerprint, and made `/status [project]` render clean `Title... — Stage` lines without inline buttons.
-
-**Refreshed pages:**
-- [[modules/bot]]
-- [[commands/bot]]
->>>>>>> 7197f40e (docs(wiki): document bot alert lifecycle)

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1990,6 +1990,7 @@ chruby and RVM are intentionally not handled — they modify PATH per-shell and 
 - [[commands/status]]
 - [[stages/open-pr]]
 
+<<<<<<< HEAD
 ## [2026-05-25T18:40:00Z] review — auto-commit successful fix-agent edits
 
 **Action:** Changed Phase 4 review recovery so a successful fix agent that leaves dirty worktree files is auto-committed by Hive with the rollback-rate trailers before fix guardrails run, instead of landing repeated `fix_dirty_worktree` errors.
@@ -2012,3 +2013,12 @@ chruby and RVM are intentionally not handled — they modify PATH per-shell and 
 
 **Refreshed pages:**
 - [[stages/review]]
+=======
+## [2026-05-25T15:45:00Z] bot — human-readable recovery alerts
+
+**Action:** Replaced bot recovery push alerts with a short human-readable template and a single Autofix button, moved alert dedupe to a persistent status-driven store, added one 8 h reminder per unchanged recovery fingerprint, and made `/status [project]` render clean `Title... — Stage` lines without inline buttons.
+
+**Refreshed pages:**
+- [[modules/bot]]
+- [[commands/bot]]
+>>>>>>> 7197f40e (docs(wiki): document bot alert lifecycle)

--- a/wiki/modules/bot.md
+++ b/wiki/modules/bot.md
@@ -22,8 +22,9 @@ and subprocess I/O.
 | `Router` | `lib/hive/bot/router.rb` | Closed-enum intent classifier and pure dispatch into slash/callback/free-text handlers. Performs allowlist auth before any handler sees an update. |
 | `Handlers::*` | `lib/hive/bot/handlers/` | Slash command, callback, and free-text logic returning descriptors; no direct Telegram I/O. |
 | `StatusWatcher` | `lib/hive/bot/status_watcher.rb` | Runs `hive status --json`, validates the envelope, returns typed rows. |
-| `NotificationDispatcher` | `lib/hive/bot/notification_dispatcher.rb` | Dedupe and send newly-entered waiting/recovery/ready rows. Suppresses ready notifications when the daemon is enabled for that project. |
-| `NotificationBuilders` | `lib/hive/bot/notification_builders.rb` | Marker/action-specific text and inline keyboards. Fingerprints rows by project/slug/marker/attrs. |
+| `NotificationDispatcher` | `lib/hive/bot/notification_dispatcher.rb` | Sends newly-entered waiting/recovery/ready rows through a persistent alert lifecycle store. Suppresses ready notifications when the daemon is enabled for that project, sends one recovery confirmation when a recovery row leaves the active set, and sends one 8 h reminder for unchanged recovery rows. |
+| `AlertStore` | `lib/hive/bot/alert_store.rb` | JSON sidecar for alert fingerprints, first-seen timestamps, reminder timestamps, and row snapshots. Corrupt files are renamed aside so the bot keeps running. |
+| `NotificationBuilders` | `lib/hive/bot/notification_builders.rb` | Marker/action-specific text and inline keyboards. Recovery alerts are human-readable and expose only a single Autofix button; fingerprints include project, slug, stage, marker, and marker attrs. |
 | `BrainstormParser` | `lib/hive/bot/brainstorm_parser.rb` | Pure parser for `## Round`, `### Q<N>.`, and `### A<N>.` blocks. |
 | `BrainstormAnswerWriter` | `lib/hive/bot/brainstorm_answer_writer.rb` | Locked, first-write-wins insertion into the next answer block, with atomic rewrite. |
 | `ConversationStore` | `lib/hive/bot/conversation_store.rb` | In-memory per-chat active answer/Codex state with TTL. No sidecar file; `brainstorm.md` stays canonical. |
@@ -44,6 +45,15 @@ hive bot start
             ├─ status loop: hive status --json → NotificationDispatcher
             └─ reaper loop: ChildSupervisor.reap_all → Telegram reply
 ```
+
+Recovery push notifications intentionally hide marker attrs, exception
+classes, phase names, and diagnostic summaries. The operator-facing
+message is `Stage stuck`, one plain-language cause sentence, and a
+single `Autofix` button. Tapping Autofix still dispatches the same
+trusted CLI sequence: clear the marker when it is clearable, then run
+the workflow verb for the row's stage. `/status [project]` is an
+explicit pull surface and renders actionable rows as `Title... — Stage`
+without inline buttons.
 
 ## Trust boundary
 

--- a/wiki/modules/bot.md
+++ b/wiki/modules/bot.md
@@ -56,7 +56,7 @@ Autofix callbacks carry a marker attribute such as `pass=2` when one is
 available, so stale Telegram buttons cannot clear a newer marker, and
 the dispatcher clears the persisted alert entry for that task before
 spawning the retry sequence. `/status [project]` is an explicit pull
-surface and renders actionable rows as `Title... — Stage` without inline
+surface and renders actionable rows as `Title… — Stage` without inline
 buttons.
 
 ## Trust boundary

--- a/wiki/modules/bot.md
+++ b/wiki/modules/bot.md
@@ -22,9 +22,9 @@ and subprocess I/O.
 | `Router` | `lib/hive/bot/router.rb` | Closed-enum intent classifier and pure dispatch into slash/callback/free-text handlers. Performs allowlist auth before any handler sees an update. |
 | `Handlers::*` | `lib/hive/bot/handlers/` | Slash command, callback, and free-text logic returning descriptors; no direct Telegram I/O. |
 | `StatusWatcher` | `lib/hive/bot/status_watcher.rb` | Runs `hive status --json`, validates the envelope, returns typed rows. |
-| `NotificationDispatcher` | `lib/hive/bot/notification_dispatcher.rb` | Sends newly-entered waiting/recovery/ready rows through a persistent alert lifecycle store. Suppresses ready notifications when the daemon is enabled for that project, sends one recovery confirmation when a recovery row leaves the active set, and sends one 8 h reminder for unchanged recovery rows. |
+| `NotificationDispatcher` | `lib/hive/bot/notification_dispatcher.rb` | Sends newly-entered waiting/recovery/ready rows through a persistent alert lifecycle store. Suppresses ready notifications when the daemon is enabled for that project, sends one recovery confirmation when a recovery row leaves the active set, treats same-task recovery fingerprint changes as superseded rather than recovered, and sends one reminder for unchanged recovery rows. |
 | `AlertStore` | `lib/hive/bot/alert_store.rb` | JSON sidecar for alert fingerprints, first-seen timestamps, reminder timestamps, and row snapshots. Corrupt files are renamed aside so the bot keeps running. |
-| `NotificationBuilders` | `lib/hive/bot/notification_builders.rb` | Marker/action-specific text and inline keyboards. Recovery alerts are human-readable and expose only a single Autofix button; fingerprints include project, slug, stage, marker, and marker attrs. |
+| `NotificationBuilders` | `lib/hive/bot/notification_builders.rb` | Marker/action-specific text and inline keyboards. Recovery alerts are human-readable; Autofix is exposed only when the diagnostic `suggested_next_action.kind` is `retry`, while manual-only states show laptop/details actions. Fingerprints include project, slug, stage, marker, and marker attrs. |
 | `BrainstormParser` | `lib/hive/bot/brainstorm_parser.rb` | Pure parser for `## Round`, `### Q<N>.`, and `### A<N>.` blocks. |
 | `BrainstormAnswerWriter` | `lib/hive/bot/brainstorm_answer_writer.rb` | Locked, first-write-wins insertion into the next answer block, with atomic rewrite. |
 | `ConversationStore` | `lib/hive/bot/conversation_store.rb` | In-memory per-chat active answer/Codex state with TTL. No sidecar file; `brainstorm.md` stays canonical. |
@@ -47,13 +47,17 @@ hive bot start
 ```
 
 Recovery push notifications intentionally hide marker attrs, exception
-classes, phase names, and diagnostic summaries. The operator-facing
-message is `Stage stuck`, one plain-language cause sentence, and a
-single `Autofix` button. Tapping Autofix still dispatches the same
-trusted CLI sequence: clear the marker when it is clearable, then run
-the workflow verb for the row's stage. `/status [project]` is an
-explicit pull surface and renders actionable rows as `Title... — Stage`
-without inline buttons.
+classes, phase names, diagnostic summaries, and diagnostic artifact
+paths. The operator-facing message is `Stage stuck` plus one
+plain-language cause sentence. `Autofix` is shown only for retryable
+diagnostics; manual-only states such as `EXECUTE_STALE` and
+fix-tampered review errors show `Open laptop` / `Show details` instead.
+Autofix callbacks carry a marker attribute such as `pass=2` when one is
+available, so stale Telegram buttons cannot clear a newer marker, and
+the dispatcher clears the persisted alert entry for that task before
+spawning the retry sequence. `/status [project]` is an explicit pull
+surface and renders actionable rows as `Title... — Stage` without inline
+buttons.
 
 ## Trust boundary
 

--- a/wiki/modules/bot.md
+++ b/wiki/modules/bot.md
@@ -3,7 +3,7 @@ title: Hive::Bot
 type: module
 source: lib/hive/bot/
 created: 2026-05-14
-updated: 2026-05-14
+updated: 2026-05-25
 tags: [bot, telegram, module, mobile]
 ---
 

--- a/wiki/state-model.md
+++ b/wiki/state-model.md
@@ -3,7 +3,7 @@ title: State Model
 type: data-model
 source: lib/hive/task.rb, lib/hive/markers.rb, lib/hive/config.rb, lib/hive/lock.rb, lib/hive/worktree.rb, lib/hive/metrics.rb, lib/hive/bot/*
 created: 2026-04-25
-updated: 2026-05-23
+updated: 2026-05-25
 tags: [state, filesystem, model, architecture, review]
 ---
 
@@ -157,6 +157,8 @@ bot:
   poll_interval_sec: 30
   long_poll_timeout_sec: 25
   notification_dedupe_window_sec: 300
+  alert_state_file: ~/.local/state/hive/.bot.alert_state.json
+  recovery_reminder_window_sec: 28800
   conversation_ttl_sec: 3600
   codex_budget_usd: 1
   codex_timeout_sec: 120
@@ -172,7 +174,7 @@ Managed by `Hive::Config.register_project` (`lib/hive/config.rb:79`); deregister
 
 Loader tolerance (`Config.registered_projects` / `load_global_config`): a non-Hash row, a row missing `name`, or a row whose `path` isn't a String is *skipped silently* instead of raising — a single hand-edit accident can no longer brick `status`/`forget`/`prune`/TUI. `Psych::Exception` (any malformed YAML — syntax, disallowed-class, alias-not-enabled) plus `Errno::EACCES`/`EISDIR` are rewrapped as `ConfigError` (exit 78); `chmod 000 ~/Dev/hive/config.yml` no longer leaks as exit-70 InternalError. `prune` is the cleanup verb for invalid rows surfaced this way (predicate `Config.droppable_registry_entry?` covers both missing-path and invalid-shape; `valid_registry_entry?` is the shared shape gate). All writes go through `write_global_config!` so the read/write classification is symmetric and a future flock upgrade (Issue #31) lands in one place. See [[commands/forget]] · [[commands/prune]] · [[modules/config]]. All writers (`register_project`, `unregister_project`, `prune_missing_projects!`) go through `Hive::Config.write_global_config!`, which rewraps `Errno::EACCES`/`EROFS`/`ENOSPC` as `Hive::ConfigError` (exit 78). The reader (`load_global_config`) likewise rewraps `Psych::SyntaxError` AND `Errno::EACCES`/`EISDIR` to `ConfigError` so a `chmod 000` on `~/Dev/hive/config.yml` surfaces as exit 78, not exit 70. Name matching in `unregister_project` is `to_s`-symmetric so a hand-edited Integer `name:` in YAML still resolves. `forget`/`prune` `--json` envelopes use `Hive::Schemas::EnvelopeEmitter` (`lib/hive.rb`) and `File.expand_path` raw `path` / `hive_state_path` to honor the schemas' "Absolute path" contract regardless of how the registry row was hand-edited.
 
-`bot:` is a global operator-surface block, not a per-project enrollment knob. `Config.load_global_bot(require_runtime: true)` merges it over `Config.global_bot_defaults`, validates integer chat IDs, poll bounds, and path strings, then requires both a non-empty allowlist and `HIVE_TELEGRAM_BOT_TOKEN` before `hive bot start` can run. Runtime files are global under `~/.local/state/hive/`: `.bot.pid` for the single-instance lock, `logs/bot.log` for structured JSON lines, and `.bot.last_seen_update_id` for Telegram reconnect summaries.
+`bot:` is a global operator-surface block, not a per-project enrollment knob. `Config.load_global_bot(require_runtime: true)` merges it over `Config.global_bot_defaults`, validates integer chat IDs, poll bounds, and path strings, then requires both a non-empty allowlist and `HIVE_TELEGRAM_BOT_TOKEN` before `hive bot start` can run. Runtime files are global under `~/.local/state/hive/`: `.bot.pid` for the single-instance lock, `logs/bot.log` for structured JSON lines, `.bot.last_seen_update_id` for Telegram reconnect summaries, and `.bot.alert_state.json` for persisted notification fingerprints, row snapshots, first-seen timestamps, and reminder timestamps.
 
 ### Per-project: `<project>/.hive-state/config.yml`
 


### PR DESCRIPTION
## Summary

Operator recovery alerts in Telegram were unreadable jargon walls ("Needs recovery: review_error marker=… phase=… reason=…") with four buttons each, and the in-memory dedupe re-fired the entire backlog after every bot restart — surfacing as ~1500 notifications per night. Recovery alerts now read as one plain-English sentence with a single `🔧 Autofix` button, dedupe is persisted to disk and keyed by `(slug, stage, error fingerprint)` so each real failure surfaces exactly once until the row's status changes, and the operator gets one `✅ Recovered` line when the row clears.

`/status [project]` was rebuilt on the same human-readable formatter so the queue reads as `Title… — Stage` lines instead of raw slugs and marker tokens.

## What changed

| Surface | Before | After |
|---|---|---|
| Recovery headline | `Stuck waiting: hive/we-need-to-improve-this-260522-db23 (6-review)` | `⚠ Review stuck — "We need to improve this…"` |
| Body | `Needs recovery: review_error phase=… reason=… marker=… exception_class=…` | One plain sentence naming the failed actor + `Tap Autofix to retry the stage cleanly.` |
| Keyboard | `Clear and retry` · `Open laptop` · `Show details` · `Refresh diagnosis` | `🔧 Autofix` |
| Dedupe key | In-memory time window per `(project, slug, marker)` | Persistent JSON store keyed by `(project, slug, stage, marker, attrs)` SHA |
| Restart behavior | Re-fires every active row on every boot | Loads prior state; only new fingerprints alert |
| Still-stuck signal | Silent forever, or re-fires on the dedupe window | One `(reminder)` per fingerprint at 8 h, never again |
| Recovery signal | None | One `✅ Recovered: "Title…" — Stage` line |
| `/status` line | `hive/we-need-to-improve-this-260522-db23 6-review needs_recovery REVIEW_ERROR` | `We need to improve this… — Review` |

## Design decisions worth scrutinizing

**Fingerprint now includes `stage`.** Without it, the same marker recurring in a different stage would be suppressed as a duplicate. R9 of the spec calls this out explicitly; the cost is that a row that healed in execute and then errors again in review re-alerts, which is what we want.

**The diagnostic summary is dropped from Telegram entirely.** Per-stage logs under `.hive-state/...` remain the authoritative postmortem surface. The `details:` / `refresh_diagnose:` callback handlers still exist so pre-redeploy messages keep routing (no "Bot got confused" replies after the deploy), but no new buttons reference them.

**Persistence is a JSON file with atomic temp+rename writes.** Path is `bot.alert_state_file` (default `~/Dev/hive/.bot.alert_state.json`), validated as a path key in `Config`. Corrupt JSON is renamed to `<path>.corrupt-<ts>` and the store starts fresh rather than crashing the bot — we trade one lost dedupe cycle for liveness. Tested in `test/unit/bot/alert_store_test.rb`.

**`AGENT_WORKING` is not in the `markers clear` allowlist**, so Autofix special-cases it: skip the clear step, dispatch the retry verb only, and let `StaleAgentHealer` rewrite the marker on the next tick. The autofix handler also no-ops gracefully on a terminal/unknown stage rather than dispatching a bogus retry verb.

**Reminder is single-shot and shares the fingerprint.** Same incident → same dedupe key → the dispatcher's reminder branch explicitly short-circuits the dedupe check once per fingerprint, then `mark_reminded` closes the door.

**One wording covers all failure categories.** A small marker→noun lookup ("review agent crashed", "execute agent stalled", "review run stalled") gives natural sentences without leaking marker tokens; unknown markers fall back to "The agent crashed before it could finish." Adding a new marker only adds one row to the lookup.

## Out of scope

- Auto-escalation to headless Codex on repeated failure (R13 accepts that the second tap just re-alerts).
- In-Telegram chat (`Chat about this`) — deferred without placeholder.
- TUI surfaces, stage runners, marker semantics, and stage logs — untouched.
- The legacy `notification_dedupe_window_sec` config key remains for back-compat but is now unused; a deprecation event is emitted on load when set.

## Test plan

`bundle exec rake test` — 3508 runs, 12612 assertions, 0 failures (covers 8 new/rewritten test files: `title_formatter_test.rb`, `alert_store_test.rb`, the dispatcher lifecycle suite, the autofix handler, `/status` project filter, config bounds, and the rewritten `notification_builders_test.rb` whose old button-count assertions no longer apply).

`bundle exec rubocop lib/hive/bot test/unit/bot test/integration/bot` — clean.

Live Telegram smoke was not run; behavior is covered by the rewritten unit + integration suite. Worth a manual tick post-merge: trigger a `review_error` row, confirm the new headline + single button, advance status to clear, confirm the `✅ Recovered` line, then restart the bot and confirm no duplicate alert.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_(1M)-D97757?logo=claude&logoColor=white)
