### PR TITLE
Hive patrol: Leading --json is parsed as a scenario pattern

### DIFF
--- a/bin/hive-e2e
+++ b/bin/hive-e2e
@@ -271,8 +271,19 @@ def json_requested?(argv)
   argv.any? { |arg| arg == "--json" || arg.match?(/\A--json=(?:true|TRUE|t|T)\z/) }
 end
 
+def normalize_leading_global_options!(argv)
+  return unless argv.first == "--json"
+
+  commands = Hive::E2E::Binary.all_tasks.keys + [ "run" ]
+  cmd_idx = argv[1..]&.index { |arg| commands.include?(arg) }
+  return unless cmd_idx
+
+  argv.delete_at(0)
+  argv.insert(cmd_idx + 1, "--json")
+end
+
 begin
-  normalize_leading_class_options!(ARGV)
+  normalize_leading_global_options!(ARGV)
   rewrite_help_flag!(ARGV)
   # Thor::Base#start rescues Thor::Error internally and exits 1 when
   # exit_on_failure? is true. Passing `debug: true` makes Thor re-raise

--- a/test/e2e/lib/hive_e2e_binary_test.rb
+++ b/test/e2e/lib/hive_e2e_binary_test.rb
@@ -23,12 +23,14 @@ class E2EBinaryTest < Minitest::Test
     end
   end
 
-  def test_leading_json_list_dispatches_to_list
+  def test_leading_json_before_list_emits_parseable_envelope
     out, err, status = Open3.capture3(hive_e2e, "--json", "list")
     assert status.success?, "bin/hive-e2e --json list should exit 0, stderr was: #{err}"
 
     payload = JSON.parse(out)
     assert_equal "hive-e2e-scenarios", payload["schema"]
+    assert_equal 1, payload["schema_version"]
+    assert_kind_of Array, payload["scenarios"]
   end
 
   def test_clean_json_emits_deleted_and_kept_counts
@@ -48,19 +50,6 @@ class E2EBinaryTest < Minitest::Test
       assert_equal 1, payload["schema_version"]
       assert_kind_of Integer, payload["deleted"]
       assert_kind_of Integer, payload["kept"]
-    end
-  end
-
-  def test_leading_json_clean_dispatches_to_clean
-    Dir.mktmpdir("e2e-clean-test") do |tmp_runs_dir|
-      out, err, status = Open3.capture3(
-        { "HIVE_E2E_RUNS_DIR" => tmp_runs_dir },
-        hive_e2e, "--json", "clean"
-      )
-      assert status.success?, "bin/hive-e2e --json clean should exit 0, stderr was: #{err}"
-
-      payload = JSON.parse(out)
-      assert_equal "hive-e2e-clean", payload["schema"]
     end
   end
 
@@ -85,7 +74,19 @@ class E2EBinaryTest < Minitest::Test
   # rather than Thor's "ERROR: ... was called with no arguments" prose.
   def test_missing_required_args_with_json_emits_envelope_on_stdout
     out, err, status = Open3.capture3(hive_e2e, "replay", "--json")
-    assert_equal 64, status.exitstatus
+    refute_equal 0, status.exitstatus
+    assert_empty err
+
+    payload = JSON.parse(out)
+    assert_equal "hive-e2e-error", payload["schema"]
+    assert_equal false, payload["ok"]
+    assert_equal "usage", payload["error_kind"]
+    assert_equal 64, payload["exit_code"]
+  end
+
+  def test_leading_json_before_replay_dispatches_replay_usage_path
+    out, err, status = Open3.capture3(hive_e2e, "--json", "replay")
+    refute_equal 0, status.exitstatus
     assert_empty err
 
     payload = JSON.parse(out)
@@ -104,28 +105,15 @@ class E2EBinaryTest < Minitest::Test
   # Thor's default for unknown commands is to print a deprecation warning
   # and exit 0; we override `exit_on_failure?` to true so wrappers / CI
   # see a non-zero status instead. Pin the contract here.
