### PR TITLE
Hive patrol: Dry-run gh stub allows browser-launch command execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,9 @@
 /.daemon.pid
 /daemon.pid
 /logs/
+# Babysitter dry-run skip log — local artifact written when gh commands are
+# skipped under HIVE_BABYSITTER_DRY_RUN; never source.
+/.babysitter-dry-run-skipped.log
 .qmd/
 /.llm-wiki/qmd-cache/
 /.llm-wiki/post-commit-refresh.log

--- a/bin/hive-babysitter-stub-gh
+++ b/bin/hive-babysitter-stub-gh
@@ -91,6 +91,11 @@ def api_read_only?(rest)
   !payload
 end
 
+def browser_launch_option?(arg)
+  arg == "--web" || arg.start_with?("--web=") ||
+    arg == "-w" || arg.start_with?("-w=")
+end
+
 def read_only?(rest)
   case rest[0]
   when "api"
@@ -115,10 +120,12 @@ def browser_option?(arg)
 end
 
 rest = stripped_global_options(argv)
+browser_launch_screened = argv.any? { |arg| browser_launch_option?(arg) }
 
-unless !argv.any? { |arg| browser_option?(arg) } && read_only?(rest)
+unless !browser_launch_screened && read_only?(rest)
   log_skip(argv)
-  warn "[dry-run] gh #{argv.join(' ')} skipped"
+  reason = browser_launch_screened ? " (browser-launch option screened)" : ""
+  warn "[dry-run] gh #{argv.join(' ')} skipped#{reason}"
   exit 0
 end
 
@@ -127,5 +134,6 @@ if real.empty?
   warn "hive-babysitter dry-run: HIVE_BABYSITTER_REAL_GH is unset; refusing to guess a path for the real gh binary"
   exit 127
 end
-%w[GH_BROWSER BROWSER].each { |key| ENV.delete(key) }
+
+%w[GH_BROWSER BROWSER GH_PAGER PAGER].each { |key| ENV.delete(key) }
 exec(real, *argv)

--- a/bin/hive-babysitter-stub-gh
+++ b/bin/hive-babysitter-stub-gh
@@ -92,8 +92,13 @@ def api_read_only?(rest)
 end
 
 def browser_launch_option?(arg)
-  arg == "--web" || arg.start_with?("--web=") ||
-    arg == "-w" || arg.start_with?("-w=")
+  return true if arg == "--web" || arg.start_with?("--web=")
+  return false unless arg.start_with?("-") && !arg.start_with?("--")
+
+  # Short-flag cluster such as "-w", "-cw", or "-w=value". The bundled cluster
+  # (before any "=" value) launches the browser whenever it contains "w".
+  cluster = arg[1..].to_s.split("=", 2).first
+  cluster.to_s.include?("w")
 end
 
 def read_only?(rest)

--- a/test/unit/babysitter/dry_run_env_test.rb
+++ b/test/unit/babysitter/dry_run_env_test.rb
@@ -254,6 +254,7 @@ class BabysitterDryRunEnvTest < Minitest::Test
     end
   end
 
+
   def test_gh_stub_screens_browser_flags_and_scrubs_browser_pager_env
     with_tmp_dir do |dir|
       real_gh = recording_binary(dir, "real-gh", env_keys: %w[GH_BROWSER BROWSER GH_PAGER PAGER])
@@ -287,7 +288,6 @@ class BabysitterDryRunEnvTest < Minitest::Test
       refute_includes real_invocations, "PAGER="
     end
   end
-
   private
 
   def assert_stubbed(env, binary, *args)
@@ -313,15 +313,12 @@ class BabysitterDryRunEnvTest < Minitest::Test
                     "#{binary} #{args.join(' ')} passed (exit 0) but never reached real #{binary}"
   end
 
