### PR TITLE
wiki: follow-up refresh — foreground v0.3.0 in dependencies

### DIFF
--- a/wiki/dependencies.md
+++ b/wiki/dependencies.md
@@ -3,7 +3,7 @@ title: Dependencies
 type: dependencies
 source: Gemfile, hive.gemspec, Gemfile.lock, web/Gemfile, web/Gemfile.lock
 created: 2026-04-25
-updated: 2026-06-12
+updated: 2026-06-13
 tags: [dependencies, gems, runtime]
 ---
 
@@ -11,10 +11,12 @@ tags: [dependencies, gems, runtime]
 
 `hive.gemspec` owns runtime gem constraints; `Gemfile` uses `gemspec`
 to pull those constraints into Bundler, then adds development/test-only
-tools. Commit `c7d8aa4f` changed the local path gem entry in
-`Gemfile.lock` from `hive-cli (0.2.3)` to `hive-cli (0.2.4)` to match
-`Hive::VERSION`; it did not change third-party gem constraints or
-resolved third-party versions.
+tools. The current checkout is `0.3.0`: `lib/hive.rb`, root
+`Gemfile.lock`, and `web/Gemfile.lock` all pin the local path gem as
+`hive-cli (0.3.0)`. Recent release lockfile commits `c7d8aa4f`
+(`0.2.4`) and `8146d481` (`0.3.0`) changed only local path gem
+metadata; they did not change third-party gem constraints or resolved
+third-party versions.
 
 ## Runtime gems
 

--- a/wiki/log.d/20260612T210436Z-v024-release-wiki-refresh.md
+++ b/wiki/log.d/20260612T210436Z-v024-release-wiki-refresh.md
@@ -2,10 +2,8 @@
 
 **Action:** Refreshed release/install and dependency wiki coverage after commit `c7d8aa4f` tagged `v0.2.4`. Read `.llm-wiki/config.json`, `AGENTS.md`, `CLAUDE.md`, [[index]], [[gaps]], and recent [[log]] entries first. Searched the configured master wiki path `/home/asterio/wikis/master/wiki` plus the default cross-project paths; only the configured master path existed and it had no matching Hive-specific `v0.2.4` / Claude model-effort release guidance. `qmd search "claude model effort v0.2.4 patrol native reviewer release"` returned no results, so verification used direct git/source/wiki reads.
 
-Inspected the clean working tree, recent git history, commit `c7d8aa4f`, and the current `lib/hive.rb`, `Gemfile.lock`, `CHANGELOG.md`, `README.md`, and `install.md`. Updated [[dependencies]] so the local path gem/version coverage points at `hive-cli (0.2.4)` and records that the lockfile change did not alter third-party dependencies. Updated [[operating]] install and release-verification snippets to `v0.2.4`, refreshed [[active-areas]] so the recent release table and release/install row reflect the current stable release, and updated [[gaps]] to carry the remaining uncertainty: no in-tree artifact proves `packaging/verify-release.sh --version=v0.2.4` or published Homebrew/AUR/GitHub Release channel verification after the tag exists. Page coverage did not change, so [[index]] needed no structural update. Did not edit compiled [[log]], and did not run `qmd update` or `qmd embed`.
+Inspected the clean working tree, recent git history, commit `c7d8aa4f`, and the then-current `lib/hive.rb`, `Gemfile.lock`, `CHANGELOG.md`, `README.md`, and `install.md`. Updated [[dependencies]] with a historical `hive-cli (0.2.4)` lockfile note and refreshed [[active-areas]] with v0.2.4 plus adjacent release/dependency rows. Current HEAD has since advanced to v0.3.0 through `8146d481`; [[operating]] and [[gaps]] already carry the current v0.3.0 install/release-verification examples and artifact-verification uncertainty from that later refresh. Page coverage did not change, so [[index]] needed no structural update. Did not edit compiled [[log]], and did not run `qmd update` or `qmd embed`.
 
 **Refreshed pages:**
 - [[active-areas]]
 - [[dependencies]]
-- [[operating]]
-- [[gaps]]

--- a/wiki/log.d/20260613T105715Z-v024-refresh-followup.md
+++ b/wiki/log.d/20260613T105715Z-v024-refresh-followup.md
@@ -1,0 +1,27 @@
+---
+date: 2026-06-13
+slug: v024-refresh-followup
+pages: [dependencies, log]
+---
+
+Post-commit wiki coverage follow-up after commit `e423632e` touched
+[[active-areas]], [[dependencies]], and
+`wiki/log.d/20260612T210436Z-v024-release-wiki-refresh.md`. Read
+`AGENTS.md`, `.llm-wiki/config.json`, [[index]], [[decisions]], [[gaps]], and
+recent compiled [[log]] entries first. `qmd search "v0.2.4 release coverage
+active areas dependencies"` returned no results, and targeted search of the
+configured master wiki path found no Hive-specific guidance.
+
+Inspected the committed diff for `e423632e`, the underlying v0.2.4 release
+commit `c7d8aa4f`, the later v0.3.0 release commit `8146d481`, and current
+`CHANGELOG.md`, `README.md`, `install.md`, `lib/hive.rb`, root `Gemfile.lock`,
+`web/Gemfile.lock`, [[active-areas]], [[dependencies]], [[operating]], and
+[[gaps]]. Confirmed current source/wiki release state is v0.3.0; the v0.2.4
+note is historical. Updated [[dependencies]] to foreground the current `0.3.0`
+path-gem state and note that both recent release lockfile commits changed only
+local path metadata. Corrected the prior v0.2.4 log fragment so its
+action/refreshed-pages list matches the committed file list and does not claim
+[[operating]] or [[gaps]] were refreshed by `e423632e`. No page coverage
+changed, so [[index]] was not edited. No new uncertainty beyond the existing
+v0.3.0 artifact-verification gap in [[gaps]] was found. Did not edit compiled
+[[log]], and did not run `qmd update` or `qmd embed`.


### PR DESCRIPTION
Automation-generated wiki refinement captured from the release worktrees after v0.3.0 shipped. Leads dependencies.md with current 0.3.0 lockfile pins; corrects the v0.2.4 log fragment to note HEAD advanced. Wiki-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)