### PR TITLE
feat(tui): render footer hints before token counters

### DIFF
--- a/lib/hive/tui/bubble_model.rb
+++ b/lib/hive/tui/bubble_model.rb
@@ -3201,7 +3201,7 @@ module Hive
             return Views::UsageFooter.render(aggregate: aggregate, width: usable_width)
           end
 
-          line = "#{Views::UsageFooter.text(aggregate)} · #{footer_hint}"
+          line = "#{footer_hint} · #{Views::UsageFooter.text(aggregate)}"
           line = Views::Format.truncate(line, usable_width) if usable_width
           Hive::Tui::Styles::HINT.render(line)
         end

--- a/test/unit/tui/bubble_model_test.rb
+++ b/test/unit/tui/bubble_model_test.rb
@@ -731,13 +731,25 @@ class HiveTuiBubbleModelTest < Minitest::Test
   def test_default_footer_fits_full_hint_at_exact_boundary_width
     hint = @model.send(:footer_hint)
     usage = Hive::Tui::Views::UsageFooter.text(Hive::UsageDb.zero_aggregate)
-    out = with_zero_usage { @model.send(:default_footer, "#{usage} · #{hint}".length) }
+    out = with_zero_usage { @model.send(:default_footer, "#{hint} · #{usage}".length) }
 
     assert_includes out, "tokens"
     assert_includes out, "[i] info"
     assert_includes out, "[q] quit"
     refute out.end_with?("…"),
            "footer at exact hint width should not truncate, got #{out.inspect}"
+  end
+
+  def test_default_footer_truncates_tokens_first_on_overflow_above_threshold
+    hint = @model.send(:footer_hint)
+    usage = Hive::Tui::Views::UsageFooter.text(Hive::UsageDb.zero_aggregate)
+    full_width = "#{hint} · #{usage}".length
+    out = with_zero_usage { @model.send(:default_footer, full_width - 5) }
+
+    assert_includes out, "[Tab] switch",
+                    "hint block must survive when overflow clips from the right"
+    refute_includes out, "tokens",
+                    "token block must be the first content clipped on overflow"
   end
 
   def test_default_footer_truncates_from_right_at_narrow_width

--- a/test/unit/tui/bubble_model_test.rb
+++ b/test/unit/tui/bubble_model_test.rb
@@ -726,6 +726,8 @@ class HiveTuiBubbleModelTest < Minitest::Test
     assert_includes out, "tokens"
     assert_includes out, "[i] info"
     assert_includes out, "[q] quit"
+    assert_operator out.index("[Tab] switch"), :<, out.index("tokens"),
+                    "hint block must precede token block at wide width"
   end
 
   def test_default_footer_fits_full_hint_at_exact_boundary_width
@@ -748,7 +750,7 @@ class HiveTuiBubbleModelTest < Minitest::Test
     assert usage.end_with?("tokens"),
            "test premise: usage text must end with `tokens` label, got #{usage.inspect}"
     full_width = "#{hint} · #{usage}".length
-    out = with_zero_usage { @model.send(:default_footer, full_width - usage.length) }
+    out = with_zero_usage { @model.send(:default_footer, full_width - 5) }
 
     assert_includes out, "[Tab] switch",
                     "hint block must survive when overflow clips from the right"
@@ -756,7 +758,7 @@ class HiveTuiBubbleModelTest < Minitest::Test
                     "token block must be the first content clipped on overflow"
   end
 
-  def test_default_footer_truncates_from_right_at_narrow_width
+  def test_default_footer_narrow_branch_drops_hints_and_keeps_usage
     out = with_zero_usage { @model.send(:default_footer, 76) }
 
     assert_includes out, "tokens"

--- a/test/unit/tui/bubble_model_test.rb
+++ b/test/unit/tui/bubble_model_test.rb
@@ -736,6 +736,8 @@ class HiveTuiBubbleModelTest < Minitest::Test
     assert_includes out, "tokens"
     assert_includes out, "[i] info"
     assert_includes out, "[q] quit"
+    assert_includes out, " · ",
+                    "hint and usage blocks must remain joined by the ` · ` separator"
     refute out.end_with?("…"),
            "footer at exact hint width should not truncate, got #{out.inspect}"
   end
@@ -743,8 +745,10 @@ class HiveTuiBubbleModelTest < Minitest::Test
   def test_default_footer_truncates_tokens_first_on_overflow_above_threshold
     hint = @model.send(:footer_hint)
     usage = Hive::Tui::Views::UsageFooter.text(Hive::UsageDb.zero_aggregate)
