### PR TITLE
refactor(daemon,bot): single-dispatcher via file-backed request queue

### DIFF
--- a/lib/hive.rb
+++ b/lib/hive.rb
@@ -33,7 +33,13 @@ module Hive
       "hive-bot-status" => 1,
       "hive-bot-stop" => 1,
       "hive-bot-reload" => 1,
-      "hive-bot-install" => 1
+      "hive-bot-install" => 1,
+      # File-backed dispatch request the bot writes for the daemon to
+      # consume. One JSON file per pending request under the state-home
+      # `dispatch_requests/` directory. See
+      # `Hive::Daemon::DispatchRequestQueue` and
+      # `Hive::Bot::DispatchRequestWriter`.
+      "hive-dispatch-request" => 1
     }.freeze
 
     # Closed enum of Diagnostic.generated_by values accepted by the

--- a/lib/hive/bot/dispatch_request_writer.rb
+++ b/lib/hive/bot/dispatch_request_writer.rb
@@ -1,0 +1,100 @@
+require "json"
+require "fileutils"
+require "securerandom"
+require "time"
+require "hive/paths"
+require "hive/daemon/dispatch_request_queue"
+
+module Hive
+  module Bot
+    # Writes a single dispatch request file into the daemon's queue
+    # directory (`<state_home>/dispatch_requests/`). The bot is the
+    # only producer today; the daemon's
+    # `Hive::Daemon::DispatchRequestQueue` is the only consumer.
+    #
+    # The write is atomic: tmp file + `File.rename` to the final
+    # path. A concurrent daemon scan therefore never observes a
+    # partial JSON document — either the file is absent or it parses
+    # whole. That's the whole reason this lives outside the bot's
+    # process-supervised `ChildSupervisor`: the bot stops being a
+    # child-process launcher for `hive run`-class verbs, and the
+    # write here is the only side-effect we still need.
+    module DispatchRequestWriter
+      module_function
+
+      SCHEMA = Hive::Daemon::DispatchRequestQueue::SCHEMA
+      SCHEMA_VERSION = Hive::Daemon::DispatchRequestQueue::SCHEMA_VERSION
+
+      # Build, atomic-write, and return the new request_id.
+      #
+      # Required:
+      #   project: the project name (matches `hive status` rows).
+      #   slug:    the task slug.
+      #   argv:    `["hive", "<verb>", ...]`. The verb must already be
+      #            in `Hive::Daemon::DispatchRequestQueue::ALLOWED_VERBS`
+      #            — callers go through the same allowlist the daemon
+      #            enforces so a typo at the call site doesn't write a
+      #            request the daemon will reject + remove.
+      #
+      # Optional:
+      #   chat_id, update_id — Telegram routing context. Carried through
+      #     to telemetry only; the daemon does not read them.
+      #   trigger — operator-facing reason for the request (e.g.
+      #     "answer_complete", "autofix", "slash_done"). Telemetry only.
+      #   state_home — test injection point.
+      #   now — clock injection.
+      def write!(project:, slug:, argv:, chat_id: nil, update_id: nil,
+                 trigger: nil, state_home: Hive::Paths.state_home,
+                 now: Time.now)
+        unless Hive::Daemon::DispatchRequestQueue.valid_argv?(argv)
+          # Caller bug: reject loudly so we never write a request the
+          # daemon would discard + log as rejected. The bot test
+          # harness asserts on this exception so the regression is
+          # caught at the unit-test layer, not in the bot's runtime
+          # logs.
+          raise ArgumentError, "argv #{argv.inspect} is not allowlisted for dispatch requests"
+        end
+
+        request_id = SecureRandom.hex(8)
+        created_at = now.utc
+        payload = {
+          "schema" => SCHEMA,
+          "schema_version" => SCHEMA_VERSION,
+          "request_id" => request_id,
+          "created_at" => created_at.iso8601,
+          "project" => project.to_s,
+          "slug" => slug.to_s,
+          "argv" => argv,
+          "requestor" => "bot",
+          "chat_id" => chat_id,
+          "update_id" => update_id,
+          "trigger" => trigger.to_s
+        }
+
+        dir = Hive::Daemon::DispatchRequestQueue.directory(state_home: state_home)
+        filename = Hive::Daemon::DispatchRequestQueue.filename_for(
+          created_at: created_at, request_id: request_id
+        )
+        final_path = File.join(dir, filename)
+        tmp_path = File.join(dir, ".#{filename}.tmp.#{Process.pid}.#{Thread.current.object_id}")
+
+        File.open(tmp_path, File::WRONLY | File::CREAT | File::TRUNC, 0o644) do |f|
+          f.write(JSON.generate(payload))
+          f.flush
+          begin
+            f.fsync
+          rescue StandardError
+            # fsync is best-effort on exotic filesystems; the atomic
+            # rename below still guarantees a consistent observable
+            # state.
+            nil
+          end
+        end
+        File.rename(tmp_path, final_path)
+        request_id
+      ensure
+        FileUtils.rm_f(tmp_path) if tmp_path && File.exist?(tmp_path)
+      end
+    end
+  end
+end

--- a/lib/hive/bot/dispatch_request_writer.rb
+++ b/lib/hive/bot/dispatch_request_writer.rb
@@ -55,6 +55,23 @@ module Hive
           raise ArgumentError, "argv #{argv.inspect} is not allowlisted for dispatch requests"
         end
 
+        # AC-04 from PR #241 ce-code-review: an empty/nil project
+        # silently becomes `""` after `project.to_s`, the daemon
+        # rejects with `:missing_project`, removes the file, and the
+        # operator sees a generic "Couldn't queue" reply. Guard at
+        # the producer boundary so the failure is loud + actionable
+        # rather than silently swallowed downstream.
+        if project.to_s.empty?
+          raise ArgumentError,
+                "project is required for dispatch requests (got #{project.inspect})"
+        end
+        # Symmetric guard for slug — the daemon's `:missing_slug`
+        # reject is the same trap.
+        if slug.to_s.empty?
+          raise ArgumentError,
+                "slug is required for dispatch requests (got #{slug.inspect})"
+        end
+
         request_id = SecureRandom.hex(8)
         created_at = now.utc
         payload = {

--- a/lib/hive/bot/dispatch_request_writer.rb
+++ b/lib/hive/bot/dispatch_request_writer.rb
@@ -81,14 +81,13 @@ module Hive
         File.open(tmp_path, File::WRONLY | File::CREAT | File::TRUNC, 0o644) do |f|
           f.write(JSON.generate(payload))
           f.flush
-          begin
-            f.fsync
-          rescue StandardError
-            # fsync is best-effort on exotic filesystems; the atomic
-            # rename below still guarantees a consistent observable
-            # state.
-            nil
-          end
+          # Best-effort fsync. If the filesystem returns EINVAL/ENOTSUP
+          # (tmpfs without fsync, some FUSE mounts) the atomic rename
+          # below still guarantees a consistent observable state. We
+          # don't rescue here because the surrounding `write!` rescue-
+          # nothing contract is itself wrapped by callers (the
+          # supervisor's enqueue_dispatch_request catches StandardError).
+          f.fsync
         end
         File.rename(tmp_path, final_path)
         request_id

--- a/lib/hive/bot/handlers/slash_handlers.rb
+++ b/lib/hive/bot/handlers/slash_handlers.rb
@@ -83,6 +83,7 @@ module Hive
           conversation_store.clear(chat_id: update.chat_id, slug: state.slug)
           @result_class.new(action: :dispatch_then_reply,
                             command_argv: [ "hive", "run", state.slug, "--json" ],
+                            project: state.respond_to?(:project) ? state.project : nil,
                             slug: state.slug)
         end
 

--- a/lib/hive/bot/supervisor.rb
+++ b/lib/hive/bot/supervisor.rb
@@ -687,12 +687,17 @@ module Hive
           project: result.project,
           slug: result.slug
         )
-        execute_dispatch(per_command, update)
-        # Clear only AFTER a successful dispatch so a dispatch failure leaves
-        # the conversation intact and the /done backstop can retry. (The
-        # earlier order cleared first, which stranded the operator if the
-        # spawn raised — they'd seen "running automatically" but /done found
-        # no conversation to dispatch.)
+        dispatched_request_id = execute_dispatch(per_command, update)
+        # C2 from PR #241 ce-code-review: ONLY clear the conversation
+        # after a successful enqueue. `enqueue_dispatch_request`
+        # rescues internally and returns nil on failure (write to a
+        # read-only state dir, ENOSPC, ArgumentError on invalid argv
+        # slipped past the router). Without the nil-check the
+        # conversation would be cleared while the request was never
+        # queued — the operator's `/done` backstop would then find
+        # no conversation to re-dispatch.
+        return unless dispatched_request_id
+
         @conversation_store.clear(chat_id: update.chat_id, slug: result.slug)
       rescue StandardError => e
         @logger.event(:send_failure, source: "auto_run_after_answers",

--- a/lib/hive/bot/supervisor.rb
+++ b/lib/hive/bot/supervisor.rb
@@ -10,6 +10,8 @@ require "hive/bot/notification_dispatcher"
 require "hive/bot/conversation_store"
 require "hive/bot/router"
 require "hive/bot/child_supervisor"
+require "hive/bot/dispatch_request_writer"
+require "hive/daemon/dispatch_request_queue"
 require "hive/bot/brainstorm_answer_writer"
 require "hive/bot/brainstorm_parser"
 require "hive/bot/title_formatter"
@@ -33,7 +35,8 @@ module Hive
 
       def initialize(config:, token:, logger: nil, telegram: nil, status_watcher: nil,
                      notification_dispatcher: nil, router: nil, child_supervisor: nil,
-                     conversation_store: nil, dry_run: false, update_state: nil)
+                     conversation_store: nil, dry_run: false, update_state: nil,
+                     dispatch_request_writer: nil)
         @config = config
         @dry_run = dry_run
         # Shared update-check state (written by the daemon). The bot owns the
@@ -55,6 +58,11 @@ module Hive
         @router = router || build_router(config)
         @child_supervisor = child_supervisor ||
           Hive::Bot::ChildSupervisor.new(logger: @logger, dry_run: dry_run)
+        # Producer-only handle to the daemon's dispatch-request queue.
+        # Tests inject a fake; production uses the module's module_function
+        # interface directly. `nil` is acceptable for dry-run / no-op modes
+        # where the writer is intentionally unused. Plan 2026-05-28-002.
+        @dispatch_request_writer = dispatch_request_writer || Hive::Bot::DispatchRequestWriter
         @notification_dispatcher = notification_dispatcher ||
           Hive::Bot::NotificationDispatcher.new(
             telegram: @telegram,
@@ -284,6 +292,18 @@ module Hive
         clear_inline_keyboard(update) if result.respond_to?(:clear_keyboard) && result.clear_keyboard
         commands = Array(result.commands)
         reset_pending = !@dry_run && needs_alert_reset?(result)
+
+        # If every command in the sequence is queue-routable (the
+        # common case post-refactor: `markers clear` + `develop`/`review`/`pr`),
+        # write all requests in arrival order and let the daemon's
+        # per-slug in-flight gate serialise execution. There is no
+        # bot-side PID to wait on, so the prior "wait for first to
+        # succeed before dispatching the next" semantics is replaced
+        # by the daemon's per-slug serialisation. Plan 2026-05-28-002.
+        if commands.all? { |argv| queue_routable?(argv) }
+          return enqueue_command_sequence(commands, result, update, reset_pending: reset_pending)
+        end
+
         failed = false
         commands.each_with_index do |argv, idx|
           per_command = @router.class::Result.new(
@@ -293,7 +313,12 @@ module Hive
             slug: result.slug
           )
           last_pid = execute_dispatch(per_command, update)
-          if idx < commands.length - 1 && last_pid
+          # last_pid is an Integer (spawned) or a String request_id
+          # (queue-routed). Only Integer PIDs can be waited on. A
+          # mixed sequence (one queue command, one spawned) falls
+          # through to the legacy path; today's mixes don't exist but
+          # the guard documents the contract for future surfaces.
+          if idx < commands.length - 1 && last_pid.is_a?(Integer)
             unless wait_for_child_success(last_pid, deadline: Time.now + (@config.fetch("clear_retry_grace_sec", 30)))
               safe_send_message(chat_id: update.chat_id, text: "Stopped because the previous command failed.")
               failed = true
@@ -316,6 +341,24 @@ module Hive
         # sync point above. Reset the alert post-dispatch — only if we did not
         # bail out of the loop on a failed precursor.
         reset_alert_for_result(result) if reset_pending && !failed
+      end
+
+      # Queue path for `dispatch_command_sequence`: write each request
+      # in arrival order, reset the alert if a reset was queued, and
+      # return. If any write raises, `enqueue_dispatch_request` has
+      # already surfaced a corrective Telegram reply and logged.
+      def enqueue_command_sequence(commands, result, update, reset_pending:)
+        commands.each do |argv|
+          per_command = @router.class::Result.new(
+            action: :dispatch_then_reply,
+            command_argv: argv,
+            project: result.project,
+            slug: result.slug
+          )
+          enqueue_dispatch_request(per_command, update)
+        end
+        reset_alert_for_result(result) if reset_pending
+        nil
       end
 
       def needs_alert_reset?(result)
@@ -439,6 +482,19 @@ module Hive
           return nil
         end
 
+        # State-mutating `hive` verbs (run/develop/brainstorm/plan/
+        # review/open-pr/artifacts/finalize/archive/markers) route
+        # through the daemon's dispatch-request queue so there is one
+        # writer of those verbs — the daemon — and the
+        # post-completion mtime baseline stays current. Plan
+        # 2026-05-28-002. Read-only verbs (status/--diagnose, new,
+        # approve) keep the in-process spawn path because they don't
+        # bump task state-file mtime and don't cause the dual-writer
+        # bug.
+        if queue_routable?(result.command_argv)
+          return enqueue_dispatch_request(result, update)
+        end
+
         project_path = project_path_for(result.project)
         pid = @child_supervisor.dispatch(
           command_argv: result.command_argv,
@@ -453,6 +509,72 @@ module Hive
         # diagnose replies still fire for Show details), so silence here
         # is signal-preserving.
         pid
+      end
+
+      # True iff argv[1] is in the daemon's queue allowlist. The bot
+      # rewrites this kind of dispatch into a request-file write; the
+      # daemon picks the request up on its next tick and spawns the
+      # child. See plan 2026-05-28-002 for why.
+      def queue_routable?(argv)
+        Hive::Daemon::DispatchRequestQueue.valid_argv?(Array(argv))
+      end
+
+      # Write a dispatch request for `result.command_argv` and log
+      # `:dispatched_command` with `via=queue` so an operator tailing
+      # bot.log can tell the two dispatch surfaces apart. Returns the
+      # request_id so callers that previously held onto a PID can
+      # still chain. Existing chain points (dispatch_command_sequence's
+      # `wait_for_child_success`) now degrade: there is no PID to
+      # wait on. The retry verb is enqueued anyway and the per-slug
+      # in-flight gate on the daemon side serialises the two.
+      def enqueue_dispatch_request(result, update)
+        request_id = @dispatch_request_writer.write!(
+          project: result.project,
+          slug: result.slug,
+          argv: Array(result.command_argv),
+          chat_id: update.chat_id,
+          update_id: update.update_id,
+          trigger: trigger_for_result(result)
+        )
+        @logger.event(:dispatched_command,
+                      project: result.project,
+                      slug: result.slug,
+                      command: Array(result.command_argv).join(" "),
+                      update_id: update.update_id,
+                      via: "queue",
+                      request_id: request_id)
+        request_id
+      rescue StandardError => e
+        # A producer-side failure (read-only state dir, ENOSPC, an
+        # invalid argv slipped past the router) must not crash the
+        # poll loop. Surface a corrective reply and log so an operator
+        # can recover.
+        @logger.event(:send_failure, source: "enqueue_dispatch_request",
+                                      chat_id: update.chat_id,
+                                      slug: result.slug,
+                                      error_class: e.class.name,
+                                      message: e.message)
+        safe_send_message(
+          chat_id: update.chat_id,
+          text: "Couldn't queue the request (#{e.class}). Try again, or open this on a laptop."
+        )
+        nil
+      end
+
+      # A coarse trigger label for telemetry. The router doesn't carry
+      # a fine-grained reason today; "slash" vs. "callback" is the
+      # best we can do without invasive Router changes. The daemon
+      # only reads this for log lines.
+      def trigger_for_result(result)
+        intent = result.respond_to?(:intent) ? result.intent : nil
+        case intent
+        when :slash_done then "slash_done"
+        when :callback_autofix, :callback_clear_and_retry then "autofix"
+        when :callback_approve then "callback_approve"
+        when :callback_findings_accept_all then "findings_accept"
+        when :callback_findings_reject_all then "findings_reject"
+        else "bot_dispatch"
+        end
       end
 
       def execute_answer_write(result, update)
@@ -584,7 +706,13 @@ module Hive
       end
 
       def start_answer(result, update)
-        path = brainstorm_path_for(result.slug, project: result.project)
+        # Backfill project from the on-disk brainstorm path. The
+        # `/answer <slug>` slash command doesn't carry project (slugs
+        # are unique enough in practice), but downstream the queue
+        # writer needs project for `find_project` lookup, so we infer
+        # it once here and stash it on the conversation state.
+        resolved_project = result.project || brainstorm_project_for(result.slug)
+        path = brainstorm_path_for(result.slug, project: resolved_project)
         question =
           if path
             Hive::Bot::BrainstormParser.next_unanswered_question(
@@ -600,7 +728,7 @@ module Hive
 
         @conversation_store.start(chat_id: update.chat_id, slug: result.slug,
                                   question_n: question.n, mode: result.mode || :path_b,
-                                  project: result.project)
+                                  project: resolved_project)
         safe_send_message(
           chat_id: update.chat_id,
           text: "Q#{question.n}: #{question.text.to_s.strip}\n\nReply with your answer."
@@ -798,13 +926,27 @@ module Hive
       end
 
       def brainstorm_path_for(slug, project: nil)
+        entry = brainstorm_project_entry_for(slug, project: project)
+        entry ? File.join(entry["hive_state_path"], "stages", "2-brainstorm", slug, "brainstorm.md") : nil
+      end
+
+      # Resolve the project name a brainstorm slug currently lives in.
+      # Returns nil when nothing matches. Used by `start_answer` to
+      # backfill `state.project` so the daemon's dispatch-request
+      # consumer can `Hive::Config.find_project(project)` on `/done`
+      # — the answer flow's slash handlers don't carry project but
+      # the on-disk brainstorm file does.
+      def brainstorm_project_for(slug, project: nil)
+        brainstorm_project_entry_for(slug, project: project)&.fetch("name", nil)
+      end
+
+      def brainstorm_project_entry_for(slug, project: nil)
         projects = Hive::Config.registered_projects
         projects = projects.select { |entry| entry["name"] == project } if project && !project.empty?
-        projects.each do |entry|
+        projects.find do |entry|
           path = File.join(entry["hive_state_path"], "stages", "2-brainstorm", slug, "brainstorm.md")
-          return path if File.exist?(path)
+          File.exist?(path)
         end
-        nil
       end
 
       def chat_ids

--- a/lib/hive/daemon/child_supervisor.rb
+++ b/lib/hive/daemon/child_supervisor.rb
@@ -18,6 +18,7 @@ module Hive
     class ChildSupervisor
       ChildExit = Struct.new(:pid, :exit_code, :project, :slug, :stage, :command,
                              :state_file_path, :started_at, :finished_at, :json_envelope,
+                             :request_id,
                              keyword_init: true)
 
       def initialize(hive_bin: ENV.fetch("HIVE_BIN", "hive"),
@@ -45,7 +46,8 @@ module Hive
       # ConcurrencyController bookkeeping stays consistent across both
       # modes.
       def spawn(command_string:, project:, slug:, stage:,
-                hive_state_path: nil, state_file_path: nil, dry_run: nil)
+                hive_state_path: nil, state_file_path: nil, dry_run: nil,
+                request_id: nil)
         effective_dry_run = dry_run.nil? ? @dry_run : dry_run
 
         argv = parse_command(command_string)
@@ -63,7 +65,8 @@ module Hive
           @running[next_dry_pid] = {
             project: project, slug: slug, stage: stage,
             command: command_string, state_file_path: state_file_path,
-            started_at: Time.now, log_path: nil, dry_run: true
+            started_at: Time.now, log_path: nil, dry_run: true,
+            request_id: request_id
           }
           return @running.keys.last
         end
@@ -85,7 +88,8 @@ module Hive
         @running[pid] = {
           project: project, slug: slug, stage: stage,
           command: command_string, state_file_path: state_file_path,
-          started_at: Time.now, log_path: log_path, dry_run: false
+          started_at: Time.now, log_path: log_path, dry_run: false,
+          request_id: request_id
         }
         pid
       end
@@ -113,7 +117,8 @@ module Hive
             pid: pid, exit_code: status.exitstatus,
             project: entry[:project], slug: entry[:slug], stage: entry[:stage],
             command: entry[:command], state_file_path: entry[:state_file_path],
-            started_at: entry[:started_at], finished_at: now, json_envelope: envelope
+            started_at: entry[:started_at], finished_at: now, json_envelope: envelope,
+            request_id: entry[:request_id]
           )
         end
         completed
@@ -131,7 +136,8 @@ module Hive
             pid: pid, exit_code: 0,
             project: entry[:project], slug: entry[:slug], stage: entry[:stage],
             command: entry[:command], state_file_path: entry[:state_file_path],
-            started_at: entry[:started_at], finished_at: now, json_envelope: nil
+            started_at: entry[:started_at], finished_at: now, json_envelope: nil,
+            request_id: entry[:request_id]
           )
         end
         completed.each { |c| @running.delete(c.pid) }

--- a/lib/hive/daemon/dispatch_request_queue.rb
+++ b/lib/hive/daemon/dispatch_request_queue.rb
@@ -110,6 +110,10 @@ module Hive
           begin
             data = JSON.parse(File.read(path))
           rescue StandardError
+            # Race: the file disappeared (or was rewritten with
+            # malformed JSON) between glob and read. Idempotent
+            # removal already covers the desired outcome — skip and
+            # let `pending`'s next pass handle it via bad_handler.
             next
           end
           next unless data.is_a?(Hash) && data["request_id"] == request_id.to_s
@@ -119,6 +123,8 @@ module Hive
         end
         removed
       rescue Errno::ENOENT
+        # Outer race: the directory itself disappeared between
+        # `directory` and `Dir.glob`. Same idempotent contract.
         false
       end
 

--- a/lib/hive/daemon/dispatch_request_queue.rb
+++ b/lib/hive/daemon/dispatch_request_queue.rb
@@ -52,8 +52,25 @@ module Hive
       ].freeze
 
       # Default directory inside `<state_home>` where pending request
-      # files live. Created lazily by `directory`.
+      # files live. Created lazily by `directory` with mode 0700 so the
+      # queue's de-facto auth boundary (any process with write access
+      # can enqueue an allowlisted verb) is at minimum scoped to the
+      # owning user. The `requestor` field in each request is NOT
+      # verified against process credentials — file ownership is.
       DIRNAME = "dispatch_requests".freeze
