### PR TITLE
feat(babysitter): auto-rebase green-but-behind PRs to keep them mergeable

### DIFF
--- a/lib/hive/babysitter/events.rb
+++ b/lib/hive/babysitter/events.rb
@@ -10,6 +10,7 @@ module Hive
         noop
         skipped
         agent-fix
+        rebase
         force-push
         pr-comment
         label-apply
@@ -20,6 +21,7 @@ module Hive
       OUTCOMES = %w[
         success
         failure
+        conflict
         timeout
         budget_exhausted
         gh-error

--- a/lib/hive/babysitter/gh_ops.rb
+++ b/lib/hive/babysitter/gh_ops.rb
@@ -6,6 +6,20 @@ module Hive
     module GhOps
       GIVE_UP_LABEL = "babysitter/needs-human".freeze
 
+      # Outcome of an auto-rebase attempt. `status` is one of :success
+      # (fetch + rebase clean), :conflict (rebase failed and was aborted —
+      # left for a human), or :failure (some other git error, e.g. the
+      # fetch failed). `success?` and `conflict?` keep call sites readable.
+      RebaseResult = Struct.new(:status, :stdout, :stderr, keyword_init: true) do
+        def success?
+          status == :success
+        end
+
+        def conflict?
+          status == :conflict
+        end
+      end
+
       module_function
 
       def force_push_with_lease(worktree, branch, cfg:, dry_run:)
@@ -17,6 +31,37 @@ module Hive
           cfg: cfg
         )
         result(status.success?, out, err)
+      end
+
+      # Rebase the worktree's HEAD onto origin/<base_ref> so a green-but-
+      # BEHIND PR becomes up-to-date with its base. Fetches the base first
+      # (a stale local origin/<base> would rebase onto the wrong commit).
+      # A rebase that hits conflicts is aborted (best-effort) and reported
+      # as :conflict so the caller leaves it for a human rather than
+      # force-pushing a half-rebased branch.
+      def rebase_onto_base(worktree, base_ref, cfg:, dry_run:)
+        return rebase_result(:success, "[dry-run] git rebase skipped", "") if dry_run
+
+        fetch_out, fetch_err, fetch_status = Hive::Gh.capture3(
+          "git", "fetch", "origin", base_ref,
+          chdir: worktree,
+          cfg: cfg
+        )
+        return rebase_result(:failure, fetch_out, fetch_err) unless fetch_status.success?
+
+        out, err, status = Hive::Gh.capture3(
+          "git", "rebase", "origin/#{base_ref}",
+          chdir: worktree,
+          cfg: cfg
+        )
+        return rebase_result(:success, out, err) if status.success?
+
+        abort_out, abort_err, _abort_status = Hive::Gh.capture3(
+          "git", "rebase", "--abort",
+          chdir: worktree,
+          cfg: cfg
+        )
+        rebase_result(:conflict, "#{out}\n#{abort_out}", "#{err}\n#{abort_err}")
       end
 
       def add_label(worktree, pr_number, label, cfg:, dry_run:)
@@ -113,6 +158,10 @@ module Hive
 
       def result(success, stdout, stderr)
         Hive::Gh::PushResult.new(success: success, stdout: stdout.to_s, stderr: stderr.to_s)
+      end
+
+      def rebase_result(status, stdout, stderr)
+        RebaseResult.new(status: status, stdout: stdout.to_s, stderr: stderr.to_s)
       end
     end
   end

--- a/lib/hive/babysitter/pr_fixer.rb
+++ b/lib/hive/babysitter/pr_fixer.rb
@@ -45,16 +45,7 @@ module Hive
         # config, and the result is threaded into ContextBuilder so the second
         # call reuses this rollup rather than re-fetching.
         status = Hive::Gh.pr_status_rollup(@project.fetch("path"), number, cfg: @cfg)
