### PR TITLE
fix(review): carry accepted finding counts

### DIFF
--- a/lib/hive/stages/review.rb
+++ b/lib/hive/stages/review.rb
@@ -74,6 +74,7 @@ module Hive
       # Phase 4 with the operator's existing `[x]` marks instead of
       # advancing past them.
       FIX_SUCCESS_FILENAME = "fix-success".freeze
+      AcceptedFindings = Data.define(:text, :count)
 
       # `reviewer_file?` is defined in `review/orchestrator_owned.rb` so
       # this module and `Review::Triage` share one definition. Re-export
@@ -378,7 +379,8 @@ module Hive
           # Branch on triage output. Read per-reviewer files for [x]
           # count (source of truth). escalations file existence + line
           # count tells us whether anything was escalated.
-          accepted = collect_accepted_findings(ctx_pass)
+          accepted_findings = collect_accepted_findings_with_count(ctx_pass)
+          accepted = accepted_findings.text
           escalations_count = count_escalations(ctx_pass)
 
           if accepted.strip.empty? && escalations_count.zero?
@@ -493,7 +495,7 @@ module Hive
           post_fix_status = worktree_status(worktree_path)
           case post_fix_status
           when :dirty
-            auto_commit = auto_commit_fix_worktree(task, cfg, ctx_pass, accepted)
+            auto_commit = auto_commit_fix_worktree(task, cfg, ctx_pass, accepted_findings)
             unless auto_commit[:success]
               Hive::Markers.set(task.state_file, :review_error,
                                 phase: :fix, reason: "fix_auto_commit_failed",
@@ -1180,17 +1182,27 @@ module Hive
       # All [x] lines across every per-reviewer file for the current
       # pass, concatenated. Used by Phase 4's fix-agent prompt.
       def collect_accepted_findings(ctx)
+        collect_accepted_findings_with_count(ctx).text
+      end
+
+      def collect_accepted_findings_with_count(ctx)
         out = +""
+        count = 0
         Dir[File.join(ctx.task_folder, "reviews", "*-#{format('%02d', ctx.pass)}.md")].sort.each do |path|
           name = File.basename(path)
           next unless reviewer_file?(name)
 
           File.readlines(path).each do |line|
-            out << "[#{name}] #{line}" if auto_fix_finding_line?(line)
+            next unless auto_fix_finding_line?(line)
+
+            out << "[#{name}] #{line}"
+            count += 1
           end
         end
-        out << collect_answered_escalation_findings(ctx)
-        out
+
+        answered = collect_answered_escalation_findings_with_count(ctx)
+        out << answered.text
+        AcceptedFindings.new(text: out, count: count + answered.count)
       end
 
       def auto_fix_finding_line?(line)
@@ -1201,12 +1213,16 @@ module Hive
       end
 
       def collect_answered_escalation_findings(ctx)
+        collect_answered_escalation_findings_with_count(ctx).text
+      end
+
+      def collect_answered_escalation_findings_with_count(ctx)
         path = Hive::Stages::Review::Triage.escalations_path(ctx)
         questions = parse_escalation_questions(path)
-        return collect_legacy_checked_escalations(path) if questions.empty?
+        return collect_legacy_checked_escalations_with_count(path) if questions.empty?
 
         answered = questions.select { |q| q[:answer].strip != "" }
-        return "" if answered.empty?
+        return AcceptedFindings.new(text: "", count: 0) if answered.empty?
 
         name = File.basename(path)
         out = +"\n# User answers from #{name}\n"
@@ -1218,21 +1234,25 @@ module Hive
           out << prefixed_block(name, q[:answer].strip)
           out << "\n"
         end
-        out
+        AcceptedFindings.new(text: out, count: answered.size)
       end
 
       def collect_legacy_checked_escalations(path)
-        return "" unless File.exist?(path)
+        collect_legacy_checked_escalations_with_count(path).text
+      end
+
+      def collect_legacy_checked_escalations_with_count(path)
+        return AcceptedFindings.new(text: "", count: 0) unless File.exist?(path)
 
         name = File.basename(path)
         lines = File.readlines(path).select { |line| auto_fix_finding_line?(line) }
-        return "" if lines.empty?
+        return AcceptedFindings.new(text: "", count: 0) if lines.empty?
 
         out = +"\n# Accepted legacy escalations from #{name}\n"
         lines.each { |line| out << "[#{name}] #{line}" }
-        out
+        AcceptedFindings.new(text: out, count: lines.size)
       rescue SystemCallError, IOError
-        ""
+        AcceptedFindings.new(text: "", count: 0)
       end
 
       def prefixed_block(name, text)
@@ -1512,7 +1532,7 @@ module Hive
         status.success? ? out.strip : nil
       end
 
-      def auto_commit_fix_worktree(task, cfg, ctx, accepted)
+      def auto_commit_fix_worktree(task, cfg, ctx, accepted_findings)
         # `git add -A` (not `-u`) is intentional: fix-agent fixes
         # routinely include new files (added test cases, extracted
         # helpers, new modules) that must land in the same commit as the
@@ -1529,7 +1549,7 @@ module Hive
           }
         end
 
