### PR TITLE
fix(launcher): orphan sweep must never kill the tmux server

### DIFF
--- a/lib/hive/claude_launcher.rb
+++ b/lib/hive/claude_launcher.rb
@@ -865,8 +865,35 @@ module Hive
       end
       return if matches.strip.empty?
 
-      out, err, status = Open3.capture3("pkill", "-f", "--", pattern)
-      log_orphan_sweep(task, matches, out, err, status)
+      # NOT pkill -f: the tmux SERVER's argv is the first session's full
+      # command line — including that task's `--add-dir` — so a blanket
+      # pattern kill from the task that happened to start the server took
+      # down the server and EVERY live hive session with it (observed as
+      # parallel brainstorms dying with tmux_session_terminated the moment
+      # a sibling finished). Kill matched pids individually, never tmux.
+      killed = []
+      skipped = []
+      matches.each_line do |line|
+        entry = line.strip
+        next if entry.empty?
+
+        pid_s, cmd = entry.split(" ", 2)
+        pid = Integer(pid_s, exception: false)
+        next unless pid && cmd
+
+        if File.basename(cmd.split(" ", 2).first.to_s) == "tmux"
+          skipped << entry
+          next
+        end
+
+        begin
+          Process.kill("TERM", pid)
+          killed << entry
+        rescue Errno::ESRCH, Errno::EPERM => e
+          skipped << "#{entry} (#{e.class})"
+        end
+      end
+      log_orphan_sweep(task, matches, killed, skipped)
     rescue Errno::ENOENT => e
       # `pgrep` / `pkill` not installed on this host. The blanket
       # rescue used to swallow this silently, disabling orphan cleanup
@@ -881,14 +908,14 @@ module Hive
       "--add-dir[[:space:]]+#{Regexp.escape(task.folder)}([[:space:]]|$)"
     end
 
-    def log_orphan_sweep(task, matches, out, err, status)
+    def log_orphan_sweep(task, matches, killed, skipped)
       log_path = orphan_sweep_log_path(task)
       rotate_orphan_sweep_log(log_path)
       File.open(log_path, "a") do |f|
         f.puts "[#{Time.now.utc.iso8601}] pgrep matches:"
         f.puts matches
-        f.puts "[#{Time.now.utc.iso8601}] pkill exit=#{status&.exitstatus} " \
-               "out=#{out.strip.inspect} err=#{err.strip.inspect}"
+        f.puts "[#{Time.now.utc.iso8601}] killed=#{killed.size} #{killed.inspect}"
+        f.puts "[#{Time.now.utc.iso8601}] skipped=#{skipped.size} #{skipped.inspect}"
       end
     rescue StandardError => e
       # Full disk / EROFS / EACCES: don't swallow silently — the

--- a/test/unit/stages/brainstorm_tmux_sentinel_test.rb
+++ b/test/unit/stages/brainstorm_tmux_sentinel_test.rb
@@ -126,6 +126,41 @@ class BrainstormTmuxSentinelTest < Minitest::Test
     end
   end
 
+  # The tmux SERVER's argv contains the first session's full command line
+  # (including `--add-dir <folder>`), so it matches the sweep pattern. The
+  # sweep must NEVER kill it — doing so destroys every live hive session on
+  # the box (observed: a finishing brainstorm killing its parallel sibling
+  # with tmux_session_terminated).
+  def test_orphan_sweep_kills_claude_but_never_the_tmux_server
+    with_tmp_task_folder do |task|
+      matches = "1084896 tmux new-session -d -s hive-x --add-dir #{task.folder} --bin claude\n" \
+                "1145777 /opt/claude-code/bin/claude --add-dir #{task.folder} --model default\n"
+      original = Open3.singleton_class.instance_method(:capture3)
+      ok = fake_status(success: true, exitstatus: 0)
+      Open3.define_singleton_method(:capture3) do |*args|
+        raise "unexpected command: #{args.inspect}" unless args.first == "pgrep"
+
+        [ matches, "", ok ]
+      end
+
+      killed_pids = []
+      with_replaced_singleton_method(Process, :kill, lambda { |sig, pid|
+        killed_pids << [ sig, pid ]
+        1
+      }) do
+        Hive::ClaudeLauncher.sweep_orphan_processes(task)
+      end
+
+      assert_equal [ [ "TERM", 1145777 ] ], killed_pids,
+                   "only the claude process may be killed — never the tmux server"
+      log = File.read(Hive::ClaudeLauncher.orphan_sweep_log_path(task))
+      assert_includes log, "killed=1"
+      assert_includes log, "skipped=1", "the tmux server must be logged as skipped"
+    ensure
+      Open3.singleton_class.send(:define_method, :capture3, original) if original
+    end
+  end
+
   def test_orphan_sweep_logs_warning_when_pgrep_fails
     with_tmp_task_folder do |task|
       original = Open3.singleton_class.instance_method(:capture3)
