### PR TITLE
fix(web): codex login uses headless device-auth + strip ANSI from surfaced URL

### DIFF
--- a/lib/hive/web/agents_auth.rb
+++ b/lib/hive/web/agents_auth.rb
@@ -22,9 +22,21 @@ module Hive
       # be a truncated prefix if the URL straddles a read boundary, so we keep
       # scanning until a whitespace-terminated match (or EOF) settles it.
       URL_SETTLED_RE = %r{https?://[^\s<>"']+(?=\s)}.freeze
+      # Terminal control sequences an agent may wrap a URL in (codex prints
+      # the device link as `\e[94m<url>\e[0m`). URL_RE only stops at
+      # whitespace, so without stripping these the surfaced href carries the
+      # trailing reset bytes and the link is broken.
+      URL_CONTROL_RE = %r{\e\[[0-9;]*[A-Za-z]|[\x00-\x1f\x7f]}.freeze
       AGENT_COMMANDS = {
         "claude" => %w[claude setup-token],
-        "codex" => %w[codex login],
+        # `--device-auth` is the headless device-flow: one authorize URL plus
+        # a one-time code the operator enters at the provider. Plain `codex
+        # login` is a localhost-callback OAuth — it starts a server on the
+        # CONTAINER's localhost:1455 and prints THAT as the first URL, which
+        # the relay would surface and which the operator's browser can never
+        # reach across the container boundary. codex itself recommends
+        # `--device-auth` "on a remote or headless machine".
+        "codex" => %w[codex login --device-auth],
         # gh is not a pipeline agent, but its login IS first-run setup: git's
         # https credential helper reads it for every push the daemon makes.
         # The flags pin the prompts away (host, protocol, no ssh key upload)
@@ -310,7 +322,7 @@ module Hive
             # truncated prefix that grows on the next read); lock it in only
             # once a whitespace-terminated match proves it is complete.
             match = tail[URL_RE]
-            session.url = match if match
+            session.url = sanitize_url(match) if match
             if tail[URL_SETTLED_RE]
               settled = true
               tail = nil
@@ -319,6 +331,13 @@ module Hive
             end
           end
         end
+      end
+
+      # Strip terminal control sequences from a URL captured by URL_RE, so a
+      # link an agent printed in color (`\e[94m<url>\e[0m`) is surfaced as a
+      # clean, clickable href rather than one carrying escape bytes.
+      def sanitize_url(url)
+        url.to_s.gsub(URL_CONTROL_RE, "")
       end
 
       # Read whatever bytes are available without blocking for a newline.

--- a/test/unit/web/agents_auth_login_test.rb
+++ b/test/unit/web/agents_auth_login_test.rb
@@ -49,6 +49,22 @@ class AgentsAuthLoginTest < Minitest::Test
     FileUtils.chmod(0o755, path)
   end
 
+  def install_fake_codex(bin_dir)
+    path = File.join(bin_dir, "codex")
+    File.write(path, <<~SH)
+      #!/usr/bin/env bash
+      # Mimic `codex login --device-auth`: a device-flow that prints the
+      # authorize URL and one-time code wrapped in ANSI color codes
+      # (\\033[94m...\\033[0m), then blocks until the operator authorizes.
+      printf '   \\033[94mhttps://auth.openai.com/codex/device\\033[0m\\n'
+      printf '   one-time code \\033[90mQ0F3-V1IO7\\033[0m\\n'
+      read -r _
+      echo "Successfully logged in"
+      exit 0
+    SH
+    FileUtils.chmod(0o755, path)
+  end
+
   def with_fake_gh
     with_tmp_dir do |dir|
       bin_dir = File.join(dir, "bin")
@@ -84,6 +100,35 @@ class AgentsAuthLoginTest < Minitest::Test
       with_env("PATH" => [ bin_dir, ENV.fetch("PATH", "") ].join(File::PATH_SEPARATOR)) do
         yield
       end
+    end
+  end
+
+  def with_fake_codex
+    with_tmp_dir do |dir|
+      bin_dir = File.join(dir, "bin")
+      FileUtils.mkdir_p(bin_dir)
+      install_fake_codex(bin_dir)
+      with_env("PATH" => [ bin_dir, ENV.fetch("PATH", "") ].join(File::PATH_SEPARATOR)) do
+        yield
+      end
+    end
+  end
+
+  # codex prints the device-flow URL in ANSI color, so URL_RE (which stops
+  # only at whitespace) captures the trailing reset bytes. The surfaced URL
+  # must be stripped clean, or the operator gets a broken href.
+  def test_codex_device_auth_url_is_surfaced_without_terminal_controls
+    with_fake_codex do
+      auth = Hive::Web::AgentsAuth.new
+      session = auth.start("codex")
+
+      url = wait_until { auth.session(session.id).url }
+      assert_equal "https://auth.openai.com/codex/device", url,
+                   "the device URL must be ANSI-stripped, not carry \\e[..m bytes that break the link"
+
+      # Unblock the fake's `read` so the PTY closes cleanly.
+      auth.complete(session.id, "x")
+      wait_until { auth.session(session.id).done }
     end
   end
 

--- a/test/unit/web/agents_auth_test.rb
+++ b/test/unit/web/agents_auth_test.rb
@@ -50,6 +50,13 @@ class AgentsAuthTest < Minitest::Test
     end
   end
 
+  def test_codex_login_uses_headless_device_auth
+    assert_equal %w[codex login --device-auth],
+                 Hive::Web::AgentsAuth::AGENT_COMMANDS.fetch("codex"),
+                 "codex must use the device-flow — plain `codex login` is a localhost-callback OAuth " \
+                 "whose container-local server the operator's browser can't reach"
+  end
+
   def test_output_for_returns_a_copy_of_the_session_buffer
     auth = Hive::Web::AgentsAuth.new
     session = Hive::Web::AgentsAuth::Session.new(id: "s", agent: "claude", output: +"hello", done: false)


### PR DESCRIPTION
## Problem

Logging **codex** in through the hivebox Agents page surfaced a useless link — the real authorize URL was only visible in the raw `<pre>` output. Two causes:

1. **Wrong flow.** The relay ran plain `codex login`, which is a **localhost-callback OAuth**: codex starts a server on the **container's** `localhost:1455` and prints that as the *first* URL. `URL_RE` grabbed it — but the operator's host browser can never reach the container's loopback, and the real `https://auth.openai.com/...` URL was stranded in the `<pre>`.
2. **ANSI in the URL.** codex prints the device link wrapped in color (`\e[94m<url>\e[0m`); `URL_RE` only stops at whitespace, so it captured the trailing reset bytes and the href was broken.

## Fix

1. `AGENT_COMMANDS["codex"]` → `codex login --device-auth` — the headless device-flow (one authorize URL + a one-time code the operator enters at the provider). codex itself prints *"On a remote or headless machine? Use `codex login --device-auth`."*
2. Strip terminal control sequences from the matched URL before storing it (`sanitize_url` + `URL_CONTROL_RE`), so any agent that colorizes its link surfaces a clean href.

## Tests
- `test_codex_device_auth_url_is_surfaced_without_terminal_controls` — a fake `codex` emits the device URL wrapped in ANSI; asserts the surfaced URL is `https://auth.openai.com/codex/device` (stripped). Verified it goes red if `sanitize_url` is removed.
- `test_codex_login_uses_headless_device_auth` — pins the `--device-auth` command.

agents_auth suites green, rubocop clean, brakeman 0 warnings, 100% coverage gate passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)