### PR TITLE
Hive patrol: Patrol success payload can violate its schema

### DIFF
--- a/schemas/hive-patrol.v1.json
+++ b/schemas/hive-patrol.v1.json
@@ -68,7 +68,7 @@
               "finding_id": { "type": "string" },
               "fingerprint": { "type": "string" },
               "reason": {
-                "enum": ["dismissed", "existing_pr", "low_confidence", "low_severity"]
+                "enum": ["dismissed", "existing_pr", "similar_to_existing", "low_confidence", "low_severity"]
               }
             }
           }

--- a/test/unit/schema_files_test.rb
+++ b/test/unit/schema_files_test.rb
@@ -1601,7 +1601,8 @@ class SchemaFilesTest < Minitest::Test
         { "pr_url" => "https://example.com/pr/2", "reason" => "review_handoff_failed" }
       ],
       "skipped_findings" => [
-        { "finding_id" => "f2", "fingerprint" => "fp2", "reason" => "low_confidence" }
+        { "finding_id" => "f2", "fingerprint" => "fp2", "reason" => "low_confidence" },
+        { "finding_id" => "f3", "fingerprint" => "fp3", "reason" => "similar_to_existing" }
       ],
       "last_scanned_sha" => "abc123"
     }


### PR DESCRIPTION
## Summary

`hive patrol PROJECT --json` emits a `hive-patrol.v1` success payload whose
`skipped_findings[].reason` is constrained by an enum. The producer
(`lib/hive/commands/patrol.rb#skip_reason`) can return `similar_to_existing`
when the similarity gate suppresses a re-worded re-file of an already-PR'd or
dismissed finding, but the published schema enum omitted that value. Every
patrol run that hit the similarity gate therefore emitted JSON that its own
schema rejects.

This adds `similar_to_existing` to the `skipped_findings[].reason` enum in
`schemas/hive-patrol.v1.json`, restoring producer/schema agreement. No producer
behaviour changes — only the contract is corrected to match what patrol already
emits.

Change set (2 files, +3/-2):

- `schemas/hive-patrol.v1.json` — add `similar_to_existing` to the
  `skipped_findings[].reason` enum.
- `test/unit/schema_files_test.rb` — extend the success-payload schema test with
  a second skipped finding using `reason: "similar_to_existing"` so the gap is
  regression-covered.

## Test plan

- `bundle exec ruby -Itest test/unit/schema_files_test.rb` — 107 runs, 410
  assertions, 0 failures; the success-payload test now validates a payload that
  carries a `similar_to_existing` skipped finding.
- `bundle exec rake test` — full suite passed.
- `bundle exec rubocop` — clean.

## Review summary

Codex native review (pass 01) returned a clean pass — **No findings** across
High / Medium / Nit. No escalations and no open user questions. Browser review
was skipped: the change touches only a JSON schema and a unit test, with no UI
surface.

## Linked task

- Patrol finding: `command-bin-hive-3`
  (fingerprint `bbd970106f097653b41f1360a24bbe8c4014bac16ea99c25e0593485815474c9`)
- Hive task: `patrol-command-bin-hive-bbd97010`
