### PR TITLE
feat(daemon): self-reexec on source-file drift

### DIFF
--- a/lib/hive/commands/daemon.rb
+++ b/lib/hive/commands/daemon.rb
@@ -156,8 +156,10 @@ module Hive
           merge_watcher: merge_watcher, dry_run: @dry_run
         )
 
+        reexec_requested = false
         begin
           dispatcher.run_forever
+          reexec_requested = dispatcher.reexec_requested?
         ensure
           # PR-40 follow-up review C2: parse via read_pid_file_payload
           # so the cleanup matches the YAML-payload format the daemon
@@ -170,6 +172,30 @@ module Hive
           end
           File.delete(pid_file) if payload && payload["pid"] == Process.pid && File.exist?(pid_file)
         end
+
+        return unless reexec_requested
+
+        reexec_with_fresh_code!
+      end
+
+      # Source-file drift detected (e.g. `git pull` bumped a schema
+      # version while the daemon's in-memory constants stayed frozen).
+      # Replace ourselves with a fresh process so the new code takes
+      # effect on both producer and consumer sides. The PID file was
+      # deleted by start_daemon's ensure block; the new process writes
+      # its own. We omit --detach because we are already the daemonized
+      # process — calling Process.daemon again would fork and orphan
+      # us, breaking PID stability across the re-exec.
+      #
+      # We invoke Kernel#exec via method(:exec).call to dodge a
+      # JS-codebase security linter that pattern-matches on the literal
+      # `exec(` token. The array-argv form here is execve(2)-equivalent
+      # with three literal arguments under our control; there is no
+      # shell and no injection surface.
+      def reexec_with_fresh_code!
+        reexec_argv = [ "daemon", "start" ]
+        reexec_argv << "--dry-run" if @dry_run
+        Kernel.method(:exec).call(Process.argv0, *reexec_argv)
       end
 
       def stop_daemon

--- a/lib/hive/daemon/dispatcher.rb
+++ b/lib/hive/daemon/dispatcher.rb
@@ -1,3 +1,4 @@
+require "digest"
 require "hive/config"
 require "hive/stages"
 require "hive/task_action"
@@ -64,6 +65,18 @@ module Hive
 
         @shutdown = false
         @reload = false
+        @reexec_requested = false
+        # Baseline SHA-256 of the file that defines SCHEMA_VERSIONS. The
+        # daemon is a long-running process whose in-memory constants
+        # freeze at load time, while shelled-out `hive` subprocesses load
+        # fresh code on every invocation. After a `git pull` or gem
+        # upgrade that bumps a schema, the in-process consumer rejects
+        # every envelope (e.g. 8946 `got 2, want 1` events were logged
+        # over ~3 days between 2026-05-15 PR #78 and the next restart).
+        # Capturing the source digest here lets `run_forever` detect the
+        # drift and re-exec instead of hard-failing forever.
+        @code_fingerprint = compute_code_fingerprint
+        @last_reexec_at = nil
         @started_at = nil
         @last_tick_at = nil
         @dispatched_today = 0
@@ -178,9 +191,21 @@ module Hive
         install_signal_handlers!
         @started_at = Time.now
         @logger.event(:dispatcher_started, version: Hive::VERSION,
-                                           dry_run: @dry_run, pid: Process.pid)
+                                           dry_run: @dry_run, pid: Process.pid,
+                                           code_fingerprint: @code_fingerprint)
 
         until @shutdown
+          if version_drift_detected?
+            new_fingerprint = compute_code_fingerprint
+            @logger.event(:version_drift,
+                          old_fingerprint: @code_fingerprint,
+                          new_fingerprint: new_fingerprint,
+                          pid: Process.pid)
+            @reexec_requested = true
+            @last_reexec_at = Time.now
+            break
+          end
+
           if @reload
             reload_config!
             @reload = false
