### PR TITLE
fix(bot,daemon): tolerate hive-status schema_version skew instead of crashing

### DIFF
--- a/lib/hive/bot/status_watcher.rb
+++ b/lib/hive/bot/status_watcher.rb
@@ -101,6 +101,17 @@ module Hive
 
         doc = JSON.parse(out)
         validate_envelope!(doc)
+        skew = schema_skew(doc)
+        # An OLDER payload (a stale `hive` on PATH than this process
+        # expects) cannot be trusted to carry the fields we read, so we
+        # do not attempt a best-effort parse — surface a clear, actionable
+        # message instead of crashing. A NEWER (or equal) payload is parsed
+        # best-effort: hive-status envelopes are additive by contract, so
+        # an updated binary's output is still readable by an older
+        # long-running process.
+        return failure(older_skew_message(doc)) if skew == :older
+
+        warn_forward_skew(doc) if skew == :newer
         Result.new(
           ok: true,
           rows: extract_rows(doc, now: now),
@@ -111,6 +122,11 @@ module Hive
       rescue JSON::ParserError => e
         failure("malformed JSON from hive status: #{e.message}")
       rescue StandardError => e
+        # A newer payload that genuinely failed best-effort extraction
+        # degrades to a clear, actionable restart message rather than an
+        # opaque "#{e.class}: ..." crash line.
+        return failure(forward_skew_message(doc)) if defined?(doc) && doc.is_a?(Hash) && schema_skew(doc) == :newer
+
         failure("#{e.class}: #{e.message}")
       end
 
@@ -121,16 +137,52 @@ module Hive
         Result.new(ok: false, rows: [], legacy_stage_dirs: [], error: message)
       end
 
+      # Envelope-shape validation (hard errors) ONLY. A missing/wrong
+      # `schema` key or `ok=false` is a malformed/failed envelope and must
+      # still raise. Schema VERSION skew is NOT validated here — it is
+      # handled tolerantly via `schema_skew` so a binary/process version
+      # mismatch never hard-crashes a long-running consumer (bot `/status`).
       def validate_envelope!(doc)
         unless doc.is_a?(Hash) && doc["schema"] == "hive-status"
           raise ArgumentError, "missing schema=hive-status in envelope"
         end
         raise ArgumentError, "envelope ok=false: #{doc['message']}" unless doc["ok"] == true
+      end
 
+      # Classify the envelope's schema_version against what THIS process
+      # was built for: :match, :newer (payload from an updated binary), or
+      # :older (a stale binary on PATH). Never raises.
+      def schema_skew(doc)
         expected = Hive::Schemas::SCHEMA_VERSIONS.fetch("hive-status")
-        return if doc["schema_version"] == expected
+        got = doc["schema_version"]
+        return :match if got == expected
+        return :newer if got.is_a?(Integer) && got > expected
 
-        raise ArgumentError, "schema_version mismatch: got #{doc['schema_version']}, want #{expected}"
+        :older
+      end
+
+      def warn_forward_skew(doc)
+        @logger&.event(
+          :poll_failure, source: "status",
+          message: "#{forward_skew_summary(doc)}; parsing best-effort. " \
+                   "Restart the hive bot to pick up the new schema."
+        )
+      end
+
+      def forward_skew_message(doc)
+        "hive status: #{forward_skew_summary(doc)}; " \
+          "restart the hive bot to pick up the new version"
+      end
+
+      def forward_skew_summary(doc)
+        expected = Hive::Schemas::SCHEMA_VERSIONS.fetch("hive-status")
+        "envelope schema v#{doc['schema_version']} is newer than this process (v#{expected})"
+      end
+
+      def older_skew_message(doc)
+        expected = Hive::Schemas::SCHEMA_VERSIONS.fetch("hive-status")
+        "hive status: envelope schema v#{doc['schema_version']} is older than this process " \
+          "(v#{expected}); update/reinstall the hive binary on PATH"
       end
 
       def extract_legacy_stage_dirs(doc)

--- a/lib/hive/daemon/dispatcher.rb
+++ b/lib/hive/daemon/dispatcher.rb
@@ -200,6 +200,11 @@ module Hive
           @logger.event(:tick_end, now: Time.now.utc.iso8601, action: "status_failure")
           return
         end
+        # Forward schema-version skew (tolerated, parsed best-effort): an
+        # updated `hive` binary emitted a newer hive-status envelope than
+        # this long-running daemon was built for. Log once; the tick
+        # proceeds on the additive payload. Restart picks up the schema.
+        @logger.event(:status_schema_skew, message: result.warning) if result.warning
         # Rebuild the per-tick set of half-migrated projects from the
         # status snapshot. Stays empty when the daemon talks to an old
         # status binary that didn't ship the field (Result#projects

--- a/lib/hive/daemon/logger.rb
+++ b/lib/hive/daemon/logger.rb
@@ -26,6 +26,7 @@ module Hive
         tick_begin
         tick_end
         status_failure
+        status_schema_skew
         dispatched
         skipped
         debouncing

--- a/lib/hive/daemon/status_consumer.rb
+++ b/lib/hive/daemon/status_consumer.rb
@@ -31,7 +31,10 @@ module Hive
           !Array(legacy_stage_dirs).empty?
         end
       end
-      Result = Struct.new(:ok, :rows, :projects, :error, keyword_init: true)
+      # `warning` carries a non-fatal advisory (currently: a forward
+      # schema-version skew was tolerated and parsed best-effort). The
+      # dispatcher logs it once per tick. nil on a clean fetch.
+      Result = Struct.new(:ok, :rows, :projects, :error, :warning, keyword_init: true)
 
       def initialize(hive_bin: ENV.fetch("HIVE_BIN", "hive"),
                      extra_env: {})
@@ -48,29 +51,81 @@ module Hive
 
         doc = JSON.parse(out)
         validate_envelope!(doc)
+        skew = schema_skew(doc)
+        # An OLDER payload (a stale `hive` on PATH than this daemon
+        # expects) can't be trusted to carry the fields the dispatcher
+        # reads, so surface a clear, actionable failure instead of
+        # advancing on stale data. A NEWER (or equal) payload is parsed
+        # best-effort: hive-status envelopes are additive by contract, so
+        # an updated binary's output stays readable by an older
+        # long-running daemon process. The dispatcher logs `warning`.
+        return Result.new(ok: false, rows: [], projects: [], error: older_skew_message(doc)) if skew == :older
+
         rows = extract_rows(doc)
         projects = extract_projects(doc)
-        Result.new(ok: true, rows: rows, projects: projects, error: nil)
+        Result.new(ok: true, rows: rows, projects: projects, error: nil,
+                   warning: (skew == :newer ? forward_skew_warning(doc) : nil))
       rescue JSON::ParserError => e
         Result.new(ok: false, rows: [], projects: [],
                    error: "malformed JSON from hive status: #{e.message}")
       rescue StandardError => e
+        # A newer payload that genuinely failed best-effort extraction
+        # degrades to a clear, actionable restart message rather than an
+        # opaque "#{e.class}: ..." line that an operator can't act on.
+        if defined?(doc) && doc.is_a?(Hash) && schema_skew(doc) == :newer
+          return Result.new(ok: false, rows: [], projects: [], error: forward_skew_message(doc))
+        end
+
         Result.new(ok: false, rows: [], projects: [], error: "#{e.class}: #{e.message}")
       end
 
       private
 
+      # Envelope-shape validation (hard errors) ONLY. A missing/wrong
+      # `schema` key or `ok=false` is a malformed/failed envelope and must
+      # still raise. Schema VERSION skew is NOT validated here — it is
+      # handled tolerantly via `schema_skew` so a binary/process version
+      # mismatch never hard-crashes the daemon tick.
       def validate_envelope!(doc)
         unless doc.is_a?(Hash) && doc["schema"] == "hive-status"
           raise ArgumentError, "missing schema=hive-status in envelope"
         end
-        unless doc["ok"] == true
-          raise ArgumentError, "envelope ok=false: #{doc['error_class']} #{doc['message']}"
-        end
-        expected = Hive::Schemas::SCHEMA_VERSIONS["hive-status"]
-        return if doc["schema_version"] == expected
+        return if doc["ok"] == true
 
-        raise ArgumentError, "schema_version mismatch: got #{doc['schema_version']}, want #{expected}"
+        raise ArgumentError, "envelope ok=false: #{doc['error_class']} #{doc['message']}"
+      end
+
+      # Classify the envelope's schema_version against what THIS daemon was
+      # built for: :match, :newer (payload from an updated binary), or
+      # :older (a stale binary on PATH). Never raises.
+      def schema_skew(doc)
+        expected = Hive::Schemas::SCHEMA_VERSIONS["hive-status"]
+        got = doc["schema_version"]
+        return :match if got == expected
+        return :newer if got.is_a?(Integer) && got > expected
+
+        :older
+      end
+
+      def forward_skew_warning(doc)
+        "#{forward_skew_summary(doc)}; parsing best-effort. " \
+          "Restart the hive daemon to pick up the new schema."
+      end
+
+      def forward_skew_message(doc)
+        "hive status: #{forward_skew_summary(doc)}; " \
+          "restart the hive daemon to pick up the new version"
+      end
+
+      def forward_skew_summary(doc)
+        expected = Hive::Schemas::SCHEMA_VERSIONS["hive-status"]
+        "envelope schema v#{doc['schema_version']} is newer than this process (v#{expected})"
+      end
+
+      def older_skew_message(doc)
+        expected = Hive::Schemas::SCHEMA_VERSIONS["hive-status"]
+        "hive status: envelope schema v#{doc['schema_version']} is older than this process " \
+          "(v#{expected}); update/reinstall the hive binary on PATH"
       end
 
       def extract_rows(doc)

--- a/lib/hive/tui/state_source.rb
+++ b/lib/hive/tui/state_source.rb
@@ -138,7 +138,12 @@ module Hive
         paths = [ registry_config_path ]
         snapshot.projects.each do |project|
           paths.concat(project_watch_paths(project))
-          project.rows.each { |row| paths << row.state_file }
+          project.rows.each do |row|
+            paths << row.state_file
+            # A runner can acquire the task lock before it writes
+            # AGENT_WORKING, so the lock file is a status-affecting path.
+            paths << File.join(row.folder, ".lock") if row.folder
+          end
         end
         paths.compact.uniq.to_h { |path| [ path, safe_mtime(path) ] }
       end

--- a/test/unit/bot/status_watcher_test.rb
+++ b/test/unit/bot/status_watcher_test.rb
@@ -168,11 +168,13 @@ class HiveBotStatusWatcherTest < Minitest::Test
 
   def test_fetch_rejects_invalid_envelopes
     expected_version = Hive::Schemas::SCHEMA_VERSIONS.fetch("hive-status")
+    # Envelope-SHAPE errors (missing schema, ok=false) remain hard
+    # failures. Schema-VERSION skew is handled tolerantly and is covered
+    # by the dedicated skew tests below, not here.
     cases = {
       "wrong schema" => [ { "schema" => "other", "ok" => true, "schema_version" => expected_version }, /missing schema/ ],
       "not ok" => [ { "schema" => "hive-status", "ok" => false, "schema_version" => expected_version,
-                       "message" => "registry unavailable" }, /envelope ok=false: registry unavailable/ ],
-      "wrong version" => [ { "schema" => "hive-status", "ok" => true, "schema_version" => -1 }, /schema_version mismatch/ ]
+                       "message" => "registry unavailable" }, /envelope ok=false: registry unavailable/ ]
     }
 
     cases.each do |label, (payload, pattern)|
