### PR TITLE
test(update): e2e for the update flow — real-process pipeline, flock proof, harness primitives

### DIFF
--- a/.github/actions/bot-e2e-setup/action.yml
+++ b/.github/actions/bot-e2e-setup/action.yml
@@ -1,0 +1,44 @@
+name: bot-e2e-setup
+description: >
+  Shared setup for the bot e2e jobs: Ruby + uv + Telethon, plus a freshly
+  bootstrapped scratch hive project (registered as "e2eproj") and a `hivebin`
+  wrapper so the bot's child dispatch resolves gems. Assumes the repo is
+  already checked out (a local composite action requires it).
+runs:
+  using: composite
+  steps:
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: "3.4"
+        bundler-cache: true
+
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v5
+
+    - name: Install Telethon
+      working-directory: test/e2e/tg
+      shell: bash
+      run: |
+        uv venv .venv
+        uv pip install --python .venv telethon
+
+    - name: Bootstrap a scratch hive project
+      shell: bash
+      env:
+        WORKSPACE: ${{ github.workspace }}
+        PROJ_ROOT: ${{ runner.temp }}
+      run: |
+        set -euo pipefail
+        proj="$PROJ_ROOT/e2eproj"
+        mkdir -p "$proj"
+        git -C "$proj" init -q
+        git -C "$proj" config user.email ci@example.com
+        git -C "$proj" config user.name "hive ci"
+        git -C "$proj" commit --allow-empty -m init -q
+        # Non-TTY stdin => `hive init` short-circuits to recommended defaults
+        # and registers the project (named after the dir: "e2eproj").
+        bundle exec ruby bin/hive init "$proj" --force < /dev/null
+        # Wrapper so the bot's child dispatch (`hive new ...`) resolves gems.
+        printf '#!/usr/bin/env bash\ncd "%s" && exec bundle exec ruby bin/hive "$@"\n' "$WORKSPACE" > "$PROJ_ROOT/hivebin"
+        chmod +x "$PROJ_ROOT/hivebin"

--- a/.github/workflows/bot-e2e.yml
+++ b/.github/workflows/bot-e2e.yml
@@ -70,3 +70,58 @@ jobs:
           TG_DRIVER_ID: ${{ secrets.TG_DRIVER_ID }}
           TG_SESSION: ${{ secrets.TG_SESSION }}
         run: .venv/bin/python run_e2e.py
+
+  # Runs AFTER idea-flow (never concurrently) — only one poller may hold the
+  # test token at a time. Asserts the bot proactively pushes the update nudge.
+  nudge-flow:
+    needs: idea-flow
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install Telethon
+        working-directory: test/e2e/tg
+        run: |
+          uv venv .venv
+          uv pip install --python .venv telethon
+
+      - name: Bootstrap a scratch hive project
+        env:
+          WORKSPACE: ${{ github.workspace }}
+          PROJ_ROOT: ${{ runner.temp }}
+        run: |
+          set -euo pipefail
+          proj="$PROJ_ROOT/e2eproj"
+          mkdir -p "$proj"
+          git -C "$proj" init -q
+          git -C "$proj" config user.email ci@example.com
+          git -C "$proj" config user.name "hive ci"
+          git -C "$proj" commit --allow-empty -m init -q
+          bundle exec ruby bin/hive init "$proj" --force < /dev/null
+          printf '#!/usr/bin/env bash\ncd "%s" && exec bundle exec ruby bin/hive "$@"\n' "$WORKSPACE" > "$PROJ_ROOT/hivebin"
+          chmod +x "$PROJ_ROOT/hivebin"
+
+      - name: Run headless update-nudge push E2E
+        working-directory: test/e2e/tg
+        env:
+          HIVE_REPO: ${{ github.workspace }}
+          BOT_LAUNCHER: "bundle exec ruby"
+          HIVE_BIN: ${{ runner.temp }}/hivebin
+          TG_CAPTURE_PROJECT: e2eproj
+          TG_BOT_USERNAME: Testivanshive_bot
+          HIVE_TEST_BOT_TOKEN: ${{ secrets.HIVE_TEST_BOT_TOKEN }}
+          TG_API_ID: ${{ secrets.TG_API_ID }}
+          TG_API_HASH: ${{ secrets.TG_API_HASH }}
+          TG_DRIVER_ID: ${{ secrets.TG_DRIVER_ID }}
+          TG_SESSION: ${{ secrets.TG_SESSION }}
+        run: .venv/bin/python run_nudge_e2e.py

--- a/.github/workflows/bot-e2e.yml
+++ b/.github/workflows/bot-e2e.yml
@@ -21,44 +21,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
-
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: "3.4"
-          bundler-cache: true
-
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v5
-
-      - name: Install Telethon
-        working-directory: test/e2e/tg
-        run: |
-          uv venv .venv
-          uv pip install --python .venv telethon
-
-      - name: Bootstrap a scratch hive project
-        env:
-          WORKSPACE: ${{ github.workspace }}
-          PROJ_ROOT: ${{ runner.temp }}
-        run: |
-          set -euo pipefail
-          proj="$PROJ_ROOT/e2eproj"
-          mkdir -p "$proj"
-          git -C "$proj" init -q
-          git -C "$proj" config user.email ci@example.com
-          git -C "$proj" config user.name "hive ci"
-          git -C "$proj" commit --allow-empty -m init -q
-          # Non-TTY stdin => `hive init` short-circuits to recommended defaults
-          # and registers the project (named after the dir: "e2eproj").
-          bundle exec ruby bin/hive init "$proj" --force < /dev/null
-          # Wrapper so the bot's child dispatch (`hive new ...`) resolves gems.
-          printf '#!/usr/bin/env bash\ncd "%s" && exec bundle exec ruby bin/hive "$@"\n' "$WORKSPACE" > "$PROJ_ROOT/hivebin"
-          chmod +x "$PROJ_ROOT/hivebin"
-
+      - uses: ./.github/actions/bot-e2e-setup
       - name: Run headless /idea E2E
         working-directory: test/e2e/tg
-        env:
+        env: &tg_env
           HIVE_REPO: ${{ github.workspace }}
           BOT_LAUNCHER: "bundle exec ruby"
           HIVE_BIN: ${{ runner.temp }}/hivebin
@@ -79,49 +45,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
-
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: "3.4"
-          bundler-cache: true
-
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v5
-
-      - name: Install Telethon
-        working-directory: test/e2e/tg
-        run: |
-          uv venv .venv
-          uv pip install --python .venv telethon
-
-      - name: Bootstrap a scratch hive project
-        env:
-          WORKSPACE: ${{ github.workspace }}
-          PROJ_ROOT: ${{ runner.temp }}
-        run: |
-          set -euo pipefail
-          proj="$PROJ_ROOT/e2eproj"
-          mkdir -p "$proj"
-          git -C "$proj" init -q
-          git -C "$proj" config user.email ci@example.com
-          git -C "$proj" config user.name "hive ci"
-          git -C "$proj" commit --allow-empty -m init -q
-          bundle exec ruby bin/hive init "$proj" --force < /dev/null
-          printf '#!/usr/bin/env bash\ncd "%s" && exec bundle exec ruby bin/hive "$@"\n' "$WORKSPACE" > "$PROJ_ROOT/hivebin"
-          chmod +x "$PROJ_ROOT/hivebin"
-
+      - uses: ./.github/actions/bot-e2e-setup
       - name: Run headless update-nudge push E2E
         working-directory: test/e2e/tg
-        env:
-          HIVE_REPO: ${{ github.workspace }}
-          BOT_LAUNCHER: "bundle exec ruby"
-          HIVE_BIN: ${{ runner.temp }}/hivebin
-          TG_CAPTURE_PROJECT: e2eproj
-          TG_BOT_USERNAME: Testivanshive_bot
-          HIVE_TEST_BOT_TOKEN: ${{ secrets.HIVE_TEST_BOT_TOKEN }}
-          TG_API_ID: ${{ secrets.TG_API_ID }}
-          TG_API_HASH: ${{ secrets.TG_API_HASH }}
-          TG_DRIVER_ID: ${{ secrets.TG_DRIVER_ID }}
-          TG_SESSION: ${{ secrets.TG_SESSION }}
+        env: *tg_env
         run: .venv/bin/python run_nudge_e2e.py

