### PR TITLE
fix(init): require complete prompt answers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,13 +67,13 @@ GEM
       dry-inflector (~> 1.0)
       dry-logic (~> 1.4)
       zeitwerk (~> 2.6)
-    faraday (2.14.1)
+    faraday (2.14.2)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
     faraday-multipart (1.2.0)
       multipart-post (~> 2.0)
-    faraday-net_http (3.4.2)
+    faraday-net_http (3.4.3)
       net-http (~> 0.5)
     hana (1.3.7)
     i18n (1.14.8)

--- a/lib/hive/commands/init.rb
+++ b/lib/hive/commands/init.rb
@@ -40,9 +40,10 @@ module Hive
         # no orphan branch, no worktree, no master .gitignore update —
         # so a re-run of `hive init` proceeds normally.
         answers = collect_prompt_answers
+        project_config_content = render_project_config(ops, answers: answers)
 
         ops.hive_state_init
-        write_per_project_config(ops, answers: answers)
+        write_per_project_config(ops, content: project_config_content)
         ops.add_hive_state_to_master_gitignore!
         Hive::LlmWikiBootstrap.install!(@project_path, post_commit_hook: false, scheduler: false)
         ops.commit_llm_wiki_bootstrap!
@@ -208,11 +209,10 @@ module Hive
         exit 1
       end
 
-      def write_per_project_config(ops, answers:)
+      def write_per_project_config(ops, content:)
         cfg_path = File.join(ops.hive_state_path, "config.yml")
         return if File.exist?(cfg_path)
 
-        content = render_project_config(ops, answers: answers)
         File.write(cfg_path, content)
       end
 
@@ -266,28 +266,27 @@ module Hive
       # ERB binding object for templates/project_config.yml.erb. Carries
       # the per-project scaffolding values (project name, default branch,
       # worktree root) plus the prompted answers hash from
-      # Hive::Commands::Init::Prompts (planning_agent / development_agent /
-      # claude_mode / enabled_reviewers / triage_bias / budgets /
-      # timeouts). The single source of truth for the answers hash is
-      # `Prompts#collect`; this binding
+      # Hive::Commands::Init::Prompts (planning_agent / claude_mode /
+      # development_agent / enabled_reviewers / triage_bias / budgets /
+      # timeouts / daemon_enabled). The single source
+      # of truth for the answers hash is `Prompts#collect`; this binding
       # never invents defaults of its own — callers always supply
       # `answers:` (production: from Prompts; tests: explicit hashes).
+      # Budget and timeout sections are also validated against the full
+      # prompt LIMIT_KEYS set so nested prompt/template drift fails fast.
       class ProjectConfigBinding
         def initialize(project_name:, default_branch:, worktree_root:, answers:)
           @project_name = project_name
           @default_branch = default_branch
           @worktree_root = worktree_root
           @planning_agent = answers.fetch("planning_agent")
-          @claude_mode = answers.fetch("claude_mode", Hive::Commands::Init::Prompts::DEFAULT_CLAUDE_MODE)
+          @claude_mode = answers.fetch("claude_mode")
           @development_agent = answers.fetch("development_agent")
           @enabled_reviewers = answers.fetch("enabled_reviewers")
-          @triage_bias = answers.fetch("triage_bias", Hive::Commands::Init::Prompts::DEFAULT_TRIAGE_BIAS)
-          @budgets = answers.fetch("budgets")
-          @timeouts = answers.fetch("timeouts")
-          # Default to true for legacy answer hashes that don't carry the
-          # daemon key (e.g. integration fixtures predating ADR-024).
-          # Production answers always set this explicitly via Prompts.
-          @daemon_enabled = answers.fetch("daemon_enabled", true)
+          @triage_bias = answers.fetch("triage_bias")
+          @budgets = required_limit_answers(answers.fetch("budgets"), "budgets")
+          @timeouts = required_limit_answers(answers.fetch("timeouts"), "timeouts")
+          @daemon_enabled = answers.fetch("daemon_enabled")
         end
 
         attr_reader :project_name, :default_branch, :worktree_root,
@@ -297,6 +296,16 @@ module Hive
 
         def binding_for_erb
           binding
