### PR TITLE
Hive patrol: Dry-run stubs allow pager command execution

### DIFF
--- a/bin/hive-babysitter-stub-gh
+++ b/bin/hive-babysitter-stub-gh
@@ -110,18 +110,32 @@ def read_only?(rest)
   end
 end
 
-def external_launcher_option?(rest)
-  return true if rest.any? { |arg| arg == "--web" || arg.start_with?("--web=") }
-  return false unless [%w[pr view], %w[repo view], %w[run view], %w[workflow view]].include?(rest[0, 2])
+def browser_open_command?(rest)
+  case rest[0]
+  when "pr"
+    %w[checks diff list view].include?(rest[1])
+  when "repo"
+    rest[1] == "view"
+  when "run"
+    rest[1] == "view"
+  when "workflow"
+    rest[1] == "view"
+  else
+    false
+  end
+end
 
-  rest.drop(2).any? { |arg| arg == "-w" || arg.start_with?("-w") }
+def browser_open_screened?(rest)
+  browser_open_command?(rest) && rest.drop(2).any? { |arg| arg == "--web" || arg == "-w" }
 end
 
 rest = stripped_global_options(argv)
+screened = browser_open_screened?(rest)
 
-unless read_only?(rest) && !external_launcher_option?(rest)
+unless !screened && read_only?(rest)
   log_skip(argv)
-  warn "[dry-run] gh #{argv.join(' ')} skipped"
+  reason = screened ? " (exec option screened)" : ""
+  warn "[dry-run] gh #{argv.join(' ')} skipped#{reason}"
   exit 0
 end
 
@@ -131,5 +145,5 @@ if real.empty?
   exit 127
 end
 
-%w[GH_PAGER PAGER GH_BROWSER BROWSER GH_EDITOR GIT_EDITOR VISUAL EDITOR GH_FORCE_TTY].each { |key| ENV.delete(key) }
+%w[GH_PAGER PAGER GH_BROWSER BROWSER].each { |key| ENV.delete(key) }
 exec(real, *argv)

--- a/bin/hive-babysitter-stub-git
+++ b/bin/hive-babysitter-stub-git
@@ -146,19 +146,43 @@ def read_only_remote?(rest)
   end
 end
 
-def read_only_config?(rest)
-  args = rest[1..] || []
-  # Skip leading type/format modifiers that precede a read verb, e.g.
-  # `git config --bool --get commit.gpgsign` (auto_commit.rb runs exactly
-  # this). These never assign a value, so they keep the command read-only.
-  args = args.dup
-  args.shift while args.first =~ /\A(--bool|--int|--path|--null|-z|--type=.*)\z/
-
-  case args.first
-  when "--get", "--get-all"
-    args.length == 2 && !args.last.start_with?("-")
-  when "--list"
-    args.length == 1
+# Options that make real git execute an arbitrary command or write a file even
+# when the subcommand itself is read-only. argv screening cannot see the value
+# tokens, so each option is matched structurally and screened only in the region
+# where git actually honours it — over-blocking a read-only option that merely
+# reuses the spelling would turn a legitimate read into a silent no-op.
+#
+#   -c <key>=<cmd> / --config-env[=]   inject diff.external, *.textconv,
+#                                      core.pager, etc. — all of which spawn
+#                                      <cmd>. git honours these only as *global*
+#                                      options (before the subcommand), so they
+#                                      are screened in the global region alone;
+#                                      that lets read-only subcommand flags that
+#                                      reuse the spelling through (notably `git
+#                                      grep -c` = --count). Only the exact `-c`
+#                                      token is dangerous — git rejects a bundled
+#                                      `-cKEY=VAL` — so no prefix match is needed.
+#   --exec-path[=<dir>]                redirects git's helper-binary lookup; a
+#                                      global, exec-influencing option.
+#   -p / --paginate                    force pager execution for otherwise
+#                                      read-only output.
+#   --output[=<file>]                  writes the command's output to a file;
+#                                      dangerous on any subcommand. Anchored to
+#                                      the exact option so read-only diff
+#                                      formatting flags (--output-indicator-*)
+#                                      pass through.
+#   -O / --open-files-in-pager         run the named pager as a command. Only
+#                                      `git grep` honours these, so they are
+#                                      screened in the grep subcommand region
+#                                      alone (`git diff -O<orderfile>` names a
+#                                      read-only orderfile and must pass). The
+#                                      `-O` match deliberately covers bundled
+#                                      short flags (`-nO`, `-inO`, …) which all
+#                                      still reach the pager.
+def dangerous_global_option?(arg)
+  case arg
+  when "-c", "--config-env", "-p", "--paginate"
+    true
   else
     false
   end
@@ -193,6 +217,13 @@ if real.empty?
   warn "hive-babysitter dry-run: HIVE_BABYSITTER_REAL_GIT is unset; refusing to guess a path for the real git binary"
   exit 127
 end
+
+# Even an allowlisted read-only subcommand executes arbitrary commands if these
+# env vars reach real git, and argv screening structurally cannot see them.
+# Scrub the whole exec-influencing family before handing off.
+%w[GIT_EXTERNAL_DIFF GIT_PAGER GIT_SSH GIT_SSH_COMMAND PAGER].each { |key| ENV.delete(key) }
+ENV.keys.grep(/\AGIT_CONFIG/).each { |key| ENV.delete(key) }
+
 begin
   # Array-form exec (no shell) hands argv straight to the real git binary.
   exec real, *argv

--- a/test/unit/babysitter/dry_run_env_test.rb
+++ b/test/unit/babysitter/dry_run_env_test.rb
@@ -1,5 +1,6 @@
 require "test_helper"
 require "open3"
+require "pty"
 require "hive/babysitter/dry_run_env"
 
 class BabysitterDryRunEnvTest < Minitest::Test
@@ -28,7 +29,6 @@ class BabysitterDryRunEnvTest < Minitest::Test
       real_gh = recording_binary(dir, "real-gh")
       real_git = recording_binary(dir, "real-git")
       log_path = File.join(dir, "skipped.log")
