### PR TITLE
fix(update): register update-flow log events — daemon crash hotfix (v0.1.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes are documented here, newest first. Hive ships frequent micro-releases (see [docs/RELEASING.md](docs/RELEASING.md#versioning-policy)): each `vX.Y.Z` git tag gets a `## X.Y.Z` section with terse bullets — no `[Unreleased]` accumulator. Versioning is [SemVer](https://semver.org): PATCH for fixes and small changes (the common case), MINOR for notable features, MAJOR for milestones.
 
+## 0.1.8
+
+- Fixed a crash in v0.1.7's update flow: the daemon's update-check log events (`update_available`, `update_check_no_result`, `update_check_error`, `update_nudge_no_command`) and the bot's (`update_nudge_pushed`, `update_nudge_error`) were never added to the loggers' closed event enums, so a real daemon raised `ArgumentError` on its first "behind" tick and crashed (and the bot logged a spurious fatal). The events are now registered, with regression tests that exercise the real loggers.
+
 ## 0.1.7
 
 - Added a daemon-driven update flow: the daemon checks the latest GitHub release (~daily) and, when you're behind, surfaces a nudge with the exact update command in the TUI footer and as a one-time Telegram bot push (brew/AUR/install.sh are nudge-only — hive never drives your package manager). Opt out via `update.check` / `update.auto` in the global config.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hive-cli (0.1.7)
+    hive-cli (0.1.8)
       bubbletea (= 0.1.4)
       lipgloss (~> 0.2.2)
       sqlite3 (~> 2.0)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Hive ships as a rubygem (`hive-cli`) attached to each GitHub Release, signed wit
 | Platform | Channel |
 |----------|---------|
 | macOS arm64 | [`brew install ivankuznetsov/hive/hive`](https://github.com/ivankuznetsov/homebrew-hive) |
-| Ubuntu 22.04+ / glibc Linux x86_64/aarch64 | <code>tmpdir="$(mktemp -d)" && trap 'rm -rf "$tmpdir"' EXIT && curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.1.7/install.sh -o "$tmpdir/hive-install.sh" && bash "$tmpdir/hive-install.sh"</code> |
+| Ubuntu 22.04+ / glibc Linux x86_64/aarch64 | <code>tmpdir="$(mktemp -d)" && trap 'rm -rf "$tmpdir"' EXIT && curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.1.8/install.sh -o "$tmpdir/hive-install.sh" && bash "$tmpdir/hive-install.sh"</code> |
 | Arch Linux x86_64/aarch64 | [`yay -S hive-bin`](https://aur.archlinux.org/packages/hive-bin) |
 
 Prerequisites: **Ruby 3.4** (the gem and its runtime deps install against this), git ≥ 2.40, authenticated `claude` ≥ 2.1.118, `codex` ≥ 0.125.0 for the default execute agent, authenticated `gh`, `tmux` ≥ 3.0 when the project uses the default `claude.mode: tmux`, and Node.js/npm for managed QMD install/repair. The bash installer reports its own installer-side prereqs (`curl`, `jq`, `gem`, checksum tool) on first run; if npm is missing, Hive still installs and `hive doctor` reports the QMD gap non-fatally.

--- a/install.md
+++ b/install.md
@@ -59,8 +59,8 @@ Ubuntu 22.04+ / glibc Linux fallback (pin to the current release tag, not `main`
 ```bash
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
-# Release maintainers: bump v0.1.7 in both installer URLs when cutting a new stable release.
-curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.1.7/install.sh -o "$tmpdir/hive-install.sh"
+# Release maintainers: bump v0.1.8 in both installer URLs when cutting a new stable release.
+curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.1.8/install.sh -o "$tmpdir/hive-install.sh"
 bash "$tmpdir/hive-install.sh"
 ```
 
@@ -69,8 +69,8 @@ To inspect the installer first, run a dry-run before the real invocation. State 
 ```bash
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
-# Release maintainers: bump v0.1.7 in both installer URLs when cutting a new stable release.
-curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.1.7/install.sh -o "$tmpdir/hive-install.sh"
+# Release maintainers: bump v0.1.8 in both installer URLs when cutting a new stable release.
+curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.1.8/install.sh -o "$tmpdir/hive-install.sh"
 bash "$tmpdir/hive-install.sh" --dry-run
 bash "$tmpdir/hive-install.sh"
 ```

--- a/lib/hive.rb
+++ b/lib/hive.rb
@@ -1,5 +1,5 @@
 module Hive
-  VERSION = "0.1.7".freeze
+  VERSION = "0.1.8".freeze
   MIN_CLAUDE_VERSION = "2.1.118".freeze
   # Canonical GitHub org + repo. Referenced by the release probe
   # (UpdateCheck), the brew tap + installer URL (Commands::Update), etc.

--- a/lib/hive/bot/logger.rb
+++ b/lib/hive/bot/logger.rb
@@ -35,6 +35,8 @@ module Hive
         unknown_stage_label
         alert_store_corrupt
         deprecated_config
+        update_nudge_pushed
+        update_nudge_error
         fatal
       ].freeze
 

--- a/lib/hive/daemon/logger.rb
+++ b/lib/hive/daemon/logger.rb
@@ -44,6 +44,10 @@ module Hive
         gh_error
         marker_healed
         marker_heal_failed
+        update_available
+        update_check_no_result
+        update_check_error
+        update_nudge_no_command
         fatal
       ].freeze
 

--- a/schemas/hive-bot-log.v1.json
+++ b/schemas/hive-bot-log.v1.json
@@ -45,6 +45,8 @@
         "unknown_stage_label",
         "alert_store_corrupt",
         "deprecated_config",
+        "update_nudge_pushed",
+        "update_nudge_error",
         "fatal"
       ]
     }

--- a/test/unit/bot/supervisor_update_nudge_test.rb
+++ b/test/unit/bot/supervisor_update_nudge_test.rb
@@ -70,6 +70,34 @@ class HiveBotSupervisorUpdateNudgeTest < Minitest::Test
     assert_empty @telegram.messages
   end
 
+  # Regression (v0.1.7 P0): :update_nudge_pushed / :update_nudge_error were not
+  # in Hive::Bot::Logger::EVENTS, so a REAL bot logger raised ArgumentError on
+  # push. The FakeLogger accepts any event and hid it — exercise the real one.
+  def test_push_does_not_raise_against_real_bot_logger
+    require "hive/bot/logger"
+    log = File.join(@dir, "bot.log")
+    real_logger = Hive::Bot::Logger.new(path: log)
+    @state.set_nudge(latest: "0.1.7", channel: "brew", command: "brew upgrade x")
+    sup = Hive::Bot::Supervisor.new(
+      config: { "chat_id_allowlist" => [ 42 ], "conversation_ttl_sec" => 60, "poll_interval_sec" => 1 },
+      token: "t", logger: real_logger, telegram: @telegram,
+      status_watcher: Object.new, notification_dispatcher: Object.new,
+      router: Object.new, child_supervisor: Object.new,
+      conversation_store: Object.new, update_state: @state
+    )
+    sup.send(:push_update_nudge) # must NOT raise
+    real_logger.close
+    assert_match(/update_nudge_pushed/, File.read(log))
+  end
+
+  def test_all_bot_update_events_are_registered
+    require "hive/bot/logger"
+    %i[update_nudge_pushed update_nudge_error].each do |event|
+      assert_includes Hive::Bot::Logger::EVENTS, event,
+                      "Supervisor#push_update_nudge emits #{event}; an unregistered event raises in the bot loop"
+    end
+  end
+
   def test_push_swallows_state_errors
     boom = Object.new
     def boom.nudge = raise(StandardError, "state boom")

--- a/test/unit/daemon/dispatcher_update_check_test.rb
+++ b/test/unit/daemon/dispatcher_update_check_test.rb
@@ -70,6 +70,36 @@ class HiveDaemonDispatcherUpdateCheckTest < Minitest::Test
     logger.events.select { |n, _| n == name }
   end
 
+  # Regression (v0.1.7 P0): the dispatcher emitted update events that were not
+  # in Hive::Daemon::Logger::EVENTS, so a REAL daemon raised ArgumentError on
+  # the first behind-tick and crashed run_forever. Unit tests used a permissive
+  # StubLogger and never caught it. Exercise the real logger here.
+  def test_behind_tick_does_not_raise_against_real_daemon_logger
+    require "hive/daemon/logger"
+    log = File.join(@dir, "daemon.log")
+    logger = Hive::Daemon::Logger.new(path: log)
+    dispatcher = Hive::Daemon::Dispatcher.new(
+      config: { "daemon" => { "poll_interval_sec" => 30 }, "update" => { "check" => true, "auto" => true } },
+      controller: Hive::Daemon::ConcurrencyController.new(
+        max_concurrent_runs: 5, max_concurrent_per_project: 5, max_runs_per_day_per_project: 100
+      ),
+      supervisor: FakeSupervisor.new, status_consumer: FakeStatusConsumer.new, logger: logger,
+      update_state: @state, update_checker: -> { result(latest: "9.9.9", behind: true) },
+      channel_detector: -> { "brew" }
+    )
+    dispatcher.tick(now: T0) # must NOT raise
+    logger.close
+    assert_match(/update_available/, File.read(log))
+  end
+
+  def test_all_dispatcher_update_events_are_registered
+    require "hive/daemon/logger"
+    %i[update_available update_check_no_result update_check_error update_nudge_no_command].each do |event|
+      assert_includes Hive::Daemon::Logger::EVENTS, event,
+                      "Dispatcher#maybe_check_for_update emits #{event}; an unregistered event crashes the daemon tick"
+    end
+  end
+
   def test_behind_on_brew_sets_nudge_and_logs
     checker = Checker.new(result(latest: "0.1.7", behind: true))
     dispatcher, logger = build(checker: checker, channel: "brew")


### PR DESCRIPTION
## Summary
**P0 hotfix for v0.1.7.** The update flow's log events were never added to the loggers' closed event enums (`Hive::Daemon::Logger::EVENTS`, `Hive::Bot::Logger::EVENTS`), which raise `ArgumentError` on unknown events. A **real** daemon therefore raised on its first "behind" tick — the error escaped `maybe_check_for_update`'s rescue (which re-raised on its own unregistered `:update_check_error`) up through `tick` → `run_forever` → **crash**. The bot logged a spurious `:fatal`.

Unit tests injected a permissive stub logger, so this was invisible until a real process ran — exactly the gap the planned update-flow e2e targets.

- Register 4 daemon events + 2 bot events; add the 2 bot events to `schemas/hive-bot-log.v1.json`.
- Regression tests exercise the **real** loggers and assert every emitted update event is registered.
- Bump to **v0.1.8** (VERSION, Gemfile.lock, installer-URL refs, CHANGELOG).

## Test plan
- [x] `rake test` — 3995 runs, 0 failures
- [x] coverage gate 100%, rubocop/brakeman/bundler-audit clean
- [x] real-logger regression: behind-tick + bot push no longer raise
- [ ] tag `v0.1.8` after merge → `release.yml` publishes all channels

🤖 Generated with [Claude Code](https://claude.com/claude-code)