### PR TITLE
feat(ci): cross-OS install verification — verifier + reusable matrix (U1–U3)

### DIFF
--- a/.github/workflows/install-verify.yml
+++ b/.github/workflows/install-verify.yml
@@ -1,0 +1,116 @@
+name: Install verify
+
+# Real installs of every channel on its native OS, run as a reusable workflow.
+# Callers: a post-release trigger and a weekly canary (added in a later unit).
+# `workflow_dispatch` lets a maintainer exercise it on demand against any
+# published version.
+#
+# This does NOT gate releases (that's the separate pre-release gem-install gate
+# in release.yml). It confirms the *published* packages actually install.
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Release tag to verify (e.g. v0.1.4)"
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release tag to verify (e.g. v0.1.4)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: ${{ matrix.channel }} / ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.runs-on }}
+    container: ${{ matrix.container }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - channel: bash
+            runs-on: ubuntu-24.04
+          - channel: bash
+            runs-on: ubuntu-24.04-arm
+          - channel: brew
+            runs-on: macos-15
+          - channel: aur
+            runs-on: ubuntu-24.04
+            container: archlinux:base-devel
+          # aarch64-AUR is deferred (Scope: Deferred to Follow-Up in the plan):
+          # the official archlinux image is x86_64-only, so it needs an
+          # Arch-Linux-ARM image + the base-devel/fakeroot/non-root-makepkg
+          # go/no-go checks. Land bash+macos arm first.
+    env:
+      VERSION: ${{ inputs.version }}
+      CHANNEL: ${{ matrix.channel }}
+    steps:
+      # Arch container needs git before actions/checkout can run.
+      - name: Bootstrap Arch toolchain
+        if: ${{ matrix.channel == 'aur' }}
+        run: |
+          pacman -Syu --noconfirm --needed git ruby ruby-erb base-devel sudo
+          # makepkg refuses root; create a passwordless-sudo build user.
+          useradd -m builder
+          echo 'builder ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/builder
+
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby (bash channel)
+        if: ${{ matrix.channel == 'bash' }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+
+      - name: Verify channel
+        if: ${{ matrix.channel != 'aur' }}
+        run: bash packaging/verify-channel.sh --channel "$CHANNEL" --version "$VERSION"
+
+      - name: Verify channel (AUR, as non-root builder)
+        if: ${{ matrix.channel == 'aur' }}
+        run: |
+          chown -R builder .
+          sudo -u builder env VERSION="$VERSION" \
+            bash packaging/verify-channel.sh --channel aur --version "$VERSION"
+
+  report:
+    name: Report failure
+    needs: verify
+    if: ${{ failure() }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Open or update the install-failure issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          VERSION: ${{ inputs.version }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          # Single job touches issues → no per-cell create race.
+          gh label create install-failure --repo "$REPO" \
+            --color B60205 --description "Cross-OS install verification failed" 2>/dev/null || true
+          body="Install verification failed for \`${VERSION}\`.
+
+          Run: ${RUN_URL}
+
+          One or more channel/OS cells failed. See the run for the failing matrix cells.
+          This issue auto-updates on repeat failures; close it once installs are green."
+          existing="$(gh issue list --repo "$REPO" --label install-failure --state open \
+            --json number --jq '.[0].number' 2>/dev/null || true)"
+          if [[ -n "$existing" ]]; then
+            gh issue comment "$existing" --repo "$REPO" --body "$body"
+            echo "updated existing install-failure issue #${existing}"
+          else
+            gh issue create --repo "$REPO" --label install-failure \
+              --title "Install verification failing" --body "$body"
+            echo "opened a new install-failure issue"
+          fi

--- a/packaging/verify-channel.sh
+++ b/packaging/verify-channel.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+#
+# verify-channel.sh — real-install verification for ONE install channel.
+#
+# Installs hive through the named channel on the current OS, then asserts the
+# same behavioral contract regardless of channel: the binary reports the target
+# version, the install-channel marker is correct, `doctor` runs, and a scratch
+# project walks init → new → status. This is the shared verifier behind the
+# pre-release gate, post-release verification, and the scheduled canary
+# (.github/workflows/install-verify.yml).
+#
+# The `bash` channel delegates to packaging/verify-release.sh, which already
+# owns the full XDG-sandboxed + leak-detection suite for install.sh. The `brew`
+# and `aur` channels install system-wide, so this script resolves their binary
+# and marker paths and runs the channel-agnostic behavioral core.
+#
+# Usage:
+#   packaging/verify-channel.sh --channel bash|brew|aur --version vX.Y.Z
+#                               [--report=text|json]
+#
+# Exit codes: 0 ok · 1 a check failed · 2 bad arguments · 3 prerequisite missing
+
+set -euo pipefail
+
+usage() {
+  cat <<'HELP'
+verify-channel.sh — real-install verification for one install channel.
+
+USAGE:
+  packaging/verify-channel.sh --channel bash|brew|aur --version vX.Y.Z
+                              [--report=text|json]
+HELP
+}
+
+CHANNEL=""
+HIVE_VERSION=""
+REPORT_FORMAT="text"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --channel=*) CHANNEL="${1#*=}"; shift ;;
+    --channel)   CHANNEL="${2:-}"; shift 2 ;;
+    --version=*) HIVE_VERSION="${1#*=}"; shift ;;
+    --version)   HIVE_VERSION="${2:-}"; shift 2 ;;
+    --report=*)  REPORT_FORMAT="${1#*=}"; shift ;;
+    -h|--help)   usage; exit 0 ;;
+    *) echo "verify-channel: unknown argument: $1 (try --help)" >&2; exit 2 ;;
+  esac
+done
+
+case "$CHANNEL" in
+  bash|brew|aur) ;;
+  *) echo "verify-channel: --channel must be bash|brew|aur (got: '${CHANNEL}')" >&2; exit 2 ;;
+esac
+case "$REPORT_FORMAT" in text|json) ;; *) echo "verify-channel: --report must be text|json" >&2; exit 2 ;; esac
+if [[ -z "$HIVE_VERSION" ]]; then
+  echo "verify-channel: --version vX.Y.Z is required" >&2; exit 2
+fi
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+# Bare semver (no leading v) — the value `hive --version` prints.
+EXPECTED_VERSION="${HIVE_VERSION#v}"
+
+# ─── bash channel: delegate to the existing full-sandbox suite ────────
+if [[ "$CHANNEL" == "bash" ]]; then
+  exec bash "$REPO_ROOT/packaging/verify-release.sh" \
+    --version="$HIVE_VERSION" --report="$REPORT_FORMAT"
+fi
+
+# ─── brew / aur: channel-agnostic behavioral core ─────────────────────
+
+PASS=0
+FAIL=0
+ok()   { printf '  ok   %s\n' "$*"; PASS=$((PASS + 1)); }
+fail() { printf '  FAIL %s\n' "$*" >&2; FAIL=$((FAIL + 1)); }
+log()  { printf '[verify-channel:%s] %s\n' "$CHANNEL" "$*"; }
+
+# Resolve the channel's install command, expected binary, and marker path.
+HIVE_BIN=""
+MARKER_PATH=""
+
+install_brew() {
+  command -v brew >/dev/null 2>&1 || { echo "brew not found" >&2; exit 3; }
+  # The formula depends_on "ruby"; the gem needs >= 3.4. Fail early with a
+  # clear message if Homebrew's ruby is older, rather than a murky gem error.
+  local brew_ruby
+  brew_ruby="$(brew list --versions ruby 2>/dev/null | awk '{print $2}' | head -n1 || true)"
+  if [[ -n "$brew_ruby" ]]; then
+    if [[ "$(printf '%s\n3.4.0\n' "$brew_ruby" | sort -V | head -n1)" != "3.4.0" ]]; then
+      log "note: Homebrew ruby ${brew_ruby} is below the gemspec floor 3.4.0 (install may fail)"
+    fi
+  fi
+  brew install ivankuznetsov/hive/hive
+  local prefix
+  prefix="$(brew --prefix)"
+  HIVE_BIN="${prefix}/bin/hive"
+  MARKER_PATH="${prefix}/share/hive/install-channel"
+}
+
+install_aur() {
+  # Real user path: an AUR helper if present, else build the published package.
+  if command -v yay >/dev/null 2>&1; then
+    yay -S --noconfirm --needed hive-bin
+  elif command -v paru >/dev/null 2>&1; then
+    paru -S --noconfirm --needed hive-bin
+  else
+    # No helper: clone the published AUR package and build it. makepkg refuses
+    # root, so the caller must run this script as a non-root user with sudo.
+    command -v makepkg >/dev/null 2>&1 || { echo "neither yay/paru nor makepkg found" >&2; exit 3; }
+    local build
+    build="$(mktemp -d)"
+    git clone --depth 1 "https://aur.archlinux.org/hive-bin.git" "$build/hive-bin"
+    ( cd "$build/hive-bin" && makepkg -si --noconfirm --needed )
+  fi
+  HIVE_BIN="/usr/bin/hive"
+  MARKER_PATH="/usr/share/hive/install-channel"
+}
+
+log "installing hive ${HIVE_VERSION} via ${CHANNEL}"
+case "$CHANNEL" in
+  brew) install_brew ;;
+  aur)  install_aur ;;
+esac
+
+# 1. binary present + version
+if [[ -x "$HIVE_BIN" ]]; then ok "binary present at ${HIVE_BIN}"; else fail "no executable at ${HIVE_BIN}"; fi
+got_version="$("$HIVE_BIN" --version 2>/dev/null | head -n1 || true)"
+if [[ "$got_version" == "$EXPECTED_VERSION" ]]; then
+  ok "hive --version == ${EXPECTED_VERSION}"
+else
+  fail "hive --version is '${got_version}', want '${EXPECTED_VERSION}'"
+fi
+
+# 2. install-channel marker
+marker_content="$(cat "$MARKER_PATH" 2>/dev/null | tr -d '[:space:]' || true)"
+if [[ "$marker_content" == "$CHANNEL" ]]; then
+  ok "install-channel marker == ${CHANNEL}"
+else
+  fail "marker at ${MARKER_PATH} is '${marker_content}', want '${CHANNEL}'"
+fi
+
+# 3. hv fallback (Apache Hive PATH-collision shim ships with every channel)
+hv_bin="$(dirname "$HIVE_BIN")/hv"
+if [[ -e "$hv_bin" ]] && "$hv_bin" --version >/dev/null 2>&1; then
+  ok "hv fallback works"
+else
+  fail "hv fallback missing or broken at ${hv_bin}"
+fi
+
+# 4. doctor runs (tolerate non-zero in a CI sandbox lacking LLM CLIs/skills;
+#    a crash lacks the signature report header).
+doctor_out="$("$HIVE_BIN" doctor 2>&1 || true)"
+if printf '%s\n' "$doctor_out" | grep -qE '^stage[[:space:]]+agent[[:space:]]+skill[[:space:]]+status' \
+   || "$HIVE_BIN" doctor >/dev/null 2>&1; then
+  ok "doctor produced its report"
+else
+  fail "doctor crashed (no signature header)"
+fi
+
+# 5. scratch project: init → new → status --json
+project="$(mktemp -d)/scratch"
+mkdir -p "$project"
+( cd "$project" \
+    && git init -q -b main \
+    && git config user.email "verify@example.invalid" \
+    && git config user.name "Verify" \
+    && git commit -q --allow-empty -m "init" )
+if "$HIVE_BIN" init "$project" >/dev/null 2>&1; then ok "hive init exited 0"; else fail "hive init failed"; fi
+if [[ -d "$project/.hive-state/stages/1-inbox" ]]; then ok ".hive-state/stages/1-inbox created"; else fail "init did not scaffold .hive-state"; fi
+if "$HIVE_BIN" new "$(basename "$project")" "channel verify smoke" >/dev/null 2>&1; then ok "hive new exited 0"; else fail "hive new failed"; fi
+status_json="$("$HIVE_BIN" status --json 2>/dev/null || true)"
+if printf '%s' "$status_json" | grep -q '"schema":"hive-status"'; then
+  ok "status --json emits hive-status envelope"
+else
+  fail "status --json did not emit a hive-status envelope"
+fi
+
+log "summary: ${PASS} passed, ${FAIL} failed"
+[[ "$FAIL" -eq 0 ]] || exit 1
+log "channel ${CHANNEL} verified for ${HIVE_VERSION}"


