### PR TITLE
feat(patrol): native codex-review reviewer as the patrol PR reviewer

### DIFF
--- a/lib/hive/cli.rb
+++ b/lib/hive/cli.rb
@@ -62,7 +62,7 @@ module Hive
 
         hive: using defaults — planning=claude, claude_mode=tmux,
         claude_permission_mode=bypassPermissions, dev=codex, reviewers=all3,
-        patrol_reviewers=codex, triage=courageous, limits=defaults,
+        patrol_reviewers=codex-native-review, triage=courageous, limits=defaults,
         daemon=enabled, babysitter=enabled, daemon_autostart=disabled
 
       With --json, init suppresses that prose and emits a single

--- a/lib/hive/commands/init/prompts.rb
+++ b/lib/hive/commands/init/prompts.rb
@@ -53,11 +53,12 @@ module Hive
           pr-review-toolkit
         ].freeze
         PATROL_REVIEWER_NAMES = %w[
+          codex-native-review
           codex-ce-code-review
           claude-ce-code-review
         ].freeze
         DEFAULT_PATROL_REVIEWER_NAMES = %w[
-          codex-ce-code-review
+          codex-native-review
         ].freeze
 
         # The effective budget/timeout keys after dropping the deprecated
@@ -198,7 +199,7 @@ module Hive
             "claude_permission_mode=#{DEFAULT_CLAUDE_PERMISSION_MODE}, " \
             "dev=#{DEFAULT_DEVELOPMENT_AGENT}, " \
             "reviewers=all#{DEFAULT_REVIEWER_NAMES.size}, " \
-            "patrol_reviewers=codex, " \
+            "patrol_reviewers=codex-native-review, " \
             "patrol_mode=#{DEFAULT_PATROL_MODE}, " \
             "triage=#{DEFAULT_TRIAGE_BIAS}, limits=defaults, daemon=enabled, " \
             "babysitter=enabled, daemon_autostart=disabled"
@@ -344,7 +345,8 @@ module Hive
 
         def prompt_patrol_reviewers
           @output.puts ""
-          @output.puts "Patrol PR review agents — blank = codex only; add Claude for broader patrol PR review:"
+          @output.puts "Patrol PR review agents — blank = codex native review (single cheap pass); " \
+                       "add ce-code-review / Claude for broader patrol PR review:"
           PATROL_REVIEWER_NAMES.each_with_index { |name, i| @output.puts "  #{i + 1}) #{name}" }
           loop do
             @output.print "  > "
@@ -363,7 +365,7 @@ module Hive
           resolve_reviewer_tokens_from(
             answer,
             choices: PATROL_REVIEWER_NAMES,
-            empty_message: "input had no patrol reviewer tokens; type a name/index list, or blank for codex only"
+            empty_message: "input had no patrol reviewer tokens; type a name/index list, or blank for codex native review"
           )
         end
 

