### PR TITLE
Hive patrol: E2E clean accepts `/tmp` as a cleanup root

### DIFF
--- a/test/e2e/lib/path_safety.rb
+++ b/test/e2e/lib/path_safety.rb
@@ -64,12 +64,17 @@ module Hive
           raise ArgumentError, "runs_dir #{root.inspect} must not be a symlinked path" unless real == root
         end
 
-        forbidden = [ "/", Dir.home, File.expand_path("../../..", __dir__) ].map { |path| File.expand_path(path) }
+        tmp_root = File.expand_path(Dir.tmpdir)
+        forbidden = [
+          "/",
+          Dir.home,
+          File.expand_path("../../..", __dir__),
+          tmp_root
+        ].map { |path| File.expand_path(path) }
         if forbidden.any? { |path| root == path }
           raise ArgumentError, "refusing to clean unsafe runs_dir #{root.inspect}"
         end
 
-        tmp_root = File.expand_path(Dir.tmpdir)
         return root if root == default_root || contained?(tmp_root, root)
 
         raise ArgumentError, "runs_dir #{root.inspect} must be the e2e runs directory or a temp test directory"

--- a/test/e2e/lib/sandbox_test.rb
+++ b/test/e2e/lib/sandbox_test.rb
@@ -67,6 +67,12 @@ class E2ESandboxTest < Minitest::Test
     end
   end
 
+  def test_cleanup_runs_refuses_tmp_root
+    assert_raises(ArgumentError) do
+      Hive::E2E::Sandbox.cleanup_runs(runs_dir: Dir.tmpdir, dry_run: true)
+    end
+  end
+
   def test_cleanup_runs_only_deletes_generated_run_directories
     Dir.mktmpdir("e2e-runs") do |runs_dir|
       old_generated = File.join(runs_dir, "2026-04-30T12-00-00Z-1234-abcd")


### PR DESCRIPTION
## Summary

`bin/hive-e2e clean` delegates to `Sandbox.cleanup_runs`, whose path-safety
check accepted `Dir.tmpdir` itself as a valid runs directory: `contained?(tmp_root, root)`
returns true when `root` equals `tmp_root`. With `HIVE_E2E_RUNS_DIR=/tmp`, cleanup
would scan every direct child of `/tmp` and delete any directory matching the
generated run-id pattern past retention — including directories the e2e harness
never created.

This change adds `Dir.tmpdir` to the `forbidden` roots list so the safety guard
rejects it outright. Cleanup is still allowed for the default runs directory or a
dedicated child temp directory the harness owns; only the bare temp root is
refused.

## Test plan

- New regression `test_cleanup_runs_refuses_tmp_root` asserts
  `Sandbox.cleanup_runs(runs_dir: Dir.tmpdir, dry_run: true)` raises `ArgumentError`.
- `bundle exec ruby -Itest -Ilib -Itest/e2e/lib test/e2e/lib/sandbox_test.rb` — passed
- `bundle exec ruby -Itest -Ilib -Itest/e2e/lib test/e2e/lib/hive_e2e_binary_test.rb` — passed
- `bundle exec rubocop` — passed

## Review summary

Codex CE code review (pass 01) reported zero findings (High/Medium/Nit all clear)
with both verification commands passing. No escalations required.

## Linked task

Hive patrol finding `command-bin-hive-2`
(fingerprint `c48fc87dcbda6b8683befc5dae7e7ad30756c830de9d4728ecea13f25264cdb6`).
