### PR TITLE
feat(bot): notify on legacy stage dirs

### DIFF
--- a/lib/hive/bot/notification_builders.rb
+++ b/lib/hive/bot/notification_builders.rb
@@ -1,5 +1,6 @@
 require "digest"
 require "json"
+require "shellwords"
 require "hive"
 require "hive/bot/title_formatter"
 
@@ -32,6 +33,8 @@ module Hive
       ].freeze
 
       def build(row, logger: nil)
+        return legacy_stage_dirs(row) if legacy_stage_dirs?(row)
+
         if READY_ACTIONS.include?(row.action)
           stage_approval(row)
         elsif row.action == Hive::Schemas::TaskActionKind::NEEDS_INPUT
@@ -43,9 +46,41 @@ module Hive
         end
       end
 
+      def legacy_stage_dirs?(row)
+        row.respond_to?(:legacy_stage_dirs) && row.action.to_s == "legacy_stage_dirs"
+      end
+
+      def legacy_stage_dirs(row)
+        command = legacy_migrate_command(row)
+        total = row.total_task_count
+        noun = total == 1 ? "task" : "tasks"
+        dirs = row.stage_dir_names.join(", ")
+        Notification.new(
+          text: "Project #{row.project} has #{total} #{noun} hidden in legacy stage dirs (#{dirs}) - " \
+                "run `#{command}`",
+          keyboard: nil
+        )
+      end
+
+      def legacy_migrate_command(row)
+        command = row.legacy_migrate_command.to_s
+        project_path = row.project_path.to_s
+        argv = command.empty? ? %w[hive migrate] : Shellwords.split(command)
+        argv << project_path unless project_path.empty?
+        Shellwords.join(argv)
+      rescue ArgumentError
+        [ "hive migrate", Shellwords.escape(project_path) ].reject(&:empty?).join(" ")
+      end
+
       def fingerprint(row)
+        return legacy_stage_dirs_fingerprint(row) if legacy_stage_dirs?(row)
+
         normalized_attrs = row.attrs.to_h.transform_keys(&:to_s).to_a.sort_by(&:first)
         Digest::SHA256.hexdigest(JSON.generate([ row.project, row.slug, row.stage, row.marker, normalized_attrs ]))
+      end
+
+      def legacy_stage_dirs_fingerprint(row)
+        Digest::SHA256.hexdigest(JSON.generate([ row.project, row.slug, row.stage, row.marker ]))
       end
 
       def recovery?(row)

--- a/lib/hive/bot/notification_dispatcher.rb
+++ b/lib/hive/bot/notification_dispatcher.rb
@@ -32,8 +32,12 @@ module Hive
       def process_rows(rows)
         current = current_notifications(rows)
         if @alert_store.fresh_install?
-          seed_silently(current)
+          immediate, seedable = current.partition do |_fingerprint, payload|
+            immediate_on_fresh_install?(payload.fetch(:row))
+          end.map(&:to_h)
+          seed_silently(seedable)
           @alert_store.mark_seeded!
+          process_current(immediate)
           return
         end
         process_recoveries(current)
@@ -57,6 +61,10 @@ module Hive
           fingerprint = NotificationBuilders.fingerprint(row)
           out[fingerprint] ||= { row: row, notification: notification }
         end
+      end
+
+      def immediate_on_fresh_install?(row)
+        NotificationBuilders.legacy_stage_dirs?(row)
       end
 
       # On a fresh AlertStore (no prior persistent state), pretend every

--- a/lib/hive/bot/status_watcher.rb
+++ b/lib/hive/bot/status_watcher.rb
@@ -16,8 +16,67 @@ module Hive
           super
         end
       end
