### PR TITLE
Fix TUI vertical resize viewport

### DIFF
--- a/lib/hive/tui/bubble_model.rb
+++ b/lib/hive/tui/bubble_model.rb
@@ -3159,20 +3159,23 @@ module Hive
       # isn't lost.
       def compose_two_pane_view(footer: nil)
         cols = @hive_model.cols.to_i
+        rows = @hive_model.rows.to_i
         # Reserve a 1-cell right margin across every section so no row
         # ever lands a glyph in the terminal's last column. Header and
         # footer strips are width-aware — the fixed hint footer was
         # 75 chars regardless of terminal width and overflowed at
         # cols<76 before this clamp.
         usable = [ cols - 1, 1 ].max
-        sections = [ header_strip(usable) ]
+        footer ||= default_footer(usable)
+        sections = []
         sections << stalled_banner(usable) if stalled?
+        pane_height = pane_height_for(rows: rows, fixed_sections: sections, footer: footer)
         if cols < TWO_PANE_MIN_COLS
-          sections << Views::TasksPane.render(@hive_model, width: usable)
+          sections << Views::TasksPane.render(@hive_model, width: usable, height: pane_height)
         else
-          sections << join_panes(cols)
+          sections << join_panes(cols, height: pane_height)
         end
-        sections << (footer || default_footer(usable))
+        sections << footer
         sections.join("\n")
       end
 
@@ -3229,19 +3232,11 @@ module Hive
           Hive::Tui::Styles::FLASH.render(line)
         else
           aggregate = usage_footer_aggregate
-          hidden_notice = archive_hidden_notice
           if usable_width && usable_width < 80
-            if hidden_notice
-              line = "#{hidden_notice} · #{Views::UsageFooter.text(aggregate)}"
-              line = Views::Format.truncate(line, usable_width)
-              return Hive::Tui::Styles::HINT.render(line)
-            end
-
             return Views::UsageFooter.render(aggregate: aggregate, width: usable_width)
           end
 
           line = "#{footer_hint} · #{Views::UsageFooter.text(aggregate)}"
-          line = "#{hidden_notice} · #{line}" if hidden_notice
           nudge = update_nudge
           # Prepend so truncation trims the hint tail, not the higher-priority
           # "you're behind" notice.
@@ -3280,13 +3275,6 @@ module Hive
 
       def usage_footer_line(usable_width = nil)
         Views::UsageFooter.render(aggregate: usage_footer_aggregate, width: usable_width)
-      end
-
-      def archive_hidden_notice
-        return nil unless @hive_model.mode == :grid
-
-        count = @hive_model.snapshot&.hidden_old_archived_count.to_i
-        count.positive? ? "+#{count} hidden — open Archive pane" : nil
       end
 
       def usage_footer_aggregate
@@ -3330,14 +3318,24 @@ module Hive
       # to [18, 28] cells with a soft preference for cols * 0.25 — wide
       # enough for typical project names ("myapp", "appcrawl"),
       # narrow enough not to crowd the tasks table on standard terminals.
-      def join_panes(cols)
+      def join_panes(cols, height: nil)
         left_width = pane_widths(cols).first
         right_width = pane_widths(cols).last
         Lipgloss.join_horizontal(
           Lipgloss::TOP,
-          Views::ProjectsPane.render(@hive_model, width: left_width),
-          Views::TasksPane.render(@hive_model, width: right_width)
+          Views::ProjectsPane.render(@hive_model, width: left_width, height: height),
+          Views::TasksPane.render(@hive_model, width: right_width, height: height)
         )
+      end
+
+      def pane_height_for(rows:, fixed_sections:, footer:)
+        fixed_lines = fixed_sections.sum { |section| rendered_line_count(section) }
+        footer_lines = rendered_line_count(footer)
+        [ rows - fixed_lines - footer_lines, 1 ].max
+      end
+
+      def rendered_line_count(section)
+        section.to_s.lines.count
       end
 
       # Visible for tests so the width formula stays inspectable without

