### PR TITLE
fix(tmux): share Claude ready timeout fallback

### DIFF
--- a/docs/notes/claude-tmux-launch-mode.md
+++ b/docs/notes/claude-tmux-launch-mode.md
@@ -97,16 +97,18 @@ the runtime can override them in the calling shell:
   Hive captures the pane tail as a fallback when the Stop hook does not
   fire.
 - `HIVE_CLAUDE_TMUX_READY_WAIT_TIMEOUT_SEC` (default `5`) — shared
-  default for the two ready-waits below. Override one of them directly
-  to tune that wait without affecting the other.
+  override for the readiness waits below when their specific env vars
+  are unset. Override one of them directly to tune that wait without
+  affecting the others.
 - `HIVE_CLAUDE_TMUX_SESSION_READY_WAIT_TIMEOUT_SEC` (defaults to the
   shared `READY_WAIT_TIMEOUT_SEC`) — budget for tmux session creation
   after `new-session -d`.
 - `HIVE_CLAUDE_TMUX_PID_READY_WAIT_TIMEOUT_SEC` (defaults to the
   shared `READY_WAIT_TIMEOUT_SEC`) — budget for the claude PID to appear
   in the pane after the wrapper execs.
-- `HIVE_CLAUDE_TMUX_CLAUDE_READY_WAIT_TIMEOUT_SEC` (default `30`) —
-  budget for Claude's interactive prompt to become ready after the tmux
+- `HIVE_CLAUDE_TMUX_CLAUDE_READY_WAIT_TIMEOUT_SEC` (defaults to the
+  shared `READY_WAIT_TIMEOUT_SEC` when set, otherwise `120`) — budget
+  for the Claude interactive prompt to become ready after the tmux
   session starts.
 - `HIVE_TMUX_PROMPT_SUBMIT_DELAY_SEC` (default `0.2`) — delay between
   pasting the prompt into tmux and pressing Enter. Claude Code processes

--- a/lib/hive/claude_launcher.rb
+++ b/lib/hive/claude_launcher.rb
@@ -646,7 +646,8 @@ module Hive
     end
 
     def claude_ready_wait_timeout
-      Float(tmux_env("CLAUDE_READY_WAIT_TIMEOUT_SEC", CLAUDE_READY_WAIT_TIMEOUT_SEC.to_s))
+      shared_timeout = tmux_env("READY_WAIT_TIMEOUT_SEC", CLAUDE_READY_WAIT_TIMEOUT_SEC.to_s)
+      Float(tmux_env("CLAUDE_READY_WAIT_TIMEOUT_SEC", shared_timeout))
     end
 
     def session_ready_wait_timeout

--- a/test/unit/claude_launcher_test.rb
+++ b/test/unit/claude_launcher_test.rb
@@ -175,27 +175,101 @@ class ClaudeLauncherTest < Minitest::Test
   end
 
   def test_legacy_brainstorm_env_timeout_is_honored
-    old_new = ENV["HIVE_CLAUDE_TMUX_READY_WAIT_TIMEOUT_SEC"]
-    old_legacy = ENV["HIVE_BRAINSTORM_TMUX_READY_WAIT_TIMEOUT_SEC"]
-    ENV.delete("HIVE_CLAUDE_TMUX_READY_WAIT_TIMEOUT_SEC")
-    ENV["HIVE_BRAINSTORM_TMUX_READY_WAIT_TIMEOUT_SEC"] = "12.5"
-
-    assert_equal 12.5, Hive::ClaudeLauncher.ready_wait_timeout
-  ensure
-    restore_env("HIVE_CLAUDE_TMUX_READY_WAIT_TIMEOUT_SEC", old_new)
-    restore_env("HIVE_BRAINSTORM_TMUX_READY_WAIT_TIMEOUT_SEC", old_legacy)
+    with_env(
+      "HIVE_CLAUDE_TMUX_READY_WAIT_TIMEOUT_SEC" => nil,
+      "HIVE_BRAINSTORM_TMUX_READY_WAIT_TIMEOUT_SEC" => "12.5"
+    ) do
+      assert_equal 12.5, Hive::ClaudeLauncher.ready_wait_timeout
+    end
   end
 
   def test_new_claude_env_timeout_wins_over_legacy
