### PR TITLE
feat(digest): default the daily digest ON when Telegram is configured; drop bot.digest_chat_id

### DIFF
--- a/lib/hive/config.rb
+++ b/lib/hive/config.rb
@@ -418,7 +418,6 @@ module Hive
       # only in HIVE_TELEGRAM_BOT_TOKEN and is never persisted.
       "bot" => {
         "enabled" => false,
-        "digest_chat_id" => nil,
         "chat_id_allowlist" => [],
         "poll_interval_sec" => 30,
         "long_poll_timeout_sec" => 25,
@@ -929,8 +928,25 @@ module Hive
       end
 
       merged = deep_merge(deep_dup(DEFAULTS["digest"]), override)
+      # Opt-out beats opt-in: when the operator hasn't pinned digest.enabled
+      # either way, default it ON for anyone who already has the Telegram bot
+      # configured with a deliverable chat. An explicit digest.enabled (true
+      # OR false) is always honored — only the unset case is derived.
+      merged["enabled"] = telegram_digest_default?(data) unless override.key?("enabled")
       validate_digest!({ "digest" => merged }, path)
       merged
+    end
+
+    # True when the global Telegram bot is enabled and has at least one
+    # allowlisted chat to deliver to — the signal that "the user has Telegram
+    # set up", used to default the daily digest on. Reads the raw config so
+    # it never depends on bot-block defaults; the bot block's own shape is
+    # validated on its own load path.
+    def telegram_digest_default?(data)
+      bot = data["bot"]
+      return false unless bot.is_a?(Hash) && bot["enabled"] == true
+
+      Array(bot["chat_id_allowlist"]).any? { |id| id.is_a?(Integer) }
     end
 
     def load_global_digest_config
@@ -2069,7 +2085,6 @@ module Hive
       end
 
       validate_bot_allowlist!(bot, source_path)
-      validate_bot_digest_chat_id!(bot, source_path)
       warn_deprecated_bot_dedupe!(bot, source_path)
       validate_bot_numbers!(bot, source_path)
       validate_bot_paths!(bot, source_path)
@@ -2101,16 +2116,6 @@ module Hive
               "bot.chat_id_allowlist[#{idx}] in #{describe_source(source_path)} must be an Integer; " \
               "got #{entry.inspect} (#{entry.class})"
       end
-    end
-
-    def validate_bot_digest_chat_id!(bot, source_path)
-      chat_id = bot["digest_chat_id"]
-      return if chat_id.nil?
-      return if chat_id.is_a?(Integer)
-
-      raise ConfigError,
-            "bot.digest_chat_id in #{describe_source(source_path)} must be an Integer; " \
-            "got #{chat_id.inspect} (#{chat_id.class})"
     end
 
     def validate_bot_numbers!(bot, source_path)

--- a/lib/hive/digest/sender.rb
+++ b/lib/hive/digest/sender.rb
@@ -49,14 +49,11 @@ module Hive
 
       def self.resolve_chat_id(cfg)
         bot = cfg.fetch("bot", {})
-        digest_chat_id = bot["digest_chat_id"]
-        return digest_chat_id unless blank?(digest_chat_id)
-
         chat_id = Array(bot["chat_id_allowlist"]).first
         return chat_id unless blank?(chat_id)
 
         raise Hive::ConfigError,
-              "bot.digest_chat_id or bot.chat_id_allowlist[0] must be configured before sending digest"
+              "bot.chat_id_allowlist[0] must be configured before sending digest"
       end
 
       # Internal helper for resolve_chat_id only; not part of the public

--- a/schemas/hive-digest.v1.json
+++ b/schemas/hive-digest.v1.json
@@ -43,7 +43,7 @@
         },
         "chat_id": {
           "type": ["integer", "string", "null"],
-          "description": "The Telegram chat the digest was sent to (the resolved bot.digest_chat_id / first allowlist entry). null on a --dry-run, which resolves no recipient. Optional: older producers omitted it, so consumers must tolerate its absence."
+          "description": "The Telegram chat the digest was sent to (the first bot.chat_id_allowlist entry). null on a --dry-run, which resolves no recipient. Optional: older producers omitted it, so consumers must tolerate its absence."
         },
         "message": {
           "type": ["string", "null"],

--- a/templates/hive_config.yml.erb
+++ b/templates/hive_config.yml.erb
@@ -28,15 +28,13 @@ registered_projects: <%= registered_projects.empty? ? "[]" : "" %>
 #   log_max_files: 5
 #   last_seen_state_file: ~/Dev/hive/.bot.last_seen_update_id
 
-# Daily shipped digest. When enabled, the daemon schedules one global
-# `hive digest` subprocess after local midnight; it sends a Telegram
-# MarkdownV2 message (chunked into several messages when it exceeds Telegram's
-# length limit) to bot.digest_chat_id, or the first allowlisted chat.
+# Daily shipped digest. Defaults ON whenever the Telegram bot is enabled with
+# at least one allowlisted chat — the daemon then schedules one global
+# `hive digest` subprocess after local midnight and sends a Telegram MarkdownV2
+# message (chunked when it exceeds Telegram's length limit) to the first
+# allowlisted chat. Set enabled: false to opt out.
 #
 # digest:
-#   enabled: false
-#   agent: ~              # defaults to patrol.agent, then claude
+#   enabled: false         # only needed to opt OUT; otherwise auto-on with the bot
+#   agent: ~               # defaults to patrol.agent, then claude
 #   max_catchup_days: 7
-#
-# bot:
-#   digest_chat_id: ~      # optional integer override for digest delivery

--- a/test/digest/e2e_test.rb
+++ b/test/digest/e2e_test.rb
@@ -136,8 +136,7 @@ class HiveDigestE2ETest < Minitest::Test
         "max_catchup_days" => 7
       },
       "bot" => {
-        "digest_chat_id" => Integer(ENV.fetch("HIVE_DIGEST_TEST_CHAT_ID")),
-        "chat_id_allowlist" => []
+        "chat_id_allowlist" => [ Integer(ENV.fetch("HIVE_DIGEST_TEST_CHAT_ID")) ]
       }
     }.to_yaml)
   end

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -2681,7 +2681,6 @@ class ConfigTest < Minitest::Test
       assert_equal false, cfg.dig("digest", "enabled")
       assert_nil cfg.dig("digest", "agent")
       assert_equal 7, cfg.dig("digest", "max_catchup_days")
