### PR TITLE
docs(readme): link Homebrew tap and publish AUR row

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ Hive ships as a rubygem (`hive-cli`) attached to each GitHub Release, signed wit
 
 | Platform | Channel |
 |----------|---------|
-| macOS arm64 | `brew install ivankuznetsov/hive/hive` |
+| macOS arm64 | [`brew install ivankuznetsov/hive/hive`](https://github.com/ivankuznetsov/homebrew-hive) |
 | Ubuntu 22.04+ / glibc Linux x86_64/aarch64 | <code>tmpdir="$(mktemp -d)" && trap 'rm -rf "$tmpdir"' EXIT && curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.1.4/install.sh -o "$tmpdir/hive-install.sh" && bash "$tmpdir/hive-install.sh"</code> |
-| Arch Linux x86_64/aarch64 | `yay -S hive-bin` |
+| Arch Linux x86_64/aarch64 | [`yay -S hive-bin`](https://aur.archlinux.org/packages/hive-bin) |
 
 Prerequisites: **Ruby 3.4** (the gem and its runtime deps install against this), git ≥ 2.40, authenticated `claude` ≥ 2.1.118, `codex` ≥ 0.125.0 for the default execute agent, authenticated `gh`, and `tmux` ≥ 3.0 when the project uses the default `claude.mode: tmux`. The bash installer reports its own installer-side prereqs (`curl`, `jq`, `gem`, checksum tool) on first run.
 


### PR DESCRIPTION
Homebrew (`ivankuznetsov/homebrew-hive`) and the AUR package (`hive-bin`) are published now.

- Link the `brew install …` command to the Homebrew tap.
- Replace the "Coming soon" Arch row with the live `yay -S hive-bin`, linked to the AUR package page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)