### PR TITLE
fix(daemon): use waiting-marker write-time as first-sight edit baseline

### DIFF
--- a/lib/hive/daemon/dispatcher.rb
+++ b/lib/hive/daemon/dispatcher.rb
@@ -442,7 +442,8 @@ module Hive
           last_dispatched_state_file_mtime:
             @controller.last_dispatched_state_file_mtime_for(project: row.project, slug: row.slug),
           now: now,
-          edit_debounce_sec: @edit_debounce_sec
+          edit_debounce_sec: @edit_debounce_sec,
+          marker_ts: row.marker_ts
         )
 
         case decision

--- a/lib/hive/daemon/policy.rb
+++ b/lib/hive/daemon/policy.rb
@@ -30,12 +30,18 @@ module Hive
     #   an early dispatch).
     #
     # First-sight policy on `kind: edit`: the daemon sees a `_WAITING`
-    # task with no prior observation. We CANNOT distinguish "agent just
-    # wrote the WAITING marker" from "user already answered hours ago",
-    # so the safe choice is to skip + record the current mtime as the
-    # baseline. The next genuine user edit (mtime > baseline) triggers
-    # dispatch. Operators of dormant-task scenarios can `touch` the
-    # state file to wake the daemon.
+    # task with no prior observation. When the row carries a `marker_ts`
+    # (the agent's WAITING-marker write-time), we use it as the baseline
+    # floor — a state-file write strictly newer than the marker is
+    # genuine user input, so we can dispatch an answer that predates the
+    # daemon's first sight (e.g. after a restart that dropped in-memory
+    # baselines, or when the bot dispatched the brainstorm so no baseline
+    # was ever recorded). Without a `marker_ts` (legacy markers) we CANNOT
+    # distinguish "agent just wrote the WAITING marker" from "user already
+    # answered hours ago", so the safe choice is to skip + record the
+    # current mtime as the baseline; the next genuine user edit (mtime >
+    # baseline) triggers dispatch. Operators of dormant-task scenarios can
+    # `touch` the state file to wake the daemon.
     #
     # Post-completion mtime refresh (handled by Dispatcher, not Policy):
     # after every child reaps, the controller's recorded mtime is
@@ -82,6 +88,12 @@ module Hive
       # @param now [Time] current time (injected for testability)
       # @param edit_debounce_sec [Integer] minimum age of mtime before a
       #   `:edit`-class row is eligible for dispatch (default 30s)
+      # @param marker_ts [Time, nil] the write-time stamped on the row's
+      #   waiting-class marker (`Hive::Markers` `ts` attr). On first sight
+      #   of an edit-resume row it serves as the baseline floor: a state
+      #   file edited after the marker was written is genuine user input.
+      #   nil for legacy markers / non-waiting rows — first-sight then
+      #   falls back to the original `:record_baseline` behavior.
       #
       # @return [Symbol] one of :dispatch, :poll_for_merge, :wait_for_debounce,
       #   :record_baseline, :skip
@@ -91,7 +103,7 @@ module Hive
       # ConcurrencyController#observe_state_file_mtime so the next tick
       # has a baseline to compare against.
       def decide(action:, stage: nil, command:, state_file_mtime:, last_dispatched_state_file_mtime:,
-                 now:, edit_debounce_sec: 30)
+                 now:, edit_debounce_sec: 30, marker_ts: nil)
         return :skip if action.nil?
         # Three branches dispatch the row's command verbatim (advance,
         # plan_approval) or via the edit-resume path (edit_resume).
@@ -114,7 +126,8 @@ module Hive
           decide_edit(state_file_mtime: state_file_mtime,
                       last_dispatched: last_dispatched_state_file_mtime,
                       now: now,
-                      debounce_sec: edit_debounce_sec)
+                      debounce_sec: edit_debounce_sec,
+                      marker_ts: marker_ts)
         else
           # `recover_execute` / `recover_review` / `agent_running` /
           # `archived` / `error` plus any unknown future TaskActionKind
@@ -147,11 +160,29 @@ module Hive
         action == "needs_input" && stage == "3-plan"
       end
 
