### PR TITLE
fix(bot,daemon): don't mask real errors behind schema-skew degrade; surface skew in bot /status

### DIFF
--- a/lib/hive/bot/logger.rb
+++ b/lib/hive/bot/logger.rb
@@ -12,6 +12,7 @@ module Hive
         bot_started
         bot_stopping
         poll_failure
+        poll_schema_skew
         update_received
         update_rejected_unauthorized
         dispatch_result_rejected_unauthorized

--- a/lib/hive/bot/status_watcher.rb
+++ b/lib/hive/bot/status_watcher.rb
@@ -75,8 +75,13 @@ module Hive
         end
       end
 
-      Result = Data.define(:ok, :rows, :legacy_stage_dirs, :error, :envelope) do
-        def initialize(ok:, rows: [], legacy_stage_dirs: [], error: nil, envelope: nil)
+      # `warning` carries a non-fatal advisory (currently: a forward
+      # schema-version skew was tolerated and parsed best-effort). The
+      # supervisor prepends a one-line banner to the rendered `/status`
+      # reply when present. nil on a clean fetch. Mirrors the daemon's
+      # StatusConsumer::Result#warning.
+      Result = Data.define(:ok, :rows, :legacy_stage_dirs, :error, :envelope, :warning) do
+        def initialize(ok:, rows: [], legacy_stage_dirs: [], error: nil, envelope: nil, warning: nil)
           super
         end
       end
@@ -100,6 +105,11 @@ module Hive
         end
 
         doc = JSON.parse(out)
+        # Envelope SHAPE validation runs OUTSIDE the best-effort extraction
+        # rescue below: a missing schema / ok=false is a real failure whose
+        # message must ALWAYS surface, even on a newer-schema doc. Folding
+        # it into the skew degrade would relabel a genuine "ok=false:
+        # <reason>" as a misleading "restart to pick up the new version".
         validate_envelope!(doc)
         skew = schema_skew(doc)
         # An OLDER payload (a stale `hive` on PATH than this process
@@ -111,29 +121,53 @@ module Hive
         # long-running process.
         return failure(older_skew_message(doc)) if skew == :older
 
+        begin
+          rows = extract_rows(doc, now: now)
+          legacy_stage_dirs = extract_legacy_stage_dirs(doc)
+        rescue StandardError => e
+          # ONLY a failure inside best-effort EXTRACTION degrades. On a
+          # newer-schema doc this is the tolerated forward-skew path, but we
+          # PRESERVE the underlying exception (class + message) in the
+          # surfaced error AND log it, so a genuine extraction bug stays
+          # recoverable instead of being masked by the friendly restart
+          # hint. On an exact/equal-version doc there is nothing to
+          # tolerate: re-raise to the outer rescue (raw "#{e.class}: ...").
+          raise unless skew == :newer
+
+          return failure(forward_skew_message(doc, underlying: e), underlying: e)
+        end
+
         warn_forward_skew(doc) if skew == :newer
         Result.new(
           ok: true,
-          rows: extract_rows(doc, now: now),
-          legacy_stage_dirs: extract_legacy_stage_dirs(doc),
+          rows: rows,
+          legacy_stage_dirs: legacy_stage_dirs,
           error: nil,
-          envelope: doc
+          envelope: doc,
+          warning: (skew == :newer ? forward_skew_warning(doc) : nil)
         )
       rescue JSON::ParserError => e
         failure("malformed JSON from hive status: #{e.message}")
       rescue StandardError => e
-        # A newer payload that genuinely failed best-effort extraction
-        # degrades to a clear, actionable restart message rather than an
-        # opaque "#{e.class}: ..." crash line.
-        return failure(forward_skew_message(doc)) if defined?(doc) && doc.is_a?(Hash) && schema_skew(doc) == :newer
-
         failure("#{e.class}: #{e.message}")
       end
 
       private
 
-      def failure(message)
+      # `underlying`, when present, is the exception that aborted
+      # best-effort extraction on a newer-schema doc. We log its class,
+      # message, and a few backtrace lines so the genuine defect stays
+      # diagnosable in the bot log even though the user-facing `error`
+      # leads with the friendly restart hint.
+      def failure(message, underlying: nil)
         @logger&.event(:poll_failure, source: "status", message: message)
+        if underlying
+          @logger&.event(
+            :poll_schema_skew, source: "status",
+            error_class: underlying.class.name, message: underlying.message,
+            backtrace: Array(underlying.backtrace).first(3)
+          )
+        end
         Result.new(ok: false, rows: [], legacy_stage_dirs: [], error: message)
       end
 
@@ -153,36 +187,57 @@ module Hive
       # was built for: :match, :newer (payload from an updated binary), or
       # :older (a stale binary on PATH). Never raises.
       def schema_skew(doc)