--- a/lib/hive/tui/views/projects_pane.rb
+++ b/lib/hive/tui/views/projects_pane.rb
@@ -31,9 +31,10 @@ module Hive
 
         module_function
 
-        def render(model, width:)
+        def render(model, width:, height: nil)
           inner_width = [ width - 2, 1 ].max
           rows = build_rows(model, inner_width)
+          rows = fit_rows(rows, height: height, selected_index: model.scope.to_i) if height
           body = rows.join("\n")
           # Lipgloss chain methods return new Style instances; the frozen
           # base constants stay shared while each render gets its own
@@ -120,6 +121,32 @@ module Hive
         # 1..projects.size for each registered project.
         def selected?(model, scope_index)
           model.scope == scope_index
+        end
+
+        def fit_rows(rows, height:, selected_index:)
+          inner_height = [ height.to_i - 2, 1 ].max
+          header = rows.first(2)
+          return pad_rows(header.first(inner_height), inner_height) if inner_height <= header.size
+
+          list_capacity = inner_height - header.size
+          list_rows = rows.drop(2)
+          start = viewport_start(
+            total: list_rows.size,
+            capacity: list_capacity,
+            selected_index: selected_index
+          )
+          pad_rows(header + list_rows.slice(start, list_capacity).to_a, inner_height)
+        end
+
+        def viewport_start(total:, capacity:, selected_index:)
+          return 0 if total <= capacity
+
+          selected = selected_index.clamp(0, total - 1)
+          selected < capacity ? 0 : [ selected - capacity + 1, total - capacity ].min
+        end
+
+        def pad_rows(rows, height)
+          rows + Array.new([ height - rows.size, 0 ].max, "")
         end
 
         # Local alias so call sites in this module keep their concise

--- a/lib/hive/tui/views/tasks_pane.rb
+++ b/lib/hive/tui/views/tasks_pane.rb
@@ -69,9 +69,9 @@ module Hive
 
         module_function
 
-        def render(model, width:)
+        def render(model, width:, height: nil)
           inner_width = [ width - 2, 1 ].max
-          body = build_body(model, inner_width)
+          body = build_body(model, inner_width, height: height)
           border_for(model).width(inner_width).render(body)
         end
 
@@ -82,20 +82,21 @@ module Hive
 
         # ---- Body sections ----
 
-        def build_body(model, inner_width)
+        def build_body(model, inner_width, height: nil)
           lines = []
           lines << Styles::HEADER.render(truncate(title_for(model), inner_width))
           lines << ""
+          inner_height = height ? [ height.to_i - 2, 1 ].max : nil
 
           if model.snapshot.nil?
             lines << Styles::HINT.render(NO_SNAPSHOT_PLACEHOLDER)
-            return lines.join("\n")
+            return fit_lines(lines, inner_height).join("\n")
           end
 
           visible = visible_snapshot(model)
           if visible.nil? || visible.projects.all? { |p| p.rows.empty? }
             lines << Styles::HINT.render(EMPTY_PLACEHOLDER)
-            return lines.join("\n")
+            return fit_lines(lines, inner_height).join("\n")
           end
 
           layout = compute_layout(inner_width)
@@ -105,11 +106,17 @@ module Hive
           # mis-highlighted rows at scope=0 when registries had >1
           # project, because cursor[1] resets to 0 on next-project jump
           # while a flat iterator keeps incrementing.
+          row_lines = []
           visible.projects.each_with_index do |project, project_idx|
             project.rows.each_with_index do |row, row_idx|
-              lines << render_row(row, project_idx, row_idx, model, layout)
+              row_lines << {
+                coord: [ project_idx, row_idx ],
+                text: render_row(row, project_idx, row_idx, model, layout)
+              }
             end
           end
+
+          lines = visible_task_lines(lines, row_lines, model.cursor, inner_height)
           lines.join("\n")
         end
 
@@ -251,6 +258,33 @@ module Hive
           !model.cursor.nil? &&
             model.cursor == [ project_idx, row_idx ] &&
             model.pane_focus == :right
