### PR TITLE
fix(finalize): fast-forward stale rebase-duplicate worktree instead of looping unpushed_commits

### DIFF
--- a/lib/hive/stages/finalize.rb
+++ b/lib/hive/stages/finalize.rb
@@ -217,10 +217,40 @@ module Hive
         push_result = Hive::Gh.push_branch(worktree_path, branch, cfg: cfg)
         return nil if push_result.success? && pushed?(worktree_path, branch)
 
+        # A remote-side auto-rebase (the PR branch rebased onto an advanced
+        # base while this worktree stayed on the old base) leaves HEAD
+        # diverged from its upstream even though every local commit's CHANGE
+        # is already on the remote as a patch-identical rebase. The push above
+        # then fails non-fast-forward and finalize would loop on
+        # unpushed_commits forever — yet the work is safely on the PR branch.
+        # Detect that case and fast-forward the worktree to its upstream
+        # instead of erroring.
+        return nil if resync_stale_rebase!(worktree_path, branch)
+
         Hive::Markers.set(task.state_file, :error,
                           reason: "unpushed_commits",
                           detail: push_result.stderr.to_s.strip[0, 200])
         { commit: "finalize_unpushed_commits", status: :error }
+      end
+
+      # Fast-forward a worktree whose local commits are all already on the
+      # upstream by patch-id — the stale side of a remote auto-rebase.
+      # Returns true (and hard-resets the worktree to its upstream) only when
+      # NO local commit carries a change missing from the upstream: `git
+      # cherry` marks an already-present change `-` and a genuinely-missing
+      # one `+`, so any `+` (real unpushed work) or a git failure returns
+      # false and the caller errors rather than discarding work.
+      def resync_stale_rebase!(worktree_path, branch)
+        upstream = "#{branch}@{u}"
+        cherry, status = capture_git(worktree_path, "cherry", upstream, "HEAD")
+        return false unless status.success?
+        return false if cherry.to_s.lines.any? { |line| line.start_with?("+") }
+
+        _out, reset_status = capture_git(worktree_path, "reset", "--hard", upstream)
+        return false unless reset_status.success?
+
+        warn "[hive] finalize: fast-forwarded stale rebase-duplicate worktree to #{upstream}"
+        true
       end
 
       # Record an auto-committed-residue event under the task's log dir so

--- a/test/integration/run_finalize_test.rb
+++ b/test/integration/run_finalize_test.rb
@@ -88,6 +88,27 @@ class RunFinalizeTest < Minitest::Test
     [ task_dir, worktree_path, pr_md ]
   end
 
+  # Advance the bare remote's branch through a scratch clone — optionally
+  # re-applying `dup_file` as a patch-identical "rebase" commit — then fetch
+  # so the worktree's upstream points at the now-diverged remote.
+  def advance_upstream!(worktree_path, slug, dup_file: nil)
+    bare = "#{worktree_path}-remote.git"
+    scratch = Dir.mktmpdir("scratch-#{slug}-")
+    @worktree_paths << scratch
+    run!("git", "clone", "--quiet", "--branch", slug, bare, scratch)
+    run!("git", "-C", scratch, "config", "user.email", "t@t")
+    run!("git", "-C", scratch, "config", "user.name", "t")
+    run!("git", "-C", scratch, "config", "commit.gpgsign", "false")
+    run!("git", "-C", scratch, "commit", "--allow-empty", "-m", "upstream advance", "--quiet")
+    if dup_file
+      File.write(File.join(scratch, dup_file), "fix\n")
+      run!("git", "-C", scratch, "add", ".")
+      run!("git", "-C", scratch, "commit", "-m", "fix", "--quiet")
+    end
+    run!("git", "-C", scratch, "push", "--quiet", "origin", slug)
+    run!("git", "-C", worktree_path, "fetch", "--quiet", "origin")
+  end
+
   def test_finalize_writes_summary_after_agent_completion
     with_tmp_global_config do
       with_tmp_git_repo do |dir|
@@ -122,6 +143,81 @@ class RunFinalizeTest < Minitest::Test
         # would silently leave the PR in draft state after finalize.
         assert_match(/arg=ready\n.*arg=https:\/\/example\.com\/pr\/9/m, gh_argv_log,
                      "finalize runner must invoke `gh pr ready <pr_url>`")
