### PR TITLE
chore(release): prepare 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes are documented here, newest first. Hive ships frequent micro-releases (see [docs/RELEASING.md](docs/RELEASING.md#versioning-policy)): each `vX.Y.Z` git tag gets a `## X.Y.Z` section with terse bullets — no `[Unreleased]` accumulator. Versioning is [SemVer](https://semver.org): PATCH for fixes and small changes (the common case), MINOR for notable features, MAJOR for milestones.
 
+## 0.2.0
+
+- Added the experimental `hive babysit` PR repair daemon. It can inspect repository projects, classify PR health, run bounded agent repair attempts, and record structured babysitter events while preserving dry-run and human-handoff paths.
+- Added the OpenClaw skill bundle and install docs, including skill coverage for the new babysitter command, so agent-facing command guidance stays in sync with the CLI.
+- Fixed daemon/bot dispatch edges around queued requests, per-child timeouts, restart baselines, deferred brainstorm answers, and missing brainstorm answer slots.
+- Fixed review/fix recovery contracts so dirty-worktree and unreadable-status states are surfaced as manual-only instead of feeding the same task back into autofix.
+- Fixed TUI snapshot polling so selection follows the focused task slug instead of drifting when rows reorder.
+- Hardened llm-wiki post-commit hook execution by sanitizing inherited Git hook environment, preventing hook-side repository checkouts from dirtying unrelated Hive worktrees.
+
 ## 0.1.10
 
 - Fixed the daemon stranding already-answered `needs_input` tasks across a restart. The `[project, slug] → state_file_mtime` baseline map (consulted by `Policy#decide_edit` to detect fresh user input) was in-memory only, so a pre-restart answer never looked "newer than baseline" on first sight and got skipped on every tick forever until you manually `touch`ed the state file. Baselines now persist to `daemon_dispatch_baselines.json` under the state home (atomic write + fail-closed load + sibling-flock + orphan-tmp sweep), reload on startup, and prune to the live task set each successful tick — bounded to the projects in the snapshot so a per-project status error doesn't wipe its baselines.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hive-cli (0.1.10)
+    hive-cli (0.2.0)
       bubbletea (= 0.1.4)
       lipgloss (~> 0.2.2)
       sqlite3 (~> 2.0)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Hive ships as a rubygem (`hive-cli`) attached to each GitHub Release, signed wit
 | Platform | Channel |
 |----------|---------|
 | macOS arm64 | [`brew install ivankuznetsov/hive/hive`](https://github.com/ivankuznetsov/homebrew-hive) |
-| Ubuntu 22.04+ / glibc Linux x86_64/aarch64 | <code>tmpdir="$(mktemp -d)" && trap 'rm -rf "$tmpdir"' EXIT && curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.1.10/install.sh -o "$tmpdir/hive-install.sh" && bash "$tmpdir/hive-install.sh"</code> |
+| Ubuntu 22.04+ / glibc Linux x86_64/aarch64 | <code>tmpdir="$(mktemp -d)" && trap 'rm -rf "$tmpdir"' EXIT && curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.2.0/install.sh -o "$tmpdir/hive-install.sh" && bash "$tmpdir/hive-install.sh"</code> |
 | Arch Linux x86_64/aarch64 | [`yay -S hive-bin`](https://aur.archlinux.org/packages/hive-bin) |
 
 Prerequisites: **Ruby 3.4** (the gem and its runtime deps install against this), git ≥ 2.40, authenticated `claude` ≥ 2.1.118, `codex` ≥ 0.125.0 for the default execute agent, authenticated `gh`, `tmux` ≥ 3.0 when the project uses the default `claude.mode: tmux`, and Node.js/npm for managed QMD install/repair. The bash installer reports its own installer-side prereqs (`curl`, `jq`, `gem`, checksum tool) on first run; if npm is missing, Hive still installs and `hive doctor` reports the QMD gap non-fatally.

--- a/install.md
+++ b/install.md
@@ -59,8 +59,8 @@ Ubuntu 22.04+ / glibc Linux fallback (pin to the current release tag, not `main`
 ```bash
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
-# Release maintainers: bump v0.1.10 in both installer URLs when cutting a new stable release.
-curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.1.10/install.sh -o "$tmpdir/hive-install.sh"
+# Release maintainers: bump v0.2.0 in both installer URLs when cutting a new stable release.
+curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.2.0/install.sh -o "$tmpdir/hive-install.sh"
 bash "$tmpdir/hive-install.sh"
 ```
 
@@ -69,8 +69,8 @@ To inspect the installer first, run a dry-run before the real invocation. State 
 ```bash
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
-# Release maintainers: bump v0.1.10 in both installer URLs when cutting a new stable release.
-curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.1.10/install.sh -o "$tmpdir/hive-install.sh"
+# Release maintainers: bump v0.2.0 in both installer URLs when cutting a new stable release.
+curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.2.0/install.sh -o "$tmpdir/hive-install.sh"
 bash "$tmpdir/hive-install.sh" --dry-run
 bash "$tmpdir/hive-install.sh"
 ```

--- a/lib/hive.rb
+++ b/lib/hive.rb
@@ -1,5 +1,5 @@
 module Hive
-  VERSION = "0.1.10".freeze
+  VERSION = "0.2.0".freeze
   MIN_CLAUDE_VERSION = "2.1.118".freeze
   # Canonical GitHub org + repo. Referenced by the release probe
   # (UpdateCheck), the brew tap + installer URL (Commands::Update), etc.

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -2,6 +2,12 @@
 
 Append-only log of all wiki operations.
 
+## [2026-06-03T02:20:04Z] release - prepare 0.2.0 after merge batch
+
+**Action:** Prepared the next minor release after the merge batch that added the experimental babysitter PR repair daemon, OpenClaw skill bundle, daemon/bot dispatch hardening, TUI slug-following fix, review/autofix dirty-worktree recovery fixes, and llm-wiki hook environment sanitization. Bumped `Hive::VERSION`, synced the lockfile package version, added a newest-first `CHANGELOG.md` section, and updated pinned installer URLs in `README.md` / `install.md` to `v0.2.0`.
+
+**Tests:** Verified `Hive::VERSION == "0.2.0"`, built `hive-cli-0.2.0.gem` locally, and checked for stale `v0.1.10` installer references outside the historical changelog entry.
+
 ## [2026-06-03T01:35:11Z] babysitter - review follow-up skill and init drift guard
 
 **Action:** Review follow-up for the experimental PR babysitter branch. Added the dedicated OpenClaw `/babysit` skill plus the planned `hive-babysit` ClawHub row so the Thor command drift guard covers the new lifecycle surface. Tightened `Hive::Commands::Init::ProjectConfigBinding` so `babysitter_enabled` and `daemon_autostart` remain required prompt-answer keys instead of silently defaulting in the ERB binding. Added a Brakeman false-positive ignore for `Gh#pr_diff_stat`: `Hive::Gh.capture3` uses `Process.spawn` argv form, and the Git revspec is a single argv element rather than shell input. The CI coverage gate exposed untested babysitter lifecycle/error branches; added focused coverage-gap tests, included `test/babysitter/**/*_test.rb` in the default Rake suite, and fixed `Hive::Babysitter::Logger#event` so a rotation reopen failure that falls back to stderr does not continue into `@file.puts` with a nil file handle.


### PR DESCRIPTION
## Summary
- bump Hive version and lockfile package version to 0.2.0
- add the 0.2.0 changelog entry for the merged daemon/babysitter/OpenClaw/TUI/hook batch
- update pinned installer URLs in README.md and install.md

## Verification
- bundle exec ruby -Ilib -e 'require "hive"; abort Hive::VERSION unless Hive::VERSION == "0.2.0"; puts Hive::VERSION'\n- gem build hive.gemspec\n- rg -n "v0\\.1\\.10|0\\.1\\.10|hive-cli-0\\.1\\.10" README.md install.md docs CHANGELOG.md Gemfile.lock lib hive.gemspec packaging test -S\n- bundle exec rake test\n