--- a/lib/hive/update_check.rb
+++ b/lib/hive/update_check.rb
@@ -13,6 +13,15 @@ module Hive
   module UpdateCheck
     API_URL = "https://api.github.com/repos/#{Hive::REPO_OWNER}/#{Hive::REPO_NAME}/releases/latest".freeze
 
+    # Base URL of the releases-latest endpoint. `HIVE_RELEASES_API_URL` overrides
+    # the GitHub default — primarily so an e2e can point a real process at a
+    # local stub server, but also a seam for forks / GitHub Enterprise /
+    # air-gapped mirrors. An exported-but-empty value is treated as unset.
+    def self.releases_url
+      override = ENV["HIVE_RELEASES_API_URL"]
+      override.nil? || override.empty? ? API_URL : override
+    end
+
     Result = Data.define(:current, :latest, :behind) do
       def behind? = behind
     end
@@ -34,7 +43,8 @@ module Hive
     end
 
     def fetch_latest_tag(http: nil, timeout: 5)
-      body = http ? http.call(API_URL) : http_get(API_URL, timeout: timeout)
+      url = releases_url
+      body = http ? http.call(url) : http_get(url, timeout: timeout)
       return nil if body.nil?
 
       JSON.parse(body)["tag_name"]
@@ -44,7 +54,7 @@ module Hive
 
     def http_get(url, timeout:)
       uri = URI(url)
-      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true,
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == "https",
                             open_timeout: timeout, read_timeout: timeout) do |http|
         req = Net::HTTP::Get.new(uri)
         req["Accept"] = "application/vnd.github+json"

--- a/test/e2e/lib/background_process.rb
+++ b/test/e2e/lib/background_process.rb
@@ -34,7 +34,7 @@ module Hive
         # SandboxEnv.with strips leaky bundler/version-manager vars and yields
         # the sandbox env; the child inherits that cleaned env at spawn time.
         SandboxEnv.with(@sandbox_dir, @run_home, @fake_claude_path) do |env|
-          @pid = Process.spawn(env.merge(stringify(@env_overrides)), *command, **spawn_opts)
+          @pid = Process.spawn(env.merge(SandboxEnv.stringify_env(@env_overrides)), *command, **spawn_opts)
         end
         Process.detach(@pid) # reap if it exits on its own; #stop still signals it
         self
@@ -45,30 +45,30 @@ module Hive
 
         Process.kill(0, @pid)
         true
-      rescue Errno::ESRCH
+      rescue Errno::ESRCH, Errno::EPERM
+        # ESRCH: gone. EPERM: the pid was recycled to another user's process,
+        # so OUR process is gone either way.
         false
       end
 
       # TERM the whole process group, then KILL after a short grace (mirrors
       # CliDriver#terminate). The grace is a kill-escalation delay, not a
       # condition wait — scenarios wait on file/log conditions, never on sleep.
+      #
+      # `pgroup: true` at spawn makes the child its own group leader, so its
+      # pgid == @pid; signal -@pid directly rather than re-deriving the pgid
+      # (which could itself raise on a reaped/recycled pid). ESRCH (already
+      # gone) and EPERM (pid recycled to a foreign process) are both no-ops.
       def stop(grace: 0.5)
         return unless @pid
 
-        pgid = Process.getpgid(@pid)
-        Process.kill("TERM", -pgid)
+        Process.kill("TERM", -@pid)
         sleep grace
-        Process.kill("KILL", -pgid)
-      rescue Errno::ESRCH
+        Process.kill("KILL", -@pid)
+      rescue Errno::ESRCH, Errno::EPERM
         nil
       ensure
         @pid = nil
-      end
-
-      private
-
-      def stringify(env)
-        env.each_with_object({}) { |(key, value), out| out[key.to_s] = value.nil? ? nil : value.to_s }
       end
     end
   end

--- a/test/e2e/lib/background_process.rb
+++ b/test/e2e/lib/background_process.rb
@@ -1,0 +1,75 @@
+require "rbconfig"
+require "fileutils"
+require_relative "paths"
+require_relative "sandbox_env"
+
+module Hive
+  module E2E
+    # A long-lived `hive` subprocess (e.g. `daemon start`, `bot start`) the
+    # harness starts and later stops. Unlike CliDriver (blocking, kill-on-
+    # timeout), this returns immediately and runs until #stop. The daemon/bot
+    # run ATTACHED (no `--detach`) so this owns the process group and can TERM
+    # the whole tree on teardown. stdout/stderr are captured to a log file for
+    # forensics; the process's own JSON-line logs go to its configured log_file.
+    class BackgroundProcess
+      attr_reader :pid, :log_path
+
+      def initialize(args:, sandbox_dir:, run_home:, env: {}, log_path: nil, fake_claude_path: Paths.fake_claude)
+        @args = args.map(&:to_s)
+        @sandbox_dir = sandbox_dir
+        @run_home = run_home
+        @env_overrides = env
+        @log_path = log_path
+        @fake_claude_path = fake_claude_path
+      end
+
+      def start
+        command = [ RbConfig.ruby, "-I#{Paths.lib_dir}", Paths.hive_bin, *@args ]
+        spawn_opts = { chdir: @sandbox_dir, pgroup: true }
+        if @log_path
+          FileUtils.mkdir_p(File.dirname(@log_path))
+          spawn_opts[:out] = @log_path
+          spawn_opts[:err] = %i[child out]
+        end
+        # SandboxEnv.with strips leaky bundler/version-manager vars and yields
+        # the sandbox env; the child inherits that cleaned env at spawn time.
+        SandboxEnv.with(@sandbox_dir, @run_home, @fake_claude_path) do |env|
+          @pid = Process.spawn(env.merge(stringify(@env_overrides)), *command, **spawn_opts)
+        end
+        Process.detach(@pid) # reap if it exits on its own; #stop still signals it
+        self
+      end
+
+      def alive?
+        return false unless @pid
+
+        Process.kill(0, @pid)
+        true
+      rescue Errno::ESRCH
+        false
+      end
+
+      # TERM the whole process group, then KILL after a short grace (mirrors
+      # CliDriver#terminate). The grace is a kill-escalation delay, not a
+      # condition wait — scenarios wait on file/log conditions, never on sleep.
+      def stop(grace: 0.5)
+        return unless @pid
+
+        pgid = Process.getpgid(@pid)
+        Process.kill("TERM", -pgid)
+        sleep grace
+        Process.kill("KILL", -pgid)
+      rescue Errno::ESRCH
+        nil
+      ensure
+        @pid = nil
+      end
+
+      private
+
+      def stringify(env)
+        env.each_with_object({}) { |(key, value), out| out[key.to_s] = value.nil? ? nil : value.to_s }
+      end
+    end
+  end
+end

--- a/test/e2e/lib/background_process_test.rb
+++ b/test/e2e/lib/background_process_test.rb
@@ -32,6 +32,8 @@ class E2EBackgroundProcessTest < Minitest::Test
       proc.stop
       sleep 0.05 while proc.alive? && Time.now < deadline
       refute proc.alive?, "stop must terminate the process group"
+    ensure
+      proc&.stop # never leak the daemon if an assertion above fails
     end
   end
 

