### PR TITLE
fix: AgentLimit false-positive + finalize merged-PR short-circuit

### DIFF
--- a/lib/hive/agent_limit.rb
+++ b/lib/hive/agent_limit.rb
@@ -51,7 +51,14 @@ module Hive
       /\b(?:http|status|response)[:=\s-]*429\b/i,
       /\b429\b[^\n]{0,40}(?:too many|rate limit|quota|requests)/i,
       /resource[_\s-]*exhausted/i,
-      /limit (?:reached|exceeded|reset)/i,
+      # Was a bare `/limit (?:reached|exceeded|reset)/i`, which matched ANY
+      # "<x> limit reached" — including healthy agent OUTPUT. A finalize agent
+      # describing a scrollable-TUI feature ("scroll limit reached", "window
+      # limit") tripped a false `limits_reached` wall (task 47). Require a
+      # usage/billing/rate qualifier so only a real provider wall matches; UI
+      # limits (scroll/window/viewport/page/buffer/line) no longer do. Honors
+      # the file's "never classify on text that can sit in a healthy pane" rule.
+      %r{(?:usage|rate|api|token|context|message|request|session|spend|spending|credit|quota|account|subscription|\d+[\s-]?hour|hourly|daily|weekly|monthly)[\s-]?limit (?:reached|exceeded|reset)}i,
       /(?:daily|monthly|usage|spend|spending) limit/i,
       /billing[^\n]{0,80}(?:credit|quota|limit)/i
     ].freeze

--- a/lib/hive/stages/finalize.rb
+++ b/lib/hive/stages/finalize.rb
@@ -35,6 +35,18 @@ module Hive
         pr_url, pr_error = pr_url_or_error(task)
         return pr_error if pr_error
 
+        # If the PR already merged out-of-band (e.g. squash-merged while the
+        # task was still mid-pipeline), finalization is moot — the merged PR is
+        # final. Short-circuit to complete instead of running the body-refresh
+        # agent or tripping verify_state!'s unpushed-commits guard on a now-
+        # stale branch. Mirrors open_pr's open_pr_already_merged recovery; fixes
+        # the recurring "merged PR stranded in 8-finalize" failure.
+        if pr_already_merged?(pr_url, cfg)
+          Hive::Markers.set(task.state_file, :complete,
+                            pr_url: pr_url, is_draft: "false", merged: "true")
+          return { commit: "finalize_already_merged", status: :complete }
+        end
+
         # Authenticate first so an auth-related push failure surfaces
         # as a clear "gh not authenticated" hard-fail (Plan R5)
         # instead of a generic git push error.
@@ -124,6 +136,15 @@ module Hive
           exit 1
         end
         pointer
+      end
+
+      # True when the PR already merged out-of-band. A GhError (gh not yet
+      # authenticated, or a transient lookup failure) returns false so finalize
+      # falls through to its normal path rather than skipping it on a flaky read.
+      def pr_already_merged?(pr_url, cfg)
+        Hive::Gh.pr_state(pr_url, cfg: cfg) == "MERGED"
+      rescue Hive::GhError
+        false
       end
 
       def pr_url_or_error(task)

--- a/test/integration/run_finalize_test.rb
+++ b/test/integration/run_finalize_test.rb
@@ -618,4 +618,41 @@ class RunFinalizeTest < Minitest::Test
       end
     end
   end
