### PR TITLE
docs(openclaw): improve ClawHub skill listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Hive publishes one OpenClaw skill through ClawHub:
 openclaw skills install hive-cli
 ```
 
+Public listing: <https://clawhub.ai/ivankuznetsov/hive-cli>.
+
 That listing installs the `/hive` slash command. Ask OpenClaw to run the guided
 setup:
 

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -41,6 +41,8 @@ The ClawHub slug is `hive-cli` because the public `hive` slug is already owned
 by another publisher. The installed slash command is still `/hive` because
 OpenClaw reads `name: hive` from `SKILL.md`.
 
+Public listing: <https://clawhub.ai/ivankuznetsov/hive-cli>.
+
 ## Setup Model
 
 `openclaw skills install hive-cli` installs the OpenClaw skill folder. It does
@@ -79,8 +81,8 @@ clawhub skill publish openclaw/skills/hive \
   --slug hive-cli \
   --name "Hive CLI" \
   --owner ivankuznetsov \
-  --version 0.1.0 \
-  --changelog "Initial Hive OpenClaw skill with guided setup"
+  --version 0.1.1 \
+  --changelog "Improve ClawHub listing summary and setup guidance"
 ```
 
 Do not run `clawhub sync` for this repository, and do not publish folders such

--- a/openclaw/skills/hive/SKILL.md
+++ b/openclaw/skills/hive/SKILL.md
@@ -1,14 +1,53 @@
 ---
 name: hive
-description: Install, set up, or drive any Hive CLI workflow from OpenClaw.
-version: 0.1.0
+description: >-
+  Run Hive's folder-based coding-agent pipeline from OpenClaw: guided CLI setup,
+  project init, task creation, plan/develop/review workflows, status, daemon,
+  and guarded admin commands.
+version: 0.1.1
 user-invocable: true
-metadata: {"openclaw": {"homepage": "https://github.com/ivankuznetsov/hive", "always": true, "install": [{"id": "homebrew", "kind": "brew", "formula": "ivankuznetsov/hive/hive", "bins": ["hive"], "label": "Install Hive CLI with Homebrew", "os": ["darwin"]}]}}
+metadata:
+  openclaw:
+    homepage: https://github.com/ivankuznetsov/hive
+    always: true
+    install:
+      - id: homebrew
+        kind: brew
+        formula: ivankuznetsov/hive/hive
+        bins: [hive]
+        label: Install Hive CLI with Homebrew
+        os: [darwin]
 ---
 
 # Hive CLI
 
-Use this skill when the user wants to install Hive, set up Hive in the current project, or inspect, create, advance, review, or administer Hive tasks through the `hive` CLI.
+Hive turns a repository into a folder-based coding-agent pipeline: ideas become tasks, tasks move through brainstorm, plan, develop, review, artifacts, and finalize stages, and the daemon keeps enrolled projects moving in the background.
+
+Use this skill when the user wants to install Hive from OpenClaw, initialize the current project, create a task, inspect status, move a task through plan/develop/review, run diagnostics, or administer Hive's daemon, bot, markers, metrics, and task registry.
+
+## Install From ClawHub
+
+Users install the OpenClaw skill with:
+
+```bash
+openclaw skills install hive-cli
+```
+
+That listing installs the `/hive` slash command. First run should normally be:
+
+```text
+/hive setup
+```
+
+## Common Paths
+
+- `/hive setup` installs or verifies the Hive CLI, enables the per-user daemon service, and optionally initializes the current repository.
+- `/hive status --json` shows the task board and next actions.
+- `/hive new . "build this feature"` creates a new Hive task in the current project.
+- `/hive plan <task-slug>`, `/hive develop <task-slug>`, and `/hive review <task-slug>` advance a task through the main coding workflow.
+- `/hive doctor` checks local runtime and skill configuration.
+
+## CLI Detection
 
 Before running a Hive workflow, check whether the Hive CLI is installed:
 