+
+      # ADR-012 slug regex. Slugs from request payloads flow into
+      # filesystem path construction (state-file lookup, log paths);
+      # any character outside this set is rejected at parse time to
+      # prevent path-traversal via the slug field.
+      SLUG_RE = /\A[a-z][a-z0-9-]{0,62}[a-z0-9]\z/
+
+      # Project name pattern. Loose alphanumeric + dot/underscore/hyphen
+      # matches the `name` keys in `Hive::Config`. The daemon's
+      # `find_project` lookup is the actual authoritative gate; this
+      # regex catches the most obvious traversal candidates (slashes,
+      # nulls, leading dots) before any path is constructed.
+      PROJECT_RE = /\A[A-Za-z0-9_.\-]+\z/
 
       # Parsed request record returned by `pending`.
       Request = Struct.new(
@@ -68,7 +85,17 @@ module Hive
       # the daemon's other state.
       def directory(state_home: Hive::Paths.state_home)
         path = File.join(state_home, DIRNAME)
-        FileUtils.mkdir_p(path)
+        # Mode 0700 enforces the user-owned-dir invariant: only the
+        # process owner can enqueue requests. Without this, a default
+        # umask of 0022 leaves the dir at 0755 and any local user
+        # could write a request (which the daemon would dispatch
+        # against an allowlisted verb). Idempotent on existing dirs;
+        # if the dir was previously created with looser perms,
+        # `chmod` to tighten.
+        FileUtils.mkdir_p(path, mode: 0o700)
+        # mkdir_p doesn't chmod existing dirs — re-tighten in case
+        # the dir was created by a prior version with default umask.
+        File.chmod(0o700, path) if File.directory?(path)
         path
       end
 
@@ -130,17 +157,36 @@ module Hive
 
       # Validate a request's argv. Returns true when:
       #   - argv is an Array of Strings
+      #   - argv has at least 2 entries (hive + verb)
       #   - argv[0] is "hive"
       #   - argv[1] (the verb) is in ALLOWED_VERBS
-      # All three checks gate this allowlist; failing any is a reject.
+      #   - argv[2] (when present and not a `--flag`) matches SLUG_RE —
+      #     the slug is the most common positional argument and the
+      #     primary path-construction surface; reject malformed slugs
+      #     at the queue boundary instead of trusting downstream parse.
+      #
+      # All checks gate the allowlist; failing any is a reject. This
+      # is the operator-trust gate against a compromised producer
+      # identity running arbitrary CLI verbs or smuggling path-
+      # traversal slugs.
       def valid_argv?(argv)
         return false unless argv.is_a?(Array)
-        return false if argv.empty?
-        return false unless argv.all? { |tok| tok.is_a?(String) }
+        return false if argv.length < 2
+        return false unless argv.all? { |tok| tok.is_a?(String) && !tok.empty? }
         return false unless argv[0] == "hive"
 
         verb = argv[1].to_s
-        ALLOWED_VERBS.include?(verb)
+        return false unless ALLOWED_VERBS.include?(verb)
+
+        # If the third positional argument is present and not a flag,
+        # treat it as a slug and validate against ADR-012's regex.
+        # `markers clear <folder>` passes a folder path (not a slug),
+        # so allow paths under hive-state when the verb is `markers`.
+        return true if argv.length < 3
+        return true if argv[2].start_with?("-")
+        return true if verb == "markers" # folder argument, not slug
+
+        SLUG_RE.match?(argv[2])
       end
 
       # Filename helper exposed for the writer side so tests can predict
@@ -190,9 +236,14 @@ module Hive
 
           project = data["project"].to_s
           return :missing_project if project.empty?
+          return :invalid_project unless PROJECT_RE.match?(project)
 
           slug = data["slug"].to_s
           return :missing_slug if slug.empty?
+          # Slugs flow into path construction in resolve_post_completion_path
+          # + log paths. Reject any character outside ADR-012's slug
+          # regex at the queue boundary to prevent path-traversal.
+          return :invalid_slug unless SLUG_RE.match?(slug)
 
           argv = data["argv"]
           return :invalid_argv unless argv.is_a?(Array)

--- a/lib/hive/daemon/dispatch_request_queue.rb
+++ b/lib/hive/daemon/dispatch_request_queue.rb
@@ -1,0 +1,221 @@
+require "json"
+require "fileutils"
+require "time"
+require "hive/paths"
+
+module Hive
+  module Daemon
+    # File-backed queue of dispatch requests written by external callers
+    # (today: the Telegram bot) and consumed by the daemon dispatcher.
+    #
+    # One JSON file per pending request under
+    # `<state_home>/dispatch_requests/`. Filenames sort lexicographically
+    # by creation time so `pending` walks the queue in arrival order.
+    # The bot atomic-writes a file via tmp + rename; the daemon reads
+    # whole files and `File.unlink`s them on dispatch or rejection. No
+    # cross-process lock is required: the atomic-write side guarantees a
+    # complete file is observable, and per-file unlink avoids contention.
+    #
+    # Schema (`hive-dispatch-request`, version 1):
+    #
+    #   {
+    #     "schema": "hive-dispatch-request",
+    #     "schema_version": 1,
+    #     "request_id": "<hex>",
+    #     "created_at": "2026-05-28T18:11:44Z",
+    #     "project": "hive",
+    #     "slug": "explore-the-simplest-way-to-260528-2503",
+    #     "argv": ["hive", "run", "...", "--json"],
+    #     "requestor": "bot",
+    #     "chat_id": 123456789,
+    #     "update_id": 926850952,
+    #     "trigger": "answer_complete"
+    #   }
+    #
+    # The dispatcher is the only writer of `hive run`-class verbs; the
+    # bot writes a request and the daemon picks it up. That removes the
+    # dual-writer race that let post-completion mtime baselines go stale
+    # (see plan 2026-05-28-002).
+    module DispatchRequestQueue
+      module_function
+
+      SCHEMA = "hive-dispatch-request".freeze
+      SCHEMA_VERSION = 1
+
+      # Allowlisted hive verbs. A request file whose argv[1] is not in
+      # this list is rejected with a logged reason and removed; this is
+      # the operator-trust gate against a compromised bot identity
+      # running arbitrary CLI verbs.
+      ALLOWED_VERBS = %w[
+        run develop brainstorm plan review open-pr artifacts finalize
+        archive markers
+      ].freeze
+
+      # Default directory inside `<state_home>` where pending request
+      # files live. Created lazily by `directory`.
+      DIRNAME = "dispatch_requests".freeze
+
+      # Parsed request record returned by `pending`.
+      Request = Struct.new(
+        :request_id, :created_at, :project, :slug, :argv, :requestor,
+        :chat_id, :update_id, :trigger, :path,
+        keyword_init: true
+      )
+
+      # Resolve (and mkdir) the requests directory. `state_home:` lets
+      # tests inject a sandbox path; production passes
+      # `Hive::Paths.state_home` so every dispatch request lives next to
+      # the daemon's other state.
+      def directory(state_home: Hive::Paths.state_home)
+        path = File.join(state_home, DIRNAME)
+        FileUtils.mkdir_p(path)
+        path
+      end
+
+      # Read and parse every pending request file in `directory`,
+      # sorted by `created_at` ascending. Malformed entries (bad JSON,
+      # missing fields, unknown schema_version, non-array argv) are
+      # skipped — `bad_handler` (when supplied) receives
+      # `(path:, reason:)` so the caller can log + remove. Returning
+      # them inline would let one bad file block all downstream
+      # processing.
+      #
+      # `now:` is accepted only for parity with other queue helpers; the
+      # caller decides what to do with a request once it's parsed.
+      def pending(state_home: Hive::Paths.state_home, bad_handler: nil)
+        dir = directory(state_home: state_home)
+        entries = []
+        Dir.glob(File.join(dir, "*.json")).each do |path|
+          parsed = parse_file(path)
+          if parsed.is_a?(Symbol)
+            bad_handler&.call(path: path, reason: parsed.to_s)
+            next
+          end
+          entries << parsed
+        end
+        entries.sort_by { |req| [ req.created_at, req.request_id.to_s ] }
+      end
+
+      # Remove the request file for `request_id`. Idempotent: a missing
+      # file is not an error. Returns true if a file was removed, false
+      # otherwise. `state_home:` mirrors `directory`.
+      def remove(request_id, state_home: Hive::Paths.state_home)
+        return false if request_id.to_s.empty?
+
+        dir = directory(state_home: state_home)
+        removed = false
+        Dir.glob(File.join(dir, "*.json")).each do |path|
+          next unless path.include?(request_id.to_s)
+
+          begin
+            data = JSON.parse(File.read(path))
+          rescue StandardError
+            next
+          end
+          next unless data.is_a?(Hash) && data["request_id"] == request_id.to_s
+
+          File.unlink(path)
+          removed = true
+        end
+        removed
+      rescue Errno::ENOENT
+        false
+      end
+
+      # Validate a request's argv. Returns true when:
+      #   - argv is an Array of Strings
+      #   - argv[0] is "hive"
+      #   - argv[1] (the verb) is in ALLOWED_VERBS
+      # All three checks gate this allowlist; failing any is a reject.
+      def valid_argv?(argv)
+        return false unless argv.is_a?(Array)
+        return false if argv.empty?
+        return false unless argv.all? { |tok| tok.is_a?(String) }
+        return false unless argv[0] == "hive"
+
+        verb = argv[1].to_s
+        ALLOWED_VERBS.include?(verb)
+      end
+
+      # Filename helper exposed for the writer side so tests can predict
+      # the on-disk layout. Pure: `created_at` + `request_id` → filename.
+      def filename_for(created_at:, request_id:)
+        ts = created_at.utc.strftime("%Y%m%dT%H%M%S%6N")
+        "#{ts}-#{request_id}.json"
+      end
+
+      # Default expiry window. Requests older than this are removed
+      # without dispatch (the daemon was down or refused them
+      # repeatedly). Tunable from the dispatcher's tick to keep the
+      # constant local but adjustable per call.
+      EXPIRY_SEC = 600
+
+      # Treat `request` as expired if `created_at` is older than
+      # `expiry_sec` relative to `now`. `created_at` is a Time; the
+      # caller decides what to do with the result (log + remove).
+      def expired?(request, now: Time.now, expiry_sec: EXPIRY_SEC)
+        return false unless request.respond_to?(:created_at)
+
+        created = request.created_at
+        return false unless created.is_a?(Time)
+
+        (now - created) > expiry_sec
+      end
+
+      class << self
+        private
+
+        def parse_file(path)
+          raw = File.read(path)
+          data = JSON.parse(raw)
+        rescue JSON::ParserError, Errno::ENOENT, Errno::EACCES, IOError
+          :malformed_json
+        else
+          parse_data(data, path: path)
+        end
+
+        def parse_data(data, path:)
+          return :not_a_hash unless data.is_a?(Hash)
+          return :wrong_schema unless data["schema"] == SCHEMA
+          return :unknown_schema_version unless data["schema_version"] == SCHEMA_VERSION
+
+          request_id = data["request_id"].to_s
+          return :missing_request_id if request_id.empty?
+
+          project = data["project"].to_s
+          return :missing_project if project.empty?
+
+          slug = data["slug"].to_s
+          return :missing_slug if slug.empty?
+
+          argv = data["argv"]
+          return :invalid_argv unless argv.is_a?(Array)
+
+          created_at = parse_time(data["created_at"])
+          return :invalid_created_at if created_at.nil?
+
+          Request.new(
+            request_id: request_id,
+            created_at: created_at,
+            project: project,
+            slug: slug,
+            argv: argv,
+            requestor: data["requestor"].to_s,
+            chat_id: data["chat_id"],
+            update_id: data["update_id"],
+            trigger: data["trigger"].to_s,
+            path: path
+          )
+        end
+
+        def parse_time(value)
+          return nil if value.nil? || value.to_s.empty?
+
+          Time.parse(value.to_s)
+        rescue ArgumentError
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/hive/daemon/dispatcher.rb
+++ b/lib/hive/daemon/dispatcher.rb
@@ -1,4 +1,5 @@
 require "digest"
+require "fileutils"
 require "shellwords"
 require "hive/config"
 require "hive/stages"
@@ -714,11 +715,9 @@ module Hive
           bad_handler: ->(path:, reason:) {
             @logger.event(:dispatch_request_rejected,
                           path: path, reason: reason)
-            begin
-              File.unlink(path)
-            rescue Errno::ENOENT
-              nil
-            end
+            # `rm_f` is idempotent — quietly does nothing if the
+            # file is already gone (concurrent retry, manual cleanup).
+            FileUtils.rm_f(path)
           }
         )
 

--- a/lib/hive/daemon/dispatcher.rb
+++ b/lib/hive/daemon/dispatcher.rb
@@ -1,4 +1,5 @@
 require "digest"
+require "shellwords"
 require "hive/config"
 require "hive/stages"
 require "hive/task_action"
@@ -8,7 +9,9 @@ require "hive/daemon/concurrency_controller"
 require "hive/daemon/child_supervisor"
 require "hive/daemon/status_consumer"
 require "hive/daemon/stale_agent_healer"
+require "hive/daemon/dispatch_request_queue"
 require "hive/daemon/logger"
+require "hive/paths"
 require "hive/update_check"
 require "hive/update_check/state"
 require "hive/install_channel"
@@ -38,7 +41,8 @@ module Hive
       # @param dry_run [Boolean]
       def initialize(config:, controller:, supervisor:, status_consumer:, logger:,
                      merge_watcher: nil, dry_run: false,
-                     update_state: nil, update_checker: nil, channel_detector: nil)
+                     update_state: nil, update_checker: nil, channel_detector: nil,
+                     dispatch_request_state_home: nil)
         @config = config
         @controller = controller
         @supervisor = supervisor
@@ -117,6 +121,10 @@ module Hive
         # see the next warning the next time it goes red, but we don't
         # actively re-emit on every tick. Issue #95.
         @legacy_layout_logged = {}
+        # Test-injectable state home for the dispatch-request queue.
+        # Production passes nil so `DispatchRequestQueue` resolves
+        # `Hive::Paths.state_home`; unit tests inject a sandbox.
+        @dispatch_request_state_home = dispatch_request_state_home
       end
 
       # Single tick: reap, fetch, dispatch. Pure dispatcher — no signal
@@ -198,6 +206,14 @@ module Hive
                         failure_count: drop[:failure_count],
                         last_error: drop[:last_error])
         end
+
+        # 3b. Dispatch-request queue (plan 2026-05-28-002). Process
+        # bot-written request files BEFORE the per-row scan so a slug
+        # whose request just spawned is already in-flight in the
+        # controller and the row scan's gate keeps the status-row loop
+        # from double-dispatching. Single-writer invariant: only the
+        # daemon spawns `hive run`-class verbs.
+        process_dispatch_requests(now: now)
 
         # 4. Per-row dispatch
         result.rows.each { |row| handle_row(row, now: now) }
@@ -366,6 +382,23 @@ module Hive
                         elapsed_sec: (now - entry.started_at).to_i,
                         envelope_marker: entry.json_envelope&.dig("marker"),
                         envelope_ok: entry.json_envelope&.dig("ok"))
+          # Request-driven runs (bot-issued, daemon-spawned) remove their
+          # queue file on reap so the daemon never re-dispatches them and
+          # an operator tailing daemon.log sees the full lifecycle:
+          # observed → dispatched → completed. The bot side is now a
+          # producer only; the daemon is the single dispatcher.
+          if entry.respond_to?(:request_id) && entry.request_id
+            Hive::Daemon::DispatchRequestQueue.remove(
+              entry.request_id, state_home: dispatch_request_state_home
+            )
+            @logger.event(:dispatch_request_completed,
+                          request_id: entry.request_id, pid: entry.pid,
+                          project: entry.project, slug: entry.slug,
+                          exit_code: entry.exit_code,
+                          elapsed_sec: (now - entry.started_at).to_i,
+                          envelope_marker: entry.json_envelope&.dig("marker"),
+                          envelope_ok: entry.json_envelope&.dig("ok"))
+          end
           @controller.record_project_dropped(project: entry.project) if entry.exit_code == Hive::ExitCodes::CONFIG
           if entry.exit_code == Hive::ExitCodes::CONFIG
             @logger.event(:project_dropped, project: entry.project)
@@ -636,8 +669,159 @@ module Hive
                               project: project, slug: slug)
       end
 
+      # Consume the file-backed dispatch-request queue (plan
+      # 2026-05-28-002). One pending file = one would-be `hive run`-
+      # class spawn. The daemon is the single dispatcher; the bot is a
+      # producer only.
+      #
+      # Per request, in this order:
+      #   1. Parse failure / bad schema → already routed via
+      #      bad_handler in DispatchRequestQueue.pending; remove and
+      #      log `:dispatch_request_rejected`.
+      #   2. Argv allowlist (defense in depth — the writer already
+      #      validates) → remove + `:dispatch_request_rejected`.
+      #   3. Expiry (10 min default) → remove +
+      #      `:dispatch_request_expired`.
+      #   4. Project dropped (CONFIG=78 from a prior child) → remove +
+      #      `:dispatch_request_rejected reason=project_dropped`.
+      #   5. Per-slug in-flight gate (controller's running_task?) →
+      #      leave the file on disk, `:dispatch_request_blocked
+      #      reason=in_flight`. Picked up next tick.
+      #   6. Concurrency gate (caps / cooldown / quarantine) → leave
+      #      the file on disk, `:dispatch_request_blocked
+      #      reason=<gate>`. Picked up next tick.
+      #   7. Spawn via `dispatch_command`, threading `request_id`
+      #      through the supervisor so `reap_completed` can unlink the
+      #      file and log `:dispatch_request_completed`.
+      def process_dispatch_requests(now:)
+        pending = Hive::Daemon::DispatchRequestQueue.pending(
+          state_home: dispatch_request_state_home,
+          bad_handler: ->(path:, reason:) {
+            @logger.event(:dispatch_request_rejected,
+                          path: path, reason: reason)
+            begin
+              File.unlink(path)
+            rescue Errno::ENOENT
+              nil
+            end
+          }
+        )
+
+        # Per-slug in-flight gate within this tick: if we just spawned
+        # for (project, slug) on this tick, defer subsequent requests
+        # for the same slug to a later tick. The controller's
+        # `running_task?` reflects spawns recorded in
+        # `record_dispatch`, so this is naturally exclusive across
+        # iterations of this loop too.
+        pending.each do |req|
+          @logger.event(:dispatch_request_observed,
+                        request_id: req.request_id, project: req.project,
+                        slug: req.slug, trigger: req.trigger,
+                        requestor: req.requestor)
+
+          unless Hive::Daemon::DispatchRequestQueue.valid_argv?(req.argv)
+            reject_request(req, reason: "invalid_argv")
+            next
+          end
+
+          if Hive::Daemon::DispatchRequestQueue.expired?(req, now: now)
+            expire_request(req)
+            next
+          end
+
+          unless Hive::Config.find_project(req.project)
+            reject_request(req, reason: "unknown_project")
+            next
+          end
+
+          gate = @controller.can_dispatch?(
+            project: req.project, slug: req.slug, now: now,
+            external_global_count: @external_active_agent_total,
+            external_project_count: external_active_agent_count_for(req.project)
+          )
+          if @controller.running_task?(project: req.project, slug: req.slug)
+            @logger.event(:dispatch_request_blocked,
+                          request_id: req.request_id, project: req.project,
+                          slug: req.slug, reason: "in_flight")
+            next
+          end
+          unless gate == :ok
+            @logger.event(:dispatch_request_blocked,
+                          request_id: req.request_id, project: req.project,
+                          slug: req.slug, reason: gate.to_s)
+            next
+          end
+
+          dispatch_request!(req, now: now)
+        end
+      end
+
+      # Build a command string from the validated argv and spawn it
+      # through the same `dispatch_command` path auto-advance uses.
+      # The on-disk request file is left in place until the child reaps
+      # (see `reap_completed`); that gives an operator a single source
+      # of truth for "what's in flight" when tailing the queue dir.
+      def dispatch_request!(req, now:)
+        command = Shellwords.join(req.argv)
+        state_file_path = resolve_request_state_file_path(req)
+        pid = dispatch_command(
+          command,
+          project: req.project, slug: req.slug,
+          # Request-driven runs don't carry a stage hint — the runner
+          # resolves the task's current stage at boot. Pass nil so the
+          # log line records `stage=nil` instead of inventing one.
+          stage: nil,
+          state_file_mtime: state_file_path && File.exist?(state_file_path) ? File.mtime(state_file_path) : nil,
+          state_file_path: state_file_path,
+          hive_state_path: nil,
+          now: now,
+          trigger: req.trigger.to_s.empty? ? "dispatch_request" : req.trigger,
+          request_id: req.request_id
+        )
+        @logger.event(:dispatch_request_dispatched,
+                      request_id: req.request_id, pid: pid,
+                      project: req.project, slug: req.slug,
+                      command: command, trigger: req.trigger,
+                      chat_id: req.chat_id, update_id: req.update_id)
+      end
+
+      def reject_request(req, reason:)
+        @logger.event(:dispatch_request_rejected,
+                      request_id: req.request_id, project: req.project,
+                      slug: req.slug, reason: reason, path: req.path)
+        Hive::Daemon::DispatchRequestQueue.remove(
+          req.request_id, state_home: dispatch_request_state_home
+        )
+      end
+
+      def expire_request(req)
+        @logger.event(:dispatch_request_expired,
+                      request_id: req.request_id, project: req.project,
+                      slug: req.slug, created_at: req.created_at.utc.iso8601,
+                      path: req.path)
+        Hive::Daemon::DispatchRequestQueue.remove(
+          req.request_id, state_home: dispatch_request_state_home
+        )
+      end
+
+      # Best-effort lookup of the task's CURRENT state file so the
+      # post-completion mtime refresh inside `reap_completed` has a
+      # path to stat. Mirrors `find_post_advance_state_file` but
+      # without the at-dispatch path (a request carries no stage hint).
+      def resolve_request_state_file_path(req)
+        project_entry = Hive::Config.find_project(req.project)
+        return nil unless project_entry
+
+        find_post_advance_state_file(project_entry["hive_state_path"], req.slug)
+      end
+
+      def dispatch_request_state_home
+        @dispatch_request_state_home || Hive::Paths.state_home
+      end
+
       def dispatch_command(command, project:, slug:, stage:, state_file_mtime:,
-                           state_file_path:, hive_state_path:, now:, trigger: "advance")
+                           state_file_path:, hive_state_path:, now:, trigger: "advance",
+                           request_id: nil)
         if @dry_run
           @logger.event(:dry_run, project: project, slug: slug, stage: stage,
                                   command: command)
@@ -647,7 +831,8 @@ module Hive
           project: project, slug: slug, stage: stage,
           hive_state_path: hive_state_path,
           state_file_path: state_file_path,
-          dry_run: @dry_run
+          dry_run: @dry_run,
+          request_id: request_id
         )
         @controller.record_dispatch(
           pid: pid, project: project, slug: slug, stage: stage,
@@ -657,6 +842,7 @@ module Hive
                                    stage: stage, command: command, trigger: trigger,
                                    dry_run: @dry_run)
         @dispatched_today += 1
+        pid
       end
 
       def enqueue_merge_watch(row)

--- a/lib/hive/daemon/dispatcher.rb
+++ b/lib/hive/daemon/dispatcher.rb
@@ -388,7 +388,10 @@ module Hive
           # an operator tailing daemon.log sees the full lifecycle:
           # observed → dispatched → completed. The bot side is now a
           # producer only; the daemon is the single dispatcher.
-          if entry.respond_to?(:request_id) && entry.request_id
+          # ChildExit always defines `request_id` (nilable on the
+          # Struct), so `respond_to?` is dead code per M-02 from
+          # PR #241 ce-code-review. Just check the value.
+          if entry.request_id
             Hive::Daemon::DispatchRequestQueue.remove(
               entry.request_id, state_home: dispatch_request_state_home
             )
@@ -733,41 +736,84 @@ module Hive
                         slug: req.slug, trigger: req.trigger,
                         requestor: req.requestor)
 
-          unless Hive::Daemon::DispatchRequestQueue.valid_argv?(req.argv)
-            reject_request(req, reason: "invalid_argv")
-            next
-          end
-
-          if Hive::Daemon::DispatchRequestQueue.expired?(req, now: now)
-            expire_request(req)
-            next
-          end
-
-          unless Hive::Config.find_project(req.project)
-            reject_request(req, reason: "unknown_project")
-            next
-          end
-
-          gate = @controller.can_dispatch?(
-            project: req.project, slug: req.slug, now: now,
-            external_global_count: @external_active_agent_total,
-            external_project_count: external_active_agent_count_for(req.project)
-          )
-          if @controller.running_task?(project: req.project, slug: req.slug)
-            @logger.event(:dispatch_request_blocked,
+          # Per-iteration rescue: a Process.spawn failure (Errno::EAGAIN
+          # / Errno::ENOMEM under fork-exhaustion) or any other
+          # StandardError in dispatch_request! must not abort the rest
+          # of the pending queue. The request file stays on disk for
+          # the next tick to retry; the failure is logged for
+          # operator visibility. Per R-01 from PR #241 ce-code-review.
+          begin
+            process_dispatch_request_iteration(req, now: now)
+          rescue StandardError => e
+            @logger.event(:dispatch_request_rejected,
                           request_id: req.request_id, project: req.project,
-                          slug: req.slug, reason: "in_flight")
-            next
+                          slug: req.slug,
+                          reason: "spawn_failure: #{e.class}: #{e.message[0, 200]}",
+                          path: req.path)
+            # Don't remove the file — let the next tick try again.
+            # If the failure is persistent (e.g. config corruption),
+            # the operator will see repeated rejected events with
+            # the same request_id.
           end
-          unless gate == :ok
-            @logger.event(:dispatch_request_blocked,
-                          request_id: req.request_id, project: req.project,
-                          slug: req.slug, reason: gate.to_s)
-            next
-          end
-
-          dispatch_request!(req, now: now)
         end