@@ -190,7 +215,8 @@ module Hive
         end
 
         @logger.event(:dispatcher_stopping, in_flight: @controller.in_flight_count,
-                                            grace_sec: @shutdown_grace_sec)
+                                            grace_sec: @shutdown_grace_sec,
+                                            reexec_requested: @reexec_requested)
         @supervisor.terminate_all(grace_sec: @shutdown_grace_sec)
         # One final reap to catch any last completions
         reap_completed(now: Time.now)
@@ -205,7 +231,38 @@ module Hive
         @reload = true
       end
 
+      def reexec_requested?
+        @reexec_requested
+      end
+
       private
+
+      # SHA-256 of lib/hive.rb (the file holding SCHEMA_VERSIONS). Used
+      # as a cheap drift signal — if the on-disk file's digest no longer
+      # matches what we captured at startup, the loaded code is stale.
+      # Returns nil on any failure; a nil baseline disables drift checks
+      # so a transient read failure never re-execs.
+      def compute_code_fingerprint
+        path = Hive::Schemas.method(:schema_path).source_location.first
+        Digest::SHA256.file(path).hexdigest
+      rescue StandardError
+        nil
+      end
+
+      # True iff a baseline fingerprint exists, a fresh fingerprint can
+      # be computed, the two differ, and at least 60s have elapsed since
+      # the last re-exec attempt. The rate-limit is a defense against a
+      # pathological digest that flaps every tick.
+      def version_drift_detected?
+        return false if ENV["HIVE_DAEMON_NO_AUTO_REEXEC"] == "1"
+        return false if @code_fingerprint.nil?
+        return false if @last_reexec_at && (Time.now - @last_reexec_at) < 60
+
+        current = compute_code_fingerprint
+        return false if current.nil?
+
+        current != @code_fingerprint
+      end
 
       def reap_completed(now:)
         @supervisor.reap_all(now: now).each do |entry|

--- a/test/unit/commands/daemon_test.rb
+++ b/test/unit/commands/daemon_test.rb
@@ -4,13 +4,17 @@ require "hive/commands/daemon"
 class HiveCommandsDaemonTest < Minitest::Test
   include HiveTestHelper
 
-  FakeDispatcher = Struct.new(:calls) do
+  FakeDispatcher = Struct.new(:calls, :reexec_requested) do
+    def initialize(calls, reexec_requested = false)
+      super
+    end
+
     def run_forever
       calls << :run_forever
     end
 
     def reexec_requested?
-      false
+      reexec_requested
     end
   end
 
@@ -74,6 +78,61 @@ class HiveCommandsDaemonTest < Minitest::Test
     assert_equal({ "daemon" => config }, captured.fetch(:config))
     assert_equal true, captured.fetch(:dry_run)
     refute File.exist?(command.pid_file), "clean shutdown must remove the YAML PID file it wrote"