@@ -22,7 +61,9 @@ else
 fi
 ```
 
-If `hive_cmd` is empty, start a guided setup instead of failing. Restate that setup will install the Hive CLI, verify it, install/enable the per-user daemon service, and optionally run `hive init` for the current project. Get explicit user confirmation before running installers.
+If `hive_cmd` is empty, start guided setup instead of failing. Restate that setup will install the Hive CLI, verify it, install or enable the per-user daemon service, and optionally run `hive init` for the current project. Get explicit user confirmation before running installers.
+
+## Guided Setup
 
 Use the host platform to choose one install path:
 
@@ -40,9 +81,13 @@ bash "$tmpdir/hive-install.sh"
 
 After install, run the strict `hive` / `hv` version check again. If neither command prints a bare `X.Y.Z` version, stop and report that setup failed or Apache Hive may be shadowing the command. If verification succeeds, run `"${hive_cmd}" daemon install` once. Then ask whether to initialize the current project; if yes, run `"${hive_cmd}" init . --json </dev/null`, followed by `"${hive_cmd}" doctor` non-fatally. Summarize the installed version, daemon setup result, project initialization result, and any missing runtime dependencies.
 
+## Dispatch Rules
+
 Treat `/hive setup`, `/hive install`, and `/hive bootstrap` as requests for the guided setup flow above. Otherwise, treat the user's slash-command text after `/hive` as arguments for `hive_cmd`. If no arguments are supplied and Hive is already installed, run `"${hive_cmd}" --help` and summarize the available workflow. Run commands from the current project/workspace directory unless the user gives another path. Pass arguments safely; do not interpolate raw user text into a shell string.
 
 Prefer `--json` when the Hive command supports it and you need structured output. Summarize the result, including task slug, stage/action, marker, and next command when present.
+
+## Safety Boundaries
 
 Before running destructive admin verbs (`drop`, `uninstall`, `update`, `forget`, `prune`, `migrate`, or `metrics`), restate the effect and get explicit user confirmation. These verbs can kill agents, remove worktrees, close draft PRs, drop registry entries, or rewrite installed software — they are not undoable.
 

--- a/test/unit/openclaw_skills_test.rb
+++ b/test/unit/openclaw_skills_test.rb
@@ -6,6 +6,10 @@ class OpenClawSkillsTest < Minitest::Test
   ROOT = Pathname.new(__dir__).join("../../openclaw/skills").expand_path
   HOMEPAGE = "https://github.com/ivankuznetsov/hive"
   CLAWHUB_SLUG = "hive-cli"
+  CLAWHUB_DESCRIPTION = "Run Hive's folder-based coding-agent pipeline from OpenClaw: " \
+                        "guided CLI setup, project init, task creation, " \
+                        "plan/develop/review workflows, status, daemon, " \
+                        "and guarded admin commands."
 
   def test_only_umbrella_skill_is_published_through_clawhub
     actual = ROOT.glob("*/SKILL.md").map { |path| path.dirname.basename.to_s }.sort
@@ -18,8 +22,8 @@ class OpenClawSkillsTest < Minitest::Test
     openclaw_metadata = metadata.fetch("metadata").fetch("openclaw")
 
     assert_equal "hive", metadata.fetch("name")
-    assert_equal "Install, set up, or drive any Hive CLI workflow from OpenClaw.", metadata.fetch("description")
-    assert_equal "0.1.0", metadata.fetch("version")
+    assert_equal CLAWHUB_DESCRIPTION, metadata.fetch("description")
+    assert_equal "0.1.1", metadata.fetch("version")
     assert_equal true, metadata.fetch("user-invocable")
     assert_equal HOMEPAGE, openclaw_metadata.fetch("homepage")
     assert_equal true, openclaw_metadata.fetch("always"), "umbrella skill must remain visible for setup"
@@ -38,6 +42,11 @@ class OpenClawSkillsTest < Minitest::Test
     assert_includes body, "/hive setup"
     assert_includes body, "/hive install"
     assert_includes body, "/hive bootstrap"
+    assert_includes body, "openclaw skills install #{CLAWHUB_SLUG}"
+    assert_includes body, "/hive new ."
+    assert_includes body, "/hive plan <task-slug>"
+    assert_includes body, "/hive develop <task-slug>"
+    assert_includes body, "/hive review <task-slug>"
     assert_includes body, "hive --version"
     assert_includes body, "hv --version"
     assert_includes body, "brew install ivankuznetsov/hive/hive"

--- a/wiki/commands.md
+++ b/wiki/commands.md
@@ -1,15 +1,77 @@
 ---
 title: Interaction Surface
 type: commands
-source: bin/hive, bin/hive-e2e
+source: bin/hive, bin/hv, bin/hive-e2e, openclaw/skills/hive/SKILL.md, openclaw/README.md
 created: 2026-05-14
-updated: 2026-05-14
+updated: 2026-06-07
 tags: [commands, api]
 ---
 
-**TLDR**: External interaction surface is derived from routes, controllers, commands, and plugin surfaces.
+**TLDR**: Hive's external interaction surface is the Thor CLI (`hive` plus the
+`hv` fallback launcher), the opt-in e2e harness, and the single ClawHub
+`hive-cli` OpenClaw skill whose installed slash command is `/hive`. The Ruby
+command/API contract lives in [[cli]] and the per-command pages. OpenClaw does
+not add a second runtime and does not publish one ClawHub listing per Hive verb.
 
 ## Source Files
 
 - `bin/hive`
+- `bin/hv`
 - `bin/hive-e2e`
+- `openclaw/skills/hive/SKILL.md`
+- `openclaw/README.md`
+
+## Surfaces
+
+### Thor CLI
+
+`bin/hive` loads `Hive::CLI` and exposes the public command set documented in
+[[cli]] and `wiki/commands/*`. The CLI includes workflow verbs (`new`,
+`brainstorm`, `plan`, `develop`, `open-pr`, `review`, `artifacts`, `finalize`,
+`archive`), daemon/bot/babysitter lifecycle commands, diagnostics, markers,
+findings, metrics, update/uninstall, registry maintenance, and `--json`
+envelopes where the command page says they exist.
+
+`bin/hv` is the Apache Hive collision fallback entrypoint. It probes only the
+owned Hive CLI locations and `HIVE_BIN_OVERRIDE`; it intentionally does not
+fall through to common Apache Hive paths. See [[operating]] for install-channel
+behavior.
+
+### OpenClaw / ClawHub
+
+`openclaw/skills/hive/SKILL.md` is the only checked-in OpenClaw skill source
+published through ClawHub. The ClawHub slug is `hive-cli`, the public listing is
+`https://clawhub.ai/ivankuznetsov/hive-cli`, and the installed slash command is
+still `/hive` because OpenClaw reads `name: hive` from the skill frontmatter.
+
+The checked-in skill version is `0.1.1`. Its frontmatter `description` is the
+public listing/search summary, while the opening markdown body documents the
+install and common workflow paths. `/hive setup`, `/hive install`, and
+`/hive bootstrap` enter the guided setup flow: verify or install the Hive CLI,
+run strict `hive`/`hv` version detection, install/enable the per-user daemon,
+and optionally run non-interactive `hive init` for the current repository.
+
+For normal use, the slash-command text after `/hive` is treated as arguments
+for the detected Hive CLI binary. Examples in the skill include
+`/hive status --json`, `/hive new . "build this feature"`, `/hive plan
+<task-slug>`, `/hive develop <task-slug>`, and `/hive review <task-slug>`.
+The skill tells agents to pass arguments safely rather than interpolate raw user
+text into a shell string, to prefer `--json` when structured output is useful,
+and to confirm before destructive or foreground/blocking admin commands.
+
+OpenClaw does not introduce Ruby routes, HTTP handlers, controllers, resolvers,
+or new executable entrypoints. It is an agent-facing wrapper over the existing
+CLI.
+
+### E2E Harness
+
+`bin/hive-e2e` is the opt-in outer test harness for scenario-driven,
+subprocess-level verification. It is documented in [[e2e]] rather than treated
+as an end-user workflow command.
+
+## Backlinks
+
+- [[index]]
+- [[cli]]
+- [[operating]]
+- [[e2e]]

--- a/wiki/gaps.md
+++ b/wiki/gaps.md
@@ -3,7 +3,7 @@ title: Gaps
 type: gaps
 source: wiki/* vs lib/, templates/, test/
 created: 2026-04-25
-updated: 2026-06-06
+updated: 2026-06-07
 tags: [gap, todo]
 ---
 
@@ -60,7 +60,7 @@ Uncertainty: this table was refreshed manually from targeted source and wiki rea
 1. **Release tag trust remains the main release-channel hardening gap.** Homebrew and AUR publishing are implemented and public install docs now route macOS users to the tap and Arch users to `yay -S hive-bin` (see ADR-032 in [[decisions]], `docs/RELEASING.md`, `README.md`, and `install.md`). The remaining trust gap is that release automation signs and publishes whatever a `vX.Y.Z` tag points at; a GitHub `v*` tag-protection ruleset and/or signed git-tag verification remains the compensating control to record before considering the release chain fully hardened.
 2. **macOS x86_64 install.sh support remains unsupported.** Current `install.sh` still accepts only `darwin-arm64` on macOS and glibc Linux `x86_64`/`aarch64`; a future follow-up can add best-effort Rosetta behavior once the release smoke matrix covers it.
 3. **Claude/Codex/Pi marketplace publishing is still a companion-package follow-up.** Claude/Codex/Pi marketplace install commands are documented in `install.md` and [[operating]], but agents must not run those commands until `ivankuznetsov/hive-skills` is actually published. This is a separate external publish step from the in-tree OpenClaw bundle in entry 4 below.
-4. **OpenClaw publishes as one ClawHub skill.** `openclaw/skills/hive/` is the only public OpenClaw skill source. It publishes to ClawHub as `hive-cli`, installs a slash command named `/hive`, and handles all workflows as `/hive ...` arguments. `/hive setup` guides first-use Hive CLI install/verification, daemon install, and optional project init. The public `hive` slug is owned by another publisher, so Hive intentionally uses `hive-cli`; shortcut listings such as `hive-plan`, `hive-work`, or `hive-babysit` are not part of the public surface.
+4. **OpenClaw ClawHub listing is published; scan completion evidence is partial.** `openclaw/skills/hive/` is the only public OpenClaw skill source. It publishes to ClawHub as `hive-cli` at `https://clawhub.ai/ivankuznetsov/hive-cli`, installs a slash command named `/hive`, and handles all workflows as `/hive ...` arguments. `/hive setup` guides first-use Hive CLI install/verification, daemon install, and optional project init. The public `hive` slug is owned by another publisher, so Hive intentionally uses `hive-cli`; shortcut listings such as `hive-plan`, `hive-work`, or `hive-babysit` are not part of the public surface. The 2026-06-07 wiki log records `clawhub inspect hive-cli --json` reporting `latest: 0.1.1` and clean moderation fields, but also records `clawhub scan --slug hive-cli --version 0.1.1 --json` hanging without returning; no checked-in artifact independently proves a completed scan command.
 
 ## Patterns detected in code but not yet documented
 

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -3,7 +3,7 @@ title: hive Wiki
 type: index
 source: wiki/**/*.md
 created: 2026-05-14
