### PR TITLE
Hive patrol: hv trusts fallback hive binaries

### DIFF
--- a/bin/hv
+++ b/bin/hv
@@ -9,8 +9,21 @@ set -euo pipefail
 
 self="$(readlink -f "$0" 2>/dev/null || echo "$0")"
 
+is_hive_cli() {
+  local version
+
+  version="$("$1" --version 2>/dev/null)" || return 1
+  [[ "$version" =~ ^[0-9]+[.][0-9]+[.][0-9]+([.-][0-9A-Za-z][0-9A-Za-z._-]*)?$ ]]
+}
+
+override="${HIVE_BIN_OVERRIDE:-}"
+if [[ -n "$override" && -x "$override" ]]; then
+  resolved="$(readlink -f "$override" 2>/dev/null || echo "$override")"
+  # Guard against `hv -> hv` chains: never exec into our own script.
+  [[ "$resolved" == "$self" ]] || exec "$override" "$@"
+fi
+
 candidates=(
-  "${HIVE_BIN_OVERRIDE:-}"
   "${XDG_BIN_HOME:-${HOME}/.local/bin}/hive"
   "${HOMEBREW_PREFIX:-/opt/homebrew}/bin/hive"
   "/usr/local/bin/hive"
@@ -23,6 +36,8 @@ for candidate in "${candidates[@]}"; do
   resolved="$(readlink -f "$candidate" 2>/dev/null || echo "$candidate")"
   # Guard against `hv -> hv` chains: never exec into our own script.
   [[ "$resolved" != "$self" ]] || continue
+
+  is_hive_cli "$candidate" || continue
 
   exec "$candidate" "$@"
 done

--- a/test/unit/hv_test.rb
+++ b/test/unit/hv_test.rb
@@ -35,4 +35,44 @@ class HvTest < Minitest::Test
       assert_equal "override:probe\n", out
     end
   end
+
+  def test_implicit_candidate_with_apache_version_is_skipped
+    with_tmp_dir do |dir|
+      xdg_hive = File.join(dir, "xdg", "hive")
+      brew_hive = File.join(dir, "brew", "bin", "hive")
+      FileUtils.mkdir_p(File.dirname(xdg_hive))
+      FileUtils.mkdir_p(File.dirname(brew_hive))
+      File.write(xdg_hive, <<~SH)
+        #!/bin/sh
+        if [ "${1:-}" = "--version" ]; then
+          echo "Hive 3.1.3"
+          exit 0
+        fi
+        echo apache:$1
+      SH
+      File.write(brew_hive, <<~SH)
+        #!/bin/sh
+        if [ "${1:-}" = "--version" ]; then
+          echo "0.2.0"
+          exit 0
+        fi
+        echo brew:$1
+      SH
+      FileUtils.chmod(0o755, xdg_hive)
+      FileUtils.chmod(0o755, brew_hive)
+
+      out, err, status = Open3.capture3(
+        {
+          "HIVE_BIN_OVERRIDE" => nil,
+          "XDG_BIN_HOME" => File.dirname(xdg_hive),
+          "HOMEBREW_PREFIX" => File.dirname(File.dirname(brew_hive))
+        },
+        HV_BIN,
+        "probe"
+      )
+
+      assert status.success?, err
+      assert_equal "brew:probe\n", out
+    end
+  end
 end

--- a/wiki/cli.md
+++ b/wiki/cli.md
@@ -3,7 +3,7 @@ title: CLI Surface
 type: api
 source: bin/hive, bin/hv, lib/hive/cli.rb
 created: 2026-04-25
-updated: 2026-06-03
+updated: 2026-06-07
 tags: [cli, api]
 ---
 
@@ -13,7 +13,7 @@ tags: [cli, api]
 
 `bin/hive` is a thin runner that loads `lib/hive` and calls `Hive::CLI.start(ARGV)`, catching `Hive::Error` to render `hive: <message>` to stderr with the error's `exit_code` (default `ExitCodes::GENERIC = 1`).
 
-`bin/hv` is a bash fallback launcher for Apache Hive name collisions. It deliberately avoids `command -v hive`; instead it probes only `HIVE_BIN_OVERRIDE`, `${XDG_BIN_HOME:-$HOME/.local/bin}/hive`, `${HOMEBREW_PREFIX:-/opt/homebrew}/bin/hive`, and `/usr/local/bin/hive`, skipping a target that resolves back to itself. It does not implicitly exec `/usr/bin/hive` or `/opt/hive/bin/hive`, because those paths may be Apache Hive installs. If no candidate is executable it exits `127` and tells the operator to set `HIVE_BIN_OVERRIDE` or install through the documented channels. See [[operating]] for channel-level `hv` behavior.
+`bin/hv` is a bash fallback launcher for Apache Hive name collisions. It deliberately avoids `command -v hive`; instead it trusts explicit `HIVE_BIN_OVERRIDE`, then probes `${XDG_BIN_HOME:-$HOME/.local/bin}/hive`, `${HOMEBREW_PREFIX:-/opt/homebrew}/bin/hive`, and `/usr/local/bin/hive`, skipping a target that resolves back to itself. Implicit candidates must answer `--version` with Hive CLI's bare semver output before `hv` execs them, so Apache-style `Hive X.Y.Z` binaries are skipped. It does not implicitly exec `/usr/bin/hive` or `/opt/hive/bin/hive`, because those paths may be Apache Hive installs. If no candidate is executable and valid it exits `127` and tells the operator to set `HIVE_BIN_OVERRIDE` or install through the documented channels. See [[operating]] for channel-level `hv` behavior.
 
 ## Command table
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -2,6 +2,15 @@
 
 Append-only log of all wiki operations.
 
+## [2026-06-07T11:15:09Z] cli/install - validate hv implicit candidates
+
+**Action:** Refreshed command/API, operating, and test coverage notes after `bin/hv` started validating implicit fallback candidates with a `--version` bare-semver probe before exec. Documented that `HIVE_BIN_OVERRIDE` remains explicitly trusted while XDG, Homebrew, and `/usr/local/bin` candidates skip Apache-style `Hive X.Y.Z` outputs. Added focused unit coverage for the Apache-style collision case. Did not run `qmd update` or `qmd embed`.
+
+**Refreshed pages:**
+- [[cli]]
+- [[operating]]
+- [[testing]]
+
 ## [2026-06-03T14:10:33Z] release/wiki - refresh v0.2.0 release prep coverage
 
 **Action:** Refreshed command/API, executable-entrypoint, install, and dependency wiki coverage after PR #289 prepared `0.2.0`. Read the required wiki pages first, inspected the release-prep diff, and verified the release claims against `lib/hive.rb`, `Gemfile.lock`, `README.md`, `install.md`, `CHANGELOG.md`, `hive.gemspec`, the babysitter dry-run stubs, `Hive::Babysitter::DryRunEnv`, and `test/unit/babysitter/dry_run_env_test.rb`. Updated stale release/install examples from `v0.1.11` to `v0.2.0`, refreshed dependency rows for `sqlite3`, `minitest`, and `rubocop`, clarified that SQLite is limited to token-usage metrics rather than workflow state, and recorded that no in-tree artifact proves published `v0.2.0` channel verification yet. Did not run `qmd update` or `qmd embed`.

--- a/wiki/operating.md
+++ b/wiki/operating.md
@@ -3,7 +3,7 @@ title: Operating Hive
 type: operating
 source: bin/hv, install.sh, lib/hive/commands/daemon.rb, lib/hive/commands/bot.rb, examples/systemd/, examples/launchd/
 created: 2026-05-07
-updated: 2026-06-03
+updated: 2026-06-07
 tags: [operating, daemon, bot, systemd, launchd, install]
 ---
 
@@ -98,9 +98,11 @@ work.
 
 Apache Hive collision: the Homebrew formula installs an `hv` symlink and the
 bash installer creates `hv` when another `hive` is already earlier on PATH. The
-in-tree `bin/hv` fallback probes only `HIVE_BIN_OVERRIDE`,
+in-tree `bin/hv` fallback trusts explicit `HIVE_BIN_OVERRIDE`, then probes only
 `${XDG_BIN_HOME:-$HOME/.local/bin}/hive`, `${HOMEBREW_PREFIX:-/opt/homebrew}/bin/hive`,
-and `/usr/local/bin/hive`; it intentionally does not fall through to
+and `/usr/local/bin/hive`. The implicit candidates must print Hive CLI's bare
+semver output for `--version`; Apache-style `Hive X.Y.Z` outputs are skipped
+before exec. It intentionally does not fall through to
 `/usr/bin/hive` or `/opt/hive/bin/hive`, because those are common Apache Hive
 locations. Use `HIVE_BIN_OVERRIDE` for a custom Hive CLI install path. The AUR
 package does not ship the gem's `bin/hv` wrapper; its `conflicts=('hive'

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -3,7 +3,7 @@ title: Testing
 type: reference
 source: test/, Rakefile, .rubocop.yml
 created: 2026-04-25
-updated: 2026-06-03
+updated: 2026-06-07
 tags: [test, minitest, fixtures]
 ---
 
@@ -64,7 +64,7 @@ task default: :test
 | `git_ops_test.rb` | `Hive::GitOps` — default-branch detection, orphan worktree bootstrap, idempotent gitignore, empty-diff commit skip. |
 | `agent_test.rb` | `Hive::Agent` — spawn/wait/timeout/SIGINT forwarding, version check. |
 | `claude_launcher_test.rb` | `Hive::ClaudeLauncher` — headless/tmux delegation, readiness deadlines, prompt submission, pane logging, tmux-session loss before terminal markers, signal cleanup, and wrapper argv policy. |
-| `hv_test.rb` | `bin/hv` — refuses unsafe Apache Hive fallback paths (`/usr/bin/hive`, `/opt/hive/bin/hive`) and verifies `HIVE_BIN_OVERRIDE` can point at a custom Hive CLI install path. |
+| `hv_test.rb` | `bin/hv` — refuses unsafe Apache Hive fallback paths (`/usr/bin/hive`, `/opt/hive/bin/hive`), skips implicit candidates with Apache-style `Hive X.Y.Z` version output, and verifies `HIVE_BIN_OVERRIDE` can point at a custom Hive CLI install path. |
 | `babysitter/dry_run_env_test.rb` | `Hive::Babysitter::DryRunEnv` plus `bin/hive-babysitter-stub-git` / `bin/hive-babysitter-stub-gh` — PATH overlay, recording fake binaries, default-deny skips, read-only passthrough, and `gh api` implicit-POST payload flag blocking. |
 
 ## Integration suite (`test/integration/`)


### PR DESCRIPTION
## Hive Patrol Finding

Slice: `command-bin-hive`
Category: `bug`
Severity: `medium`
Confidence: `medium`
Fingerprint: `dd705519bed7cfa088c62db1c753fd905e92e64849aad5c225ce0540b4f08060`

The hv fallback removed two known Apache Hive paths, but it still execs the first executable named hive in XDG, Homebrew, or /usr/local locations without checking that the candidate is the Hive CLI. If Apache Hive or another program owns one of those paths, hv reports success and launches the wrong binary, which is the collision this wrapper is supposed to avoid.

## Evidence

- bin/hv:12 candidates=(
- bin/hv:27 exec "$candidate" "$@"

## Applied Fix

Validate implicit candidates before exec, for example by requiring candidate --version to match Hive CLI's bare semver output or another explicit marker. Treat HIVE_BIN_OVERRIDE as either explicitly trusted or validate it with a clearer override-specific error. Add a regression with a fake candidate that prints Apache-style 'Hive X.Y.Z'.

## Validation

- lint: passed (`bundle exec rubocop`)
- test: passed (`bundle exec rake test`)

## Diffstat

```text
 bin/hv               | 17 ++++++++++++++++-
 test/unit/hv_test.rb | 40 ++++++++++++++++++++++++++++++++++++++++
 wiki/cli.md          |  4 ++--
 wiki/log.md          |  9 +++++++++
 wiki/operating.md    |  8 +++++---
 wiki/testing.md      |  4 ++--
 6 files changed, 74 insertions(+), 8 deletions(-)

```
