### PR TITLE
Hive patrol: Leading value-form JSON options are misrouted

### DIFF
--- a/bin/hive-e2e
+++ b/bin/hive-e2e
@@ -250,36 +250,38 @@ def rewrite_help_flag!(argv)
   argv.replace(argv[0...cmd_idx] + [ "help", cmd ])
 end
 
-def normalize_leading_class_options!(argv)
-  return if argv.length < 2
-
-  leading_class_options = []
-  leading_class_options << argv.shift while argv.first == "--json" || argv.first == "--no-json"
-  return if leading_class_options.empty? || argv.empty?
-  return argv.unshift(*leading_class_options) unless %w[clean help list replay run version].include?(argv.first)
-
-  argv.insert(1, *leading_class_options)
-end
-
 # Mirror Thor's boolean grammar for --json so the envelope/prose decision
 # matches what the inner commands actually parse. Thor's truthy set for a
 # boolean option value is the exact-match list `true`, `TRUE`, `t`, `T` (NOT
 # case-insensitive — `True`/`tRuE` are not honored), so we accept bare `--json`
-# plus exactly those spellings. `--json=false`, `--json=0`, `--no-json`, and
+# plus exactly those spellings. Falsey spellings remain non-JSON, and
 # non-boolean spellings such as `--json=1` fall through to Thor's prose path.
 def json_requested?(argv)
-  argv.any? { |arg| arg == "--json" || arg.match?(/\A--json=(?:true|TRUE|t|T)\z/) }
+  argv.any? { |arg| truthy_json_option?(arg) }
+end
+
+def truthy_json_option?(arg)
+  arg == "--json" || (arg.is_a?(String) && arg.match?(/\A--json=(?:true|TRUE|t|T)\z/))
+end
+
+def falsey_json_option?(arg)
+  arg == "--no-json" || (arg.is_a?(String) && arg.match?(/\A--json=(?:false|FALSE|f|F)\z/))
 end
 
 def normalize_leading_global_options!(argv)
-  return unless argv.first == "--json"
+  return if argv.length < 2
+
+  leading_class_options = []
+  while truthy_json_option?(argv.first) || falsey_json_option?(argv.first)
+    option = argv.shift
+    leading_class_options << (truthy_json_option?(option) ? "--json" : option)
+  end
+  return if leading_class_options.empty? || argv.empty?
 
   commands = Hive::E2E::Binary.all_tasks.keys + [ "run" ]
-  cmd_idx = argv[1..]&.index { |arg| commands.include?(arg) }
-  return unless cmd_idx
+  return argv.unshift(*leading_class_options) unless commands.include?(argv.first)
 
-  argv.delete_at(0)
-  argv.insert(cmd_idx + 1, "--json")
+  argv.insert(1, *leading_class_options)
 end
 
 begin

--- a/test/e2e/lib/hive_e2e_binary_test.rb
+++ b/test/e2e/lib/hive_e2e_binary_test.rb
@@ -39,6 +39,24 @@ class E2EBinaryTest < Minitest::Test
     assert_equal "hive-e2e-scenarios", payload["schema"]
   end
 
+  def test_leading_truthy_json_value_list_dispatches_to_list
+    %w[--json=true --json=t].each do |flag|
+      out, err, status = Open3.capture3(hive_e2e, flag, "list")
+      assert status.success?, "bin/hive-e2e #{flag} list should exit 0, stderr was: #{err}"
+
+      payload = JSON.parse(out)
+      assert_equal "hive-e2e-scenarios", payload["schema"]
+    end
+  end
+
+  def test_leading_falsey_json_value_list_dispatches_to_human_list
+    out, err, status = Open3.capture3(hive_e2e, "--json=false", "list")
+    assert status.success?, "bin/hive-e2e --json=false list should exit 0, stderr was: #{err}"
+    assert_empty err
+    assert_match(/^full_pipeline_happy_path/, out)
+    refute_includes out, "\"schema\""
+  end
+
   def test_clean_json_emits_deleted_and_kept_counts
     # Redirect the runs dir to a temp location so the contract test cannot
     # delete real forensic artifacts under test/e2e/runs/. Without this the