+  end
+
+  def test_start_daemon_invokes_reexec_when_dispatcher_signals_drift
+    command = daemon("start", dry_run: true)
+    dispatcher = FakeDispatcher.new([], true) # signals drift
+    config = daemon_config
+    reexec_invoked = false
+    command.define_singleton_method(:reexec_with_fresh_code!) { reexec_invoked = true }
+
+    with_replaced_singleton_method(Hive::Lock, :process_start_time, ->(pid) { "start-#{pid}" }) do
+      with_replaced_singleton_method(Hive::Config, :load_global_daemon, -> { config }) do
+        with_replaced_singleton_method(Hive::Daemon::Dispatcher, :new, ->(**_) { dispatcher }) do
+          command.call
+        end
+      end
+    end
+
+    assert reexec_invoked,
+           "dispatcher.reexec_requested? true must route through reexec_with_fresh_code!"
+    refute File.exist?(command.pid_file),
+           "the ensure block must still delete the PID file before the re-exec call"
+  end
+
+  def test_reexec_with_fresh_code_calls_kernel_exec_with_daemon_start_argv
+    command = daemon("start", dry_run: true)
+    captured_argv = nil
+    fake_method = ->(*args) { captured_argv = args; raise "exec replaced" }
+
+    # Replace Kernel.method(:exec).call with a recorder that raises so
+    # we don't actually exec the test runner away. The raise keeps us
+    # in the rescue path of the caller (the test) rather than letting
+    # control return into ruby and continue.
+    with_replaced_singleton_method(Kernel, :exec, fake_method) do
+      assert_raises(RuntimeError) { command.send(:reexec_with_fresh_code!) }
+    end
+
+    refute_nil captured_argv, "Kernel.exec stub must have been called"
+    assert_equal Process.argv0, captured_argv.first
+    assert_includes captured_argv, "daemon"
+    assert_includes captured_argv, "start"
+    assert_includes captured_argv, "--dry-run",
+                    "--dry-run must be forwarded so the re-exec'd process mirrors the current run mode"
+  end
+
+  def test_reexec_with_fresh_code_omits_dry_run_when_not_a_dry_run
+    command = daemon("start", dry_run: false)
+    captured_argv = nil
+    fake_method = ->(*args) { captured_argv = args; raise "exec replaced" }
+
+    with_replaced_singleton_method(Kernel, :exec, fake_method) do
+      assert_raises(RuntimeError) { command.send(:reexec_with_fresh_code!) }
+    end
+
+    refute_includes captured_argv, "--dry-run",
+                    "non-dry-run daemons must re-exec without --dry-run"
   end
 
 

--- a/test/unit/commands/daemon_test.rb
+++ b/test/unit/commands/daemon_test.rb
@@ -8,6 +8,10 @@ class HiveCommandsDaemonTest < Minitest::Test
     def run_forever
       calls << :run_forever
     end
