### PR TITLE
fix(bot): acknowledge successful /idea capture (silent picker) + headless E2E

### DIFF
--- a/.github/workflows/bot-e2e.yml
+++ b/.github/workflows/bot-e2e.yml
@@ -7,6 +7,10 @@ name: bot-e2e
 # a time, so this must not run concurrently or on every push.
 on:
   workflow_dispatch:
+  # Temporary: lets the workflow run on this feature branch before it lands on
+  # the default branch (where workflow_dispatch registers). Remove before merge.
+  push:
+    branches: [fix-idea-ack]
 
 concurrency:
   group: bot-e2e

--- a/.github/workflows/bot-e2e.yml
+++ b/.github/workflows/bot-e2e.yml
@@ -7,10 +7,6 @@ name: bot-e2e
 # a time, so this must not run concurrently or on every push.
 on:
   workflow_dispatch:
-  # Temporary: lets the workflow run on this feature branch before it lands on
-  # the default branch (where workflow_dispatch registers). Remove before merge.
-  push:
-    branches: [fix-idea-ack]
 
 concurrency:
   group: bot-e2e

--- a/.github/workflows/bot-e2e.yml
+++ b/.github/workflows/bot-e2e.yml
@@ -1,0 +1,72 @@
+name: bot-e2e
+
+# Headless end-to-end test of the Telegram bot /idea capture flow. Drives a
+# real @BotFather test bot via a Telethon user-client (account session stored
+# as the TG_SESSION secret). Manual-only: automating a user account against
+# Telegram is gentle-use-only, and only one poller may hold the test token at
+# a time, so this must not run concurrently or on every push.
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: bot-e2e
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  idea-flow:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install Telethon
+        working-directory: test/e2e/tg
+        run: |
+          uv venv .venv
+          uv pip install --python .venv telethon
+
+      - name: Bootstrap a scratch hive project
+        env:
+          WORKSPACE: ${{ github.workspace }}
+          PROJ_ROOT: ${{ runner.temp }}
+        run: |
+          set -euo pipefail
+          proj="$PROJ_ROOT/e2eproj"
+          mkdir -p "$proj"
+          git -C "$proj" init -q
+          git -C "$proj" config user.email ci@example.com
+          git -C "$proj" config user.name "hive ci"
+          git -C "$proj" commit --allow-empty -m init -q
+          # Non-TTY stdin => `hive init` short-circuits to recommended defaults
+          # and registers the project (named after the dir: "e2eproj").
+          bundle exec ruby bin/hive init "$proj" --force < /dev/null
+          # Wrapper so the bot's child dispatch (`hive new ...`) resolves gems.
+          printf '#!/usr/bin/env bash\ncd "%s" && exec bundle exec ruby bin/hive "$@"\n' "$WORKSPACE" > "$PROJ_ROOT/hivebin"
+          chmod +x "$PROJ_ROOT/hivebin"
+
+      - name: Run headless /idea E2E
+        working-directory: test/e2e/tg
+        env:
+          HIVE_REPO: ${{ github.workspace }}
+          BOT_LAUNCHER: "bundle exec ruby"
+          HIVE_BIN: ${{ runner.temp }}/hivebin
+          TG_CAPTURE_PROJECT: e2eproj
+          TG_BOT_USERNAME: Testivanshive_bot
+          HIVE_TEST_BOT_TOKEN: ${{ secrets.HIVE_TEST_BOT_TOKEN }}
+          TG_API_ID: ${{ secrets.TG_API_ID }}
+          TG_API_HASH: ${{ secrets.TG_API_HASH }}
+          TG_DRIVER_ID: ${{ secrets.TG_DRIVER_ID }}
+          TG_SESSION: ${{ secrets.TG_SESSION }}
+        run: .venv/bin/python run_e2e.py

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,10 @@
 .qmd/
 /.llm-wiki/qmd-cache/
 .worktrees/
+
+# Telegram E2E headless client (Telethon) — local secrets/artifacts
+test/e2e/tg/.venv/
+test/e2e/tg/*.session
+test/e2e/tg/*.session-journal
+test/e2e/tg/.code_hash
+**/__pycache__/

--- a/docs/solutions/ui-bugs/idea-picker-tap-no-acknowledgment-2026-05-27.md
+++ b/docs/solutions/ui-bugs/idea-picker-tap-no-acknowledgment-2026-05-27.md
@@ -1,0 +1,106 @@
+---
+title: Telegram /idea picker tap gave no acknowledgment (silent-on-success dispatch)
+date: 2026-05-27
+category: ui-bugs
+module: hive/bot
+problem_type: ui_bug
+component: service_object
+severity: medium
+related_components:
+  - tooling
+symptoms:
+  - "Tapping a project in the /idea picker produced no reply — the button looked dead"
+  - "A second tap of the same project button replied \"That idea picker expired. Send /idea <text> again.\""
+  - "For daemon-off projects the captured inbox idea produced zero follow-up signal"
+root_cause: logic_error
+resolution_type: code_fix
+tags:
+  - telegram-bot
+  - idea-capture
+  - supervisor
+  - child-process
+  - callback-handler
+  - exit-code
+  - notification-suppression
+---
+
+# Telegram /idea picker tap gave no acknowledgment (silent-on-success dispatch)
+
+## Problem
+
+Picking a project from the Telegram `/idea` picker dispatched `hive new` as a child process, but `Supervisor#child_completion_text` returned `nil` for every exit-0 child. A successful idea capture therefore produced no reply — the picker button looked dead.
+
+## Symptoms
+
+- After `/idea <text>`, tapping a project in the inline picker appeared to do nothing (no confirmation, no error).
+- A confused second tap replied: `That idea picker expired. Send /idea <text> again.`
+- The idea was actually captured into `1-inbox` the whole time — there was just no acknowledgment, and no delayed follow-up either: inbox tasks carry action `ready_to_brainstorm`, which `NotificationDispatcher#suppress_ready_action?` suppresses when the project daemon is disabled.
+
+## What Didn't Work
+
+No real dead ends — this was diagnosed first try by tracing the full causal chain. The trap is that the failure *looks* like a dispatch or token-expiry bug: the visible message is "idea picker expired", and the picker token is consumed on first tap (`@pending_ideas.delete(token)` at `lib/hive/bot/handlers/callback_handlers.rb:138-140`). It is actually a missing-ack bug.
+
+Future readers: do **not** chase the token/expiry logic in `CallbackHandlers#idea_project`. The token consumption and the "expired" branch are correct. The first tap succeeds silently; the re-tap only *reveals* the silence. The bug lives in the reaper's silent-on-success path, not the picker.
+
+## Solution
+
+Commit `64f8db64`, `lib/hive/bot/supervisor.rb`.
+
+Before:
+
+```ruby
+elsif child.exit_code == 0
+  # Clean success — no message. Operators see this signal via the
+  # next status row (or its absence). The "Command completed" ack
+  # was operational chatter with no actionable content.
+  nil
+```
+
+After:
+
+```ruby
+elsif child.exit_code == 0
+  # Clean success — no message for most commands ... The lone
+  # exception is `hive new`: idea capture is fire-and-forget with no
+  # status row the operator is watching ...
+  new_capture_text(child)
+```
+
+```ruby
+# argv[0] is rewritten to the resolved hive binary by
+# ChildSupervisor#normalize_hive_bin, so key on the verb at argv[1].
+def new_capture_text(child)
+  argv = Array(child.command_argv)
+  return nil unless argv[1].to_s == "new"
+
+  project = child.project || argv[2]
+  suffix = project ? " in #{project}" : ""
+  "Captured your idea#{suffix}. It's in the inbox — move it to 2-brainstorm to start."
+end
+```
+
+Detection keys on `argv[1]`, **not** `argv[0]`: `ChildSupervisor#normalize_hive_bin` rewrites `argv[0]` to a resolved absolute binary path (e.g. `/usr/local/bin/hive`), so the literal `"hive"` is gone by the time the reaper sees it — but the verb (`"new"`) is stable at index 1. All other exit-0 commands still return `nil`.
+
+## Why This Works
+
+The root cause is two compounding gaps:
+
+1. The dispatch path (`CallbackHandlers#idea_project` → `dispatch_then_reply` → `hive new`) was **silent on success**.
+2. The resulting `1-inbox` state has **no follow-up signal** — its `ready_to_brainstorm` action is suppressed with the daemon off, and there is no status row the operator is watching for a freshly-captured idea.
+
+Most commands are fine staying silent because their effect surfaces in the next status row or a downstream notification; `hive new` had neither, so the only correct fix is an explicit ack at the moment the result lands. `/approve` and `/done` share the silent-success shape but were deliberately left unchanged: they degrade gracefully — a re-tap hits `WRONG_STAGE` → "Already advanced by another device", and the stage advance emits a downstream notification.
+
+## Prevention
+
+- Tests added in `test/unit/bot/supervisor_test.rb`:
+  - `test_child_completion_text_acknowledges_successful_idea_capture` — confirms the ack names the project.
+  - `test_child_completion_text_acknowledges_capture_when_hive_bin_resolved` — locks in `argv[1]` detection against the resolved-binary-path regression.
+  - `test_child_completion_text_stays_silent_for_non_new_success` — guards the silent default for all other commands.
+- **General guard:** fire-and-forget dispatch that is silent on success needs an explicit acknowledgment whenever the result lands in a state that has no follow-up signal (no status row, no downstream notification, suppressed action).
+- **How to spot other instances:** audit every `dispatch_then_reply` / `dispatch_commands` callback for commands whose success produces neither a status-row change the operator is watching nor a downstream push. Each such command needs its own confirmation in `child_completion_text`. Flag any new exit-0 branch that returns `nil` unconditionally and pair it with the question: "is there a follow-up signal for this command's result state?"
+
+## Related Issues
+
+- GitHub #96 — `feat(bot): notify on legacy_stage_dirs transition` (closed); adjacent bot-notification-completeness work.
+- GitHub #91 — Bot lacks Refresh-diagnosis equivalent of TUI R keystroke (closed); adjacent bot-feedback work.
+- `docs/solutions/architecture-patterns/daemon-plan-approval-policy-exception-2026-05-15.md` — thematic only: another "durable success produced no observable advance" surface, different mechanism.