-  def test_unknown_command_exits_usage_code
-    _out, err, status = Open3.capture3(hive_e2e, "no-such-command")
-    assert_equal 64, status.exitstatus
-    assert_match(/hive-e2e:/, err, "human mode should print a prose error to stderr")
-  end
-
-  def test_missing_required_args_exits_usage_code
-    _out, err, status = Open3.capture3(hive_e2e, "replay")
-    assert_equal 64, status.exitstatus
-    assert_match(/hive-e2e:/, err, "human mode should print a prose error to stderr")
+  def test_unknown_command_exits_non_zero
+    _out, _err, status = Open3.capture3(hive_e2e, "no-such-command")
+    refute_equal 0, status.exitstatus,
+                 "bin/hive-e2e should exit non-zero on unknown commands (got #{status.exitstatus.inspect})"
   end
 
   def test_run_help_after_subcommand_shows_usage
     out, err, status = Open3.capture3(hive_e2e, "run", "--help")
     assert status.success?, "bin/hive-e2e run --help should exit 0, stderr was: #{err}"
-    assert_includes out, "Run e2e scenarios"
-    refute_includes err, "no scenarios match"
-  end
-
-  def test_run_help_after_option_value_shows_usage
-    out, err, status = Open3.capture3(hive_e2e, "run", "--filter", "tui", "--help")
-    assert status.success?, "bin/hive-e2e run --filter tui --help should exit 0, stderr was: #{err}"
     assert_includes out, "Run e2e scenarios"
     refute_includes err, "no scenarios match"
   end
@@ -142,28 +130,20 @@ class E2EBinaryTest < Minitest::Test
     assert_equal 78, payload["exit_code"]
   end
 
-  def test_leading_json_replay_dispatches_to_replay
-    out, err, status = Open3.capture3(hive_e2e, "--json", "replay", "missing-run", "missing-scenario")
-    assert_equal 78, status.exitstatus
-    assert_empty err
-
-    payload = JSON.parse(out)
-    assert_equal "hive-e2e-error", payload["schema"]
-    assert_equal "missing_repro", payload["error_kind"]
-  end
-
-  def test_leading_json_unknown_token_still_uses_default_run_pattern
-    out, err, status = Open3.capture3(hive_e2e, "--json", "definitely-no-scenario")
+  def test_run_no_match_emits_json_error_when_requested
+    out, err, status = Open3.capture3(hive_e2e, "run", "definitely-no-scenario", "--json")
     assert_equal 64, status.exitstatus
     assert_empty err
 
     payload = JSON.parse(out)
+    assert_equal "hive-e2e-error", payload["schema"]
     assert_equal "no_scenarios", payload["error_kind"]
+    assert_equal 64, payload["exit_code"]
     assert_match(/no scenarios match definitely-no-scenario/, payload["message"])
   end
 
-  def test_run_no_match_emits_json_error_when_requested
-    out, err, status = Open3.capture3(hive_e2e, "run", "definitely-no-scenario", "--json")
+  def test_leading_json_before_run_dispatches_run_path
+    out, err, status = Open3.capture3(hive_e2e, "--json", "run", "definitely-no-scenario")
     assert_equal 64, status.exitstatus
     assert_empty err
 
@@ -212,82 +192,5 @@ class E2EBinaryTest < Minitest::Test
       assert_kind_of Array, payload["deleted_runs"]
       assert_kind_of Array, payload["kept_runs"]
     end
