### PR TITLE
release: v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes are documented here, newest first. Hive ships frequent micro-releases (see [docs/RELEASING.md](docs/RELEASING.md#versioning-policy)): each `vX.Y.Z` git tag gets a `## X.Y.Z` section with terse bullets — no `[Unreleased]` accumulator. Versioning is [SemVer](https://semver.org): PATCH for fixes and small changes (the common case), MINOR for notable features, MAJOR for milestones.
 
+## 0.2.2
+
+Hotfix: claude launches were failing for every subscriber whose Claude Code shows the plan-inclusion banner.
+
+### Limits detection — false positive + hardening
+
+- **Fix**: Claude Code's informational startup/footer line — "Included in your plan limits until Jun 22, then switch to usage credits to continue." — matched the bare `usage credits` limit pattern, so every healthy claude launch (daemon, TUI-triggered runs, CLI verbs, bot dispatches) was classified `limits_reached` and killed in seconds; the same footer text persists for the whole session, so the mid-run sentinel poll was also killing healthy running agents.
+- **Hardening so chrome copy changes can't repeat this**: readiness now wins at launch (no fail-fast limit check while claude is still painting its UI; only a session that never becomes ready is classified, by the post-timeout check), and limit patterns run line-by-line behind a benign filter (plan-inclusion promos, `/status` usage hints, reset-date notices, box-drawing chrome). The documented bias: a missed wall degrades to a clean timeout the daemon healer retries; a false positive killed healthy sessions everywhere.
+
 ## 0.2.1
 
 Patrol reviews get dramatically cheaper, the Telegram bot now confirms successes, a scrollable TUI help overlay, daemon archive-recovery, a wave of patrol-found CLI/dry-run safety fixes, and a new public website.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hive-cli (0.2.1)
+    hive-cli (0.2.2)
       bubbletea (= 0.1.4)
       faraday (>= 2.14.2, < 3.0)
       faraday-multipart (~> 1.0)

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Hive ships as a rubygem (`hive-cli`) attached to each GitHub Release, signed wit
 | Platform | Channel |
 |----------|---------|
 | macOS arm64 | [`brew install ivankuznetsov/hive/hive`](https://github.com/ivankuznetsov/homebrew-hive) |
-| Ubuntu 22.04+ / glibc Linux x86_64/aarch64 | <code>tmpdir="$(mktemp -d)" && trap 'rm -rf "$tmpdir"' EXIT && curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.2.1/install.sh -o "$tmpdir/hive-install.sh" && bash "$tmpdir/hive-install.sh"</code> |
+| Ubuntu 22.04+ / glibc Linux x86_64/aarch64 | <code>tmpdir="$(mktemp -d)" && trap 'rm -rf "$tmpdir"' EXIT && curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.2.2/install.sh -o "$tmpdir/hive-install.sh" && bash "$tmpdir/hive-install.sh"</code> |
 | Arch Linux x86_64/aarch64 | [`yay -S hive-bin`](https://aur.archlinux.org/packages/hive-bin) |
 
 Prerequisites: **Ruby 3.4** (the gem and its runtime deps install against this), git ≥ 2.40, authenticated `claude` ≥ 2.1.118, `codex` ≥ 0.125.0 for the default execute agent, authenticated `gh`, `tmux` ≥ 3.0 when the project uses the default `claude.mode: tmux`, and Node.js/npm for managed QMD install/repair. The bash installer reports its own installer-side prereqs (`curl`, `jq`, `gem`, checksum tool) on first run; if npm is missing, Hive still installs and `hive doctor` reports the QMD gap non-fatally.

--- a/install.md
+++ b/install.md
@@ -59,8 +59,8 @@ Ubuntu 22.04+ / glibc Linux fallback (pin to the current release tag, not `main`
 ```bash
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
-# Release maintainers: bump v0.2.1 in both installer URLs when cutting a new stable release.
-curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.2.1/install.sh -o "$tmpdir/hive-install.sh"
+# Release maintainers: bump v0.2.2 in both installer URLs when cutting a new stable release.
+curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.2.2/install.sh -o "$tmpdir/hive-install.sh"
 bash "$tmpdir/hive-install.sh"
 ```
 
@@ -69,8 +69,8 @@ To inspect the installer first, run a dry-run before the real invocation. State 
 ```bash
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
-# Release maintainers: bump v0.2.1 in both installer URLs when cutting a new stable release.
-curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.2.1/install.sh -o "$tmpdir/hive-install.sh"
+# Release maintainers: bump v0.2.2 in both installer URLs when cutting a new stable release.
+curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.2.2/install.sh -o "$tmpdir/hive-install.sh"
 bash "$tmpdir/hive-install.sh" --dry-run
 bash "$tmpdir/hive-install.sh"
 ```

--- a/lib/hive.rb
+++ b/lib/hive.rb
@@ -1,5 +1,5 @@
 module Hive
-  VERSION = "0.2.1".freeze
+  VERSION = "0.2.2".freeze
   MIN_CLAUDE_VERSION = "2.1.118".freeze
   # Canonical GitHub org + repo. Referenced by the release probe
   # (UpdateCheck), the brew tap + installer URL (Commands::Update), etc.


### PR DESCRIPTION
Patch release carrying the limits-detection hotfix (#444): Claude Code's plan-inclusion banner was classified as a usage wall, killing every healthy claude launch and mid-run session for subscribers on current Claude Code builds. Includes the chrome-proof hardening (readiness-wins launch ordering, line-based benign-filtered matching).

Bump VERSION + Gemfile.lock + installer URL refs, add the 0.2.2 CHANGELOG section. Tag `v0.2.2` after merge to publish gem/brew/AUR via release.yml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)