### PR TITLE
feat(update): daemon-driven version check + channel-aware nudge

### DIFF
--- a/lib/hive.rb
+++ b/lib/hive.rb
@@ -1,6 +1,11 @@
 module Hive
   VERSION = "0.1.6".freeze
   MIN_CLAUDE_VERSION = "2.1.118".freeze
+  # Canonical GitHub org + repo. Referenced by the release probe
+  # (UpdateCheck), the brew tap + installer URL (Commands::Update), etc.
+  # One place to change on a repository rename.
+  REPO_OWNER = "ivankuznetsov".freeze
+  REPO_NAME = "hive".freeze
 
   module Schemas
     # JSON schema versions for the agent-callable contracts emitted by the

--- a/lib/hive/bot/supervisor.rb
+++ b/lib/hive/bot/supervisor.rb
@@ -14,6 +14,7 @@ require "hive/bot/brainstorm_answer_writer"
 require "hive/bot/brainstorm_parser"
 require "hive/bot/title_formatter"
 require "hive/task"
+require "hive/update_check/state"
 
 module Hive
   module Bot
@@ -32,9 +33,12 @@ module Hive
 
       def initialize(config:, token:, logger: nil, telegram: nil, status_watcher: nil,
                      notification_dispatcher: nil, router: nil, child_supervisor: nil,
-                     conversation_store: nil, dry_run: false)
+                     conversation_store: nil, dry_run: false, update_state: nil)
         @config = config
         @dry_run = dry_run
+        # Shared update-check state (written by the daemon). The bot owns the
+        # once-per-version push; the daemon never touches last_notified_version.
+        @update_state = update_state || Hive::UpdateCheck::State.new
         @logger = logger || Hive::Bot::Logger.new(
           path: config.fetch("log_file"),
           max_bytes: config.fetch("log_max_bytes"),
@@ -219,6 +223,7 @@ module Hive
           begin
             reload_config_if_requested
             status_tick
+            push_update_nudge
           rescue StandardError => e
             @logger.event(:fatal, source: "status_loop", error_class: e.class.name,
                                    message: e.message, backtrace: Array(e.backtrace).first(10).join("\n"))
@@ -763,6 +768,29 @@ module Hive
 
       def chat_ids
         Array(@config.fetch("chat_id_allowlist"))
+      end
+
+      # Push the daemon-written update nudge to the allowlist exactly once per
+      # newly-seen version (de-duped via the shared state). Records "notified"
+      # only after a send succeeds, so an all-failed push retries next tick.
+      # Resilient: any error is logged and never breaks the status loop.
+      def push_update_nudge
+        nudge = @update_state.nudge
+        return unless nudge
+        return unless @update_state.should_notify?(nudge.latest)
+
+        text = update_nudge_message(nudge)
+        delivered = chat_ids.map { |chat_id| safe_send_message(chat_id: chat_id, text: text) }
+        return unless delivered.any?
+
+        @update_state.record_notified!(nudge.latest)
+        @logger.event(:update_nudge_pushed, latest: nudge.latest, channel: nudge.channel)
+      rescue StandardError => e
+        @logger.event(:update_nudge_error, error_class: e.class.name, message: e.message)
+      end
+
+      def update_nudge_message(nudge)
+        "hive #{nudge.latest} is available (current #{Hive::VERSION}).\nUpdate: #{nudge.command}"
       end
 
       def read_last_seen_update_id

--- a/lib/hive/bot/supervisor.rb
+++ b/lib/hive/bot/supervisor.rb
@@ -39,6 +39,10 @@ module Hive
         # Shared update-check state (written by the daemon). The bot owns the
         # once-per-version push; the daemon never touches last_notified_version.
         @update_state = update_state || Hive::UpdateCheck::State.new
+        # Process-lifetime latch of versions already pushed. Backs up the
+        # persisted dedup: if record_notified! can't write (read-only/full
+        # state dir), this still stops the status loop re-pushing every tick.
+        @nudged_versions = {}
         @logger = logger || Hive::Bot::Logger.new(
           path: config.fetch("log_file"),
           max_bytes: config.fetch("log_max_bytes"),
@@ -771,18 +775,21 @@ module Hive
       end
 
       # Push the daemon-written update nudge to the allowlist exactly once per
-      # newly-seen version (de-duped via the shared state). Records "notified"
-      # only after a send succeeds, so an all-failed push retries next tick.
-      # Resilient: any error is logged and never breaks the status loop.
+      # newly-seen version. De-duped by BOTH the persisted state (survives a
+      # restart) and an in-memory latch (survives a failed state write). Records
+      # "notified" only after a send succeeds, so an all-failed push retries
+      # next tick. Resilient: any error is logged and never breaks the loop.
       def push_update_nudge
         nudge = @update_state.nudge
         return unless nudge
+        return if @nudged_versions[nudge.latest]
         return unless @update_state.should_notify?(nudge.latest)
 
         text = update_nudge_message(nudge)
         delivered = chat_ids.map { |chat_id| safe_send_message(chat_id: chat_id, text: text) }
         return unless delivered.any?
 
+        @nudged_versions[nudge.latest] = true
         @update_state.record_notified!(nudge.latest)
         @logger.event(:update_nudge_pushed, latest: nudge.latest, channel: nudge.channel)
       rescue StandardError => e

--- a/lib/hive/commands/bot.rb
+++ b/lib/hive/commands/bot.rb
@@ -8,6 +8,7 @@ require "hive/lock"
 require "hive/bot/supervisor"
 require "hive/bot/logger"
 require "hive/paths"
+require "hive/update_check/state"
 
 module Hive
   module Commands
@@ -82,7 +83,11 @@ module Hive
         supervisor = Hive::Bot::Supervisor.new(
           config: bot_config,
           token: Hive::Config.telegram_bot_token!,
-          dry_run: @dry_run
+          dry_run: @dry_run,
+          # Same shared state file the daemon writes — makes the cross-process
+          # contract visible at the call site (Supervisor would default to this
+          # anyway).
+          update_state: Hive::UpdateCheck::State.new
         )
         supervisor.run_forever
       ensure

--- a/lib/hive/commands/daemon.rb
+++ b/lib/hive/commands/daemon.rb
@@ -12,6 +12,7 @@ require "hive/daemon/status_consumer"
 require "hive/daemon/pr_merge_watcher"
 require "hive/daemon/logger"
 require "hive/invoked_binary"
+require "hive/update_check/state"
 
 module Hive
   module Commands
@@ -320,7 +321,11 @@ module Hive
             "log_file" => log_file,
             "service_installed" => service_state["service_installed"],
             "service_enabled" => service_state["service_enabled"],
-            "unit_path" => service_state["unit_path"]
+            "unit_path" => service_state["unit_path"],
+            # Agent-native parity with the TUI footer / bot push: expose the
+            # update nudge so a programmatic caller can detect "behind" too.
+            "current_version" => Hive::VERSION,
+            "update_nudge" => update_nudge_payload
           )
         elsif running
           puts "hive daemon: running (pid #{pid}, uptime #{uptime_sec}s)"
@@ -341,6 +346,17 @@ module Hive
         Hive::Commands::Daemon::ServiceInstaller.new.service_state
       rescue StandardError
         { "service_installed" => nil, "service_enabled" => nil, "unit_path" => nil }
+      end
+
+      # The daemon-written update nudge, as a plain Hash for the status
+      # envelope (nil when current or unknown). Never raises out of status.
+      def update_nudge_payload
+        nudge = Hive::UpdateCheck::State.new.nudge
+        return nil unless nudge
+
+        { "latest" => nudge.latest, "channel" => nudge.channel, "command" => nudge.command }
+      rescue StandardError
+        nil
       end
 
       def reload_daemon

--- a/lib/hive/commands/daemon.rb
+++ b/lib/hive/commands/daemon.rb
@@ -133,7 +133,7 @@ module Hive
         # etc.) actually take effect. PR-40 review P1 #2: this used to
         # call merge_defaults({}) which discarded the global config.
         daemon_cfg = Hive::Config.load_global_daemon
-        config = { "daemon" => daemon_cfg }
+        config = { "daemon" => daemon_cfg, "update" => Hive::Config.load_global_update }
 
         controller = Hive::Daemon::ConcurrencyController.new(
           max_concurrent_runs: daemon_cfg.fetch("max_concurrent_runs"),

--- a/lib/hive/commands/daemon.rb
+++ b/lib/hive/commands/daemon.rb
@@ -154,7 +154,8 @@ module Hive
         dispatcher = Hive::Daemon::Dispatcher.new(
           config: config, controller: controller, supervisor: supervisor,
           status_consumer: status_consumer, logger: logger,
-          merge_watcher: merge_watcher, dry_run: @dry_run
+          merge_watcher: merge_watcher, dry_run: @dry_run,
+          update_state: Hive::UpdateCheck::State.new
         )
 
         reexec_requested = false

--- a/lib/hive/commands/update.rb
+++ b/lib/hive/commands/update.rb
@@ -16,6 +16,20 @@ module Hive
       BREW_TAP = "#{REPO_OWNER}/#{REPO_NAME}/hive".freeze
       INSTALL_URL = "https://raw.githubusercontent.com/#{REPO_OWNER}/#{REPO_NAME}/main/install.sh".freeze
 
+      # Canonical one-line command shown to the user when they're behind,
+      # per channel. Reuses BREW_TAP so a tap rename stays a one-diff change.
+      # Returns nil for dev (git clone — `git pull` is the right move, but
+      # there's no single canonical command to nudge). The bash channel is
+      # nudge-only until the daemon auto-update spike (U7) lands; `hive update`
+      # re-runs the installer in place.
+      def self.nudge_command(channel)
+        case channel
+        when "brew" then "brew upgrade #{BREW_TAP}"
+        when "aur" then "yay -S hive-bin"
+        when "bash" then "hive update"
+        end
+      end
+
       def initialize(dry_run: false, output: $stdout, runner: nil, env: ENV, channel: nil)
         @dry_run = dry_run
         @output = output

--- a/lib/hive/commands/update.rb
+++ b/lib/hive/commands/update.rb
@@ -5,30 +5,26 @@ require "shellwords"
 module Hive
   module Commands
     class Update
-      # Centralised org+repo + brew tap so a future rename of the
-      # repository is a one-diff change. The installer URL pins to the
-      # default branch so older bash-channel installs can fetch the
-      # newest installer rather than re-running their own vX.Y.Z script
-      # forever. The script is downloaded to a tmpfile before execution;
+      # Org+repo come from Hive::REPO_OWNER/REPO_NAME (one rename point). The
+      # installer URL pins to the default branch so older bash-channel installs
+      # fetch the newest installer rather than re-running their own vX.Y.Z
+      # script forever. The script is downloaded to a tmpfile before execution;
       # no pipe-to-bash path is used here.
-      REPO_OWNER = "ivankuznetsov".freeze
-      REPO_NAME = "hive".freeze
-      BREW_TAP = "#{REPO_OWNER}/#{REPO_NAME}/hive".freeze
-      INSTALL_URL = "https://raw.githubusercontent.com/#{REPO_OWNER}/#{REPO_NAME}/main/install.sh".freeze
+      BREW_TAP = "#{Hive::REPO_OWNER}/#{Hive::REPO_NAME}/hive".freeze
+      INSTALL_URL = "https://raw.githubusercontent.com/#{Hive::REPO_OWNER}/#{Hive::REPO_NAME}/main/install.sh".freeze
 
       # Canonical one-line command shown to the user when they're behind,
       # per channel. Reuses BREW_TAP so a tap rename stays a one-diff change.
       # Returns nil for dev (git clone — `git pull` is the right move, but
-      # there's no single canonical command to nudge). The bash channel is
-      # nudge-only until the daemon auto-update spike (U7) lands; `hive update`
-      # re-runs the installer in place. The aur nudge mirrors `aur_command`'s
-      # `-Syu` (not a bare `-S`): a DB sync is required, or a stale local DB
-      # would "update" to an older hive-bin than the release being nudged.
+      # there's no single canonical command to nudge). bash and aur both nudge
+      # `hive update`: bash because auto-update (U7) isn't built yet, and aur
+      # because the real updater picks yay OR paru at runtime — a hardcoded
+      # `yay …` nudge would fail for paru-only users. `hive update` re-dispatches
+      # to whichever helper the install actually has.
       def self.nudge_command(channel)
         case channel
         when "brew" then "brew upgrade #{BREW_TAP}"
-        when "aur" then "yay -Syu hive-bin"
-        when "bash" then "hive update"
+        when "aur", "bash" then "hive update"
         end
       end
 

--- a/lib/hive/commands/update.rb
+++ b/lib/hive/commands/update.rb
@@ -21,11 +21,13 @@ module Hive
       # Returns nil for dev (git clone — `git pull` is the right move, but
       # there's no single canonical command to nudge). The bash channel is
       # nudge-only until the daemon auto-update spike (U7) lands; `hive update`
-      # re-runs the installer in place.
+      # re-runs the installer in place. The aur nudge mirrors `aur_command`'s
+      # `-Syu` (not a bare `-S`): a DB sync is required, or a stale local DB
+      # would "update" to an older hive-bin than the release being nudged.
       def self.nudge_command(channel)
         case channel
         when "brew" then "brew upgrade #{BREW_TAP}"
-        when "aur" then "yay -S hive-bin"
+        when "aur" then "yay -Syu hive-bin"
         when "bash" then "hive update"
         end
       end

--- a/lib/hive/config.rb
+++ b/lib/hive/config.rb
@@ -263,6 +263,15 @@ module Hive
         "log_max_bytes" => 10_485_760,
         "log_max_files" => 5
       },
+      # Update flow (plan 2026-05-27-002). The daemon checks the latest
+      # release on a throttled cadence and, on the install.sh channel,
+      # auto-updates when idle; brew/AUR get a nudge. Both knobs default
+      # ON during the dev period — `check: false` disables the probe
+      # entirely; `auto: false` keeps checks/nudges but never self-updates.
+      "update" => {
+        "check" => true,
+        "auto" => true
+      },
       # Global Telegram bot settings. The bot is an operator surface
       # across every registered project, so runtime code loads these
       # from the global config via load_global_bot. The token lives
@@ -660,6 +669,38 @@ module Hive
       # cfg["daemon"].
       validate_daemon!({ "daemon" => merged }, path)
       merged
+    end
+
+    # Load the global `update` block (auto/check) from the XDG config
+    # path, merged over DEFAULTS["update"]. Used by `hive daemon start`
+    # so an operator's opt-out actually takes effect at runtime. Returns
+    # the bare defaults when no global config exists.
+    def load_global_update
+      Hive::Paths.ensure_migrated!
+      validate_hive_home!
+      path = global_config_path
+      data = File.exist?(path) ? load_global_config(path) : {}
+      raise ConfigError, "global config at #{path} must be a hash" unless data.is_a?(Hash)
+
+      override = data["update"] || {}
+      unless override.is_a?(Hash)
+        raise ConfigError,
+              "update in #{describe_source(path)} must be a Hash; got #{override.class}"
+      end
+
+      merged = deep_merge(deep_dup(DEFAULTS["update"]), override)
+      validate_update!(merged, path)
+      merged
+    end
+
+    def validate_update!(merged, path)
+      %w[check auto].each do |key|
+        value = merged[key]
+        next if [ true, false ].include?(value)
+
+        raise ConfigError,
+              "update.#{key} in #{describe_source(path)} must be true or false; got #{value.inspect}"
+      end
     end
 
     # Load and validate the global `bot` block from the XDG config path.

--- a/lib/hive/daemon/dispatcher.rb
+++ b/lib/hive/daemon/dispatcher.rb
@@ -43,6 +43,9 @@ module Hive
         @dry_run = dry_run
 
         @daemon_cfg = config["daemon"] || {}
+        @update_cfg = config["update"] || Hive::Config::DEFAULTS["update"]
+        @update_check_enabled = @update_cfg.fetch("check", true)
+        @update_auto_enabled = @update_cfg.fetch("auto", true)
         @edit_debounce_sec = @daemon_cfg.fetch("edit_debounce_sec", 30)
         @shutdown_grace_sec = @daemon_cfg.fetch("shutdown_grace_sec", 600)
         @poll_interval_sec = @daemon_cfg.fetch("poll_interval_sec", 30)

--- a/lib/hive/daemon/dispatcher.rb
+++ b/lib/hive/daemon/dispatcher.rb
@@ -57,7 +57,9 @@ module Hive
         @daemon_cfg = config["daemon"] || {}
         @update_cfg = config["update"] || Hive::Config::DEFAULTS["update"]
         @update_check_enabled = @update_cfg.fetch("check", true)
-        @update_auto_enabled = @update_cfg.fetch("auto", true)
+        # NOTE: `update.auto` is intentionally NOT read here yet — bash
+        # auto-update (U7) is the only consumer and is deferred, so every
+        # channel is nudge-only. U7 will read it when it lands.
         @edit_debounce_sec = @daemon_cfg.fetch("edit_debounce_sec", 30)
         @shutdown_grace_sec = @daemon_cfg.fetch("shutdown_grace_sec", 600)
         @poll_interval_sec = @daemon_cfg.fetch("poll_interval_sec", 30)
@@ -259,11 +261,16 @@ module Hive
       # Throttled (~daily) probe of the latest published release. On the
       # brew/AUR/bash channels it records a nudge (version + exact update
       # command) into the shared state file; the TUI footer renders it and
-      # the bot pushes it once per version. Auto-update for the bash channel
-      # is deferred to U7 (gated by `@update_auto_enabled`) — every channel
-      # is nudge-only for now. dev clones are skipped. Resilient by contract:
-      # an offline/rate-limited/parse failure degrades silently (R7/G4) and
-      # never raises out of a tick.
+      # the bot pushes it once per version. Auto-update (bash channel, U7) is
+      # deferred, so every channel is nudge-only for now. dev clones are
+      # skipped. Resilient by contract: an offline/rate-limited/parse failure
+      # degrades silently (R7/G4) and never raises out of a tick.
+      #
+      # `record_check!` runs BEFORE the probe on purpose: a failed probe still
+      # consumes the daily throttle so an offline daemon can't hammer GitHub
+      # (and trip the 60/hr anonymous rate limit) every tick. The cost is that
+      # a transient blip defers the next attempt by ~a day — acceptable given
+      # the daily cadence and nudge-only stakes.
       def maybe_check_for_update(now:)
         return unless @update_check_enabled
         return unless @update_state
@@ -271,7 +278,12 @@ module Hive
 
         @update_state.record_check!(now)
         result = @update_checker.call
-        return if result.nil?
+        if result.nil?
+          # Distinguish "checked, GitHub unreachable" from "checked, current"
+          # so an operator debugging a missing nudge has a signal.
+          @logger.event(:update_check_no_result)
+          return
+        end
 
         channel = @channel_detector.call
         if channel == "dev" || !result.behind?

--- a/lib/hive/daemon/dispatcher.rb
+++ b/lib/hive/daemon/dispatcher.rb
@@ -292,6 +292,13 @@ module Hive
         end
 
         command = Hive::Commands::Update.nudge_command(channel)
+        if command.nil?
+          # An unrecognized channel has no canonical command; don't persist a
+          # nudge with an empty command (it would render "update X.Y.Z: ").
+          @logger.event(:update_nudge_no_command, channel: channel, latest: result.latest)
+          return
+        end
+
         @update_state.set_nudge(latest: result.latest, channel: channel, command: command)
         @logger.event(:update_available, current: result.current, latest: result.latest,
                                          channel: channel, command: command)
@@ -733,7 +740,9 @@ module Hive
         # PR-40 review P1 #2: rebase on the global ~/Dev/hive/config.yml's
         # daemon block, not bare DEFAULTS.
         @daemon_cfg = Hive::Config.load_global_daemon
-        @config = { "daemon" => @daemon_cfg }
+        @update_cfg = Hive::Config.load_global_update
+        @config = { "daemon" => @daemon_cfg, "update" => @update_cfg }
+        @update_check_enabled = @update_cfg.fetch("check", true)
         @edit_debounce_sec = @daemon_cfg.fetch("edit_debounce_sec", 30)
         @shutdown_grace_sec = @daemon_cfg.fetch("shutdown_grace_sec", 600)
         @poll_interval_sec = @daemon_cfg.fetch("poll_interval_sec", 30)

--- a/lib/hive/daemon/dispatcher.rb
+++ b/lib/hive/daemon/dispatcher.rb
@@ -9,6 +9,10 @@ require "hive/daemon/child_supervisor"
 require "hive/daemon/status_consumer"
 require "hive/daemon/stale_agent_healer"
 require "hive/daemon/logger"
+require "hive/update_check"
+require "hive/update_check/state"
+require "hive/install_channel"
+require "hive/commands/update"
 
 module Hive
   module Daemon
@@ -33,7 +37,8 @@ module Hive
       # @param merge_watcher [PrMergeWatcher, nil]
       # @param dry_run [Boolean]
       def initialize(config:, controller:, supervisor:, status_consumer:, logger:,
-                     merge_watcher: nil, dry_run: false)
+                     merge_watcher: nil, dry_run: false,
+                     update_state: nil, update_checker: nil, channel_detector: nil)
         @config = config
         @controller = controller
         @supervisor = supervisor
