### PR TITLE
docs(config): document daemon.max_concurrent_patrol_scans

### DIFF
--- a/wiki/log.d/20260608-101500-patrol-scan-budget-doc.md
+++ b/wiki/log.d/20260608-101500-patrol-scan-budget-doc.md
@@ -1,0 +1,6 @@
+## [2026-06-08T10:15:00Z] config — document daemon.max_concurrent_patrol_scans
+
+**Action:** `wiki/modules/config.md` did not mention `daemon.max_concurrent_patrol_scans` even though the setting is live on `main` (`Config::DEFAULTS` daemon block = 1, validated `>= 1`, enforced by `Hive::Daemon::ConcurrencyController` as a `:patrol_scan_cap` separate from task-dispatch slots). Added a grounded sentence to the notable-defaults prose: daemon-scheduled `hive patrol PROJECT` scans run on their own in-flight budget so a long codex-backed scan never consumes a `daemon.max_concurrent_runs` task slot (scans tagged `kind: :patrol_scan`, excluded from the per-project/global caps).
+
+**Refreshed pages:**
+- [[modules/config]]

--- a/wiki/modules/config.md
+++ b/wiki/modules/config.md
@@ -110,7 +110,7 @@ tags: [config, yaml, validation]
 }
 ```
 
-`worktree_root: nil` is intentional — the actual default is computed lazily by `Worktree#worktree_root` as `~/Dev/<project>.worktrees`. `review.reviewers` defaults to `[]`; the recommended set ships live (uncommented) in `templates/project_config.yml.erb` so a fresh `hive init` produces a populated reviewer list. `patrol.review.reviewers` defaults to the narrower patrol list, Codex CE code review only; fresh init can optionally add Claude CE code review for patrol PRs.
+`worktree_root: nil` is intentional — the actual default is computed lazily by `Worktree#worktree_root` as `~/Dev/<project>.worktrees`. `review.reviewers` defaults to `[]`; the recommended set ships live (uncommented) in `templates/project_config.yml.erb` so a fresh `hive init` produces a populated reviewer list. `patrol.review.reviewers` defaults to the narrower patrol list, Codex CE code review only; fresh init can optionally add Claude CE code review for patrol PRs. `daemon.max_concurrent_patrol_scans` (default `1`, validated `>= 1`) bounds daemon-scheduled `hive patrol PROJECT` scans on a **separate** in-flight budget from task dispatch: a long codex-backed scan never consumes a `daemon.max_concurrent_runs` task slot — scans are tagged `kind: :patrol_scan` in the dispatcher and excluded from the per-project/global task caps, counted only against this independent cap (see `Hive::Daemon::ConcurrencyController#can_dispatch?` → `:patrol_scan_cap`).
 
 ## Module functions
 


### PR DESCRIPTION
Adds the missing documentation for `daemon.max_concurrent_patrol_scans` to `wiki/modules/config.md`. The setting is live on `main` (`Config::DEFAULTS` daemon block = `1`, validated `>= 1`, enforced by `Hive::Daemon::ConcurrencyController` as a separate `:patrol_scan_cap`) but the wiki never documented it.

Grounded in `lib/hive/config.rb` (default + `validate_daemon!` floor) and `lib/hive/daemon/concurrency_controller.rb` (`kind: :patrol_scan`, excluded from task caps).

Surfaced while reconciling stale per-worktree wiki snapshots — this was the one genuinely-missing, still-accurate doc gap. (The other candidate, a standalone `wiki/openclaw.md`, was **not** added: it described 22 per-verb skills, which is stale — `main` has a single `/hive` skill and already documents OpenClaw correctly in `commands.md`/`operating.md`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)