--- a/test/e2e/lib/background_process_test.rb
+++ b/test/e2e/lib/background_process_test.rb
@@ -1,0 +1,55 @@
+require_relative "../../test_helper"
+require_relative "background_process"
+require "tmpdir"
+
+class E2EBackgroundProcessTest < Minitest::Test
+  # Use a trivial long-lived hive invocation: `hive daemon start` in an empty
+  # sandbox runs attached and ticks. We assert lifecycle (start → alive → stop),
+  # not daemon behavior.
+  def with_sandbox
+    Dir.mktmpdir("sandbox") do |sandbox|
+      Dir.mktmpdir("home") do |home|
+        File.write(File.join(sandbox, "Gemfile"), "source \"https://rubygems.org\"\n")
+        yield sandbox, home
+      end
+    end
+  end
+
+  def test_starts_attached_and_stops
+    with_sandbox do |sandbox, home|
+      log = File.join(home, "bg.log")
+      proc = Hive::E2E::BackgroundProcess.new(
+        args: %w[daemon start],
+        sandbox_dir: sandbox, run_home: home,
+        env: { "HIVE_DAEMON_NO_AUTO_REEXEC" => "1" }, log_path: log
+      ).start
+
+      # Wait for liveness by polling, not a fixed sleep.
+      deadline = Time.now + 10
+      sleep 0.05 until proc.alive? || Time.now > deadline
+      assert proc.alive?, "background daemon should be running"
+
+      proc.stop
+      sleep 0.05 while proc.alive? && Time.now < deadline
+      refute proc.alive?, "stop must terminate the process group"
+    end
+  end
+
+  def test_child_inherits_sandbox_home
+    with_sandbox do |sandbox, home|
+      log = File.join(home, "bg.log")
+      proc = Hive::E2E::BackgroundProcess.new(
+        args: %w[daemon start],
+        sandbox_dir: sandbox, run_home: home,
+        env: { "HIVE_DAEMON_NO_AUTO_REEXEC" => "1" }, log_path: log
+      ).start
+      deadline = Time.now + 10
+      # The daemon writes its pid file under the sandbox HIVE_HOME, proving the
+      # child inherited the injected env rather than the real home.
+      sleep 0.05 until File.exist?(File.join(home, ".daemon.pid")) || Time.now > deadline
+      assert File.exist?(File.join(home, ".daemon.pid")), "daemon pid file should land under the sandbox home"
+    ensure
+      proc&.stop
+    end
+  end
+end

--- a/test/e2e/lib/cli_driver.rb
+++ b/test/e2e/lib/cli_driver.rb
@@ -45,7 +45,7 @@ module Hive
         started = monotonic_time
         result = nil
         SandboxEnv.with(@sandbox_dir, @run_home, @fake_claude_path) do |env|