-      assert_nil cfg.dig("bot", "digest_chat_id")
     end
   end
 
@@ -2700,6 +2699,72 @@ class ConfigTest < Minitest::Test
       assert_equal true, cfg["enabled"]
       assert_equal "codex", cfg["agent"]
       assert_equal 3, cfg["max_catchup_days"]
+    end
+  end
+
+  def test_load_global_digest_block_defaults_enabled_on_when_bot_configured
+    with_tmp_global_config do |home|
+      File.write(File.join(home, "config.yml"), <<~YAML)
+        registered_projects: []
+        bot:
+          enabled: true
+          chat_id_allowlist:
+            - 60499527
+      YAML
+
+      cfg = Hive::Config.load_global_digest_block
+
+      assert_equal true, cfg["enabled"],
+                   "digest should auto-enable when the Telegram bot is configured with a chat"
+    end
+  end
+
+  def test_load_global_digest_block_honors_explicit_disable_even_with_bot
+    with_tmp_global_config do |home|
+      File.write(File.join(home, "config.yml"), <<~YAML)
+        registered_projects: []
+        digest:
+          enabled: false
+        bot:
+          enabled: true
+          chat_id_allowlist:
+            - 60499527
+      YAML
+
+      cfg = Hive::Config.load_global_digest_block
+
+      assert_equal false, cfg["enabled"],
+                   "an explicit digest.enabled: false must always be honored as an opt-out"
+    end
+  end
+
+  def test_load_global_digest_block_stays_off_without_a_deliverable_bot
+    with_tmp_global_config do |home|
+      # Bot enabled but no chat to deliver to: auto-enabling would only
+      # dispatch a paid categorizer that then fails at send time.
+      File.write(File.join(home, "config.yml"), <<~YAML)
+        registered_projects: []
+        bot:
+          enabled: true
+          chat_id_allowlist: []
+      YAML
+
+      assert_equal false, Hive::Config.load_global_digest_block["enabled"],
+                   "no allowlisted chat means no deliverable digest, so stay off"
+    end
+
+    with_tmp_global_config do |home|
+      # Chat present but bot disabled: the user has not turned Telegram on.
+      File.write(File.join(home, "config.yml"), <<~YAML)
+        registered_projects: []
+        bot:
+          enabled: false
+          chat_id_allowlist:
+            - 60499527
+      YAML
+
+      assert_equal false, Hive::Config.load_global_digest_block["enabled"],
+                   "a disabled bot means Telegram is not set up, so stay off"
     end
   end
 
