### PR TITLE
feat(ci): pre-release gate + post-release/canary install verification (U4–U6)

### DIFF
--- a/.github/workflows/install-canary.yml
+++ b/.github/workflows/install-canary.yml
@@ -1,0 +1,41 @@
+name: Install canary
+
+# Weekly real-install of the latest release across all channels/OSes, to catch
+# environmental drift (rubygems platform gems, Ruby bumps, Homebrew/Arch base
+# changes) even when no new release is cut. A failure opens/updates the
+# install-failure issue (via install-verify.yml's report job).
+
+on:
+  schedule:
+    # Mondays 06:00 UTC.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  resolve-latest:
+    name: Resolve latest release
+    runs-on: ubuntu-24.04
+    outputs:
+      version: ${{ steps.latest.outputs.version }}
+    steps:
+      - name: Find latest published release tag
+        id: latest
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          version="$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName --jq '.tagName')"
+          [[ -n "$version" ]] || { echo "no published release found" >&2; exit 1; }
+          echo "verifying latest release: ${version}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+  verify:
+    needs: resolve-latest
+    uses: ./.github/workflows/install-verify.yml
+    with:
+      version: ${{ needs.resolve-latest.outputs.version }}
+    permissions:
+      contents: read
+      issues: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,10 +52,47 @@ jobs:
           path: hive-cli-*.gem
           if-no-files-found: error
 
+  install-gate:
+    name: gem-install gate / ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.runs-on }}
+    needs: build
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [macos-15, ubuntu-24.04-arm]
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: hive-cli-gem
+          path: dist
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+      - name: gem install the built gem
+        # Native-runner expansion of build's "Smoke test built gem":
+        # confirm the gem installs + runs on macOS arm64 and Linux arm64
+        # before publishing. x86_64 is already covered by `build`. The
+        # gem is arch=any Ruby, so no Arch/emulated cell here — a flaky
+        # emulated cell must never block a release (real Arch install is
+        # covered post-release by install-verify.yml).
+        run: |
+          gem_file="$(ls dist/hive-cli-*.gem | head -n 1)"
+          [[ -s "$gem_file" ]] || { echo "no hive-cli-*.gem artifact" >&2; exit 1; }
+          sandbox="$(mktemp -d)/gem-sandbox"
+          mkdir -p "$sandbox"
+          GEM_HOME="$sandbox" GEM_PATH="$sandbox" gem install "$gem_file" \
+            --install-dir "$sandbox" \
+            --bindir "$sandbox/bin" \
+            --no-document \
+            --source https://rubygems.org
+          GEM_HOME="$sandbox" GEM_PATH="$sandbox" "$sandbox/bin/hive" --version
+
   release-finalize:
     name: Publish GitHub release
     runs-on: ubuntu-24.04
-    needs: build
+    needs: [build, install-gate]
     permissions:
       contents: write
       id-token: write
@@ -233,3 +270,17 @@ jobs:
             git commit -m "hive-bin ${PKG_VERSION}"
             git push
           fi
+
+  # Post-release: now that the gem is released and the brew/AUR packages
+  # are published, do the REAL channel installs (brew install / yay -S /
+  # install.sh) of this version. Runs whenever release-finalize succeeded,
+  # regardless of whether aur-publish ran (it self-skips without the secret).
+  post-release-verify:
+    needs: [release-finalize, aur-publish]
+    if: ${{ always() && needs.release-finalize.result == 'success' }}
+    uses: ./.github/workflows/install-verify.yml
+    with:
+      version: ${{ github.ref_name }}
+    permissions:
+      contents: read
+      issues: write

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -175,6 +175,37 @@ version until you bump it manually or set the token.
 
 ---
 
