### PR TITLE
Hive patrol: Inherited TEST bypasses hive-eval scenario confinement

### DIFF
--- a/test/eval/support/reporter_test.rb
+++ b/test/eval/support/reporter_test.rb
@@ -102,6 +102,28 @@ class HiveEvalReporterTest < Minitest::Test
     end
   end
 
+  def test_cli_ignores_inherited_test_when_running_all_scenarios
+    Dir.mktmpdir("hive-eval-report") do |dir|
+      root = File.expand_path("../../..", __dir__)
+      scenario_dir = File.join(root, "test", "eval", "scenarios") + File::SEPARATOR
+      report = File.join(dir, "all.json")
+
+      _out, err, _status = Open3.capture3(
+        { "HIVE_EVAL_NO_JUDGE" => "1", "TEST" => "test/eval/support/scaffold_test.rb" },
+        "bin/hive-eval", "--no-judge", "--report", report
+      )
+
+      assert File.exist?(report), err
+      files = JSON.parse(File.read(report))
+        .fetch("scenarios")
+        .map { |entry| File.expand_path(entry.fetch("file"), root) }
+
+      refute_empty files
+      assert files.all? { |file| file.start_with?(scenario_dir) },
+             "expected only scenario files, got #{files.inspect}"
+    end
+  end
+
   def test_cli_rejects_scenario_paths_outside_scenario_dir
     Dir.mktmpdir("hive-eval-report") do |dir|
       report = File.join(dir, "outside.json")


### PR DESCRIPTION
## Summary

`bin/hive-eval` builds an explicit child environment for the `rake test:eval`
run but only set `TEST` when `--scenario` was supplied. Without `--scenario`,
the child inherited any ambient `TEST` value. Because `Rake::TestTask` honors
`TEST`, an inherited `TEST=some/other_test.rb` could make `hive-eval` run an
arbitrary test file and silently skip the scenario set — bypassing both
`HIVE_EVAL_SCENARIOS_ONLY` and the safe-basename validation. The reported
reproduction (`TEST=test/eval/support/reporter_test.rb bin/hive-eval --no-judge
--report ...`) exited 0 with an empty scenario report instead of running the
scenarios.

The fix owns `TEST` explicitly in the child environment: it is now seeded to
`nil` in the base env hash, so the all-scenarios path clears any inherited
value, while the `--scenario` path continues to set it to the validated
scenario path.

## Test plan

- Added `test_cli_ignores_inherited_test_when_running_all_scenarios` in
  `test/eval/support/reporter_test.rb`: invokes `bin/hive-eval` with an
  inherited `TEST` pointing outside `test/eval/scenarios`, then asserts the
  report is non-empty and every reported file lives under the scenarios
  directory.
- `bundle exec ruby -Itest test/eval/support/reporter_test.rb` — 6 runs, 28
  assertions, 0 failures.

## Review summary

Codex CE code review (pass 01) found no High, Medium, or Nit issues. All
findings were auto-resolved; no user escalations were raised.

## Linked task

- Patrol finding: `command-bin-hive-eval-1`
  (fingerprint `fa196400ae078d027b604f6db234c8ba3c773bca78bc114ad3128b580c33a82b`)
- Task folder:
  `/home/asterio/Dev/hive/.hive-state/stages/6-review/patrol-command-bin-hive-eval-fa196400`