-updated: 2026-06-06
+updated: 2026-06-07
 tags: [index, wiki]
 ---
 
@@ -11,9 +11,9 @@ tags: [index, wiki]
 **TLDR**: Catalog of the LLM-maintained wiki for `hive`.
 
 Page count: 74
-Updated: 2026-06-06
+Updated: 2026-06-07
 
-Folder-as-agent pipeline: a Ruby 3.4 / Thor CLI control plane that drives a nine-stage filesystem state machine (`1-inbox` → `2-brainstorm` → `3-plan` → `4-execute` → `5-open-pr` → `6-review` → `7-artifacts` → `8-finalize` → `9-done`) where stage agents run via configurable AgentProfile CLIs (`claude` default, `codex`, `pi`) and `mv` between directories is the approval primitive. The public release surface is the `hive-cli` rubygem installed through Homebrew, AUR, or `install.sh`, with `hv` as the Apache Hive collision fallback entrypoint; `hive init` now separates normal PR reviewers from narrower patrol PR reviewers, `hive patrol` hands opened PRs into `6-review` by default, and `hive babysit` plus the single in-tree OpenClaw `/hive` skill are covered by dedicated command/module pages.
+Folder-as-agent pipeline: a Ruby 3.4 / Thor CLI control plane that drives a nine-stage filesystem state machine (`1-inbox` → `2-brainstorm` → `3-plan` → `4-execute` → `5-open-pr` → `6-review` → `7-artifacts` → `8-finalize` → `9-done`) where stage agents run via configurable AgentProfile CLIs (`claude` default, `codex`, `pi`) and `mv` between directories is the approval primitive. The public release surface is the `hive-cli` rubygem installed through Homebrew, AUR, or `install.sh`, with `hv` as the Apache Hive collision fallback entrypoint; `hive init` now separates normal PR reviewers from narrower patrol PR reviewers, `hive patrol` hands opened PRs into `6-review` by default, and `hive babysit` plus the single ClawHub `hive-cli` listing that installs the OpenClaw `/hive` skill are covered by dedicated command/module pages.
 
 ## Pages
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -2,6 +2,17 @@
 
 Append-only log of all wiki operations.
 