--- a/docs/solutions/ui-bugs/idea-picker-tap-no-acknowledgment-2026-05-27.md
+++ b/docs/solutions/ui-bugs/idea-picker-tap-no-acknowledgment-2026-05-27.md
@@ -11,7 +11,7 @@ related_components:
 symptoms:
   - "Tapping a project in the /idea picker produced no reply — the button looked dead"
   - "A second tap of the same project button replied \"That idea picker expired. Send /idea <text> again.\""
-  - "For daemon-off projects the captured inbox idea produced zero follow-up signal"
+  - "The captured inbox idea produced no immediate signal — its ready_to_brainstorm notification is suppressed on daemon-on projects and only fires on a later poll tick when daemon-off"
 root_cause: logic_error
 resolution_type: code_fix
 tags:
@@ -34,7 +34,7 @@ Picking a project from the Telegram `/idea` picker dispatched `hive new` as a ch
 
 - After `/idea <text>`, tapping a project in the inline picker appeared to do nothing (no confirmation, no error).
 - A confused second tap replied: `That idea picker expired. Send /idea <text> again.`
-- The idea was actually captured into `1-inbox` the whole time — there was just no acknowledgment, and no delayed follow-up either: inbox tasks carry action `ready_to_brainstorm`, which `NotificationDispatcher#suppress_ready_action?` suppresses when the project daemon is disabled.
+- The idea was actually captured into `1-inbox` the whole time — there was just no acknowledgment, and no *immediate* follow-up either: inbox tasks carry action `ready_to_brainstorm`, which `NotificationDispatcher#suppress_ready_action?` suppresses when the project daemon is **enabled** (the daemon dispatches the transition itself); when the daemon is off the alert fires, but only on a later dispatcher poll tick, never at tap time.
 
 ## What Didn't Work
 
@@ -44,7 +44,7 @@ Future readers: do **not** chase the token/expiry logic in `CallbackHandlers#ide
 
 ## Solution
 
-Commit `64f8db64`, `lib/hive/bot/supervisor.rb`.
+PR #226, `lib/hive/bot/supervisor.rb`.
 
 Before:
 
@@ -86,7 +86,7 @@ Detection keys on `argv[1]`, **not** `argv[0]`: `ChildSupervisor#normalize_hive_
 The root cause is two compounding gaps:
 
 1. The dispatch path (`CallbackHandlers#idea_project` → `dispatch_then_reply` → `hive new`) was **silent on success**.
-2. The resulting `1-inbox` state has **no follow-up signal** — its `ready_to_brainstorm` action is suppressed with the daemon off, and there is no status row the operator is watching for a freshly-captured idea.
+2. The resulting `1-inbox` state has **no immediate follow-up signal** — its `ready_to_brainstorm` action is suppressed entirely when the daemon is on, and when the daemon is off it only fires on a later poll tick (never at tap time); there is no status row the operator is watching for a freshly-captured idea.
 
 Most commands are fine staying silent because their effect surfaces in the next status row or a downstream notification; `hive new` had neither, so the only correct fix is an explicit ack at the moment the result lands. `/approve` and `/done` share the silent-success shape but were deliberately left unchanged: they degrade gracefully — a re-tap hits `WRONG_STAGE` → "Already advanced by another device", and the stage advance emits a downstream notification.
 

--- a/lib/hive/bot/supervisor.rb
+++ b/lib/hive/bot/supervisor.rb
@@ -626,13 +626,28 @@ module Hive
         elsif child.exit_code == Hive::ExitCodes::TEMPFAIL
           "Try again - another run holds the lock"
         elsif child.exit_code == 0
-          # Clean success — no message. Operators see this signal via the
-          # next status row (or its absence). The "Command completed" ack
-          # was operational chatter with no actionable content.
-          nil
+          # Clean success — no message for most commands. Operators see the
+          # signal via the next status row (or its absence). The lone
+          # exception is `hive new`: idea capture is fire-and-forget with no
+          # status row the operator is watching, so silence made a successful
+          # capture look like a dead button — and because the picker token is
+          # consumed on tap, a confused re-tap then reported "idea picker
+          # expired". Acknowledge it so the operator knows the idea landed.
+          new_capture_text(child)
         else
           "Command failed with exit #{child.exit_code || 'unknown'}; see #{child.log_path}"
         end
+      end
+
+      # argv[0] is rewritten to the resolved hive binary by
+      # ChildSupervisor#normalize_hive_bin, so key on the verb at argv[1].
+      def new_capture_text(child)
+        argv = Array(child.command_argv)
+        return nil unless argv[1].to_s == "new"
+
+        project = child.project || argv[2]
+        suffix = project ? " in #{project}" : ""
+        "Captured your idea#{suffix}. It's in the inbox — move it to 2-brainstorm to start."
       end
 
       QUEUE_DISPLAY_CAP = 10

--- a/test/e2e/tg/_drive.py
+++ b/test/e2e/tg/_drive.py
@@ -52,6 +52,9 @@ def drive(client, bot, project):
         for btn in row:
             if btn.text.replace("★", "").strip() == project:
                 target = btn
+                break
+        if target:
+            break
     if not target:
         labels = [b.text for row in picker.buttons for b in row]
         print(f"FAIL project '{project}' not in picker; saw {labels}")

