### PR TITLE
fix(agent,review): surface usage-limit as limits_reached, not generic failure

### DIFF
--- a/lib/hive/agent.rb
+++ b/lib/hive/agent.rb
@@ -113,6 +113,7 @@ module Hive
       log_file = log_path
       final_message = nil
       final_message_source = nil
+      limit_text = nil
       last_usage = nil
       plain_tail = +""
       stdin_file = prompt_stdin_file
@@ -148,6 +149,16 @@ module Hive
             elsif json.nil?
               plain_tail << line
               plain_tail = plain_tail.byteslice(-FINAL_MESSAGE_TAIL_BYTES, FINAL_MESSAGE_TAIL_BYTES) || plain_tail
+            end
+            # Capture a usage/credit-limit signal straight from the raw stream.
+            # Some CLIs (notably codex) report "you've hit your usage limit" as a
+            # structured {"type":"error",...} / turn.failed JSON event that
+            # MessageExtractor does not surface as a final message — so without
+            # scanning the raw line the limit text never reaches handle_exit and
+            # the run is misreported as a generic failure (exit_code=1).
+            if limit_text.nil? && Hive::AgentLimit.limit_reached?(line)
+              detail = json && (json["message"] || (json["error"].is_a?(Hash) ? json["error"]["message"] : nil))
+              limit_text = (detail || line).to_s.strip
             end
             usage = json && @profile.extract_usage_event(json)
             last_usage = usage if usage
@@ -217,6 +228,7 @@ module Hive
         log_file: log_file,
         final_message: message,
         final_message_source: message_source,
+        limit_text: limit_text,
         usage: last_usage,
         model: last_usage && last_usage[:model],
         status: nil
@@ -349,10 +361,15 @@ module Hive
     def limit_error_message(result)
       return nil if result[:exit_code] == 0 && !result[:timed_out]
 
-      text = result[:final_message].to_s
-      return nil unless Hive::AgentLimit.limit_reached?(text)
+      # Prefer the limit text captured directly from the raw stream
+      # (result[:limit_text]); it catches CLIs like codex that emit the
+      # limit notice as a structured event the final-message extractor
+      # drops. Fall back to scanning final_message for older paths.
+      limit = result[:limit_text].to_s
+      limit = result[:final_message].to_s unless Hive::AgentLimit.limit_reached?(limit)
+      return nil unless Hive::AgentLimit.limit_reached?(limit)
 
-      Hive::AgentLimit.error_message(text, agent: @profile.name)
+      Hive::AgentLimit.error_message(limit, agent: @profile.name)
     end
 
     def handle_exit_state_file_marker(result)

--- a/lib/hive/stages/review.rb
+++ b/lib/hive/stages/review.rb
@@ -13,6 +13,7 @@ require "hive/stages/clean_exit"
 require "hive/worktree"
 require "hive/git_ops"
 require "hive/markers"
+require "hive/agent_limit"
 require "hive/reviewers"
 require "hive/agent_profiles"
 require "hive/stages/review/context"
@@ -355,10 +356,13 @@ module Hive
             if reviewers_result == :wall_clock_exceeded
               return finalize_wall_clock_stale(task, started_at, pass: pass)
             end