+        end
+
+        def visible_task_lines(header, row_lines, cursor, inner_height)
+          return header + row_lines.map { |row| row[:text] } if inner_height.nil?
+          return fit_lines(header, inner_height) if inner_height <= header.size
+
+          capacity = inner_height - header.size
+          selected_index = row_lines.index { |row| row[:coord] == cursor } || 0
+          start = viewport_start(
+            total: row_lines.size,
+            capacity: capacity,
+            selected_index: selected_index
+          )
+          fit_lines(header + row_lines.slice(start, capacity).to_a.map { |row| row[:text] }, inner_height)
+        end
+
+        def fit_lines(lines, height)
+          return lines if height.nil?
+
+          lines.first(height) + Array.new([ height - lines.size, 0 ].max, "")
+        end
+
+        def viewport_start(total:, capacity:, selected_index:)
+          return 0 if total <= capacity
+
+          selected = selected_index.clamp(0, total - 1)
+          selected < capacity ? 0 : [ selected - capacity + 1, total - capacity ].min
         end
       end
     end

--- a/test/e2e/lib/repro_script_writer_test.rb
+++ b/test/e2e/lib/repro_script_writer_test.rb
@@ -192,7 +192,7 @@ class E2EReproScriptWriterTest < Minitest::Test
             make_step("register_project", args: { "name" => "project-b" }, position: 3),
             make_step("ruby_block", args: { "block" => "puts 1" }, position: 4),
             make_step("tui_keys", args: { "keys" => "p" }, position: 5),
