### PR TITLE
Hive patrol: hv self-recursion guard is not portable to macOS

### DIFF
--- a/bin/hv
+++ b/bin/hv
@@ -7,7 +7,20 @@ set -euo pipefail
 # hive` resolves to Apache Hive. Instead, probe known install
 # locations in priority order.
 
-self="$(readlink -f "$0" 2>/dev/null || echo "$0")"
+canonical_path() {
+  realpath "$1" 2>/dev/null && return
+  ruby -e 'puts File.realpath(ARGV.fetch(0))' "$1" 2>/dev/null && return
+  python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$1" 2>/dev/null && return
+  readlink -f "$1" 2>/dev/null && return
+  # All canonicalizers absent (rare): fall back to the raw path, but warn
+  # — an unresolved path can defeat the hv->hv self-recursion guard, and
+  # under `set -euo pipefail` a silent runaway re-exec would otherwise
+  # leave no diagnostic.
+  echo "hv: warning: could not canonicalize '$1'; using it unresolved (self-recursion guard may be unreliable)" >&2
+  echo "$1"
+}
+
+self="$(canonical_path "$0")"
 xdg_bin_home="${XDG_BIN_HOME:-${HOME:+$HOME/.local/bin}}"
 
 # A misbehaving candidate must not hang `hv`: one that blocks reading
@@ -39,7 +52,7 @@ for candidate in "${candidates[@]}"; do
   [[ -n "$candidate" ]] || continue
   [[ -x "$candidate" ]] || continue
 
-  resolved="$(readlink -f "$candidate" 2>/dev/null || echo "$candidate")"
+  resolved="$(canonical_path "$candidate")"
   # Guard against `hv -> hv` chains: never exec into our own script.
   [[ "$resolved" != "$self" ]] || continue
 

--- a/test/unit/hv_test.rb
+++ b/test/unit/hv_test.rb
@@ -1,5 +1,6 @@
 require "test_helper"
 require "open3"
+require "timeout"
 
 class HvTest < Minitest::Test
   include HiveTestHelper
@@ -89,6 +90,105 @@ class HvTest < Minitest::Test
 
       assert status.success?, err
       assert_equal "override:probe\n", out
+    end
+  end
+
+  def test_self_recursion_guard_resolves_symlinks_via_realpath_rung
+    assert_recursion_guard_holds(disabled_resolvers: [])
+  end
+
+  def test_self_recursion_guard_resolves_symlinks_via_ruby_rung
+    assert_recursion_guard_holds(disabled_resolvers: %w[realpath])
+  end
+
+  def test_self_recursion_guard_resolves_symlinks_via_python_rung
+    assert_recursion_guard_holds(disabled_resolvers: %w[realpath ruby])
+  end
+
+  def test_self_recursion_guard_resolves_symlinks_via_readlink_rung
+    assert_recursion_guard_holds(disabled_resolvers: %w[realpath ruby python3])
+  end
+
+  def test_canonical_path_warns_when_all_resolvers_fail
+    with_tmp_dir do |dir|
+      fake_bin = write_failing_resolvers(dir, %w[realpath ruby python3 readlink])
+
+      # A non-symlink override: with every resolver disabled, canonical_path
+      # falls through to the raw-path rung. The override path differs from
+      # the raw `hv` path, so the guard does not skip it and execs the
+      # override — exercising the echo rung without risking a runaway.
+      override = File.join(dir, "custom", "hive")
+      FileUtils.mkdir_p(File.dirname(override))
+      File.write(override, "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo 1.2.3; exit 0; fi\necho override:$1\n")
+      FileUtils.chmod(0o755, override)
+
+      out, err, status = capture_hv_with_timeout(
+        {
+          "HIVE_BIN_OVERRIDE" => override,
+          "XDG_BIN_HOME" => File.join(dir, "empty-xdg"),
+          "HOMEBREW_PREFIX" => File.join(dir, "empty-homebrew"),
+          "PATH" => [ fake_bin, ENV.fetch("PATH", "") ].join(File::PATH_SEPARATOR)
+        },
+        "probe"
+      )
+
+      assert status.success?, err
+      assert_equal "override:probe\n", out
+      assert_includes err, "could not canonicalize",
+                      "the raw-path fallthrough must emit a stderr diagnostic so a runaway is never silent"
+    end
+  end
+
+  private
+
+  def assert_recursion_guard_holds(disabled_resolvers:)
+    with_tmp_dir do |dir|
+      fake_bin = write_failing_resolvers(dir, disabled_resolvers)
+
+      override = File.join(dir, "custom", "hive")
+      FileUtils.mkdir_p(File.dirname(override))
+      FileUtils.ln_s(HV_BIN, override)
+
+      out, err, status = capture_hv_with_timeout(
+        {
+          "HIVE_BIN_OVERRIDE" => override,
+          "XDG_BIN_HOME" => File.join(dir, "empty-xdg"),
+          "HOMEBREW_PREFIX" => File.join(dir, "empty-homebrew"),
+          "PATH" => [ fake_bin, ENV.fetch("PATH", "") ].join(File::PATH_SEPARATOR)
+        },
+        "probe"
+      )
+
+      assert_equal "", out
+      assert_equal 127, status.exitstatus, err
+      assert_includes err, "hive binary not found"
+    end
+  end
+
+  def write_failing_resolvers(dir, names)
+    fake_bin = File.join(dir, "bin")
+    FileUtils.mkdir_p(fake_bin)
+    names.each do |name|
+      stub = File.join(fake_bin, name)
+      File.write(stub, "#!/bin/sh\nexit 1\n")
+      FileUtils.chmod(0o755, stub)
+    end
+    fake_bin
+  end
+
+  def capture_hv_with_timeout(env, *args)
+    Open3.popen3(env, HV_BIN, *args) do |stdin, stdout, stderr, wait_thread|
+      stdin.close
+      out_reader = Thread.new { stdout.read }
+      err_reader = Thread.new { stderr.read }
+      status = Timeout.timeout(2) { wait_thread.value }
+      [ out_reader.value, err_reader.value, status ]
+    rescue Timeout::Error
+      Process.kill("TERM", wait_thread.pid)
+      Process.wait(wait_thread.pid)
+      raise
+    rescue Errno::ESRCH, Errno::ECHILD
+      raise Timeout::Error, "hv did not exit"
     end
   end
 end