-        if already_green?(status)
-          Hive::Babysitter::Events.emit(
-            project: @project,
-            pr: number,
-            action: "noop",
-            outcome: "already-green",
-            duration_ms: duration_ms(started)
-          )
-          return :already_green
-        end
+        return handle_green(status, started) if already_green?(status)
 
         worktree = Hive::Babysitter::Worktree.materialize(@project, @pr)
         context = Hive::Babysitter::ContextBuilder.build(
@@ -112,6 +103,84 @@ module Hive
 
       def already_green?(status)
         status["mergeable"].to_s == "MERGEABLE" && checks_green_or_queued?(status["statusCheckRollup"])
+      end
+
+      # A green PR is normally a noop. But strict branch protection on the
+      # base requires the head to be up-to-date with it, so a green PR that
+      # is BEHIND main can never merge until rebased. When auto-rebase is on
+      # (default), rebase onto the base and force-push so the PR becomes
+      # CLEAN/mergeable; conflicts are left for a human (no force-push).
+      def handle_green(status, started)
+        return auto_rebase(started) if behind?(status) && auto_rebase_enabled?
+
+        Hive::Babysitter::Events.emit(
+          project: @project,
+          pr: number,
+          action: "noop",
+          outcome: "already-green",
+          duration_ms: duration_ms(started)
+        )
+        :already_green
+      end
+
+      def behind?(status)
+        merge_state = status["mergeStateStatus"]
+        merge_state = @pr["mergeStateStatus"] if merge_state.nil?
+        merge_state.to_s.upcase == "BEHIND"
+      end
+
+      # nil (key absent) is treated as enabled; only an explicit `false`
+      # opts out. Mirrors the "do not silently flip legacy projects"
+      # convention used elsewhere in babysitter config.
+      def auto_rebase_enabled?
+        @cfg.dig("babysitter", "auto_rebase") != false
+      end
+
+      def auto_rebase(started)
+        if @dry_run
+          Hive::Babysitter::Events.emit(
+            project: @project,
+            pr: number,
+            action: "rebase",
+            outcome: "dry_run",
+            duration_ms: duration_ms(started)
+          )
+          return :dry_run
+        end
+
+        worktree = Hive::Babysitter::Worktree.materialize(@project, @pr)
+        rebase = Hive::Babysitter::GhOps.rebase_onto_base(
+          worktree.path,
+          @pr.fetch("baseRefName"),
+          cfg: @cfg,
+          dry_run: @dry_run
+        )
+
+        unless rebase.success?
+          Hive::Babysitter::Events.emit(
+            project: @project,
+            pr: number,
+            action: "rebase",
+            outcome: rebase.conflict? ? "conflict" : "failure",
+            duration_ms: duration_ms(started)
+          )
+          return rebase.conflict? ? :rebase_conflict : :failure
+        end
+
+        push = Hive::Babysitter::GhOps.force_push_with_lease(
+          worktree.path,
+          worktree.branch,
+          cfg: @cfg,
+          dry_run: @dry_run
+        )
+        Hive::Babysitter::Events.emit(
+          project: @project,
+          pr: number,
+          action: "rebase",
+          outcome: push.success? ? "success" : "failure",
+          duration_ms: duration_ms(started)
+        )
+        push.success? ? :rebased : :failure
       end
 
       def checks_green_or_queued?(checks)

--- a/lib/hive/babysitter/project_tick.rb
+++ b/lib/hive/babysitter/project_tick.rb
@@ -59,9 +59,9 @@ module Hive
             end
 
           case outcome
-          when :success then summary[:fixed] += 1
+          when :success, :rebased then summary[:fixed] += 1
           when :already_green, :noop, :dry_run then summary[:untouched] += 1
-          when :give_up, :failure, :timeout, :budget_exhausted, :fork_pr then summary[:needs_human] += 1
+          when :give_up, :failure, :timeout, :budget_exhausted, :fork_pr, :rebase_conflict then summary[:needs_human] += 1
           end
         end
 

--- a/lib/hive/config.rb
+++ b/lib/hive/config.rb
@@ -308,6 +308,10 @@ module Hive
         "max_concurrent_prs" => 2,
         "labels_ignore" => %w[wip do-not-merge draft],
         "dry_run" => false,
+        # Auto-rebase green-but-BEHIND PRs onto their base and force-push so
+        # strict "branch must be up-to-date" protection can merge them.
+        # Conflicting rebases are left for a human. Set to false to disable.
+        "auto_rebase" => true,
         "budget_minutes" => 30,
         "budget_usd" => 50
       },
@@ -1569,7 +1573,7 @@ module Hive
       babysitter = cfg["babysitter"]
       return if babysitter.nil?
 
-      %w[enabled dry_run].each do |key|
+      %w[enabled dry_run auto_rebase].each do |key|
         value = babysitter[key]
         next if value.nil? || value == true || value == false
 

--- a/templates/project_config.yml.erb
+++ b/templates/project_config.yml.erb
@@ -181,6 +181,10 @@ babysitter:
     - do-not-merge
     - draft
   dry_run: false
+  # Rebase green PRs that have fallen BEHIND the base branch and force-push
+  # so strict "branch must be up-to-date" protection can still merge them.
+  # Conflicting rebases are left for a human. Set false to disable.
+  auto_rebase: true
   budget_minutes: 30
   budget_usd: 50
 

--- a/test/unit/babysitter/events_test.rb
+++ b/test/unit/babysitter/events_test.rb
@@ -29,6 +29,33 @@ class BabysitterEventsTest < Minitest::Test
     end
   end
 
+  def test_emit_accepts_rebase_action_and_conflict_outcome
+    with_tmp_dir do |dir|
+      project = project_entry(dir)
+      record = Hive::Babysitter::Events.emit(
+        project: project,
+        pr: 42,
+        action: "rebase",
+        outcome: "conflict",
+        duration_ms: 5
+      )
+      assert_equal "rebase", record.fetch("action")
+      assert_equal "conflict", record.fetch("outcome")
+    end
+  end
+
+  def test_emit_raises_on_unknown_action_and_outcome
+    with_tmp_dir do |dir|
+      project = project_entry(dir)
+      assert_raises(ArgumentError) do
+        Hive::Babysitter::Events.emit(project: project, action: "teleport", outcome: "success")
+      end
+      assert_raises(ArgumentError) do
+        Hive::Babysitter::Events.emit(project: project, action: "rebase", outcome: "exploded")
+      end
+    end
+  end
+
   def test_status_writer_appends_summary_lines
     with_tmp_dir do |dir|
       project = project_entry(dir)

--- a/test/unit/babysitter/gh_ops_test.rb
+++ b/test/unit/babysitter/gh_ops_test.rb
@@ -41,4 +41,63 @@ class BabysitterGhOpsTest < Minitest::Test
     end
     refute called
   end
