### PR TITLE
Hive patrol: gh passthrough keeps exec-influencing environment

### DIFF
--- a/bin/hive-babysitter-stub-gh
+++ b/bin/hive-babysitter-stub-gh
@@ -93,4 +93,7 @@ if real.empty?
   warn "hive-babysitter dry-run: HIVE_BABYSITTER_REAL_GH is unset; refusing to guess a path for the real gh binary"
   exit 127
 end
+
+%w[GH_PAGER PAGER GH_BROWSER BROWSER GH_EDITOR GIT_EDITOR VISUAL EDITOR GH_FORCE_TTY].each { |key| ENV.delete(key) }
+
 exec(real, *argv)

--- a/test/unit/babysitter/dry_run_env_test.rb
+++ b/test/unit/babysitter/dry_run_env_test.rb
@@ -150,6 +150,23 @@ class BabysitterDryRunEnvTest < Minitest::Test
     end
   end
 
+  def test_gh_passthrough_scrubs_exec_influencing_environment
+    with_tmp_dir do |dir|
+      scrubbed_keys = %w[GH_PAGER PAGER GH_BROWSER BROWSER GH_EDITOR GIT_EDITOR VISUAL EDITOR GH_FORCE_TTY]
+      real_gh = env_recording_binary(dir, "real-gh", scrubbed_keys)
+      env = { "HIVE_BABYSITTER_REAL_GH" => real_gh }
+      scrubbed_keys.each { |key| env[key] = "touch pwned" }
+
+      _out, err, status = Open3.capture3(env, stub_path("gh"), "pr", "view", "42")
+
+      assert status.success?, err
+      recorded_env = File.read(File.join(dir, "real-gh-env.log"))
+      scrubbed_keys.each do |key|
+        assert_includes recorded_env, "#{key}=nil"
+      end
+    end
+  end
+
   private
 
   def assert_stubbed(env, binary, *args)
@@ -169,6 +186,19 @@ class BabysitterDryRunEnvTest < Minitest::Test
       #!/usr/bin/env ruby
       File.open(#{File.join(dir, "real.log").dump}, "a") do |file|
         file.puts(([File.basename($PROGRAM_NAME)] + ARGV).join(" "))
+      end
+    RUBY
+    FileUtils.chmod("+x", path)
+    path
+  end
+
+  def env_recording_binary(dir, name, keys)
+    path = File.join(dir, name)
+    File.write(path, <<~RUBY)
+      #!/usr/bin/env ruby
+      keys = #{keys.inspect}
+      File.open(#{File.join(dir, "#{name}-env.log").dump}, "a") do |file|
+        keys.each { |key| file.puts("\#{key}=\#{ENV[key].inspect}") }
       end
     RUBY
     FileUtils.chmod("+x", path)


### PR DESCRIPTION
## Hive Patrol Finding

Slice: `command-bin-hive-babysitter-stub-gh`
Category: `security`
Severity: `high`
Confidence: `medium`
Fingerprint: `515fd1213e960cfff09c0802a9d5973b81169b66cd73f6602d7eb4bf3237f21d`

Unlike the git stub, the gh stub execs the real binary without clearing environment variables that make gh launch external programs. A dry-run agent can set values such as `GH_PAGER`, `PAGER`, `GH_BROWSER`, `BROWSER`, or `GH_FORCE_TTY` and then run an allowlisted read command, turning the dry-run passthrough into command execution.

## Evidence

- bin/hive-babysitter-stub-gh:91 real = ENV["HIVE_BABYSITTER_REAL_GH"].to_s
- bin/hive-babysitter-stub-gh:96 exec(real, *argv)
- bin/hive-babysitter-stub-git:150 %w[GIT_EXTERNAL_DIFF GIT_PAGER GIT_SSH GIT_SSH_COMMAND].each { |key| ENV.delete(key) }

## Applied Fix

Delete gh exec-influencing variables before `exec`, including `GH_PAGER`, `PAGER`, `GH_BROWSER`, `BROWSER`, `GH_EDITOR`, `GIT_EDITOR`, `VISUAL`, `EDITOR`, and `GH_FORCE_TTY`. Add a recording real-gh regression test that proves those keys are unset on passthrough.

## Validation

- lint: passed (`bundle exec rubocop`)
- test: passed (`bundle exec rake test`)

## Diffstat

```text
 bin/hive-babysitter-stub-gh              |  3 +++
 test/unit/babysitter/dry_run_env_test.rb | 30 ++++++++++++++++++++++++++++++
 2 files changed, 33 insertions(+)

```