-      Result = Data.define(:ok, :rows, :error, :envelope) do
-        def initialize(ok:, rows: [], error: nil, envelope: nil)
+
+      LegacyStageDirs = Data.define(:project, :project_path, :hive_state_path,
+                                    :legacy_stage_dirs, :legacy_migrate_command) do
+        def initialize(project:, project_path: nil, hive_state_path: nil,
+                       legacy_stage_dirs: [], legacy_migrate_command: nil)
+          super(
+            project: project,
+            project_path: project_path,
+            hive_state_path: hive_state_path,
+            legacy_stage_dirs: normalize_stage_dirs(legacy_stage_dirs),
+            legacy_migrate_command: legacy_migrate_command
+          )
+        end
+
+        def slug
+          "__legacy_stage_dirs__"
+        end
+
+        def stage
+          "legacy_stage_dirs"
+        end
+
+        def marker
+          "legacy_stage_dirs"
+        end
+
+        def action
+          "legacy_stage_dirs"
+        end
+
+        def attrs
+          {
+            "stage_dirs" => stage_dir_names.join(","),
+            "task_count" => total_task_count.to_s
+          }
+        end
+
+        def stage_dir_names
+          legacy_stage_dirs.map { |entry| entry.fetch("stage_dir") }
+        end
+
+        def total_task_count
+          legacy_stage_dirs.sum { |entry| entry.fetch("task_count").to_i }
+        end
+
+        private
+
+        def normalize_stage_dirs(entries)
+          Array(entries).filter_map do |entry|
+            raw = entry.is_a?(Hash) ? entry : {}
+            stage_dir = raw["stage_dir"].to_s
+            task_count = raw["task_count"].to_i
+            next if stage_dir.empty? || task_count <= 0
+
+            { "stage_dir" => stage_dir, "task_count" => task_count }
+          end.freeze
+        end
+      end
+
+      Result = Data.define(:ok, :rows, :legacy_stage_dirs, :error, :envelope) do
+        def initialize(ok:, rows: [], legacy_stage_dirs: [], error: nil, envelope: nil)
           super
         end
       end
@@ -42,7 +101,13 @@ module Hive
 
         doc = JSON.parse(out)
         validate_envelope!(doc)
-        Result.new(ok: true, rows: extract_rows(doc, now: now), error: nil, envelope: doc)
+        Result.new(
+          ok: true,
+          rows: extract_rows(doc, now: now),
+          legacy_stage_dirs: extract_legacy_stage_dirs(doc),
+          error: nil,
+          envelope: doc
+        )
       rescue JSON::ParserError => e
         failure("malformed JSON from hive status: #{e.message}")
       rescue StandardError => e
@@ -53,7 +118,7 @@ module Hive
 
       def failure(message)
         @logger&.event(:poll_failure, source: "status", message: message)
-        Result.new(ok: false, rows: [], error: message)
+        Result.new(ok: false, rows: [], legacy_stage_dirs: [], error: message)
       end
 
       def validate_envelope!(doc)
@@ -66,6 +131,23 @@ module Hive
         return if doc["schema_version"] == expected
 
         raise ArgumentError, "schema_version mismatch: got #{doc['schema_version']}, want #{expected}"
+      end
+
+      def extract_legacy_stage_dirs(doc)
+        Array(doc["projects"]).filter_map do |project_doc|
+          next if project_doc["error"]
+
+          entry = LegacyStageDirs.new(
+            project: project_doc["name"],
+            project_path: project_doc["path"],
+            hive_state_path: project_doc["hive_state_path"],
+            legacy_stage_dirs: project_doc["legacy_stage_dirs"],
+            legacy_migrate_command: project_doc["legacy_migrate_command"]
+          )
+          next if entry.legacy_stage_dirs.empty?
+
+          entry
+        end
       end
 
       def extract_rows(doc, now:)

--- a/lib/hive/bot/supervisor.rb
+++ b/lib/hive/bot/supervisor.rb
@@ -128,7 +128,7 @@ module Hive
         return result unless result.ok
 
         @latest_status_rows = result.rows
-        @notification_dispatcher.process_rows(result.rows)
+        @notification_dispatcher.process_rows(notification_inputs_for(result))
         result
       end
 
@@ -177,6 +177,10 @@ module Hive
           conversation_store: @conversation_store,
           status_snapshot_provider: -> { latest_status_rows }
         )
+      end
+
+      def notification_inputs_for(result)
+        Array(result.rows) + (result.respond_to?(:legacy_stage_dirs) ? Array(result.legacy_stage_dirs) : [])
       end
 
       def poll_loop
@@ -332,9 +336,9 @@ module Hive
         end
       end
 
-      def project_filter_miss_text(project, rows)
+      def project_filter_miss_text(project, rows, legacy_stage_dirs = [])
         registered = registered_project_names
-        active = rows.map { |row| row.project.to_s }.uniq
+        active = (Array(rows) + Array(legacy_stage_dirs)).map { |row| row.project.to_s }.uniq
         if registered.include?(project.to_s) || active.include?(project.to_s)
           "No tasks for project #{project}."
         else
@@ -397,18 +401,25 @@ module Hive
           end
 
           rows = fetch_result.rows
+          legacy_stage_dirs = status_legacy_stage_dirs(fetch_result)
           if result.project && !result.project.to_s.empty?
-            filtered = rows.select { |row| row.project == result.project }
-            if filtered.empty?
-              safe_send_message(chat_id: update.chat_id, text: project_filter_miss_text(result.project, rows))
+            filtered_rows = rows.select { |row| row.project == result.project }
+            filtered_legacy_stage_dirs = legacy_stage_dirs.select { |row| row.project == result.project }
+            if filtered_rows.empty? && filtered_legacy_stage_dirs.empty?
+              safe_send_message(
+                chat_id: update.chat_id,
+                text: project_filter_miss_text(result.project, rows, legacy_stage_dirs)
+              )
               return nil
             end