+      end
+    end
+  end
+
+  # A remote-side auto-rebase (e.g. base churn while several PRs merge in
+  # quick succession) advances the PR branch and rebases the fix onto it,
+  # leaving the local finalize worktree on the old base with a commit whose
+  # CHANGE is already upstream (patch-identical). Finalize must fast-forward
+  # the worktree instead of looping on unpushed_commits.
+  def test_finalize_resyncs_stale_rebase_duplicate_instead_of_unpushed_error
+    with_tmp_global_config do
+      with_tmp_git_repo do |dir|
+        slug = "fix-bug-260424-aaaa"
+        task_dir, worktree_path, pr_md = setup_finalize_task(dir)
+
+        # Local fix commit (patch P) on the old base.
+        File.write(File.join(worktree_path, "fixfile"), "fix\n")
+        run!("git", "-C", worktree_path, "add", ".")
+        run!("git", "-C", worktree_path, "commit", "-m", "fix", "--quiet")
+
+        # Upstream advances and re-applies patch P as a patch-identical rebase.
+        advance_upstream!(worktree_path, slug, dup_file: "fixfile")
+
+        ENV["HIVE_FAKE_CLAUDE_WRITE_FILE"] = pr_md
+        ENV["HIVE_FAKE_CLAUDE_WRITE_CONTENT"] = <<~MD
+          ---
+          pr_url: https://example.com/pr/9
+          pr_number: 9
+          ---
+
+          ## Summary
+          final
+
+          <!-- COMPLETE pr_url=https://example.com/pr/9 is_draft=false -->
+        MD
+
+        capture_io { Hive::Commands::Run.new(task_dir).call }
+
+        marker = Hive::Markers.current(pr_md)
+        assert_equal :complete, marker.name,
+                     "stale rebase-duplicate must resync and finalize, not error unpushed_commits"
+        head = run!("git", "-C", worktree_path, "rev-parse", "HEAD").strip
+        upstream = run!("git", "-C", worktree_path, "rev-parse", "#{slug}@{u}").strip
+        assert_equal upstream, head, "finalize must fast-forward the stale worktree to its upstream"
+      end
+    end
+  end
+
+  # The guardrail: a local commit whose change is genuinely NOT upstream
+  # (diverged, push fails non-fast-forward) must still error — never be
+  # silently reset away by the rebase-duplicate fast-forward.
+  def test_finalize_errors_on_genuine_unpushed_commit_when_diverged
+    with_tmp_global_config do
+      with_tmp_git_repo do |dir|
+        slug = "fix-bug-260424-aaaa"
+        task_dir, worktree_path, pr_md = setup_finalize_task(dir)
+
+        File.write(File.join(worktree_path, "uniquefile"), "unique\n")
+        run!("git", "-C", worktree_path, "add", ".")
+        run!("git", "-C", worktree_path, "commit", "-m", "unique work", "--quiet")
+        head_before = run!("git", "-C", worktree_path, "rev-parse", "HEAD").strip
+
+        # Upstream advances WITHOUT that change → diverged, push non-ff.
+        advance_upstream!(worktree_path, slug)
+
+        _out, _err, status = with_captured_exit { Hive::Commands::Run.new(task_dir).call }
+
+        assert_equal Hive::ExitCodes::TASK_IN_ERROR, status
+        marker = Hive::Markers.current(pr_md)
+        assert_equal :error, marker.name
+        assert_equal "unpushed_commits", marker.attrs["reason"],
+                     "a genuinely unpushed unique commit must still error, never be silently discarded"
+        head_after = run!("git", "-C", worktree_path, "rev-parse", "HEAD").strip
+        assert_equal head_before, head_after,
+                     "finalize must NOT reset a worktree that holds real unpushed work"
       end
     end
   end


### PR DESCRIPTION
## Problem

When several PRs merge back-to-back, the base churns and hive's auto-rebase advances the PR branch on the **remote** (rebasing the fix onto the new base). If the local **finalize worktree** stays on the old base, its commit becomes **patch-identical to a commit already on the remote but with a different SHA**. `pushed?` (HEAD == upstream) is false, `git push` fails non-fast-forward, and finalize loops on `unpushed_commits` every ~30s — even though the work is already safely on the PR branch.

Observed live on **task 1248** (`patrol-command-bin-hv-a45e7a9a`) after I merged #492 → #496 → #497 in quick succession: local `f1199bd2` (base #492) vs remote `f728f15e` (base #497), **identical patch-id** `f392321d…`. Pushing the local commit would be *wrong* — it'd force the stale base back over the correctly-rebased remote.

## Fix

In `verify_state!`, after the push fails to reconcile HEAD with upstream, call `resync_stale_rebase!`: it runs `git cherry <upstream> HEAD` (patch-id comparison). If **every** ahead-commit is already upstream (all `-`, or none), the worktree is a stale pre-rebase copy → hard-reset it to the upstream and proceed on the rebased code. Any `+` line (a change genuinely missing upstream) or a git failure returns false and finalize still errors — **real unpushed work is never discarded.**

## Tests

- `…resyncs_stale_rebase_duplicate_instead_of_unpushed_error` — builds the exact divergence (local fix on old base; upstream advanced + patch-identical rebase) and asserts finalize completes and the worktree is fast-forwarded to upstream.
- `…errors_on_genuine_unpushed_commit_when_diverged` — a local commit whose change is **not** upstream still errors `unpushed_commits`, and the worktree HEAD is left untouched (guardrail against silent data loss).

finalize suite green (23 runs), rubocop clean, brakeman 0 warnings, `HIVE_COVERAGE_MIN_LINE=100 rake coverage` gate passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)