### PR TITLE
fix(claude-launcher): preserve project-owned .claude/settings.json

### DIFF
--- a/lib/hive/claude_launcher.rb
+++ b/lib/hive/claude_launcher.rb
@@ -744,6 +744,20 @@ module Hive
     def cleanup_scratch(settings_path)
       return unless settings_path
 
+      # If StopHookInstaller backed up a project-owned settings.json
+      # before overwriting (because the file was already present at
+      # install time), restore it from the backup. Otherwise this
+      # cleanup unconditionally deletes the file — destructive when
+      # the project committed `.claude/settings.json` (e.g. via
+      # `hive init`'s llm-wiki bootstrap), and the source of recurring
+      # `dirty_worktree` markers in 4-execute / 6-review / 8-finalize.
+      backup_path = "#{settings_path}#{Hive::StopHookInstaller::BACKUP_SUFFIX}"
+      if File.exist?(backup_path)
+        File.chmod(0o644, settings_path) if File.exist?(settings_path)
+        FileUtils.mv(backup_path, settings_path)
+        return
+      end
+
       File.delete(settings_path) if File.exist?(settings_path)
       dir = File.dirname(settings_path)
       Dir.rmdir(dir) if Dir.exist?(dir) && Dir.empty?(dir)

--- a/lib/hive/stop_hook_installer.rb
+++ b/lib/hive/stop_hook_installer.rb
@@ -5,6 +5,7 @@ require "shellwords"
 module Hive
   module StopHookInstaller
     HOOK_PATH = File.expand_path("scripts/stop_hook.sh", __dir__)
+    BACKUP_SUFFIX = ".hive-pre-install"
 
     module_function
 
@@ -31,6 +32,21 @@ module Hive
       claude_dir = File.join(target_dir, ".claude")
       FileUtils.mkdir_p(claude_dir)
       settings_path = File.join(claude_dir, "settings.json")
+      # If a project-owned `.claude/settings.json` is already present
+      # (e.g. committed by `hive init`'s llm-wiki bootstrap or by the
+      # operator), back it up so cleanup_scratch can restore it. Without
+      # this, the unconditional delete below would destroy the project's
+      # plugin/hook configuration and the post-stage dirty-worktree check
+      # would fire `EXECUTE_WAITING reason=dirty_worktree` (and the
+      # equivalent in 6-review / 8-finalize). Only back up on the FIRST
+      # install in a spawn pair: if a backup already exists, the current
+      # settings.json is the hive-installed stub from a prior install
+      # call, not the project's original — re-backing up would overwrite
+      # the original with the stub and lose it forever.
+      backup_path = "#{settings_path}#{BACKUP_SUFFIX}"
+      if File.exist?(settings_path) && !File.exist?(backup_path)
+        FileUtils.cp(settings_path, backup_path)
+      end
       # Brainstorm Claude runs with --permission-mode bypassPermissions
       # plus Write/Edit in --allowedTools, both scoped to this stage_dir.
       # A prompt-injected idea.md could otherwise direct the agent to

--- a/test/unit/claude_launcher_test.rb
+++ b/test/unit/claude_launcher_test.rb
@@ -484,6 +484,41 @@ class ClaudeLauncherTest < Minitest::Test
     end
   end
 
+  def test_cleanup_scratch_restores_project_owned_settings_from_backup
+    with_tmp_task do |task|
+      settings = File.join(task.folder, ".claude", "settings.json")
+      FileUtils.mkdir_p(File.dirname(settings))
+      backup = "#{settings}#{Hive::StopHookInstaller::BACKUP_SUFFIX}"
+      # Simulate state mid-spawn: backup holds the project's original
+      # content, settings.json holds the hive-installed Stop-hook stub.
+      File.write(backup, %({"enabledPlugins":{"frontend-design@official":true}}))
+      File.write(settings, %({"hooks":{"Stop":[]}}))
+      File.chmod(0o444, settings) # installer marks it read-only
+
+      Hive::ClaudeLauncher.cleanup_scratch(settings)
+
+      refute File.exist?(backup), "backup must be removed after restoring"
+      assert File.exist?(settings),
+             "settings.json must remain — restored from backup, not deleted"
+      assert_equal %({"enabledPlugins":{"frontend-design@official":true}}),
+                   File.read(settings),
+                   "restored content must match the project's original byte-for-byte"
+    end
+  end
+
+  def test_cleanup_scratch_deletes_when_no_backup_exists
+    with_tmp_task do |task|
+      settings = File.join(task.folder, ".claude", "settings.json")
+      FileUtils.mkdir_p(File.dirname(settings))
+      File.write(settings, "{}")
+
+      Hive::ClaudeLauncher.cleanup_scratch(settings)
+
+      refute File.exist?(settings),
+             "no-backup case (project did not own the file) must keep the delete-on-cleanup semantics"
+    end
+  end
+
   def test_safe_with_log_mentions_task_folder_when_available
     task = Struct.new(:folder).new("/tmp/example-task")
 