-            rows = filtered
+            rows = filtered_rows
+            legacy_stage_dirs = filtered_legacy_stage_dirs
           end
           if result.slug
             safe_send_message(chat_id: update.chat_id, text: render_details(rows, result.project, result.slug))
           else
-            safe_send_message(chat_id: update.chat_id, text: render_queue(rows),
+            safe_send_message(chat_id: update.chat_id,
+                              text: render_queue(rows, legacy_stage_dirs: legacy_stage_dirs),
                               reply_markup: status_keyboard(rows))
           end
           return nil
@@ -626,9 +637,12 @@ module Hive
 
       QUEUE_DISPLAY_CAP = 10
 
-      def render_queue(rows)
+      def render_queue(rows, legacy_stage_dirs: [])
         actionable = actionable_queue_rows(rows)
-        return "No active Hive tasks." if actionable.empty?
+        legacy_lines = legacy_stage_dirs.map do |row|
+          Hive::Bot::NotificationBuilders.legacy_stage_dirs(row).text
+        end
+        return (legacy_lines + [ "No active Hive tasks." ]).join("\n") if actionable.empty?
 
         lines = actionable.first(QUEUE_DISPLAY_CAP).map do |row|
           "#{Hive::Bot::TitleFormatter.title_from_slug(row.slug)} — " \
@@ -638,7 +652,7 @@ module Hive
         if actionable.size > QUEUE_DISPLAY_CAP
           lines << "+ #{actionable.size - QUEUE_DISPLAY_CAP} more tasks — open on a laptop for the full list."
         end
-        ([ header ] + lines).join("\n")
+        (legacy_lines + [ header ] + lines).join("\n")
       end
 
       # Inline keyboard for the /status (and /queue) reply: one button per
@@ -703,6 +717,12 @@ module Hive
 
       def actionable_queue_rows(rows)
         Array(rows).reject { |row| %w[archived agent_running].include?(row.action) }
+      end
+
+      def status_legacy_stage_dirs(fetch_result)
+        return [] unless fetch_result.respond_to?(:legacy_stage_dirs)
+
+        Array(fetch_result.legacy_stage_dirs)
       end
 
       def status_command?(argv)

--- a/test/unit/bot/notification_builders_test.rb
+++ b/test/unit/bot/notification_builders_test.rb
@@ -21,12 +21,49 @@ class HiveBotNotificationBuildersTest < Minitest::Test
     )
   end
 
+  def legacy_stage_dirs(task_count: 3, command: "hive migrate")
+    Hive::Bot::StatusWatcher::LegacyStageDirs.new(
+      project: "hive",
+      project_path: "/tmp/hive",
+      hive_state_path: "/tmp/hive/.hive-state",
+      legacy_stage_dirs: [
+        { "stage_dir" => "5-review", "task_count" => task_count - 1 },
+        { "stage_dir" => "6-pr", "task_count" => 1 }
+      ],
+      legacy_migrate_command: command
+    )
+  end
+
   def retry_diagnostic(command: "hive review slug --json")
     { "suggested_next_action" => { "kind" => "retry", "command" => command } }
   end
 
   def manual_diagnostic
     { "suggested_next_action" => { "kind" => "manual_fix", "command" => nil } }
+  end
+
+  def test_legacy_stage_dirs_notification_renders_project_count_dirs_and_command
+    notification = Hive::Bot::NotificationBuilders.build(legacy_stage_dirs)
+
+    assert_equal "Project hive has 3 tasks hidden in legacy stage dirs (5-review, 6-pr) - run `hive migrate /tmp/hive`",
+                 notification.text
+    assert_nil notification.keyboard
+  end
+
+  def test_legacy_stage_dirs_notification_renders_singular_and_command_fallback
+    notification = Hive::Bot::NotificationBuilders.build(legacy_stage_dirs(task_count: 1, command: nil))
+
+    assert_equal "Project hive has 1 task hidden in legacy stage dirs (6-pr) - run `hive migrate /tmp/hive`",
+                 notification.text
+    assert_nil notification.keyboard
+  end
+
+  def test_legacy_stage_dirs_notification_handles_malformed_command_payload
+    notification = Hive::Bot::NotificationBuilders.build(legacy_stage_dirs(command: "hive 'migrate"))
+
+    assert_equal "Project hive has 3 tasks hidden in legacy stage dirs (5-review, 6-pr) - run `hive migrate /tmp/hive`",
+                 notification.text
+    assert_nil notification.keyboard
   end
 
   def test_ready_to_plan_builds_approval_keyboard