--- a/test/e2e/tg/_drive.py
+++ b/test/e2e/tg/_drive.py
@@ -1,0 +1,69 @@
+"""Shared /idea drive logic for the headless E2E harness.
+
+Both entrypoints reuse this: run_e2e.py (owns the bot child, CI path) and
+drive_idea.py (bare driver invoked by run_idea_e2e.sh). Keeping the
+send -> tap-picker -> assert-ack sequence in one place stops the two
+drivers from drifting (e.g. the ack string or the star-prefix label rule).
+"""
+import time
+
+POLL_INTERVAL_SEC = 1.5
+DEFAULT_TIMEOUT_SEC = 40
+SCAN_LIMIT = 8
+ACK_MARKER = "Captured your idea"
+
+
+def wait_for(client, bot, predicate, timeout=DEFAULT_TIMEOUT_SEC, after_id=0):
+    """Poll the bot chat for the newest incoming message matching predicate."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        for msg in client.iter_messages(bot, limit=SCAN_LIMIT):
+            if msg.id <= after_id or msg.out:
+                continue
+            if predicate(msg):
+                return msg
+        time.sleep(POLL_INTERVAL_SEC)
+    return None
+
+
+def drive(client, bot, project):
+    """Send /idea, tap the project picker, assert the capture ack.
+
+    Returns a process exit code (0 PASS / 1 FAIL) and prints a single
+    PASS/FAIL line plus the derived idea text (IDEA_TEXT=...).
+    """
+    if not client.is_user_authorized():
+        print("FAIL driver not authorized; run login.py first")
+        return 1
+
+    baseline = max((m.id for m in client.iter_messages(bot, limit=1)), default=0)
+    nonce = f"e2e ack probe {int(time.time())}"
+    print(f"IDEA_TEXT={nonce}")
+    client.send_message(bot, f"/idea {nonce}")
+
+    picker = wait_for(client, bot, lambda m: bool(m.buttons), after_id=baseline)
+    if not picker:
+        print("FAIL no project picker appeared")
+        return 1
+
+    # Button label may be plain or star-prefixed for the last-used project.
+    target = None
+    for row in picker.buttons:
+        for btn in row:
+            if btn.text.replace("★", "").strip() == project:
+                target = btn
+    if not target:
+        labels = [b.text for row in picker.buttons for b in row]
+        print(f"FAIL project '{project}' not in picker; saw {labels}")
+        return 1
+    target.click()
+
+    ack = wait_for(client, bot, lambda m: ACK_MARKER in (m.message or ""),
+                   after_id=picker.id)
+    if not ack:
+        print("FAIL no capture acknowledgment after tapping picker")
+        return 1
+
+    ok = project in ack.message
+    print(f"{'PASS' if ok else 'FAIL'} ack={ack.message!r}")
+    return 0 if ok else 1

--- a/test/e2e/tg/bot_harness.rb
+++ b/test/e2e/tg/bot_harness.rb
@@ -1,0 +1,28 @@
+#!/usr/bin/env ruby
+# Runs the hive bot supervisor FROM THIS CHECKOUT (so local fixes are
+# exercised) against the @BotFather TEST token, with all persistent state
+# redirected to /tmp and the allowlist overridden to the headless driver
+# account — so the production bot's token, offset, and alert state are
+# never touched.
+#
+# Env:
+#   HIVE_TEST_BOT_TOKEN   - the test bot token (required)
+#   HIVE_TEST_ALLOWLIST   - comma-separated chat ids (required)
+$LOAD_PATH.unshift(File.expand_path("../../../lib", __dir__))
+require "hive"
+require "hive/config"
+require "hive/bot/supervisor"
+
+token = ENV.fetch("HIVE_TEST_BOT_TOKEN")
+allowlist = ENV.fetch("HIVE_TEST_ALLOWLIST").split(",").map { |s| Integer(s.strip) }
+
+cfg = Hive::Config.load_global_bot.merge(
+  "chat_id_allowlist"    => allowlist,
+  "log_file"             => "/tmp/hive-e2e-bot.log",
+  "last_seen_state_file" => "/tmp/hive-e2e-bot.last_seen",
+  "alert_state_file"     => "/tmp/hive-e2e-bot.alerts",
+  "pid_file"             => "/tmp/hive-e2e-bot.pid"
+)
+
+warn "[e2e-bot] fixed supervisor up; allowlist=#{allowlist.inspect} log=#{cfg['log_file']}"
+Hive::Bot::Supervisor.new(config: cfg, token: token, dry_run: false).run_forever

--- a/test/e2e/tg/drive_idea.py
+++ b/test/e2e/tg/drive_idea.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Headless E2E driver for the hive bot /idea flow.
+
+Acts as a real Telegram user (Telethon): sends `/idea <nonce>` to the test
+bot, taps the project picker button, and asserts the bot replies with the
+capture acknowledgment. Prints a single PASS/FAIL line and exits 0/1.
+
+Env: TG_API_ID, TG_API_HASH, TG_BOT_USERNAME, TG_CAPTURE_PROJECT (default shipped).
+Prints the derived idea text on stdout as `IDEA_TEXT=...` so the orchestrator
+can clean up the scratch capture.
+"""
+import os
+import sys
+import time
+
+from telethon.sync import TelegramClient
+
+API_ID = int(os.environ["TG_API_ID"])
+API_HASH = os.environ["TG_API_HASH"]
+BOT = os.environ["TG_BOT_USERNAME"]
+PROJECT = os.environ.get("TG_CAPTURE_PROJECT", "shipped")
+HERE = os.path.dirname(os.path.abspath(__file__))
+SESSION = os.path.join(HERE, "hive_e2e")
+
+NONCE = f"e2e ack probe {int(time.time())}"
+
+
+def wait_for(client, predicate, timeout=40, after_id=0):
+    """Poll the bot chat for the newest incoming message matching predicate."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        for msg in client.iter_messages(BOT, limit=8):
+            if msg.id <= after_id or msg.out:
+                continue
+            if predicate(msg):
+                return msg
+        time.sleep(1.5)
+    return None
+
+
+def main():
+    client = TelegramClient(SESSION, API_ID, API_HASH)
+    client.connect()
+    try:
+        if not client.is_user_authorized():
+            print("FAIL not authorized; run login.py first")
+            return 1
+
+        baseline = max((m.id for m in client.iter_messages(BOT, limit=1)), default=0)
+        print(f"IDEA_TEXT={NONCE}")
+        client.send_message(BOT, f"/idea {NONCE}")
+
+        picker = wait_for(client, lambda m: bool(m.buttons), after_id=baseline)
+        if not picker:
+            print("FAIL no project picker appeared")
+            return 1
+
+        # Find and click the target project button (label may be plain or
+        # star-prefixed for the last-used project).
+        target = None
+        for row in picker.buttons:
+            for btn in row:
+                if btn.text.replace("★", "").strip() == PROJECT:
+                    target = btn
+        if not target:
+            labels = [b.text for row in picker.buttons for b in row]
+            print(f"FAIL project '{PROJECT}' not in picker; saw {labels}")
+            return 1
+        target.click()
+
+        ack = wait_for(
+            client,
+            lambda m: "Captured your idea" in (m.message or ""),
+            timeout=40,
+            after_id=picker.id,
+        )
+        if not ack:
+            print("FAIL no capture acknowledgment after tapping picker")
+            return 1
+
+        ok = PROJECT in ack.message
+        print(f"{'PASS' if ok else 'FAIL'} ack={ack.message!r}")
+        return 0 if ok else 1
+    finally:
+        client.disconnect()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/e2e/tg/drive_idea.py
+++ b/test/e2e/tg/drive_idea.py
@@ -5,15 +5,17 @@ Acts as a real Telegram user (Telethon): sends `/idea <nonce>` to the test
 bot, taps the project picker button, and asserts the bot replies with the
 capture acknowledgment. Prints a single PASS/FAIL line and exits 0/1.
 
+Expects a bot already polling the test token (run_idea_e2e.sh owns that).
+The shared send -> tap -> assert sequence lives in _drive.py.
+
 Env: TG_API_ID, TG_API_HASH, TG_BOT_USERNAME, TG_CAPTURE_PROJECT (default shipped).
-Prints the derived idea text on stdout as `IDEA_TEXT=...` so the orchestrator
-can clean up the scratch capture.
 """
 import os
 import sys
-import time
 
 from telethon.sync import TelegramClient
+
+from _drive import drive
 
 API_ID = int(os.environ["TG_API_ID"])
 API_HASH = os.environ["TG_API_HASH"]
@@ -22,65 +24,12 @@ PROJECT = os.environ.get("TG_CAPTURE_PROJECT", "shipped")
 HERE = os.path.dirname(os.path.abspath(__file__))
 SESSION = os.path.join(HERE, "hive_e2e")
 
-NONCE = f"e2e ack probe {int(time.time())}"
-
-
-def wait_for(client, predicate, timeout=40, after_id=0):
-    """Poll the bot chat for the newest incoming message matching predicate."""
-    deadline = time.time() + timeout
-    while time.time() < deadline:
-        for msg in client.iter_messages(BOT, limit=8):
-            if msg.id <= after_id or msg.out:
-                continue
-            if predicate(msg):
-                return msg
-        time.sleep(1.5)
-    return None
-
 
 def main():
     client = TelegramClient(SESSION, API_ID, API_HASH)
     client.connect()
     try:
-        if not client.is_user_authorized():
-            print("FAIL not authorized; run login.py first")
-            return 1
-
-        baseline = max((m.id for m in client.iter_messages(BOT, limit=1)), default=0)
-        print(f"IDEA_TEXT={NONCE}")
-        client.send_message(BOT, f"/idea {NONCE}")
-
-        picker = wait_for(client, lambda m: bool(m.buttons), after_id=baseline)
-        if not picker:
-            print("FAIL no project picker appeared")
-            return 1
-
-        # Find and click the target project button (label may be plain or
-        # star-prefixed for the last-used project).
-        target = None
-        for row in picker.buttons:
-            for btn in row:
-                if btn.text.replace("★", "").strip() == PROJECT:
-                    target = btn
-        if not target:
-            labels = [b.text for row in picker.buttons for b in row]
-            print(f"FAIL project '{PROJECT}' not in picker; saw {labels}")
-            return 1
-        target.click()
-
-        ack = wait_for(
-            client,
-            lambda m: "Captured your idea" in (m.message or ""),
-            timeout=40,
-            after_id=picker.id,
-        )
-        if not ack:
-            print("FAIL no capture acknowledgment after tapping picker")
-            return 1
-
-        ok = PROJECT in ack.message
-        print(f"{'PASS' if ok else 'FAIL'} ack={ack.message!r}")
-        return 0 if ok else 1
+        return drive(client, BOT, PROJECT)
     finally:
         client.disconnect()
 