-      def decide_edit(state_file_mtime:, last_dispatched:, now:, debounce_sec:)
+      def decide_edit(state_file_mtime:, last_dispatched:, now:, debounce_sec:, marker_ts: nil)
         return :skip if state_file_mtime.nil?
 
         if last_dispatched.nil?
-          # First sight of this `kind: edit` row. We can't distinguish
+          # First sight of this `kind: edit` row.
+          #
+          # With a `marker_ts` (the agent's WAITING-marker write-time) we
+          # CAN distinguish "agent just asked" from "user already
+          # answered": the marker fixes the ask time, so any state-file
+          # write strictly newer than it is genuine user input. This is
+          # the baseline floor — it lets us dispatch an answer that
+          # predates the daemon's first sight of the row (after a restart
+          # that lost the in-memory baseline, or when the bot dispatched
+          # the brainstorm so no baseline was ever recorded). Debounce
+          # still applies so a mid-save draft doesn't fire early.
+          unless marker_ts.nil?
+            return :record_baseline if state_file_mtime <= marker_ts
+            return :wait_for_debounce if (now - state_file_mtime) < debounce_sec
+
+            return :dispatch
+          end
+
+          # Legacy / non-waiting markers carry no `ts`. We can't tell
           # "agent just wrote the WAITING marker" from "user answered
           # hours ago", so we record the current mtime as the baseline
           # and skip. The dispatcher must observe this signal to seed

--- a/lib/hive/daemon/status_consumer.rb
+++ b/lib/hive/daemon/status_consumer.rb
@@ -1,6 +1,7 @@
 require "open3"
 require "json"
 require "time"
+require "hive/markers"
 
 module Hive
   module Daemon
@@ -17,7 +18,7 @@ module Hive
       # healer and dispatcher both need this so they don't race the runner
       # during the pre-claude window (issue #144).
       Row = Struct.new(:project, :slug, :stage, :marker, :folder, :state_file,
-                       :state_file_mtime, :action, :suggested_command, :claude_pid_alive,
+                       :state_file_mtime, :marker_ts, :action, :suggested_command, :claude_pid_alive,
                        :live_task_lock, :diagnostic,
                        keyword_init: true)
       # Aggregated per-project legacy-layout signal lifted out of each
@@ -90,6 +91,7 @@ module Hive
               folder: task["folder"],
               state_file: task["state_file"],
               state_file_mtime: parse_mtime(task["mtime"], task["state_file"]),
+              marker_ts: read_marker_ts(task["state_file"]),
               action: task["action"],
               suggested_command: task["suggested_command"],
               claude_pid_alive: task["claude_pid_alive"],
@@ -126,6 +128,22 @@ module Hive
         # If the envelope didn't include mtime, or it didn't parse,
         # stat the state file directly. nil if the file is gone.
         File.mtime(state_file_path) if state_file_path && File.exist?(state_file_path)
+      end
+
+      # The write-time stamped on a waiting-class marker (see
+      # Hive::Markers.attrs_with_waiting_ts), parsed to a Time. The daemon
+      # policy uses it as the first-sight baseline floor for edit-resume
+      # rows. nil when there is no state file, no `ts` attr (legacy or
+      # non-waiting marker), or the value doesn't parse.
+      def read_marker_ts(state_file_path)
+        return nil unless state_file_path && File.exist?(state_file_path)
+
+        ts = Hive::Markers.current(state_file_path).attrs["ts"]
+        return nil if ts.nil? || ts.empty?
+
+        Time.parse(ts)
+      rescue ArgumentError
+        nil
       end
     end
   end

--- a/lib/hive/markers.rb
+++ b/lib/hive/markers.rb
@@ -1,4 +1,5 @@
 require "securerandom"
+require "time"
 
 module Hive
   module Markers
@@ -45,7 +46,15 @@ module Hive
     # code here updates both consumers; previously each module had its
     # own private copy and would drift on edit.
     KILL_CLASS_EXIT_CODES = %w[130 137 143].freeze
