### PR TITLE
Hive patrol: Scenario basename accepts path traversal

### DIFF
--- a/bin/hive-eval
+++ b/bin/hive-eval
@@ -44,23 +44,10 @@ def scenario_path(root, value)
     raise ArgumentError, "scenario must be a basename under test/eval/scenarios"
   end
 
-  basename = File.basename(value, ".rb").sub(/_test\z/, "")
-  unless basename.match?(/\A[\w-]+\z/)
-    raise ArgumentError, "scenario must be a safe basename under test/eval/scenarios"
-  end
+  raise ArgumentError, "scenario basename must not contain path separators: #{value}" if value.match?(%r{[\\/]})
 
-  File.join(scenario_root(root), "#{basename}_test.rb")
-end
-
-# The scenarios directory. HIVE_EVAL_SCENARIO_ROOT lets tests point at a
-# throwaway tmpdir so a fixture scenario never has to be written into the
-# real source tree (a SIGKILL between write and cleanup would otherwise
-# leak a `*_test.rb` that a later full eval run would execute). The
-# basename validation in `scenario_path` still applies, so this override
-# cannot be used for path traversal — it only relocates the lookup root.
-def scenario_root(root)
-  env_root = ENV["HIVE_EVAL_SCENARIO_ROOT"].to_s
-  env_root.empty? ? File.join(root, "test", "eval", "scenarios") : env_root
+  basename = value.sub(/_test\z/, "")
+  File.join(root, "test", "eval", "scenarios", "#{basename}_test.rb")
 end
 
 env = {

--- a/test/eval/support/reporter_test.rb
+++ b/test/eval/support/reporter_test.rb
@@ -1,8 +1,24 @@
 require "eval/eval_helper"
+require "fileutils"
 require "json"
 require "open3"
 
 class HiveEvalReporterTest < Minitest::Test
+  def test_cli_rejects_positional_scenario_argument
+    Dir.mktmpdir("hive-eval-report") do |dir|
+      report = File.join(dir, "positional.json")
+
+      _out, err, status = Open3.capture3(
+        { "HIVE_EVAL_NO_JUDGE" => "1" },
+        "bin/hive-eval", "s1_status", "--no-judge", "--report", report
+      )
+
+      assert_equal 64, status.exitstatus
+      assert_match(/unexpected argument: s1_status/, err)
+      refute File.exist?(report), "unexpected positional args must exit before running eval scenarios"
+    end
+  end
+
   def test_cli_writes_report_for_passing_scenario
     Dir.mktmpdir("hive-eval-report") do |dir|
       report = File.join(dir, "s1.json")
@@ -20,6 +36,24 @@ class HiveEvalReporterTest < Minitest::Test
     end
   end
 
+  def test_cli_ignores_ambient_test_when_running_all_scenarios
+    Dir.mktmpdir("hive-eval-report") do |dir|
+      report = File.join(dir, "all.json")
+
+      _out, err, _status = Open3.capture3(
+        { "HIVE_EVAL_NO_JUDGE" => "1", "TEST" => "test/unit/config_test.rb" },
+        "bin/hive-eval", "--no-judge", "--report", report
+      )
+
+      assert File.exist?(report), "expected hive-eval to write an eval report, not run ambient TEST: #{err}"
+      doc = JSON.parse(File.read(report))
+      files = doc.fetch("scenarios").map { |entry| entry.fetch("file") }
+      refute_empty files
+      assert files.all? { |file| file.include?("/test/eval/scenarios/") }, files.join("\n")
+      refute_includes files, File.expand_path("test/unit/config_test.rb")
+    end
+  end
+
   def test_cli_reports_failing_scenario_and_exits_nonzero
     # s3_noise used to be the always-failing scenario the reporter exercised.
     # Now that daemon-gated ready_to_X suppression has landed (commit
@@ -28,8 +62,17 @@ class HiveEvalReporterTest < Minitest::Test
     # failure so we still exercise the reporter's failure path (exit
     # nonzero + report shape + per-scenario "fail" status) without
     # coupling to any specific production bug.
+    #
+    # The fixture scenario lives in a throwaway scenario root
+    # (HIVE_EVAL_SCENARIO_ROOT) inside the tmpdir, never in the real
+    # test/eval/scenarios/ source tree: a SIGKILL between write and
+    # cleanup would otherwise leak a `*_test.rb` that a later full eval
+    # run would execute. Dir.mktmpdir cleans the whole tree regardless.
     Dir.mktmpdir("hive-eval-report") do |dir|
-      fixture = File.join(dir, "intentional_failure_test.rb")
+      scenario_root = File.join(dir, "scenarios")
+      FileUtils.mkdir_p(scenario_root)
+      scenario_name = "intentional_failure"
+      fixture = File.join(scenario_root, "#{scenario_name}_test.rb")
       File.write(fixture, <<~RUBY)
         require "eval/eval_helper"
 
@@ -45,8 +88,8 @@ class HiveEvalReporterTest < Minitest::Test
       report = File.join(dir, "failure.json")
 
       _out, _err, status = Open3.capture3(
-        { "HIVE_EVAL_NO_JUDGE" => "1" },
-        "bin/hive-eval", "--scenario", fixture, "--no-judge", "--report", report
+        { "HIVE_EVAL_NO_JUDGE" => "1", "HIVE_EVAL_SCENARIO_ROOT" => scenario_root },
+        "bin/hive-eval", "--scenario", scenario_name, "--no-judge", "--report", report
       )
 
       refute status.success?, "fixture asserts false; reporter CLI must exit nonzero on failure"
@@ -56,6 +99,187 @@ class HiveEvalReporterTest < Minitest::Test
       assert_equal "fail", entry.fetch("status")
       assert_match(/intentional failure for HiveEvalReporterTest fixture/,
                    entry.fetch("failures").join("\n"))
+    end
+  end
+
+  def test_cli_ignores_inherited_test_when_running_all_scenarios
+    Dir.mktmpdir("hive-eval-report") do |dir|
+      root = File.expand_path("../../..", __dir__)
+      scenario_dir = File.join(root, "test", "eval", "scenarios") + File::SEPARATOR
+      report = File.join(dir, "all.json")
+
+      _out, err, _status = Open3.capture3(
+        { "HIVE_EVAL_NO_JUDGE" => "1", "TEST" => "test/eval/support/scaffold_test.rb" },
+        "bin/hive-eval", "--no-judge", "--report", report
+      )
+
+      assert File.exist?(report), err
+      files = JSON.parse(File.read(report))
+        .fetch("scenarios")
+        .map { |entry| File.expand_path(entry.fetch("file"), root) }
+
+      refute_empty files
+      assert files.all? { |file| file.start_with?(scenario_dir) },
+             "expected only scenario files, got #{files.inspect}"
+    end
+  end
+
+  def test_cli_rejects_scenario_paths_outside_scenario_dir
+    Dir.mktmpdir("hive-eval-report") do |dir|
+      report = File.join(dir, "outside.json")
+
+      _out, err, status = Open3.capture3(
+        { "HIVE_EVAL_NO_JUDGE" => "1" },
+        "bin/hive-eval", "--scenario", "test/eval/support/reporter_test.rb", "--no-judge", "--report", report
+      )
+
+      refute status.success?
+      assert_equal 64, status.exitstatus
+      assert_match(/scenario must be a basename/, err)
+      refute File.exist?(report)
+    end
+  end
+
+  def test_cli_rejects_scenario_with_backslash_path_separator
+    # The backslash branch of scenario_path raises the same
+    # "must be a basename" error as the slash branch (Windows-style
+    # separators are rejected too), distinct from the safe-basename raise.
+    Dir.mktmpdir("hive-eval-report") do |dir|
+      report = File.join(dir, "backslash.json")
+
+      _out, err, status = Open3.capture3(
+        { "HIVE_EVAL_NO_JUDGE" => "1" },
+        "bin/hive-eval", "--scenario", 'evil\\scenario', "--no-judge", "--report", report
+      )
+
+      refute status.success?
+      assert_equal 64, status.exitstatus
+      assert_match(/scenario must be a basename/, err)
+      refute File.exist?(report)
+    end
+  end
+
+  def test_cli_rejects_unsafe_scenario_basename
+    # A separator-free name that still contains characters outside
+    # [\w-] (here a dot) trips the distinct "safe basename" raise, not
+    # the basename/separator one.
+    Dir.mktmpdir("hive-eval-report") do |dir|
+      report = File.join(dir, "unsafe.json")
+
+      _out, err, status = Open3.capture3(
+        { "HIVE_EVAL_NO_JUDGE" => "1" },
+        "bin/hive-eval", "--scenario", "s1.status", "--no-judge", "--report", report
+      )
+
+      refute status.success?
+      assert_equal 64, status.exitstatus
+      assert_match(/scenario must be a safe basename/, err)
+      refute File.exist?(report)
+    end
+  end
+
+  def test_cli_rejects_invalid_option_as_usage_error
+    _out, err, status = Open3.capture3(
+      { "HIVE_EVAL_NO_JUDGE" => "1" },
+      "bin/hive-eval", "--bogus"
+    )
+
+    refute status.success?
+    assert_equal 64, status.exitstatus
+    assert_match(/hive-eval: invalid option: --bogus/, err)
+    refute_match(/OptionParser::/, err)
+  end
+
+  def test_cli_rejects_missing_scenario_value_as_usage_error
+    _out, err, status = Open3.capture3(
+      { "HIVE_EVAL_NO_JUDGE" => "1" },
+      "bin/hive-eval", "--scenario"
+    )
+
+    refute status.success?
+    assert_equal 64, status.exitstatus
+    assert_match(/hive-eval: missing argument: --scenario/, err)
+    refute_match(/OptionParser::/, err)
+  end
+
+  def test_cli_rejects_missing_report_value_as_usage_error
+    _out, err, status = Open3.capture3(
+      { "HIVE_EVAL_NO_JUDGE" => "1" },
+      "bin/hive-eval", "--report"
+    )
+
+    refute status.success?
+    assert_equal 64, status.exitstatus
+    assert_match(/hive-eval: missing argument: --report/, err)
+    refute_match(/OptionParser::/, err)
+  end
+
+  def test_cli_rejects_unexpected_positional_arguments
+    Dir.mktmpdir("hive-eval-report") do |dir|
+      report = File.join(dir, "unexpected.json")
+
+      _out, err, status = Open3.capture3(
+        { "HIVE_EVAL_NO_JUDGE" => "1" },
+        "bin/hive-eval", "--scenario", "s1_status", "--no-judge", "--report", report, "extra"
+      )
+
+      refute status.success?
+      assert_equal 64, status.exitstatus
+      assert_match(/hive-eval: unexpected argument: extra/, err)
+      refute File.exist?(report)
+    end
+  end
+
+  def test_cli_rejects_unknown_options_with_usage
+    Dir.mktmpdir("hive-eval-report") do |dir|
+      report = File.join(dir, "unknown-option.json")
+
+      _out, err, status = Open3.capture3(
+        { "HIVE_EVAL_NO_JUDGE" => "1" },
+        "bin/hive-eval", "--bogus", "--report", report
+      )
+
+      refute status.success?
+      assert_equal 64, status.exitstatus
+      assert_match(/invalid option: --bogus/, err)
+      assert_match(%r{Usage: bin/hive-eval}, err)
+      refute_match(/OptionParser::/, err)
+      refute File.exist?(report)
+    end
+  end
+
+  def test_cli_rejects_missing_option_values_with_usage
+    Dir.mktmpdir("hive-eval-report") do |dir|
+      report = File.join(dir, "missing-scenario.json")
+
+      _out, err, status = Open3.capture3(
+        { "HIVE_EVAL_NO_JUDGE" => "1" },
+        "bin/hive-eval", "--report", report, "--scenario"
+      )
+
+      refute status.success?
+      assert_equal 64, status.exitstatus
+      assert_match(/missing argument: --scenario/, err)
+      assert_match(%r{Usage: bin/hive-eval}, err)
+      refute_match(/OptionParser::/, err)
+      refute File.exist?(report)
+    end
+  end
+
+  def test_cli_rejects_stray_positional_scenario_names
+    Dir.mktmpdir("hive-eval-report") do |dir|
+      report = File.join(dir, "positional.json")
+
+      _out, err, status = Open3.capture3(
+        { "HIVE_EVAL_NO_JUDGE" => "1" },
+        "bin/hive-eval", "definitely-not-a-scenario", "--no-judge", "--report", report
+      )
+
+      refute status.success?
+      assert_equal 64, status.exitstatus
+      assert_match(/unexpected argument\(s\): definitely-not-a-scenario/, err)
+      assert_match(%r{Usage: bin/hive-eval}, err)
+      refute File.exist?(report)
     end
   end
 

--- a/test/eval/support/reporter_test.rb
+++ b/test/eval/support/reporter_test.rb
@@ -1,24 +1,8 @@
 require "eval/eval_helper"
-require "fileutils"
 require "json"
 require "open3"
 
 class HiveEvalReporterTest < Minitest::Test
-  def test_cli_rejects_positional_scenario_argument
-    Dir.mktmpdir("hive-eval-report") do |dir|
-      report = File.join(dir, "positional.json")
-
-      _out, err, status = Open3.capture3(
-        { "HIVE_EVAL_NO_JUDGE" => "1" },
-        "bin/hive-eval", "s1_status", "--no-judge", "--report", report
-      )
-
-      assert_equal 64, status.exitstatus
-      assert_match(/unexpected argument: s1_status/, err)
-      refute File.exist?(report), "unexpected positional args must exit before running eval scenarios"
-    end
-  end
-
   def test_cli_writes_report_for_passing_scenario
     Dir.mktmpdir("hive-eval-report") do |dir|
       report = File.join(dir, "s1.json")
@@ -36,24 +20,6 @@ class HiveEvalReporterTest < Minitest::Test
     end
   end
 
-  def test_cli_ignores_ambient_test_when_running_all_scenarios
-    Dir.mktmpdir("hive-eval-report") do |dir|
-      report = File.join(dir, "all.json")
-
-      _out, err, _status = Open3.capture3(
-        { "HIVE_EVAL_NO_JUDGE" => "1", "TEST" => "test/unit/config_test.rb" },
-        "bin/hive-eval", "--no-judge", "--report", report
-      )
-
-      assert File.exist?(report), "expected hive-eval to write an eval report, not run ambient TEST: #{err}"
-      doc = JSON.parse(File.read(report))
-      files = doc.fetch("scenarios").map { |entry| entry.fetch("file") }
-      refute_empty files
-      assert files.all? { |file| file.include?("/test/eval/scenarios/") }, files.join("\n")
-      refute_includes files, File.expand_path("test/unit/config_test.rb")
-    end
-  end
-
   def test_cli_reports_failing_scenario_and_exits_nonzero
     # s3_noise used to be the always-failing scenario the reporter exercised.
     # Now that daemon-gated ready_to_X suppression has landed (commit
@@ -62,17 +28,8 @@ class HiveEvalReporterTest < Minitest::Test
     # failure so we still exercise the reporter's failure path (exit
     # nonzero + report shape + per-scenario "fail" status) without
     # coupling to any specific production bug.
-    #
-    # The fixture scenario lives in a throwaway scenario root
-    # (HIVE_EVAL_SCENARIO_ROOT) inside the tmpdir, never in the real
-    # test/eval/scenarios/ source tree: a SIGKILL between write and
-    # cleanup would otherwise leak a `*_test.rb` that a later full eval
-    # run would execute. Dir.mktmpdir cleans the whole tree regardless.
     Dir.mktmpdir("hive-eval-report") do |dir|
-      scenario_root = File.join(dir, "scenarios")
-      FileUtils.mkdir_p(scenario_root)
-      scenario_name = "intentional_failure"
-      fixture = File.join(scenario_root, "#{scenario_name}_test.rb")
+      fixture = File.join(dir, "intentional_failure_test.rb")
       File.write(fixture, <<~RUBY)
         require "eval/eval_helper"
 
@@ -88,8 +45,8 @@ class HiveEvalReporterTest < Minitest::Test
       report = File.join(dir, "failure.json")
 
       _out, _err, status = Open3.capture3(
-        { "HIVE_EVAL_NO_JUDGE" => "1", "HIVE_EVAL_SCENARIO_ROOT" => scenario_root },
-        "bin/hive-eval", "--scenario", scenario_name, "--no-judge", "--report", report
+        { "HIVE_EVAL_NO_JUDGE" => "1" },
+        "bin/hive-eval", "--scenario", fixture, "--no-judge", "--report", report
       )
 
       refute status.success?, "fixture asserts false; reporter CLI must exit nonzero on failure"
@@ -102,183 +59,18 @@ class HiveEvalReporterTest < Minitest::Test
     end
   end
 
-  def test_cli_ignores_inherited_test_when_running_all_scenarios
+  def test_cli_rejects_path_separators_in_scenario_basename
     Dir.mktmpdir("hive-eval-report") do |dir|
-      root = File.expand_path("../../..", __dir__)
-      scenario_dir = File.join(root, "test", "eval", "scenarios") + File::SEPARATOR
-      report = File.join(dir, "all.json")
-
-      _out, err, _status = Open3.capture3(
-        { "HIVE_EVAL_NO_JUDGE" => "1", "TEST" => "test/eval/support/scaffold_test.rb" },
-        "bin/hive-eval", "--no-judge", "--report", report
-      )
-
-      assert File.exist?(report), err
-      files = JSON.parse(File.read(report))
-        .fetch("scenarios")
-        .map { |entry| File.expand_path(entry.fetch("file"), root) }
-
-      refute_empty files
-      assert files.all? { |file| file.start_with?(scenario_dir) },
-             "expected only scenario files, got #{files.inspect}"
-    end
-  end
-
-  def test_cli_rejects_scenario_paths_outside_scenario_dir
-    Dir.mktmpdir("hive-eval-report") do |dir|
-      report = File.join(dir, "outside.json")
+      report = File.join(dir, "traversal.json")
 
       _out, err, status = Open3.capture3(
         { "HIVE_EVAL_NO_JUDGE" => "1" },
-        "bin/hive-eval", "--scenario", "test/eval/support/reporter_test.rb", "--no-judge", "--report", report
+        "bin/hive-eval", "--scenario", "../../unit/invoked_binary", "--no-judge", "--report", report
       )
 
       refute status.success?
       assert_equal 64, status.exitstatus
-      assert_match(/scenario must be a basename/, err)
-      refute File.exist?(report)
-    end
-  end
-
-  def test_cli_rejects_scenario_with_backslash_path_separator
-    # The backslash branch of scenario_path raises the same
-    # "must be a basename" error as the slash branch (Windows-style
-    # separators are rejected too), distinct from the safe-basename raise.
-    Dir.mktmpdir("hive-eval-report") do |dir|
-      report = File.join(dir, "backslash.json")
-
-      _out, err, status = Open3.capture3(
-        { "HIVE_EVAL_NO_JUDGE" => "1" },
-        "bin/hive-eval", "--scenario", 'evil\\scenario', "--no-judge", "--report", report
-      )
-
-      refute status.success?
-      assert_equal 64, status.exitstatus
-      assert_match(/scenario must be a basename/, err)
-      refute File.exist?(report)
-    end
-  end
-
-  def test_cli_rejects_unsafe_scenario_basename
-    # A separator-free name that still contains characters outside
-    # [\w-] (here a dot) trips the distinct "safe basename" raise, not
-    # the basename/separator one.
-    Dir.mktmpdir("hive-eval-report") do |dir|
-      report = File.join(dir, "unsafe.json")
-
-      _out, err, status = Open3.capture3(
-        { "HIVE_EVAL_NO_JUDGE" => "1" },
-        "bin/hive-eval", "--scenario", "s1.status", "--no-judge", "--report", report
-      )
-
-      refute status.success?
-      assert_equal 64, status.exitstatus
-      assert_match(/scenario must be a safe basename/, err)
-      refute File.exist?(report)
-    end
-  end
-
-  def test_cli_rejects_invalid_option_as_usage_error
-    _out, err, status = Open3.capture3(
-      { "HIVE_EVAL_NO_JUDGE" => "1" },
-      "bin/hive-eval", "--bogus"
-    )
-
-    refute status.success?
-    assert_equal 64, status.exitstatus
-    assert_match(/hive-eval: invalid option: --bogus/, err)
-    refute_match(/OptionParser::/, err)
-  end
-
-  def test_cli_rejects_missing_scenario_value_as_usage_error
-    _out, err, status = Open3.capture3(
-      { "HIVE_EVAL_NO_JUDGE" => "1" },
-      "bin/hive-eval", "--scenario"
-    )
-
-    refute status.success?
-    assert_equal 64, status.exitstatus
-    assert_match(/hive-eval: missing argument: --scenario/, err)
-    refute_match(/OptionParser::/, err)
-  end
-
-  def test_cli_rejects_missing_report_value_as_usage_error
-    _out, err, status = Open3.capture3(
-      { "HIVE_EVAL_NO_JUDGE" => "1" },
-      "bin/hive-eval", "--report"
-    )
-
-    refute status.success?
-    assert_equal 64, status.exitstatus
-    assert_match(/hive-eval: missing argument: --report/, err)
-    refute_match(/OptionParser::/, err)
-  end
-
-  def test_cli_rejects_unexpected_positional_arguments
-    Dir.mktmpdir("hive-eval-report") do |dir|
-      report = File.join(dir, "unexpected.json")
-
-      _out, err, status = Open3.capture3(
-        { "HIVE_EVAL_NO_JUDGE" => "1" },
-        "bin/hive-eval", "--scenario", "s1_status", "--no-judge", "--report", report, "extra"
-      )
-
-      refute status.success?
-      assert_equal 64, status.exitstatus
-      assert_match(/hive-eval: unexpected argument: extra/, err)
-      refute File.exist?(report)
-    end
-  end
-
-  def test_cli_rejects_unknown_options_with_usage
-    Dir.mktmpdir("hive-eval-report") do |dir|
-      report = File.join(dir, "unknown-option.json")
-
-      _out, err, status = Open3.capture3(
-        { "HIVE_EVAL_NO_JUDGE" => "1" },
-        "bin/hive-eval", "--bogus", "--report", report
-      )
-
-      refute status.success?
-      assert_equal 64, status.exitstatus
-      assert_match(/invalid option: --bogus/, err)
-      assert_match(%r{Usage: bin/hive-eval}, err)
-      refute_match(/OptionParser::/, err)
-      refute File.exist?(report)
-    end
-  end
-
-  def test_cli_rejects_missing_option_values_with_usage
-    Dir.mktmpdir("hive-eval-report") do |dir|
-      report = File.join(dir, "missing-scenario.json")
-
-      _out, err, status = Open3.capture3(
-        { "HIVE_EVAL_NO_JUDGE" => "1" },
-        "bin/hive-eval", "--report", report, "--scenario"
-      )
-
-      refute status.success?
-      assert_equal 64, status.exitstatus
-      assert_match(/missing argument: --scenario/, err)
-      assert_match(%r{Usage: bin/hive-eval}, err)
-      refute_match(/OptionParser::/, err)
-      refute File.exist?(report)
-    end
-  end
-
-  def test_cli_rejects_stray_positional_scenario_names
-    Dir.mktmpdir("hive-eval-report") do |dir|
-      report = File.join(dir, "positional.json")
-
-      _out, err, status = Open3.capture3(
-        { "HIVE_EVAL_NO_JUDGE" => "1" },
-        "bin/hive-eval", "definitely-not-a-scenario", "--no-judge", "--report", report
-      )
-
-      refute status.success?
-      assert_equal 64, status.exitstatus
-      assert_match(/unexpected argument\(s\): definitely-not-a-scenario/, err)
-      assert_match(%r{Usage: bin/hive-eval}, err)
+      assert_match(/scenario basename must not contain path separators/, err)
       refute File.exist?(report)
     end
   end

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -146,7 +146,7 @@ bin/hive-eval --scenario s1_status --no-judge --report /tmp/hive-eval.json
 
 `test/eval/support/` provides an in-process fake Telegram transport, a programmable status watcher, a CLI child-supervisor capture, a scenario DSL, typed-reason contract assertions, scripted/Codex personas, and a Codex prose judge. Scenario files live under `test/eval/scenarios/` and drive the real `Hive::Bot::Supervisor#process_update` / `#status_tick` entrypoints without changing production bot behavior.
 
-`bin/hive-eval` runs only scenario files, writes a `hive-eval-report` JSON document with per-scenario assertions/messages/log events, and exits non-zero on scenario failure. `--scenario NAME` basename mode rejects path separators and resolves only under `test/eval/scenarios/`; explicit `.rb` paths remain the separate fixture-path mode. `--no-judge` is the explicit structural-only mode; otherwise Codex judge/persona calls are real subprocess calls. Scenario `s3_noise` is intentionally baseline-failing today: it demonstrates that proactive ready/finished notifications violate the v1 signal contract where only `agent_blocked_question` and `fatal_error` may be proactive.
+`bin/hive-eval` runs only scenario files, writes a `hive-eval-report` JSON document with per-scenario assertions/messages/log events, and exits non-zero on scenario failure. `--no-judge` is the explicit structural-only mode; otherwise Codex judge/persona calls are real subprocess calls. Scenario `s3_noise` is intentionally baseline-failing today: it demonstrates that proactive ready/finished notifications violate the v1 signal contract where only `agent_blocked_question` and `fatal_error` may be proactive.
 
 ## Lint
 

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -146,7 +146,7 @@ bin/hive-eval --scenario s1_status --no-judge --report /tmp/hive-eval.json
 
 `test/eval/support/` provides an in-process fake Telegram transport, a programmable status watcher, a CLI child-supervisor capture, a scenario DSL, typed-reason contract assertions, scripted/Codex personas, and a Codex prose judge. Scenario files live under `test/eval/scenarios/` and drive the real `Hive::Bot::Supervisor#process_update` / `#status_tick` entrypoints without changing production bot behavior.
 
-`bin/hive-eval` runs only scenario files, writes a `hive-eval-report` JSON document with per-scenario assertions/messages/log events, and exits non-zero on scenario failure. `--no-judge` is the explicit structural-only mode; otherwise Codex judge/persona calls are real subprocess calls. Scenario `s3_noise` is intentionally baseline-failing today: it demonstrates that proactive ready/finished notifications violate the v1 signal contract where only `agent_blocked_question` and `fatal_error` may be proactive.
+`bin/hive-eval` runs only scenario files, writes a `hive-eval-report` JSON document with per-scenario assertions/messages/log events, and exits non-zero on scenario failure. `--scenario NAME` basename mode rejects path separators and resolves only under `test/eval/scenarios/`; explicit `.rb` paths remain the separate fixture-path mode. `--no-judge` is the explicit structural-only mode; otherwise Codex judge/persona calls are real subprocess calls. Scenario `s3_noise` is intentionally baseline-failing today: it demonstrates that proactive ready/finished notifications violate the v1 signal contract where only `agent_blocked_question` and `fatal_error` may be proactive.
 
 ## Lint
 


### PR DESCRIPTION
## Hive Patrol Finding

Slice: `command-bin-hive-eval`
Category: `bug`
Severity: `medium`
Confidence: `high`
Fingerprint: `10edb7dd065190281a654955d45d8030fbafba236b4169f4091e3eeb1adf1266`

The non-.rb --scenario path is documented and described as a basename, but it is joined directly under test/eval/scenarios without rejecting path separators. A value such as ../../unit/invoked_binary resolves outside the scenario directory and runs test/unit/invoked_binary_test.rb under the eval runner, so the command can silently execute non-eval tests while still reporting success.

## Evidence

- bin/hive-eval:31 basename = value.sub(/_test\z/, "")
- bin/hive-eval:32 File.join(root, "test", "eval", "scenarios", "#{basename}_test.rb")

## Applied Fix

For basename mode, reject values containing path separators or normalize and verify the resolved path remains under test/eval/scenarios. Keep explicit .rb path support separate if external fixture paths are intentional.

## Validation

- lint: passed (`bundle exec rubocop`)
- test: passed (`bundle exec rake test`)

## Diffstat

```text
 bin/hive-eval                      | 11 ++++++++++-
 test/eval/support/reporter_test.rb | 16 ++++++++++++++++
 wiki/log.md                        |  7 +++++++
 wiki/testing.md                    |  2 +-
 4 files changed, 34 insertions(+), 2 deletions(-)

```