@@ -2758,7 +2823,8 @@ class ConfigTest < Minitest::Test
         timeout_sec:
           digest: 34
         bot:
-          digest_chat_id: 12345
+          chat_id_allowlist:
+            - 12345
       YAML
 
       cfg = Hive::Config.load_global_digest_config
@@ -2766,7 +2832,7 @@ class ConfigTest < Minitest::Test
       assert_equal true, cfg.dig("digest", "enabled")
       assert_equal 12, cfg.dig("budget_usd", "digest")
       assert_equal 34, cfg.dig("timeout_sec", "digest")
-      assert_equal 12_345, cfg.dig("bot", "digest_chat_id")
+      assert_equal [ 12_345 ], cfg.dig("bot", "chat_id_allowlist")
       assert_equal File.join(home, "logs", "bot.log"), cfg.dig("bot", "log_file")
     end
   end
@@ -2928,19 +2994,6 @@ class ConfigTest < Minitest::Test
 
       err = assert_raises(Hive::ConfigError) { Hive::Config.load_global_bot }
       assert_match(/bot.chat_id_allowlist\[0\].*Integer/, err.message)
-    end
-  end
-
-  def test_load_global_bot_rejects_string_digest_chat_id
-    with_tmp_global_config do |home|
-      File.write(File.join(home, "config.yml"), <<~YAML)
-        registered_projects: []
-        bot:
-          digest_chat_id: "12345"
-      YAML
-
-      err = assert_raises(Hive::ConfigError) { Hive::Config.load_global_bot }
-      assert_match(/bot\.digest_chat_id.*Integer/, err.message)
     end
   end
 

--- a/test/unit/digest/sender_test.rb
+++ b/test/unit/digest/sender_test.rb
@@ -10,13 +10,7 @@ require "hive/paths"
 class HiveDigestSenderTest < Minitest::Test
   include HiveTestHelper
 
-  def test_resolve_chat_id_prefers_digest_chat_id
-    cfg = { "bot" => { "digest_chat_id" => 123, "chat_id_allowlist" => [ 456 ] } }
-
-    assert_equal 123, Hive::Digest::Sender.resolve_chat_id(cfg)
-  end
-
-  def test_resolve_chat_id_falls_back_to_first_allowlist_entry
+  def test_resolve_chat_id_uses_first_allowlist_entry
     cfg = { "bot" => { "chat_id_allowlist" => [ 456, 789 ] } }
 
     assert_equal 456, Hive::Digest::Sender.resolve_chat_id(cfg)
@@ -27,7 +21,7 @@ class HiveDigestSenderTest < Minitest::Test
       Hive::Digest::Sender.resolve_chat_id({ "bot" => { "chat_id_allowlist" => [] } })
     end
 
-    assert_match(/digest_chat_id/, error.message)
+    assert_match(/chat_id_allowlist/, error.message)
   end
 
   def test_dry_run_returns_text_without_token_or_chat
@@ -59,7 +53,7 @@ class HiveDigestSenderTest < Minitest::Test
   end
 
   def test_preflight_raises_when_token_missing
-    sender = Hive::Digest::Sender.new(cfg: { "bot" => { "digest_chat_id" => 123 } })
+    sender = Hive::Digest::Sender.new(cfg: { "bot" => { "chat_id_allowlist" => [ 123 ] } })
 
     with_env("HIVE_TELEGRAM_BOT_TOKEN" => nil) do
       assert_raises(Hive::ConfigError) { sender.preflight! }