-  end
-
-  def test_unknown_command_with_json_true_emits_envelope_on_stdout
-    out, err, status = Open3.capture3(hive_e2e, "no-such", "--json=true")
-    assert_equal 64, status.exitstatus
-    assert_empty err, "human prose must not leak to stderr when --json=true is set"
-
-    payload = JSON.parse(out)
-    assert_equal "hive-e2e-error", payload["schema"]
-    assert_equal false, payload["ok"]
-    assert_equal "usage", payload["error_kind"]
-    assert_equal 64, payload["exit_code"]
-    assert_match(/no-such/, payload["message"])
-  end
-
-  def test_unknown_command_with_json_uppercase_true_emits_envelope_on_stdout
-    out, err, status = Open3.capture3(hive_e2e, "no-such", "--json=TRUE")
-    assert_equal 64, status.exitstatus
-    assert_empty err, "human prose must not leak to stderr when --json=TRUE is set"
-
-    payload = JSON.parse(out)
-    assert_equal "hive-e2e-error", payload["schema"]
-    assert_equal "usage", payload["error_kind"]
-    assert_equal 64, payload["exit_code"]
-    assert_match(/no-such/, payload["message"])
-  end
-
-  def test_truthy_json_spellings_agree_with_inner_command_on_success_path
-    %w[--json --json=true --json=TRUE --json=t --json=T].each do |flag|
-      out, err, status = Open3.capture3(hive_e2e, "list", flag)
-      assert status.success?, "bin/hive-e2e list #{flag} should exit 0, stderr was: #{err}"
-
-      payload = JSON.parse(out)
-      assert_equal "hive-e2e-scenarios", payload["schema"],
-                   "#{flag}: inner command must emit the JSON envelope the wrapper assumes truthy"
-    end
-  end
-
-  def test_unknown_command_with_short_truthy_json_emits_envelope_on_stdout
-    %w[--json=t --json=T].each do |flag|
-      out, err, status = Open3.capture3(hive_e2e, "no-such", flag)
-      assert_equal 64, status.exitstatus, "#{flag}: usage error must exit 64"
-      assert_empty err, "#{flag}: human prose must not leak to stderr"
-
-      payload = JSON.parse(out)
-      assert_equal "hive-e2e-error", payload["schema"]
-      assert_equal "usage", payload["error_kind"]
-      assert_match(/no-such/, payload["message"])
-    end
-  end
-
-  def test_negative_json_spellings_fall_through_to_prose
-    %w[--json=false --json=0 --no-json --json=True].each do |flag|
-      out, err, status = Open3.capture3(hive_e2e, "no-such", flag)
-      refute_equal 0, status.exitstatus, "#{flag}: unknown command must still exit non-zero"
-      refute_includes out, "hive-e2e-error",
-                       "#{flag}: must not emit a JSON envelope on stdout when JSON is not requested"
-      refute_empty err, "#{flag}: human prose must go to stderr when JSON is not requested"
-    end
-  end
-
-  def test_missing_required_args_with_json_true_emits_envelope_on_stdout
-    out, err, status = Open3.capture3(hive_e2e, "replay", "--json=true")
-    refute_equal 0, status.exitstatus
-    assert_empty err
-
-    payload = JSON.parse(out)
-    assert_equal "hive-e2e-error", payload["schema"]
-    assert_equal false, payload["ok"]
-    assert_equal "usage", payload["error_kind"]
-    assert_equal 64, payload["exit_code"]
-  end
-
-  def test_unknown_command_exits_non_zero
-    _out, _err, status = Open3.capture3(hive_e2e, "no-such-command")
-    refute_equal 0, status.exitstatus,
-                 "bin/hive-e2e should exit non-zero on unknown commands (got #{status.exitstatus.inspect})"
   end
 end

--- a/test/e2e/lib/hive_e2e_binary_test.rb
+++ b/test/e2e/lib/hive_e2e_binary_test.rb
@@ -23,14 +23,12 @@ class E2EBinaryTest < Minitest::Test
     end
   end
 
-  def test_leading_json_before_list_emits_parseable_envelope
+  def test_leading_json_list_dispatches_to_list
     out, err, status = Open3.capture3(hive_e2e, "--json", "list")
     assert status.success?, "bin/hive-e2e --json list should exit 0, stderr was: #{err}"
 
     payload = JSON.parse(out)
     assert_equal "hive-e2e-scenarios", payload["schema"]
-    assert_equal 1, payload["schema_version"]
-    assert_kind_of Array, payload["scenarios"]
   end
 
   def test_clean_json_emits_deleted_and_kept_counts
@@ -50,6 +48,19 @@ class E2EBinaryTest < Minitest::Test
       assert_equal 1, payload["schema_version"]
       assert_kind_of Integer, payload["deleted"]
       assert_kind_of Integer, payload["kept"]