@@ -184,6 +186,61 @@ class HiveBotStatusWatcherTest < Minitest::Test
         assert_match pattern, result.error, label
         assert_equal :poll_failure, logger.events.first.fetch(:name), label
       end
+    end
+  end
+
+  # ── schema_version skew (forward-tolerant; must never raise) ───────────
+
+  # A NEWER envelope (expected+1) from an updated binary that the
+  # long-running bot hasn't restarted to match. hive-status envelopes are
+  # additive, so the rows still parse — the bot keeps working and only
+  # logs a one-line skew warning. This is the production incident path
+  # (`got 3, want 2`) that previously hard-failed every /status.
+  def test_fetch_tolerates_newer_schema_version_best_effort
+    expected = Hive::Schemas::SCHEMA_VERSIONS.fetch("hive-status")
+    payload = envelope([ task(slug: "newer-schema") ])
+    payload["schema_version"] = expected + 1
+
+    with_fake_status(JSON.generate(payload)) do |bin|
+      logger = CapturingLogger.new
+      result = Hive::Bot::StatusWatcher.new(hive_bin: bin, logger: logger).fetch
+
+      assert result.ok, "newer schema must parse best-effort, not fail: #{result.error.inspect}"
+      assert_equal [ "newer-schema" ], result.rows.map(&:slug)
+      skew_event = logger.events.find { |e| e.fetch(:payload)[:message].to_s.match?(/newer than this process/) }
+      refute_nil skew_event, "expected a best-effort skew warning to be logged"
+      assert_match(/restart the hive bot/i, skew_event.fetch(:payload).fetch(:message))
+    end
+  end
+
+  # An OLDER envelope (expected-1): a stale `hive` binary on PATH. We can't
+  # trust its fields, so the bot returns a clear, actionable message
+  # (update/reinstall) rather than crashing.
+  def test_fetch_older_schema_version_returns_actionable_failure
+    expected = Hive::Schemas::SCHEMA_VERSIONS.fetch("hive-status")
+    payload = envelope([ task(slug: "older-schema") ])
+    payload["schema_version"] = expected - 1
+
+    with_fake_status(JSON.generate(payload)) do |bin|
+      logger = CapturingLogger.new
+      result = Hive::Bot::StatusWatcher.new(hive_bin: bin, logger: logger).fetch
+
+      refute result.ok, "older schema must not be parsed as trustworthy"
+      assert_match(/older than this process/, result.error)
+      assert_match(/update\/reinstall the hive binary/, result.error)
+      assert_equal :poll_failure, logger.events.first.fetch(:name)
+    end
+  end
+
+  # Exact match keeps the pre-existing happy path: no warning, rows parse.
+  def test_fetch_exact_schema_version_match_has_no_skew_warning
+    with_fake_status(JSON.generate(envelope([ task(slug: "exact") ]))) do |bin|
+      logger = CapturingLogger.new
+      result = Hive::Bot::StatusWatcher.new(hive_bin: bin, logger: logger).fetch
+
+      assert result.ok, result.error
+      assert_equal [ "exact" ], result.rows.map(&:slug)
+      assert_empty logger.events, "exact-match fetch must not log any skew warning"
     end
   end
 

