### PR TITLE
feat(web): complete operator-ward (device-flow) logins in the Agents UI

### DIFF
--- a/lib/hive/web/agents_auth.rb
+++ b/lib/hive/web/agents_auth.rb
@@ -46,6 +46,14 @@ module Hive
         "gh" => %w[gh auth login --hostname github.com --git-protocol https --web --skip-ssh-key]
       }.freeze
 
+      # Agents whose login is OPERATOR-WARD: the one-time code is entered at
+      # the provider and the CLI polls in the background — nothing is pasted
+      # back into the CLI. The relay must keep refreshing the status page until
+      # the child exits (`done`) rather than show a paste-the-code form. codex
+      # `--device-auth` and gh's device flow are both poll-type; claude
+      # `setup-token` is the only paste-back flow.
+      POLL_LOGIN_AGENTS = %w[codex gh].freeze
+
       # Hard ceiling on in-flight login attempts. Each holds a PTY (2 fds + a
       # child + a reader thread); a small cap stops a stuck-CLI pile-up from
       # leaking the box's resources.
@@ -132,6 +140,13 @@ module Hive
 
       def url_for(id)
         @mutex.synchronize { @sessions[id]&.url }
+      end
+
+      # Whether this agent's login is operator-ward (poll-type) rather than
+      # paste-back — the view keeps refreshing until `done` and hides the
+      # paste-the-code form for these. See POLL_LOGIN_AGENTS.
+      def poll_login?(agent)
+        POLL_LOGIN_AGENTS.include?(agent.to_s)
       end
 
       # Block until the CLI has printed its authorize URL (or the bounded

--- a/test/unit/web/agents_auth_test.rb
+++ b/test/unit/web/agents_auth_test.rb
@@ -57,6 +57,13 @@ class AgentsAuthTest < Minitest::Test
                  "whose container-local server the operator's browser can't reach"
   end
 
+  def test_poll_login_distinguishes_operator_ward_from_paste_back_agents
+    auth = Hive::Web::AgentsAuth.new
+    assert auth.poll_login?("codex"), "codex --device-auth is operator-ward (code entered at provider, CLI polls)"
+    assert auth.poll_login?("gh"), "gh device flow is operator-ward"
+    refute auth.poll_login?("claude"), "claude setup-token is paste-back (code returned to the CLI)"
+  end
+
   def test_sanitize_url_strips_ansi_color_wrapping
     auth = Hive::Web::AgentsAuth.new
     assert_equal "https://auth.openai.com/codex/device",

--- a/web/app/controllers/agents_controller.rb
+++ b/web/app/controllers/agents_controller.rb
@@ -13,14 +13,17 @@ class AgentsController < ApplicationController
     redirect_to agent_login_status_path(params[:agent], login.id)
   end
 
-  # The waiting view inside a polled turbo-frame: re-renders until the
-  # authorize URL is captured, then shows it plus the code form.
+  # The waiting view inside a polled turbo-frame. For paste-back agents it
+  # re-renders until the authorize URL is captured, then shows the code form.
+  # For operator-ward (poll-type) agents it keeps polling until the CLI exits,
+  # so the page reflects completion without the operator pasting anything.
   def login_status
     @login_session = agents_auth.session(params[:session_id])
     raise Hive::InvalidTaskPath, "unknown login session" unless @login_session
 
     @session_output = agents_auth.output_for(@login_session.id)
     @session_url = agents_auth.url_for(@login_session.id)
+    @poll_login = agents_auth.poll_login?(@login_session.agent)
     @statuses = agents_auth.statuses
     render :index
   end

--- a/web/app/views/agents/index.html.erb
+++ b/web/app/views/agents/index.html.erb
@@ -23,23 +23,39 @@
 </div>
 
 <% if defined?(@login_session) && @login_session %>
-  <%# The poll controller refreshes via frame.reload(), which re-fetches the
-      frame's OWN src — without one, reload() is a silent no-op and the
-      operator would wait on "Waiting for the login URL…" forever. %>
+  <%# Keep polling while there is no URL yet, OR for an operator-ward
+      (poll-type) agent whose CLI is still running — the operator enters the
+      code at the provider and we refresh until the child exits. A paste-back
+      agent stops polling once its URL is shown (it waits on the form). The
+      poll controller reload()s the frame's OWN src, so a src is required
+      whenever polling. %>
+  <% poll_login = (defined?(@poll_login) && @poll_login) %>
+  <% polling = !@login_session.done && (@session_url.nil? || poll_login) %>
   <%= turbo_frame_tag "agent-login",
-        src: (@session_url ? nil : agent_login_status_path(@login_session.agent, @login_session.id)),
-        data: ({ controller: "poll", poll_interval_value: 2000 } unless @session_url) do %>
+        src: (polling ? agent_login_status_path(@login_session.agent, @login_session.id) : nil),
+        data: ({ controller: "poll", poll_interval_value: 2000 } if polling) do %>
     <div class="card">
       <h2><%= @login_session.agent %> login</h2>