@@ -41,6 +46,13 @@ module Hive
         @logger = logger
         @merge_watcher = merge_watcher
         @dry_run = dry_run
+
+        # Update-flow collaborators (plan 2026-05-27-002). The check runs
+        # only when a state store is injected (the daemon does so); existing
+        # tests that omit it get an inert dispatcher with no network access.
+        @update_state = update_state
+        @update_checker = update_checker || -> { Hive::UpdateCheck.latest }
+        @channel_detector = channel_detector || -> { Hive::InstallChannel.detect }
 
         @daemon_cfg = config["daemon"] || {}
         @update_cfg = config["update"] || Hive::Config::DEFAULTS["update"]
@@ -118,6 +130,10 @@ module Hive
         @enabled_cache.clear
         @logger.event(:tick_begin, now: now.utc.iso8601)
         reset_active_agent_snapshot
+
+        # 0. Throttled release check (independent of task status). Sets the
+        # TUI-footer nudge state when behind; resilient — never crashes a tick.
+        maybe_check_for_update(now: now)
 
         # 1. Reap completed children, update controller, log decisions
         reap_completed(now: now)
@@ -239,6 +255,37 @@ module Hive
       end
 
       private
+
+      # Throttled (~daily) probe of the latest published release. On the
+      # brew/AUR/bash channels it records a nudge (version + exact update
+      # command) into the shared state file; the TUI footer renders it and
+      # the bot pushes it once per version. Auto-update for the bash channel
+      # is deferred to U7 (gated by `@update_auto_enabled`) — every channel
+      # is nudge-only for now. dev clones are skipped. Resilient by contract:
+      # an offline/rate-limited/parse failure degrades silently (R7/G4) and
+      # never raises out of a tick.
+      def maybe_check_for_update(now:)
+        return unless @update_check_enabled
+        return unless @update_state
+        return unless @update_state.due?(now)
+
+        @update_state.record_check!(now)
+        result = @update_checker.call
+        return if result.nil?
+
+        channel = @channel_detector.call
+        if channel == "dev" || !result.behind?
+          @update_state.clear_nudge!
+          return
+        end
+
+        command = Hive::Commands::Update.nudge_command(channel)
+        @update_state.set_nudge(latest: result.latest, channel: channel, command: command)
+        @logger.event(:update_available, current: result.current, latest: result.latest,
+                                         channel: channel, command: command)
+      rescue StandardError => e
+        @logger.event(:update_check_error, error_class: e.class.name, message: e.message)
+      end
 
       # SHA-256 of lib/hive.rb (the file holding SCHEMA_VERSIONS). Used
       # as a cheap drift signal — if the on-disk file's digest no longer

--- a/lib/hive/tui/bubble_model.rb
+++ b/lib/hive/tui/bubble_model.rb
@@ -38,6 +38,7 @@ require "hive/tui/views/new_idea_prompt"
 require "hive/tui/views/new_idea_project_picker"
 require "hive/tui/views/token_stats"
 require "hive/tui/views/usage_footer"
+require "hive/update_check/state"
 
 module Hive
   module Tui
@@ -108,11 +109,19 @@ module Hive
       def initialize(
         hive_model: Hive::Tui::Model.initial,
         dispatch: ->(_msg) { },
-        clipboard_probe: ->(pasted_text:) { Hive::Tui::Clipboard.probe(pasted_text: pasted_text) }
+        clipboard_probe: ->(pasted_text:) { Hive::Tui::Clipboard.probe(pasted_text: pasted_text) },
+        update_state: nil
       )
         @hive_model = hive_model
         @dispatch = dispatch
         @clipboard_probe = clipboard_probe
+        # Shared update-check state (written by the daemon). Read on a short
+        # TTL so the footer reflects a new nudge without re-reading the file
+        # on every render frame. Lazily constructed so tests and non-daemon
+        # sessions pay nothing until the footer asks.
+        @update_state = update_state
+        @update_nudge_cache = nil
+        @update_nudge_checked_at = nil
         # `@healed_folders` is touched from the main runner thread
         # (`auto_heal_kill_class_errors` registers folders before
         # spawning heals) AND from heal Threads (which refresh the
@@ -3202,9 +3211,40 @@ module Hive
           end
 
           line = "#{footer_hint} · #{Views::UsageFooter.text(aggregate)}"
+          nudge = update_nudge
+          # Prepend so truncation trims the hint tail, not the higher-priority
+          # "you're behind" notice.
+          line = "#{update_nudge_label(nudge)} · #{line}" if nudge
           line = Views::Format.truncate(line, usable_width) if usable_width
           Hive::Tui::Styles::HINT.render(line)
         end
+      end
+
+      UPDATE_NUDGE_TTL_SEC = 10
+
+      def update_nudge_label(nudge)
+        "update #{nudge.latest}: #{nudge.command}"
+      end
+
+      # Read the daemon-written nudge at most once per TTL window. Any error
+      # (missing/corrupt state) degrades to "no nudge" so the footer never
+      # breaks.
+      def update_nudge
+        now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        if @update_nudge_checked_at && (now - @update_nudge_checked_at) < UPDATE_NUDGE_TTL_SEC
+          return @update_nudge_cache
+        end
+
+        @update_nudge_checked_at = now
+        @update_nudge_cache = update_check_state&.nudge
+      rescue StandardError
+        @update_nudge_cache = nil
+      end
+
+      def update_check_state
+        @update_state ||= Hive::UpdateCheck::State.new
+      rescue StandardError
+        nil
       end
 
       def usage_footer_line(usable_width = nil)

