### PR TITLE
fix(daemon): register version drift log event

### DIFF
--- a/lib/hive/daemon/logger.rb
+++ b/lib/hive/daemon/logger.rb
@@ -49,6 +49,7 @@ module Hive
         update_check_no_result
         update_check_error
         update_nudge_no_command
+        version_drift
         daemon_dispatch_baselines_corrupt
         daemon_dispatch_baselines_lock_error
         daemon_dispatch_baselines_write_error


### PR DESCRIPTION
## Summary
- add `version_drift` to the closed daemon logger event enum
- prevents daemon crashes when source-code drift is detected and the dispatcher tries to request reexec

## Verification
- bundle exec ruby -Itest test/unit/daemon/logger_test.rb
- bundle exec ruby -Itest test/unit/daemon/dispatcher_reexec_test.rb
- local daemon restarted on patched checkout and dispatched patrol without hitting the unknown-event crash