-    INTERNAL_ATTR_KEYS = %w[marker_id].freeze
+    INTERNAL_ATTR_KEYS = %w[marker_id ts].freeze
+
+    # Waiting-class markers carry an internal `ts` write-time stamp (see
+    # `attrs_with_waiting_ts`). The daemon's first-sight edit policy uses
+    # it as the baseline floor: any state-file edit after the marker was
+    # written is treated as user input, so an answer that predates the
+    # daemon's first sight of the row (after a restart, or when the bot
+    # dispatched the brainstorm) is no longer stranded.
+    WAITING_MARKER_NAMES = %w[WAITING EXECUTE_WAITING REVIEW_WAITING].freeze
 
     State = Struct.new(:name, :attrs, :raw, keyword_init: true) do
       def none?
@@ -82,6 +91,7 @@ module Hive
       raise ArgumentError, "unknown marker #{marker_name}" unless KNOWN_NAMES.include?(marker_name)
 
       attrs = attrs_with_error_marker_id(marker_name, attrs)
+      attrs = attrs_with_waiting_ts(marker_name, attrs)
       new_marker = build_marker(marker_name, attrs)
       ensure_dir(state_file_path)
       with_markers_lock(state_file_path) do
@@ -144,6 +154,18 @@ module Hive
       return attrs unless attrs["marker_id"].to_s.empty? && attrs[:marker_id].to_s.empty?
 
       attrs.merge("marker_id" => SecureRandom.hex(8))
+    end
+
+    # Stamp the UTC write-time on waiting-class markers so the daemon can
+    # tell "agent just asked" from "user already answered". Skips non-
+    # waiting markers, and preserves any caller-supplied `ts` (string or
+    # symbol key) — important for deterministic tests that pin the stamp.
+    def attrs_with_waiting_ts(marker_name, attrs)
+      attrs = attrs ? attrs.to_h : {}
+      return attrs unless WAITING_MARKER_NAMES.include?(marker_name)
+      return attrs unless attrs["ts"].to_s.empty? && attrs[:ts].to_s.empty?
+
+      attrs.merge("ts" => Time.now.utc.iso8601)
     end
 
     def display_attrs(attrs)

--- a/test/unit/daemon/dispatcher_test.rb
+++ b/test/unit/daemon/dispatcher_test.rb
@@ -140,13 +140,13 @@ class HiveDaemonDispatcherTest < Minitest::Test
   def row(project: "p1", slug: "s1", stage: "1-inbox", marker: "waiting",
           action: "ready_to_brainstorm", command: "hive brainstorm s1",
           mtime: T0 - 600, claude_pid_alive: nil, live_task_lock: nil,
-          state_file: nil, folder: nil)
+          state_file: nil, folder: nil, marker_ts: nil)
     folder ||= make_existing_row_folder(project: project, stage: stage, slug: slug)
     Row.new(
       project: project, slug: slug, stage: stage, marker: marker,
       folder: folder,
       state_file: state_file || File.join(folder, "idea.md"),
-      state_file_mtime: mtime, action: action,
+      state_file_mtime: mtime, marker_ts: marker_ts, action: action,
       suggested_command: command, claude_pid_alive: claude_pid_alive,
       live_task_lock: live_task_lock
     )
@@ -402,6 +402,27 @@ class HiveDaemonDispatcherTest < Minitest::Test
     # Logged as :skipped with reason: baseline_recorded
     skipped = logger.events.find { |(n, a)| n == :skipped && a[:reason] == "baseline_recorded" }
     refute_nil skipped, "must log :skipped reason: baseline_recorded"
+  end
+
+  def test_edit_action_first_sight_with_marker_ts_dispatches_answered_task
+    # Regression: a brainstorm/needs_input task the user already answered
+    # before the daemon's first sight (after a daemon restart, or when the
+    # bot dispatched the brainstorm so no baseline was recorded) used to be
+    # stranded forever. With the agent's WAITING-marker write-time
+    # (marker_ts) as the baseline floor, a state-file edit newer than the
+    # ask is recognised as user input and dispatched on first sight.
+    asked_at = T0 - 600
+    answered_at = T0 - 60 # after the ask, past the 30s debounce
+    rows = [ row(action: "needs_input", marker: "waiting",
+                 command: "hive brainstorm s1 --from 2-brainstorm",
+                 mtime: answered_at, marker_ts: asked_at) ]
+    dispatcher, sup, _ctrl, logger, _mw = make_dispatcher(rows: rows)
+    dispatcher.tick(now: T0)
+
+    assert_equal 1, sup.spawned.size,
+                 "an answer that predates the daemon's first sight must still dispatch"
+    assert_equal "hive brainstorm s1 --from 2-brainstorm", sup.spawned.first[:command]
+    assert events_include?(logger, :dispatched)
   end
 
   def test_plan_needs_input_first_sight_dispatches_without_baseline

