### PR TITLE
Hive patrol: Asciinema v3 casts ignore requested terminal size

### DIFF
--- a/test/e2e/lib/asciinema_driver.rb
+++ b/test/e2e/lib/asciinema_driver.rb
@@ -40,6 +40,7 @@ module Hive
         @cast_path = cast_path
         @rows = rows
         @cols = cols
+        @version = nil
         @pid = nil
         preflight!
       end
@@ -51,7 +52,7 @@ module Hive
         command = "tmux -L #{@socket_name.shellescape} attach -t #{@session_name.shellescape}"
         @pid = Process.spawn(
           self.class.binary, "rec", "--overwrite",
-          "--rows", @rows.to_s, "--cols", @cols.to_s,
+          *recorder_size_args,
           "--output-format=asciicast-v2",
           "--command", command,
           @cast_path,
@@ -124,6 +125,14 @@ module Hive
       def preflight!
         found = self.class.version
         raise Unavailable, "asciinema >= 2.4 is required for TUI e2e casts" unless found && found >= MIN_VERSION
+
+        @version = found
+      end
+
+      def recorder_size_args
+        return [ "--window-size", "#{@cols}x#{@rows}" ] if @version.segments.first >= 3
+
+        [ "--rows", @rows.to_s, "--cols", @cols.to_s ]
       end
     end
   end

--- a/test/e2e/lib/asciinema_driver_test.rb
+++ b/test/e2e/lib/asciinema_driver_test.rb
@@ -33,4 +33,44 @@ class E2EAsciinemaDriverTest < Minitest::Test
       ENV["HIVE_ASCIINEMA_BIN"] = old
     end
   end
+
+  def test_uses_window_size_arg_for_v3_binary
+    Dir.mktmpdir("asciinema") do |dir|
+      script = File.join(dir, "asciinema")
+      cast = File.join(dir, "cast.json")
+      args = File.join(dir, "args.json")
+      File.write(script, <<~RUBY)
+        #!/usr/bin/env ruby
+        require "json"
+
+        if ARGV == ["--version"]
+          puts "asciinema 3.2.0"
+          exit 0
+        end
+
+        if ARGV.first == "rec"
+          File.write(#{args.inspect}, JSON.dump(ARGV))
+          File.write(ARGV.last, %({"version":2,"width":200,"height":50}\\n))
+          sleep 30
+        end
+      RUBY
+      File.chmod(0o755, script)
+
+      old = ENV["HIVE_ASCIINEMA_BIN"]
+      ENV["HIVE_ASCIINEMA_BIN"] = script
+      driver = Hive::E2E::AsciinemaDriver.new(socket_name: "fake", session_name: "fake", cast_path: cast)
+      driver.start
+      deadline = Time.now + 2
+      sleep 0.05 until File.exist?(args) || Time.now >= deadline
+      driver.stop
+
+      argv = JSON.parse(File.read(args))
+      assert_includes argv, "--window-size"
+      assert_includes argv, "200x50"
+      refute_includes argv, "--rows"
+      refute_includes argv, "--cols"
+    ensure
+      ENV["HIVE_ASCIINEMA_BIN"] = old
+    end
+  end
 end


### PR DESCRIPTION
## Hive Patrol Finding

Slice: `test-suite-test-babysitter-acceptance-dry-run-test-rb`
Category: `bug`
Severity: `medium`
Confidence: `medium`
Fingerprint: `9f700153635184da6c2a5806c68d6c32001e81e6a50635fbe930afdafd17dc57`

The e2e cast recorder still passes legacy --rows/--cols flags. On the local supported asciinema 3.2.0 CLI those flags are accepted but the resulting asciicast header records the default 80x24 size, not the requested 200x50. TUI failure artifacts can therefore be cropped or materially different from the pane size the harness intended to capture.

## Evidence

- test/e2e/lib/asciinema_driver.rb:53 self.class.binary, "rec", "--overwrite",
- test/e2e/lib/asciinema_driver.rb:54 "--rows", @rows.to_s, "--cols", @cols.to_s,

## Applied Fix

Build the asciinema arguments from the detected major version: use --window-size "#{cols}x#{rows}" for asciinema 3.x and keep --cols/--rows only for 2.x, then add a test with a fake v3 binary that asserts the v3 argument form.

## Validation

- lint: passed (`bundle exec rubocop`)
- test: passed (`bundle exec rake test`)

## Diffstat

```text
 test/e2e/lib/asciinema_driver.rb      | 11 +++++++++-
 test/e2e/lib/asciinema_driver_test.rb | 40 +++++++++++++++++++++++++++++++++++
 2 files changed, 50 insertions(+), 1 deletion(-)

```
