### PR TITLE
Hive patrol: gh dry-run pass-through can execute pager/browser commands

### DIFF
--- a/bin/hive-babysitter-stub-gh
+++ b/bin/hive-babysitter-stub-gh
@@ -110,13 +110,16 @@ def read_only?(rest)
   end
 end
 
-def browser_option?(arg)
-  arg == "--web" || arg.start_with?("--web=") || arg == "-w" || arg.start_with?("-w=")
+def external_launcher_option?(rest)
+  return true if rest.any? { |arg| arg == "--web" || arg.start_with?("--web=") }
+  return false unless [%w[pr view], %w[repo view], %w[run view], %w[workflow view]].include?(rest[0, 2])
+
+  rest.drop(2).any? { |arg| arg == "-w" || arg.start_with?("-w") }
 end
 
 rest = stripped_global_options(argv)
 
-unless !argv.any? { |arg| browser_option?(arg) } && read_only?(rest)
+unless read_only?(rest) && !external_launcher_option?(rest)
   log_skip(argv)
   warn "[dry-run] gh #{argv.join(' ')} skipped"
   exit 0
@@ -127,5 +130,6 @@ if real.empty?
   warn "hive-babysitter dry-run: HIVE_BABYSITTER_REAL_GH is unset; refusing to guess a path for the real gh binary"
   exit 127
 end
-%w[GH_BROWSER BROWSER].each { |key| ENV.delete(key) }
+
+%w[GH_PAGER PAGER GH_BROWSER BROWSER GH_EDITOR GIT_EDITOR VISUAL EDITOR GH_FORCE_TTY].each { |key| ENV.delete(key) }
 exec(real, *argv)

--- a/test/unit/babysitter/dry_run_env_test.rb
+++ b/test/unit/babysitter/dry_run_env_test.rb
@@ -254,6 +254,50 @@ class BabysitterDryRunEnvTest < Minitest::Test
     end
   end
 
+  def test_gh_stub_scrubs_exec_influencing_environment_before_passthrough
+    with_tmp_dir do |dir|
+      env_keys = %w[GH_PAGER PAGER GH_BROWSER BROWSER GH_EDITOR GIT_EDITOR VISUAL EDITOR GH_FORCE_TTY]
+      real_gh = recording_env_binary(dir, "real-gh", env_keys)
+      env = {
+        "HIVE_BABYSITTER_REAL_GH" => real_gh,
+        "HIVE_BABYSITTER_DRY_RUN_LOG" => File.join(dir, "skipped.log"),
+        "GH_PAGER" => "touch pager-pwned",
+        "PAGER" => "touch pager-pwned",
+        "GH_BROWSER" => "touch browser-pwned",
+        "BROWSER" => "touch browser-pwned",
+        "GH_EDITOR" => "touch editor-pwned",
+        "GIT_EDITOR" => "touch editor-pwned",
+        "VISUAL" => "touch editor-pwned",
+        "EDITOR" => "touch editor-pwned",
+        "GH_FORCE_TTY" => "80"
+      }
+
+      _out, err, status = Open3.capture3(env, stub_path("gh"), "repo", "view", "owner/repo")
+
+      assert status.success?, err
+      assert_equal env_keys.map { |key| "#{key}=<unset>" }.join("\n") + "\n", File.read(File.join(dir, "env.log"))
+    end
+  end
+
+  def test_gh_stub_skips_browser_launch_flags
+    with_tmp_dir do |dir|
+      real_gh = recording_binary(dir, "real-gh")
+      env = {
+        "HIVE_BABYSITTER_REAL_GH" => real_gh,
+        "HIVE_BABYSITTER_DRY_RUN_LOG" => File.join(dir, "skipped.log"),
+        "GH_BROWSER" => "touch browser-pwned",
+        "BROWSER" => "touch browser-pwned"
+      }
+
+      assert_stubbed env, "gh", "repo", "view", "owner/repo", "--web"
+      assert_stubbed env, "gh", "repo", "view", "owner/repo", "--web=true"
+      assert_stubbed env, "gh", "pr", "view", "42", "--web"
+      assert_stubbed env, "gh", "repo", "view", "owner/repo", "-w"
+
+      refute File.exist?(File.join(dir, "real.log"))
+    end
+  end
+
   private
 
   def assert_stubbed(env, binary, *args)
