### PR TITLE
Hive patrol: AUR wrapper loses stable invoked binary path

### DIFF
--- a/packaging/aur/PKGBUILD.template
+++ b/packaging/aur/PKGBUILD.template
@@ -64,6 +64,7 @@ package() {
 #!/usr/bin/env bash
 export GEM_HOME="/usr/share/hive/gems"
 export GEM_PATH="\${GEM_HOME}\${GEM_PATH:+:\$GEM_PATH}"
+export HIVE_INVOKED_BIN="\${HIVE_INVOKED_BIN:-\$0}"
 exec "/usr/share/hive/gems/bin/hive" "\$@"
 WRAPPER
   chmod 755 "${pkgdir}/usr/bin/hive"

--- a/test/unit/packaging/render_test.rb
+++ b/test/unit/packaging/render_test.rb
@@ -37,6 +37,19 @@ class PackagingRenderTest < Minitest::Test
     assert_includes out, "sha256sums=('#{SAMPLE_SHA}')"
   end
 
+  def test_pkgbuild_wrapper_preserves_user_facing_binary_for_daemon_units
+    template = File.read(PKGBUILD_TEMPLATE)
+    out = Hive::PackagingRender.render(
+      template, { "version" => "0.1.1", "sha256_gem" => SAMPLE_SHA }, PKGBUILD_TEMPLATE
+    )
+    export_line = 'export HIVE_INVOKED_BIN="\${HIVE_INVOKED_BIN:-\$0}"'
+    exec_line = 'exec "/usr/share/hive/gems/bin/hive" "\$@"'
+
+    assert_includes out, export_line
+    assert_includes out, exec_line
+    assert_operator out.index(export_line), :<, out.index(exec_line)
+  end
+
   def test_render_raises_on_undefined_variable
     err = assert_raises(Hive::PackagingRender::Error) do
       Hive::PackagingRender.render(


### PR DESCRIPTION
## Summary

The AUR `-bin` package generates a `/usr/bin/hive` wrapper that exports
`GEM_HOME`/`GEM_PATH` and then `exec`s the gem-installed binstub, but unlike the
`install.sh` and Homebrew wrappers it never exported `HIVE_INVOKED_BIN`. Without
it, `Hive::InvokedBinary.path` falls back to the execed binstub's
`$PROGRAM_NAME`, and `ServiceInstaller` bakes that inner
`/usr/share/hive/gems/bin/hive` path into the systemd unit. The daemon then
starts without the wrapper's `GEM_HOME`/`GEM_PATH`, so AUR autostart can fail to
load the packaged gems after reboot.

This adds `export HIVE_INVOKED_BIN="${HIVE_INVOKED_BIN:-$0}"` to the AUR wrapper
immediately before the `exec`, bringing it to parity with the bash installer
(`install.sh:501`) and the Homebrew formula
(`packaging/homebrew/hive.rb.erb:34`), so the stable user-facing
`/usr/bin/hive` path is preserved for daemon units.

- `packaging/aur/PKGBUILD.template` — emit the `HIVE_INVOKED_BIN` export in the
  generated wrapper, ordered before the `exec` line.

## Test plan

- `bundle exec ruby -Itest test/unit/packaging/render_test.rb` — passes
  (9 runs, 42 assertions, 0 failures), including the new
  `test_pkgbuild_wrapper_preserves_user_facing_binary_for_daemon_units`, which
  renders the template and asserts both wrapper lines are present and that the
  `HIVE_INVOKED_BIN` export precedes the `exec`.
- `bundle exec rubocop` — passed.
- `bundle exec rake test` — passed.

## Review summary

Automated patrol review (`codex-native-review`) returned a clean pass — no
correctness, security, or maintainability regressions in the branch diff. No
findings were raised, so nothing required remediation.

## Linked task

/home/asterio/Dev/hive/.hive-state/stages/6-review/patrol-command-bin-hv-a45e7a9a