-        expected = Hive::Schemas::SCHEMA_VERSIONS.fetch("hive-status")
         got = doc["schema_version"]
-        return :match if got == expected
-        return :newer if got.is_a?(Integer) && got > expected
+        return :match if got == expected_schema_version
+        return :newer if got.is_a?(Integer) && got > expected_schema_version
 
         :older
       end
 
+      # The forward-skew advisory is logged under a DISTINCT event name
+      # (not :poll_failure) so it isn't conflated with real fetch failures
+      # — the success path tolerated a newer schema, it didn't fail.
       def warn_forward_skew(doc)
         @logger&.event(
-          :poll_failure, source: "status",
+          :poll_schema_skew, source: "status",
           message: "#{forward_skew_summary(doc)}; parsing best-effort. " \
                    "Restart the hive bot to pick up the new schema."
         )
       end
 
-      def forward_skew_message(doc)
+      # Non-fatal advisory carried on the success-path Result#warning so the
+      # supervisor can surface a banner on `/status`.
+      def forward_skew_warning(doc)
+        "#{forward_skew_summary(doc)}; parsing best-effort. " \
+          "Restart the hive bot to pick up the new schema."
+      end
+
+      # `underlying` is the exception that aborted best-effort extraction on
+      # a newer-schema doc. We append its class + message so the genuine
+      # defect stays diagnosable in the surfaced error instead of being
+      # masked by the friendly restart hint.
+      def forward_skew_message(doc, underlying:)
         "hive status: #{forward_skew_summary(doc)}; " \
-          "restart the hive bot to pick up the new version"
+          "restart the hive bot to pick up the new version " \
+          "(underlying error: #{underlying.class}: #{underlying.message})"
       end
 
       def forward_skew_summary(doc)
-        expected = Hive::Schemas::SCHEMA_VERSIONS.fetch("hive-status")
-        "envelope schema v#{doc['schema_version']} is newer than this process (v#{expected})"
+        "envelope schema v#{doc['schema_version']} is newer than this process (v#{expected_schema_version})"
       end
 
       def older_skew_message(doc)
-        expected = Hive::Schemas::SCHEMA_VERSIONS.fetch("hive-status")
         "hive status: envelope schema v#{doc['schema_version']} is older than this process " \
-          "(v#{expected}); update/reinstall the hive binary on PATH"
+          "(v#{expected_schema_version}); update/reinstall the hive binary on PATH"
+      end
+
+      # Computed once and reused. Uses the non-raising `[]` form (not
+      # `.fetch`) so it never introduces a fresh KeyError inside a
+      # rescue-reachable skew path if the "hive-status" key were ever
+      # absent — Finding 4 from the #416 review. Mirrors the daemon's
+      # StatusConsumer.
+      def expected_schema_version
+        @expected_schema_version ||= Hive::Schemas::SCHEMA_VERSIONS["hive-status"]
       end
 
       def extract_legacy_stage_dirs(doc)

--- a/lib/hive/bot/supervisor.rb
+++ b/lib/hive/bot/supervisor.rb
@@ -838,6 +838,14 @@ module Hive
         @notification_dispatcher.reset_task(**reset)
       end
 
+      # One-line plain-text advisory prepended to a `/status` reply when the
+      # StatusWatcher tolerated a forward schema-version skew (the rendered
+      # data was parsed best-effort and may be incomplete).
+      def status_skew_banner
+        "⚠️ hive status: running on a newer schema than this bot understands; " \
+          "data may be incomplete — restart the bot."
+      end
+
       def render_status_json(envelope, project_filter)
         return "{}" if envelope.nil?
 
@@ -907,6 +915,14 @@ module Hive
             error = "unknown error" if error.empty?
             safe_send_message(chat_id: update.chat_id, text: "hive status unavailable: #{error}")
             return nil
+          end
+
+          # Forward schema-version skew: the data below was parsed
+          # best-effort from a NEWER hive-status envelope than this bot
+          # understands and may be incomplete. The user otherwise sees a
+          # normal status with no hint, so prepend a one-line advisory.
+          if status_fetch_warning(fetch_result)
+            safe_send_message(chat_id: update.chat_id, text: status_skew_banner)
           end
 
           if result.respond_to?(:format) && result.format == :json
@@ -1369,6 +1385,15 @@ module Hive
 
       def status_command?(argv)
         Array(argv) == [ "hive", "status", "--json" ]
