### PR TITLE
Hive patrol: leading truthy JSON flags misdispatch

### DIFF
--- a/bin/hive
+++ b/bin/hive
@@ -16,7 +16,7 @@ end
 def normalize_leading_json_options!(argv)
   json_options = %w[--json --no-json --skip-json]
   leading = []
-  leading << argv.shift while json_options.include?(argv.first)
+  leading << argv.shift while json_options.include?(argv.first) || argv.first&.match?(/\A--json=(?:true|TRUE|t|T)\z/)
   return if leading.empty?
 
   cmd_idx = argv.index { |a| !a.start_with?("-") }
@@ -45,7 +45,7 @@ normalize_leading_json_options!(ARGV)
 rewrite_help_flag!(ARGV)
 
 def json_requested?(argv)
-  argv.any? { |arg| arg == "--json" || arg.match?(/\A--json=(true|1|yes)\z/i) }
+  argv.any? { |arg| arg == "--json" || arg.match?(/\A--json=(?:true|TRUE|t|T)\z/) }
 end
 
 def json_usage_error_contract(argv)

--- a/bin/hive-e2e
+++ b/bin/hive-e2e
@@ -272,14 +272,15 @@ def json_requested?(argv)
 end
 
 def normalize_leading_global_options!(argv)
-  return unless argv.first == "--json"
+  leading_json = argv.first
+  return unless leading_json && json_requested?([ leading_json ])
 
   commands = Hive::E2E::Binary.all_tasks.keys + [ "run" ]
   cmd_idx = argv[1..]&.index { |arg| commands.include?(arg) }
   return unless cmd_idx
 
   argv.delete_at(0)
-  argv.insert(cmd_idx + 1, "--json")
+  argv.insert(cmd_idx + 1, leading_json)
 end
 
 begin

--- a/test/e2e/lib/hive_e2e_binary_test.rb
+++ b/test/e2e/lib/hive_e2e_binary_test.rb
@@ -39,6 +39,15 @@ class E2EBinaryTest < Minitest::Test
     assert_equal "hive-e2e-scenarios", payload["schema"]
   end
 
+  def test_leading_truthy_json_list_dispatches_to_list
+    %w[--json=true --json=t].each do |flag|
+      out, err, status = Open3.capture3(hive_e2e, flag, "list")
+      assert status.success?, "bin/hive-e2e #{flag} list should exit 0, stderr was: #{err}"
+      assert_includes out, '"schema": "hive-e2e-scenarios"', flag
+      refute_includes out, "no scenarios match list", flag
+    end
+  end
+
   def test_clean_json_emits_deleted_and_kept_counts
     # Redirect the runs dir to a temp location so the contract test cannot
     # delete real forensic artifacts under test/e2e/runs/. Without this the

--- a/test/integration/cli_version_test.rb
+++ b/test/integration/cli_version_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "json"
 require "open3"
 require "rbconfig"
 
@@ -22,12 +23,14 @@ class CliVersionTest < Minitest::Test
     refute_includes err, "No value provided for required arguments"
   end
 
-  def test_bin_hive_accepts_json_before_status_command
+  def test_bin_hive_accepts_leading_truthy_json_before_status_command
     with_tmp_global_config do
-      leading = JSON.parse(run!(RbConfig.ruby, "-Ilib", "bin/hive", "--json", "status"))
-      trailing = JSON.parse(run!(RbConfig.ruby, "-Ilib", "bin/hive", "status", "--json"))
+      %w[--json --json=true --json=t].each do |flag|
+        leading = JSON.parse(run!(RbConfig.ruby, "-Ilib", "bin/hive", flag, "status"))
+        trailing = JSON.parse(run!(RbConfig.ruby, "-Ilib", "bin/hive", "status", flag))
 
-      assert_equal without_generated_at(trailing), without_generated_at(leading)
+        assert_equal without_generated_at(trailing), without_generated_at(leading), flag
+      end
     end
   end
 


### PR DESCRIPTION
## Hive Patrol Finding

Slice: `command-bin-hive-eval`
Category: `bug`
Severity: `medium`
Confidence: `high`
Fingerprint: `48807805f725ea7a09e1a48d0ced0b50d1223105eeb1ea6938ae41cc87536421`

The wrappers recognize explicit truthy JSON flags such as --json=true when deciding whether JSON was requested, but their leading-option normalization only moves bare --json. As a result, leading --json=true changes dispatch: bin/hive-e2e --json=true list is treated as a scenario pattern, and bin/hive --json=true status prints command help instead of the status JSON envelope.

## Evidence

- bin/hive-e2e:271 argv.any? { |arg| arg == "--json" || arg.match?(/\A--json=(?:true|TRUE|t|T)\z/) }
- bin/hive-e2e:275 return unless argv.first == "--json"
- bin/hive:17 json_options = %w[--json --no-json --skip-json]
- bin/hive:48 argv.any? { |arg| arg == "--json" || arg.match?(/\A--json=(true|1|yes)\z/i) }

## Applied Fix

Normalize the same truthy forms that json_requested? accepts, or narrow json_requested? to the normalized grammar. Add tests for leading --json=true and --json=t on both bin/hive and bin/hive-e2e.

## Validation

- lint: passed (`bundle exec rubocop`)
- test: passed (`bundle exec rake test`)

## Diffstat

```text
 bin/hive                             |  4 ++--
 bin/hive-e2e                         |  5 +++--
 test/e2e/lib/hive_e2e_binary_test.rb |  9 +++++++++
 test/integration/cli_version_test.rb | 11 +++++++----
 4 files changed, 21 insertions(+), 8 deletions(-)

```
