### PR TITLE
Hive patrol: Unusable e2e repros report generic failure

### DIFF
--- a/schemas/hive-e2e-error.v1.json
+++ b/schemas/hive-e2e-error.v1.json
@@ -11,7 +11,7 @@
     "ok": { "const": false },
     "error_kind": {
       "type": "string",
-      "enum": ["usage", "no_scenarios", "preflight", "run_failed", "missing_repro", "error"]
+      "enum": ["usage", "no_scenarios", "preflight", "run_failed", "missing_repro", "unusable_repro", "error"]
     },
     "message": { "type": "string" },
     "exit_code": { "type": "integer", "minimum": 0, "maximum": 255 },

--- a/test/e2e/lib/hive_e2e_binary_test.rb
+++ b/test/e2e/lib/hive_e2e_binary_test.rb
@@ -161,18 +161,18 @@ class E2EBinaryTest < Minitest::Test
     assert_equal 78, payload["exit_code"]
   end
 
-  def test_replay_non_executable_repro_emits_config_error
+  def test_replay_non_executable_repro_emits_json_artifact_error_when_requested
     Dir.mktmpdir("e2e-replay-test") do |tmp_runs_dir|
-      scenario_dir = File.join(tmp_runs_dir, "run-1", "scenarios", "scenario-a")
-      FileUtils.mkdir_p(scenario_dir)
-      script = File.join(scenario_dir, "repro.sh")
-      File.write(script, "#!/usr/bin/env sh\necho replayed\n")
+      script = File.join(tmp_runs_dir, "run-1", "scenarios", "scenario-1", "repro.sh")
+      FileUtils.mkdir_p(File.dirname(script))
+      File.write(script, "#!/usr/bin/env bash\nexit 0\n")
       File.chmod(0o644, script)
 
       out, err, status = Open3.capture3(
         { "HIVE_E2E_RUNS_DIR" => tmp_runs_dir },
-        hive_e2e, "replay", "--json", "run-1", "scenario-a"
+        hive_e2e, "replay", "--json", "run-1", "scenario-1"
       )
+
       assert_equal 78, status.exitstatus
       assert_empty err
 

--- a/wiki/e2e.md
+++ b/wiki/e2e.md
@@ -3,7 +3,7 @@ title: Agentic E2E Suite
 type: reference
 source: test/e2e/, bin/hive-e2e, Rakefile
 created: 2026-04-29
-updated: 2026-06-16
+updated: 2026-06-17
 tags: [test, e2e, tui, artifacts]
 ---
 
@@ -32,7 +32,7 @@ bin/hive-e2e clean              # old run cleanup
 | `64` | usage error: unknown command, missing required Thor arguments, unsafe replay path, invalid retention window, or no matching scenarios |
 | `78` | preflight/config failure: missing `tmux`, missing `asciinema` when required, missing replay repro artifact, or a replay `repro.sh` that is not a regular executable file |
 
-Thor is started exactly once with `debug: true` so `Thor::Error` re-raises into the executable's outer rescue instead of taking Thor's built-in human path; a second `Binary.start` call would rerun successful commands and emit duplicate JSON envelopes. That outer rescue maps both human and `--json` usage failures to `64`. With `--json`, usage and preflight failures emit a `hive-e2e-error` envelope on stdout with `ok: false`, `error_kind`, `message`, and `exit_code`; human mode prefixes prose errors with `hive-e2e:` on stderr and exits with the same code. Top-level `--version` / `-v` is intercepted before Thor dispatch so binary smoke tests get only `Hive::VERSION`.
+Thor is started exactly once with `debug: true` so `Thor::Error` re-raises into the executable's outer rescue instead of taking Thor's built-in human path; a second `Binary.start` call would rerun successful commands and emit duplicate JSON envelopes. That outer rescue maps both human and `--json` usage failures to `64`. With `--json`, usage and preflight failures emit a `hive-e2e-error` envelope on stdout with `ok: false`, `error_kind`, `message`, and `exit_code`; human mode prefixes prose errors with `hive-e2e:` on stderr and exits with the same code. Replay artifact failures are split: a missing `repro.sh` emits `error_kind: "missing_repro"`, while an existing but non-executable `repro.sh` emits `error_kind: "unusable_repro"`; both exit `78`. Top-level `--version` / `-v` is intercepted before Thor dispatch so binary smoke tests get only `Hive::VERSION`.
 Successful `--json` commands emit exactly one top-level JSON document on stdout, including `list --json` and `clean --json`, so wrapper callers can parse stdout directly.
 
 `bin/hive-e2e replay RUN_ID SCENARIO` validates safe run/scenario basenames,