--- a/lib/hive/update_check.rb
+++ b/lib/hive/update_check.rb
@@ -11,9 +11,7 @@ module Hive
   # unparseable version) returns nil. The daemon calls this on a tick and must
   # not crash because GitHub is unreachable or rate-limiting.
   module UpdateCheck
-    REPO_OWNER = "ivankuznetsov".freeze
-    REPO_NAME = "hive".freeze
-    API_URL = "https://api.github.com/repos/#{REPO_OWNER}/#{REPO_NAME}/releases/latest".freeze
+    API_URL = "https://api.github.com/repos/#{Hive::REPO_OWNER}/#{Hive::REPO_NAME}/releases/latest".freeze
 
     Result = Data.define(:current, :latest, :behind) do
       def behind? = behind

--- a/lib/hive/update_check.rb
+++ b/lib/hive/update_check.rb
@@ -1,0 +1,67 @@
+require "net/http"
+require "json"
+require "hive"
+
+module Hive
+  # Queries the latest published GitHub release and reports whether the running
+  # version is behind. Pure query, no side effects, no persistence (state lives
+  # in Hive::UpdateCheck::State). Mirrors install.sh's `latest_version` probe.
+  #
+  # NEVER raises: every failure path (network, HTTP error, malformed JSON,
+  # unparseable version) returns nil. The daemon calls this on a tick and must
+  # not crash because GitHub is unreachable or rate-limiting.
+  module UpdateCheck
+    REPO_OWNER = "ivankuznetsov".freeze
+    REPO_NAME = "hive".freeze
+    API_URL = "https://api.github.com/repos/#{REPO_OWNER}/#{REPO_NAME}/releases/latest".freeze
+
+    Result = Data.define(:current, :latest, :behind) do
+      def behind? = behind
+    end
+
+    module_function
+
+    # @param current [String] the running version (bare semver)
+    # @param http [#call, nil] injectable seam for tests: called with the URL,
+    #   returns the response body string (or raises to simulate failure)
+    # @return [Result, nil] nil on any failure
+    def latest(current: Hive::VERSION, http: nil, timeout: 5)
+      tag = fetch_latest_tag(http: http, timeout: timeout)
+      return nil if tag.nil? || tag.empty?
+
+      latest_version = tag.sub(/\Av/, "")
+      Result.new(current: current, latest: latest_version, behind: newer?(latest_version, current))
+    rescue StandardError
+      nil
+    end
+
+    def fetch_latest_tag(http: nil, timeout: 5)
+      body = http ? http.call(API_URL) : http_get(API_URL, timeout: timeout)
+      return nil if body.nil?
+
+      JSON.parse(body)["tag_name"]
+    rescue StandardError
+      nil
+    end
+
+    def http_get(url, timeout:)
+      uri = URI(url)
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true,
+                            open_timeout: timeout, read_timeout: timeout) do |http|
+        req = Net::HTTP::Get.new(uri)
+        req["Accept"] = "application/vnd.github+json"
+        req["User-Agent"] = "hive-update-check"
+        http.request(req)
+      end
+      res.is_a?(Net::HTTPSuccess) ? res.body : nil
+    end
+
+    # True iff `latest` is a strictly newer release than `current`. Never
+    # downgrades (local dev builds ahead of the latest tag are not "behind").
+    def newer?(latest_version, current)
+      Gem::Version.new(latest_version) > Gem::Version.new(current)
+    rescue ArgumentError
+      false
+    end
+  end
+end

--- a/lib/hive/update_check/state.rb
+++ b/lib/hive/update_check/state.rb
@@ -92,7 +92,9 @@ module Hive
         synchronize do
           load!
           raw = @data["nudge"]
-          next nil unless raw.is_a?(Hash) && !raw["latest"].to_s.empty?
+          # Require both latest AND command: a hand-edited/partial file with a
+          # version but no command would otherwise render "update X.Y.Z: ".
+          next nil unless raw.is_a?(Hash) && !raw["latest"].to_s.empty? && !raw["command"].to_s.empty?
 
           Nudge.new(latest: raw["latest"], channel: raw["channel"], command: raw["command"])
         end
@@ -146,8 +148,12 @@ module Hive
         return unless File.directory?(dir)
 
         Dir.glob(File.join(dir, ".#{File.basename(@path)}.*.tmp")).each { |orphan| FileUtils.rm_f(orphan) }
-      rescue StandardError
-        nil
+      rescue StandardError => e
+        # Best-effort, but log it: a persistently failing sweep (broken
+        # permissions on the state dir) would otherwise silently leak tmp
+        # files forever with no diagnostic.
+        @logger&.event(:update_check_tmp_sweep_error, path: @path,
+                                                      error_class: e.class.name, message: e.message)
       end
 
       def persist_locked!

--- a/lib/hive/update_check/state.rb
+++ b/lib/hive/update_check/state.rb
@@ -1,0 +1,165 @@
+require "json"
+require "fileutils"
+require "time"
+require "hive/paths"
+
+module Hive
+  module UpdateCheck
+    # Persists the daemon's update-check bookkeeping: when it last probed
+    # GitHub (throttle), the last version it notified about (de-dupe), and the
+    # active nudge payload the TUI footer renders. JSON on disk, atomic write,
+    # fail-closed load (a corrupt file degrades to empty rather than raising).
+    # Mirrors Hive::Bot::AlertStore's persistence discipline.
+    class State
+      SCHEMA_VERSION = 1
+      DEFAULT_WINDOW_SEC = 86_400 # ~daily
+
+      Nudge = Data.define(:latest, :channel, :command)
+
+      def self.default_path
+        File.join(Hive::Paths.state_home, "update_check.json")
+      end
+
+      def initialize(path: self.class.default_path, logger: nil)
+        @path = path ? File.expand_path(path) : nil
+        @logger = logger
+        @mutex = Mutex.new
+        @data = empty_data
+        clean_orphaned_tmp_files!
+        load!
+      end
+
+      # Enough time elapsed since the last check to probe again? Always true
+      # when never checked (e.g. on daemon start).
+      def due?(now, window: DEFAULT_WINDOW_SEC)
+        synchronize do
+          last = parse_time(@data["last_check_at"])
+          last.nil? || (now - last) >= window
+        end
+      end
+
+      def record_check!(now)
+        synchronize do
+          @data["last_check_at"] = timestamp(now)
+          persist_locked!
+        end
+      end
+
+      # Have we already notified about this version? De-dupes the bot push so
+      # it fires once per newly-seen release, not once per tick.
+      def should_notify?(version)
+        synchronize { @data["last_notified_version"].to_s != version.to_s }
+      end
+
+      def record_notified!(version)
+        synchronize do
+          @data["last_notified_version"] = version.to_s
+          persist_locked!
+        end
+      end
+
+      def set_nudge(latest:, channel:, command:)
+        synchronize do
+          @data["nudge"] = { "latest" => latest.to_s, "channel" => channel.to_s, "command" => command.to_s }
+          persist_locked!
+        end
+      end
+
+      def clear_nudge!
+        synchronize do
+          next if @data["nudge"].nil?
+
+          @data["nudge"] = nil
+          persist_locked!
+        end
+      end
+
+      def nudge
+        synchronize do
+          raw = @data["nudge"]
+          next nil unless raw.is_a?(Hash) && !raw["latest"].to_s.empty?
+
+          Nudge.new(latest: raw["latest"], channel: raw["channel"], command: raw["command"])
+        end
+      end
+
+      private
+
+      def synchronize(&block)
+        @mutex.synchronize(&block)
+      end
+
+      def empty_data
+        { "schema_version" => SCHEMA_VERSION, "last_check_at" => nil,
+          "last_notified_version" => nil, "nudge" => nil }
+      end
+
+      def load!
+        return unless @path && File.exist?(@path)
+
+        raw = begin
+          File.read(@path)
+        rescue SystemCallError, IOError => e
+          handle_corrupt!(e)
+          return
+        end
+
+        parsed = JSON.parse(raw)
+        raise JSON::ParserError, "invalid update_check state schema" unless valid_schema?(parsed)
+
+        @data = empty_data.merge(parsed.slice("last_check_at", "last_notified_version", "nudge"))
+      rescue JSON::ParserError, TypeError => e
+        handle_corrupt!(e)
+      end
+
+      def valid_schema?(parsed)
+        parsed.is_a?(Hash) && parsed["schema_version"] == SCHEMA_VERSION
+      end
+
+      def handle_corrupt!(error)
+        @logger&.event(:update_check_state_corrupt, path: @path,
+                                                     error_class: error.class.name, message: error.message)
+        @data = empty_data
+      end
+
+      # SIGKILL/power-loss between write(tmp) and rename leaves a hidden tmp
+      # in the parent dir; sweep stragglers on construction (best-effort).
+      def clean_orphaned_tmp_files!
+        return unless @path
+
+        dir = File.dirname(@path)
+        return unless File.directory?(dir)
+
+        Dir.glob(File.join(dir, ".#{File.basename(@path)}.*.tmp")).each { |orphan| FileUtils.rm_f(orphan) }
+      rescue StandardError
+        nil
+      end
+
+      def persist_locked!
+        return unless @path
+
+        FileUtils.mkdir_p(File.dirname(@path))
+        tmp_path = File.join(File.dirname(@path), ".#{File.basename(@path)}.#{$$}.#{Thread.current.object_id}.tmp")
+        File.open(tmp_path, "w") do |f|
+          f.write(JSON.pretty_generate(@data))
+          f.fsync
+        end
+        File.rename(tmp_path, @path)
+      ensure
+        FileUtils.rm_f(tmp_path) if tmp_path && File.exist?(tmp_path)
+      end
+
+      def timestamp(time)
+        time.utc.iso8601
+      end
+
+      def parse_time(value)
+        return nil if value.nil? || value.to_s.empty?
+
+        Time.parse(value.to_s)
+      rescue ArgumentError
+        nil
+      end
+    end
+  end
+end

--- a/lib/hive/update_check/state.rb
+++ b/lib/hive/update_check/state.rb
@@ -13,12 +13,16 @@ module Hive
     #
     # This file is shared across processes: the daemon writes `nudge` +
     # `last_check_at`, the bot writes `last_notified_version`, and the TUI
-    # reads `nudge`. To avoid one process clobbering another's keys with a
-    # stale in-memory copy, every operation re-reads the file from disk first
-    # — the daily cadence makes the extra read negligible.
+    # reads `nudge`. Mutating ops hold an exclusive `flock` on a sibling
+    # `<path>.lock` across the whole read-modify-write so two processes can't
+    # clobber each other's keys (an in-process Mutex alone wouldn't span
+    # processes). Reads are lock-free — `persist_locked!`'s atomic rename means
+    # a reader always sees a complete old-or-new file. If the lock can't be
+    # acquired (exotic FS), ops degrade to best-effort without it.
     class State
       SCHEMA_VERSION = 1
       DEFAULT_WINDOW_SEC = 86_400 # ~daily
+      STALE_TMP_SEC = 60 # only sweep orphan tmp files older than this
 
       Nudge = Data.define(:latest, :channel, :command)
 
@@ -31,6 +35,10 @@ module Hive
         @logger = logger
         @mutex = Mutex.new
         @data = empty_data
+        # Set true when the on-disk file carries a NEWER schema_version than
+        # this process understands: read what we recognize, but never write
+        # back (overwriting would downgrade a newer process's state).
+        @suspend_writes = false
         clean_orphaned_tmp_files!
         load!
       end
@@ -46,10 +54,12 @@ module Hive
       end
 
       def record_check!(now)
-        synchronize do
-          load!
-          @data["last_check_at"] = timestamp(now)
-          persist_locked!
+        with_lock do
+          synchronize do
+            load!
+            @data["last_check_at"] = timestamp(now)
+            persist_locked!
+          end
         end
       end
 
@@ -63,28 +73,34 @@ module Hive
       end
 
       def record_notified!(version)
-        synchronize do
-          load!
-          @data["last_notified_version"] = version.to_s
-          persist_locked!
+        with_lock do
+          synchronize do
+            load!
+            @data["last_notified_version"] = version.to_s
+            persist_locked!
+          end
         end
       end
 
       def set_nudge(latest:, channel:, command:)
-        synchronize do
-          load!
-          @data["nudge"] = { "latest" => latest.to_s, "channel" => channel.to_s, "command" => command.to_s }
-          persist_locked!
+        with_lock do
+          synchronize do
+            load!
+            @data["nudge"] = { "latest" => latest.to_s, "channel" => channel.to_s, "command" => command.to_s }
+            persist_locked!
+          end
         end
       end
 
       def clear_nudge!
-        synchronize do
-          load!
-          next if @data["nudge"].nil?
+        with_lock do
+          synchronize do
+            load!
+            next if @data["nudge"].nil?
 
-          @data["nudge"] = nil
-          persist_locked!
+            @data["nudge"] = nil
+            persist_locked!
+          end
         end
       end
 
@@ -106,12 +122,47 @@ module Hive
         @mutex.synchronize(&block)
       end
 
