### PR TITLE
docs(wiki): record live Claude tmux dogfood run

### DIFF
--- a/wiki/log.md
+++ b/wiki/log.md
@@ -2,6 +2,13 @@
 
 Append-only log of all wiki operations.
 
+## [2026-05-25T14:33:37Z] testing - live global Claude tmux dogfood
+
+**Action:** Dogfooded the merged project-global `claude.mode: tmux` path against real Claude in a disposable project. The run used a temporary `HIVE_HOME` plus private `HIVE_TMUX_SOCKET`, verified `hive doctor --json`, ran brainstorm to `marker_after=waiting`, filled the answer, reran to `marker_after=complete`, confirmed `round_waiting`/`round_complete` events, `hive status --json` `ready_to_plan`, and tmux cleanup.
+
+**Refreshed pages:**
+- [[testing]] - recorded the live dogfood shape and evidence for global Claude tmux mode.
+
 ## [2026-05-25T00:00:00Z] testing - default 100 percent coverage gate
 
 **Action:** Made `bundle exec rake coverage` enforce 100% line coverage by default, with CI also exporting `HIVE_COVERAGE_MIN_LINE=100` explicitly. Added unit coverage for the default threshold and updated the ProcessKill permission-denied tests to exercise production-reachable `EPERM` behavior.

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -92,6 +92,18 @@ bin/hive-e2e run
 
 The six starter scenarios copy `test/e2e/sample-project/` into a per-run sandbox, set `HIVE_HOME` to a run-local directory, and call the real `bin/hive` as a subprocess. `SandboxEnv` routes both Claude and Codex profile binaries to `test/fixtures/fake-claude`; scenarios that exercise `4-execute` with the default Codex profile must ask the fixture to create a real worktree commit, or execute will correctly stop at `EXECUTE_WAITING reason=no_worktree_changes`. TUI scenarios use private tmux sockets (`hive-e2e-<run-id>`) so they never touch the operator's daily tmux server.
 
+## Live Claude tmux dogfood
+
+The global `claude.mode: tmux` path was manually dogfooded on 2026-05-25 in a disposable git project with a temporary `HIVE_HOME` and private `HIVE_TMUX_SOCKET`. The run used Claude Code 2.1.133 and tmux 3.6a.
+
+Run shape:
+
+- `hive init .` in non-TTY mode rendered `claude.mode: tmux`.
+- `hive doctor --json` reported `claude/tmux` present (`tmux 3.6`) and all configured stage/reviewer skills present.
+- `hive new project "Dogfood..."`, then `hive brainstorm <slug> --project project --json`, launched real Claude through tmux and returned `marker_after: waiting`.
+- After filling `A1`, `hive brainstorm <slug> --from 2-brainstorm --project project --json` returned `marker_after: complete`.
+- `events.jsonl` recorded `round_waiting` then `round_complete`; `hive status --json` reported `marker: complete`, `action: ready_to_plan`, and `claude_pid: null`; both private tmux sockets were gone after cleanup.
+
 ## Eval suite (`test/eval/`)
 
 The Telegram bot eval harness is opt-in and separate from the default suite:


### PR DESCRIPTION
## Summary

Capture the 2026-05-25 manual dogfood of the merged project-global `claude.mode: tmux` path against real Claude in a disposable project.

- Adds a **Live Claude tmux dogfood** section to `wiki/testing.md` recording the run shape: `hive init`, `hive doctor --json`, brainstorm `marker_after=waiting` then `complete`, `round_waiting`/`round_complete` events, `status --json` `ready_to_plan`, and tmux socket cleanup.
- Appends the matching entry to `wiki/log.md`.

Docs-only change; no code paths touched.

## Test plan

- [x] `git diff` reviewed — wiki text only.
- [x] No linters or test suites affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)