--- a/test/unit/daemon/policy_test.rb
+++ b/test/unit/daemon/policy_test.rb
@@ -185,6 +185,57 @@ class HiveDaemonPolicyTest < Minitest::Test
                                             edit_debounce_sec: 60)
   end
 
+  # ── edit-resume first-sight with a marker_ts baseline floor ────────────
+  # When the row carries the agent's WAITING-marker write-time, first
+  # sight can tell "agent just asked" from "user already answered": a
+  # state-file write strictly newer than the marker is genuine input. This
+  # de-strands tasks answered before the daemon's first sight (after a
+  # restart, or when the bot dispatched the brainstorm).
+
+  def test_first_sight_with_marker_ts_older_than_edit_dispatches
+    # User answered AFTER the marker was written, debounce elapsed → fire,
+    # even though this is the daemon's first sight (last_dispatched nil).
+    assert_equal :dispatch,
+                 decide(action: "needs_input",
+                        command: "hive brainstorm slug-a --from 2-brainstorm",
+                        state_file_mtime: T0 - 60,
+                        last_dispatched_state_file_mtime: nil,
+                        marker_ts: T0 - 600)
+  end
+
+  def test_first_sight_with_marker_ts_older_but_within_debounce_waits
+    # Answer landed after the ask but only 5s ago — let the file settle.
+    assert_equal :wait_for_debounce,
+                 decide(action: "needs_input",
+                        command: "hive brainstorm slug-a --from 2-brainstorm",
+                        state_file_mtime: T0 - 5,
+                        last_dispatched_state_file_mtime: nil,
+                        marker_ts: T0 - 600)
+  end
+
+  def test_first_sight_with_marker_ts_equal_to_mtime_records_baseline
+    # Unanswered: the only write to the file IS the agent's WAITING marker
+    # (mtime == marker_ts). Not user input → record baseline, don't fire.
+    asked_at = T0 - 600
+    assert_equal :record_baseline,
+                 decide(action: "needs_input",
+                        command: "hive brainstorm slug-a --from 2-brainstorm",
+                        state_file_mtime: asked_at,
+                        last_dispatched_state_file_mtime: nil,
+                        marker_ts: asked_at)
+  end
+
+  def test_first_sight_with_nil_marker_ts_records_baseline
+    # Back-compat: legacy markers carry no ts → original first-sight
+    # behavior (record baseline, never dispatch on first sight).
+    assert_equal :record_baseline,
+                 decide(action: "needs_input",
+                        command: "hive brainstorm slug-a --from 2-brainstorm",
+                        state_file_mtime: T0 - 60,
+                        last_dispatched_state_file_mtime: nil,
+                        marker_ts: nil)
+  end
+
   # ── skip actions: human-required states ────────────────────────────────
 
   def test_recover_execute_skips
@@ -323,7 +374,8 @@ class HiveDaemonPolicyTest < Minitest::Test
   private
 
   def decide(action:, command:, stage: nil, state_file_mtime: nil,
-             last_dispatched_state_file_mtime: nil, now: T0, edit_debounce_sec: 30)
+             last_dispatched_state_file_mtime: nil, now: T0, edit_debounce_sec: 30,
+             marker_ts: nil)
     Hive::Daemon::Policy.decide(
       action: action,
       stage: stage,
@@ -331,7 +383,8 @@ class HiveDaemonPolicyTest < Minitest::Test
       state_file_mtime: state_file_mtime,
       last_dispatched_state_file_mtime: last_dispatched_state_file_mtime,
       now: now,
-      edit_debounce_sec: edit_debounce_sec
+      edit_debounce_sec: edit_debounce_sec,
+      marker_ts: marker_ts
     )
   end
 end

--- a/test/unit/daemon/status_consumer_test.rb
+++ b/test/unit/daemon/status_consumer_test.rb
@@ -185,6 +185,81 @@ class HiveDaemonStatusConsumerTest < Minitest::Test
     end
   end
 
