### PR TITLE
fix(packaging): repair AUR + Homebrew real-install bugs caught by install-verify

### DIFF
--- a/packaging/aur/PKGBUILD.template
+++ b/packaging/aur/PKGBUILD.template
@@ -47,27 +47,32 @@ package() {
   # `gem install --install-dir` requires the .gem file path, not the
   # extracted source. `noextract` keeps the .gem intact during
   # makepkg's source preparation step.
+  # `--ignore-dependencies` is a boolean flag (no value): the runtime
+  # deps install by default. Passing `=false` makes gem's OptionParser
+  # raise NeedlessArgument and abort package().
   gem install \
     --install-dir "${gem_home}" \
     --bindir "${gem_home}/bin" \
     --no-document \
-    --ignore-dependencies=false \
     "${srcdir}/hive-cli-${pkgver}.gem"
 
-  # User-facing wrappers under /usr/bin that set GEM_PATH before
-  # exec'ing the gem-installed bin. Without this, `hive` would only
-  # work when the user's default GEM_PATH includes the vendored gem
-  # home.
+  # User-facing /usr/bin/hive wrapper that sets GEM_PATH before exec'ing
+  # the gem-installed bin. Without this, `hive` would only work when the
+  # user's default GEM_PATH includes the vendored gem home.
   install -dm755 "${pkgdir}/usr/bin"
-  for name in hive hv; do
-    cat > "${pkgdir}/usr/bin/${name}" <<WRAPPER
+  cat > "${pkgdir}/usr/bin/hive" <<WRAPPER
 #!/usr/bin/env bash
 export GEM_HOME="/usr/share/hive/gems"
 export GEM_PATH="\${GEM_HOME}\${GEM_PATH:+:\$GEM_PATH}"
-exec "/usr/share/hive/gems/bin/${name}" "\$@"
+exec "/usr/share/hive/gems/bin/hive" "\$@"
 WRAPPER
-    chmod 755 "${pkgdir}/usr/bin/${name}"
-  done
+  chmod 755 "${pkgdir}/usr/bin/hive"
+
+  # `hv` is a symlink to our hive wrapper, NOT the gem's bin/hv: bin/hv is
+  # a bash script, but `gem install` generates a Ruby binstub for every
+  # executable, and a Ruby binstub cannot run a bash program. Pointing hv
+  # at the working hive wrapper gives the Apache-Hive-collision shim.
+  ln -s hive "${pkgdir}/usr/bin/hv"
 
   install -Dm644 "${gem_home}/gems/hive-cli-${pkgver}/LICENSE" \
     "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"

--- a/packaging/homebrew/hive.rb.erb
+++ b/packaging/homebrew/hive.rb.erb
@@ -18,21 +18,29 @@ class Hive < Formula
            "--install-dir", libexec,
            "--no-document",
            "--bindir", libexec/"bin"
-    (libexec/"share/hive").mkpath
-    (libexec/"share/hive/install-channel").write "brew\n"
+    # Marker under <prefix>/share (linked into the Homebrew prefix), NOT
+    # libexec/share — libexec is private and never linked, so a marker
+    # there is invisible to Hive::InstallChannel, which probes
+    # <prefix>/share/hive/install-channel.
+    (share/"hive").mkpath
+    (share/"hive/install-channel").write "brew\n"
 
-    # Symlink user-facing bins through libexec wrappers so GEM_PATH
-    # is set when hive resolves bubbletea, lipgloss, etc.
-    %w[hive hv].each do |name|
-      (bin/name).write <<~SH
-        #!/bin/bash
-        export GEM_HOME="#{libexec}"
-        export GEM_PATH="${GEM_HOME}${GEM_PATH:+:$GEM_PATH}"
-        export HIVE_INVOKED_BIN="${HIVE_INVOKED_BIN:-$0}"
-        exec "#{libexec}/bin/#{name}" "$@"
-      SH
-      (bin/name).chmod 0755
-    end
+    # User-facing bin/hive wrapper that exports GEM_HOME/GEM_PATH before
+    # exec'ing the gem-installed hive so it resolves bubbletea, lipgloss, etc.
+    (bin/"hive").write <<~SH
+      #!/bin/bash
+      export GEM_HOME="#{libexec}"
+      export GEM_PATH="${GEM_HOME}${GEM_PATH:+:$GEM_PATH}"
+      export HIVE_INVOKED_BIN="${HIVE_INVOKED_BIN:-$0}"
+      exec "#{libexec}/bin/hive" "$@"
+    SH
+    (bin/"hive").chmod 0755
+
+    # hv is a symlink to the hive wrapper, NOT the gem's bin/hv: bin/hv is
+    # a bash script and `gem install` wraps every executable in a Ruby
+    # binstub that cannot run it. The symlink gives a working Apache-Hive
+    # collision shim that runs our hive.
+    bin.install_symlink "hive" => "hv"
   end
 
   def caveats

--- a/packaging/verify-release.sh
+++ b/packaging/verify-release.sh
@@ -437,7 +437,10 @@ if [[ "$DAEMON_INSTALL_AVAILABLE" -eq 1 ]]; then
   set -e
 
   DAEMON_SCHEMA="$(jq -r '.schema // empty' "$DAEMON_INSTALL_JSON" 2>/dev/null || true)"
-  DAEMON_OK="$(jq -r '.ok // empty' "$DAEMON_INSTALL_JSON" 2>/dev/null || true)"
+  # `.ok | tostring` not `.ok // empty`: jq's `//` treats boolean false as
+  # absent, so `.ok // empty` yields "" when ok is false — making the
+  # rc=70/ok=false assertion below never match. tostring gives "false".
+  DAEMON_OK="$(jq -r '.ok | tostring' "$DAEMON_INSTALL_JSON" 2>/dev/null || true)"
   DAEMON_OUTCOME="$(jq -r '.outcome // empty' "$DAEMON_INSTALL_JSON" 2>/dev/null || true)"
 
   if [[ "$DAEMON_SCHEMA" == "hive-daemon-install" ]]; then


### PR DESCRIPTION
## Summary

The new `install-verify` matrix (#213), run against v0.1.4, caught three real bugs that the dry-run CI never could. Locally reproduced + fixed all three.

- **AUR `package()` aborted** on `gem install --ignore-dependencies=false` — the flag takes no value, so gem's OptionParser raised `NeedlessArgument`. **`yay -S hive-bin` was broken for every user** (the publish job only runs `makepkg --printsrcinfo`, never a real build). Removed the bogus flag. Verified locally: `makepkg` now builds `hive-bin` cleanly.
- **`hv` was broken on brew + AUR.** `bin/hv` is a bash script, but `gem install` generates a Ruby binstub for every executable, and a Ruby binstub can't run a bash program (`install.sh` already sidesteps this by symlinking). Made `hv` a symlink to the working `hive` wrapper in both packages. Verified: the rebuilt AUR package ships `usr/bin/hv -> hive`.
- **Homebrew channel marker undetectable.** The formula wrote it under `libexec/share/hive` (libexec is never linked into the prefix), but `Hive::InstallChannel` probes `<prefix>/share/hive/install-channel`. Write it under `<prefix>/share` instead.
- **`verify-release.sh` test-harness bug:** the daemon-install `rc=70/ok=false` assertion read `jq '.ok // empty'`, and jq's `//` collapses boolean `false` → empty, so it never matched. Use `.ok | tostring`. (Latent; the pinned-v0.1.0 CI skips the daemon step.)

After this merges, a patch release republishes the fixed PKGBUILD + formula, and I'll re-run `install-verify` to confirm all cells green.

## Test plan
- [ ] CI green
- [ ] Local `makepkg` builds hive-bin (done) with `hv -> hive` + marker `aur` (done)
- [ ] Post-release `install-verify` against the new version → bash/brew/aur cells green

🤖 Generated with [Claude Code](https://claude.com/claude-code)