--- a/lib/hive/config.rb
+++ b/lib/hive/config.rb
@@ -345,15 +345,22 @@ module Hive
         "review" => {
           "max_context_files" => 24,
           "max_owned_files" => 12,
+          # Patrol PRs flow into 6-review the same as human PRs, but patrol
+          # opens many PRs per cycle — running the multi-persona
+          # ce-code-review fan-out (6–18 subagents) on each is expensive.
+          # The patrol default is therefore the single-pass native
+          # `codex review` adapter (kind: codex_review): one tuned,
+          # read-only review whose stdout is captured into the GFM-checkbox
+          # findings file, leaving the triage/fix loop unchanged. Human PRs
+          # keep the richer review.reviewers set. Override per project via
+          # patrol.review.reviewers in <hive-state>/config.yml.
           "reviewers" => [
             {
-              "name" => "codex-ce-code-review",
-              "kind" => "agent",
+              "name" => "codex-native-review",
+              "kind" => "codex_review",
               "agent" => "codex",
-              "skill" => "ce-code-review",
-              "output_basename" => "codex-ce-code-review",
-              "prompt_template" => "reviewer_codex_ce_code_review.md.erb",
-              "budget_usd" => 50,
+              "output_basename" => "codex-native-review",
+              "prompt_template" => "reviewer_codex_native_review.md.erb",
               "timeout_sec" => 5400
             }
           ]
@@ -452,6 +459,11 @@ module Hive
     CLAUDE_MODES = %w[headless tmux].freeze
     CLAUDE_PERMISSION_MODES = %w[acceptEdits auto bypassPermissions default dontAsk plan].freeze
     AUTO_COMMIT_SIGN_POLICIES = %w[inherit bypass fail].freeze
+    # Accepted reviewer `kind` values in config. "agent" (default) and
+    # "codex_review" are dispatchable adapters; "linter" is accepted at
+    # config-load time but rejected at dispatch with a pointer to
+    # review.ci.command (Hive::Reviewers.dispatch).
+    REVIEWER_KINDS = %w[agent codex_review linter].freeze
     EXPLICIT_CLAUDE_MODE_KEY = :__hive_explicit_claude_mode
     EXPLICIT_BRAINSTORM_RUNTIME_KEY = :__hive_explicit_brainstorm_runtime
 
@@ -1284,11 +1296,28 @@ module Hive
                 "#{label}[#{idx}] in #{describe_source(source_path)} must be a Hash; got #{entry.class}"
         end
 
+        # Reviewer kind discriminator. Optional; defaults to "agent".
+        # "codex_review" selects the native-`codex review` adapter, which
+        # captures `codex review` stdout instead of spawning a CE skill —
+        # so it needs no `skill` field. "linter" is rejected at dispatch
+        # time (Hive::Reviewers.dispatch) with a pointer to review.ci.command;
+        # we accept it here so that the more actionable dispatch-time error
+        # is the one the user sees.
+        kind = entry["kind"]
+        unless kind.nil? || REVIEWER_KINDS.include?(kind)
+          raise ConfigError,
+                "#{label}[#{idx}].kind in #{describe_source(source_path)} must be one of " \
+                "#{REVIEWER_KINDS.inspect}; got #{kind.inspect}"
+        end
+
         # Required fields: presence + non-empty. Missing or blank values
         # would otherwise NoMethodError or yield broken filenames mid-spawn
         # (closes ce-code-review AC-6). Mirrors the framing used by the
-        # output_basename / agent checks below.
-        %w[name skill prompt_template].each do |field|
+        # output_basename / agent checks below. `skill` is required only
+        # for skill-driven adapters; the codex_review adapter runs codex's
+        # built-in review and takes no CE skill, so it is exempt.
+        required = kind == "codex_review" ? %w[name prompt_template] : %w[name skill prompt_template]
+        required.each do |field|
           value = entry[field]
           missing = value.nil? || (value.is_a?(String) && value.strip.empty?)
           next unless missing

--- a/lib/hive/config.rb
+++ b/lib/hive/config.rb
@@ -1315,8 +1315,14 @@ module Hive
         # (closes ce-code-review AC-6). Mirrors the framing used by the
         # output_basename / agent checks below. `skill` is required only
         # for skill-driven adapters; the codex_review adapter runs codex's
-        # built-in review and takes no CE skill, so it is exempt.
-        required = kind == "codex_review" ? %w[name prompt_template] : %w[name skill prompt_template]
+        # built-in review and takes no CE skill, so it is exempt. The
+        # codex_review adapter DOES require `agent` (it resolves the codex
+        # binary via Hive::AgentProfiles.lookup(spec.fetch("agent")) — see
+        # lib/hive/reviewers/codex_review.rb), so require it here to fail at
+        # load instead of crashing mid-dispatch with a KeyError. (The generic
+        # validate_agent_name! below returns early on nil, so without this
+        # entry a codex_review spec missing `agent` would pass load.)
+        required = kind == "codex_review" ? %w[name agent prompt_template] : %w[name skill prompt_template]
         required.each do |field|
           value = entry[field]
           missing = value.nil? || (value.is_a?(String) && value.strip.empty?)

--- a/lib/hive/reviewers.rb
+++ b/lib/hive/reviewers.rb
@@ -1,18 +1,28 @@
 require "hive/reviewers/base"
 require "hive/reviewers/synthetic_task"
 require "hive/reviewers/agent"
+require "hive/reviewers/codex_review"
 
 module Hive
   # Reviewer adapters for the 6-review stage.
   #
-  # v1 supports a single reviewer kind: agent-based reviewers that spawn
-  # an LLM CLI (claude / codex / pi) with a rendered prompt invoking a
-  # CE skill on the worktree's diff. Tool-specific linters (rubocop,
-  # brakeman, etc.) are NOT a hive concept — they belong in the
-  # project's CI command, which the 6-review runner invokes via U7's
-  # CI-fix loop (`review.ci.command`). Hardcoding linter knowledge in
-  # hive would couple the orchestrator to one ecosystem (Ruby/Rails);
-  # the per-project `bin/ci` pattern keeps hive ecosystem-agnostic.
+  # Two reviewer kinds ship today:
+  #
+  # - "agent" (default): spawns an LLM CLI (claude / codex / pi) with a
+  #   rendered prompt invoking a CE skill on the worktree's diff; the
+  #   agent writes the findings file itself (Hive::Reviewers::Agent).
+  # - "codex_review": runs codex's native, single-pass `codex review`
+  #   subcommand and captures its stdout into the findings file
+  #   (Hive::Reviewers::CodexReview). This is the patrol-default reviewer —
+  #   one cheap tuned pass instead of the multi-persona ce-code-review
+  #   fan-out — and needs no CE `skill`.
+  #
+  # Tool-specific linters (rubocop, brakeman, etc.) are NOT a hive
+  # concept — they belong in the project's CI command, which the 6-review
+  # runner invokes via U7's CI-fix loop (`review.ci.command`). Hardcoding
+  # linter knowledge in hive would couple the orchestrator to one
+  # ecosystem (Ruby/Rails); the per-project `bin/ci` pattern keeps hive
+  # ecosystem-agnostic.
   module Reviewers
     # Default attempt budget for a reviewer adapter (Hive::Reviewers::Agent).
     # A reviewer spec can override via the optional `max_attempts` field;
@@ -29,10 +39,11 @@ module Hive
     end
 
     # Build a reviewer adapter from a config spec + per-spawn context.
-    # The `kind` field is optional and defaults to "agent" (the only
-    # supported kind in v1). If a config explicitly sets `kind: linter`,
-    # raise a helpful error pointing the user at `review.ci.command`
-    # rather than silently ignoring the request.
+    # The `kind` field is optional and defaults to "agent". A
+    # `kind: codex_review` spec selects the native-`codex review` adapter.
+    # If a config explicitly sets `kind: linter`, raise a helpful error
+    # pointing the user at `review.ci.command` rather than silently
+    # ignoring the request.
     #
     # `cfg:` (optional, default nil) flows the merged project config to
     # the adapter so `agents.<name>.<key>` overrides reach the
@@ -43,6 +54,8 @@ module Hive
       case kind
       when "agent"
         Agent.new(spec, ctx, cfg: cfg)
+      when "codex_review"
+        CodexReview.new(spec, ctx, cfg: cfg)
       when "linter"
         raise UnknownKindError, <<~MSG.strip
           reviewer kind "linter" is not supported in v1.
@@ -55,7 +68,7 @@ module Hive
         MSG
       else
         raise UnknownKindError,
-              "unknown reviewer kind: #{kind.inspect} (expected 'agent')"
+              "unknown reviewer kind: #{kind.inspect} (expected 'agent' or 'codex_review')"
       end
     end
   end

--- a/lib/hive/reviewers/codex_review.rb
+++ b/lib/hive/reviewers/codex_review.rb
@@ -1,0 +1,291 @@
+require "open3"
+require "shellwords"
+require "hive/reviewers/base"
+require "hive/reviewers/plan_context"
+require "hive/agent_profiles"
+require "hive/stages/base"
+
+module Hive
+  module Reviewers
+    # Native-`codex review` reviewer.
+    #
+    # Unlike Hive::Reviewers::Agent (which spawns `codex exec /ce-code-review`
+    # and lets the agent WRITE the findings file itself), this adapter runs
+    # codex's built-in `codex review` subcommand — a single tuned, read-only
+    # code-review pass — and CAPTURES its stdout, then writes that stdout to
+    # `reviews/<output_basename>-<pass>.md`. It is the patrol-default reviewer:
+    # one cheap pass instead of the multi-persona ce-code-review fan-out.
+    #
+    # Why a custom PROMPT instead of `--base`:
+    #   `codex review --base <BRANCH>` works, but the codex CLI's argument
+    #   parser makes `--base` MUTUALLY EXCLUSIVE with a custom `[PROMPT]`
+    #   ("the argument '--base <BRANCH>' cannot be used with '[PROMPT]'").
+    #   The native `--base` review emits codex's own free-form summary, NOT
+    #   Hive's GFM-checkbox findings format, so it can't feed the triage/fix
+    #   loop unchanged. We therefore use the custom-PROMPT mode and have the
+    #   prompt itself (a) scope the review to `git diff <base>...HEAD` and
+    #   (b) coerce the High/Medium/Nit checkbox output. argv is
+    #   `[codex, "review", "--title", <title>, <prompt>]`.
+    #
+    # Token usage: `codex review` emits a human-readable transcript on stdout
+    # with no machine-parseable per-token usage event (that only exists for
+    # `codex exec --json`). We therefore intentionally do NOT record usage —
+    # fabricating zeros would pollute UsageDb. If a future codex release adds
+    # a usage line to `codex review`, wire it through Base.record_usage here.
+    class CodexReview < Base
+      # Reuse Agent's per-reviewer wall-clock default (2h) so a config that
+      # omits timeout_sec behaves identically across reviewer kinds.
+      DEFAULT_TIMEOUT_SEC = 7200
+
+      # Cap captured stdout so a runaway review can't OOM the host. A real
+      # review is a few KB; 4 MiB is generous headroom.
+      MAX_OUTPUT_BYTES = 4 * 1024 * 1024
+
+      # Findings file is valid only if it contains at least one severity
+      # header. Anything else (banner-only output, an interrupted run, a
+      # usage-limit error) is treated as a reviewer failure.
+      SEVERITY_HEADER = /^##\s+(High|Medium|Nit)\b/i.freeze
+
+      def initialize(spec, ctx, cfg: nil)
+        super(spec, ctx)
+        @cfg = cfg
+      end
+
+      def run!(deadline: nil)
+        ensure_reviews_dir!
+
+        profile = Hive::AgentProfiles.lookup(spec.fetch("agent"), cfg: @cfg)
+        begin
+          profile.check_version!
+        rescue Hive::AgentError => e
+          return error_result("preflight failed: #{e.message}")
+        end
+
+        prompt = render_prompt
+        configured_timeout = spec["timeout_sec"] || DEFAULT_TIMEOUT_SEC
+        max_attempts = max_attempts_from_spec
+
+        attempts = 0
+        run = nil
+        loop do
+          attempts += 1
+          # Clear any partial file from a prior crashed attempt so a stale
+          # file can't satisfy this attempt's format check.
+          delete_output!
+
+          spawn_timeout = effective_timeout(configured_timeout, deadline)
+          if spawn_timeout && spawn_timeout <= 0
+            return error_result("deadline reached before attempt #{attempts}", attempts, max_attempts)
+          end
+
+          run = run_codex_review(profile.bin, prompt, spawn_timeout || configured_timeout)
+          break if run.success? && valid_findings?(run.stdout)
+          break if attempts >= max_attempts
+
+          sleep_seconds = backoff_seconds_for(attempts)
+          if deadline
+            remaining = deadline_remaining(deadline)
+            break if remaining <= 0
+
+            sleep_seconds = [ sleep_seconds, remaining ].min
+          end
+          backoff(sleep_seconds)
+        end
+
+        finalize(run, attempts, max_attempts)
+      end
+
+      private
+
+      # Captured-process result. exit_code is nil on launch failure / timeout.
+      Run = Struct.new(:stdout, :exit_code, :error) do
+        def success?
+          error.nil? && exit_code&.zero? || false
+        end
+      end
+
+      def finalize(run, attempts, max_attempts)
+        if run && run.success? && valid_findings?(run.stdout)
+          File.write(output_path, normalize_output(run.stdout))
+          return Result.new(name: name, output_path: output_path, status: :ok, error_message: nil)
+        end
+
+        # Failure: leave no malformed findings file behind — triage would
+        # otherwise treat it as real reviewer output.
+        delete_output!
+        error_result(failure_message(run), attempts, max_attempts)
+      end
+
+      def failure_message(run)
+        return "codex review produced no output" if run.nil?
+        return run.error if run.error
+        unless run.exit_code&.zero?
+          return "codex review exited with status=#{run.exit_code.inspect}"
+        end
+
+        "codex review output missing High/Medium/Nit findings headers"
+      end
+
+      def error_result(base_msg, attempts = nil, max_attempts = nil)
+        msg =
+          if attempts && max_attempts && max_attempts > 1
+            "#{base_msg} after #{attempts} attempt(s)"
+          else
+            base_msg
+          end
+        Result.new(name: name, output_path: output_path, status: :error, error_message: msg)
+      end
+
+      def valid_findings?(stdout)
+        stdout.to_s.match?(SEVERITY_HEADER)
+      end
+
+      # Trim leading codex banner noise so the published findings file starts
+      # at the first severity header. Everything from the first `## High|
+      # Medium|Nit` onward is the model's structured output.
+      def normalize_output(stdout)
+        text = stdout.to_s
+        idx = text =~ SEVERITY_HEADER
+        body = idx ? text[idx..] : text
+        body = body.rstrip
+        body.empty? ? body : "#{body}\n"
+      end
+
+      # Run `codex review --title <title> <prompt>` in the worktree, capturing
+      # combined stdout+stderr with a wall-clock timeout. On timeout the
+      # process group is signalled so a hung review can't outlive the budget.
+      #
+      # The codex binary's existence is already proven by `check_version!`
+      # (the caller's preflight), so a spawn-time ENOENT is unreachable here
+      # — we deliberately do not re-rescue it.
+      def run_codex_review(bin, prompt, timeout_sec)
+        argv = [ bin, "review", "--title", review_title, prompt ]
+
+        pipe_r, pipe_w = IO.pipe
+        pid = Process.spawn(*argv, chdir: ctx.worktree_path, pgroup: true, out: pipe_w, err: pipe_w)
+        pipe_w.close
+
+        capture_run(pipe_r, pid, timeout_sec)
+      end
+
+      def capture_run(pipe_r, pid, timeout_sec)
+        reader = Thread.new { pipe_r.read(MAX_OUTPUT_BYTES) }
+
+        status = wait_with_timeout(pid, timeout_sec)
+        if status.nil?
+          terminate(pid)
+          reader.join(2)
+          reader.kill if reader.alive?
+          pipe_r.close unless pipe_r.closed?
+          return Run.new(nil, nil, "codex review timed out after #{timeout_sec}s")
+        end
+
+        combined = reader.value.to_s
+        pipe_r.close unless pipe_r.closed?
+        combined = combined.dup.force_encoding(Encoding::UTF_8)
+        combined.scrub!("?")
+        Run.new(combined, status.exitstatus, nil)
+      end
+
+      # Poll for the child to exit, returning its Process::Status, or nil if
+      # `timeout_sec` elapses first.
+      def wait_with_timeout(pid, timeout_sec)
+        deadline = Time.now + timeout_sec
+        loop do
+          _, status = Process.wait2(pid, Process::WNOHANG)
+          return status if status
+          return nil if Time.now > deadline
+
+          sleep 0.05
+        end
+      end
+
+      # TERM the child's process group (best-effort), then reap it. The
+      # short KILL escalation is intentionally omitted — codex review is
+      # read-only and TERM-clean; the reader-thread join + pipe close bound
+      # the wait regardless.
+      def terminate(pid)
+        Process.kill("TERM", -Process.getpgid(pid))
+      rescue Errno::ESRCH, Errno::EPERM, Errno::ECHILD
+        nil
+      ensure
+        reap(pid)
+      end
+
+      def reap(pid)
+        Process.wait(pid)
+      rescue Errno::ECHILD
+        nil
+      end
+
+      # Short, deterministic title for the review summary. codex truncates
+      # long titles; keep it to the project + pass.
+      def review_title
+        "hive patrol review: #{File.basename(ctx.worktree_path)} pass #{ctx.pass}"
+      end
+
+      def render_prompt
+        template_path = Hive::Stages::Base.resolve_template_path(
+          spec.fetch("prompt_template"),
+          hive_state_dir: Hive::Stages::Base.hive_state_dir_for_task_folder(ctx.task_folder)
+        )
+        tag = Hive::Stages::Base.user_supplied_tag
+        Hive::Stages::Base.render_resolved_path(
+          template_path,
+          Hive::Stages::Base::TemplateBindings.new(
+            project_name: File.basename(ctx.worktree_path),
+            worktree_path: ctx.worktree_path,
+            task_folder: ctx.task_folder,
+            default_branch: ctx.default_branch,
+            pass: ctx.pass,
+            output_path: output_path,
+            user_supplied_tag: tag,
+            plan_context_section: Hive::Reviewers::PlanContext.render(ctx.task_folder, tag)
+          )
+        )
+      end
+
+      def max_attempts_from_spec
+        value = spec["max_attempts"]
+        return Hive::Reviewers::DEFAULT_REVIEWER_MAX_ATTEMPTS if value.nil?
+
+        Integer(value)
+      rescue ArgumentError
+        warn "[hive.reviewers] reviewer #{spec['name'].inspect}: invalid max_attempts " \
+             "#{value.inspect}; using default #{Hive::Reviewers::DEFAULT_REVIEWER_MAX_ATTEMPTS}"
+        Hive::Reviewers::DEFAULT_REVIEWER_MAX_ATTEMPTS
+      end
+
+      def backoff_seconds_for(failed_attempt)
+        [ 2**(failed_attempt - 1), Hive::Reviewers::REVIEWER_BACKOFF_CAP_SEC ].min
+      end
+
+      def backoff(seconds)
+        sleep(seconds)
+      end
+
+      def deadline_remaining(deadline)
+        deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      end
+
+      def effective_timeout(configured_timeout, deadline)
+        return configured_timeout unless deadline
+
+        remaining = deadline_remaining(deadline)
+        return remaining.floor if remaining <= 0
+
+        [ configured_timeout, remaining.floor ].min
+      end
+
+      def delete_output!
+        File.delete(output_path)
+      rescue Errno::ENOENT
+        nil
+      rescue SystemCallError => e
+        raise Hive::Error,
+              "reviewer #{name.inspect}: failed to clear partial output_path #{output_path}: " \
+              "#{e.class}: #{e.message}"
+      end
+    end
+  end
+end

--- a/lib/hive/reviewers/codex_review.rb
+++ b/lib/hive/reviewers/codex_review.rb
@@ -1,5 +1,3 @@
-require "open3"
-require "shellwords"
 require "hive/reviewers/base"
 require "hive/reviewers/plan_context"
 require "hive/agent_profiles"
@@ -37,8 +35,11 @@ module Hive
       # omits timeout_sec behaves identically across reviewer kinds.
       DEFAULT_TIMEOUT_SEC = 7200
 
-      # Cap captured stdout so a runaway review can't OOM the host. A real
-      # review is a few KB; 4 MiB is generous headroom.
+      # Cap the bytes RETAINED from a runaway review so it can't OOM the
+      # host. This is NOT a hard abort: the reader keeps draining the pipe
+      # past the cap (discarding the overflow) so the child always reaches
+      # EOF promptly and never blocks forever on a full pipe. A real review
+      # is a few KB; 4 MiB is generous headroom.
       MAX_OUTPUT_BYTES = 4 * 1024 * 1024
 
       # Findings file is valid only if it contains at least one severity
@@ -169,7 +170,19 @@ module Hive
       end
 
       def capture_run(pipe_r, pid, timeout_sec)
-        reader = Thread.new { pipe_r.read(MAX_OUTPUT_BYTES) }
+        # Drain the pipe FULLY in chunks but RETAIN at most MAX_OUTPUT_BYTES.
+        # Reading exactly MAX_OUTPUT_BYTES and stopping would leave the pipe
+        # full once a review emits more than the cap, blocking the child on
+        # write() forever — the run would then only end at the wall-clock
+        # timeout. Keep reading past the cap (discarding overflow) so EOF is
+        # always reached and the child can exit promptly.
+        reader = Thread.new do
+          buf = +"".b
+          while (chunk = pipe_r.read(65_536))
+            buf << chunk if buf.bytesize < MAX_OUTPUT_BYTES
+          end
+          buf.byteslice(0, MAX_OUTPUT_BYTES)
+        end
 
         status = wait_with_timeout(pid, timeout_sec)
         if status.nil?
@@ -200,16 +213,35 @@ module Hive
         end
       end
 
-      # TERM the child's process group (best-effort), then reap it. The
-      # short KILL escalation is intentionally omitted — codex review is
-      # read-only and TERM-clean; the reader-thread join + pipe close bound
-      # the wait regardless.
+      # TERM the child's process group (best-effort), give it a short grace,
+      # then KILL the group if anything in it is still alive before reaping.
+      # codex review is normally TERM-clean, but a wedged child (e.g. stuck
+      # in uninterruptible IO or ignoring TERM) would otherwise keep the pipe
+      # write-end open and stall the reader join; the KILL escalation
+      # guarantees the group is torn down.
       def terminate(pid)
-        Process.kill("TERM", -Process.getpgid(pid))
+        pgid = Process.getpgid(pid)
+        Process.kill("TERM", -pgid)
+        sleep 1
+        Process.kill("KILL", -pgid) if process_group_alive?(pgid)
       rescue Errno::ESRCH, Errno::EPERM, Errno::ECHILD
         nil
       ensure
         reap(pid)
+      end
+
+      # Best-effort liveness probe for a process group. `Process.kill(0, ...)`
+      # signals nothing but raises ESRCH when no process in the group exists,
+      # so a clean return means the group still has at least one member.
+      def process_group_alive?(pgid)
+        Process.kill(0, -pgid)
+        true
+      rescue Errno::ESRCH, Errno::ECHILD
+        false
+      rescue Errno::EPERM
+        # The group exists but we lack permission to signal it — treat as
+        # alive so the KILL attempt still fires (and is itself guarded).
+        true
       end
 
       def reap(pid)

--- a/templates/project_config.yml.erb
+++ b/templates/project_config.yml.erb
@@ -218,13 +218,24 @@ patrol:
     lint: null
     typecheck: null
     test: null
-  # Review handoff for patrol-created PRs uses a narrower reviewer set
-  # than normal feature PRs. Keep Codex on by default; optionally add
+  # Review handoff for patrol-created PRs uses a cheaper reviewer set
+  # than normal feature PRs. The default is the native `codex review`
+  # single-pass adapter; optionally add the ce-code-review fan-out or
   # Claude during init when you want broader patrol review coverage.
   review:
     max_context_files: 24
     max_owned_files: 12
     reviewers:
+<% if patrol_reviewers.include?("codex-native-review") -%>
+      # Native `codex review` — one cheap, tuned, read-only pass whose
+      # stdout is captured into the findings file. Needs no CE skill.
+      - name: codex-native-review
+        kind: codex_review
+        agent: codex
+        output_basename: codex-native-review
+        prompt_template: reviewer_codex_native_review.md.erb
+        timeout_sec: 5400
+<% end -%>
 <% if patrol_reviewers.include?("codex-ce-code-review") -%>
       - name: codex-ce-code-review
         kind: agent

--- a/templates/reviewer_codex_native_review.md.erb
+++ b/templates/reviewer_codex_native_review.md.erb
@@ -1,0 +1,37 @@
+You are performing a single-pass code review for project <%= project_name %>.
+
+Worktree (cwd): <%= worktree_path %>
+Default branch (compare against): <%= default_branch %>
+Pass: <%= pass %>
+
+<%= plan_context_section %>
+Scope:
+
+Review ONLY the changes introduced on this branch, i.e. the diff produced by
+`git diff <%= default_branch %>...HEAD` in the current worktree. Do not review
+unrelated pre-existing code. Focus on correctness, security, data loss,
+concurrency, and clear maintainability regressions.
+
+Output contract (STRICT):
+
+Print to stdout ONLY the findings, as GFM checkboxes grouped by severity, in
+exactly this shape and nothing else (no preamble, no summary, no closing text):
+
+## High
+- [ ] <finding>: <one-line justification>
+
+## Medium
+- [ ] <finding>: <one-line justification>
+
+## Nit
+- [ ] <finding>: <one-line justification>
+
+Rules:
+- Always print all three headers (`## High`, `## Medium`, `## Nit`), in that
+  order, even when a severity has no findings.
+- Under a severity with no findings, print exactly one line: `No findings.`
+- Every real finding is an unchecked checkbox `- [ ] ...` — never `- [x]`.
+  The triage agent ticks `[x]` on auto-fixable items downstream.
+- One finding per line; keep the justification to a single line.
+- Do NOT print the diff, file listings, reasoning, or any prose outside the
+  three severity sections.

--- a/test/fixtures/fake-codex
+++ b/test/fixtures/fake-codex
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Minimal fake codex CLI for CodexReview reviewer tests. Handles two
+# subcommands:
+#
+#   --version        prints a parseable version line (default 0.139.0;
+#                    override with HIVE_FAKE_CODEX_VERSION, e.g. "0.1.0"
+#                    to simulate a too-old binary below min_version).
+#
+#   review [...]     logs argv to HIVE_FAKE_CODEX_ARGV_LOG (if set), then
+#                    prints HIVE_FAKE_CODEX_STDOUT (default: a valid
+#                    GFM-checkbox findings block) and exits with
+#                    HIVE_FAKE_CODEX_EXIT (default 0). HIVE_FAKE_CODEX_HANG
+#                    sleeps that many seconds first (timeout tests).
+set -u
+
+if [[ "${1:-}" == "--version" ]]; then
+  printf 'codex-cli %s\n' "${HIVE_FAKE_CODEX_VERSION:-0.139.0}"
+  exit 0
+fi
+
+if [[ "${1:-}" == "review" ]]; then
+  if [[ -n "${HIVE_FAKE_CODEX_ARGV_LOG:-}" ]]; then
+    mkdir -p "$(dirname "${HIVE_FAKE_CODEX_ARGV_LOG}")"
+    {
+      echo "---"
+      echo "cwd=$(pwd)"
+      for a in "$@"; do
+        printf 'arg=%s\n' "$a"
+      done
+    } >> "${HIVE_FAKE_CODEX_ARGV_LOG}"
+  fi
+
+  if [[ -n "${HIVE_FAKE_CODEX_HANG:-}" ]]; then
+    sleep "${HIVE_FAKE_CODEX_HANG}"
+  fi
+
+  default_out='OpenAI Codex v0.139.0
+--------
+user
+changes against main
+codex
+## High
+- [ ] uses subtraction instead of addition: breaks add()
+## Medium
+No findings.
+## Nit
+No findings.'
+
+  printf '%s\n' "${HIVE_FAKE_CODEX_STDOUT-$default_out}"
+  exit "${HIVE_FAKE_CODEX_EXIT:-0}"
+fi
+
+echo "fake-codex: unsupported argv: $*" >&2
+exit 99

--- a/test/fixtures/fake-codex
+++ b/test/fixtures/fake-codex
@@ -11,6 +11,13 @@
 #                    GFM-checkbox findings block) and exits with
 #                    HIVE_FAKE_CODEX_EXIT (default 0). HIVE_FAKE_CODEX_HANG
 #                    sleeps that many seconds first (timeout tests).
+#
+#                    HIVE_FAKE_CODEX_BIG_MIB, when set, emits valid findings
+#                    headers first, then floods stdout with that many MiB of
+#                    filler so the total combined output exceeds the
+#                    reviewer's MAX_OUTPUT_BYTES retain cap. Used to prove the
+#                    reader fully drains the pipe (no write() deadlock) instead
+#                    of stopping at the cap and wedging the child.
 set -u
 
 if [[ "${1:-}" == "--version" ]]; then
@@ -32,6 +39,21 @@ if [[ "${1:-}" == "review" ]]; then
 
   if [[ -n "${HIVE_FAKE_CODEX_HANG:-}" ]]; then
     sleep "${HIVE_FAKE_CODEX_HANG}"
+  fi
+
+  if [[ -n "${HIVE_FAKE_CODEX_BIG_MIB:-}" ]]; then
+    # Valid findings headers up front (inside the retained cap), then a
+    # flood of filler that pushes the total past MAX_OUTPUT_BYTES. If the
+    # reader stopped reading at the cap, this write() would block forever.
+    printf 'OpenAI Codex v0.139.0\n## High\n- [ ] big: overflow case\n## Medium\nNo findings.\n## Nit\nNo findings.\n'
+    # Emit HIVE_FAKE_CODEX_BIG_MIB chunks of ~1 MiB each.
+    chunk="$(head -c 1048576 /dev/zero | tr '\0' 'x')"
+    i=0
+    while [[ "$i" -lt "${HIVE_FAKE_CODEX_BIG_MIB}" ]]; do
+      printf '%s\n' "$chunk"
+      i=$((i + 1))
+    done
+    exit "${HIVE_FAKE_CODEX_EXIT:-0}"
   fi
 
   default_out='OpenAI Codex v0.139.0

--- a/test/integration/init_test.rb
+++ b/test/integration/init_test.rb
@@ -99,7 +99,9 @@ class InitTest < Minitest::Test
     # Order: planning, claude_mode, claude_permission_mode, development,
     # reviewers, patrol_reviewers, patrol_mode, triage, then limits, daemon-enable, babysitter-enable,
     # daemon-autostart, confirm.
-    inputs = ([ "codex", "2", "", "pi", "2", "2", "high", "safetyist", "60,120" ] +
+    # patrol_reviewers index 3 = claude-ce-code-review (1=codex-native-review,
+    # 2=codex-ce-code-review, 3=claude-ce-code-review).
+    inputs = ([ "codex", "2", "", "pi", "2", "3", "high", "safetyist", "60,120" ] +
               ([ "" ] * (Hive::Commands::Init::Prompts::LIMIT_KEYS.size - 1)) +
               [ "n", "", "", "" ]).join("\n") + "\n"
 
@@ -398,7 +400,8 @@ class InitTest < Minitest::Test
 
         patrol_reviewers = cfg.dig("patrol", "review", "reviewers")
         assert_kind_of Array, patrol_reviewers
-        assert_equal [ "codex-ce-code-review" ], patrol_reviewers.map { |r| r["name"] }
+        assert_equal [ "codex-native-review" ], patrol_reviewers.map { |r| r["name"] }
+        assert_equal "codex_review", patrol_reviewers.first["kind"]
 
         # Each entry references a registered AgentProfile.
         (reviewers + patrol_reviewers).each do |entry|
@@ -667,8 +670,8 @@ class InitTest < Minitest::Test
         assert_equal %w[claude-ce-code-review pr-review-toolkit], names,
                      "only the two selected reviewers should be rendered"
         patrol_names = cfg.dig("patrol", "review", "reviewers").map { |r| r["name"] }
-        assert_equal %w[codex-ce-code-review], patrol_names,
-                     "blank patrol reviewer prompt should render codex-only patrol review"
+        assert_equal %w[codex-native-review], patrol_names,
+                     "blank patrol reviewer prompt should render the codex native-review default"
         assert_equal "high", cfg.dig("patrol", "mode")
         assert_equal "timer", cfg.dig("patrol", "trigger")
         assert_equal 7200, cfg.dig("patrol", "poll_interval_sec")

--- a/test/unit/commands/init/prompts_test.rb
+++ b/test/unit/commands/init/prompts_test.rb
@@ -139,7 +139,7 @@ class InitPromptsTest < Minitest::Test
     prompts, output = make_prompts(interactive_input)
     prompts.collect
     assert_match(/limits\s+= all defaults/, output.string)
-    assert_match(/patrol_reviewers\s+= \[codex-ce-code-review\]/, output.string)
+    assert_match(/patrol_reviewers\s+= \[codex-native-review\]/, output.string)
     assert_match(/patrol_mode\s+= low/, output.string)
   end
 
@@ -300,20 +300,21 @@ class InitPromptsTest < Minitest::Test
     assert_equal REVIEWER_NAMES, answers["enabled_reviewers"]
   end
 
-  def test_interactive_patrol_reviewers_blank_accepts_codex_only
+  def test_interactive_patrol_reviewers_blank_accepts_codex_native_only
     prompts, _output = make_prompts(interactive_input(patrol_reviewers: ""))
     answers = prompts.collect
-    assert_equal %w[codex-ce-code-review], answers["patrol_reviewers"]
+    assert_equal %w[codex-native-review], answers["patrol_reviewers"]
   end
 
-  def test_interactive_patrol_reviewers_can_add_claude
-    prompts, _output = make_prompts(interactive_input(patrol_reviewers: "1,2"))
+  def test_interactive_patrol_reviewers_can_add_ce_code_review
+    # 1 = codex-native-review, 2 = codex-ce-code-review, 3 = claude-ce-code-review
+    prompts, _output = make_prompts(interactive_input(patrol_reviewers: "2,3"))
     answers = prompts.collect
     assert_equal %w[codex-ce-code-review claude-ce-code-review], answers["patrol_reviewers"]
   end
 
   def test_interactive_patrol_reviewers_reject_pr_toolkit
-    raw = interactive_input(patrol_reviewers: "pr-review-toolkit\n2")
+    raw = interactive_input(patrol_reviewers: "pr-review-toolkit\n3")
     prompts, output, _summary = make_prompts(raw)
     answers = prompts.collect
     assert_equal %w[claude-ce-code-review], answers["patrol_reviewers"]

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -45,8 +45,13 @@ class ConfigTest < Minitest::Test
       assert_nil cfg.dig("patrol", "commands", "test")
       assert_equal 12, cfg.dig("patrol", "review", "max_owned_files")
       assert_equal 24, cfg.dig("patrol", "review", "max_context_files")
-      assert_equal %w[codex-ce-code-review],
+      assert_equal %w[codex-native-review],
                    cfg.dig("patrol", "review", "reviewers").map { |entry| entry.fetch("name") }
+      native = cfg.dig("patrol", "review", "reviewers").first
+      assert_equal "codex_review", native["kind"]
+      assert_equal "codex", native["agent"]
+      assert_equal "reviewer_codex_native_review.md.erb", native["prompt_template"]
+      refute native.key?("skill"), "the codex-native patrol reviewer takes no CE skill"
     end
   end
 
@@ -998,6 +1003,80 @@ class ConfigTest < Minitest::Test
       YAML
       err = assert_raises(Hive::ConfigError) { Hive::Config.load(dir) }
       assert_match(/duplicate output_basename "collision"/, err.message)
+    end
+  end
+
+  def test_load_accepts_codex_review_reviewer_without_skill
+    with_tmp_dir do |dir|
+      FileUtils.mkdir_p(File.join(dir, ".hive-state"))
+      File.write(File.join(dir, ".hive-state", "config.yml"), <<~YAML)
+        review:
+          reviewers:
+            - name: codex-native-review
+              kind: codex_review
+              agent: codex
+              output_basename: codex-native-review
+              prompt_template: reviewer_codex_native_review.md.erb
+      YAML
+      cfg = Hive::Config.load(dir)
+      reviewer = cfg.dig("review", "reviewers").first
+      assert_equal "codex_review", reviewer["kind"]
+      refute reviewer.key?("skill"), "codex_review needs no skill"
+    end
+  end
+
+  def test_load_still_requires_name_and_basename_uniqueness_for_codex_review
+    with_tmp_dir do |dir|
+      FileUtils.mkdir_p(File.join(dir, ".hive-state"))
+      File.write(File.join(dir, ".hive-state", "config.yml"), <<~YAML)
+        review:
+          reviewers:
+            - name: dup-native
+              kind: codex_review
+              agent: codex
+              output_basename: a
+              prompt_template: reviewer_codex_native_review.md.erb
+            - name: dup-native
+              kind: codex_review
+              agent: codex
+              output_basename: b
+              prompt_template: reviewer_codex_native_review.md.erb
+      YAML
+      err = assert_raises(Hive::ConfigError) { Hive::Config.load(dir) }
+      assert_match(/duplicate name "dup-native"/, err.message)
+    end
+  end
+
+  def test_load_requires_prompt_template_for_codex_review
+    with_tmp_dir do |dir|
+      FileUtils.mkdir_p(File.join(dir, ".hive-state"))
+      File.write(File.join(dir, ".hive-state", "config.yml"), <<~YAML)
+        review:
+          reviewers:
+            - name: codex-native-review
+              kind: codex_review
+              agent: codex
+              output_basename: codex-native-review
+      YAML
+      err = assert_raises(Hive::ConfigError) { Hive::Config.load(dir) }
+      assert_match(/review\.reviewers\[0\]\.prompt_template.*is missing/, err.message)
+    end
+  end
+
+  def test_load_rejects_unknown_reviewer_kind
+    with_tmp_dir do |dir|
+      FileUtils.mkdir_p(File.join(dir, ".hive-state"))
+      File.write(File.join(dir, ".hive-state", "config.yml"), <<~YAML)
+        review:
+          reviewers:
+            - name: bogus
+              kind: nonsense
+              agent: codex
+              output_basename: bogus
+              prompt_template: reviewer_codex_native_review.md.erb
+      YAML
+      err = assert_raises(Hive::ConfigError) { Hive::Config.load(dir) }
+      assert_match(/kind.*must be one of/, err.message)
     end
   end
 

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -1063,6 +1063,67 @@ class ConfigTest < Minitest::Test
     end
   end
 
+  def test_load_requires_agent_for_codex_review
+    with_tmp_dir do |dir|
+      FileUtils.mkdir_p(File.join(dir, ".hive-state"))
+      # codex_review resolves the codex binary via
+      # Hive::AgentProfiles.lookup(spec.fetch("agent")); a spec missing
+      # `agent` would crash mid-dispatch with KeyError, so it must fail at
+      # config load. (The generic validate_agent_name! returns early on nil,
+      # so without `agent` in the required list this entry would pass load.)
+      File.write(File.join(dir, ".hive-state", "config.yml"), <<~YAML)
+        review:
+          reviewers:
+            - name: codex-native-review
+              kind: codex_review
+              output_basename: codex-native-review
+              prompt_template: reviewer_codex_native_review.md.erb
+      YAML
+      err = assert_raises(Hive::ConfigError) { Hive::Config.load(dir) }
+      assert_match(/review\.reviewers\[0\]\.agent.*is missing/, err.message)
+    end
+  end
+
+  def test_load_requires_name_for_codex_review
+    with_tmp_dir do |dir|
+      FileUtils.mkdir_p(File.join(dir, ".hive-state"))
+      File.write(File.join(dir, ".hive-state", "config.yml"), <<~YAML)
+        review:
+          reviewers:
+            - kind: codex_review
+              agent: codex
+              output_basename: codex-native-review
+              prompt_template: reviewer_codex_native_review.md.erb
+      YAML
+      err = assert_raises(Hive::ConfigError) { Hive::Config.load(dir) }
+      assert_match(/review\.reviewers\[0\]\.name.*is missing/, err.message)
+    end
+  end
+
+  def test_load_accepts_linter_reviewer_kind_at_config_load
+    with_tmp_dir do |dir|
+      FileUtils.mkdir_p(File.join(dir, ".hive-state"))
+      # `linter` is deliberately accepted at config-load time and rejected
+      # only at dispatch (Hive::Reviewers.dispatch) so the more actionable
+      # dispatch-time error — pointing at review.ci.command — is what the
+      # user sees. Pin that design: load must NOT raise and the kind must
+      # round-trip.
+      File.write(File.join(dir, ".hive-state", "config.yml"), <<~YAML)
+        review:
+          reviewers:
+            - name: my-linter
+              kind: linter
+              skill: ce-code-review
+              output_basename: my-linter
+              prompt_template: reviewer_codex_native_review.md.erb
+      YAML
+      cfg = Hive::Config.load(dir)
+      reviewer = cfg.dig("review", "reviewers").first
+      assert_equal "linter", reviewer["kind"],
+                   "linter kind is accepted at config load and rejected only at dispatch"
+    end
+  end
+
   def test_load_rejects_unknown_reviewer_kind
     with_tmp_dir do |dir|
       FileUtils.mkdir_p(File.join(dir, ".hive-state"))

--- a/test/unit/reviewers/codex_review_test.rb
+++ b/test/unit/reviewers/codex_review_test.rb
@@ -16,7 +16,7 @@ class ReviewersCodexReviewTest < Minitest::Test
   def teardown
     ENV["HIVE_CODEX_BIN"] = @prev_bin
     %w[HIVE_FAKE_CODEX_STDOUT HIVE_FAKE_CODEX_EXIT HIVE_FAKE_CODEX_ARGV_LOG
-       HIVE_FAKE_CODEX_HANG HIVE_FAKE_CODEX_VERSION].each { |k| ENV.delete(k) }
+       HIVE_FAKE_CODEX_HANG HIVE_FAKE_CODEX_VERSION HIVE_FAKE_CODEX_BIG_MIB].each { |k| ENV.delete(k) }
     Hive::AgentProfile.reset_version_cache!
   end
 
@@ -115,6 +115,50 @@ class ReviewersCodexReviewTest < Minitest::Test
 
       assert result.ok?, "a single severity header is enough to count as valid findings"
       assert_equal "## Medium\n- [ ] thing: reason\n", File.read(reviewer.output_path)
+    end
+  end
+
+  def test_trims_banner_and_trailing_blanks_to_exact_findings_body
+    with_tmp_dir do |dir|
+      # Banner before the first header, plus trailing blank lines after the
+      # findings. normalize_output must drop the banner, rstrip the trailing
+      # blanks, and append exactly one newline.
+      ENV["HIVE_FAKE_CODEX_STDOUT"] = "OpenAI Codex v0.139.0\nsome banner\n## High\n- [ ] x: y\n\n\n"
+      reviewer = build_reviewer(dir)
+
+      result = reviewer.run!
+
+      assert result.ok?, "expected :ok, got #{result.status} (#{result.error_message})"
+      assert_equal "## High\n- [ ] x: y\n", File.read(reviewer.output_path),
+                   "banner trimmed to first header and exactly one trailing newline"
+    end
+  end
+
+  # --- FIX 1: full pipe drain (no write() deadlock past the retain cap) ---
+
+  def test_oversized_output_drains_without_deadlock_and_yields_valid_findings
+    with_tmp_dir do |dir|
+      # Emit valid headers up front, then ~6 MiB of filler — past the 4 MiB
+      # MAX_OUTPUT_BYTES retain cap. If the reader stopped at the cap the
+      # child would block on write() forever and the run would only end via
+      # the wall-clock timeout. A generous-but-finite timeout proves the run
+      # completes promptly because the pipe is fully drained.
+      ENV["HIVE_FAKE_CODEX_BIG_MIB"] = "6"
+      reviewer = build_reviewer(dir, "timeout_sec" => 60, "max_attempts" => 1)
+
+      started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      result = reviewer.run!
+      elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+
+      assert result.ok?,
+             "oversized output must still produce valid findings, got #{result.status} (#{result.error_message})"
+      assert elapsed < 30,
+             "run must finish promptly (drained pipe), not hang to timeout; took #{elapsed.round(1)}s"
+      body = File.read(reviewer.output_path)
+      assert body.start_with?("## High"), "retained findings must start at the first severity header"
+      assert_includes body, "big: overflow case"
+      assert_operator File.size(reviewer.output_path), :<=, Hive::Reviewers::CodexReview::MAX_OUTPUT_BYTES,
+                      "retained output must not exceed the cap"
     end
   end
 
@@ -296,6 +340,73 @@ class ReviewersCodexReviewTest < Minitest::Test
       assert result.error?
       assert_match(/timed out after 1s/, result.error_message)
       refute File.exist?(reviewer.output_path)
+    end
+  end
+
+  def test_terminate_escalates_to_kill_when_term_is_ignored
+    with_tmp_dir do |dir|
+      reviewer = build_reviewer(dir)
+      # Child traps (ignores) TERM and sleeps. TERM alone won't reap it, so
+      # terminate must escalate to KILL after the grace and then reap it.
+      pid = Process.spawn("trap '' TERM; sleep 30", pgroup: true)
+      # Let the shell install the trap before we signal.
+      sleep 0.2
+
+      # terminate must not raise even though TERM is ignored.
+      reviewer.send(:terminate, pid)
+      # The process group must be gone after KILL escalation + reap.
+      refute reviewer.send(:process_group_alive?, Process.getpgid(pid)),
+             "process group must be torn down by the KILL escalation"
+    rescue Errno::ESRCH
+      # getpgid after reap can race to ESRCH — that itself proves the group
+      # is gone, which is the assertion's intent.
+      assert true
+    end
+  end
+
+  def test_process_group_alive_true_for_running_group
+    with_tmp_dir do |dir|
+      reviewer = build_reviewer(dir)
+      pid = Process.spawn("sleep 30", pgroup: true)
+      begin
+        assert reviewer.send(:process_group_alive?, Process.getpgid(pid)),
+               "a running group must report alive"
+      ensure
+        Process.kill("KILL", pid)
+        Process.wait(pid)
+      end
+    end
+  end
+
+  def test_process_group_alive_false_for_dead_group
+    with_tmp_dir do |dir|
+      reviewer = build_reviewer(dir)
+      # Spawn a child in its own group, capture its pgid, then reap it. The
+      # group no longer exists, so the liveness probe (Process.kill(0, ...))
+      # raises ESRCH and the probe reports false.
+      pid = Process.spawn("true", pgroup: true)
+      pgid = Process.getpgid(pid)
+      Process.wait(pid)
+
+      refute reviewer.send(:process_group_alive?, pgid),
+             "a reaped group must report not-alive"
+    end
+  end
+
+  def test_process_group_alive_treats_eperm_as_alive
+    with_tmp_dir do |dir|
+      reviewer = build_reviewer(dir)
+      # A group we can see but not signal (EPERM) must be treated as alive so
+      # the guarded KILL attempt still fires. Temporarily make Process.kill
+      # raise EPERM to simulate the unsignalable-but-present case.
+      original = Process.method(:kill)
+      Process.singleton_class.send(:define_method, :kill) { |*| raise Errno::EPERM }
+      begin
+        assert reviewer.send(:process_group_alive?, 12_345),
+               "EPERM (exists but unsignalable) must be treated as alive"
+      ensure
+        Process.singleton_class.send(:define_method, :kill, original)
+      end
     end
   end
 

--- a/test/unit/reviewers/codex_review_test.rb
+++ b/test/unit/reviewers/codex_review_test.rb
@@ -1,0 +1,407 @@
+require "test_helper"
+require "hive/reviewers"
+require "hive/agent_profiles"
+
+class ReviewersCodexReviewTest < Minitest::Test
+  include HiveTestHelper
+
+  FAKE_BIN = File.expand_path("../../fixtures/fake-codex", __dir__)
+
+  def setup
+    @prev_bin = ENV["HIVE_CODEX_BIN"]
+    ENV["HIVE_CODEX_BIN"] = FAKE_BIN
+    Hive::AgentProfile.reset_version_cache!
+  end
+
+  def teardown
+    ENV["HIVE_CODEX_BIN"] = @prev_bin
+    %w[HIVE_FAKE_CODEX_STDOUT HIVE_FAKE_CODEX_EXIT HIVE_FAKE_CODEX_ARGV_LOG
+       HIVE_FAKE_CODEX_HANG HIVE_FAKE_CODEX_VERSION].each { |k| ENV.delete(k) }
+    Hive::AgentProfile.reset_version_cache!
+  end
+
+  def make_ctx(dir)
+    Hive::Reviewers::Context.new(
+      worktree_path: dir,
+      task_folder: File.join(dir, ".hive-state", "stages", "6-review", "test"),
+      default_branch: "main",
+      pass: 1
+    )
+  end
+
+  def make_spec(overrides = {})
+    {
+      "name" => "codex-native-review",
+      "kind" => "codex_review",
+      "agent" => "codex",
+      "output_basename" => "codex-native-review",
+      "prompt_template" => "reviewer_codex_native_review.md.erb",
+      "timeout_sec" => 5
+    }.merge(overrides)
+  end
+
+  def build_reviewer(dir, overrides = {})
+    ctx = make_ctx(dir)
+    FileUtils.mkdir_p(ctx.task_folder)
+    Hive::Reviewers::CodexReview.new(make_spec(overrides), ctx)
+  end
+
+  # --- argv construction -------------------------------------------------
+
+  def test_builds_codex_review_argv_with_title_and_prompt
+    with_tmp_dir do |dir|
+      log = File.join(dir, "argv.log")
+      ENV["HIVE_FAKE_CODEX_ARGV_LOG"] = log
+      reviewer = build_reviewer(dir)
+
+      result = reviewer.run!
+
+      assert result.ok?, "expected :ok, got #{result.status} (#{result.error_message})"
+      raw = File.read(log)
+      # Leading positional args are logged one-per-line; the trailing
+      # prompt arg is multi-line, so assert against the raw log.
+      args = raw.lines.grep(/^arg=/).map { |l| l.sub(/^arg=/, "").chomp }
+      assert_equal "review", args[0], "first codex arg must be the review subcommand"
+      title_idx = args.index("--title")
+      refute_nil title_idx, "argv must carry --title"
+      assert_includes args[title_idx + 1], "pass 1", "title carries the pass number"
+      # codex rejects --base alongside a custom prompt, so we never pass --base.
+      refute_includes args, "--base", "must NOT pass --base (mutually exclusive with custom prompt)"
+      assert_includes raw, "git diff main...HEAD",
+                      "prompt must scope the review to the base-branch diff"
+      assert_includes raw, "## High", "prompt must coerce the GFM findings format"
+    end
+  end
+
+  def test_runs_codex_in_worktree_cwd
+    with_tmp_dir do |dir|
+      log = File.join(dir, "argv.log")
+      ENV["HIVE_FAKE_CODEX_ARGV_LOG"] = log
+      reviewer = build_reviewer(dir)
+
+      reviewer.run!
+
+      cwd_line = File.readlines(log).grep(/^cwd=/).first.to_s.chomp.sub(/^cwd=/, "")
+      assert_equal File.realpath(dir), File.realpath(cwd_line),
+                   "codex review must run with cwd = the worktree path"
+    end
+  end
+
+  # --- stdout -> findings file ------------------------------------------
+
+  def test_captures_stdout_into_findings_file
+    with_tmp_dir do |dir|
+      reviewer = build_reviewer(dir)
+
+      result = reviewer.run!
+
+      assert result.ok?
+      assert_equal reviewer.output_path, result.output_path
+      assert File.exist?(reviewer.output_path), "findings file must be written"
+      body = File.read(reviewer.output_path)
+      assert body.start_with?("## High"), "banner noise must be trimmed to the first severity header"
+      assert_includes body, "uses subtraction instead of addition"
+      assert_includes body, "## Nit"
+      refute_includes body, "OpenAI Codex", "codex banner must not leak into the findings file"
+    end
+  end
+
+  def test_accepts_output_with_only_some_severity_headers
+    with_tmp_dir do |dir|
+      ENV["HIVE_FAKE_CODEX_STDOUT"] = "## Medium\n- [ ] thing: reason\n"
+      reviewer = build_reviewer(dir)
+
+      result = reviewer.run!
+
+      assert result.ok?, "a single severity header is enough to count as valid findings"
+      assert_equal "## Medium\n- [ ] thing: reason\n", File.read(reviewer.output_path)
+    end
+  end
+
+  # --- malformed / empty stdout -> error, no findings file --------------
+
+  def test_malformed_stdout_yields_error_and_no_findings_file
+    with_tmp_dir do |dir|
+      ENV["HIVE_FAKE_CODEX_STDOUT"] = "OpenAI Codex v0.139.0\nReview was interrupted.\n"
+      reviewer = build_reviewer(dir, "max_attempts" => 1)
+
+      result = reviewer.run!
+
+      assert result.error?, "missing High/Medium/Nit headers must fail the reviewer"
+      assert_match(/missing High\/Medium\/Nit/, result.error_message)
+      refute File.exist?(reviewer.output_path),
+             "a malformed findings file must not be left behind for triage"
+    end
+  end
+
+  def test_empty_stdout_yields_error
+    with_tmp_dir do |dir|
+      ENV["HIVE_FAKE_CODEX_STDOUT"] = ""
+      reviewer = build_reviewer(dir, "max_attempts" => 1)
+
+      result = reviewer.run!
+
+      assert result.error?
+      refute File.exist?(reviewer.output_path)
+    end
+  end
+
+  def test_nonzero_exit_yields_error
+    with_tmp_dir do |dir|
+      ENV["HIVE_FAKE_CODEX_EXIT"] = "1"
+      ENV["HIVE_FAKE_CODEX_STDOUT"] = "ERROR: You've hit your usage limit.\n"
+      reviewer = build_reviewer(dir, "max_attempts" => 1)
+
+      result = reviewer.run!
+
+      assert result.error?
+      assert_match(/exited with status=1/, result.error_message)
+      refute File.exist?(reviewer.output_path)
+    end
+  end
+
+  def test_missing_binary_yields_error
+    with_tmp_dir do |dir|
+      ENV["HIVE_CODEX_BIN"] = File.join(dir, "does-not-exist-codex")
+      reviewer = build_reviewer(dir, "max_attempts" => 1)
+
+      result = reviewer.run!
+
+      assert result.error?
+      assert_match(/preflight failed|not runnable/, result.error_message)
+      refute File.exist?(reviewer.output_path)
+    end
+  end
+
+  # --- retry / multi-attempt message ------------------------------------
+
+  def test_retries_then_succeeds_and_appends_no_attempt_suffix_on_success
+    with_tmp_dir do |dir|
+      reviewer = build_reviewer(dir, "max_attempts" => 2)
+      # Patch backoff to avoid real sleeps.
+      def reviewer.backoff(_seconds) = nil
+
+      result = reviewer.run!
+
+      assert result.ok?
+    end
+  end
+
+  def test_error_message_includes_attempt_count_when_retry_enabled
+    with_tmp_dir do |dir|
+      ENV["HIVE_FAKE_CODEX_STDOUT"] = "no headers here\n"
+      reviewer = build_reviewer(dir, "max_attempts" => 2)
+      # Real backoff path, but zero-duration so sleep(0) returns instantly.
+      def reviewer.backoff_seconds_for(_attempt) = 0
+
+      result = reviewer.run!
+
+      assert result.error?
+      assert_match(/after 2 attempt\(s\)/, result.error_message)
+    end
+  end
+
+  def test_retry_with_future_deadline_clamps_backoff_then_retries
+    with_tmp_dir do |dir|
+      ENV["HIVE_FAKE_CODEX_STDOUT"] = "no headers here\n"
+      reviewer = build_reviewer(dir, "max_attempts" => 2)
+      def reviewer.backoff_seconds_for(_attempt) = 0
+
+      # A far-future deadline leaves ample budget, so the loop takes the
+      # clamp branch (`[backoff, remaining].min`) and still retries.
+      future = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 3600
+      result = reviewer.run!(deadline: future)
+
+      assert result.error?
+      assert_match(/after 2 attempt\(s\)/, result.error_message)
+    end
+  end
+
+  def test_invalid_max_attempts_falls_back_to_default_with_warning
+    with_tmp_dir do |dir|
+      reviewer = build_reviewer(dir, "max_attempts" => "two")
+      def reviewer.backoff(_seconds) = nil
+
+      out, err = capture_subprocess_io do
+        @result = reviewer.run!
+      end
+      _ = out
+
+      assert @result.ok?
+      assert_match(/invalid max_attempts/, err)
+    end
+  end
+
+  # --- deadline handling -------------------------------------------------
+
+  def test_deadline_already_passed_yields_error_without_spawning
+    with_tmp_dir do |dir|
+      log = File.join(dir, "argv.log")
+      ENV["HIVE_FAKE_CODEX_ARGV_LOG"] = log
+      reviewer = build_reviewer(dir, "max_attempts" => 1)
+
+      past = Process.clock_gettime(Process::CLOCK_MONOTONIC) - 10
+      result = reviewer.run!(deadline: past)
+
+      assert result.error?
+      assert_match(/deadline reached/, result.error_message)
+      refute File.exist?(log), "no codex spawn when the deadline is already in the past"
+    end
+  end
+
+  def test_future_deadline_allows_spawn
+    with_tmp_dir do |dir|
+      reviewer = build_reviewer(dir)
+
+      future = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 3600
+      result = reviewer.run!(deadline: future)
+
+      assert result.ok?
+    end
+  end
+
+  def test_deadline_exhausted_between_failed_attempts_stops_retry
+    with_tmp_dir do |dir|
+      ENV["HIVE_FAKE_CODEX_STDOUT"] = "no headers\n"
+      reviewer = build_reviewer(dir, "max_attempts" => 3)
+      # deadline_remaining is consulted twice per attempt: once by
+      # effective_timeout (needs a positive budget so the spawn proceeds),
+      # then once in the retry backoff check. Feed a large value first, then
+      # a non-positive one so the loop breaks on `remaining <= 0` rather than
+      # exhausting all 3 attempts.
+      slack = [ 9999.0, 0.0 ]
+      reviewer.define_singleton_method(:deadline_remaining) do |_deadline|
+        slack.shift || -1
+      end
+      def reviewer.backoff(_seconds) = nil
+
+      future = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 3600
+      result = reviewer.run!(deadline: future)
+
+      assert result.error?
+      # Broke after the first failed attempt (not all 3).
+      assert_match(/after 1 attempt\(s\)/, result.error_message)
+    end
+  end
+
+  # --- timeout -----------------------------------------------------------
+
+  def test_timeout_kills_the_subprocess_and_errors
+    with_tmp_dir do |dir|
+      ENV["HIVE_FAKE_CODEX_HANG"] = "30"
+      reviewer = build_reviewer(dir, "timeout_sec" => 1, "max_attempts" => 1)
+
+      result = reviewer.run!
+
+      assert result.error?
+      assert_match(/timed out after 1s/, result.error_message)
+      refute File.exist?(reviewer.output_path)
+    end
+  end
+
+  def test_terminate_is_quiet_when_process_already_gone
+    with_tmp_dir do |dir|
+      reviewer = build_reviewer(dir)
+      # Spawn a trivial child, reap it, then ask terminate to act on the
+      # now-dead pid. Both the kill (ESRCH) and the reap (ECHILD) must be
+      # swallowed without raising.
+      pid = Process.spawn("true", pgroup: true)
+      Process.wait(pid)
+
+      assert_nil reviewer.send(:terminate, pid),
+                 "terminate must be a no-op for an already-reaped pid"
+      assert_nil reviewer.send(:reap, pid),
+                 "reap must swallow ECHILD for an already-reaped pid"
+    end
+  end
+
+  # --- version gate ------------------------------------------------------
+
+  def test_below_min_version_yields_preflight_error
+    with_tmp_dir do |dir|
+      ENV["HIVE_FAKE_CODEX_VERSION"] = "0.1.0"
+      reviewer = build_reviewer(dir, "max_attempts" => 1)
+
+      result = reviewer.run!
+
+      assert result.error?
+      assert_match(/preflight failed/, result.error_message)
+    end
+  end
+
+  # --- prompt rendering --------------------------------------------------
+
+  def test_prompt_template_renders_base_branch_and_format_contract
+    with_tmp_dir do |dir|
+      reviewer = build_reviewer(dir)
+      File.write(
+        File.join(reviewer.ctx.task_folder, "plan.md"),
+        "# Plan\n\n## Goals\n- G1. Keep add() additive.\n"
+      )
+      prompt = reviewer.send(:render_prompt)
+
+      assert_includes prompt, "git diff main...HEAD"
+      assert_includes prompt, "## High"
+      assert_includes prompt, "## Medium"
+      assert_includes prompt, "## Nit"
+      assert_includes prompt, "No findings."
+      assert_match(/Plan context \(authoritative on scope\)/, prompt,
+                   "native-review template must embed the plan-context section")
+      assert_includes prompt, "G1. Keep add() additive.",
+                      "plan.md content must be inlined into the prompt"
+    end
+  end
+
+  def test_prompt_template_falls_back_to_absent_note_when_plan_missing
+    with_tmp_dir do |dir|
+      reviewer = build_reviewer(dir)
+      prompt = reviewer.send(:render_prompt)
+
+      assert_match(/no plan\.md found/, prompt)
+    end
+  end
+
+  def test_delete_output_reraises_on_non_enoent_system_call_error
+    with_tmp_dir do |dir|
+      reviewer = build_reviewer(dir)
+      # Point output_path at a directory; File.delete raises EISDIR/EPERM
+      # (a non-ENOENT SystemCallError) which must surface as a named
+      # Hive::Error rather than being swallowed like a missing file.
+      a_dir = File.join(dir, "a-directory")
+      FileUtils.mkdir_p(a_dir)
+      reviewer.define_singleton_method(:output_path) { a_dir }
+
+      err = assert_raises(Hive::Error) { reviewer.send(:delete_output!) }
+      assert_match(/failed to clear partial output_path/, err.message)
+    end
+  end
+
+  # --- dispatch ----------------------------------------------------------
+
+  def test_dispatch_selects_codex_review_for_codex_review_kind
+    with_tmp_dir do |dir|
+      ctx = make_ctx(dir)
+      adapter = Hive::Reviewers.dispatch(make_spec, ctx)
+      assert_instance_of Hive::Reviewers::CodexReview, adapter
+    end
+  end
+
+  def test_dispatch_defaults_to_agent_when_kind_absent
+    with_tmp_dir do |dir|
+      ctx = make_ctx(dir)
+      spec = make_spec.tap { |s| s.delete("kind") }.merge("skill" => "ce-code-review")
+      adapter = Hive::Reviewers.dispatch(spec, ctx)
+      assert_instance_of Hive::Reviewers::Agent, adapter
+    end
+  end
+
+  def test_dispatch_rejects_unknown_kind
+    with_tmp_dir do |dir|
+      ctx = make_ctx(dir)
+      err = assert_raises(Hive::Reviewers::UnknownKindError) do
+        Hive::Reviewers.dispatch(make_spec("kind" => "bogus"), ctx)
+      end
+      assert_match(/codex_review/, err.message)
+    end
+  end
+end

--- a/wiki/log.d/20260610T143000Z-codex-native-review-reviewer.md
+++ b/wiki/log.d/20260610T143000Z-codex-native-review-reviewer.md
@@ -1,0 +1,16 @@
+## [2026-06-10T14:30:00Z] feat — codex native-review reviewer as the patrol PR reviewer
+
+**Action:** Added `Hive::Reviewers::CodexReview` (`lib/hive/reviewers/codex_review.rb`), a new reviewer adapter that runs codex's native single-pass `codex review` subcommand and captures its stdout into the `reviews/<output_basename>-<pass>.md` GFM-checkbox findings file, replacing the expensive multi-persona `ce-code-review` fan-out for patrol PRs. Wired it as the DEFAULT `patrol.review.reviewers` entry in `Hive::Config::DEFAULTS` (`name: codex-native-review`, `kind: codex_review`, `agent: codex`, `prompt_template: reviewer_codex_native_review.md.erb`); human-PR `review.reviewers` is unchanged.
+
+**Design notes (verified against codex-cli 0.139.0):**
+- `codex review --base <BRANCH>` works but is MUTUALLY EXCLUSIVE with a custom `[PROMPT]` (`"the argument '--base <BRANCH>' cannot be used with '[PROMPT]'"`), and the native `--base` output is codex's own free-form summary, not Hive's checkbox format. So the adapter uses **custom-PROMPT mode**: argv is `[codex, "review", "--title", <title>, <prompt>]` (never `--base`), and the prompt itself scopes the review to `git diff <default_branch>...HEAD` and coerces the High/Medium/Nit output.
+- Output is captured (combined stdout+stderr) under a wall-clock timeout with process-group TERM on timeout; validated to contain ≥1 `## High|Medium|Nit` header, else the per-reviewer error path runs and no malformed findings file is left for triage.
+- No `UsageDb` recording — `codex review` surfaces no machine-parseable usage event (that's `codex exec --json` only); fabricating zeros would pollute the ledger.
+
+**Dispatch / config:** `Hive::Reviewers.dispatch` gained a `codex_review` branch on the existing `kind` discriminator. `Hive::Config.validate_reviewer_entries!` now validates `kind` against `REVIEWER_KINDS = %w[agent codex_review linter]` and exempts `codex_review` from the `skill` requirement (name/output_basename uniqueness still enforced). `hive init`'s patrol-reviewer multiselect adds `codex-native-review` as index 1 / the blank default.
+
+**Tests/quality:** New `test/unit/reviewers/codex_review_test.rb` + `test/fixtures/fake-codex` (fakes the codex subprocess; no real codex spawned). `bundle exec rake coverage` → 100.00% line coverage, gate passed, 0 failures. `bundle exec rubocop` on changed Ruby files → no offenses.
+
+**Refreshed pages:**
+- [[modules/reviewers]]
+- [[modules/patrol]]

--- a/wiki/modules/patrol.md
+++ b/wiki/modules/patrol.md
@@ -3,8 +3,8 @@ title: Hive::Patrol
 type: module
 source: lib/hive/patrol/
 created: 2026-05-28
-updated: 2026-06-08
-tags: [module, patrol, review, worktree, pr]
+updated: 2026-06-10
+tags: [module, patrol, review, worktree, pr, codex]
 ---
 
 **TLDR**: `Hive::Patrol::*` is the repository-patrol engine behind [[commands/patrol]]. It keeps clawpatch-style work units and audit state as plain JSON under `.hive-state/patrol/`, delegates review/fix reasoning to configured Hive agent profiles, records patrol review/fix token usage in `Hive::UsageDb`, validates fixes in isolated worktrees, opens PRs, and by default hands opened PRs into the normal `6-review` flow through `Hive::Patrol::ReviewHandoff`.
@@ -41,6 +41,10 @@ Patrol state is deliberately inspectable and removable:
 ```
 
 The managed repository worktree is not edited by fixes. `Fixer` uses [[modules/worktree]] to create a branch named `hive-patrol/<feature-id>-<fingerprint8>` under the project's worktree root. When `patrol.review_prs` is enabled (default), that worktree is kept after PR creation and referenced by a synthetic `6-review` task with display name `Patrol: <finding title>`. When disabled, the successful local worktree is removed after the branch is pushed and the PR opens.
+
+## Patrol PR reviewer (cheap by default)
+
+Patrol PRs flow into `6-review` and are reviewed by `patrol.review.reviewers` (a separate set from human PRs' `review.reviewers`) — see [[stages/review]] `run_reviewers` → `patrol_task?` routing. Because patrol opens many PRs per cycle, the **DEFAULT patrol reviewer is the native single-pass `codex review`** adapter (`kind: codex_review`, `name: codex-native-review`), not the multi-persona `ce-code-review` fan-out (6–18 subagents). It runs one tuned, read-only `codex review` and captures stdout into the GFM-checkbox findings file the triage/fix loop already consumes, so the loop is unchanged. See [[modules/reviewers]] `Reviewers::CodexReview` for argv/format details. Operators can override `patrol.review.reviewers` per project to add the ce-code-review fan-out or Claude.
 
 ## Daemon triggers
 

--- a/wiki/modules/reviewers.md
+++ b/wiki/modules/reviewers.md
@@ -1,13 +1,13 @@
 ---
 title: Hive::Reviewers
 type: module
-source: lib/hive/reviewers.rb, lib/hive/reviewers/{base,agent,synthetic_task,plan_context}.rb
+source: lib/hive/reviewers.rb, lib/hive/reviewers/{base,agent,codex_review,synthetic_task,plan_context}.rb
 created: 2026-04-26
-updated: 2026-05-22
-tags: [reviewer, dispatch, agent, architecture]
+updated: 2026-06-10
+tags: [reviewer, dispatch, agent, codex, patrol, architecture]
 ---
 
-**TLDR**: Reviewer adapter layer for the 6-review stage's Phase 2. `Hive::Reviewers.dispatch(spec, ctx)` returns an adapter (currently only the agent-based `Reviewers::Agent`) that spawns an LLM CLI with the configured skill and prompt; the agent writes findings to `reviews/<output_basename>-<pass>.md`. `Reviewers::Context` carries per-spawn fields; `Reviewers::Result` is the return shape; `Reviewers::SyntheticTask` is the task-shaped facade `spawn_agent` requires for headless sub-spawns inside the review stage. `Reviewers::PlanContext` renders the task's `plan.md` into an authoritative-on-scope block embedded in every reviewer system prompt, so reviewers stop flagging plan-deferred scope as defects. Tool-specific linters are NOT a reviewer kind — they belong in `review.ci.command` per ADR-014. References ADR-014 / ADR-015.
+**TLDR**: Reviewer adapter layer for the 6-review stage's Phase 2. `Hive::Reviewers.dispatch(spec, ctx)` returns an adapter keyed by the spec's `kind`: `"agent"` (default → `Reviewers::Agent`, spawns an LLM CLI with the configured CE skill+prompt; the agent writes the findings file itself) or `"codex_review"` (→ `Reviewers::CodexReview`, runs codex's native single-pass `codex review` and CAPTURES its stdout into the findings file — the cheap patrol default). Either way findings land in `reviews/<output_basename>-<pass>.md` in the GFM-checkbox format the triage/fix loop consumes. `Reviewers::Context` carries per-spawn fields; `Reviewers::Result` is the return shape; `Reviewers::SyntheticTask` is the task-shaped facade `spawn_agent` requires for headless sub-spawns inside the review stage. `Reviewers::PlanContext` renders the task's `plan.md` into an authoritative-on-scope block embedded in every reviewer system prompt, so reviewers stop flagging plan-deferred scope as defects. Tool-specific linters are NOT a reviewer kind — they belong in `review.ci.command` per ADR-014. References ADR-014 / ADR-015.
 
 ## Public API
 
@@ -18,7 +18,7 @@ Hive::Reviewers::Result.new(name:, output_path:, status:, error_message:)
 Hive::Reviewers.synthetic_task_for(ctx)        # → SyntheticTask facade
 ```
 
-`dispatch`'s `kind` discriminator defaults to `"agent"`. An explicit `kind: "linter"` raises `UnknownKindError` (exit code `CONFIG = 78`) with a message pointing the user at `review.ci.command` rather than silently ignoring the request.
+`dispatch`'s `kind` discriminator defaults to `"agent"`; `"codex_review"` selects `Reviewers::CodexReview`. An explicit `kind: "linter"` raises `UnknownKindError` (exit code `CONFIG = 78`) with a message pointing the user at `review.ci.command` rather than silently ignoring the request. Any other value also raises `UnknownKindError`.
 
 ## `Reviewers::Base`
 
@@ -44,6 +44,19 @@ When `claude.mode: tmux`, `Stages::Review.run_reviewers` opens one shared `Hive:
 
 `status_mode: :output_file_exists` is critical: reviewer spawns own a per-pass output file, not the task marker — the orchestrator's `REVIEW_WORKING` marker must persist across each reviewer's spawn (per ADR-021).
 
+## `Reviewers::CodexReview`
+
+Native-`codex review` adapter (added 2026-06-10). The **patrol-default** reviewer: one cheap, tuned, read-only `codex review` pass instead of the multi-persona `ce-code-review` fan-out (6–18 subagents). `run!`:
+
+1. Resolves the codex profile via `AgentProfiles.lookup(spec["agent"])` and calls `check_version!` (preflight; missing binary → `:error "preflight failed: …"`).
+2. Renders `templates/reviewer_codex_native_review.md.erb` (no `skill_invocation` binding — codex review takes no CE skill).
+3. Spawns `codex review --title <title> <prompt>` with `cwd = worktree_path`, capturing combined stdout+stderr under a wall-clock timeout (`spec["timeout_sec"]`, default 7200; process-group TERM on timeout).
+4. Validates: stdout must contain at least one `## High|Medium|Nit` header. Valid → trims the codex banner to the first severity header and writes the rest to `output_path`. Invalid / non-zero exit / timeout → deletes any partial file and returns `:error` (so triage never sees a malformed findings file). Shares Agent's `max_attempts` retry + monotonic `deadline:` handling.
+
+**Why no `--base`**: the codex CLI's parser makes `--base <BRANCH>` mutually exclusive with a custom `[PROMPT]` (`"the argument '--base <BRANCH>' cannot be used with '[PROMPT]'"`), and the native `--base` review emits codex's own free-form summary, not Hive's GFM-checkbox format. So the adapter uses custom-PROMPT mode and the prompt itself scopes the review to `git diff <default_branch>...HEAD` and coerces the output format. argv never includes `--base`.
+
+**Usage**: `codex review` emits a human-readable transcript with no machine-parseable per-token usage event (that exists only for `codex exec --json`), so the adapter intentionally does NOT record `UsageDb` usage — fabricating zeros would pollute the ledger.
+
 ## `Reviewers::SyntheticTask`
 
 `Stages::Base.spawn_agent` expects a task-shaped object (`folder`, `state_file`, `log_dir`, `stage_name`). For sub-spawns inside the review stage there is no real task object per spawn — every reviewer / triage / ci-fix / browser-test invocation needs its own task-like facade so `Hive::Agent` can write per-spawn logs and locks without colliding with the orchestrator's outer task.
@@ -65,12 +78,26 @@ Reviewers live in `cfg.review.reviewers`. Each entry:
   timeout_sec: 3600                  # optional; default 3600
 ```
 
-`Hive::Config.validate_reviewers!` enforces uniqueness on `name` and `output_basename`, non-empty `output_basename`, registered `agent`, and presence of `name` / `skill` / `prompt_template`. The Array replaces wholesale on per-project override (no per-element merge — see [[modules/config]] deep-merge semantics).
+A `codex_review` entry omits `skill` and `budget_usd`:
+
+```yaml
+- name: codex-native-review
+  kind: codex_review
+  agent: codex
+  prompt_template: reviewer_codex_native_review.md.erb
+  output_basename: codex-native-review
+  timeout_sec: 5400
+```
+
+`Hive::Config.validate_reviewers!` enforces uniqueness on `name` and `output_basename`, non-empty `output_basename`, registered `agent`, a `kind` in `REVIEWER_KINDS = %w[agent codex_review linter]`, and presence of `name` / `prompt_template`. `skill` is required for every kind EXCEPT `codex_review` (which runs codex's built-in review and needs none). The Array replaces wholesale on per-project override (no per-element merge — see [[modules/config]] deep-merge semantics).
+
+The DEFAULTS `patrol.review.reviewers` is the single `codex-native-review` entry above; normal `review.reviewers` (human PRs) keeps the ce-code-review set. `hive init`'s patrol-reviewer multiselect now offers `codex-native-review` (index 1, the blank default), `codex-ce-code-review`, and `claude-ce-code-review`.
 
 ## Tests
 
 - `test/unit/reviewers_test.rb` — dispatch (agent / linter / unknown), Context / Result shape.
 - `test/unit/reviewers/agent_test.rb` — adapter render + spawn integration.
+- `test/unit/reviewers/codex_review_test.rb` — `codex review` argv (no `--base`), cwd, stdout→findings, banner trim, malformed/empty/non-zero → error + no file, timeout kill, version gate, retry/deadline, dispatch, prompt render. Fakes the codex subprocess via `test/fixtures/fake-codex` + `HIVE_CODEX_BIN`.
 - `test/unit/reviewers/synthetic_task_test.rb` — facade shape.
 
 ## Backlinks


### PR DESCRIPTION
## Why

Patrol opens many PRs per cycle that flow into `6-review`. The previous patrol reviewer was `codex-ce-code-review` — codex running the multi-persona `ce-code-review` CE skill, a 6–18 subagent fan-out — run once per patrol PR. That is very expensive for the volume patrol produces.

codex-cli 0.139.0 ships a native `codex review` subcommand: a single tuned, read-only code-review pass. This PR adds a reviewer that drives it and makes it the **patrol default**, while leaving human-PR `review.reviewers` on the richer ce-code-review set.

## What

- **`Hive::Reviewers::CodexReview`** (`lib/hive/reviewers/codex_review.rb`) — runs `codex review` in the worktree, captures combined stdout under the reviewers-phase wall-clock timeout (process-group TERM on timeout), and writes the result to `reviews/<output_basename>-<pass>.md` in Hive's existing GFM-checkbox findings format. Reuses `Reviewers::Base`; mirrors `Agent`'s `max_attempts` retry + monotonic `deadline:` handling.
- **Dispatch** — `Hive::Reviewers.dispatch` gains a `codex_review` branch on the existing `kind` discriminator; absent/`agent` → the existing `Reviewers::Agent`.
- **Config** — `validate_reviewer_entries!` validates `kind` against `REVIEWER_KINDS = %w[agent codex_review linter]` and exempts `codex_review` from the `skill` requirement (codex review needs no CE skill); `name`/`output_basename` uniqueness still enforced.
- **Patrol default** — `Config::DEFAULTS` `patrol.review.reviewers` is now the single `codex-native-review` entry. `review.reviewers` (human PRs) and the normal init reviewers are unchanged. `hive init`'s patrol-reviewer multiselect offers `codex-native-review` as the blank default.
- **Template** — `templates/reviewer_codex_native_review.md.erb` instructs `codex review` to scope to `git diff <base>...HEAD` and emit ONLY the High/Medium/Nit checkboxes.

## Key design decision: no `--base`

`codex review --base <BRANCH>` is **mutually exclusive** with a custom `[PROMPT]` in the codex CLI parser (`"the argument '--base <BRANCH>' cannot be used with '[PROMPT]'"`), and the native `--base` output is codex's own free-form summary — not Hive's checkbox format the triage/fix loop consumes. So the adapter uses custom-PROMPT mode: argv is `[codex, "review", "--title", <title>, <prompt>]` and the prompt itself carries both the base-branch scope and the output-format contract.

## Validation

- Output must contain ≥1 `## High|Medium|Nit` header; missing → reviewer failure via the `errors-NN.md` path, no malformed findings file left for triage.
- No `UsageDb` recording — `codex review` surfaces no machine-parseable usage event (that's `codex exec --json` only).

## Tests / quality

- New `test/unit/reviewers/codex_review_test.rb` + `test/fixtures/fake-codex` fake the codex subprocess (no real codex spawned). Covers argv (no `--base`), cwd, stdout→findings, banner trim, malformed/empty/non-zero/timeout → error + no file, version gate, retry/deadline, dispatch, config validation, prompt render.
- `bundle exec rake coverage` → **100.00% line coverage, gate passed, 0 failures**.
- `bundle exec rubocop` on changed Ruby files → no offenses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)