### PR TITLE
chore(release): bump to v0.1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes are documented here, newest first. Hive ships frequent micro-releases (see [docs/RELEASING.md](docs/RELEASING.md#versioning-policy)): each `vX.Y.Z` git tag gets a `## X.Y.Z` section with terse bullets — no `[Unreleased]` accumulator. Versioning is [SemVer](https://semver.org): PATCH for fixes and small changes (the common case), MINOR for notable features, MAJOR for milestones.
 
+## 0.1.10
+
+- Fixed the daemon stranding already-answered `needs_input` tasks across a restart. The `[project, slug] → state_file_mtime` baseline map (consulted by `Policy#decide_edit` to detect fresh user input) was in-memory only, so a pre-restart answer never looked "newer than baseline" on first sight and got skipped on every tick forever until you manually `touch`ed the state file. Baselines now persist to `daemon_dispatch_baselines.json` under the state home (atomic write + fail-closed load + sibling-flock + orphan-tmp sweep), reload on startup, and prune to the live task set each successful tick — bounded to the projects in the snapshot so a per-project status error doesn't wipe its baselines.
+- Fixed features getting stuck for hours at `8-finalize` with `:error reason=dirty_worktree` whenever a stage left orphan edits behind (e.g. a `6-review` fix agent that wrote one more file after the per-pass auto-commit window closed). Promoted "the worktree is clean at stage exit" to a stage-level invariant enforced once in `Hive::Stages::Base.with_stage_events`: residue is auto-committed as `chore(<stage>): commit residual worktree changes` with `Hive-Auto-Commit: residue` trailers, gated by the existing `review.fix.auto_commit.scope_check` allowlist and skipped for the four pause markers. `Finalize.verify_state!` re-runs the same check on entry so any feature already stuck pre-merge self-heals on its next tick. The bot routes dirty-worktree `:error` markers as manual-only, stopping the Autofix retry loop.
+
 ## 0.1.9
 
 - Fixed every tmux-mode Claude launch failing with `claude_launch_failed` after a Claude Code TUI update moved the input caret to the end of a context-prefixed line (`<cwd> <git-status>  ❯`) with a hint footer beneath it. The readiness check now detects the caret at the start or end of its line and tolerates the footer, so brainstorm/plan/review stop timing out. Hardened to be robust to future caret repositioning.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hive-cli (0.1.9)
+    hive-cli (0.1.10)
       bubbletea (= 0.1.4)
       lipgloss (~> 0.2.2)
       sqlite3 (~> 2.0)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Hive ships as a rubygem (`hive-cli`) attached to each GitHub Release, signed wit
 | Platform | Channel |
 |----------|---------|
 | macOS arm64 | [`brew install ivankuznetsov/hive/hive`](https://github.com/ivankuznetsov/homebrew-hive) |
-| Ubuntu 22.04+ / glibc Linux x86_64/aarch64 | <code>tmpdir="$(mktemp -d)" && trap 'rm -rf "$tmpdir"' EXIT && curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.1.9/install.sh -o "$tmpdir/hive-install.sh" && bash "$tmpdir/hive-install.sh"</code> |
+| Ubuntu 22.04+ / glibc Linux x86_64/aarch64 | <code>tmpdir="$(mktemp -d)" && trap 'rm -rf "$tmpdir"' EXIT && curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.1.10/install.sh -o "$tmpdir/hive-install.sh" && bash "$tmpdir/hive-install.sh"</code> |
 | Arch Linux x86_64/aarch64 | [`yay -S hive-bin`](https://aur.archlinux.org/packages/hive-bin) |
 
 Prerequisites: **Ruby 3.4** (the gem and its runtime deps install against this), git ≥ 2.40, authenticated `claude` ≥ 2.1.118, `codex` ≥ 0.125.0 for the default execute agent, authenticated `gh`, `tmux` ≥ 3.0 when the project uses the default `claude.mode: tmux`, and Node.js/npm for managed QMD install/repair. The bash installer reports its own installer-side prereqs (`curl`, `jq`, `gem`, checksum tool) on first run; if npm is missing, Hive still installs and `hive doctor` reports the QMD gap non-fatally.

--- a/install.md
+++ b/install.md
@@ -59,8 +59,8 @@ Ubuntu 22.04+ / glibc Linux fallback (pin to the current release tag, not `main`
 ```bash
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
-# Release maintainers: bump v0.1.9 in both installer URLs when cutting a new stable release.
-curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.1.9/install.sh -o "$tmpdir/hive-install.sh"
+# Release maintainers: bump v0.1.10 in both installer URLs when cutting a new stable release.
+curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.1.10/install.sh -o "$tmpdir/hive-install.sh"
 bash "$tmpdir/hive-install.sh"
 ```
 
@@ -69,8 +69,8 @@ To inspect the installer first, run a dry-run before the real invocation. State 
 ```bash
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
-# Release maintainers: bump v0.1.9 in both installer URLs when cutting a new stable release.
-curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.1.9/install.sh -o "$tmpdir/hive-install.sh"
+# Release maintainers: bump v0.1.10 in both installer URLs when cutting a new stable release.
+curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.1.10/install.sh -o "$tmpdir/hive-install.sh"
 bash "$tmpdir/hive-install.sh" --dry-run
 bash "$tmpdir/hive-install.sh"
 ```

--- a/lib/hive.rb
+++ b/lib/hive.rb
@@ -1,5 +1,5 @@
 module Hive
-  VERSION = "0.1.9".freeze
+  VERSION = "0.1.10".freeze
   MIN_CLAUDE_VERSION = "2.1.118".freeze
   # Canonical GitHub org + repo. Referenced by the release probe
   # (UpdateCheck), the brew tap + installer URL (Commands::Update), etc.


### PR DESCRIPTION
## Summary

Release v0.1.10. Bumps `VERSION`, `Gemfile.lock`, and the `v0.1.x` installer-URL refs in README/install.md, and adds the CHANGELOG section.

Fixes since v0.1.9:
- **#230** — daemon no longer strands already-answered `needs_input` tasks across a restart. Baselines now persist to `daemon_dispatch_baselines.json` (atomic write + fail-closed load + sibling-flock + orphan-tmp sweep), reload on startup, and prune to the live task set each successful tick.
- **#232** — stages no longer leave features stuck for hours at `8-finalize` with `:error reason=dirty_worktree`. "Worktree is clean at stage exit" is now a stage-level invariant; residue is auto-committed via the existing scope-check allowlist; the bot routes dirty-worktree errors as manual-only so the Autofix retry loop stops.

Non-user-visible (no release notes line):
- **#225** — e2e test coverage for the update flow.
- **#237** — repro.sh harness fixes for `{run_home}` writes + new stateful kinds (only matters when reproducing e2e failures locally).

## Test plan
- [x] `bundle check` passes with the new lock; `cli --version` test green (`bin/hive --version` → `0.1.10`).
- [x] No remaining stray `v0.1.9` release refs (CHANGELOG history excepted).
- [x] Rebased on `origin/main` to include #232 and #237.
- [ ] On merge: tag `v0.1.10` and push to trigger `release.yml` (gem + cosign + Homebrew + AUR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)