### PR TITLE
fix(tmux): wait for large paste to settle before submitting prompt

### DIFF
--- a/lib/hive/tmux_runner.rb
+++ b/lib/hive/tmux_runner.rb
@@ -21,6 +21,16 @@ module Hive
     DEFAULT_COLS = 200
     DEFAULT_ROWS = 50
     DEFAULT_PROMPT_SUBMIT_DELAY_SEC = 0.2
+    # Upper bound on how long to wait for a pasted prompt to finish
+    # rendering before submitting; if the pane never stabilizes we submit
+    # anyway rather than stranding the prompt.
+    DEFAULT_PROMPT_SETTLE_TIMEOUT_SEC = 30.0
+    # Consecutive identical pane-tail captures that mean the bracketed
+    # paste has finished rendering into the input box.
+    PROMPT_SETTLE_STABLE_POLLS = 2
+    # Tail bytes compared between polls — enough to include the input box
+    # region at the bottom of the pane.
+    PROMPT_SETTLE_CAPTURE_BYTES = 4096
     DEFAULT_COMMAND_TIMEOUT_SEC = 10.0
 
     attr_reader :name, :cwd, :env
@@ -76,7 +86,14 @@ module Hive
         # instead of keeping the prompt multi-line. The explicit
         # send_keys("Enter") below is the single, intended submit.
         run_tmux("paste-buffer", "-d", "-r", "-b", buffer_name, "-t", target_pane)
-        sleep prompt_submit_delay_sec
+        # A large bracketed paste renders into the agent's input box over
+        # many frames. A fixed sleep here let `Enter` fire mid-ingest on
+        # big prompts, so the submit was swallowed and the prompt sat
+        # STAGED — the agent never started and the stage burned its whole
+        # timeout (observed: review triage with ~30 paste chunks idling
+        # 15+ min). Wait until the pane stops changing (paste fully
+        # rendered) before the single submit so `Enter` always lands.
+        wait_for_paste_to_settle
         # If tmux disappears here, the prompt was pasted but never submitted.
         # Surface the typed failure immediately instead of waiting for stage timeout.
         send_keys("Enter")
@@ -126,6 +143,40 @@ module Hive
 
     def prompt_submit_delay_sec
       Float(ENV.fetch("HIVE_TMUX_PROMPT_SUBMIT_DELAY_SEC", DEFAULT_PROMPT_SUBMIT_DELAY_SEC.to_s))
+    end
+
+    def prompt_settle_timeout_sec
+      Float(ENV.fetch("HIVE_TMUX_PROMPT_SETTLE_TIMEOUT_SEC", DEFAULT_PROMPT_SETTLE_TIMEOUT_SEC.to_s))
+    end
+
+    # Poll the pane until its tail stops changing across
+    # PROMPT_SETTLE_STABLE_POLLS consecutive captures — i.e. the bracketed
+    # paste has finished rendering into the input box — then return so the
+    # caller's single `Enter` submits a settled prompt. The poll interval
+    # is `prompt_submit_delay_sec`. Bounded by `prompt_settle_timeout_sec`:
+    # if the pane never stabilizes, or a capture fails, submit anyway
+    # rather than stranding the prompt (a real server loss then surfaces
+    # on the `send_keys("Enter")` that follows).
+    def wait_for_paste_to_settle
+      deadline = Time.now + prompt_settle_timeout_sec
+      previous = nil
+      stable = 0
+      loop do
+        sleep prompt_submit_delay_sec
+        begin
+          current = capture_pane_tail(bytes: PROMPT_SETTLE_CAPTURE_BYTES)
+        rescue Hive::TmuxError
+          return
+        end
+        if current == previous
+          stable += 1
+          return if stable >= PROMPT_SETTLE_STABLE_POLLS
+        else
+          stable = 0
+        end
+        previous = current
+        return if Time.now >= deadline
+      end
     end
 
     def target_pane

--- a/test/unit/tmux_runner_test.rb
+++ b/test/unit/tmux_runner_test.rb
@@ -143,6 +143,119 @@ class TmuxRunnerTest < Minitest::Test
     end
   end
 