--- a/test/unit/bot/notification_dispatcher_test.rb
+++ b/test/unit/bot/notification_dispatcher_test.rb
@@ -21,6 +21,19 @@ class HiveBotNotificationDispatcherTest < Minitest::Test
     )
   end
 
+  def legacy_stage_dirs(review_count: 2, pr_count: 1)
+    Hive::Bot::StatusWatcher::LegacyStageDirs.new(
+      project: "hive",
+      project_path: "/tmp/hive",
+      hive_state_path: "/tmp/hive/.hive-state",
+      legacy_stage_dirs: [
+        { "stage_dir" => "5-review", "task_count" => review_count },
+        { "stage_dir" => "6-pr", "task_count" => pr_count }
+      ],
+      legacy_migrate_command: "hive migrate"
+    )
+  end
+
   def recovery_row(attrs: { "pass" => "1" }, slug: "stuck-task-260525-abcd", stage: "6-review")
     row(action: "recover_review", marker: "review_error", attrs: attrs, slug: slug, stage: stage)
   end
@@ -53,6 +66,44 @@ class HiveBotNotificationDispatcherTest < Minitest::Test
 
   def logger
     @logger ||= StubLogger.new
+  end
+
+  def test_legacy_stage_dirs_notify_once_and_refire_after_clean_transition
+    d = dispatcher
+    legacy = legacy_stage_dirs
+    changed_while_dirty = legacy_stage_dirs(review_count: 3)
+
+    d.process_rows([ legacy ])
+    d.process_rows([ legacy ])
+    d.process_rows([ changed_while_dirty ])
+    d.process_rows([])
+    d.process_rows([ changed_while_dirty ])
+
+    assert_equal 2, telegram.messages.size
+    assert_equal "Project hive has 3 tasks hidden in legacy stage dirs (5-review, 6-pr) - run `hive migrate /tmp/hive`",
+                 telegram.messages.first[:text]
+    assert_equal "Project hive has 4 tasks hidden in legacy stage dirs (5-review, 6-pr) - run `hive migrate /tmp/hive`",
+                 telegram.messages.last[:text]
+    assert(logger.events.any? { |name, _| name == :notification_skipped_dedupe },
+           "legacy-stage warning must dedupe while the project remains legacy-dirty")
+  end
+
+  def test_fresh_install_still_alerts_legacy_stage_dirs
+    with_tmp_dir do |dir|
+      path = File.join(dir, "alerts.json")
+      d = dispatcher(path: path, fresh_install: true)
+      legacy = legacy_stage_dirs
+      pre_existing = recovery_row
+
+      d.process_rows([ pre_existing, legacy ])
+      d.process_rows([ pre_existing, legacy ])
+
+      assert_equal 1, telegram.messages.size
+      assert_equal "Project hive has 3 tasks hidden in legacy stage dirs (5-review, 6-pr) - run `hive migrate /tmp/hive`",
+                   telegram.messages.first[:text]
+      assert(logger.events.any? { |name, attrs| name == :fresh_install_seeded && attrs[:fingerprint_count] == 1 },
+             "fresh install should seed task backlog without seeding legacy-stage migration warnings")
+    end
   end
 
   def test_process_rows_sends_new_input_gate_notification

--- a/test/unit/bot/status_watcher_test.rb
+++ b/test/unit/bot/status_watcher_test.rb
@@ -94,6 +94,61 @@ class HiveBotStatusWatcherTest < Minitest::Test
     end
   end
 