+      end
+
+      # Non-fatal forward schema-skew advisory carried on the fetch Result,
+      # if any. Tolerant of result objects that predate the `warning` field
+      # (mirrors `status_legacy_stage_dirs`).
+      def status_fetch_warning(fetch_result)
+        return nil unless fetch_result.respond_to?(:warning)
+
+        fetch_result.warning
       end
 
       def next_unanswered_question_n(brainstorm_path)

--- a/lib/hive/daemon/status_consumer.rb
+++ b/lib/hive/daemon/status_consumer.rb
@@ -50,6 +50,11 @@ module Hive
         end
 
         doc = JSON.parse(out)
+        # Envelope SHAPE validation runs OUTSIDE the best-effort extraction
+        # rescue below: a missing schema / ok=false is a real failure whose
+        # message must ALWAYS surface, even on a newer-schema doc. Folding
+        # it into the skew degrade would relabel a genuine "ok=false:
+        # <reason>" as a misleading "restart to pick up the new version".
         validate_envelope!(doc)
         skew = schema_skew(doc)
         # An OLDER payload (a stale `hive` on PATH than this daemon
@@ -61,21 +66,29 @@ module Hive
         # long-running daemon process. The dispatcher logs `warning`.
         return Result.new(ok: false, rows: [], projects: [], error: older_skew_message(doc)) if skew == :older
 
-        rows = extract_rows(doc)
-        projects = extract_projects(doc)
+        begin
+          rows = extract_rows(doc)
+          projects = extract_projects(doc)
+        rescue StandardError => e
+          # ONLY a failure inside best-effort EXTRACTION degrades. On a
+          # newer-schema doc this is the tolerated forward-skew path, but we
+          # PRESERVE the underlying exception (class + message) in the
+          # surfaced error so a genuine extraction bug stays recoverable —
+          # an operator who restarts into the same buggy binary would
+          # otherwise keep chasing the friendly "restart" hint. On an
+          # exact/equal-version doc there is nothing to tolerate: re-raise to
+          # the outer rescue, which records the raw "#{e.class}: ...".
+          raise unless skew == :newer
+
+          return Result.new(ok: false, rows: [], projects: [],
+                            error: forward_skew_message(doc, underlying: e))
+        end
         Result.new(ok: true, rows: rows, projects: projects, error: nil,
                    warning: (skew == :newer ? forward_skew_warning(doc) : nil))
       rescue JSON::ParserError => e
         Result.new(ok: false, rows: [], projects: [],
                    error: "malformed JSON from hive status: #{e.message}")
       rescue StandardError => e
-        # A newer payload that genuinely failed best-effort extraction
-        # degrades to a clear, actionable restart message rather than an
-        # opaque "#{e.class}: ..." line that an operator can't act on.
-        if defined?(doc) && doc.is_a?(Hash) && schema_skew(doc) == :newer
-          return Result.new(ok: false, rows: [], projects: [], error: forward_skew_message(doc))
-        end
-
         Result.new(ok: false, rows: [], projects: [], error: "#{e.class}: #{e.message}")
       end
 
@@ -112,9 +125,16 @@ module Hive
           "Restart the hive daemon to pick up the new schema."
       end
 
-      def forward_skew_message(doc)
+      # `underlying` is the exception that aborted best-effort extraction on
+      # a newer-schema doc. We append its class + message so the genuine
+      # defect stays diagnosable in the daemon log / status_failure event
+      # instead of being masked by the friendly restart hint — an operator
+      # who restarts into the same buggy binary would otherwise keep
+      # chasing the hint.
+      def forward_skew_message(doc, underlying:)
         "hive status: #{forward_skew_summary(doc)}; " \
-          "restart the hive daemon to pick up the new version"
+          "restart the hive daemon to pick up the new version " \
+          "(underlying error: #{underlying.class}: #{underlying.message})"
       end
 
       def forward_skew_summary(doc)

--- a/schemas/hive-bot-log.v2.json
+++ b/schemas/hive-bot-log.v2.json
@@ -22,6 +22,7 @@
         "bot_started",
         "bot_stopping",
         "poll_failure",
+        "poll_schema_skew",
         "update_received",
         "update_rejected_unauthorized",
         "dispatch_result_rejected_unauthorized",

--- a/test/unit/bot/status_watcher_test.rb
+++ b/test/unit/bot/status_watcher_test.rb
@@ -234,7 +234,9 @@ class HiveBotStatusWatcherTest < Minitest::Test
 
   # A NEWER envelope whose best-effort extraction still throws (e.g. a
   # malformed project entry) must degrade to the actionable restart
-  # message, not an opaque crash.
+  # message, not an opaque crash — AND preserve the underlying exception
+  # (in the message and the log) so a genuine extraction bug, falsely
+  # presenting as a version skew, stays diagnosable.
   def test_fetch_newer_schema_failing_extraction_degrades_to_restart_message
     expected = Hive::Schemas::SCHEMA_VERSIONS.fetch("hive-status")
     payload = envelope([])
