### PR TITLE
test(web): exercise binary PTY output through the agent-login relay and view

### DIFF
--- a/test/unit/web/agents_auth_login_test.rb
+++ b/test/unit/web/agents_auth_login_test.rb
@@ -14,9 +14,16 @@ class AgentsAuthLoginTest < Minitest::Test
     path = File.join(bin_dir, "claude")
     File.write(path, <<~SH)
       #!/usr/bin/env bash
-      # Mimic `claude setup-token`: print an authorize URL, wait for a code,
-      # succeed only if a non-empty code is pasted.
+      # Mimic `claude setup-token` running in a REAL pty: emit the kind of
+      # raw bytes the Claude Code TUI actually writes — ANSI control
+      # sequences, a box-drawing glyph, and a trailing lone UTF-8
+      # continuation byte (a multibyte char split across a 4096-byte
+      # readpartial boundary). That stream is ASCII-8BIT and NOT valid
+      # UTF-8, so the relay's output_for must scrub it render-safe (else the
+      # Agents <pre> view 500s). A clean-ASCII fake hid exactly this bug.
+      printf '\\033[2K\\033[1m\\342\\226\\210\\033[0m\\n'
       echo "Open #{AUTH_URL} to authenticate"
+      printf '\\342'
       read -r code
       if [ -n "$code" ]; then
         echo "token stored"
@@ -111,6 +118,17 @@ class AgentsAuthLoginTest < Minitest::Test
 
       wait_until { auth.session(session.id).done }
       assert_nil auth.session(session.id).error, "a relayed valid code must finish without error"
+
+      # End-to-end guard for the Agents-page 500: the fake emits real binary
+      # PTY bytes (assert the raw buffer is genuinely invalid UTF-8), and the
+      # relay must hand the view a scrubbed, render-safe UTF-8 string.
+      raw = auth.session(session.id).output
+      refute raw.dup.force_encoding(Encoding::UTF_8).valid_encoding?,
+             "the fake CLI must emit real binary so this exercises the scrub, not a clean-ASCII shortcut"
+      relayed = auth.output_for(session.id)
+      assert_equal Encoding::UTF_8, relayed.encoding, "relayed output must reach the view as UTF-8"
+      assert relayed.valid_encoding?,
+             "binary CLI bytes must be scrubbed render-safe — else <pre><%= @session_output %></pre> 500s"
     end
   end
 

--- a/web/test/integration/agents_test.rb
+++ b/web/test/integration/agents_test.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+
+# Regression guard for the Agents login-status 500. The CLI relay buffers
+# raw ASCII-8BIT PTY bytes; rendering them into the UTF-8 `<pre>` view raised
+# Encoding::CompatibilityError (a 500 on /agents/<agent>/login/<id>). The lib
+# suite never caught it — its only direct `output_for` test used clean ASCII
+# and the login fakes echoed clean text, and nothing drove the controller +
+# view. This exercises the exact layer that broke: a binary-output session
+# rendered through the real view.
+class AgentsTest < ActionDispatch::IntegrationTest
+  teardown do
+    # AgentsController.agents_auth is a class-memoized process singleton —
+    # drop it so a seeded session can't leak into another test.
+    AgentsController.instance_variable_set(:@agents_auth, nil)
+  end
+
+  test "login_status renders binary CLI output as 200, not a 500" do
+    sign_in!(login: "alice")
+
+    auth = AgentsController.agents_auth
+    # Raw PTY bytes: ANSI clear-line, a box glyph, and a lone UTF-8
+    # continuation byte (a multibyte char split across a readpartial
+    # boundary) — invalid UTF-8, the shape that crashed the <pre> view.
+    binary = +"".b
+    binary << "\e[2K".b << "█".b << " Open https://example.com/auth ".b << "\xE2".b
+    session = Hive::Web::AgentsAuth::Session.new(
+      id: "sess-bin", agent: "claude",
+      output: binary, url: "https://example.com/auth", done: false
+    )
+    auth.instance_variable_get(:@sessions)["sess-bin"] = session
+
+    get agent_login_status_path("claude", "sess-bin")
+
+    assert_response :success
+    assert_match "https://example.com/auth", response.body,
+                 "the authorize URL must render so the operator can finish login"
+  end
+end


### PR DESCRIPTION
## Why

The agent-login **500** fixed in #497 (`Encoding::CompatibilityError` rendering binary CLI output into the UTF-8 `<pre>` view) slipped through CI because **every test fed clean output**:
- the one direct `output_for` unit test used `+"hello"`,
- the login-relay fakes (`install_fake_claude`/`_gh`) echoed plain ASCII — never the ANSI/control bytes and split-multibyte sequences a real CLI emits in a PTY,
- and **no test drove the Agents controller + view**, so the layer that actually crashed was never rendered.

100% line coverage didn't help: the defect is a cross-layer interaction (a lib method returns binary; a view in `web/app/` assumes UTF-8), not an uncovered line.

## What

Closes both gaps — **test-only, no production change**:

1. **`install_fake_claude` now emits realistic binary** (ANSI clear-line + bold, a `█` box glyph, and a trailing lone UTF-8 continuation byte), so the whole login-relay suite runs through real binary. `test_start_surfaces_authorize_url_then_complete_relays_code` now asserts the raw session buffer is **genuinely invalid UTF-8** *and* that `output_for` returns a **scrubbed, valid-UTF-8** string — so it fails if either the fake is re-sanitized or the scrub is removed.
2. **New `web/test/integration/agents_test.rb`** drives `GET login_status` with a binary-output session and asserts **200**, rendering the exact `<pre>` that 500'd. Verified it goes **red** (the 500 surfaces) when the scrub is reverted.

## Checks
- lib login suite green (14 runs); full web suite green (60 runs)
- rubocop clean (root + web config); brakeman 0 warnings
- `HIVE_COVERAGE_MIN_LINE=100 rake coverage` gate passed
- Regression-catch verified: reverting `output_for`'s scrub turns the new web test red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)