### PR TITLE
Hive patrol: Dry-run gh stub lets destructive PR commands through

### DIFF
--- a/bin/hive-babysitter-stub-gh
+++ b/bin/hive-babysitter-stub-gh
@@ -27,13 +27,14 @@ loop do
   end
 end
 
-mutating =
-  rest[0, 2] == %w[pr comment] ||
-  rest[0, 2] == %w[pr edit] ||
-  rest[0, 2] == %w[pr review] ||
-  rest[0, 2] == %w[run rerun]
+read_only =
+  rest[0, 2] == %w[auth status] ||
+  rest[0, 2] == %w[pr list] ||
+  rest[0, 2] == %w[pr view] ||
+  rest[0, 2] == %w[run list] ||
+  rest[0, 2] == %w[run view]
 
-if mutating
+unless read_only
   log_skip(argv)
   warn "[dry-run] gh #{argv.join(' ')} skipped"
   exit 0

--- a/test/unit/babysitter/dry_run_env_test.rb
+++ b/test/unit/babysitter/dry_run_env_test.rb
@@ -22,4 +22,43 @@ class BabysitterDryRunEnvTest < Minitest::Test
       assert_includes log, "gh pr comment 42 --body hi skipped"
     end
   end
+
+  def test_gh_dry_run_skips_destructive_pr_commands_without_execing_real_gh
+    with_tmp_dir do |dir|
+      marker = File.join(dir, "real-gh-ran")
+      real_gh = File.join(dir, "real-gh")
+      File.write(real_gh, <<~SH)
+        #!/bin/sh
+        echo "$@" >> #{marker}
+        exit 9
+      SH
+      FileUtils.chmod("+x", real_gh)
+
+      old_real_gh = ENV["HIVE_BABYSITTER_REAL_GH"]
+      old_log = ENV["HIVE_BABYSITTER_DRY_RUN_LOG"]
+      ENV["HIVE_BABYSITTER_REAL_GH"] = real_gh
+      ENV["HIVE_BABYSITTER_DRY_RUN_LOG"] = File.join(dir, ".babysitter-dry-run-skipped.log")
+
+      begin
+        stub = File.expand_path("../../../bin/hive-babysitter-stub-gh", __dir__)
+        [
+          %w[pr close 42],
+          %w[pr merge 42],
+          %w[pr ready 42]
+        ].each do |argv|
+          _out, err, status = Open3.capture3(stub, *argv)
+          assert status.success?, err
+        end
+      ensure
+        old_real_gh.nil? ? ENV.delete("HIVE_BABYSITTER_REAL_GH") : ENV["HIVE_BABYSITTER_REAL_GH"] = old_real_gh
+        old_log.nil? ? ENV.delete("HIVE_BABYSITTER_DRY_RUN_LOG") : ENV["HIVE_BABYSITTER_DRY_RUN_LOG"] = old_log
+      end
+
+      refute File.exist?(marker), "destructive dry-run gh pr commands must not reach the real gh binary"
+      log = File.read(File.join(dir, ".babysitter-dry-run-skipped.log"))
+      assert_includes log, "gh pr close 42 skipped"
+      assert_includes log, "gh pr merge 42 skipped"
+      assert_includes log, "gh pr ready 42 skipped"
+    end
+  end
 end


### PR DESCRIPTION
## Hive Patrol Finding

Slice: `command-bin-hive-babysitter-stub-gh`
Category: `bug`
Severity: `high`
Confidence: `high`
Fingerprint: `54150388e55fd295ddc68318f8ce70a93a55f32686d5db6fe8cd8faeade8b601`

The dry-run gh wrapper only suppresses pr comment/edit/review and run rerun. Other common PR-mutating commands such as gh pr close, gh pr merge, gh pr ready, gh pr reopen, and gh pr create are classified as non-mutating and are exec'd into the real gh binary. During babysitter dry-run, an agent that invokes any of those commands can still mutate GitHub, violating the dry-run contract.

## Evidence

- bin/hive-babysitter-stub-gh:30 mutating =
- bin/hive-babysitter-stub-gh:31 rest[0, 2] == %w[pr comment] ||
- bin/hive-babysitter-stub-gh:47 exec(real, *argv)
- test/babysitter/acceptance/dry_run_test.rb:17 command_results << system("git", "push", "origin", "HEAD:feature", "--force-with-lease", out: File::NULL, err: File::NULL)
- test/babysitter/acceptance/dry_run_test.rb:18 command_results << system("gh", "pr", "comment", "42", "--body", "would comment", out: File::NULL, err: File::NULL)

## Applied Fix

Change the stub to denylist or, preferably, allowlist safe gh subcommands for dry-run. At minimum, treat all mutating gh pr subcommands (close, create, merge, ready, reopen, lock/unlock where supported, edit, comment, review) and mutating gh run actions as skipped, and add executable tests that prove close/merge/ready do not reach HIVE_BABYSITTER_REAL_GH.

## Validation

- lint: passed (`bundle exec rubocop`)
- test: passed (`bundle exec rake test`)

## Diffstat

```text
 bin/hive-babysitter-stub-gh              | 13 ++++++-----
 test/unit/babysitter/dry_run_env_test.rb | 39 ++++++++++++++++++++++++++++++++
 2 files changed, 46 insertions(+), 6 deletions(-)

```
