### PR TITLE
Heal orphaned REVIEW_WORKING markers after a signal kill

### DIFF
--- a/lib/hive/daemon/stale_agent_healer.rb
+++ b/lib/hive/daemon/stale_agent_healer.rb
@@ -7,9 +7,11 @@ require "hive/markers"
 module Hive
   module Daemon
     # Tick-time healer for in-flight markers whose backing agent isn't
-    # actually alive. Rewrites stale markers to ERROR / REVIEW_ERROR with
-    # a `reason` attribute so the existing red-status surface in
-    # Hive::TaskAction kicks in and the disk truth stops lying.
+    # actually alive, so the disk truth stops lying. The `agent_*` paths
+    # rewrite the marker to ERROR / REVIEW_ERROR with a `reason` attribute
+    # so the existing red-status surface in Hive::TaskAction kicks in; the
+    # REVIEW_WORKING paths instead CLEAR the marker (and drop the stale
+    # .lock) so the daemon simply re-dispatches review.
     #
     # Two failure modes are healed, distinguished by the row's
     # `claude_pid_alive` field (populated by Hive::Commands::Status from
@@ -33,8 +35,10 @@ module Hive
     #   - `review_agent_died` — the review parent still holds a
     #                        verified-live .lock but its Claude child died
     #                        (live_task_lock == true, claude_pid_alive ==
-    #                        false). Terminate the wedged holder and clear
-    #                        the marker (issue #320).
+    #                        false) AND the holder has no live child
+    #                        processes (the actual "wedged" signal).
+    #                        Terminate the wedged holder and clear the
+    #                        marker (issue #320).
     #   - `review_orphaned`  — no verified-live lock holder
     #                        (live_task_lock != true) and the marker is
     #                        older than the grace window. A signal kill —
@@ -376,6 +380,15 @@ module Hive
       def release_task_lock(row)
         File.delete(File.join(row.folder.to_s, ".lock"))
       rescue Errno::ENOENT
+        nil
+      rescue SystemCallError
+        # The marker heal has already succeeded by the time we drop the
+        # lock. A stale .lock we cannot delete (EACCES, EROFS, EISDIR, …)
+        # is non-fatal residue, not a failed heal — swallow it so it does
+        # not propagate to the caller's rescue and mislabel a succeeded
+        # heal as `marker_heal_failed` (which would also suppress the
+        # `marker_healed` success event). A later tick or the next
+        # dispatch reconciles the leaked lock.
         nil
       end
 

--- a/lib/hive/daemon/stale_agent_healer.rb
+++ b/lib/hive/daemon/stale_agent_healer.rb
@@ -29,6 +29,22 @@ module Hive
     #                        process died before recording its PID in
     #                        the lock.
     #
+    # REVIEW_WORKING markers are healed on two analogous paths:
+    #   - `review_agent_died` — the review parent still holds a
+    #                        verified-live .lock but its Claude child died
+    #                        (live_task_lock == true, claude_pid_alive ==
+    #                        false). Terminate the wedged holder and clear
+    #                        the marker (issue #320).
+    #   - `review_orphaned`  — no verified-live lock holder
+    #                        (live_task_lock != true) and the marker is
+    #                        older than the grace window. A signal kill —
+    #                        daemon restart SIGTERM/SIGKILL, OOM, hard
+    #                        reboot — tore down the whole review tree
+    #                        before it could write a terminal marker;
+    #                        Stages::Review's in-process rescue never runs
+    #                        on a kill. Clear the marker + drop any stale
+    #                        lock so review re-dispatches.
+    #
     # Skip cases:
     #   - controller.running_task? returns true (an in-process dispatch
     #     is live; do not race it)
@@ -49,6 +65,7 @@ module Hive
         agent_died
         agent_orphaned
         review_agent_died
+        review_orphaned
         reviewer_tmux_session_terminated
       ].freeze
       REVIEW_ERROR_AUTO_RECOVERY_LIMIT = 3
@@ -87,7 +104,7 @@ module Hive
           end
 
           if row.marker.to_s == "review_working"
-            heal_review_row_if_stale(row)
+            heal_review_row_if_stale(row, now: now)
             next
           end
 
@@ -204,8 +221,18 @@ module Hive
         File.join(row.folder.to_s, "reviews", "errors-#{format('%02d', pass)}.md")
       end
 
-      def heal_review_row_if_stale(row)
-        return unless row.live_task_lock == true
+      def heal_review_row_if_stale(row, now:)
+        if row.live_task_lock == true
+          heal_wedged_review_row(row)
+        else
+          heal_orphaned_review_row(row, now: now)
+        end
+      end
+
+      # Case A (issue #320): the review parent still holds a verified-live
+      # .lock but its Claude child died — terminate the wedged holder,
+      # drop the lock, and clear the marker so the daemon retries review.
+      def heal_wedged_review_row(row)
         return unless row.claude_pid_alive == false
 
         holder = task_lock_holder(row)