@@ -68,7 +62,7 @@ class HiveDigestSenderTest < Minitest::Test
 
   def test_preflight_passes_when_recipient_and_token_present
     with_env("HIVE_TELEGRAM_BOT_TOKEN" => "token") do
-      sender = Hive::Digest::Sender.new(cfg: { "bot" => { "digest_chat_id" => 123 } })
+      sender = Hive::Digest::Sender.new(cfg: { "bot" => { "chat_id_allowlist" => [ 123 ] } })
 
       assert_nil sender.preflight!
     end
@@ -92,7 +86,7 @@ class HiveDigestSenderTest < Minitest::Test
 
       with_env("HIVE_TELEGRAM_BOT_TOKEN" => "token") do
         sender = Hive::Digest::Sender.new(
-          cfg: { "bot" => { "digest_chat_id" => 123 } },
+          cfg: { "bot" => { "chat_id_allowlist" => [ 123 ] } },
           telegram_factory: ->(token:, logger:) { client },
           logger: logger
         )
@@ -167,7 +161,7 @@ class HiveDigestSenderTest < Minitest::Test
 
     with_env("HIVE_TELEGRAM_BOT_TOKEN" => "token") do
       sender = Hive::Digest::Sender.new(
-        cfg: { "bot" => { "digest_chat_id" => 123 } },
+        cfg: { "bot" => { "chat_id_allowlist" => [ 123 ] } },
         telegram_factory: factory,
         logger: Object.new
       )