--- a/wiki/e2e.md
+++ b/wiki/e2e.md
@@ -3,7 +3,7 @@ title: Agentic E2E Suite
 type: reference
 source: test/e2e/, bin/hive-e2e, Rakefile
 created: 2026-04-29
-updated: 2026-06-08
+updated: 2026-06-09
 tags: [test, e2e, tui, artifacts]
 ---
 
@@ -39,6 +39,10 @@ Successful `--json` commands emit exactly one top-level JSON document on stdout,
 dispatch and rewrites command-local `--help` / `-h` before scenario selection.
 That keeps help requests non-mutating and preflight-free even when command
 options precede the help flag, e.g. `bin/hive-e2e run --filter tui --help`.
+Leading `--json` class options are normalized before Thor dispatch, so
+`bin/hive-e2e --json=true list` / `--json=t list` route to `list --json`.
+Falsey leading forms such as `--json=false` and `--no-json` are also moved
+after the command but remain non-JSON.
 
 ## Layout
 

--- a/wiki/log.d/20260609-100758-e2e-leading-json-values.md
+++ b/wiki/log.d/20260609-100758-e2e-leading-json-values.md
@@ -1,0 +1,11 @@
+## [2026-06-09T10:07:58Z] e2e binary leading JSON values
+
+**Action:** Fixed `bin/hive-e2e` leading class-option normalization so
+`--json=true` and `--json=t` before `list` are relocated after the command and
+emit the `hive-e2e-scenarios` JSON envelope instead of falling into the default
+`run` pattern path. Falsey leading JSON forms such as `--json=false` and
+`--no-json` are relocated too, but stay non-JSON. Removed the duplicate Thor
+dispatch call so successful JSON commands emit a single parseable document.
+
+**Validation:** `bundle exec ruby -Itest -Itest/e2e/lib test/e2e/lib/hive_e2e_binary_test.rb`
+and `bundle exec rake e2e:lib_test`.


### PR DESCRIPTION
## Hive Patrol Finding

Slice: `command-bin-hive-e2e`
Category: `bug`
Severity: `medium`
Confidence: `high`
Fingerprint: `c86c54f722d67ef379618e5a5a685f365aad6e7a9096326988e067eadc7efdfc`

json_requested? treats --json=true, --json=TRUE, --json=t, and --json=T as truthy, but normalize_leading_global_options! only moves a bare leading --json after the command. Invocations such as bin/hive-e2e --json=true list are therefore dispatched as the default run command with pattern list, returning no_scenarios instead of listing scenarios as JSON.

## Evidence

- bin/hive-e2e:270 def json_requested?(argv)
- bin/hive-e2e:274 def normalize_leading_global_options!(argv)
- bin/hive-e2e:275 return unless argv.first == "--json"

## Applied Fix

Normalize the same boolean spellings accepted by json_requested?, including negative forms that should remain non-JSON, before Thor dispatch; add focused tests for leading --json=true and --json=t before list.

## Validation

- lint: passed (`bundle exec rubocop`)
- test: passed (`bundle exec rake test`)

## Diffstat

```text
 bin/hive-e2e                                       | 46 +++++-------
 lib/hive/tui/state_source.rb                       |  7 +-
 test/e2e/lib/hive_e2e_binary_test.rb               | 18 +++++
 test/unit/tui/state_source_test.rb                 | 86 ++++++++++++++++++++++
 wiki/commands/tui.md                               |  9 ++-
 wiki/e2e.md                                        |  6 +-
 wiki/log.d/20260608-113952-tui-lock-fingerprint.md |  6 ++
 .../20260609-100758-e2e-leading-json-values.md     | 11 +++
 8 files changed, 157 insertions(+), 32 deletions(-)

```