+      # Hold an exclusive cross-process lock around a read-modify-write. The
+      # block runs exactly once whether or not the lock was acquired — a lock
+      # failure logs and degrades to best-effort rather than crashing a tick.
+      def with_lock
+        return yield unless @path
+
+        lock = acquire_lock
+        begin
+          yield
+        ensure
+          release_lock(lock)
+        end
+      end
+
+      def acquire_lock
+        FileUtils.mkdir_p(File.dirname(@path))
+        handle = File.open("#{@path}.lock", File::RDWR | File::CREAT, 0o600)
+        handle.flock(File::LOCK_EX)
+        handle
+      rescue SystemCallError, IOError => e
+        @logger&.event(:update_check_state_lock_error, path: @path,
+                                                        error_class: e.class.name, message: e.message)
+        nil
+      end
+
+      def release_lock(handle)
+        return unless handle
+
+        handle.flock(File::LOCK_UN)
+        handle.close
+      rescue StandardError
+        nil
+      end
+
       def empty_data
         { "schema_version" => SCHEMA_VERSION, "last_check_at" => nil,
           "last_notified_version" => nil, "nudge" => nil }
       end
 
       def load!
+        @suspend_writes = false
         return unless @path && File.exist?(@path)
 
         raw = begin
@@ -122,15 +173,23 @@ module Hive
         end
 
         parsed = JSON.parse(raw)
-        raise JSON::ParserError, "invalid update_check state schema" unless valid_schema?(parsed)
+        version = parsed.is_a?(Hash) ? parsed["schema_version"] : nil
+        raise JSON::ParserError, "invalid update_check state schema" unless version.is_a?(Integer)
+
+        if version > SCHEMA_VERSION
+          # Forward-compat: a newer hive wrote this. Read recognized keys but
+          # suspend writes so a rolling micro-release upgrade can't have an
+          # older process clobber the newer file (regenerable, but churny).
+          @suspend_writes = true
+        elsif version < SCHEMA_VERSION
+          # No older schema exists yet; until a real migration path is needed,
+          # an older version is treated as corrupt and reset.
+          raise JSON::ParserError, "unsupported update_check schema_version #{version}"
+        end
 
         @data = empty_data.merge(parsed.slice("last_check_at", "last_notified_version", "nudge"))
       rescue JSON::ParserError, TypeError => e
         handle_corrupt!(e)
-      end
-
-      def valid_schema?(parsed)
-        parsed.is_a?(Hash) && parsed["schema_version"] == SCHEMA_VERSION
       end
 
       def handle_corrupt!(error)
@@ -147,7 +206,14 @@ module Hive
         dir = File.dirname(@path)
         return unless File.directory?(dir)
 
-        Dir.glob(File.join(dir, ".#{File.basename(@path)}.*.tmp")).each { |orphan| FileUtils.rm_f(orphan) }
+        # Only reap stragglers older than the stale window — a fresh tmp may
+        # be another live process's in-flight write, and rm-ing it would
+        # ENOENT its rename and lose that write.
+        Dir.glob(File.join(dir, ".#{File.basename(@path)}.*.tmp")).each do |orphan|
+          FileUtils.rm_f(orphan) if (Time.now - File.mtime(orphan)) > STALE_TMP_SEC
+        rescue SystemCallError
+          next
+        end
       rescue StandardError => e
         # Best-effort, but log it: a persistently failing sweep (broken
         # permissions on the state dir) would otherwise silently leak tmp
@@ -158,6 +224,7 @@ module Hive
 
       def persist_locked!
         return unless @path
+        return if @suspend_writes
 
         FileUtils.mkdir_p(File.dirname(@path))
         tmp_path = File.join(File.dirname(@path), ".#{File.basename(@path)}.#{$$}.#{Thread.current.object_id}.tmp")
@@ -166,8 +233,23 @@ module Hive
           f.fsync
         end
         File.rename(tmp_path, @path)
+        fsync_dir(File.dirname(@path))
+      rescue SystemCallError, IOError => e
+        # A broken/read-only/full state dir must not crash a daemon tick or a
+        # bot loop. Log and degrade — the in-memory value still serves this
+        # process; callers guard against re-spam with their own latches.
+        @logger&.event(:update_check_state_write_error, path: @path,
+                                                         error_class: e.class.name, message: e.message)
       ensure
         FileUtils.rm_f(tmp_path) if tmp_path && File.exist?(tmp_path)
+      end
+
+      # Directory fsync after rename so the rename is durable on journaled
+      # filesystems (matches Hive::Bot::AlertStore). Best-effort.
+      def fsync_dir(dir)
+        Dir.open(dir) { |d| d.fsync }
+      rescue StandardError
+        nil
       end
 
       def timestamp(time)

--- a/lib/hive/update_check/state.rb
+++ b/lib/hive/update_check/state.rb
@@ -10,6 +10,12 @@ module Hive
     # active nudge payload the TUI footer renders. JSON on disk, atomic write,
     # fail-closed load (a corrupt file degrades to empty rather than raising).
     # Mirrors Hive::Bot::AlertStore's persistence discipline.
+    #
+    # This file is shared across processes: the daemon writes `nudge` +
+    # `last_check_at`, the bot writes `last_notified_version`, and the TUI
+    # reads `nudge`. To avoid one process clobbering another's keys with a
+    # stale in-memory copy, every operation re-reads the file from disk first
+    # — the daily cadence makes the extra read negligible.
     class State
       SCHEMA_VERSION = 1
       DEFAULT_WINDOW_SEC = 86_400 # ~daily
@@ -33,6 +39,7 @@ module Hive
       # when never checked (e.g. on daemon start).
       def due?(now, window: DEFAULT_WINDOW_SEC)
         synchronize do
+          load!
           last = parse_time(@data["last_check_at"])
           last.nil? || (now - last) >= window
         end
@@ -40,6 +47,7 @@ module Hive
 
       def record_check!(now)
         synchronize do
+          load!
           @data["last_check_at"] = timestamp(now)
           persist_locked!
         end
@@ -48,11 +56,15 @@ module Hive
       # Have we already notified about this version? De-dupes the bot push so
       # it fires once per newly-seen release, not once per tick.
       def should_notify?(version)
-        synchronize { @data["last_notified_version"].to_s != version.to_s }
+        synchronize do
+          load!
+          @data["last_notified_version"].to_s != version.to_s
+        end
       end
 
       def record_notified!(version)
         synchronize do
+          load!
           @data["last_notified_version"] = version.to_s
           persist_locked!
         end
@@ -60,6 +72,7 @@ module Hive
 
       def set_nudge(latest:, channel:, command:)
         synchronize do
+          load!
           @data["nudge"] = { "latest" => latest.to_s, "channel" => channel.to_s, "command" => command.to_s }
           persist_locked!
         end
@@ -67,6 +80,7 @@ module Hive
 
       def clear_nudge!
         synchronize do
+          load!
           next if @data["nudge"].nil?
 
           @data["nudge"] = nil
@@ -76,6 +90,7 @@ module Hive
 
       def nudge
         synchronize do
+          load!
           raw = @data["nudge"]
           next nil unless raw.is_a?(Hash) && !raw["latest"].to_s.empty?
 

--- a/schemas/hive-daemon-status.v1.json
+++ b/schemas/hive-daemon-status.v1.json
@@ -21,7 +21,9 @@
         "log_file",
         "service_installed",
         "service_enabled",
-        "unit_path"
+        "unit_path",
+        "current_version",
+        "update_nudge"
       ],
       "properties": {
         "schema": { "const": "hive-daemon-status" },
@@ -58,6 +60,21 @@
         "unit_path": {
           "type": ["string", "null"],
           "description": "Absolute path of the autostart unit file; null on unsupported platforms or if the probe could not run."
+        },
+        "current_version": {
+          "type": "string",
+          "description": "The running hive version, so a caller can compare against update_nudge.latest itself."
+        },
+        "update_nudge": {
+          "type": ["object", "null"],
+          "description": "Available-update nudge written by the daemon, or null when up to date / unknown.",
+          "additionalProperties": false,
+          "required": ["latest", "channel", "command"],
+          "properties": {
+            "latest": { "type": "string", "description": "Latest published release version." },
+            "channel": { "type": "string", "description": "Detected install channel (brew/aur/bash)." },
+            "command": { "type": "string", "description": "Exact command to update on this channel." }
+          }
         }
       }
     }

--- a/test/unit/bot/supervisor_test.rb
+++ b/test/unit/bot/supervisor_test.rb
@@ -1234,6 +1234,18 @@ class HiveBotSupervisorTest < Minitest::Test
     assert_equal "status exploded", event.fetch(:payload).fetch(:message)
   end
 
+  def test_status_loop_invokes_update_nudge_push
+    supervisor = @supervisor
+    pushed = false
+    @supervisor.define_singleton_method(:status_tick) { supervisor.request_shutdown! }
+    @supervisor.define_singleton_method(:push_update_nudge) { pushed = true }
+    @supervisor.define_singleton_method(:interruptible_sleep) { |_seconds| }
+
+    @supervisor.send(:status_loop)
+
+    assert pushed, "status_loop must invoke push_update_nudge each iteration"
+  end
+
   def test_reaper_loop_logs_reap_failures
     supervisor = @supervisor
     @supervisor.define_singleton_method(:reap_children) do

--- a/test/unit/bot/supervisor_update_nudge_test.rb
+++ b/test/unit/bot/supervisor_update_nudge_test.rb
@@ -1,0 +1,82 @@
+require "test_helper"
+require "tmpdir"
+require "hive/bot/supervisor"
+require "hive/update_check/state"
+
+# Pins the bot's once-per-version update push (plan 2026-05-27-002, U5).
+class HiveBotSupervisorUpdateNudgeTest < Minitest::Test
+  FakeTelegram = Struct.new(:messages, :fail_first, keyword_init: true) do
+    def send_message(chat_id:, text:, reply_markup: nil)
+      if fail_first && messages.empty? && !@failed
+        @failed = true
+        raise "telegram boom"
+      end
+      messages << { chat_id: chat_id, text: text }
+    end
+  end
+
+  FakeLogger = Struct.new(:events, keyword_init: true) do
+    def event(name, **payload) = events << { name: name, payload: payload }
+    def close; end
+  end
+
+  def setup
+    @dir = Dir.mktmpdir
+    @state = Hive::UpdateCheck::State.new(path: File.join(@dir, "update_check.json"))
+    @telegram = FakeTelegram.new(messages: [])
+    @logger = FakeLogger.new(events: [])
+  end
+
+  def teardown
+    FileUtils.remove_entry(@dir)
+  end
+
+  def supervisor(telegram: @telegram)
+    Hive::Bot::Supervisor.new(
+      config: { "chat_id_allowlist" => [ 42, 43 ], "conversation_ttl_sec" => 60, "poll_interval_sec" => 1 },
+      token: "t", logger: @logger, telegram: telegram,
+      status_watcher: Object.new, notification_dispatcher: Object.new,
+      router: Object.new, child_supervisor: Object.new,
+      conversation_store: Object.new, update_state: @state
+    )
+  end
+
+  def event_names
+    @logger.events.map { |e| e[:name] }
+  end
+
+  def test_pushes_once_to_allowlist_when_nudge_present
+    @state.set_nudge(latest: "0.1.7", channel: "brew", command: "brew upgrade ivankuznetsov/hive/hive")
+    sup = supervisor
+    sup.send(:push_update_nudge)
+
+    assert_equal [ 42, 43 ], @telegram.messages.map { |m| m[:chat_id] }
+    assert_match(/0\.1\.7 is available/, @telegram.messages.first[:text])
+    assert_match(/brew upgrade ivankuznetsov\/hive\/hive/, @telegram.messages.first[:text])
+    assert_includes event_names, :update_nudge_pushed
+  end
+
+  def test_does_not_repush_same_version
+    @state.set_nudge(latest: "0.1.7", channel: "brew", command: "brew upgrade x")
+    sup = supervisor
+    sup.send(:push_update_nudge)
+    sup.send(:push_update_nudge)
+    assert_equal 2, @telegram.messages.size, "two chats, one version, one round of pushes"
+  end
+
+  def test_no_push_when_no_nudge
+    supervisor.send(:push_update_nudge)
+    assert_empty @telegram.messages
+  end
+
+  def test_partial_success_records_notified
+    # First chat's send raises (swallowed by safe_send_message → nil); the
+    # second chat delivers. Since something was delivered, the version is
+    # recorded as notified and won't be re-pushed.
+    failing = FakeTelegram.new(messages: [], fail_first: true)
+    @state.set_nudge(latest: "0.1.7", channel: "brew", command: "brew upgrade x")
+    sup = supervisor(telegram: failing)
+    sup.send(:push_update_nudge)
+    refute @state.should_notify?("0.1.7"), "a partial success still records the version as notified"
+  end
+end

--- a/test/unit/bot/supervisor_update_nudge_test.rb
+++ b/test/unit/bot/supervisor_update_nudge_test.rb
@@ -5,8 +5,9 @@ require "hive/update_check/state"
 
 # Pins the bot's once-per-version update push (plan 2026-05-27-002, U5).
 class HiveBotSupervisorUpdateNudgeTest < Minitest::Test
-  FakeTelegram = Struct.new(:messages, :fail_first, keyword_init: true) do
+  FakeTelegram = Struct.new(:messages, :fail_first, :fail_all, keyword_init: true) do
     def send_message(chat_id:, text:, reply_markup: nil)
+      raise "telegram down" if fail_all
       if fail_first && messages.empty? && !@failed
         @failed = true
         raise "telegram boom"
@@ -67,6 +68,18 @@ class HiveBotSupervisorUpdateNudgeTest < Minitest::Test
   def test_no_push_when_no_nudge
     supervisor.send(:push_update_nudge)
     assert_empty @telegram.messages
