### PR TITLE
docs(wiki): refresh active-areas with daemon-autostart status

### DIFF
--- a/wiki/active-areas.md
+++ b/wiki/active-areas.md
@@ -11,6 +11,8 @@ tags: [roadmap, status]
 
 ## Status
 
+Daemon autostart hardening landed on `main` via #189 (2026-05-26): autostart is now install-time/global infrastructure. A Linux host without systemd-user writes the unit and reports the `unsupported` success outcome (exit 0) instead of a spurious failure; `install.sh` captures the real install exit code and carries the verified `hive`/`hv` wrapper through daemon install + `hive init`; `Hive::InvokedBinary` replaces the dead `which` delegators. See log entries 2026-05-26 (21:22Z / 22:55Z / 23:30Z) and ADR-024.
+
 Recent history inspected on 2026-05-25:
 
 | Commit | Area | Notes |


### PR DESCRIPTION
## Summary
- Refreshes `wiki/active-areas.md` to record the install-time daemon autostart hardening merged in #189 (ADR-024).
- No-systemd Linux hosts now report the `unsupported` success outcome (exit 0) instead of a spurious failure; `install.sh` captures the real install exit code and carries the verified `hive`/`hv` wrapper through daemon install + `hive init`; `Hive::InvokedBinary` replaces the dead `which` delegators.
- Picks up the auto-maintained TLDR refresh that the wiki hook generated during the #189 work.

## Test plan
- [x] Docs-only change; `wiki/active-areas.md` reads correctly and references are accurate (#189, ADR-024, log entries 21:22Z/22:55Z/23:30Z).

🤖 Generated with [Claude Code](https://claude.com/claude-code)