-        message = fix_auto_commit_message(task, cfg, ctx, accepted)
+        message = fix_auto_commit_message(task, cfg, ctx, accepted_findings)
         commit_out, commit_err, commit_status = Open3.capture3(
           "git", "-C", ctx.worktree_path,
           "-c", "commit.gpgsign=false",
@@ -1549,27 +1569,18 @@ module Hive
         { success: true, head: git_head(ctx.worktree_path) }
       end
 
-      def fix_auto_commit_message(task, cfg, ctx, accepted)
+      def fix_auto_commit_message(task, cfg, ctx, accepted_findings)
         pass = format("%02d", ctx.pass)
         <<~MSG.chomp
           fix(review): apply pass #{pass} findings
 
           Hive-Task-Slug: #{task.slug}
           Hive-Fix-Pass: #{pass}
-          Hive-Fix-Findings: #{accepted_finding_count(accepted)}
+          Hive-Fix-Findings: #{[ accepted_findings.count.to_i, 1 ].max}
           Hive-Triage-Bias: #{sanitize_trailer_value(triage_bias_for(cfg))}
           Hive-Reviewer-Sources: #{sanitize_trailer_value(reviewer_sources_for(ctx))}
           Hive-Fix-Phase: fix
         MSG
-      end
-
-      def accepted_finding_count(accepted)
-        count = accepted.to_s.lines.count do |line|
-          line.match?(/^\[[^\]]+\]\s+-\s+\[x\]\s+/) ||
-            line.match?(/^\[[^\]]+\]\s+USER-ANSWERED ESCALATION\b/)
-        end
-
-        count.positive? ? count : 1
       end
 
       def git_command_message(command, out, err)

--- a/test/integration/run_review_test.rb
+++ b/test/integration/run_review_test.rb
@@ -483,8 +483,21 @@ class RunReviewTest < Minitest::Test
         folder = setup_review_task(dir)
         worktree = YAML.safe_load(File.read(File.join(folder, "worktree.yml")))["path"]
         FileUtils.mkdir_p(File.join(folder, "reviews"))
-        File.write(File.join(folder, "reviews", "local-reviewer-01.md"),
-                   "## High\n- [x] apply a fix\n")
+        File.write(File.join(folder, "reviews", "local-reviewer-01.md"), <<~MD)
+          ## High
+          - [x] apply a fix
+          - [x] apply another fix
+        MD
+        File.write(File.join(folder, "reviews", "escalations-01.md"), <<~MD)
+          # Escalations for pass 01
+
+          ## Round 1
+
+          ### Q1. Which config key should the fix use?
+          Source: local-reviewer-01.md
+          ### A1.
+          Use execute.agent.
+        MD
         Hive::Markers.set(File.join(folder, "task.md"), :review_waiting, pass: 1, escalations: 1)
 
         dirty_file = File.join(worktree, "dirty-fix.txt")
@@ -512,7 +525,7 @@ class RunReviewTest < Minitest::Test
         assert_includes commit, "fix(review): apply pass 01 findings"
         assert_includes commit, "Hive-Task-Slug: feat-x-260424-aaaa"
         assert_includes commit, "Hive-Fix-Pass: 01"
