### PR TITLE
Dispatch later pipeline stages first (drain near-done work)

### DIFF
--- a/lib/hive/daemon/dispatcher.rb
+++ b/lib/hive/daemon/dispatcher.rb
@@ -256,8 +256,10 @@ module Hive
           dispatch_patrol_with_gates(patrol_dispatch, now: now)
         end
 
-        # 4. Per-row dispatch
-        result.rows.each { |row| handle_row(row, now: now) }
+        # 4. Per-row dispatch, later pipeline stages first (see
+        # dispatch_priority_order) so work nearest completion drains
+        # ahead of newer earlier-stage work when slots are scarce.
+        dispatch_priority_order(result.rows).each { |row| handle_row(row, now: now) }
 
         # 5. Bound the persisted dispatch-baseline file to the live task set.
         # Only reached on a SUCCESSFUL status fetch (the `unless result.ok`
@@ -817,6 +819,25 @@ module Hive
           now: now,
           trigger: trigger
         )
+      end
+
+      # Order rows so tasks closer to the end of the pipeline dispatch
+      # first: a 7-artifacts row before a 6-review row, an 8-finalize
+      # before both. When concurrency slots are scarce this drains work
+      # nearest completion ahead of newer earlier-stage work (a WIP-limit
+      # — don't start a fresh review while finalizes wait on a slot).
+      # Stable within a stage (original status order preserved), and
+      # unranked/unknown stages sort last.
+      def dispatch_priority_order(rows)
+        rows.each_with_index
+            .sort_by { |row, idx| [ -stage_rank(row.stage), idx ] }
+            .map(&:first)
+      end
+
+      # Pipeline position of a stage dir (higher = closer to done); -1 for
+      # an unrecognized stage so it deprioritizes behind every known stage.
+      def stage_rank(stage)
+        Hive::Stages::DIRS.index(stage.to_s) || -1
       end
 
       def observe_external_running_rows(rows)

--- a/test/unit/daemon/dispatcher_test.rb
+++ b/test/unit/daemon/dispatcher_test.rb
@@ -234,6 +234,41 @@ class HiveDaemonDispatcherTest < Minitest::Test
     assert events_include?(logger, :dispatched)
   end
 
+  def test_dispatches_later_pipeline_stages_first
+    # Rows supplied in pipeline order; the dispatcher must flip them so the
+    # task closest to done (8-finalize) claims a slot before earlier-stage
+    # work (6-review), draining the pipeline rather than starving it.
+    rows = [
+      row(slug: "rev", stage: "6-review", action: "ready_to_plan", command: "hive run rev"),
+      row(slug: "art", stage: "7-artifacts", action: "ready_to_plan", command: "hive run art"),
+      row(slug: "fin", stage: "8-finalize", action: "ready_to_plan", command: "hive run fin")
+    ]
+    dispatcher, sup, = make_dispatcher(rows: rows)
+
+    dispatcher.tick(now: T0)
+
+    assert_equal %w[8-finalize 7-artifacts 6-review], sup.spawned.map { |s| s[:stage] },
+                 "tasks closer to the end of the pipeline must dispatch first"
+  end
+
+  def test_dispatch_priority_order_is_later_stage_first_and_stable
+    rows = [
+      row(slug: "a", stage: "2-brainstorm"),
+      row(slug: "b", stage: "7-artifacts"),
+      row(slug: "c", stage: "6-review"),
+      row(slug: "d", stage: "7-artifacts"),
+      row(slug: "e", stage: "9-done")
+    ]
+    dispatcher, = make_dispatcher
+
+    ordered = dispatcher.send(:dispatch_priority_order, rows)
+
+    assert_equal %w[9-done 7-artifacts 7-artifacts 6-review 2-brainstorm],
+                 ordered.map(&:stage), "later stages first"
+    assert_equal %w[b d], ordered.select { |r| r.stage == "7-artifacts" }.map(&:slug),
+                 "stable within a stage — original status order preserved"
+  end
+
   def test_advance_action_skips_when_task_folder_vanished_after_snapshot
     missing = File.join(Dir.tmpdir, "hive-dispatcher-missing-#{Process.pid}-#{rand(1_000_000)}")
     FileUtils.rm_rf(missing)


### PR DESCRIPTION
## Problem
The daemon's per-row dispatch loop iterated `result.rows` in `hive status` order — stage-dir order (`1-inbox → 9-done`). With a limited `max_concurrent_runs`, earlier-stage rows (e.g. `6-review`) were always considered first and claimed every free slot, so tasks closer to done (`7-artifacts`, `8-finalize`) waited behind newly-started reviews. Work accumulated at the tail of the pipeline instead of flushing out — observed as "Ready to finalize" tasks sitting idle while new reviews kept starting.

## Fix
Order dispatch candidates by **pipeline position descending** before the per-row loop (`dispatch_priority_order` / `stage_rank`): a task nearest completion takes a slot before newer earlier-stage work. A WIP-limit — drain finalizes before starting fresh reviews. The sort is **stable within a stage** (original status order preserved), and unranked/unknown stages sort last. No change to the gating itself (`can_dispatch?`, in-flight checks) — only the order candidates are considered.

## Tests
`test/unit/daemon/dispatcher_test.rb`:
- `test_dispatches_later_pipeline_stages_first` — rows supplied in pipeline order spawn in `8-finalize → 7-artifacts → 6-review` order.
- `test_dispatch_priority_order_is_later_stage_first_and_stable` — direct ordering + within-stage stability.

Full dispatcher suite green (104 runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)