-  def recording_binary(dir, name, env_keys: [])
+  def recording_binary(dir, name)
     path = File.join(dir, name)
     File.write(path, <<~RUBY)
       #!/usr/bin/env ruby
       File.open(#{File.join(dir, "real.log").dump}, "a") do |file|
         file.puts(([File.basename($PROGRAM_NAME)] + ARGV).join(" "))
-        #{env_keys.inspect}.each do |key|
-          file.puts("\#{key}=\#{ENV[key]}") if ENV.key?(key)
-        end
       end
     RUBY
     FileUtils.chmod("+x", path)

--- a/test/unit/babysitter/dry_run_env_test.rb
+++ b/test/unit/babysitter/dry_run_env_test.rb
@@ -270,12 +270,14 @@ class BabysitterDryRunEnvTest < Minitest::Test
       assert_stubbed env, "gh", "pr", "view", "42", "--web"
       assert_stubbed env, "gh", "repo", "view", "--web"
       assert_stubbed env, "gh", "run", "view", "123", "-w"
+      assert_stubbed env, "gh", "pr", "view", "42", "-cw"
       assert_passes env, "gh", "pr", "view", "42"
 
       skipped = File.read(log_path)
       assert_includes skipped, "gh pr view 42 --web skipped"
       assert_includes skipped, "gh repo view --web skipped"
       assert_includes skipped, "gh run view 123 -w skipped"
+      assert_includes skipped, "gh pr view 42 -cw skipped"
 
       real_invocations = File.read(File.join(dir, "real.log"))
       assert_includes real_invocations, "real-gh pr view 42"

--- a/test/unit/babysitter/dry_run_env_test.rb
+++ b/test/unit/babysitter/dry_run_env_test.rb
@@ -254,6 +254,38 @@ class BabysitterDryRunEnvTest < Minitest::Test
     end
   end
 
+  def test_gh_stub_screens_browser_flags_and_scrubs_browser_pager_env
+    with_tmp_dir do |dir|
+      real_gh = recording_binary(dir, "real-gh", env_keys: %w[GH_BROWSER BROWSER GH_PAGER PAGER])
+      log_path = File.join(dir, "skipped.log")
+      env = {
+        "HIVE_BABYSITTER_REAL_GH" => real_gh,
+        "HIVE_BABYSITTER_DRY_RUN_LOG" => log_path,
+        "GH_BROWSER" => "touch pwned",
+        "BROWSER" => "touch pwned",
+        "GH_PAGER" => "touch pwned",
+        "PAGER" => "touch pwned"
+      }
+
+      assert_stubbed env, "gh", "pr", "view", "42", "--web"
+      assert_stubbed env, "gh", "repo", "view", "--web"
+      assert_stubbed env, "gh", "run", "view", "123", "-w"
+      assert_passes env, "gh", "pr", "view", "42"
+
+      skipped = File.read(log_path)
+      assert_includes skipped, "gh pr view 42 --web skipped"
+      assert_includes skipped, "gh repo view --web skipped"
+      assert_includes skipped, "gh run view 123 -w skipped"
+
+      real_invocations = File.read(File.join(dir, "real.log"))
+      assert_includes real_invocations, "real-gh pr view 42"
+      refute_includes real_invocations, "GH_BROWSER="
+      refute_includes real_invocations, "BROWSER="
+      refute_includes real_invocations, "GH_PAGER="
+      refute_includes real_invocations, "PAGER="
+    end
+  end
+
   private
 
   def assert_stubbed(env, binary, *args)
@@ -279,12 +311,15 @@ class BabysitterDryRunEnvTest < Minitest::Test
                     "#{binary} #{args.join(' ')} passed (exit 0) but never reached real #{binary}"
   end
 
-  def recording_binary(dir, name)
+  def recording_binary(dir, name, env_keys: [])
     path = File.join(dir, name)
     File.write(path, <<~RUBY)
       #!/usr/bin/env ruby
       File.open(#{File.join(dir, "real.log").dump}, "a") do |file|
         file.puts(([File.basename($PROGRAM_NAME)] + ARGV).join(" "))
+        #{env_keys.inspect}.each do |key|
+          file.puts("\#{key}=\#{ENV[key]}") if ENV.key?(key)
+        end
       end
     RUBY
     FileUtils.chmod("+x", path)


### PR DESCRIPTION
## Summary

Closes a default-deny bypass in the babysitter dry-run `gh` stub (`bin/hive-babysitter-stub-gh`). The stub allowlists read-looking subcommands (`gh pr view`, `gh repo view`, `gh run view`) and then execs the real `gh`. Those subcommands accept `--web`/`-w`, which makes `gh` spawn a browser command taken from `GH_BROWSER`/`BROWSER` — so an agent could smuggle arbitrary command execution through an allowlisted "read-only" invocation.

This change screens browser-launch flags before exec and scrubs the exec-influencing environment, matching the git stub's hardening:

- `browser_launch_option?` detects `--web`, `--web=…`, and short-flag clusters that contain `w` (`-w`, `-cw`, `-w=value`). Any screened invocation is logged and skipped instead of passed through.
- Before the legitimate exec path, `GH_BROWSER`, `BROWSER`, `GH_PAGER`, and `PAGER` are deleted from the environment so the real `gh` cannot be steered into launching an attacker-controlled command.
- The local `.babysitter-dry-run-skipped.log` artifact is now gitignored (and a previously committed copy was removed) so dry-run runs no longer dirty the worktree.

## Test plan

- `bundle exec ruby -Itest test/unit/babysitter/dry_run_env_test.rb` — new `test_gh_stub_screens_browser_flags_and_scrubs_browser_pager_env` asserts that `--web`, `-w`, and the bundled `-cw` cluster are all skipped (and logged), that a plain `gh pr view 42` still passes through, and that none of the four browser/pager env vars reach the real binary. The recording stub helper was extended to capture env keys for the negative assertions.

## Review summary

Three CE code-review passes ran against the branch.

- **Pass 01 (High):** Bundled `gh -w` short-flag clusters (`-cw`) bypassed the original `--web`-only guard. Auto-fixed by detecting `w` inside short-flag clusters in `browser_launch_option?`.
- **Pass 02 (Nit):** A generated `.babysitter-dry-run-skipped.log` was committed at the repo root. Auto-fixed by removing it and adding a `.gitignore` entry.
- The remaining pass-02 High/Medium findings were two-dot-diff artifacts: the reviewer used `origin/main..HEAD` while `origin/main` sits 4 commits ahead of this branch's merge-base, so upstream-only commits (#385, #386, #387, dirty-PR recovery) surfaced as reverse hunks. None of those files appear in the branch's actual three-dot diff; all marked RESOLVED/NO-FIX (stale).
- **Pass 03:** Zero findings across all tiers; validation clean (`git diff --check` on both diff forms, tests green).

## Linked task

Patrol finding `command-bin-hive-e2e-1` (fingerprint `e24da59bd9f52b88e730fb6b4d22754d8ec8a45c0dfee87965da9059b3baac64`).
Task folder: `.hive-state/stages/8-finalize/patrol-command-bin-hive-e2e-e24da59b`