-        assert_includes commit, "Hive-Fix-Findings: 1"
+        assert_includes commit, "Hive-Fix-Findings: 3"
         assert_includes commit, "Hive-Triage-Bias: courageous"
         assert_includes commit, "Hive-Reviewer-Sources: local-reviewer"
         assert_includes commit, "Hive-Fix-Phase: fix"

--- a/test/unit/current_main_coverage_gap_test.rb
+++ b/test/unit/current_main_coverage_gap_test.rb
@@ -85,6 +85,10 @@ class CurrentMainCoverageGapTest < Minitest::Test
     )
   end
 
+  def accepted_findings(text = "## High\n- [x] apply a fix\n", count: 1)
+    Hive::Stages::Review::AcceptedFindings.new(text: text, count: count)
+  end
+
   def with_fake_profile(profile = FakeProfile.new(:codex))
     with_replaced_singleton_method(Hive::AgentProfiles, :lookup, ->(*_args, **_kwargs) { profile }) do
       yield profile
@@ -435,7 +439,7 @@ class CurrentMainCoverageGapTest < Minitest::Test
       ok_status = ReviewCommandStatus.new(true)
 
       with_replaced_singleton_method(Open3, :capture3, ->(*_argv) { [ "", "", fail_status ] }) do
-        result = Hive::Stages::Review.send(:auto_commit_fix_worktree, task, cfg, ctx, "## High\n- [x] apply a fix\n")
+        result = Hive::Stages::Review.send(:auto_commit_fix_worktree, task, cfg, ctx, accepted_findings)
 
         refute result[:success]
         assert_equal "git add -A failed", result[:message]
@@ -447,7 +451,7 @@ class CurrentMainCoverageGapTest < Minitest::Test
         [ "", "", ok_status ]
       ]
       with_replaced_singleton_method(Open3, :capture3, ->(*_argv) { responses.shift }) do
-        result = Hive::Stages::Review.send(:auto_commit_fix_worktree, task, cfg, ctx, "## High\n- [x] apply a fix\n")
+        result = Hive::Stages::Review.send(:auto_commit_fix_worktree, task, cfg, ctx, accepted_findings)
 
         refute result[:success]
         assert_equal "git commit failed: stderr detail\nstdout detail", result[:message]
@@ -478,7 +482,7 @@ class CurrentMainCoverageGapTest < Minitest::Test
         captured_argv << argv
         responses.shift
       }) do
-        result = Hive::Stages::Review.send(:auto_commit_fix_worktree, task, cfg, ctx, "## High\n- [x] apply a fix\n")
+        result = Hive::Stages::Review.send(:auto_commit_fix_worktree, task, cfg, ctx, accepted_findings)
 
         refute result[:success]
         assert_includes result[:message], "git commit failed"
@@ -507,12 +511,26 @@ class CurrentMainCoverageGapTest < Minitest::Test
         [ "", "reset boom", fail_status ]
       ]
       with_replaced_singleton_method(Open3, :capture3, ->(*_argv) { responses.shift }) do
-        result = Hive::Stages::Review.send(:auto_commit_fix_worktree, task, cfg, ctx, "## High\n- [x] apply a fix\n")
+        result = Hive::Stages::Review.send(:auto_commit_fix_worktree, task, cfg, ctx, accepted_findings)
 
         refute result[:success]
         assert_includes result[:message], "git commit failed"
         assert_includes result[:message], "git reset HEAD -- failed"
       end
+    end
+  end
+
+  def test_fix_auto_commit_message_uses_collected_finding_count
+    with_tmp_dir do |root|
+      folder = task_folder(root)
+      ctx = review_ctx(root, folder)
+      task = fake_task(root, folder)
+      cfg = { "review" => {} }
+      accepted = accepted_findings("source one\nsource two\n", count: 2)
+
+      message = Hive::Stages::Review.send(:fix_auto_commit_message, task, cfg, ctx, accepted)
+
+      assert_includes message, "Hive-Fix-Findings: 2"
     end
   end
 
@@ -525,7 +543,7 @@ class CurrentMainCoverageGapTest < Minitest::Test
 
       with_replaced_singleton_method(Hive::Stages::Review, :triage_bias_for, ->(_cfg) { "courageous\nHive-Forged: yes" }) do
         with_replaced_singleton_method(Hive::Stages::Review, :reviewer_sources_for, ->(_ctx) { "alpha\nHive-Forged: beta" }) do