@@ -237,6 +264,47 @@ module Hive
                       slug: row.slug,
                       stage: row.stage,
                       reason: "review_agent_died",
+                      error: "#{e.class}: #{e.message}")
+      end
+
+      # Case B: no verified-live lock holder. A signal kill — daemon
+      # restart SIGTERM/SIGKILL, OOM, or a hard reboot — tore down the
+      # whole review process tree before it could write a terminal
+      # marker, orphaning REVIEW_WORKING. The in-process rescue in
+      # Stages::Review only runs for Ruby-level exceptions, never for a
+      # kill, and the wedged-holder path above requires a live holder, so
+      # nothing else reconciles this. Past the grace window — so we don't
+      # race a runner that just set REVIEW_WORKING but hasn't recorded its
+      # lock yet (controller.running_task? already excludes in-process
+      # dispatches) — clear the marker and drop any stale .lock so the
+      # daemon re-dispatches review under normal concurrency control.
+      def heal_orphaned_review_row(row, now:)
+        mtime = row.state_file_mtime
+        return unless mtime && (now - mtime) > @grace_sec
+
+        marker_attrs = review_marker_attrs(row)
+        return unless Hive::Markers.clear_current(
+          row.state_file,
+          expected_name: :review_working,
+          match_attrs: marker_attrs
+        )
+
+        release_task_lock(row)
+        @logger.event(:marker_healed,
+                      project: row.project,
+                      slug: row.slug,
+                      stage: row.stage,
+                      prior_marker: row.marker,
+                      reason: "review_orphaned",
+                      state_file: row.state_file,
+                      phase: marker_attrs["phase"],
+                      pass: marker_attrs["pass"])
+      rescue StandardError => e
+        @logger.event(:marker_heal_failed,
+                      project: row.project,
+                      slug: row.slug,
+                      stage: row.stage,
+                      reason: "review_orphaned",
                       error: "#{e.class}: #{e.message}")
       end
 

--- a/test/unit/daemon/stale_agent_healer_test.rb
+++ b/test/unit/daemon/stale_agent_healer_test.rb
@@ -309,6 +309,89 @@ class HiveDaemonStaleAgentHealerTest < Minitest::Test
     end
   end
 
+  # Case B: a signal kill (e.g. daemon restart SIGTERM/SIGKILL) tore down
+  # the whole review tree, leaving REVIEW_WORKING with a stale .lock whose
+  # holder is gone. live_task_lock is false. Past grace, the marker clears
+  # and the stale lock is removed so the daemon re-dispatches review.
+  def test_heals_orphaned_review_working_when_holder_is_gone_past_grace
+    with_marker_file do |state_file|
+      File.write(state_file, "# task\n\n<!-- REVIEW_WORKING phase=triage pass=2 -->\n")
+      lock_path = File.join(File.dirname(state_file), ".lock")
+      File.write(lock_path, { "pid" => 999_999, "claude_pid" => 999_998 }.to_yaml)
+      row = make_row(
+        state_file,
+        pid_alive: false,
+        mtime: NOW - 1000,
+        stage: "6-review",
+        marker: "review_working",
+        marker_attrs: { "phase" => "triage", "pass" => "2" },
+        action: "agent_running",
+        live_task_lock: false
+      )
+
+      heal([ row ])
+
+      heal_event = @logger.events.find { |name, _| name == :marker_healed }
+      assert heal_event, "expected orphaned review heal, got: #{@logger.events.inspect}"
+      assert_equal "review_orphaned", heal_event[1][:reason]
+      assert_equal "triage", heal_event[1][:phase]
+      assert_equal "2", heal_event[1][:pass]
+      refute File.exist?(lock_path), "stale review lock should be removed so the daemon re-dispatches"
+      refute_match(/REVIEW_WORKING|REVIEW_ERROR/, File.read(state_file),
+                   "orphaned REVIEW_WORKING should clear so review re-dispatches under the cap")
+    end
+  end
+
+  # Case B with no .lock at all (the holder died before/without recording
+  # one, or a restart removed it): claude_pid_alive and live_task_lock are
+  # both nil. Past grace, still healed; release_task_lock tolerates ENOENT.
+  def test_heals_orphaned_review_working_with_no_lock_file
+    with_marker_file do |state_file|
+      File.write(state_file, "# task\n\n<!-- REVIEW_WORKING phase=reviewers pass=1 -->\n")
+      row = make_row(
+        state_file,
+        pid_alive: nil,
+        mtime: NOW - 1000,
+        stage: "6-review",
+        marker: "review_working",
+        marker_attrs: { "phase" => "reviewers", "pass" => "1" },
+        action: "agent_running",
+        live_task_lock: nil
+      )
+
+      heal([ row ])
+
+      heal_event = @logger.events.find { |name, _| name == :marker_healed }
+      assert heal_event, "expected orphaned review heal with no lock, got: #{@logger.events.inspect}"
+      assert_equal "review_orphaned", heal_event[1][:reason]
+      refute_match(/REVIEW_WORKING/, File.read(state_file))
+    end
+  end
+
+  # Guard against racing a runner that just set REVIEW_WORKING but hasn't
+  # recorded its lock yet: within the grace window, leave it alone.
+  def test_leaves_orphaned_review_working_within_grace
+    with_marker_file do |state_file|
+      File.write(state_file, "# task\n\n<!-- REVIEW_WORKING phase=reviewers pass=1 -->\n")
+      row = make_row(
+        state_file,
+        pid_alive: nil,
+        mtime: NOW - 100,
+        stage: "6-review",
+        marker: "review_working",
+        marker_attrs: { "phase" => "reviewers", "pass" => "1" },
+        action: "agent_running",
+        live_task_lock: false
+      )
+
+      heal([ row ])
+
+      refute @logger.events.any? { |name, _| name == :marker_healed },
+             "a freshly-set REVIEW_WORKING without a recorded lock yet must not be healed within grace"
+      assert_match(/REVIEW_WORKING/, File.read(state_file))
+    end
+  end
+
   def test_auto_recovers_reviewer_partial_failure_when_errors_are_tmux_session_terminated
     with_marker_file do |state_file|
       File.write(state_file, "# task\n\n<!-- REVIEW_ERROR phase=reviewers reason=reviewer_partial_failure pass=1 -->\n")