+  end
+
+  def test_all_sends_fail_does_not_record_and_retries_next_tick
+    failing = FakeTelegram.new(messages: [], fail_all: true)
+    @state.set_nudge(latest: "0.1.7", channel: "brew", command: "brew upgrade x")
+    sup = supervisor(telegram: failing)
+    sup.send(:push_update_nudge)
+
+    assert_empty failing.messages
+    assert @state.should_notify?("0.1.7"),
+           "a total send failure must NOT mark notified, so the next tick retries"
+    refute_includes event_names, :update_nudge_pushed
   end
 
   def test_partial_success_records_notified

--- a/test/unit/bot/supervisor_update_nudge_test.rb
+++ b/test/unit/bot/supervisor_update_nudge_test.rb
@@ -70,6 +70,35 @@ class HiveBotSupervisorUpdateNudgeTest < Minitest::Test
     assert_empty @telegram.messages
   end
 
+  def test_push_swallows_state_errors
+    boom = Object.new
+    def boom.nudge = raise(StandardError, "state boom")
+    sup = Hive::Bot::Supervisor.new(
+      config: { "chat_id_allowlist" => [ 42 ], "conversation_ttl_sec" => 60, "poll_interval_sec" => 1 },
+      token: "t", logger: @logger, telegram: @telegram,
+      status_watcher: Object.new, notification_dispatcher: Object.new,
+      router: Object.new, child_supervisor: Object.new,
+      conversation_store: Object.new, update_state: boom
+    )
+    sup.send(:push_update_nudge) # must not raise
+    assert_empty @telegram.messages
+    assert_includes event_names, :update_nudge_error
+  end
+
+  def test_in_memory_latch_prevents_repush_after_persisted_dedup_lost
+    @state.set_nudge(latest: "0.1.7", channel: "brew", command: "brew upgrade x")
+    sup = supervisor
+    sup.send(:push_update_nudge)
+    assert_equal 2, @telegram.messages.size
+
+    # Simulate the persisted dedup being lost (write failed / file reset): the
+    # in-memory latch must still suppress a re-push for this process lifetime.
+    @state.record_notified!("")
+    assert @state.should_notify?("0.1.7"), "precondition: disk no longer remembers the notify"
+    sup.send(:push_update_nudge)
+    assert_equal 2, @telegram.messages.size, "in-memory latch prevents re-push when disk dedup is lost"
+  end
+
   def test_all_sends_fail_does_not_record_and_retries_next_tick
     failing = FakeTelegram.new(messages: [], fail_all: true)
     @state.set_nudge(latest: "0.1.7", channel: "brew", command: "brew upgrade x")

--- a/test/unit/commands/daemon_test.rb
+++ b/test/unit/commands/daemon_test.rb
@@ -225,6 +225,37 @@ class HiveCommandsDaemonTest < Minitest::Test
   end
 
 
+  def test_status_json_includes_update_nudge_when_present
+    with_env("HIVE_HOME" => @home) do
+      Hive::UpdateCheck::State.new.set_nudge(latest: "9.9.9", channel: "brew",
+                                             command: "brew upgrade ivankuznetsov/hive/hive")
+      command = daemon("status", json: true)
+      write_pid_payload(pid: 1234)
+      command.define_singleton_method(:pid_alive?) { |pid| pid == 1234 }
+      command.define_singleton_method(:pid_owned_by_us?) { |_payload, pid| pid == 1234 }
+
+      out, _err = capture_io { command.call }
+      doc = JSON.parse(out)
+      assert_equal "9.9.9", doc.dig("update_nudge", "latest")
+      assert_equal "brew", doc.dig("update_nudge", "channel")
+      assert_equal Hive::VERSION, doc.fetch("current_version")
+    end
+  end
+
+  def test_status_json_update_nudge_null_when_state_raises
+    command = daemon("status", json: true)
+    write_pid_payload(pid: 1234)
+    command.define_singleton_method(:pid_alive?) { |pid| pid == 1234 }
+    command.define_singleton_method(:pid_owned_by_us?) { |_payload, pid| pid == 1234 }
+
+    out, _err = with_replaced_singleton_method(
+      Hive::UpdateCheck::State, :new, ->(*_a, **_k) { raise "state boom" }
+    ) { capture_io { command.call } }
+    doc = JSON.parse(out)
+    assert_nil doc.fetch("update_nudge"), "a failed state read degrades update_nudge to null, not a crash"
+    assert_equal true, doc.fetch("running")
+  end
+
   def test_status_json_merges_service_state_fields
     command = daemon("status", json: true)
     write_pid_payload(pid: 1234)

--- a/test/unit/commands/daemon_test.rb
+++ b/test/unit/commands/daemon_test.rb
@@ -71,19 +71,22 @@ class HiveCommandsDaemonTest < Minitest::Test
     config = daemon_config
     captured = nil
 
+    update_config = { "check" => true, "auto" => true }
     with_replaced_singleton_method(Hive::Lock, :process_start_time, ->(pid) { "start-#{pid}" }) do
       with_replaced_singleton_method(Hive::Config, :load_global_daemon, -> { config }) do
-        with_replaced_singleton_method(Hive::Daemon::Dispatcher, :new, lambda { |**kwargs|
-          captured = kwargs
-          dispatcher
-        }) do
-          command.call
+        with_replaced_singleton_method(Hive::Config, :load_global_update, -> { update_config }) do
+          with_replaced_singleton_method(Hive::Daemon::Dispatcher, :new, lambda { |**kwargs|
+            captured = kwargs
+            dispatcher
+          }) do
+            command.call
+          end
         end
       end
     end
 
     assert_equal [ :run_forever ], dispatcher.calls
-    assert_equal({ "daemon" => config }, captured.fetch(:config))
+    assert_equal({ "daemon" => config, "update" => update_config }, captured.fetch(:config))
     assert_equal true, captured.fetch(:dry_run)
     refute File.exist?(command.pid_file), "clean shutdown must remove the YAML PID file it wrote"
   end

--- a/test/unit/commands/update_test.rb
+++ b/test/unit/commands/update_test.rb
@@ -161,7 +161,8 @@ class UpdateCommandTest < Minitest::Test
 
   def test_nudge_command_per_channel
     assert_equal "brew upgrade ivankuznetsov/hive/hive", Hive::Commands::Update.nudge_command("brew")
-    assert_equal "yay -Syu hive-bin", Hive::Commands::Update.nudge_command("aur")
+    # aur + bash both nudge `hive update` (aur: paru-vs-yay picked at runtime).
+    assert_equal "hive update", Hive::Commands::Update.nudge_command("aur")
     assert_equal "hive update", Hive::Commands::Update.nudge_command("bash")
     assert_nil Hive::Commands::Update.nudge_command("dev")
   end

--- a/test/unit/commands/update_test.rb
+++ b/test/unit/commands/update_test.rb
@@ -158,4 +158,11 @@ class UpdateCommandTest < Minitest::Test
 
     assert_match(/required helper 'curl' not found/, err.message)
   end
+
+  def test_nudge_command_per_channel
+    assert_equal "brew upgrade ivankuznetsov/hive/hive", Hive::Commands::Update.nudge_command("brew")
+    assert_equal "yay -S hive-bin", Hive::Commands::Update.nudge_command("aur")
+    assert_equal "hive update", Hive::Commands::Update.nudge_command("bash")
+    assert_nil Hive::Commands::Update.nudge_command("dev")
+  end
 end

--- a/test/unit/commands/update_test.rb
+++ b/test/unit/commands/update_test.rb
@@ -161,7 +161,7 @@ class UpdateCommandTest < Minitest::Test
 
   def test_nudge_command_per_channel
     assert_equal "brew upgrade ivankuznetsov/hive/hive", Hive::Commands::Update.nudge_command("brew")
-    assert_equal "yay -S hive-bin", Hive::Commands::Update.nudge_command("aur")
+    assert_equal "yay -Syu hive-bin", Hive::Commands::Update.nudge_command("aur")
     assert_equal "hive update", Hive::Commands::Update.nudge_command("bash")
     assert_nil Hive::Commands::Update.nudge_command("dev")
   end

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -1989,6 +1989,29 @@ class ConfigTest < Minitest::Test
     end
   end
 
+  def test_load_global_update_falls_back_to_defaults_when_no_file
+    Dir.mktmpdir do |dir|
+      old = ENV["HIVE_HOME"]
+      ENV["HIVE_HOME"] = dir
+      cfg = Hive::Config.load_global_update
+      assert_equal true, cfg["check"]
+      assert_equal true, cfg["auto"]
+    ensure
+      ENV["HIVE_HOME"] = old
+    end
+  end
+
+  def test_load_global_update_rejects_non_hash_block
+    with_tmp_global_config do |home|
+      File.write(File.join(home, "config.yml"), <<~YAML)
+        registered_projects: []
+        update: enabled
+      YAML
+      err = assert_raises(Hive::ConfigError) { Hive::Config.load_global_update }
+      assert_match(/update.*must be a Hash/, err.message)
+    end
+  end
+
   def test_load_global_update_rejects_non_boolean
     with_tmp_global_config do |home|
       File.write(File.join(home, "config.yml"), <<~YAML)

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -1967,6 +1967,40 @@ class ConfigTest < Minitest::Test
     end
   end
 
+  def test_load_global_update_defaults_on
+    with_tmp_global_config do |home|
+      File.write(File.join(home, "config.yml"), { "registered_projects" => [] }.to_yaml)
+      cfg = Hive::Config.load_global_update
+      assert_equal true, cfg["check"]
+      assert_equal true, cfg["auto"]
+    end
+  end
+
+  def test_load_global_update_honors_overrides
+    with_tmp_global_config do |home|
+      File.write(File.join(home, "config.yml"), <<~YAML)
+        registered_projects: []
+        update:
+          auto: false
+      YAML
+      cfg = Hive::Config.load_global_update
+      assert_equal false, cfg["auto"], "operator opt-out of auto-update must take effect"
+      assert_equal true, cfg["check"], "unspecified keys fall back to defaults"
+    end
+  end
+
+  def test_load_global_update_rejects_non_boolean
+    with_tmp_global_config do |home|
+      File.write(File.join(home, "config.yml"), <<~YAML)
+        registered_projects: []
+        update:
+          check: sometimes
+      YAML
+      err = assert_raises(Hive::ConfigError) { Hive::Config.load_global_update }
+      assert_match(/update\.check.*must be true or false/, err.message)
+    end
+  end
+
   # ── Telegram bot global settings ──────────────────────────────────────
 
   def test_load_returns_documented_bot_defaults_when_key_absent

--- a/test/unit/daemon/dispatcher_update_check_test.rb
+++ b/test/unit/daemon/dispatcher_update_check_test.rb
@@ -118,6 +118,8 @@ class HiveDaemonDispatcherUpdateCheckTest < Minitest::Test
     assert_nil @state.nudge
     assert_empty events(logger, :update_available)
     assert_empty events(logger, :update_check_error), "nil result is not an error, just no info"
+    assert_equal 1, events(logger, :update_check_no_result).size,
+                 "an unreachable check logs a distinct signal so operators can see it"
   end
 
   def test_checker_exception_does_not_crash_tick

--- a/test/unit/daemon/dispatcher_update_check_test.rb
+++ b/test/unit/daemon/dispatcher_update_check_test.rb
@@ -91,6 +91,16 @@ class HiveDaemonDispatcherUpdateCheckTest < Minitest::Test
     assert_equal "hive update", @state.nudge.command, "bash is nudge-only until U7 lands"
   end
 
+  def test_unknown_channel_does_not_persist_nudge
+    checker = Checker.new(result(latest: "0.1.7", behind: true))
+    dispatcher, logger = build(checker: checker, channel: "snap")
+    dispatcher.tick(now: T0)
+
+    assert_nil @state.nudge, "an unknown channel has no canonical command — no nudge"
+    assert_empty events(logger, :update_available)
+    assert_equal 1, events(logger, :update_nudge_no_command).size
+  end
+
   def test_dev_channel_skips_and_clears_nudge
     @state.set_nudge(latest: "0.1.6", channel: "brew", command: "brew upgrade x")
     checker = Checker.new(result(latest: "0.1.7", behind: true))