-          message = Hive::Stages::Review.send(:fix_auto_commit_message, task, cfg, ctx, "## High\n- [x] apply a fix\n")
+          message = Hive::Stages::Review.send(:fix_auto_commit_message, task, cfg, ctx, accepted_findings)
 
           assert_equal 1, message.scan(/^Hive-Triage-Bias:/).length
           assert_equal 1, message.scan(/^Hive-Reviewer-Sources:/).length

--- a/test/unit/stages/review/escalation_questions_test.rb
+++ b/test/unit/stages/review/escalation_questions_test.rb
@@ -63,6 +63,11 @@ class ReviewEscalationQuestionsTest < Minitest::Test
         ### Q2. Should we add a new abstraction?
         Source: codex-ce-code-review-01.md
         ### A2.
+        No, keep the fix local to the current helper.
+
+        ### Q3. Should this remain manual?
+        Source: codex-ce-code-review-01.md
+        ### A3.
       MD
 
       ctx = make_ctx(dir, task_folder)
@@ -70,16 +75,21 @@ class ReviewEscalationQuestionsTest < Minitest::Test
       accepted = payload.text
       answered = Hive::Stages::Review.collect_answered_escalation_findings(ctx)
 
-      assert_equal 3, payload.count
+      assert_equal 4, payload.count
       assert_equal accepted, Hive::Stages::Review.collect_accepted_findings(ctx)
       assert_includes accepted, "AUTO-FIX: rename the confusing helper"
       assert_includes accepted, "legacy accepted finding without a label"
       assert_includes accepted, "USER-ANSWERED ESCALATION Q1"
       assert_includes accepted, "Use execute.agent"
+      assert_includes accepted, "USER-ANSWERED ESCALATION Q2"
+      assert_includes accepted, "Should we add a new abstraction?"
+      assert_includes accepted, "keep the fix local"
       assert_includes answered, "USER-ANSWERED ESCALATION Q1"
+      assert_includes answered, "USER-ANSWERED ESCALATION Q2"
       assert_includes answered, "Use execute.agent"
+      assert_includes answered, "keep the fix local"
       refute_includes accepted, "RESOLVED/NO-FIX"
-      refute_includes accepted, "Should we add a new abstraction?"
+      refute_includes accepted, "Should this remain manual?"
     end
   end
 
@@ -108,6 +118,9 @@ class ReviewEscalationQuestionsTest < Minitest::Test
       assert_equal 1, payload.count
       assert_includes accepted, "Accepted legacy escalations from escalations-01.md"
       assert_includes accepted, "apply the requested legacy escalation fix"
+      assert_equal accepted, Hive::Stages::Review.collect_legacy_checked_escalations(
+        Hive::Stages::Review::Triage.escalations_path(ctx)
+      )
       assert_equal 1, Hive::Stages::Review.count_escalations(ctx)
     end
   end

--- a/test/unit/stages/review/escalation_questions_test.rb
+++ b/test/unit/stages/review/escalation_questions_test.rb
@@ -66,12 +66,18 @@ class ReviewEscalationQuestionsTest < Minitest::Test
       MD
 
       ctx = make_ctx(dir, task_folder)
-      accepted = Hive::Stages::Review.collect_accepted_findings(ctx)
+      payload = Hive::Stages::Review.collect_accepted_findings_with_count(ctx)
+      accepted = payload.text
+      answered = Hive::Stages::Review.collect_answered_escalation_findings(ctx)
 
+      assert_equal 3, payload.count
+      assert_equal accepted, Hive::Stages::Review.collect_accepted_findings(ctx)
       assert_includes accepted, "AUTO-FIX: rename the confusing helper"
       assert_includes accepted, "legacy accepted finding without a label"
       assert_includes accepted, "USER-ANSWERED ESCALATION Q1"
       assert_includes accepted, "Use execute.agent"
+      assert_includes answered, "USER-ANSWERED ESCALATION Q1"
+      assert_includes answered, "Use execute.agent"
       refute_includes accepted, "RESOLVED/NO-FIX"
       refute_includes accepted, "Should we add a new abstraction?"
     end
