### PR TITLE
fix(release): repository_dispatch payload + non-fatal brew notify

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,22 +102,24 @@ jobs:
             --verify-tag
       - name: Notify Homebrew tap
         if: ${{ env.HOMEBREW_TAP_TOKEN != '' }}
+        # Non-fatal: a tap dispatch hiccup must not abort the release or
+        # block the downstream aur-publish job (which `needs` this job).
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ env.HOMEBREW_TAP_TOKEN }}
           REF_NAME: ${{ github.ref_name }}
         run: |
           version="${REF_NAME#v}"
           gem_sha="$(awk '/hive-cli-/ {print $1}' dist/SHA256SUMS)"
-          # Build the payload via jq so version/sha values can't break
-          # out of the JSON object (a tag like `v0.1","event_type":"x`
-          # injected via string concat would otherwise smuggle keys).
-          payload="$(jq -nc --arg version "$version" --arg sha "$gem_sha" \
-            '{version: $version, sha256_gem: $sha}')"
+          # Send the WHOLE request body via jq + --input so client_payload
+          # is a real JSON object. (`--raw-field client_payload=<json>`
+          # sends it as a string, which the dispatch API rejects with
+          # HTTP 422 "is not an object".) Building it with jq also keeps
+          # version/sha from breaking out of the JSON.
           echo "notify-homebrew: dispatching event_type=hive-release version=${version}"
-          gh api repos/ivankuznetsov/homebrew-hive/dispatches \
-            --method POST \
-            --field event_type=hive-release \
-            --raw-field "client_payload=${payload}"
+          jq -nc --arg version "$version" --arg sha "$gem_sha" \
+            '{event_type: "hive-release", client_payload: {version: $version, sha256_gem: $sha}}' \
+            | gh api repos/ivankuznetsov/homebrew-hive/dispatches --method POST --input -
       - name: Notify Homebrew tap (audit when skipped)
         if: ${{ env.HOMEBREW_TAP_TOKEN == '' }}
         run: |


### PR DESCRIPTION
## Summary

The v0.1.1 release exposed a pre-existing bug in the `Notify Homebrew tap` step of `release.yml`: it sent `client_payload` via `--raw-field client_payload=<json-string>`, so GitHub received a **string** and rejected the dispatch with `HTTP 422 "is not an object"`. That step failure aborted the `release-finalize` job before the AUR gate, so neither channel auto-updated (only the gem published).

This had never surfaced because the step only runs when `HOMEBREW_TAP_TOKEN` is set — which first happened for v0.1.1.

## Fix

- Build the **entire** dispatch body with `jq` (`{event_type, client_payload: {…}}`) and send it via `gh api … --input -`, so `client_payload` is a real object.
- Mark the step `continue-on-error: true` so a tap-dispatch hiccup can never abort the release or block the downstream `aur-publish` job (which `needs` `release-finalize`).

Verified out-of-band: firing the corrected dispatch manually updated the tap formula to 0.1.1 successfully.

## Test plan
- [ ] CI green
- [ ] Next release dispatches to the tap without the 422 and the AUR job runs even if the tap dispatch fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)