### PR TITLE
fix(release): AUR ssh host-key verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,8 +208,11 @@ jobs:
       - name: Push to AUR
         run: |
           install -dm700 ~/.ssh
-          # TOFU on first contact; AUR's host key is stable thereafter.
-          ssh-keyscan aur.archlinux.org >> ~/.ssh/known_hosts 2>/dev/null
+          # Accept AUR's host key on first connect (TOFU) and record it.
+          # ssh-keyscan was unreliable in the container (clone failed with
+          # "Host key verification failed"); accept-new auto-trusts the key
+          # on first use. The SSH key auth below is the real access gate.
+          export GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=$HOME/.ssh/known_hosts"
           eval "$(ssh-agent -s)"
           # Load the key straight from env into the agent via stdin — the
           # private key is never written to disk (so a compromised gem dep


### PR DESCRIPTION
v0.1.3's aur-publish reached the AUR push but failed with `Host key verification failed` — ssh-keyscan didn't populate known_hosts in the container (key auth itself succeeded). Switch to `GIT_SSH_COMMAND` with `StrictHostKeyChecking=accept-new` so ssh trusts AUR's host key on first connect. Next release should complete the push and create hive-bin.