### PR TITLE
Hive patrol: e2e library test suite is red

### DIFF
--- a/test/e2e/lib/json_validator_test.rb
+++ b/test/e2e/lib/json_validator_test.rb
@@ -5,7 +5,7 @@ class E2EJsonValidatorTest < Minitest::Test
   def test_validates_status_payload
     payload = {
       "schema" => "hive-status",
-      "schema_version" => 1,
+      "schema_version" => Hive::Schemas::SCHEMA_VERSIONS.fetch("hive-status"),
       "ok" => true,
       "generated_at" => Time.now.utc.iso8601,
       "projects" => []


### PR DESCRIPTION
## Summary

The e2e library test suite was red because `test/e2e/lib/json_validator_test.rb` hardcoded `"schema_version" => 1` in the `hive-status` payload fixture. The canonical schema version lives in `Hive::Schemas::SCHEMA_VERSIONS` (`lib/hive.rb`), and once it was bumped past `1` the literal fixture no longer matched what the validator expects, so the test failed.

This PR replaces the hardcoded literal with a lookup against the source of truth:

```ruby
"schema_version" => Hive::Schemas::SCHEMA_VERSIONS.fetch("hive-status"),
```

This mirrors how production code reads the version (e.g. `lib/hive/bot/status_watcher.rb:130`), so the fixture now tracks the canonical version automatically and future schema bumps will not silently break this test.

## Test plan

- Run the e2e library suite covering `E2EJsonValidatorTest#test_validates_status_payload` and confirm it is green.
- The change is a single-line fixture fix with no production-code impact; `SCHEMA_VERSIONS.fetch("hive-status")` is the same accessor already used throughout `lib/`.

## Review summary

Automated CE code review (pass 01) ran against the diff. The reviewer's initial pass flagged nine findings, but triage determined all nine were artifacts of a stale two-dot diff range (`origin/main..HEAD`) against a merge-base that trailed `origin/main` by nine commits — they rendered upstream features the branch had not yet merged as phantom "removals." The real change set (three-dot `origin/main...HEAD`, identical to what this PR merges) is the single-line schema-version fix above, and none of the flagged files are touched by it. All findings were resolved as no-fix; no escalations or user questions were raised.

## Linked task

/home/asterio/Dev/hive/.hive-state/stages/6-review/patrol-test-suite-test-babysitter-acceptance-dry-run-test-rb-ba3