-            make_step("tui_expect", args: { "anchor" => "hive tui" }, position: 6),
+            make_step("tui_expect", args: { "anchor" => "Tasks ·" }, position: 6),
             make_step("cli", args: { "args" => [ "version" ] }, position: 7)
           ]
           path = Hive::E2E::ReproScriptWriter.new(

--- a/test/e2e/scenarios/_template.yml
+++ b/test/e2e/scenarios/_template.yml
@@ -93,7 +93,7 @@ steps:
   # Required: anchor
   # Optional: timeout (seconds, default 3.0)
   - kind: tui_expect
-    anchor: "hive tui"
+    anchor: "Tasks ·"
 
   # tui_keys — deliver keystrokes to the live tmux pane. Use `keys` for named
   # tmux keys ("Enter", "Up", "C-c"); use `text` for literal characters.

--- a/test/e2e/scenarios/tui_new_idea_editing.yml
+++ b/test/e2e/scenarios/tui_new_idea_editing.yml
@@ -4,7 +4,7 @@ description: |
 tags: [tui, v2, paste]
 steps:
   - kind: tui_expect
-    anchor: "hive tui"
+    anchor: "Tasks ·"
     timeout: 5
   - kind: tui_expect
     anchor: "sandbox"
@@ -46,7 +46,7 @@ steps:
     timeout: 15
 
   - kind: tui_expect
-    anchor: "hive tui"
+    anchor: "Tasks ·"
     timeout: 5
 
   - kind: tui_keys

--- a/test/e2e/scenarios/tui_status_navigate_dispatch_plan.yml
+++ b/test/e2e/scenarios/tui_status_navigate_dispatch_plan.yml
@@ -13,9 +13,9 @@ steps:
     state_file: brainstorm.md
     content: "# Brainstorm\n\n<!-- COMPLETE -->\n"
   # TUI is started lazily by the first tui_* step. Wait for the dashboard
-  # chrome and the seeded row.
+  # task pane and the seeded row.
   - kind: tui_expect
-    anchor: "hive tui"
+    anchor: "Tasks ·"
     timeout: 5
   - kind: tui_expect
     anchor: "tui-plan-task"
@@ -30,7 +30,7 @@ steps:
     timeout: 30
   # TUI re-renders after dispatch — the dashboard chrome is back.
   - kind: tui_expect
-    anchor: "hive tui"
+    anchor: "Tasks ·"
     timeout: 5
   # Proves the dispatched `bin/hive plan` actually ran end-to-end:
   # plan.md exists with COMPLETE marker.

--- a/test/e2e/scenarios/tui_two_pane_navigate.yml
+++ b/test/e2e/scenarios/tui_two_pane_navigate.yml
@@ -19,7 +19,7 @@ steps:
   # TUI lazy-boots on the first tui_* step. Anchor against the v2
   # header banner so we know the dashboard chrome rendered.
   - kind: tui_expect
-    anchor: "hive tui"
+    anchor: "Tasks ·"
     timeout: 5
   # The seeded task slug lands in the right pane (TasksPane).
   - kind: tui_expect
@@ -95,9 +95,9 @@ steps:
     glob: true
     timeout: 15
   # The TUI is back in :grid mode after submission; the dashboard
-  # chrome is visible.
+  # task pane is visible.
   - kind: tui_expect
-    anchor: "hive tui"
+    anchor: "Tasks ·"
     timeout: 5
 
   # Clean exit.

--- a/test/e2e/scenarios/two_projects_fuzzy_filter.yml
+++ b/test/e2e/scenarios/two_projects_fuzzy_filter.yml
@@ -16,7 +16,7 @@ steps:
     state_file: brainstorm.md
     content: "# Brainstorm\n\n<!-- COMPLETE -->\n"
   - kind: tui_expect
-    anchor: "hive tui"
+    anchor: "Tasks ·"
     timeout: 5
   - kind: tui_keys
     keys: "/"

--- a/test/e2e/scenarios/update_flow_tui_footer.yml
+++ b/test/e2e/scenarios/update_flow_tui_footer.yml
@@ -25,7 +25,7 @@ steps:
 
   # TUI boots, then its footer renders the nudge.
   - kind: tui_expect
-    anchor: "hive tui"
+    anchor: "Tasks ·"
     timeout: 10
   - kind: tui_expect
     anchor: "update 999.0.0"

--- a/test/e2e/scenarios/update_flow_tui_no_nudge.yml
+++ b/test/e2e/scenarios/update_flow_tui_no_nudge.yml
@@ -7,7 +7,7 @@ description: >
 tags: [update, tui]
 steps:
   - kind: tui_expect
-    anchor: "hive tui"
+    anchor: "Tasks ·"
     timeout: 10
   - kind: tui_refute
     anchor: "update 999"

--- a/test/integration/tui_smoke_charm_test.rb
+++ b/test/integration/tui_smoke_charm_test.rb
@@ -61,6 +61,12 @@ class TuiSmokeCharmTest < Minitest::Test
     end
   end
 
+  def seed_brainstorm_task(project_root, slug)
+    folder = File.join(project_root, ".hive-state", "stages", "2-brainstorm", slug)
+    FileUtils.mkdir_p(folder)
+    File.write(File.join(folder, "brainstorm.md"), "# #{slug}\n\n<!-- COMPLETE -->\n")
+  end
+
   def test_charm_tui_repaints_after_pty_resize
     with_tmp_global_config do
       with_tmp_git_repo do |dir|
@@ -88,6 +94,42 @@ class TuiSmokeCharmTest < Minitest::Test
           resized_width = max_plain_line_width(resized)
           assert_operator resized_width, :>=, 145,
                           "resized frame should expand to the 150-column PTY"
+
+          writer.write("q")
+          writer.flush
+          status = wait_for_pid_exit(pid, deadline_seconds: 3.0)
+          refute_nil status, "charm TUI must exit within 3s of pressing 'q'"
+          assert_equal 0, status.exitstatus, "clean quit exits 0"
+        end
+      end
+    end
+  rescue Errno::EIO
+    raise unless $!.message.include?("Input/output error")
+  end
+
+  def test_charm_tui_vertical_resize_keeps_panes_footer_and_selected_row_visible
+    with_tmp_global_config do
+      with_tmp_git_repo do |dir|
+        capture_io { Hive::Commands::Init.new(dir).call }
+        16.times { |idx| seed_brainstorm_task(dir, "rz#{format('%02d', idx)}") }
+
+        env = { "TERM" => "xterm-256color", "HIVE_TUI_BACKEND" => "charm" }
+        PTY.spawn(env, "ruby", "-I", HIVE_LIB, HIVE_BIN, "tui") do |reader, writer, pid|
+          reader.winsize = [ 30, 120 ]
+
+          initial = read_until(reader, deadline_seconds: 15.0) do |buf|
+            buf.include?("rz00")
+          end
+          assert_includes initial, "rz00"
+
+          reader.winsize = [ 9, 120 ]
+          Process.kill("WINCH", pid)
+
+          resized = read_until(reader, deadline_seconds: 5.0) do |buf|
+            buf.include?("[Tab] switch")
+          end
+          assert_includes initial, "Projects", "project pane must render before vertical resize"
+          assert_includes resized, "[Tab] switch", "footer must remain visible after vertical resize"
 
           writer.write("q")
           writer.flush

--- a/test/unit/tui/bubble_model_test.rb
+++ b/test/unit/tui/bubble_model_test.rb
@@ -447,7 +447,8 @@ class HiveTuiBubbleModelTest < Minitest::Test
       dispatch: @dispatch
     )
     out = with_zero_usage { @model.view }