+## [2026-06-07T10:37:00Z] openclaw - improve ClawHub listing copy
+
+**Action:** Checked live ClawHub examples and confirmed the public detail page uses `SKILL.md` frontmatter `description` as the hero/search/OpenGraph summary, then renders the opening markdown body under the `SKILL.md` tab. Updated Hive's single `hive-cli` ClawHub skill to version `0.1.1` with a more specific summary for the folder-based coding-agent pipeline, added a visible install/common-path section before the agent runtime rules, kept the single `/hive` umbrella model, and refreshed README/OpenClaw docs plus [[index]] and [[operating]]. Published `hive-cli@0.1.1` under `ivankuznetsov`; `clawhub inspect hive-cli --json` now reports `latest: 0.1.1` and the new summary. The explicit `clawhub scan --slug hive-cli --version 0.1.1 --json` command submitted but hung without returning; the registry inspect moderation fields still report `verdict: clean`, `isSuspicious: false`, and `isMalwareBlocked: false`.
+
+**Tests:** `bundle exec ruby -Itest test/unit/openclaw_skills_test.rb`; `bundle exec rubocop --format simple test/unit/openclaw_skills_test.rb`; YAML frontmatter parse check; `git diff --check`.
+
+**Refreshed pages:**
+- [[index]]
+- [[operating]]
+- [[log]]
+
 ## [2026-06-06T19:12:04Z] bot - tighten audio answer coverage docs
 
 **Action:** Followed up the audio-answer E2E work after the CI coverage gate exposed unhit voice edge branches. Added focused coverage for legacy answer-prompt reattach, unmatched voice replies, no-project voice confirm, missing voice file IDs, payload/download failures, disabled answer transcription, no-speech/unsupported/failed audio answers, failed idea transcription with an existing non-voice draft, default transcriber client setup, and malformed transcription language entries. Refreshed stale [[commands/bot]] and [[modules/bot]] metadata/TLDR so the bot overview mentions transcribed voice answers. The earlier PR #332 wiki lookup used `qmd search "telegram voice e2e audio answers bot"` and found no relevant project guidance; no new page coverage was needed. Did not run `qmd update` or `qmd embed`.

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -2,6 +2,18 @@
 
 Append-only log of all wiki operations.
 
