### PR TITLE
Hive patrol: Short web flags bypass gh dry-run guard

### DIFF
--- a/bin/hive-babysitter-stub-gh
+++ b/bin/hive-babysitter-stub-gh
@@ -112,7 +112,15 @@ end
 
 def external_launcher_option?(rest)
   return true if rest.any? { |arg| arg == "--web" || arg.start_with?("--web=") }
-  return false unless [%w[pr view], %w[repo view], %w[run view], %w[workflow view]].include?(rest[0, 2])
+  return false unless [
+    %w[pr checks],
+    %w[pr diff],
+    %w[pr list],
+    %w[pr view],
+    %w[repo view],
+    %w[run view],
+    %w[workflow view]
+  ].include?(rest[0, 2])
 
   rest.drop(2).any? { |arg| arg == "-w" || arg.start_with?("-w") }
 end

--- a/test/unit/babysitter/dry_run_env_test.rb
+++ b/test/unit/babysitter/dry_run_env_test.rb
@@ -60,6 +60,7 @@ class BabysitterDryRunEnvTest < Minitest::Test
       assert_passes env, "gh", "api", "repos/owner/repo"
       assert_passes env, "gh", "api", "--method", "GET", "repos/owner/repo/issues", "-f", "state=open"
       assert_passes env, "gh", "api", "--method", "GET", "repos/owner/repo/issues", "-F", "state=open"
+      assert_passes env, "gh", "run", "list", "-w", "ci.yml"
 
       # Glued/inline @file payload forms must be caught on explicit GET too,
       # not just the space-separated `-F q=@secret` form: each branch
@@ -316,6 +317,12 @@ class BabysitterDryRunEnvTest < Minitest::Test
       assert_stubbed env, "gh", "repo", "view", "owner/repo", "--web=true"
       assert_stubbed env, "gh", "pr", "view", "42", "--web"
       assert_stubbed env, "gh", "repo", "view", "owner/repo", "-w"
+      assert_stubbed env, "gh", "pr", "checks", "42", "-w"
+      assert_stubbed env, "gh", "pr", "checks", "42", "-wdetails"
+      assert_stubbed env, "gh", "pr", "diff", "42", "-w"
+      assert_stubbed env, "gh", "pr", "diff", "42", "-wdiff"
+      assert_stubbed env, "gh", "pr", "list", "-w"
+      assert_stubbed env, "gh", "pr", "list", "-wopen"
 
       refute File.exist?(File.join(dir, "real.log"))
     end


### PR DESCRIPTION
## Hive Patrol Finding

Slice: `command-bin-hive-babysitter-stub-gh`
Category: `security`
Severity: `medium`
Confidence: `high`
Fingerprint: `71aca32aec3d9104b3fe04ba59dd95f646723a3b78f99d317b5f1f8bb46d901c`

The stub blocks `--web` everywhere and short `-w` only for selected `view` commands, but current gh also exposes `-w, --web` on allowed read-only commands such as `gh pr checks`, `gh pr diff`, and `gh pr list`. Those short forms pass through to the real gh binary during dry-run and can launch a browser or other local opener despite the dry-run boundary.

## Evidence

- bin/hive-babysitter-stub-gh:101 %w[checks diff list status view].include?(rest[1])
- bin/hive-babysitter-stub-gh:114 return true if rest.any? { |arg| arg == "--web" || arg.start_with?("--web=") }
- bin/hive-babysitter-stub-gh:117 rest.drop(2).any? { |arg| arg == "-w" || arg.start_with?("-w") }

## Applied Fix

Extend `external_launcher_option?` to reject `-w`/attached `-w...` for every allowed gh command where `-w` means web launch, including `pr checks`, `pr diff`, and `pr list`, while preserving read-only meanings such as `gh run list -w <workflow>`. Add focused stub tests for the missed short forms.

## Validation

- lint: passed (`bundle exec rubocop`)
- test: passed (`bundle exec rake test`)

## Diffstat

```text
 bin/hive-babysitter-stub-gh              | 10 +++++++++-
 test/unit/babysitter/dry_run_env_test.rb |  7 +++++++
 2 files changed, 16 insertions(+), 1 deletion(-)

```