+  def test_fetch_exposes_legacy_stage_dirs_for_transition_notifications
+    payload = envelope([])
+    project = payload.fetch("projects").first
+    project["legacy_stage_dirs"] = [
+      { "stage_dir" => "5-review", "task_count" => 2 },
+      { "stage_dir" => "6-pr", "task_count" => 1 }
+    ]
+    project["legacy_migrate_command"] = "hive migrate"
+
+    with_fake_status(JSON.generate(payload)) do |bin|
+      result = Hive::Bot::StatusWatcher.new(hive_bin: bin).fetch
+
+      assert result.ok, result.error
+      legacy = result.legacy_stage_dirs
+      assert_equal 1, legacy.size
+      entry = legacy.first
+      assert_equal "hive", entry.project
+      assert_equal "/tmp/hive", entry.project_path
+      assert_equal "/tmp/hive/.hive-state", entry.hive_state_path
+      assert_equal [ "5-review", "6-pr" ], entry.stage_dir_names
+      assert_equal 3, entry.total_task_count
+      assert_equal "hive migrate", entry.legacy_migrate_command
+      assert_equal "legacy_stage_dirs", entry.action
+    end
+  end
+
+  def test_fetch_skips_missing_empty_and_project_error_legacy_stage_dirs
+    payload = envelope([])
+    payload.fetch("projects").first.delete("legacy_stage_dirs")
+    payload["projects"] << {
+      "name" => "clean",
+      "path" => "/tmp/clean",
+      "hive_state_path" => "/tmp/clean/.hive-state",
+      "tasks" => [],
+      "legacy_stage_dirs" => [],
+      "legacy_migrate_command" => nil
+    }
+    payload["projects"] << {
+      "name" => "broken",
+      "path" => "/tmp/broken",
+      "hive_state_path" => "/tmp/broken/.hive-state",
+      "error" => "not_initialised",
+      "tasks" => [],
+      "legacy_stage_dirs" => [ { "stage_dir" => "5-review", "task_count" => 1 } ],
+      "legacy_migrate_command" => "hive migrate"
+    }
+
+    with_fake_status(JSON.generate(payload)) do |bin|
+      result = Hive::Bot::StatusWatcher.new(hive_bin: bin).fetch
+
+      assert result.ok, result.error
+      assert_empty result.legacy_stage_dirs
+    end
+  end
+
   def test_fetch_logs_nonzero_status_failure
     logger = CapturingLogger.new
 

--- a/test/unit/bot/supervisor_test.rb
+++ b/test/unit/bot/supervisor_test.rb
@@ -8,7 +8,7 @@ class HiveBotSupervisorTest < Minitest::Test
   Update = Struct.new(:chat_id, :update_id, :message_id, keyword_init: true)
   Row = Struct.new(:project, :slug, :stage, :action, :action_label, :marker, :attrs, :diagnostic,
                    keyword_init: true)
-  StatusResult = Struct.new(:ok, :rows, :error, :envelope, keyword_init: true)
+  StatusResult = Struct.new(:ok, :rows, :legacy_stage_dirs, :error, :envelope, keyword_init: true)
 
   FakeTelegram = Struct.new(:messages, :raise_on_send, :keyboard_clears,
                             :commands_registered, :raise_on_set_my_commands, keyword_init: true) do
@@ -151,6 +151,16 @@ class HiveBotSupervisorTest < Minitest::Test
     )
   end
 
