### PR TITLE
feat(patrol): add continuous scheduler trigger

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -162,7 +162,7 @@ daemon:
 
 patrol:
   enabled: false
-  trigger: new_commits       # or `timer`
+  trigger: continuous        # or `new_commits` / `timer`
   poll_interval_sec: 600
   agent: claude
   min_confidence_to_fix: medium

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -39,7 +39,7 @@ hive reject-finding <slug> --severity nit
 
 `hive patrol PROJECT [--dry-run] [--json]` runs one repository patrol cycle for a registered project whose `.hive-state/config.yml` has `patrol.enabled: true`. The cycle maps semantic feature slices, reviews each slice with the configured patrol agent, attempts fixes above the confidence gate in isolated worktrees, runs configured validation commands, and opens PRs only for validated fixes. It never writes to `1-inbox/` or any stage folder.
 
-The daemon can schedule patrol automatically through `patrol.trigger` (`new_commits` by default; `continuous` keeps scanning on the timer even when the default branch is unchanged) and `patrol.poll_interval_sec`, but the command is also useful for a one-off scan:
+The daemon can schedule patrol automatically through `patrol.trigger` (`continuous` by default — scans on a default-branch change or once per `poll_interval_sec`; `new_commits` restricts scanning to default-branch changes only) and `patrol.poll_interval_sec`, but the command is also useful for a one-off scan:
 
 ```bash
 hive patrol my-project --json

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -39,7 +39,7 @@ hive reject-finding <slug> --severity nit
 
 `hive patrol PROJECT [--dry-run] [--json]` runs one repository patrol cycle for a registered project whose `.hive-state/config.yml` has `patrol.enabled: true`. The cycle maps semantic feature slices, reviews each slice with the configured patrol agent, attempts fixes above the confidence gate in isolated worktrees, runs configured validation commands, and opens PRs only for validated fixes. It never writes to `1-inbox/` or any stage folder.
 
-The daemon can schedule patrol automatically through `patrol.trigger` (`new_commits` by default) and `patrol.poll_interval_sec`, but the command is also useful for a one-off scan:
+The daemon can schedule patrol automatically through `patrol.trigger` (`new_commits` by default; `continuous` keeps scanning on the timer even when the default branch is unchanged) and `patrol.poll_interval_sec`, but the command is also useful for a one-off scan:
 
 ```bash
 hive patrol my-project --json

--- a/lib/hive/config.rb
+++ b/lib/hive/config.rb
@@ -1555,7 +1555,7 @@ module Hive
       end
     end
 