--- a/test/e2e/tg/export_session.py
+++ b/test/e2e/tg/export_session.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Print a Telethon StringSession for the existing hive_e2e file session.
+
+Used once to seed the TG_SESSION GitHub Actions secret (CI can't do an
+interactive login). Output is a secret — pipe it straight into
+`gh secret set TG_SESSION`, never echo it to a shared log.
+"""
+import os
+
+from telethon.sync import TelegramClient
+from telethon.sessions import StringSession
+
+API_ID = int(os.environ["TG_API_ID"])
+API_HASH = os.environ["TG_API_HASH"]
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+client = TelegramClient(os.path.join(HERE, "hive_e2e"), API_ID, API_HASH)
+client.connect()
+try:
+    if not client.is_user_authorized():
+        raise SystemExit("file session is not authorized; run login.py first")
+    ss = StringSession()
+    ss.set_dc(client.session.dc_id, client.session.server_address, client.session.port)
+    ss.auth_key = client.session.auth_key
+    print(StringSession.save(ss))
+finally:
+    client.disconnect()

--- a/test/e2e/tg/login.py
+++ b/test/e2e/tg/login.py
@@ -4,8 +4,11 @@
 Usage:
   python login.py request            # send the SMS/app code to TG_PHONE
   python login.py confirm <CODE>     # sign in (or sign up a new account)
-  python login.py confirm <CODE> --password <2FA>   # if 2FA is set
   python login.py whoami             # print the logged-in account id/name
+
+If the account has 2FA enabled, `confirm` prompts for the password securely
+via getpass (never read from argv, to keep it out of shell history / the
+process table). For a non-interactive run, set TG_2FA_PASSWORD in the env.
 
 Reads TG_API_ID / TG_API_HASH / TG_PHONE from the environment.
 Persists the session to hive_e2e.session and the code hash to .code_hash.
@@ -14,6 +17,7 @@ Uses explicit connect()/disconnect() so Telethon never prompts on stdin.
 import os
 import sys
 import json
+import getpass
 
 from telethon.sync import TelegramClient
 from telethon.tl.functions.auth import ResendCodeRequest
@@ -66,7 +70,19 @@ def resend():
         client.disconnect()
 
 
-def confirm(code, password=None):
+def _twofa_password():
+    # Prefer an env var for non-interactive runs; otherwise prompt securely so
+    # the password never lands in argv / shell history / the process table.
+    env = os.environ.get("TG_2FA_PASSWORD")
+    if env:
+        return env
+    if not sys.stdin.isatty():
+        print("2FA_REQUIRED: set TG_2FA_PASSWORD (no TTY to prompt on)")
+        sys.exit(2)
+    return getpass.getpass("2FA password: ")
+
+
+def confirm(code):
     with open(HASH_FILE) as fh:
         phone_code_hash = fh.read().strip()
     client = _client()
@@ -77,10 +93,7 @@ def confirm(code, password=None):
             client.sign_up(code=code, first_name="Hive E2E",
                            phone=PHONE, phone_code_hash=phone_code_hash)
         except SessionPasswordNeededError:
-            if not password:
-                print("2FA_REQUIRED: re-run with --password <your-2fa-password>")
-                sys.exit(2)
-            client.sign_in(password=password)
+            client.sign_in(password=_twofa_password())
         me = client.get_me()
         print(f"LOGGED_IN id={me.id} name={me.first_name!r} username={me.username!r}")
     finally:
@@ -107,10 +120,7 @@ if __name__ == "__main__":
     elif cmd == "resend":
         resend()
     elif cmd == "confirm":
-        pw = None
-        if "--password" in sys.argv:
-            pw = sys.argv[sys.argv.index("--password") + 1]
-        confirm(sys.argv[2], pw)
+        confirm(sys.argv[2])
     elif cmd == "whoami":
         whoami()
     else:

--- a/test/e2e/tg/login.py
+++ b/test/e2e/tg/login.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""One-time interactive login for the headless E2E Telegram user-client.
+
+Usage:
+  python login.py request            # send the SMS/app code to TG_PHONE
+  python login.py confirm <CODE>     # sign in (or sign up a new account)
+  python login.py confirm <CODE> --password <2FA>   # if 2FA is set
+  python login.py whoami             # print the logged-in account id/name
+
+Reads TG_API_ID / TG_API_HASH / TG_PHONE from the environment.
+Persists the session to hive_e2e.session and the code hash to .code_hash.
+Uses explicit connect()/disconnect() so Telethon never prompts on stdin.
+"""
+import os
+import sys
+import json
+
+from telethon.sync import TelegramClient
+from telethon.tl.functions.auth import ResendCodeRequest
+from telethon.errors import (
+    PhoneNumberUnoccupiedError,
+    SessionPasswordNeededError,
+)
+
+API_ID = int(os.environ["TG_API_ID"])
+API_HASH = os.environ["TG_API_HASH"]
+PHONE = os.environ["TG_PHONE"]
+HERE = os.path.dirname(os.path.abspath(__file__))
+SESSION = os.path.join(HERE, "hive_e2e")
+HASH_FILE = os.path.join(HERE, ".code_hash")
+
+
+def _client():
+    c = TelegramClient(SESSION, API_ID, API_HASH)
+    c.connect()
+    return c
+
+
+def request():
+    client = _client()
+    try:
+        if client.is_user_authorized():
+            me = client.get_me()
+            print(f"ALREADY_AUTHORIZED id={me.id} name={me.first_name!r}")
+            return
+        sent = client.send_code_request(PHONE)
+        with open(HASH_FILE, "w") as fh:
+            fh.write(sent.phone_code_hash)
+        print(f"CODE_SENT type={sent.type.__class__.__name__}")
+        print("Now run: python login.py confirm <CODE>")
+    finally:
+        client.disconnect()
+
+
+def resend():
+    with open(HASH_FILE) as fh:
+        phone_code_hash = fh.read().strip()
+    client = _client()
+    try:
+        sent = client(ResendCodeRequest(phone_number=PHONE, phone_code_hash=phone_code_hash))
+        with open(HASH_FILE, "w") as fh:
+            fh.write(sent.phone_code_hash)
+        nxt = sent.next_type.__class__.__name__ if sent.next_type else None
+        print(f"RESENT type={sent.type.__class__.__name__} next_type={nxt}")
+    finally:
+        client.disconnect()
+
+
+def confirm(code, password=None):
+    with open(HASH_FILE) as fh:
+        phone_code_hash = fh.read().strip()
+    client = _client()
+    try:
+        try:
+            client.sign_in(phone=PHONE, code=code, phone_code_hash=phone_code_hash)
+        except PhoneNumberUnoccupiedError:
+            client.sign_up(code=code, first_name="Hive E2E",
+                           phone=PHONE, phone_code_hash=phone_code_hash)
+        except SessionPasswordNeededError:
+            if not password:
+                print("2FA_REQUIRED: re-run with --password <your-2fa-password>")
+                sys.exit(2)
+            client.sign_in(password=password)
+        me = client.get_me()
+        print(f"LOGGED_IN id={me.id} name={me.first_name!r} username={me.username!r}")
+    finally:
+        client.disconnect()
+
+
+def whoami():
+    client = _client()
+    try:
+        if not client.is_user_authorized():
+            print("NOT_AUTHORIZED")
+            sys.exit(1)
+        me = client.get_me()
+        print(json.dumps({"id": me.id, "first_name": me.first_name,
+                          "username": me.username, "phone": me.phone}))
+    finally:
+        client.disconnect()
+
+
+if __name__ == "__main__":
+    cmd = sys.argv[1] if len(sys.argv) > 1 else ""
+    if cmd == "request":
+        request()
+    elif cmd == "resend":
+        resend()
+    elif cmd == "confirm":
+        pw = None
+        if "--password" in sys.argv:
+            pw = sys.argv[sys.argv.index("--password") + 1]
+        confirm(sys.argv[2], pw)
+    elif cmd == "whoami":
+        whoami()
+    else:
+        print(__doc__)
+        sys.exit(1)