+## [2026-06-07T10:45:00Z] wiki - refresh OpenClaw command/API coverage after ClawHub listing copy commit
+
+**Action:** Refreshed command/API surface coverage after commit `704b9705` (`docs(openclaw): improve ClawHub skill listing`) changed README/OpenClaw documentation, `openclaw/skills/hive/SKILL.md`, `test/unit/openclaw_skills_test.rb`, and existing wiki pages. Read `AGENTS.md`, [[index]], [[architecture]], [[decisions]], [[gaps]], and recent [[log]] entries first; also read `.llm-wiki/config.json`. `qmd search "command API surface routes handlers entrypoints README"` returned existing OpenClaw and release-context hits. Verified the committed diff plus `README.md`, `openclaw/README.md`, `openclaw/skills/hive/SKILL.md`, `test/unit/openclaw_skills_test.rb`, [[operating]], [[cli]], and [[commands]]. The commit does not add Ruby routes, HTTP handlers, Thor command handlers, or executable entrypoints; the changed public surface is the OpenClaw/ClawHub wrapper over the existing CLI.
+
+**Coverage:** Expanded [[commands]] so it covers `bin/hv`, the single ClawHub `hive-cli` listing, `/hive` slash-command dispatch, guided setup aliases, safe argument passing, JSON preference, and destructive/foreground confirmation rules. Updated [[operating]] source metadata and OpenClaw operating text for the public listing URL and checked-in skill version `0.1.1`. Recorded in [[gaps]] that `clawhub inspect` evidence is logged but the explicit `clawhub scan --slug hive-cli --version 0.1.1 --json` command did not return a durable checked-in artifact. No page count change, so [[index]] did not need a catalog edit. Did not run `qmd update` or `qmd embed`.
+
+**Refreshed pages:**
+- [[commands]]
+- [[operating]]
+- [[gaps]]
+- [[log]]
+
 ## [2026-06-07T10:37:00Z] openclaw - improve ClawHub listing copy
 
 **Action:** Checked live ClawHub examples and confirmed the public detail page uses `SKILL.md` frontmatter `description` as the hero/search/OpenGraph summary, then renders the opening markdown body under the `SKILL.md` tab. Updated Hive's single `hive-cli` ClawHub skill to version `0.1.1` with a more specific summary for the folder-based coding-agent pipeline, added a visible install/common-path section before the agent runtime rules, kept the single `/hive` umbrella model, and refreshed README/OpenClaw docs plus [[index]] and [[operating]]. Published `hive-cli@0.1.1` under `ivankuznetsov`; `clawhub inspect hive-cli --json` now reports `latest: 0.1.1` and the new summary. The explicit `clawhub scan --slug hive-cli --version 0.1.1 --json` command submitted but hung without returning; the registry inspect moderation fields still report `verdict: clean`, `isSuspicious: false`, and `isMalwareBlocked: false`.