--- a/test/unit/daemon/stale_agent_healer_test.rb
+++ b/test/unit/daemon/stale_agent_healer_test.rb
@@ -392,6 +392,43 @@ class HiveDaemonStaleAgentHealerTest < Minitest::Test
     end
   end
 
+  # Mirror of the Case A failure test for the orphaned (Case B) path: a
+  # disk error while clearing the marker must log marker_heal_failed with
+  # reason "review_orphaned" and never crash the tick.
+  def test_orphaned_review_working_heal_logs_failure_when_marker_clear_raises
+    with_marker_file do |state_file|
+      File.write(state_file, "# task\n\n<!-- REVIEW_WORKING phase=triage pass=2 -->\n")
+      row = make_row(
+        state_file,
+        pid_alive: false,
+        mtime: NOW - 1000,
+        stage: "6-review",
+        marker: "review_working",
+        marker_attrs: { "phase" => "triage", "pass" => "2" },
+        action: "agent_running",
+        live_task_lock: false
+      )
+
+      original = Hive::Markers.method(:clear_current)
+      Hive::Markers.define_singleton_method(:clear_current) do |path, *args|
+        raise Errno::ENOSPC, "no space left" if path == state_file
+
+        original.call(path, *args)
+      end
+
+      begin
+        heal([ row ])
+      ensure
+        Hive::Markers.define_singleton_method(:clear_current, &original)
+      end
+
+      failure = @logger.events.find { |name, _| name == :marker_heal_failed }
+      assert failure, "expected marker_heal_failed, got: #{@logger.events.inspect}"
+      assert_equal "review_orphaned", failure[1][:reason]
+      assert_match(/ENOSPC/, failure[1][:error])
+    end
+  end
+
   def test_auto_recovers_reviewer_partial_failure_when_errors_are_tmux_session_terminated
     with_marker_file do |state_file|
       File.write(state_file, "# task\n\n<!-- REVIEW_ERROR phase=reviewers reason=reviewer_partial_failure pass=1 -->\n")


### PR DESCRIPTION
## Problem
A daemon restart (SIGTERM/SIGKILL), OOM, or hard reboot kills the whole review process tree before it can write a terminal marker, orphaning the transient `REVIEW_WORKING` marker. `Stages::Review`'s in-process `rescue` only runs for Ruby exceptions, never for a signal kill, and the healer's existing `review_working` path (#320) only handles the *holder-alive / Claude-child-dead* wedge (`live_task_lock == true`). So restart-orphaned reviews showed as "Agent running" forever — not counted against the concurrency cap, but never advancing — and had to be cleared by hand.

## Fix
Add a `review_orphaned` heal path mirroring the execute-side `agent_orphaned`: when a `REVIEW_WORKING` row has **no verified-live lock holder** (`live_task_lock != true`) and is **older than the grace window**, clear the marker and drop any stale `.lock` so the daemon re-dispatches review under normal concurrency control.

Guards against false positives:
- `controller.running_task?` already excludes in-process dispatches.
- The grace window protects a runner that just set `REVIEW_WORKING` but hasn't recorded its lock yet.
- The holder-alive/child-dead wedge keeps its existing `review_agent_died` path unchanged.

## Tests
`test/unit/daemon/stale_agent_healer_test.rb`: stale-lock-holder-gone, no-lock-file, and within-grace-skip cases. Full healer suite green (27 runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)