### PR TITLE
wiki: v0.2.4 release coverage refresh (llm-wiki automation)

### DIFF
--- a/wiki/active-areas.md
+++ b/wiki/active-areas.md
@@ -19,7 +19,9 @@ Recent release/dependency history inspected on 2026-06-12:
 |--------|------|-------|
 | `64b11b41` | Release | Prepares v0.3.0: sets `Hive::VERSION` and the lockfile path gem to `0.3.0`, points public Linux installer snippets at `v0.3.0`, and adds release notes for hivebox alpha, the first GHCR hivebox image release, session-limit healing, dispatch-request/drop schema v2, golden-path E2E, and Windows installer harness coverage. |
 | `2e307a19` | Dependency lockfile | Relocks the root bundle after the earlier `rack-test` manifest removal; root `Gemfile.lock` no longer lists `rack-test` as a resolved gem or top-level dependency. |
+| `416c8a9c` | Wiki refresh | Documents the patrol native `codex review` reviewer default and associated init/config/review page drift. |
 | `c7d8aa4f` | Release | Tags v0.2.4 from `main`; the release prep commit sets `Hive::VERSION` and the lockfile path gem to `0.2.4`, points public Linux installer snippets at `v0.2.4`, and adds release notes for `claude.model` / `claude.effort` pins. |
+| `d9f9887d` | Claude launch config | Adds project-global `claude.model` / `claude.effort` pins for both headless and tmux Hive-launched Claude sessions, with `hive init` prompts and schema/test coverage. |
 | `6b9f14bb` | Wiki refresh | Documents v0.2.3 release prep plus the Claude/tmux orphan-sweep contract across release, agent, brainstorm, testing, and gaps pages. |
 | `1c3baa8a` | Release | Tags v0.2.3 from `main`; the release prep commit sets `Hive::VERSION` and the lockfile path gem to `0.2.3` and points public Linux installer snippets at `v0.2.3`. |
 | `024b29b0` | Claude/tmux cleanup | Replaces blanket orphan-sweep `pkill -f` with `pgrep` plus per-PID `TERM`, skipping matched `tmux` server commands and logging killed/skipped rows. |

--- a/wiki/dependencies.md
+++ b/wiki/dependencies.md
@@ -9,6 +9,13 @@ tags: [dependencies, gems, runtime]
 
 **TLDR**: The `hive-cli` gem has eight direct runtime gems; root development/test tooling is declared in `Gemfile`; the Rails hivebox app under `web/` carries its own bundle. Sinatra, rack-protection, and puma left the gem runtime with the Rails web rewrite, while the web bundle owns Rails/Turbo/solid-stack dependencies plus Redcarpet for sanitized markdown artifact rendering.
 
+`hive.gemspec` owns runtime gem constraints; `Gemfile` uses `gemspec`
+to pull those constraints into Bundler, then adds development/test-only
+tools. Commit `c7d8aa4f` changed the local path gem entry in
+`Gemfile.lock` from `hive-cli (0.2.3)` to `hive-cli (0.2.4)` to match
+`Hive::VERSION`; it did not change third-party gem constraints or
+resolved third-party versions.
+
 ## Runtime gems
 
 | Gem | Version | Purpose |

--- a/wiki/log.d/20260612T210436Z-v024-release-wiki-refresh.md
+++ b/wiki/log.d/20260612T210436Z-v024-release-wiki-refresh.md
@@ -1,0 +1,11 @@
+## [2026-06-12T21:04:36Z] release/wiki — refresh v0.2.4 release coverage
+
+**Action:** Refreshed release/install and dependency wiki coverage after commit `c7d8aa4f` tagged `v0.2.4`. Read `.llm-wiki/config.json`, `AGENTS.md`, `CLAUDE.md`, [[index]], [[gaps]], and recent [[log]] entries first. Searched the configured master wiki path `/home/asterio/wikis/master/wiki` plus the default cross-project paths; only the configured master path existed and it had no matching Hive-specific `v0.2.4` / Claude model-effort release guidance. `qmd search "claude model effort v0.2.4 patrol native reviewer release"` returned no results, so verification used direct git/source/wiki reads.
+
+Inspected the clean working tree, recent git history, commit `c7d8aa4f`, and the current `lib/hive.rb`, `Gemfile.lock`, `CHANGELOG.md`, `README.md`, and `install.md`. Updated [[dependencies]] so the local path gem/version coverage points at `hive-cli (0.2.4)` and records that the lockfile change did not alter third-party dependencies. Updated [[operating]] install and release-verification snippets to `v0.2.4`, refreshed [[active-areas]] so the recent release table and release/install row reflect the current stable release, and updated [[gaps]] to carry the remaining uncertainty: no in-tree artifact proves `packaging/verify-release.sh --version=v0.2.4` or published Homebrew/AUR/GitHub Release channel verification after the tag exists. Page coverage did not change, so [[index]] needed no structural update. Did not edit compiled [[log]], and did not run `qmd update` or `qmd embed`.
+
+**Refreshed pages:**
+- [[active-areas]]
+- [[dependencies]]
+- [[operating]]
+- [[gaps]]


### PR DESCRIPTION
Automation-produced wiki refresh that was sitting uncommitted on the canonical checkout; rebased over the hivebox merge with table-union conflict resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)