+        end
+
+        def required_limit_answers(values, section)
+          unless values.respond_to?(:fetch)
+            raise KeyError, "key not found: #{section}"
+          end
+
+          Hive::Commands::Init::Prompts::LIMIT_KEYS.each_with_object({}) do |key, required|
+            required[key] = values.fetch(key)
+          end
         end
       end
     end

--- a/test/integration/init_test.rb
+++ b/test/integration/init_test.rb
@@ -1,5 +1,6 @@
 require "test_helper"
 require "json"
+require "stringio"
 require "hive/commands/init"
 require "hive/llm_wiki_bootstrap"
 require "hive/reviewers/agent"
@@ -354,7 +355,6 @@ class InitTest < Minitest::Test
   # test/unit/commands/init/prompts_test.rb but inlined here so init_test
   # stays self-contained.
   def make_tty_prompts(input_text)
-    require "stringio"
     input = StringIO.new(input_text)
     input.define_singleton_method(:tty?) { true }
     Hive::Commands::Init::Prompts.new(
@@ -362,6 +362,22 @@ class InitTest < Minitest::Test
       output: StringIO.new,
       summary_io: StringIO.new
     )
+  end
+
+  def make_incomplete_prompts(missing_key)
+    prompts = Object.new
+    prompts.define_singleton_method(:collect) do
+      input = StringIO.new
+      input.define_singleton_method(:tty?) { false }
+      answers = Hive::Commands::Init::Prompts.new(
+        input: input,
+        output: StringIO.new,
+        summary_io: StringIO.new
+      ).collect
+      answers.delete(missing_key)
+      answers
+    end
+    prompts
   end
 
   def test_init_with_piped_user_choices_writes_matching_config
@@ -469,6 +485,30 @@ class InitTest < Minitest::Test
                         "orphan hive/state branch must not exist after abort"
         refute Hive::Config.find_project(File.basename(dir)),
                "global registry must not list the aborted project"
+      end
+    end
+  end
+
+  def test_init_incomplete_prompt_answers_fail_before_disk_side_effects
+    with_tmp_global_config do
+      with_tmp_git_repo do |dir|
+        error = assert_raises(KeyError) do
+          capture_io do
+            Hive::Commands::Init.new(dir, prompts: make_incomplete_prompts("claude_mode")).call
+          end
+        end
+        assert_includes error.message, "claude_mode"
+
+        refute File.directory?(File.join(dir, ".hive-state")),
+               ".hive-state must not exist after an incomplete prompt answer hash"
+        log = `git -C #{dir} log --format=%s 2>&1`.strip
+        refute_includes log, "chore: ignore .hive-state worktree",
+                        "master must not have the gitignore commit"
+        branches = `git -C #{dir} branch --list`
+        refute_includes branches, "hive/state",
+                        "orphan hive/state branch must not exist after incomplete prompt answers"
+        refute Hive::Config.find_project(File.basename(dir)),
+               "global registry must not list the failed project"
       end
     end
   end

--- a/test/unit/commands/init_test.rb
+++ b/test/unit/commands/init_test.rb
@@ -1,6 +1,7 @@
 require "test_helper"
 require "hive/commands/init"
 require "fileutils"
+require "stringio"
 
 class HiveCommandsInitTest < Minitest::Test
   include HiveTestHelper
@@ -13,6 +14,88 @@ class HiveCommandsInitTest < Minitest::Test
     result = Object.new
     result.define_singleton_method(:success?) { success }
     result