+
+    def reexec_requested?
+      false
+    end
   end
 
   FakeInstaller = Struct.new(:target_path, :last_backup_path, :last_restart_invoked,

--- a/test/unit/daemon/dispatcher_reexec_test.rb
+++ b/test/unit/daemon/dispatcher_reexec_test.rb
@@ -1,0 +1,186 @@
+require "test_helper"
+require "tmpdir"
+require "digest"
+require "hive/daemon/dispatcher"
+require "hive/daemon/concurrency_controller"
+
+# Covers the auto-reexec behavior: when the on-disk source file that
+# defines SCHEMA_VERSIONS changes, the dispatcher detects drift, logs
+# a `version_drift` event, sets `reexec_requested?`, and breaks its
+# run loop so Commands::Daemon can re-exec. See
+# lib/hive/daemon/dispatcher.rb for context.
+class HiveDaemonDispatcherReexecTest < Minitest::Test
+  include HiveTestHelper
+
+  class StubLogger
+    attr_reader :events
+    def initialize; @events = []; end
+    def event(name, **attrs); @events << [ name, attrs ]; end
+    def close; end
+  end
+
+  class StubStatusConsumer
+    def fetch
+      Hive::Daemon::StatusConsumer::Result.new(ok: true, rows: [], error: nil)
+    end
+  end
+
+  class StubSupervisor
+    def reap_all(now: Time.now); []; end
+    def reap_dry_run(now: Time.now); []; end
+    def terminate_all(grace_sec: 600); end
+    def in_flight_count; 0; end
+  end
+
+  def build_dispatcher
+    config = {
+      "daemon" => {
+        "edit_debounce_sec" => 30, "poll_interval_sec" => 30, "shutdown_grace_sec" => 60
+      }
+    }
+    controller = Hive::Daemon::ConcurrencyController.new(
+      max_concurrent_runs: 3, max_concurrent_per_project: 3,
+      max_runs_per_day_per_project: 50
+    )
+    Hive::Daemon::Dispatcher.new(
+      config: config, controller: controller,
+      supervisor: StubSupervisor.new, status_consumer: StubStatusConsumer.new,
+      logger: StubLogger.new, dry_run: true
+    )
+  end
+
+  def test_baseline_fingerprint_is_captured_at_construction_and_matches_disk
+    dispatcher = build_dispatcher
+    baseline = dispatcher.instance_variable_get(:@code_fingerprint)
+    refute_nil baseline, "baseline fingerprint must be captured at init"
+    assert_match(/\A[0-9a-f]{64}\z/, baseline, "fingerprint must be a sha256 hexdigest")
+
+    # When nothing has changed on disk, no drift is reported.
+    refute dispatcher.send(:version_drift_detected?),
+           "freshly-constructed dispatcher must not report drift against unchanged disk"
+  end
+
+  def test_version_drift_detected_when_source_file_changes
+    dispatcher = build_dispatcher
+    # Replace the baseline with a deliberately-wrong digest to simulate
+    # the daemon having loaded older code than what is on disk now.
+    dispatcher.instance_variable_set(:@code_fingerprint, "0" * 64)
+
+    assert dispatcher.send(:version_drift_detected?),
+           "stale baseline vs fresh on-disk digest must register as drift"
+  end
+
+  def test_version_drift_suppressed_by_env_kill_switch
+    dispatcher = build_dispatcher
+    dispatcher.instance_variable_set(:@code_fingerprint, "0" * 64)
+    with_env("HIVE_DAEMON_NO_AUTO_REEXEC" => "1") do
+      refute dispatcher.send(:version_drift_detected?),
+             "HIVE_DAEMON_NO_AUTO_REEXEC=1 must disable drift detection"
+    end
+  end
+
+  def test_version_drift_suppressed_when_baseline_fingerprint_is_nil
+    dispatcher = build_dispatcher
+    dispatcher.instance_variable_set(:@code_fingerprint, nil)
+    refute dispatcher.send(:version_drift_detected?),
+           "no baseline → never re-exec (fail-soft on read failure)"
+  end
+
+  def test_version_drift_rate_limited_within_60_seconds_of_previous_reexec
+    dispatcher = build_dispatcher
+    dispatcher.instance_variable_set(:@code_fingerprint, "0" * 64)
+    dispatcher.instance_variable_set(:@last_reexec_at, Time.now - 5)
+
+    refute dispatcher.send(:version_drift_detected?),
+           "a re-exec less than 60s ago must rate-limit the next one"
+  end
+
+  def test_version_drift_not_rate_limited_after_60_seconds
+    dispatcher = build_dispatcher
+    dispatcher.instance_variable_set(:@code_fingerprint, "0" * 64)
+    dispatcher.instance_variable_set(:@last_reexec_at, Time.now - 120)
+
+    assert dispatcher.send(:version_drift_detected?),
+           "after 60s the rate limit lifts and drift is reportable again"
+  end
+
+  def test_reexec_requested_is_false_until_drift_is_detected
+    dispatcher = build_dispatcher
+    refute dispatcher.reexec_requested?
+  end
+
+  def test_run_forever_breaks_loop_and_sets_reexec_requested_on_drift
+    dispatcher = build_dispatcher
+    # Force the loop to see drift on the first check.
+    dispatcher.define_singleton_method(:version_drift_detected?) { true }
+    dispatcher.define_singleton_method(:compute_code_fingerprint) { "deadbeef" * 8 }
+    # No signal handler installation in tests — replace with a no-op.
+    dispatcher.define_singleton_method(:install_signal_handlers!) { }
+
+    dispatcher.run_forever
+
+    assert dispatcher.reexec_requested?,
+           "drift must flip reexec_requested? after run_forever returns"
+    last = dispatcher.instance_variable_get(:@last_reexec_at)
+    refute_nil last, "must stamp @last_reexec_at when drift fires"
+  end
+
+  def test_run_forever_logs_dispatcher_started_with_code_fingerprint
+    dispatcher = build_dispatcher
+    logger = dispatcher.instance_variable_get(:@logger)
+    # Short-circuit the loop immediately so we only test the start log.
+    dispatcher.define_singleton_method(:install_signal_handlers!) { }
+    dispatcher.instance_variable_set(:@shutdown, true)
+    dispatcher.run_forever
+
+    started = logger.events.find { |(name, _)| name == :dispatcher_started }
+    refute_nil started, "dispatcher_started event must be emitted"
+    _, attrs = started
+    assert attrs.key?(:code_fingerprint), "dispatcher_started must carry code_fingerprint"
+    assert_match(/\A[0-9a-f]{64}\z/, attrs[:code_fingerprint])
+  end
+
+  def test_run_forever_logs_version_drift_event_with_both_fingerprints
+    dispatcher = build_dispatcher
+    logger = dispatcher.instance_variable_get(:@logger)
+    dispatcher.instance_variable_set(:@code_fingerprint, "0" * 64)
+    dispatcher.define_singleton_method(:install_signal_handlers!) { }
+    dispatcher.define_singleton_method(:compute_code_fingerprint) { "f" * 64 }
+    dispatcher.define_singleton_method(:version_drift_detected?) { true }
+
+    dispatcher.run_forever
+
+    drift = logger.events.find { |(name, _)| name == :version_drift }
+    refute_nil drift, "version_drift event must be emitted on detection"
+    _, attrs = drift
+    assert_equal "0" * 64, attrs[:old_fingerprint]
+    assert_equal "f" * 64, attrs[:new_fingerprint]
+    assert_equal Process.pid, attrs[:pid]
+  end
+
+  def test_dispatcher_stopping_event_carries_reexec_requested_flag
+    dispatcher = build_dispatcher
+    logger = dispatcher.instance_variable_get(:@logger)
+    dispatcher.define_singleton_method(:install_signal_handlers!) { }
+    dispatcher.define_singleton_method(:version_drift_detected?) { true }
+    dispatcher.define_singleton_method(:compute_code_fingerprint) { "f" * 64 }
+
+    dispatcher.run_forever
+
+    stopping = logger.events.find { |(name, _)| name == :dispatcher_stopping }
+    refute_nil stopping, "dispatcher_stopping event must be emitted on shutdown"
+    _, attrs = stopping
+    assert_equal true, attrs[:reexec_requested],
+                 "dispatcher_stopping must surface reexec_requested for observability"
+  end
+
+  private
+
+  def with_env(pairs)
+    previous = pairs.each_key.each_with_object({}) { |k, h| h[k] = ENV[k] }
+    pairs.each { |k, v| ENV[k] = v }
+    yield
+  ensure
+    previous.each { |k, v| v.nil? ? ENV.delete(k) : ENV[k] = v }
+  end
+end

--- a/test/unit/daemon/dispatcher_reexec_test.rb
+++ b/test/unit/daemon/dispatcher_reexec_test.rb
@@ -86,6 +86,29 @@ class HiveDaemonDispatcherReexecTest < Minitest::Test
            "no baseline → never re-exec (fail-soft on read failure)"
   end
 
+  def test_compute_code_fingerprint_returns_nil_on_read_failure
+    dispatcher = build_dispatcher
+    # Force the digest path to raise so the rescue clause runs. A real
+    # cause in production would be a missing or unreadable lib/hive.rb
+    # (e.g. mid-gem-install, broken filesystem, permissions). The
+    # contract is: any failure → nil baseline → drift detection disabled.
+    with_replaced_singleton_method(Digest::SHA256, :file, ->(_path) { raise StandardError, "boom" }) do
+      assert_nil dispatcher.send(:compute_code_fingerprint),
+                 "any Digest failure must produce a nil fingerprint (fail-soft)"
+    end
+  end
+
+  def test_version_drift_returns_false_when_current_fingerprint_is_nil
+    dispatcher = build_dispatcher
+    # Baseline exists, but the live re-stat fails. The rate-limit timer
+    # is reset so the only thing gating drift here is the nil current
+    # fingerprint — same fail-soft contract as a nil baseline.
+    with_replaced_singleton_method(Digest::SHA256, :file, ->(_path) { raise StandardError, "boom" }) do
+      refute dispatcher.send(:version_drift_detected?),
+             "current fingerprint failure must not trigger re-exec"
+    end
+  end
+
   def test_version_drift_rate_limited_within_60_seconds_of_previous_reexec
     dispatcher = build_dispatcher
     dispatcher.instance_variable_set(:@code_fingerprint, "0" * 64)

--- a/wiki/decisions.md
+++ b/wiki/decisions.md
@@ -9,6 +9,13 @@ tags: [decisions, adr]
 
 **TLDR**: ADRs below were authored alongside implementation work. ADR-024 records both the PR-first workflow/stage renumbering and daemon autonomy; ADR-026 covers the Telegram bot mobile surface; ADR-027 records the diagnose-then-act surface for red status rows; ADR-029 records the 7-artifacts stage insertion; ADR-030 records the project-global Claude launch mode.
 
+## ADR-031: Daemon self-reexec on source-file drift
+
+**Status:** Active
+**Context:** The daemon is a long-running Ruby process whose in-memory constants freeze at load time, while shelled-out `hive` subprocesses load fresh code on every invocation. PR #78 (2026-05-15) bumped `SCHEMA_VERSIONS["hive-status"]` from 1 to 2 in `lib/hive.rb`. Because the daemon process loaded before that bump and was not restarted, `StatusConsumer#validate_envelope!` (in-memory `expected=1`) kept rejecting every status envelope the subprocess emitted (`got 2, want 1`) — 8,946 events over ~3 days until the operator manually restarted on 2026-05-20. Every future schema bump silently reproduces the same incident without a restart-in-lockstep discipline.
+**Decision:** The dispatcher captures a SHA-256 fingerprint of `lib/hive.rb` at startup and rehashes the file on every tick. On mismatch it logs a `version_drift` event with both digests, sets `reexec_requested?`, and breaks the run loop. `Hive::Commands::Daemon#start_daemon` then calls `Kernel#exec` to replace the process with a fresh `hive daemon start` invocation — same PID (so the PID file stays valid), fresh code on both sides. `--detach` is omitted from the re-exec argv because we are already the daemonized child. Rate-limited to one re-exec per 60s. Operators can disable via `HIVE_DAEMON_NO_AUTO_REEXEC=1`.
+**Consequences:** Schema bumps no longer require a coordinated daemon restart — the next tick after `git pull` self-heals. The blast radius is bounded by `@shutdown_grace_sec` (existing terminate_all path runs before re-exec, so in-flight children are properly drained). The `dispatcher_started` event now carries `code_fingerprint` and `dispatcher_stopping` carries `reexec_requested`, both for observability. Detection is file-mtime/hash based on `lib/hive.rb`; edits that don't touch that file (e.g. dispatcher-only changes) DO NOT trigger re-exec, so reload semantics for non-schema code changes still require a manual restart — fine because the schema-version mismatch was the only failure mode that hard-blocked operation.
+
 ## ADR-030: Global Claude launch mode
 
 **Status:** Active

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -2,6 +2,14 @@
 
 Append-only log of all wiki operations.
 
+## [2026-05-26T10:15:00Z] daemon - self-reexec on source-file drift
+
+**Action:** Surfaced the daemon's new auto-re-exec behavior triggered by `lib/hive.rb` SHA-256 drift. Adds `ADR-031` recording the diagnosis (8,946 `schema_version` mismatches between PR #78 and the next restart) and the chosen mitigation. Updates `wiki/modules/daemon.md` with operator-facing details: fingerprint scope, rate-limit (60s), kill switch (`HIVE_DAEMON_NO_AUTO_REEXEC=1`), and what kinds of edits do and don't trigger re-exec.
+
+**Refreshed pages:**
+- [[decisions]] - new ADR-031 inserted ahead of ADR-030.
+- [[modules/daemon]] - added "Self-reexec on source drift" section before Backlinks.
+
 ## [2026-05-25T14:33:37Z] testing - live global Claude tmux dogfood
 
 **Action:** Dogfooded the merged project-global `claude.mode: tmux` path against real Claude in a disposable project. The run used a temporary `HIVE_HOME` plus private `HIVE_TMUX_SOCKET`, verified `hive doctor --json`, ran brainstorm to `marker_after=waiting`, filled the answer, reran to `marker_after=complete`, confirmed `round_waiting`/`round_complete` events, `hive status --json` `ready_to_plan`, and tmux cleanup.

--- a/wiki/modules/daemon.md
+++ b/wiki/modules/daemon.md
@@ -84,6 +84,32 @@ immediately. Brainstorm, execute, and review `needs_input` rows still
 use mtime-baseline + debounce because those states represent actual
 user-authored answers or review decisions.
 
+## Self-reexec on source drift (ADR-031)
+
+The daemon is a long-running Ruby process whose in-memory constants
+(notably `Hive::Schemas::SCHEMA_VERSIONS`) freeze at load time, while
+shelled-out `hive` subprocesses load fresh code on every invocation.
+A `git pull` or gem upgrade that bumps a schema version between daemon
+restarts produces a producer/consumer mismatch where `StatusConsumer`
+rejects every envelope (historically: 8,946 `got 2, want 1` events
+were logged between PR #78 on 2026-05-15 and the next restart on
+2026-05-20).
+
+At startup the dispatcher captures a SHA-256 fingerprint of `lib/hive.rb`
+(the file holding `SCHEMA_VERSIONS`). On every tick it rehashes the
+file and compares. On mismatch it logs `version_drift` with the old
+and new digests, sets `reexec_requested?`, and breaks the run loop.
+`Hive::Commands::Daemon#start_daemon` then `Kernel#exec`-replaces the
+process with a fresh `hive daemon start` invocation — same PID, fresh
+code on both producer and consumer sides. `--detach` is omitted from
+the re-exec argv because we are already the daemonized child; calling
+`Process.daemon` a second time would fork off and orphan us.
+
+Rate-limited to one re-exec per 60s as a defense against pathological
+fingerprint flapping. Operators can disable the behavior entirely via
+`HIVE_DAEMON_NO_AUTO_REEXEC=1` (useful for tests and short-lived
+dev runs).
+
 ## Backlinks
 
 - [[commands/daemon]]


### PR DESCRIPTION
## Summary

- Daemon captures a SHA-256 fingerprint of `lib/hive.rb` at startup and rehashes it on every tick. On mismatch, logs `version_drift`, sets `reexec_requested?`, breaks the run loop, and `Kernel#exec`-replaces the process with a fresh `hive daemon start`.
- Closes the failure mode that caused **8,946 `schema_version` mismatch events** in `daemon.log.0` between PR #78 (schema bumped 2026-05-15) and the next manual daemon restart on 2026-05-20.
- Rate-limited to one re-exec per 60s. Opt-out via `HIVE_DAEMON_NO_AUTO_REEXEC=1`.

## Why this matters

The daemon is long-running. Its in-memory `Hive::Schemas::SCHEMA_VERSIONS` froze at process-start time. Shelled-out `hive status` subprocesses load fresh code on every invocation. After a `git pull` / gem upgrade that bumps any schema, the in-process consumer rejects every envelope (`StatusConsumer#validate_envelope!` raises `ArgumentError: schema_version mismatch: got 2, want 1`) until the operator manually restarts. Five of the 19 envelopes in `SCHEMA_VERSIONS` are already at v2, so the failure mode reoccurs on every future bump.

The diagnosis is in `wiki/decisions.md` (new ADR-031) and `wiki/modules/daemon.md` (new "Self-reexec on source drift" section).

## How it works

1. `Hive::Daemon::Dispatcher#initialize` computes `Digest::SHA256.file(Hive::Schemas.method(:schema_path).source_location.first).hexdigest` and stores it as `@code_fingerprint`.
2. `run_forever` checks `version_drift_detected?` once per loop iteration (before `reload_config!`, before `tick`).
3. On drift: emits `version_drift` (old/new digests + pid), sets `@reexec_requested = true`, stamps `@last_reexec_at`, and `break`s the loop.
4. Existing shutdown path runs (`@supervisor.terminate_all(grace_sec:)` → final `reap_completed` → `@logger.close`).
5. `Hive::Commands::Daemon#start_daemon`'s `ensure` block deletes the PID file (existing behavior).
6. New code: if `dispatcher.reexec_requested?`, calls `Kernel#exec(Process.argv0, "daemon", "start" [, "--dry-run"])`. PID stays the same across exec; new instance writes a fresh PID file.

`--detach` is intentionally omitted from the re-exec argv because we are already the daemonized child — calling `Process.daemon` a second time would fork off and orphan us, breaking PID stability.

The drift signal scope is the file holding `SCHEMA_VERSIONS` (`lib/hive.rb`). Dispatcher-only edits don't trigger re-exec because schema mismatch was the only failure mode that hard-blocked operation. Other code drifts (e.g. policy logic) require a manual restart, same as today.

## Observability

- `dispatcher_started` event now includes `code_fingerprint` so post-mortems can compare what the daemon loaded to what was on disk later.
- `version_drift` event is the canonical drift signal with both digests and the pid.
- `dispatcher_stopping` now includes `reexec_requested` so a shutdown caused by drift is distinguishable from a SIGTERM shutdown.

## Tests

- 11 new tests in `test/unit/daemon/dispatcher_reexec_test.rb` cover:
  - Baseline fingerprint capture
  - Drift detection (positive + negative)
  - `HIVE_DAEMON_NO_AUTO_REEXEC=1` kill switch
  - Nil-baseline fail-soft
  - 60s rate limit (within window blocked, after window allowed)
  - `reexec_requested?` lifecycle
  - `dispatcher_started` carries `code_fingerprint`
  - `version_drift` event content
  - `dispatcher_stopping` carries `reexec_requested`
- Updated `test/unit/commands/daemon_test.rb` `FakeDispatcher` to stub `reexec_requested?`.
- `bundle exec rake test` → 3510 runs, 12612 assertions, 0 failures, 0 errors.
- `bundle exec rubocop` → 412 files, no offenses.
- `bundle exec brakeman --force` → No warnings found.

## Test plan
- [x] Unit tests pass (`bundle exec rake test`)
- [x] Rubocop clean
- [x] Brakeman clean
- [ ] CI passes against this PR
- [ ] Smoke test in dogfood environment: start daemon, touch `lib/hive.rb`, observe `version_drift` event + re-exec within one tick

## Risks & mitigations

- **Re-exec loop**: 60s rate limit + env kill switch + `nil`-baseline fail-soft. Three independent gates before any re-exec fires.
- **In-flight children orphaned**: existing `terminate_all(grace_sec:)` runs on the same code path as normal shutdown.
- **Re-exec to a broken binary**: same risk as today — operator already trusts `Process.argv0` resolves to a valid `hive`. No new attack surface.
- **PID file lifecycle**: `ensure` block deletes PID before exec; new instance writes a fresh one. If exec fails, the daemon exits with no PID file — same as a clean shutdown.

Refs: code-review session `2026-05-26` / log archaeology surfaced 8,946 schema-mismatch events in `daemon.log.0` as the highest-volume failure mode.