--- a/wiki/e2e.md
+++ b/wiki/e2e.md
@@ -30,7 +30,7 @@ bin/hive-e2e clean              # old run cleanup
 | `0` | all selected scenarios passed |
 | `1` | one or more scenarios failed, or an unclassified harness error occurred |
 | `64` | usage error: unknown command, missing required Thor arguments, unsafe replay path, invalid retention window, or no matching scenarios |
-| `78` | preflight/config failure: missing `tmux`, missing `asciinema` when required, missing replay repro artifact, or a replay `repro.sh` that exists but is not a regular executable file |
+| `78` | preflight/config failure: missing `tmux`, missing `asciinema` when required, missing replay repro artifact, or a replay `repro.sh` that is not a regular executable file |
 
 Thor is started exactly once with `debug: true` so `Thor::Error` re-raises into the executable's outer rescue instead of taking Thor's built-in human path; a second `Binary.start` call would rerun successful commands and emit duplicate JSON envelopes. That outer rescue maps both human and `--json` usage failures to `64`. With `--json`, usage and preflight failures emit a `hive-e2e-error` envelope on stdout with `ok: false`, `error_kind`, `message`, and `exit_code`; human mode prefixes prose errors with `hive-e2e:` on stderr and exits with the same code. Top-level `--version` / `-v` is intercepted before Thor dispatch so binary smoke tests get only `Hive::VERSION`.
 Successful `--json` commands emit exactly one top-level JSON document on stdout, including `list --json` and `clean --json`, so wrapper callers can parse stdout directly.

--- a/wiki/log.d/20260617T012143Z-e2e-unusable-repro.md
+++ b/wiki/log.d/20260617T012143Z-e2e-unusable-repro.md
@@ -1,0 +1,3 @@
+## [2026-06-17T01:21:43Z] e2e - classify non-executable replay repro artifacts
+
+**Action:** Fixed `bin/hive-e2e replay` so a stored `repro.sh` that exists but is not executable is reported as a deterministic replay artifact config failure instead of falling through to the generic outer error rescue. JSON callers now receive `error_kind: "unusable_repro"` with exit `78`. Added focused coverage in `test/e2e/lib/hive_e2e_binary_test.rb` and refreshed [[e2e]] / [[testing]] contract wording. Did not run `qmd update` or `qmd embed`.

--- a/wiki/log.d/20260617T013055Z-e2e-unusable-repro-audit.md
+++ b/wiki/log.d/20260617T013055Z-e2e-unusable-repro-audit.md
@@ -1,0 +1,8 @@
+## [2026-06-17T01:30:55Z] wiki - audit unusable e2e replay coverage
+
+**Action:** Refreshed command/API and executable-entrypoint wiki coverage after commit `6ce31190` changed `bin/hive-e2e`, `test/e2e/lib/hive_e2e_binary_test.rb`, and existing e2e wiki pages. Read `AGENTS.md`, `.llm-wiki/config.json`, [[index]], [[architecture]], [[decisions]], [[gaps]], and recent [[log]] entries first; `qmd search "routes handlers commands executable entrypoints README command API surface"` surfaced prior wrapper/e2e refreshes, and the configured master wiki path only had general route/API coverage guidance. Inspected the committed diff plus current `bin/hive-e2e`, `test/e2e/lib/hive_e2e_binary_test.rb`, [[e2e]], [[testing]], and [[gaps]]. Updated [[e2e]] so the replay JSON contract explicitly distinguishes `missing_repro` from `unusable_repro`, updated [[testing]] to name missing and non-executable replay artifact validation, and carried the remaining uncertainty forward in [[gaps]]: no checked-in artifact proves a real retained failure bundle lost executable mode before replay, and no live patrol/babysitter wrapper consumption of the e2e JSON surface was found. Page coverage did not change, so [[index]] did not need a catalog update. Did not run `qmd update` or `qmd embed`.
+
+**Refreshed pages:**
+- [[e2e]]
+- [[testing]]
+- [[gaps]]

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -143,9 +143,9 @@ successful `list --json` / `clean --json` calls, unknown-command JSON errors,
 missing argument errors, top-level version output, command-local help after
 command options (`run --filter tui --help`), leading JSON option normalization,
 malformed JSON assignment rejection, last-JSON-boolean-wins usage-error mode,
-replay path safety including non-executable `repro.sh` config errors, cleanup
-retention validation, and the single-dispatch invariant for successful JSON
-commands.
+replay path safety, missing and non-executable replay artifact validation,
+cleanup retention validation, and the single-dispatch invariant for successful
+JSON commands.
 
 The install-smoke workflow's `verify-release.sh (end-to-end behavior)` job
 runs `packaging/verify-release.sh --version=v0.1.0` against the published