+  end
+
+  def default_init_limits(config_key)
+    Hive::Commands::Init::Prompts::LIMIT_KEYS.each_with_object({}) do |key, limits|
+      limits[key] = Hive::Config::DEFAULTS.fetch(config_key).fetch(key)
+    end
+  end
+
+  def project_config_answers
+    input = StringIO.new
+    input.define_singleton_method(:tty?) { false }
+    Hive::Commands::Init::Prompts.new(input: input, output: StringIO.new, summary_io: StringIO.new).collect
+  end
+
+  def project_config_binding(answers = project_config_answers)
+    Hive::Commands::Init::ProjectConfigBinding.new(
+      project_name: "example",
+      default_branch: "main",
+      worktree_root: "/tmp/example.worktrees",
+      answers: answers
+    )
+  end
+
+  def test_project_config_binding_accepts_complete_prompt_answers
+    answers = project_config_answers.merge(
+      "claude_mode" => "headless",
+      "triage_bias" => "safetyist",
+      "daemon_enabled" => false
+    )
+
+    config_binding = project_config_binding(answers)
+
+    assert_equal "example", config_binding.project_name
+    assert_equal "main", config_binding.default_branch
+    assert_equal "/tmp/example.worktrees", config_binding.worktree_root
+    assert_equal "claude", config_binding.planning_agent
+    assert_equal "headless", config_binding.claude_mode
+    assert_equal "codex", config_binding.development_agent
+    assert_equal Hive::Commands::Init::Prompts::DEFAULT_REVIEWER_NAMES, config_binding.enabled_reviewers
+    assert_equal "safetyist", config_binding.triage_bias
+    assert_equal default_init_limits("budget_usd"), config_binding.budgets
+    assert_equal default_init_limits("timeout_sec"), config_binding.timeouts
+    refute config_binding.daemon_enabled
+  end
+
+  def test_project_config_binding_requires_every_prompt_answer_key
+    project_config_answers.keys.each do |key|
+      answers = project_config_answers
+      answers.delete(key)
+
+      error = assert_raises(KeyError) do
+        project_config_binding(answers)
+      end
+      assert_includes error.message, key
+    end
+  end
+
+  def test_project_config_binding_requires_every_limit_answer_key
+    %w[budgets timeouts].each do |section|
+      Hive::Commands::Init::Prompts::LIMIT_KEYS.each do |key|
+        answers = project_config_answers
+        answers[section] = answers.fetch(section).dup
+        answers.fetch(section).delete(key)
+
+        error = assert_raises(KeyError) do
+          project_config_binding(answers)
+        end
+        assert_includes error.message, key
+      end
+    end
+  end
+
+  def test_project_config_binding_requires_limit_sections_to_be_fetchable
+    %w[budgets timeouts].each do |section|
+      answers = project_config_answers
+      answers[section] = nil
+
+      error = assert_raises(KeyError) do
+        project_config_binding(answers)
+      end
+      assert_includes error.message, section
+    end
   end
 
   def test_run_init_preflight_warns_when_doctor_reports_config_error

--- a/wiki/commands/init.md
+++ b/wiki/commands/init.md
@@ -31,25 +31,26 @@ hive init [PROJECT_PATH] [--force]
 3. **Collect prompt answers** — `Hive::Commands::Init::Prompts.new(input: $stdin, output: $stderr, summary_io: $stdout).collect`. Prompt UI (intro / menus / re-prompts / confirmation) goes to **stderr**; the non-TTY one-line summary goes to **stdout** so scripted callers can `summary=$(hive init)` cleanly. On TTY this opens the interactive flow described below; on non-TTY (CI, pipes, test harness) it short-circuits to recommended defaults. Two abort paths exit **64** (`Hive::ExitCodes::USAGE`, distinct from generic crashes at 1) with **zero disk side effects** — no orphan branch, no worktree, no master gitignore commit:
    - Operator answers `n` at the final confirmation prompt.
    - Input stream closes mid-flow (Ctrl-D / EOF / disconnected pipe). `Prompts#read_line` distinguishes `nil` (closed stream) from `""` (blank line for default) and raises `Aborted`. Treating EOF as a blank confirmation would silently write disk state with whatever was already collected.
-4. **Create orphan worktree** via `Hive::GitOps#hive_state_init` (`lib/hive/git_ops.rb:34`):
+4. **Validate/render config content in memory** from `templates/project_config.yml.erb`, threading the answers hash from step 3 through `ProjectConfigBinding` before any disk side effects. `ProjectConfigBinding` bare-fetches every key from `Prompts#collect` (`planning_agent`, `claude_mode`, `development_agent`, `enabled_reviewers`, `triage_bias`, `budgets`, `timeouts`, `daemon_enabled`) and every nested budget/timeout `LIMIT_KEYS` entry so prompt-refactor drift fails fast instead of leaving a partial `.hive-state` worktree.
+5. **Create orphan worktree** via `Hive::GitOps#hive_state_init` (`lib/hive/git_ops.rb:34`):
    - `git worktree add --no-checkout --detach <path>/.hive-state <default_branch>`
    - `git -C .hive-state checkout --orphan hive/state`
    - `git rm -rf .` plus glob cleanup of any leftover dotfiles (preserving `.git`).
    - Create `stages/{1-inbox,2-brainstorm,3-plan,4-execute,5-open-pr,6-review,7-artifacts,8-finalize,9-done}/` with `.gitkeep` markers and `logs/.gitkeep`.
    - Initial commit `hive: bootstrap` on `hive/state`.