@@ -249,6 +251,72 @@ class HiveBotStatusWatcherTest < Minitest::Test
 
       refute result.ok, "a newer payload that fails extraction must surface a failure, not raise"
       assert_match(/restart the hive bot to pick up the new version/i, result.error)
+      assert_match(/underlying error: TypeError:/, result.error,
+                   "the real exception must be preserved in the surfaced message, not swallowed")
+
+      skew_log = logger.events.find { |e| e.fetch(:name) == :poll_schema_skew }
+      refute_nil skew_log, "the underlying extraction error must be logged for recovery"
+      assert_equal "TypeError", skew_log.fetch(:payload).fetch(:error_class)
+      refute_empty Array(skew_log.fetch(:payload)[:backtrace]), "expected backtrace lines for the real defect"
+    end
+  end
+
+  # FINDING 1(b): a NEWER envelope that ALSO fails validate (ok=false) must
+  # surface the REAL ok=false reason, never the skew restart hint. The
+  # ok=false ArgumentError must not be folded into the newer-skew degrade.
+  def test_fetch_newer_schema_with_ok_false_surfaces_real_reason_not_skew_hint
+    expected = Hive::Schemas::SCHEMA_VERSIONS.fetch("hive-status")
+    payload = {
+      "schema" => "hive-status",
+      "schema_version" => expected + 1,
+      "ok" => false,
+      "message" => "registry unavailable"
+    }
+
+    with_fake_status(JSON.generate(payload)) do |bin|
+      logger = CapturingLogger.new
+      result = Hive::Bot::StatusWatcher.new(hive_bin: bin, logger: logger).fetch
+
+      refute result.ok
+      assert_match(/envelope ok=false: registry unavailable/, result.error,
+                   "the real ok=false reason must surface even on a newer-schema doc")
+      refute_match(/restart the hive bot to pick up the new version/i, result.error,
+                   "an ok=false envelope must NOT be relabeled as a version skew")
+    end
+  end
+
+  # FINDING 2: a NEWER best-effort SUCCESS must carry a Result#warning so
+  # the supervisor can surface a banner — the user otherwise sees a normal
+  # status with no hint the data may be incomplete.
+  def test_fetch_newer_schema_success_sets_result_warning
+    expected = Hive::Schemas::SCHEMA_VERSIONS.fetch("hive-status")
+    payload = envelope([ task(slug: "newer-warn") ])
+    payload["schema_version"] = expected + 1
+
+    with_fake_status(JSON.generate(payload)) do |bin|
+      result = Hive::Bot::StatusWatcher.new(hive_bin: bin).fetch
+
+      assert result.ok, result.error
+      refute_nil result.warning, "a tolerated forward skew must set Result#warning"
+      assert_match(/newer than this process/, result.warning)
+      assert_match(/restart the hive bot/i, result.warning)
+    end
+  end
+
+  # FINDING 3: the success-path forward-skew advisory fires under the
+  # DISTINCT :poll_schema_skew event, not the overloaded :poll_failure.
+  def test_fetch_newer_schema_logs_distinct_poll_schema_skew_event
+    expected = Hive::Schemas::SCHEMA_VERSIONS.fetch("hive-status")
+    payload = envelope([ task(slug: "newer-event") ])
+    payload["schema_version"] = expected + 1
+
+    with_fake_status(JSON.generate(payload)) do |bin|
+      logger = CapturingLogger.new
+      result = Hive::Bot::StatusWatcher.new(hive_bin: bin, logger: logger).fetch
+
+      assert result.ok, result.error
+      assert_equal [ :poll_schema_skew ], logger.events.map { |e| e.fetch(:name) },
+                   "success-path skew must log exactly one :poll_schema_skew event, not :poll_failure"
     end
   end
 

--- a/test/unit/bot/supervisor_test.rb
+++ b/test/unit/bot/supervisor_test.rb
@@ -9,7 +9,7 @@ class HiveBotSupervisorTest < Minitest::Test
   Update = Struct.new(:chat_id, :update_id, :message_id, keyword_init: true)
   Row = Struct.new(:project, :slug, :stage, :action, :action_label, :marker, :attrs, :diagnostic,
                    keyword_init: true)
-  StatusResult = Struct.new(:ok, :rows, :legacy_stage_dirs, :error, :envelope, keyword_init: true)
+  StatusResult = Struct.new(:ok, :rows, :legacy_stage_dirs, :error, :envelope, :warning, keyword_init: true)
 
   FakeTelegram = Struct.new(:messages, :raise_on_send, :keyboard_clears,
                             :commands_registered, :raise_on_set_my_commands, keyword_init: true) do
