### PR TITLE
docs: add Discord community link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 # Hive
 
+Community: [join the Hive Discord](https://discord.gg/Qg5E7rMt) for questions,
+feedback, and release discussions.
+
 Hive turns a rough software idea into a merge-ready pull request through a multi-agent pipeline you can watch as it works. You sketch an idea in a few sentences, open the `hive tui` dashboard, and watch the work move forward: brainstorm pins down what you actually want, plan fixes the approach, execute writes the code, review hardens it, and finalize ships the PR. You can step in at any stage with a normal editor — every artefact is a markdown file in a stage folder, inspectable and editable by you or by another agent.
 
 The mental model is folders. Every task is a directory; the folder's location is the task state. Moving a task from `2-brainstorm/` to `3-plan/` is the approval gesture, and every stage writes a durable artefact the next stage can trust. That practice — making each step's output strong enough for the next one to run autonomously — is called *compound engineering*. It's how Hive carries work from rough idea to merged PR while letting humans drop in on their own terms instead of a chat thread's.

--- a/wiki/log.d/20260607-144100-discord-readme-link.md
+++ b/wiki/log.d/20260607-144100-discord-readme-link.md
@@ -1,0 +1,6 @@
+## [2026-06-07T14:41:00Z] docs - add public Discord link to README
+
+**Action:** Added the public Hive Discord invite from Ivan's Hive announcement post to the top of the GitHub README, verified the invite redirects through `discord.com/invite/Qg5E7rMt` with HTTP 200, and recorded the canonical community URL in [[operating]]. No command/API behavior changed.
+
+**Refreshed pages:**
+- [[operating]]

--- a/wiki/operating.md
+++ b/wiki/operating.md
@@ -1,7 +1,7 @@
 ---
 title: Operating Hive
 type: operating
-source: bin/hv, install.sh, lib/hive/commands/daemon.rb, lib/hive/commands/babysit.rb, lib/hive/commands/bot.rb, examples/systemd/, examples/launchd/, openclaw/skills/hive/SKILL.md, openclaw/README.md
+source: README.md, bin/hv, install.sh, lib/hive/commands/daemon.rb, lib/hive/commands/babysit.rb, lib/hive/commands/bot.rb, examples/systemd/, examples/launchd/, openclaw/skills/hive/SKILL.md, openclaw/README.md
 created: 2026-05-07
 updated: 2026-06-07
 tags: [operating, daemon, bot, systemd, launchd, install]
@@ -10,7 +10,7 @@ tags: [operating, daemon, bot, systemd, launchd, install]
 **TLDR**: Day-2 guide for running the hive daemon, experimental PR babysitter, and Telegram bot.
 Covers install-time daemon autostart, per-project daemon/babysitter enrollment, bot token/allowlist setup,
 autostart on macOS (launchd) and Linux (systemd), dry-run shakedowns,
-log inspection, and how to disable automation mid-flight.
+log inspection, community support, and how to disable automation mid-flight.
 
 ## Worktree-first workflow
 
@@ -163,6 +163,12 @@ aggregate-changelog verification path and tells agents to reserve mutating
 `hive wiki compile-log` runs for merge/rebase cleanup or explicit user requests.
 The naked `hive` ClawHub slug is already owned by another publisher, so it is
 intentionally not used.
+
+## Community
+
+The public Hive Discord group is `https://discord.gg/Qg5E7rMt`. Keep the
+GitHub README link pointed at that invite unless a newer canonical community
+URL is announced.
 
 ## Release verification
 


### PR DESCRIPTION
## Summary

The GitHub README now gives visitors a direct path into the Hive Discord community before the project overview. The operating wiki records the same invite as the current canonical community URL so future docs updates have a source of truth.

## Verification

- `curl -I -L https://discord.gg/Qg5E7rMt` returns `200` after redirecting to `discord.com/invite/Qg5E7rMt`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5_Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
