### PR TITLE
fix(reviewers): drop codex session transcript from the published findings

### DIFF
--- a/lib/hive/reviewers/codex_review.rb
+++ b/lib/hive/reviewers/codex_review.rb
@@ -47,6 +47,16 @@ module Hive
       # usage-limit error) is treated as a reviewer failure.
       SEVERITY_HEADER = /^##\s+(High|Medium|Nit)\b/i.freeze
 
+      # `codex review` streams its whole session to stdout: the (prompt-echoed)
+      # findings block, then a tool-call transcript of bare `exec`/`thinking`/
+      # `codex` section markers (each `exec` block can be hundreds of lines —
+      # cat'd files, diffs, even a full test run), then codex's final
+      # assistant message under the last `codex` marker. A bare line that is
+      # exactly one of these markers delimits the transcript that
+      # `normalize_output` drops; `CODEX_REPLY` is the final-message marker.
+      SESSION_MARKER = /\A(?:exec|thinking|codex)\z/.freeze
+      CODEX_REPLY = /\Acodex\z/.freeze
+
       def initialize(spec, ctx, cfg: nil)
         super(spec, ctx)
         @cfg = cfg
@@ -141,15 +151,32 @@ module Hive
         stdout.to_s.match?(SEVERITY_HEADER)
       end
 
-      # Trim leading codex banner noise so the published findings file starts
-      # at the first severity header. Everything from the first `## High|
-      # Medium|Nit` onward is the model's structured output.
+      # Trim codex's stdout to the findings triage needs to read: drop the
+      # leading banner (start at the first severity header) AND the tool-call
+      # transcript in the middle, keeping the leading findings block plus
+      # codex's final message. Handing triage the raw transcript (seen at
+      # 96 KB–565 KB) bloats its prompt and has caused triage timeouts.
       def normalize_output(stdout)
         text = stdout.to_s
         idx = text =~ SEVERITY_HEADER
         body = idx ? text[idx..] : text
-        body = body.rstrip
+        body = drop_session_transcript(body).rstrip
         body.empty? ? body : "#{body}\n"
+      end
+
+      # Discard the `exec`/`thinking`/`codex` session transcript that sits
+      # between the leading findings block and codex's final assistant message.
+      # No session marker → return the body unchanged (already-clean output, or
+      # a shape we don't recognize — never produce worse than the raw body).
+      def drop_session_transcript(body)
+        lines = body.lines
+        first = lines.index { |line| line.chomp.match?(SESSION_MARKER) }
+        return body unless first
+
+        last_reply = lines.rindex { |line| line.chomp.match?(CODEX_REPLY) }
+        head = lines[0...first].join.rstrip
+        reply = last_reply && last_reply >= first ? lines[(last_reply + 1)..].join.strip : ""
+        reply.empty? ? head : "#{head}\n\n#{reply}"
       end
 
       # Run `codex review --title <title> <prompt>` in the worktree, capturing

--- a/test/unit/reviewers/codex_review_test.rb
+++ b/test/unit/reviewers/codex_review_test.rb
@@ -134,6 +134,81 @@ class ReviewersCodexReviewTest < Minitest::Test
     end
   end
 