### PR DESCRIPTION
## Summary

Phase 1+2 of the cross-OS install verification plan: the building blocks that let CI do **real installs** of each channel on its native OS (no macOS/Ubuntu hardware needed).

- **U1** `packaging/verify-channel.sh` — channel-parametrized verifier (`--channel bash|brew|aur --version vX.Y.Z`). `bash` delegates to the existing `verify-release.sh` (full XDG/leak suite, untouched); `brew`/`aur` install system-wide and run the shared behavioral core: version == target, per-channel install-channel marker (`<prefix>/share/hive` vs `/usr/share/hive`), `hv` fallback, `doctor`, and a scratch `init → new → status --json`. Includes a Homebrew Ruby ≥ 3.4 floor note.
- **U2** `.github/workflows/install-verify.yml` — reusable `workflow_call` (+ `workflow_dispatch`) with a `fail-fast: false` matrix: `bash`/ubuntu-24.04, `bash`/ubuntu-24.04-arm, `brew`/macos-15, `aur`/archlinux-container. aarch64-AUR is deferred (official `archlinux` image is x86_64-only — needs an ALARM image; documented in the plan).
- **U3** a single `report` job (`needs: verify`, `if: failure()`, `issues: write`) opens/updates one `install-failure` issue via `gh` — single job, so no per-cell create race.

Deliberately **not** in this PR (later phases): U4 pre-release gate in `release.yml`, U5 post-release + canary callers, U6 docs.

## Validation
- Lint-clean: `actionlint` + `shellcheck` + `bash -n`; verify-channel.sh arg-parsing error paths exercised locally.
- macOS / Arch / aarch64 cells can only run on GitHub-hosted runners — validate post-merge via `gh workflow run install-verify.yml -f version=v0.1.4` (workflow_dispatch requires the workflow on the default branch).

## Test plan
- [ ] CI green on this PR
- [ ] Post-merge: `workflow_dispatch` against v0.1.4 → bash/brew/aur cells green; bogus version → one `install-failure` issue opened

🤖 Generated with [Claude Code](https://claude.com/claude-code)