+
+  def test_rebase_onto_base_fetches_then_rebases_on_success
+    ok = Hive::Gh::CommandStatus.new(exitstatus: 0)
+    commands = []
+    with_replaced_singleton_method(Hive::Gh, :capture3, lambda { |*cmd, **_kwargs|
+      commands << cmd
+      [ "ok", "", ok ]
+    }) do
+      result = Hive::Babysitter::GhOps.rebase_onto_base("/tmp/wt", "main", cfg: {}, dry_run: false)
+      assert result.success?
+      refute result.conflict?
+    end
+
+    assert_equal %w[git fetch origin main], commands[0]
+    assert_equal %w[git rebase origin/main], commands[1]
+    assert_equal 2, commands.size, "no abort on a clean rebase"
+  end
+
+  def test_rebase_onto_base_aborts_and_reports_conflict_on_failure
+    ok = Hive::Gh::CommandStatus.new(exitstatus: 0)
+    bad = Hive::Gh::CommandStatus.new(exitstatus: 1)
+    commands = []
+    with_replaced_singleton_method(Hive::Gh, :capture3, lambda { |*cmd, **_kwargs|
+      commands << cmd
+      status = cmd[0, 2] == %w[git rebase] && cmd[2] != "--abort" ? bad : ok
+      [ "out", "err", status ]
+    }) do
+      result = Hive::Babysitter::GhOps.rebase_onto_base("/tmp/wt", "main", cfg: {}, dry_run: false)
+      assert result.conflict?
+      refute result.success?
+    end
+
+    assert_equal %w[git rebase --abort], commands.last
+  end
+
+  def test_rebase_onto_base_reports_failure_when_fetch_fails
+    bad = Hive::Gh::CommandStatus.new(exitstatus: 1)
+    commands = []
+    with_replaced_singleton_method(Hive::Gh, :capture3, lambda { |*cmd, **_kwargs|
+      commands << cmd
+      [ "out", "fetch boom", bad ]
+    }) do
+      result = Hive::Babysitter::GhOps.rebase_onto_base("/tmp/wt", "main", cfg: {}, dry_run: false)
+      refute result.success?
+      refute result.conflict?
+      assert_equal :failure, result.status
+    end
+
+    assert_equal 1, commands.size, "stops after a failed fetch"
+  end
+
+  def test_rebase_onto_base_dry_run_skips_git
+    called = false
+    with_replaced_singleton_method(Hive::Gh, :capture3, ->(*_cmd, **_kwargs) { called = true }) do
+      result = Hive::Babysitter::GhOps.rebase_onto_base("/tmp/wt", "main", cfg: {}, dry_run: true)
+      assert result.success?
+    end
+    refute called
+  end
 end

--- a/test/unit/babysitter/pr_fixer_test.rb
+++ b/test/unit/babysitter/pr_fixer_test.rb
@@ -131,6 +131,193 @@ class BabysitterPrFixerTest < Minitest::Test
     end
   end
 
