### PR TITLE
Hive patrol: Babysitter dry-run allows PR-closing gh commands

### DIFF
--- a/test/babysitter/acceptance/dry_run_test.rb
+++ b/test/babysitter/acceptance/dry_run_test.rb
@@ -16,6 +16,7 @@ class BabysitterAcceptanceDryRunTest < Minitest::Test
         with_replaced_singleton_method(Hive::Stages::Base, :spawn_agent, lambda { |_task, **_kwargs|
           command_results << system("git", "push", "origin", "HEAD:feature", "--force-with-lease", out: File::NULL, err: File::NULL)
           command_results << system("gh", "pr", "comment", "42", "--body", "would comment", out: File::NULL, err: File::NULL)
+          command_results << system("gh", "--repo=owner/repo", "pr", "close", "42", out: File::NULL, err: File::NULL)
           File.write(File.join(worktree_path, ".babysitter-dry-run-plan.md"), "would repair PR 42\n")
           { status: :ok }
         }) do
@@ -31,10 +32,11 @@ class BabysitterAcceptanceDryRunTest < Minitest::Test
         end
       end
 
-      assert_equal [ true, true ], command_results
+      assert_equal [ true, true, true ], command_results
       skipped = File.read(File.join(worktree_path, ".babysitter-dry-run-skipped.log"))
       assert_includes skipped, "git push origin HEAD:feature --force-with-lease"
       assert_includes skipped, "gh pr comment 42 --body would comment"
+      assert_includes skipped, "gh --repo=owner/repo pr close 42"
       assert File.exist?(File.join(worktree_path, ".babysitter-dry-run-plan.md"))
       assert babysitter_events(project).any? { |event|
         event["action"] == "dry_run" && event["outcome"] == "dry_run" && event["pr"] == 42

--- a/test/unit/babysitter/dry_run_env_test.rb
+++ b/test/unit/babysitter/dry_run_env_test.rb
@@ -35,6 +35,13 @@ class BabysitterDryRunEnvTest < Minitest::Test
       }
 
       assert_stubbed env, "gh", "-R", "owner/repo", "pr", "ready", "42"
+      assert_stubbed env, "gh", "--repo=owner/repo", "pr", "close", "42"
+      assert_stubbed env, "gh", "--repo=owner/repo", "pr", "reopen", "42"
+      assert_stubbed env, "gh", "--repo=owner/repo", "pr", "merge", "42"
+      assert_stubbed env, "gh", "--repo=owner/repo", "pr", "lock", "42"
+      assert_stubbed env, "gh", "--repo=owner/repo", "pr", "unlock", "42"
+      assert_stubbed env, "gh", "--repo=owner/repo", "pr", "edit", "42", "--add-label", "ready"
+      assert_stubbed env, "gh", "--repo=owner/repo", "pr", "edit", "42", "--add-assignee", "@me"
       assert_stubbed env, "gh", "api", "-X", "POST", "repos/owner/repo/dispatches"
       assert_stubbed env, "gh", "workflow", "run", "release.yml"
       assert_stubbed env, "gh", "totally-new-write-command", "arg"
@@ -50,6 +57,13 @@ class BabysitterDryRunEnvTest < Minitest::Test
 
       skipped = File.read(log_path)
       assert_includes skipped, "gh -R owner/repo pr ready 42 skipped"
+      assert_includes skipped, "gh --repo=owner/repo pr close 42 skipped"
+      assert_includes skipped, "gh --repo=owner/repo pr reopen 42 skipped"
+      assert_includes skipped, "gh --repo=owner/repo pr merge 42 skipped"
+      assert_includes skipped, "gh --repo=owner/repo pr lock 42 skipped"
+      assert_includes skipped, "gh --repo=owner/repo pr unlock 42 skipped"
+      assert_includes skipped, "gh --repo=owner/repo pr edit 42 --add-label ready skipped"
+      assert_includes skipped, "gh --repo=owner/repo pr edit 42 --add-assignee @me skipped"
       assert_includes skipped, "gh api -X POST repos/owner/repo/dispatches skipped"
       assert_includes skipped, "gh workflow run release.yml skipped"
       assert_includes skipped, "git -C #{dir} push origin HEAD:feature skipped"


### PR DESCRIPTION
## Hive Patrol Finding

Slice: `command-bin-hive`
Category: `security`
Severity: `medium`
Confidence: `high`
Fingerprint: `c8bdb24380268e6b53a2d16c9bb3f1aa2d42c151d503532458dc50dcbd1dbce5`

The babysitter dry-run gh stub only suppresses pr comment, pr edit, pr review, and run rerun. Other GitHub-mutating PR commands such as gh pr close are delegated to the real gh binary during a dry run, so an agent can still close a real PR even though dry-run mode is documented as preventing GitHub mutation through the PATH overlay.

## Evidence

- bin/hive-babysitter-stub-gh:30 mutating =
- bin/hive-babysitter-stub-gh:47 exec(real, *argv)
- wiki/commands/babysit.md:67 The stubs skip common mutating commands (`git push`, `gh pr comment`, `gh pr edit`, `gh run rerun`, etc.)

## Applied Fix

Expand the gh stub's denylist to cover the remaining mutating PR commands the babysitter agent could plausibly run, at minimum pr close, pr reopen, pr ready, pr merge, pr lock/unlock, and label/assignee mutations. Add unit and acceptance coverage that these commands are logged and skipped when invoked with global options such as --repo=owner/repo.

## Validation

- lint: passed (`bundle exec rubocop`)
- test: passed (`bundle exec rake test`)

## Diffstat

```text
 bin/hive-babysitter-stub-gh                | 75 +++++++++++++++++++-------
 bin/hive-babysitter-stub-git               | 49 ++++++++++-------
 lib/hive/daemon/logger.rb                  |  1 +
 test/babysitter/acceptance/dry_run_test.rb |  4 +-
 test/unit/babysitter/dry_run_env_test.rb   | 84 ++++++++++++++++++++++++++++++
 wiki/commands/babysit.md                   |  6 ++-
 wiki/gaps.md                               |  1 +
 wiki/log.md                                | 17 ++++++
 wiki/modules/babysitter.md                 |  4 +-
 9 files changed, 197 insertions(+), 44 deletions(-)

```