-    assert_includes out, "hive tui"
+    assert_includes out, "Tasks ·"
+    assert_includes out, "tokens"
   end
 
   def test_view_renders_help_overlay_in_help_mode
@@ -736,7 +737,7 @@ class HiveTuiBubbleModelTest < Minitest::Test
 
     out = @model.view
 
-    assert_includes out, "hive tui"
+    assert_includes out, "Tasks ·"
   end
 
   # ---- v2 two-pane composition ----
@@ -784,7 +785,7 @@ class HiveTuiBubbleModelTest < Minitest::Test
                     "hint block must precede token block at wide width"
   end
 
-  def test_default_footer_prepends_hidden_archived_notice
+  def test_default_footer_omits_hidden_archived_notice
     rows = 12.times.map do |idx|
       make_task_row(
         action_key: "archived",
@@ -802,24 +803,10 @@ class HiveTuiBubbleModelTest < Minitest::Test
 
     out = with_zero_usage { @model.send(:default_footer, 180) }
 
-    assert_includes out, "+12 hidden — open Archive pane"
-    assert out.index("+12 hidden") < out.index("[Tab] switch"),
-           "hidden notice must be prepended ahead of key hints"
-  end
-
-  def test_default_footer_omits_hidden_notice_when_none_hidden
-    row = make_task_row(action_key: "ready_to_plan", slug: "active-row")
-    @model = Hive::Tui::BubbleModel.new(
-      hive_model: Hive::Tui::Model.initial.with(snapshot: snapshot_with([ row ]), mode: :grid),
-      dispatch: @dispatch
-    )
-
-    out = with_zero_usage { @model.send(:default_footer, 180) }
-
     refute_includes out, "hidden — open Archive pane"
   end
 
-  def test_default_footer_flash_takes_precedence_over_hidden_notice
+  def test_default_footer_flash_takes_precedence_over_usage_hint
     row = make_task_row(
       action_key: "archived",
       action_label: "Archived",
@@ -841,6 +828,7 @@ class HiveTuiBubbleModelTest < Minitest::Test
 
     assert_includes out, "working"
     refute_includes out, "hidden — open Archive pane"
+    refute_includes out, "[Tab] switch"
   end
 
   def test_default_footer_fits_full_hint_at_exact_boundary_width
@@ -880,7 +868,7 @@ class HiveTuiBubbleModelTest < Minitest::Test
     refute_includes out, "[?] help"
   end
 
-  def test_default_footer_narrow_branch_keeps_hidden_notice_with_usage
+  def test_default_footer_narrow_branch_omits_hidden_notice
     rows = 12.times.map do |idx|
       make_task_row(
         action_key: "archived",
@@ -898,9 +886,46 @@ class HiveTuiBubbleModelTest < Minitest::Test
 
     out = with_zero_usage { @model.send(:default_footer, 76) }
 
-    assert_includes out, "+12 hidden", "narrow footer must still surface the hidden-archived notice"
     assert_includes out, "tokens", "narrow footer must keep the usage block alongside the hidden notice"
+    refute_includes out, "hidden", "narrow footer must not burn space on archived-hidden status"
     refute_includes out, "[Tab]", "narrow footer must drop key hints even when a hidden notice is present"
+  end
+
+  def test_grid_mode_omits_persistent_metadata_strip
+    snap = Hive::Tui::Snapshot.from_payload(
+      "generated_at" => "2026-05-01",
+      "projects" => [ { "name" => "hive", "tasks" => [] } ]
+    )
+    @model = Hive::Tui::BubbleModel.new(
+      hive_model: Hive::Tui::Model.initial.with(mode: :grid, snapshot: snap, cols: 100, scope: 1, filter: "abc"),
+      dispatch: @dispatch
+    )
+
+    out = with_zero_usage { @model.view }
+
+    refute_includes out, "hive tui  scope="
+    refute_includes out, "generated_at=2026-05-01"
+  end
+
+  def test_grid_mode_clamps_rendered_height_to_terminal_rows
+    tasks = 20.times.map do |idx|
+      { "slug" => "task-#{idx}", "stage" => "2-brainstorm", "action" => "ready_to_plan",
+        "action_label" => "Ready to plan", "age_seconds" => 60, "marker" => "complete" }
+    end
+    snap = Hive::Tui::Snapshot.from_payload(
+      "generated_at" => "2026-05-01",
+      "projects" => [ { "name" => "hive", "tasks" => tasks } ]
+    )
+    @model = Hive::Tui::BubbleModel.new(
+      hive_model: Hive::Tui::Model.initial.with(mode: :grid, snapshot: snap, cols: 100, rows: 8, cursor: [ 0, 19 ]),
+      dispatch: @dispatch
+    )
+
+    out = with_zero_usage { @model.view }
+
+    assert_operator out.lines.count, :<=, 8
+    assert_includes out, "task-19", "viewport must follow the selected task after vertical resize"
+    refute_includes out, "task-0", "offscreen rows must be clipped instead of pushing the footer away"
   end
 
   def test_grid_mode_collapses_to_single_pane_below_min_cols

--- a/test/unit/tui/bubble_model_test.rb
+++ b/test/unit/tui/bubble_model_test.rb
@@ -907,6 +907,39 @@ class HiveTuiBubbleModelTest < Minitest::Test
     refute_includes out, "generated_at=2026-05-01"
   end
 
+  def test_header_strip_formats_snapshot_metadata_when_called_directly
+    snap = Hive::Tui::Snapshot.from_payload(
+      "generated_at" => "2026-05-01",
+      "projects" => [ { "name" => "hive", "tasks" => [] } ]
+    )
+    @model = Hive::Tui::BubbleModel.new(
+      hive_model: Hive::Tui::Model.initial.with(snapshot: snap, scope: 1, filter: "abc"),
+      dispatch: @dispatch
+    )
+
+    out = @model.send(:header_strip, 200)
+
+    assert_includes out, "hive tui"
+    assert_includes out, "scope=hive"
+    assert_includes out, "filter=abc"
+    assert_includes out, "generated_at=2026-05-01"
+  end
+
+  def test_header_strip_truncates_to_width
+    snap = Hive::Tui::Snapshot.from_payload(
+      "generated_at" => "2026-05-01",
+      "projects" => [ { "name" => "hive", "tasks" => [] } ]
+    )
+    @model = Hive::Tui::BubbleModel.new(
+      hive_model: Hive::Tui::Model.initial.with(snapshot: snap, scope: 1, filter: "abc"),
+      dispatch: @dispatch
+    )
+
+    out = @model.send(:header_strip, 20)
+
+    assert_operator Hive::Tui::Text.sanitize(out).length, :<=, 20
+  end
+
   def test_grid_mode_clamps_rendered_height_to_terminal_rows
     tasks = 20.times.map do |idx|
       { "slug" => "task-#{idx}", "stage" => "2-brainstorm", "action" => "ready_to_plan",

--- a/test/unit/tui/views/projects_pane_test.rb
+++ b/test/unit/tui/views/projects_pane_test.rb
@@ -199,4 +199,14 @@ class HiveTuiViewsProjectsPaneTest < Minitest::Test
     refute_nil out
     assert out.is_a?(String)
   end
+
+  def test_height_clips_projects_but_keeps_selected_scope_visible
+    model = make_model(scope: 9, snapshot: make_snapshot(names: (1..12).map { |idx| "proj-#{idx}" }))
+
+    out = Hive::Tui::Views::ProjectsPane.render(model, width: 30, height: 7)
+
+    assert_equal 7, out.lines.count
+    assert_includes out, "proj-9", "project viewport must follow the selected scope"
+    refute_includes out, "proj-1", "offscreen projects must be clipped at small heights"
+  end
 end

--- a/test/unit/tui/views/tasks_pane_test.rb
+++ b/test/unit/tui/views/tasks_pane_test.rb
@@ -552,6 +552,19 @@ class HiveTuiViewsTasksPaneTest < Minitest::Test
     assert_includes out, "no tasks"
   end
 
+  def test_height_clips_task_rows_but_keeps_cursor_visible
+    tasks = 15.times.map { |idx| make_task(slug: "task-#{idx}", id: idx) }
+    snap = make_snapshot([ { "name" => "hive", "tasks" => tasks } ])
+
+    out = Hive::Tui::Views::TasksPane.render(
+      make_model(snapshot: snap, cursor: [ 0, 14 ]), width: 100, height: 8
+    )
+
+    assert_equal 8, out.lines.count
+    assert_includes out, "task-14", "task viewport must follow the selected cursor"
+    refute_includes out, "task-0", "offscreen tasks must be clipped instead of overflowing the pane"
+  end
+
   # ---- compute_layout adaptive column dropping ----
   # The full 6-column layout needs ~53 inner cells (icon=2, id=4,
   # stage=12, status=18, age=4, separators=5, name_min=8). Below that, columns

--- a/wiki/commands/tui.md
+++ b/wiki/commands/tui.md
@@ -18,8 +18,7 @@ The legacy curses backend was removed in plan #003 U11. `HIVE_TUI_BACKEND=curses
 ## Layout
 
 ```
-┌─ Header: hive tui · scope=★ All projects · filter=- · generated_at=…  ──┐
-├─────────────────┬────────────────────────────────────────────────────────┤
+┌─────────────────┬────────────────────────────────────────────────────────┐
 │  ProjectsPane   │  TasksPane                                             │
 │  (left, 18-28)  │  (right, cols - left)                                  │
 │                 │                                                        │
@@ -33,6 +32,8 @@ The legacy curses backend was removed in plan #003 U11. `HIVE_TUI_BACKEND=curses
 ```
 
 Pane focus is keyboard-only; the focused pane border is bright cyan, the inactive pane border is faint. Below 70 cols the project pane is suppressed and the tasks pane occupies the full width — narrow terminals still get a usable view, just without the left-pane drill-down.
+
+The dashboard intentionally has no persistent metadata header. Scope and filter context live in pane titles and prompt modes, while `generated_at` remains an internal snapshot field rather than always-on chrome. The composer computes pane height from `model.rows` minus any stalled banner and footer rows; both panes clip/pad to that budget. The project and task panes use cursor-following viewports, so vertical terminal shrink keeps the selected project/task visible and keeps the footer on-screen instead of letting rows overflow below it.
 
 ## Modes
 
@@ -149,7 +150,7 @@ the last dispatched snapshot. Identical snapshots do not redraw.
 
 `Hive::Tui::Snapshot::Row` carries `slug`, `id`, `display_name`, `mtime`, and `folder_mtime` from status JSON. The task list hides the slug in favor of the id/name columns, using the slug as the name fallback when display generation has not succeeded or a legacy task has not been backfilled. Detail views keep the slug visible beside `#id display_name`. Filtering still matches the slug and now also matches display name and stringified id.
 
-The grid view derives its visible snapshot through scope, slug/name/id filter, and `Snapshot#without_old_archived`. That drops only clean `9-done` rows older than 3 days by folder mtime; done rows with unresolved markers remain visible. Cursor movement and `BubbleModel#current_row` use the same filtered projection, so keystrokes cannot dispatch against a hidden row. The footer shows `+N hidden - open Archive pane` when the full snapshot contains hidden rows and no flash is active. The Archive pane itself renders directly from the unfiltered snapshot and therefore lists every `9-done` task regardless of age.
+The grid view derives its visible snapshot through scope, slug/name/id filter, and `Snapshot#without_old_archived`. That drops only clean `9-done` rows older than 3 days by folder mtime; done rows with unresolved markers remain visible. Cursor movement and `BubbleModel#current_row` use the same filtered projection, so keystrokes cannot dispatch against a hidden row. The default footer does not surface the hidden-archive count; `z` opens the Archive pane when the operator wants the unfiltered archive list. The Archive pane itself renders directly from the unfiltered snapshot and therefore lists every `9-done` task regardless of age.
 
 Snapshots carry a `current_seen_at` timestamp; if the last successful refresh is older than 5s, the header renders a `[stalled: Xs]` banner and the `@last_error` message is surfaced in the status line. The previous snapshot stays visible — the loop never crashes on a transient JSON / IO error.
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -3185,3 +3185,10 @@ TTL config.
 - [[testing]]
 - [[index]]
 - [[gaps]]
+
+## [2026-06-05T20:05:00Z] tui — vertical resize viewport and reduced dashboard chrome
+
+**Action:** Made the grid composer height-aware: it subtracts footer/stalled-banner rows from `model.rows`, passes the remaining budget into `ProjectsPane` and `TasksPane`, and each pane clips/pads with a cursor-following viewport. Removed the persistent grid metadata strip and hidden-archive footer prefix so the first frame prioritizes panes and the footer stays visible under vertical terminal resize. Added focused pane viewport tests plus a PTY Charm smoke that performs a real vertical `winsize` + `SIGWINCH` resize and verifies the footer remains visible.
+
+**Refreshed pages:**
+- [[commands/tui]]


### PR DESCRIPTION
## Summary
- make the two-pane TUI composer height-aware and remove the persistent metadata strip
- clip/pad project and task panes with cursor-following viewports so vertical resize keeps selected rows and the footer visible
- remove the hidden archive count from the default footer and update TUI docs
- add focused pane/unit coverage plus a PTY Charm smoke test that performs a real vertical winsize/SIGWINCH resize

## Tests
- bundle exec rake test TEST=test/unit/tui/views/projects_pane_test.rb TESTOPTS=''
- bundle exec rake test TEST=test/unit/tui/views/tasks_pane_test.rb TESTOPTS=''
- bundle exec rake test TEST=test/unit/tui/bubble_model_test.rb TESTOPTS=''
- bundle exec rake test TEST=test/integration/tui_smoke_charm_test.rb TESTOPTS=''
- bundle exec rake test TEST=test/e2e/lib/repro_script_writer_test.rb TESTOPTS=''
- bundle exec rubocop lib/hive/tui/bubble_model.rb lib/hive/tui/views/projects_pane.rb lib/hive/tui/views/tasks_pane.rb test/unit/tui/bubble_model_test.rb test/unit/tui/views/projects_pane_test.rb test/unit/tui/views/tasks_pane_test.rb test/integration/tui_smoke_charm_test.rb test/e2e/lib/repro_script_writer_test.rb