+  def green_behind_status
+    {
+      "mergeable" => "MERGEABLE",
+      "mergeStateStatus" => "BEHIND",
+      "statusCheckRollup" => [ { "name" => "ci", "conclusion" => "SUCCESS" } ]
+    }
+  end
+
+  def test_green_but_behind_rebases_force_pushes_and_reports_rebased
+    with_tmp_dir do |dir|
+      project = project_entry(dir)
+      worktree_path = File.join(dir, "wt")
+      FileUtils.mkdir_p(worktree_path)
+      pushed = []
+      spawned = false
+
+      status = green_behind_status
+      with_replaced_singleton_method(Hive::Gh, :pr_status_rollup, ->(_p, _n, **_k) { status }) do
+        with_replaced_singleton_method(Hive::Babysitter::Worktree, :materialize, ->(_pr, _proj) { WorktreeResult.new(path: worktree_path, branch: "feature") }) do
+          with_replaced_singleton_method(Hive::Babysitter::GhOps, :rebase_onto_base, ->(*_a, **_k) { Hive::Babysitter::GhOps::RebaseResult.new(status: :success, stdout: "", stderr: "") }) do
+            with_replaced_singleton_method(Hive::Babysitter::GhOps, :force_push_with_lease, lambda { |*args, **_k|
+              pushed << args
+              Hive::Gh::PushResult.new(success: true, stdout: "", stderr: "")
+            }) do
+              with_replaced_singleton_method(Hive::Stages::Base, :spawn_agent, ->(*_a, **_k) { spawned = true }) do
+                outcome = Hive::Babysitter::PrFixer.run(pr, project, cfg, dry_run: false, logger: nil, inflight: Set.new)
+                assert_equal :rebased, outcome
+              end
+            end
+          end
+        end
+      end
+
+      refute spawned, "rebase path must not spawn the fix agent"
+      assert_equal 1, pushed.size
+      assert_equal [ worktree_path, "feature" ], pushed.first
+      events = read_events(project)
+      assert events.any? { |e| e["action"] == "rebase" && e["outcome"] == "success" }
+    end
+  end
+
+  def test_green_but_behind_rebase_conflict_reports_conflict_without_push
+    with_tmp_dir do |dir|
+      project = project_entry(dir)
+      worktree_path = File.join(dir, "wt")
+      FileUtils.mkdir_p(worktree_path)
+      pushed = false
+      spawned = false
+
+      # Rollup omits mergeStateStatus; behind? falls back to the PR object
+      # (the listing carries it). Exercises the @pr fallback branch.
+      status = { "mergeable" => "MERGEABLE", "statusCheckRollup" => [ { "conclusion" => "SUCCESS" } ] }
+      behind_pr = pr.merge("mergeStateStatus" => "BEHIND")
+      with_replaced_singleton_method(Hive::Gh, :pr_status_rollup, ->(_p, _n, **_k) { status }) do
+        with_replaced_singleton_method(Hive::Babysitter::Worktree, :materialize, ->(_pr, _proj) { WorktreeResult.new(path: worktree_path, branch: "feature") }) do
+          with_replaced_singleton_method(Hive::Babysitter::GhOps, :rebase_onto_base, ->(*_a, **_k) { Hive::Babysitter::GhOps::RebaseResult.new(status: :conflict, stdout: "", stderr: "") }) do
+            with_replaced_singleton_method(Hive::Babysitter::GhOps, :force_push_with_lease, ->(*_a, **_k) { pushed = true }) do
+              with_replaced_singleton_method(Hive::Stages::Base, :spawn_agent, ->(*_a, **_k) { spawned = true }) do
+                outcome = Hive::Babysitter::PrFixer.run(behind_pr, project, cfg, dry_run: false, logger: nil, inflight: Set.new)
+                assert_equal :rebase_conflict, outcome
+              end
+            end
+          end
+        end
+      end
+
+      refute pushed, "a conflicting rebase must not force-push"
+      refute spawned, "a conflicting rebase must not spawn the fix agent"
+      events = read_events(project)
+      assert events.any? { |e| e["action"] == "rebase" && e["outcome"] == "conflict" }
+    end
+  end
+
+  def test_green_but_behind_reports_failure_when_force_push_fails
+    with_tmp_dir do |dir|
+      project = project_entry(dir)
+      worktree_path = File.join(dir, "wt")
+      FileUtils.mkdir_p(worktree_path)
+
+      status = green_behind_status
+      with_replaced_singleton_method(Hive::Gh, :pr_status_rollup, ->(_p, _n, **_k) { status }) do
+        with_replaced_singleton_method(Hive::Babysitter::Worktree, :materialize, ->(_pr, _proj) { WorktreeResult.new(path: worktree_path, branch: "feature") }) do
+          with_replaced_singleton_method(Hive::Babysitter::GhOps, :rebase_onto_base, ->(*_a, **_k) { Hive::Babysitter::GhOps::RebaseResult.new(status: :success, stdout: "", stderr: "") }) do
+            with_replaced_singleton_method(Hive::Babysitter::GhOps, :force_push_with_lease, ->(*_a, **_k) { Hive::Gh::PushResult.new(success: false, stdout: "", stderr: "rejected") }) do
+              outcome = Hive::Babysitter::PrFixer.run(pr, project, cfg, dry_run: false, logger: nil, inflight: Set.new)
+              assert_equal :failure, outcome
+            end
+          end
+        end
+      end
+
+      events = read_events(project)
+      assert events.any? { |e| e["action"] == "rebase" && e["outcome"] == "failure" }
+    end
+  end
+
+  def test_green_but_behind_reports_failure_when_rebase_errors
+    with_tmp_dir do |dir|
+      project = project_entry(dir)
+      worktree_path = File.join(dir, "wt")
+      FileUtils.mkdir_p(worktree_path)
+      pushed = false
+
+      status = green_behind_status
+      with_replaced_singleton_method(Hive::Gh, :pr_status_rollup, ->(_p, _n, **_k) { status }) do
+        with_replaced_singleton_method(Hive::Babysitter::Worktree, :materialize, ->(_pr, _proj) { WorktreeResult.new(path: worktree_path, branch: "feature") }) do
+          with_replaced_singleton_method(Hive::Babysitter::GhOps, :rebase_onto_base, ->(*_a, **_k) { Hive::Babysitter::GhOps::RebaseResult.new(status: :failure, stdout: "", stderr: "fetch boom") }) do
+            with_replaced_singleton_method(Hive::Babysitter::GhOps, :force_push_with_lease, ->(*_a, **_k) { pushed = true }) do
+              outcome = Hive::Babysitter::PrFixer.run(pr, project, cfg, dry_run: false, logger: nil, inflight: Set.new)
+              assert_equal :failure, outcome
+            end
+          end
+        end
+      end
+
+      refute pushed, "a failed rebase must not force-push"
+      events = read_events(project)
+      assert events.any? { |e| e["action"] == "rebase" && e["outcome"] == "failure" }
+    end
+  end
+
+  def test_green_but_behind_with_auto_rebase_disabled_noops
+    with_tmp_dir do |dir|
+      project = project_entry(dir)
+      materialized = false
+      disabled_cfg = cfg.merge("babysitter" => cfg.fetch("babysitter").merge("auto_rebase" => false))
+
+      status = green_behind_status
+      with_replaced_singleton_method(Hive::Gh, :pr_status_rollup, ->(_p, _n, **_k) { status }) do
+        with_replaced_singleton_method(Hive::Babysitter::Worktree, :materialize, ->(*_a) { materialized = true }) do
+          outcome = Hive::Babysitter::PrFixer.run(pr, project, disabled_cfg, dry_run: false, logger: nil, inflight: Set.new)
+          assert_equal :already_green, outcome
+        end
+      end
+
+      refute materialized, "auto_rebase: false must not materialize a worktree"
+      event = JSON.parse(File.read(File.join(project.fetch("hive_state_path"), "babysitter", "events.jsonl")))
+      assert_equal "noop", event.fetch("action")
+      assert_equal "already-green", event.fetch("outcome")
+    end
+  end
+
+  def test_green_and_not_behind_noops_without_rebase
+    with_tmp_dir do |dir|
+      project = project_entry(dir)
+      materialized = false
+      status = {
+        "mergeable" => "MERGEABLE",
+        "mergeStateStatus" => "CLEAN",
+        "statusCheckRollup" => [ { "name" => "ci", "conclusion" => "SUCCESS" } ]
+      }
+
+      with_replaced_singleton_method(Hive::Gh, :pr_status_rollup, ->(_p, _n, **_k) { status }) do
+        with_replaced_singleton_method(Hive::Babysitter::Worktree, :materialize, ->(*_a) { materialized = true }) do
+          outcome = Hive::Babysitter::PrFixer.run(pr, project, cfg, dry_run: false, logger: nil, inflight: Set.new)
+          assert_equal :already_green, outcome
+        end
+      end
+
+      refute materialized
+    end
+  end
+
+  def test_dry_run_green_but_behind_emits_rebase_dry_run_without_git
+    with_tmp_dir do |dir|
+      project = project_entry(dir)
+      materialized = false
+
+      status = green_behind_status
+      with_replaced_singleton_method(Hive::Gh, :pr_status_rollup, ->(_p, _n, **_k) { status }) do
+        with_replaced_singleton_method(Hive::Babysitter::Worktree, :materialize, ->(*_a) { materialized = true }) do
+          outcome = Hive::Babysitter::PrFixer.run(pr, project, cfg, dry_run: true, logger: nil, inflight: Set.new)
+          assert_equal :dry_run, outcome
+        end
+      end
+
+      refute materialized, "dry-run must not touch git"
+      event = JSON.parse(File.read(File.join(project.fetch("hive_state_path"), "babysitter", "events.jsonl")))
+      assert_equal "rebase", event.fetch("action")
+      assert_equal "dry_run", event.fetch("outcome")
+    end
+  end
+
+  def read_events(project)
+    File.readlines(File.join(project.fetch("hive_state_path"), "babysitter", "events.jsonl")).map { |line| JSON.parse(line) }
+  end
+
   def stub_non_green_context(project, worktree_path)
     status = { "mergeable" => "CONFLICTING", "statusCheckRollup" => [ { "conclusion" => "FAILURE" } ] }
     context = Hive::Babysitter::ContextBuilder::Context.new(

--- a/test/unit/babysitter/project_tick_test.rb
+++ b/test/unit/babysitter/project_tick_test.rb
@@ -131,6 +131,28 @@ class BabysitterProjectTickTest < Minitest::Test
     end
   end
 
+  def test_rebased_and_conflict_outcomes_are_tallied
+    with_tmp_dir do |dir|
+      project = project_entry(dir)
+      write_config(dir, babysitter: { "enabled" => true, "labels_ignore" => [], "max_concurrent_prs" => 2 })
+      logger = make_logger(dir)
+      prs = [
+        { "number" => 20, "labels" => [], "updatedAt" => "2026-05-26T10:00:00Z" },
+        { "number" => 21, "labels" => [], "updatedAt" => "2026-05-26T11:00:00Z" }
+      ]
+      outcomes = { 20 => :rebased, 21 => :rebase_conflict }
+
+      with_replaced_singleton_method(Hive::Gh, :list_open_prs, ->(_path, **_kwargs) { prs }) do
+        with_replaced_singleton_method(Hive::Babysitter::PrFixer, :run, ->(pr, *_args, **_kwargs) { outcomes.fetch(pr["number"]) }) do
+          summary = Hive::Babysitter::ProjectTick.run(project, dry_run: false, logger: logger, inflight: Set.new)
+          assert_equal({ total: 2, fixed: 1, untouched: 0, needs_human: 1 }, summary)
+        end
+      end
+    ensure
+      logger&.close
+    end
+  end
+
   def test_gh_error_emits_event_and_does_not_spawn_agent
     with_tmp_dir do |dir|
       project = project_entry(dir)

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -1966,6 +1966,7 @@ class ConfigTest < Minitest::Test
           "max_concurrent_prs" => 2,
           "labels_ignore" => %w[wip do-not-merge draft],
           "dry_run" => false,
+          "auto_rebase" => true,
           "budget_minutes" => 30,
           "budget_usd" => 50
         },