-    PATROL_TRIGGERS = %w[new_commits timer].freeze
+    PATROL_TRIGGERS = %w[new_commits timer continuous].freeze
     PATROL_CONFIDENCE_LEVELS = %w[low medium high].freeze
     PATROL_NUMERIC_BOUNDS = [
       [ "poll_interval_sec", 60 ],

--- a/lib/hive/config.rb
+++ b/lib/hive/config.rb
@@ -315,7 +315,7 @@ module Hive
       # successful fixes only as GitHub PRs.
       "patrol" => {
         "enabled" => false,
-        "trigger" => "new_commits",
+        "trigger" => "continuous",
         "poll_interval_sec" => 600,
         "agent" => "claude",
         "min_confidence_to_fix" => "medium",

--- a/lib/hive/daemon/patrol_scheduler.rb
+++ b/lib/hive/daemon/patrol_scheduler.rb
@@ -122,13 +122,23 @@ module Hive
         state = read_state(entry.fetch("path"))
         case patrol.fetch("trigger", "new_commits")
         when "timer"
-          last = parse_time(state["last_run_at"])
-          last.nil? || (now - last) >= patrol.fetch("poll_interval_sec", 600)
+          timer_due?(state, patrol, now)
+        when "continuous"
+          default_branch_changed?(entry, cfg, state) || timer_due?(state, patrol, now)
         else
-          branch = @git.default_branch(entry.fetch("path"), cfg: cfg)
-          current = @git.rev_parse(entry.fetch("path"), branch)
-          current != state["last_scanned_sha"]
+          default_branch_changed?(entry, cfg, state)
         end
+      end
+
+      def timer_due?(state, patrol, now)
+        last = parse_time(state["last_run_at"])
+        last.nil? || (now - last) >= patrol.fetch("poll_interval_sec", 600)
+      end
+
+      def default_branch_changed?(entry, cfg, state)
+        branch = @git.default_branch(entry.fetch("path"), cfg: cfg)
+        current = @git.rev_parse(entry.fetch("path"), branch)
+        current != state["last_scanned_sha"]
       end
 
       def read_state(project_root)

--- a/lib/hive/daemon/patrol_scheduler.rb
+++ b/lib/hive/daemon/patrol_scheduler.rb
@@ -120,7 +120,7 @@ module Hive
 
       def due?(entry, cfg, patrol, now)
         state = read_state(entry.fetch("path"))
-        case patrol.fetch("trigger", "new_commits")
+        case patrol.fetch("trigger", "continuous")
         when "timer"
           timer_due?(state, patrol, now)
         when "continuous"

--- a/templates/project_config.yml.erb
+++ b/templates/project_config.yml.erb
@@ -189,7 +189,9 @@ babysitter:
 # to 1-inbox or any stage folder.
 patrol:
   enabled: false
-  trigger: new_commits
+  # trigger: continuous (default) scans on default-branch SHA change OR
+  # every poll_interval_sec; new_commits = SHA-change only; timer = interval only.
+  trigger: continuous
   poll_interval_sec: 600
   agent: claude
   min_confidence_to_fix: medium

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -25,7 +25,7 @@ class ConfigTest < Minitest::Test
       cfg = Hive::Config.load(dir)
 
       assert_equal false, cfg.dig("patrol", "enabled")
-      assert_equal "new_commits", cfg.dig("patrol", "trigger")
+      assert_equal "continuous", cfg.dig("patrol", "trigger")
       assert_equal 600, cfg.dig("patrol", "poll_interval_sec")
       assert_equal "claude", cfg.dig("patrol", "agent")
       assert_equal "medium", cfg.dig("patrol", "min_confidence_to_fix")

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -46,7 +46,7 @@ class ConfigTest < Minitest::Test
       File.write(File.join(dir, ".hive-state", "config.yml"), <<~YAML)
         patrol:
           enabled: true
-          trigger: timer
+          trigger: continuous
           commands:
             test: bundle exec rake test
       YAML
@@ -54,7 +54,7 @@ class ConfigTest < Minitest::Test
       cfg = Hive::Config.load(dir)
 
       assert_equal true, cfg.dig("patrol", "enabled")
-      assert_equal "timer", cfg.dig("patrol", "trigger")
+      assert_equal "continuous", cfg.dig("patrol", "trigger")
       assert_equal 600, cfg.dig("patrol", "poll_interval_sec"),
                    "sibling patrol defaults must survive deep merge"
       assert_equal "bundle exec rake test", cfg.dig("patrol", "commands", "test")
@@ -75,6 +75,7 @@ class ConfigTest < Minitest::Test
       assert_match(/patrol\.trigger/, err.message)
       assert_match(/new_commits/, err.message)
       assert_match(/timer/, err.message)
+      assert_match(/continuous/, err.message)
     end
   end
 

--- a/test/unit/daemon/patrol_scheduler_test.rb
+++ b/test/unit/daemon/patrol_scheduler_test.rb
@@ -110,6 +110,52 @@ class HiveDaemonPatrolSchedulerTest < Minitest::Test
     end
   end
 
+  def test_continuous_mode_dispatches_when_default_branch_changes_even_before_timer
+    with_tmp_dir do |dir|
+      cfg = enabled_cfg("patrol" => {
+        "enabled" => true,
+        "trigger" => "continuous",
+        "poll_interval_sec" => 600
+      })
+      write_state(dir, "last_run_at" => (T0 - 599).utc.iso8601, "last_scanned_sha" => "old")
+      git = FakeGit.new(sha: "new")
+
+      dispatches = scheduler(project_entry(dir), cfg, git: git).tick(now: T0)
+
+      assert_equal 1, dispatches.size
+    end
+  end
+
+  def test_continuous_mode_dispatches_when_timer_elapses_without_new_commits
+    with_tmp_dir do |dir|
+      cfg = enabled_cfg("patrol" => {
+        "enabled" => true,
+        "trigger" => "continuous",
+        "poll_interval_sec" => 600
+      })
+      write_state(dir, "last_run_at" => (T0 - 600).utc.iso8601, "last_scanned_sha" => "same")
+      git = FakeGit.new(sha: "same")
+
+      dispatches = scheduler(project_entry(dir), cfg, git: git).tick(now: T0)
+
+      assert_equal 1, dispatches.size
+    end
+  end
+
+  def test_continuous_mode_waits_when_timer_and_sha_are_unchanged
+    with_tmp_dir do |dir|
+      cfg = enabled_cfg("patrol" => {
+        "enabled" => true,
+        "trigger" => "continuous",
+        "poll_interval_sec" => 600
+      })
+      write_state(dir, "last_run_at" => (T0 - 599).utc.iso8601, "last_scanned_sha" => "same")
+      git = FakeGit.new(sha: "same")
+
+      assert_empty scheduler(project_entry(dir), cfg, git: git).tick(now: T0)
+    end
+  end
+
   def test_disabled_project_never_dispatches
     with_tmp_dir do |dir|
       cfg = enabled_cfg("patrol" => { "enabled" => false })

--- a/test/unit/daemon/patrol_scheduler_test.rb
+++ b/test/unit/daemon/patrol_scheduler_test.rb
@@ -86,9 +86,10 @@ class HiveDaemonPatrolSchedulerTest < Minitest::Test
 
   def test_unchanged_sha_is_not_due
     with_tmp_dir do |dir|
+      cfg = enabled_cfg("patrol" => { "enabled" => true, "trigger" => "new_commits" })
       write_state(dir, "last_scanned_sha" => "same")
       git = FakeGit.new(sha: "same")
-      assert_empty scheduler(project_entry(dir), enabled_cfg, git: git).tick(now: T0)
+      assert_empty scheduler(project_entry(dir), cfg, git: git).tick(now: T0)
     end
   end
 
@@ -198,9 +199,10 @@ class HiveDaemonPatrolSchedulerTest < Minitest::Test
   # every ~30s tick.
   def test_new_commits_due_check_is_throttled_to_poll_interval
     with_tmp_dir do |dir|
+      cfg = enabled_cfg("patrol" => { "enabled" => true, "trigger" => "new_commits" })
       write_state(dir, "last_scanned_sha" => "same")
       git = CountingGit.new(sha: "same")
-      sched = scheduler(project_entry(dir), enabled_cfg, git: git)
+      sched = scheduler(project_entry(dir), cfg, git: git)
 
       assert_empty sched.tick(now: T0)
       assert_equal 1, git.rev_parse_calls

--- a/wiki/commands/patrol.md
+++ b/wiki/commands/patrol.md
@@ -22,7 +22,7 @@ hive patrol my-project --json
 ```yaml
 patrol:
   enabled: true
-  trigger: new_commits
+  trigger: continuous
   agent: claude
   min_confidence_to_fix: medium
   max_prs_per_cycle: 3
@@ -30,6 +30,12 @@ patrol:
   commands:
     test: bundle exec rake test
 ```
+
+`patrol.trigger` accepts three modes:
+
+- `new_commits` runs only when the default branch SHA differs from `last_scanned_sha`.
+- `timer` runs whenever `last_run_at` is older than `poll_interval_sec`.
+- `continuous` is the hybrid mode for larger repos: it runs when either the default branch moved or the timer interval elapsed, so patrol can keep mining existing slices between merges while still reacting to fresh `main` changes.
 
 ## Steps
 

--- a/wiki/commands/patrol.md
+++ b/wiki/commands/patrol.md
@@ -31,11 +31,11 @@ patrol:
     test: bundle exec rake test
 ```
 
-`patrol.trigger` accepts three modes:
+`patrol.trigger` accepts three modes (default `continuous`):
 
+- `continuous` (default) is the hybrid mode: it runs when either the default branch moved or the timer interval elapsed, so patrol can keep mining existing slices between merges while still reacting to fresh `main` changes.
 - `new_commits` runs only when the default branch SHA differs from `last_scanned_sha`.
 - `timer` runs whenever `last_run_at` is older than `poll_interval_sec`.
-- `continuous` is the hybrid mode for larger repos: it runs when either the default branch moved or the timer interval elapsed, so patrol can keep mining existing slices between merges while still reacting to fresh `main` changes.
 
 ## Steps
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -2,6 +2,10 @@
 
 Append-only log of all wiki operations.
 
+## [2026-06-05T09:30:00Z] patrol - continuous hybrid trigger
+
+**Action:** Added and documented `patrol.trigger: continuous`, a hybrid daemon scheduling mode that dispatches patrol when either the default branch SHA changed or `poll_interval_sec` elapsed. This keeps large repositories under active patrol between infrequent merges while preserving the `last_scanned_sha` freshness marker after each successful scan. Updated [[commands/patrol]] and [[modules/patrol]].
+
 ## [2026-06-05T09:10:00Z] babysitter - refresh rebased PR-head cache refs
 
 **Action:** Documented the babysitter worktree fix that force-refreshes internal `refs/hive-babysitter/pr-*` cache refs when fetching `pull/<PR>/head`. The refs are Hive-owned cache refs, not user branches, so force-updating them is the correct behavior when a PR branch is rebased or force-pushed; otherwise `git fetch pull/<PR>/head:refs/hive-babysitter/pr-<PR>` can fail with a non-fast-forward reject and leave babysitter unable to inspect that PR. Updated [[modules/babysitter]].

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -2,6 +2,14 @@
 
 Append-only log of all wiki operations.
 
+## [2026-06-05T13:30:00Z] patrol - make `continuous` the default trigger
+
+**Action:** Flipped the default `patrol.trigger` from `new_commits` to `continuous` so patrol keeps mining existing feature slices on the `poll_interval_sec` timer (in addition to default-branch SHA changes) out of the box. Changed `Config::DEFAULTS["patrol"]["trigger"]`, the `PatrolScheduler#due?` fetch fallback, the init template (`templates/project_config.yml.erb`, with an inline mode comment), and the `config_test` default assertion. Refreshed [[commands/patrol]], [[modules/patrol]], and `docs/cli.md` to mark `continuous` as the default. `new_commits` / `timer` remain opt-in.
+
+**Refreshed pages:**
+- [[commands/patrol]]
+- [[modules/patrol]]
+
 ## [2026-06-05T09:30:00Z] patrol - continuous hybrid trigger
 
 **Action:** Added and documented `patrol.trigger: continuous`, a hybrid daemon scheduling mode that dispatches patrol when either the default branch SHA changed or `poll_interval_sec` elapsed. This keeps large repositories under active patrol between infrequent merges while preserving the `last_scanned_sha` freshness marker after each successful scan. Updated [[commands/patrol]] and [[modules/patrol]].

--- a/wiki/modules/patrol.md
+++ b/wiki/modules/patrol.md
@@ -43,7 +43,7 @@ The managed repository worktree is not edited by fixes. `Fixer` uses [[modules/w
 
 ## Daemon triggers
 
-`Hive::Daemon::PatrolScheduler` supports three `patrol.trigger` modes. `new_commits` preserves the original conservative behavior and dispatches only when the default branch SHA changes. `timer` dispatches solely from `last_run_at` age. `continuous` is the hybrid mode for larger repositories: it dispatches when either the default branch SHA changed or `poll_interval_sec` has elapsed, allowing patrol to keep reviewing existing feature slices between infrequent merges while still recording the current `last_scanned_sha` after each successful scan.
+`Hive::Daemon::PatrolScheduler` supports three `patrol.trigger` modes; `continuous` is the default. `continuous` is the hybrid mode for larger repositories: it dispatches when either the default branch SHA changed or `poll_interval_sec` has elapsed, allowing patrol to keep reviewing existing feature slices between infrequent merges while still recording the current `last_scanned_sha` after each successful scan. `new_commits` preserves the original conservative behavior and dispatches only when the default branch SHA changes. `timer` dispatches solely from `last_run_at` age.
 
 ## Safety invariants
 

--- a/wiki/modules/patrol.md
+++ b/wiki/modules/patrol.md
@@ -41,6 +41,10 @@ Patrol state is deliberately inspectable and removable:
 
 The managed repository worktree is not edited by fixes. `Fixer` uses [[modules/worktree]] to create a branch named `hive-patrol/<feature-id>-<fingerprint8>` under the project's worktree root.
 
+## Daemon triggers
+
+`Hive::Daemon::PatrolScheduler` supports three `patrol.trigger` modes. `new_commits` preserves the original conservative behavior and dispatches only when the default branch SHA changes. `timer` dispatches solely from `last_run_at` age. `continuous` is the hybrid mode for larger repositories: it dispatches when either the default branch SHA changed or `poll_interval_sec` has elapsed, allowing patrol to keep reviewing existing feature slices between infrequent merges while still recording the current `last_scanned_sha` after each successful scan.
+
 ## Safety invariants
 
 - Patrol is opt-in: `patrol.enabled` defaults false and the daemon still requires `daemon.enabled`.


### PR DESCRIPTION
## Summary
- add `patrol.trigger: continuous` as a hybrid scheduling mode
- dispatch patrol when either the default branch SHA changed or `poll_interval_sec` elapsed
- keep existing `new_commits` and `timer` behavior unchanged
- document the new mode in CLI/docs/wiki

## Verification
- `bundle exec ruby -Itest test/unit/daemon/patrol_scheduler_test.rb`
- `bundle exec ruby -Itest test/unit/config_test.rb`
- `ruby -c lib/hive/daemon/patrol_scheduler.rb`
- `ruby -c lib/hive/config.rb`
- `git diff --check`