### PR TITLE
chore(release): bump to v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed — release channel publishing
+
+- Fixed the `release.yml` Homebrew-tap dispatch, which sent `client_payload` as a JSON string (rejected with HTTP 422) and aborted the publish job before the AUR step. The dispatch now sends a proper object, and the tap-notify step is non-fatal so it can never block the AUR publish.
+
 ### Added — Homebrew tap + AUR publishing
 
 - Finished the Homebrew and AUR install channels (previously only `install.sh` worked). A `vX.Y.Z` tag now publishes the signed `hive-cli` gem and fans out to both channels: `release.yml` dispatches to the `ivankuznetsov/homebrew-hive` tap (which renders `Formula/hive.rb` from the repo's ERB template) and runs an `aur-publish` job that cosign-verifies the gem (pinned signing identity) before rendering the `PKGBUILD`, regenerating `.SRCINFO` via `makepkg --printsrcinfo`, and pushing to the AUR `hive-bin` package.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hive-cli (0.1.1)
+    hive-cli (0.1.2)
       bubbletea (= 0.1.4)
       lipgloss (~> 0.2.2)
       sqlite3 (~> 2.0)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Hive ships as a rubygem (`hive-cli`) attached to each GitHub Release, signed wit
 | Platform | Channel |
 |----------|---------|
 | macOS arm64 | `brew install ivankuznetsov/hive/hive` |
-| Ubuntu 22.04+ / glibc Linux x86_64/aarch64 | <code>tmpdir="$(mktemp -d)" && trap 'rm -rf "$tmpdir"' EXIT && curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.1.1/install.sh -o "$tmpdir/hive-install.sh" && bash "$tmpdir/hive-install.sh"</code> |
+| Ubuntu 22.04+ / glibc Linux x86_64/aarch64 | <code>tmpdir="$(mktemp -d)" && trap 'rm -rf "$tmpdir"' EXIT && curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.1.2/install.sh -o "$tmpdir/hive-install.sh" && bash "$tmpdir/hive-install.sh"</code> |
 | Arch Linux x86_64/aarch64 | _Coming soon_ (`yay -S hive-bin`) — use the Linux installer above until the AUR package is published. |
 
 Prerequisites: **Ruby 3.4** (the gem and its runtime deps install against this), git ≥ 2.40, authenticated `claude` ≥ 2.1.118, `codex` ≥ 0.125.0 for the default execute agent, authenticated `gh`, and `tmux` ≥ 3.0 when the project uses the default `claude.mode: tmux`. The bash installer reports its own installer-side prereqs (`curl`, `jq`, `gem`, checksum tool) on first run.

--- a/install.md
+++ b/install.md
@@ -57,8 +57,8 @@ Ubuntu 22.04+ / glibc Linux fallback (pin to the current release tag, not `main`
 ```bash
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
-# Release maintainers: bump v0.1.1 in both installer URLs when cutting a new stable release.
-curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.1.1/install.sh -o "$tmpdir/hive-install.sh"
+# Release maintainers: bump v0.1.2 in both installer URLs when cutting a new stable release.
+curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.1.2/install.sh -o "$tmpdir/hive-install.sh"
 bash "$tmpdir/hive-install.sh"
 ```
 
@@ -67,8 +67,8 @@ To inspect the installer first, run a dry-run before the real invocation. State 
 ```bash
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
-# Release maintainers: bump v0.1.1 in both installer URLs when cutting a new stable release.
-curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.1.1/install.sh -o "$tmpdir/hive-install.sh"
+# Release maintainers: bump v0.1.2 in both installer URLs when cutting a new stable release.
+curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.1.2/install.sh -o "$tmpdir/hive-install.sh"
 bash "$tmpdir/hive-install.sh" --dry-run
 bash "$tmpdir/hive-install.sh"
 ```

--- a/lib/hive.rb
+++ b/lib/hive.rb
@@ -1,5 +1,5 @@
 module Hive
-  VERSION = "0.1.1".freeze
+  VERSION = "0.1.2".freeze
   MIN_CLAUDE_VERSION = "2.1.118".freeze
 
   module Schemas


### PR DESCRIPTION
## Summary

Cuts **v0.1.2** — the release that runs the now-fixed publish pipeline (#198) end-to-end, including the AUR `aur-publish` job which has not yet executed.

- `Hive::VERSION` → 0.1.2 (+ Gemfile.lock sync).
- CHANGELOG: note the release-dispatch fix.
- Bump installer-script URL refs v0.1.1 → v0.1.2.

## Why a new patch instead of re-running v0.1.1

The v0.1.1 release published the gem and (after a manual corrected dispatch) the Homebrew formula, but its `aur-publish` job never ran because the brew-notify bug aborted the job first. Re-running v0.1.1 would use the buggy workflow pinned at that tag. v0.1.2 runs the fixed pipeline cleanly and validates the AUR job for the first time.

## After merge

```sh
git checkout main && git pull && git tag v0.1.2 && git push origin v0.1.2
```

Expected: gem 0.1.2 + signed checksums → tap formula auto-bumps to 0.1.2 → `aur-publish` creates/updates `hive-bin` at 0.1.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)