### PR TITLE
Hive patrol: sandbox-tree artifacts include top-level .git entries

### DIFF
--- a/test/e2e/lib/artifact_capture.rb
+++ b/test/e2e/lib/artifact_capture.rb
@@ -191,7 +191,10 @@ module Hive
 
         Dir.chdir(@sandbox_dir) do
           Dir.glob("**/*", File::FNM_DOTMATCH)
-            .reject { |path| path == "." || path == ".." || path.include?("/.git/") }
+            .reject do |path|
+              path == "." || path == ".." || path == ".git" ||
+                path.start_with?(".git/") || path.include?("/.git/")
+            end
             .sort
             .join("\n") + "\n"
         end

--- a/test/e2e/lib/artifact_capture_test.rb
+++ b/test/e2e/lib/artifact_capture_test.rb
@@ -63,6 +63,21 @@ class E2EArtifactCaptureTest < Minitest::Test
     end
   end
 
+  def test_sandbox_tree_excludes_top_level_git_metadata
+    with_dirs do |scenario_dir, sandbox, run_home|
+      assert system("git", "-C", sandbox, "init", "-b", "master", "--quiet"),
+        "expected git init fixture setup to succeed"
+      File.write(File.join(sandbox, "visible.txt"), "visible\n")
+
+      collect(scenario_dir, sandbox, run_home)
+
+      tree = File.read(File.join(scenario_dir, "sandbox-tree.txt"))
+      assert_includes tree, "visible.txt\n"
+      refute tree.lines.any? { |line| line == ".git\n" || line.start_with?(".git/") },
+        "sandbox-tree.txt must not publish git metadata paths"
+    end
+  end
+
   def test_log_tails_are_last_n_lines_per_log_file
     with_dirs do |scenario_dir, sandbox, run_home|
       logs_root = File.join(sandbox, ".hive-state", "logs", "myslug")


### PR DESCRIPTION
## Summary

Patrol finding `test-suite-test-babysitter-acceptance-dry-run-test-rb-1` flagged that `ArtifactCapture#sandbox_tree` only excluded paths containing `/.git/`. For a normal sandbox repository, the top-level `.git` directory and its immediate entries (`.git`, `.git/config`, `.git/objects`, …) do not contain that substring, so failure artifacts still published the full git-metadata tree in `sandbox-tree.txt` — noisy diagnostics that also exposed repository-internal path names despite the intended exclusion.

This branch widens the reject predicate in `test/e2e/lib/artifact_capture.rb` to also skip `path == ".git"` and `path.start_with?(".git/")` alongside the existing `path.include?("/.git/")` check, so top-level git metadata no longer appears in the captured sandbox tree.

## Test plan

- `bundle exec rubocop` — lint passed.
- `bundle exec rake test` — full test suite passed.
- New regression `test_sandbox_tree_excludes_top_level_git_metadata` initializes a sandbox git repo plus a visible file, runs the capture, and asserts `sandbox-tree.txt` includes `visible.txt` but contains no `.git` or `.git/…` entries.

## Review summary

The standard 6-review pass produced no actionable code findings against this diff. The single reviewer entry was an infrastructure error — `codex-native-review` exited status=1 after 2 attempts — not a finding about the change itself. `task.md` carries `REVIEW_COMPLETE pass=1 browser=skipped`.

## Linked task

- Patrol finding: `test-suite-test-babysitter-acceptance-dry-run-test-rb-1`
- Fingerprint: `fd3c7bcf2345447700e0d0b7f6620a1fc03be7d902b7880d0d149d2b08b0e891`
- Commit `9ce1dfc1` — `fix(patrol): sandbox-tree artifacts include top-level .git entries` (19 insertions, 1 deletion across 2 files).