--- a/test/e2e/tg/run_e2e.py
+++ b/test/e2e/tg/run_e2e.py
@@ -25,35 +25,56 @@ PROJECT = os.environ.get("TG_CAPTURE_PROJECT", "shipped")
 DRIVER_ID = os.environ["TG_DRIVER_ID"]
 SESSION = os.path.join(HERE, "hive_e2e")
 LOG = "/tmp/hive-e2e-bot.log"
+BOT_OUT = "/tmp/hive-e2e-bot.out"
+
+
+def _dump_bot_output(reason):
+    print(f"FAIL bot did not start: {reason}")
+    try:
+        with open(BOT_OUT) as fh:
+            tail = fh.read().splitlines()[-20:]
+        if tail:
+            print("--- bot output (last 20 lines) ---")
+            print("\n".join(tail))
+    except FileNotFoundError:
+        print(f"(no bot output captured at {BOT_OUT})")
 
 
 def start_bot():
-    for p in ("/tmp/hive-e2e-bot.log", "/tmp/hive-e2e-bot.last_seen",
-              "/tmp/hive-e2e-bot.alerts", "/tmp/hive-e2e-bot.pid"):
+    for p in (LOG, "/tmp/hive-e2e-bot.last_seen",
+              "/tmp/hive-e2e-bot.alerts", "/tmp/hive-e2e-bot.pid", BOT_OUT):
         try:
             os.remove(p)
         except FileNotFoundError:
             pass
     env = dict(os.environ, HIVE_TEST_ALLOWLIST=DRIVER_ID)
     # CI installs gems via bundler, so the bot must run under `bundle exec`;
-    # locally BOT_LAUNCHER defaults to a bare `ruby`. The bot logs to LOG on
-    # its own, so its stdout/stderr go to DEVNULL (subprocess owns/closes the FD).
+    # locally BOT_LAUNCHER defaults to a bare `ruby`. Capture the bot's
+    # stdout/stderr to BOT_OUT (not /dev/null) so a startup crash is
+    # diagnosable; the file — not this process's stdout pipe — receives it.
     launcher = os.environ.get("BOT_LAUNCHER", "ruby").split()
-    proc = subprocess.Popen(
-        [*launcher, os.path.join(HERE, "bot_harness.rb")],
-        env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-        stdin=subprocess.DEVNULL, start_new_session=True, cwd=REPO,
-    )
+    with open(BOT_OUT, "w") as out:
+        proc = subprocess.Popen(
+            [*launcher, os.path.join(HERE, "bot_harness.rb")],
+            env=env, stdout=out, stderr=out,
+            stdin=subprocess.DEVNULL, start_new_session=True, cwd=REPO,
+        )
     for _ in range(40):
         if proc.poll() is not None:
+            _dump_bot_output(f"process exited early (code {proc.returncode})")
             return None
         try:
-            if '"event":"bot_started"' in open(LOG).read():
-                return proc
+            with open(LOG) as fh:
+                if '"event":"bot_started"' in fh.read():
+                    return proc
         except FileNotFoundError:
             pass
         time.sleep(0.5)
-    return proc  # started but no log line; let driver try anyway
+    # Alive but never reported bot_started — wedged. Fail loudly rather than
+    # letting the driver burn its picker timeout and mis-blame the protocol.
+    stop_bot(proc)
+    _dump_bot_output("alive but never logged bot_started within the deadline")
+    return None
 
 
 def stop_bot(proc):
@@ -76,7 +97,7 @@ def _session():
 def main():
     proc = start_bot()
     if proc is None:
-        print("FAIL bot did not start"); return 1
+        return 1  # start_bot already printed the FAIL + bot output
     client = TelegramClient(_session(), API_ID, API_HASH)
     client.connect()
     try:

--- a/test/e2e/tg/run_e2e.py
+++ b/test/e2e/tg/run_e2e.py
@@ -14,6 +14,8 @@ import subprocess
 from telethon.sync import TelegramClient
 from telethon.sessions import StringSession
 
+from _drive import drive
+
 REPO = os.environ.get("HIVE_REPO", "/home/asterio/Dev/hive")
 HERE = os.path.join(REPO, "test/e2e/tg")
 API_ID = int(os.environ["TG_API_ID"])
@@ -33,13 +35,13 @@ def start_bot():
         except FileNotFoundError:
             pass
     env = dict(os.environ, HIVE_TEST_ALLOWLIST=DRIVER_ID)
-    devnull = open(os.devnull, "w")
     # CI installs gems via bundler, so the bot must run under `bundle exec`;
-    # locally BOT_LAUNCHER defaults to a bare `ruby`.
+    # locally BOT_LAUNCHER defaults to a bare `ruby`. The bot logs to LOG on
+    # its own, so its stdout/stderr go to DEVNULL (subprocess owns/closes the FD).
     launcher = os.environ.get("BOT_LAUNCHER", "ruby").split()
     proc = subprocess.Popen(
         [*launcher, os.path.join(HERE, "bot_harness.rb")],
-        env=env, stdout=devnull, stderr=devnull,
+        env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
         stdin=subprocess.DEVNULL, start_new_session=True, cwd=REPO,
     )
     for _ in range(40):
@@ -64,18 +66,6 @@ def stop_bot(proc):
     proc.wait(timeout=5)
 
 
-def wait_for(client, predicate, timeout=40, after_id=0):
-    deadline = time.time() + timeout
-    while time.time() < deadline:
-        for msg in client.iter_messages(BOT, limit=8):
-            if msg.id <= after_id or msg.out:
-                continue
-            if predicate(msg):
-                return msg
-        time.sleep(1.5)
-    return None
-
-
 def _session():
     # CI passes the session as a StringSession via TG_SESSION (no interactive
     # login possible); locally we fall back to the hive_e2e file session.
@@ -83,46 +73,16 @@ def _session():
     return StringSession(s) if s else SESSION
 
 
-def drive():
-    client = TelegramClient(_session(), API_ID, API_HASH)
-    client.connect()
-    try:
-        if not client.is_user_authorized():
-            print("FAIL driver not authorized"); return 1
-        baseline = max((m.id for m in client.iter_messages(BOT, limit=1)), default=0)
-        nonce = f"e2e ack probe {int(time.time())}"
-        print(f"IDEA_TEXT={nonce}")
-        client.send_message(BOT, f"/idea {nonce}")
-        picker = wait_for(client, lambda m: bool(m.buttons), after_id=baseline)
-        if not picker:
-            print("FAIL no project picker"); return 1
-        target = None
-        for row in picker.buttons:
-            for btn in row:
-                if btn.text.replace("★", "").strip() == PROJECT:
-                    target = btn
-        if not target:
-            print("FAIL project button not found:",
-                  [b.text for r in picker.buttons for b in r]); return 1
-        target.click()
-        ack = wait_for(client, lambda m: "Captured your idea" in (m.message or ""),
-                       timeout=40, after_id=picker.id)
-        if not ack:
-            print("FAIL no capture acknowledgment"); return 1
-        ok = PROJECT in ack.message
-        print(f"{'PASS' if ok else 'FAIL'} ack={ack.message!r}")
-        return 0 if ok else 1
-    finally:
-        client.disconnect()
-
-
 def main():
     proc = start_bot()
     if proc is None:
         print("FAIL bot did not start"); return 1
+    client = TelegramClient(_session(), API_ID, API_HASH)
+    client.connect()
     try:
-        return drive()
+        return drive(client, BOT, PROJECT)
     finally:
+        client.disconnect()
         stop_bot(proc)
 
 