-    old_new = ENV["HIVE_CLAUDE_TMUX_READY_WAIT_TIMEOUT_SEC"]
-    old_legacy = ENV["HIVE_BRAINSTORM_TMUX_READY_WAIT_TIMEOUT_SEC"]
-    ENV["HIVE_CLAUDE_TMUX_READY_WAIT_TIMEOUT_SEC"] = "4.25"
-    ENV["HIVE_BRAINSTORM_TMUX_READY_WAIT_TIMEOUT_SEC"] = "12.5"
+    with_env(
+      "HIVE_CLAUDE_TMUX_READY_WAIT_TIMEOUT_SEC" => "4.25",
+      "HIVE_BRAINSTORM_TMUX_READY_WAIT_TIMEOUT_SEC" => "12.5"
+    ) do
+      assert_equal 4.25, Hive::ClaudeLauncher.ready_wait_timeout
+    end
+  end
 
-    assert_equal 4.25, Hive::ClaudeLauncher.ready_wait_timeout
-  ensure
-    restore_env("HIVE_CLAUDE_TMUX_READY_WAIT_TIMEOUT_SEC", old_new)
-    restore_env("HIVE_BRAINSTORM_TMUX_READY_WAIT_TIMEOUT_SEC", old_legacy)
+  def test_claude_ready_timeout_inherits_new_shared_ready_timeout_when_specific_unset
+    with_env(
+      "HIVE_CLAUDE_TMUX_CLAUDE_READY_WAIT_TIMEOUT_SEC" => nil,
+      "HIVE_BRAINSTORM_TMUX_CLAUDE_READY_WAIT_TIMEOUT_SEC" => nil,
+      "HIVE_CLAUDE_TMUX_READY_WAIT_TIMEOUT_SEC" => "8.75",
+      "HIVE_BRAINSTORM_TMUX_READY_WAIT_TIMEOUT_SEC" => "12.5"
+    ) do
+      assert_equal 8.75, Hive::ClaudeLauncher.claude_ready_wait_timeout
+    end
+  end
+
+  def test_claude_ready_timeout_inherits_legacy_shared_ready_timeout_when_specific_unset
+    with_env(
+      "HIVE_CLAUDE_TMUX_CLAUDE_READY_WAIT_TIMEOUT_SEC" => nil,
+      "HIVE_BRAINSTORM_TMUX_CLAUDE_READY_WAIT_TIMEOUT_SEC" => nil,
+      "HIVE_CLAUDE_TMUX_READY_WAIT_TIMEOUT_SEC" => nil,
+      "HIVE_BRAINSTORM_TMUX_READY_WAIT_TIMEOUT_SEC" => "12.5"
+    ) do
+      assert_equal 12.5, Hive::ClaudeLauncher.claude_ready_wait_timeout
+    end
+  end
+
+  def test_claude_ready_timeout_specific_setting_wins_over_shared_ready_timeout
+    with_env(
+      "HIVE_CLAUDE_TMUX_CLAUDE_READY_WAIT_TIMEOUT_SEC" => "30.5",
+      "HIVE_BRAINSTORM_TMUX_CLAUDE_READY_WAIT_TIMEOUT_SEC" => "40.5",
+      "HIVE_CLAUDE_TMUX_READY_WAIT_TIMEOUT_SEC" => "8.75",
+      "HIVE_BRAINSTORM_TMUX_READY_WAIT_TIMEOUT_SEC" => "12.5"
+    ) do
+      assert_equal 30.5, Hive::ClaudeLauncher.claude_ready_wait_timeout
+    end
+  end
+
+  def test_claude_ready_timeout_legacy_specific_setting_wins_over_shared_ready_timeout
+    with_env(
+      "HIVE_CLAUDE_TMUX_CLAUDE_READY_WAIT_TIMEOUT_SEC" => nil,
+      "HIVE_BRAINSTORM_TMUX_CLAUDE_READY_WAIT_TIMEOUT_SEC" => "40.5",
+      "HIVE_CLAUDE_TMUX_READY_WAIT_TIMEOUT_SEC" => "8.75",
+      "HIVE_BRAINSTORM_TMUX_READY_WAIT_TIMEOUT_SEC" => "12.5"
+    ) do
+      assert_equal 40.5, Hive::ClaudeLauncher.claude_ready_wait_timeout
+    end
+  end
+
+  def test_claude_ready_timeout_valid_specific_setting_wins_over_invalid_shared_timeout
+    with_env(
+      "HIVE_CLAUDE_TMUX_CLAUDE_READY_WAIT_TIMEOUT_SEC" => "30.5",
+      "HIVE_BRAINSTORM_TMUX_CLAUDE_READY_WAIT_TIMEOUT_SEC" => nil,
+      "HIVE_CLAUDE_TMUX_READY_WAIT_TIMEOUT_SEC" => "not-a-float",
+      "HIVE_BRAINSTORM_TMUX_READY_WAIT_TIMEOUT_SEC" => nil
+    ) do
+      assert_equal 30.5, Hive::ClaudeLauncher.claude_ready_wait_timeout
+    end
+  end
+
+  def test_claude_ready_timeout_raises_for_invalid_inherited_shared_timeout
+    with_env(
+      "HIVE_CLAUDE_TMUX_CLAUDE_READY_WAIT_TIMEOUT_SEC" => nil,
+      "HIVE_BRAINSTORM_TMUX_CLAUDE_READY_WAIT_TIMEOUT_SEC" => nil,
+      "HIVE_CLAUDE_TMUX_READY_WAIT_TIMEOUT_SEC" => "not-a-float",
+      "HIVE_BRAINSTORM_TMUX_READY_WAIT_TIMEOUT_SEC" => nil
+    ) do
+      assert_raises(ArgumentError) do
+        Hive::ClaudeLauncher.claude_ready_wait_timeout
+      end
+    end
+  end
+
+  def test_claude_ready_timeout_keeps_long_default_without_shared_override
+    with_env(
+      "HIVE_CLAUDE_TMUX_CLAUDE_READY_WAIT_TIMEOUT_SEC" => nil,
+      "HIVE_BRAINSTORM_TMUX_CLAUDE_READY_WAIT_TIMEOUT_SEC" => nil,
+      "HIVE_CLAUDE_TMUX_READY_WAIT_TIMEOUT_SEC" => nil,
+      "HIVE_BRAINSTORM_TMUX_READY_WAIT_TIMEOUT_SEC" => nil
+    ) do
+      assert_equal Hive::ClaudeLauncher::CLAUDE_READY_WAIT_TIMEOUT_SEC,
+                   Hive::ClaudeLauncher.claude_ready_wait_timeout
+    end
   end
 
   def test_spawn_claude_bang_propagates_agent_error_unchanged