@@ -1988,6 +1989,32 @@ class ConfigTest < Minitest::Test
       assert_equal "10m", cfg.dig("babysitter", "interval")
       assert_equal 2, cfg.dig("babysitter", "max_concurrent_prs")
       assert_equal %w[wip do-not-merge draft], cfg.dig("babysitter", "labels_ignore")
+    end
+  end
+
+  def test_load_babysitter_auto_rebase_defaults_true_and_round_trips
+    with_tmp_dir do |dir|
+      assert_equal true, Hive::Config.load(dir).dig("babysitter", "auto_rebase")
+
+      FileUtils.mkdir_p(File.join(dir, ".hive-state"))
+      File.write(File.join(dir, ".hive-state", "config.yml"), <<~YAML)
+        babysitter:
+          auto_rebase: false
+      YAML
+      assert_equal false, Hive::Config.load(dir).dig("babysitter", "auto_rebase")
+    end
+  end
+
+  def test_load_rejects_non_boolean_babysitter_auto_rebase
+    with_tmp_dir do |dir|
+      FileUtils.mkdir_p(File.join(dir, ".hive-state"))
+      File.write(File.join(dir, ".hive-state", "config.yml"), <<~YAML)
+        babysitter:
+          auto_rebase: "yes"
+      YAML
+
+      err = assert_raises(Hive::ConfigError) { Hive::Config.load(dir) }
+      assert_match(/babysitter\.auto_rebase.*must be a boolean/, err.message)
     end
   end
 

--- a/wiki/commands/babysit.md
+++ b/wiki/commands/babysit.md
@@ -45,11 +45,12 @@ babysitter:
   max_concurrent_prs: 2
   labels_ignore: [wip, do-not-merge, draft]
   dry_run: false
