### PR TITLE
docs(readme): drop stale "once published" AUR caveat

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The result Hive built in that reel lives at [ivankuznetsov/shipped](https://gith
 
 ## Install
 
-Hive ships as a rubygem (`hive-cli`) attached to each GitHub Release, signed with cosign keyless attestation. Each available channel below downloads the same `.gem`, verifies the signature, and runs `gem install` against it. The `install.sh` channel then runs `hive daemon install` automatically; the Homebrew (and, once published, AUR) package prints a one-line reminder to run it once, and `hive init .` also ensures it. Either way the per-user systemd-user (Linux) or launchd (macOS) daemon service ends up enabled by default, and `hive init .` only decides whether that project is enrolled for daemon dispatch.
+Hive ships as a rubygem (`hive-cli`) attached to each GitHub Release, signed with cosign keyless attestation. Each available channel below downloads the same `.gem`, verifies the signature, and runs `gem install` against it. The `install.sh` channel then runs `hive daemon install` automatically; the Homebrew and AUR packages print a one-line reminder to run it once, and `hive init .` also ensures it. Either way the per-user systemd-user (Linux) or launchd (macOS) daemon service ends up enabled by default, and `hive init .` only decides whether that project is enrolled for daemon dispatch.
 
 | Platform | Channel |
 |----------|---------|


### PR DESCRIPTION
The AUR package (`hive-bin`) is published now, so the install intro's "the Homebrew (and, once published, AUR) package" hedge is stale. Reword to "the Homebrew and AUR packages".

🤖 Generated with [Claude Code](https://claude.com/claude-code)