### PR TITLE
Give patrol scans a separate concurrency budget

### DIFF
--- a/lib/hive/commands/daemon.rb
+++ b/lib/hive/commands/daemon.rb
@@ -162,6 +162,7 @@ module Hive
           max_concurrent_runs: daemon_cfg.fetch("max_concurrent_runs"),
           max_concurrent_per_project: daemon_cfg.fetch("max_concurrent_per_project"),
           max_runs_per_day_per_project: daemon_cfg.fetch("max_runs_per_day_per_project"),
+          max_concurrent_patrol_scans: daemon_cfg.fetch("max_concurrent_patrol_scans"),
           # Persist first-sight dispatch baselines so a daemon restart doesn't
           # re-strand already-answered needs_input tasks. The store owns all
           # `:daemon_dispatch_baselines_*` typed events via its own logger.

--- a/lib/hive/config.rb
+++ b/lib/hive/config.rb
@@ -268,6 +268,9 @@ module Hive
         "max_concurrent_runs" => 3,
         "max_concurrent_per_project" => 3,
         "max_runs_per_day_per_project" => 50,
+        # Patrol scans (`hive patrol PROJECT`) run on their own budget so a
+        # long codex-backed scan never consumes a task-dispatch slot.
+        "max_concurrent_patrol_scans" => 1,
         "transient_retry_backoff_sec" => 60,
         "shutdown_grace_sec" => 600,
         # R-02: per-child wall-clock timeout for daemon-spawned `hive`
@@ -1477,6 +1480,7 @@ module Hive
       [ "pr_merge_poll_interval_sec", 60 ],
       [ "max_concurrent_runs", 1 ],
       [ "max_concurrent_per_project", 1 ],
+      [ "max_concurrent_patrol_scans", 1 ],
       [ "max_runs_per_day_per_project", 1 ],
       [ "transient_retry_backoff_sec", 1 ],
       [ "shutdown_grace_sec", 0 ],

--- a/lib/hive/daemon/concurrency_controller.rb
+++ b/lib/hive/daemon/concurrency_controller.rb
@@ -34,10 +34,15 @@ module Hive
       attr_reader :max_concurrent_runs, :max_concurrent_per_project, :max_runs_per_day_per_project
 
       def initialize(max_concurrent_runs:, max_concurrent_per_project:, max_runs_per_day_per_project:,
-                     dispatch_state: nil)
+                     max_concurrent_patrol_scans: 1, dispatch_state: nil)
         @max_concurrent_runs = max_concurrent_runs
         @max_concurrent_per_project = max_concurrent_per_project
         @max_runs_per_day_per_project = max_runs_per_day_per_project
+        # Patrol SCANS (`hive patrol PROJECT`) run on a SEPARATE budget so a
+        # long codex-backed scan never consumes a task-dispatch slot. They
+        # are tagged `kind: :patrol_scan` in @running and excluded from the
+        # task caps below; this counter bounds them independently.
+        @max_concurrent_patrol_scans = max_concurrent_patrol_scans
         # Optional Hive::Daemon::DispatchBaselines store. When present, the
         # `[project, slug] => mtime` baseline map survives daemon restarts so
         # an already-answered needs_input row isn't re-stranded on first sight
@@ -88,14 +93,39 @@ module Hive
 
         external_global = [ @external_running_global, external_global_count.to_i ].max
         external_project = [ @external_running_by_project[project].to_i, external_project_count.to_i ].max
-        active_global_count = @running.size + external_global
-        active_project_count = @running.count { |_pid, entry| entry[:project] == project } + external_project
+        # Task caps count only task-kind runs; patrol scans live on their
+        # own budget (see can_dispatch_patrol_scan?) so a running scan never
+        # eats a task slot.
+        active_global_count = task_running_count + external_global
+        active_project_count = task_running_count(project: project) + external_project
 
         return :global_cap  if active_global_count >= @max_concurrent_runs
         return :project_cap if active_project_count >= @max_concurrent_per_project
         return :daily_cap   if daily_count_for(project, now) >= @max_runs_per_day_per_project
 
         :ok