+      end
+
+      # Body of one queue iteration. Extracted so the rescue in
+      # process_dispatch_requests captures any error from the gate
+      # checks AND the actual spawn. Returns nil; side effects via
+      # @controller, @logger, and the queue's remove() call.
+      def process_dispatch_request_iteration(req, now:)
+        unless Hive::Daemon::DispatchRequestQueue.valid_argv?(req.argv)
+          reject_request(req, reason: "invalid_argv")
+          return
+        end
+
+        if Hive::Daemon::DispatchRequestQueue.expired?(req, now: now)
+          expire_request(req)
+          return
+        end
+
+        unless Hive::Config.find_project(req.project)
+          reject_request(req, reason: "unknown_project")
+          return
+        end
+
+        # C4 from PR #241 ce-code-review: gate on project_enabled? so a
+        # disabled project's queued requests don't dispatch. The
+        # auto-advance path (handle_row) already does this; the
+        # request path must mirror to keep the single-dispatcher
+        # invariant honest.
+        unless project_enabled?(req.project)
+          @logger.event(:dispatch_request_blocked,
+                        request_id: req.request_id, project: req.project,
+                        slug: req.slug, reason: "project_disabled")
+          return
+        end
+
+        # Reverse the gate-evaluation order from the previous version:
+        # check the cheap, deterministic running_task? gate first so an
+        # in-flight slug doesn't incur the can_dispatch? scan. Per R-04
+        # / M-05 from PR #241 ce-code-review.
+        if @controller.running_task?(project: req.project, slug: req.slug)
+          @logger.event(:dispatch_request_blocked,
+                        request_id: req.request_id, project: req.project,
+                        slug: req.slug, reason: "in_flight")
+          return
+        end
+
+        gate = @controller.can_dispatch?(
+          project: req.project, slug: req.slug, now: now,
+          external_global_count: @external_active_agent_total,
+          external_project_count: external_active_agent_count_for(req.project)
+        )
+        unless gate == :ok
+          @logger.event(:dispatch_request_blocked,
+                        request_id: req.request_id, project: req.project,
+                        slug: req.slug, reason: gate.to_s)
+          return
+        end
+
+        dispatch_request!(req, now: now)
       end
 
       # Build a command string from the validated argv and spawn it

--- a/lib/hive/daemon/dispatcher.rb
+++ b/lib/hive/daemon/dispatcher.rb
@@ -544,6 +544,21 @@ module Hive
           return
         end
 
+        # Per-slug in-flight gate — prevents the row scan from
+        # double-dispatching a slug the dispatch-request queue just
+        # spawned earlier in this same tick. The status snapshot was
+        # taken BEFORE process_dispatch_requests, so a needs_input
+        # row that just had its request fired would otherwise hit
+        # handle_row → dispatch_or_block with no signal of the in-
+        # flight child. The controller's `running_task?` predicate
+        # reflects `record_dispatch` calls, so the gate is naturally
+        # correct across tick-internal ordering.
+        if @controller.running_task?(project: row.project, slug: row.slug)
+          @logger.event(:blocked, project: row.project, slug: row.slug,
+                                  stage: row.stage, reason: "in_flight")
+          return
+        end
+
         gate = @controller.can_dispatch?(
           project: row.project, slug: row.slug, now: now,
           external_global_count: @external_active_agent_total,

--- a/lib/hive/daemon/logger.rb
+++ b/lib/hive/daemon/logger.rb
@@ -55,6 +55,12 @@ module Hive
         daemon_dispatch_baselines_unexpected_error
         daemon_dispatch_baselines_loaded
         daemon_dispatch_baselines_newer_schema_suspended
+        dispatch_request_observed
+        dispatch_request_dispatched
+        dispatch_request_completed
+        dispatch_request_rejected
+        dispatch_request_blocked
+        dispatch_request_expired
         fatal
       ].freeze
 

--- a/schemas/hive-dispatch-request.v1.json
+++ b/schemas/hive-dispatch-request.v1.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/ivankuznetsov/hive/blob/main/schemas/hive-dispatch-request.v1.json",
+  "title": "hive dispatch request (v1)",
+  "description": "One JSON file under <state_home>/dispatch_requests/, atomic-written by a non-daemon producer (today: the Telegram bot) and consumed by the daemon dispatcher. v1 is strict-version-matched — any schema_version != 1 is rejected with reason=unknown_schema_version and the file removed. The single-dispatcher invariant requires that the bot is the only writer of state-mutating hive verbs; allowed verbs are the closed set in `argv[1]` below. Forward-compat requires a coordinated bot→daemon upgrade: bump SCHEMA_VERSION and add a v2 schema before the producer emits it.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "schema_version",
+    "request_id",
+    "created_at",
+    "project",
+    "slug",
+    "argv",
+    "requestor"
+  ],
+  "properties": {
+    "schema": {
+      "const": "hive-dispatch-request"
+    },
+    "schema_version": {
+      "const": 1
+    },
+    "request_id": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8,32}$",
+      "description": "Hex string identifying the request. Bot uses SecureRandom.hex(8); other producers must use a comparable random ID."
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 UTC timestamp at production. Daemon uses this for arrival-order sorting and the 600s expiry."
+    },
+    "project": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9_.-]+$",
+      "minLength": 1,
+      "description": "Registered hive project name. Must match `Hive::Config.find_project` lookup; daemon rejects with reason=unknown_project on miss."
+    },
+    "slug": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-]{0,62}[a-z0-9]$",
+      "description": "Hive task slug. ADR-012 regex. Daemon constructs paths from this; path-traversal candidates are rejected via the regex (no '/', no '..', no uppercase)."
+    },
+    "argv": {
+      "type": "array",
+      "minItems": 2,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "description": "Full argv to spawn. argv[0] must be 'hive'; argv[1] must be in the closed ALLOWED_VERBS enum (see below). The full argv is array-form-spawned (no shell), so quoting is irrelevant; downstream verbs each validate their own arguments."
+    },
+    "requestor": {
+      "type": "string",
+      "enum": ["bot"],
+      "description": "Identity of the producer. Currently 'bot' is the only registered producer. Note: the daemon does NOT verify this field against a process credential — the queue dir's filesystem permissions (mode 0700) are the de-facto auth boundary."
+    },
+    "chat_id": {
+      "type": ["integer", "null"],
+      "description": "Telegram chat ID for completion/error replies. Only set when requestor=bot."
+    },
+    "update_id": {
+      "type": ["integer", "null"],
+      "description": "Telegram update ID for correlation/idempotency. Only set when requestor=bot."
+    },
+    "trigger": {
+      "type": ["string", "null"],
+      "description": "Free-form label for what caused this dispatch (e.g. 'answer_complete', 'autofix_button'). Optional; informational only."
+    }
+  },
+  "$defs": {
+    "ALLOWED_VERBS": {
+      "type": "array",
+      "items": {
+        "enum": [
+          "run",
+          "develop",
+          "brainstorm",
+          "plan",
+          "review",
+          "open-pr",
+          "artifacts",
+          "finalize",
+          "archive",
+          "markers"
+        ]
+      },
+      "description": "Closed set of verbs the daemon will dispatch on behalf of an external producer. Must stay in sync with `Hive::Daemon::DispatchRequestQueue::ALLOWED_VERBS` — a test asserts the cross-list equality."
+    }
+  }
+}

--- a/test/integration/bot/scenarios/s1_brainstorm_test.rb
+++ b/test/integration/bot/scenarios/s1_brainstorm_test.rb
@@ -1,7 +1,9 @@
 require "test_helper"
+require "json"
 require "hive/bot/supervisor"
 require "hive/bot/telegram"
 require "hive/bot/brainstorm_parser"
+require "hive/daemon/dispatch_request_queue"
 
 class HiveBotScenarioBrainstormTest < Minitest::Test
   include HiveTestHelper
@@ -59,7 +61,18 @@ class HiveBotScenarioBrainstormTest < Minitest::Test
 
     answers = Hive::Bot::BrainstormParser.parse(brainstorm).map(&:answer)
     assert_equal [ "Answer 1", "Answer 2", "Answer 3", "Answer 4" ], answers
-    assert_equal [ "hive", "run", slug, "--json" ], child.commands.last
+    # After plan 2026-05-28-002, `hive run` is queue-routable: the bot
+    # writes a dispatch-request file under <HIVE_HOME>/dispatch_requests/
+    # instead of spawning a child. The daemon picks the request up.
+    assert_empty child.commands,
+                 "hive run must no longer spawn from the bot — it's the daemon's job now"
+    request_files = Dir.glob(File.join(@home, "dispatch_requests", "*.json"))
+    assert_equal 1, request_files.size, "exactly one dispatch request must have landed in the queue"
+    payload = JSON.parse(File.read(request_files.first))
+    assert_equal [ "hive", "run", slug, "--json" ], payload["argv"]
+    assert_equal "hive", payload["project"]
+    assert_equal slug, payload["slug"]
+    assert_equal "bot", payload["requestor"]
   end
 
   private

--- a/test/integration/dispatch_request_concurrency_test.rb
+++ b/test/integration/dispatch_request_concurrency_test.rb
@@ -1,0 +1,188 @@
+require "test_helper"
+require "json"
+require "fileutils"
+require "tmpdir"
+require "hive/daemon/dispatcher"
+require "hive/daemon/concurrency_controller"
+require "hive/daemon/dispatch_request_queue"
+require "hive/bot/dispatch_request_writer"
+
+# Plan 2026-05-28-002 §"Tests":
+#   "Two requests for same slug → second blocked until first reaps.
+#    Request blocked by per-slug quarantine → not dispatched, file
+#    stays for retry."
+class HiveDispatchRequestConcurrencyTest < Minitest::Test
+  include HiveTestHelper
+
+  Row = Hive::Daemon::StatusConsumer::Row
+  ProjectInfo = Hive::Daemon::StatusConsumer::ProjectInfo
+  ChildExit = Hive::Daemon::ChildSupervisor::ChildExit
+
+  T0 = Time.utc(2026, 5, 28, 18, 10, 0)
+
+  class FakeStatusConsumer
+    attr_accessor :result
+    def fetch
+      @result || Hive::Daemon::StatusConsumer::Result.new(ok: true, rows: [], projects: [], error: nil)
+    end
+  end
+
+  class FakeSupervisor
+    attr_reader :spawned
+    attr_accessor :reap_queue
+    def initialize
+      @spawned = []
+      @next_pid = 2000
+      @reap_queue = []
+    end
+
+    def spawn(command_string:, project:, slug:, stage:,
+              hive_state_path: nil, state_file_path: nil, dry_run: nil, request_id: nil)
+      pid = @next_pid
+      @next_pid += 1
+      @spawned << { pid: pid, command: command_string, slug: slug, request_id: request_id }
+      pid
+    end
+
+    def reap_all(now: Time.now)
+      out = @reap_queue
+      @reap_queue = []
+      out
+    end
+
+    def reap_dry_run(now: Time.now) = []
+    def terminate_all(grace_sec: 600); end
+    def in_flight_count = @spawned.size
+  end
+
+  class StubLogger
+    attr_reader :events
+    def initialize
+      @events = []
+    end
+
+    def event(name, **attrs)
+      @events << [ name, attrs ]
+    end
+
+    def close; end
+  end
+
+  def setup
+    @state_home = Dir.mktmpdir("hive-concurrency-state")
+    @project = "hive"
+    @slug = "concurrent-260528-aaaa"
+    @hive_state_path = File.join(@state_home, "project_state")
+    FileUtils.mkdir_p(File.join(@hive_state_path, "stages", "2-brainstorm", @slug))
+
+    @supervisor = FakeSupervisor.new
+    @status_consumer = FakeStatusConsumer.new
+    @logger = StubLogger.new
+    @controller = Hive::Daemon::ConcurrencyController.new(
+      max_concurrent_runs: 5, max_concurrent_per_project: 5,
+      max_runs_per_day_per_project: 100
+    )
+
+    @dispatcher = Hive::Daemon::Dispatcher.new(
+      config: { "daemon" => { "edit_debounce_sec" => 30, "poll_interval_sec" => 30 } },
+      controller: @controller, supervisor: @supervisor,
+      status_consumer: @status_consumer, logger: @logger,
+      dispatch_request_state_home: @state_home
+    )
+    @dispatcher.define_singleton_method(:project_enabled?) { |_| true }
+    @original_find_project = Hive::Config.method(:find_project)
+    project = @project
+    state_home = @state_home
+    hive_state = @hive_state_path
+    Hive::Config.define_singleton_method(:find_project) do |name|
+      next nil unless name == project
+
+      { "name" => project, "path" => state_home, "hive_state_path" => hive_state }
+    end
+  end
+
+  def teardown
+    FileUtils.remove_entry(@state_home) if @state_home && File.exist?(@state_home)
+    Hive::Config.define_singleton_method(:find_project, @original_find_project) if @original_find_project
+  end
+
+  def queue_files
+    Dir.glob(File.join(@state_home, "dispatch_requests", "*.json")).sort
+  end
+
+  def test_two_requests_for_same_slug_serialise_by_per_slug_gate
+    request_a = Hive::Bot::DispatchRequestWriter.write!(
+      project: @project, slug: @slug,
+      argv: [ "hive", "run", @slug, "--json" ],
+      trigger: "answer_complete",
+      state_home: @state_home, now: T0
+    )
+    # Same slug, different argv (the second request would dispatch
+    # the retry verb if the first hadn't claimed the in-flight slot).
+    request_b = Hive::Bot::DispatchRequestWriter.write!(
+      project: @project, slug: @slug,
+      argv: [ "hive", "markers", "clear", @slug, "--name", "ERROR" ],
+      trigger: "autofix",
+      state_home: @state_home, now: T0 + 1
+    )
+
+    @dispatcher.tick(now: T0 + 2)
+
+    assert_equal 1, @supervisor.spawned.size,
+                 "exactly one of the two same-slug requests must dispatch this tick"
+    assert_equal request_a, @supervisor.spawned.first[:request_id],
+                 "the earlier-created request must win the in-flight slot"
+
+    blocked = @logger.events.find { |(n, attrs)|
+      n == :dispatch_request_blocked && attrs[:request_id] == request_b
+    }
+    refute_nil blocked, "the second same-slug request must log :dispatch_request_blocked"
+    assert_equal "in_flight", blocked[1][:reason]
+
+    # The deferred request's file must remain on disk for the next tick.
+    remaining_ids = queue_files.map { |path| JSON.parse(File.read(path))["request_id"] }
+    assert_includes remaining_ids, request_b
+
+    # Reap the first child. record_completion uses the tick's `now`
+    # for completed_at, so the SUCCESS_COOLDOWN_SEC (60) extends past
+    # this tick. We need TWO subsequent ticks: one to reap and start
+    # the cooldown, a later one (past cooldown_until) to dispatch B.
+    pid_a = @supervisor.spawned.first[:pid]
+    @supervisor.reap_queue = [
+      ChildExit.new(
+        pid: pid_a, exit_code: 0, project: @project, slug: @slug, stage: nil,
+        command: "hive run #{@slug} --json", state_file_path: nil,
+        started_at: T0, finished_at: T0 + 60, json_envelope: nil,
+        request_id: request_a
+      )
+    ]
+    @dispatcher.tick(now: T0 + 120) # reap, set cooldown_until = T0 + 180
+    assert_equal 1, @supervisor.spawned.size,
+                 "tick 2 reaps but cooldown blocks the deferred request"
+
+    @dispatcher.tick(now: T0 + 200) # cooldown cleared
+    assert_equal 2, @supervisor.spawned.size,
+                 "after cooldown clears, the third tick must dispatch the deferred request"
+    assert_equal request_b, @supervisor.spawned.last[:request_id]
+  end
+
+  def test_quarantined_slug_request_stays_on_disk_for_retry
+    @controller.instance_variable_get(:@quarantine).add([ @project, @slug ])
+
+    request_id = Hive::Bot::DispatchRequestWriter.write!(
+      project: @project, slug: @slug,
+      argv: [ "hive", "run", @slug, "--json" ],
+      state_home: @state_home, now: T0
+    )
+
+    @dispatcher.tick(now: T0 + 1)
+
+    assert_empty @supervisor.spawned, "a quarantined slug must not dispatch"
+    blocked = @logger.events.find { |(n, attrs)|
+      n == :dispatch_request_blocked && attrs[:request_id] == request_id
+    }
+    refute_nil blocked, "the quarantined request must log :dispatch_request_blocked"
+    assert_equal "quarantined", blocked[1][:reason]
+    refute_empty queue_files, "blocked-by-quarantine requests stay on disk for a later tick"
+  end
+end

--- a/test/integration/dispatch_request_roundtrip_test.rb
+++ b/test/integration/dispatch_request_roundtrip_test.rb
@@ -1,0 +1,221 @@
+require "test_helper"
+require "json"
+require "fileutils"
+require "tmpdir"
+require "hive/daemon/dispatcher"
+require "hive/daemon/concurrency_controller"
+require "hive/daemon/dispatch_request_queue"
+require "hive/bot/dispatch_request_writer"
+
+# Plan 2026-05-28-002 §"Tests":
+#   "Bot writes a request → daemon picks up → child runs → controller
+#    baseline updated → no redundant redispatch on next tick."
+#
+# Drives the real `Hive::Daemon::Dispatcher#tick` with a real
+# `Hive::Daemon::ConcurrencyController` and a real
+# `Hive::Daemon::DispatchRequestQueue`. The only fakes are
+# StatusConsumer (so we don't shell out to `hive status`) and
+# ChildSupervisor (so we control the spawn/reap timing
+# deterministically). The bot side is the production
+# `DispatchRequestWriter`.
+class HiveDispatchRequestRoundtripTest < Minitest::Test
+  include HiveTestHelper
+
+  Row = Hive::Daemon::StatusConsumer::Row
+  ProjectInfo = Hive::Daemon::StatusConsumer::ProjectInfo
+  ChildExit = Hive::Daemon::ChildSupervisor::ChildExit
+
+  T0 = Time.utc(2026, 5, 28, 18, 10, 0)
+
+  class FakeStatusConsumer
+    attr_accessor :result
+    def fetch
+      @result || Hive::Daemon::StatusConsumer::Result.new(ok: true, rows: [], projects: [], error: nil)
+    end
+  end
+
+  class FakeSupervisor
+    attr_reader :spawned
+    attr_accessor :reap_queue
+    def initialize
+      @spawned = []
+      @next_pid = 1000
+      @reap_queue = []
+    end
+
+    def spawn(command_string:, project:, slug:, stage:,
+              hive_state_path: nil, state_file_path: nil, dry_run: nil, request_id: nil)
+      pid = @next_pid
+      @next_pid += 1
+      @spawned << {
+        pid: pid, command: command_string, project: project, slug: slug,
+        request_id: request_id, state_file_path: state_file_path
+      }
+      pid
+    end
+
+    def reap_all(now: Time.now)
+      out = @reap_queue
+      @reap_queue = []
+      out
+    end
+
+    def reap_dry_run(now: Time.now)
+      []
+    end
+
+    def terminate_all(grace_sec: 600); end
+
+    def in_flight_count
+      @spawned.size
+    end
+  end
+
+  class StubLogger
+    attr_reader :events
+    def initialize
+      @events = []
+    end
+
+    def event(name, **attrs)
+      @events << [ name, attrs ]
+    end
+
+    def close; end
+  end
+
+  def setup
+    @state_home = Dir.mktmpdir("hive-roundtrip-state")
+    @project = "hive"
+    @slug = "test-roundtrip-260528-aaaa"
+    @hive_state_path = File.join(@state_home, "project_state")
+    @stage_dir = File.join(@hive_state_path, "stages", "2-brainstorm", @slug)
+    FileUtils.mkdir_p(@stage_dir)
+    @brainstorm_path = File.join(@stage_dir, "brainstorm.md")
+    File.write(@brainstorm_path, "## Round 1\n\n<!-- WAITING -->\n")
+
+    @supervisor = FakeSupervisor.new
+    @status_consumer = FakeStatusConsumer.new
+    @logger = StubLogger.new
+    @controller = Hive::Daemon::ConcurrencyController.new(
+      max_concurrent_runs: 5, max_concurrent_per_project: 5,
+      max_runs_per_day_per_project: 100
+    )
+
+    @dispatcher = Hive::Daemon::Dispatcher.new(
+      config: { "daemon" => { "edit_debounce_sec" => 30, "poll_interval_sec" => 30 } },
+      controller: @controller, supervisor: @supervisor,
+      status_consumer: @status_consumer, logger: @logger,
+      dispatch_request_state_home: @state_home
+    )
+    @dispatcher.define_singleton_method(:project_enabled?) { |_| true }
+    stub_find_project!
+  end
+
+  def teardown
+    FileUtils.remove_entry(@state_home) if @state_home && File.exist?(@state_home)
+    restore_find_project!
+  end
+
+  def stub_find_project!
+    @original_find_project = Hive::Config.method(:find_project)
+    state_home = @state_home
+    project = @project
+    hive_state = @hive_state_path
+    Hive::Config.define_singleton_method(:find_project) do |name|
+      next nil unless name == project
+
+      { "name" => project, "path" => state_home, "hive_state_path" => hive_state }
+    end
+  end
+
+  def restore_find_project!
+    Hive::Config.define_singleton_method(:find_project, @original_find_project) if @original_find_project
+  end
+
+  def needs_input_row(mtime:)
+    Row.new(
+      project: @project, slug: @slug, stage: "2-brainstorm",
+      marker: "waiting", folder: @stage_dir,
+      state_file: @brainstorm_path, state_file_mtime: mtime,
+      action: "needs_input", suggested_command: "hive run #{@slug}",
+      claude_pid_alive: nil, live_task_lock: nil
+    )
+  end
+
+  def set_status_rows(rows)
+    @status_consumer.result = Hive::Daemon::StatusConsumer::Result.new(
+      ok: true,
+      rows: rows,
+      projects: [ ProjectInfo.new(name: @project, legacy_stage_dirs: []) ],
+      error: nil
+    )
+  end
+
+  # ── ROUNDTRIP: bot writes → daemon picks up → child runs → no
+  # redundant redispatch on the next tick ────────────────────────────
+  def test_bot_request_picked_up_and_no_redundant_redispatch
+    # 1. Bot writes the request file.
+    request_id = Hive::Bot::DispatchRequestWriter.write!(
+      project: @project, slug: @slug,
+      argv: [ "hive", "run", @slug, "--json" ],
+      chat_id: 12345, update_id: 1, trigger: "answer_complete",
+      state_home: @state_home, now: T0
+    )
+
+    # 2. Daemon tick 1. Picks up the request and spawns.
+    @dispatcher.tick(now: T0 + 1)
+
+    assert_equal 1, @supervisor.spawned.size, "daemon must pick up the request and spawn exactly once"
+    assert_equal request_id, @supervisor.spawned.first[:request_id],
+                 "the spawn must carry the request_id for reap-time unlink"
+    refute_empty Dir.glob(File.join(@state_home, "dispatch_requests", "*.json")),
+                 "request file stays on disk until the child reaps"
+
+    # 3. The child writes a fresh marker; brainstorm.md mtime bumps.
+    new_mtime = T0 + 30
+    File.utime(new_mtime, new_mtime, @brainstorm_path)
+
+    # 4. Child completes. Reap arrives. The daemon's reap path must
+    #    refresh the controller's baseline mtime AND unlink the
+    #    request file.
+    pid = @supervisor.spawned.first[:pid]
+    @supervisor.reap_queue = [
+      ChildExit.new(
+        pid: pid, exit_code: 0, project: @project, slug: @slug, stage: nil,
+        command: "hive run #{@slug} --json", state_file_path: @brainstorm_path,
+        started_at: T0, finished_at: T0 + 90, json_envelope: nil,
+        request_id: request_id
+      )
+    ]
+
+    # 5. Tick 2: status now shows the row as needs_input with the NEW
+    #    mtime (the agent's own write). If the baseline was stale,
+    #    Policy.decide_edit would return :dispatch and the daemon
+    #    would re-spawn. The post-completion mtime refresh prevents
+    #    that.
+    set_status_rows([ needs_input_row(mtime: new_mtime) ])
+    @dispatcher.tick(now: T0 + 90)
+
+    # The reap must have:
+    #   - unlinked the request file
+    #   - logged :dispatch_request_completed
+    #   - refreshed the controller's baseline to the new mtime
+    assert_empty Dir.glob(File.join(@state_home, "dispatch_requests", "*.json")),
+                 "request file must be unlinked on reap"
+    completed = @logger.events.find { |(n, _)| n == :dispatch_request_completed }
+    refute_nil completed
+    baseline = @controller.last_dispatched_state_file_mtime_for(project: @project, slug: @slug)
+    assert_equal new_mtime.to_i, baseline.to_i,
+                 "post-completion mtime refresh must seed the baseline to the agent's own write"
+
+    # 6. Tick 3 (well past the debounce window): the row's mtime
+    #    equals the baseline → Policy.decide_edit returns :skip → no
+    #    redundant spawn. This is the regression we're fixing.
+    set_status_rows([ needs_input_row(mtime: new_mtime) ])
+    @dispatcher.tick(now: T0 + 180)
+
+    assert_equal 1, @supervisor.spawned.size,
+                 "after baseline refresh, the next tick must NOT re-dispatch — single-dispatcher invariant holds"
+  end
+end