+  # ── marker_ts plumbing (daemon first-sight baseline floor) ─────────────
+
+  def test_marker_ts_parsed_from_waiting_marker
+    with_tmp_dir do |dir|
+      state_file = File.join(dir, "idea.md")
+      Hive::Markers.set(state_file, :waiting, ts: "2026-05-27T10:00:00Z")
+
+      task = task_row(slug: "ts-row")
+      task["state_file"] = state_file
+      payload = make_envelope(projects: [ {
+        "name" => "p", "path" => dir, "hive_state_path" => File.join(dir, ".h"),
+        "tasks" => [ task ]
+      } ])
+
+      with_fake_status(JSON.generate(payload)) do |bin|
+        result = Hive::Daemon::StatusConsumer.new(hive_bin: bin).fetch
+        assert result.ok
+        assert_equal Time.parse("2026-05-27T10:00:00Z"), result.rows.first.marker_ts
+      end
+    end
+  end
+
+  def test_marker_ts_nil_when_marker_has_no_ts
+    with_tmp_dir do |dir|
+      state_file = File.join(dir, "idea.md")
+      # Non-waiting marker → no ts stamp.
+      Hive::Markers.set(state_file, :complete)
+
+      task = task_row(slug: "no-ts")
+      task["state_file"] = state_file
+      payload = make_envelope(projects: [ {
+        "name" => "p", "path" => dir, "hive_state_path" => File.join(dir, ".h"),
+        "tasks" => [ task ]
+      } ])
+
+      with_fake_status(JSON.generate(payload)) do |bin|
+        result = Hive::Daemon::StatusConsumer.new(hive_bin: bin).fetch
+        assert result.ok
+        assert_nil result.rows.first.marker_ts
+      end
+    end
+  end
+
+  def test_marker_ts_nil_on_unparseable_value
+    with_tmp_dir do |dir|
+      state_file = File.join(dir, "idea.md")
+      File.write(state_file, "<!-- WAITING ts=not-a-time -->\n")
+
+      task = task_row(slug: "bad-ts")
+      task["state_file"] = state_file
+      payload = make_envelope(projects: [ {
+        "name" => "p", "path" => dir, "hive_state_path" => File.join(dir, ".h"),
+        "tasks" => [ task ]
+      } ])
+
+      with_fake_status(JSON.generate(payload)) do |bin|
+        result = Hive::Daemon::StatusConsumer.new(hive_bin: bin).fetch
+        assert result.ok
+        assert_nil result.rows.first.marker_ts
+      end
+    end
+  end
+
+  def test_marker_ts_nil_when_state_file_missing
+    payload = make_envelope(projects: [ {
+      "name" => "p", "path" => "/tmp/p", "hive_state_path" => "/tmp/p/.h",
+      "tasks" => [ task_row(slug: "gone") ]
+    } ])
+    with_fake_status(JSON.generate(payload)) do |bin|
+      result = Hive::Daemon::StatusConsumer.new(hive_bin: bin).fetch
+      assert result.ok
+      assert_nil result.rows.first.marker_ts
+    end
+  end
+
   # ── failure modes ─────────────────────────────────────────────────────
 
   def test_non_zero_exit_returns_not_ok

--- a/test/unit/markers_test.rb
+++ b/test/unit/markers_test.rb
@@ -148,7 +148,9 @@ class MarkersTest < Minitest::Test
     with_tmp_dir do |dir|
       file = File.join(dir, "x.md")
       Hive::Markers.set(file, :waiting)
-      assert_includes File.read(file), "<!-- WAITING -->"
+      # Waiting-class markers carry an internal `ts` write-time stamp.
+      assert_match(/<!-- WAITING ts=\S+ -->/, File.read(file))
+      assert_equal :waiting, Hive::Markers.current(file).name
     end
   end
 
@@ -382,5 +384,48 @@ class MarkersTest < Minitest::Test
       file = File.join(dir, "task.md")
       assert_raises(ArgumentError) { Hive::Markers.set(file, :review_typo) }
     end