+  def legacy_stage_dirs(project: "hive", project_path: "/tmp/hive")
+    Hive::Bot::StatusWatcher::LegacyStageDirs.new(
+      project: project,
+      project_path: project_path,
+      hive_state_path: File.join(project_path, ".hive-state"),
+      legacy_stage_dirs: [ { "stage_dir" => "6-pr", "task_count" => 1 } ],
+      legacy_migrate_command: "hive migrate"
+    )
+  end
+
   def row(project: "hive", slug: "task", stage: "3-plan", action: "ready_to_develop",
           action_label: "Develop", marker: "COMPLETE", attrs: {}, diagnostic: nil)
     Row.new(project: project, slug: slug, stage: stage, action: action,
@@ -176,6 +186,15 @@ class HiveBotSupervisorTest < Minitest::Test
       calls << kwargs
       outcome
     end
+  end
+
+  def test_status_tick_includes_legacy_stage_dirs_in_notification_inputs
+    legacy = legacy_stage_dirs
+    @status_watcher.result = StatusResult.new(ok: true, rows: [], legacy_stage_dirs: [ legacy ])
+
+    @supervisor.status_tick
+
+    assert_equal [ [ legacy ] ], @notification_dispatcher.processed
   end
 
   def test_reply_for_child_renders_status_diagnose_success_envelope
@@ -549,6 +568,44 @@ class HiveBotSupervisorTest < Minitest::Test
     # ready_to_develop row → an approve button on the /status reply.
     callbacks = @telegram.messages.last.fetch(:reply_markup).flatten.map { |btn| btn[:callback_data] }
     assert_includes callbacks, "approve:develop:hive:alpha:3-plan"
+  end
+
+  def test_execute_dispatch_renders_legacy_stage_dirs_in_status_queue
+    @status_watcher.result = StatusResult.new(ok: true, rows: [], legacy_stage_dirs: [ legacy_stage_dirs ])
+    result = FakeRouter::Result.new(action: :dispatch_then_reply, command_argv: [ "hive", "status", "--json" ])
+
+    pid = @supervisor.send(:execute_dispatch, result, Update.new(chat_id: 42, update_id: 10))
+
+    assert_nil pid
+    assert_empty @child_supervisor.dispatched
+    message = @telegram.messages.last
+    assert_includes message.fetch(:text),
+                    "Project hive has 1 task hidden in legacy stage dirs (6-pr) - run `hive migrate /tmp/hive`"
+    assert_includes message.fetch(:text), "No active Hive tasks."
+    assert_nil message[:reply_markup]
+  end
+
+  def test_execute_dispatch_filters_legacy_stage_dirs_by_project
+    other_legacy = legacy_stage_dirs(project: "other", project_path: "/tmp/other")
+    @status_watcher.result = StatusResult.new(
+      ok: true,
+      rows: [ row(project: "hive", slug: "alpha-260525-abcd") ],
+      legacy_stage_dirs: [ other_legacy ]
+    )
+    result = FakeRouter::Result.new(
+      action: :dispatch_then_reply,
+      command_argv: [ "hive", "status", "--json" ],
+      project: "other"
+    )
+
+    @supervisor.send(:execute_dispatch, result, Update.new(chat_id: 42, update_id: 10))
+
+    message = @telegram.messages.last
+    assert_includes message.fetch(:text),
+                    "Project other has 1 task hidden in legacy stage dirs (6-pr) - run `hive migrate /tmp/other`"
+    assert_includes message.fetch(:text), "No active Hive tasks."
+    refute_includes message.fetch(:text), "Alpha"
+    assert_nil message[:reply_markup]
   end
 
   def test_execute_dispatch_filters_status_by_project

--- a/wiki/commands/bot.md
+++ b/wiki/commands/bot.md
@@ -92,6 +92,7 @@ Push notifications use callback data that routes to:
 - Brainstorm waits: `Answer in chat` starts the same `/answer` conversation.
 - Review triage: `Accept all` / `Reject all` dispatch `hive accept-finding` or `hive reject-finding` with `--all`.
 - Recovery markers: `Autofix` appears only when the diagnostic suggested action is `retry`. It dispatches `hive markers clear ... --name <MARKER> --match-attr <key=value> --json` when a marker attribute is available, then dispatches the stage's workflow verb when one exists and resets the persisted alert entry for that task. Manual-only recovery states show `Open laptop` / `Show details`; legacy `Clear and retry` buttons from older messages still route to the same guarded recovery sequence.
+- Legacy stage-directory warnings are text-only project-level alerts. They tell the operator to run `hive migrate <project_path>`, have no inline action, dedupe while the project remains legacy-dirty, and re-alert after the project reports clean then regresses.
 - `Open laptop` is an explicit no-op reply for disagreements that do not fit the MVP button set.
 
 ## Config

--- a/wiki/commands/status.md
+++ b/wiki/commands/status.md
@@ -3,7 +3,7 @@ title: hive status
 type: command
 source: lib/hive/commands/status.rb
 created: 2026-04-25
-updated: 2026-05-25
+updated: 2026-05-26
 tags: [command, status, observability, json, diagnostics, legacy-dirs]
 ---
 
@@ -35,7 +35,7 @@ When the field is non-empty, the text output prints a warning under the project 
     run `hive migrate` to move them into the current layout
 ```
 
-The warning is singular for one hidden task (`1 task hidden`) and plural otherwise. The TUI projects pane mirrors the warning by prefixing the affected project's name with `⚠` and the short hint `legacy dirs — run hive migrate`. Running `hive migrate` moves the slugs into the canonical stage directory listed in `Hive::Commands::Migrate::STAGE_RENAMES`, and after the next status poll the warning disappears.
+The warning is singular for one hidden task (`1 task hidden`) and plural otherwise. The TUI projects pane mirrors the warning by prefixing the affected project's name with `⚠` and the short hint `legacy dirs — run hive migrate`. The Telegram bot also sends a proactive project-level notification on the clean-to-legacy transition, deduped by the bot alert store while the project remains legacy-dirty, even if the hidden task count changes. Bot messages include a project-path-scoped `hive migrate <project_path>` command because the bot is global. Running `hive migrate` moves the slugs into the canonical stage directory listed in `Hive::Commands::Migrate::STAGE_RENAMES`, and after the next status poll the warning disappears.
 
 The `legacy_stage_dirs` field is an additive, non-breaking extension of `urn:hive:schema:status:v2` (see [[schemas]] and the policy comment in `lib/hive.rb` — additive optional fields do **not** bump `SCHEMA_VERSIONS["hive-status"]`).
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -2,6 +2,23 @@
 
 Append-only log of all wiki operations.
 
+## [2026-05-27T04:25:37Z] bot - legacy warning status parity
+
+**Action:** Code-review follow-up for #174: Telegram legacy-stage warnings now render project-scoped `hive migrate <project_path>` commands and the pull `/status`/`/queue` surface includes the same project-level warning even when there are no canonical task rows. Bot docs now describe daemon-aware ready notifications and the text-only legacy warning.
+
+**Refreshed pages:**
+- [[modules/bot]] - corrected ready-alert semantics and recorded `/status` legacy warning parity.
+- [[commands/bot]] - documented the text-only legacy-stage warning.
+- [[commands/status]] - recorded the bot's project-path-scoped migrate command.
+
+## [2026-05-27T04:17:33Z] bot - legacy warning dedupe follow-up
+
+**Action:** Code-review follow-up for #174: legacy-stage Telegram warning fingerprints are project-level, so changes to hidden task counts or stage-dir detail do not re-alert until the project reports clean and later regresses again. Fresh alert-store seeding now leaves legacy-stage migration warnings eligible for immediate delivery. Added dispatcher/status-watcher/builder regression coverage.
+
+**Refreshed pages:**
+- [[modules/bot]] - clarified project-level dedupe while legacy-dirty.
+- [[commands/status]] - clarified bot dedupe semantics.
+
 ## [2026-05-27T02:41:29Z] dependencies - faraday audit floor
 
 **Action:** Updated the lockfile security floor for Telegram Bot API HTTP transport after `bundler-audit --update` began flagging `faraday` 2.14.1 for CVE-2026-33637 / GHSA-5rv5-xj5j-3484. `Gemfile.lock` now resolves `faraday` 2.14.2 and `faraday-net_http` 3.4.3.
@@ -68,6 +85,14 @@ Append-only log of all wiki operations.
 **Action:** Documented the launcher's new backup/restore behavior for `.claude/settings.json`. Root cause was that `StopHookInstaller.install_at` unconditionally deleted-and-overwrote the file, then `cleanup_scratch` unconditionally deleted it on spawn end — destructive for any project that committed `.claude/settings.json` via `hive init`'s llm-wiki bootstrap (`git_ops.rb:140`). Symptom was a recurring `dirty_worktree` marker in 4-execute / 6-review / 8-finalize because the post-stage check saw the deletion in `git status`. Fix: snapshot the existing file to `.claude/settings.json.hive-pre-install` before the install overwrite (only on first install per spawn pair, to avoid backing up the hive stub on re-entry), and have `cleanup_scratch` prefer restore-from-backup over delete.
 
 **Refreshed pages:** None — fix is internal launcher plumbing; existing module pages remain accurate.
+
+## [2026-05-26T12:19:00Z] bot - legacy stage directory notifications
+
+**Action:** Documented the Telegram bot parity path for `legacy_stage_dirs`. `StatusWatcher` now surfaces project-level legacy-stage warnings, `Supervisor#status_tick` feeds them through the alert lifecycle with task rows, and the bot sends one deduped notification on the clean-to-legacy transition telling the operator to run `hive migrate`.
+
+**Refreshed pages:**
+- [[modules/bot]] - recorded the watcher/supervisor/dispatcher notification flow.
+- [[commands/status]] - noted bot parity for legacy-stage warnings.
 
 ## [2026-05-26T11:49:11Z] brainstorm - fail fast on tmux prompt submit loss
 

--- a/wiki/modules/bot.md
+++ b/wiki/modules/bot.md
@@ -3,7 +3,7 @@ title: Hive::Bot
 type: module
 source: lib/hive/bot/
 created: 2026-05-14
-updated: 2026-05-25
+updated: 2026-05-26
 tags: [bot, telegram, module, mobile]
 ---
 
@@ -21,8 +21,8 @@ and subprocess I/O.
 | `Telegram` | `lib/hive/bot/telegram.rb` | Thin `telegram-bot-ruby` wrapper for `getUpdates`, `sendMessage`, message splitting, markdown escaping, and typed `Update` records. |
 | `Router` | `lib/hive/bot/router.rb` | Closed-enum intent classifier and pure dispatch into slash/callback/free-text handlers. Performs allowlist auth before any handler sees an update. |
 | `Handlers::*` | `lib/hive/bot/handlers/` | Slash command, callback, and free-text logic returning descriptors; no direct Telegram I/O. |
-| `StatusWatcher` | `lib/hive/bot/status_watcher.rb` | Runs `hive status --json`, validates the envelope, returns typed rows. |
-| `NotificationDispatcher` | `lib/hive/bot/notification_dispatcher.rb` | Sends newly-entered waiting/recovery/ready rows through a persistent alert lifecycle store. Suppresses ready notifications when the daemon is enabled for that project, sends one recovery confirmation when a recovery row leaves the active set, treats same-task recovery fingerprint changes as superseded rather than recovered, and sends one reminder for unchanged recovery rows. |
+| `StatusWatcher` | `lib/hive/bot/status_watcher.rb` | Runs `hive status --json`, validates the envelope, returns typed task rows plus project-level legacy-stage warnings. |
+| `NotificationDispatcher` | `lib/hive/bot/notification_dispatcher.rb` | Sends newly-entered waiting/recovery rows, daemon-disabled ready approvals, and project-level legacy-stage warnings through a persistent alert lifecycle store. Ready notifications are suppressed when the daemon is enabled for that project; recovery rows get one confirmation when they leave the active set, same-task recovery fingerprint changes are treated as superseded rather than recovered, and unchanged recovery rows get one reminder. |
 | `AlertStore` | `lib/hive/bot/alert_store.rb` | JSON sidecar for alert fingerprints, first-seen timestamps, reminder timestamps, and row snapshots. Corrupt files are renamed aside so the bot keeps running. |
 | `NotificationBuilders` | `lib/hive/bot/notification_builders.rb` | Marker/action-specific text and inline keyboards. Recovery alerts are human-readable; Autofix is exposed only when the diagnostic `suggested_next_action.kind` is `retry`, while manual-only states show laptop/details actions. Fingerprints include project, slug, stage, marker, and marker attrs. |
 | `BrainstormParser` | `lib/hive/bot/brainstorm_parser.rb` | Pure parser for `## Round`, `### Q<N>.`, and `### A<N>.` blocks. |
@@ -58,6 +58,8 @@ the dispatcher clears the persisted alert entry for that task before
 spawning the retry sequence. `/status [project]` is an explicit pull
 surface and renders actionable rows as `Title… — Stage` without inline
 buttons.
+
+Legacy stage-directory warnings are proactive as project-level notifications. `StatusWatcher` converts non-empty `legacy_stage_dirs` project payloads into synthetic notification inputs, `Supervisor#status_tick` feeds them through the same `NotificationDispatcher` as task rows, and `NotificationBuilders` renders a message like `Project P has N tasks hidden in legacy stage dirs (...) - run hive migrate <project_path>`. The same warning appears in `/status` and `/queue` replies. The alert-store fingerprint is project-level rather than count-level, so the warning dedupes while the project remains legacy-dirty, drops when the project returns clean, and alerts again on a later clean-to-legacy transition. Fresh alert-store seeding still suppresses historical task backlog, but legacy-stage warnings alert immediately because first bot startup after an upgrade is when operators need the migration prompt.
 
 ## Trust boundary
 


### PR DESCRIPTION
## Summary
- expose project-level legacy_stage_dirs from StatusWatcher results
- feed legacy-stage warnings through the existing bot alert lifecycle alongside task rows
- render one deduped Telegram notification telling the operator to run hive migrate, and re-alert only after the project returns clean then regresses again
- update bot/status wiki documentation

Closes #96

## Tests
- ruby -c lib/hive/bot/status_watcher.rb
- ruby -c lib/hive/bot/notification_builders.rb
- ruby -c lib/hive/bot/supervisor.rb
- ruby -c test/unit/bot/status_watcher_test.rb
- ruby -c test/unit/bot/notification_builders_test.rb
- ruby -c test/unit/bot/supervisor_test.rb
- ruby -c test/unit/bot/notification_dispatcher_test.rb
- bundle exec ruby -Itest -Ilib test/unit/bot/status_watcher_test.rb --name '/legacy_stage_dirs/'
- bundle exec ruby -Itest -Ilib test/unit/bot/notification_builders_test.rb --name '/legacy_stage_dirs/'
- bundle exec ruby -Itest -Ilib test/unit/bot/supervisor_test.rb --name '/legacy_stage_dirs/'
- bundle exec ruby -Itest -Ilib test/unit/bot/notification_dispatcher_test.rb --name '/legacy_stage_dirs/'
- bundle exec ruby -Itest -Ilib test/unit/bot/status_watcher_test.rb
- bundle exec ruby -Itest -Ilib test/unit/bot/notification_builders_test.rb
- bundle exec ruby -Itest -Ilib test/unit/bot/supervisor_test.rb
- bundle exec ruby -Itest -Ilib test/unit/bot/notification_dispatcher_test.rb
- bundle exec rubocop lib/hive/bot/status_watcher.rb lib/hive/bot/supervisor.rb lib/hive/bot/notification_builders.rb test/unit/bot/status_watcher_test.rb test/unit/bot/supervisor_test.rb test/unit/bot/notification_builders_test.rb test/unit/bot/notification_dispatcher_test.rb
- git diff --check
- bundle exec rake test
- bundle exec rake coverage