--- a/test/unit/stop_hook_installer_test.rb
+++ b/test/unit/stop_hook_installer_test.rb
@@ -77,6 +77,55 @@ class StopHookInstallerTest < Minitest::Test
     end
   end
 
+  def test_install_backs_up_existing_project_owned_settings
+    with_tmp_dir do |dir|
+      claude_dir = File.join(dir, ".claude")
+      FileUtils.mkdir_p(claude_dir)
+      project_settings = File.join(claude_dir, "settings.json")
+      project_body = %({"enabledPlugins":{"frontend-design@official":true}})
+      File.write(project_settings, project_body)
+
+      Hive::StopHookInstaller.install(stage_dir: dir)
+
+      backup_path = "#{project_settings}#{Hive::StopHookInstaller::BACKUP_SUFFIX}"
+      assert File.exist?(backup_path),
+             "a pre-existing project-owned .claude/settings.json must be backed up before overwrite"
+      assert_equal project_body, File.read(backup_path),
+                   "the backup must hold the project's original content verbatim"
+    end
+  end
+
+  def test_install_skips_backup_when_no_existing_settings_present
+    with_tmp_dir do |dir|
+      Hive::StopHookInstaller.install(stage_dir: dir)
+
+      backup_path = File.join(dir, ".claude", "settings.json#{Hive::StopHookInstaller::BACKUP_SUFFIX}")
+      refute File.exist?(backup_path),
+             "no backup must be written when nothing existed to overwrite (the scratch case)"
+    end
+  end
+
+  def test_install_does_not_overwrite_existing_backup
+    with_tmp_dir do |dir|
+      claude_dir = File.join(dir, ".claude")
+      FileUtils.mkdir_p(claude_dir)
+      project_settings = File.join(claude_dir, "settings.json")
+      project_body = %({"original":"project-owned"})
+      File.write(project_settings, project_body)
+
+      # First install backs up the project file. Second install runs
+      # against the hive-installed stub; if it re-backed up, the stub
+      # would clobber the original. The invariant: backup is captured
+      # once per install/cleanup pair and never re-captured mid-pair.
+      Hive::StopHookInstaller.install(stage_dir: dir)
+      Hive::StopHookInstaller.install(stage_dir: dir)
+
+      backup_path = "#{project_settings}#{Hive::StopHookInstaller::BACKUP_SUFFIX}"
+      assert_equal project_body, File.read(backup_path),
+                   "second install must NOT overwrite the existing backup with the hive stub"
+    end
+  end
+
   def test_stop_hook_writes_result_json_and_done
     with_tmp_dir do |dir|
       payload = %({"session_id":"abc","transcript_path":"/tmp/transcript.jsonl"})

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -2,6 +2,12 @@
 
 Append-only log of all wiki operations.
 
+## [2026-05-26T14:30:00Z] claude-launcher - preserve project-owned .claude/settings.json
+
+**Action:** Documented the launcher's new backup/restore behavior for `.claude/settings.json`. Root cause was that `StopHookInstaller.install_at` unconditionally deleted-and-overwrote the file, then `cleanup_scratch` unconditionally deleted it on spawn end — destructive for any project that committed `.claude/settings.json` via `hive init`'s llm-wiki bootstrap (`git_ops.rb:140`). Symptom was a recurring `dirty_worktree` marker in 4-execute / 6-review / 8-finalize because the post-stage check saw the deletion in `git status`. Fix: snapshot the existing file to `.claude/settings.json.hive-pre-install` before the install overwrite (only on first install per spawn pair, to avoid backing up the hive stub on re-entry), and have `cleanup_scratch` prefer restore-from-backup over delete.
+
+**Refreshed pages:** None — fix is internal launcher plumbing; existing module pages remain accurate.
+
 ## [2026-05-26T10:15:00Z] daemon - self-reexec on source-file drift
 
 **Action:** Surfaced the daemon's new auto-re-exec behavior triggered by `lib/hive.rb` SHA-256 drift. Adds `ADR-031` recording the diagnosis (8,946 `schema_version` mismatches between PR #78 and the next restart) and the chosen mitigation. Updates `wiki/modules/daemon.md` with operator-facing details: fingerprint scope, rate-limit (60s), kill switch (`HIVE_DAEMON_NO_AUTO_REEXEC=1`), and what kinds of edits do and don't trigger re-exec.