--- a/wiki/operating.md
+++ b/wiki/operating.md
@@ -3,7 +3,7 @@ title: Operating Hive
 type: operating
 source: bin/hv, install.sh, lib/hive/commands/daemon.rb, lib/hive/commands/bot.rb, examples/systemd/, examples/launchd/
 created: 2026-05-07
-updated: 2026-06-05
+updated: 2026-06-07
 tags: [operating, daemon, bot, systemd, launchd, install]
 ---
 
@@ -149,12 +149,15 @@ core install still succeeds without it:
 
 OpenClaw support now lives in-tree under `openclaw/skills/hive/`. It is one
 skill, not a TypeScript plugin and not a multi-listing bundle: the ClawHub slug
-is `hive-cli`, and the installed slash command is `/hive`. `/hive setup` guides
-confirmed Hive install, strict `hive`/`hv` version verification,
-`hive daemon install`, and optional non-interactive `hive init`; after setup,
-users pass normal CLI verbs as `/hive status --json`, `/hive plan <slug>`,
-`/hive develop <slug>`, and so on. The naked `hive` ClawHub slug is already
-owned by another publisher, so it is intentionally not used.
+is `hive-cli`, and the installed slash command is `/hive`. ClawHub uses the
+skill frontmatter `description` as the public page summary and search text, so
+listing copy belongs in that field and in the opening `SKILL.md` body for the
+single umbrella skill. `/hive setup` guides confirmed Hive install, strict
+`hive`/`hv` version verification, `hive daemon install`, and optional
+non-interactive `hive init`; after setup, users pass normal CLI verbs as
+`/hive status --json`, `/hive plan <slug>`, `/hive develop <slug>`, and so on.
+The naked `hive` ClawHub slug is already owned by another publisher, so it is
+intentionally not used.
 
 ## Release verification
 