+  auto_rebase: true
   budget_minutes: 30
   budget_usd: 50
 ```
 
-`ProjectTick` reloads the project config on every tick, so changing `babysitter.enabled: false` is the kill switch and takes effect within one poll interval. `interval` accepts integer seconds or strings like `10m`, `30s`, and `1h`.
+`ProjectTick` reloads the project config on every tick, so changing `babysitter.enabled: false` is the kill switch and takes effect within one poll interval. `interval` accepts integer seconds or strings like `10m`, `30s`, and `1h`. `auto_rebase` (default `true`; `false` disables) controls auto-rebasing green-but-`BEHIND` PRs — see PR Processing below.
 
 ## PR Processing
 
@@ -62,7 +63,7 @@ For each enabled project, the babysitter:
 5. Sorts oldest-updated first and truncates to `max_concurrent_prs`.
 6. Runs `Hive::Babysitter::PrFixer` on each selected PR.
 
-`PrFixer` first checks `gh pr view --json mergeable,statusCheckRollup`. If the PR is mergeable and checks are successful or queued, it records a `noop` event and does not spawn an agent. Otherwise it materializes `<project>/.hive-state/babysitter/worktrees/<pr-number>/`, gathers failing-job logs plus diff stats, renders `templates/babysitter_pr_fix_prompt.md.erb`, and spawns the configured `execute.agent` through `Hive::Stages::Base.spawn_agent` with `status_mode: :exit_code_only`.
+`PrFixer` first checks `gh pr view --json mergeable,mergeStateStatus,statusCheckRollup`. If the PR is mergeable and checks are successful or queued (green), it normally records a `noop`/`already-green` event and does not spawn an agent. The exception: a green PR whose `mergeStateStatus` is `BEHIND` cannot merge under strict "branch must be up-to-date" protection. When `auto_rebase` is enabled (default), `PrFixer#handle_green` materializes the PR worktree, runs `GhOps.rebase_onto_base` (`git fetch origin <base>` then `git rebase origin/<base>`), and on a clean rebase force-pushes with `--force-with-lease` so the PR becomes `CLEAN`/mergeable (emits `rebase`/`success`, counted as `fixed`). A rebase that conflicts is aborted and left for a human: no force-push, no fix agent, no label (emits `rebase`/`conflict`, counted as `needs_human`); it is re-evaluated cheaply on the next tick. With `auto_rebase: false` a green-but-`BEHIND` PR just `noop`s. If the PR is not green, `PrFixer` materializes the worktree, gathers failing-job logs plus diff stats, renders `templates/babysitter_pr_fix_prompt.md.erb`, and spawns the configured `execute.agent` through `Hive::Stages::Base.spawn_agent` with `status_mode: :exit_code_only`.
 
 On success, the babysitter is silent on the PR. On failure, timeout, or budget exhaustion it applies `babysitter/needs-human` and posts one give-up comment per PR per UTC hour.
 

--- a/wiki/log.d/20260608-191521-babysitter-auto-rebase-behind-prs.md
+++ b/wiki/log.d/20260608-191521-babysitter-auto-rebase-behind-prs.md
@@ -1,0 +1,30 @@
+---
+ts: 2026-06-08T19:15:21Z
+slug: babysitter-auto-rebase-behind-prs
+tags: [babysitter, github, decision]
+---
+
+## Babysitter: auto-rebase green-but-BEHIND PRs to keep them mergeable
+
+**Problem.** Strict branch protection on `main` requires a PR branch to be up-to-date with the base before it can merge. When `main` advances, an open PR goes `mergeStateStatus=BEHIND` — but it is still `mergeable=MERGEABLE` and green, so `PrFixer#already_green?` short-circuited to a `noop`/`already-green` event. The PR stayed BEHIND and un-mergeable forever; the babysitter did nothing about it.
+
+**Change.** When a PR is green, `PrFixer` now routes through `handle_green`:
+
+- **green + `BEHIND` + auto-rebase enabled** → materialize the PR worktree, `GhOps.rebase_onto_base` (`git fetch origin <base>` then `git rebase origin/<base>`), then on a clean rebase `GhOps.force_push_with_lease`. Emits `rebase`/`success`; returns `:rebased` (tallied as `fixed`). A rebase that hits conflicts is `git rebase --abort`ed and left for a human — no force-push, no fix agent, no label — emits `rebase`/`conflict`; returns `:rebase_conflict` (tallied as `needs_human`); re-evaluated cheaply next tick. A fetch/other failure or a failed push emits `rebase`/`failure` and returns `:failure`. Dry-run emits `rebase`/`dry_run`, returns `:dry_run`, and touches no git.
+- **green + not `BEHIND`** → unchanged `noop`/`already-green`.
+
+`behind?` reads `status["mergeStateStatus"]` from the rollup, falling back to the PR object's `mergeStateStatus`. Auto-rebase is gated on `babysitter.auto_rebase` with **nil treated as true** — only an explicit `false` opts out (mirrors the "do not silently flip legacy projects" convention).
+
+**New rebase helper.** `GhOps.rebase_onto_base(worktree, base_ref, cfg:, dry_run:)` returns a `RebaseResult` Struct (`status` ∈ `:success`/`:conflict`/`:failure`, plus `stdout`/`stderr` and `success?`/`conflict?` predicates), built via `Hive::Gh.capture3` in the same style as `force_push_with_lease`. Conflicts run a best-effort `git rebase --abort`.
+
+**Events.** Added action `rebase` and outcome `conflict` to the closed allowlists in `events.rb`; `emit` still raises on anything outside them.
+
+**Config.** Added `babysitter.auto_rebase => true` to `Config::DEFAULTS` and to `templates/project_config.yml.erb`; `validate_babysitter!` now boolean-validates `auto_rebase` alongside `enabled`/`dry_run`.
+
+**Tally.** `ProjectTick` maps `:rebased` → `fixed` and `:rebase_conflict` → `needs_human`.
+
+**Tests.** `gh_ops_test` (rebase success / conflict-abort / fetch-failure / dry-run), `pr_fixer_test` (green+BEHIND → rebased + push, conflict → no push + no agent, push-failure → failure, rebase-error → failure, `auto_rebase:false` → noop, green+CLEAN → noop, dry-run → rebase/dry_run + no git, plus the `@pr` mergeStateStatus fallback), `events_test` (rebase/conflict accepted; unknown still raises), `project_tick_test` (`:rebased`/`:rebase_conflict` tally), `config_test` (auto_rebase default true + round-trip + non-boolean rejected). Full `rake test` green: 4975 runs, 0 failures/0 errors, 100% line-coverage gate satisfied. rubocop clean on changed files.
+
+**Refreshed pages:**
+- [[modules/babysitter]]
+- [[commands/babysit]]

--- a/wiki/modules/babysitter.md
+++ b/wiki/modules/babysitter.md
@@ -3,7 +3,7 @@ title: Hive::Babysitter
 type: module
 source: lib/hive/babysitter/
 created: 2026-05-26
-updated: 2026-06-07
+updated: 2026-06-08
 tags: [babysitter, module, daemon, github, agents]
 ---
 
