### PR TITLE
release: v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 All notable changes are documented here, newest first. Hive ships frequent micro-releases (see [docs/RELEASING.md](docs/RELEASING.md#versioning-policy)): each `vX.Y.Z` git tag gets a `## X.Y.Z` section with terse bullets — no `[Unreleased]` accumulator. Versioning is [SemVer](https://semver.org): PATCH for fixes and small changes (the common case), MINOR for notable features, MAJOR for milestones.
 
+## 0.2.1
+
+Patrol reviews get dramatically cheaper, the Telegram bot now confirms successes, a scrollable TUI help overlay, daemon archive-recovery, a wave of patrol-found CLI/dry-run safety fixes, and a new public website.
+
+### Patrol — much cheaper reviews
+
+- **Native `codex review` reviewer**: patrol PRs are now reviewed by codex's single-pass `codex review` instead of the multi-persona `ce-code-review` fan-out — far cheaper per review, via a new `kind: codex_review` reviewer. Human PRs keep the full `ce-code-review`.
+- The `hive init` patrol default stays **medium** (the commit-driven `low` mode is costlier on high-velocity repos).
+
+### Telegram bot
+
+- The bot now **confirms successful actions**, not just failures — the daemon→bot channel relays all completions, and a misleading "exit 0" diagnosis on an empty result is fixed.
+
+### TUI
+
+- New **scrollable, word-wrapping help overlay**, including mouse-wheel scrolling.
+
+### Daemon
+
+- Fixed: a task whose finalize errored on an **already-merged PR** now archives cleanly instead of getting stuck.
+
+### Safety & CLI hardening
+
+- Fixed: leading `--json=true/1/yes` no longer leaks option values as commands or targets — unified JSON-flag normalization + rejection across `hive` and `hive-e2e`.
+- Fixed: `hive-e2e` no longer dispatches successful commands twice, and no longer emits duplicate JSON documents.
+- Fixed: the patrol/babysitter **dry-run git stub** now blocks `git grep -O`/pager abbreviations and short-option clusters, and `--textconv` / `cat-file --filters` external-command seams (with hardened, hermetic git passthrough).
+- Fixed: `hive-eval` honors the scenario-root override.
+
+### Docs & website
+
+- New public website — **[hivecli.sh](https://hivecli.sh)**: an outcome-first landing page, curated docs, and AI-native `llms.txt` / per-page markdown. The README now links to it.
+
+### Packaging & internals
+
+- Bumped `sqlite3` 2.9.4 → 2.9.5.
+- GitHub Release notes are now pulled from the matching `CHANGELOG.md` section.
+- Hardened two flaky subprocess-timing tests (the `hv` recursion guard and a tmux pane-capture test).
+
 ## 0.2.0
 
 A big release: smarter and cheaper autonomous **patrol**, a new PR-repair **babysitter**, a richer **Telegram bot**, and a much more resilient **daemon** — plus a wave of reliability/tmux and safety fixes.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hive-cli (0.2.0)
+    hive-cli (0.2.1)
       bubbletea (= 0.1.4)
       faraday (>= 2.14.2, < 3.0)
       faraday-multipart (~> 1.0)

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Hive ships as a rubygem (`hive-cli`) attached to each GitHub Release, signed wit
 | Platform | Channel |
 |----------|---------|
 | macOS arm64 | [`brew install ivankuznetsov/hive/hive`](https://github.com/ivankuznetsov/homebrew-hive) |
-| Ubuntu 22.04+ / glibc Linux x86_64/aarch64 | <code>tmpdir="$(mktemp -d)" && trap 'rm -rf "$tmpdir"' EXIT && curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.2.0/install.sh -o "$tmpdir/hive-install.sh" && bash "$tmpdir/hive-install.sh"</code> |
+| Ubuntu 22.04+ / glibc Linux x86_64/aarch64 | <code>tmpdir="$(mktemp -d)" && trap 'rm -rf "$tmpdir"' EXIT && curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.2.1/install.sh -o "$tmpdir/hive-install.sh" && bash "$tmpdir/hive-install.sh"</code> |
 | Arch Linux x86_64/aarch64 | [`yay -S hive-bin`](https://aur.archlinux.org/packages/hive-bin) |
 
 Prerequisites: **Ruby 3.4** (the gem and its runtime deps install against this), git ≥ 2.40, authenticated `claude` ≥ 2.1.118, `codex` ≥ 0.125.0 for the default execute agent, authenticated `gh`, `tmux` ≥ 3.0 when the project uses the default `claude.mode: tmux`, and Node.js/npm for managed QMD install/repair. The bash installer reports its own installer-side prereqs (`curl`, `jq`, `gem`, checksum tool) on first run; if npm is missing, Hive still installs and `hive doctor` reports the QMD gap non-fatally.

--- a/install.md
+++ b/install.md
@@ -59,8 +59,8 @@ Ubuntu 22.04+ / glibc Linux fallback (pin to the current release tag, not `main`
 ```bash
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
-# Release maintainers: bump v0.2.0 in both installer URLs when cutting a new stable release.
-curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.2.0/install.sh -o "$tmpdir/hive-install.sh"
+# Release maintainers: bump v0.2.1 in both installer URLs when cutting a new stable release.
+curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.2.1/install.sh -o "$tmpdir/hive-install.sh"
 bash "$tmpdir/hive-install.sh"
 ```
 
@@ -69,8 +69,8 @@ To inspect the installer first, run a dry-run before the real invocation. State 
 ```bash
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
-# Release maintainers: bump v0.2.0 in both installer URLs when cutting a new stable release.
-curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.2.0/install.sh -o "$tmpdir/hive-install.sh"
+# Release maintainers: bump v0.2.1 in both installer URLs when cutting a new stable release.
+curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.2.1/install.sh -o "$tmpdir/hive-install.sh"
 bash "$tmpdir/hive-install.sh" --dry-run
 bash "$tmpdir/hive-install.sh"
 ```

--- a/lib/hive.rb
+++ b/lib/hive.rb
@@ -1,5 +1,5 @@
 module Hive
-  VERSION = "0.2.0".freeze
+  VERSION = "0.2.1".freeze
   MIN_CLAUDE_VERSION = "2.1.118".freeze
   # Canonical GitHub org + repo. Referenced by the release probe
   # (UpdateCheck), the brew tap + installer URL (Commands::Update), etc.


### PR DESCRIPTION
Cuts **v0.2.1**: bumps `VERSION` (lib/hive.rb) + `Gemfile.lock`, the `v0.2.1` installer-URL refs (README/install.md), and adds the `## 0.2.1` CHANGELOG section.

Merge → then tag `v0.2.1` to trigger the gem + Homebrew + AUR publish via `release.yml` (release notes come from the CHANGELOG section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)