@@ -255,6 +255,40 @@ class HiveBotSupervisorTest < Minitest::Test
     @supervisor.status_tick
 
     assert_equal [ [ legacy ] ], @notification_dispatcher.processed
+  end
+
+  # FINDING 2: a /status whose fetch tolerated a forward schema skew
+  # (Result#warning set) must prepend a plain-text banner before the
+  # rendered queue, so the user knows the data may be incomplete.
+  def test_status_render_prepends_skew_banner_when_fetch_carries_warning
+    @status_watcher.result = StatusResult.new(
+      ok: true, rows: [ row(slug: "newer-task") ], legacy_stage_dirs: [],
+      warning: "envelope schema v4 is newer than this process (v3); parsing best-effort."
+    )
+    result = FakeRouter::Result.new(action: :dispatch_then_reply,
+                                    command_argv: [ "hive", "status", "--json" ])
+
+    @supervisor.send(:execute_result, result, Update.new(chat_id: 42, update_id: 1))
+
+    banner = @telegram.messages.first.fetch(:text)
+    assert_match(/newer schema than this bot understands/, banner,
+                 "the first message must be the skew advisory banner")
+    assert_match(/restart the bot/i, banner)
+    # The queue still renders after the banner.
+    assert @telegram.messages.size >= 2, "the rendered status must follow the banner"
+  end
+
+  # A clean fetch (no warning) must NOT prepend any banner.
+  def test_status_render_omits_skew_banner_when_no_warning
+    @status_watcher.result = StatusResult.new(ok: true, rows: [ row(slug: "clean-task") ],
+                                              legacy_stage_dirs: [], warning: nil)
+    result = FakeRouter::Result.new(action: :dispatch_then_reply,
+                                    command_argv: [ "hive", "status", "--json" ])
+
+    @supervisor.send(:execute_result, result, Update.new(chat_id: 42, update_id: 1))
+
+    refute(@telegram.messages.any? { |m| m.fetch(:text).match?(/newer schema than this bot understands/) },
+           "a clean fetch must not show the skew banner")
   end
 
   def test_reply_for_child_renders_status_diagnose_success_envelope

--- a/test/unit/daemon/status_consumer_test.rb
+++ b/test/unit/daemon/status_consumer_test.rb
@@ -255,7 +255,9 @@ class HiveDaemonStatusConsumerTest < Minitest::Test
   end
 
   # A NEWER envelope whose best-effort extraction still throws degrades to
-  # the actionable restart message instead of crashing the tick.
+  # the actionable restart message instead of crashing the tick — AND
+  # preserves the underlying exception in the surfaced error so a genuine
+  # extraction bug, falsely presenting as a version skew, stays diagnosable.
   def test_newer_schema_failing_extraction_degrades_to_restart_message
     expected = Hive::Schemas::SCHEMA_VERSIONS["hive-status"]
     # A non-Hash project entry makes extract_rows raise (Integer#[] with a
@@ -266,6 +268,45 @@ class HiveDaemonStatusConsumerTest < Minitest::Test
       result = consumer.fetch
       refute result.ok, "a newer payload that fails extraction must surface a failure, not raise"
       assert_match(/restart the hive daemon to pick up the new version/i, result.error)
+      assert_match(/underlying error: TypeError:/, result.error,
+                   "the real exception must be preserved in the surfaced error, not swallowed")
+    end
+  end
+
+  # An EXACT/equal-version envelope whose extraction throws is NOT a skew —
+  # it must surface the raw "#{e.class}: ..." line, never the friendly
+  # restart hint (which would mislead an operator into a no-op restart).
+  def test_exact_schema_failing_extraction_surfaces_raw_error_not_skew_hint
+    payload = make_envelope(projects: [ 42 ])
+    with_fake_status(JSON.generate(payload)) do |bin|
+      consumer = Hive::Daemon::StatusConsumer.new(hive_bin: bin)
+      result = consumer.fetch
+      refute result.ok
+      assert_match(/TypeError:/, result.error)
+      refute_match(/restart the hive daemon/i, result.error,
+                   "an exact-version extraction bug must not be relabeled a version skew")
+    end
+  end
+
+  # FINDING 1(b): a NEWER envelope that ALSO fails validate (ok=false) must
+  # surface the REAL ok=false reason, never the skew restart hint.
+  def test_newer_schema_with_ok_false_surfaces_real_reason_not_skew_hint
+    expected = Hive::Schemas::SCHEMA_VERSIONS["hive-status"]
+    payload = {
+      "schema" => "hive-status",
+      "schema_version" => expected + 1,
+      "ok" => false,
+      "error_class" => "ConfigError",
+      "message" => "bad config"
+    }
+    with_fake_status(JSON.generate(payload)) do |bin|
+      consumer = Hive::Daemon::StatusConsumer.new(hive_bin: bin)
+      result = consumer.fetch
+      refute result.ok
+      assert_match(/envelope ok=false: ConfigError bad config/, result.error,
+                   "the real ok=false reason must surface even on a newer-schema doc")
+      refute_match(/restart the hive daemon to pick up the new version/i, result.error,
+                   "an ok=false envelope must NOT be relabeled as a version skew")
     end
   end
 