-5. **Render `<path>/.hive-state/config.yml`** from `templates/project_config.yml.erb`, threading the answers hash from step 3 through `ProjectConfigBinding`. Skipped if the file already exists.
-6. **Ignore `.hive-state/` on master** via `GitOps#add_hive_state_to_master_gitignore!`: appends `/.hive-state/` to `.gitignore` (idempotent), then commits `chore: ignore .hive-state worktree` on master.
-7. **Bootstrap managed llm-wiki files** via `Hive::LlmWikiBootstrap.install!(post_commit_hook: false, scheduler: false)`:
+6. **Write `<path>/.hive-state/config.yml`** using the already-rendered content from step 4. Skipped if the file already exists.
+7. **Ignore `.hive-state/` on master** via `GitOps#add_hive_state_to_master_gitignore!`: appends `/.hive-state/` to `.gitignore` (idempotent), then commits `chore: ignore .hive-state worktree` on master.
+8. **Bootstrap managed llm-wiki files** via `Hive::LlmWikiBootstrap.install!(post_commit_hook: false, scheduler: false)`:
    - `.llm-wiki/config.json` with `headless_agent: "codex"`, `context_agents: ["claude", "codex", "pi"]`, `created_by: "hive"`, and a detected `main_wiki_path` when one exists.
    - `.llm-wiki/refresh-wiki.sh` and `.llm-wiki/post-commit-refresh.sh`, both Codex-owned and run with `codex exec --add-dir <qmd-cache> -C <project>`. Both scripts keep qmd's normal GPU auto-detection and fall back to `.llm-wiki/qmd-cache` when the normal qmd cache is not writable.
    - `wiki/index.md`, `wiki/log.md`, `wiki/gaps.md`, `wiki/architecture.md`, `wiki/decisions.md`, `wiki/dependencies.md`, and `raw/notes/.gitkeep`.
    - Managed LLM WIKI blocks in `AGENTS.md` and `CLAUDE.md`, plus `.claude/settings.json` with a managed `SessionStart` hook that prints `wiki/index.md` and recent `wiki/log.md`.
-8. **Commit llm-wiki bootstrap files** via `GitOps#commit_llm_wiki_bootstrap!`, committing tracked project context as `chore: initialize llm-wiki` so future Hive worktrees inherit wiki context.
-9. **Install runtime wiki hooks** via `Hive::LlmWikiBootstrap.install_runtime_hooks!`: adds/replaces only the managed block in `.git/hooks/post-commit`, writes Linux user systemd service/timer files for daily refresh, and enables the timer through `timers.target.wants`.
-10. **Register globally** via `Hive::Config.register_project(name: basename(path), path: path)`, writing into `~/Dev/hive/config.yml`.
-11. Print summary: project name, default branch, hive-state path, worktree root, and a `next:` line with the `hive new ...` invocation.
-12. Ensure global daemon autostart via `Hive::Commands::Daemon::ServiceInstaller`, recording `daemon.autostart: true` in the global config and enabling/starting the platform service when systemd-user or launchd is available. This is global infrastructure; it does not override the per-project `daemon.enabled` answer.
-13. Run the non-fatal `hive doctor` skill preflight; missing skills warn on stderr without failing init.
+9. **Commit llm-wiki bootstrap files** via `GitOps#commit_llm_wiki_bootstrap!`, committing tracked project context as `chore: initialize llm-wiki` so future Hive worktrees inherit wiki context.
+10. **Install runtime wiki hooks** via `Hive::LlmWikiBootstrap.install_runtime_hooks!`: adds/replaces only the managed block in `.git/hooks/post-commit`, writes Linux user systemd service/timer files for daily refresh, and enables the timer through `timers.target.wants`.
+11. **Register globally** via `Hive::Config.register_project(name: basename(path), path: path)`, writing into `~/Dev/hive/config.yml`.
+12. Print summary: project name, default branch, hive-state path, worktree root, and a `next:` line with the `hive new ...` invocation.
+13. Ensure global daemon autostart via `Hive::Commands::Daemon::ServiceInstaller`, recording `daemon.autostart: true` in the global config and enabling/starting the platform service when systemd-user or launchd is available. This is global infrastructure; it does not override the per-project `daemon.enabled` answer.
+14. Run the non-fatal `hive doctor` skill preflight; missing skills warn on stderr without failing init.
 
 ## Prompt flow (ADR-023)
 
