### PR TITLE
fix(web): scrub binary PTY output so agent-login status page can't 500

### DIFF
--- a/lib/hive/web/agents_auth.rb
+++ b/lib/hive/web/agents_auth.rb
@@ -104,7 +104,16 @@ module Hive
       # makes the happens-before relationship explicit and survives a future
       # non-GVL runtime).
       def output_for(id)
-        @mutex.synchronize { @sessions[id]&.output&.dup }
+        raw = @mutex.synchronize { @sessions[id]&.output&.dup }
+        return nil unless raw
+
+        # The buffer is raw PTY bytes — `readpartial` returns ASCII-8BIT, and a
+        # 4096-byte read can split a UTF-8 multibyte char or carry terminal
+        # control sequences. Rendered straight into the UTF-8 `<pre>` it raised
+        # Encoding::CompatibilityError (a 500 on the login-status page).
+        # Reinterpret as UTF-8 and drop invalid byte sequences so the
+        # operator-facing CLI output always renders.
+        raw.force_encoding(Encoding::UTF_8).scrub("")
       end
 
       def url_for(id)

--- a/test/unit/web/agents_auth_test.rb
+++ b/test/unit/web/agents_auth_test.rb
@@ -62,6 +62,30 @@ class AgentsAuthTest < Minitest::Test
     assert_nil auth.output_for("missing"), "an unknown session id yields nil"
   end
 
+  def test_output_for_returns_render_safe_utf8_for_binary_pty_output
+    auth = Hive::Web::AgentsAuth.new
+    # Raw PTY bytes (readpartial returns ASCII-8BIT): an ANSI clear-line
+    # sequence, a box-drawing glyph, and a lone UTF-8 continuation byte left
+    # when a 4096-byte read splits a multibyte char. The trailing \xE2 makes
+    # the buffer invalid UTF-8 — exactly what raised Encoding::CompatibilityError
+    # when the <pre> view interpolated it (the login-status 500).
+    binary = +"".b
+    binary << "\e[2K".b << "█".b << " login".b << "\xE2".b
+    refute binary.dup.force_encoding(Encoding::UTF_8).valid_encoding?,
+           "fixture must be invalid UTF-8 so the test actually exercises the scrub"
+    session = Hive::Web::AgentsAuth::Session.new(id: "s", agent: "claude", output: binary, done: false)
+    auth.instance_variable_get(:@sessions)["s"] = session
+
+    out = auth.output_for("s")
+
+    assert_equal Encoding::UTF_8, out.encoding, "output_for must hand the view a UTF-8 string"
+    assert out.valid_encoding?, "invalid bytes must be scrubbed so the <pre> view can't raise"
+    # Faithful reproduction of the failing render: a UTF-8 buffer absorbing
+    # the value. With a binary buffer this raised Encoding::CompatibilityError.
+    rendered = (+"<pre>").force_encoding(Encoding::UTF_8) << out
+    assert_includes rendered, "login", "scrubbing must preserve the legible CLI text"
+  end
+
   def test_start_rejects_when_too_many_logins_are_in_flight
     auth = Hive::Web::AgentsAuth.new
     sessions = auth.instance_variable_get(:@sessions)


### PR DESCRIPTION
## Problem

Logging in an agent (claude/codex) through the hivebox web UI returned **HTTP 500**:

```
ActionView::Template::Error (incompatible character encodings: UTF-8 and BINARY (ASCII-8BIT))
app/views/agents/index.html.erb:50:  <pre><%= @session_output %></pre>
app/controllers/agents_controller.rb:25:in 'AgentsController#login_status'
```

The login itself works — `start_login` spawns the real CLI login in a PTY and redirects fine. The crash is in **rendering** the status page: `AgentsAuth#output_for` returns the raw PTY buffer, which is **ASCII-8BIT** (`readpartial` returns binary; a 4096-byte read can split a UTF-8 multibyte char, and the stream carries terminal control sequences). Interpolating those bytes into the UTF-8 `<pre>` raises `Encoding::CompatibilityError`.

## Fix

In `output_for`, reinterpret the buffered bytes as UTF-8 and `scrub` invalid sequences before handing them to the view, so the CLI output always renders. The raw `session.output` buffer (used by the URL scanner) is left untouched.

## Test

`test_output_for_returns_render_safe_utf8_for_binary_pty_output` injects a session whose buffer holds an ANSI sequence, a box-drawing glyph, and a lone UTF-8 continuation byte (invalid UTF-8 — asserted), then verifies `output_for` returns a valid-encoding UTF-8 string and that a UTF-8 buffer can absorb it without raising (the exact render path that 500'd).

agents_auth suite green (8 runs), rubocop clean, brakeman 0 warnings, `HIVE_COVERAGE_MIN_LINE=100 rake coverage` gate passed.

Note: reaches running hiveboxes only via a new image — for now, agents can be logged in from the container terminal (`docker exec -it hivebox claude setup-token` / `codex login`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)