@@ -17,10 +17,10 @@ tags: [babysitter, module, daemon, github, agents]
 | `Hive::Babysitter::Logger` | `lib/hive/babysitter/logger.rb` | Rotated JSON-line process log at `$HIVE_HOME/logs/babysitter.log`. |
 | `Hive::Babysitter::Interval` | `lib/hive/babysitter/interval.rb` | Parses integer seconds or `\d+[smh]` duration strings. |
 | `Hive::Babysitter::ProjectTick` | `lib/hive/babysitter/project_tick.rb` | One-project tick: reload config, list PRs, filter labels, enforce `max_concurrent_prs`, call `PrFixer`. |
-| `Hive::Babysitter::PrFixer` | `lib/hive/babysitter/pr_fixer.rb` | Per-PR precheck, worktree setup, context gathering, prompt render, agent spawn, give-up handling. |
+| `Hive::Babysitter::PrFixer` | `lib/hive/babysitter/pr_fixer.rb` | Per-PR precheck, green-but-`BEHIND` auto-rebase, worktree setup, context gathering, prompt render, agent spawn, give-up handling. |
 | `Hive::Babysitter::ContextBuilder` | `lib/hive/babysitter/context_builder.rb` | Builds prompt-ready status rollup, failing-job logs, and diff stat. |
 | `Hive::Babysitter::Worktree` | `lib/hive/babysitter/worktree.rb` | Recreates `.hive-state/babysitter/worktrees/<pr>/` from a force-refreshed internal PR-head ref, so rebased or force-pushed PRs do not wedge the babysitter cache. |
-| `Hive::Babysitter::GhOps` | `lib/hive/babysitter/gh_ops.rb` | Hive-driven GitHub side effects: force-with-lease push, label, comment, rerun. Honors dry-run. |
+| `Hive::Babysitter::GhOps` | `lib/hive/babysitter/gh_ops.rb` | Hive-driven GitHub/git side effects: force-with-lease push, `rebase_onto_base` (fetch base + rebase, abort-on-conflict, returns a `RebaseResult` of `:success`/`:conflict`/`:failure`), label, comment, rerun. Honors dry-run. |
 | `Hive::Babysitter::DryRunEnv` | `lib/hive/babysitter/dry_run_env.rb` + `bin/hive-babysitter-stub-git` / `bin/hive-babysitter-stub-gh` | PATH overlay for agent-side dry-run `git` / `gh` stubs. |
 | `Hive::Babysitter::Events` | `lib/hive/babysitter/events.rb` | Append-only per-project JSONL events under `.hive-state/babysitter/events.jsonl`. |
 | `Hive::Babysitter::StatusWriter` | `lib/hive/babysitter/status_writer.rb` | Human-readable loop summary appended to `.hive-state/babysitter/status.md`. |
@@ -36,7 +36,11 @@ hive babysit start
                  -> Gh.list_open_prs
                  -> PrFixer.run(pr, project, cfg, dry_run:, logger:, inflight:)
                       -> Gh.pr_status_rollup
-                      -> Worktree.materialize
+                      -> handle_green (green + BEHIND + auto_rebase):
+                           -> Worktree.materialize
+                           -> GhOps.rebase_onto_base -> GhOps.force_push_with_lease  (=> :rebased)
+                           -> conflict: emit rebase/conflict, no push        (=> :rebase_conflict)
+                      -> (not green) Worktree.materialize
                       -> ContextBuilder.build
                       -> Stages::Base.spawn_agent(profile: execute.agent)
                       -> GhOps.add_label / post_pr_comment on give-up
@@ -52,9 +56,11 @@ Each action appends one JSON object:
 {"ts":"2026-05-26T11:40:00Z","stage":"babysitter","project":"demo","pr":42,"action":"agent-fix","outcome":"success","duration_ms":612000}
 ```
 
-Closed action enum: `list-prs`, `noop`, `skipped`, `agent-fix`, `force-push`, `pr-comment`, `label-apply`, `give-up`, `dry_run`.
+Closed action enum: `list-prs`, `noop`, `skipped`, `agent-fix`, `rebase`, `force-push`, `pr-comment`, `label-apply`, `give-up`, `dry_run`.
 
-Closed outcome enum: `success`, `failure`, `timeout`, `budget_exhausted`, `gh-error`, `already-green`, `label_ignored`, `draft_pr`, `fork_pr`, `dry_run`.
+Closed outcome enum: `success`, `failure`, `conflict`, `timeout`, `budget_exhausted`, `gh-error`, `already-green`, `label_ignored`, `draft_pr`, `fork_pr`, `dry_run`.
+
+`emit` raises `ArgumentError` on any action/outcome outside these allowlists.
 
 ## Boundaries
 
@@ -64,6 +70,7 @@ Closed outcome enum: `success`, `failure`, `timeout`, `budget_exhausted`, `gh-er
 - `hive babysit reload` is config/log-setting only. The detached process keeps Ruby code loaded from its original start; after checkout updates or release upgrades, use `hive babysit restart --detach`. `hive babysit status` compares the PID-file `started_at` to the current source mtime and prints a restart recommendation when the running process predates the checkout. This prevents stale validators from silently skipping projects after config enum changes such as `patrol.trigger: continuous`.
 - `ProjectTick` asks `gh pr list` for `mergeStateStatus` and sorts selected candidates by actionability before applying `babysitter.max_concurrent_prs`: `DIRTY` / `BLOCKED` / `UNSTABLE` first, then `BEHIND` / `UNKNOWN`, then clean or missing states. Updated time remains the tie-breaker. This prevents a large old backlog of neutral PRs from starving conflicted/red PRs such as patrol output that needs immediate repair.
 - Draft PRs are skipped before worktree materialization; `labels_ignore: [draft]` is not relied on because draft status is not a GitHub label.
