### PR TITLE
Hive patrol: Live TUI logs bypass truncation

### DIFF
--- a/test/e2e/lib/artifact_capture.rb
+++ b/test/e2e/lib/artifact_capture.rb
@@ -51,6 +51,7 @@ module Hive
         guard("state") { copy_tree(File.join(@sandbox_dir, ".hive-state", "stages"), File.join(@scenario_dir, "state")) }
         guard("logs") { copy_logs_with_tails }
         guard("tui-subprocess") { copy_tui_subprocess_diagnostics }
+        guard("tui-subprocess-live") { remove_live_tui_subprocess_diagnostics }
         guard("step-results.json") { write("step-results.json", JSON.pretty_generate(step_results)) }
         write_manifest
       end
@@ -146,6 +147,11 @@ module Hive
         else
           FileUtils.cp(source, dest)
         end
+      end
+
+      def remove_live_tui_subprocess_diagnostics
+        live_dir = File.join(@scenario_dir, "tui-subprocess-live")
+        FileUtils.rm_rf(live_dir)
       end
 
       def tail_lines(path, count)

--- a/test/e2e/lib/artifact_capture_test.rb
+++ b/test/e2e/lib/artifact_capture_test.rb
@@ -164,25 +164,30 @@ class E2EArtifactCaptureTest < Minitest::Test
       copied_spawn = File.join(scenario_dir, "tui-subprocess", "hive-tui-spawn-BIG.log")
       assert File.size(copied_spawn) < File.size(spawn_log),
              "artifact bundle should not copy oversized per-spawn captures wholesale"
-      assert File.size("#{copied_spawn}.tail") <= File.size(copied_spawn),
-             "tail companion should be derived from the truncated bundle copy"
       assert_includes File.read(copied_spawn, 128), "truncated to last"
     end
   end
 
-  def test_manifest_excludes_live_tui_subprocess_logs
+  def test_tui_subprocess_live_logs_are_removed_before_manifest
     with_dirs do |scenario_dir, sandbox, run_home|
-      log_dir = File.join(scenario_dir, "tui-subprocess-live")
-      FileUtils.mkdir_p(log_dir)
-      File.write(File.join(log_dir, "hive-tui-spawn-LIVE.log"), "LIVE\n")
+      live_dir = File.join(scenario_dir, "tui-subprocess-live")
+      FileUtils.mkdir_p(live_dir)
+      oversized_bytes = Hive::E2E::ArtifactCapture::TUI_SPAWN_CAPTURE_MAX_BYTES + 10
+      spawn_log = File.join(live_dir, "hive-tui-spawn-BIG.log")
+      File.write(spawn_log, "x" * oversized_bytes)
 
-      collect(scenario_dir, sandbox, run_home, tui_log_dir: log_dir)
+      collect(scenario_dir, sandbox, run_home, tui_log_dir: live_dir)
+
+      copied_spawn = File.join(scenario_dir, "tui-subprocess", "hive-tui-spawn-BIG.log")
+      assert File.exist?(copied_spawn), "bounded per-spawn copy should be retained"
+      assert_operator File.size(copied_spawn), :<, oversized_bytes,
+                      "oversized live output should only be retained through the truncated copy"
+      refute File.directory?(live_dir), "unbounded live TUI log directory should not remain in the bundle"
 
       manifest = JSON.parse(File.read(File.join(scenario_dir, "manifest.json")))
-      paths = manifest["files"].map { |file| file["path"] }
+      paths = manifest.fetch("files").map { |file| file.fetch("path") }
       refute paths.any? { |path| path.start_with?("tui-subprocess-live/") },
-        "manifest should publish only curated tui-subprocess copies, not live logs"
-      assert_includes paths, "tui-subprocess/hive-tui-spawn-LIVE.log"
+             "manifest should not include unbounded live TUI logs"
     end
   end
 

--- a/test/e2e/lib/artifact_capture_test.rb
+++ b/test/e2e/lib/artifact_capture_test.rb
@@ -164,7 +164,40 @@ class E2EArtifactCaptureTest < Minitest::Test
       copied_spawn = File.join(scenario_dir, "tui-subprocess", "hive-tui-spawn-BIG.log")
       assert File.size(copied_spawn) < File.size(spawn_log),
              "artifact bundle should not copy oversized per-spawn captures wholesale"
+      assert File.size("#{copied_spawn}.tail") <= File.size(copied_spawn),
+             "tail companion should be derived from the truncated bundle copy"
       assert_includes File.read(copied_spawn, 128), "truncated to last"