--- a/test/unit/bot/status_watcher_test.rb
+++ b/test/unit/bot/status_watcher_test.rb
@@ -232,6 +232,26 @@ class HiveBotStatusWatcherTest < Minitest::Test
     end
   end
 
+  # A NEWER envelope whose best-effort extraction still throws (e.g. a
+  # malformed project entry) must degrade to the actionable restart
+  # message, not an opaque crash.
+  def test_fetch_newer_schema_failing_extraction_degrades_to_restart_message
+    expected = Hive::Schemas::SCHEMA_VERSIONS.fetch("hive-status")
+    payload = envelope([])
+    payload["schema_version"] = expected + 1
+    # A non-Hash project entry makes extract_rows raise (Integer#[] with a
+    # String key), exercising the newer-skew rescue path.
+    payload["projects"] = [ 42 ]
+
+    with_fake_status(JSON.generate(payload)) do |bin|
+      logger = CapturingLogger.new
+      result = Hive::Bot::StatusWatcher.new(hive_bin: bin, logger: logger).fetch
+
+      refute result.ok, "a newer payload that fails extraction must surface a failure, not raise"
+      assert_match(/restart the hive bot to pick up the new version/i, result.error)
+    end
+  end
+
   # Exact match keeps the pre-existing happy path: no warning, rows parse.
   def test_fetch_exact_schema_version_match_has_no_skew_warning
     with_fake_status(JSON.generate(envelope([ task(slug: "exact") ]))) do |bin|