+      end
+
+      # Gate for a patrol SCAN dispatch. Scans have their own concurrency
+      # budget so they never compete with task dispatch for the global cap.
+      #   :ok | :project_dropped | :patrol_scan_cap
+      def can_dispatch_patrol_scan?(project:, now: Time.now)
+        return :project_dropped if @dropped_projects.include?(project)
+
+        scan_count = @running.count { |_pid, entry| entry[:kind] == :patrol_scan }
+        return :patrol_scan_cap if scan_count >= @max_concurrent_patrol_scans
+
+        :ok
+      end
+
+      # Number of running task-kind dispatches (patrol scans excluded),
+      # optionally scoped to one project.
+      def task_running_count(project: nil)
+        @running.count do |_pid, entry|
+          next false if entry[:kind] == :patrol_scan
+
+          project.nil? || entry[:project] == project
+        end
       end
 
       # Refresh counts for active agent rows discovered from `hive status`
@@ -143,14 +173,15 @@ module Hive
       # slot for the (project, today) pair (refunded later if the run
       # exits with TEMPFAIL — see record_completion).
       def record_dispatch(pid:, project:, slug:, stage:, command:,
-                          started_at:, state_file_mtime:)
+                          started_at:, state_file_mtime:, kind: :task)
         @running[pid] = {
           project: project,
           slug: slug,
           stage: stage,
           command: command,
           started_at: started_at,
-          state_file_mtime_at_dispatch: state_file_mtime
+          state_file_mtime_at_dispatch: state_file_mtime,
+          kind: kind
         }
         @daily_counts[[ project, started_at.to_date ]] += 1
         if state_file_mtime

--- a/lib/hive/daemon/dispatcher.rb
+++ b/lib/hive/daemon/dispatcher.rb
@@ -950,11 +950,10 @@ module Hive
           return
         end
 
-        gate = @controller.can_dispatch?(
-          project: project, slug: slug, now: now,
-          external_global_count: @external_active_agent_total,
-          external_project_count: external_active_agent_count_for(project)
-        )
+        # Patrol scans use their OWN concurrency budget (not the task
+        # max_concurrent_runs) so a long codex-backed scan never starves
+        # task dispatch — a running scan no longer eats a task slot.
+        gate = @controller.can_dispatch_patrol_scan?(project: project, now: now)
         unless gate == :ok
           @logger.event(:blocked, project: project, slug: slug,
                                   stage: patrol_dispatch[:stage],
@@ -971,7 +970,8 @@ module Hive
           state_file_path: patrol_dispatch[:state_file_path],
           hive_state_path: patrol_dispatch[:hive_state_path],
           now: now,
-          trigger: "patrol"
+          trigger: "patrol",
+          kind: :patrol_scan
         )
       rescue StandardError => e
         # A spawn error is a genuine failure: route it through `complete`
@@ -1343,7 +1343,7 @@ module Hive
 
       def dispatch_command(command, project:, slug:, stage:, state_file_mtime:,
                            state_file_path:, hive_state_path:, now:, trigger: "advance",
-                           request_id: nil)
+                           request_id: nil, kind: :task)
         if @dry_run
           @logger.event(:dry_run, project: project, slug: slug, stage: stage,
                                   command: command)