-            if reviewers_result == :all_failed
-              Hive::Markers.set(task.state_file, :review_error,
-                                phase: :reviewers, reason: "all_failed", pass: pass)
-              return { commit: "reviewers_all_failed_pass_#{format('%02d', pass)}",
+            if reviewers_result == :all_failed || reviewers_result == :all_failed_limit
+              limit = reviewers_result == :all_failed_limit
+              reason = limit ? "limits_reached" : "all_failed"
+              attrs = { phase: :reviewers, reason: reason, pass: pass }
+              attrs[:message] = "all reviewers hit a usage/credit limit" if limit
+              Hive::Markers.set(task.state_file, :review_error, attrs)
+              return { commit: "reviewers_#{reason}_pass_#{format('%02d', pass)}",
                        status: :review_error }
             end
 
@@ -975,6 +979,10 @@ module Hive
         remaining_specs = specs.length
 
         statuses = []
+        # Collect per-reviewer error messages so an all-failed phase can be
+        # classified (e.g. every reviewer hit a usage/credit limit) instead of
+        # being flattened to a generic "all_failed".
+        error_messages = []
         # Partition into claude-tmux specs vs everything else so the
         # shared tmux session covers ONLY the group that needs it: a
         # mixed reviewer list keeps non-claude reviewers running in
@@ -994,6 +1002,7 @@ module Hive
             return :wall_clock_exceeded if result == :wall_clock_exceeded
 
             statuses << result.status
+            error_messages << result.error_message if result.error?
             handle_reviewer_result(task, cfg, ctx, spec, result)
             remaining_specs -= 1
           end
@@ -1020,6 +1029,7 @@ module Hive
               return :wall_clock_exceeded if result == :wall_clock_exceeded
 
               statuses << result.status
+              error_messages << result.error_message if result.error?
               handle_reviewer_result(task, cfg, ctx, spec, result)
               remaining_specs -= 1
             end
@@ -1035,6 +1045,7 @@ module Hive
             return :wall_clock_exceeded if result == :wall_clock_exceeded
 
             statuses << result.status
+            error_messages << result.error_message if result.error?
             handle_reviewer_result(task, cfg, ctx, spec, result)
             remaining_specs -= 1
           end
@@ -1043,7 +1054,19 @@ module Hive
         return :wall_clock_exceeded if started_at && max_wall_clock_sec &&
                                        wall_clock_exceeded?(started_at, max_wall_clock_sec)
 
-        statuses.all?(:error) ? :all_failed : :ok
+        if statuses.all?(:error)
+          # Every reviewer failed. If the failures are usage/credit-limit
+          # errors (e.g. codex "you've hit your usage limit"), surface that
+          # distinctly so the run is marked limits_reached rather than a
+          # generic all_failed.
+          if error_messages.any? { |m| Hive::AgentLimit.limit_reached?(m.to_s) }
+            :all_failed_limit
+          else
+            :all_failed
+          end
+        else
+          :ok
+        end
       end
 
       def reviewer_specs_for(cfg, task)

--- a/test/unit/agent_test.rb
+++ b/test/unit/agent_test.rb
@@ -594,6 +594,54 @@ class AgentTest < Minitest::Test
     end
   end
 
+  def test_classifies_limit_from_limit_text_when_final_message_is_clean
+    # Codex surfaces the usage-limit notice as a structured stream event, so
+    # final_message ends up clean (e.g. "exit_code=1") while limit_text carries
+    # the real signal. handle_exit must classify off limit_text, not just
+    # final_message.
+    with_tmp_dir do |dir|
+      task = make_task(dir)
+      File.write(task.state_file, "")
+      agent = Hive::Agent.new(task: task, prompt: "x", max_budget_usd: 1, timeout_sec: 5)
+      result = {
+        timed_out: false,
+        exit_code: 1,
+        final_message: "",
+        limit_text: "You've hit your usage limit. Visit .../usage to purchase more credits."
+      }
+
+      agent.handle_exit(result)
+
+      assert_equal :error, result[:status]
+      assert_match(/\Alimits reached for claude:/, result[:error_message])
+      assert_equal "limits_reached", Hive::Markers.current(task.state_file).attrs["reason"]
+    end
+  end
+
+  def test_captures_usage_limit_from_structured_error_stream_event
+    # End-to-end: a codex-style {"type":"error","message":"...usage limit..."}
+    # JSON event (which MessageExtractor does not surface as a final message)
+    # plus a nonzero exit must be reported as limits_reached, not exit_code=1.
+    with_tmp_dir do |dir|
+      task = make_task(dir)
+      File.write(task.state_file, "<!-- WAITING -->\n")
+      ENV["HIVE_FAKE_CLAUDE_OUTPUT"] = JSON.generate(
+        "type" => "error",
+        "message" => "You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again later."
+      )
+      ENV["HIVE_FAKE_CLAUDE_EXIT"] = "1"
+
+      result = Hive::Agent.new(task: task, prompt: "x", max_budget_usd: 1, timeout_sec: 5).run!
+
+      assert_match(/usage limit/i, result[:limit_text].to_s,
+                   "limit text must be captured from the structured error stream event")
+      assert_equal :error, result[:status]
+      assert_match(/\Alimits reached for claude:/, result[:error_message].to_s,
+                   "must classify as limits-reached, not a generic exit_code failure")
+      assert_equal "limits_reached", Hive::Markers.current(task.state_file).attrs["reason"]
+    end
+  end
+
   def test_output_file_mode_classifies_limits_before_missing_expected_output
     with_tmp_dir do |dir|
       task = make_task(dir)

--- a/test/unit/stages/review/run_reviewers_test.rb
+++ b/test/unit/stages/review/run_reviewers_test.rb
@@ -776,6 +776,38 @@ class RunReviewersTest < Minitest::Test
     end
   end
 
+  # Every reviewer failing specifically because of a usage/credit limit must
+  # be classified as :all_failed_limit (so the marker becomes
+  # reason=limits_reached) rather than a generic :all_failed.
+  class LimitErroringReviewer < Hive::Reviewers::Base
+    def run!(deadline: nil)
+      Hive::Reviewers::Result.new(
+        name: name, output_path: output_path, status: :error,
+        error_message: "limits reached for codex: You've hit your usage limit. Visit .../usage to purchase more credits."
+      )
+    end
+  end
+
+  def test_all_failed_due_to_usage_limit_returns_all_failed_limit
+    with_tmp_dir do |dir|
+      cfg = {
+        "review" => {
+          "reviewers" => [
+            { "name" => "a", "output_basename" => "a" },
+            { "name" => "b", "output_basename" => "b" }
+          ]
+        }
+      }
+      adapters = cfg["review"]["reviewers"].map { |spec| LimitErroringReviewer.new(spec, make_ctx(dir)) }
+
+      with_stubbed_dispatch(adapters) do
+        result = Hive::Stages::Review.run_reviewers(cfg, make_ctx(dir), Task.new(dir, File.join(dir, "task.md")))
+        assert_equal :all_failed_limit, result,
+                     "all reviewers failing with a usage-limit error must surface :all_failed_limit"
+      end
+    end
+  end
+
   def test_first_reviewer_raise_does_not_abort_second
     with_tmp_dir do |dir|
       cfg = {

--- a/wiki/log.d/20260608-000000-limit-reached-status.md
+++ b/wiki/log.d/20260608-000000-limit-reached-status.md
@@ -1,0 +1,6 @@
+## [2026-06-08T00:00:00Z] agent/review — surface usage-limit as limits_reached, not generic failure
+
+**Action:** Patrol/review tasks were landing in a red `reason=all_failed` (and agents in generic `exit_code=1`) when the underlying CLI had actually hit a usage/credit limit. Root cause: codex reports the limit as a structured `{"type":"error","message":"…you've hit your usage limit…"}` / `turn.failed` JSON stream event, which `MessageExtractor` does not surface as a final message, so the limit text never reached `Agent#handle_exit` (which only scanned `final_message`). Fix: `Agent#spawn_and_wait` now scans every raw stream line via `Hive::AgentLimit` and captures `result[:limit_text]`; `limit_error_message` prefers it. In `Stages::Review.run_reviewers`, per-reviewer error messages are collected and an all-failed phase whose failures are limit errors returns `:all_failed_limit`, landing a `REVIEW_ERROR reason=limits_reached message="all reviewers hit a usage/credit limit"` marker instead of `reason=all_failed`. Added agent unit tests (limit_text path + end-to-end structured-error capture) and a run_reviewers `:all_failed_limit` test.
+
+**Refreshed pages:**
+- [[testing]]


### PR DESCRIPTION
## Problem

Patrol/review tasks were piling up in **red `reason=all_failed`** (and agents in generic `exit_code=1`) when the real cause was the **codex CLI hitting a usage/credit limit** — "you've hit your usage limit … purchase more credits". The status was misleading: "failed" instead of "limit reached".

## Root cause

Codex emits the limit as a **structured JSON stream event** — `{"type":"error","message":"…usage limit…"}` and `turn.failed` — and exits `1`. `Agent::MessageExtractor` only surfaces assistant/result messages, so that line was dropped from both `final_message` and `plain_tail`. `Agent#handle_exit` → `limit_error_message` only scanned `final_message`, so the limit text never reached classification. The reviewers phase then flattened the all-error result to `REVIEW_ERROR reason=all_failed`.

(`Hive::AgentLimit` already *matches* the wording — `/(?:daily|monthly|usage|spend|spending) limit/` — it just never received the text.)

## Fix

- **`lib/hive/agent.rb`** — `spawn_and_wait` scans every raw stream line through `Hive::AgentLimit` and captures `result[:limit_text]`; `limit_error_message` prefers it (falls back to `final_message`).
- **`lib/hive/stages/review.rb`** — `run_reviewers` collects per-reviewer error messages; an all-failed phase whose failures are limit errors returns `:all_failed_limit`, landing `REVIEW_ERROR reason=limits_reached message="all reviewers hit a usage/credit limit"` instead of `reason=all_failed`.

## Tests

- `agent_test`: `limit_text` classification path + end-to-end capture of a codex-style structured error event (exit 1 → `limits_reached`).
- `run_reviewers_test`: `:all_failed_limit` classification when all reviewers fail with a limit error.

Verified against the live codex CLI (credit currently exhausted): it prints `{"type":"error","message":"You've hit your usage limit. Visit …/usage to purchase more credits…"}` to stdout with exit 1 — exactly the path this fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)