### PR TITLE
Hive patrol: hv aborts on executable directories

### DIFF
--- a/bin/hv
+++ b/bin/hv
@@ -36,7 +36,7 @@ candidates=(
 
 for candidate in "${candidates[@]}"; do
   [[ -n "$candidate" ]] || continue
-  [[ -x "$candidate" ]] || continue
+  [[ -f "$candidate" && -x "$candidate" ]] || continue
 
   resolved="$(readlink -f "$candidate" 2>/dev/null || echo "$candidate")"
   # Guard against `hv -> hv` chains: never exec into our own script.

--- a/test/unit/hv_test.rb
+++ b/test/unit/hv_test.rb
@@ -68,4 +68,28 @@ class HvTest < Minitest::Test
       refute_includes out, "wrong:probe"
     end
   end
+
+  def test_executable_directory_candidate_does_not_abort_fallback_search
+    with_tmp_dir do |dir|
+      xdg_hive = File.join(dir, "xdg-bin", "hive")
+      homebrew_hive = File.join(dir, "homebrew", "bin", "hive")
+      FileUtils.mkdir_p(xdg_hive)
+      FileUtils.mkdir_p(File.dirname(homebrew_hive))
+      File.write(homebrew_hive, "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo 1.2.3; exit 0; fi\necho homebrew:$1\n")
+      FileUtils.chmod(0o755, homebrew_hive)
+
+      out, err, status = Open3.capture3(
+        {
+          "HIVE_BIN_OVERRIDE" => nil,
+          "XDG_BIN_HOME" => File.dirname(xdg_hive),
+          "HOMEBREW_PREFIX" => File.join(dir, "homebrew")
+        },
+        HV_BIN,
+        "probe"
+      )
+
+      assert status.success?, err
+      assert_equal "homebrew:probe\n", out
+    end
+  end
 end


### PR DESCRIPTION
## Summary

`bin/hv` is a wrapper that walks a list of candidate paths and `exec`s the first runnable `hive` it finds (override → `$XDG_BIN_HOME/hive` → Homebrew → `/usr/local/bin/hive`). The candidate gate was `[[ -x "$candidate" ]]`, which is also true for directories, since directories normally carry the execute bit. When an earlier candidate such as `$XDG_BIN_HOME/hive` happened to be a directory, the wrapper would `exec` it, fail with exit 126, and abort — never falling through to a later, valid binary.

The fix tightens the gate to require a regular file as well: `[[ -f "$candidate" && -x "$candidate" ]]`. Directory candidates are now skipped, and the search continues to the next entry.

- `bin/hv` — candidate test now requires an executable **regular file**.
- `wiki/cli.md`, `wiki/operating.md`, `wiki/testing.md`, `wiki/index.md`, `wiki/gaps.md`, `wiki/log.md` — docs updated to record the regular-file requirement.

## Test plan

- `bundle exec rubocop` — passed.
- `bundle exec rake test` — passed.
- Added `test/unit/hv_test.rb#test_executable_directory_candidate_does_not_abort_fallback_search`: places an executable **directory** at the first candidate (`$XDG_BIN_HOME/hive`) and a valid binary at the Homebrew candidate, then asserts the wrapper skips the directory and execs the Homebrew binary (`homebrew:probe`).

## Review summary

Two Codex CE review passes. One Medium finding in pass 01 — `wiki/operating.md` was not refreshed for the regular-file requirement — was auto-fixed by mirroring the `wiki/cli.md` phrasing into `wiki/operating.md`. Pass 02 found no issues. No High or Nit findings, and no items required escalation to the user.

## Linked task

- Patrol finding: `command-bin-hv-2` (fingerprint `aca30d7d5b40bb1930c93cba099cdb44f268390cd3f5d8f15a4d5f58818694e1`)
- Task folder: `/home/asterio/Dev/hive/.hive-state/stages/6-review/patrol-command-bin-hv-aca30d7d`