--- a/test/unit/daemon/dispatcher_update_check_test.rb
+++ b/test/unit/daemon/dispatcher_update_check_test.rb
@@ -1,0 +1,154 @@
+require "test_helper"
+require "tmpdir"
+require "hive/daemon/dispatcher"
+require "hive/daemon/concurrency_controller"
+require "hive/update_check"
+require "hive/update_check/state"
+
+# Pins the update-flow integration in Dispatcher#tick (plan 2026-05-27-002,
+# U3): throttled release check, channel branch, nudge state, resilience.
+class HiveDaemonDispatcherUpdateCheckTest < Minitest::Test
+  T0 = Time.utc(2026, 5, 27, 12, 0, 0)
+
+  class FakeStatusConsumer
+    def fetch
+      Hive::Daemon::StatusConsumer::Result.new(ok: true, rows: [], error: nil)
+    end
+  end
+
+  class FakeSupervisor
+    def reap_all(now: Time.now) = []
+    def reap_dry_run(now: Time.now) = []
+    def terminate_all(grace_sec: 600); end
+    def in_flight_count = 0
+  end
+
+  class StubLogger
+    attr_reader :events
+    def initialize = @events = []
+    def event(name, **attrs) = @events << [ name, attrs ]
+    def close; end
+  end
+
+  class Checker
+    attr_reader :calls
+    def initialize(result) = (@result = result; @calls = 0)
+    def call = (@calls += 1; @result)
+  end
+
+  def setup
+    @dir = Dir.mktmpdir
+    @state = Hive::UpdateCheck::State.new(path: File.join(@dir, "update_check.json"))
+  end
+
+  def teardown
+    FileUtils.remove_entry(@dir)
+  end
+
+  def build(checker:, channel:, update_cfg: { "check" => true, "auto" => true })
+    logger = StubLogger.new
+    dispatcher = Hive::Daemon::Dispatcher.new(
+      config: { "daemon" => { "poll_interval_sec" => 30 }, "update" => update_cfg },
+      controller: Hive::Daemon::ConcurrencyController.new(
+        max_concurrent_runs: 5, max_concurrent_per_project: 5, max_runs_per_day_per_project: 100
+      ),
+      supervisor: FakeSupervisor.new,
+      status_consumer: FakeStatusConsumer.new,
+      logger: logger,
+      update_state: @state,
+      update_checker: -> { checker.call },
+      channel_detector: -> { channel }
+    )
+    [ dispatcher, logger ]
+  end
+
+  def result(latest:, behind:, current: "0.1.5")
+    Hive::UpdateCheck::Result.new(current: current, latest: latest, behind: behind)
+  end
+
+  def events(logger, name)
+    logger.events.select { |n, _| n == name }
+  end
+
+  def test_behind_on_brew_sets_nudge_and_logs
+    checker = Checker.new(result(latest: "0.1.7", behind: true))
+    dispatcher, logger = build(checker: checker, channel: "brew")
+    dispatcher.tick(now: T0)
+
+    nudge = @state.nudge
+    assert nudge, "expected a nudge to be recorded when behind"
+    assert_equal "0.1.7", nudge.latest
+    assert_equal "brew", nudge.channel
+    assert_equal "brew upgrade ivankuznetsov/hive/hive", nudge.command
+    assert_equal 1, events(logger, :update_available).size
+  end
+
+  def test_bash_channel_is_nudge_only
+    checker = Checker.new(result(latest: "0.1.7", behind: true))
+    dispatcher, = build(checker: checker, channel: "bash")
+    dispatcher.tick(now: T0)
+
+    assert_equal "hive update", @state.nudge.command, "bash is nudge-only until U7 lands"
+  end
+
+  def test_dev_channel_skips_and_clears_nudge
+    @state.set_nudge(latest: "0.1.6", channel: "brew", command: "brew upgrade x")
+    checker = Checker.new(result(latest: "0.1.7", behind: true))
+    dispatcher, logger = build(checker: checker, channel: "dev")
+    dispatcher.tick(now: T0)
+
+    assert_nil @state.nudge, "dev clones must not carry a nudge"
+    assert_empty events(logger, :update_available)
+  end
+
+  def test_not_behind_clears_nudge
+    @state.set_nudge(latest: "0.1.6", channel: "brew", command: "brew upgrade x")
+    checker = Checker.new(result(latest: "0.1.7", behind: false))
+    dispatcher, = build(checker: checker, channel: "brew")
+    dispatcher.tick(now: T0)
+
+    assert_nil @state.nudge, "a current install must clear any stale nudge"
+  end
+
+  def test_offline_check_degrades_silently
+    checker = Checker.new(nil)
+    dispatcher, logger = build(checker: checker, channel: "brew")
+    dispatcher.tick(now: T0)
+
+    assert_nil @state.nudge
+    assert_empty events(logger, :update_available)
+    assert_empty events(logger, :update_check_error), "nil result is not an error, just no info"
+  end
+
+  def test_checker_exception_does_not_crash_tick
+    boom = Object.new
+    def boom.call = raise(StandardError, "kaboom")
+    logger = StubLogger.new
+    dispatcher = Hive::Daemon::Dispatcher.new(
+      config: { "daemon" => { "poll_interval_sec" => 30 }, "update" => { "check" => true, "auto" => true } },
+      controller: Hive::Daemon::ConcurrencyController.new(
+        max_concurrent_runs: 5, max_concurrent_per_project: 5, max_runs_per_day_per_project: 100
+      ),
+      supervisor: FakeSupervisor.new, status_consumer: FakeStatusConsumer.new, logger: logger,
+      update_state: @state, update_checker: -> { boom.call }, channel_detector: -> { "brew" }
+    )
+    dispatcher.tick(now: T0) # must not raise
+    assert_equal 1, events(logger, :update_check_error).size
+  end
+
+  def test_throttled_to_once_per_window
+    checker = Checker.new(result(latest: "0.1.7", behind: true))
+    dispatcher, = build(checker: checker, channel: "brew")
+    dispatcher.tick(now: T0)
+    dispatcher.tick(now: T0 + 3600) # within the daily window
+    assert_equal 1, checker.calls, "must not re-probe GitHub within the throttle window"
+  end
+
+  def test_disabled_check_never_probes
+    checker = Checker.new(result(latest: "0.1.7", behind: true))
+    dispatcher, = build(checker: checker, channel: "brew", update_cfg: { "check" => false, "auto" => true })
+    dispatcher.tick(now: T0)
+    assert_equal 0, checker.calls
+    assert_nil @state.nudge
+  end
+end

--- a/test/unit/schema_files_test.rb
+++ b/test/unit/schema_files_test.rb
@@ -1236,7 +1236,7 @@ class SchemaFilesTest < Minitest::Test
     # are required-but-nullable in the schema.
     producer_required = %w[
       schema schema_version ok running pid uptime_sec pid_file log_file
-      service_installed service_enabled unit_path
+      service_installed service_enabled unit_path current_version update_nudge
     ].sort
     assert_equal producer_required, schema_required,
                  "schema/producer required-key drift in hive-daemon-status.v1.json"

--- a/test/unit/tui/bubble_model_update_nudge_test.rb
+++ b/test/unit/tui/bubble_model_update_nudge_test.rb
@@ -6,6 +6,8 @@ require "hive/update_check/state"
 # Pins the TUI footer's update-nudge read path (plan 2026-05-27-002, U5):
 # the model surfaces the daemon-written nudge and degrades to nil when absent.
 class HiveTuiBubbleModelUpdateNudgeTest < Minitest::Test
+  include HiveTestHelper
+
   def setup
     @dir = Dir.mktmpdir
     @state = Hive::UpdateCheck::State.new(path: File.join(@dir, "update_check.json"))
@@ -44,5 +46,32 @@ class HiveTuiBubbleModelUpdateNudgeTest < Minitest::Test
     # lapses — proves the footer doesn't re-read the file every frame.
     @state.set_nudge(latest: "0.1.7", channel: "brew", command: "brew upgrade x")
     assert_nil m.send(:update_nudge), "within TTL the cached (nil) value is returned"
+  end
+
+  def test_nudge_refreshes_after_ttl_expires
+    m = model
+    assert_nil m.send(:update_nudge) # caches nil at "now"
+    @state.set_nudge(latest: "0.1.7", channel: "brew", command: "brew upgrade x")
+    # Age the cached check timestamp past the TTL window so the next read
+    # re-reads the file and picks up the newly-written nudge.
+    stale = Process.clock_gettime(Process::CLOCK_MONOTONIC) - (Hive::Tui::BubbleModel::UPDATE_NUDGE_TTL_SEC + 5)
+    m.instance_variable_set(:@update_nudge_checked_at, stale)
+    nudge = m.send(:update_nudge)
+    assert nudge, "cache must refresh once the TTL window elapses"
+    assert_equal "0.1.7", nudge.latest
+  end
+
+  def test_update_nudge_swallows_state_errors
+    boom = Object.new
+    def boom.nudge = raise(StandardError, "state boom")
+    m = Hive::Tui::BubbleModel.new(update_state: boom)
+    assert_nil m.send(:update_nudge), "a raising state must degrade the footer to no-nudge, not crash"
+  end
+
+  def test_update_check_state_swallows_construction_errors
+    m = Hive::Tui::BubbleModel.new(update_state: nil)
+    with_replaced_singleton_method(Hive::UpdateCheck::State, :new, ->(*_a, **_k) { raise "no state" }) do
+      assert_nil m.send(:update_check_state), "a failed lazy State construction degrades to nil"
+    end
   end
 end

--- a/test/unit/tui/bubble_model_update_nudge_test.rb
+++ b/test/unit/tui/bubble_model_update_nudge_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+require "tmpdir"
+require "hive/tui/bubble_model"
+require "hive/update_check/state"
+
+# Pins the TUI footer's update-nudge read path (plan 2026-05-27-002, U5):
+# the model surfaces the daemon-written nudge and degrades to nil when absent.
+class HiveTuiBubbleModelUpdateNudgeTest < Minitest::Test
+  def setup
+    @dir = Dir.mktmpdir
+    @state = Hive::UpdateCheck::State.new(path: File.join(@dir, "update_check.json"))
+  end
+
+  def teardown
+    FileUtils.remove_entry(@dir)
+  end
+
+  def model
+    Hive::Tui::BubbleModel.new(update_state: @state)
+  end
+
+  def test_no_nudge_when_state_empty
+    assert_nil model.send(:update_nudge)
+  end
+
+  def test_reads_daemon_written_nudge
+    @state.set_nudge(latest: "0.1.7", channel: "brew", command: "brew upgrade ivankuznetsov/hive/hive")
+    nudge = model.send(:update_nudge)
+    assert nudge
+    assert_equal "0.1.7", nudge.latest
+  end
+
+  def test_nudge_label_format
+    @state.set_nudge(latest: "0.1.7", channel: "brew", command: "brew upgrade ivankuznetsov/hive/hive")
+    m = model
+    label = m.send(:update_nudge_label, m.send(:update_nudge))
+    assert_equal "update 0.1.7: brew upgrade ivankuznetsov/hive/hive", label
+  end
+
+  def test_read_is_cached_within_ttl
+    m = model
+    assert_nil m.send(:update_nudge)
+    # A nudge written after the first (cached) read is not seen until the TTL
+    # lapses — proves the footer doesn't re-read the file every frame.
+    @state.set_nudge(latest: "0.1.7", channel: "brew", command: "brew upgrade x")
+    assert_nil m.send(:update_nudge), "within TTL the cached (nil) value is returned"
+  end
+end

--- a/test/unit/update_check_state_test.rb
+++ b/test/unit/update_check_state_test.rb
@@ -3,6 +3,14 @@ require "tmpdir"
 require "hive/update_check/state"
 
 class UpdateCheckStateTest < Minitest::Test
+  include HiveTestHelper
+
+  class RecordingLogger
+    attr_reader :events
+    def initialize = @events = []
+    def event(name, **attrs) = @events << [ name, attrs ]
+  end
+
   def setup
     @dir = Dir.mktmpdir
     @path = File.join(@dir, "update_check.json")
@@ -64,9 +72,33 @@ class UpdateCheckStateTest < Minitest::Test
     assert_nil s.nudge
   end
 
-  def test_wrong_schema_version_degrades_to_empty
-    File.write(@path, JSON.generate({ "schema_version" => 99, "last_notified_version" => "9.9.9" }))
-    assert state.should_notify?("0.1.7"), "incompatible schema must not leak stale notified-version"
+  def test_newer_schema_is_read_but_not_overwritten
+    # Forward-compat: a newer hive wrote schema_version 99. An older process
+    # must read recognized keys but never write back (no downgrade churn
+    # during a rolling micro-release upgrade).
+    File.write(@path, JSON.generate({ "schema_version" => 99, "last_notified_version" => "9.9.9",
+                                       "nudge" => { "latest" => "9.9.9", "channel" => "brew",
+                                                    "command" => "brew upgrade x" } }))
+    s = state
+    assert_equal "9.9.9", s.nudge.latest, "recognized keys from a newer file are still read"
+    refute s.should_notify?("9.9.9"), "the newer file's notified-version is honored"
+
+    s.record_check!(@now) # write suspended — must not rewrite the newer file
+    on_disk = JSON.parse(File.read(@path))
+    assert_equal 99, on_disk["schema_version"], "older process must not downgrade a newer-schema file"
+    assert_nil on_disk["last_check_at"], "suspended write left the newer file untouched"
+  end
+
+  def test_non_integer_schema_degrades_to_empty
+    File.write(@path, JSON.generate({ "schema_version" => "two", "last_notified_version" => "9.9.9" }))
+    assert state.should_notify?("0.1.7"), "a non-integer schema_version is corrupt → reset to empty"
+  end
+
+  def test_clear_nudge_is_idempotent
+    s = state
+    assert_nil s.nudge
+    s.clear_nudge! # already nil — must not raise
+    assert_nil state.nudge
   end
 
   def test_persists_across_instances
@@ -98,5 +130,75 @@ class UpdateCheckStateTest < Minitest::Test
     assert_equal "0.1.7", fresh.nudge.latest
     refute fresh.should_notify?("0.1.7"), "notified-version (bot-written) must survive the daemon's write"
     refute fresh.due?(@now + 10, window: 86_400), "check timestamp must survive too"