+    end
+  end
+
+  def test_manifest_excludes_live_tui_subprocess_logs
+    with_dirs do |scenario_dir, sandbox, run_home|
+      log_dir = File.join(scenario_dir, "tui-subprocess-live")
+      FileUtils.mkdir_p(log_dir)
+      File.write(File.join(log_dir, "hive-tui-spawn-LIVE.log"), "LIVE\n")
+
+      collect(scenario_dir, sandbox, run_home, tui_log_dir: log_dir)
+
+      manifest = JSON.parse(File.read(File.join(scenario_dir, "manifest.json")))
+      paths = manifest["files"].map { |file| file["path"] }
+      refute paths.any? { |path| path.start_with?("tui-subprocess-live/") },
+        "manifest should publish only curated tui-subprocess copies, not live logs"
+      assert_includes paths, "tui-subprocess/hive-tui-spawn-LIVE.log"
+    end
+  end
+
+  def test_env_snapshot_is_json_with_schema_version
+    with_dirs do |scenario_dir, sandbox, run_home|
+      collect(scenario_dir, sandbox, run_home)
+
+      json_path = File.join(scenario_dir, "env-snapshot.json")
+      assert File.exist?(json_path), "env-snapshot must be JSON, not plaintext"
+
+      payload = JSON.parse(File.read(json_path))
+      assert_equal "hive-e2e-env-snapshot", payload["schema"]
+      assert_equal 1, payload["schema_version"]
+      assert_kind_of String, payload["ruby"]
+      assert_kind_of String, payload["platform"]
     end
   end
 
@@ -188,21 +221,6 @@ class E2EArtifactCaptureTest < Minitest::Test
       paths = manifest.fetch("files").map { |file| file.fetch("path") }
       refute paths.any? { |path| path.start_with?("tui-subprocess-live/") },
              "manifest should not include unbounded live TUI logs"
-    end
-  end
-
-  def test_env_snapshot_is_json_with_schema_version
-    with_dirs do |scenario_dir, sandbox, run_home|
-      collect(scenario_dir, sandbox, run_home)
-
-      json_path = File.join(scenario_dir, "env-snapshot.json")
-      assert File.exist?(json_path), "env-snapshot must be JSON, not plaintext"
-
-      payload = JSON.parse(File.read(json_path))
-      assert_equal "hive-e2e-env-snapshot", payload["schema"]
-      assert_equal 1, payload["schema_version"]
-      assert_kind_of String, payload["ruby"]
-      assert_kind_of String, payload["platform"]
     end
   end
 end


### PR DESCRIPTION
## Summary

Patrol found that the E2E artifact bundle could grow unbounded despite `TUI_SPAWN_CAPTURE_MAX_BYTES`. `ArtifactCapture` truncates per-spawn TUI logs into `tui-subprocess/`, but the *live* log directory (`tui-subprocess-live/`) sits inside the scenario artifact directory, and `write_manifest` includes every file under that directory. The original untruncated `tui-subprocess-live/hive-tui-spawn-*.log` files therefore stayed in the retained failure bundle, so a verbose failed TUI subprocess could still produce very large artifacts.

This change removes the live TUI log directory after the bounded per-spawn diagnostics are copied and before the manifest is written:

- `artifact_capture.rb`: adds a `tui-subprocess-live` capture guard that calls `remove_live_tui_subprocess_diagnostics`, which `FileUtils.rm_rf`s the `tui-subprocess-live` directory inside `scenario_dir`. It runs after `copy_tui_subprocess_diagnostics` (the bounded copy) and before `write_manifest`, so the truncated copy is preserved while the unbounded originals are dropped.

## Test plan

- Added `test_tui_subprocess_live_logs_are_removed_before_manifest` in `artifact_capture_test.rb`, which:
  - seeds an oversized (`TUI_SPAWN_CAPTURE_MAX_BYTES + 10`) live spawn log,
  - asserts the bounded `tui-subprocess/` copy is retained and is smaller than the original,
  - asserts the `tui-subprocess-live/` directory no longer exists in the bundle,
  - asserts `manifest.json` contains no `tui-subprocess-live/` paths.

## Review summary

Codex CE code review (pass 01) reported no High, Medium, or Nit findings. No escalations were raised; there were no open questions for the user.

## Linked task

- Patrol finding: `test-suite-test-babysitter-acceptance-dry-run-test-rb-1`
- Fingerprint: `8287be61f22b7df39c8d11b42f4b5ee6c65d5fe670240c47608147027a482007`
- Task folder: `/home/asterio/Dev/hive/.hive-state/stages/6-review/patrol-test-suite-test-babysitter-acceptance-dry-run-test-rb-828`
