### PR TITLE
fix(review): self-heal triage/fix usage-limit failures

### DIFF
--- a/lib/hive/stages/review.rb
+++ b/lib/hive/stages/review.rb
@@ -388,9 +388,12 @@ module Hive
                 return { commit: "triage_tampered_pass_#{format('%02d', pass)}",
                          status: :review_error }
               when :error
-                Hive::Markers.set(task.state_file, :review_error,
-                                  phase: :triage, reason: "triage_failed", pass: pass)
-                return { commit: "triage_error_pass_#{format('%02d', pass)}",
+                limited = mark_review_phase_failure(
+                  task, phase: :triage, terminal_reason: "triage_failed",
+                  pass: pass, error_message: triage_result.error_message
+                )
+                label = limited ? "triage_limits_reached" : "triage_error"
+                return { commit: "#{label}_pass_#{format('%02d', pass)}",
                          status: :review_error }
               end
             else
@@ -509,9 +512,12 @@ module Hive
           end
 
           if agent_failed?(fix_result)
-            Hive::Markers.set(task.state_file, :review_error,
-                              phase: :fix, reason: "fix_failed", pass: pass)
-            return { commit: "fix_error_pass_#{format('%02d', pass)}",
+            limited = mark_review_phase_failure(
+              task, phase: :fix, terminal_reason: "fix_failed",
+              pass: pass, error_message: fix_result && fix_result[:error_message]
+            )
+            label = limited ? "fix_limits_reached" : "fix_error"
+            return { commit: "#{label}_pass_#{format('%02d', pass)}",
                      status: :review_error }
           end
 
@@ -771,6 +777,30 @@ module Hive
                           reason: "wall_clock", pass: pass, elapsed: elapsed)
         { commit: "stale_wall_clock_pass_#{format('%02d', pass)}",
           status: :review_stale }
+      end
+
+      # A per-pass review-phase agent (triage, fix) that died because the
+      # provider hit a usage/credit limit must self-heal like the reviewers
+      # phase already does — not sit terminally red until a human retries.
+      # When the captured error text reads as a limit, stamp
+      # `reason: limits_reached` plus a `retry_after` cooldown the daemon
+      # healer honors (StaleAgentHealer#auto_recoverable_review_error?);
+      # otherwise write the terminal `<phase>_failed` marker as before.
+      # A timeout (no limit text) stays terminal — only an actual limit
+      # earns the self-healing retry stamp. Returns whether the limit path
+      # was taken so the caller can label its commit.
+      def mark_review_phase_failure(task, phase:, terminal_reason:, pass:, error_message:)
+        if Hive::AgentLimit.limit_reached?(error_message.to_s)
+          Hive::Markers.set(task.state_file, :review_error,
+                            phase: phase, reason: "limits_reached", pass: pass,
+                            message: "#{phase} hit a usage/credit limit",
+                            retry_after: Hive::AgentLimit.retry_after)
+          true
+        else
+          Hive::Markers.set(task.state_file, :review_error,
+                            phase: phase, reason: terminal_reason, pass: pass)
+          false
+        end
       end
 
       # Pass to start at on a fresh hive run. Falls back to 1 when no

--- a/test/integration/run_review_test.rb
+++ b/test/integration/run_review_test.rb
@@ -479,6 +479,80 @@ class RunReviewTest < Minitest::Test
     end
   end
 
+  # A triage agent that dies on a provider usage/credit limit must self-heal
+  # like the reviewers phase already does — reason=limits_reached + a
+  # retry_after the daemon healer honors — not sit terminally on
+  # triage_failed. (Patrol PRs review with codex but still triage with
+  # claude, so a claude session-limit wall stranded three patrol tasks.)
+  def test_triage_usage_limit_self_heals_as_limits_reached_with_retry_after
+    with_tmp_global_config do
+      with_tmp_git_repo do |dir|
+        folder = setup_review_task(dir)
+        Hive::Stages::Review::Triage.singleton_class.alias_method(:__orig_triage_run_lp!, :run!)
+        Hive::Stages::Review::Triage.define_singleton_method(:run!) do |cfg:, ctx:|
+          Hive::Stages::Review::Triage::Result.new(
+            status: :error,
+            escalations_path: File.join(ctx.task_folder, "reviews", "escalations-#{format('%02d', ctx.pass)}.md"),
+            error_message: "limits reached for claude: You've hit your session limit · resets 8pm (Europe/London)",
+            tampered_files: []
+          )
+        end
+        begin
+          capture_io do
+            assert_raises(Hive::TaskInErrorState) { Hive::Commands::Run.new(folder).call }
+          end
+          marker = Hive::Markers.current(File.join(folder, "task.md"))
+          assert_equal :review_error, marker.name
+          assert_equal "triage", marker.attrs["phase"]
+          assert_equal "limits_reached", marker.attrs["reason"],
+                       "a triage usage-limit failure must self-heal, not sit terminal on triage_failed"
+          refute_nil marker.attrs["retry_after"],
+                     "the limits_reached marker must carry the retry_after cooldown the healer reads"
+          assert Time.parse(marker.attrs["retry_after"]) > Time.now - 5,
+                 "retry_after must be a future cooldown stamp"
+        ensure
+          Hive::Stages::Review::Triage.singleton_class.alias_method(:run!, :__orig_triage_run_lp!)
+          Hive::Stages::Review::Triage.singleton_class.send(:remove_method, :__orig_triage_run_lp!)
+        end
+      end
+    end
+  end
+
+  # A non-limit triage failure (e.g. a timeout) must stay terminal: only an
+  # actual usage/credit limit earns the self-healing retry stamp, so a real
+  # bug can't masquerade as a transient limit and loop forever.
+  def test_triage_non_limit_error_stays_terminal_triage_failed
+    with_tmp_global_config do
+      with_tmp_git_repo do |dir|
+        folder = setup_review_task(dir)
+        Hive::Stages::Review::Triage.singleton_class.alias_method(:__orig_triage_run_np!, :run!)
+        Hive::Stages::Review::Triage.define_singleton_method(:run!) do |cfg:, ctx:|
+          Hive::Stages::Review::Triage::Result.new(
+            status: :error,
+            escalations_path: File.join(ctx.task_folder, "reviews", "escalations-#{format('%02d', ctx.pass)}.md"),
+            error_message: "triage agent failed (timeout)",
+            tampered_files: []
+          )
+        end
+        begin
+          capture_io do
+            assert_raises(Hive::TaskInErrorState) { Hive::Commands::Run.new(folder).call }
+          end
+          marker = Hive::Markers.current(File.join(folder, "task.md"))
+          assert_equal :review_error, marker.name
+          assert_equal "triage", marker.attrs["phase"]
+          assert_equal "triage_failed", marker.attrs["reason"],
+                       "a non-limit triage failure must stay terminal (no false self-heal)"
+          assert_nil marker.attrs["retry_after"],
+                     "a terminal triage_failed must not carry a retry_after"
+        ensure
+          Hive::Stages::Review::Triage.singleton_class.alias_method(:run!, :__orig_triage_run_np!)
+          Hive::Stages::Review::Triage.singleton_class.send(:remove_method, :__orig_triage_run_np!)
+        end
+      end
+    end
+  end
+
   def test_review_fix_agent_dirty_worktree_is_auto_committed
     with_tmp_global_config do
       with_tmp_git_repo do |dir|


### PR DESCRIPTION
## Problem

The 6-review reviewers phase self-heals a usage/credit limit (`reason=limits_reached` + `retry_after` the daemon healer honors), but the **triage** and **fix** phases marked *any* spawn failure as terminal `triage_failed`/`fix_failed` — including a provider limit wall. So a Claude session limit during triage strands the task red with no self-heal.

Dogfooded: three patrol review tasks hit `You've hit your session limit · resets 8pm (Europe/London)` during triage and sat terminally on `triage_failed`. (Patrol reviews with codex but still triages with claude — separate question.)

## Fix

`mark_review_phase_failure` detects a limit in the captured error text and writes the same self-healing `limits_reached` + `retry_after` marker the reviewers phase already does; the existing `StaleAgentHealer#auto_recoverable_review_error?` (line 519) picks it up once the cooldown elapses — no healer change needed. Non-limit failures (timeouts, real errors) stay terminal so a genuine bug can't masquerade as a transient limit.

Two integration tests cover both branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)