+  def test_send_prompt_waits_for_paste_to_settle_before_enter
+    with_tmp_dir do |dir|
+      log_path = File.join(dir, "tmux.log")
+      counter = File.join(dir, "cap.count")
+      fake = write_fake_tmux(dir, <<~RUBY)
+        #!/usr/bin/env ruby
+        args = ARGV.dup
+        args.shift(2) if args.first == "-L"
+        File.open(#{log_path.dump}, "a") { |log| log.puts(args.join(" ")) }
+        case args.first
+        when "capture-pane"
+          n = (File.read(#{counter.dump}) rescue "0").to_i
+          File.write(#{counter.dump}, (n + 1).to_s)
+          # First two captures differ (paste still rendering); then stable.
+          STDOUT.write(n < 2 ? "render-\#{n}" : "settled")
+          exit 0
+        else
+          exit 0
+        end
+      RUBY
+      runner = Hive::TmuxRunner.new(
+        name: unique_name("settle"), cwd: dir, tmux_bin: fake, socket_name: @socket_name
+      )
+
+      submitted = with_env("HIVE_TMUX_PROMPT_SUBMIT_DELAY_SEC" => "0") do
+        runner.send_prompt("big prompt")
+      end
+      assert submitted
+
+      lines = File.readlines(log_path).map(&:strip)
+      captures = lines.count { |line| line.split.first == "capture-pane" }
+      send_index = lines.rindex { |line| line.split.first == "send-keys" }
+      last_capture_index = lines.rindex { |line| line.split.first == "capture-pane" }
+
+      assert_operator captures, :>=, 3,
+                      "must keep polling capture-pane until the paste stops changing; got #{captures}"
+      assert send_index, "must submit with send-keys"
+      assert_operator last_capture_index, :<, send_index,
+                      "Enter must be sent only AFTER the pane settles"
+      assert_match(/Enter/, lines.fetch(send_index))
+    end
+  end
+
+  def test_send_prompt_submits_at_deadline_when_pane_never_settles
+    with_tmp_dir do |dir|
+      log_path = File.join(dir, "tmux.log")
+      counter = File.join(dir, "cap.count")
+      fake = write_fake_tmux(dir, <<~RUBY)
+        #!/usr/bin/env ruby
+        args = ARGV.dup
+        args.shift(2) if args.first == "-L"
+        File.open(#{log_path.dump}, "a") { |log| log.puts(args.join(" ")) }
+        case args.first
+        when "capture-pane"
+          n = (File.read(#{counter.dump}) rescue "0").to_i
+          File.write(#{counter.dump}, (n + 1).to_s)
+          STDOUT.write("frame-\#{n}") # always changing — never settles
+          exit 0
+        else
+          exit 0
+        end
+      RUBY
+      runner = Hive::TmuxRunner.new(
+        name: unique_name("nosettle"), cwd: dir, tmux_bin: fake, socket_name: @socket_name
+      )
+
+      submitted = with_env(
+        "HIVE_TMUX_PROMPT_SUBMIT_DELAY_SEC" => "0",
+        "HIVE_TMUX_PROMPT_SETTLE_TIMEOUT_SEC" => "0.05"
+      ) do
+        runner.send_prompt("big prompt")
+      end
+      assert submitted, "must still submit at the settle deadline even if the pane never stabilizes"
+
+      lines = File.readlines(log_path).map(&:strip)
+      assert(lines.any? { |line| line.split.first == "send-keys" && line.include?("Enter") },
+             "Enter must still be sent once the settle deadline passes")
+    end
+  end
+
+  def test_send_prompt_submits_when_pane_capture_fails
+    with_tmp_dir do |dir|
+      log_path = File.join(dir, "tmux.log")
+      fake = write_fake_tmux(dir, <<~RUBY)
+        #!/usr/bin/env ruby
+        args = ARGV.dup
+        args.shift(2) if args.first == "-L"
+        File.open(#{log_path.dump}, "a") { |log| log.puts(args.join(" ")) }
+        case args.first
+        when "capture-pane"
+          warn "no server running on /tmp/tmux-test"
+          exit 1
+        else
+          exit 0
+        end
+      RUBY
+      runner = Hive::TmuxRunner.new(
+        name: unique_name("capfail"), cwd: dir, tmux_bin: fake, socket_name: @socket_name
+      )
+
+      submitted = with_env("HIVE_TMUX_PROMPT_SUBMIT_DELAY_SEC" => "0") do
+        runner.send_prompt("hi")
+      end
+      assert submitted, "a failed pane capture must fall back to submitting, not raise"
+
+      lines = File.readlines(log_path).map(&:strip)
+      assert(lines.any? { |line| line.split.first == "capture-pane" },
+             "must attempt at least one capture before falling back")
+      assert(lines.any? { |line| line.split.first == "send-keys" && line.include?("Enter") },
+             "must still send Enter after a capture failure")
+    end
+  end
+
   def test_capture_pane_tail_returns_bounded_output
     with_tmp_dir do |dir|
       runner = runner(name: unique_name("tail"), cwd: dir)


### PR DESCRIPTION
## Problem

In `claude.mode=tmux`, a stage's prompt is pasted into the agent's tmux input box and submitted with a single `Enter`. `TmuxRunner#send_prompt` slept a **fixed `0.2s`** before that Enter. For a large prompt — review **triage** bundles every reviewer file, producing ~30 bracketed-paste chunks / thousands of lines — the Claude TUI is still ingesting the paste at 200 ms, so the lone Enter fires **mid-ingest and is swallowed**. The prompt then sits **STAGED** in the input box, the agent never starts, and the stage burns its **entire timeout**.

Caught live: two triage panes idle 15+ min with the full prompt staged but unsubmitted; a manual `Enter` started both agents instantly. This is why review "runs much longer… waits for a timeout and doesn't finish itself" — it's a *submit* failure that scales with prompt size, not a marker/completion issue.

## Fix

Replace the fixed sleep with `wait_for_paste_to_settle`: poll the pane tail until it stops changing across `PROMPT_SETTLE_STABLE_POLLS` (2) consecutive captures — i.e. the paste has finished rendering — then send the single Enter. 

- **Agent-agnostic**: pure visual stability, no TUI/Claude-specific parsing; stays in the generic `TmuxRunner` layer.
- **Bounded**: `HIVE_TMUX_PROMPT_SETTLE_TIMEOUT_SEC` (default 30s). If the pane never stabilizes, or a capture raises, submit anyway rather than stranding the prompt (a real server loss still surfaces on the following `send_keys("Enter")`).

## Tests

- `…waits_for_paste_to_settle_before_enter` — fake tmux returns changing-then-stable captures; asserts Enter is sent only after the captures stabilize.
- `…submits_at_deadline_when_pane_never_settles` — always-changing pane; asserts Enter still fires at the settle deadline.
- `…submits_when_pane_capture_fails` — capture raises; asserts fallback submit.

tmux_runner suite green (16 runs), rubocop clean, brakeman 0 warnings, `HIVE_COVERAGE_MIN_LINE=100 rake coverage` gate passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)