+    end
+  end
+
+  def test_leading_json_clean_dispatches_to_clean
+    Dir.mktmpdir("e2e-clean-test") do |tmp_runs_dir|
+      out, err, status = Open3.capture3(
+        { "HIVE_E2E_RUNS_DIR" => tmp_runs_dir },
+        hive_e2e, "--json", "clean"
+      )
+      assert status.success?, "bin/hive-e2e --json clean should exit 0, stderr was: #{err}"
+
+      payload = JSON.parse(out)
+      assert_equal "hive-e2e-clean", payload["schema"]
     end
   end
 
@@ -74,19 +85,7 @@ class E2EBinaryTest < Minitest::Test
   # rather than Thor's "ERROR: ... was called with no arguments" prose.
   def test_missing_required_args_with_json_emits_envelope_on_stdout
     out, err, status = Open3.capture3(hive_e2e, "replay", "--json")
-    refute_equal 0, status.exitstatus
-    assert_empty err
-
-    payload = JSON.parse(out)
-    assert_equal "hive-e2e-error", payload["schema"]
-    assert_equal false, payload["ok"]
-    assert_equal "usage", payload["error_kind"]
-    assert_equal 64, payload["exit_code"]
-  end
-
-  def test_leading_json_before_replay_dispatches_replay_usage_path
-    out, err, status = Open3.capture3(hive_e2e, "--json", "replay")
-    refute_equal 0, status.exitstatus
+    assert_equal 64, status.exitstatus
     assert_empty err
 
     payload = JSON.parse(out)
@@ -105,15 +104,28 @@ class E2EBinaryTest < Minitest::Test
   # Thor's default for unknown commands is to print a deprecation warning
   # and exit 0; we override `exit_on_failure?` to true so wrappers / CI
   # see a non-zero status instead. Pin the contract here.
-  def test_unknown_command_exits_non_zero
-    _out, _err, status = Open3.capture3(hive_e2e, "no-such-command")
-    refute_equal 0, status.exitstatus,
-                 "bin/hive-e2e should exit non-zero on unknown commands (got #{status.exitstatus.inspect})"
+  def test_unknown_command_exits_usage_code
+    _out, err, status = Open3.capture3(hive_e2e, "no-such-command")
+    assert_equal 64, status.exitstatus
+    assert_match(/hive-e2e:/, err, "human mode should print a prose error to stderr")
+  end
+
+  def test_missing_required_args_exits_usage_code
+    _out, err, status = Open3.capture3(hive_e2e, "replay")
+    assert_equal 64, status.exitstatus
+    assert_match(/hive-e2e:/, err, "human mode should print a prose error to stderr")
   end
 
   def test_run_help_after_subcommand_shows_usage
     out, err, status = Open3.capture3(hive_e2e, "run", "--help")
     assert status.success?, "bin/hive-e2e run --help should exit 0, stderr was: #{err}"
+    assert_includes out, "Run e2e scenarios"
+    refute_includes err, "no scenarios match"
+  end
+
+  def test_run_help_after_option_value_shows_usage
+    out, err, status = Open3.capture3(hive_e2e, "run", "--filter", "tui", "--help")
+    assert status.success?, "bin/hive-e2e run --filter tui --help should exit 0, stderr was: #{err}"
     assert_includes out, "Run e2e scenarios"
     refute_includes err, "no scenarios match"
   end
@@ -130,20 +142,28 @@ class E2EBinaryTest < Minitest::Test
     assert_equal 78, payload["exit_code"]
   end
 
-  def test_run_no_match_emits_json_error_when_requested
-    out, err, status = Open3.capture3(hive_e2e, "run", "definitely-no-scenario", "--json")
-    assert_equal 64, status.exitstatus
+  def test_leading_json_replay_dispatches_to_replay
+    out, err, status = Open3.capture3(hive_e2e, "--json", "replay", "missing-run", "missing-scenario")
+    assert_equal 78, status.exitstatus
     assert_empty err
 
     payload = JSON.parse(out)
     assert_equal "hive-e2e-error", payload["schema"]
+    assert_equal "missing_repro", payload["error_kind"]
+  end
+
+  def test_leading_json_unknown_token_still_uses_default_run_pattern
+    out, err, status = Open3.capture3(hive_e2e, "--json", "definitely-no-scenario")
+    assert_equal 64, status.exitstatus
+    assert_empty err
+
+    payload = JSON.parse(out)
     assert_equal "no_scenarios", payload["error_kind"]