--- a/test/e2e/tg/run_e2e.py
+++ b/test/e2e/tg/run_e2e.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Single-process headless E2E: own the test bot as a child, drive it, kill it.
+
+The bot child's stdout/stderr go to /dev/null (it logs to /tmp/hive-e2e-bot.log
+on its own), so it never holds this process's stdout pipe. We stay foreground
+the whole time and exit 0/1 with a PASS/FAIL line.
+"""
+import os
+import sys
+import time
+import signal
+import subprocess
+
+from telethon.sync import TelegramClient
+from telethon.sessions import StringSession
+
+REPO = os.environ.get("HIVE_REPO", "/home/asterio/Dev/hive")
+HERE = os.path.join(REPO, "test/e2e/tg")
+API_ID = int(os.environ["TG_API_ID"])
+API_HASH = os.environ["TG_API_HASH"]
+BOT = os.environ.get("TG_BOT_USERNAME", "Testivanshive_bot")
+PROJECT = os.environ.get("TG_CAPTURE_PROJECT", "shipped")
+DRIVER_ID = os.environ["TG_DRIVER_ID"]
+SESSION = os.path.join(HERE, "hive_e2e")
+LOG = "/tmp/hive-e2e-bot.log"
+
+
+def start_bot():
+    for p in ("/tmp/hive-e2e-bot.log", "/tmp/hive-e2e-bot.last_seen",
+              "/tmp/hive-e2e-bot.alerts", "/tmp/hive-e2e-bot.pid"):
+        try:
+            os.remove(p)
+        except FileNotFoundError:
+            pass
+    env = dict(os.environ, HIVE_TEST_ALLOWLIST=DRIVER_ID)
+    devnull = open(os.devnull, "w")
+    proc = subprocess.Popen(
+        ["ruby", os.path.join(HERE, "bot_harness.rb")],
+        env=env, stdout=devnull, stderr=devnull,
+        stdin=subprocess.DEVNULL, start_new_session=True,
+    )
+    for _ in range(40):
+        if proc.poll() is not None:
+            return None
+        try:
+            if '"event":"bot_started"' in open(LOG).read():
+                return proc
+        except FileNotFoundError:
+            pass
+        time.sleep(0.5)
+    return proc  # started but no log line; let driver try anyway
+
+
+def stop_bot(proc):
+    if not proc:
+        return
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    proc.wait(timeout=5)
+
+
+def wait_for(client, predicate, timeout=40, after_id=0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        for msg in client.iter_messages(BOT, limit=8):
+            if msg.id <= after_id or msg.out:
+                continue
+            if predicate(msg):
+                return msg
+        time.sleep(1.5)
+    return None
+
+
+def _session():
+    # CI passes the session as a StringSession via TG_SESSION (no interactive
+    # login possible); locally we fall back to the hive_e2e file session.
+    s = os.environ.get("TG_SESSION")
+    return StringSession(s) if s else SESSION
+
+
+def drive():
+    client = TelegramClient(_session(), API_ID, API_HASH)
+    client.connect()
+    try:
+        if not client.is_user_authorized():
+            print("FAIL driver not authorized"); return 1
+        baseline = max((m.id for m in client.iter_messages(BOT, limit=1)), default=0)
+        nonce = f"e2e ack probe {int(time.time())}"
+        print(f"IDEA_TEXT={nonce}")
+        client.send_message(BOT, f"/idea {nonce}")
+        picker = wait_for(client, lambda m: bool(m.buttons), after_id=baseline)
+        if not picker:
+            print("FAIL no project picker"); return 1
+        target = None
+        for row in picker.buttons:
+            for btn in row:
+                if btn.text.replace("★", "").strip() == PROJECT:
+                    target = btn
+        if not target:
+            print("FAIL project button not found:",
+                  [b.text for r in picker.buttons for b in r]); return 1
+        target.click()
+        ack = wait_for(client, lambda m: "Captured your idea" in (m.message or ""),
+                       timeout=40, after_id=picker.id)
+        if not ack:
+            print("FAIL no capture acknowledgment"); return 1
+        ok = PROJECT in ack.message
+        print(f"{'PASS' if ok else 'FAIL'} ack={ack.message!r}")
+        return 0 if ok else 1
+    finally:
+        client.disconnect()
+
+
+def main():
+    proc = start_bot()
+    if proc is None:
+        print("FAIL bot did not start"); return 1
+    try:
+        return drive()
+    finally:
+        stop_bot(proc)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/e2e/tg/run_e2e.py
+++ b/test/e2e/tg/run_e2e.py
@@ -34,10 +34,13 @@ def start_bot():
             pass
     env = dict(os.environ, HIVE_TEST_ALLOWLIST=DRIVER_ID)
     devnull = open(os.devnull, "w")
+    # CI installs gems via bundler, so the bot must run under `bundle exec`;
+    # locally BOT_LAUNCHER defaults to a bare `ruby`.
+    launcher = os.environ.get("BOT_LAUNCHER", "ruby").split()
     proc = subprocess.Popen(
-        ["ruby", os.path.join(HERE, "bot_harness.rb")],
+        [*launcher, os.path.join(HERE, "bot_harness.rb")],
         env=env, stdout=devnull, stderr=devnull,
-        stdin=subprocess.DEVNULL, start_new_session=True,
+        stdin=subprocess.DEVNULL, start_new_session=True, cwd=REPO,
     )
     for _ in range(40):
         if proc.poll() is not None:

--- a/test/e2e/tg/run_idea_e2e.sh
+++ b/test/e2e/tg/run_idea_e2e.sh
@@ -6,9 +6,12 @@
 set -uo pipefail
 REPO="/home/asterio/Dev/hive"
 HERE="$REPO/test/e2e/tg"
-cd "$REPO"
+cd "$REPO" || exit 1
 
-set -a; . ./.env; set +a
+set -a
+# shellcheck source=/dev/null  # .env is gitignored, not present at lint time
+. ./.env
+set +a
 : "${HIVE_TEST_BOT_TOKEN:?}"; : "${TG_API_ID:?}"; : "${TG_API_HASH:?}"; : "${TG_DRIVER_ID:?}"
 export HIVE_TEST_ALLOWLIST="$TG_DRIVER_ID"
 export TG_BOT_USERNAME="Testivanshive_bot"
@@ -26,6 +29,7 @@ fi
 BASELINE="$(git -C "$STATE_REPO" rev-parse HEAD)"
 echo "scratch state repo: $STATE_REPO @ baseline $BASELINE"
 
+# shellcheck disable=SC2329  # invoked indirectly via `trap cleanup EXIT`
 cleanup() {
   [ -n "${BOT_PID:-}" ] && kill "$BOT_PID" 2>/dev/null
   sleep 1; [ -n "${BOT_PID:-}" ] && kill -9 "$BOT_PID" 2>/dev/null
@@ -52,6 +56,7 @@ for _ in $(seq 1 30); do
 done
 echo "bot up (pid $BOT_PID); driving..."
 
+# shellcheck source=/dev/null  # venv activate script is generated, not in-repo
 . "$HERE/.venv/bin/activate"
 python "$HERE/drive_idea.py"
 RESULT=$?

--- a/test/e2e/tg/run_idea_e2e.sh
+++ b/test/e2e/tg/run_idea_e2e.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# End-to-end test of the bot /idea capture-acknowledgment flow, fully headless.
+# Starts the fixed bot (test token, /tmp state, driver in allowlist), drives it
+# with the Telethon user-client, asserts the ack, then restores the scratch
+# project's state repo to its pre-test HEAD. Never touches the production bot.
+set -uo pipefail
+REPO="/home/asterio/Dev/hive"
+HERE="$REPO/test/e2e/tg"
+cd "$REPO"
+
+set -a; . ./.env; set +a
+: "${HIVE_TEST_BOT_TOKEN:?}"; : "${TG_API_ID:?}"; : "${TG_API_HASH:?}"; : "${TG_DRIVER_ID:?}"
+export HIVE_TEST_ALLOWLIST="$TG_DRIVER_ID"
+export TG_BOT_USERNAME="Testivanshive_bot"
+export TG_CAPTURE_PROJECT="${TG_CAPTURE_PROJECT:-shipped}"
+
+STATE_REPO="$(ruby -Ilib -e 'require "hive"; require "hive/config"; print Hive::Config.find_project(ENV["TG_CAPTURE_PROJECT"])["hive_state_path"]')"
+BASELINE="$(git -C "$STATE_REPO" rev-parse HEAD)"
+echo "scratch state repo: $STATE_REPO @ baseline $BASELINE"
+
+cleanup() {
+  [ -n "${BOT_PID:-}" ] && kill "$BOT_PID" 2>/dev/null
+  sleep 1; [ -n "${BOT_PID:-}" ] && kill -9 "$BOT_PID" 2>/dev/null
+  # Restore scratch project state to pre-test HEAD (drops the test capture
+  # commit + its dispatch logs). Safe: baseline was captured this run.
+  if [ -n "${BASELINE:-}" ]; then
+    git -C "$STATE_REPO" reset --hard "$BASELINE" >/dev/null 2>&1
+    git -C "$STATE_REPO" clean -fdq stages/1-inbox 2>/dev/null
+    echo "restored $STATE_REPO to $BASELINE"
+  fi
+  rm -f /tmp/hive-e2e-bot.log /tmp/hive-e2e-bot.last_seen /tmp/hive-e2e-bot.alerts /tmp/hive-e2e-bot.pid /tmp/hive-e2e-bot.out
+}
+trap cleanup EXIT
+
+rm -f /tmp/hive-e2e-bot.*
+ruby "$HERE/bot_harness.rb" >/tmp/hive-e2e-bot.out 2>&1 &
+BOT_PID=$!
+
+# Wait for the bot to come up (bot_started in its log).
+for _ in $(seq 1 30); do
+  grep -q '"event":"bot_started"' /tmp/hive-e2e-bot.log 2>/dev/null && break
+  kill -0 "$BOT_PID" 2>/dev/null || { echo "BOT DIED:"; cat /tmp/hive-e2e-bot.out; exit 1; }
+  sleep 0.5
+done
+echo "bot up (pid $BOT_PID); driving..."
+
+. "$HERE/.venv/bin/activate"
+python "$HERE/drive_idea.py"
+RESULT=$?
+
+echo "=== bot dispatch events ==="
+grep -E '"event":"(update_received|command_completed|send_failure)"' /tmp/hive-e2e-bot.log 2>/dev/null | tail -6
+exit $RESULT

--- a/test/e2e/tg/run_idea_e2e.sh
+++ b/test/e2e/tg/run_idea_e2e.sh
@@ -14,7 +14,15 @@ export HIVE_TEST_ALLOWLIST="$TG_DRIVER_ID"
 export TG_BOT_USERNAME="Testivanshive_bot"
 export TG_CAPTURE_PROJECT="${TG_CAPTURE_PROJECT:-shipped}"
 
-STATE_REPO="$(ruby -Ilib -e 'require "hive"; require "hive/config"; print Hive::Config.find_project(ENV["TG_CAPTURE_PROJECT"])["hive_state_path"]')"
+# Resolve the scratch project's state repo. The `&.` guards an unregistered
+# project (find_project -> nil): without it, an empty STATE_REPO would make the
+# cleanup `git reset --hard` below operate on the MAIN hive checkout (cwd).
+STATE_REPO="$(ruby -Ilib -e 'require "hive"; require "hive/config"; p = Hive::Config.find_project(ENV["TG_CAPTURE_PROJECT"]); print(p&.fetch("hive_state_path", nil) || "")')"
+if [ -z "$STATE_REPO" ] || [ "$(git -C "$STATE_REPO" rev-parse --show-toplevel 2>/dev/null)" != "$(cd "$STATE_REPO" 2>/dev/null && pwd -P)" ]; then
+  echo "ERROR: TG_CAPTURE_PROJECT='$TG_CAPTURE_PROJECT' is not a registered hive project with its own state git repo." >&2
+  echo "       Refusing to run — cleanup would otherwise git-reset the wrong repo. Register it with 'hive init' first." >&2
+  exit 1
+fi
 BASELINE="$(git -C "$STATE_REPO" rev-parse HEAD)"
 echo "scratch state repo: $STATE_REPO @ baseline $BASELINE"
 

--- a/test/unit/bot/supervisor_test.rb
+++ b/test/unit/bot/supervisor_test.rb
@@ -135,13 +135,15 @@ class HiveBotSupervisorTest < Minitest::Test
     )
   end
 
-  def child_exit(exit_code: 0, envelope: nil, log_path: "/tmp/hive-bot.log", pid: 123)
+  def child_exit(exit_code: 0, envelope: nil, log_path: "/tmp/hive-bot.log", pid: 123,
+                 project: "hive",
+                 command_argv: [ "hive", "status", "--diagnose", "red-task-260518-aaaa", "--json" ])
     ChildExit.new(
       pid: pid,
       exit_code: exit_code,
-      project: "hive",
+      project: project,
       slug: "red-task-260518-aaaa",
-      command_argv: [ "hive", "status", "--diagnose", "red-task-260518-aaaa", "--json" ],
+      command_argv: command_argv,
       chat_id: 42,
       update_id: 99,
       started_at: Time.now,
@@ -467,6 +469,38 @@ class HiveBotSupervisorTest < Minitest::Test
     assert_nil @supervisor.send(:child_completion_text, child_exit(exit_code: 0)),
                "clean exit must not produce a Telegram ack — 'Command completed' was operational chatter"
     assert_includes @supervisor.send(:child_completion_text, child_exit(exit_code: 17)), "Command failed with exit 17"
+  end
+
+  def test_child_completion_text_acknowledges_successful_idea_capture
+    text = @supervisor.send(
+      :child_completion_text,
+      child_exit(exit_code: 0, project: "writero",
+                 command_argv: [ "hive", "new", "writero", "an idea", "--json" ])
+    )
+
+    assert_includes text, "Captured your idea",
+                     "a successful `hive new` must confirm the capture so the picker doesn't look dead"
+    assert_includes text, "writero", "the confirmation should name the project the idea landed in"
+  end
+
+  def test_child_completion_text_acknowledges_capture_when_hive_bin_resolved
+    # ChildSupervisor#normalize_hive_bin rewrites argv[0] to a resolved
+    # binary path, so detection must key on the verb at argv[1], not argv[0].
+    text = @supervisor.send(
+      :child_completion_text,
+      child_exit(exit_code: 0, project: "writero",
+                 command_argv: [ "/usr/local/bin/hive", "new", "writero", "an idea", "--json" ])
+    )
+
+    assert_includes text, "Captured your idea",
+                     "capture ack must survive argv[0] being a resolved hive binary path"
+  end
+
+  def test_child_completion_text_stays_silent_for_non_new_success
+    assert_nil @supervisor.send(
+      :child_completion_text,
+      child_exit(exit_code: 0, command_argv: [ "hive", "run", "some-slug", "--json" ])
+    ), "exit-0 commands other than `hive new` must stay silent (signal shows in the next status row)"
   end
 
   def test_send_reconnect_summary_skips_empty_update_list

--- a/test/unit/bot/supervisor_test.rb
+++ b/test/unit/bot/supervisor_test.rb
@@ -496,6 +496,35 @@ class HiveBotSupervisorTest < Minitest::Test
                      "capture ack must survive argv[0] being a resolved hive binary path"
   end
 
+  def test_child_completion_text_falls_back_to_argv_project_when_child_project_nil
+    text = @supervisor.send(
+      :child_completion_text,
+      child_exit(exit_code: 0, project: nil,
+                 command_argv: [ "hive", "new", "writero", "an idea", "--json" ])
+    )
+
+    assert_includes text, "Captured your idea"
+    assert_includes text, "writero",
+                     "with child.project nil the ack must name the project from argv[2]"
+  end
+
+  def test_child_completion_text_omits_project_suffix_when_unknown
+    text = @supervisor.send(
+      :child_completion_text,
+      child_exit(exit_code: 0, project: nil, command_argv: [ "hive", "new" ])
+    )
+
+    assert_equal "Captured your idea. It's in the inbox — move it to 2-brainstorm to start.", text,
+                 "with no project from child or argv, the ack drops the ' in <project>' suffix"
+  end
+
+  def test_child_completion_text_stays_silent_for_short_argv
+    assert_nil @supervisor.send(:child_completion_text, child_exit(exit_code: 0, command_argv: [ "hive" ])),
+               "a 1-element argv has no verb at argv[1], so exit-0 stays silent"
+    assert_nil @supervisor.send(:child_completion_text, child_exit(exit_code: 0, command_argv: [])),
+               "an empty argv has no verb, so exit-0 stays silent"
+  end
+
   def test_child_completion_text_stays_silent_for_non_new_success
     assert_nil @supervisor.send(
       :child_completion_text,

--- a/test/unit/bot/supervisor_test.rb
+++ b/test/unit/bot/supervisor_test.rb
@@ -404,6 +404,22 @@ class HiveBotSupervisorTest < Minitest::Test
                  "exit_code 0 must not produce a Telegram ack (child_completion_text returns nil)"
   end
 
+  def test_reap_children_delivers_idea_capture_ack_through_the_full_reaper_path
+    @child_supervisor.reap_batches << [
+      child_exit(exit_code: 0, project: "writero",
+                 command_argv: [ "hive", "new", "writero", "an idea", "--json" ])
+    ]
+
+    @supervisor.reap_children
+
+    # End-to-end wiring: reap_children -> reply_for_child -> child_completion_text
+    # -> @telegram.send_message. Unit tests calling child_completion_text directly
+    # would miss a regression where reply_for_child stops reaching it for exit-0.
+    message = @telegram.messages.last
+    assert_equal 42, message.fetch(:chat_id), "the ack must go to the child's chat_id"
+    assert_includes message.fetch(:text), "Captured your idea in writero"
+  end
+
   def test_finalize_completed_brainstorm_in_dry_run_announces_without_dispatching
     supervisor = Hive::Bot::Supervisor.new(
       config: @config, token: "test-token", logger: @logger, telegram: @telegram,

--- a/wiki/commands/bot.md
+++ b/wiki/commands/bot.md
@@ -82,10 +82,11 @@ Commands dispatched as child processes (`hive new`, `hive approve`,
 operator normally sees the effect in the next status row or push
 notification. The lone exception is `hive new`: an idea lands in
 `1-inbox`, whose `ready_to_brainstorm` notification is **suppressed
-entirely when the project's daemon is disabled** (`suppress_ready_action?`)
-and otherwise delayed a full status tick — so a silent success looked
-like a dead button, and because the picker token is consumed on tap, a
-confused re-tap reported "idea picker expired." `child_completion_text`
+entirely when the project's daemon is enabled** (`suppress_ready_action?`,
+since the daemon dispatches the transition itself) and, when the daemon
+is off, only fires on a later dispatcher poll tick — never at tap time.
+So a silent success looked like a dead button, and because the picker
+token is consumed on tap, a confused re-tap reported "idea picker expired." `child_completion_text`
 therefore acknowledges a successful `hive new` (keyed on the verb at
 `argv[1]`, since `ChildSupervisor#normalize_hive_bin` rewrites `argv[0]`
 to a resolved binary path). `/approve` and `/done` share the same

--- a/wiki/commands/bot.md
+++ b/wiki/commands/bot.md
@@ -39,7 +39,7 @@ hive bot install [--force] [--json]
 |--------------|----------|
 | `/status [--json] [project]` | Renders actionable rows from `hive status --json` as `Title… — Stage`; when a project name is supplied, filters to that project. Pass `--json` to receive the raw `hive-status` envelope instead of human prose (intended for automated callers). The prose form is intentionally not a versioned contract — automated tooling that needs a stable shape MUST use `--json`, which echoes the `hive-status` envelope schema. |
 | `/queue` | Same actionable-row view as `/status`, without a project filter. |
-| `/idea <text>` | Shows a project picker. Tapping a project dispatches `hive new <project> <text>`. |
+| `/idea <text>` | Shows a project picker. Tapping a project dispatches `hive new <project> <text>` and, on success, replies `"Captured your idea in <project>. It's in the inbox — move it to 2-brainstorm to start."` The picker token is single-use (consumed on tap); a re-tap of a spent picker replies `"That idea picker expired. Send /idea <text> again."` |
 | `/answer <slug>` | Starts Path B brainstorm answering; each free-text reply writes the current unanswered `### A<N>.` block under the task lock. |
 | `/approve <slug>` | Dispatches `hive approve <slug> --json` for the direct approval surface. Inline approval buttons usually use the workflow verb instead. |
 | `/autofix <slug>` | Dispatches the same `hive markers clear` + retry-verb sequence the inline 🔧 Autofix button dispatches. Resolves the slug against the latest `StatusWatcher` snapshot. Replies `"Hive has no automatic recovery for this state - open it on a laptop."` for manual-only markers and `"No retry verb for stage X."` when the stage has none. |
@@ -73,6 +73,26 @@ The reply stays text-only when no row is actionable. The `/answer`,
 `/approve`, `/autofix`, `/details` slash commands remain typeable
 (and appear in the quick-actions menu) for operators who prefer
 typing or scripting.
+
+### Dispatch acknowledgment on success
+
+Commands dispatched as child processes (`hive new`, `hive approve`,
+`hive run`, recovery sequences) are **silent on exit 0** by design:
+`Supervisor#child_completion_text` only speaks on failure, because the
+operator normally sees the effect in the next status row or push
+notification. The lone exception is `hive new`: an idea lands in
+`1-inbox`, whose `ready_to_brainstorm` notification is **suppressed
+entirely when the project's daemon is disabled** (`suppress_ready_action?`)
+and otherwise delayed a full status tick — so a silent success looked
+like a dead button, and because the picker token is consumed on tap, a
+confused re-tap reported "idea picker expired." `child_completion_text`
+therefore acknowledges a successful `hive new` (keyed on the verb at
+`argv[1]`, since `ChildSupervisor#normalize_hive_bin` rewrites `argv[0]`
+to a resolved binary path). `/approve` and `/done` share the same
+silent-success shape but degrade gracefully — they advance the task into
+a state the daemon/next tick re-surfaces, and a double-tap hits
+`WRONG_STAGE` → `"Already advanced by another device"` rather than a
+misleading message.
 
 On bot start the supervisor calls Telegram's `setMyCommands` so the
 blue quick-actions menu (shown when the operator taps the `/` icon in

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -2390,7 +2390,7 @@ chruby and RVM are intentionally not handled — they modify PATH per-shell and 
 **Refreshed pages:**
 - [[decisions]]
 
-## [2026-05-27T00:00:00Z] bot — acknowledge successful /idea capture
+## [2026-05-27T13:30:00Z] bot — acknowledge successful /idea capture
 
 **Action:** Fixed the `/idea` project picker appearing to do nothing on tap. `Supervisor#child_completion_text` returned nil for every exit-0 child, so a successful `hive new` (idea capture) sent no confirmation; the picker token was already consumed, so a confused re-tap reported "idea picker expired." `child_completion_text` now confirms a successful `hive new` (keyed on the verb at `argv[1]`, since `normalize_hive_bin` rewrites `argv[0]`). Audit found `/approve` and `/done` share the silent-success shape but degrade gracefully (downstream notification + WRONG_STAGE on re-tap), so they were left as-is.
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -2389,3 +2389,10 @@ chruby and RVM are intentionally not handled — they modify PATH per-shell and 
 
 **Refreshed pages:**
 - [[decisions]]
+
+## [2026-05-27T00:00:00Z] bot — acknowledge successful /idea capture
+
+**Action:** Fixed the `/idea` project picker appearing to do nothing on tap. `Supervisor#child_completion_text` returned nil for every exit-0 child, so a successful `hive new` (idea capture) sent no confirmation; the picker token was already consumed, so a confused re-tap reported "idea picker expired." `child_completion_text` now confirms a successful `hive new` (keyed on the verb at `argv[1]`, since `normalize_hive_bin` rewrites `argv[0]`). Audit found `/approve` and `/done` share the silent-success shape but degrade gracefully (downstream notification + WRONG_STAGE on re-tap), so they were left as-is.
+
+**Refreshed pages:**
+- [[commands/bot]]


### PR DESCRIPTION
## Summary
- **Bug:** Tapping a project in the Telegram `/idea` picker appeared to do nothing, and a re-tap reported "That idea picker expired." Root cause: `Supervisor#child_completion_text` returned `nil` for every exit-0 child, so a successful `hive new` idea capture sent zero acknowledgment; the single-use picker token was already consumed, so the re-tap hit the "expired" branch.
- **Fix:** `child_completion_text` now confirms a successful `hive new` ("Captured your idea in <project>…"), keyed on the verb at `argv[1]` since `ChildSupervisor#normalize_hive_bin` rewrites `argv[0]` to a resolved binary path. All other exit-0 commands stay silent (their effect surfaces in the next status row / push notification). `/approve` and `/done` share the silent-success shape but degrade gracefully (downstream notification + `WRONG_STAGE` on re-tap), so they were left unchanged.
- **Docs:** wiki (`commands/bot.md` + log) and a learning at `docs/solutions/ui-bugs/`.
- **Headless E2E harness** (`test/e2e/tg/`): a Telethon user-client drives the real bot (send `/idea` → tap picker → assert ack) against a separate @BotFather test token with `/tmp` state, so the production bot is never touched. `bot-e2e.yml` runs it on `workflow_dispatch`.

## Validation
Three ways:
- Unit tests in `test/unit/bot/supervisor_test.rb` (ack names the project, survives a resolved-binary `argv[1]`, stays silent for non-`new` exit-0).
- Manual real tap in Telegram ("Captured your idea in shipped…").
- Autonomous CI run of `bot-e2e.yml`: `PASS ack="Captured your idea in e2eproj. It's in the inbox — move it to 2-brainstorm to start."`

## Notes
- `bot-e2e.yml` is `workflow_dispatch`-only (gentle Telegram use; single poller per token). Secrets live in GitHub Actions secrets; sessions/venv/.env are gitignored.

## Test plan
- [x] `ruby -Itest test/unit/bot/supervisor_test.rb` green
- [x] rubocop clean on changed files
- [x] `bot-e2e.yml` passes on real Actions