--- a/wiki/commands/bot.md
+++ b/wiki/commands/bot.md
@@ -3,7 +3,7 @@ title: hive bot
 type: command
 source: lib/hive/commands/bot.rb, lib/hive/bot/*
 created: 2026-05-14
-updated: 2026-06-12
+updated: 2026-06-18
 tags: [command, bot, telegram, mobile, json]
 ---
 
@@ -168,7 +168,6 @@ The bot is global, not per-project:
 bot:
   enabled: false
   chat_id_allowlist: [123456789]
-  digest_chat_id: 123456789
   poll_interval_sec: 30
   long_poll_timeout_sec: 25
   notification_dedupe_window_sec: 300
@@ -209,11 +208,10 @@ token or empty allowlist makes `hive bot start` raise `Hive::ConfigError`
 (exit 78). Unknown chat IDs are logged once per bot lifetime and ignored
 silently.
 
-The shipped-digest sender reuses the same Telegram token and bot client. Its
-direct API prefers `bot.digest_chat_id` for the daily digest destination and
-falls back to the first `bot.chat_id_allowlist` entry; see [[commands/digest]]
-and [[modules/digest]]. `bot.digest_chat_id` is optional and does not authorize
-normal bot chats; the allowlist remains the bot's chat-auth boundary.
+The shipped-digest sender reuses the same Telegram token and bot client. The
+daily digest delivers to `bot.chat_id_allowlist[0]`; there is no separate digest
+chat setting. See [[commands/digest]] and [[modules/digest]]. The allowlist
+remains the bot's chat-auth boundary.
 
 Voice transcription uses `bot.transcription.api_key_env` for the OpenAI
 audio API key (default `HIVE_WHISPER_API_KEY`); the key is not persisted.

--- a/wiki/commands/daemon.md
+++ b/wiki/commands/daemon.md
@@ -3,7 +3,7 @@ title: hive daemon
 type: command
 source: lib/hive/commands/daemon.rb, lib/hive/daemon/*
 created: 2026-05-06
-updated: 2026-06-14
+updated: 2026-06-18
 tags: [command, daemon, automation, json]
 ---
 
@@ -57,8 +57,6 @@ digest:
   enabled: false
   agent: null
   max_catchup_days: 7
-bot:
-  digest_chat_id: null
 ```
 
 `hive daemon start` loads this block via `Hive::Config.load_global_digest_block` and

--- a/wiki/commands/digest.md
+++ b/wiki/commands/digest.md
@@ -3,7 +3,7 @@ title: hive digest
 type: command
 source: lib/hive/cli.rb, lib/hive/commands/digest.rb, lib/hive/digest.rb, lib/hive/digest/
 created: 2026-06-14
-updated: 2026-06-14
+updated: 2026-06-18
 tags: [command, digest, telegram, json]
 ---
 
@@ -14,8 +14,8 @@ calendar date, asks an agent to classify and summarize them when there is
 work to report, renders Telegram MarkdownV2, and sends through the bot
 Telegram client. Runtime config is loaded through
 `Hive::Config.load_global_digest_config`, so real sends can use
-`digest.agent`, `budget_usd.digest`, `timeout_sec.digest`,
-`bot.digest_chat_id`, and `bot.chat_id_allowlist`. See [[modules/digest]].
+`digest.agent`, `budget_usd.digest`, `timeout_sec.digest`, and
+`bot.chat_id_allowlist`. See [[modules/digest]].
 
 ## Synopsis
 
@@ -116,8 +116,7 @@ the direct API can still override that with `cfg:`. Supported keys:
 - `patrol.agent` — fallback summarizer agent.
 - `budget_usd.digest` — categorizer budget override; default is `50`.
 - `timeout_sec.digest` — categorizer timeout override; default is `1800`.
-- `bot.digest_chat_id` — preferred Telegram chat id for delivery.
-- `bot.chat_id_allowlist[0]` — delivery fallback when no digest chat is set.
+- `bot.chat_id_allowlist[0]` — Telegram chat id the digest is delivered to.
 - `bot.log_file` — Telegram client log path fallback.
 
 `Digest::Sender` always gets the bot token from
@@ -125,8 +124,15 @@ the direct API can still override that with `cfg:`. Supported keys:
 `HIVE_TELEGRAM_BOT_TOKEN`.
 
 The daemon schedules the command through `Hive::Daemon::DigestScheduler` when
-`digest.enabled: true`, dispatching `hive digest --date <day> --json` once per
-owed local day.
+`digest.enabled` is on, dispatching `hive digest --date <day> --json` once per
+owed local day. The digest is **opt-out**: when the operator has not set
+`digest.enabled` either way, `Hive::Config.load_global_digest_block` derives it
+from the bot config — it auto-enables (`true`) when the Telegram bot is
+configured with an allowlisted chat (`bot.enabled == true` and
+`bot.chat_id_allowlist` has at least one integer chat id), and is `false`
+otherwise. An explicit `digest.enabled: false` is the opt-out (and an explicit
+`digest.enabled: true` is always honored). See [[modules/config]] and
+[[commands/daemon]].
 
 ## Tests
 

--- a/wiki/decisions.md
+++ b/wiki/decisions.md
@@ -510,6 +510,16 @@ Historical schemas (`schemas/hive-status.v1.json`, `schemas/hive-stage-action.v1
 
 **Consequences:** Daemon, bot, TUI, status JSON, and humans see `ready_to_artifacts` after `REVIEW_COMPLETE`, then `ready_to_finalize` only after `artifact.md` carries `COMPLETE`. `hive migrate` maps both the pre-open-pr layout and the previous canonical `7-finalize` / `8-done` directories to the current names. Artifact packaging and handoff work has a dedicated agent-backed stage without overloading finalize.
 
+## ADR-030: Daily digest defaults ON when the Telegram bot is configured; drop the separate `bot.digest_chat_id`
+
+**Status:** Active
+
+**Context:** The shipped digest shipped opt-in (`digest.enabled` defaulted to `false`), so an operator who had already set up the Telegram bot with an allowlisted chat still received nothing at midnight until they discovered and set `digest.enabled: true` — the most common "why didn't I get a digest" case. The separate `bot.digest_chat_id` override added a second delivery-target knob that nobody needed: `Digest::Sender.resolve_chat_id` already fell back to `bot.chat_id_allowlist[0]`, which is where operators wanted the digest anyway.
+
+**Decision:** Make the digest opt-out instead of opt-in. `Config.load_global_digest_block` now derives `digest.enabled` from the bot config when the operator has not pinned it either way: it is `true` when `bot.enabled == true` and `bot.chat_id_allowlist` has at least one integer chat, else `false`. An explicit `digest.enabled` (true **or** false) is always honored — only the unset case is derived (`override.key?("enabled")` gate). Both scheduler-config callers (`Commands::Daemon#start_daemon` and the dispatcher's SIGHUP reconfigure) go through `load_global_digest_block`, so the derived value flows everywhere with no second code path. Remove `bot.digest_chat_id` entirely — from `DEFAULTS`, its validator (`validate_bot_digest_chat_id!`), the config template, and the JSON schema description. `Digest::Sender.resolve_chat_id` now resolves to `bot.chat_id_allowlist[0]` only and raises `"bot.chat_id_allowlist[0] must be configured before sending digest"` when absent.
+
+**Consequences:** Anyone running the Telegram bot with an allowlisted chat starts getting the midnight digest after the next local midnight (first enabled tick only initializes the `digest_state.json` cursor; it does not back-fill history — run `hive digest` manually for the current day). The auto-enable requires a *deliverable* chat so the daemon never dispatches a paid categorizer that would fail at send time. Operators who deliberately want no digest set `digest.enabled: false`. Existing configs that still carry `bot.digest_chat_id` are silently ignored (no validation error) and route to the allowlist instead. See [[modules/digest]], [[commands/digest]], [[modules/config]].
+
 ## Source
 
 Once `git log` accumulates real history, future updates should add ADRs from substantive merge commits or refactor messages.

--- a/wiki/log.d/20260618T200500Z-digest-default-on-telegram.md
+++ b/wiki/log.d/20260618T200500Z-digest-default-on-telegram.md
@@ -1,0 +1,33 @@
+## [2026-06-18T20:05:00Z] digest — default ON when Telegram bot is configured; drop `bot.digest_chat_id`
+
+**Action:** Made the daily shipped digest opt-out instead of opt-in, and removed
+the separate `bot.digest_chat_id` setting.
+
+- `Hive::Config.load_global_digest_block` now derives `digest.enabled` from the
+  bot config when the operator has not pinned it: `true` when `bot.enabled ==
+  true` and `bot.chat_id_allowlist` has at least one integer chat, else `false`.
+  An explicit `digest.enabled` (true or false) is always honored — only the
+  unset case is derived (`override.key?("enabled")` gate). New private predicate
+  `Config.telegram_digest_default?(data)`. Both scheduler-config callers
+  (`Commands::Daemon#start_daemon`, dispatcher SIGHUP reconfigure) load through
+  this method, so no second code path.
+- Removed `bot.digest_chat_id`: gone from `DEFAULTS["bot"]`, validator
+  `validate_bot_digest_chat_id!` deleted, removed from `templates/hive_config.yml.erb`
+  and the `schemas/hive-digest.v1.json` description. `Digest::Sender.resolve_chat_id`
+  now resolves to `bot.chat_id_allowlist[0]` only and raises
+  `"bot.chat_id_allowlist[0] must be configured before sending digest"` when absent.
+- Tests: new `load_global_digest_block` cases for auto-enable derivation
+  (bot-configured → on; explicit false honored; no chat / disabled bot → off);
+  `digest/sender_test` resolves via the allowlist; removed the
+  `digest_chat_id` validation test; updated the digest e2e fixture.
+
+Documented as [[decisions]] ADR-030. Refreshed [[commands/digest]],
+[[modules/digest]], [[modules/config]], [[commands/bot]], and [[commands/daemon]].
+
+**Refreshed pages:**
+- [[decisions]]
+- [[commands/digest]]
+- [[modules/digest]]
+- [[modules/config]]
+- [[commands/bot]]
+- [[commands/daemon]]

--- a/wiki/modules/config.md
+++ b/wiki/modules/config.md
@@ -3,11 +3,11 @@ title: Hive::Config
 type: module
 source: lib/hive/config.rb
 created: 2026-04-25
-updated: 2026-06-14
+updated: 2026-06-18
 tags: [config, yaml, validation]
 ---
 
-**TLDR**: Two YAML configs — global at `~/.config/hive/config.yml` (registered projects plus daemon, bot, digest, update, and web settings, including voice-transcription defaults; `HIVE_HOME/config.yml` when overridden, legacy `~/Dev/hive/config.yml` when migrated) and per-project at `<project>/.hive-state/config.yml` (default branch, worktree root, budgets, timeouts, **stage agents**, project-global `claude.mode`/`claude.permission_mode` plus `claude.model`/`claude.effort` pins, review-stage roles, daemon enrollment, experimental babysitter enrollment, patrol mode/enrollment and PR handoff). `Config.load(project_root)` resolves `patrol.mode` into scheduler knobs, **recursively** deep-merges per-project values onto `Config::DEFAULTS`, then runs `validate!`. Arrays (notably `review.reviewers`, `patrol.review.reviewers`, `bot.transcription.supported_languages`, and `babysitter.labels_ignore`) are replaced wholesale, never per-element merged. The daily shipped digest uses `digest.agent`, `digest.max_catchup_days`, `budget_usd.digest`, `timeout_sec.digest`, and `bot.digest_chat_id`; `Hive::Digest.run` defaults through `Config.load_global_digest_config`.
+**TLDR**: Two YAML configs — global at `~/.config/hive/config.yml` (registered projects plus daemon, bot, digest, update, and web settings, including voice-transcription defaults; `HIVE_HOME/config.yml` when overridden, legacy `~/Dev/hive/config.yml` when migrated) and per-project at `<project>/.hive-state/config.yml` (default branch, worktree root, budgets, timeouts, **stage agents**, project-global `claude.mode`/`claude.permission_mode` plus `claude.model`/`claude.effort` pins, review-stage roles, daemon enrollment, experimental babysitter enrollment, patrol mode/enrollment and PR handoff). `Config.load(project_root)` resolves `patrol.mode` into scheduler knobs, **recursively** deep-merges per-project values onto `Config::DEFAULTS`, then runs `validate!`. Arrays (notably `review.reviewers`, `patrol.review.reviewers`, `bot.transcription.supported_languages`, and `babysitter.labels_ignore`) are replaced wholesale, never per-element merged. The daily shipped digest uses `digest.agent`, `digest.max_catchup_days`, `budget_usd.digest`, `timeout_sec.digest`, and `bot.chat_id_allowlist[0]`; `Hive::Digest.run` defaults through `Config.load_global_digest_config`.
 
 ## Defaults (`Config::DEFAULTS`)
 
@@ -104,7 +104,6 @@ tags: [config, yaml, validation]
   },
   "digest" => { "enabled" => false, "agent" => nil, "max_catchup_days" => 7 },
   "bot" => {
-    "digest_chat_id" => nil,
     "idea_attachment_max_bytes" => 20 * 1024 * 1024,
     "idea_attachment_max_count" => 10,
     "idea_draft_ttl_sec" => 900,
@@ -139,13 +138,20 @@ keys are:
   agent.
 - `budget_usd.digest` and `timeout_sec.digest` for categorizer limits,
   defaulting inside `Hive::Digest::Categorizer` to `50` and `1800`.
-- `bot.digest_chat_id`, then `bot.chat_id_allowlist[0]`, for Telegram delivery.
+- `bot.chat_id_allowlist[0]` for Telegram delivery.
 - `bot.log_file` for the sender's bot logger path.
 
 `load_global_digest_block` returns only the validated `digest` block for
-`Hive::Commands::Daemon`, which wires `DigestScheduler`. `bot.digest_chat_id`
-is optional and must be an Integer when set; delivery falls back to the first
-`bot.chat_id_allowlist` entry.
+`Hive::Commands::Daemon`, which wires `DigestScheduler`. Delivery resolves to
+`bot.chat_id_allowlist[0]`. The digest is **opt-out**: when the operator has not
+set `digest.enabled`, `load_global_digest_block` derives it from the bot config —
+`true` when `bot.enabled == true` and `bot.chat_id_allowlist` has at least one
+integer chat id, else `false` (the predicate is the private
+`Config.telegram_digest_default?(data)` helper). An explicit `digest.enabled`
+(true or false) is always honored; only the unset case is derived. Both
+scheduler-config callers (`Commands::Daemon#start_daemon` and the dispatcher
+SIGHUP reconfigure) load through `load_global_digest_block`, so the derived
+value applies in both.
 
 ## Module functions
 
@@ -258,7 +264,7 @@ cfg.dig("patrol", "review", "reviewers")
 cfg.dig("digest", "agent")
 cfg.dig("budget_usd", "digest")
 cfg.dig("timeout_sec", "digest")
-cfg.dig("bot", "digest_chat_id")
+cfg.dig("bot", "chat_id_allowlist")
 cfg["worktree_root"]
 ```
 

--- a/wiki/modules/digest.md
+++ b/wiki/modules/digest.md
@@ -3,7 +3,7 @@ title: Hive::Digest
 type: module
 source: lib/hive/digest.rb, lib/hive/digest/, templates/digest_prompt.md.erb
 created: 2026-06-14
-updated: 2026-06-14
+updated: 2026-06-18
 tags: [digest, shipped, telegram, module]
 ---
 
@@ -98,9 +98,10 @@ falls back to the PR title or display label for summary when needed.
 
 ## Delivery Contract
 
-`Digest::Sender.resolve_chat_id(cfg)` prefers `bot.digest_chat_id`, then the
-first `bot.chat_id_allowlist` entry. Missing both raises `Hive::ConfigError`.
-Dry-run bypasses token and chat lookup entirely.
+`Digest::Sender.resolve_chat_id(cfg)` resolves to `bot.chat_id_allowlist[0]`
+only and raises `Hive::ConfigError`
+(`"bot.chat_id_allowlist[0] must be configured before sending digest"`) when no
+allowlisted chat is set. Dry-run bypasses token and chat lookup entirely.
 
 Real delivery builds `Hive::Bot::Telegram` with
 `Hive::Config.telegram_bot_token!` and calls:
@@ -143,6 +144,12 @@ cursor; a non-zero exit clears the pending marker, leaves the cursor for retry,
 and records an escalating failure backoff (`60`/`300`/`900`s) so the same date
 is **not** re-dispatched every tick. `digest.enabled` / `max_catchup_days` are
 re-read on SIGHUP (the scheduler is reconfigured in place within one tick).
+
+`digest.enabled` is **opt-out**: when the operator has not set it, both
+scheduler-config callers load it through `Config.load_global_digest_block`,
+which derives the flag ON from the bot config (the bot is enabled with an
+allowlisted chat) and OFF otherwise — see [[commands/daemon]] and
+[[modules/config]]. An explicit value (true or false) is always honored.
 
 ## Tests
 


### PR DESCRIPTION
## Why

The shipped digest was **opt-in** — `digest.enabled` defaulted to `false`. So an operator who already had the Telegram bot configured with an allowlisted chat still received nothing at midnight until they discovered and flipped `digest.enabled: true`. This is the most common "why didn't I get a digest" case. (It's exactly what happened locally: the daemon never even initialized `digest_state.json` because the scheduler short-circuits when disabled.)

## What

**Digest is now opt-out.** `Config.load_global_digest_block` derives `digest.enabled` from the bot config when the operator hasn't pinned it either way:

- `true` when `bot.enabled == true` **and** `bot.chat_id_allowlist` has at least one integer chat
- otherwise `false`
- an explicit `digest.enabled` (true **or** false) is always honored — only the unset case is derived

The auto-enable requires a *deliverable* chat so the daemon never dispatches a paid categorizer that would just fail at send time. Both scheduler-config callers (`Commands::Daemon#start_daemon` and the dispatcher SIGHUP reconfigure) load through `load_global_digest_block`, so the derived value applies everywhere with no second code path.

**Dropped `bot.digest_chat_id`.** It only duplicated the `chat_id_allowlist[0]` fallback that `resolve_chat_id` already used. Removed from `DEFAULTS`, its validator (`validate_bot_digest_chat_id!`), the config template, and the JSON schema description. `Digest::Sender.resolve_chat_id` now resolves to `bot.chat_id_allowlist[0]` only. Existing configs that still carry `bot.digest_chat_id` are silently ignored and route to the allowlist (no validation error).

## Tests

- New `load_global_digest_block` cases: auto-enable when bot configured; explicit `false` honored; off when no chat / bot disabled.
- `digest/sender_test` resolves via the allowlist; removed the obsolete `digest_chat_id` validation test; updated the digest e2e fixture.
- Full `config_test.rb` (208), digest sender/run, daemon digest_scheduler + dispatcher, and `commands/digest_test` all green locally; rubocop clean.

## Docs

ADR-030 in `wiki/decisions.md`; refreshed the digest / config / bot / daemon wiki pages + changelog fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)