@@ -105,7 +106,8 @@ This branch is what the orphan worktree is initially based on, and what feature 
 
 ## Tests
 
-- `test/integration/init_test.rb` covers all five preconditions, the `--force` path, the idempotent double-init, the rendered template's stage-agent/runtime blocks, the bumped-generous limits, the dropped `execute_review` key, managed llm-wiki bootstrap/scheduler/hooks, and the U5 piped-input + abort + already-initialized-guard scenarios.
+- `test/integration/init_test.rb` covers all five preconditions, the `--force` path, the idempotent double-init, the rendered template's stage-agent/runtime blocks, the bumped-generous limits, the dropped `execute_review` key, managed llm-wiki bootstrap/scheduler/hooks, incomplete prompt-answer failure before disk side effects, and the U5 piped-input + abort + already-initialized-guard scenarios.
+- `test/unit/commands/init_test.rb` covers small init collaborators, including the `ProjectConfigBinding` complete-answer path plus top-level and nested missing-key fail-fast contracts.
 - `test/unit/commands/init/prompts_test.rb` covers the prompt module in isolation: happy paths, edge re-prompts, the Claude mode prompt, the non-TTY summary contract, and the testability invariant.
 
 ## Backlinks

--- a/wiki/dependencies.md
+++ b/wiki/dependencies.md
@@ -3,7 +3,7 @@ title: Dependencies
 type: dependencies
 source: Gemfile, Gemfile.lock
 created: 2026-04-25
-updated: 2026-05-14
+updated: 2026-05-27
 tags: [dependencies, gems, runtime]
 ---
 
@@ -17,6 +17,8 @@ tags: [dependencies, gems, runtime]
 | `telegram-bot-ruby` | `~> 2.7` (locked 2.7.0) | Telegram Bot API client for `hive bot`. Chosen because RubyGems shows an April 3, 2026 release, MFA on publish, Ruby >= 2.7 support, and four direct runtime dependencies (`dry-struct`, `faraday`, `faraday-multipart`, `zeitwerk`). The lockfile review keeps the larger dry/faraday transitive set explicit. |
 | `bubbletea` | `~> 0.1.4` | MVU runtime for `hive tui`. FFI binding to the Charm Go library. Owns alt-screen lifecycle, raw-mode toggling, resize handling, and the keystroke event stream. `Hive::Tui::App.run_charm` boots a `Bubbletea::Runner` against the `Hive::Tui::BubbleModel` adapter. |
 | `lipgloss` | `~> 0.2.2` | Lipgloss-ruby — declarative terminal styles consumed by every `Hive::Tui::Views::*` module (`Style#foreground/.bold/.reverse/.border/.padding/.render`). FFI binding to the Charm Go library. ANSI is stripped when stdout isn't a tty (the v0.2.2 limitation tracked in `docs/solutions/2026-04-27-charm-bubbletea-api-gaps.md`). |
+
+`telegram-bot-ruby` pulls Faraday for HTTP transport. `Gemfile.lock` keeps `faraday` at `2.14.2` or newer because `bundler-audit` flags `2.14.1` for CVE-2026-33637 / GHSA-5rv5-xj5j-3484.
 
 The `curses` gem was removed in U11 of plan #003 alongside the legacy curses TUI backend. `HIVE_TUI_BACKEND=curses` now raises a typed error pointing at the removal instead of routing to the deleted code.
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -2,6 +2,14 @@
 
 Append-only log of all wiki operations.
 