@@ -1358,7 +1358,8 @@ module Hive
         )
         @controller.record_dispatch(
           pid: pid, project: project, slug: slug, stage: stage,
-          command: command, started_at: now, state_file_mtime: state_file_mtime
+          command: command, started_at: now, state_file_mtime: state_file_mtime,
+          kind: kind
         )
         @logger.event(:dispatched, pid: pid, project: project, slug: slug,
                                    stage: stage, command: command, trigger: trigger,

--- a/test/unit/commands/daemon_test.rb
+++ b/test/unit/commands/daemon_test.rb
@@ -57,6 +57,7 @@ class HiveCommandsDaemonTest < Minitest::Test
       "max_concurrent_runs" => 2,
       "max_concurrent_per_project" => 1,
       "max_runs_per_day_per_project" => 3,
+      "max_concurrent_patrol_scans" => 1,
       "log_file" => File.join(@home, "logs", "daemon.log"),
       "log_max_bytes" => 1024,
       "log_max_files" => 2,

--- a/test/unit/daemon/concurrency_controller_test.rb
+++ b/test/unit/daemon/concurrency_controller_test.rb
@@ -11,20 +11,65 @@ require "hive/daemon/dispatch_baselines"
 class HiveDaemonConcurrencyControllerTest < Minitest::Test
   T0 = Time.utc(2026, 5, 6, 12, 0, 0)
 
-  def make(global: 3, per_project: 1, daily: 50)
+  def make(global: 3, per_project: 1, daily: 50, patrol_scans: 1)
     Hive::Daemon::ConcurrencyController.new(
       max_concurrent_runs: global,
       max_concurrent_per_project: per_project,
-      max_runs_per_day_per_project: daily
+      max_runs_per_day_per_project: daily,
+      max_concurrent_patrol_scans: patrol_scans
     )
   end
 
-  def dispatch(c, pid, project, slug, mtime: T0 - 60, started_at: T0)
+  def dispatch(c, pid, project, slug, mtime: T0 - 60, started_at: T0, kind: :task)
     c.record_dispatch(
       pid: pid, project: project, slug: slug,
       stage: "6-review", command: "hive run #{slug}",
-      started_at: started_at, state_file_mtime: mtime
+      started_at: started_at, state_file_mtime: mtime, kind: kind
     )
+  end
+
+  # ── patrol-scan separate budget ────────────────────────────────────────
+
+  def test_patrol_scan_does_not_count_against_task_global_cap
+    c = make(global: 2, per_project: 5)
+    dispatch(c, 100, "hive", "patrol-scan", kind: :patrol_scan)
+    # Scan is running, but task slots are untouched: two tasks still fit.
+    assert_equal :ok, c.can_dispatch?(project: "p1", slug: "s1", now: T0)
+    dispatch(c, 101, "p1", "s1")
+    assert_equal :ok, c.can_dispatch?(project: "p2", slug: "s2", now: T0)
+    dispatch(c, 102, "p2", "s2")
+    # Now both TASK slots are full (scan excluded) → global_cap.
+    assert_equal :global_cap, c.can_dispatch?(project: "p3", slug: "s3", now: T0)
+  end
+
+  def test_patrol_scan_excluded_from_per_project_cap
+    c = make(global: 5, per_project: 1)
+    dispatch(c, 100, "hive", "patrol-scan", kind: :patrol_scan)
+    # A scan for project "hive" does not consume hive's per-project task slot.
+    assert_equal :ok, c.can_dispatch?(project: "hive", slug: "s1", now: T0)
+  end
+
+  def test_can_dispatch_patrol_scan_respects_its_own_budget
+    c = make(patrol_scans: 1)
+    assert_equal :ok, c.can_dispatch_patrol_scan?(project: "hive", now: T0)
+    dispatch(c, 100, "hive", "patrol-scan", kind: :patrol_scan)
+    assert_equal :patrol_scan_cap, c.can_dispatch_patrol_scan?(project: "hive", now: T0)
+  end
+
+  def test_running_tasks_do_not_block_a_patrol_scan
+    c = make(global: 2, patrol_scans: 1)
+    dispatch(c, 100, "p1", "s1")
+    dispatch(c, 101, "p2", "s2") # task global cap full
+    # Task cap is full, but a scan is on its own budget → still allowed.
+    assert_equal :ok, c.can_dispatch_patrol_scan?(project: "hive", now: T0)
+  end
+
+  def test_patrol_scan_slot_frees_on_completion
+    c = make(patrol_scans: 1)
+    dispatch(c, 100, "hive", "patrol-scan", kind: :patrol_scan)
+    assert_equal :patrol_scan_cap, c.can_dispatch_patrol_scan?(project: "hive", now: T0)
+    c.record_completion(pid: 100, exit_code: 0, completed_at: T0)
+    assert_equal :ok, c.can_dispatch_patrol_scan?(project: "hive", now: T0)
   end
 
   # ── caps ──────────────────────────────────────────────────────────────

--- a/test/unit/daemon/dispatcher_test.rb
+++ b/test/unit/daemon/dispatcher_test.rb
@@ -510,13 +510,15 @@ class HiveDaemonDispatcherTest < Minitest::Test
                     "a gated patrol must release the scheduler's pending marker or the project wedges forever"
   end
 
-  def test_patrol_dispatch_respects_capacity
-    dispatcher, sup, ctrl, logger, _mw, patrol = make_dispatcher(
+  def test_patrol_scan_not_blocked_by_full_task_cap
+    dispatcher, sup, ctrl, _logger, _mw, patrol = make_dispatcher(
       rows: [], with_patrol_scheduler: true
     )
+    # Fill the TASK cap with a task-kind run.
     ctrl.instance_variable_set(:@max_concurrent_runs, 1)
     ctrl.record_dispatch(pid: 999, project: "p1", slug: "running", stage: "6-review",
-                         command: "hive review running", started_at: T0, state_file_mtime: T0 - 60)
+                         command: "hive review running", started_at: T0,
+                         state_file_mtime: T0 - 60, kind: :task)
     patrol.next_dispatches = [ {
       project: "p1", slug: "patrol", stage: "patrol",
       command: "hive patrol p1 --json", state_file_mtime: nil,
@@ -525,12 +527,33 @@ class HiveDaemonDispatcherTest < Minitest::Test
 
     dispatcher.tick(now: T0)
 
+    assert_equal 1, sup.spawned.size,
+                 "a patrol scan runs on its own budget and is not blocked by a full task cap"
+    assert_equal "hive patrol p1 --json", sup.spawned.first[:command]
+  end
+
+  def test_patrol_scan_blocked_when_its_own_budget_is_full
+    dispatcher, sup, ctrl, logger, _mw, patrol = make_dispatcher(
+      rows: [], with_patrol_scheduler: true
+    )
+    # Fill the patrol-scan budget (default 1) with a running scan.
+    ctrl.record_dispatch(pid: 999, project: "p1", slug: "patrol-running", stage: "patrol",
+                         command: "hive patrol p1 --json", started_at: T0,
+                         state_file_mtime: nil, kind: :patrol_scan)
+    patrol.next_dispatches = [ {
+      project: "p2", slug: "patrol", stage: "patrol",
+      command: "hive patrol p2 --json", state_file_mtime: nil,
+      state_file_path: nil, hive_state_path: nil
+    } ]
+
+    dispatcher.tick(now: T0)
+
     assert_equal 0, sup.spawned.size
     blocked = logger.events.find { |(name, attrs)| name == :blocked && attrs[:action] == "patrol" }
     refute_nil blocked
-    assert_equal "global_cap", blocked[1][:reason]
-    assert_includes patrol.cancelled, "p1",
-                    "a capacity-gated patrol must release its pending marker so it retries when capacity frees"
+    assert_equal "patrol_scan_cap", blocked[1][:reason]
+    assert_includes patrol.cancelled, "p2",
+                    "a budget-gated patrol must release its pending marker so it retries when the scan budget frees"
   end
 
   def test_patrol_dispatch_skips_legacy_layout_project


### PR DESCRIPTION
## Problem
`hive patrol PROJECT` scans were dispatched through the same gate as task runs (`can_dispatch?` → `record_dispatch`), so a scan counted against `max_concurrent_runs`. A scan runs a long codex analysis (~10–20 min), so while it ran it held one of the (default 3) task slots — observed live as the daemon processing **only 2 tasks** at a time, with the 3rd slot occupied by a running `hive patrol` scan and everything else blocked `global_cap`.

## Fix
- Tag dispatches with `kind` (`:task` default; `:patrol_scan` for scans), stored in `@running`.
- Task caps (`can_dispatch?`, global + per-project) count **only task-kind** runs (`task_running_count`).
- Patrol scans gated by a separate `daemon.max_concurrent_patrol_scans` budget (default **1**) via new `can_dispatch_patrol_scan?`; `dispatch_patrol_with_gates` uses it and tags the dispatch `kind: :patrol_scan`.
- Net: a running scan no longer steals a task slot — tasks always get the full `max_concurrent_runs`, and scans run alongside on their own small budget.

## Tests
- `concurrency_controller_test.rb`: scan excluded from task global + per-project caps; own budget enforced; running tasks don't block a scan; slot frees on completion.
- `dispatcher_test.rb`: rewrote the old `test_patrol_dispatch_respects_capacity` (which encoded the now-removed "scan blocked by task cap" behavior) into `test_patrol_scan_not_blocked_by_full_task_cap` and `test_patrol_scan_blocked_when_its_own_budget_is_full` (reason `patrol_scan_cap`).
- `daemon_test.rb` fixture updated with the new key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)