### PR TITLE
Hive patrol: Dry-run acceptance test can execute real mutations when the guard regresses

### DIFF
--- a/test/babysitter/acceptance/dry_run_test.rb
+++ b/test/babysitter/acceptance/dry_run_test.rb
@@ -9,28 +9,34 @@ class BabysitterAcceptanceDryRunTest < Minitest::Test
       project = babysitter_project(dir)
       worktree_path = File.join(dir, "worktree")
       FileUtils.mkdir_p(worktree_path)
+      tripwire_bin = File.join(dir, "tripwire-bin")
+      tripwire_log = File.join(dir, "tripwire.log")
+      install_tripwire_binary(tripwire_bin, "git", tripwire_log)
+      install_tripwire_binary(tripwire_bin, "gh", tripwire_log)
       pr = babysitter_pr
       command_results = []
 
-      with_non_green_babysitter_context(project, worktree_path, pr) do
-        with_replaced_singleton_method(Hive::Stages::Base, :spawn_agent, lambda { |_task, **kwargs|
-          Dir.chdir(kwargs.fetch(:cwd)) do
-            command_results << system("git", "push", "origin", "HEAD:feature", "--force-with-lease", out: File::NULL, err: File::NULL)
-            command_results << system("gh", "pr", "comment", "42", "--body", "would comment", out: File::NULL, err: File::NULL)
-            command_results << system("gh", "--repo=owner/repo", "pr", "close", "42", out: File::NULL, err: File::NULL)
-            File.write(File.join(worktree_path, ".babysitter-dry-run-plan.md"), "would repair PR 42\n")
-            { status: :ok }
+      with_env("PATH" => [ tripwire_bin, ENV.fetch("PATH", "") ].join(File::PATH_SEPARATOR)) do
+        with_non_green_babysitter_context(project, worktree_path, pr) do
+          with_replaced_singleton_method(Hive::Stages::Base, :spawn_agent, lambda { |_task, **kwargs|
+            Dir.chdir(kwargs.fetch(:cwd)) do
+              command_results << system("git", "push", "origin", "HEAD:feature", "--force-with-lease", out: File::NULL, err: File::NULL)
+              command_results << system("gh", "pr", "comment", "42", "--body", "would comment", out: File::NULL, err: File::NULL)
+              command_results << system("gh", "--repo=owner/repo", "pr", "close", "42", out: File::NULL, err: File::NULL)
+              File.write(File.join(worktree_path, ".babysitter-dry-run-plan.md"), "would repair PR 42\n")
+              { status: :ok }
+            end
+          }) do
+            outcome = Hive::Babysitter::PrFixer.run(
+              pr,
+              project,
+              babysitter_cfg,
+              dry_run: true,
+              logger: acceptance_logger,
+              inflight: Set.new
+            )
+            assert_equal :dry_run, outcome
           end
-        }) do
-          outcome = Hive::Babysitter::PrFixer.run(
-            pr,
-            project,
-            babysitter_cfg,
-            dry_run: true,
-            logger: acceptance_logger,
-            inflight: Set.new
-          )
-          assert_equal :dry_run, outcome
         end
       end
 
@@ -44,6 +50,7 @@ class BabysitterAcceptanceDryRunTest < Minitest::Test
       # commands were skipped rather than executed.
       assert command_results.all?,
              "each intercepted git/gh shim must exit 0 (#{command_results.inspect})"
+      flunk "dry-run probes escaped the PATH overlay: #{File.read(tripwire_log)}" if File.exist?(tripwire_log)
       skipped = File.read(File.join(worktree_path, ".babysitter-dry-run-skipped.log"))
       assert_includes skipped, "git push origin HEAD:feature --force-with-lease",
                       "the force-push must be intercepted, never reaching the real remote"
@@ -57,5 +64,20 @@ class BabysitterAcceptanceDryRunTest < Minitest::Test
         event["action"] == "dry_run" && event["outcome"] == "dry_run" && event["pr"] == 42
       }
     end
+  end
+
+  private
+
+  def install_tripwire_binary(dir, name, log_path)
+    FileUtils.mkdir_p(dir)
+    path = File.join(dir, name)
+    File.write(path, <<~RUBY)
+      #!/usr/bin/env ruby
+      File.open(#{log_path.dump}, "a") do |file|
+        file.puts(([File.basename($PROGRAM_NAME)] + ARGV).join(" "))
+      end
+      exit 1
+    RUBY
+    FileUtils.chmod("+x", path)
   end
 end


### PR DESCRIPTION
## Hive Patrol Finding

Slice: `test-suite-test-babysitter-acceptance-dry-run-test-rb`
Category: `bug`
Severity: `high`
Confidence: `high`
Fingerprint: `4a80c0c3909f731a57ef82bbeccb6e33580307c82d4d40b7563897049023c6da`

The acceptance test verifies the dry-run PATH overlay by issuing real mutating commands from the test process. If DryRunEnv.with_env stops prepending the stubs, points at the wrong overlay, or spawn_agent stops being wrapped, these probes fall through to the developer or CI environment instead of failing harmlessly. Because the lambda runs in the test process cwd, the git push can target the repository checkout rather than the temporary worktree, and the gh calls can comment on or close a real PR when gh is authenticated.

## Evidence

- test/babysitter/acceptance/dry_run_test.rb:16 with_replaced_singleton_method(Hive::Stages::Base, :spawn_agent, lambda { |_task, **_kwargs|
- test/babysitter/acceptance/dry_run_test.rb:17 command_results << system("git", "push", "origin", "HEAD:feature", "--force-with-lease", out: File::NULL, err: File::NULL)
- test/babysitter/acceptance/dry_run_test.rb:18 command_results << system("gh", "pr", "comment", "42", "--body", "would comment", out: File::NULL, err: File::NULL)

## Applied Fix

Make the probe commands impossible to mutate external state even when the dry-run overlay is broken. For example, prepend fake git and gh binaries that record and fail on writes, set HIVE_BABYSITTER_REAL_GIT/HIVE_BABYSITTER_REAL_GH to harmless recording scripts, or run the lambda in an isolated non-repository directory with no real gh available. Keep the assertion on the dry-run skipped log, but do not let the negative path reach real git or gh.

## Validation

- lint: passed (`bundle exec rubocop`)
- test: passed (`bundle exec rake test`)

## Diffstat

```text
 test/babysitter/acceptance/dry_run_test.rb | 56 +++++++++++++++++++++---------
 1 file changed, 39 insertions(+), 17 deletions(-)

```