+## Install verification
+
+CI does **real installs** of every channel on its native OS (no macOS/Ubuntu
+hardware needed — GitHub-hosted runners + containers). Three layers, all backed
+by `packaging/verify-channel.sh` and the reusable `.github/workflows/install-verify.yml`:
+
+1. **Pre-release gate** (`install-gate` in `release.yml`) — `gem install`s the
+   freshly-built gem on `macos-15` + `ubuntu-24.04-arm` before publishing.
+   `release-finalize` `needs:` it, so a gem that won't install never reaches
+   brew/AUR. Native runners only (the gem is `arch=any`; no emulated cell can
+   block a release).
+2. **Post-release verification** (`post-release-verify` in `release.yml`) — after
+   publish, runs the **real** `brew install` / `yay -S hive-bin` / `install.sh`
+   of the just-released version.
+3. **Weekly canary** (`install-canary.yml`, Mondays 06:00 UTC + `workflow_dispatch`)
+   — re-installs the latest release to catch dependency / base-image drift.
+
+Any failure opens or updates a single **`install-failure`** GitHub issue (one
+aggregation job, so no duplicate spam) naming the run. To check a specific
+version on demand:
+
+```sh
+gh workflow run install-verify.yml -f version=vX.Y.Z
+```
+
+Scope note: aarch64 covers `install.sh` (`ubuntu-24.04-arm`) and macOS (arm64);
+aarch64-AUR is deferred (the official `archlinux` image is x86_64-only — needs an
+Arch-Linux-ARM image).
+
+---
+
 ## Troubleshooting
 
 - **AUR job skipped** → `AUR_SSH_PRIVATE_KEY` is unset, or `release-finalize`

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -2,6 +2,10 @@
 
 Append-only log of all wiki operations.
 
+## [2026-05-27T12:00:00Z] ci — cross-OS install verification (real installs)
+
+**Action:** CI now does real installs of every channel on its native OS via `packaging/verify-channel.sh` + the reusable `.github/workflows/install-verify.yml` (matrix: bash/ubuntu x86+arm, brew/macos-15, aur/arch container). Three layers: a pre-release `install-gate` in `release.yml` (gem-installs on macos+ubuntu-arm before publishing), `post-release-verify` (real brew/yay/install.sh of the published version), and a weekly `install-canary.yml`. Failures open/update a single `install-failure` GitHub issue. This matrix immediately caught and drove fixes for real channel bugs (broken `yay -S hive-bin`, brew `hv` shim, brew marker path) shipped in v0.1.5. aarch64-AUR deferred (official `archlinux` image is x86_64-only). Runbook: `docs/RELEASING.md#install-verification`.
+
 ## [2026-05-27T09:50:00Z] bot/daemon — service-state in status --json + uninstall teardown doc
 
 **Action:** Review follow-up on the autostart PR. Added a non-mutating `service_state` probe to `ServiceInstaller::Base` (read-only `systemctl --user is-enabled` / `launchctl list`) and surfaced `service_installed` / `service_enabled` / `unit_path` in BOTH `hive bot status --json` and `hive daemon status --json` (additive to the v1 envelopes), closing the agent-native gap where an agent could install/uninstall the autostart unit but not query its state without a mutating call. Documented the new fields in [[commands/bot]] and [[commands/daemon]], and filled the [[commands/uninstall]] gap (it documented the daemon-service teardown but never the bot-service teardown added in this PR). Also made the `hive bot install` `--help` long_desc spell out the `outcome`-branching agent idiom (parse the envelope's `outcome`, re-run with `--force` on `drifted`).


### PR DESCRIPTION
## Summary

Final phases of cross-OS install verification — wires the reusable `install-verify.yml` (#213) into the release flow.

- **U4 — pre-release gate.** New `install-gate` job in `release.yml` `gem install`s the built gem on `macos-15` + `ubuntu-24.04-arm` before publishing; `release-finalize` `needs:` it, so a gem that won't install never reaches brew/AUR. Native runners only (the gem is `arch=any`; no emulated cell can block a release — real Arch install is the post-release layer).
- **U5 — post-release + canary.** `post-release-verify` (in `release.yml`) calls `install-verify.yml` with the published tag for the real `brew install`/`yay -S`/`install.sh`. New `install-canary.yml` re-verifies the latest release weekly (+ `workflow_dispatch`).
- **U6 — docs.** `docs/RELEASING.md` "Install verification" section + wiki log.

Completes the plan (`~/Dev/hive-private/docs/plans/2026-05-27-001-...`). The matrix already proved itself in v0.1.5 (caught + drove fixes for the broken AUR package and brew shim).

## Test plan
- [ ] CI green on this PR
- [ ] Next release shows `install-gate` green ahead of publish, then `post-release-verify` green
- [ ] `install-canary.yml` runs on its weekly schedule / on manual dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)