--- a/test/integration/dispatch_request_uniqueness_test.rb
+++ b/test/integration/dispatch_request_uniqueness_test.rb
@@ -1,0 +1,121 @@
+require "test_helper"
+require "json"
+require "fileutils"
+require "tmpdir"
+require "hive/daemon/dispatcher"
+require "hive/daemon/concurrency_controller"
+require "hive/daemon/dispatch_request_queue"
+require "hive/bot/dispatch_request_writer"
+
+# Plan 2026-05-28-002 §"Tests":
+#   "10-min expiry: a request older than the threshold is removed
+#    without dispatch."
+class HiveDispatchRequestUniquenessTest < Minitest::Test
+  include HiveTestHelper
+
+  Row = Hive::Daemon::StatusConsumer::Row
+
+  T0 = Time.utc(2026, 5, 28, 18, 0, 0)
+
+  class FakeStatusConsumer
+    def fetch
+      Hive::Daemon::StatusConsumer::Result.new(ok: true, rows: [], projects: [], error: nil)
+    end
+  end
+
+  class FakeSupervisor
+    attr_reader :spawned
+    def initialize
+      @spawned = []
+    end
+
+    def spawn(**kwargs)
+      @spawned << kwargs
+      1234
+    end
+
+    def reap_all(now: Time.now) = []
+    def reap_dry_run(now: Time.now) = []
+    def terminate_all(grace_sec: 600); end
+    def in_flight_count = 0
+  end
+
+  class StubLogger
+    attr_reader :events
+    def initialize
+      @events = []
+    end
+
+    def event(name, **attrs)
+      @events << [ name, attrs ]
+    end
+
+    def close; end
+  end
+
+  def setup
+    @state_home = Dir.mktmpdir("hive-uniqueness-state")
+    @project = "hive"
+    @slug = "stale-260528-aaaa"
+    @supervisor = FakeSupervisor.new
+    @logger = StubLogger.new
+    @controller = Hive::Daemon::ConcurrencyController.new(
+      max_concurrent_runs: 5, max_concurrent_per_project: 5,
+      max_runs_per_day_per_project: 100
+    )
+    @dispatcher = Hive::Daemon::Dispatcher.new(
+      config: { "daemon" => { "edit_debounce_sec" => 30, "poll_interval_sec" => 30 } },
+      controller: @controller, supervisor: @supervisor,
+      status_consumer: FakeStatusConsumer.new, logger: @logger,
+      dispatch_request_state_home: @state_home
+    )
+    @dispatcher.define_singleton_method(:project_enabled?) { |_| true }
+    @original_find_project = Hive::Config.method(:find_project)
+    project = @project
+    state_home = @state_home
+    Hive::Config.define_singleton_method(:find_project) do |name|
+      name == project ? { "name" => project, "path" => state_home, "hive_state_path" => state_home } : nil
+    end
+  end
+
+  def teardown
+    FileUtils.remove_entry(@state_home) if @state_home && File.exist?(@state_home)
+    Hive::Config.define_singleton_method(:find_project, @original_find_project) if @original_find_project
+  end
+
+  def queue_files
+    Dir.glob(File.join(@state_home, "dispatch_requests", "*.json"))
+  end
+
+  def test_request_older_than_ten_minutes_is_pruned_without_dispatch
+    eleven_minutes_ago = T0 - (11 * 60)
+    request_id = Hive::Bot::DispatchRequestWriter.write!(
+      project: @project, slug: @slug,
+      argv: [ "hive", "run", @slug, "--json" ],
+      state_home: @state_home, now: eleven_minutes_ago
+    )
+
+    @dispatcher.tick(now: T0)
+
+    assert_empty @supervisor.spawned, "an expired request must not dispatch"
+    expired = @logger.events.find { |(n, attrs)|
+      n == :dispatch_request_expired && attrs[:request_id] == request_id
+    }
+    refute_nil expired, "the expired request must log :dispatch_request_expired"
+    assert_empty queue_files, "expired request files must be removed from the queue dir"
+  end
+
+  def test_request_within_window_still_dispatches
+    nine_minutes_ago = T0 - (9 * 60)
+    Hive::Bot::DispatchRequestWriter.write!(
+      project: @project, slug: @slug,
+      argv: [ "hive", "run", @slug, "--json" ],
+      state_home: @state_home, now: nine_minutes_ago
+    )
+
+    @dispatcher.tick(now: T0)
+
+    assert_equal 1, @supervisor.spawned.size,
+                 "a request inside the 10-min window must dispatch normally"
+  end
+end

--- a/test/integration/notification_exactly_once_test.rb
+++ b/test/integration/notification_exactly_once_test.rb
@@ -1,0 +1,144 @@
+require "test_helper"
+require "fileutils"
+require "tmpdir"
+require "hive/bot/notification_dispatcher"
+require "hive/bot/notification_builders"
+require "hive/bot/status_watcher"
+require "hive/bot/alert_store"
+
+# Plan 2026-05-28-002 §7 "UX behavior preservation":
+#   After the dual-writer collapses to one (daemon-only), the bot's
+#   "next question" message comes from the daemon's notification path
+#   — same code as today, just no longer competing with the bot-side
+#   reaper. This test pins the exactly-one-notification-per-state-
+#   change invariant against the live NotificationDispatcher to make
+#   sure the refactor didn't introduce a double-send or a missed-send.
+class HiveBotNotificationExactlyOnceTest < Minitest::Test
+  include HiveTestHelper
+
+  Row = Hive::Bot::StatusWatcher::Row
+
+  class FakeTelegram
+    attr_reader :messages
+    def initialize
+      @messages = []
+    end
+
+    def send_message(chat_id:, text:, reply_markup: nil)
+      @messages << { chat_id: chat_id, text: text, reply_markup: reply_markup }
+    end
+  end
+
+  class StubLogger
+    attr_reader :events
+    def initialize
+      @events = []
+    end
+
+    def event(name, **attrs)
+      @events << [ name, attrs ]
+    end
+
+    def close; end
+  end
+
+  def needs_input_row(project: "hive", slug: "s1", stage: "2-brainstorm",
+                     marker: "waiting", attrs: { "round" => "1" },
+                     state_file_mtime: Time.utc(2026, 5, 28, 18, 0, 0))
+    Row.new(
+      project: project, slug: slug, stage: stage, marker: marker,
+      folder: "/tmp/#{slug}",
+      state_file: "/tmp/#{slug}/brainstorm.md",
+      state_file_mtime: state_file_mtime,
+      action: "needs_input",
+      suggested_command: "hive run #{slug}",
+      attrs: attrs
+    )
+  end
+
+  def build_dispatcher(alert_path:)
+    telegram = FakeTelegram.new
+    logger = StubLogger.new
+    bot_cfg = {
+      "alert_state_file" => alert_path,
+      "chat_id_allowlist" => [ 42 ],
+      "recovery_grace_sec" => 60,
+      "reminder_interval_sec" => 86_400
+    }
+    dispatcher = Hive::Bot::NotificationDispatcher.new(
+      telegram: telegram, logger: logger, bot_config: bot_cfg,
+      daemon_enabled: ->(_project) { true }
+    )
+    # Fresh-install seeding suppresses initial alerts. Pre-mark the
+    # store as seeded so the first tick fires normally — the scenario
+    # under test is what happens AFTER the bot has been running.
+    dispatcher.instance_variable_get(:@alert_store).mark_seeded!
+    [ dispatcher, telegram, logger ]
+  end
+
+  def test_round_1_question_fires_exactly_one_notification
+    Dir.mktmpdir("hive-notif") do |dir|
+      dispatcher, telegram, logger = build_dispatcher(alert_path: File.join(dir, "alerts.json"))
+      row = needs_input_row
+      dispatcher.process_rows([ row ])
+
+      notifications_sent = logger.events.count { |(n, _)| n == :notification_sent }
+      assert_equal 1, notifications_sent,
+                   "first sighting of a needs_input/waiting row must fire exactly one notification"
+      assert_equal 1, telegram.messages.size
+
+      # Same row, same fingerprint, next tick → must NOT re-fire.
+      dispatcher.process_rows([ row ])
+      again = logger.events.count { |(n, _)| n == :notification_sent }
+      assert_equal 1, again,
+                   "the same fingerprint on a subsequent tick must dedupe — no second notification"
+    end
+  end
+
+  def test_round_2_after_agent_writes_new_questions_fires_exactly_one_more
+    Dir.mktmpdir("hive-notif") do |dir|
+      dispatcher, telegram, logger = build_dispatcher(alert_path: File.join(dir, "alerts.json"))
+      round_1 = needs_input_row(attrs: { "round" => "1" })
+      dispatcher.process_rows([ round_1 ])
+      assert_equal 1, logger.events.count { |(n, _)| n == :notification_sent },
+                   "round 1 fires once"
+
+      # Simulate the agent's `hive run` cycle:
+      #   - row transitions to agent_running (no waiting fingerprint visible)
+      #   - then back to needs_input/waiting with NEW attrs (round=2)
+      # The fingerprint changes because marker attrs include the round.
+      agent_running = Row.new(
+        project: "hive", slug: "s1", stage: "2-brainstorm", marker: nil,
+        folder: "/tmp/s1", state_file: "/tmp/s1/brainstorm.md",
+        state_file_mtime: Time.utc(2026, 5, 28, 18, 10, 0),
+        action: "agent_running", suggested_command: nil,
+        attrs: {}
+      )
+      dispatcher.process_rows([ agent_running ])
+
+      round_2 = needs_input_row(attrs: { "round" => "2" },
+                                state_file_mtime: Time.utc(2026, 5, 28, 18, 13, 9))
+      dispatcher.process_rows([ round_2 ])
+
+      total = logger.events.count { |(n, _)| n == :notification_sent }
+      assert_equal 2, total,
+                   "round 2 (new fingerprint) must fire exactly one ADDITIONAL notification"
+      assert_equal 2, telegram.messages.size,
+                   "exactly two Telegram sends across the full round-1 → round-2 cycle"
+    end
+  end
+
+  def test_unchanged_row_across_three_ticks_fires_only_once
+    Dir.mktmpdir("hive-notif") do |dir|
+      dispatcher, _telegram, logger = build_dispatcher(alert_path: File.join(dir, "alerts.json"))
+      row = needs_input_row
+
+      3.times { dispatcher.process_rows([ row ]) }
+
+      sent = logger.events.count { |(n, _)| n == :notification_sent }
+      assert_equal 1, sent,
+                   "a stable fingerprint across N ticks must produce exactly one notification " \
+                   "— no daemon-driven double-send"
+    end
+  end
+end

--- a/test/integration/regression_redundant_redispatch_test.rb
+++ b/test/integration/regression_redundant_redispatch_test.rb
@@ -1,0 +1,248 @@
+require "test_helper"
+require "json"
+require "fileutils"
+require "tmpdir"
+require "hive/daemon/dispatcher"
+require "hive/daemon/concurrency_controller"
+require "hive/daemon/dispatch_request_queue"
+require "hive/bot/dispatch_request_writer"
+
+# Regression test for the 2026-05-28 redundant-redispatch bug.
+#
+# Plan 2026-05-28-002 Problem section: when the bot dispatched
+# `hive run` directly, the daemon's `last_dispatched_mtime` stayed
+# stale because the bot — not the daemon — owned the child. The
+# agent's own write to brainstorm.md looked like a "new user edit"
+# on the next tick, so the daemon dispatched a SECOND runner that
+# held the task lock for 1-2 min while the bot rejected legitimate
+# user answers with "Try again - another run holds the lock".
+#
+# Smoking gun in the original incident:
+#
+#   18:13:14  debouncing   mtime=18:13:09     ← agent's write
+#   18:13:44  dispatched   trigger=advance    ← redundant daemon redispatch
+#
+# This test replays that exact sequence against the post-fix code
+# path. The acceptance criterion (plan §"Acceptance" item 3): "no
+# redundant redispatch within 60s of a bot-driven `hive run`."
+class HiveRegressionRedundantRedispatchTest < Minitest::Test
+  include HiveTestHelper
+
+  Row = Hive::Daemon::StatusConsumer::Row
+  ProjectInfo = Hive::Daemon::StatusConsumer::ProjectInfo
+  ChildExit = Hive::Daemon::ChildSupervisor::ChildExit
+
+  # T0 == the 18:13 incident's relative t=0.
+  T_BOT_ANSWER = Time.utc(2026, 5, 28, 18, 13, 4)  # bot finishes writing Q10's answer
+  T_AGENT_WRITE = Time.utc(2026, 5, 28, 18, 13, 9) # agent's write to brainstorm.md
+  T_FIRST_TICK = Time.utc(2026, 5, 28, 18, 13, 14) # daemon picks up the request
+  T_REAP_TICK = Time.utc(2026, 5, 28, 18, 13, 30)  # child exits, daemon reaps
+  T_NEXT_TICK = Time.utc(2026, 5, 28, 18, 13, 44)  # 30s later — the redundant-redispatch tick
+
+  class FakeStatusConsumer
+    attr_accessor :result
+    def fetch
+      @result || Hive::Daemon::StatusConsumer::Result.new(ok: true, rows: [], projects: [], error: nil)
+    end
+  end
+
+  class FakeSupervisor
+    attr_reader :spawned
+    attr_accessor :reap_queue
+    def initialize
+      @spawned = []
+      @next_pid = 5000
+      @reap_queue = []
+    end
+
+    def spawn(command_string:, project:, slug:, stage:,
+              hive_state_path: nil, state_file_path: nil, dry_run: nil, request_id: nil)
+      pid = @next_pid
+      @next_pid += 1
+      @spawned << { pid: pid, command: command_string, slug: slug,
+                    request_id: request_id, state_file_path: state_file_path,
+                    spawned_at_tick: @current_tick }
+      pid
+    end
+
+    def reap_all(now: Time.now)
+      @current_tick = now
+      out = @reap_queue
+      @reap_queue = []
+      out
+    end
+
+    def reap_dry_run(now: Time.now) = []
+    def terminate_all(grace_sec: 600); end
+    def in_flight_count = @spawned.size
+  end
+
+  class StubLogger
+    attr_reader :events
+    def initialize
+      @events = []
+    end
+
+    def event(name, **attrs)
+      @events << [ name, attrs ]
+    end
+
+    def close; end
+  end
+
+  def setup
+    @state_home = Dir.mktmpdir("hive-regression-state")
+    @project = "hive"
+    @slug = "explore-the-simplest-way-to-260528-2503"
+    @hive_state_path = File.join(@state_home, "project_state")
+    @stage_dir = File.join(@hive_state_path, "stages", "2-brainstorm", @slug)
+    FileUtils.mkdir_p(@stage_dir)
+    @brainstorm_path = File.join(@stage_dir, "brainstorm.md")
+    File.write(@brainstorm_path, "## Round 1\n\n<!-- WAITING -->\n")
+    # Pre-set the brainstorm.md mtime to T_BOT_ANSWER (the answer write
+    # bumped it before the agent's tick).
+    File.utime(T_BOT_ANSWER, T_BOT_ANSWER, @brainstorm_path)
+
+    @supervisor = FakeSupervisor.new
+    @status_consumer = FakeStatusConsumer.new
+    @logger = StubLogger.new
+    @controller = Hive::Daemon::ConcurrencyController.new(
+      max_concurrent_runs: 5, max_concurrent_per_project: 5,
+      max_runs_per_day_per_project: 100
+    )
+    @dispatcher = Hive::Daemon::Dispatcher.new(
+      config: { "daemon" => { "edit_debounce_sec" => 30, "poll_interval_sec" => 30 } },
+      controller: @controller, supervisor: @supervisor,
+      status_consumer: @status_consumer, logger: @logger,
+      dispatch_request_state_home: @state_home
+    )
+    @dispatcher.define_singleton_method(:project_enabled?) { |_| true }
+    @original_find_project = Hive::Config.method(:find_project)
+    project = @project
+    state_home = @state_home
+    hive_state = @hive_state_path
+    Hive::Config.define_singleton_method(:find_project) do |name|
+      next nil unless name == project
+
+      { "name" => project, "path" => state_home, "hive_state_path" => hive_state }
+    end
+  end
+
+  def teardown
+    FileUtils.remove_entry(@state_home) if @state_home && File.exist?(@state_home)
+    Hive::Config.define_singleton_method(:find_project, @original_find_project) if @original_find_project
+  end
+
+  def needs_input_row(mtime:)
+    Row.new(
+      project: @project, slug: @slug, stage: "2-brainstorm",
+      marker: "waiting", folder: @stage_dir,
+      state_file: @brainstorm_path, state_file_mtime: mtime,
+      action: "needs_input", suggested_command: "hive run #{@slug}",
+      claude_pid_alive: nil, live_task_lock: nil
+    )
+  end
+
+  def set_status_rows(rows)
+    @status_consumer.result = Hive::Daemon::StatusConsumer::Result.new(
+      ok: true,
+      rows: rows,
+      projects: [ ProjectInfo.new(name: @project, legacy_stage_dirs: []) ],
+      error: nil
+    )
+  end
+
+  def test_no_redundant_redispatch_within_60s_of_bot_driven_hive_run
+    # Replay the exact 2026-05-28 18:13 sequence:
+    #
+    # 1. T_BOT_ANSWER: bot finishes writing Q10's answer and ENQUEUES
+    #    a `hive run` request (post-refactor). The brainstorm.md
+    #    mtime is at T_BOT_ANSWER (the answer write).
+    request_id = Hive::Bot::DispatchRequestWriter.write!(
+      project: @project, slug: @slug,
+      argv: [ "hive", "run", @slug, "--json" ],
+      chat_id: 12345, update_id: 926_850_952, trigger: "answer_complete",
+      state_home: @state_home, now: T_BOT_ANSWER
+    )
+
+    # 2. T_FIRST_TICK (18:13:14): daemon's first tick picks up the
+    #    request and spawns. record_dispatch seeds the baseline to
+    #    T_BOT_ANSWER (the mtime at dispatch time).
+    set_status_rows([ needs_input_row(mtime: T_BOT_ANSWER) ])
+    @dispatcher.tick(now: T_FIRST_TICK)
+
+    assert_equal 1, @supervisor.spawned.size, "tick 1 dispatches the queued request"
+    assert_equal request_id, @supervisor.spawned.first[:request_id]
+
+    # 3. T_AGENT_WRITE (18:13:09 — note: in real-world the agent's
+    #    write happened BEFORE the daemon's tick. Either order is
+    #    fine for the regression because the post-completion mtime
+    #    refresh covers both). Simulate the agent's write by
+    #    bumping the brainstorm.md mtime past T_BOT_ANSWER.
+    agent_write_mtime = T_AGENT_WRITE
+    File.utime(agent_write_mtime, agent_write_mtime, @brainstorm_path)
+
+    # 4. T_REAP_TICK (18:13:30): child exits. The daemon's reap
+    #    refreshes the baseline to the brainstorm.md's CURRENT mtime
+    #    (the agent's last write, post-completion).
+    pid = @supervisor.spawned.first[:pid]
+    @supervisor.reap_queue = [
+      ChildExit.new(
+        pid: pid, exit_code: 0, project: @project, slug: @slug, stage: nil,
+        command: "hive run #{@slug} --json", state_file_path: @brainstorm_path,
+        started_at: T_FIRST_TICK, finished_at: T_REAP_TICK, json_envelope: nil,
+        request_id: request_id
+      )
+    ]
+    # Status now reports the row with the agent's write mtime — the
+    # debounce window has elapsed (>30s since T_AGENT_WRITE).
+    set_status_rows([ needs_input_row(mtime: agent_write_mtime) ])
+    @dispatcher.tick(now: T_REAP_TICK)
+
+    completed = @logger.events.find { |(n, _)| n == :dispatch_request_completed }
+    refute_nil completed, "reap must log :dispatch_request_completed"
+    baseline_after_reap = @controller.last_dispatched_state_file_mtime_for(
+      project: @project, slug: @slug
+    )
+    assert_equal agent_write_mtime.to_i, baseline_after_reap.to_i,
+                 "post-completion refresh must seed the baseline to the agent's last write — " \
+                 "the very property whose absence caused the 18:13 redundant redispatch"
+
+    # 5. T_NEXT_TICK (18:13:44 — exactly 30s after T_FIRST_TICK):
+    #    THE bug-tick. Pre-fix, this was when the daemon dispatched
+    #    `trigger=advance` against a stale baseline. Post-fix, the
+    #    row mtime equals the baseline → Policy returns :skip → no
+    #    redundant spawn.
+    set_status_rows([ needs_input_row(mtime: agent_write_mtime) ])
+    @dispatcher.tick(now: T_NEXT_TICK)
+
+    spawn_count_after_bug_window = @supervisor.spawned.size
+    assert_equal 1, spawn_count_after_bug_window,
+                 "ACCEPTANCE CRITERION: no redundant redispatch within 60s of a " \
+                 "bot-driven `hive run`. Only the original request must have spawned."
+
+    # The daemon.log must show NO :dispatched event for trigger=advance
+    # within the 18:13 window — the regression's smoking gun.
+    bug_dispatches = @logger.events.select do |(n, attrs)|
+      n == :dispatched &&
+        attrs[:trigger] == "advance" &&
+        attrs[:slug] == @slug
+    end
+    assert_empty bug_dispatches,
+                 "the daemon must NOT have logged an :advance dispatch — " \
+                 "any such event is the original bug"
+
+    # The :skipped event for the row scan must record either
+    # baseline_recorded or no skip at all (mtime == baseline yields
+    # Policy :skip), confirming the gate is the post-completion
+    # baseline refresh.
+    # The events.jsonl evidence trail:
+    observed = @logger.events.count { |(n, _)| n == :dispatch_request_observed }
+    dispatched_via_request = @logger.events.count { |(n, _)| n == :dispatch_request_dispatched }
+    completed_via_request = @logger.events.count { |(n, _)| n == :dispatch_request_completed }
+    assert_equal 1, observed, "exactly one :dispatch_request_observed event"
+    assert_equal 1, dispatched_via_request,
+                 "exactly one :dispatch_request_dispatched event — no shadow second dispatch"
+    assert_equal 1, completed_via_request, "exactly one :dispatch_request_completed event"
+  end
+end

--- a/test/unit/bot/dispatch_request_writer_test.rb
+++ b/test/unit/bot/dispatch_request_writer_test.rb
@@ -64,7 +64,10 @@ class HiveBotDispatchRequestWriterTest < Minitest::Test
 
   def test_write_is_atomic_no_partial_files_remain
     Dir.mktmpdir("hive-writer") do |dir|