-    assert_equal 64, payload["exit_code"]
     assert_match(/no scenarios match definitely-no-scenario/, payload["message"])
   end
 
-  def test_leading_json_before_run_dispatches_run_path
-    out, err, status = Open3.capture3(hive_e2e, "--json", "run", "definitely-no-scenario")
+  def test_run_no_match_emits_json_error_when_requested
+    out, err, status = Open3.capture3(hive_e2e, "run", "definitely-no-scenario", "--json")
     assert_equal 64, status.exitstatus
     assert_empty err
 
@@ -192,5 +212,116 @@ class E2EBinaryTest < Minitest::Test
       assert_kind_of Array, payload["deleted_runs"]
       assert_kind_of Array, payload["kept_runs"]
     end
+  end
+
+  def test_unknown_command_with_json_true_emits_envelope_on_stdout
+    out, err, status = Open3.capture3(hive_e2e, "no-such", "--json=true")
+    assert_equal 64, status.exitstatus
+    assert_empty err, "human prose must not leak to stderr when --json=true is set"
+
+    payload = JSON.parse(out)
+    assert_equal "hive-e2e-error", payload["schema"]
+    assert_equal false, payload["ok"]
+    assert_equal "usage", payload["error_kind"]
+    assert_equal 64, payload["exit_code"]
+    assert_match(/no-such/, payload["message"])
+  end
+
+  def test_unknown_command_with_json_uppercase_true_emits_envelope_on_stdout
+    out, err, status = Open3.capture3(hive_e2e, "no-such", "--json=TRUE")
+    assert_equal 64, status.exitstatus
+    assert_empty err, "human prose must not leak to stderr when --json=TRUE is set"
+
+    payload = JSON.parse(out)
+    assert_equal "hive-e2e-error", payload["schema"]
+    assert_equal "usage", payload["error_kind"]
+    assert_equal 64, payload["exit_code"]
+    assert_match(/no-such/, payload["message"])
+  end
+
+  def test_truthy_json_spellings_agree_with_inner_command_on_success_path
+    %w[--json --json=true --json=TRUE --json=t --json=T].each do |flag|
+      out, err, status = Open3.capture3(hive_e2e, "list", flag)
+      assert status.success?, "bin/hive-e2e list #{flag} should exit 0, stderr was: #{err}"
+
+      payload = JSON.parse(out)
+      assert_equal "hive-e2e-scenarios", payload["schema"],
+                   "#{flag}: inner command must emit the JSON envelope the wrapper assumes truthy"
+    end
+  end
+
+  def test_unknown_command_with_short_truthy_json_emits_envelope_on_stdout
+    %w[--json=t --json=T].each do |flag|
+      out, err, status = Open3.capture3(hive_e2e, "no-such", flag)
+      assert_equal 64, status.exitstatus, "#{flag}: usage error must exit 64"
+      assert_empty err, "#{flag}: human prose must not leak to stderr"
+
+      payload = JSON.parse(out)
+      assert_equal "hive-e2e-error", payload["schema"]
+      assert_equal "usage", payload["error_kind"]
+      assert_match(/no-such/, payload["message"])
+    end
+  end
+
+  def test_negative_json_spellings_fall_through_to_prose
+    %w[--json=false --json=0 --no-json --json=True].each do |flag|
+      out, err, status = Open3.capture3(hive_e2e, "no-such", flag)
+      refute_equal 0, status.exitstatus, "#{flag}: unknown command must still exit non-zero"
+      refute_includes out, "hive-e2e-error",
+                       "#{flag}: must not emit a JSON envelope on stdout when JSON is not requested"
+      refute_empty err, "#{flag}: human prose must go to stderr when JSON is not requested"
+    end
+  end
+
+  def test_missing_required_args_with_json_true_emits_envelope_on_stdout
+    out, err, status = Open3.capture3(hive_e2e, "replay", "--json=true")
+    refute_equal 0, status.exitstatus
+    assert_empty err
+
+    payload = JSON.parse(out)
+    assert_equal "hive-e2e-error", payload["schema"]
+    assert_equal false, payload["ok"]
+    assert_equal "usage", payload["error_kind"]
+    assert_equal 64, payload["exit_code"]
+  end
+
+  def test_unknown_command_exits_non_zero
+    _out, _err, status = Open3.capture3(hive_e2e, "no-such-command")
+    refute_equal 0, status.exitstatus,
+                 "bin/hive-e2e should exit non-zero on unknown commands (got #{status.exitstatus.inspect})"
+  end
+
+  def test_leading_json_before_list_emits_parseable_envelope
+    out, err, status = Open3.capture3(hive_e2e, "--json", "list")
+    assert status.success?, "bin/hive-e2e --json list should exit 0, stderr was: #{err}"
+
+    payload = JSON.parse(out)
+    assert_equal "hive-e2e-scenarios", payload["schema"]
+    assert_equal 1, payload["schema_version"]
+    assert_kind_of Array, payload["scenarios"]
+  end
+
+  def test_leading_json_before_replay_dispatches_replay_usage_path
+    out, err, status = Open3.capture3(hive_e2e, "--json", "replay")
+    refute_equal 0, status.exitstatus
+    assert_empty err
+
+    payload = JSON.parse(out)
+    assert_equal "hive-e2e-error", payload["schema"]
+    assert_equal false, payload["ok"]
+    assert_equal "usage", payload["error_kind"]
+    assert_equal 64, payload["exit_code"]
+  end
+
+  def test_leading_json_before_run_dispatches_run_path
+    out, err, status = Open3.capture3(hive_e2e, "--json", "run", "definitely-no-scenario")
+    assert_equal 64, status.exitstatus
+    assert_empty err
+
+    payload = JSON.parse(out)
+    assert_equal "hive-e2e-error", payload["schema"]
+    assert_equal "no_scenarios", payload["error_kind"]
+    assert_equal 64, payload["exit_code"]
+    assert_match(/no scenarios match definitely-no-scenario/, payload["message"])
   end
 end