@@ -385,10 +459,6 @@ class ClaudeLauncherTest < Minitest::Test
       FileUtils.mkdir_p(folder)
       yield Hive::Task.new(folder)
     end
-  end
-
-  def restore_env(key, value)
-    value.nil? ? ENV.delete(key) : ENV[key] = value
   end
 
   # Unify on the UnboundMethod capture+rebind stub pattern used in

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -69,6 +69,13 @@ Append-only log of all wiki operations.
 
 **Refreshed pages:** None — fix is internal launcher plumbing; existing module pages remain accurate.
 
+## [2026-05-26T11:27:00Z] brainstorm - Claude tmux ready timeout fallback
+
+**Action:** Documented the shared Claude tmux readiness fallback. `CLAUDE_READY` now follows the shared `READY_WAIT_TIMEOUT_SEC` env override when its specific env var is unset, while keeping the long 120s bare default for slow Claude TUI startup.
+
+**Refreshed pages:**
+- [[stages/brainstorm]] - recorded the `HIVE_CLAUDE_TMUX_*` readiness inheritance contract.
+
 ## [2026-05-26T11:14:24Z] init - prompt answer binding fail-fast
 
 **Action:** Restored `ProjectConfigBinding` to the documented "never invent defaults" contract. The binding now requires the complete current `Prompts#collect` answer hash, validates every nested budget/timeout `LIMIT_KEYS` entry, and `hive init` renders the config immediately after prompt collection so incomplete prompt data raises before `.hive-state` or `hive/state` can be created.