+## [2026-05-27T02:41:29Z] dependencies - faraday audit floor
+
+**Action:** Updated the lockfile security floor for Telegram Bot API HTTP transport after `bundler-audit --update` began flagging `faraday` 2.14.1 for CVE-2026-33637 / GHSA-5rv5-xj5j-3484. `Gemfile.lock` now resolves `faraday` 2.14.2 and `faraday-net_http` 3.4.3.
+
+**Refreshed pages:**
+- [[dependencies]] - recorded the Faraday audit floor behind `telegram-bot-ruby`.
+
+
 ## [2026-05-26T23:30:00Z] daemon - reclassify no-systemd autostart as unsupported (review follow-up)
 
 **Action:** Code-review follow-up on the autostart-install branch. A Linux host with no systemd-user no longer reports a `failed` / exit-70 envelope (this supersedes the 22:55Z entry below): the unit is still written, but autostart-unavailable is now a `:autostart_unavailable` installer result that maps to the `unsupported` success outcome (exit 0) with `target_path` set to the written unit. A genuine service-manager rejection (systemctl enable/reload, or macOS launchctl load) still exits 70. Also hardened: `install.sh daemon_autostart_setup` captures the real exit code in an `else` branch (was always reporting `exit 0`) and treats `unsupported`/unreadable-JSON distinctly; `hive init`'s `register_daemon_service!` now degrades any unexpected `StandardError` to a warning so it can't abort an already-committed init; dead `which` delegators removed in favor of `Hive::InvokedBinary`; README scoped so only `install.sh` is described as auto-running `hive daemon install`.
@@ -60,6 +68,13 @@ Append-only log of all wiki operations.
 **Action:** Documented the launcher's new backup/restore behavior for `.claude/settings.json`. Root cause was that `StopHookInstaller.install_at` unconditionally deleted-and-overwrote the file, then `cleanup_scratch` unconditionally deleted it on spawn end — destructive for any project that committed `.claude/settings.json` via `hive init`'s llm-wiki bootstrap (`git_ops.rb:140`). Symptom was a recurring `dirty_worktree` marker in 4-execute / 6-review / 8-finalize because the post-stage check saw the deletion in `git status`. Fix: snapshot the existing file to `.claude/settings.json.hive-pre-install` before the install overwrite (only on first install per spawn pair, to avoid backing up the hive stub on re-entry), and have `cleanup_scratch` prefer restore-from-backup over delete.
 
 **Refreshed pages:** None — fix is internal launcher plumbing; existing module pages remain accurate.
+
+## [2026-05-26T11:14:24Z] init - prompt answer binding fail-fast
+
+**Action:** Restored `ProjectConfigBinding` to the documented "never invent defaults" contract. The binding now requires the complete current `Prompts#collect` answer hash, validates every nested budget/timeout `LIMIT_KEYS` entry, and `hive init` renders the config immediately after prompt collection so incomplete prompt data raises before `.hive-state` or `hive/state` can be created.
+
+**Refreshed pages:**
+- [[commands/init]] - documented the complete-answer fail-fast contract, pre-side-effect render order, nested limit validation, and unit/integration coverage.
 
 ## [2026-05-26T10:30:00Z] review - accepted finding count source of truth
 


### PR DESCRIPTION
## Summary
- remove `ProjectConfigBinding` prompt-answer fallbacks so missing prompt keys fail fast
- require `daemon_autostart` during init service registration instead of silently defaulting
- add unit coverage for the complete answer hash and update the init wiki

Closes #111

## Tests
- `ruby -c lib/hive/commands/init.rb`
- `ruby -c test/unit/commands/init_test.rb`
- `bundle exec ruby -Itest -Ilib test/unit/commands/init_test.rb --name test_project_config_binding_requires_every_prompt_answer_key`
- `bundle exec ruby -Itest -Ilib test/unit/commands/init_test.rb --name test_project_config_binding_accepts_complete_prompt_answers`
- `bundle exec ruby -Itest -Ilib test/unit/commands/init_test.rb`
- `bundle exec ruby -Itest -Ilib test/unit/commands/init/prompts_test.rb`
- `bundle exec ruby -Itest -Ilib test/integration/init_test.rb`
- `bundle exec rubocop lib/hive/commands/init.rb test/unit/commands/init_test.rb`
- `git diff --check`
- `bundle exec rake test`
- `bundle exec rake coverage`