+  # `codex review` streams its whole session: the findings block, then a long
+  # exec/tool transcript, then its final message. The transcript must be
+  # dropped so triage isn't handed hundreds of KB (which has timed it out);
+  # the leading block and codex's final verdict are kept.
+  def test_drops_session_transcript_keeping_head_and_final_message
+    with_tmp_dir do |dir|
+      flood = (1..400).map { |i| "  cat'd SKILL.md / git diff line #{i}" }.join("\n")
+      ENV["HIVE_FAKE_CODEX_STDOUT"] = <<~OUT
+        OpenAI Codex v0.139.0
+        ## High
+        - [ ] <finding>: <one-line justification>
+
+        ## Medium
+        No findings.
+
+        ## Nit
+        No findings.
+
+        Rules:
+        - Always print all three headers, in order.
+        exec
+        /usr/bin/bash -lc "cat SKILL.md && git diff origin/main...HEAD" in /worktree
+         succeeded in 12ms:
+        #{flood}
+        exec
+        /usr/bin/bash -lc "bundle exec ruby -Itest test/foo_test.rb" in /worktree
+         succeeded in 3458ms:
+        13 runs, 46 assertions, 0 failures, 0 errors, 0 skips
+        codex
+        The diff is clean. No correctness, security, or data-loss regressions were identified.
+      OUT
+      raw_bytes = ENV["HIVE_FAKE_CODEX_STDOUT"].bytesize
+      reviewer = build_reviewer(dir)
+
+      result = reviewer.run!
+
+      assert result.ok?, "expected :ok, got #{result.status} (#{result.error_message})"
+      body = File.read(reviewer.output_path)
+      assert_includes body, "## High", "the severity-header block must survive (valid_findings? + format)"
+      assert_includes body, "The diff is clean. No correctness", "codex's final verdict must be surfaced"
+      refute_includes body, "succeeded in", "the exec/tool transcript must be dropped"
+      refute_includes body, "bundle exec ruby", "transcript commands must be dropped"
+      refute_includes body, "git diff line 200", "the hundreds of transcript lines must be dropped"
+      assert_operator body.bytesize, :<, raw_bytes / 4,
+                      "published findings must be a fraction of the raw transcript"
+    end
+  end
+
+  def test_drops_transcript_with_no_trailing_codex_reply_keeps_head
+    with_tmp_dir do |dir|
+      ENV["HIVE_FAKE_CODEX_STDOUT"] = <<~OUT
+        ## High
+        - [ ] real bug: explain it
+        ## Medium
+        No findings.
+        ## Nit
+        No findings.
+        exec
+        /usr/bin/bash -lc "git diff" in /worktree
+         succeeded in 5ms:
+        some transcript diff output here
+        more transcript lines
+      OUT
+      reviewer = build_reviewer(dir)
+
+      result = reviewer.run!
+
+      assert result.ok?, "expected :ok, got #{result.status} (#{result.error_message})"
+      body = File.read(reviewer.output_path)
+      assert_includes body, "- [ ] real bug: explain it", "the head findings block must survive"
+      refute_includes body, "succeeded in", "transcript dropped even with no trailing codex reply"
+      refute_includes body, "some transcript diff output", "transcript dropped"
+    end
+  end
+
   # --- FIX 1: full pipe drain (no write() deadlock past the retain cap) ---
 
   def test_oversized_output_drains_without_deadlock_and_yields_valid_findings


### PR DESCRIPTION
## Problem (root cause of task 1332's triage failure)

`codex review` streams its **entire session** to stdout: the prompt-echoed findings block, then a tool-call transcript (bare `exec`/`thinking`/`codex` sections — each `exec` block can be hundreds of lines of cat'd files, diffs, even a full test run), then codex's final message. `normalize_output` only trimmed the leading banner (anchored on the first `## High`) and **kept everything after** — so triage received the whole transcript, observed at **96 KB–565 KB**.

That bloats triage's prompt. On **task 1332** the triage agent hit a transient Claude API 500 while adjudicating a 96 KB codex transcript, stranded, and burned the full 30-min stage timeout → `triage_failed`.

## Fix

`drop_session_transcript`: keep the leading findings block + codex's final message (everything after the last `codex` marker), discarding the `exec`/tool transcript between them. No session marker → return the body unchanged (clean output or an unrecognized shape — never worse than before).

**Validated on a real 565 KB sample → 4.9 KB (0.9%)**, preserving both the `## High/Medium/Nit` block and codex's actual `[P1]` findings.

## Tests
- transcript-drop: head + final verdict kept, `exec`/`succeeded in`/the 400 flood lines dropped, output < 25% of raw.
- transcript with no trailing `codex` reply → head kept, transcript dropped.
- existing clean-output tests unchanged (fallback path).

codex_review suite green (32 runs), rubocop clean, brakeman 0 warnings, 100% coverage gate passed.

Note: a related follow-up — codex rate-limit failures classify as `all_failed` (manual) instead of `limits_reached` (auto-retry), because the codex-reviewer failure path doesn't run codex's stderr through `AgentLimit.limit_reached?` (which already recognizes codex's wording). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)