+
+  # A PR merged out-of-band (squash-merged while the task was still
+  # mid-pipeline) must finalize-complete via the short-circuit, NOT run the
+  # body-refresh agent or trip the unpushed-commits guard — the recurring
+  # "merged PR stranded in 8-finalize" failure.
+  def test_finalize_short_circuits_when_pr_already_merged
+    with_tmp_global_config do
+      with_tmp_git_repo do |dir|
+        task_dir, _worktree_path, pr_md = setup_finalize_task(dir)
+
+        with_stubbed_singleton_method(Hive::Gh, :pr_state, ->(*_a, **_k) { "MERGED" }) do
+          capture_io { Hive::Commands::Run.new(task_dir).call }
+        end
+
+        marker = Hive::Markers.current(pr_md)
+        assert_equal :complete, marker.name, "a merged PR must finalize-complete via the short-circuit"
+        assert_equal "true", marker.attrs["merged"]
+        assert_equal "false", marker.attrs["is_draft"]
+        refute_match(/arg=ready/, gh_argv_log, "merged short-circuit must not run `gh pr ready`")
+        refute File.exist?(File.join(task_dir, "summary.md")),
+               "merged short-circuit skips the body-refresh agent, so no summary.md"
+      end
+    end
+  end
+
+  def test_pr_already_merged_classifies_state_and_falls_through_on_error
+    with_stubbed_singleton_method(Hive::Gh, :pr_state, ->(*_a, **_k) { "MERGED" }) do
+      assert Hive::Stages::Finalize.pr_already_merged?("https://example.com/pr/9", {})
+    end
+    with_stubbed_singleton_method(Hive::Gh, :pr_state, ->(*_a, **_k) { "OPEN" }) do
+      refute Hive::Stages::Finalize.pr_already_merged?("https://example.com/pr/9", {})
+    end
+    with_stubbed_singleton_method(Hive::Gh, :pr_state, ->(*_a, **_k) { raise Hive::GhError, "boom" }) do
+      refute Hive::Stages::Finalize.pr_already_merged?("https://example.com/pr/9", {}),
+             "a GhError on the state lookup must fall through to the normal finalize path"
+    end
+  end
 end

--- a/test/unit/agent_limit_test.rb
+++ b/test/unit/agent_limit_test.rb
@@ -148,4 +148,34 @@ class AgentLimitTest < Minitest::Test
   ensure
     original.each { |key, value| value.nil? ? ENV.delete(key) : ENV[key] = value }
   end
+
+  # Regression for task 47: a finalize agent describing a scrollable-TUI help
+  # feature ("scroll limit reached", "window limit") tripped a false
+  # limits_reached wall via the old bare `/limit (?:reached|exceeded|reset)/i`.
+  # Healthy agent OUTPUT must never classify as a usage wall.
+  def test_does_not_classify_ui_feature_limit_text_as_a_wall
+    [
+      "The viewport scrolls until the scroll limit is reached at the bottom.",
+      "Help now shows one window at a time; the page limit reset on resize.",
+      "| Viewport | window limit reached | ows |",
+      "re-clamped on resize so a shrink keeps a valid position"
+    ].each do |line|
+      refute Hive::AgentLimit.limit_reached?(line),
+             "UI/feature text must not classify as a usage wall: #{line.inspect}"
+    end
+  end
+
+  def test_detects_usage_credit_and_time_window_walls
+    [
+      "usage limit reached",
+      "credit limit exceeded",
+      "token limit reached for this request",
+      "5-hour limit reached",
+      "weekly limit reached",
+      "account limit reached"
+    ].each do |line|
+      assert Hive::AgentLimit.limit_reached?(line),
+             "a real provider wall must still classify: #{line.inspect}"
+    end
+  end
 end


### PR DESCRIPTION
Two bugs surfaced while clearing a backlog of already-merged tasks stranded in 8-finalize.

## 1. `AgentLimit` false-positive (the limit that wasn't a cap)
The bare `/limit (?:reached|exceeded|reset)/i` pattern matched **any** "<x> limit reached" — including healthy agent *output*. A finalize agent describing a scrollable-TUI help feature ("scroll limit reached", "window limit") tripped a fake `limits_reached` wall (task 47). Tightened it to require a usage/billing/rate qualifier (`usage|rate|api|token|credit|session|N-hour|weekly|…`), so UI limits (scroll/window/viewport/page/buffer) no longer match while every real provider wall still does. Honors the file's own "never classify on text that can sit in a healthy pane" rule.

## 2. finalize merged-PR short-circuit (the recurring 8-finalize strand)
When a PR was merged out-of-band while its task was still mid-pipeline, finalize ran the body-refresh agent and tripped `verify_state!`'s unpushed-commits guard on a now-stale branch — stranding the task in 8-finalize (hit repeatedly: 1111/1095/1001). finalize now short-circuits to `:complete` when the PR is already `MERGED` (mirrors open-pr's `open_pr_already_merged`), with a `GhError` fall-through so a flaky lookup doesn't skip a real finalize.

Behavioral tests for both; **100% coverage**, rubocop + brakeman clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)