--- a/test/unit/daemon/dispatcher_test.rb
+++ b/test/unit/daemon/dispatcher_test.rb
@@ -932,6 +932,25 @@ class HiveDaemonDispatcherTest < Minitest::Test
     assert events_include?(logger, :status_failure)
   end
 
+  # A forward schema-version skew (newer binary, daemon not restarted) is
+  # tolerated: the consumer returns ok=true with a non-fatal `warning`,
+  # the tick proceeds and dispatches, and the dispatcher logs the skew
+  # once instead of crashing the tick.
+  def test_forward_schema_skew_warning_is_logged_and_tick_proceeds
+    rows = [ row(action: "ready_to_plan", command: "hive plan s1 --from 2-brainstorm") ]
+    dispatcher, sup, _ctrl, logger, _mw = make_dispatcher(rows: rows)
+    project = Hive::Daemon::StatusConsumer::ProjectInfo.new(name: "p1", legacy_stage_dirs: [])
+    dispatcher.instance_variable_get(:@status_consumer).next_result =
+      Hive::Daemon::StatusConsumer::Result.new(
+        ok: true, rows: rows, projects: [ project ], error: nil,
+        warning: "envelope schema v99 is newer than this process (v3); parsing best-effort. " \
+                 "Restart the hive daemon to pick up the new schema."
+      )
+    dispatcher.tick(now: T0)
+    assert_equal 1, sup.spawned.size, "forward-skew tick must still dispatch"
+    assert events_include?(logger, :status_schema_skew)
+  end
+
   # ── dry run ───────────────────────────────────────────────────────────
 
   def test_dry_run_passes_flag_to_supervisor

--- a/test/unit/daemon/status_consumer_test.rb
+++ b/test/unit/daemon/status_consumer_test.rb
@@ -254,6 +254,21 @@ class HiveDaemonStatusConsumerTest < Minitest::Test
     end
   end
 
