### PR TITLE
Hive patrol: Dry-run gh api allows cache writes

### DIFF
--- a/bin/hive-babysitter-stub-gh
+++ b/bin/hive-babysitter-stub-gh
@@ -42,6 +42,7 @@ def api_read_only?(rest)
   method = nil
   payload = false
   unsafe_payload = false
+  cache = false
   index = 1
   while index < rest.length
     arg = rest[index]
@@ -66,6 +67,9 @@ def api_read_only?(rest)
       payload = true
       unsafe_payload = true
       index += 2
+    when "--cache"
+      cache = true
+      index += 2
     when /\A-f.+\z/, /\A--raw-field=.+\z/
       payload = true
       index += 1
@@ -81,14 +85,17 @@ def api_read_only?(rest)
       payload = true
       unsafe_payload = true
       index += 1
+    when /\A--cache=.*\z/
+      cache = true
+      index += 1
     else
       index += 1
     end
   end
 
-  return method.casecmp("GET").zero? && !unsafe_payload if method
+  return method.casecmp("GET").zero? && !unsafe_payload && !cache if method
 
-  !payload
+  !payload && !cache
 end
 
 def read_only?(rest)

--- a/test/unit/babysitter/dry_run_env_test.rb
+++ b/test/unit/babysitter/dry_run_env_test.rb
@@ -302,6 +302,27 @@ class BabysitterDryRunEnvTest < Minitest::Test
     end
   end
 
+  def test_gh_api_cache_flags_are_skipped_without_writing_cache
+    with_tmp_dir do |dir|
+      cache_dir = File.join(dir, "cache")
+      log_path = File.join(dir, "skipped.log")
+      real_gh = cache_writing_gh_binary(dir, "real-gh")
+      env = {
+        "HIVE_BABYSITTER_REAL_GH" => real_gh,
+        "HIVE_BABYSITTER_DRY_RUN_LOG" => log_path,
+        "XDG_CACHE_HOME" => cache_dir
+      }
+
+      assert_stubbed env, "gh", "api", "--method", "GET", "--cache", "1h", "rate_limit"
+      assert_stubbed env, "gh", "api", "--method=GET", "--cache=1h", "rate_limit"
+
+      refute_path_exists File.join(cache_dir, "gh")
+      skipped = File.read(log_path)
+      assert_includes skipped, "gh api --method GET --cache 1h rate_limit skipped"
+      assert_includes skipped, "gh api --method=GET --cache=1h rate_limit skipped"
+    end
+  end
+
   def test_gh_stub_skips_browser_launch_flags
     with_tmp_dir do |dir|
       real_gh = recording_binary(dir, "real-gh")
@@ -507,6 +528,19 @@ class BabysitterDryRunEnvTest < Minitest::Test
       File.open(#{File.join(dir, "real.log").dump}, "a") do |file|
         file.puts(([File.basename($PROGRAM_NAME)] + ARGV).join(" "))
       end
+    RUBY
+    FileUtils.chmod("+x", path)
+    path
+  end
+
+  def cache_writing_gh_binary(dir, name)
+    path = File.join(dir, name)
+    File.write(path, <<~RUBY)
+      #!/usr/bin/env ruby
+      require "fileutils"
+      cache_path = File.join(ENV.fetch("XDG_CACHE_HOME"), "gh")
+      FileUtils.mkdir_p(cache_path)
+      File.write(File.join(cache_path, "api-cache"), ARGV.join(" "))
     RUBY
     FileUtils.chmod("+x", path)
     path


### PR DESCRIPTION
## Summary

Closes a dry-run escape hatch in the babysitter's `gh` stub (`bin/hive-babysitter-stub-gh`): `gh api --method GET --cache 1h ...` was classified as a read-only passthrough because the API screen only treated payload/body flags as unsafe, yet real `gh` persists cache entries under `XDG_CACHE_HOME` — so a dry-run agent could still create filesystem state by pointing `XDG_CACHE_HOME` at a writable directory.

`api_read_only?` now tracks `--cache` (separate-value form) and `--cache=<duration>` (glued form) alongside the payload flags, and rejects the invocation on both classification paths — explicit `GET` and the no-method default — so cache-flag calls are skipped and logged instead of reaching the real binary.

Patrol finding: `command-bin-hive-babysitter-stub-gh-1` (security / medium / high confidence), fingerprint `e0117297df4a60b5b63f310dd445d8eb90e8e6bf9b71a0939102a0e9dc89376b`.

## Test plan

- New regression `test_gh_api_cache_flags_are_skipped_without_writing_cache` in `test/unit/babysitter/dry_run_env_test.rb`: points `XDG_CACHE_HOME` at a temp directory, drives both `--cache 1h` and `--cache=1h` spellings through the stub with a cache-writing fake `gh`, asserts both are skipped and logged, and asserts no `cache/gh` files are created.
- Targeted suite: `bundle exec ruby -Itest test/unit/babysitter/dry_run_env_test.rb` — 9 runs, 780 assertions, 0 failures, 0 errors.
- Patrol validation: `bundle exec rake test` passed, `bundle exec rubocop` clean.

## Review summary

- `codex-native-review` pass 1: no High, Medium, or Nit findings. The reviewer verified the diff against `origin/main` for correctness, security, data-loss, concurrency, and maintainability regressions and reported none; the targeted dry-run env test passed during review.
- Triage cross-checked the diff against the patrol finding: both `--cache` forms are rejected on both `api_read_only?` paths and the regression test asserts no cache writes — exactly the recommended fix. No escalations.

## Linked task

`/home/asterio/Dev/hive/.hive-state/stages/8-finalize/patrol-command-bin-hive-babysitter-stub-gh-e0117297`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