+- **Auto-rebase of green-but-`BEHIND` PRs** (default on; `babysitter.auto_rebase: false` to disable): strict branch protection on the base requires a PR head to be up-to-date with the base before it can merge, so a conflict-free, green PR that goes `mergeStateStatus=BEHIND` when the base advances is `mergeable=MERGEABLE` + green and would `noop` forever, staying un-mergeable. `PrFixer#handle_green` detects `BEHIND` (from the status rollup, falling back to the PR object's `mergeStateStatus`) and, when enabled, materializes the worktree, `GhOps.rebase_onto_base` (fetch base + `git rebase origin/<base>`), then `GhOps.force_push_with_lease` so the PR becomes `CLEAN`/mergeable (`:rebased`, counted as `fixed`). A rebase that hits conflicts is aborted and left for a human — no force-push, no fix agent, no label (`:rebase_conflict`, counted as `needs_human`); it is re-evaluated cheaply next tick. Dry-run emits a `rebase`/`dry_run` event and touches no git. A green PR that is not `BEHIND` is the usual `noop`/`already-green`.
 - No Telegram or install/service integration in v1.
 - No success PR comments.
 - Dry-run is best-effort because absolute-path binary invocations can bypass the PATH overlay. Within the overlay, the `git` / `gh` stubs are default-deny: they strip leading global options, skip unknown commands, and only pass through known read-only commands to the real binary. The `git` stub rejects every leading `-c` / `--config-env` global config override (glued or separate) before passthrough - rejecting the whole config-override category instead of enumerating dangerous keys, since git keeps adding exec-capable keys (`diff.external`, `diff.<driver>.textconv`/`command`, `filter.<driver>.*`, `gpg.<format>.program`, pagers, hooks, aliases, protocol/include helpers, ...). It also skips leading global pager/exec-path switches (scoped to the global region so a subcommand `-p` like `git log -p` still passes) and the command options `--ext-diff`, the grep-only `--open-files-in-pager` (and its `-O` short form, glued or separate - on `diff`/`log`/`show` `-O` is the read-only `--output-ordering`, which stays allowed), and the file-writing `--output` / `-o` - the file-write guard is scoped past `grep`, whose `-o` / `--only-matching` is a read-only match filter, and past `ls-files -o` / `--others` (a read), while the long-form `--output` write still skips; option scanning stops at the `--` pathspec separator. The `git` stub mirrors the `-c` rejection onto git's environment-variable config path, fail-closed: it skips when any of `GIT_EXTERNAL_DIFF`, `GIT_SSH_COMMAND`, `GIT_SSH`, `GIT_PROXY_COMMAND`, `GIT_CONFIG_PARAMETERS`, `GIT_CONFIG_GLOBAL`, or `GIT_CONFIG_SYSTEM` is set, or when `GIT_CONFIG_COUNT` is set to anything that does not cleanly parse to `0` (a positive count carries attacker-controlled `GIT_CONFIG_KEY_n`/`GIT_CONFIG_VALUE_n` exec-capable keys, and a non-numeric value is rejected by default-deny rather than trusted). These cover both command-naming vars git execs directly and config-injection channels; this is a denylist of the known exec-capable seams, not an exhaustive bar. `GIT_PAGER` / `core.pager` is intentionally left unguarded because non-TTY dry-run stdout does not auto-spawn a pager. `gh api` passes through only when it has no method and no payload flags, or when the method is explicitly GET; payload flags such as `-f`, `-F`, `--raw-field`, `--field`, and `--input` make a no-method call skip because the GitHub CLI can treat them as write payloads. `git config` only passes through for read forms (`--get`, `--get-all`, `--list`).


### PR DESCRIPTION
## Problem

Branch protection on `main` is strict: a PR branch must be **up-to-date with `main`** before it can merge. When `main` advances, open PRs go `mergeStateStatus=BEHIND` and can't merge even though they're conflict-free and green. The babysitter did nothing about this — `PrFixer#already_green?` returns true for a BEHIND-but-green PR (`mergeable=MERGEABLE` + green), so it short-circuited to a `noop`/`already-green` event and the PR stayed BEHIND and un-mergeable forever.

## Behavior

`PrFixer#handle_green` now distinguishes green-but-`BEHIND` PRs from clean ones:

- **green + `BEHIND` + auto-rebase enabled** (default): materialize the PR worktree, `GhOps.rebase_onto_base` (`git fetch origin <base>` then `git rebase origin/<base>`), then `force_push_with_lease`. The PR becomes `CLEAN`/mergeable. Emits `rebase`/`success`; returns `:rebased` (tallied as `fixed`).
- **rebase conflict**: `git rebase --abort` and leave it for a human — no force-push, no fix agent, no label. Emits `rebase`/`conflict`; returns `:rebase_conflict` (tallied as `needs_human`); re-evaluated cheaply next tick.
- **dry-run**: emits `rebase`/`dry_run`, touches no git.
- **green + not `BEHIND`**: unchanged `noop`/`already-green`.

Auto-rebase is gated on `babysitter.auto_rebase` — **default on**, with `nil` treated as true; only an explicit `babysitter.auto_rebase: false` disables it (mirrors the "do not silently flip legacy projects" convention). Force-push always uses `--force-with-lease`.

## Changes

- `GhOps.rebase_onto_base` + `RebaseResult` struct (`:success`/`:conflict`/`:failure`).
- `Events`: added action `rebase` and outcome `conflict` to the closed allowlists.
- `ProjectTick`: `:rebased` → `fixed`, `:rebase_conflict` → `needs_human`.
- `Config`: `babysitter.auto_rebase => true` default + boolean validation + template knob.
- Wiki: refreshed `modules/babysitter`, `commands/babysit`; added a `log.d` fragment.

## Validation

- Full `rake test`: 4975 runs, 0 failures, 0 errors (100% line-coverage gate satisfied).
- rubocop: 0 offenses on all changed `.rb` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)