+  end
+
+  def test_older_schema_degrades_to_empty
+    File.write(@path, JSON.generate({ "schema_version" => 0, "last_notified_version" => "9.9.9" }))
+    assert state.should_notify?("0.1.7"), "an older schema_version is reset to empty"
+  end
+
+  def test_malformed_last_check_at_is_treated_as_never_checked
+    File.write(@path, JSON.generate({ "schema_version" => 1, "last_check_at" => "not-a-date" }))
+    assert state.due?(@now), "an unparseable timestamp degrades to never-checked, never raises"
+  end
+
+  def test_stale_orphan_tmp_is_swept_but_fresh_one_kept
+    stale = File.join(@dir, ".update_check.json.1.1.tmp")
+    fresh = File.join(@dir, ".update_check.json.2.2.tmp")
+    File.write(stale, "old")
+    File.write(fresh, "in-flight")
+    File.utime(Time.now - 300, Time.now - 300, stale)
+    Hive::UpdateCheck::State.new(path: @path)
+    refute File.exist?(stale), "stragglers older than the stale window are swept"
+    assert File.exist?(fresh), "a fresh tmp may be a live process's in-flight write — keep it"
+  end
+
+  def test_dangling_symlink_tmp_does_not_abort_sweep
+    link = File.join(@dir, ".update_check.json.x.tmp")
+    File.symlink(File.join(@dir, "no-such-target"), link)
+    # File.mtime on the dangling link raises ENOENT — the per-entry rescue
+    # must skip it without aborting construction.
+    Hive::UpdateCheck::State.new(path: @path)
+  end
+
+  def test_glob_failure_during_sweep_is_logged
+    logger = RecordingLogger.new
+    with_replaced_singleton_method(Dir, :glob, ->(*_a, **_k) { raise IOError, "synthetic glob failure" }) do
+      Hive::UpdateCheck::State.new(path: @path, logger: logger)
+    end
+    assert(logger.events.any? { |name, _| name == :update_check_tmp_sweep_error })
+  end
+
+  def test_unwritable_state_dir_degrades_without_raising
+    logger = RecordingLogger.new
+    afile = File.join(@dir, "afile")
+    File.write(afile, "x")
+    # Parent of the path is a regular file → mkdir_p raises ENOTDIR in both
+    # acquire_lock and persist_locked!; both rescues must fire, no crash.
+    s = Hive::UpdateCheck::State.new(path: File.join(afile, "sub", "update_check.json"), logger: logger)
+    s.record_check!(@now)
+    assert(logger.events.any? { |name, _| name == :update_check_state_lock_error })
+    assert(logger.events.any? { |name, _| name == :update_check_state_write_error })
+  end
+
+  def test_unreadable_file_is_treated_as_corrupt
+    logger = RecordingLogger.new
+    File.write(@path, JSON.generate({ "schema_version" => 1, "last_notified_version" => "9.9.9" }))
+    File.chmod(0o000, @path)
+    s = Hive::UpdateCheck::State.new(path: @path, logger: logger)
+    assert s.should_notify?("0.1.7"), "an unreadable file degrades to empty (corrupt), never raises"
+    assert(logger.events.any? { |name, _| name == :update_check_state_corrupt })
+  ensure
+    File.chmod(0o644, @path) if @path && File.exist?(@path)
+  end
+
+  def test_release_lock_swallows_errors
+    bad = Object.new
+    def bad.flock(_mode) = raise(IOError, "boom")
+    state.send(:release_lock, bad) # must not raise
+  end
+
+  def test_fsync_dir_swallows_errors
+    state.send(:fsync_dir, File.join(@dir, "does-not-exist")) # Dir.open raises → nil
   end
 end

--- a/test/unit/update_check_state_test.rb
+++ b/test/unit/update_check_state_test.rb
@@ -73,4 +73,30 @@ class UpdateCheckStateTest < Minitest::Test
     state.record_check!(@now)
     refute state.due?(@now + 10, window: 86_400), "check timestamp must survive a reload"
   end
+
+  def test_due_exactly_at_window_boundary
+    s = state
+    s.record_check!(@now)
+    assert state.due?(@now + 86_400, window: 86_400),
+           "due? uses >= so a check is due exactly one window later (no off-by-one drift)"
+  end
+
+  def test_cross_process_writes_do_not_clobber_each_other
+    # The whole reason every op re-reads disk: the daemon writes `nudge` while
+    # the bot writes `last_notified_version`, each from its own instance. A
+    # stale in-memory copy in either would erase the other's key. Interleave
+    # three separate instances against one file, then assert all keys survive.
+    daemon = state
+    bot = state
+
+    daemon.set_nudge(latest: "0.1.7", channel: "brew", command: "brew upgrade x")
+    bot.record_notified!("0.1.7")   # bot must not erase the daemon's nudge
+    daemon.record_check!(@now)       # daemon must not erase the bot's notified-version
+
+    fresh = state
+    assert fresh.nudge, "nudge (daemon-written) must survive the bot's write"
+    assert_equal "0.1.7", fresh.nudge.latest
+    refute fresh.should_notify?("0.1.7"), "notified-version (bot-written) must survive the daemon's write"
+    refute fresh.due?(@now + 10, window: 86_400), "check timestamp must survive too"
+  end
 end

--- a/test/unit/update_check_state_test.rb
+++ b/test/unit/update_check_state_test.rb
@@ -1,0 +1,76 @@
+require "test_helper"
+require "tmpdir"
+require "hive/update_check/state"
+
+class UpdateCheckStateTest < Minitest::Test
+  def setup
+    @dir = Dir.mktmpdir
+    @path = File.join(@dir, "update_check.json")
+    @now = Time.utc(2026, 5, 27, 12, 0, 0)
+  end
+
+  def teardown
+    FileUtils.remove_entry(@dir)
+  end
+
+  def state
+    Hive::UpdateCheck::State.new(path: @path)
+  end
+
+  def test_due_when_never_checked
+    assert state.due?(@now)
+  end
+
+  def test_not_due_within_window
+    s = state
+    s.record_check!(@now)
+    refute state.due?(@now + 3600, window: 86_400), "should not be due an hour after a check"
+  end
+
+  def test_due_after_window_elapses
+    s = state
+    s.record_check!(@now)
+    assert state.due?(@now + 90_000, window: 86_400), "should be due once the window has elapsed"
+  end
+
+  def test_should_notify_once_per_version
+    s = state
+    assert s.should_notify?("0.1.7")
+    s.record_notified!("0.1.7")
+    refute state.should_notify?("0.1.7"), "must not re-notify the same version after a restart"
+    assert state.should_notify?("0.1.8"), "a newer version is notifiable again"
+  end
+
+  def test_nudge_roundtrip_and_clear
+    s = state
+    s.set_nudge(latest: "0.1.7", channel: "brew", command: "brew upgrade ivankuznetsov/hive/hive")
+    n = state.nudge
+    assert_equal "0.1.7", n.latest
+    assert_equal "brew", n.channel
+    assert_equal "brew upgrade ivankuznetsov/hive/hive", n.command
+
+    s.clear_nudge!
+    assert_nil state.nudge
+  end
+
+  def test_nudge_nil_when_unset
+    assert_nil state.nudge
+  end
+
+  def test_corrupt_file_degrades_to_empty
+    File.write(@path, "{ not valid json")
+    s = state
+    assert s.due?(@now), "corrupt state should behave as a fresh (due) state"
+    assert_nil s.nudge
+  end
+
+  def test_wrong_schema_version_degrades_to_empty
+    File.write(@path, JSON.generate({ "schema_version" => 99, "last_notified_version" => "9.9.9" }))
+    assert state.should_notify?("0.1.7"), "incompatible schema must not leak stale notified-version"
+  end
+
+  def test_persists_across_instances
+    state.record_check!(@now)
+    refute state.due?(@now + 10, window: 86_400), "check timestamp must survive a reload"
+  end
+end

--- a/test/unit/update_check_test.rb
+++ b/test/unit/update_check_test.rb
@@ -1,7 +1,10 @@
 require "test_helper"
+require "net/http"
 require "hive/update_check"
 
 class UpdateCheckTest < Minitest::Test
+  include HiveTestHelper
+
   def stub_http(body)
     ->(_url) { body }
   end
@@ -52,5 +55,35 @@ class UpdateCheckTest < Minitest::Test
 
   def test_unparseable_version_is_not_behind
     refute Hive::UpdateCheck.newer?("not.a.version", "0.1.5")
+  end
+
+  def test_non_string_tag_is_swallowed
+    # tag_name as a number → tag.empty? raises NoMethodError → outer rescue → nil
+    assert_nil Hive::UpdateCheck.latest(current: "0.1.5", http: ->(_url) { '{"tag_name": 123}' })
+  end
+
+  def test_real_http_path_parses_success_response
+    body = '{"tag_name":"v9.9.9"}'
+    response = Net::HTTPOK.new("1.1", "200", "OK")
+    response.instance_variable_set(:@read, true)
+    response.instance_variable_set(:@body, body)
+    fake_http = Object.new
+    fake_http.define_singleton_method(:request) { |_req| response }
+    # No `http:` injected → exercises the real Net::HTTP code path in http_get.
+    with_replaced_singleton_method(Net::HTTP, :start, ->(*_a, **_k, &blk) { blk.call(fake_http) }) do
+      result = Hive::UpdateCheck.latest(current: "0.1.5")
+      assert result
+      assert_equal "9.9.9", result.latest
+      assert result.behind?
+    end
+  end
+
+  def test_real_http_path_returns_nil_on_non_success
+    response = Net::HTTPNotFound.new("1.1", "404", "Not Found")
+    fake_http = Object.new
+    fake_http.define_singleton_method(:request) { |_req| response }
+    with_replaced_singleton_method(Net::HTTP, :start, ->(*_a, **_k, &blk) { blk.call(fake_http) }) do
+      assert_nil Hive::UpdateCheck.latest(current: "0.1.5"), "a non-2xx response yields no info"
+    end
   end
 end

--- a/test/unit/update_check_test.rb
+++ b/test/unit/update_check_test.rb
@@ -1,0 +1,56 @@
+require "test_helper"
+require "hive/update_check"
+
+class UpdateCheckTest < Minitest::Test
+  def stub_http(body)
+    ->(_url) { body }
+  end
+
+  def test_behind_when_latest_is_newer
+    result = Hive::UpdateCheck.latest(current: "0.1.5", http: stub_http('{"tag_name":"v0.1.7"}'))
+    assert result
+    assert_equal "0.1.7", result.latest
+    assert_equal "0.1.5", result.current
+    assert result.behind?
+  end
+
+  def test_not_behind_when_current_equals_latest
+    result = Hive::UpdateCheck.latest(current: "0.1.7", http: stub_http('{"tag_name":"v0.1.7"}'))
+    assert result
+    refute result.behind?
+  end
+
+  def test_not_behind_when_current_is_ahead
+    # Local dev build ahead of the latest tag must never be flagged "behind".
+    result = Hive::UpdateCheck.latest(current: "0.2.0", http: stub_http('{"tag_name":"v0.1.7"}'))
+    assert result
+    refute result.behind?
+  end
+
+  def test_handles_tag_without_v_prefix
+    result = Hive::UpdateCheck.latest(current: "0.1.5", http: stub_http('{"tag_name":"0.1.7"}'))
+    assert_equal "0.1.7", result.latest
+    assert result.behind?
+  end
+
+  def test_returns_nil_when_http_raises
+    boom = ->(_url) { raise SocketError, "getaddrinfo: Name or service not known" }
+    assert_nil Hive::UpdateCheck.latest(current: "0.1.5", http: boom)
+  end
+
+  def test_returns_nil_on_malformed_json
+    assert_nil Hive::UpdateCheck.latest(current: "0.1.5", http: stub_http("not json"))
+  end
+
+  def test_returns_nil_when_body_nil
+    assert_nil Hive::UpdateCheck.latest(current: "0.1.5", http: ->(_url) { nil })
+  end
+
+  def test_returns_nil_when_tag_missing
+    assert_nil Hive::UpdateCheck.latest(current: "0.1.5", http: stub_http('{"name":"no tag here"}'))
+  end
+
+  def test_unparseable_version_is_not_behind
+    refute Hive::UpdateCheck.newer?("not.a.version", "0.1.5")
+  end
+end

--- a/wiki/commands/update.md
+++ b/wiki/commands/update.md
@@ -43,7 +43,7 @@ The bash channel deliberately downloads to a tempfile rather than piping remote 
 
 ## Nudge command (shared with the update flow)
 
-`Hive::Commands::Update.nudge_command(channel)` returns the canonical one-line update command per channel — `brew upgrade ivankuznetsov/hive/hive`, `yay -Syu hive-bin`, or `hive update` (bash) — and `nil` for `dev` (git clone has no single canonical command). The daemon-driven [[update-flow]] uses this string when it records a per-version nudge; the bash channel stays nudge-only until the auto-update spike (U7). The `aur` nudge mirrors `aur_command`'s `-Syu` so a stale local DB can't "update" to an older `hive-bin`.
+`Hive::Commands::Update.nudge_command(channel)` returns the canonical one-line update command per channel — `brew upgrade ivankuznetsov/hive/hive` for brew, and `hive update` for both `aur` and `bash` — and `nil` for `dev` (git clone has no single canonical command). The daemon-driven [[update-flow]] uses this string when it records a per-version nudge. The `aur` and `bash` channels nudge `hive update` rather than a raw package-manager command: `aur` because the real updater picks `yay` or `paru` at runtime (a hardcoded `yay …` would fail for paru-only users), and `bash` because in-place auto-update (U7) isn't built yet.
 
 ## Tests
 

--- a/wiki/commands/update.md
+++ b/wiki/commands/update.md
@@ -3,7 +3,7 @@ title: hive update
 type: command
 source: lib/hive/commands/update.rb, lib/hive/install_channel.rb
 created: 2026-05-21
-updated: 2026-05-21
+updated: 2026-05-27
 tags: [command, install, update]
 ---
 