-      <% if @session_url %>
+      <% if @login_session.done %>
+        <% if @login_session.error %>
+          <p>Login failed: <%= @login_session.error %></p>
+        <% else %>
+          <p><%= @login_session.agent %> is now logged in.</p>
+        <% end %>
+        <p><%= link_to "Back to agents", agents_path %></p>
+      <% elsif @session_url %>
         <p>Open the provider page and authorize:</p>
         <p><%= link_to @session_url, @session_url, target: "_blank", rel: "noopener" %></p>
-        <%= form_with url: agent_login_complete_path(@login_session.agent, @login_session.id), class: "form-grid" do |f| %>
-          <div class="form-row">
-            <%= f.label :code, "Paste the code (or full callback URL) the provider returned" %>
-            <%= f.text_field :code, required: true %>
-          </div>
-          <p><%= f.submit "Complete login", data: { turbo_submits_with: "Completing…" } %></p>
+        <% if poll_login %>
+          <p class="muted">Enter the one-time code shown in the CLI output below at the provider page. This page updates automatically when login completes.</p>
+        <% else %>
+          <%= form_with url: agent_login_complete_path(@login_session.agent, @login_session.id), class: "form-grid" do |f| %>
+            <div class="form-row">
+              <%= f.label :code, "Paste the code (or full callback URL) the provider returned" %>
+              <%= f.text_field :code, required: true %>
+            </div>
+            <p><%= f.submit "Complete login", data: { turbo_submits_with: "Completing…" } %></p>
+          <% end %>
         <% end %>
       <% else %>
         <p class="muted">Waiting for the login URL from the CLI…</p>

--- a/web/test/integration/agents_test.rb
+++ b/web/test/integration/agents_test.rb
@@ -35,4 +35,55 @@ class AgentsTest < ActionDispatch::IntegrationTest
     assert_match "https://example.com/auth", response.body,
                  "the authorize URL must render so the operator can finish login"
   end
+
+  test "operator-ward agent (codex) keeps polling and shows no paste-back form" do
+    sign_in!(login: "alice")
+    seed_session("sess-codex", agent: "codex", url: "https://auth.openai.com/codex/device",
+                 output: "Enter this code: Q0F3-V1IO7", done: false)
+
+    get agent_login_status_path("codex", "sess-codex")
+
+    assert_response :success
+    assert_match "https://auth.openai.com/codex/device", response.body
+    assert_match "updates automatically", response.body
+    assert_match 'data-controller="poll"', response.body,
+                 "a poll-type agent must keep refreshing until the CLI exits"
+    assert_no_match(/Complete login/, response.body,
+                    "operator-ward agents must not show a paste-the-code form")
+  end
+
+  test "operator-ward agent shows success and stops polling once done" do
+    sign_in!(login: "alice")
+    seed_session("sess-done", agent: "codex", url: "https://auth.openai.com/codex/device",
+                 output: "done", done: true)
+
+    get agent_login_status_path("codex", "sess-done")
+
+    assert_response :success
+    assert_match "is now logged in", response.body
+    assert_no_match(/data-controller="poll"/, response.body,
+                    "polling must stop once the login is done")
+  end
+
+  test "paste-back agent (claude) keeps the code form and stops polling at the URL" do
+    sign_in!(login: "alice")
+    seed_session("sess-claude", agent: "claude", url: "https://claude.ai/device",
+                 output: "paste the code", done: false)
+
+    get agent_login_status_path("claude", "sess-claude")
+
+    assert_response :success
+    assert_match "Complete login", response.body, "paste-back agents keep the code form"
+    assert_no_match(/data-controller="poll"/, response.body,
+                    "a paste-back agent stops polling once its URL is shown")
+  end
+
+  private
+
+  def seed_session(id, agent:, url:, output:, done:, error: nil)
+    session = Hive::Web::AgentsAuth::Session.new(
+      id: id, agent: agent, url: url, output: +output, done: done, error: error
+    )
+    AgentsController.agents_auth.instance_variable_get(:@sessions)[id] = session
+  end
 end


### PR DESCRIPTION
Follow-up to the #502 review (PR A of 2; PR B was #503).

## Problem (P1, correctness + testing)

codex `--device-auth` and gh are **operator-ward** device flows — the one-time code is entered *at the provider* and the CLI polls in the background; nothing is pasted back. But the login-status view showed a `required` paste-the-code form and **stopped polling once the URL was captured**. So the token saved while the UI was stuck on an inapplicable form and never reflected completion without a manual page refresh.

## Fix

- `AgentsAuth#poll_login?(agent)` + `POLL_LOGIN_AGENTS = %w[codex gh]` — claude `setup-token` is the only paste-back flow.
- View, for poll-type agents: keep the turbo-frame **polling until `session.done`** and replace the paste form with *"authorize at the provider; this page updates automatically."* Add a done → success (or error) state.
- Paste-back agents (claude) unchanged: form shown, polling stops at the URL.

## Tests
- `poll_login?` unit (codex/gh true, claude false).
- Web integration: codex keeps polling + no form; codex-done shows success + polling stops; claude keeps the form (regression guard). The existing binary-output test still passes.

agents suites green, full web suite green (63 runs), rubocop clean, brakeman 0 warnings, 100% lib coverage gate passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)