### PR TITLE
fix(babysitter): skip draft PRs

### DIFF
--- a/lib/hive/babysitter/events.rb
+++ b/lib/hive/babysitter/events.rb
@@ -25,6 +25,7 @@ module Hive
         gh-error
         already-green
         label_ignored
+        draft_pr
         fork_pr
         dry_run
       ].freeze

--- a/lib/hive/babysitter/project_tick.rb
+++ b/lib/hive/babysitter/project_tick.rb
@@ -90,6 +90,16 @@ module Hive
         limit = cfg.dig("babysitter", "max_concurrent_prs").to_i
         prs.filter_map do |pr|
           number = pr["number"]
+          if pr["isDraft"] == true
+            Hive::Babysitter::Events.emit(
+              project: project_entry,
+              pr: number,
+              action: "skipped",
+              outcome: "draft_pr"
+            )
+            next
+          end
+
           labels = Array(pr["labels"]).filter_map { |entry| entry.is_a?(Hash) ? entry["name"] : entry }
           if (labels.map { |label| label.to_s.downcase } & ignored).any?
             Hive::Babysitter::Events.emit(

--- a/test/unit/babysitter/project_tick_test.rb
+++ b/test/unit/babysitter/project_tick_test.rb
@@ -59,6 +59,42 @@ class BabysitterProjectTickTest < Minitest::Test
     end
   end
 
+  def test_skips_draft_prs_before_spawning_agent
+    with_tmp_dir do |dir|
+      project = project_entry(dir)
+      write_config(
+        dir,
+        babysitter: {
+          "enabled" => true,
+          "labels_ignore" => %w[wip do-not-merge draft],
+          "max_concurrent_prs" => 2
+        }
+      )
+      prs = [
+        { "number" => 10, "isDraft" => true, "labels" => [], "updatedAt" => "2026-05-26T09:00:00Z" },
+        { "number" => 11, "isDraft" => false, "labels" => [], "updatedAt" => "2026-05-26T10:00:00Z" }
+      ]
+      called = []
+      logger = make_logger(dir)
+
+      with_replaced_singleton_method(Hive::Gh, :list_open_prs, ->(_path, **_kwargs) { prs }) do
+        with_replaced_singleton_method(Hive::Babysitter::PrFixer, :run, lambda { |pr, _project, _cfg, **_kwargs|
+          called << pr["number"]
+          :dry_run
+        }) do
+          summary = Hive::Babysitter::ProjectTick.run(project, dry_run: true, logger: logger, inflight: Set.new)
+          assert_equal({ total: 1, fixed: 0, untouched: 1, needs_human: 0 }, summary)
+        end
+      end
+
+      assert_equal [ 11 ], called
+      events = File.readlines(File.join(project.fetch("hive_state_path"), "babysitter", "events.jsonl")).map { |line| JSON.parse(line) }
+      assert events.any? { |event| event["action"] == "skipped" && event["outcome"] == "draft_pr" && event["pr"] == 10 }
+    ensure
+      logger&.close
+    end
+  end
+
   def test_gh_error_emits_event_and_does_not_spawn_agent
     with_tmp_dir do |dir|
       project = project_entry(dir)

--- a/wiki/commands/babysit.md
+++ b/wiki/commands/babysit.md
@@ -53,10 +53,11 @@ babysitter:
 For each enabled project, the babysitter:
 
 1. Runs `gh pr list --state open` through `Hive::Gh.list_open_prs`.
-2. Skips PRs whose labels intersect `labels_ignore` case-insensitively.
-3. Skips PRs already in the in-process in-flight set.
-4. Sorts oldest-updated first and truncates to `max_concurrent_prs`.
-5. Runs `Hive::Babysitter::PrFixer` on each selected PR.
+2. Skips draft PRs before worktree materialization.
+3. Skips PRs whose labels intersect `labels_ignore` case-insensitively.
+4. Skips PRs already in the in-process in-flight set.
+5. Sorts oldest-updated first and truncates to `max_concurrent_prs`.
+6. Runs `Hive::Babysitter::PrFixer` on each selected PR.
 
 `PrFixer` first checks `gh pr view --json mergeable,statusCheckRollup`. If the PR is mergeable and checks are successful or queued, it records a `noop` event and does not spawn an agent. Otherwise it materializes `<project>/.hive-state/babysitter/worktrees/<pr-number>/`, gathers failing-job logs plus diff stats, renders `templates/babysitter_pr_fix_prompt.md.erb`, and spawns the configured `execute.agent` through `Hive::Stages::Base.spawn_agent` with `status_mode: :exit_code_only`.
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -2,6 +2,14 @@
 
 Append-only log of all wiki operations.
 
+## [2026-06-03T11:05:00Z] babysitter - skip draft PRs explicitly
+
+**Action:** Fixed the babysitter PR selector so GitHub draft PRs are skipped before worktree materialization and agent spawn. The prior label filter treated `draft` as a label, but GitHub exposes draft state as `isDraft`; live babysitter activity showed draft PR #278 being selected despite `labels_ignore: [draft]`. Added the `draft_pr` skipped event outcome and focused ProjectTick coverage.
+
+**Refreshed pages:**
+- [[commands/babysit]]
+- [[modules/babysitter]]
+
 ## [2026-06-03T10:48:47Z] babysitter - refresh dry-run stub API coverage
 
 **Action:** Refreshed wiki command/API surface coverage after commit `889b0b65` changed the babysitter dry-run `git` and `gh` stub executables from mutating-command blocklists to read-only allowlists. Verified the committed diff and current source for `bin/hive-babysitter-stub-git`, `bin/hive-babysitter-stub-gh`, `lib/hive/babysitter/dry_run_env.rb`, `lib/hive/babysitter/gh_ops.rb`, and `test/unit/babysitter/dry_run_env_test.rb`. Expanded the `hive babysit --dry-run` docs with the exact current pass-through surface, refreshed babysitter module metadata, and recorded the remaining live-agent dry-run smoke uncertainty. Did not run `qmd update` or `qmd embed`.

--- a/wiki/modules/babysitter.md
+++ b/wiki/modules/babysitter.md
@@ -54,13 +54,14 @@ Each action appends one JSON object:
 
 Closed action enum: `list-prs`, `noop`, `skipped`, `agent-fix`, `force-push`, `pr-comment`, `label-apply`, `give-up`, `dry_run`.
 
-Closed outcome enum: `success`, `failure`, `timeout`, `budget_exhausted`, `gh-error`, `already-green`, `label_ignored`, `fork_pr`, `dry_run`.
+Closed outcome enum: `success`, `failure`, `timeout`, `budget_exhausted`, `gh-error`, `already-green`, `label_ignored`, `draft_pr`, `fork_pr`, `dry_run`.
 
 ## Boundaries
 
 - Separate from `Hive::Daemon`; no shared `ConcurrencyController` and no task-folder dispatch.
 - Separate PID and log files: `$HIVE_HOME/.babysitter.pid`, `$HIVE_HOME/logs/babysitter.log`.
 - Per-project opt-in only: `babysitter.enabled`.
+- Draft PRs are skipped before worktree materialization; `labels_ignore: [draft]` is not relied on because draft status is not a GitHub label.
 - No Telegram or install/service integration in v1.
 - No success PR comments.
 - Dry-run is best-effort because absolute-path binary invocations can bypass the PATH overlay. Within the overlay, the `git` / `gh` stubs are default-deny: they strip leading global options, skip unknown commands, and only pass through known read-only commands to the real binary. `gh api` only passes through when no method is supplied or the method is GET; `git config` only passes through for read forms (`--get`, `--get-all`, `--list`).


### PR DESCRIPTION
## Summary
- skip GitHub draft PRs before babysitter materializes worktrees or starts agents
- add a closed `draft_pr` skipped outcome for babysitter events
- add ProjectTick coverage proving draft PRs do not spawn `PrFixer`
- update babysitter wiki docs for draft handling

## Tests
- bundle exec ruby -Itest test/unit/babysitter/project_tick_test.rb test/unit/babysitter/events_test.rb
- bundle exec rubocop lib/hive/babysitter/project_tick.rb lib/hive/babysitter/events.rb test/unit/babysitter/project_tick_test.rb