+    assert usage.end_with?("tokens"),
+           "test premise: usage text must end with `tokens` label, got #{usage.inspect}"
     full_width = "#{hint} · #{usage}".length
-    out = with_zero_usage { @model.send(:default_footer, full_width - 5) }
+    out = with_zero_usage { @model.send(:default_footer, full_width - usage.length) }
 
     assert_includes out, "[Tab] switch",
                     "hint block must survive when overflow clips from the right"

--- a/test/unit/tui/bubble_model_test.rb
+++ b/test/unit/tui/bubble_model_test.rb
@@ -747,15 +747,16 @@ class HiveTuiBubbleModelTest < Minitest::Test
   def test_default_footer_truncates_tokens_first_on_overflow_above_threshold
     hint = @model.send(:footer_hint)
     usage = Hive::Tui::Views::UsageFooter.text(Hive::UsageDb.zero_aggregate)
-    assert usage.end_with?("tokens"),
+    tail_label = "tokens"
+    assert usage.end_with?(tail_label),
            "test premise: usage text must end with `tokens` label, got #{usage.inspect}"
     full_width = "#{hint} · #{usage}".length
     out = with_zero_usage { @model.send(:default_footer, full_width - 5) }
 
     assert_includes out, "[Tab] switch",
                     "hint block must survive when overflow clips from the right"
-    refute_includes out, "tokens",
-                    "token block must be the first content clipped on overflow"
+    refute out.end_with?(tail_label),
+           "trailing token label must be the first content clipped on overflow"
   end
 
   def test_default_footer_narrow_branch_drops_hints_and_keeps_usage

--- a/wiki/commands/tui.md
+++ b/wiki/commands/tui.md
@@ -28,7 +28,7 @@ The legacy curses backend was removed in plan #003 U11. `HIVE_TUI_BACKEND=curses
 │  myapp          │  ⚠  oauth-…       6-review      Needs recovery      1h │
 │  appcrawl       │                                                        │
 ├─────────────────┴────────────────────────────────────────────────────────┤
-│ Footer: [Tab]  [Enter]  [n] new  [/] filter  [?] help  [i] info  [q] quit│
+│ Footer: [Tab] ... [q] quit · today ... • 7d ... • all ... • tokens        │
 └──────────────────────────────────────────────────────────────────────────┘
 ```
 

--- a/wiki/commands/tui.md
+++ b/wiki/commands/tui.md
@@ -28,7 +28,7 @@ The legacy curses backend was removed in plan #003 U11. `HIVE_TUI_BACKEND=curses
 │  myapp          │  ⚠  oauth-…       6-review      Needs recovery      1h │
 │  appcrawl       │                                                        │
 ├─────────────────┴────────────────────────────────────────────────────────┤
-│ Footer: [Tab] ... [q] quit · today ... • 7d ... • all ... • tokens        │
+│ Footer: [Tab] ... [q] quit · today ... • 7d ... • all ... • tokens       │
 └──────────────────────────────────────────────────────────────────────────┘
 ```
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -160,6 +160,14 @@ Append-only log of all wiki operations.
 
 **Refreshed pages:** None — fix is internal launcher plumbing; existing module pages remain accurate.
 
+## [2026-05-26T14:11:12Z] tui - token footer ordering
+
+**Action:** Documented that the grid-mode footer now renders action hints before the compact token usage block on wide terminals, preserving the ` · ` separator between blocks and leaving the below-80-column compact-only usage path unchanged.
+
+**Refreshed pages:**
+- [[token-usage]] - updated the TUI surface description and example footer order.
+- [[commands/tui]] - refreshed the dashboard footer diagram to show hints before usage.
+
 ## [2026-05-26T12:19:00Z] bot - legacy stage directory notifications
 
 **Action:** Documented the Telegram bot parity path for `legacy_stage_dirs`. `StatusWatcher` now surfaces project-level legacy-stage warnings, `Supervisor#status_tick` feeds them through the alert lifecycle with task rows, and the bot sends one deduped notification on the clean-to-legacy transition telling the operator to run `hive migrate`.

--- a/wiki/token-usage.md
+++ b/wiki/token-usage.md
@@ -1,9 +1,9 @@
 ---
 title: Token Usage Stats
 type: observability