@@ -285,6 +329,22 @@ class BabysitterDryRunEnvTest < Minitest::Test
       #!/usr/bin/env ruby
       File.open(#{File.join(dir, "real.log").dump}, "a") do |file|
         file.puts(([File.basename($PROGRAM_NAME)] + ARGV).join(" "))
+      end
+    RUBY
+    FileUtils.chmod("+x", path)
+    path
+  end
+
+  def recording_env_binary(dir, name, keys)
+    path = File.join(dir, name)
+    File.write(path, <<~RUBY)
+      #!/usr/bin/env ruby
+      keys = #{keys.inspect}
+      File.open(#{File.join(dir, "env.log").dump}, "a") do |file|
+        keys.each do |key|
+          value = ENV.key?(key) ? ENV.fetch(key) : "<unset>"
+          file.puts("\#{key}=\#{value}")
+        end
       end
     RUBY
     FileUtils.chmod("+x", path)

--- a/test/unit/babysitter/dry_run_env_test.rb
+++ b/test/unit/babysitter/dry_run_env_test.rb
@@ -254,6 +254,7 @@ class BabysitterDryRunEnvTest < Minitest::Test
     end
   end
 
+
   def test_gh_stub_scrubs_exec_influencing_environment_before_passthrough
     with_tmp_dir do |dir|
       env_keys = %w[GH_PAGER PAGER GH_BROWSER BROWSER GH_EDITOR GIT_EDITOR VISUAL EDITOR GH_FORCE_TTY]
@@ -297,7 +298,6 @@ class BabysitterDryRunEnvTest < Minitest::Test
       refute File.exist?(File.join(dir, "real.log"))
     end
   end
-
   private
 
   def assert_stubbed(env, binary, *args)
@@ -335,6 +335,10 @@ class BabysitterDryRunEnvTest < Minitest::Test
     path
   end
 
+  def stub_path(binary)
+    File.expand_path("../../../bin/hive-babysitter-stub-#{binary}", __dir__)
+  end
+
   def recording_env_binary(dir, name, keys)
     path = File.join(dir, name)
     File.write(path, <<~RUBY)
@@ -349,9 +353,5 @@ class BabysitterDryRunEnvTest < Minitest::Test
     RUBY
     FileUtils.chmod("+x", path)
     path
-  end
-
-  def stub_path(binary)
-    File.expand_path("../../../bin/hive-babysitter-stub-#{binary}", __dir__)
   end
 end


### PR DESCRIPTION
## Summary

The babysitter `gh` dry-run stub (`bin/hive-babysitter-stub-gh`) allowlists read-only-looking commands such as `gh repo view` and `gh pr view`, then `exec`s the real `gh` with the caller environment intact. GitHub CLI honors exec-influencing environment variables and flags on those paths, so a read-only command could still run arbitrary commands — bypassing the dry-run stub's read-only safety model:

- `GH_PAGER` / `PAGER` could launch a pager command on `view` output.
- `GH_BROWSER` / `BROWSER` (plus the `--web` / `-w` launch flags) could open — and execute — a browser command.
- Editor variables (`GH_EDITOR`, `GIT_EDITOR`, `VISUAL`, `EDITOR`) are in the same exec-influencing class.

This change closes that gap to match the safety model the adjacent `git` stub already enforces:

- **Reject external-launch flags** on allowlisted reads: `--web` / `--web=...` on any command, and `-w` on `pr view`, `repo view`, `run view`, and `workflow view` now fall through to the skip path instead of passing through.
- **Scrub exec-influencing environment** before `exec`ing the real `gh`: `GH_PAGER`, `PAGER`, `GH_BROWSER`, `BROWSER`, `GH_EDITOR`, `GIT_EDITOR`, `VISUAL`, `EDITOR`, and `GH_FORCE_TTY` are deleted from the environment.

## Test plan

Added two regression tests in `test/unit/babysitter/dry_run_env_test.rb`:

- `test_gh_stub_scrubs_exec_influencing_environment_before_passthrough` — sets every exec-influencing variable to a payload and asserts all nine keys are unset by the time the real `gh` binary runs.
- `test_gh_stub_skips_browser_launch_flags` — asserts `--web`, `--web=true`, `-w`, and `pr view --web` are skipped (never reach the real binary).

Run with:

```
ruby -Itest test/unit/babysitter/dry_run_env_test.rb
```

## Review summary

Codex CE code review (pass 01) raised four findings (1 High, 2 Medium, 1 Nit). All four were confirmed to be diff-base staleness artifacts, not real branch changes: the reviewer diffed `origin/main..HEAD` while the branch is behind `origin/main` (merge-base `f10f13ca`), so three unmerged mainline commits — `b0ffc7d8` (#385), `4323c3fa` (#386), `94944baf` (#387) — appeared as reversions. The branch's actual commits only touch `bin/hive-babysitter-stub-gh`, its regression tests, and related wiki pages; those mainline commits are preserved on rebase/merge. No code fix was warranted.

## Linked task

Patrol finding `command-bin-hv-1` (fingerprint `2b6678fd664776739b232f04a91ae79b604d6c1661c1bfb5fd6987e87aff3bd1`).

Task: `/home/asterio/Dev/hive/.hive-state/stages/8-finalize/patrol-command-bin-hv-2b6678fd`