@@ -199,7 +199,7 @@ credentials inside a running box.
 
 The live Telegram bot E2E wrapper lives at `test/e2e/tg/run_idea_e2e.sh` and is also opt-in because it uses a real Bot API test token plus a Telethon user session. In default text mode it drives `/idea <nonce>` through the project picker. With `TG_IDEA_MODE=voice`, the wrapper requires the voice fixture and `HIVE_WHISPER_API_KEY`, starts the bot from the current checkout, drives a new voice idea through transcript confirmation/project selection, seeds a temporary `2-brainstorm/<slug>/brainstorm.md` in the scratch project, then sends `/answer <slug>` and answers Q1 with the same voice note. Cleanup resets the scratch state repo to the captured baseline and removes temporary inbox/brainstorm folders.
 
-`test/e2e/lib/hive_e2e_binary_test.rb` is the focused contract suite for the executable itself. It pins `list --json`, `clean --json`, leading JSON option normalization including `--json=true`, duplicate JSON boolean handling where a final false flag chooses prose, malformed `--json=1` / `--json=yes` rejection, error-envelope shapes, help/version handling, replay path validation, non-executable `repro.sh` handling (`unusable_repro`, exit `78`), and the usage exit-code contract: unknown commands and missing required arguments exit `64` in both human and `--json` modes. Human usage errors are expected to print a `hive-e2e:`-prefixed prose message on stderr.
+`test/e2e/lib/hive_e2e_binary_test.rb` is the focused contract suite for the executable itself. It pins `list --json`, `clean --json`, leading JSON option normalization including `--json=true`, duplicate JSON boolean handling where a final false flag chooses prose, malformed `--json=1` / `--json=yes` rejection, error-envelope shapes, help/version handling, replay path validation, missing/non-executable replay artifact errors (`missing_repro` / `unusable_repro`, exit `78`), and the usage exit-code contract: unknown commands and missing required arguments exit `64` in both human and `--json` modes. Human usage errors are expected to print a `hive-e2e:`-prefixed prose message on stderr.
 
 ## Live Claude tmux dogfood
 


### PR DESCRIPTION
## Summary

`bin/hive-e2e replay` previously checked only that `repro.sh` *existed* before
`exec`-ing it. When the artifact existed but had lost its executable mode, the
`exec` failed and was caught by the outer `StandardError` rescue, which emitted
the generic `error_kind: "error"` with exit `1`. Automation could not tell a bad
stored repro apart from a harness crash.

This PR makes that failure deterministic:

- **`bin/hive-e2e`** — adds a `File.executable?(script)` guard before `exec`.
  A non-executable `repro.sh` now exits with the config code (`78`) and reports
  the new `error_kind: "unusable_repro"` instead of a generic harness error.
- **`schemas/hive-e2e-error.v1.json`** — adds `"unusable_repro"` to the
  `error_kind` enum so the new replay-error envelope passes schema validation
  for downstream consumers.
- **`wiki/`** — refreshes the e2e/testing pages and records the change in the
  changelog fragments and gaps log.

## Test plan

- Added `test_replay_non_executable_repro_emits_json_artifact_error_when_requested`
  in `test/e2e/lib/hive_e2e_binary_test.rb`: writes a non-executable `repro.sh`
  under a temp runs dir, runs `hive-e2e replay --json`, and asserts exit `78`,
  empty stderr, and a `hive-e2e-error` JSON payload with `ok: false`,
  `error_kind: "unusable_repro"`, and a `not executable` message.
- Existing `bin/hive-e2e` binary tests continue to cover the `missing_repro`
  and generic-error paths, so the new branch is verified without regressing the
  surrounding envelope behavior.

## Review summary

Two passes of codex native review ran on the branch.

- **High:** none.
- **Medium:** one real finding — the published schema enum omitted
  `unusable_repro` while the producer already emitted it. Auto-fixed by adding
  the value to `schemas/hive-e2e-error.v1.json` (commit `a8691064`); pass 2
  confirmed the producer and schema are back in sync and found no correctness
  regressions.
- **Nits / escalations:** none. All findings were auto-fixed or resolved from
  project context; no user questions were raised.

## Linked task

Patrol finding `command-bin-hive-3`
(fingerprint `109e25f538105ef852dc077c698c2344d85e020b0195ac1106ace2a159753db8`).

Task folder: `/home/asterio/Dev/hive/.hive-state/stages/6-review/patrol-command-bin-hive-109e25f5`