@@ -177,9 +212,8 @@ class BrainstormTmuxSentinelTest < Minitest::Test
   def test_orphan_sweep_logging_ignores_missing_task_folder
     with_tmp_dir do |dir|
       task = Struct.new(:folder).new(File.join(dir, "missing"))
-      status_ok = fake_status(success: true, exitstatus: 0)
 
-      assert_nil Hive::ClaudeLauncher.log_orphan_sweep(task, "123 claude", "", "", status_ok)
+      assert_nil Hive::ClaudeLauncher.log_orphan_sweep(task, "123 claude", [ "123 claude" ], [])
       assert_nil Hive::ClaudeLauncher.log_orphan_sweep_warning(task, "pgrep failed")
     end
   end
@@ -389,15 +423,22 @@ class BrainstormTmuxSentinelTest < Minitest::Test
         end
       end
 
-      Hive::ClaudeLauncher.sweep_orphan_processes(task)
+      killed = []
+      with_replaced_singleton_method(Process, :kill, lambda { |sig, pid|
+        killed << [ sig, pid ]
+        1
+      }) do
+        Hive::ClaudeLauncher.sweep_orphan_processes(task)
+      end
 
       assert_equal "pgrep", calls.fetch(0).fetch(0)
       assert_equal "--", calls.fetch(0).fetch(2)
       assert_match(/\A--add-dir\[.+\]/, calls.fetch(0).fetch(3))
       refute_includes calls.fetch(0).fetch(3), "(?:"
-      assert_equal "pkill", calls.fetch(1).fetch(0)
-      assert_equal "--", calls.fetch(1).fetch(2)
-      assert_equal calls.fetch(0).fetch(3), calls.fetch(1).fetch(3)
+      # pkill is gone (it could match — and kill — the tmux server); matched
+      # pids are killed individually instead.
+      assert_equal 1, calls.size, "only pgrep shells out now"
+      assert_equal [ [ "TERM", 123 ] ], killed
     ensure
       Open3.singleton_class.send(:define_method, :capture3, original) if original
     end


### PR DESCRIPTION
## Summary

The claude orphan sweep runs `pkill -f -- '--add-dir <task folder>'` when a stage run finishes. The **tmux server itself matches that pattern** whenever the swept task happened to start the server: a daemonized tmux server keeps its original `tmux new-session … --add-dir <folder> …` argv. Killing it destroys **every live hive session on the box**, not just the orphan.

Observed while dogfooding hivebox (PR #300): two brainstorms running in parallel; the moment one finished its round, the sibling died with `tmux_session_terminated` at the same second. The finishing task's sweep log shows the pgrep match was the `tmux new-session` server process and `pkill exit=0`.

**Exposure on v0.2.2:** any time two or more claude tasks run concurrently in tmux mode and the task that started the server completes first — i.e., routine daemon parallelism randomly kills in-flight siblings.

## Fix

Replace the blanket `pkill -f` with individual kills of pgrep-matched pids, skipping any process whose command is `tmux`; killed/skipped sets are logged in the sweep log.

## Tests

Regression pins the exact observed shape: a pgrep result containing the tmux-server line plus a claude line must TERM only the claude pid and log the server as skipped. The double-dash/pgrep-contract test updated for the per-pid path (only pgrep shells out now). Sentinel suite 31 runs green on this branch.

Cherry-picked from the hivebox branch (single commit, ca01bbbc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)