### PR TITLE
chore(release): bump to v0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes are documented here, newest first. Hive ships frequent micro-releases (see [docs/RELEASING.md](docs/RELEASING.md#versioning-policy)): each `vX.Y.Z` git tag gets a `## X.Y.Z` section with terse bullets — no `[Unreleased]` accumulator. Versioning is [SemVer](https://semver.org): PATCH for fixes and small changes (the common case), MINOR for notable features, MAJOR for milestones.
 
+## 0.1.9
+
+- Fixed every tmux-mode Claude launch failing with `claude_launch_failed` after a Claude Code TUI update moved the input caret to the end of a context-prefixed line (`<cwd> <git-status>  ❯`) with a hint footer beneath it. The readiness check now detects the caret at the start or end of its line and tolerates the footer, so brainstorm/plan/review stop timing out. Hardened to be robust to future caret repositioning.
+- Fixed the Telegram bot `/idea` flow giving no feedback on success: capturing an idea through the silent project picker now sends an acknowledgement.
+
 ## 0.1.8
 
 - Fixed a crash in v0.1.7's update flow: the daemon's update-check log events (`update_available`, `update_check_no_result`, `update_check_error`, `update_nudge_no_command`) and the bot's (`update_nudge_pushed`, `update_nudge_error`) were never added to the loggers' closed event enums, so a real daemon raised `ArgumentError` on its first "behind" tick and crashed (and the bot logged a spurious fatal). The events are now registered, with regression tests that exercise the real loggers.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hive-cli (0.1.8)
+    hive-cli (0.1.9)
       bubbletea (= 0.1.4)
       lipgloss (~> 0.2.2)
       sqlite3 (~> 2.0)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Hive ships as a rubygem (`hive-cli`) attached to each GitHub Release, signed wit
 | Platform | Channel |
 |----------|---------|
 | macOS arm64 | [`brew install ivankuznetsov/hive/hive`](https://github.com/ivankuznetsov/homebrew-hive) |
-| Ubuntu 22.04+ / glibc Linux x86_64/aarch64 | <code>tmpdir="$(mktemp -d)" && trap 'rm -rf "$tmpdir"' EXIT && curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.1.8/install.sh -o "$tmpdir/hive-install.sh" && bash "$tmpdir/hive-install.sh"</code> |
+| Ubuntu 22.04+ / glibc Linux x86_64/aarch64 | <code>tmpdir="$(mktemp -d)" && trap 'rm -rf "$tmpdir"' EXIT && curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.1.9/install.sh -o "$tmpdir/hive-install.sh" && bash "$tmpdir/hive-install.sh"</code> |
 | Arch Linux x86_64/aarch64 | [`yay -S hive-bin`](https://aur.archlinux.org/packages/hive-bin) |
 
 Prerequisites: **Ruby 3.4** (the gem and its runtime deps install against this), git ≥ 2.40, authenticated `claude` ≥ 2.1.118, `codex` ≥ 0.125.0 for the default execute agent, authenticated `gh`, `tmux` ≥ 3.0 when the project uses the default `claude.mode: tmux`, and Node.js/npm for managed QMD install/repair. The bash installer reports its own installer-side prereqs (`curl`, `jq`, `gem`, checksum tool) on first run; if npm is missing, Hive still installs and `hive doctor` reports the QMD gap non-fatally.

--- a/install.md
+++ b/install.md
@@ -59,8 +59,8 @@ Ubuntu 22.04+ / glibc Linux fallback (pin to the current release tag, not `main`
 ```bash
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
-# Release maintainers: bump v0.1.8 in both installer URLs when cutting a new stable release.
-curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.1.8/install.sh -o "$tmpdir/hive-install.sh"
+# Release maintainers: bump v0.1.9 in both installer URLs when cutting a new stable release.
+curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.1.9/install.sh -o "$tmpdir/hive-install.sh"
 bash "$tmpdir/hive-install.sh"
 ```
 
@@ -69,8 +69,8 @@ To inspect the installer first, run a dry-run before the real invocation. State 
 ```bash
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
-# Release maintainers: bump v0.1.8 in both installer URLs when cutting a new stable release.
-curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.1.8/install.sh -o "$tmpdir/hive-install.sh"
+# Release maintainers: bump v0.1.9 in both installer URLs when cutting a new stable release.
+curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.1.9/install.sh -o "$tmpdir/hive-install.sh"
 bash "$tmpdir/hive-install.sh" --dry-run
 bash "$tmpdir/hive-install.sh"
 ```

--- a/lib/hive.rb
+++ b/lib/hive.rb
@@ -1,5 +1,5 @@
 module Hive
-  VERSION = "0.1.8".freeze
+  VERSION = "0.1.9".freeze
   MIN_CLAUDE_VERSION = "2.1.118".freeze
   # Canonical GitHub org + repo. Referenced by the release probe
   # (UpdateCheck), the brew tap + installer URL (Commands::Update), etc.


### PR DESCRIPTION
## Summary
Release v0.1.9. Bumps `VERSION`, `Gemfile.lock`, and the `v0.1.x` installer-URL refs in README/install.md, and adds the CHANGELOG section.

Fixes since v0.1.8:
- **#227** — tmux Claude launches stopped failing with `claude_launch_failed`: the readiness check now detects the input caret at the line start *or* end and tolerates the new hint footer (a Claude Code TUI change broke the old last-line/line-start anchor). Hardened against future caret repositioning.
- **#226** — Telegram bot `/idea` now acknowledges a successful capture made via the silent project picker.

## Test plan
- [x] `bundle check` passes with the new lock; `cli --version` test green.
- [x] No remaining stray `v0.1.8` release refs (CHANGELOG history excepted).
- [ ] On merge: tag `v0.1.9` and push to trigger `release.yml` (gem + cosign + Homebrew + AUR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)