### PR TITLE
fix(web): sanitize_url splits adjacent URLs instead of splicing them

### DIFF
--- a/lib/hive/web/agents_auth.rb
+++ b/lib/hive/web/agents_auth.rb
@@ -22,11 +22,13 @@ module Hive
       # be a truncated prefix if the URL straddles a read boundary, so we keep
       # scanning until a whitespace-terminated match (or EOF) settles it.
       URL_SETTLED_RE = %r{https?://[^\s<>"']+(?=\s)}.freeze
-      # Terminal control sequences an agent may wrap a URL in (codex prints
-      # the device link as `\e[94m<url>\e[0m`). URL_RE only stops at
-      # whitespace, so without stripping these the surfaced href carries the
-      # trailing reset bytes and the link is broken.
-      URL_CONTROL_RE = %r{\e\[[0-9;]*[A-Za-z]|[\x00-\x1f\x7f]}.freeze
+      # Terminal control runs an agent may wrap a URL in — CSI/SGR color
+      # sequences (codex prints the device link as `\e[94m<url>\e[0m`) and any
+      # bare C0/DEL byte (a lone ESC left when a sequence straddles a read
+      # boundary, or an OSC/DCS introducer). URL_RE only stops at whitespace,
+      # so these ride into the captured match; sanitize_url replaces each run
+      # with a space (never deletes — see there) before re-extracting the URL.
+      TERMINAL_CONTROL_RE = %r{\e\[[0-9;]*[A-Za-z]|[\x00-\x1f\x7f]}.freeze
       AGENT_COMMANDS = {
         "claude" => %w[claude setup-token],
         # `--device-auth` is the headless device-flow: one authorize URL plus
@@ -333,11 +335,17 @@ module Hive
         end
       end
 
-      # Strip terminal control sequences from a URL captured by URL_RE, so a
-      # link an agent printed in color (`\e[94m<url>\e[0m`) is surfaced as a
-      # clean, clickable href rather than one carrying escape bytes.
+      # Turn a raw URL_RE capture into a clean, clickable href. Replace each
+      # terminal-control run with a SPACE — never delete it — then re-extract
+      # the first whitespace-terminated http(s) URL. Deleting would splice two
+      # URLs an agent printed back-to-back (separated only by an SGR reset)
+      # into one href: `…/device\e[0mhttps://evil` -> `…/devicehttps://evil`.
+      # Substituting a space instead lets URL_RE stop at the boundary, so the
+      # trailing color reset, any OSC-8 wrapper residue, and a second URL are
+      # all dropped, and the authorize URL is surfaced verbatim.
       def sanitize_url(url)
-        url.to_s.gsub(URL_CONTROL_RE, "")
+        candidate = url.to_s.gsub(TERMINAL_CONTROL_RE, " ")
+        candidate[URL_RE] || candidate.strip
       end
 
       # Read whatever bytes are available without blocking for a newline.

--- a/test/unit/web/agents_auth_test.rb
+++ b/test/unit/web/agents_auth_test.rb
@@ -57,6 +57,33 @@ class AgentsAuthTest < Minitest::Test
                  "whose container-local server the operator's browser can't reach"
   end
 
+  def test_sanitize_url_strips_ansi_color_wrapping
+    auth = Hive::Web::AgentsAuth.new
+    assert_equal "https://auth.openai.com/codex/device",
+                 auth.send(:sanitize_url, "\e[94mhttps://auth.openai.com/codex/device\e[0m")
+  end
+
+  def test_sanitize_url_preserves_a_clean_url_with_query_and_fragment
+    auth = Hive::Web::AgentsAuth.new
+    url = "https://auth.example/cb?code=ABC%20123&state=x#frag"
+    assert_equal url, auth.send(:sanitize_url, url),
+                 "percent-encoding, query string, and fragment must survive untouched"
+  end
+
+  def test_sanitize_url_does_not_splice_two_adjacent_urls
+    auth = Hive::Web::AgentsAuth.new
+    spliced = "https://auth.openai.com/codex/device\e[0mhttps://evil.example/steal"
+    assert_equal "https://auth.openai.com/codex/device", auth.send(:sanitize_url, spliced),
+                 "a control sequence between two URLs must split them, never concatenate into one href"
+  end
+
+  def test_sanitize_url_extracts_target_from_osc8_hyperlink
+    auth = Hive::Web::AgentsAuth.new
+    osc8 = "\e]8;;https://auth.openai.com/codex/device\e\\open\e]8;;\e\\"
+    assert_equal "https://auth.openai.com/codex/device", auth.send(:sanitize_url, osc8),
+                 "an OSC-8 hyperlink must surface its target URL with no escape/residue bytes"
+  end
+
   def test_output_for_returns_a_copy_of_the_session_buffer
     auth = Hive::Web::AgentsAuth.new
     session = Hive::Web::AgentsAuth::Session.new(id: "s", agent: "claude", output: +"hello", done: false)

--- a/wiki/log.d/20260616T111405Z-codex-device-auth-url-sanitize.md
+++ b/wiki/log.d/20260616T111405Z-codex-device-auth-url-sanitize.md
@@ -1,0 +1,34 @@
+---
+date: 2026-06-16
+slug: codex-device-auth-url-sanitize
+pages: [decisions, gaps]
+---
+
+Decisions captured for the hivebox web agent-login relay
+(`lib/hive/web/agents_auth.rb`, the PTY OAuth relay from ADR-035).
+
+**codex login uses the headless device-flow.** `AGENT_COMMANDS["codex"]`
+changed from `codex login` to `codex login --device-auth` (#502). Plain
+`codex login` is a localhost-callback OAuth: it starts a server on the
+*container's* `localhost:1455` and prints that as the first URL, which the
+operator's host browser can never reach across the container boundary, and
+which `URL_RE` would surface ahead of the real provider URL. `--device-auth`
+is the RFC-8628 device-flow (one authorize URL + a one-time code entered at
+the provider) — codex itself recommends it "on a remote or headless machine".
+
+**Surfaced URLs are sanitized before becoming an href.** Agents print the
+device link wrapped in terminal control sequences (codex: `\e[94m<url>\e[0m`).
+`URL_RE` only stops at whitespace, so the raw match carries those bytes.
+`sanitize_url` now replaces each `TERMINAL_CONTROL_RE` run with a **space**
+(not a deletion — deleting would splice two back-to-back URLs into one href,
+`…/device\e[0mhttps://evil` → `…/devicehttps://evil`) and re-extracts the
+first whitespace-terminated URL via `URL_RE`. This drops the trailing color
+reset, OSC-8 wrapper residue, and any trailing second URL.
+
+**Known gap (see [[gaps]]):** codex `--device-auth` (and `gh`) are
+*operator-ward* device flows — the one-time code is entered at the provider
+and the CLI polls in the background; nothing is pasted back. The relay's
+login-status view still shows a `required` paste-code form and stops polling
+once the URL is captured, so the token saves but the UI does not auto-reflect
+completion. A follow-up reworks the view/controller to keep polling until
+`session.done` and suppress the paste form for poll-type agents.


### PR DESCRIPTION
Follow-up to the #502 code review (PR B of 2).

## Problem (adversarial finding, confidence 100)

`sanitize_url` deleted terminal-control runs with `gsub(URL_CONTROL_RE, "")`. Deleting the separator **splices two URLs** an agent printed back-to-back into one href:

```
"https://auth.openai.com/codex/device\e[0mhttps://evil.example/steal"
  → "https://auth.openai.com/codex/devicehttps://evil.example/steal"   # one bogus href
```

A phishing-href risk under a compromised/malicious CLI, and it also left OSC-8 wrapper residue (`]8;;`, `\`).

## Fix

Replace each `TERMINAL_CONTROL_RE` run with a **space** (not a deletion), then re-extract the first whitespace-terminated URL via the existing `URL_RE`. Adjacent URLs split at the boundary; trailing color resets, OSC-8 residue, and any second URL are dropped; the authorize URL is surfaced verbatim. Also renamed `URL_CONTROL_RE` → `TERMINAL_CONTROL_RE` (it strips bare C0/DEL bytes too, not just ANSI) and corrected the comment.

## Tests
Four `sanitize_url` unit cases: ANSI color wrap, clean-URL no-op (percent-encoding + query + fragment preserved), the two-adjacent-URLs splice case, and an OSC-8 hyperlink. Plus a `wiki/log.d` fragment recording the codex device-auth + sanitize_url decisions and the operator-ward completion gap (the PR A follow-up).

Dropped one review finding as a false positive: `sanitize_url` is already private (below the `private` marker at line 178).

agents suites green, rubocop clean, brakeman 0 warnings, 100% coverage gate passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)