### PR DESCRIPTION
## Summary

Fixes the recurring `dirty_worktree` marker observed in 4-execute, 6-review (Phase 4 fix step), and 8-finalize on projects that commit `.claude/settings.json` (e.g. via `hive init`'s llm-wiki bootstrap path at `git_ops.rb:140`).

## Root cause

1. `Hive::StopHookInstaller#install_at` unconditionally `File.delete`'d any existing `.claude/settings.json` in the cwd, then wrote a Stop-hook-only stub.
2. `Hive::ClaudeLauncher#cleanup_scratch` unconditionally `File.delete`'d the stub on spawn end.
3. The post-stage dirty-worktree check then observed `D .claude/settings.json` in `git status --porcelain` and emitted `EXECUTE_WAITING reason=dirty_worktree` / `fix_dirty_worktree` / `finalize_dirty_worktree`.

PR #154 papered over (3) for the 6-review post-fix case by auto-committing fix-agent edits. That didn't address the cause, so the bug kept surfacing in other stages.

Diagnosis incident: writero/4-execute/we-need-to-support-media-260526-c4c0 hit it today. After Claude finished the implementation work and committed 4 substantive commits, the launcher cleanup deleted the project's committed \`.claude/settings.json\` and the post-stage dirty check fired.

Commit log shows this exact pattern across stages:
- 2db31f34, 6ab59a4c — 4-execute/.../execute_waiting_dirty_worktree
- ae0273f4, a6d57917, becd798e — 8-finalize/.../finalize_dirty_worktree
- Multiple 6-review/.../fix_dirty_worktree_pass_NN

## Fix

1. **StopHookInstaller#install_at**: snapshot the pre-existing \`.claude/settings.json\` to \`.claude/settings.json.hive-pre-install\` before the install overwrite. Skip the snapshot if a backup already exists, so a re-entrant install in the same spawn pair cannot clobber the real original with the hive stub.
2. **ClaudeLauncher#cleanup_scratch**: prefer restore-from-backup over delete. If the backup exists, \`FileUtils.mv\` it back over \`settings.json\` and return. Otherwise fall through to the existing delete path.

The "scratch" semantics survive intact for projects that don't ship \`.claude/settings.json\` — no backup means cleanup falls through to the existing delete-and-prune-empty-dir path.

## Tests

New unit tests in test/unit/stop_hook_installer_test.rb:
- test_install_backs_up_existing_project_owned_settings
- test_install_skips_backup_when_no_existing_settings_present
- test_install_does_not_overwrite_existing_backup

New unit tests in test/unit/claude_launcher_test.rb:
- test_cleanup_scratch_restores_project_owned_settings_from_backup
- test_cleanup_scratch_deletes_when_no_backup_exists

Verification:
- bundle exec rake test → 3605 runs, 12942 assertions, 0 failures, 0 errors, 2 skips
- bundle exec rubocop → no offenses on touched files
- E2E signal: against the live writero task, restoring the file via git checkout HEAD -- .claude/settings.json brought the worktree back to clean and hive approve --force advanced it to 5-open-pr. After this fix, the next spawn on that task should leave the worktree clean automatically.

## Test plan
- [x] Unit tests pass locally
- [x] Rubocop clean
- [ ] CI passes
- [ ] Smoke: hand the writero task back to the daemon and confirm 5-open-pr completes without tripping dirty_worktree

## Risks

- **Backup file leak**: if cleanup_scratch is never called (process killed before ensure fires), the .hive-pre-install backup persists. Next spawn's install_at sees backup-exists and skips re-backup; the actual settings.json at that point is the previous run's hive stub. Subsequent cleanup_scratch restores the original from backup. So the leak is self-healing on the next clean spawn pair.
- **Backup file visible in git status**: tests confirm the backup is removed by cleanup_scratch via FileUtils.mv. A killed-before-ensure crash leaves the backup until next spawn. Adding *.hive-pre-install to .gitignore would belt-and-suspenders this; deferred since the self-healing path makes it cosmetic.

Refs: writero/4-execute/we-need-to-support-media-260526-c4c0 incident; PR #154's 6-review-only auto-commit workaround.