### PR DESCRIPTION
## Summary

Patrol opened this PR for **`hv` self-recursion guard is not portable to macOS** (finding `command-bin-hive-e2e-2`), and it folded in a second dogfood fix for TUI task context and archive counts that landed on the same branch.

- **Portable canonicalization in `bin/hv`** — `readlink -f` is unsupported on macOS/BSD, so the old fallback left symlink paths unresolved and a candidate pointing back at the wrapper could bypass the `hv → hv` self-recursion guard and re-exec the wrapper forever. Replaced both call sites with a `canonical_path()` helper that tries `realpath`, then a Ruby `File.realpath`, then `python3 os.path.realpath`, then `readlink -f`. If every resolver is absent it falls back to the raw path but now emits a stderr warning, so a runaway re-exec under `set -euo pipefail` is never silent.
- **Archive hiding keyed on row `mtime`** (`lib/hive/archive_filter.rb`) — `hide?` now ages out archived `9-done` rows on the state-file `mtime` (the same timestamp rendered as row age), falling back to `folder_mtime` only for older consumers. The `RESOLVED_MARKER_NAMES` allowlist and the dead `marker_name:` kwarg were removed; archived rows older than 3 days are hidden from daily surfaces regardless of marker. This is a deliberate, locked product decision — the `+N hidden` count is still surfaced and `hive archive` stays unfiltered.
- **Display-width-aware TUI columns** (`lib/hive/tui/views/format.rb`, `tasks_pane.rb`, `snapshot.rb`) — `truncate`/`ljust_cells`/`rjust_cells`/`take_cells`/`display_width` fit and justify on terminal cell width rather than character count, so wide glyphs (emoji) no longer shift the ID column.
- **Patrol review tasks now seed `idea.md`** (`lib/hive/patrol/review_handoff.rb`) — synthetic patrol tasks get an `idea.md` rendering the finding's title, description, recommendation, and evidence, with the evidence renderer hardened against nil/string/symbol-keyed entries.

## Test plan

- `bundle exec rubocop` — clean on all changed lib files.
- Focused unit suites for every changed file pass (`archive_filter`, `snapshot`, `tasks_pane`, `format`, `review_handoff`, `hv`, `commands/status`).
- New coverage added: `test/unit/tui/views/format_test.rb` (cell-width edges), `test/unit/patrol/review_handoff_test.rb` (`idea.md` rendering + evidence fallbacks), and `test/unit/hv_test.rb` exercising each canonicalization fallback rung rather than only forcing `readlink` to fail.

## Review summary

Two compound-engineering passes plus a pr-review-toolkit pass ran (`claude-ce`, `codex-ce`, `pr-review-toolkit`). No High or Medium findings stood against the true task scope.

- Several reviewers' High/Medium findings were diff-base artifacts: they diffed `origin/main..HEAD`, but local `origin/main` had advanced past this branch's merge-base (`23cf47b9`) with PRs #351, #330, and #326, which a two-dot diff renders as inverted "changes" this branch never made. Those were resolved as out of scope.
- In-scope findings were auto-fixed in pass 01 (`fix(review): apply pass 01 findings` and follow-ups): stderr warning on the `bin/hv` fallthrough, `Array(finding.evidence)` coercion, removal of the dead `marker_name:` kwarg, `idea_text` hoist, new `format`/`review_handoff`/`hv` tests, and aligned wiki docs (`status.md`, `gaps.md`).
- Pass 02 reported zero findings. The archive-visibility tradeoff (failure-state rows can leave daily surfaces purely on age) is recorded as an intentional, locked product decision.

## Linked task

- Patrol finding: `command-bin-hive-e2e-2`
- Fingerprint: `bb21a6337c72c42149c607b1c26f9b392a2f48b8a26a6fea9099fe9f0150128a`
- Task folder: `.hive-state/stages/8-finalize/patrol-command-bin-hive-e2e-bb21a633`