@@ -96,8 +102,10 @@ class ReviewEscalationQuestionsTest < Minitest::Test
       MD
 
       ctx = make_ctx(dir, task_folder)
-      accepted = Hive::Stages::Review.collect_accepted_findings(ctx)
+      payload = Hive::Stages::Review.collect_accepted_findings_with_count(ctx)
+      accepted = payload.text
 
+      assert_equal 1, payload.count
       assert_includes accepted, "Accepted legacy escalations from escalations-01.md"
       assert_includes accepted, "apply the requested legacy escalation fix"
       assert_equal 1, Hive::Stages::Review.count_escalations(ctx)

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -61,6 +61,14 @@ Append-only log of all wiki operations.
 
 **Refreshed pages:** None — fix is internal launcher plumbing; existing module pages remain accurate.
 
+## [2026-05-26T10:30:00Z] review - accepted finding count source of truth
+
+**Action:** Fixed issue #156 by carrying accepted-findings text and count together through the 6-review Phase 4 path. The auto-commit fallback now writes `Hive-Fix-Findings` from the collector's count instead of reparsing rendered accepted-findings lines, removing the duplicate line-format regexes.
+
+**Refreshed pages:**
+- [[stages/review]] - documented that auto-commit fallback uses the collector count for `Hive-Fix-Findings`.
+- [[modules/metrics]] - clarified the trailer's count source.
+
 ## [2026-05-26T10:15:00Z] daemon - self-reexec on source-file drift
 
 **Action:** Surfaced the daemon's new auto-re-exec behavior triggered by `lib/hive.rb` SHA-256 drift. Adds `ADR-031` recording the diagnosis (8,946 `schema_version` mismatches between PR #78 and the next restart) and the chosen mitigation. Updates `wiki/modules/daemon.md` with operator-facing details: fingerprint scope, rate-limit (60s), kill switch (`HIVE_DAEMON_NO_AUTO_REEXEC=1`), and what kinds of edits do and don't trigger re-exec.

--- a/wiki/modules/metrics.md
+++ b/wiki/modules/metrics.md
@@ -3,7 +3,7 @@ title: Hive::Metrics
 type: module
 source: lib/hive/metrics.rb
 created: 2026-04-26
-updated: 2026-04-26
+updated: 2026-05-26T10:30:00Z
 tags: [metrics, rollback, trailers, observability]
 ---
 