--- a/wiki/stages/brainstorm.md
+++ b/wiki/stages/brainstorm.md
@@ -3,7 +3,7 @@ title: 2-brainstorm stage
 type: stage
 source: lib/hive/stages/brainstorm.rb, lib/hive/stages/brainstorm_tmux.rb, lib/hive/tmux_runner.rb, templates/brainstorm_prompt.md.erb
 created: 2026-04-25
-updated: 2026-05-22
+updated: 2026-05-26
 tags: [stage, brainstorm, qa, tmux]
 ---
 
@@ -14,6 +14,7 @@ tags: [stage, brainstorm, qa, tmux]
 - **State file**: `brainstorm.md` (touched empty if absent so the marker write has a target).
 - **Prompt**: `templates/brainstorm_prompt.md.erb`, rendered with `project_name`, `task_folder`, `idea_text`. Idea text is wrapped in `<user_supplied content_type="idea_text">…</user_supplied>` per the prompt-injection boundary policy.
 - **Agent invocation**: `cwd = task.folder`, `--add-dir <task.folder>`, `log_label = "brainstorm"`. For `claude.mode: tmux`, `Hive::ClaudeLauncher` starts Claude through `interactive_claude_wrapper.sh`, unsets API-key env vars, passes `--permission-mode bypassPermissions` and `--allowedTools Read,Write,Edit,LS`, waits for the TUI prompt, and then pastes/submits the rendered prompt with a short delay so Enter does not race the paste.
+- **Tmux readiness env vars**: `Hive::ClaudeLauncher` owns `HIVE_CLAUDE_TMUX_*` readiness settings. `SESSION_READY`, `PID_READY`, and `CLAUDE_READY` inherit `HIVE_CLAUDE_TMUX_READY_WAIT_TIMEOUT_SEC` when their specific env var is unset; `CLAUDE_READY` otherwise keeps a 120s bare default for slow Claude TUI startup. Legacy `HIVE_BRAINSTORM_TMUX_*` names remain fallback inputs during the migration window.
 - **Profile**: `Hive::Stages::Base.stage_profile(cfg, "brainstorm")` — reads `cfg.dig("brainstorm", "agent")` with `|| "claude"` fallback so legacy configs keep working. Spawn pins `status_mode: :state_file_marker` regardless of profile, because brainstorm's lifecycle contract is the WAITING/COMPLETE marker the agent writes to `brainstorm.md` — codex's profile default `:output_file_exists` would never satisfy that.
 - **Budgets**: `cfg["budget_usd"]["brainstorm"]` (default 50), `cfg["timeout_sec"]["brainstorm"]` (default 1800). Bumped ~5× in plan 2026-05-04-001 — generous sanity caps for runaway agents, not cost targets.
 


### PR DESCRIPTION
## Summary
- make `HIVE_CLAUDE_TMUX_CLAUDE_READY_WAIT_TIMEOUT_SEC` fall back through shared `READY_WAIT_TIMEOUT_SEC` when no specific Claude-ready env var is set
- keep the long 120s Claude-ready default when neither specific nor shared env vars are configured
- document the updated readiness precedence in the tmux note and brainstorm wiki

Closes #110

## Tests
- `ruby -c lib/hive/claude_launcher.rb`
- `ruby -c test/unit/claude_launcher_test.rb`
- `bundle exec ruby -Itest -Ilib test/unit/claude_launcher_test.rb --name /claude_ready_timeout/`
- `bundle exec ruby -Itest -Ilib test/unit/claude_launcher_test.rb`
- `bundle exec rubocop lib/hive/claude_launcher.rb test/unit/claude_launcher_test.rb`
- `git diff --check`
- `bundle exec ruby -Itest -Ilib test/unit/stages/brainstorm_tmux_sentinel_test.rb`
- `bundle exec ruby -Itest -Ilib test/integration/run_brainstorm_tmux_test.rb`
- `bundle exec rake test`
- `bundle exec rake coverage`