@@ -41,6 +41,10 @@ A missing marker means `dev`, the git-checkout fallback. Malformed markers fail 
 
 The bash channel deliberately downloads to a tempfile rather than piping remote script bytes into a shell. Helper preflight checks make missing `brew`, `curl`, `yay`, or `paru` errors actionable.
 
+## Nudge command (shared with the update flow)
+
+`Hive::Commands::Update.nudge_command(channel)` returns the canonical one-line update command per channel — `brew upgrade ivankuznetsov/hive/hive`, `yay -Syu hive-bin`, or `hive update` (bash) — and `nil` for `dev` (git clone has no single canonical command). The daemon-driven [[update-flow]] uses this string when it records a per-version nudge; the bash channel stays nudge-only until the auto-update spike (U7). The `aur` nudge mirrors `aur_command`'s `-Syu` so a stale local DB can't "update" to an older `hive-bin`.
+
 ## Tests
 
 - `test/unit/commands/update_test.rb` covers channel selection, dry-run output, bash-prefix reuse, helper preflights, malformed marker handling, and AUR helper fallback.
@@ -48,4 +52,4 @@ The bash channel deliberately downloads to a tempfile rather than piping remote 
 
 ## Backlinks
 
-- [[cli]] · [[operating]] · [[modules/config]]
+- [[cli]] · [[operating]] · [[modules/config]] · [[update-flow]]

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -45,6 +45,7 @@ Folder-as-agent pipeline: a Ruby 3.4 / Thor CLI control plane that drives a nine
 - [[dependencies]] — `wiki/dependencies.md`
 - [[e2e]] — `wiki/e2e.md`
 - [[gaps]] — `wiki/gaps.md`
+- [[update-flow]] — `wiki/update-flow.md`
 - [[index]] — `wiki/index.md`
 - [[log]] — `wiki/log.md`
 - [[modules/agent]] — `wiki/modules/agent.md`

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -2,6 +2,13 @@
 
 Append-only log of all wiki operations.
 
+## [2026-05-27T18:00:00Z] feat — daemon-driven update flow (check + nudge, U1–U5)
+
+**Action:** Added the update flow (plan 2026-05-27-002): `Hive::UpdateCheck` release probe, `UpdateCheck::State` shared JSON store, `update.check`/`update.auto` config, dispatcher integration (throttled check + per-channel nudge), and the nudge surfaces (TUI footer + once-per-version bot push). Every channel is nudge-only for now; bash auto-update (U7) is deferred.
+
+**New/refreshed pages:**
+- [[update-flow]]
+
 ## [2026-05-27T12:00:00Z] ci — cross-OS install verification (real installs)
 
 **Action:** CI now does real installs of every channel on its native OS via `packaging/verify-channel.sh` + the reusable `.github/workflows/install-verify.yml` (matrix: bash/ubuntu x86+arm, brew/macos-15, aur/arch container). Three layers: a pre-release `install-gate` in `release.yml` (gem-installs on macos+ubuntu-arm before publishing), `post-release-verify` (real brew/yay/install.sh of the published version), and a weekly `install-canary.yml`. Failures open/update a single `install-failure` GitHub issue. This matrix immediately caught and drove fixes for real channel bugs (broken `yay -S hive-bin`, brew `hv` shim, brew marker path) shipped in v0.1.5. aarch64-AUR deferred (official `archlinux` image is x86_64-only). Runbook: `docs/RELEASING.md#install-verification`.

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -7,7 +7,7 @@ Append-only log of all wiki operations.
 **Action:** Added the update flow (plan 2026-05-27-002): `Hive::UpdateCheck` release probe, `UpdateCheck::State` shared JSON store, `update.check`/`update.auto` config, dispatcher integration (throttled check + per-channel nudge), and the nudge surfaces (TUI footer + once-per-version bot push). Every channel is nudge-only for now; bash auto-update (U7) is deferred.
 
 **New/refreshed pages:**
-- [[update-flow]]
+- [[update-flow]] · [[state-model]] · [[commands/update]]
 
 ## [2026-05-27T12:00:00Z] ci — cross-OS install verification (real installs)
 

--- a/wiki/state-model.md
+++ b/wiki/state-model.md
@@ -169,7 +169,12 @@ bot:
   log_max_bytes: 10485760
   log_max_files: 5
   last_seen_state_file: ~/.local/state/hive/.bot.last_seen_update_id
+update:                          # update-check knobs (plan 2026-05-27-002, U4)
+  check: true                    # daemon probes GitHub latest release when idle
+  auto: true                     # self-update when possible; false keeps checks/nudges only
 ```
+
+`update:` is a global block merged over `DEFAULTS["update"]` by `Config.load_global_update` (used by `hive daemon start`). Both keys are booleans validated by `Config.validate_update!` (a non-Hash block or non-boolean key raises `ConfigError`, exit 78). `auto: false` keeps the daily check and brew/AUR nudge but never self-updates. The check's bookkeeping lives in the `update_check.json` runtime file (see below), not in this config.
 
 Managed by `Hive::Config.register_project`; deregistered by `unregister_project` (one row, by name) and `prune_missing_projects!` (every row whose `path` is missing, whose stored valid `real_path` no longer matches the current target, OR whose shape is invalid). Registry writers serialize on the sticky sibling `config.yml.lock` and replace `config.yml` via tempfile + `fsync` + atomic rename. `HIVE_HOME` overrides the XDG default `~/.config/hive`; legacy `~/Dev/hive/config.yml` is migrated when no XDG config exists.
 

--- a/wiki/update-flow.md
+++ b/wiki/update-flow.md
@@ -25,9 +25,13 @@ tags: [architecture, daemon, bot, tui, update, decision]
 
 - **install.sh (bash)** — nudge-only today (`hive update`). Auto-update (re-run installer + ADR-031 self-re-exec when idle) is deferred to U7.
 - **brew** — nudge `brew upgrade ivankuznetsov/hive/hive`. hive never drives brew.
-- **aur** — nudge `yay -Syu hive-bin` (mirrors `aur_command`'s `-Syu`; a DB sync is required or a stale local DB could install an older `hive-bin`). hive never drives the AUR helper.
+- **aur** — nudge `hive update` (the real updater picks `yay` OR `paru` at runtime; a hardcoded `yay …` would fail for paru-only users). hive never drives the AUR helper itself.
 - **dev** — git clone; skipped entirely.
 
 ## Deferred (U7)
 
 Bash auto-update from the daemon: drain in-flight work, run `hive update`, re-exec into the new version (idle = active-agent snapshot empty AND `controller.in_flight_count == 0`). Needs a live systemd-user daemon spike because the updater currently `Kernel.exec`s. Non-daemon users are also not nudged in this scope.
+
+## Backlinks
+
+- [[state-model]] · [[modules/config]] · [[commands/update]] · [[architecture]] · [[decisions]]

--- a/wiki/update-flow.md
+++ b/wiki/update-flow.md
@@ -1,0 +1,33 @@
+---
+title: Update flow (daemon-driven version check + nudge)
+type: feature
+source: lib/hive/update_check.rb, lib/hive/update_check/state.rb, lib/hive/daemon/dispatcher.rb, lib/hive/bot/supervisor.rb, lib/hive/tui/bubble_model.rb
+created: 2026-05-27
+updated: 2026-05-27
+tags: [architecture, daemon, bot, tui, update, decision]
+---
+
+**TLDR**: During the fast dev-release period the daemon checks the latest GitHub release on a throttled (~daily) cadence and, when the running version is behind, records a nudge (version + exact update command) that the TUI footer renders and the bot pushes once per version. Auto-update is **not** implemented yet — every channel is nudge-only until the bash auto-update spike (U7) lands. See [[commands/update]] and [[decisions]].
+
+## Pieces
+
+- **`Hive::UpdateCheck.latest`** — probes `https://api.github.com/repos/ivankuznetsov/hive/releases/latest`, parses `tag_name`, compares to `Hive::VERSION`. Returns a `Result(current, latest, behind)` or `nil` on **any** failure (offline, rate-limit, malformed JSON, unparseable version). Never raises — the daemon calls it on a tick and must not crash.
+- **`Hive::UpdateCheck::State`** — JSON state under `Paths.state_home/update_check.json`. Holds `last_check_at` (throttle), `last_notified_version` (de-dupe), and the active `nudge` payload (`latest`/`channel`/`command`). Atomic write, fail-closed load. **Shared across processes**: the daemon writes `nudge` + `last_check_at`; the bot writes `last_notified_version`; the TUI reads `nudge`. Every operation re-reads the file first so one process can't clobber another's keys with a stale in-memory copy.
+- **Dispatcher integration** (`maybe_check_for_update`) — runs at the top of each `tick`, throttled by `state.due?`. Branches on `InstallChannel.detect`: `dev` → clear nudge + skip; brew/aur/bash → set the nudge with `Update.nudge_command(channel)` and log `:update_available`. Resilient: wrapped so an error logs `:update_check_error` and never breaks the tick. Runs only when an `update_state` is injected (the daemon does; unit tests stay inert/offline).
+- **TUI footer** (`bubble_model.rb`) — reads `state.nudge` on a 10s TTL cache and prepends `update <ver>: <command>` to the hint line (prepended so truncation trims the hint, not the notice).
+- **Bot push** (`supervisor.rb` `push_update_nudge`, called from `status_loop`) — reads `state.nudge`; if `should_notify?(latest)`, sends to the `chat_id_allowlist` and records notified **only after a delivery succeeds** (all-failed pushes retry next tick). Once per version.
+
+## Config
+
+`update.check` (default `true`) gates the whole probe. `update.auto` (default `true`) is reserved for the deferred bash auto-update — currently read but not yet consulted. Loaded via `Config.load_global_update`, validated as booleans.
+
+## Channels
+
+- **install.sh (bash)** — nudge-only today (`hive update`). Auto-update (re-run installer + ADR-031 self-re-exec when idle) is deferred to U7.
+- **brew** — nudge `brew upgrade ivankuznetsov/hive/hive`. hive never drives brew.
+- **aur** — nudge `yay -S hive-bin`. hive never drives the AUR helper.
+- **dev** — git clone; skipped entirely.
+
+## Deferred (U7)
+
+Bash auto-update from the daemon: drain in-flight work, run `hive update`, re-exec into the new version (idle = active-agent snapshot empty AND `controller.in_flight_count == 0`). Needs a live systemd-user daemon spike because the updater currently `Kernel.exec`s. Non-daemon users are also not nudged in this scope.

--- a/wiki/update-flow.md
+++ b/wiki/update-flow.md
@@ -25,7 +25,7 @@ tags: [architecture, daemon, bot, tui, update, decision]
 
 - **install.sh (bash)** — nudge-only today (`hive update`). Auto-update (re-run installer + ADR-031 self-re-exec when idle) is deferred to U7.
 - **brew** — nudge `brew upgrade ivankuznetsov/hive/hive`. hive never drives brew.
-- **aur** — nudge `yay -S hive-bin`. hive never drives the AUR helper.
+- **aur** — nudge `yay -Syu hive-bin` (mirrors `aur_command`'s `-Syu`; a DB sync is required or a stale local DB could install an older `hive-bin`). hive never drives the AUR helper.
 - **dev** — git clone; skipped entirely.
 
 ## Deferred (U7)


### PR DESCRIPTION
## Summary

During the fast dev-release period, a running hive never noticed it was behind. This adds a **daemon-driven update flow**: the always-running daemon probes the latest GitHub release on a throttled (~daily) cadence, and when the install is behind it records a *nudge* (version + exact update command) into a shared state file that the **TUI footer** renders and the **Telegram bot** pushes once per version.

- **install.sh / brew / aur** → nudge only, with the exact channel command (`hive update` / `brew upgrade …` / `yay -Syu hive-bin`). hive never drives a package manager.
- **dev** clones → skipped.
- Resilient by contract: an offline / rate-limited / malformed-JSON check degrades silently and never crashes a daemon tick.
- Opt-out via config: `update.check` and `update.auto` (both default on).

**Bash auto-update is intentionally deferred (U7)** — it needs a live systemd-user daemon spike (re-exec while idle). Every channel is nudge-only for now.

## Implementation units
- **U1** `lib/hive/update_check.rb` — release probe, returns `nil` on any failure (never raises).
- **U2** `lib/hive/update_check/state.rb` — shared JSON state (throttle / notified-version / nudge); atomic write, fail-closed, re-reads disk on every op so daemon/bot/TUI can't clobber each other's keys.
- **U4** `update.check` / `update.auto` config + `Config.load_global_update` validator.
- **U3** dispatcher `maybe_check_for_update` wired into `tick` (throttled, channel-branched, resilient).
- **U5** TUI footer (10s TTL read) + bot `push_update_nudge` (once per version, records notified only on delivery).

## Review
Ran a multi-agent review (general, tests, silent-failure, type-design, comments). No critical bugs. Addressed: removed a dead config ivar + misleading comment, aligned the AUR nudge to `-Syu` (a bare `-S` could install a stale `hive-bin`), added observability events for silent degradations, guarded `State#nudge`, and added cross-process / all-sends-fail / throttle-boundary tests.

## Test plan
- [x] `rake test` — 3966 runs, 0 failures (+ new unit suites for probe, state, dispatcher, bot, TUI, config)
- [x] rubocop clean, brakeman 0 warnings, bundler-audit clean
- [ ] Manual: run the daemon behind a release and confirm the TUI footer + one bot push

🤖 Generated with [Claude Code](https://claude.com/claude-code)