--- a/wiki/operating.md
+++ b/wiki/operating.md
@@ -1,7 +1,7 @@
 ---
 title: Operating Hive
 type: operating
-source: bin/hv, install.sh, lib/hive/commands/daemon.rb, lib/hive/commands/bot.rb, examples/systemd/, examples/launchd/
+source: bin/hv, install.sh, lib/hive/commands/daemon.rb, lib/hive/commands/bot.rb, examples/systemd/, examples/launchd/, openclaw/skills/hive/SKILL.md, openclaw/README.md
 created: 2026-05-07
 updated: 2026-06-07
 tags: [operating, daemon, bot, systemd, launchd, install]
@@ -149,12 +149,14 @@ core install still succeeds without it:
 
 OpenClaw support now lives in-tree under `openclaw/skills/hive/`. It is one
 skill, not a TypeScript plugin and not a multi-listing bundle: the ClawHub slug
-is `hive-cli`, and the installed slash command is `/hive`. ClawHub uses the
-skill frontmatter `description` as the public page summary and search text, so
-listing copy belongs in that field and in the opening `SKILL.md` body for the
-single umbrella skill. `/hive setup` guides confirmed Hive install, strict
-`hive`/`hv` version verification, `hive daemon install`, and optional
-non-interactive `hive init`; after setup, users pass normal CLI verbs as
+is `hive-cli`, the public listing is
+`https://clawhub.ai/ivankuznetsov/hive-cli`, and the installed slash command is
+`/hive`. The checked-in skill is version `0.1.1`. ClawHub uses the skill
+frontmatter `description` as the public page summary and search text, so listing
+copy belongs in that field and in the opening `SKILL.md` body for the single
+umbrella skill. `/hive setup` guides confirmed Hive install, strict `hive`/`hv`
+version verification, `hive daemon install`, and optional non-interactive
+`hive init`; after setup, users pass normal CLI verbs as
 `/hive status --json`, `/hive plan <slug>`, `/hive develop <slug>`, and so on.
 The naked `hive` ClawHub slug is already owned by another publisher, so it is
 intentionally not used.


### PR DESCRIPTION
## Summary

The ClawHub listing now describes Hive as a folder-based coding-agent pipeline instead of a generic CLI wrapper. `hive-cli@0.1.1` is already published under `ivankuznetsov`, and the source docs/tests now pin the new summary/version while preserving the single `/hive` umbrella skill model.

## Verification

- `bundle exec ruby -Itest test/unit/openclaw_skills_test.rb`
- `bundle exec rubocop --format simple test/unit/openclaw_skills_test.rb`
- YAML frontmatter parse check for `openclaw/skills/hive/SKILL.md`
- `git diff --check`
- `npx --yes clawhub inspect hive-cli --json` reports `latest: 0.1.1`
- `curl -I -L https://clawhub.ai/skills/hive-cli` redirects to the public page and returns `200`

Note: `npx --yes clawhub scan --slug hive-cli --version 0.1.1 --json` submitted but did not return; the hanging process was stopped. The registry inspect moderation fields still report `verdict: clean`, `isSuspicious: false`, and `isMalwareBlocked: false`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5_Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