+  end
+
+  # --- waiting-marker `ts` stamp (daemon first-sight baseline) ------------
+
+  # The daemon's first-sight edit policy needs the agent's "ask time" to
+  # tell an already-answered task from a freshly-asked one. set stamps a
+  # `ts` on waiting-class markers; it must round-trip through current.
+  def test_waiting_class_markers_carry_ts_that_round_trips
+    with_tmp_dir do |dir|
+      %i[waiting execute_waiting review_waiting].each do |name|
+        file = File.join(dir, "#{name}.md")
+        Hive::Markers.set(file, name)
+        ts = Hive::Markers.current(file).attrs["ts"]
+        refute_nil ts, "#{name} should carry a ts stamp"
+        # Parses as an ISO-8601 UTC time.
+        assert_kind_of Time, Time.parse(ts)
+      end
+    end
+  end
+
+  def test_waiting_marker_preserves_caller_supplied_ts
+    with_tmp_dir do |dir|
+      file = File.join(dir, "x.md")
+      Hive::Markers.set(file, :waiting, ts: "2020-01-01T00:00:00Z")
+      assert_equal "2020-01-01T00:00:00Z", Hive::Markers.current(file).attrs["ts"]
+    end
+  end
+
+  def test_non_waiting_markers_get_no_ts
+    with_tmp_dir do |dir|
+      %i[complete agent_working execute_complete review_complete].each do |name|
+        file = File.join(dir, "#{name}.md")
+        Hive::Markers.set(file, name)
+        assert_nil Hive::Markers.current(file).attrs["ts"],
+                   "#{name} must not carry a ts stamp"
+      end
+    end
+  end
+
+  def test_display_attrs_hides_internal_ts
+    attrs = { "escalations" => "1", "ts" => "2026-05-27T12:00:00Z" }
+
+    assert_equal({ "escalations" => "1" }, Hive::Markers.display_attrs(attrs))
   end
 end


### PR DESCRIPTION
## Summary
The auto-advancing daemon stranded `needs_input` (brainstorm/execute/review-waiting) tasks the user had **already answered**. `Policy#decide_edit` recorded the current state-file mtime as the baseline on first sight and only dispatched on a *strictly-newer* edit — so an answer that predated the daemon's first sight was never "newer" and the task was skipped on every tick forever. This happens routinely:
- after a **daemon restart** (in-memory baselines are lost), and
- when the **bot** dispatched the brainstorm, so the daemon never recorded a baseline for it.

This was hit live: answered brainstorms sat in "Needs your input" and never advanced until the state file was manually `touch`ed.

## Fix
Stamp a UTC `ts` write-time on waiting-class markers (`WAITING` / `EXECUTE_WAITING` / `REVIEW_WAITING`) in `Markers.set` — mirroring the existing `ERROR` `marker_id` stamping — and surface it to the daemon as `Row#marker_ts`. On first sight of an edit-resume row, `Policy` now uses the marker's write-time as the **baseline floor**:

| First-sight case | Decision |
|---|---|
| `marker_ts` present, `mtime <= marker_ts` (agent just asked, no answer yet) | `:record_baseline` |
| `marker_ts` present, `mtime > marker_ts`, debounce not met | `:wait_for_debounce` |
| `marker_ts` present, `mtime > marker_ts`, debounce met | `:dispatch` |
| `marker_ts` nil (legacy / non-waiting) | `:record_baseline` (unchanged) |

The marker write-time fixes the "ask time", so any later answer is reliably detected as user input even across a daemon restart or a bot-dispatched brainstorm.

## Notes
- `ts` is an **internal** attr (added to `INTERNAL_ATTR_KEYS`), hidden from operator-facing marker display.
- **Fully back-compat**: with no `marker_ts`, the original first-sight `:record_baseline` behavior is byte-identical.
- `read_marker_ts` degrades to nil on missing file / no `ts` / unparseable timestamp.

## Test plan
- [x] `test/unit/markers_test.rb` — waiting markers get a round-tripping `ts`; caller-supplied `ts` preserved; non-waiting markers get none; `ts` excluded from `display_attrs`.
- [x] `test/unit/daemon/policy_test.rb` — all four first-sight cases above; existing cases unchanged.
- [x] `test/unit/daemon/{status_consumer,dispatcher}_test.rb` — `marker_ts` plumbing.
- [x] `rake coverage` 100% (4020 runs, 0 failures), `rubocop` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)