-          result = spawn_and_capture(env.merge(stringify_env(env_overrides)), args, cwd, timeout)
+          result = spawn_and_capture(env.merge(SandboxEnv.stringify_env(env_overrides)), args, cwd, timeout)
         end
         duration = monotonic_time - started
         result = Result.new(stdout: result.stdout, stderr: result.stderr, exit_code: result.exit_code,
@@ -62,10 +62,6 @@ module Hive
       private
 
       ProcessResult = Data.define(:stdout, :stderr, :exit_code, :timed_out)
-
-      def stringify_env(env)
-        env.each_with_object({}) { |(key, value), out| out[key.to_s] = value.nil? ? nil : value.to_s }
-      end
 
       def spawn_and_capture(env, args, cwd, timeout)
         stdout = +""

--- a/test/e2e/lib/path_safety.rb
+++ b/test/e2e/lib/path_safety.rb
@@ -23,6 +23,18 @@ module Hive
         text
       end
 
+      # Resolve `value` against the FIRST of `roots` that contains it, falling
+      # back to the first root so an escape (or malformed path) fails closed
+      # with that root's error. Lets a path live under the sandbox project dir
+      # OR its sibling run_home (HIVE_HOME) — the update flow's state and
+      # install-channel marker live under run_home. StepExecutor#expand_path and
+      # ReproScriptWriter both call this so the live run and the generated
+      # repro.sh validate scenario paths identically.
+      def contained_path_any!(roots, value, label)
+        root = roots.find { |r| contained?(r, File.expand_path(value.to_s, r)) } || roots.first
+        contained_path!(root, value, label)
+      end
+
       def contained_path!(root, value, label)
         root_path = File.expand_path(root)
         value_text = value.to_s

--- a/test/e2e/lib/releases_stub_server.rb
+++ b/test/e2e/lib/releases_stub_server.rb
@@ -41,6 +41,7 @@ module Hive
       end
 
       def respond(client)
+        client.timeout = 2 # don't let a half-open client park the serve loop (IO#timeout, Ruby 3.2+)
         client.gets("\r\n\r\n") # consume request line + headers
         body = JSON.generate("tag_name" => @tag)
         client.write("HTTP/1.1 200 OK\r\n" \

--- a/test/e2e/lib/releases_stub_server.rb
+++ b/test/e2e/lib/releases_stub_server.rb
@@ -1,0 +1,57 @@
+require "socket"
+require "json"
+
+module Hive
+  module E2E
+    # A throwaway localhost HTTP server that serves a controlled GitHub
+    # `releases/latest` response, so a real `hive` process pointed at it via
+    # `HIVE_RELEASES_API_URL` sees a deterministic `tag_name`. Hermetic by
+    # construction (binds 127.0.0.1 on an ephemeral port; no network). Plain
+    # `TCPServer` rather than WEBrick to avoid a bundled-gem dependency.
+    class ReleasesStubServer
+      attr_reader :url
+
+      def initialize(tag:)
+        @tag = tag.to_s
+        @server = TCPServer.new("127.0.0.1", 0)
+        port = @server.addr[1]
+        @url = "http://127.0.0.1:#{port}/releases/latest"
+        @running = true
+        @thread = Thread.new { serve_loop }
+      end
+
+      def stop
+        @running = false
+        @server.close
+        @thread&.join(2)
+      end
+
+      private
+
+      def serve_loop
+        while @running
+          client =
+            begin
+              @server.accept
+            rescue IOError, Errno::EBADF
+              break # socket closed by #stop
+            end
+          respond(client)
+        end
+      end
+
+      def respond(client)
+        client.gets("\r\n\r\n") # consume request line + headers
+        body = JSON.generate("tag_name" => @tag)
+        client.write("HTTP/1.1 200 OK\r\n" \
+                     "Content-Type: application/json\r\n" \
+                     "Content-Length: #{body.bytesize}\r\n" \
+                     "Connection: close\r\n\r\n#{body}")
+      rescue StandardError
+        nil # a dropped/!malformed client connection must not kill the loop
+      ensure
+        client&.close
+      end
+    end
+  end
+end

--- a/test/e2e/lib/releases_stub_server_test.rb
+++ b/test/e2e/lib/releases_stub_server_test.rb
@@ -23,9 +23,10 @@ class E2EReleasesStubServerTest < Minitest::Test
     server = Hive::E2E::ReleasesStubServer.new(tag: "v1.0.0")
     port = URI(server.url).port
     server.stop
-    # Port should be free to rebind after stop.
+    # Re-binding the same port must not raise Errno::EADDRINUSE — that raise-free
+    # rebind is the proof stop released the port. Assert it's the same port.
     rebind = TCPServer.new("127.0.0.1", port)
-    assert rebind, "port #{port} should be reusable after stop"
+    assert_equal port, rebind.addr[1], "stop should free the port for rebinding"
     rebind.close
   end
 end

--- a/test/e2e/lib/releases_stub_server_test.rb
+++ b/test/e2e/lib/releases_stub_server_test.rb
@@ -1,0 +1,31 @@
+require_relative "../../test_helper"
+require_relative "releases_stub_server"
+require "hive/update_check"
+
+class E2EReleasesStubServerTest < Minitest::Test
+  def test_serves_controlled_tag_to_a_real_update_check_probe
+    server = Hive::E2E::ReleasesStubServer.new(tag: "v999.0.0")
+    begin
+      # A real UpdateCheck process pointed at the stub (no http: injection)
+      # must parse the controlled tag and report "behind".
+      ENV["HIVE_RELEASES_API_URL"] = server.url
+      result = Hive::UpdateCheck.latest(current: "0.1.0")
+      assert result, "probe against the stub should return a result"
+      assert_equal "999.0.0", result.latest
+      assert result.behind?
+    ensure
+      ENV.delete("HIVE_RELEASES_API_URL")
+      server.stop
+    end
+  end
+
+  def test_stop_releases_the_port
+    server = Hive::E2E::ReleasesStubServer.new(tag: "v1.0.0")
+    port = URI(server.url).port
+    server.stop
+    # Port should be free to rebind after stop.
+    rebind = TCPServer.new("127.0.0.1", port)
+    assert rebind, "port #{port} should be reusable after stop"
+    rebind.close
+  end
+end

--- a/test/e2e/lib/repro_script_writer.rb
+++ b/test/e2e/lib/repro_script_writer.rb
@@ -9,7 +9,7 @@ require_relative "string_expander"
 module Hive
   module E2E
     class ReproScriptWriter
-      LIVE_TMUX_KINDS = %w[tui_keys tui_expect wait_subprocess].freeze
+      LIVE_TMUX_KINDS = %w[tui_keys tui_expect tui_refute wait_subprocess].freeze
 
       def initialize(scenario_dir:, sandbox_dir:, run_home:, steps:, failed_index:, scenario_name: nil, expander_context: nil)
         @scenario_dir = scenario_dir
@@ -77,6 +77,18 @@ module Hive
           emit_assertion(step)
         when *LIVE_TMUX_KINDS
           [ "# step #{step.position} skipped: requires live tmux (kind=#{step.kind})" ]
+        when "start_releases_stub"
+          [ "# step #{step.position} start_releases_stub: serves release tag " \
+            "#{expand_string(step.args["tag"].to_s).inspect} — a harness-owned local stub; " \
+            "set HIVE_RELEASES_API_URL to a server returning that tag to replay manually" ]
+        when "spawn_background"
+          bg = expand(step.args.fetch("args")).map(&:to_s)
+          [ "# step #{step.position} spawn_background id=#{expand_string(step.args["id"].to_s)}: " \
+            "harness runs `hive #{bg.join(' ')}` attached (HIVE_DAEMON_NO_AUTO_REEXEC=1, " \
+            "HIVE_RELEASES_API_URL=<stub>) and stops it at teardown — run it manually to replay" ]
+        when "stop_process"
+          [ "# step #{step.position} stop_process id=#{expand_string(step.args["id"].to_s)}: " \
+            "harness-managed teardown; no-op in a flat repro" ]
         else
           [ "# step #{step.position} skipped: kind=#{step.kind} (stateful)" ]
         end
@@ -149,7 +161,7 @@ module Hive
       def emit_write_file(step)
         path = expand_string(step.args.fetch("path").to_s)
         content = expand_string(step.args.fetch("content").to_s)
-        full = PathSafety.contained_path!(@sandbox_dir, path, "write_file path")
+        full = PathSafety.contained_path_any!([ @sandbox_dir, @run_home ], path, "write_file path")
         [
           "# step #{step.position} write_file: #{path}",
           "mkdir -p #{Shellwords.escape(File.dirname(full))}",
@@ -196,7 +208,7 @@ module Hive
       end
 
       def emit_assertion(step)
-        path = PathSafety.contained_path!(@sandbox_dir, expand_string(step.args.fetch("path").to_s), "#{step.kind} path")
+        path = PathSafety.contained_path_any!([ @sandbox_dir, @run_home ], expand_string(step.args.fetch("path").to_s), "#{step.kind} path")
         ruby = case step.kind
         when "state_assert" then state_assert_ruby(step, path)
         when "log_assert" then log_assert_ruby(step, path)
@@ -383,8 +395,7 @@ module Hive
       end
 
       def expand_path(value)
-        expanded = expand_string(value.to_s)
-        PathSafety.contained_path!(@sandbox_dir, expanded, "scenario path")
+        PathSafety.contained_path_any!([ @sandbox_dir, @run_home ], expand_string(value.to_s), "scenario path")
       end
     end
   end

--- a/test/e2e/lib/repro_script_writer_test.rb
+++ b/test/e2e/lib/repro_script_writer_test.rb
@@ -9,6 +9,37 @@ class E2EReproScriptWriterTest < Minitest::Test
     Hive::E2E::Step.new(kind: kind, args: args, description: "", position: position)
   end
 
+  # Regression (ce-code-review): update-flow scenarios write/assert under
+  # {run_home} and use the new stateful step kinds. The repro must NOT abort
+  # at "step 1 not replayable" — run_home paths replay, and the harness-owned
+  # kinds emit informative comments instead of a bare skip.
+  def test_run_home_paths_and_new_kinds_produce_a_usable_repro
+    Dir.mktmpdir("scenario") do |scenario_dir|
+      Dir.mktmpdir("sandbox") do |sandbox|
+        Dir.mktmpdir("home") do |run_home|
+          steps = [
+            make_step("write_file", args: { "path" => "{run_home}/install-channel", "content" => "brew\n" }, position: 1),
+            make_step("start_releases_stub", args: { "tag" => "v999.0.0" }, position: 2),
+            make_step("spawn_background", args: { "id" => "daemon", "args" => %w[daemon start] }, position: 3),
+            make_step("state_assert", args: { "path" => "{run_home}/update_check.json", "match" => "999" }, position: 4),
+            make_step("stop_process", args: { "id" => "daemon" }, position: 5)
+          ]
+          body = File.read(Hive::E2E::ReproScriptWriter.new(
+            scenario_dir: scenario_dir, sandbox_dir: sandbox, run_home: run_home,
+            steps: steps, failed_index: 5
+          ).write)
+
+          refute_match(/not replayable/, body, "run_home write_file must replay, not abort the repro")
+          assert_match(/cat > \S*install-channel/, body, "run_home write_file should emit a heredoc")
+          assert_includes body, File.join(run_home, "update_check.json")
+          assert_match(/start_releases_stub: serves release tag/, body)
+          assert_match(/spawn_background id=daemon: harness runs `hive daemon start`/, body)
+          assert_match(/stop_process id=daemon/, body)
+        end
+      end
+    end
+  end
+
   def test_writes_executable_script_with_shebang_env_and_cli_command
     Dir.mktmpdir("scenario") do |scenario_dir|
       Dir.mktmpdir("sandbox") do |sandbox|

--- a/test/e2e/lib/sandbox_env.rb
+++ b/test/e2e/lib/sandbox_env.rb
@@ -32,6 +32,12 @@ module Hive
 
       module_function
 
+      # Stringify an env-overrides hash: keys to strings, values to strings
+      # except nil (which Process.spawn / Open3 treat as "unset this var").
+      def stringify_env(env)
+        env.each_with_object({}) { |(key, value), out| out[key.to_s] = value.nil? ? nil : value.to_s }
+      end
+
       def with(sandbox_dir, run_home, fake_claude_path = Paths.fake_claude)
         Bundler.with_unbundled_env do
           LEAKY_KEYS.each { |key| ENV.delete(key) }

--- a/test/e2e/lib/scenario_parser.rb
+++ b/test/e2e/lib/scenario_parser.rb
@@ -17,13 +17,15 @@ module Hive
       end
 
       STEP_KINDS = %w[
-        cli tui_keys tui_expect state_assert json_assert seed_state write_file
+        cli tui_keys tui_expect tui_refute state_assert json_assert seed_state write_file
         register_project wait_subprocess editor_action log_assert ruby_block
+        start_releases_stub spawn_background stop_process
       ].freeze
 
       REQUIRED_KEYS = {
         "cli" => %w[args],
         "tui_expect" => %w[anchor],
+        "tui_refute" => %w[anchor],
         "state_assert" => %w[path],
         "json_assert" => %w[args schema],
         "seed_state" => %w[stage],
@@ -31,7 +33,10 @@ module Hive
         "register_project" => %w[name],
         "editor_action" => %w[args],
         "log_assert" => %w[path match],
-        "ruby_block" => %w[block]
+        "ruby_block" => %w[block],
+        "start_releases_stub" => %w[tag],
+        "spawn_background" => %w[id args],
+        "stop_process" => %w[id]
       }.freeze
 
       def self.parse(path)
@@ -81,7 +86,7 @@ module Hive
 
       def validate_step_types(kind, step)
         case kind
-        when "cli", "json_assert", "editor_action"
+        when "cli", "json_assert", "editor_action", "spawn_background"
           invalid!("#{kind}.args must be an array", line_for(kind)) unless step["args"].is_a?(Array)
         when "tui_keys"
           key_count = %w[keys text].count { |key| step.key?(key) }

--- a/test/e2e/lib/step_executor.rb
+++ b/test/e2e/lib/step_executor.rb
@@ -429,7 +429,12 @@ module Hive
 
       def expand_path(value)
         expanded = expand_string(value.to_s)
+        # Allow the sandbox project dir OR its HIVE_HOME (run_home) — both are
+        # test-controlled. The update flow's state (update_check.json) and the
+        # install-channel marker live under run_home, a sibling of the project.
         PathSafety.contained_path!(@ctx.sandbox_dir, expanded, "scenario path")
+      rescue ArgumentError
+        PathSafety.contained_path!(@ctx.run_home, expanded, "scenario path")
       end
 
       def contained_relative_path(root, value, label)

--- a/test/e2e/lib/step_executor.rb
+++ b/test/e2e/lib/step_executor.rb
@@ -433,15 +433,10 @@ module Hive
       end
 
       def expand_path(value)
-        expanded = expand_string(value.to_s)
         # Allow the sandbox project dir OR its HIVE_HOME (run_home) — both are
         # test-controlled. The update flow's state (update_check.json) and the
         # install-channel marker live under run_home, a sibling of the project.
-        # Branch on the explicit `contained?` predicate rather than rescuing the
-        # sandbox-escape ArgumentError, so a genuinely malformed path still
-        # surfaces as itself (and escaping BOTH roots fails closed below).
-        root = PathSafety.contained?(@ctx.run_home, expanded) ? @ctx.run_home : @ctx.sandbox_dir
-        PathSafety.contained_path!(root, expanded, "scenario path")
+        PathSafety.contained_path_any!([ @ctx.sandbox_dir, @ctx.run_home ], expand_string(value.to_s), "scenario path")
       end
 
       def contained_relative_path(root, value, label)

--- a/test/e2e/lib/step_executor.rb
+++ b/test/e2e/lib/step_executor.rb
@@ -6,7 +6,9 @@ require "hive/lock"
 require "hive/markers"
 require "hive/stages"
 require_relative "artifact_capture"
+require_relative "background_process"
 require_relative "cli_driver"
+require_relative "releases_stub_server"
 require_relative "diff_walker"
 require_relative "json_validator"
 require_relative "paths"
@@ -78,8 +80,18 @@ module Hive
       rescue StandardError => e
         on_failure(e, started)
       ensure
+        teardown_harness_processes
         @tmux_lifecycle.stop_asciinema(delete: !@preserve_cast)
         @tmux_lifecycle.cleanup
+      end
+
+      # Reap any long-lived processes / stub servers a scenario started, so they
+      # never outlive the scenario (TERM the daemon/bot pgroup, close the stub).
+      def teardown_harness_processes
+        (@ctx.harness_state[:background] || {}).each_value { |proc| proc.stop }
+        @ctx.harness_state[:releases_stub]&.stop
+      rescue StandardError
+        nil
       end
 
       private
@@ -251,10 +263,72 @@ module Hive
 
       def step_log_assert(step)
         path = expand_path(step.args.fetch("path"))
+        regex = Regexp.new(expand_string(step.args.fetch("match")))
+        # Optional polling: a long-lived process (e.g. the bot) writes its log
+        # asynchronously, so wait up to `timeout` for the line to appear — an
+        # explicit condition wait, not a fixed sleep.
+        deadline = Time.now + (step.args["timeout"] || 0).to_f
+        loop do
+          return if File.exist?(path) && File.read(path).match?(regex)
+          break if Time.now >= deadline
+
+          sleep 0.2
+        end
         raise StepFailure.new(step, "log file not found: #{path}") unless File.exist?(path)
 
-        regex = Regexp.new(expand_string(step.args.fetch("match")))
-        raise StepFailure.new(step, "expected #{path} to match #{regex.inspect}") unless File.read(path).match?(regex)
+        raise StepFailure.new(step, "expected #{path} to match #{regex.inspect}")
+      end
+
+      def step_start_releases_stub(step)
+        tag = expand_string(step.args.fetch("tag"))
+        @ctx.harness_state[:releases_stub]&.stop
+        @ctx.harness_state[:releases_stub] = ReleasesStubServer.new(tag: tag)
+      end
+
+      def step_spawn_background(step)
+        id = expand_string(step.args.fetch("id"))
+        args = expand(step.args.fetch("args"))
+        env = expand(step.args["env"] || {})
+        # Auto-inject the running stub's URL so scenarios don't have to thread
+        # an ephemeral port through; an explicit env entry still wins.
+        if (stub = @ctx.harness_state[:releases_stub]) && !env.key?("HIVE_RELEASES_API_URL")
+          env = env.merge("HIVE_RELEASES_API_URL" => stub.url)
+        end
+        procs = (@ctx.harness_state[:background] ||= {})
+        procs[id]&.stop
+        procs[id] = BackgroundProcess.new(
+          args: args, sandbox_dir: @ctx.sandbox_dir, run_home: @ctx.run_home,
+          env: env, log_path: File.join(@ctx.run_home, "background", "#{id}.log")
+        ).start
+      end
+
+      def step_stop_process(step)
+        id = expand_string(step.args.fetch("id"))
+        proc = (@ctx.harness_state[:background] || {})[id]
+        raise StepFailure.new(step, "no background process #{id.inspect}") unless proc
+
+        proc.stop
+      end
+
+      def step_tui_refute(step)
+        tmux = @tmux_lifecycle.start_session
+        anchor = expand_string(step.args.fetch("anchor"))
+        deadline = monotonic_time + (step.args["timeout"] || 2.0).to_f
+        # Assert absence only on a STABLE frame (two equal captures), so we
+        # don't pass on a mid-render frame that simply hasn't drawn it yet.
+        previous = nil
+        loop do
+          pane = tmux.capture_pane
+          if pane == previous
+            raise StepFailure.new(step, "expected TUI to NOT contain #{anchor.inspect}") if pane.include?(anchor)
+            return
+          end
+          previous = pane
+          break if monotonic_time >= deadline
+
+          sleep 0.1
+        end
+        raise StepFailure.new(step, "expected TUI to NOT contain #{anchor.inspect}") if previous.to_s.include?(anchor)
       end
 
       # ---- helpers -------------------------------------------------------

--- a/test/e2e/lib/step_executor.rb
+++ b/test/e2e/lib/step_executor.rb
@@ -85,16 +85,21 @@ module Hive
         @tmux_lifecycle.cleanup
       end
 
+      private
+
       # Reap any long-lived processes / stub servers a scenario started, so they
       # never outlive the scenario (TERM the daemon/bot pgroup, close the stub).
+      # Each stop is rescued independently so one failure can't abandon the rest.
       def teardown_harness_processes
-        (@ctx.harness_state[:background] || {}).each_value { |proc| proc.stop }
-        @ctx.harness_state[:releases_stub]&.stop
+        (@ctx.harness_state[:background] || {}).each_value { |proc| safe_stop(proc) }
+        safe_stop(@ctx.harness_state[:releases_stub])
+      end
+
+      def safe_stop(stoppable)
+        stoppable&.stop
       rescue StandardError
         nil
       end
-
-      private
 
       def dispatch(step)
         send("step_#{step.kind}", step)
@@ -432,9 +437,11 @@ module Hive
         # Allow the sandbox project dir OR its HIVE_HOME (run_home) — both are
         # test-controlled. The update flow's state (update_check.json) and the
         # install-channel marker live under run_home, a sibling of the project.
-        PathSafety.contained_path!(@ctx.sandbox_dir, expanded, "scenario path")
-      rescue ArgumentError
-        PathSafety.contained_path!(@ctx.run_home, expanded, "scenario path")
+        # Branch on the explicit `contained?` predicate rather than rescuing the
+        # sandbox-escape ArgumentError, so a genuinely malformed path still
+        # surfaces as itself (and escaping BOTH roots fails closed below).
+        root = PathSafety.contained?(@ctx.run_home, expanded) ? @ctx.run_home : @ctx.sandbox_dir
+        PathSafety.contained_path!(root, expanded, "scenario path")
       end
 
       def contained_relative_path(root, value, label)

--- a/test/e2e/scenarios/update_flow_pipeline.yml
+++ b/test/e2e/scenarios/update_flow_pipeline.yml
@@ -1,0 +1,44 @@
+name: update_flow_pipeline
+description: >
+  Full pipeline (behind): a real `hive daemon` probes a controlled "latest"
+  release via the local stub, detects it is behind, writes update_check.json,
+  and the nudge surfaces in `hive daemon status --json` and the TUI footer.
+tags: [update, daemon]
+steps:
+  # Force the brew install channel so the nudge command is the real brew string.
+  - kind: write_file
+    path: "{run_home}/install-channel"
+    content: "brew\n"
+
+  # Local stub serves a version far above the running one → guaranteed "behind".
+  - kind: start_releases_stub
+    tag: "v999.0.0"
+
+  # Start the real daemon attached; the stub URL is auto-injected as
+  # HIVE_RELEASES_API_URL. Disable ADR-031 self-re-exec for a stable test.
+  - kind: spawn_background
+    id: daemon
+    args: [daemon, start]
+    env:
+      HIVE_DAEMON_NO_AUTO_REEXEC: "1"
+
+  # The update check runs on the first tick; wait for the nudge to land.
+  - kind: state_assert
+    path: "{run_home}/update_check.json"
+    match: '"latest": "999\.0\.0"'
+    timeout: 30
+
+  # --json surface: agents can see the available update + current version.
+  - kind: json_assert
+    args: [daemon, status, --json]
+    schema: hive-daemon-status
+    pick: [update_nudge, latest]
+    equals: "999.0.0"
+  - kind: json_assert
+    args: [daemon, status, --json]
+    schema: hive-daemon-status
+    pick: [update_nudge, command]
+    equals: "brew upgrade ivankuznetsov/hive/hive"
+
+  - kind: stop_process
+    id: daemon

--- a/test/e2e/scenarios/update_flow_tui_footer.yml
+++ b/test/e2e/scenarios/update_flow_tui_footer.yml
@@ -1,0 +1,34 @@
+name: update_flow_tui_footer
+description: >
+  TUI footer surfaces the update nudge while behind. A real daemon writes the
+  nudge; the TUI (launched after the daemon stops — it reads update_check.json
+  independently) renders "update <ver>: <command>" in its footer.
+  (tui-tagged: runs where a tmux/TTY is available, like the other tui scenarios.)
+tags: [update, tui]
+steps:
+  - kind: write_file
+    path: "{run_home}/install-channel"
+    content: "brew\n"
+  - kind: start_releases_stub
+    tag: "v999.0.0"
+  - kind: spawn_background
+    id: daemon
+    args: [daemon, start]
+    env:
+      HIVE_DAEMON_NO_AUTO_REEXEC: "1"
+  - kind: state_assert
+    path: "{run_home}/update_check.json"
+    match: '"latest": "999\.0\.0"'
+    timeout: 30
+  - kind: stop_process
+    id: daemon
+
+  # TUI boots, then its footer renders the nudge.
+  - kind: tui_expect
+    anchor: "hive tui"
+    timeout: 10
+  - kind: tui_expect
+    anchor: "update 999.0.0"
+    timeout: 10
+  - kind: tui_keys
+    keys: "q"

--- a/test/e2e/scenarios/update_flow_tui_no_nudge.yml
+++ b/test/e2e/scenarios/update_flow_tui_no_nudge.yml
@@ -1,0 +1,16 @@
+name: update_flow_tui_no_nudge
+description: >
+  Negative: with no nudge present, the TUI footer shows no update notice. Pairs
+  with update_flow_tui_footer.yml (positive) to verify both states (per the
+  project E2E rules: assert presence AND absence).
+  (tui-tagged: runs where a tmux/TTY is available.)
+tags: [update, tui]
+steps:
+  - kind: tui_expect
+    anchor: "hive tui"
+    timeout: 10
+  - kind: tui_refute
+    anchor: "update 999"
+    timeout: 3
+  - kind: tui_keys
+    keys: "q"

--- a/test/e2e/scenarios/update_flow_up_to_date.yml
+++ b/test/e2e/scenarios/update_flow_up_to_date.yml
@@ -1,0 +1,36 @@
+name: update_flow_up_to_date
+description: >
+  Up-to-date path: the stub serves a version at/below the running one, so the
+  daemon's check finds nothing behind — no nudge is written and
+  `hive daemon status --json` reports update_nudge null.
+tags: [update, daemon]
+steps:
+  - kind: write_file
+    path: "{run_home}/install-channel"
+    content: "brew\n"
+
+  # A version below the running one → never "behind".
+  - kind: start_releases_stub
+    tag: "v0.0.1"
+
+  - kind: spawn_background
+    id: daemon
+    args: [daemon, start]
+    env:
+      HIVE_DAEMON_NO_AUTO_REEXEC: "1"
+
+  # Wait until the check has run (last_check_at is recorded at the start of the
+  # check, immediately before the synchronous probe), then assert no nudge.
+  - kind: state_assert
+    path: "{run_home}/update_check.json"
+    match: '"last_check_at": "20'
+    timeout: 30
+
+  - kind: json_assert
+    args: [daemon, status, --json]
+    schema: hive-daemon-status
+    pick: [update_nudge]
+    equals: null
+
+  - kind: stop_process
+    id: daemon

--- a/test/e2e/tg/_drive.py
+++ b/test/e2e/tg/_drive.py
@@ -72,20 +72,23 @@ def drive(client, bot, project):
     return 0 if ok else 1
 
 
-def drive_nudge(client, bot, version, command):
+def drive_nudge(client, bot, version, command, after_id=0):
     """Assert the bot proactively pushes the update nudge.
 
     Unlike the /idea flow, the push is unsolicited: the bot's status loop reads
-    the seeded update_check.json and sends "hive <version> is available …".
-    The driver sends nothing — it just waits for the incoming push and checks
-    both the version and the exact update command made it through.
+    the seeded update_check.json and sends "hive <version> is available …". The
+    driver sends nothing — it waits for the incoming push and checks both the
+    version and the exact update command. `after_id` MUST be a chat baseline
+    captured BEFORE the bot was started, so a same-version push left by a prior
+    run can't satisfy the wait (false PASS) — and so the real push, which can
+    arrive the instant the bot boots, is never excluded (false FAIL).
     """
     if not client.is_user_authorized():
         print("FAIL driver not authorized; run login.py first")
         return 1
 
     marker = f"{version} is available"
-    push = wait_for(client, bot, lambda m: marker in (m.message or ""))
+    push = wait_for(client, bot, lambda m: marker in (m.message or ""), after_id=after_id)
     if not push:
         print(f"FAIL no update nudge push containing {marker!r}")
         return 1

--- a/test/e2e/tg/_drive.py
+++ b/test/e2e/tg/_drive.py
@@ -70,3 +70,26 @@ def drive(client, bot, project):
     ok = project in ack.message
     print(f"{'PASS' if ok else 'FAIL'} ack={ack.message!r}")
     return 0 if ok else 1
+
+
+def drive_nudge(client, bot, version, command):
+    """Assert the bot proactively pushes the update nudge.
+
+    Unlike the /idea flow, the push is unsolicited: the bot's status loop reads
+    the seeded update_check.json and sends "hive <version> is available …".
+    The driver sends nothing — it just waits for the incoming push and checks
+    both the version and the exact update command made it through.
+    """
+    if not client.is_user_authorized():
+        print("FAIL driver not authorized; run login.py first")
+        return 1
+
+    marker = f"{version} is available"
+    push = wait_for(client, bot, lambda m: marker in (m.message or ""))
+    if not push:
+        print(f"FAIL no update nudge push containing {marker!r}")
+        return 1
+
+    ok = command in push.message
+    print(f"{'PASS' if ok else 'FAIL'} nudge={push.message!r}")
+    return 0 if ok else 1

--- a/test/e2e/tg/run_nudge_e2e.py
+++ b/test/e2e/tg/run_nudge_e2e.py
@@ -6,14 +6,16 @@ Seeds a nudge into the bot's update_check.json, starts the test bot as a child
 "hive <ver> is available … Update: <command>" to the driver account. The driver
 sends nothing — the push is unsolicited, fired from the bot's status loop.
 
-Unlike the daemon-side e2e scenarios, no release probe runs here: we seed the
-nudge directly, so this isolates the bot's push surface end-to-end over real
-Telegram. Manual / secrets-gated, same as run_e2e.py.
+Runs under an isolated HIVE_HOME (a fresh tmpdir) so neither the seed nor the
+bot ever touches the developer's real ~/.local/state/hive on a local run. No
+release probe runs — we seed the nudge directly, isolating the bot's push
+surface end-to-end over real Telegram. Manual / secrets-gated, same as run_e2e.py.
 """
 import json
 import os
 import subprocess
 import sys
+import tempfile
 
 from telethon.sync import TelegramClient
 
@@ -24,15 +26,28 @@ VERSION = "999.0.0"
 COMMAND = "brew upgrade ivankuznetsov/hive/hive"
 
 
-def seed_nudge():
-    # Resolve the bot's update_check.json path under the SAME env the bot runs
-    # with, so the seed lands exactly where the bot's status loop reads it.
-    path = subprocess.check_output(
-        ["ruby", "-Ilib", "-e",
-         'require "hive/update_check/state"; print Hive::UpdateCheck::State.default_path'],
-        cwd=REPO, text=True).strip()
+def seed_nudge(hive_home):
+    """Write a nudge to the bot's update_check.json under the isolated HIVE_HOME.
+
+    Resolves the path via the SAME env the bot runs with (so the seed lands
+    where the status loop reads it), then refuses to write unless it is inside
+    the isolated home — a guard against ever clobbering real developer state.
+    Returns the path on success, None on any failure (with a FAIL line).
+    """
+    env = dict(os.environ, HIVE_HOME=hive_home)
+    try:
+        path = subprocess.check_output(
+            ["ruby", "-Ilib", "-e",
+             'require "hive/update_check/state"; print Hive::UpdateCheck::State.default_path'],
+            cwd=REPO, env=env, text=True, stderr=subprocess.STDOUT).strip()
+    except subprocess.CalledProcessError as e:
+        print(f"FAIL could not resolve update_check.json path: {e.output.strip()}")
+        return None
+    if not path or not os.path.realpath(path).startswith(os.path.realpath(hive_home) + os.sep):
+        print(f"FAIL refusing to seed outside the isolated HIVE_HOME (resolved {path!r})")
+        return None
     os.makedirs(os.path.dirname(path), exist_ok=True)
-    with open(path, "w") as fh:
+    with open(path, "w", encoding="utf-8") as fh:
         json.dump({
             "schema_version": 1,
             "last_check_at": None,
@@ -40,20 +55,33 @@ def seed_nudge():
             "nudge": {"latest": VERSION, "channel": "brew", "command": COMMAND},
         }, fh)
     print(f"seeded nudge ({VERSION}) at {path}")
+    return path
 
 
 def main():
-    seed_nudge()
-    proc = start_bot()
-    if proc is None:
-        return 1  # start_bot already printed the FAIL + bot output
+    hive_home = tempfile.mkdtemp(prefix="hive-nudge-e2e-")
+    os.environ["HIVE_HOME"] = hive_home  # isolates the seed AND the spawned bot
+    if seed_nudge(hive_home) is None:
+        return 1
     client = TelegramClient(_session(), API_ID, API_HASH)
     client.connect()
     try:
-        return drive_nudge(client, BOT, VERSION, COMMAND)
+        if not client.is_user_authorized():
+            print("FAIL driver not authorized; run login.py first")
+            return 1
+        # Baseline the chat BEFORE the bot starts pushing, so the wait excludes
+        # any same-version push from a prior run but catches this run's push
+        # even though it can arrive the instant the bot boots.
+        baseline = max((m.id for m in client.iter_messages(BOT, limit=1)), default=0)
+        proc = start_bot()
+        if proc is None:
+            return 1  # start_bot already printed the FAIL + bot output
+        try:
+            return drive_nudge(client, BOT, VERSION, COMMAND, after_id=baseline)
+        finally:
+            stop_bot(proc)
     finally:
         client.disconnect()
-        stop_bot(proc)
 
 
 if __name__ == "__main__":

--- a/test/e2e/tg/run_nudge_e2e.py
+++ b/test/e2e/tg/run_nudge_e2e.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Headless E2E: the bot proactively pushes the update-available nudge.
+
+Seeds a nudge into the bot's update_check.json, starts the test bot as a child
+(reusing run_e2e.py's lifecycle), and asserts via Telethon that the bot pushes
+"hive <ver> is available … Update: <command>" to the driver account. The driver
+sends nothing — the push is unsolicited, fired from the bot's status loop.
+
+Unlike the daemon-side e2e scenarios, no release probe runs here: we seed the
+nudge directly, so this isolates the bot's push surface end-to-end over real
+Telegram. Manual / secrets-gated, same as run_e2e.py.
+"""
+import json
+import os
+import subprocess
+import sys
+
+from telethon.sync import TelegramClient
+
+from _drive import drive_nudge
+from run_e2e import API_HASH, API_ID, BOT, REPO, _session, start_bot, stop_bot
+
+VERSION = "999.0.0"
+COMMAND = "brew upgrade ivankuznetsov/hive/hive"
+
+
+def seed_nudge():
+    # Resolve the bot's update_check.json path under the SAME env the bot runs
+    # with, so the seed lands exactly where the bot's status loop reads it.
+    path = subprocess.check_output(
+        ["ruby", "-Ilib", "-e",
+         'require "hive/update_check/state"; print Hive::UpdateCheck::State.default_path'],
+        cwd=REPO, text=True).strip()
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as fh:
+        json.dump({
+            "schema_version": 1,
+            "last_check_at": None,
+            "last_notified_version": None,  # null → the bot pushes once
+            "nudge": {"latest": VERSION, "channel": "brew", "command": COMMAND},
+        }, fh)
+    print(f"seeded nudge ({VERSION}) at {path}")
+
+
+def main():
+    seed_nudge()
+    proc = start_bot()
+    if proc is None:
+        return 1  # start_bot already printed the FAIL + bot output
+    client = TelegramClient(_session(), API_ID, API_HASH)
+    client.connect()
+    try:
+        return drive_nudge(client, BOT, VERSION, COMMAND)
+    finally:
+        client.disconnect()
+        stop_bot(proc)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/integration/update_check_state_cross_process_test.rb
+++ b/test/integration/update_check_state_cross_process_test.rb
@@ -1,0 +1,70 @@
+require "test_helper"
+require "tmpdir"
+require "json"
+
+# U7 — cross-process flock proof (plan 2026-05-27-003).
+#
+# The unit test `test_cross_process_writes_do_not_clobber_each_other` drives two
+# State instances in ONE process — serialized by the in-process Mutex, so it
+# can't prove the cross-process `flock`. This is its real-process counterpart:
+# two independent OS processes hammer the same `update_check.json`, one writing
+# `nudge` (daemon role) and one writing `last_notified_version` (bot role).
+#
+# Without the flock, each op's load!→mutate→persist read-modify-write races: a
+# process that loaded an EARLY value then writes the whole @data back AFTER the
+# other process's latest write clobbers it with a stale value. Each process
+# writes a monotonically increasing value, so the proof is that BOTH keys end at
+# each process's LAST write — a stale clobber leaves one behind. (Asserting
+# merely non-nil would be vacuous: every write persists all keys, so neither
+# key goes nil once both have written.) Characterized with the flock bypassed:
+# ~40% of runs show a regressed value; with the flock it is deterministic.
+class UpdateCheckStateCrossProcessTest < Minitest::Test
+  ITERATIONS = 500
+
+  def test_concurrent_processes_do_not_clobber_each_others_keys
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, "update_check.json")
+      go = File.join(dir, "go")
+      writer = write_child_script(dir)
+      lib = File.expand_path("../../lib", __dir__)
+
+      # Spawn both, then release them together via the `go` barrier so their
+      # write loops genuinely overlap (otherwise one could finish before the
+      # other starts and the flock would never be contended).
+      pids = %w[daemon bot].map do |role|
+        Process.spawn(RbConfig.ruby, "-I#{lib}", writer, path, role, ITERATIONS.to_s, go)
+      end
+      File.write(go, "go")
+      statuses = pids.map { |pid| Process.waitpid2(pid).last }
+
+      assert(statuses.all?(&:success?), "both writer processes should exit cleanly: #{statuses.inspect}")
+      last = ITERATIONS - 1
+      data = JSON.parse(File.read(path))
+      assert_equal "9.9.#{last}", data.dig("nudge", "latest"),
+                   "the daemon's LAST nudge must win — a stale bot RMW clobbering it means the flock failed"
+      assert_equal "8.8.#{last}", data["last_notified_version"],
+                   "the bot's LAST notified-version must win — a stale daemon RMW clobbering it means the flock failed"
+    end
+  end
+
+  private
+
+  def write_child_script(dir)
+    path = File.join(dir, "cross_process_writer.rb")
+    File.write(path, <<~RUBY)
+      require "hive/update_check/state"
+      state = Hive::UpdateCheck::State.new(path: ARGV[0])
+      role = ARGV[1]
+      go = ARGV[3]
+      sleep 0.001 until File.exist?(go) # start barrier — both loops begin together
+      Integer(ARGV[2]).times do |i|
+        if role == "daemon"
+          state.set_nudge(latest: "9.9.\#{i}", channel: "brew", command: "hive update")
+        else
+          state.record_notified!("8.8.\#{i}")
+        end
+      end
+    RUBY
+    path
+  end
+end

--- a/test/unit/update_check_test.rb
+++ b/test/unit/update_check_test.rb
@@ -113,4 +113,22 @@ class UpdateCheckTest < Minitest::Test
       assert_equal "0.2.0", result.latest
     end
   end
+
+  def test_http_get_use_ssl_follows_the_url_scheme
+    response = Net::HTTPOK.new("1.1", "200", "OK")
+    response.instance_variable_set(:@read, true)
+    response.instance_variable_set(:@body, '{"tag_name":"v1.0.0"}')
+    fake_http = Object.new
+    fake_http.define_singleton_method(:request) { |_req| response }
+    captured = []
+    stub = lambda do |*_args, **kwargs, &blk|
+      captured << kwargs[:use_ssl]
+      blk.call(fake_http)
+    end
+    with_replaced_singleton_method(Net::HTTP, :start, stub) do
+      with_env("HIVE_RELEASES_API_URL" => "https://example.test/x") { Hive::UpdateCheck.latest(current: "0.1.0") }
+      with_env("HIVE_RELEASES_API_URL" => "http://127.0.0.1:9/x") { Hive::UpdateCheck.latest(current: "0.1.0") }
+    end
+    assert_equal [ true, false ], captured, "use_ssl must follow the URL scheme (https→true, http→false)"
+  end
 end

--- a/test/unit/update_check_test.rb
+++ b/test/unit/update_check_test.rb
@@ -86,4 +86,31 @@ class UpdateCheckTest < Minitest::Test
       assert_nil Hive::UpdateCheck.latest(current: "0.1.5"), "a non-2xx response yields no info"
     end
   end
+
+  def test_releases_url_defaults_to_github
+    with_env("HIVE_RELEASES_API_URL" => nil) do
+      assert_equal Hive::UpdateCheck::API_URL, Hive::UpdateCheck.releases_url
+    end
+  end
+
+  def test_releases_url_honors_env_override
+    with_env("HIVE_RELEASES_API_URL" => "http://127.0.0.1:9999/releases/latest") do
+      assert_equal "http://127.0.0.1:9999/releases/latest", Hive::UpdateCheck.releases_url
+    end
+  end
+
+  def test_releases_url_treats_empty_override_as_unset
+    with_env("HIVE_RELEASES_API_URL" => "") do
+      assert_equal Hive::UpdateCheck::API_URL, Hive::UpdateCheck.releases_url
+    end
+  end
+
+  def test_latest_probes_the_overridden_url
+    with_env("HIVE_RELEASES_API_URL" => "http://localhost:1234/x") do
+      seen = nil
+      result = Hive::UpdateCheck.latest(current: "0.1.5", http: ->(url) { seen = url; '{"tag_name":"v0.2.0"}' })
+      assert_equal "http://localhost:1234/x", seen, "the probe must hit the overridden URL"
+      assert_equal "0.2.0", result.latest
+    end
+  end
 end


### PR DESCRIPTION
## Summary
Implements the update-flow e2e plan (`2026-05-27-003`). The headline is proven with **real processes**: a live `hive daemon`, pointed at a local stub release, detects "behind", writes `update_check.json`, and the nudge surfaces in `hive daemon status --json`.

### Units
- **U1** — `HIVE_RELEASES_API_URL` override on `Hive::UpdateCheck` (also a forks/Enterprise/air-gapped seam); `http_get` now respects the URL scheme. Unit-tested.
- **U2** — `ReleasesStubServer` harness primitive (zero-dep `TCPServer`) serving a controlled `tag_name`. Lib-tested.
- **U3** — `BackgroundProcess` primitive: starts `hive daemon`/`bot` **attached** (no `--detach`), TERMs the pgroup on teardown; `start_releases_stub`/`spawn_background`/`stop_process` steps + `log_assert` polling. Lib-tested against a real daemon.
- **U4** — `tui_refute` step (footer absence assertion).
- **U5** — scenarios: `update_flow_pipeline` (behind → nudge in `--json`) and `update_flow_up_to_date` (not behind → `update_nudge` null) **pass locally**; `update_flow_tui_footer` + `update_flow_tui_no_nudge` are `tui`-tagged for CI.
- **U7** — `test/integration/update_check_state_cross_process_test.rb`: two real processes hammer one `update_check.json`; asserts each process's last write survives. **Characterized**: ~40% lost-update without the flock, deterministic with it.

### Verified locally
`rake test` 4000/0 · coverage **100%** · rubocop/brakeman/bundler-audit clean · `rake e2e --filter daemon` → both daemon scenarios pass · `rake e2e:lib_test` green for the new primitives.

### Notes / not in this PR
- **TUI footer scenarios run in CI, not locally** — *no* tui scenario runs in this environment (the pre-existing `tui_two_pane_navigate` fails identically: tmux/TTY). They follow the working tui-scenario pattern.
- **U6 (real-process bot push) deferred**: a hermetic real `hive bot start` needs a Telegram-endpoint seam (analogous to `HIVE_RELEASES_API_URL`) the client doesn't have. The push is already hermetically covered by `supervisor_update_nudge_test` + the v0.1.8 real-`Bot::Logger` test; the live path is the already-deferred opt-in Telegram leg.
- Pre-existing unrelated failure in `e2e:lib_test`: `json_validator_test` (status-v2 schema) fails on clean `main` too — untouched here.

## Test plan
- [x] `rake test`, coverage 100%, linters
- [x] daemon e2e scenarios pass with a real daemon
- [ ] CI runs the `tui`-tagged footer scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)