-      W.write!(project: "p", slug: "s", argv: [ "hive", "run", "s" ],
+      # SEC-5 from PR #241 ce-code-review: slug must satisfy the
+      # ADR-012 regex (min 2 chars). Use a realistic slug shape.
+      W.write!(project: "hive", slug: "task-260528-aaaa",
+               argv: [ "hive", "run", "task-260528-aaaa" ],
                state_home: dir, now: Time.utc(2026, 5, 28, 18, 0, 0))
 
       queue_dir = Q.directory(state_home: dir)
@@ -78,18 +81,56 @@ class HiveBotDispatchRequestWriterTest < Minitest::Test
 
   def test_write_rejects_non_allowlisted_argv
     Dir.mktmpdir("hive-writer") do |dir|
+      good_slug = "task-260528-aaaa"
       assert_raises(ArgumentError) do
-        W.write!(project: "p", slug: "s", argv: [ "hive", "doctor" ], state_home: dir)
+        W.write!(project: "hive", slug: good_slug, argv: [ "hive", "doctor" ], state_home: dir)
       end
       assert_raises(ArgumentError) do
-        W.write!(project: "p", slug: "s", argv: [ "echo", "rm", "-rf" ], state_home: dir)
+        W.write!(project: "hive", slug: good_slug, argv: [ "echo", "rm", "-rf" ], state_home: dir)
       end
       assert_raises(ArgumentError) do
-        W.write!(project: "p", slug: "s", argv: "hive run s", state_home: dir)
+        W.write!(project: "hive", slug: good_slug, argv: "hive run #{good_slug}", state_home: dir)
       end
       # Nothing should have been written.
       files = Dir.glob(File.join(Q.directory(state_home: dir), "*.json"))
       assert_empty files
+    end
+  end
+
+  # AC-04 from PR #241 ce-code-review: empty project or slug must
+  # raise loudly at the producer boundary, not silently make the
+  # daemon reject + reply "Couldn't queue".
+  def test_write_rejects_empty_project_or_slug
+    Dir.mktmpdir("hive-writer") do |dir|
+      good_argv = [ "hive", "run", "task-260528-aaaa" ]
+
+      empty_project = assert_raises(ArgumentError) do
+        W.write!(project: "", slug: "task-260528-aaaa", argv: good_argv, state_home: dir)
+      end
+      assert_match(/project is required/, empty_project.message)
+
+      empty_slug = assert_raises(ArgumentError) do
+        W.write!(project: "hive", slug: "", argv: good_argv, state_home: dir)
+      end
+      assert_match(/slug is required/, empty_slug.message)
+
+      files = Dir.glob(File.join(Q.directory(state_home: dir), "*.json"))
+      assert_empty files
+    end
+  end
+
+  # SEC-3 from PR #241 ce-code-review: queue dir must be 0700 so the
+  # producer/consumer auth boundary is at least scoped to the
+  # owning user. Default umask of 0022 would leave it world-readable
+  # and any local user could enqueue a request.
+  def test_directory_is_created_with_user_only_permissions
+    Dir.mktmpdir("hive-writer") do |dir|
+      W.write!(project: "hive", slug: "task-260528-aaaa",
+               argv: [ "hive", "run", "task-260528-aaaa" ], state_home: dir)
+      queue_dir = File.join(dir, "dispatch_requests")
+      mode = File.stat(queue_dir).mode & 0o777
+      assert_equal 0o700, mode,
+                   "queue dir must be user-only (got #{mode.to_s(8)})"
     end
   end
 

--- a/test/unit/bot/dispatch_request_writer_test.rb
+++ b/test/unit/bot/dispatch_request_writer_test.rb
@@ -1,0 +1,114 @@
+require "test_helper"
+require "json"
+require "fileutils"
+require "tmpdir"
+require "hive/bot/dispatch_request_writer"
+require "hive/daemon/dispatch_request_queue"
+
+class HiveBotDispatchRequestWriterTest < Minitest::Test
+  include HiveTestHelper
+
+  W = Hive::Bot::DispatchRequestWriter
+  Q = Hive::Daemon::DispatchRequestQueue
+
+  def test_write_emits_schema_versioned_json_with_required_fields
+    Dir.mktmpdir("hive-writer") do |dir|
+      request_id = W.write!(
+        project: "hive",
+        slug: "explore-the-simplest-way-to-260528-2503",
+        argv: [ "hive", "run", "explore-the-simplest-way-to-260528-2503", "--json" ],
+        chat_id: 123_456_789,
+        update_id: 926_850_952,
+        trigger: "answer_complete",
+        state_home: dir,
+        now: Time.utc(2026, 5, 28, 18, 11, 44)
+      )
+
+      assert_kind_of String, request_id
+      refute_empty request_id
+
+      files = Dir.glob(File.join(Q.directory(state_home: dir), "*.json"))
+      assert_equal 1, files.size
+
+      payload = JSON.parse(File.read(files.first))
+      assert_equal "hive-dispatch-request", payload["schema"]
+      assert_equal 1, payload["schema_version"]
+      assert_equal request_id, payload["request_id"]
+      assert_equal "2026-05-28T18:11:44Z", payload["created_at"]
+      assert_equal "hive", payload["project"]
+      assert_equal "explore-the-simplest-way-to-260528-2503", payload["slug"]
+      assert_equal [ "hive", "run", "explore-the-simplest-way-to-260528-2503", "--json" ], payload["argv"]
+      assert_equal "bot", payload["requestor"]
+      assert_equal 123_456_789, payload["chat_id"]
+      assert_equal 926_850_952, payload["update_id"]
+      assert_equal "answer_complete", payload["trigger"]
+    end
+  end
+
+  def test_write_uses_chronologically_sortable_filename
+    Dir.mktmpdir("hive-writer") do |dir|
+      W.write!(project: "p", slug: "first", argv: [ "hive", "run", "first" ],
+               state_home: dir, now: Time.utc(2026, 5, 28, 18, 0, 0))
+      W.write!(project: "p", slug: "second", argv: [ "hive", "run", "second" ],
+               state_home: dir, now: Time.utc(2026, 5, 28, 18, 1, 0))
+
+      files = Dir.glob(File.join(Q.directory(state_home: dir), "*.json")).sort
+      # Filenames sort lexicographically by created_at, so sorting on
+      # the filename and on the time-ordering of the requests must
+      # agree.
+      first, second = files.map { |path| JSON.parse(File.read(path))["slug"] }
+      assert_equal "first", first
+      assert_equal "second", second
+    end
+  end
+
+  def test_write_is_atomic_no_partial_files_remain
+    Dir.mktmpdir("hive-writer") do |dir|
+      W.write!(project: "p", slug: "s", argv: [ "hive", "run", "s" ],
+               state_home: dir, now: Time.utc(2026, 5, 28, 18, 0, 0))
+
+      queue_dir = Q.directory(state_home: dir)
+      # Atomic write must leave no `.tmp.<pid>.<tid>` siblings on
+      # success — a concurrent daemon scan looks at *.json only, but a
+      # stale .tmp would leak across runs.
+      tmps = Dir.glob(File.join(queue_dir, ".*.tmp.*"))
+      assert_empty tmps, "atomic write must not leak tmp files: #{tmps.inspect}"
+    end
+  end
+
+  def test_write_rejects_non_allowlisted_argv
+    Dir.mktmpdir("hive-writer") do |dir|
+      assert_raises(ArgumentError) do
+        W.write!(project: "p", slug: "s", argv: [ "hive", "doctor" ], state_home: dir)
+      end
+      assert_raises(ArgumentError) do
+        W.write!(project: "p", slug: "s", argv: [ "echo", "rm", "-rf" ], state_home: dir)
+      end
+      assert_raises(ArgumentError) do
+        W.write!(project: "p", slug: "s", argv: "hive run s", state_home: dir)
+      end
+      # Nothing should have been written.
+      files = Dir.glob(File.join(Q.directory(state_home: dir), "*.json"))
+      assert_empty files
+    end
+  end
+
+  def test_write_produces_a_parseable_request_via_pending
+    Dir.mktmpdir("hive-writer") do |dir|
+      W.write!(project: "hive", slug: "s1",
+               argv: [ "hive", "markers", "clear", "s1", "--name", "ERROR", "--project", "hive", "--json" ],
+               trigger: "autofix",
+               state_home: dir,
+               now: Time.utc(2026, 5, 28, 18, 0, 0))
+
+      pending = Q.pending(state_home: dir)
+      assert_equal 1, pending.size
+      req = pending.first
+      assert_equal "hive", req.project
+      assert_equal "s1", req.slug
+      assert_equal "bot", req.requestor
+      assert_equal "autofix", req.trigger
+      assert_equal "markers", req.argv[1]
+    end
+  end
+end

--- a/test/unit/bot/supervisor_test.rb
+++ b/test/unit/bot/supervisor_test.rb
@@ -76,6 +76,24 @@ class HiveBotSupervisorTest < Minitest::Test
     end
   end
 
+  # Captures every dispatch-request write so tests can assert that the
+  # queue-routable bot verbs (run/develop/brainstorm/plan/review/
+  # open-pr/artifacts/finalize/archive/markers) no longer spawn — they
+  # land here instead. `write!` returns a request_id so the supervisor's
+  # logging path that includes it stays exercised.
+  FakeDispatchRequestWriter = Struct.new(:writes, :next_request_id, :raise_on_write, keyword_init: true) do
+    def write!(project:, slug:, argv:, chat_id: nil, update_id: nil, trigger: nil)
+      raise raise_on_write if raise_on_write
+
+      id = next_request_id || "req-#{writes.length + 1}"
+      writes << {
+        project: project, slug: slug, argv: argv, chat_id: chat_id,
+        update_id: update_id, trigger: trigger, request_id: id
+      }
+      id
+    end
+  end
+
   FakeConversationStore = Struct.new(:starts, :updates, :states, :ttl_updates, keyword_init: true) do
     def start(**kwargs)
       starts << kwargs
@@ -102,6 +120,18 @@ class HiveBotSupervisorTest < Minitest::Test
     def update_ttl(ttl)
       ttl_updates << ttl
     end
+
+    def clear(chat_id:, slug: nil)
+      if slug
+        states.delete([ chat_id, slug ])
+      else
+        states.delete_if { |key, _| key.first == chat_id }
+      end
+    end
+
+    def pending_confirm_count(chat_id:)
+      states.count { |key, state| key.first == chat_id && state.respond_to?(:awaiting_confirm) && state.awaiting_confirm }
+    end
   end
 
   def setup
@@ -111,6 +141,7 @@ class HiveBotSupervisorTest < Minitest::Test
     @child_supervisor = FakeChildSupervisor.new(dispatch_pid: 123, dispatched: [], completed: {}, reap_batches: [])
     @conversation_store = FakeConversationStore.new(starts: [], updates: [], states: {}, ttl_updates: [])
     @notification_dispatcher = FakeNotificationDispatcher.new(processed: [], reset_tasks: [])
+    @dispatch_request_writer = FakeDispatchRequestWriter.new(writes: [])
     # Drive the real constructor so any future invariant added to
     # Supervisor#initialize is exercised by every test in this file. We
     # inject all collaborators so the constructor's `||=` defaults never
@@ -131,7 +162,8 @@ class HiveBotSupervisorTest < Minitest::Test
       router: FakeRouter.new,
       child_supervisor: @child_supervisor,
       conversation_store: @conversation_store,
-      dry_run: false
+      dry_run: false,
+      dispatch_request_writer: @dispatch_request_writer
     )
   end
 
@@ -337,7 +369,8 @@ class HiveBotSupervisorTest < Minitest::Test
       config: @config, token: "test-token", logger: @logger, telegram: @telegram,
       status_watcher: @status_watcher, notification_dispatcher: @notification_dispatcher,
       router: nil, child_supervisor: @child_supervisor,
-      conversation_store: @conversation_store, dry_run: false
+      conversation_store: @conversation_store, dry_run: false,
+      dispatch_request_writer: @dispatch_request_writer
     )
     supervisor.instance_variable_set(:@latest_status_rows, [ retryable ])
     supervisor.instance_variable_set(:@reload, true)
@@ -356,10 +389,12 @@ class HiveBotSupervisorTest < Minitest::Test
     )
     supervisor.process_update(update)
 
-    dispatched = @child_supervisor.dispatched.map { |d| d[:command_argv] }
-    assert(dispatched.any? { |argv| argv[0, 3] == [ "hive", "markers", "clear" ] },
-           "after SIGHUP reload, /autofix must still resolve the slug and dispatch the " \
+    queued = @dispatch_request_writer.writes.map { |w| w[:argv] }
+    assert(queued.any? { |argv| argv[0, 3] == [ "hive", "markers", "clear" ] },
+           "after SIGHUP reload, /autofix must still resolve the slug and queue the " \
            "recover sequence — proving the rebuilt Router kept status_snapshot_provider")
+    assert_empty @child_supervisor.dispatched,
+                 "queue-routable verbs must not spawn from the bot (single-dispatcher invariant)"
   end
 
   def test_default_status_snapshot_provider_dispatches_recover_sequence_for_cached_row
@@ -375,7 +410,8 @@ class HiveBotSupervisorTest < Minitest::Test
       config: @config, token: "test-token", logger: @logger, telegram: @telegram,
       status_watcher: @status_watcher, notification_dispatcher: @notification_dispatcher,
       router: nil, child_supervisor: @child_supervisor,
-      conversation_store: @conversation_store, dry_run: false
+      conversation_store: @conversation_store, dry_run: false,
+      dispatch_request_writer: @dispatch_request_writer
     )
     supervisor.instance_variable_set(:@latest_status_rows, [ retryable ])
 
@@ -385,10 +421,12 @@ class HiveBotSupervisorTest < Minitest::Test
     )
     supervisor.process_update(update)
 
-    dispatched = @child_supervisor.dispatched.map { |d| d[:command_argv] }
-    assert(dispatched.any? { |argv| argv[0, 3] == [ "hive", "markers", "clear" ] },
+    queued = @dispatch_request_writer.writes.map { |w| w[:argv] }
+    assert(queued.any? { |argv| argv[0, 3] == [ "hive", "markers", "clear" ] },
            "default snapshot provider must route /autofix through latest_status_rows " \
-           "to a real recover-sequence dispatch")
+           "to a real recover-sequence queued dispatch")
+    assert_empty @child_supervisor.dispatched,
+                 "queue-routable verbs must not spawn from the bot (single-dispatcher invariant)"
   end
 
   def test_reap_children_dispatches_reply_for_each_completed_child
@@ -425,7 +463,8 @@ class HiveBotSupervisorTest < Minitest::Test
       config: @config, token: "test-token", logger: @logger, telegram: @telegram,
       status_watcher: @status_watcher, notification_dispatcher: @notification_dispatcher,
       router: FakeRouter.new, child_supervisor: @child_supervisor,
-      conversation_store: @conversation_store, dry_run: true
+      conversation_store: @conversation_store, dry_run: true,
+      dispatch_request_writer: @dispatch_request_writer
     )
     result = FakeRouter::Result.new(slug: "done-260526-aaaa", project: "hive")
     update = Update.new(chat_id: 42, update_id: 7, message_id: 1)
@@ -435,20 +474,37 @@ class HiveBotSupervisorTest < Minitest::Test
     assert_match(/All questions answered/, @telegram.messages.last.fetch(:text))
     assert_match(/Dry-run: not dispatching/, @telegram.messages.last.fetch(:text))
     assert_empty @child_supervisor.dispatched, "dry-run must not dispatch hive run"
+    assert_empty @dispatch_request_writer.writes, "dry-run must not write a dispatch request either"
   end
 
-  def test_auto_run_after_answers_recovers_and_logs_when_dispatch_raises
-    @child_supervisor.define_singleton_method(:dispatch) { |**| raise "spawn failed" }
+  def test_auto_run_after_answers_recovers_and_logs_when_queue_write_raises
+    @dispatch_request_writer.raise_on_write = RuntimeError.new("write failed")
     result = FakeRouter::Result.new(slug: "x-260526-aaaa", project: "hive")
     update = Update.new(chat_id: 42, update_id: 7, message_id: 1)
 
     @supervisor.send(:auto_run_after_answers, result, update)
 
-    assert_match(/couldn't start the next round/, @telegram.messages.last.fetch(:text),
-                 "a dispatch failure after the completion ack must surface a corrective message")
+    assert_match(/Couldn't queue the request/, @telegram.messages.last.fetch(:text),
+                 "a queue-write failure must surface a corrective message")
     failure = @logger.events.find { |e| e[:name] == :send_failure }
     refute_nil failure
-    assert_equal "auto_run_after_answers", failure.fetch(:payload).fetch(:source)
+    assert_equal "enqueue_dispatch_request", failure.fetch(:payload).fetch(:source)
+  end
+
+  def test_auto_run_after_answers_writes_dispatch_request_not_spawn
+    result = FakeRouter::Result.new(slug: "x-260526-aaaa", project: "hive")
+    update = Update.new(chat_id: 42, update_id: 7, message_id: 1)
+
+    @supervisor.send(:auto_run_after_answers, result, update)
+
+    assert_equal 1, @dispatch_request_writer.writes.size,
+                 "answer-complete must write exactly one dispatch request"
+    write = @dispatch_request_writer.writes.first
+    assert_equal "hive", write[:project]
+    assert_equal "x-260526-aaaa", write[:slug]
+    assert_equal [ "hive", "run", "x-260526-aaaa", "--json" ], write[:argv]
+    assert_empty @child_supervisor.dispatched,
+                 "the bot must NOT spawn `hive run` itself anymore — that's the daemon's job now"
   end
 
   def test_register_bot_commands_sends_full_command_list_to_telegram
@@ -825,52 +881,13 @@ class HiveBotSupervisorTest < Minitest::Test
     assert_equal "Dry run: hive plan task", @telegram.messages.last.fetch(:text)
   end
 