--- a/wiki/log.d/20260608-142201-status-schema-skew-fix-forward.md
+++ b/wiki/log.d/20260608-142201-status-schema-skew-fix-forward.md
@@ -1,0 +1,21 @@
+## [2026-06-08T14:22:01Z] bot, daemon — fix-forward on #416: don't mask real errors behind the schema-skew degrade; surface skew in bot /status
+
+**Action:** Fix-forward on #416 (commit 8b1cf115) addressing pr-review-toolkit findings on the `hive-status` forward-skew handling in `Hive::Bot::StatusWatcher#fetch` and `Hive::Daemon::StatusConsumer#fetch`.
+
+**Findings fixed:**
+
+1. **(CRITICAL) The `:newer` rescue over-swallowed and discarded the real error.** The single broad `rescue StandardError` keyed the "just restart" message off `schema_skew(doc) == :newer` alone and threw away `e`. Two consequences: (a) a genuine bug in `extract_rows`/`extract_projects`/`extract_legacy_stage_dirs` on a newer doc got relabeled "restart to pick up the new version" (operator restarts → same bug → defect stays invisible); (b) `validate_envelope!`'s own `ArgumentError` ("envelope ok=false: …" / "missing schema") is a `StandardError` too, so on a `:newer` doc it ALSO degraded to the skew message, masking the real `ok=false` reason. **Fix:** both `#fetch` methods now run `validate_envelope!` OUTSIDE the degrade, and wrap ONLY the extraction phase in its own `begin/rescue`. That inner rescue `raise unless skew == :newer` (an exact/equal-version extraction throw re-raises to surface the raw `#{e.class}: …`); when it does degrade, the surfaced message PRESERVES the underlying exception (`… (underlying error: <Class>: <msg>)`). The bot also logs the underlying error (class + message + first 3 backtrace lines) under `:poll_schema_skew`. Existing `JSON::ParserError` handling kept before the broad rescue.
+
+2. **(HIGH) Bot `/status` showed degraded data with NO indicator.** Added a `warning` field to the bot `StatusWatcher::Result` (mirrors the daemon Result), populated on the `:newer` best-effort success path. `Supervisor#execute_dispatch` prepends a plain-text banner ("⚠️ hive status: running on a newer schema than this bot understands; data may be incomplete — restart the bot.") when the fetch carries a warning (via `status_fetch_warning`, tolerant of older Result shapes like `status_legacy_stage_dirs`).
+
+3. **(MEDIUM) Forward-skew advisory was logged under `:poll_failure` (overloaded).** The bot's `warn_forward_skew` (and the new underlying-error log) now use a distinct `:poll_schema_skew` event. Added `poll_schema_skew` to `Hive::Bot::Logger::EVENTS` and to the `hive-bot-log.v2` schema `event` enum (additive append — no SCHEMA_VERSION bump). The daemon already used a distinct `:status_schema_skew`.
+
+4. **(LOW) KeyError-in-rescue fragility.** The bot's `schema_skew`/`forward_skew_summary`/`older_skew_message` used `SCHEMA_VERSIONS.fetch("hive-status")`, which would raise `KeyError` inside a rescue-reachable path if the key were absent. Replaced with a memoized `expected_schema_version` using the non-raising `["hive-status"]` form, computed once and reused (mirrors the daemon, which already used `[]`).
+
+**Deferred (not implemented):** per-tick / per-poll log dedup of the skew advisory — currently it can log once per tick/poll while the skew persists. Noted as a follow-up enhancement.
+
+**Tests:** `status_watcher_test.rb` and `status_consumer_test.rb` extended — a `:newer` + `ok=false` envelope returns the REAL ok=false message (not the skew hint); a `:newer` extraction throw returns a message containing BOTH the restart hint AND the underlying `e.class: e.message` and logs the real error (bot), result `ok:false`, never raises; an exact-version extraction throw surfaces the raw error (not the skew hint). Bot: `:newer` best-effort success sets `Result#warning`; supervisor render prepends the banner (and omits it when clean). `:poll_schema_skew` fires on the bot success-path skew. The `hive-bot-log` logger test (whitelist scan + schema-valid emit) covers the new event. Full coverage gate green at 100.0% (changed files all 100%).
+
+**Refreshed pages:**
+- [[modules/bot]]
+- [[modules/daemon]]