+  # A NEWER envelope whose best-effort extraction still throws degrades to
+  # the actionable restart message instead of crashing the tick.
+  def test_newer_schema_failing_extraction_degrades_to_restart_message
+    expected = Hive::Schemas::SCHEMA_VERSIONS["hive-status"]
+    # A non-Hash project entry makes extract_rows raise (Integer#[] with a
+    # String key), exercising the newer-skew rescue path.
+    payload = make_envelope(projects: [ 42 ]).merge("schema_version" => expected + 1)
+    with_fake_status(JSON.generate(payload)) do |bin|
+      consumer = Hive::Daemon::StatusConsumer.new(hive_bin: bin)
+      result = consumer.fetch
+      refute result.ok, "a newer payload that fails extraction must surface a failure, not raise"
+      assert_match(/restart the hive daemon to pick up the new version/i, result.error)
+    end
+  end
+
   # Exact match keeps the pre-existing happy path: ok, no warning.
   def test_exact_schema_version_match_has_no_warning
     payload = make_envelope(projects: [ {

--- a/test/unit/daemon/status_consumer_test.rb
+++ b/test/unit/daemon/status_consumer_test.rb
@@ -215,13 +215,57 @@ class HiveDaemonStatusConsumerTest < Minitest::Test
     end
   end
 
-  def test_schema_version_mismatch_returns_not_ok
-    payload = make_envelope.merge("schema_version" => 99)
+  # ── schema_version skew (forward-tolerant; must never crash a tick) ────
+
+  # A NEWER envelope (expected+1) from an updated `hive` binary that the
+  # long-running daemon hasn't restarted to match. hive-status envelopes
+  # are additive, so rows still parse — the daemon keeps dispatching and
+  # surfaces a non-fatal `warning` the dispatcher logs once per tick.
+  def test_newer_schema_version_parses_best_effort_with_warning
+    expected = Hive::Schemas::SCHEMA_VERSIONS["hive-status"]
+    payload = make_envelope(projects: [ {
+      "name" => "p", "path" => "/tmp/p", "hive_state_path" => "/tmp/p/.h",
+      "tasks" => [ task_row(slug: "newer") ]
+    } ]).merge("schema_version" => expected + 1)
+
+    with_fake_status(JSON.generate(payload)) do |bin|
+      consumer = Hive::Daemon::StatusConsumer.new(hive_bin: bin)
+      result = consumer.fetch
+      assert result.ok, "newer schema must parse best-effort: #{result.error.inspect}"
+      assert_equal [ "newer" ], result.rows.map(&:slug)
+      refute_nil result.warning, "expected a best-effort skew warning"
+      assert_match(/newer than this process/, result.warning)
+      assert_match(/restart the hive daemon/i, result.warning)
+    end
+  end
+
+  # An OLDER envelope (expected-1): a stale `hive` binary on PATH. The
+  # daemon refuses to advance on untrustworthy data and surfaces a clear,
+  # actionable message instead of crashing the tick.
+  def test_older_schema_version_returns_actionable_failure
+    expected = Hive::Schemas::SCHEMA_VERSIONS["hive-status"]
+    payload = make_envelope.merge("schema_version" => expected - 1)
     with_fake_status(JSON.generate(payload)) do |bin|
       consumer = Hive::Daemon::StatusConsumer.new(hive_bin: bin)
       result = consumer.fetch
       refute result.ok
-      assert_match(/schema_version mismatch/, result.error)
+      assert_match(/older than this process/, result.error)
+      assert_match(/update\/reinstall the hive binary/, result.error)
+    end
+  end
+
+  # Exact match keeps the pre-existing happy path: ok, no warning.
+  def test_exact_schema_version_match_has_no_warning
+    payload = make_envelope(projects: [ {
+      "name" => "p", "path" => "/tmp/p", "hive_state_path" => "/tmp/p/.h",
+      "tasks" => [ task_row(slug: "exact") ]
+    } ])
+    with_fake_status(JSON.generate(payload)) do |bin|
+      consumer = Hive::Daemon::StatusConsumer.new(hive_bin: bin)
+      result = consumer.fetch
+      assert result.ok, result.error
+      assert_equal [ "exact" ], result.rows.map(&:slug)
+      assert_nil result.warning, "exact-match fetch must not carry a skew warning"
     end
   end
 

--- a/test/unit/tui/state_source_test.rb
+++ b/test/unit/tui/state_source_test.rb
@@ -261,6 +261,92 @@ class TuiStateSourceTest < Minitest::Test
     end
   end
 
+  def test_refresh_once_reparses_when_task_lock_appears
+    with_seeded_project do |_project, _dir|
+      calls = 0
+      patch = Module.new do
+        define_method(:json_payload) do |projects|
+          calls += 1
+          super(projects)
+        end
+      end
+      Hive::Commands::Status.prepend(patch)
+
+      source = Hive::Tui::StateSource.new(poll_interval_seconds: 0.05)
+      source.send(:refresh_once)
+      first = source.current
+      row = first.rows.first
+      assert_equal "ready_to_brainstorm", row.action_key
+
+      File.write(File.join(row.folder, ".lock"), Hive::Lock.base_payload.to_yaml)
+      source.send(:refresh_once)
+
+      refute_same first, source.current
+      assert_equal 2, calls, "task .lock changes must invalidate the cached snapshot"
+      assert_equal "agent_running", source.current.rows.first.action_key
+      assert_equal true, source.current.rows.first.live_task_lock
+    end
+  end
+
+  def test_refresh_once_reparses_when_task_lock_disappears
+    with_seeded_project do |_project, _dir|
+      calls = 0
+      patch = Module.new do
+        define_method(:json_payload) do |projects|
+          calls += 1
+          super(projects)
+        end
+      end
+      Hive::Commands::Status.prepend(patch)
+
+      source = Hive::Tui::StateSource.new(poll_interval_seconds: 0.05)
+      source.send(:refresh_once)
+      lock_path = File.join(source.current.rows.first.folder, ".lock")
+      File.write(lock_path, Hive::Lock.base_payload.to_yaml)
+      source.send(:refresh_once)
+      locked = source.current
+      assert_equal "agent_running", locked.rows.first.action_key
+
+      File.delete(lock_path)
+      source.send(:refresh_once)
+
+      refute_same locked, source.current
+      assert_equal 3, calls, "task .lock removal must invalidate the cached snapshot"
+      assert_equal "ready_to_brainstorm", source.current.rows.first.action_key
+      assert_equal false, source.current.rows.first.live_task_lock
+    end
+  end
+
+  def test_refresh_once_reparses_when_task_lock_mtime_changes
+    with_seeded_project do |_project, _dir|
+      calls = 0
+      patch = Module.new do
+        define_method(:json_payload) do |projects|
+          calls += 1
+          super(projects)
+        end
+      end
+      Hive::Commands::Status.prepend(patch)
+
+      source = Hive::Tui::StateSource.new(poll_interval_seconds: 0.05)
+      source.send(:refresh_once)
+      row = source.current.rows.first
+      lock_path = File.join(row.folder, ".lock")
+      File.write(lock_path, Hive::Lock.base_payload.to_yaml)
+      source.send(:refresh_once)
+      locked = source.current
+
+      updated_at = Time.now + 5
+      File.utime(updated_at, updated_at, lock_path)
+      source.send(:refresh_once)
+
+      refute_same locked, source.current
+      assert_equal 3, calls, "task .lock mtime changes must invalidate the cached snapshot"
+      assert_equal "agent_running", source.current.rows.first.action_key
+      assert_equal true, source.current.rows.first.live_task_lock
+    end
+  end
+
   def test_safe_mtime_returns_nil_when_mtime_raises_on_existing_path
     # state_source.rb 152: the file may vanish (or error) between the
     # File.exist? check and File.mtime. The rescue must degrade to nil

--- a/wiki/commands/bot.md
+++ b/wiki/commands/bot.md
@@ -268,6 +268,19 @@ Events include `bot_started`, `poll_failure`, `update_received`,
 `notification_sent`, `dispatched_command`, `command_completed`,
 `answer_written`, `reconnect_summary`, and `fatal`.
 
+## Forward-tolerant `hive status` schema-version skew
+
+`Hive::Bot::StatusWatcher` (the consumer behind `/status`) does NOT raise
+on a `hive-status` `schema_version` mismatch — that would hard-crash
+`/status` whenever the `hive` gem is bumped under a running bot. A newer
+payload is parsed best-effort (additive-envelope contract) and logs a
+`poll_failure` skew warning; an older payload (stale binary on PATH) or a
+newer payload that genuinely fails to parse returns an actionable
+`failure(...)` result telling the operator to restart the bot or
+update/reinstall the binary. The full classification (`:match` /
+`:newer` / `:older`) and the matching daemon behavior live in
+[[modules/daemon]] §"Forward-tolerant schema-version skew".
+
 ## Autostart
 
 `hive bot install` gives the bot the same reboot-survivable per-user

--- a/wiki/commands/tui.md
+++ b/wiki/commands/tui.md
@@ -132,10 +132,11 @@ in-process whenever the cached mtime
 fingerprint changes; otherwise it reuses the previous `Snapshot` and
 only refreshes `current_seen_at`. The fingerprint watches the global
 project registry (`Hive::Config.global_config_path`), each visible
-row's state file, plus the project's `.hive-state/stages` directory and
-stage children, so ordinary marker edits, newly-created task folders,
-and `hive init`/`forget` registry changes all invalidate the cache
-without reparsing unchanged status data. A time-bounded fallback
+row's state file and `.lock`, plus the project's `.hive-state/stages`
+directory and stage children, so ordinary marker edits, newly-created
+task folders, runner lock acquisition/release, and `hive init`/`forget`
+registry changes all invalidate the cache without reparsing unchanged
+status data. A time-bounded fallback
 (`LIVENESS_REPARSE_FALLBACK_SECONDS`, 3s) forces a full re-parse even
 when the fingerprint is unchanged, so liveness-derived fields
 (`live_task_lock`, `claude_pid_alive`) that flip without touching any

--- a/wiki/log.d/20260608-113952-tui-lock-fingerprint.md
+++ b/wiki/log.d/20260608-113952-tui-lock-fingerprint.md
@@ -1,0 +1,6 @@
+## [2026-06-08T11:39:52Z] tui — refresh immediately when task lock changes
+
+**Action:** Fixed a TUI stale-status window where a task could keep rendering as `Needs your input` after its answered row had already been picked up by a live runner. Root cause: `Hive::Tui::StateSource` cached status snapshots by registry/stage/state-file mtimes but did not include each task's `.lock`; a runner can acquire that lock before `AGENT_WORKING` is written, and `Hive::TaskAction` intentionally classifies a live lock as `agent_running`. The fingerprint now watches `<task>/.lock` so lock creation, update, and removal force an immediate status reparse. Added StateSource coverage for lock appearance, disappearance, and mtime updates.
+
+**Refreshed pages:**
+- [[commands/tui]]

--- a/wiki/log.d/20260608-124908-status-schema-skew-tolerance.md
+++ b/wiki/log.d/20260608-124908-status-schema-skew-tolerance.md
@@ -1,0 +1,13 @@
+## [2026-06-08T12:49:08Z] bot, daemon — tolerate hive-status schema_version skew instead of crashing
+
+**Action:** Made both long-running `hive-status` consumers forward-tolerant of a `schema_version` skew instead of raising a raw `ArgumentError`. Root cause: `Hive::Bot::StatusWatcher#validate_envelope!` and `Hive::Daemon::StatusConsumer#validate_envelope!` enforced an EXACT match against the in-memory `Hive::Schemas::SCHEMA_VERSIONS.fetch("hive-status")`. When the gem is updated (schema bumped) but the bot/daemon process is NOT restarted, the in-memory `expected` is stale while the `hive status --json` subprocess emits the newer version, so the consumer hard-failed. In production this surfaced as the Telegram bot replying `hive status unavailable: ArgumentError: schema_version mismatch: got 3, want 2` to every `/status` until restart.
+
+Fix: `validate_envelope!` now enforces only the envelope SHAPE (missing/wrong `schema`, `ok=false`) as a hard error. Version skew is classified by a new `schema_skew(doc)` → `:match` / `:newer` / `:older`. `:newer` (updated binary, additive envelope) parses best-effort and logs a one-line skew warning (bot: `poll_failure`; daemon: new closed-enum `:status_schema_skew` event surfaced via a new non-fatal `Result#warning` the dispatcher logs once per tick); if best-effort extraction throws, it degrades to an actionable `… is newer than this process (vM); restart the hive bot/daemon to pick up the new version`. `:older` (stale binary on PATH) returns an actionable `… is older than this process (vM); update/reinstall the hive binary on PATH`. `:match` is the unchanged happy path. The contract: a long-running consumer never crashes `/status` (or a daemon tick) with a raw `ArgumentError` purely because a schema_version was bumped without a restart.
+
+`Hive::Bot::Supervisor#diagnose_reply_for_child` consumes the sibling `hive-status-diagnose` envelope but only checks `schema == ...` (never `schema_version`), so it did NOT share the brittleness and was left out of scope.
+
+Tests: extended `status_watcher_test.rb` (+3) and `status_consumer_test.rb` (replaced the old mismatch test with +3) to prove newer = best-effort parse/warning, older = actionable failure, exact = unchanged, and that envelope-shape errors still hard-fail; added a dispatcher test proving a forward-skew result still dispatches and logs `:status_schema_skew`.
+
+**Refreshed pages:**
+- [[modules/daemon]]
+- [[commands/bot]]

--- a/wiki/modules/daemon.md
+++ b/wiki/modules/daemon.md
@@ -21,7 +21,7 @@ the safety-relevant decisions are unit-testable without forking.
 | `Hive::Daemon::Policy` | `lib/hive/daemon/policy.rb` | Pure switch over `Hive::Schemas::TaskActionKind`, stage context, mtime debounce, and `answers_pending` → `:dispatch` / `:poll_for_merge` / `:wait_for_debounce` / `:wait_for_answers` / `:record_baseline` / `:skip`. Source of truth for "should this row fire a child?". |
 | `Hive::Daemon::ConcurrencyController` | `lib/hive/daemon/concurrency_controller.rb` | In-memory budget gate: caps (global / per-project / per-day rate), WRONG_STAGE protective backoff, transient backoff schedule, quarantine, dropped projects, last-dispatched mtime tracking. SUCCESS exits do not cool down; the next stage may dispatch immediately. The last-dispatched mtime map is write-through-persisted via an injected `DispatchBaselines` store so it survives restart (see "Persisted dispatch baselines" below); everything else is intentionally in-memory. |
 | `Hive::Daemon::DispatchBaselines` | `lib/hive/daemon/dispatch_baselines.rb` | Crash-safe JSON store for the `[project, slug] → state_file_mtime` baseline map (`daemon_dispatch_baselines.json` under the state home). Atomic write + fail-closed load; mirrors `Hive::UpdateCheck::State`. Stops answered `needs_input` tasks being re-stranded across a daemon restart. |
-| `Hive::Daemon::StatusConsumer` | `lib/hive/daemon/status_consumer.rb` | Wraps `Open3.capture3("hive status --json")`; returns typed `Row` records. Validates schema version; surfaces parse failures as `Result(ok: false)`. Coerces `tasks[].live_task_lock` to strict boolean so daemon consumers can detect a live runner before a Claude PID is attached, and carries marker attrs so recovery code can preserve `REVIEW_WORKING phase/pass` when rewriting markers. |
+| `Hive::Daemon::StatusConsumer` | `lib/hive/daemon/status_consumer.rb` | Wraps `Open3.capture3("hive status --json")`; returns typed `Row` records. Validates the envelope SHAPE (missing/wrong `schema`, `ok=false`) as a hard `Result(ok: false)`, but tolerates schema-VERSION skew (see "Forward-tolerant schema-version skew" below) so a binary/process version mismatch never crashes a tick. Coerces `tasks[].live_task_lock` to strict boolean so daemon consumers can detect a live runner before a Claude PID is attached, and carries marker attrs so recovery code can preserve `REVIEW_WORKING phase/pass` when rewriting markers. |
 | `Hive::Daemon::ChildSupervisor` | `lib/hive/daemon/child_supervisor.rb` | Spawns `hive ...` subprocesses with `pgroup: true`; reaps via `Process.wait(-1, WNOHANG)`; parses JSON envelopes from child stdout; supports `terminate_all(grace_sec:)` with TERM→KILL escalation. |
 | `Hive::Daemon::Dispatcher` | `lib/hive/daemon/dispatcher.rb` | The poll-classify-dispatch loop. Glues all of the above. Public `tick(now:)` for tests, `run_forever` for production with TERM/INT/HUP signal traps. |
 | `Hive::Daemon::Logger` | `lib/hive/daemon/logger.rb` | One-JSON-line-per-event structured logger. Closed event enum (unknown name raises). Size-rotated. |
@@ -505,6 +505,47 @@ Rate-limited to one re-exec per 60s as a defense against pathological
 fingerprint flapping. Operators can disable the behavior entirely via
 `HIVE_DAEMON_NO_AUTO_REEXEC=1` (useful for tests and short-lived
 dev runs).
+
+## Forward-tolerant schema-version skew
+
+`StatusConsumer#validate_envelope!` enforces only the envelope SHAPE
+(`schema == "hive-status"` and `ok == true`) as a hard error. The
+`schema_version` is NOT validated there — it is classified by
+`schema_skew(doc)` into `:match` / `:newer` / `:older` and handled
+tolerantly, because the long-running daemon holds an in-memory
+`SCHEMA_VERSIONS.fetch("hive-status")` that goes stale the moment the
+`hive` gem is updated under it without a restart. The pre-fix code raised
+`ArgumentError, "schema_version mismatch: got N, want M"` on any
+inequality; that same brittleness hard-crashed the Telegram bot's
+`/status` (`got 3, want 2`) after a schema bump until the bot was
+restarted.
+
+Behavior by skew (both `StatusConsumer` and `Hive::Bot::StatusWatcher`):
+
+- **`:newer`** (payload version > process version — an updated binary):
+  parse best-effort. `hive-status` envelopes are additive by contract
+  (see [[commands/status]] and ADR-028 carve-out in [[decisions]]), so a
+  newer payload is still readable. The consumer returns `ok: true` and
+  carries a non-fatal `Result#warning`; the dispatcher logs it once per
+  tick as `:status_schema_skew` and keeps dispatching. If best-effort
+  extraction genuinely throws downstream, it degrades to the actionable
+  failure `hive status: envelope schema vN is newer than this process
+  (vM); restart the hive daemon to pick up the new version` rather than an
+  opaque `#{e.class}: …` line.
+- **`:older`** (payload version < process version — a stale binary on
+  PATH): not parsed as trustworthy. Returns `Result(ok: false)` with
+  `… is older than this process (vM); update/reinstall the hive binary on
+  PATH`.
+- **`:match`**: unchanged happy path; no warning.
+
+The contract: a long-running consumer must NEVER crash a tick (or the
+bot's `/status`) with a raw `ArgumentError` purely because a
+`schema_version` was bumped without a restart. It either keeps working
+(forward-compatible) or returns a clear "restart to pick up vN" message.
+
+`Hive::Bot::Supervisor#diagnose_reply_for_child` consumes the sibling
+`hive-status-diagnose` envelope but only checks `schema == ...` and never
+`schema_version`, so it did NOT share this brittleness and was left as-is.
 
 ## Backlinks
 


### PR DESCRIPTION
## The incident

The Telegram bot's `/status` hard-crashed in production, replying:

```
hive status unavailable: ArgumentError: schema_version mismatch: got 3, want 2
```

to **every** `/status` until the bot was restarted.

Both long-running `hive-status` consumers — the bot's `StatusWatcher` and the daemon's `StatusConsumer` — enforced an EXACT `schema_version` match against the in-memory `Hive::Schemas::SCHEMA_VERSIONS["hive-status"]` and raised `ArgumentError` on any inequality. When the `hive` gem is updated (a schema bump) but the bot/daemon process is **not** restarted, the in-memory `expected` is stale while the `hive status --json` subprocess (the updated binary) emits the newer version → the consumer hard-fails on every tick.

## The fix

`validate_envelope!` now enforces only the envelope **shape** (a missing/wrong `schema` key or `ok=false` is still a hard error — that's a malformed/failed envelope). Schema **version** skew is classified by a new `schema_skew(doc)` into `:match` / `:newer` / `:older` and handled forward-tolerantly:

- **`:newer`** (payload from an updated binary): parse best-effort — `hive-status` envelopes are additive by contract, so a newer payload is still readable. Returns `ok: true` and logs a one-line skew warning (bot: `poll_failure`; daemon: a new closed-enum `:status_schema_skew` event surfaced via a non-fatal `Result#warning` the dispatcher logs once per tick). If best-effort extraction genuinely throws downstream, it degrades to an actionable `hive status: envelope schema vN is newer than this process (vM); restart the hive bot/daemon to pick up the new version` instead of an opaque crash.
- **`:older`** (stale binary on PATH): not parsed as trustworthy — returns the actionable `… is older than this process (vM); update/reinstall the hive binary on PATH`.
- **`:match`**: unchanged happy path; no warning.

**Contract:** a long-running consumer must NEVER crash `/status` (or a daemon tick) with a raw `ArgumentError` purely because a `schema_version` was bumped without a restart. It either keeps working (forward-compatible) or returns a clear "restart to pick up vN" message.

### hive-status-diagnose

`Hive::Bot::Supervisor#diagnose_reply_for_child` consumes the sibling `hive-status-diagnose` envelope but only checks `schema == "hive-status-diagnose"` and never `schema_version` — it did **not** share the brittle raw-raise pattern, so it was left out of scope (noted in the wiki).

## Tests

- `status_watcher_test.rb`: newer = best-effort parse + skew warning; older = actionable failure; exact = unchanged; envelope-shape errors still hard-fail.
- `status_consumer_test.rb`: same matrix (replaced the old exact-mismatch test); asserts `Result#warning` on newer, actionable `error` on older, no warning on exact.
- `dispatcher_test.rb`: a forward-skew result still dispatches and logs `:status_schema_skew` (tick does not crash).
- `logger_test.rb` (enum) covers the new `:status_schema_skew` event automatically.

All touched suites: 0 failures / 0 errors. Rubocop on changed files: 0 offenses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)