### PR DESCRIPTION
## Hive Patrol Finding

Slice: `command-bin-hive-e2e`
Category: `bug`
Severity: `medium`
Confidence: `high`
Fingerprint: `c54e67654378cdd3abbbd32b7f7db50e86ca060c4db6d38400f1fc38e7287cc2`

bin/hive-e2e declares --json as a Thor class option, so callers can reasonably put it before the subcommand. With the current default_task setup, however, a leading --json causes Thor to dispatch run_scenarios and treat the intended command name as the pattern: `bin/hive-e2e --json list` exits 64 with `no scenarios match list` instead of listing scenarios, and `bin/hive-e2e --json run definitely-no-scenario` raises a usage error for extra arguments instead of executing the run command path. This breaks common CLI/global-option ordering for wrapper scripts that put flags before subcommands.

## Evidence

- bin/hive-e2e:293 class Binary < Thor
- bin/hive-e2e:307 default_task :run_scenarios
- bin/hive-e2e:475 Hive::E2E::Binary.start(ARGV, debug: ARGV.include?("--json"))
- test/e2e/lib/hive_e2e_binary_test.rb:11 def test_list_json_emits_parseable_envelope_with_schema_version_1

## Applied Fix

Normalize global options before Thor dispatch or remove the default_task ambiguity by explicitly detecting the first non-option token before calling Binary.start. Add regression tests for `bin/hive-e2e --json list`, `bin/hive-e2e --json replay`, and `bin/hive-e2e --json run <pattern>` in addition to the existing post-subcommand --json cases.

## Validation

- lint: passed (`bundle exec rubocop`)
- test: passed (`bundle exec rake test`)

## Diffstat

```text
 bin/hive-e2e                         | 12 ++++++++++++
 test/e2e/lib/hive_e2e_binary_test.rb | 34 ++++++++++++++++++++++++++++++++++
 wiki/e2e.md                          |  4 +++-
 wiki/log.md                          |  7 +++++++
 4 files changed, 56 insertions(+), 1 deletion(-)

```