--- a/wiki/modules/bot.md
+++ b/wiki/modules/bot.md
@@ -83,6 +83,33 @@ buttons when task metadata is available.
 
 Legacy stage-directory warnings are proactive as project-level notifications. `StatusWatcher` converts non-empty `legacy_stage_dirs` project payloads into synthetic notification inputs, `Supervisor#status_tick` feeds them through the same `NotificationDispatcher` as task rows, and `NotificationBuilders` renders a message like `Project P has N tasks hidden in legacy stage dirs (...) - run hive migrate <project_path>`. The same warning appears in `/status` and `/queue` replies. The alert-store fingerprint is project-level rather than count-level, so the warning dedupes while the project remains legacy-dirty, drops when the project returns clean, and alerts again on a later clean-to-legacy transition. Fresh alert-store seeding still suppresses historical task backlog, but legacy-stage warnings alert immediately because first bot startup after an upgrade is when operators need the migration prompt.
 
+### Forward schema-version skew on `/status`
+
+`StatusWatcher#fetch` is forward-tolerant of a newer `hive-status`
+`schema_version` than this long-running bot was built for — the shared
+mechanism is documented under [[modules/daemon]] § *Forward-tolerant
+schema-version skew*. Bot-specific behaviour (fix-forward on #416):
+
+- On a `:newer` best-effort SUCCESS the `Result` carries a non-fatal
+  `warning`. `Supervisor#execute_dispatch` prepends a one-line plain-text
+  banner ("⚠️ hive status: running on a newer schema than this bot
+  understands; data may be incomplete — restart the bot.") to the
+  `/status` (and `/queue`) reply, so the Telegram operator sees the
+  advisory rather than a normal-looking status with a silent log line.
+- The success-path skew advisory is logged under the **distinct**
+  `:poll_schema_skew` event (not the overloaded `:poll_failure`), so it
+  isn't conflated with real fetch failures. `:poll_schema_skew` is in
+  `Hive::Bot::Logger::EVENTS` and the `hive-bot-log.v2` schema enum
+  (additive append — no schema-version bump).
+- `validate_envelope!` (shape / `ok=false`) runs OUTSIDE the best-effort
+  extraction rescue: a `:newer` envelope that ALSO has `ok=false` surfaces
+  its real `envelope ok=false: <reason>`, never the skew hint. A throw
+  inside extraction on a `:newer` doc degrades to the restart message but
+  **preserves the underlying exception** in the surfaced `error` (`…
+  (underlying error: <Class>: <msg>)`) AND logs it under
+  `:poll_schema_skew` (class + message + first backtrace lines) so a real
+  extraction defect stays recoverable.
+
 ## Trust boundary
 
 The bot does not move task folders or invent approval policy. State

--- a/wiki/modules/daemon.md
+++ b/wiki/modules/daemon.md
@@ -528,20 +528,35 @@ Behavior by skew (both `StatusConsumer` and `Hive::Bot::StatusWatcher`):
   newer payload is still readable. The consumer returns `ok: true` and
   carries a non-fatal `Result#warning`; the dispatcher logs it once per
   tick as `:status_schema_skew` and keeps dispatching. If best-effort
-  extraction genuinely throws downstream, it degrades to the actionable
-  failure `hive status: envelope schema vN is newer than this process
-  (vM); restart the hive daemon to pick up the new version` rather than an
-  opaque `#{e.class}: …` line.
+  extraction (`extract_rows`/`extract_projects`) genuinely throws, it
+  degrades to the actionable failure `hive status: envelope schema vN is
+  newer than this process (vM); restart the hive daemon to pick up the new
+  version (underlying error: <Class>: <msg>)` — the **underlying exception
+  is preserved**, not swallowed, so a genuine extraction bug that merely
+  coincides with a newer schema stays diagnosable instead of being
+  relabeled "just restart" forever.
 - **`:older`** (payload version < process version — a stale binary on
   PATH): not parsed as trustworthy. Returns `Result(ok: false)` with
   `… is older than this process (vM); update/reinstall the hive binary on
   PATH`.
 - **`:match`**: unchanged happy path; no warning.
 
+**Validation runs OUTSIDE the skew degrade (fix-forward on #416).**
+`validate_envelope!` (shape + `ok==true`) is called before the
+best-effort extraction block, and extraction is wrapped in its own
+`begin/rescue`. So an envelope that is both `:newer` AND `ok=false`
+surfaces its real `envelope ok=false: <reason>` message — never the skew
+restart hint. Only a throw inside extraction degrades, and only when
+`skew == :newer`; an equal/exact-version extraction throw re-raises to the
+outer rescue and surfaces the raw `#{e.class}: …` line (a real bug, not a
+skew).
+
 The contract: a long-running consumer must NEVER crash a tick (or the
 bot's `/status`) with a raw `ArgumentError` purely because a
 `schema_version` was bumped without a restart. It either keeps working
-(forward-compatible) or returns a clear "restart to pick up vN" message.
+(forward-compatible) or returns a clear "restart to pick up vN" message —
+without ever masking the real `ok=false` reason or a genuine extraction
+defect.
 
 `Hive::Bot::Supervisor#diagnose_reply_for_child` consumes the sibling
 `hive-status-diagnose` envelope but only checks `schema == ...` and never


### PR DESCRIPTION
Fix-forward on #416 (merged as 8b1cf115), addressing findings from a pr-review-toolkit review of the `hive-status` forward schema-version skew handling in `Hive::Bot::StatusWatcher#fetch` and `Hive::Daemon::StatusConsumer#fetch`.

## Findings fixed

### FINDING 1 (CRITICAL) — the `:newer` rescue over-swallowed and discarded the real error
The single broad `rescue StandardError` keyed the "just restart" message off `schema_skew(doc) == :newer` alone and threw away the real exception. Two bad consequences:
- (a) a genuine bug in `extract_rows`/`extract_projects`/`extract_legacy_stage_dirs` on a newer-schema doc got relabeled "restart to pick up the new version" — operator restarts, hits the same bug, the real defect stays invisible;
- (b) `validate_envelope!`'s own `ArgumentError` ("envelope ok=false: …" / "missing schema") is a `StandardError` too, so on a `:newer` doc it ALSO degraded to the skew message, masking the real `ok=false` reason.

**Fix:** both `#fetch` methods now run `validate_envelope!` OUTSIDE the degrade, and wrap ONLY the extraction phase in its own `begin/rescue`. That inner rescue `raise unless skew == :newer` (an exact/equal-version extraction throw re-raises to surface the raw `#{e.class}: …`); when it does degrade, the surfaced message PRESERVES the underlying exception (`… (underlying error: <Class>: <msg>)`), and the bot also logs it (class + message + first backtrace lines). The existing `JSON::ParserError` handling stays ahead of the broad rescue.

### FINDING 2 (HIGH) — bot `/status` showed degraded data with NO indicator
Added a `warning` field to the bot `StatusWatcher::Result` (mirrors the daemon Result), populated on the `:newer` best-effort success path. `Supervisor#execute_dispatch` prepends a one-line plain-text banner ("⚠️ hive status: running on a newer schema than this bot understands; data may be incomplete — restart the bot.") to the `/status`/`/queue` reply when the fetch carries a warning.

### FINDING 3 (MEDIUM) — forward-skew advisory logged under `:poll_failure` (overloaded)
The bot success-path advisory now logs under a distinct `:poll_schema_skew` event. Added to `Hive::Bot::Logger::EVENTS` and the `hive-bot-log.v2` schema `event` enum (additive append — no SCHEMA_VERSION bump). The daemon already used a distinct `:status_schema_skew`.

### FINDING 4 (LOW) — KeyError-in-rescue fragility
The bot's skew helpers used `SCHEMA_VERSIONS.fetch("hive-status")`, which would raise `KeyError` inside a rescue-reachable path if the key were absent. Replaced with a memoized `expected_schema_version` using the non-raising `["hive-status"]` form (mirrors the daemon, which already used `[]`).

## Deferred
Per-tick / per-poll dedup of the skew advisory log line is **not** implemented here — it can still log once per tick/poll while the skew persists. Noted as a follow-up enhancement.

## Tests
- A `:newer` envelope that FAILS validate (`ok=false`) returns the REAL `ok=false` message, not the skew hint (bot + daemon).
- A `:newer` envelope whose extraction throws returns a message containing BOTH the restart hint AND the underlying `e.class: e.message`, logs the real error (bot), result `ok:false`, never raises (bot + daemon).
- An exact-version extraction throw surfaces the raw error, not the skew hint (daemon).
- Bot `:newer` best-effort SUCCESS sets `Result#warning`; supervisor render prepends the banner (and omits it when clean).
- `:poll_schema_skew` fires on the bot success-path skew and is accepted by the logger enum + schema.

Affected unit + integration tests pass with 0 failures/errors. Rubocop clean on changed `.rb` files. Full coverage gate green at 100.0% (all four changed lib files at 100%). Wiki updated (`modules/bot`, `modules/daemon`, + a `log.d` fragment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)