### PR TITLE
Hive patrol: Released Faraday constraint misses the audited security floor

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     hive-cli (0.2.0)
       bubbletea (= 0.1.4)
-      faraday (~> 2.0)
+      faraday (>= 2.14.2, < 3.0)
       faraday-multipart (~> 1.0)
       lipgloss (~> 0.2.2)
       sqlite3 (~> 2.0)

--- a/hive.gemspec
+++ b/hive.gemspec
@@ -56,7 +56,7 @@ Gem::Specification.new do |spec|
   # transitively through telegram-bot-ruby today, but declaring them directly
   # keeps transcription from breaking with a LoadError if an upstream bump
   # drops or re-scopes them.
-  spec.add_dependency "faraday", "~> 2.0"
+  spec.add_dependency "faraday", ">= 2.14.2", "< 3.0"
   spec.add_dependency "faraday-multipart", "~> 1.0"
   spec.add_dependency "lipgloss", "~> 0.2.2"
   spec.add_dependency "sqlite3", "~> 2.0"


### PR DESCRIPTION
## Summary

The released `hive-cli` gem only constrained Faraday to `~> 2.0`. The `Gemfile` delegates runtime dependencies to the gemspec, so the lockfile resolves the audited-safe `faraday 2.14.2`, but the published gem metadata still accepted older 2.x releases. A downstream bundle carrying its own Faraday constraint could therefore install `hive-cli` against the audit-flagged `faraday 2.14.1` (CVE-2026-33637 / GHSA-5rv5-xj5j-3484) even though local CI and `bundler-audit` only ever see the safe locked version.

This PR raises the released runtime constraint to the audited security floor so the package metadata and the audited lockfile enforce the same minimum:

- `hive.gemspec` — `faraday` dependency changed from `~> 2.0` to `>= 2.14.2, < 3.0`.
- `Gemfile.lock` — path-gem spec regenerated to match (`faraday (>= 2.14.2, < 3.0)`), still resolving `2.14.2`.
- `wiki/dependencies.md` — Faraday and `faraday-multipart` promoted to explicit runtime rows, `hive.gemspec` added to the source set, the audit floor recorded as a released gemspec constraint, and stale dev/test rows and the RuboCop command corrected.
- `wiki/gaps.md` + `wiki/log.d/` — recorded the refresh and the remaining gap that no install-channel smoke yet proves a published gem resolves the corrected floor.

## Test plan

- `bundle check` — lockfile satisfies the new constraint.
- `bundle exec ruby -Itest test/unit/gemspec_test.rb` — gemspec dependency assertions pass.
- `bundle exec bundler-audit check` — no vulnerable resolved gems.

## Review summary

Codex CE code review (pass 01) ran `git diff origin/main..HEAD` over `hive.gemspec` and `Gemfile.lock` with `bundle check`, the gemspec unit test, and `bundler-audit` all passing. No High, Medium, or Nit findings; no escalations.

## Linked task

Patrol finding `package-gemfile-1` — `/home/asterio/Dev/hive/.hive-state/stages/6-review/patrol-package-gemfile-9eb92e16`