-  def test_dispatch_command_sequence_stops_after_failed_first_child
-    failed = child_exit(exit_code: 1, pid: 123)
-    @child_supervisor.completed[123] = failed
-    result = FakeRouter::Result.new(
-      action: :dispatch_commands,
-      commands: [ [ "hive", "markers", "clear" ], [ "hive", "develop", "task" ] ],
-      project: "hive",
-      slug: "task"
-    )
-
-    @supervisor.send(:dispatch_command_sequence, result, Update.new(chat_id: 42, update_id: 12))
-
-    assert_equal 1, @child_supervisor.dispatched.length
-    assert_equal "Stopped because the previous command failed.", @telegram.messages.last.fetch(:text)
-  end
-
-  def test_dispatch_command_sequence_resets_alert_for_single_command
-    result = FakeRouter::Result.new(
-      action: :dispatch_commands,
-      commands: [ [ "hive", "review", "task", "--json" ] ],
-      project: "hive",
-      slug: "task",
-      alert_reset: { project: "hive", slug: "task", stage: "6-review" }
-    )
-
-    @supervisor.send(:dispatch_command_sequence, result, Update.new(chat_id: 42, update_id: 12))
-
-    assert_equal [ { project: "hive", slug: "task", stage: "6-review", marker: nil, match_attr: nil } ],
-                 @notification_dispatcher.reset_tasks
-    assert_equal [ "hive", "review", "task", "--json" ], @child_supervisor.dispatched.first.fetch(:command_argv)
-  end
-
-  def test_dispatch_command_sequence_defers_alert_reset_until_markers_clear_succeeds
-    # markers-clear (pid 200) completes with exit 0; retry verb is fire-and-forget.
-    @child_supervisor.dispatch_pid = 200
-    @child_supervisor.completed[200] = child_exit(exit_code: 0, pid: 200)
-    reset_snapshot_at_dispatch = []
-    notification = @notification_dispatcher
-    dispatched_list = @child_supervisor.dispatched
-    dispatch_pid_value = @child_supervisor.dispatch_pid
-    @child_supervisor.define_singleton_method(:dispatch) do |**kwargs|
-      reset_snapshot_at_dispatch << notification.reset_tasks.dup
-      dispatched_list << kwargs
-      dispatch_pid_value
-    end
-
+  # Queue-routable command sequences (the post-refactor common case)
+  # write all requests in order; the daemon's per-slug in-flight gate
+  # serialises execution. There is no bot-side wait between commands
+  # and no "stopped because the previous command failed" reply — that
+  # error path now belongs to the daemon's `child_exited` event and
+  # the bot's subsequent status polling. Plan 2026-05-28-002.
+  def test_dispatch_command_sequence_writes_all_queue_requests_in_order
     result = FakeRouter::Result.new(
       action: :dispatch_commands,
       commands: [
@@ -884,23 +901,41 @@ class HiveBotSupervisorTest < Minitest::Test
 
     @supervisor.send(:dispatch_command_sequence, result, Update.new(chat_id: 42, update_id: 12))
 
-    assert_equal 2, @child_supervisor.dispatched.length
-    assert_equal [], reset_snapshot_at_dispatch[0],
-                 "reset_task must NOT have been called when the first command (markers clear) dispatches"
-    assert_equal [ { project: "hive", slug: "task", stage: "6-review", marker: nil, match_attr: nil } ],
-                 reset_snapshot_at_dispatch[1],
-                 "reset_task must have been called exactly once before the retry verb dispatches"
-    assert_equal [ { project: "hive", slug: "task", stage: "6-review", marker: nil, match_attr: nil } ],
-                 @notification_dispatcher.reset_tasks
+    assert_empty @child_supervisor.dispatched,
+                 "queue-routable verbs must NOT spawn from the bot — single-dispatcher invariant"
+    assert_equal 2, @dispatch_request_writer.writes.size,
+                 "both `markers clear` and the retry verb must land in the queue"
+    assert_equal [ "hive", "markers", "clear", "task", "--name", "REVIEW_ERROR" ],
+                 @dispatch_request_writer.writes[0][:argv]
+    assert_equal [ "hive", "review", "task", "--from", "6-review", "--json" ],
+                 @dispatch_request_writer.writes[1][:argv]
   end
 
-  def test_dispatch_command_sequence_skips_alert_reset_when_markers_clear_fails
-    @child_supervisor.completed[123] = child_exit(exit_code: 1, pid: 123)
+  def test_dispatch_command_sequence_resets_alert_after_queue_writes
+    result = FakeRouter::Result.new(
+      action: :dispatch_commands,
+      commands: [ [ "hive", "review", "task", "--json" ] ],
+      project: "hive",
+      slug: "task",
+      alert_reset: { project: "hive", slug: "task", stage: "6-review" }
+    )
+
+    @supervisor.send(:dispatch_command_sequence, result, Update.new(chat_id: 42, update_id: 12))
+
+    assert_equal [ { project: "hive", slug: "task", stage: "6-review", marker: nil, match_attr: nil } ],
+                 @notification_dispatcher.reset_tasks
+    assert_equal 1, @dispatch_request_writer.writes.size
+    assert_equal [ "hive", "review", "task", "--json" ],
+                 @dispatch_request_writer.writes.first[:argv]
+    assert_empty @child_supervisor.dispatched
+  end
+
+  def test_dispatch_command_sequence_resets_alert_once_for_two_command_queue_sequence
     result = FakeRouter::Result.new(
       action: :dispatch_commands,
       commands: [
-        [ "hive", "markers", "clear", "task" ],
-        [ "hive", "review", "task" ]
+        [ "hive", "markers", "clear", "task", "--name", "REVIEW_ERROR" ],
+        [ "hive", "review", "task", "--from", "6-review", "--json" ]
       ],
       project: "hive",
       slug: "task",
@@ -909,9 +944,13 @@ class HiveBotSupervisorTest < Minitest::Test
 
     @supervisor.send(:dispatch_command_sequence, result, Update.new(chat_id: 42, update_id: 12))
 
-    assert_equal 1, @child_supervisor.dispatched.length, "retry verb must not run when markers-clear fails"
-    assert_empty @notification_dispatcher.reset_tasks,
-                 "alert reset must NOT fire when the markers-clear precursor fails"
+    # The reset must fire exactly once for the whole sequence — the
+    # daemon's per-slug gate serialises execution and the bot has no
+    # PID to wait on, so the prior "reset between commands" semantics
+    # collapses into "reset after the sequence is queued".
+    assert_equal 1, @notification_dispatcher.reset_tasks.size
+    assert_equal({ project: "hive", slug: "task", stage: "6-review", marker: nil, match_attr: nil },
+                 @notification_dispatcher.reset_tasks.first)
   end
 
   def test_dispatch_command_sequence_skips_alert_reset_in_dry_run
@@ -947,8 +986,11 @@ class HiveBotSupervisorTest < Minitest::Test
     failure = @logger.events.find { |evt| evt[:name] == :send_failure }
     refute_nil failure, ":send_failure must be logged when edit_message_reply_markup raises"
     assert_equal "edit_message_reply_markup", failure[:payload][:source]
-    assert_equal 1, @child_supervisor.dispatched.length,
-                 "the command must still dispatch even when keyboard clear fails"
+    # `develop` is queue-routable, so the request lands in the writer
+    # rather than @child_supervisor.dispatched.
+    assert_equal 1, @dispatch_request_writer.writes.length,
+                 "the queue-routable command must still be enqueued even when keyboard clear fails"
+    assert_empty @child_supervisor.dispatched
   end
 
   def test_registered_project_names_returns_empty_when_config_raises

--- a/test/unit/bot/supervisor_test.rb
+++ b/test/unit/bot/supervisor_test.rb
@@ -58,6 +58,7 @@ class HiveBotSupervisorTest < Minitest::Test
   class FakeRouter
     Result = Struct.new(:action, :text, :reply_markup, :command_argv, :commands, :project, :slug,
                         :question_n, :answer_text, :mode, :alert_reset, :clear_keyboard, :format,
+                        :intent,
                         keyword_init: true)
   end
 
@@ -489,6 +490,43 @@ class HiveBotSupervisorTest < Minitest::Test
     failure = @logger.events.find { |e| e[:name] == :send_failure }
     refute_nil failure
     assert_equal "enqueue_dispatch_request", failure.fetch(:payload).fetch(:source)
+  end
+
+  # `auto_run_after_answers`'s outer rescue catches anything that
+  # escapes `execute_dispatch`. The queue-write path catches
+  # internally, but a writer that raises something OTHER than
+  # StandardError would skip the inner rescue. Force that path by
+  # stubbing `execute_dispatch` to raise directly.
+  def test_auto_run_after_answers_outer_rescue_surfaces_corrective_message
+    result = FakeRouter::Result.new(slug: "x-260526-aaaa", project: "hive")
+    update = Update.new(chat_id: 42, update_id: 7, message_id: 1)
+    @supervisor.define_singleton_method(:execute_dispatch) do |*|
+      raise "spawn pipeline blew up"
+    end
+
+    @supervisor.send(:auto_run_after_answers, result, update)
+
+    assert_match(/couldn't start the next round automatically/,
+                 @telegram.messages.last.fetch(:text))
+    failure = @logger.events.find { |e| e[:name] == :send_failure }
+    refute_nil failure
+    assert_equal "auto_run_after_answers", failure.fetch(:payload).fetch(:source)
+  end
+
+  def test_trigger_for_result_maps_intents_for_telemetry
+    %i[
+      slash_done callback_autofix callback_clear_and_retry callback_approve
+      callback_findings_accept_all callback_findings_reject_all callback_show_details
+    ].each do |intent|
+      result = FakeRouter::Result.new(intent: intent)
+      trigger = @supervisor.send(:trigger_for_result, result)
+      assert_kind_of String, trigger, "intent #{intent} must map to a string trigger label"
+      refute_empty trigger
+    end
+    # Unknown intent → generic label
+    assert_equal "bot_dispatch", @supervisor.send(:trigger_for_result, FakeRouter::Result.new(intent: :something_new))
+    # Missing intent attr → generic label (responds_to? false branch)
+    assert_equal "bot_dispatch", @supervisor.send(:trigger_for_result, Object.new)
   end
 
   def test_auto_run_after_answers_writes_dispatch_request_not_spawn
@@ -928,6 +966,67 @@ class HiveBotSupervisorTest < Minitest::Test
     assert_equal [ "hive", "review", "task", "--json" ],
                  @dispatch_request_writer.writes.first[:argv]
     assert_empty @child_supervisor.dispatched
+  end
+
+  # Mixed sequence: `accept-finding` (not queue-routable, spawns) +
+  # retry verb (queue-routable, writes a request). The findings
+  # callbacks are the one remaining mixed surface in the codebase
+  # — `RecoverySequence` is now all-queue. The bot waits on the
+  # accept-finding child like before; the retry verb lands in the
+  # queue with no wait.
+  def test_dispatch_command_sequence_mixed_spawn_and_queue_waits_then_enqueues
+    @child_supervisor.dispatch_pid = 700
+    @child_supervisor.completed[700] = child_exit(exit_code: 0, pid: 700)
+    result = FakeRouter::Result.new(
+      action: :dispatch_commands,
+      commands: [
+        [ "hive", "accept-finding", "--all", "--stage", "6-review",
+          "--project", "hive", "task", "--json" ],
+        [ "hive", "review", "task", "--from", "6-review", "--project", "hive", "--json" ]
+      ],
+      project: "hive",
+      slug: "task",
+      alert_reset: { project: "hive", slug: "task", stage: "6-review" }
+    )
+
+    @supervisor.send(:dispatch_command_sequence, result, Update.new(chat_id: 42, update_id: 12))
+
+    assert_equal 1, @child_supervisor.dispatched.length,
+                 "the non-queue-routable command (accept-finding) must spawn from the bot"
+    assert_equal [ "hive", "accept-finding", "--all", "--stage", "6-review",
+                   "--project", "hive", "task", "--json" ],
+                 @child_supervisor.dispatched.first.fetch(:command_argv)
+    assert_equal 1, @dispatch_request_writer.writes.length,
+                 "the queue-routable retry verb must land in the queue"
+    assert_equal [ "hive", "review", "task", "--from", "6-review", "--project", "hive", "--json" ],
+                 @dispatch_request_writer.writes.first[:argv]
+    assert_equal 1, @notification_dispatcher.reset_tasks.length,
+                 "alert reset fires once between the two commands"
+  end
+
+  def test_dispatch_command_sequence_mixed_aborts_when_spawn_fails
+    @child_supervisor.dispatch_pid = 701
+    @child_supervisor.completed[701] = child_exit(exit_code: 1, pid: 701)
+    result = FakeRouter::Result.new(
+      action: :dispatch_commands,
+      commands: [
+        [ "hive", "accept-finding", "--all", "--project", "hive", "task", "--json" ],
+        [ "hive", "review", "task", "--from", "6-review", "--project", "hive", "--json" ]
+      ],
+      project: "hive",
+      slug: "task",
+      alert_reset: { project: "hive", slug: "task", stage: "6-review" }
+    )
+
+    @supervisor.send(:dispatch_command_sequence, result, Update.new(chat_id: 42, update_id: 12))
+
+    assert_equal 1, @child_supervisor.dispatched.length,
+                 "only the first command spawned before the wait detected failure"
+    assert_empty @dispatch_request_writer.writes,
+                 "retry verb must NOT be enqueued when the spawn precursor fails"
+    assert_empty @notification_dispatcher.reset_tasks,
+                 "alert reset must NOT fire when the spawn precursor fails"
+    assert_includes @telegram.messages.last.fetch(:text), "Stopped because the previous command failed"
   end
 
   def test_dispatch_command_sequence_resets_alert_once_for_two_command_queue_sequence

--- a/test/unit/daemon/dispatch_request_queue_test.rb
+++ b/test/unit/daemon/dispatch_request_queue_test.rb
@@ -1,0 +1,233 @@
+require "test_helper"
+require "fileutils"
+require "json"
+require "tmpdir"
+require "hive/daemon/dispatch_request_queue"
+
+class HiveDaemonDispatchRequestQueueTest < Minitest::Test
+  include HiveTestHelper
+
+  Q = Hive::Daemon::DispatchRequestQueue
+
+  def write_request(state_home, request_id:, created_at:, argv: [ "hive", "run", "slug-x", "--json" ],
+                    project: "hive", slug: "slug-x", requestor: "bot", chat_id: 42,
+                    update_id: 99, trigger: "answer_complete", schema_version: 1,
+                    schema: "hive-dispatch-request")
+    dir = Q.directory(state_home: state_home)
+    filename = Q.filename_for(created_at: created_at, request_id: request_id)
+    path = File.join(dir, filename)
+    payload = {
+      "schema" => schema,
+      "schema_version" => schema_version,
+      "request_id" => request_id,
+      "created_at" => created_at.utc.iso8601(6),
+      "project" => project,
+      "slug" => slug,
+      "argv" => argv,
+      "requestor" => requestor,
+      "chat_id" => chat_id,
+      "update_id" => update_id,
+      "trigger" => trigger
+    }
+    File.write(path, JSON.generate(payload))
+    path
+  end
+
+  def test_directory_creates_under_state_home
+    Dir.mktmpdir("hive-dispatch-queue") do |dir|
+      path = Q.directory(state_home: dir)
+      assert File.directory?(path)
+      assert_equal File.join(dir, "dispatch_requests"), path
+    end
+  end
+
+  def test_pending_returns_requests_sorted_by_created_at
+    Dir.mktmpdir("hive-dispatch-queue") do |dir|
+      later = Time.utc(2026, 5, 28, 18, 13, 9)
+      earlier = Time.utc(2026, 5, 28, 18, 11, 44)
+      write_request(dir, request_id: "B", created_at: later, slug: "second")
+      write_request(dir, request_id: "A", created_at: earlier, slug: "first")
+
+      pending = Q.pending(state_home: dir)
+      assert_equal %w[first second], pending.map(&:slug)
+      assert_equal %w[A B], pending.map(&:request_id)
+    end
+  end
+
+  def test_pending_skips_malformed_json_via_bad_handler
+    Dir.mktmpdir("hive-dispatch-queue") do |dir|
+      good = write_request(dir, request_id: "OK", created_at: Time.utc(2026, 5, 28, 18, 0, 0), slug: "good")
+      bad_path = File.join(Q.directory(state_home: dir), "20260528T180000000000-BROKEN.json")
+      File.write(bad_path, "{not json")
+
+      seen_bads = []
+      pending = Q.pending(state_home: dir, bad_handler: ->(path:, reason:) {
+        seen_bads << { path: path, reason: reason }
+      })
+
+      assert_equal [ "good" ], pending.map(&:slug)
+      assert_equal 1, seen_bads.size
+      assert_equal bad_path, seen_bads.first[:path]
+      assert_equal "malformed_json", seen_bads.first[:reason]
+      # Good entry must round-trip
+      assert_equal good, pending.first.path
+    end
+  end
+
+  def test_pending_rejects_wrong_schema
+    Dir.mktmpdir("hive-dispatch-queue") do |dir|
+      write_request(dir, request_id: "BAD", created_at: Time.utc(2026, 5, 28, 18, 0, 0),
+                    schema: "not-our-schema")
+
+      seen = []
+      Q.pending(state_home: dir, bad_handler: ->(path:, reason:) { seen << reason })
+      assert_equal [ "wrong_schema" ], seen
+    end
+  end
+
+  def test_pending_rejects_unknown_schema_version
+    Dir.mktmpdir("hive-dispatch-queue") do |dir|
+      write_request(dir, request_id: "BAD", created_at: Time.utc(2026, 5, 28, 18, 0, 0),
+                    schema_version: 999)
+      reasons = []
+      Q.pending(state_home: dir, bad_handler: ->(path:, reason:) { reasons << reason })
+      assert_equal [ "unknown_schema_version" ], reasons
+    end
+  end
+
+  def test_pending_rejects_missing_fields_and_bad_created_at
+    Dir.mktmpdir("hive-dispatch-queue") do |dir|
+      dir_path = Q.directory(state_home: dir)
+      # Missing request_id
+      File.write(File.join(dir_path, "20260528T180000000000-A.json"), JSON.generate(
+        "schema" => "hive-dispatch-request",
+        "schema_version" => 1,
+        "request_id" => "",
+        "created_at" => Time.utc(2026, 5, 28).iso8601,
+        "project" => "hive",
+        "slug" => "s",
+        "argv" => [ "hive", "run", "s" ]
+      ))
+      # Missing project
+      File.write(File.join(dir_path, "20260528T180000000001-B.json"), JSON.generate(
+        "schema" => "hive-dispatch-request",
+        "schema_version" => 1,
+        "request_id" => "B",
+        "created_at" => Time.utc(2026, 5, 28).iso8601,
+        "project" => "",
+        "slug" => "s",
+        "argv" => [ "hive", "run", "s" ]
+      ))
+      # Missing slug
+      File.write(File.join(dir_path, "20260528T180000000002-C.json"), JSON.generate(
+        "schema" => "hive-dispatch-request",
+        "schema_version" => 1,
+        "request_id" => "C",
+        "created_at" => Time.utc(2026, 5, 28).iso8601,
+        "project" => "p",
+        "slug" => "",
+        "argv" => [ "hive", "run", "s" ]
+      ))
+      # Invalid argv type
+      File.write(File.join(dir_path, "20260528T180000000003-D.json"), JSON.generate(
+        "schema" => "hive-dispatch-request",
+        "schema_version" => 1,
+        "request_id" => "D",
+        "created_at" => Time.utc(2026, 5, 28).iso8601,
+        "project" => "p",
+        "slug" => "s",
+        "argv" => "hive run s"
+      ))
+      # Bad created_at
+      File.write(File.join(dir_path, "20260528T180000000004-E.json"), JSON.generate(
+        "schema" => "hive-dispatch-request",
+        "schema_version" => 1,
+        "request_id" => "E",
+        "created_at" => "not-a-time",
+        "project" => "p",
+        "slug" => "s",
+        "argv" => [ "hive", "run", "s" ]
+      ))
+      # Root not a hash
+      File.write(File.join(dir_path, "20260528T180000000005-F.json"), JSON.generate([ "array", "root" ]))
+
+      reasons = []
+      Q.pending(state_home: dir, bad_handler: ->(path:, reason:) { reasons << reason })
+      assert_equal %w[
+        missing_request_id missing_project missing_slug invalid_argv invalid_created_at not_a_hash
+      ], reasons
+    end
+  end
+
+  def test_remove_is_idempotent
+    Dir.mktmpdir("hive-dispatch-queue") do |dir|
+      path = write_request(dir, request_id: "RM-1", created_at: Time.utc(2026, 5, 28, 18, 0, 0))
+      assert File.exist?(path)
+
+      assert Q.remove("RM-1", state_home: dir)
+      refute File.exist?(path)
+      # Second remove is a no-op, not an error.
+      refute Q.remove("RM-1", state_home: dir)
+    end
+  end
+
+  def test_remove_ignores_empty_request_id
+    Dir.mktmpdir("hive-dispatch-queue") do |dir|
+      refute Q.remove("", state_home: dir)
+      refute Q.remove(nil, state_home: dir)
+    end
+  end
+
+  def test_remove_does_not_touch_other_requests
+    Dir.mktmpdir("hive-dispatch-queue") do |dir|
+      a = write_request(dir, request_id: "AAA", created_at: Time.utc(2026, 5, 28, 18, 0, 0), slug: "a")
+      b = write_request(dir, request_id: "BBB", created_at: Time.utc(2026, 5, 28, 18, 0, 1), slug: "b")
+
+      Q.remove("AAA", state_home: dir)
+
+      refute File.exist?(a)
+      assert File.exist?(b)
+    end
+  end
+
+  def test_valid_argv_accepts_allowlisted_verbs
+    %w[run develop brainstorm plan review open-pr artifacts finalize archive markers].each do |verb|
+      argv = [ "hive", verb, "slug" ]
+      assert Q.valid_argv?(argv), "argv must accept #{verb}"
+    end
+  end
+
+  def test_valid_argv_rejects_non_allowlisted_verbs
+    refute Q.valid_argv?([ "hive", "doctor" ])
+    refute Q.valid_argv?([ "hive", "status", "--json" ])
+    refute Q.valid_argv?([ "hive", "new", "project", "idea" ])
+    refute Q.valid_argv?([ "hive", "approve", "slug" ])
+  end
+
+  def test_valid_argv_rejects_non_hive_first_token_and_malformed_argv
+    refute Q.valid_argv?([ "echo", "rm", "-rf" ])
+    refute Q.valid_argv?([ "/bin/sh", "-c", "evil" ])
+    refute Q.valid_argv?(nil)
+    refute Q.valid_argv?([])
+    refute Q.valid_argv?("hive run slug")
+    refute Q.valid_argv?([ "hive", :run, "slug" ])
+  end
+
+  def test_filename_for_is_chronologically_sortable
+    a = Q.filename_for(created_at: Time.utc(2026, 5, 28, 18, 11, 44), request_id: "A")
+    b = Q.filename_for(created_at: Time.utc(2026, 5, 28, 18, 13, 9), request_id: "B")
+    assert_operator a, :<, b
+  end
+
+  def test_expired_compares_against_now
+    later = Time.utc(2026, 5, 28, 19, 0, 0)
+    request = Q::Request.new(
+      request_id: "X", created_at: Time.utc(2026, 5, 28, 18, 0, 0),
+      project: "p", slug: "s", argv: [ "hive", "run", "s" ], requestor: "bot",
+      chat_id: nil, update_id: nil, trigger: "answer_complete", path: nil
+    )
+
+    assert Q.expired?(request, now: later, expiry_sec: 600)
+    refute Q.expired?(request, now: later, expiry_sec: 7200)
+  end
+end

--- a/test/unit/daemon/dispatch_request_queue_test.rb
+++ b/test/unit/daemon/dispatch_request_queue_test.rb
@@ -178,6 +178,41 @@ class HiveDaemonDispatchRequestQueueTest < Minitest::Test
     end
   end
 
+  def test_remove_skips_malformed_file_whose_path_matches_request_id
+    Dir.mktmpdir("hive-dispatch-queue") do |dir|
+      # A malformed file whose path contains the request_id but
+      # whose body is not valid JSON. `remove` must skip it
+      # gracefully and report nothing was removed (no exception).
+      good_path = write_request(dir, request_id: "GOODID", created_at: Time.utc(2026, 5, 28, 18, 0, 0))
+      bad_path = File.join(Q.directory(state_home: dir), "20260528T180000000001-GOODID.json")
+      File.write(bad_path, "{not json")
+
+      removed = Q.remove("GOODID", state_home: dir)
+      assert removed, "the well-formed file with matching request_id must still be removed"
+      refute File.exist?(good_path)
+      assert File.exist?(bad_path), "the malformed file must be left for the pending-side bad_handler"
+    end
+  end
+
+  def test_remove_returns_false_when_directory_is_missing
+    Dir.mktmpdir("hive-dispatch-queue") do |dir|
+      missing_state_home = File.join(dir, "does-not-exist")
+      # Simulate the post-directory-creation race by removing the
+      # dir we just created. Subsequent glob returns []; the outer
+      # rescue is reached when the FS surfaces ENOENT during the
+      # operation (rare but possible on tmpfs under heavy churn).
+      # Drive the rescue by stubbing Dir.glob to raise ENOENT:
+      Dir.singleton_class.alias_method(:__orig_glob, :glob) unless Dir.singleton_class.method_defined?(:__orig_glob)
+      Dir.define_singleton_method(:glob) { |*| raise Errno::ENOENT, "vanished" }
+      begin
+        refute Q.remove("ANY", state_home: missing_state_home),
+               "outer ENOENT rescue must return false instead of raising"
+      ensure
+        Dir.define_singleton_method(:glob, Dir.singleton_class.instance_method(:__orig_glob).bind(Dir))
+      end
+    end
+  end
+
   def test_remove_does_not_touch_other_requests
     Dir.mktmpdir("hive-dispatch-queue") do |dir|
       a = write_request(dir, request_id: "AAA", created_at: Time.utc(2026, 5, 28, 18, 0, 0), slug: "a")

--- a/test/unit/daemon/dispatch_request_queue_test.rb
+++ b/test/unit/daemon/dispatch_request_queue_test.rb
@@ -98,63 +98,66 @@ class HiveDaemonDispatchRequestQueueTest < Minitest::Test
   def test_pending_rejects_missing_fields_and_bad_created_at
     Dir.mktmpdir("hive-dispatch-queue") do |dir|
       dir_path = Q.directory(state_home: dir)
+      # Use realistic placeholders that pass the project/slug regex
+      # gates (SEC-5 from PR #241 ce-code-review) so each fixture
+      # below targets exactly ONE rejection reason — without this,
+      # the new slug check short-circuits before reaching the
+      # original invalid_argv / invalid_created_at branches.
+      good_slug = "task-260528-aaaa"
+      good_project = "test-project"
+      good_argv = [ "hive", "run", good_slug ]
+      ts = Time.utc(2026, 5, 28).iso8601
+
       # Missing request_id
       File.write(File.join(dir_path, "20260528T180000000000-A.json"), JSON.generate(
-        "schema" => "hive-dispatch-request",
-        "schema_version" => 1,
-        "request_id" => "",
-        "created_at" => Time.utc(2026, 5, 28).iso8601,
-        "project" => "hive",
-        "slug" => "s",
-        "argv" => [ "hive", "run", "s" ]
+        "schema" => "hive-dispatch-request", "schema_version" => 1,
+        "request_id" => "", "created_at" => ts,
+        "project" => good_project, "slug" => good_slug, "argv" => good_argv
       ))
       # Missing project
       File.write(File.join(dir_path, "20260528T180000000001-B.json"), JSON.generate(
-        "schema" => "hive-dispatch-request",
-        "schema_version" => 1,
-        "request_id" => "B",
-        "created_at" => Time.utc(2026, 5, 28).iso8601,
-        "project" => "",
-        "slug" => "s",
-        "argv" => [ "hive", "run", "s" ]
+        "schema" => "hive-dispatch-request", "schema_version" => 1,
+        "request_id" => "B", "created_at" => ts,
+        "project" => "", "slug" => good_slug, "argv" => good_argv
+      ))
+      # Invalid project (path-traversal candidate)
+      File.write(File.join(dir_path, "20260528T180000000002-B2.json"), JSON.generate(
+        "schema" => "hive-dispatch-request", "schema_version" => 1,
+        "request_id" => "B2", "created_at" => ts,
+        "project" => "../etc/passwd", "slug" => good_slug, "argv" => good_argv
       ))
       # Missing slug
-      File.write(File.join(dir_path, "20260528T180000000002-C.json"), JSON.generate(
-        "schema" => "hive-dispatch-request",
-        "schema_version" => 1,
-        "request_id" => "C",
-        "created_at" => Time.utc(2026, 5, 28).iso8601,
-        "project" => "p",
-        "slug" => "",
-        "argv" => [ "hive", "run", "s" ]
+      File.write(File.join(dir_path, "20260528T180000000003-C.json"), JSON.generate(
+        "schema" => "hive-dispatch-request", "schema_version" => 1,
+        "request_id" => "C", "created_at" => ts,
+        "project" => good_project, "slug" => "", "argv" => good_argv
+      ))
+      # Invalid slug (path-traversal candidate)
+      File.write(File.join(dir_path, "20260528T180000000004-C2.json"), JSON.generate(
+        "schema" => "hive-dispatch-request", "schema_version" => 1,
+        "request_id" => "C2", "created_at" => ts,
+        "project" => good_project, "slug" => "../escape", "argv" => good_argv
       ))
       # Invalid argv type
-      File.write(File.join(dir_path, "20260528T180000000003-D.json"), JSON.generate(
-        "schema" => "hive-dispatch-request",
-        "schema_version" => 1,
-        "request_id" => "D",
-        "created_at" => Time.utc(2026, 5, 28).iso8601,
-        "project" => "p",
-        "slug" => "s",
-        "argv" => "hive run s"
+      File.write(File.join(dir_path, "20260528T180000000005-D.json"), JSON.generate(
+        "schema" => "hive-dispatch-request", "schema_version" => 1,
+        "request_id" => "D", "created_at" => ts,
+        "project" => good_project, "slug" => good_slug,
+        "argv" => "hive run #{good_slug}"
       ))
       # Bad created_at
-      File.write(File.join(dir_path, "20260528T180000000004-E.json"), JSON.generate(
-        "schema" => "hive-dispatch-request",
-        "schema_version" => 1,
-        "request_id" => "E",
-        "created_at" => "not-a-time",
-        "project" => "p",
-        "slug" => "s",
-        "argv" => [ "hive", "run", "s" ]
+      File.write(File.join(dir_path, "20260528T180000000006-E.json"), JSON.generate(
+        "schema" => "hive-dispatch-request", "schema_version" => 1,
+        "request_id" => "E", "created_at" => "not-a-time",
+        "project" => good_project, "slug" => good_slug, "argv" => good_argv
       ))
       # Root not a hash
-      File.write(File.join(dir_path, "20260528T180000000005-F.json"), JSON.generate([ "array", "root" ]))
+      File.write(File.join(dir_path, "20260528T180000000007-F.json"), JSON.generate([ "array", "root" ]))
 
       reasons = []
       Q.pending(state_home: dir, bad_handler: ->(path:, reason:) { reasons << reason })
       assert_equal %w[
-        missing_request_id missing_project missing_slug invalid_argv invalid_created_at not_a_hash
+        missing_request_id missing_project invalid_project missing_slug invalid_slug invalid_argv invalid_created_at not_a_hash
       ], reasons
     end
   end

--- a/test/unit/daemon/dispatcher_test.rb
+++ b/test/unit/daemon/dispatcher_test.rb
@@ -1337,6 +1337,58 @@ end
     end
   end
 
+  def test_dispatch_request_expired_removed_without_dispatch
+    Dir.mktmpdir("hive-dispatch-queue") do |state_home|
+      dispatcher, sup, _ctrl, logger, _mw = make_dispatcher(
+        rows: [], dispatch_request_state_home: state_home
+      )
+      # Created 11 minutes before "now"
+      ancient = T0 - (11 * 60)
+      write_request_file(state_home, slug: "s1", request_id: "OLD", created_at: ancient)
+      stub_find_project!(dispatcher, "p1")
+      begin
+        dispatcher.tick(now: T0)
+
+        expired = logger.events.find { |(n, _)| n == :dispatch_request_expired }
+        refute_nil expired, "a 11-min-old request must be reaped before dispatch"
+        assert_empty sup.spawned
+        files = Dir.glob(File.join(Q.directory(state_home: state_home), "*.json"))
+        assert_empty files, "expired requests must be unlinked from the queue dir"
+      ensure
+        restore_find_project!
+      end
+    end
+  end
+
+  def test_per_slug_in_flight_gate_within_one_tick_blocks_same_slug_row_dispatch
+    Dir.mktmpdir("hive-dispatch-queue") do |state_home|
+      # A row exists for the same slug as the queued request. The
+      # request scan fires first and `record_dispatch`'s the controller.
+      # When the row scan later sees the same slug, `dispatch_or_block`
+      # must consult the controller and refuse rather than spawn a
+      # second child against the same task.
+      row_for_same_slug = row(slug: "s1", action: "ready_to_plan",
+                              command: "hive plan s1 --from 2-brainstorm")
+      dispatcher, sup, _ctrl, logger, _mw = make_dispatcher(
+        rows: [ row_for_same_slug ], dispatch_request_state_home: state_home
+      )
+      write_request_file(state_home, slug: "s1", request_id: "FIRST")
+      stub_find_project!(dispatcher, "p1")
+      begin
+        dispatcher.tick(now: T0)
+
+        # Exactly one spawn — for the request — not two.
+        assert_equal 1, sup.spawned.size,
+                     "per-slug in-flight gate must keep the row scan from double-spawning"
+        assert_equal "FIRST", sup.spawned.first[:request_id]
+        blocked = logger.events.find { |(n, attrs)| n == :blocked && attrs[:reason] == "in_flight" }
+        refute_nil blocked, "row scan must log :blocked reason=in_flight when slug is already running"
+      ensure
+        restore_find_project!
+      end
+    end
+  end
+
   def test_dispatch_request_completed_logs_on_child_reap
     Dir.mktmpdir("hive-dispatch-queue") do |state_home|
       dispatcher, sup, _ctrl, logger, _mw = make_dispatcher(

--- a/test/unit/daemon/dispatcher_test.rb
+++ b/test/unit/daemon/dispatcher_test.rb
@@ -1337,6 +1337,89 @@ end
     end
   end
 
+  # C4 from PR #241 ce-code-review: process_dispatch_requests must
+  # gate on project_enabled? so a disabled project's queued requests
+  # don't dispatch. Mirrors handle_row's project_enabled? gate.
+  def test_dispatch_request_blocked_when_project_is_disabled
+    Dir.mktmpdir("hive-dispatch-queue") do |state_home|
+      dispatcher, sup, _ctrl, logger, _mw = make_dispatcher(
+        rows: [], dispatch_request_state_home: state_home
+      )
+      write_request_file(state_home, slug: "s1", request_id: "DISABLED")
+      stub_find_project!(dispatcher, "p1")
+      # Force the project to look disabled.
+      dispatcher.define_singleton_method(:project_enabled?) { |_| false }
+      begin
+        dispatcher.tick(now: T0)
+
+        blocked = logger.events.find do |(n, attrs)|
+          n == :dispatch_request_blocked && attrs[:request_id] == "DISABLED"
+        end
+        refute_nil blocked, ":dispatch_request_blocked must fire for a disabled project"
+        assert_equal "project_disabled", blocked[1][:reason]
+        # Request file stays on disk for retry once project is re-enabled.
+        files = Dir.glob(File.join(Q.directory(state_home: state_home), "*.json"))
+        assert_equal 1, files.size,
+                     "disabled-project block must NOT remove the request file"
+        assert_empty sup.spawned
+      ensure
+        restore_find_project!
+      end
+    end
+  end
+
+  # R-01 from PR #241 ce-code-review: a spawn failure (Errno::EAGAIN
+  # under fork-exhaustion, or any other StandardError raised by
+  # dispatch_request!) must not abort the rest of the pending queue.
+  # The failure is logged and the request file is left on disk for
+  # the next tick to retry.
+  def test_dispatch_request_spawn_failure_logs_and_does_not_abort_subsequent_iterations
+    Dir.mktmpdir("hive-dispatch-queue") do |state_home|
+      dispatcher, sup, _ctrl, logger, _mw = make_dispatcher(
+        rows: [], dispatch_request_state_home: state_home
+      )
+      # Two requests for different slugs in the same tick. The first
+      # raises on dispatch; the second must still be processed.
+      write_request_file(state_home, slug: "s1", request_id: "FAIL1",
+                          created_at: T0)
+      write_request_file(state_home, slug: "s2", request_id: "OK2",
+                          created_at: T0 + 1)
+      stub_find_project!(dispatcher, "p1")
+
+      # Make dispatch_request! raise the FIRST time and succeed after.
+      original = dispatcher.method(:dispatch_request!)
+      call_count = 0
+      dispatcher.define_singleton_method(:dispatch_request!) do |req, now:|
+        call_count += 1
+        raise Errno::EAGAIN, "fork: Resource temporarily unavailable" if call_count == 1
+
+        original.call(req, now: now)
+      end
+
+      begin
+        dispatcher.tick(now: T0)
+
+        # First request → logged as rejected, file left on disk.
+        failed = logger.events.find do |(n, attrs)|
+          n == :dispatch_request_rejected && attrs[:request_id] == "FAIL1"
+        end
+        refute_nil failed,
+                   "spawn failure must surface as :dispatch_request_rejected"
+        assert_match(/spawn_failure: Errno::EAGAIN/, failed[1][:reason])
+        # File NOT removed — next tick retries.
+        files_after = Dir.glob(File.join(Q.directory(state_home: state_home), "*.json"))
+        assert(files_after.any? { |p| p.include?("FAIL1") },
+               "FAIL1 file must remain for retry")
+
+        # Second request still dispatched despite the first's failure.
+        assert(sup.spawned.any? { |entry| entry[:request_id] == "OK2" },
+               "subsequent request must dispatch even after a prior iteration raised")
+      ensure
+        restore_find_project!
+      end
+    end
+  end
+
   def test_malformed_request_file_routes_through_bad_handler
     Dir.mktmpdir("hive-dispatch-queue") do |state_home|
       dispatcher, sup, _ctrl, logger, _mw = make_dispatcher(

--- a/test/unit/daemon/dispatcher_test.rb
+++ b/test/unit/daemon/dispatcher_test.rb
@@ -44,12 +44,14 @@ class HiveDaemonDispatcherTest < Minitest::Test
     end
 
     def spawn(command_string:, project:, slug:, stage:,
-              hive_state_path: nil, state_file_path: nil, dry_run: nil)
+              hive_state_path: nil, state_file_path: nil, dry_run: nil,
+              request_id: nil)
       pid = @next_pid
       @next_pid += 1
       @spawned << {
         pid: pid, command: command_string, project: project, slug: slug,
-        stage: stage, state_file_path: state_file_path, dry_run: dry_run
+        stage: stage, state_file_path: state_file_path, dry_run: dry_run,
+        request_id: request_id
       }
       pid
     end
@@ -98,7 +100,8 @@ class HiveDaemonDispatcherTest < Minitest::Test
   # ── construction helpers ───────────────────────────────────────────────
 
   def make_dispatcher(rows: [], dry_run: false, with_merge_watcher: false,
-                      project_enabled: true, dispatch_state: nil, status_result: nil)
+                      project_enabled: true, dispatch_state: nil, status_result: nil,
+                      dispatch_request_state_home: nil)
     config = {
       "daemon" => {
         "edit_debounce_sec" => 30,
@@ -135,7 +138,8 @@ class HiveDaemonDispatcherTest < Minitest::Test
       status_consumer: status,
       logger: logger,
       merge_watcher: merge_watcher,
-      dry_run: dry_run
+      dry_run: dry_run,
+      dispatch_request_state_home: dispatch_request_state_home
     )
     # Bypass the Hive::Config.find_project / Config.load lookup chain
     # for unit tests — stub the predicate directly.
@@ -1195,6 +1199,176 @@ end
       # Sanity: writero/answered's baseline is still there too (mtime == baseline → :skip).
       assert_equal T0 - 600,
                    ctrl.last_dispatched_state_file_mtime_for(project: "writero", slug: "answered")
+    end
+  end
+
+  # ── dispatch-request queue integration ───────────────────────────────
+
+  Q = Hive::Daemon::DispatchRequestQueue
+
+  def write_request_file(dir, slug:, request_id:, created_at: T0, argv: nil, project: "p1",
+                         trigger: "answer_complete")
+    argv ||= [ "hive", "run", slug, "--json" ]
+    path = File.join(Q.directory(state_home: dir), Q.filename_for(created_at: created_at, request_id: request_id))
+    payload = {
+      "schema" => "hive-dispatch-request",
+      "schema_version" => 1,
+      "request_id" => request_id,
+      "created_at" => created_at.utc.iso8601,
+      "project" => project,
+      "slug" => slug,
+      "argv" => argv,
+      "requestor" => "bot",
+      "chat_id" => 42,
+      "update_id" => 99,
+      "trigger" => trigger
+    }
+    File.write(path, JSON.generate(payload))
+    path
+  end
+
+  def stub_find_project!(dispatcher, project_name)
+    Hive::Config.singleton_class.alias_method(:__orig_find_project, :find_project) unless Hive::Config.singleton_class.method_defined?(:__orig_find_project)
+    Hive::Config.define_singleton_method(:find_project) do |name|
+      name == project_name ? { "name" => project_name, "path" => "/tmp/nonexistent", "hive_state_path" => "/tmp/nonexistent/.hive-state" } : nil
+    end
+    dispatcher
+  end
+
+  def restore_find_project!
+    if Hive::Config.singleton_class.method_defined?(:__orig_find_project)
+      Hive::Config.define_singleton_method(:find_project, Hive::Config.method(:__orig_find_project))
+    end
+  end
+
+  def test_dispatch_request_observed_logged_and_dispatched
+    Dir.mktmpdir("hive-dispatch-queue") do |state_home|
+      dispatcher, sup, _ctrl, logger, _mw = make_dispatcher(
+        rows: [], dispatch_request_state_home: state_home
+      )
+      write_request_file(state_home, slug: "s1", request_id: "R1")
+      stub_find_project!(dispatcher, "p1")
+      begin
+        dispatcher.tick(now: T0)
+
+        observed = logger.events.find { |(n, _)| n == :dispatch_request_observed }
+        dispatched = logger.events.find { |(n, _)| n == :dispatch_request_dispatched }
+        refute_nil observed
+        refute_nil dispatched
+        assert_equal "R1", observed[1][:request_id]
+        assert_equal 1, sup.spawned.size
+        assert_equal "hive run s1 --json", sup.spawned.first[:command]
+        assert_equal "R1", sup.spawned.first[:request_id]
+      ensure
+        restore_find_project!
+      end
+    end
+  end
+
+  def test_dispatch_request_rejected_when_argv_not_allowlisted
+    Dir.mktmpdir("hive-dispatch-queue") do |state_home|
+      dispatcher, sup, _ctrl, logger, _mw = make_dispatcher(
+        rows: [], dispatch_request_state_home: state_home
+      )
+      write_request_file(state_home, slug: "s1", request_id: "BAD",
+                         argv: [ "hive", "doctor" ])
+      stub_find_project!(dispatcher, "p1")
+      begin
+        dispatcher.tick(now: T0)
+
+        rejected = logger.events.find { |(n, attrs)| n == :dispatch_request_rejected && attrs[:request_id] == "BAD" }
+        refute_nil rejected
+        assert_equal "invalid_argv", rejected[1][:reason]
+        assert_empty sup.spawned
+        assert_empty Dir.glob(File.join(Q.directory(state_home: state_home), "*.json"))
+      ensure
+        restore_find_project!
+      end
+    end
+  end
+
+  def test_dispatch_request_rejected_when_project_unknown
+    Dir.mktmpdir("hive-dispatch-queue") do |state_home|
+      dispatcher, sup, _ctrl, logger, _mw = make_dispatcher(
+        rows: [], dispatch_request_state_home: state_home
+      )
+      write_request_file(state_home, slug: "s1", request_id: "RX", project: "unknown-proj")
+      # No stub for find_project ⇒ returns nil
+      Hive::Config.singleton_class.alias_method(:__orig_find_project, :find_project) unless Hive::Config.singleton_class.method_defined?(:__orig_find_project)
+      Hive::Config.define_singleton_method(:find_project) { |_| nil }
+      begin
+        dispatcher.tick(now: T0)
+
+        rejected = logger.events.find { |(n, attrs)| n == :dispatch_request_rejected && attrs[:request_id] == "RX" }
+        refute_nil rejected
+        assert_equal "unknown_project", rejected[1][:reason]
+        assert_empty sup.spawned
+      ensure
+        restore_find_project!
+      end
+    end
+  end
+
+  def test_dispatch_request_blocked_when_in_flight_for_same_slug
+    Dir.mktmpdir("hive-dispatch-queue") do |state_home|
+      dispatcher, sup, ctrl, logger, _mw = make_dispatcher(
+        rows: [], dispatch_request_state_home: state_home
+      )
+      # Pre-seed an in-flight slot for (p1, s1)
+      ctrl.record_dispatch(pid: 7777, project: "p1", slug: "s1", stage: nil,
+                           command: "hive run s1", started_at: T0,
+                           state_file_mtime: nil)
+      write_request_file(state_home, slug: "s1", request_id: "DEF")
+      stub_find_project!(dispatcher, "p1")
+      begin
+        dispatcher.tick(now: T0)
+
+        blocked = logger.events.find { |(n, _)| n == :dispatch_request_blocked }
+        refute_nil blocked
+        assert_equal "in_flight", blocked[1][:reason]
+        # The request file MUST remain on disk for the next tick.
+        files = Dir.glob(File.join(Q.directory(state_home: state_home), "*.json"))
+        assert_equal 1, files.size
+        # Sup must NOT have spawned this request (only the pre-seeded slot exists).
+        assert_empty sup.spawned
+      ensure
+        restore_find_project!
+      end
+    end
+  end
+
+  def test_dispatch_request_completed_logs_on_child_reap
+    Dir.mktmpdir("hive-dispatch-queue") do |state_home|
+      dispatcher, sup, _ctrl, logger, _mw = make_dispatcher(
+        rows: [], dispatch_request_state_home: state_home
+      )
+      write_request_file(state_home, slug: "s1", request_id: "REQ-X")
+      stub_find_project!(dispatcher, "p1")
+      begin
+        dispatcher.tick(now: T0)
+        spawned_pid = sup.spawned.first[:pid]
+        sup.define_singleton_method(:reap_all) do |now: Time.now|
+          [
+            ChildExit.new(
+              pid: spawned_pid, exit_code: 0, project: "p1", slug: "s1", stage: nil,
+              command: "hive run s1 --json", state_file_path: nil,
+              started_at: T0, finished_at: now, json_envelope: nil,
+              request_id: "REQ-X"
+            )
+          ]
+        end
+
+        dispatcher.tick(now: T0 + 60)
+
+        completed = logger.events.find { |(n, _)| n == :dispatch_request_completed }
+        refute_nil completed
+        assert_equal "REQ-X", completed[1][:request_id]
+        # The file MUST have been unlinked.
+        files = Dir.glob(File.join(Q.directory(state_home: state_home), "*.json"))
+        assert_empty files
+      ensure
+        restore_find_project!
+      end
     end
   end
 

--- a/test/unit/daemon/dispatcher_test.rb
+++ b/test/unit/daemon/dispatcher_test.rb
@@ -1337,6 +1337,37 @@ end
     end
   end
 
+  def test_malformed_request_file_routes_through_bad_handler
+    Dir.mktmpdir("hive-dispatch-queue") do |state_home|
+      dispatcher, sup, _ctrl, logger, _mw = make_dispatcher(
+        rows: [], dispatch_request_state_home: state_home
+      )
+      # Write a syntactically broken JSON file directly into the
+      # queue dir so DispatchRequestQueue.pending routes it through
+      # the bad_handler the dispatcher injects (which logs +
+      # unlinks).
+      dir = Q.directory(state_home: state_home)
+      File.write(File.join(dir, "20260528T180000000000-BAD.json"), "{not json")
+      stub_find_project!(dispatcher, "p1")
+      begin
+        dispatcher.tick(now: T0)
+
+        rejected = logger.events.find { |(n, attrs)|
+          n == :dispatch_request_rejected && attrs[:reason] == "malformed_json"
+        }
+        refute_nil rejected,
+                   ":dispatch_request_rejected reason=malformed_json must fire from the queue's bad_handler"
+        assert_empty sup.spawned
+        # The bad_handler must unlink the file so the queue doesn't
+        # re-process it on every tick.
+        assert_empty Dir.glob(File.join(dir, "*.json")),
+                     "malformed files must be unlinked once the bad_handler logs them"
+      ensure
+        restore_find_project!
+      end
+    end
+  end
+
   def test_dispatch_request_expired_removed_without_dispatch
     Dir.mktmpdir("hive-dispatch-queue") do |state_home|
       dispatcher, sup, _ctrl, logger, _mw = make_dispatcher(

--- a/wiki/architecture.md
+++ b/wiki/architecture.md
@@ -200,6 +200,51 @@ with the same per-spawn `<user_supplied_<hex>>` nonce boundary as stage
 prompts, and Codex only returns a draft. The bot writes the literal
 confirmed draft; Codex never edits `brainstorm.md` directly.
 
+## Dispatch flow (single-dispatcher contract, plan 2026-05-28-002)
+
+For state-mutating workflow verbs (`run`, `develop`, `brainstorm`,
+`plan`, `review`, `open-pr`, `artifacts`, `finalize`, `archive`,
+`markers clear`) there is exactly ONE writer: the daemon. The bot
+and any future external caller (TUI, web UI) are producers that
+write file-backed JSON requests; the daemon's tick loop is the
+only thing that calls `Process.spawn` on those verbs.
+
+```
+operator → /done in Telegram
+   └─ Hive::Bot::Supervisor#execute_dispatch
+        └─ Hive::Bot::DispatchRequestWriter.write!
+             └─ <state_home>/dispatch_requests/<ts>-<id>.json
+                  ↑ atomic tmp + File.rename — partial reads impossible
+   ┄ wait for next daemon tick ┄
+   └─ Hive::Daemon::Dispatcher#tick
+        └─ Hive::Daemon::DispatchRequestQueue.pending
+             └─ allowlist + expiry + per-slug in-flight gate
+                  └─ Hive::Daemon::ChildSupervisor#spawn (with request_id)
+                       └─ hive run ... (the real subprocess)
+                            └─ reap_completed
+                                 ├─ controller.observe_state_file_mtime (refresh baseline)
+                                 ├─ DispatchRequestQueue.remove(request_id)
+                                 └─ :dispatch_request_completed event
+```
+
+Read-only verbs (`hive status`, `hive status --diagnose`,
+`hive doctor`, `gh pr view`) and verbs outside the allowlist
+(`hive new`, `hive approve`, `hive accept-finding`,
+`hive reject-finding`) still spawn directly from the bot via
+`Hive::Bot::ChildSupervisor`. They don't bump task state-file
+mtimes and don't cause the dual-writer race the queue exists to
+prevent.
+
+Why the file-backed queue beats an event bus or sockets: every
+hive-state-mutating operation already touches the filesystem
+under one well-known root (`Hive::Paths.state_home`), the
+atomic-rename idiom is already standard in this codebase
+(`Hive::Markers.write_atomic`, `DispatchBaselines#persist!`),
+and the daemon's tick was already a single-threaded sequential
+loop. The queue is the smallest possible addition that satisfies
+the single-dispatcher invariant. See [[modules/daemon]]
+§"Single-dispatcher" for the per-step gates and telemetry events.
+
 ## Code conventions
 
 - Ruby 3.4, frozen-string-literal **disabled** (per `.rubocop.yml`).

--- a/wiki/decisions.md
+++ b/wiki/decisions.md
@@ -7,7 +7,29 @@ updated: 2026-05-25
 tags: [decisions, adr]
 ---
 
-**TLDR**: ADRs below were authored alongside implementation work. ADR-024 records both the PR-first workflow/stage renumbering and daemon autonomy; ADR-026 covers the Telegram bot mobile surface; ADR-027 records the diagnose-then-act surface for red status rows; ADR-029 records the 7-artifacts stage insertion; ADR-030 records the project-global Claude launch mode and its permission-mode follow-up.
+**TLDR**: ADRs below were authored alongside implementation work. ADR-024 records both the PR-first workflow/stage renumbering and daemon autonomy; ADR-026 covers the Telegram bot mobile surface (subprocess caller for non-state-mutating verbs); ADR-027 records the diagnose-then-act surface for red status rows; ADR-029 records the 7-artifacts stage insertion; ADR-030 records the project-global Claude launch mode and its permission-mode follow-up; **ADR-033 supersedes the subprocess-caller portion of ADR-026 for state-mutating verbs — the bot now writes file-backed dispatch requests that the daemon consumes, making the daemon the sole spawner of `hive run`-class children**.
+
+## ADR-033: Single-dispatcher for state-mutating `hive` verbs via file-backed request queue
+
+**Status:** Active (shipped with plan `2026-05-28-002-refactor-single-dispatcher-via-request-queue`; supersedes the "subprocess caller" portion of ADR-026 for the allowlisted verb set).
+
+**Context:** ADR-026 made the Telegram bot a subprocess caller — it directly `Process.spawn`ed `hive run` (and friends) on its own. ADR-024 made the daemon track per-slug `state_file_mtime` baselines to suppress redundant edit-resume dispatches; that tracking relies on the daemon being the writer that observes the post-completion mtime via its own `ChildSupervisor.reap_all`. When the bot was a parallel writer of `hive run`, the daemon's `ConcurrencyController#observe_state_file_mtime` was never called for bot-driven children. The daemon's baseline went stale, and on its next tick the agent's own write to brainstorm.md looked like a "new user edit" — the daemon dispatched a redundant runner that held `Hive::Lock.with_task_lock` for 1–2 min, during which the bot rejected legitimate user answers with "Try again — another run holds the lock." Diagnosed 2026-05-28 on `explore-the-simplest-way-to-260528-2503`.
+
+**Decision:** Eliminate the dual-writer for state-mutating `hive` verbs by routing all of them through a file-backed request queue at `<state_home>/dispatch_requests/`. The bot stops being a subprocess caller for the allowlisted verb set; instead it writes a JSON request file via `Hive::Bot::DispatchRequestWriter.write!` (atomic via tmp + rename). The daemon's tick loop scans the queue via `Hive::Daemon::DispatchRequestQueue.pending`, validates argv against `ALLOWED_VERBS` (and the request's slug against ADR-012's regex + project against a name regex), and dispatches through the same code path as auto-advance. The daemon's existing reap + `refresh_post_completion_mtime` then keeps the baseline current.
+
+The new schema `hive-dispatch-request@1` is registered in `Hive::Schemas::SCHEMA_VERSIONS` and published at `schemas/hive-dispatch-request.v1.json` (per ADR-025 — every entry in SCHEMA_VERSIONS must have a corresponding schema file).
+
+The allowlist is closed: `run develop brainstorm plan review open-pr artifacts finalize archive markers`. Adding a new state-mutating verb to the daemon requires updating `ALLOWED_VERBS` and the schema's `$defs.ALLOWED_VERBS` in lockstep — a unit test asserts cross-list equality.
+
+**Relationship to ADR-026:** ADR-026's "subprocess caller" model still holds for the **non-queue-routable** verbs that don't bump task-state mtime: `hive status`, `hive doctor`, `hive new`, `hive approve`, `hive accept-finding`, `hive reject-finding`. The bot's `ChildSupervisor#dispatch` continues to spawn those directly via `Process.spawn`. The line is drawn at "does this verb's child write to the task state file?" — if yes, queue-route; if no, direct-spawn.
+
+**Consequences:**
+- The daemon is now the SOLE process that spawns `hive run`-class children. The structural cause of the cross-process mtime-baseline bug is gone.
+- The queue dir is created with mode 0700: the producer/consumer authentication boundary is the filesystem-permissions invariant. The `requestor` field in each request is informational only; the daemon does NOT verify it against process credentials. Multi-user hosts therefore depend on per-user `~/.local/state/hive/` ownership, which is the existing operating-system assumption.
+- A new request type expires after 600s. If the daemon is down for longer, queued requests are pruned on its next tick (logged as `dispatch_request_expired`). Operators restarting after extended outage see no automatic re-trigger.
+- Telemetry: 5 daemon events (`dispatch_request_observed/dispatched/completed/rejected/blocked/expired`) provide a full lifecycle trace keyed by `request_id`. The bot continues to log via `:dispatched_command` with `via=queue` and `request_id` so the same correlation ID grep works across daemon.log and bot.log.
+- A per-iteration rescue in `process_dispatch_requests` ensures one request's `Process.spawn` failure (Errno::EAGAIN under fork-exhaustion etc.) does not abort the rest of the tick — the failing request's file stays on disk for the next tick to retry.
+- Notification preservation: the bot's "next question" message is now driven exclusively by the daemon's notification path (status-poll). A `notification_exactly_once` integration test pins the invariant. There is a slightly larger latency window (one tick) between agent completion and operator notification compared to the pre-refactor bot-side reaper, but the deduplication guarantee is stronger.
 
 ## ADR-031: Daemon self-reexec on source-file drift
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -2,6 +2,41 @@
 
 Append-only log of all wiki operations.
 
+## [2026-05-28T23:30:00Z] fix — PR #241 ce-code-review fixups: schema file, argv+slug validation, security hardening, reliability
+
+**Action:** Addressed 14 findings from `/ce-code-review` on PR #241 across 10 reviewers (correctness, testing, maintainability, project-standards, agent-native, learnings, reliability, security, adversarial, api-contract, cli-readiness):
+
+1. **PS-01/AC-01 — Schema file**: Added `schemas/hive-dispatch-request.v1.json`. Was registered in `SCHEMA_VERSIONS` but the corresponding file was missing, breaking `test/unit/schema_files_test.rb`'s invariant that every key has a published schema. External validators / third-party producers can now reference it.
+2. **SEC-1+SEC-5+L-1 — Slug/project/argv validation**: `valid_argv?` now requires argv length ≥ 2, all non-empty strings, and validates the positional slug at `argv[2]` against ADR-012's regex (`^[a-z][a-z0-9-]{0,62}[a-z0-9]$`) for non-`markers` verbs. `parse_data` validates `project` against a name regex and `slug` against the ADR-012 regex — blocks path-traversal candidates at the queue boundary.
+3. **SEC-3 — Queue dir 0700**: `directory()` now `mkdir_p(..., mode: 0o700)` plus chmod-tightens an already-existing dir. Without this, default umask 0022 left the dir world-readable.
+4. **C2 — Conversation preservation on queue write failure**: `auto_run_after_answers` only clears the conversation on a non-nil dispatch return. A queue write failure (read-only state dir, ENOSPC) no longer strands the operator without a `/done` backstop.
+5. **AC-04 — Producer-side project/slug guards**: `DispatchRequestWriter.write!` raises `ArgumentError` on empty project or slug. Producer-side failure is louder and actionable rather than swallowed downstream.
+6. **R-01 — Per-iteration rescue in `process_dispatch_requests`**: A `Process.spawn` failure (Errno::EAGAIN under fork-exhaustion) in one iteration no longer aborts the rest of the pending queue. Failure logs `reason: spawn_failure: <class>: <message>` and the request file stays for retry.
+7. **C4 — `project_enabled?` gate**: Mirrors `handle_row`. A disabled project's queued requests log `:dispatch_request_blocked reason=project_disabled` and stay for retry once re-enabled.
+8. **R-04/M-05 — Gate ordering**: `running_task?` now precedes `can_dispatch?` so an in-flight slug doesn't incur the more expensive cap-counting scan.
+9. **M-02 — Dead `respond_to?` guard removed**: `ChildExit` always defines `request_id` (nilable); the `respond_to?` check was dead code.
+10. **PS-02 — ADR-033 added**: Records the single-dispatcher invariant. Supersedes ADR-026's "subprocess caller" model for state-mutating verbs while preserving it for read-only verbs (status / doctor / new / approve / accept-finding / reject-finding).
+
+**Tests added** (5):
+- `test_dispatch_request_blocked_when_project_is_disabled` (C4).
+- `test_dispatch_request_spawn_failure_logs_and_does_not_abort_subsequent_iterations` (R-01).
+- `test_write_rejects_empty_project_or_slug` (AC-04).
+- `test_directory_is_created_with_user_only_permissions` (SEC-3).
+- Updated `test_pending_rejects_missing_fields_and_bad_created_at` to cover new `invalid_project` and `invalid_slug` reasons (SEC-5).
+
+**Coverage:** 100.00% line coverage (17667/17667). RuboCop clean. Full suite: 4131 / 15061 / 0 failures / 0 errors / 2 skips.
+
+**Refreshed pages:**
+- [[decisions]] — ADR-033 records the single-dispatcher invariant and the ADR-026 amendment.
+
+**Deferred** (out of scope for the fix pass; tracked as follow-ups):
+- AN-1/AN-2/AN-3: `hive bot dispatch-requests --json` / `hive dispatch drain` / `hive dispatch enqueue` CLI verbs.
+- R-02: per-verb child timeout (current behavior: hung child indefinitely locks per-slug gate until daemon restart).
+- ADV-1: child non-zero exit → Telegram error reply (currently observable only in daemon.log).
+- C3: atomic claim + restart-recovery to prevent duplicate dispatch after daemon SIGKILL.
+- AC-02: clarify whether `:dispatch_request_written` event should exist alongside `:dispatched_command via=queue` (current implementation uses the latter; consistent with bot.log conventions).
+- AC-05: alert-reset timing change in `dispatch_command_sequence` for queue-routable sequences.
+
 ## [2026-05-28T22:30:00Z] fix — PR #239 ce-code-review fixups: Q-context-aware answer-slot scan + ENOENT distinction + structured answer_slot_missing event
 
 **Action:** Addressed 10 findings from `/ce-code-review` on PR #239:

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -16,6 +16,61 @@ Append-only log of all wiki operations.
 **Refreshed pages:**
 - [[modules/bot]] — `BrainstormParser` and `BrainstormAnswerWriter` rows expanded to describe the lenient-A-header rule, Q-context-aware slot location, and the `:answer_slot_missing` / `:question_not_found` mapping.
 
+## [2026-05-28T21:00:00Z] refactor — single-dispatcher via file-backed dispatch-request queue (plan 2026-05-28-002)
+
+**Action:** Eliminated the bot↔daemon dual-writer race for
+`hive run`-class verbs. Before: both the daemon AND the bot could
+spawn `hive run`, but only the daemon refreshed its
+`last_dispatched_mtime` baseline on reap. Bot-spawned reaps were
+invisible to the daemon, so the agent's own write to brainstorm.md
+looked like a new user edit on the next tick → redundant redispatch
+→ task lock held 1-2 min → bot rejects user answers with "Try again
+— another run holds the lock". Smoking gun on 2026-05-28 18:13:14
+→ 18:13:44 in `daemon.log`.
+
+The fix collapses the two dispatchers into one:
+
+- New `Hive::Daemon::DispatchRequestQueue` (`lib/hive/daemon/dispatch_request_queue.rb`):
+  file-backed queue at `<state_home>/dispatch_requests/<ts>-<id>.json`,
+  allowlists `run develop brainstorm plan review open-pr artifacts
+  finalize archive markers`. Schema `hive-dispatch-request` v1.
+- New `Hive::Bot::DispatchRequestWriter` (`lib/hive/bot/dispatch_request_writer.rb`):
+  atomic tmp+rename JSON write. Validates argv against the queue's
+  allowlist at the call site too.
+- `Hive::Daemon::Dispatcher#tick` runs
+  `process_dispatch_requests(now:)` BEFORE the per-row scan. Gates
+  per request: allowlist → expiry (10 min) → project lookup →
+  per-slug in-flight → concurrency caps → spawn. Threads
+  `request_id` through `ChildSupervisor#spawn` and `ChildExit` so
+  `reap_completed` can unlink the file and log
+  `:dispatch_request_completed`.
+- `Hive::Bot::Supervisor#execute_dispatch` rewrites queue-routable
+  argv into `DispatchRequestWriter.write!`; the bot stops being a
+  child-process launcher for those verbs.
+- Per-slug in-flight gate added to `dispatch_or_block` so the
+  row scan can't double-spawn a slug whose request just dispatched
+  earlier in the same tick.
+
+New telemetry events in `daemon.log`:
+`dispatch_request_observed/_dispatched/_completed/_blocked/
+_rejected/_expired`. Bot's `:dispatched_command` event gains a
+`via=queue` tag and `request_id` to distinguish the two paths.
+
+**Tests:** four integration tests including
+`test/integration/regression_redundant_redispatch_test.rb` which
+replays the exact 18:13 sequence and asserts no redundant
+redispatch.
+
+**Refreshed pages:**
+- [[modules/daemon]] — new module-map row for
+  `DispatchRequestQueue`; new "Single-dispatcher" section describing
+  per-step gates + telemetry.
+- [[modules/bot]] — new module-map row for `DispatchRequestWriter`;
+  new "Single-dispatcher invariant" section with the audit
+  command.
+- [[architecture]] — new "Dispatch flow" section with the bot →
+  queue → daemon → child diagram.
+
 ## [2026-05-28T13:50:00Z] fix — CleanExit follow-ups: bot callback reason encoding + agent-actionable next_action
 
 **Action:** Two further CleanExit fixes:

--- a/wiki/modules/bot.md
+++ b/wiki/modules/bot.md
@@ -29,7 +29,8 @@ and subprocess I/O.
 | `BrainstormAnswerWriter` | `lib/hive/bot/brainstorm_answer_writer.rb` | Locked, first-write-wins insertion into the next answer block, with atomic rewrite. Slot location is **Q-context-aware**: walks forward from the parser-identified target Q's line, returning the first empty A-section before the next block boundary. Returns `:answer_slot_missing` (distinct from `:question_not_found`) when Q{n} is in the file but no fillable A-slot is locatable; the supervisor renders a repair-specific Telegram reply for this case. `Errno::ENOENT` on the underlying file is mapped to `:question_not_found` (not lock contention). |
 | `ConversationStore` | `lib/hive/bot/conversation_store.rb` | In-memory per-chat active answer/Codex state with TTL. No sidecar file; `brainstorm.md` stays canonical. |
 | `CodexConversation` | `lib/hive/bot/codex_conversation.rb` | Short-lived Path A Codex spawn wrapper. Parses `BOT_REPLY`, `BOT_DRAFT`, and `BOT_ERROR` lines. |
-| `ChildSupervisor` | `lib/hive/bot/child_supervisor.rb` | Spawns child `hive ...` commands with `pgroup: true`, writes per-dispatch logs, reaps with `Process.wait2(-1, WNOHANG)`. |
+| `ChildSupervisor` | `lib/hive/bot/child_supervisor.rb` | Spawns child `hive ...` commands with `pgroup: true`, writes per-dispatch logs, reaps with `Process.wait2(-1, WNOHANG)`. After plan 2026-05-28-002 the bot only reaches this path for **non-queue-routable** verbs (read-only `hive status --diagnose` for /details, `hive new` for the idea picker, `hive approve` for the /approve slash command, `hive accept-finding` / `hive reject-finding` for findings replies). State-mutating workflow verbs are written to the daemon's dispatch-request queue instead — see `DispatchRequestWriter` below. |
+| `DispatchRequestWriter` | `lib/hive/bot/dispatch_request_writer.rb` | Producer-only client of the daemon's dispatch-request queue. Atomic tmp+rename JSON write into `<state_home>/dispatch_requests/`. Argv validated against `Hive::Daemon::DispatchRequestQueue::ALLOWED_VERBS` at the call site too, so a typo in a slash handler raises locally rather than silently writing a request the daemon would discard. Returns a `request_id` the daemon echoes back in its `dispatch_request_*` events. |
 | `Logger` | `lib/hive/bot/logger.rb` | JSON-line structured logger with size rotation and closed event enum. |
 | `Commands::Bot` | `lib/hive/commands/bot.rb` | Thor command surface and PID-file lifecycle. |
 
@@ -74,6 +75,35 @@ re-parses the file under the lock, refuses non-empty answer slots, and
 inserts the literal confirmed text. Two devices racing the same question
 therefore produce one answer and one "already answered" reply, not a
 merged or overwritten block.
+
+## Single-dispatcher invariant (plan 2026-05-28-002)
+
+The bot is producer-only for state-mutating workflow verbs. When
+`Supervisor#execute_dispatch` sees an argv whose verb is in
+`Hive::Daemon::DispatchRequestQueue::ALLOWED_VERBS`
+(`run develop brainstorm plan review open-pr artifacts finalize
+archive markers`), the dispatch is rewritten to
+`DispatchRequestWriter.write!` and a `:dispatched_command via=queue
+request_id=…` event is logged. The daemon picks up the request
+on its next tick.
+
+For multi-command sequences (`dispatch_command_sequence`, used by
+Autofix's `markers clear` + retry-verb pair), the bot writes every
+queue-routable command in arrival order. The daemon's per-slug
+in-flight gate serialises execution; the bot has no PID to wait on
+between commands.
+
+Audit (CI-enforced post-merge):
+
+```
+rg -n 'Process.spawn|spawn!|system\(' lib/hive/bot/
+# Only match: lib/hive/bot/child_supervisor.rb's Process.spawn,
+# which is now reached only by the read-only / non-queue-routable
+# verbs above. No matches for ALLOWED_VERBS.
+```
+
+See [[modules/daemon]] §"Single-dispatcher" and [[architecture]]
+§"Dispatch flow" for the daemon side of the contract.
 
 ## Eval harness
 

--- a/wiki/modules/daemon.md
+++ b/wiki/modules/daemon.md
@@ -27,6 +27,7 @@ the safety-relevant decisions are unit-testable without forking.
 | `Hive::Daemon::PlanApproval` | `lib/hive/daemon/plan_approval.rb` | Safely turns daemon-enabled `3-plan` approval pauses into `hive develop ... --from 3-plan` dispatches by validating command shape and flipping `WAITING` to `COMPLETE`. |
 | `Hive::Daemon::StaleAgentHealer` | `lib/hive/daemon/stale_agent_healer.rb` | Rewrites stale `AGENT_WORKING` markers to `ERROR reason=agent_died` or `ERROR reason=agent_orphaned`, while skipping live controller slots, half-migrated projects, and rows with `live_task_lock: true`. |
 | `Hive::Daemon::PrMergeWatcher` | `lib/hive/daemon/pr_merge_watcher.rb` | Polls `gh pr view --json state` for tasks at 8-finalize/`:complete`. On `MERGED` returns an archive dispatch entry the dispatcher fires. Backs off + drops on persistent gh failures. |
+| `Hive::Daemon::DispatchRequestQueue` | `lib/hive/daemon/dispatch_request_queue.rb` | File-backed queue (`<state_home>/dispatch_requests/*.json`) of dispatch requests written by external callers (today: the Telegram bot via `Hive::Bot::DispatchRequestWriter`) and consumed by the dispatcher's tick loop. Allowlists state-mutating verbs (`run develop brainstorm plan review open-pr artifacts finalize archive markers`); rejects everything else with a logged `:dispatch_request_rejected` event. The single-dispatcher invariant lives here: the bot writes, the daemon dispatches. See [[architecture]] §"Single-dispatcher contract". |
 | `Hive::Commands::Daemon` | `lib/hive/commands/daemon.rb` | Thor subcommand surface (`start` / `stop` / `status` / `reload` / `tail`). Owns the PID file + signal-based stop/reload. |
 
 ## Wiring
@@ -36,14 +37,23 @@ hive daemon start
   └─ Hive::Commands::Daemon
        ├─ writes ~/Dev/hive/.daemon.pid
        └─ Hive::Daemon::Dispatcher.run_forever
-            ├─ Hive::Daemon::Logger      (~/Dev/hive/logs/daemon.log, JSON-line)
+            ├─ Hive::Daemon::Logger              (~/Dev/hive/logs/daemon.log, JSON-line)
             ├─ Hive::Daemon::ConcurrencyController
-            ├─ Hive::Daemon::ChildSupervisor   (Process.spawn pgroup: true)
-            ├─ Hive::Daemon::StatusConsumer    (Open3.capture3 hive status --json)
-            ├─ Hive::Daemon::PrMergeWatcher    (Open3.capture3 gh pr view)
-            ├─ Hive::Daemon::StaleAgentHealer  (AGENT_WORKING repair)
-            └─ Hive::Daemon::Policy            (pure decisions)
+            ├─ Hive::Daemon::ChildSupervisor     (Process.spawn pgroup: true)
+            ├─ Hive::Daemon::StatusConsumer      (Open3.capture3 hive status --json)
+            ├─ Hive::Daemon::DispatchRequestQueue (<state_home>/dispatch_requests/*.json)
+            ├─ Hive::Daemon::PrMergeWatcher      (Open3.capture3 gh pr view)
+            ├─ Hive::Daemon::StaleAgentHealer    (AGENT_WORKING repair)
+            └─ Hive::Daemon::Policy              (pure decisions)
 ```
+
+Each tick runs in order: reap completed children → fetch status →
+**process dispatch requests** → handle PR-merge watcher → per-row
+dispatch → prune baselines. Dispatch requests come BEFORE the
+row-scan so a slug whose request just dispatched this tick is
+already in-flight in the controller and the row scan's per-slug
+in-flight gate (`controller.running_task?`) keeps the same tick
+from double-spawning.
 
 `Hive::Daemon::Policy` and `Hive::Daemon::ConcurrencyController` have no
 I/O at all — fully unit-testable without forking. The other modules
@@ -170,6 +180,59 @@ between a bot-dispatched brainstorm's `WAITING` write and the user's
 answer, no baseline was ever recorded, so the answer becomes the baseline
 on first start and the task waits for the next edit. The daemon is
 normally up, so the window is tiny; the operator can re-save / `touch`.
+
+## Single-dispatcher: bot writes requests, daemon dispatches
+
+Before plan 2026-05-28-002, both the daemon AND the Telegram bot
+could spawn `hive run`-class verbs. The daemon tracked an in-memory
+`last_dispatched_mtime` baseline per `(project, slug)` and refreshed
+it on every reap — but only on reaps of children IT spawned. The
+bot's `hive run` child was reaped by the bot's `ChildSupervisor`,
+so the daemon never saw the post-completion mtime bump from the
+agent's own write. On the next tick the row's mtime exceeded the
+stale baseline; Policy returned `:dispatch`; the daemon spawned a
+redundant runner that held the per-task lock for 1-2 min, during
+which the bot rejected legitimate user answers with "Try again —
+another run holds the lock".
+
+The fix collapses the two dispatchers into one. The bot is
+producer-only: it writes a JSON request file via
+`Hive::Bot::DispatchRequestWriter.write!` into
+`<state_home>/dispatch_requests/`. The daemon's tick loop consumes
+the queue via `Hive::Daemon::DispatchRequestQueue.pending`,
+validates the argv against an allowlist
+(`run develop brainstorm plan review open-pr artifacts finalize
+archive markers`), threads the `request_id` through `spawn → reap`
+so `reap_completed` can unlink the file and log the lifecycle:
+
+```
+:dispatch_request_observed   request_id=… project=… slug=…
+:dispatch_request_dispatched pid=… command=…   (only when dispatched)
+:dispatch_request_blocked    reason=in_flight|cooldown|…
+:dispatch_request_completed  pid=… exit_code=… elapsed_sec=…
+:dispatch_request_rejected   reason=invalid_argv|unknown_project|…
+:dispatch_request_expired    created_at=…
+```
+
+Lifecycle gates inside `process_dispatch_requests`:
+
+1. Allowlist (`valid_argv?`) — invalid → reject + remove.
+2. Expiry (`DispatchRequestQueue::EXPIRY_SEC` = 600s) — old → expire + remove.
+3. `find_project` lookup — unknown → reject + remove.
+4. `controller.running_task?` — already in flight for this slug →
+   blocked, file stays for the next tick.
+5. `controller.can_dispatch?` gate (caps / cooldown / quarantine) —
+   blocked → file stays for the next tick.
+6. Otherwise → spawn via `dispatch_command`, threading `request_id`
+   into `ChildSupervisor#spawn` and `ChildExit#request_id`.
+
+`reap_completed` always refreshes the controller's
+`last_dispatched_mtime` baseline (no longer just for daemon-spawned
+children — the bot doesn't spawn them anymore). The bug dissolves:
+the same code that observes the mtime is the only producer of the
+spawn.
+
+See [[architecture]] §"Dispatch flow" for the cross-layer picture.
 
 ## Self-reexec on source drift (ADR-031)
 


### PR DESCRIPTION
## The bug

On 2026-05-28 18:13 a brainstorm task got stuck in a redispatch
loop: the daemon and the bot were both writing to it. The smoking
gun in `~/.local/state/hive/logs/daemon.log`:

```
18:13:14  debouncing   mtime=18:13:09     ← agent's write (from bot's hive run)
18:13:44  dispatched   trigger=advance    ← redundant daemon redispatch (BUG)
```

The bot dispatched `hive run` directly via its own `ChildSupervisor`.
The daemon's `ConcurrencyController` only refreshed its
`last_dispatched_mtime` baseline on reaps it owned — bot-spawned
children were invisible to it. So the agent's own write to
brainstorm.md looked like a new user edit on the next tick →
redundant runner → task lock held 1-2 min → bot rejects legitimate
user answers with "Try again - another run holds the lock".

## The fix

Collapse the two dispatchers into one. The bot becomes a producer
only: it writes a JSON request file. The daemon's tick loop is the
only thing that calls `Process.spawn` for queue-allowlisted verbs.

```
operator → /done → Hive::Bot::Supervisor#execute_dispatch
                     └─ Hive::Bot::DispatchRequestWriter.write!
                          └─ <state_home>/dispatch_requests/<ts>-<id>.json
                                      ↓
                          Hive::Daemon::Dispatcher#tick
                            └─ DispatchRequestQueue.pending
                                 └─ allowlist + expiry + per-slug gate
                                      └─ ChildSupervisor.spawn (with request_id)
                                           └─ hive run … (real subprocess)
                                                └─ reap_completed:
                                                     refresh baseline + unlink
```

The post-completion mtime refresh now runs on every reap — there's
no longer an external path. The bug dissolves because the same
code that observes the mtime is the only producer of the spawn.

Allowlist (`Hive::Daemon::DispatchRequestQueue::ALLOWED_VERBS`):
`run develop brainstorm plan review open-pr artifacts finalize
archive markers`. Read-only verbs (`hive status`, `--diagnose`)
and verbs outside the allowlist (`hive new`, `hive approve`,
`accept-finding`, `reject-finding`) keep the in-process spawn
path — they don't bump task state-file mtimes and don't cause the
dual-writer race.

## What proves it

`test/integration/regression_redundant_redispatch_test.rb` replays
the exact 18:13:14 → 18:13:44 sequence and asserts:

- exactly one `:dispatch_request_observed` event
- exactly one `:dispatch_request_dispatched` event
- exactly one `:dispatch_request_completed` event
- **zero** `:dispatched trigger=advance` events in the bug window
- the controller's baseline equals the agent's last write after reap

```
bundle exec ruby -Itest test/integration/regression_redundant_redispatch_test.rb
# 1 runs, 10 assertions, 0 failures, 0 errors, 0 skips
```

## Bot audit

CI-enforceable post-merge:

```
$ rg -n 'Process.spawn|spawn!|system\(' lib/hive/bot/
lib/hive/bot/child_supervisor.rb:49:  pid = Process.spawn(*argv, chdir: cwd, pgroup: true, out: log_io, err: log_io)
```

The only remaining match is reached for read-only / non-queue-routable
verbs only (per plan §"Non-goals"). No matches for any
`ALLOWED_VERBS` verb anywhere in `lib/hive/bot/`.

## Tests + coverage

- 4127 runs, 15042 assertions, 0 failures, 0 errors, 2 skips
- 100.00% line coverage (17647/17647) under
  `HIVE_COVERAGE_MIN_LINE=100 bundle exec rake coverage`
- `bundle exec rubocop`: 466 files, zero offenses

## Telemetry

New events in `daemon.log` (closed enum, registered in `Logger::EVENTS`):

```
dispatch_request_observed   request_id=… project=… slug=…
dispatch_request_dispatched pid=… command=…
dispatch_request_blocked    reason=in_flight|cooldown|quarantined|…
dispatch_request_completed  pid=… exit_code=… elapsed_sec=…
dispatch_request_rejected   reason=invalid_argv|unknown_project|…
dispatch_request_expired    created_at=…
```

Bot's `:dispatched_command` event gains `via=queue` + `request_id`
to distinguish the two surfaces.

## Plan

Full plan: `~/Dev/hive-private/docs/plans/2026-05-28-002-refactor-single-dispatcher-via-request-queue-plan.md`
(in hive-private, not in this public repo).

## Commit history

8 implementation commits + 1 coverage tightening commit, one per
plan step. Each commit builds and passes its own targeted tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