@@ -35,7 +35,7 @@ Fix-agent commits emit the following trailers (see `templates/fix_prompt.md.erb`
 |---------|-----------|-------|
 | `Hive-Task-Slug` | both | Task slug (folder basename). |
 | `Hive-Fix-Pass` | both | `01` … `NN` zero-padded. The presence of this trailer is what marks a commit as a "fix-agent commit." |
-| `Hive-Fix-Findings` | review-fix only | Count of `[x]` items applied in this commit. |
+| `Hive-Fix-Findings` | review-fix only | Count of accepted findings applied in this commit; the review runner carries this count alongside the accepted-findings text so auto-commit fallback does not reparse prompt text. |
 | `Hive-Triage-Bias` | review-fix only | `courageous` / `safetyist` / custom. |
 | `Hive-Reviewer-Sources` | review-fix only | Comma-separated reviewer-file basenames (no NN). |
 | `Hive-Fix-Phase` | both | `ci` (Phase 1) or `fix` (Phase 4). |

--- a/wiki/stages/review.md
+++ b/wiki/stages/review.md
@@ -3,7 +3,7 @@ title: 6-review stage
 type: stage
 source: lib/hive/stages/review.rb, lib/hive/stages/review/{ci_fix,triage,browser_test,fix_guardrail}.rb, templates/{fix,ci_fix,browser_test,triage_*}*.erb
 created: 2026-04-26
-updated: 2026-05-26T10:00:00Z
+updated: 2026-05-26T10:30:00Z
 tags: [stage, review, autonomous-loop, ci, triage, fix-guardrail]
 ---
 
@@ -91,7 +91,7 @@ The escalations digest is mirrored to the PR with the same publisher path and du
 
 ## Phase 4 — fix (`spawn_fix_agent`)
 
-Spawns the fix agent (`cfg.review.fix.agent`, default `claude`) with the concatenated `[x]` lines from every per-reviewer file for the current pass, wrapped in the `<user_supplied>` nonce. The fix prompt requires git trailers on every commit (`Hive-Task-Slug`, `Hive-Fix-Pass`, `Hive-Fix-Findings`, `Hive-Triage-Bias`, `Hive-Reviewer-Sources`, `Hive-Fix-Phase: fix`) — consumed by `hive metrics rollback-rate` (U14). Phase 4 first refuses pre-existing worktree dirt with `REVIEW_ERROR phase=fix reason=fix_dirty_worktree`, so Hive never auto-commits unrelated manual edits. If a successful fix agent starts from a clean tree and exits with uncommitted worktree changes, the runner stages and commits those changes with the same trailers before guardrail evaluation; commit failure yields `REVIEW_ERROR phase=fix reason=fix_auto_commit_failed`.
+Spawns the fix agent (`cfg.review.fix.agent`, default `claude`) with the concatenated `[x]` lines from every per-reviewer file for the current pass, wrapped in the `<user_supplied>` nonce. The fix prompt requires git trailers on every commit (`Hive-Task-Slug`, `Hive-Fix-Pass`, `Hive-Fix-Findings`, `Hive-Triage-Bias`, `Hive-Reviewer-Sources`, `Hive-Fix-Phase: fix`) — consumed by `hive metrics rollback-rate` (U14). Phase 4 first refuses pre-existing worktree dirt with `REVIEW_ERROR phase=fix reason=fix_dirty_worktree`, so Hive never auto-commits unrelated manual edits. If a successful fix agent starts from a clean tree and exits with uncommitted worktree changes, the runner stages and commits those changes with the same trailers before guardrail evaluation; `Hive-Fix-Findings` comes from the accepted-findings collector's count, not from reparsing the rendered prompt text. Commit failure yields `REVIEW_ERROR phase=fix reason=fix_auto_commit_failed`.
 
 Plan / worktree.yml / task.md are SHA-256 protected around the fix spawn; tampering → `REVIEW_ERROR phase=fix reason=fix_tampered`.
 


### PR DESCRIPTION
## Summary
- Carries accepted findings as a text/count payload through review Phase 4.
- Removes the duplicate `accepted_finding_count` regex parser from auto-commit trailer generation.
- Keeps the existing string-returning collector helpers delegating to the count-aware collectors for compatibility.
- Updates review and metrics wiki pages with the trailer count source of truth.

Closes #156

## Tests
- `ruby -c lib/hive/stages/review.rb`
- `ruby -c test/unit/stages/review/escalation_questions_test.rb`
- `ruby -c test/unit/current_main_coverage_gap_test.rb`
- `bundle exec ruby -Itest -Ilib test/unit/stages/review/escalation_questions_test.rb`
- `bundle exec ruby -Itest -Ilib test/unit/current_main_coverage_gap_test.rb`
- `bundle exec ruby -Itest -Ilib test/integration/run_review_test.rb`
- `bundle exec rubocop lib/hive/stages/review.rb test/unit/stages/review/escalation_questions_test.rb test/unit/current_main_coverage_gap_test.rb`
- `bundle exec rake test`
- `bundle exec rake coverage` - 3500 runs, 12599 assertions, 0 failures, 0 errors, 2 skips; line coverage 100.00% (15435/15435)

## Post-Deploy Monitoring & Validation
- Inspect new fix-agent commits for `Hive-Fix-Findings:` and compare the value with accepted findings in `reviews/*-NN.md` plus answered escalations in `escalations-NN.md`.
- Watch rollback-rate metrics consumers that read the `Hive-Fix-Findings` trailer.
- Healthy signal: fallback auto-commits report counts above 1 when multiple accepted findings or answered escalations were applied.
- Failure signal: `Hive-Fix-Findings` stays at 1 despite multiple accepted findings; rollback by reverting this commit.

## Code Review
- Local pre-PR review completed after the full suite and coverage gate.
- Checked compatibility helpers still return strings while the auto-commit path uses collector-owned counts.

Compound Engineered with GPT-5 Codex