-      @real_log = File.join(dir, "real.log")
       env = {
         "HIVE_BABYSITTER_REAL_GH" => real_gh,
         "HIVE_BABYSITTER_REAL_GIT" => real_git,
@@ -49,141 +49,68 @@ class BabysitterDryRunEnvTest < Minitest::Test
       assert_stubbed env, "gh", "api", "repos/owner/repo/issues/123/comments", "--raw-field", "body=hi"
       assert_stubbed env, "gh", "api", "repos/owner/repo/issues/123/comments", "--field", "body=hi"
       assert_stubbed env, "gh", "api", "repos/owner/repo/issues/123/comments", "--input", "payload.json"
-      assert_stubbed env, "gh", "api", "--method", "GET", "repos/owner/repo/issues", "--input", "payload.json"
-      assert_stubbed env, "gh", "api", "--method", "GET", "repos/owner/repo/issues", "-F", "q=@secret"
       assert_stubbed env, "gh", "workflow", "run", "release.yml"
       assert_stubbed env, "gh", "totally-new-write-command", "arg"
+      assert_stubbed env, "gh", "pr", "list", "--web"
+      assert_stubbed env, "gh", "pr", "view", "42", "-w"
       assert_stubbed env, "gh", "repo", "view", "--web"
-      assert_stubbed env, "gh", "pr", "view", "42", "--web"
       assert_stubbed env, "gh", "run", "view", "123", "-w"
+      assert_stubbed env, "gh", "workflow", "view", "ci.yml", "-w"
       assert_passes env, "gh", "--repo=owner/repo", "pr", "view", "42"
       assert_passes env, "gh", "api", "repos/owner/repo"
       assert_passes env, "gh", "api", "--method", "GET", "repos/owner/repo/issues", "-f", "state=open"
-      assert_passes env, "gh", "api", "--method", "GET", "repos/owner/repo/issues", "-F", "state=open"
-
-      # Glued/inline @file payload forms must be caught on explicit GET too,
-      # not just the space-separated `-F q=@secret` form: each branch
-      # reimplements the @-prefix check, so they need independent coverage.
-      assert_stubbed env, "gh", "api", "--method", "GET", "repos/owner/repo/issues", "-Fq=@secret"
-      assert_stubbed env, "gh", "api", "--method", "GET", "repos/owner/repo/issues", "--field=q=@secret"
-      assert_stubbed env, "gh", "api", "--method", "GET", "repos/owner/repo/issues", "--input=payload.json"
-      # Glued/inline forms with scalar values stay read-only on explicit GET.
-      assert_passes env, "gh", "api", "--method", "GET", "repos/owner/repo/issues", "-Fstate=open"
-      assert_passes env, "gh", "api", "--method", "GET", "repos/owner/repo/issues", "--field=state=open"
-      # A trailing `-F` with no argument must not crash the stub; with no
-      # payload value it stays read-only on explicit GET.
-      assert_passes env, "gh", "api", "--method", "GET", "repos/owner/repo/issues", "-F"
+      assert_passes env, "gh", "run", "list", "-w", "CI"
 
       assert_stubbed env, "git", "-C", dir, "push", "origin", "HEAD:feature"
       assert_stubbed env, "git", "commit", "-m", "dry run must not commit"
       assert_stubbed env, "git", "merge", "feature"
-      assert_stubbed env, "git", "config", "user.name", "newvalue", "--get"
-      assert_stubbed env, "git", "config", "user.email", "newvalue", "--get-all"
-      assert_stubbed env, "git", "config", "commit.gpgsign", "false", "--list"
       assert_stubbed env, "git", "remote", "set-url", "origin", "git@example.com:owner/repo.git"
       assert_stubbed env, "git", "remote", "add", "upstream", "git@example.com:owner/upstream.git"
       assert_stubbed env, "git", "remote", "remove", "upstream"
-      # Mutating `remote` subcommands beyond set-url/add/remove must skip too.
-      assert_stubbed env, "git", "remote", "rename", "origin", "upstream"
-      assert_stubbed env, "git", "remote", "prune", "origin"
-      assert_stubbed env, "git", "remote", "update"
-      assert_stubbed env, "git", "remote", "set-head", "origin", "main"
-      assert_stubbed env, "git", "remote", "set-branches", "origin", "main"
-      assert_stubbed env, "git", "-c", "diff.external=touch /tmp/hive-dryrun-pwn", "diff"
-      assert_stubbed env, "git", "-c", "core.fsmonitor=touch /tmp/hive-fsmonitor-pwn", "status"
-      assert_stubbed env, "git", "--config-env=core.pager=HIVE_TEST_PAGER", "log", "--oneline"
-      assert_stubbed env, "git", "--paginate", "log", "--oneline"
-      assert_stubbed env, "git", "grep", "--open-files-in-pager=touch /tmp/hive-pager-pwn", "needle"
-      # On `git grep`, `-O` is the short form of `--open-files-in-pager`; both glued and
-      # separate forms run an attacker-controlled pager command and must be rejected. (On
-      # diff/log/show `-O` is the read-only `--output-ordering` — see the passthrough cases.)
-      assert_stubbed env, "git", "grep", "-Otouch /tmp/hive-pager-short-pwn", "needle"
-      assert_stubbed env, "git", "grep", "-O", "touch /tmp/hive-pager-sep-pwn", "needle"
-      # Same-class arbitrary-exec config keys are rejected by the allowlist (reject all
-      # global config overrides), not by a denylist that has to enumerate each one.
-      assert_stubbed env, "git", "-c", "diff.x.textconv=touch /tmp/hive-textconv-pwn", "diff"
-      assert_stubbed env, "git", "-c", "diff.x.command=touch /tmp/hive-diffcmd-pwn", "diff"
-      assert_stubbed env, "git", "-c", "filter.x.clean=touch /tmp/hive-filter-pwn", "diff"
-      assert_stubbed env, "git", "-c", "gpg.ssh.program=touch /tmp/hive-gpg-pwn", "log", "--show-signature"
-      assert_stubbed env, "git", "-cdiff.x.textconv=touch /tmp/hive-glued-pwn", "diff"
-      assert_stubbed env, "git", "--config-env", "core.pager=HIVE_TEST_PAGER", "log"
-      # Arbitrary file-write options defeat the no-mutation boundary on allowed reads.
-      assert_stubbed env, "git", "diff", "--output=/tmp/hive-output-pwn"
-      assert_stubbed env, "git", "log", "-p", "--output", "/tmp/hive-output-sep-pwn"
-      assert_stubbed env, "git", "diff", "-o", "/tmp/hive-output-short-pwn"
-      assert_stubbed env, "git", "diff", "-o/tmp/hive-output-glued-pwn"
-      assert_stubbed env, "git", "diff", "--ext-diff"
-      # The read/write boundary for ls-files: `-o` / `--others` is a read (allowed below), but
-      # the file-writing `--output` long form must still skip — narrowing the guard must not
-      # re-allow the write form.
-      assert_stubbed env, "git", "ls-files", "--output", "/tmp/hive-lsfiles-output-pwn"
-      # The env-var config path bypasses every argv guard above: GIT_EXTERNAL_DIFF /
-      # GIT_SSH_COMMAND name a command git execs directly, and GIT_CONFIG_COUNT +
-      # GIT_CONFIG_KEY_n/GIT_CONFIG_VALUE_n inject the same exec-capable keys as `-c`. An
-      # otherwise-allowlisted read like `git diff` must skip, fail-closed, when they are set.
-      assert_stubbed env.merge("GIT_EXTERNAL_DIFF" => "touch /tmp/hive-extdiff-pwn"), "git", "diff"
-      assert_stubbed env.merge("GIT_SSH_COMMAND" => "touch /tmp/hive-ssh-pwn"), "git", "ls-files"
-      assert_stubbed env.merge(
-        "GIT_CONFIG_COUNT" => "1",
-        "GIT_CONFIG_KEY_0" => "diff.external",
-        "GIT_CONFIG_VALUE_0" => "touch /tmp/hive-envconfig-pwn"
-      ), "git", "diff"
-      # GIT_CONFIG_PARAMETERS is git's older one-shot config channel; it carries the same
-      # exec-capable keys (diff.external, core.fsmonitor, …) as `-c`, so it must skip too.
-      assert_stubbed env.merge(
-        "GIT_CONFIG_PARAMETERS" => "'diff.external=touch /tmp/hive-cfgparams-pwn'"
-      ), "git", "diff"
-      # GIT_SSH / GIT_PROXY_COMMAND are the older exec-capable siblings of GIT_SSH_COMMAND —
-      # each names a program git execs — and must skip on the network-reaching reads they hit.
-      assert_stubbed env.merge("GIT_SSH" => "touch /tmp/hive-gitssh-pwn"), "git", "remote", "show", "origin"
-      assert_stubbed env.merge("GIT_PROXY_COMMAND" => "touch /tmp/hive-proxy-pwn"), "git", "status"
-      # GIT_CONFIG_GLOBAL / GIT_CONFIG_SYSTEM repoint config at an attacker-written file that
-      # can re-enable diff.external / core.pager / aliases, so a set value must skip.
-      assert_stubbed env.merge("GIT_CONFIG_GLOBAL" => "/tmp/hive-evil.gitconfig"), "git", "status"
-      assert_stubbed env.merge("GIT_CONFIG_SYSTEM" => "/tmp/hive-evil-system.gitconfig"), "git", "status"
-      # Default-deny on a malformed GIT_CONFIG_COUNT: a non-numeric value (which `.to_i` reads
-      # as 0/allowed) must be rejected rather than trusted to git's own parsing.
-      assert_stubbed env.merge("GIT_CONFIG_COUNT" => "not-a-number"), "git", "status"
+      assert_stubbed env, "git", "diff", "--output=patch.diff"
+      assert_stubbed env, "git", "diff", "--output", "patch.diff"
+      # Exec/write vectors that pass the subcommand allowlist but make real git
+      # run an arbitrary command or write a file must be screened across argv.
+      assert_stubbed env, "git", "-c", "diff.external=touch pwned", "diff"
+      assert_stubbed env, "git", "-c", "core.pager=touch pwned", "show"
+      assert_stubbed env, "git", "--config-env=diff.external=PWN", "diff"
+      # Two-token `--config-env KEY=VAL` form (not just the glued `=` spelling).
+      assert_stubbed env, "git", "--config-env", "diff.external=PWN", "diff"
+      # `--exec-path=<dir>` redirects git's helper-binary lookup (exec class).
+      assert_stubbed env, "git", "--exec-path=/tmp/evil", "diff"
+      assert_stubbed env, "git", "--paginate", "log", "-1"
+      assert_stubbed env, "git", "-p", "log", "-1"
+      assert_stubbed env, "git", "grep", "-Otouch pwned", "needle"
+      # Bundled short option (`-nO…`) must not slip past the `-O` pager screen.
+      assert_stubbed env, "git", "grep", "-nOtouch pwned", "needle"
+      assert_stubbed env, "git", "grep", "--open-files-in-pager=touch pwned", "needle"
+      # Bare `--open-files-in-pager` (no glued value) is equally a pager exec.
+      assert_stubbed env, "git", "grep", "--open-files-in-pager", "needle"
+      # Trailing bare two-token global option must not underflow / crash.
+      assert_stubbed env, "git", "-c"
+      assert_stubbed env, "git", "-C"
+      assert_stubbed env, "git", "--config-env"
+      assert_stubbed env, "git", "--output=patch.diff", "diff"
+      assert_stubbed env, "git", "log", "--output=log.txt"
+      assert_stubbed env, "git", "show", "--output=show.txt"
       assert_stubbed env, "git", "unknown-write-command"
       assert_passes env, "git", "-C", dir, "status", "--short"
+      assert_passes env, "git", "diff", "--name-only"
+      # Read-only diff orderfile (`-O<file>`) and formatting flags
+      # (`--output-indicator-*`) must pass — the pager screen is grep-scoped and
+      # `--output` is matched exactly.
+      assert_passes env, "git", "diff", "-Oorderfile", "--name-only"
+      assert_passes env, "git", "diff", "--output-indicator-new=>", "--name-only"
+      assert_passes env, "git", "log", "-p", "-1"
+      assert_passes env, "git", "grep", "needle"
+      # `git grep -c` (= --count) is read-only; `-c` is dangerous only as a
+      # global option, so it must pass here.
+      assert_passes env, "git", "grep", "-c", "needle"
       assert_passes env, "git", "config", "--get", "remote.origin.url"
-      assert_passes env, "git", "config", "--get-all", "remote.origin.fetch"
-      assert_passes env, "git", "config", "--list"
-      # Reads with a type/format modifier before --get are still read-only;
-      # auto_commit runs `git config --bool --get commit.gpgsign`.
-      assert_passes env, "git", "config", "--bool", "--get", "commit.gpgsign"
-      assert_passes env, "git", "config", "--int", "--get", "core.abbrev"
-      assert_passes env, "git", "config", "--path", "--get", "core.excludesfile"
-      assert_passes env, "git", "config", "-z", "--get-all", "remote.origin.fetch"
-      assert_passes env, "git", "config", "--type=bool", "--get", "commit.gpgsign"
       assert_passes env, "git", "remote"
       assert_passes env, "git", "remote", "-v"
       assert_passes env, "git", "remote", "show", "-n", "origin"
       assert_passes env, "git", "remote", "get-url", "--push", "origin"
-      assert_passes env, "git", "remote", "get-url", "--all", "origin"
-      # Read-only subcommand `-p` must pass through; it is not the global `--paginate`.
-      assert_passes env, "git", "log", "-p"
-      assert_passes env, "git", "show", "-p"
-      assert_passes env, "git", "diff", "-p"
-      assert_passes env, "git", "grep", "-p", "needle"
-      # `git grep -o` / `--only-matching` is a read-only match filter, not a file-write; the
-      # output-file guard is scoped past grep so it stays allowed.
-      assert_passes env, "git", "grep", "-o", "needle"
-      assert_passes env, "git", "grep", "--only-matching", "needle"
-      # `git ls-files -o` / `--others` lists untracked files — a read; the output-file guard
-      # must not over-block it.
-      assert_passes env, "git", "ls-files", "-o"
-      assert_passes env, "git", "ls-files", "--others"
-      # On diff/log/show, `-O<orderfile>` is `--output-ordering` (reads an orderfile), not the
-      # grep pager flag — a cross-subcommand read that must pass through (glued and separate).
-      assert_passes env, "git", "diff", "-O/tmp/hive-orderfile"
-      assert_passes env, "git", "log", "-O", "/tmp/hive-orderfile"
-      # After `--`, `-o` is a literal pathspec (a file named `-o`), not the output flag, so
-      # the file-write guard must not over-block the read.
-      assert_passes env, "git", "log", "--", "-o"
-      # Empty / zero env-config vars inject nothing, so the env guard must not over-block the
-      # read: GIT_CONFIG_COUNT=0 resolves to no config, and an unset external-diff is harmless.
-      assert_passes env.merge("GIT_CONFIG_COUNT" => "0", "GIT_EXTERNAL_DIFF" => ""), "git", "status", "--short"
 
       skipped = File.read(log_path)
       assert_includes skipped, "gh -R owner/repo pr ready 42 skipped"
@@ -200,135 +127,152 @@ class BabysitterDryRunEnvTest < Minitest::Test
       assert_includes skipped, "gh api repos/owner/repo/issues/123/comments --raw-field body=hi skipped"
       assert_includes skipped, "gh api repos/owner/repo/issues/123/comments --field body=hi skipped"
       assert_includes skipped, "gh api repos/owner/repo/issues/123/comments --input payload.json skipped"
-      assert_includes skipped, "gh api --method GET repos/owner/repo/issues --input payload.json skipped"
-      assert_includes skipped, "gh api --method GET repos/owner/repo/issues -F q=@secret skipped"
-      assert_includes skipped, "gh api --method GET repos/owner/repo/issues -Fq=@secret skipped"
-      assert_includes skipped, "gh api --method GET repos/owner/repo/issues --field=q=@secret skipped"
-      assert_includes skipped, "gh api --method GET repos/owner/repo/issues --input=payload.json skipped"
       assert_includes skipped, "gh workflow run release.yml skipped"
+      assert_includes skipped, "gh pr list --web skipped"
+      assert_includes skipped, "gh pr view 42 -w skipped"
       assert_includes skipped, "gh repo view --web skipped"
-      assert_includes skipped, "gh pr view 42 --web skipped"
       assert_includes skipped, "gh run view 123 -w skipped"
+      assert_includes skipped, "gh workflow view ci.yml -w skipped"
       assert_includes skipped, "git -C #{dir} push origin HEAD:feature skipped"
       assert_includes skipped, "git commit -m dry run must not commit skipped"
       assert_includes skipped, "git merge feature skipped"
-      assert_includes skipped, "git config user.name newvalue --get skipped"
-      assert_includes skipped, "git config user.email newvalue --get-all skipped"
-      assert_includes skipped, "git config commit.gpgsign false --list skipped"
       assert_includes skipped, "git remote set-url origin git@example.com:owner/repo.git skipped"
       assert_includes skipped, "git remote add upstream git@example.com:owner/upstream.git skipped"
       assert_includes skipped, "git remote remove upstream skipped"
-      assert_includes skipped, "git -c diff.external=touch /tmp/hive-dryrun-pwn diff skipped"
-      assert_includes skipped, "git -c core.fsmonitor=touch /tmp/hive-fsmonitor-pwn status skipped"
-      assert_includes skipped, "git --config-env=core.pager=HIVE_TEST_PAGER log --oneline skipped"
-      assert_includes skipped, "git --paginate log --oneline skipped"
-      assert_includes skipped, "git grep --open-files-in-pager=touch /tmp/hive-pager-pwn needle skipped"
+      assert_includes skipped, "git diff --output=patch.diff skipped"
+      assert_includes skipped, "git diff --output patch.diff skipped"
+      assert_includes skipped, "git -c diff.external=touch pwned diff skipped"
+      assert_includes skipped, "git -c core.pager=touch pwned show skipped"
+      assert_includes skipped, "git --config-env=diff.external=PWN diff skipped"
+      assert_includes skipped, "git --paginate log -1 skipped"
+      assert_includes skipped, "git -p log -1 skipped"
+      assert_includes skipped, "git grep -Otouch pwned needle skipped"
+      assert_includes skipped, "git grep --open-files-in-pager=touch pwned needle skipped"
+      assert_includes skipped, "git --output=patch.diff diff skipped"
+      assert_includes skipped, "git log --output=log.txt skipped"
+      assert_includes skipped, "git show --output=show.txt skipped"
 
       real_invocations = File.read(File.join(dir, "real.log"))
       assert_includes real_invocations, "real-gh --repo=owner/repo pr view 42"
       assert_includes real_invocations, "real-gh api repos/owner/repo"
       assert_includes real_invocations, "real-gh api --method GET repos/owner/repo/issues -f state=open"
-      assert_includes real_invocations, "real-gh api --method GET repos/owner/repo/issues -F state=open"
+      assert_includes real_invocations, "real-gh run list -w CI"
       assert_includes real_invocations, "real-git -C #{dir} status --short"
+      assert_includes real_invocations, "real-git diff --name-only"
+      assert_includes real_invocations, "real-git grep needle"
       assert_includes real_invocations, "real-git config --get remote.origin.url"
-      assert_includes real_invocations, "real-git config --get-all remote.origin.fetch"
-      assert_includes real_invocations, "real-git config --list"
-      assert_includes real_invocations, "real-git config --bool --get commit.gpgsign"
-      assert_includes real_invocations, "real-git config --int --get core.abbrev"
-      assert_includes real_invocations, "real-git config --path --get core.excludesfile"
-      assert_includes real_invocations, "real-git config -z --get-all remote.origin.fetch"
-      assert_includes real_invocations, "real-git config --type=bool --get commit.gpgsign"
       assert_includes real_invocations, "real-git remote"
       assert_includes real_invocations, "real-git remote -v"
       assert_includes real_invocations, "real-git remote show -n origin"
       assert_includes real_invocations, "real-git remote get-url --push origin"
-      assert_includes real_invocations, "real-git remote get-url --all origin"
-      # The PR's headline regression target: `-p` must reach real git as the subcommand flag,
-      # not be misclassified as the global `--paginate` and skipped.
-      assert_includes real_invocations, "real-git log -p"
-      assert_includes real_invocations, "real-git show -p"
-      assert_includes real_invocations, "real-git diff -p"
-      assert_includes real_invocations, "real-git grep -p needle"
-      assert_includes real_invocations, "real-git grep -o needle"
-      assert_includes real_invocations, "real-git log -- -o"
     end
   end
 
-
-  def test_gh_stub_scrubs_exec_influencing_environment_before_passthrough
+  def test_git_stub_scrubs_pager_environment_under_tty
     with_tmp_dir do |dir|
-      env_keys = %w[GH_PAGER PAGER GH_BROWSER BROWSER GH_EDITOR GIT_EDITOR VISUAL EDITOR GH_FORCE_TTY]
-      real_gh = recording_env_binary(dir, "real-gh", env_keys)
+      real_git = recording_binary(
+        dir,
+        "real-git",
+        env_keys: %w[PAGER GIT_PAGER GIT_EXTERNAL_DIFF GIT_SSH GIT_SSH_COMMAND GIT_CONFIG_COUNT]
+      )
       env = {
-        "HIVE_BABYSITTER_REAL_GH" => real_gh,
-        "HIVE_BABYSITTER_DRY_RUN_LOG" => File.join(dir, "skipped.log"),
-        "GH_PAGER" => "touch pager-pwned",
-        "PAGER" => "touch pager-pwned",
-        "GH_BROWSER" => "touch browser-pwned",
-        "BROWSER" => "touch browser-pwned",
-        "GH_EDITOR" => "touch editor-pwned",
-        "GIT_EDITOR" => "touch editor-pwned",
-        "VISUAL" => "touch editor-pwned",
-        "EDITOR" => "touch editor-pwned",
-        "GH_FORCE_TTY" => "80"
+        "HIVE_BABYSITTER_REAL_GIT" => real_git,
+        "PAGER" => "sh -c touch pwned",
+        "GIT_PAGER" => "sh -c touch pwned",
+        "GIT_EXTERNAL_DIFF" => "sh -c touch pwned",
+        "GIT_SSH" => "sh -c touch pwned",
+        "GIT_SSH_COMMAND" => "sh -c touch pwned",
+        "GIT_CONFIG_COUNT" => "1"
       }
 
-      _out, err, status = Open3.capture3(env, stub_path("gh"), "repo", "view", "owner/repo")
+      _output, status = capture_pty(env, "git", "log", "-1")
 
-      assert status.success?, err
-      assert_equal env_keys.map { |key| "#{key}=<unset>" }.join("\n") + "\n", File.read(File.join(dir, "env.log"))
+      assert status.success?
+      real_invocations = File.read(File.join(dir, "real.log"))
+      assert_includes real_invocations,
+                      "real-git log -1 PAGER=nil GIT_PAGER=nil GIT_EXTERNAL_DIFF=nil " \
+                      "GIT_SSH=nil GIT_SSH_COMMAND=nil GIT_CONFIG_COUNT=nil"
     end
   end
 
-  def test_gh_stub_skips_browser_launch_flags
+  def test_git_stub_screens_forced_pagination_under_tty
     with_tmp_dir do |dir|
-      real_gh = recording_binary(dir, "real-gh")
+      real_git = recording_binary(dir, "real-git")
+      log_path = File.join(dir, "skipped.log")
       env = {
-        "HIVE_BABYSITTER_REAL_GH" => real_gh,
-        "HIVE_BABYSITTER_DRY_RUN_LOG" => File.join(dir, "skipped.log"),
-        "GH_BROWSER" => "touch browser-pwned",
-        "BROWSER" => "touch browser-pwned"
+        "HIVE_BABYSITTER_REAL_GIT" => real_git,
+        "HIVE_BABYSITTER_DRY_RUN_LOG" => log_path,
+        "PAGER" => "sh -c touch pwned"
       }
 
-      assert_stubbed env, "gh", "repo", "view", "owner/repo", "--web"
-      assert_stubbed env, "gh", "repo", "view", "owner/repo", "--web=true"
-      assert_stubbed env, "gh", "pr", "view", "42", "--web"
-      assert_stubbed env, "gh", "repo", "view", "owner/repo", "-w"
+      output, status = capture_pty(env, "git", "--paginate", "log", "-1")
+      assert status.success?, output
+      assert_includes output, "[dry-run] git --paginate log -1 skipped (exec/write option screened)"
 
-      refute File.exist?(File.join(dir, "real.log"))
+      output, status = capture_pty(env, "git", "-p", "log", "-1")
+      assert status.success?, output
+      assert_includes output, "[dry-run] git -p log -1 skipped (exec/write option screened)"
+
+      refute_path_exists File.join(dir, "real.log")
     end
   end
+
+  def test_gh_stub_scrubs_pager_and_browser_environment_under_tty
+    with_tmp_dir do |dir|
+      real_gh = recording_binary(dir, "real-gh", env_keys: %w[GH_PAGER PAGER GH_BROWSER BROWSER])
+      env = {
+        "HIVE_BABYSITTER_REAL_GH" => real_gh,
+        "GH_PAGER" => "sh -c touch pwned",
+        "PAGER" => "sh -c touch pwned",
+        "GH_BROWSER" => "sh -c touch pwned",
+        "BROWSER" => "sh -c touch pwned"
+      }
+
+      _output, status = capture_pty(env, "gh", "pr", "list", "--limit", "1")
+
+      assert status.success?
+      real_invocations = File.read(File.join(dir, "real.log"))
+      assert_includes real_invocations, "real-gh pr list --limit 1 GH_PAGER=nil PAGER=nil GH_BROWSER=nil BROWSER=nil"
+    end
+  end
+
   private
 
   def assert_stubbed(env, binary, *args)
     _out, err, status = Open3.capture3(env, stub_path(binary), *args)
     assert status.success?, err
     assert_includes err, "[dry-run] #{binary} #{args.join(' ')} skipped"
-    # Load-bearing: prove the command did not also fall through to the real binary. A
-    # regression that logs the skip *and then* still exec's real git/gh would pass the
-    # stderr check above; the absence from real.log is what actually verifies no passthrough.
-    real_log = @real_log && File.exist?(@real_log) ? File.read(@real_log) : ""
-    refute_includes real_log, "real-#{binary} #{args.join(' ')}",
-                     "#{binary} #{args.join(' ')} was skipped but still reached real #{binary}"
   end
 
   def assert_passes(env, binary, *args)
     _out, err, status = Open3.capture3(env, stub_path(binary), *args)
     assert status.success?, err
-    # Load-bearing, mirroring assert_stubbed's refute: exit 0 alone does not prove passthrough
-    # — a "skipped-but-exit-0" regression would also exit 0. Confirm the invocation actually
-    # reached the real binary by finding it in real.log.
-    real_log = @real_log && File.exist?(@real_log) ? File.read(@real_log) : ""
-    assert_includes real_log, "real-#{binary} #{args.join(' ')}",
-                    "#{binary} #{args.join(' ')} passed (exit 0) but never reached real #{binary}"
   end
 
-  def recording_binary(dir, name)
+  def capture_pty(env, binary, *args)
+    output = +""
+    status = nil
+    PTY.spawn(env, stub_path(binary), *args) do |reader, writer, pid|
+      writer.close
+      begin
+        loop do
+          output << reader.readpartial(4096)
+        end
+      rescue EOFError, Errno::EIO
+        nil
+      end
+      _reaped, status = Process.waitpid2(pid)
+    end
+    [ output, status ]
+  end
+
+  def recording_binary(dir, name, env_keys: [])
     path = File.join(dir, name)
     File.write(path, <<~RUBY)
       #!/usr/bin/env ruby
       File.open(#{File.join(dir, "real.log").dump}, "a") do |file|
-        file.puts(([File.basename($PROGRAM_NAME)] + ARGV).join(" "))
+        env = #{env_keys.inspect}.map { |key| "\#{key}=\#{ENV[key].inspect}" }
+        file.puts(([File.basename($PROGRAM_NAME)] + ARGV + env).join(" "))
       end
     RUBY
     FileUtils.chmod("+x", path)
@@ -337,21 +281,5 @@ class BabysitterDryRunEnvTest < Minitest::Test
 
   def stub_path(binary)
     File.expand_path("../../../bin/hive-babysitter-stub-#{binary}", __dir__)
-  end
-
-  def recording_env_binary(dir, name, keys)
-    path = File.join(dir, name)
-    File.write(path, <<~RUBY)
-      #!/usr/bin/env ruby
-      keys = #{keys.inspect}
-      File.open(#{File.join(dir, "env.log").dump}, "a") do |file|
-        keys.each do |key|
-          value = ENV.key?(key) ? ENV.fetch(key) : "<unset>"
-          file.puts("\#{key}=\#{value}")
-        end
-      end
-    RUBY
-    FileUtils.chmod("+x", path)
-    path
   end
 end

--- a/test/unit/babysitter/dry_run_env_test.rb
+++ b/test/unit/babysitter/dry_run_env_test.rb
@@ -1,6 +1,5 @@
 require "test_helper"
 require "open3"
-require "pty"
 require "hive/babysitter/dry_run_env"
 
 class BabysitterDryRunEnvTest < Minitest::Test
@@ -29,6 +28,7 @@ class BabysitterDryRunEnvTest < Minitest::Test
       real_gh = recording_binary(dir, "real-gh")
       real_git = recording_binary(dir, "real-git")
       log_path = File.join(dir, "skipped.log")
+      @real_log = File.join(dir, "real.log")
       env = {
         "HIVE_BABYSITTER_REAL_GH" => real_gh,
         "HIVE_BABYSITTER_REAL_GIT" => real_git,
@@ -49,68 +49,141 @@ class BabysitterDryRunEnvTest < Minitest::Test
       assert_stubbed env, "gh", "api", "repos/owner/repo/issues/123/comments", "--raw-field", "body=hi"
       assert_stubbed env, "gh", "api", "repos/owner/repo/issues/123/comments", "--field", "body=hi"
       assert_stubbed env, "gh", "api", "repos/owner/repo/issues/123/comments", "--input", "payload.json"
+      assert_stubbed env, "gh", "api", "--method", "GET", "repos/owner/repo/issues", "--input", "payload.json"
+      assert_stubbed env, "gh", "api", "--method", "GET", "repos/owner/repo/issues", "-F", "q=@secret"
       assert_stubbed env, "gh", "workflow", "run", "release.yml"
       assert_stubbed env, "gh", "totally-new-write-command", "arg"
-      assert_stubbed env, "gh", "pr", "list", "--web"
-      assert_stubbed env, "gh", "pr", "view", "42", "-w"
       assert_stubbed env, "gh", "repo", "view", "--web"
+      assert_stubbed env, "gh", "pr", "view", "42", "--web"
       assert_stubbed env, "gh", "run", "view", "123", "-w"
-      assert_stubbed env, "gh", "workflow", "view", "ci.yml", "-w"
       assert_passes env, "gh", "--repo=owner/repo", "pr", "view", "42"
       assert_passes env, "gh", "api", "repos/owner/repo"
       assert_passes env, "gh", "api", "--method", "GET", "repos/owner/repo/issues", "-f", "state=open"
-      assert_passes env, "gh", "run", "list", "-w", "CI"
+      assert_passes env, "gh", "api", "--method", "GET", "repos/owner/repo/issues", "-F", "state=open"
+
+      # Glued/inline @file payload forms must be caught on explicit GET too,
+      # not just the space-separated `-F q=@secret` form: each branch
+      # reimplements the @-prefix check, so they need independent coverage.
+      assert_stubbed env, "gh", "api", "--method", "GET", "repos/owner/repo/issues", "-Fq=@secret"
+      assert_stubbed env, "gh", "api", "--method", "GET", "repos/owner/repo/issues", "--field=q=@secret"
+      assert_stubbed env, "gh", "api", "--method", "GET", "repos/owner/repo/issues", "--input=payload.json"
+      # Glued/inline forms with scalar values stay read-only on explicit GET.
+      assert_passes env, "gh", "api", "--method", "GET", "repos/owner/repo/issues", "-Fstate=open"
+      assert_passes env, "gh", "api", "--method", "GET", "repos/owner/repo/issues", "--field=state=open"
+      # A trailing `-F` with no argument must not crash the stub; with no
+      # payload value it stays read-only on explicit GET.
+      assert_passes env, "gh", "api", "--method", "GET", "repos/owner/repo/issues", "-F"
 
       assert_stubbed env, "git", "-C", dir, "push", "origin", "HEAD:feature"
       assert_stubbed env, "git", "commit", "-m", "dry run must not commit"
       assert_stubbed env, "git", "merge", "feature"
+      assert_stubbed env, "git", "config", "user.name", "newvalue", "--get"
+      assert_stubbed env, "git", "config", "user.email", "newvalue", "--get-all"
+      assert_stubbed env, "git", "config", "commit.gpgsign", "false", "--list"
       assert_stubbed env, "git", "remote", "set-url", "origin", "git@example.com:owner/repo.git"
       assert_stubbed env, "git", "remote", "add", "upstream", "git@example.com:owner/upstream.git"
       assert_stubbed env, "git", "remote", "remove", "upstream"
-      assert_stubbed env, "git", "diff", "--output=patch.diff"
-      assert_stubbed env, "git", "diff", "--output", "patch.diff"
-      # Exec/write vectors that pass the subcommand allowlist but make real git
-      # run an arbitrary command or write a file must be screened across argv.
-      assert_stubbed env, "git", "-c", "diff.external=touch pwned", "diff"
-      assert_stubbed env, "git", "-c", "core.pager=touch pwned", "show"
-      assert_stubbed env, "git", "--config-env=diff.external=PWN", "diff"
-      # Two-token `--config-env KEY=VAL` form (not just the glued `=` spelling).
-      assert_stubbed env, "git", "--config-env", "diff.external=PWN", "diff"
-      # `--exec-path=<dir>` redirects git's helper-binary lookup (exec class).
-      assert_stubbed env, "git", "--exec-path=/tmp/evil", "diff"
-      assert_stubbed env, "git", "--paginate", "log", "-1"
-      assert_stubbed env, "git", "-p", "log", "-1"
-      assert_stubbed env, "git", "grep", "-Otouch pwned", "needle"
-      # Bundled short option (`-nO…`) must not slip past the `-O` pager screen.
-      assert_stubbed env, "git", "grep", "-nOtouch pwned", "needle"
-      assert_stubbed env, "git", "grep", "--open-files-in-pager=touch pwned", "needle"
-      # Bare `--open-files-in-pager` (no glued value) is equally a pager exec.
-      assert_stubbed env, "git", "grep", "--open-files-in-pager", "needle"
-      # Trailing bare two-token global option must not underflow / crash.
-      assert_stubbed env, "git", "-c"
-      assert_stubbed env, "git", "-C"
-      assert_stubbed env, "git", "--config-env"
-      assert_stubbed env, "git", "--output=patch.diff", "diff"
-      assert_stubbed env, "git", "log", "--output=log.txt"
-      assert_stubbed env, "git", "show", "--output=show.txt"
+      # Mutating `remote` subcommands beyond set-url/add/remove must skip too.
+      assert_stubbed env, "git", "remote", "rename", "origin", "upstream"
+      assert_stubbed env, "git", "remote", "prune", "origin"
+      assert_stubbed env, "git", "remote", "update"
+      assert_stubbed env, "git", "remote", "set-head", "origin", "main"
+      assert_stubbed env, "git", "remote", "set-branches", "origin", "main"
+      assert_stubbed env, "git", "-c", "diff.external=touch /tmp/hive-dryrun-pwn", "diff"
+      assert_stubbed env, "git", "-c", "core.fsmonitor=touch /tmp/hive-fsmonitor-pwn", "status"
+      assert_stubbed env, "git", "--config-env=core.pager=HIVE_TEST_PAGER", "log", "--oneline"
+      assert_stubbed env, "git", "--paginate", "log", "--oneline"
+      assert_stubbed env, "git", "grep", "--open-files-in-pager=touch /tmp/hive-pager-pwn", "needle"
+      # On `git grep`, `-O` is the short form of `--open-files-in-pager`; both glued and
+      # separate forms run an attacker-controlled pager command and must be rejected. (On
+      # diff/log/show `-O` is the read-only `--output-ordering` — see the passthrough cases.)
+      assert_stubbed env, "git", "grep", "-Otouch /tmp/hive-pager-short-pwn", "needle"
+      assert_stubbed env, "git", "grep", "-O", "touch /tmp/hive-pager-sep-pwn", "needle"
+      # Same-class arbitrary-exec config keys are rejected by the allowlist (reject all
+      # global config overrides), not by a denylist that has to enumerate each one.
+      assert_stubbed env, "git", "-c", "diff.x.textconv=touch /tmp/hive-textconv-pwn", "diff"
+      assert_stubbed env, "git", "-c", "diff.x.command=touch /tmp/hive-diffcmd-pwn", "diff"
+      assert_stubbed env, "git", "-c", "filter.x.clean=touch /tmp/hive-filter-pwn", "diff"
+      assert_stubbed env, "git", "-c", "gpg.ssh.program=touch /tmp/hive-gpg-pwn", "log", "--show-signature"
+      assert_stubbed env, "git", "-cdiff.x.textconv=touch /tmp/hive-glued-pwn", "diff"
+      assert_stubbed env, "git", "--config-env", "core.pager=HIVE_TEST_PAGER", "log"
+      # Arbitrary file-write options defeat the no-mutation boundary on allowed reads.
+      assert_stubbed env, "git", "diff", "--output=/tmp/hive-output-pwn"
+      assert_stubbed env, "git", "log", "-p", "--output", "/tmp/hive-output-sep-pwn"
+      assert_stubbed env, "git", "diff", "-o", "/tmp/hive-output-short-pwn"
+      assert_stubbed env, "git", "diff", "-o/tmp/hive-output-glued-pwn"
+      assert_stubbed env, "git", "diff", "--ext-diff"
+      # The read/write boundary for ls-files: `-o` / `--others` is a read (allowed below), but
+      # the file-writing `--output` long form must still skip — narrowing the guard must not
+      # re-allow the write form.
+      assert_stubbed env, "git", "ls-files", "--output", "/tmp/hive-lsfiles-output-pwn"
+      # The env-var config path bypasses every argv guard above: GIT_EXTERNAL_DIFF /
+      # GIT_SSH_COMMAND name a command git execs directly, and GIT_CONFIG_COUNT +
+      # GIT_CONFIG_KEY_n/GIT_CONFIG_VALUE_n inject the same exec-capable keys as `-c`. An
+      # otherwise-allowlisted read like `git diff` must skip, fail-closed, when they are set.
+      assert_stubbed env.merge("GIT_EXTERNAL_DIFF" => "touch /tmp/hive-extdiff-pwn"), "git", "diff"
+      assert_stubbed env.merge("GIT_SSH_COMMAND" => "touch /tmp/hive-ssh-pwn"), "git", "ls-files"
+      assert_stubbed env.merge(
+        "GIT_CONFIG_COUNT" => "1",
+        "GIT_CONFIG_KEY_0" => "diff.external",
+        "GIT_CONFIG_VALUE_0" => "touch /tmp/hive-envconfig-pwn"
+      ), "git", "diff"
+      # GIT_CONFIG_PARAMETERS is git's older one-shot config channel; it carries the same
+      # exec-capable keys (diff.external, core.fsmonitor, …) as `-c`, so it must skip too.
+      assert_stubbed env.merge(
+        "GIT_CONFIG_PARAMETERS" => "'diff.external=touch /tmp/hive-cfgparams-pwn'"
+      ), "git", "diff"
+      # GIT_SSH / GIT_PROXY_COMMAND are the older exec-capable siblings of GIT_SSH_COMMAND —
+      # each names a program git execs — and must skip on the network-reaching reads they hit.
+      assert_stubbed env.merge("GIT_SSH" => "touch /tmp/hive-gitssh-pwn"), "git", "remote", "show", "origin"
+      assert_stubbed env.merge("GIT_PROXY_COMMAND" => "touch /tmp/hive-proxy-pwn"), "git", "status"
+      # GIT_CONFIG_GLOBAL / GIT_CONFIG_SYSTEM repoint config at an attacker-written file that
+      # can re-enable diff.external / core.pager / aliases, so a set value must skip.
+      assert_stubbed env.merge("GIT_CONFIG_GLOBAL" => "/tmp/hive-evil.gitconfig"), "git", "status"
+      assert_stubbed env.merge("GIT_CONFIG_SYSTEM" => "/tmp/hive-evil-system.gitconfig"), "git", "status"
+      # Default-deny on a malformed GIT_CONFIG_COUNT: a non-numeric value (which `.to_i` reads
+      # as 0/allowed) must be rejected rather than trusted to git's own parsing.
+      assert_stubbed env.merge("GIT_CONFIG_COUNT" => "not-a-number"), "git", "status"
       assert_stubbed env, "git", "unknown-write-command"
       assert_passes env, "git", "-C", dir, "status", "--short"
-      assert_passes env, "git", "diff", "--name-only"
-      # Read-only diff orderfile (`-O<file>`) and formatting flags
-      # (`--output-indicator-*`) must pass — the pager screen is grep-scoped and
-      # `--output` is matched exactly.
-      assert_passes env, "git", "diff", "-Oorderfile", "--name-only"
-      assert_passes env, "git", "diff", "--output-indicator-new=>", "--name-only"
-      assert_passes env, "git", "log", "-p", "-1"
-      assert_passes env, "git", "grep", "needle"
-      # `git grep -c` (= --count) is read-only; `-c` is dangerous only as a
-      # global option, so it must pass here.
-      assert_passes env, "git", "grep", "-c", "needle"
       assert_passes env, "git", "config", "--get", "remote.origin.url"
+      assert_passes env, "git", "config", "--get-all", "remote.origin.fetch"
+      assert_passes env, "git", "config", "--list"
+      # Reads with a type/format modifier before --get are still read-only;
+      # auto_commit runs `git config --bool --get commit.gpgsign`.
+      assert_passes env, "git", "config", "--bool", "--get", "commit.gpgsign"
+      assert_passes env, "git", "config", "--int", "--get", "core.abbrev"
+      assert_passes env, "git", "config", "--path", "--get", "core.excludesfile"
+      assert_passes env, "git", "config", "-z", "--get-all", "remote.origin.fetch"
+      assert_passes env, "git", "config", "--type=bool", "--get", "commit.gpgsign"
       assert_passes env, "git", "remote"
       assert_passes env, "git", "remote", "-v"
       assert_passes env, "git", "remote", "show", "-n", "origin"
       assert_passes env, "git", "remote", "get-url", "--push", "origin"
+      assert_passes env, "git", "remote", "get-url", "--all", "origin"
+      # Read-only subcommand `-p` must pass through; it is not the global `--paginate`.
+      assert_passes env, "git", "log", "-p"
+      assert_passes env, "git", "show", "-p"
+      assert_passes env, "git", "diff", "-p"
+      assert_passes env, "git", "grep", "-p", "needle"
+      # `git grep -o` / `--only-matching` is a read-only match filter, not a file-write; the
+      # output-file guard is scoped past grep so it stays allowed.
+      assert_passes env, "git", "grep", "-o", "needle"
+      assert_passes env, "git", "grep", "--only-matching", "needle"
+      # `git ls-files -o` / `--others` lists untracked files — a read; the output-file guard
+      # must not over-block it.
+      assert_passes env, "git", "ls-files", "-o"
+      assert_passes env, "git", "ls-files", "--others"
+      # On diff/log/show, `-O<orderfile>` is `--output-ordering` (reads an orderfile), not the
+      # grep pager flag — a cross-subcommand read that must pass through (glued and separate).
+      assert_passes env, "git", "diff", "-O/tmp/hive-orderfile"
+      assert_passes env, "git", "log", "-O", "/tmp/hive-orderfile"
+      # After `--`, `-o` is a literal pathspec (a file named `-o`), not the output flag, so
+      # the file-write guard must not over-block the read.
+      assert_passes env, "git", "log", "--", "-o"
+      # Empty / zero env-config vars inject nothing, so the env guard must not over-block the
+      # read: GIT_CONFIG_COUNT=0 resolves to no config, and an unset external-diff is harmless.
+      assert_passes env.merge("GIT_CONFIG_COUNT" => "0", "GIT_EXTERNAL_DIFF" => ""), "git", "status", "--short"
 
       skipped = File.read(log_path)
       assert_includes skipped, "gh -R owner/repo pr ready 42 skipped"
@@ -127,44 +200,102 @@ class BabysitterDryRunEnvTest < Minitest::Test
       assert_includes skipped, "gh api repos/owner/repo/issues/123/comments --raw-field body=hi skipped"
       assert_includes skipped, "gh api repos/owner/repo/issues/123/comments --field body=hi skipped"
       assert_includes skipped, "gh api repos/owner/repo/issues/123/comments --input payload.json skipped"
+      assert_includes skipped, "gh api --method GET repos/owner/repo/issues --input payload.json skipped"
+      assert_includes skipped, "gh api --method GET repos/owner/repo/issues -F q=@secret skipped"
+      assert_includes skipped, "gh api --method GET repos/owner/repo/issues -Fq=@secret skipped"
+      assert_includes skipped, "gh api --method GET repos/owner/repo/issues --field=q=@secret skipped"
+      assert_includes skipped, "gh api --method GET repos/owner/repo/issues --input=payload.json skipped"
       assert_includes skipped, "gh workflow run release.yml skipped"
-      assert_includes skipped, "gh pr list --web skipped"
-      assert_includes skipped, "gh pr view 42 -w skipped"
       assert_includes skipped, "gh repo view --web skipped"
+      assert_includes skipped, "gh pr view 42 --web skipped"
       assert_includes skipped, "gh run view 123 -w skipped"
-      assert_includes skipped, "gh workflow view ci.yml -w skipped"
       assert_includes skipped, "git -C #{dir} push origin HEAD:feature skipped"
       assert_includes skipped, "git commit -m dry run must not commit skipped"
       assert_includes skipped, "git merge feature skipped"
+      assert_includes skipped, "git config user.name newvalue --get skipped"
+      assert_includes skipped, "git config user.email newvalue --get-all skipped"
+      assert_includes skipped, "git config commit.gpgsign false --list skipped"
       assert_includes skipped, "git remote set-url origin git@example.com:owner/repo.git skipped"
       assert_includes skipped, "git remote add upstream git@example.com:owner/upstream.git skipped"
       assert_includes skipped, "git remote remove upstream skipped"
-      assert_includes skipped, "git diff --output=patch.diff skipped"
-      assert_includes skipped, "git diff --output patch.diff skipped"
-      assert_includes skipped, "git -c diff.external=touch pwned diff skipped"
-      assert_includes skipped, "git -c core.pager=touch pwned show skipped"
-      assert_includes skipped, "git --config-env=diff.external=PWN diff skipped"
-      assert_includes skipped, "git --paginate log -1 skipped"
-      assert_includes skipped, "git -p log -1 skipped"
-      assert_includes skipped, "git grep -Otouch pwned needle skipped"
-      assert_includes skipped, "git grep --open-files-in-pager=touch pwned needle skipped"
-      assert_includes skipped, "git --output=patch.diff diff skipped"
-      assert_includes skipped, "git log --output=log.txt skipped"
-      assert_includes skipped, "git show --output=show.txt skipped"
+      assert_includes skipped, "git -c diff.external=touch /tmp/hive-dryrun-pwn diff skipped"
+      assert_includes skipped, "git -c core.fsmonitor=touch /tmp/hive-fsmonitor-pwn status skipped"
+      assert_includes skipped, "git --config-env=core.pager=HIVE_TEST_PAGER log --oneline skipped"
+      assert_includes skipped, "git --paginate log --oneline skipped"
+      assert_includes skipped, "git grep --open-files-in-pager=touch /tmp/hive-pager-pwn needle skipped"
 
       real_invocations = File.read(File.join(dir, "real.log"))
       assert_includes real_invocations, "real-gh --repo=owner/repo pr view 42"
       assert_includes real_invocations, "real-gh api repos/owner/repo"
       assert_includes real_invocations, "real-gh api --method GET repos/owner/repo/issues -f state=open"
-      assert_includes real_invocations, "real-gh run list -w CI"
+      assert_includes real_invocations, "real-gh api --method GET repos/owner/repo/issues -F state=open"
       assert_includes real_invocations, "real-git -C #{dir} status --short"
-      assert_includes real_invocations, "real-git diff --name-only"
-      assert_includes real_invocations, "real-git grep needle"
       assert_includes real_invocations, "real-git config --get remote.origin.url"
+      assert_includes real_invocations, "real-git config --get-all remote.origin.fetch"
+      assert_includes real_invocations, "real-git config --list"
+      assert_includes real_invocations, "real-git config --bool --get commit.gpgsign"
+      assert_includes real_invocations, "real-git config --int --get core.abbrev"
+      assert_includes real_invocations, "real-git config --path --get core.excludesfile"
+      assert_includes real_invocations, "real-git config -z --get-all remote.origin.fetch"
+      assert_includes real_invocations, "real-git config --type=bool --get commit.gpgsign"
       assert_includes real_invocations, "real-git remote"
       assert_includes real_invocations, "real-git remote -v"
       assert_includes real_invocations, "real-git remote show -n origin"
       assert_includes real_invocations, "real-git remote get-url --push origin"
+      assert_includes real_invocations, "real-git remote get-url --all origin"
+      # The PR's headline regression target: `-p` must reach real git as the subcommand flag,
+      # not be misclassified as the global `--paginate` and skipped.
+      assert_includes real_invocations, "real-git log -p"
+      assert_includes real_invocations, "real-git show -p"
+      assert_includes real_invocations, "real-git diff -p"
+      assert_includes real_invocations, "real-git grep -p needle"
+      assert_includes real_invocations, "real-git grep -o needle"
+      assert_includes real_invocations, "real-git log -- -o"
+    end
+  end
+
+
+  def test_gh_stub_scrubs_exec_influencing_environment_before_passthrough
+    with_tmp_dir do |dir|
+      env_keys = %w[GH_PAGER PAGER GH_BROWSER BROWSER GH_EDITOR GIT_EDITOR VISUAL EDITOR GH_FORCE_TTY]
+      real_gh = recording_env_binary(dir, "real-gh", env_keys)
+      env = {
+        "HIVE_BABYSITTER_REAL_GH" => real_gh,
+        "HIVE_BABYSITTER_DRY_RUN_LOG" => File.join(dir, "skipped.log"),
+        "GH_PAGER" => "touch pager-pwned",
+        "PAGER" => "touch pager-pwned",
+        "GH_BROWSER" => "touch browser-pwned",
+        "BROWSER" => "touch browser-pwned",
+        "GH_EDITOR" => "touch editor-pwned",
+        "GIT_EDITOR" => "touch editor-pwned",
+        "VISUAL" => "touch editor-pwned",
+        "EDITOR" => "touch editor-pwned",
+        "GH_FORCE_TTY" => "80"
+      }
+
+      _out, err, status = Open3.capture3(env, stub_path("gh"), "repo", "view", "owner/repo")
+
+      assert status.success?, err
+      assert_equal env_keys.map { |key| "#{key}=<unset>" }.join("\n") + "\n", File.read(File.join(dir, "env.log"))
+    end
+  end
+
+  def test_gh_stub_skips_browser_launch_flags
+    with_tmp_dir do |dir|
+      real_gh = recording_binary(dir, "real-gh")
+      env = {
+        "HIVE_BABYSITTER_REAL_GH" => real_gh,
+        "HIVE_BABYSITTER_DRY_RUN_LOG" => File.join(dir, "skipped.log"),
+        "GH_BROWSER" => "touch browser-pwned",
+        "BROWSER" => "touch browser-pwned"
+      }
+
+      assert_stubbed env, "gh", "repo", "view", "owner/repo", "--web"
+      assert_stubbed env, "gh", "repo", "view", "owner/repo", "--web=true"
+      assert_stubbed env, "gh", "pr", "view", "42", "--web"
+      assert_stubbed env, "gh", "repo", "view", "owner/repo", "-w"
+
+      refute File.exist?(File.join(dir, "real.log"))
     end
   end
 
@@ -235,18 +366,61 @@ class BabysitterDryRunEnvTest < Minitest::Test
       assert_includes real_invocations, "real-gh pr list --limit 1 GH_PAGER=nil PAGER=nil GH_BROWSER=nil BROWSER=nil"
     end
   end
-
   private
 
   def assert_stubbed(env, binary, *args)
     _out, err, status = Open3.capture3(env, stub_path(binary), *args)
     assert status.success?, err
     assert_includes err, "[dry-run] #{binary} #{args.join(' ')} skipped"
+    # Load-bearing: prove the command did not also fall through to the real binary. A
+    # regression that logs the skip *and then* still exec's real git/gh would pass the
+    # stderr check above; the absence from real.log is what actually verifies no passthrough.
+    real_log = @real_log && File.exist?(@real_log) ? File.read(@real_log) : ""
+    refute_includes real_log, "real-#{binary} #{args.join(' ')}",
+                     "#{binary} #{args.join(' ')} was skipped but still reached real #{binary}"
   end
 
   def assert_passes(env, binary, *args)
     _out, err, status = Open3.capture3(env, stub_path(binary), *args)
     assert status.success?, err
+    # Load-bearing, mirroring assert_stubbed's refute: exit 0 alone does not prove passthrough
+    # — a "skipped-but-exit-0" regression would also exit 0. Confirm the invocation actually
+    # reached the real binary by finding it in real.log.
+    real_log = @real_log && File.exist?(@real_log) ? File.read(@real_log) : ""
+    assert_includes real_log, "real-#{binary} #{args.join(' ')}",
+                    "#{binary} #{args.join(' ')} passed (exit 0) but never reached real #{binary}"
+  end
+
+  def recording_binary(dir, name)
+    path = File.join(dir, name)
+    File.write(path, <<~RUBY)
+      #!/usr/bin/env ruby
+      File.open(#{File.join(dir, "real.log").dump}, "a") do |file|
+        file.puts(([File.basename($PROGRAM_NAME)] + ARGV).join(" "))
+      end
+    RUBY
+    FileUtils.chmod("+x", path)
+    path
+  end
+
+  def stub_path(binary)
+    File.expand_path("../../../bin/hive-babysitter-stub-#{binary}", __dir__)
+  end
+
+  def recording_env_binary(dir, name, keys)
+    path = File.join(dir, name)
+    File.write(path, <<~RUBY)
+      #!/usr/bin/env ruby
+      keys = #{keys.inspect}
+      File.open(#{File.join(dir, "env.log").dump}, "a") do |file|
+        keys.each do |key|
+          value = ENV.key?(key) ? ENV.fetch(key) : "<unset>"
+          file.puts("\#{key}=\#{value}")
+        end
+      end
+    RUBY
+    FileUtils.chmod("+x", path)
+    path
   end
 
   def capture_pty(env, binary, *args)
@@ -264,22 +438,5 @@ class BabysitterDryRunEnvTest < Minitest::Test
       _reaped, status = Process.waitpid2(pid)
     end
     [ output, status ]
-  end
-
-  def recording_binary(dir, name, env_keys: [])
-    path = File.join(dir, name)
-    File.write(path, <<~RUBY)
-      #!/usr/bin/env ruby
-      File.open(#{File.join(dir, "real.log").dump}, "a") do |file|
-        env = #{env_keys.inspect}.map { |key| "\#{key}=\#{ENV[key].inspect}" }
-        file.puts(([File.basename($PROGRAM_NAME)] + ARGV + env).join(" "))
-      end
-    RUBY
-    FileUtils.chmod("+x", path)
-    path
-  end
-
-  def stub_path(binary)
-    File.expand_path("../../../bin/hive-babysitter-stub-#{binary}", __dir__)
   end
 end

--- a/wiki/log.d/20260607T171151Z-babysitter-dry-run-pager-env.md
+++ b/wiki/log.d/20260607T171151Z-babysitter-dry-run-pager-env.md
@@ -1,0 +1,7 @@
+## [2026-06-07T17:11:51Z] babysitter — harden dry-run pager/browser exec paths
+
+**Action:** Hardened the babysitter dry-run `git` / `gh` stubs after patrol found TTY pager execution still reachable through allowlisted reads. `bin/hive-babysitter-stub-git` now treats global `-p` / `--paginate` as exec-screened options and deletes generic `PAGER` before handoff in addition to the existing Git-specific env scrub. `bin/hive-babysitter-stub-gh` now deletes `GH_PAGER`, `PAGER`, `GH_BROWSER`, and `BROWSER` before handoff, and skips documented browser-opening `--web` / `-w` flags on read subcommands while preserving non-browser `gh run list -w <workflow>`.
+
+**Coverage:** `test/unit/babysitter/dry_run_env_test.rb` now runs focused PTY regressions with hostile pager/browser env vars, verifies forced git pagination is skipped without invoking the real binary, and keeps safe read forms such as `git log -p -1` and `gh run list -w CI` passing.
+
+**Refs:** [[modules/babysitter]], [[commands/babysit]], [[testing]], [[gaps]]

--- a/wiki/log.d/20260607T171151Z-babysitter-dry-run-pager-env.md
+++ b/wiki/log.d/20260607T171151Z-babysitter-dry-run-pager-env.md
@@ -1,7 +1,0 @@
-## [2026-06-07T17:11:51Z] babysitter — harden dry-run pager/browser exec paths
-
-**Action:** Hardened the babysitter dry-run `git` / `gh` stubs after patrol found TTY pager execution still reachable through allowlisted reads. `bin/hive-babysitter-stub-git` now treats global `-p` / `--paginate` as exec-screened options and deletes generic `PAGER` before handoff in addition to the existing Git-specific env scrub. `bin/hive-babysitter-stub-gh` now deletes `GH_PAGER`, `PAGER`, `GH_BROWSER`, and `BROWSER` before handoff, and skips documented browser-opening `--web` / `-w` flags on read subcommands while preserving non-browser `gh run list -w <workflow>`.
-
-**Coverage:** `test/unit/babysitter/dry_run_env_test.rb` now runs focused PTY regressions with hostile pager/browser env vars, verifies forced git pagination is skipped without invoking the real binary, and keeps safe read forms such as `git log -p -1` and `gh run list -w CI` passing.
-
-**Refs:** [[modules/babysitter]], [[commands/babysit]], [[testing]], [[gaps]]


### PR DESCRIPTION
## Hive Patrol Finding

Slice: `command-bin-hive-e2e`
Category: `security`
Severity: `medium`
Confidence: `high`
Fingerprint: `9e8edd53ce16238bf5c0d75204c191cbccc307ab3fe6c433f9743beabd48436c`

The babysitter dry-run stubs pass allowlisted read commands through to real git/gh while leaving pager execution paths available. In a TTY, `PAGER='sh -c ...' bin/hive-babysitter-stub-git --paginate log -1` executes the pager command, and `GH_PAGER='sh -c ...' bin/hive-babysitter-stub-gh pr list --limit 1` does the same for gh. That bypasses the dry-run guard's explicit attempt to block exec-capable read invocations.

## Evidence

- bin/hive-babysitter-stub-git:104 def exec_or_write_screened?(argv, rest)
- bin/hive-babysitter-stub-git:150 %w[GIT_EXTERNAL_DIFF GIT_PAGER GIT_SSH GIT_SSH_COMMAND].each { |key| ENV.delete(key) }
- bin/hive-babysitter-stub-gh:64 def read_only?(rest)
- bin/hive-babysitter-stub-gh:96 exec(real, *argv)

## Applied Fix

For git, screen or skip global pagination flags such as `-p` and `--paginate`, and scrub `PAGER` in addition to the Git-specific variables before exec. For gh, scrub `GH_PAGER` and other gh/browser exec-influencing environment variables or force pager-off behavior before passing allowlisted reads through. Add regression tests that run the stubs under a pseudo-TTY with hostile pager env vars.

## Validation

- lint: passed (`bundle exec rubocop`)
- test: passed (`bundle exec rake test`)

## Diffstat

```text
 bin/hive-babysitter-stub-gh                        |  27 +++++-
 bin/hive-babysitter-stub-git                       |   6 +-
 test/unit/babysitter/dry_run_env_test.rb           | 108 ++++++++++++++++++++-
 wiki/commands/babysit.md                           |   4 +-
 wiki/gaps.md                                       |   2 +-
 ...0260607T171151Z-babysitter-dry-run-pager-env.md |   7 ++
 wiki/modules/babysitter.md                         |   2 +-
 wiki/testing.md                                    |   2 +-
 8 files changed, 147 insertions(+), 11 deletions(-)

```
