### PR TITLE
fix(bench): preflight delegates to hive-bench's canonical SecretScan

### DIFF
--- a/lib/hive/commands/bench_submit.rb
+++ b/lib/hive/commands/bench_submit.rb
@@ -13,6 +13,11 @@ module Hive
     # duplicated) plus a local secret preflight so a contributor never opens a PR
     # that the hive-bench validator would reject for leaked credentials.
     #
+    # The preflight delegates to hive-bench's canonical SecretScan — the exact
+    # module the validator's gate uses — rather than a local pattern copy, so the
+    # local check can never silently drift weaker than the gate that will judge
+    # the PR. There is one pattern set, and it lives in hive-bench.
+    #
     # Locates the hive-bench checkout via HIVE_BENCH_PATH (or ~/Dev/hive-bench).
     # The extractor invocation and the PR open are seams for testing.
     class BenchSubmit
@@ -135,19 +140,29 @@ module Hive
         raise UsageError, "git #{args.first} failed: #{err.strip}" unless status.success?
       end
 
+      # Run hive-bench's own SecretScan (one source of truth) in a child ruby —
+      # array-form, no shell — over the spec paths. Each finding comes back as
+      # "<label> in <file>:<line>". Refuses if the canonical scanner is absent,
+      # rather than fall back to a weaker check that could pass a real secret.
+      RUNNER = <<~'RUBY'
+        require "secret_scan"
+        HiveBench::SecretScan.scan_files(ARGV).each { |f| puts "#{f.label}:#{f.line}" }
+      RUBY
+
       def local_secret_scan(paths)
-        patterns = {
-          "private key" => /-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----/,
-          "github token" => /\bgh[pousr]_[A-Za-z0-9]{20,}\b/,
-          "openai key" => /\bsk-(?:ant-)?[A-Za-z0-9-]{20,}\b/,
-          "aws key" => /\bAKIA[0-9A-Z]{16}\b/
-        }
-        paths.flat_map do |path|
-          File.read(path).each_line.with_index.filter_map do |line, i|
-            label, = patterns.find { |_l, re| line.match?(re) }
-            "#{label} in #{File.basename(path)}:#{i + 1}" if label
-          end
+        return [] if paths.empty?
+
+        scanner = File.join(@bench_path, "validator", "secret_scan.rb")
+        unless File.file?(scanner)
+          raise UsageError, "hive-bench secret scanner not found at #{scanner} — " \
+                            "can't guarantee parity with the validator; update your hive-bench checkout"
         end
+
+        cmd = [ "ruby", "-I", File.join(@bench_path, "validator"), "-e", RUNNER, "--", *paths ]
+        out, err, status = Open3.capture3(*cmd)
+        raise UsageError, "secret scan failed: #{err.strip}" unless status.success?
+
+        out.each_line.map(&:strip).reject(&:empty?)
       end
 
       def report(entry_dir, pr_url)

--- a/test/unit/commands/bench_submit_test.rb
+++ b/test/unit/commands/bench_submit_test.rb
@@ -119,11 +119,61 @@ class BenchSubmitCommandTest < Minitest::Test
 
   def cmd = Hive::Commands::BenchSubmit.new("fix-thing-260601-aa11", bench_path: @bench, projects: projects)
 
-  def test_local_secret_scan_finds_and_passes
+  # A minimal-but-real HiveBench::SecretScan in the fixture bench checkout. The
+  # preflight DELEGATES to this (single source of truth); pattern completeness is
+  # hive-bench's own concern (tested there), so here we only prove that
+  # bench_submit invokes the canonical scanner and parses its findings.
+  def write_bench_scanner(body = nil)
+    dir = File.join(@bench, "validator")
+    FileUtils.mkdir_p(dir)
+    File.write(File.join(dir, "secret_scan.rb"), body || <<~'RUBY')
+      module HiveBench
+        module SecretScan
+          module_function
+          Finding = Data.define(:label, :line, :snippet)
+          PATTERNS = { "github token" => /\bgh[pousr]_[A-Za-z0-9]{20,}\b/ }.freeze
+          def scan_files(paths)
+            paths.flat_map do |path|
+              next [] unless File.file?(path)
+
+              File.read(path).each_line.with_index.flat_map do |line, i|
+                PATTERNS.select { |_l, re| line.match?(re) }
+                        .map { |l, _| Finding.new(label: "#{l} in #{File.basename(path)}", line: i + 1, snippet: line.strip) }
+              end
+            end
+          end
+        end
+      end
+    RUBY
+  end
+
+  def test_local_secret_scan_delegates_to_canonical_bench_scanner
+    write_bench_scanner
     File.write(File.join(@done, "leak.md"), "token = ghp_#{"a" * 36}\n")
     found = cmd.send(:local_secret_scan, [ File.join(@done, "leak.md"), File.join(@done, "plan.md") ])
-    assert(found.any? { |f| f.include?("github token") })
-    assert_empty cmd.send(:local_secret_scan, [ File.join(@done, "plan.md") ])
+
+    assert(found.any? { |f| f.include?("github token") && f.include?("leak.md") }, "delegated finding surfaced")
+    assert_empty cmd.send(:local_secret_scan, [ File.join(@done, "plan.md") ]), "clean spec yields no findings"
+  end
+
+  def test_local_secret_scan_empty_paths_short_circuits
+    assert_empty cmd.send(:local_secret_scan, [])
+  end
+
+  def test_local_secret_scan_requires_the_canonical_scanner
+    # @bench has no validator/secret_scan.rb — must refuse, not fall back weaker.
+    err = assert_raises(Hive::Commands::BenchSubmit::UsageError) do
+      cmd.send(:local_secret_scan, [ File.join(@done, "plan.md") ])
+    end
+    assert_match(/parity with the validator/, err.message)
+  end
+
+  def test_local_secret_scan_raises_when_scanner_errors
+    write_bench_scanner("raise 'boom'\n")
+    err = assert_raises(Hive::Commands::BenchSubmit::UsageError) do
+      cmd.send(:local_secret_scan, [ File.join(@done, "plan.md") ])
+    end
+    assert_match(/secret scan failed/, err.message)
   end
 
   def test_report_json_and_text


### PR DESCRIPTION
Follow-up from the `/pr-review-toolkit:review-pr` pass on the benchmark work.

**Problem.** `hive bench submit`'s local secret preflight kept its own 4-pattern copy that had drifted weaker than the hive-bench validator's 9 patterns. A submission could pass the local check and then be rejected by the gate — the opposite of the preflight's purpose. (Fails closed, so never a leak; a UX/parity gap.)

**Fix.** The preflight now delegates to hive-bench's canonical `SecretScan` (run in a child ruby, array-form, no shell) over the spec paths. bench_submit carries **zero** patterns — one source of truth, in hive-bench, so the local check can never be weaker than the gate. Refuses rather than falling back weaker if the canonical scanner is missing.

**Tests.** Delegation contract proven against a minimal real scanner fixture (pattern completeness is hive-bench's own test); empty-paths / missing-scanner / scanner-error branches covered. `bench_submit.rb` 90/90, rubocop + brakeman clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)