-source: lib/hive/usage_db.rb, lib/hive/agent_profiles/usage_extractors.rb, lib/hive/tui/views/token_stats.rb
+source: lib/hive/usage_db.rb, lib/hive/agent_profiles/usage_extractors.rb, lib/hive/tui/views/token_stats.rb, lib/hive/tui/bubble_model.rb
 created: 2026-05-24
-updated: 2026-05-25
+updated: 2026-05-26
 tags: [observability, tui, sqlite, agent]
 ---
 
@@ -69,10 +69,10 @@ The scope hash accepts `project_slug:` and `task_slug:` filters. `task_slug` is 
 
 ## TUI Surfaces
 
-`hive tui` shows a compact usage footer in grid mode. The compact footer intentionally omits the `30d` bucket; use the full `T` matrix for that window:
+`hive tui` shows a compact usage block in the grid-mode footer. On wide terminals, the keybinding hints render first, then ` · `, then the compact usage block so right-side truncation clips token counters before actions. Below 80 usable columns, the existing compact-only footer path still renders just the usage block. The compact block intentionally omits the `30d` bucket; use the full `T` matrix for that window:
 
 ```text
-today 1.2M/400k/200k • 7d ... • all ... • tokens
+[Tab] switch ... [q] quit · today 1.2M/400k/200k • 7d ... • all ... • tokens
 ```
 
 The tuple is `input/output/cached`. Units use `k` and `M` with compact one-decimal formatting. Footer scope follows the current selection:


### PR DESCRIPTION
## Summary

Wide TUI footers previously rendered token counters first, pushing the action hints toward the right edge so they clipped before the counters under right-side truncation. The wide-terminal branch of `default_footer` (`lib/hive/tui/bubble_model.rb`) now renders the keybinding hints first, then the ` · ` separator, then the compact token block — so when terminal width gets tight, the token counters are the first content to drop while higher-priority action hints survive.

Scope is intentionally a single string-interpolation swap. The token block stays an atomic unit (internal `•` separators untouched) and the inter-block ` · ` separator is preserved. The narrow (`< 80` columns) branch, which already renders only the usage block, is left unchanged on purpose — flipping its priority to hints-only is a separate decision held out of scope.

Changes:
- `lib/hive/tui/bubble_model.rb`: swap interpolation order in the wide-terminal branch of `default_footer`.
- `test/unit/tui/bubble_model_test.rb`: add `test_default_footer_truncates_tokens_first_on_overflow_above_threshold` to lock the new clip-from-right behavior; assert hint-precedes-token ordering and ` · ` separator presence at wide width; rename the narrow-branch test to describe what it actually exercises.
- `wiki/token-usage.md`, `wiki/commands/tui.md`, `wiki/log.md`: refresh the dashboard footer description/diagram and log the change.

## Test plan

- [x] `bundle exec rake test TEST=test/unit/tui/bubble_model_test.rb`
- [x] `bundle exec rake test TEST=test/integration/tui_usage_footer_test.rb`
- [x] `bundle exec rake test` — `3601 runs, 12938 assertions, 0 failures, 0 errors, 2 skips`
- [x] `git diff --check` clean
- [ ] Manual: launch `bin/hive tui` against a project with recorded usage and confirm the dashboard status line reads `[Tab] switch … [q] quit · today … • 7d … • all … • tokens`

## Review summary

Two Compound Engineering review passes (Claude + Codex, 2 passes each). No High or Medium findings in any pass. All Nit-level findings were auto-fixed or resolved:

- Added an explicit ordering assertion (`[Tab] switch` precedes `tokens`) at wide width.
- Added an explicit ` · ` separator assertion so a dropped/renamed joiner fails loudly.
- Added a `usage.end_with?("tokens")` premise check to guard the overflow test against future label changes.
- Aligned the overflow test's clip margin with the plan's `full_width - 5`.
- Renamed the misleading `test_default_footer_truncates_from_right_at_narrow_width` to `test_default_footer_narrow_branch_drops_hints_and_keeps_usage` to match what it actually exercises.
- Fixed the `wiki/commands/tui.md` footer ASCII diagram alignment.

Note: the `pr-review-toolkit` reviewer failed to start (tmux prompt-readiness infra error) in both passes; the CE reviewers ran successfully and produced the findings above.

## Linked task

- Original request: "move token counters after the actions"
- Hive task slug: `move-token-counters-after-the-260526-d32a`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_(1M)-D97757?logo=claude&logoColor=white)
