### PR TITLE
refactor(workflow): derive stage constants from one descriptor

### DIFF
--- a/lib/hive/stages.rb
+++ b/lib/hive/stages.rb
@@ -2,8 +2,9 @@ require "hive/workflows/registry"
 
 module Hive
   # Public source of truth for the stage list. Consumers (GitOps init, Status
-  # ordering, Run#next_stage_dir, Approve resolution) all read from here so
-  # adding or renaming a stage follows the default workflow descriptor.
+  # ordering, Run#next_stage_dir, Approve resolution) all read from here, and
+  # because `DIRS` derives from the default workflow descriptor, adding or
+  # renaming a stage in the descriptor flows through to every consumer.
   module Stages
     DIRS = Hive::Workflows::Registry.default.stages.map(&:dir).freeze
     NAMES = DIRS.map { |d| d.split("-", 2).last }.freeze

--- a/lib/hive/stages.rb
+++ b/lib/hive/stages.rb
@@ -1,19 +1,11 @@
+require "hive/workflows/registry"
+
 module Hive
-  # Single source of truth for the stage list. Consumers (GitOps init, Status
+  # Public source of truth for the stage list. Consumers (GitOps init, Status
   # ordering, Run#next_stage_dir, Approve resolution) all read from here so
-  # adding or renaming a stage is a one-file change.
+  # adding or renaming a stage follows the default workflow descriptor.
   module Stages
-    DIRS = %w[
-      1-inbox
-      2-brainstorm
-      3-plan
-      4-execute
-      5-open-pr
-      6-review
-      7-artifacts
-      8-finalize
-      9-done
-    ].freeze
+    DIRS = Hive::Workflows::Registry.default.stages.map(&:dir).freeze
     NAMES = DIRS.map { |d| d.split("-", 2).last }.freeze
     SHORT_TO_FULL = DIRS.each_with_object({}) { |d, h| h[d.split("-", 2).last] = d }.freeze
 

--- a/lib/hive/task.rb
+++ b/lib/hive/task.rb
@@ -1,22 +1,15 @@
 require "yaml"
 require "hive/stages"
 require "hive/task_meta"
+require "hive/workflows/registry"
 require "hive/worktree"
 
 module Hive
   class Task
-    STAGE_NAMES = %w[inbox brainstorm plan execute open-pr review artifacts finalize done].freeze
-    STATE_FILES = {
-      "inbox" => "idea.md",
-      "brainstorm" => "brainstorm.md",
-      "plan" => "plan.md",
-      "execute" => "task.md",
-      "open-pr" => "pr.md",
-      "review" => "task.md",
-      "artifacts" => "artifact.md",
-      "finalize" => "pr.md",
-      "done" => "task.md"
-    }.freeze
+    STAGE_NAMES = Hive::Workflows::Registry.default.stages.map(&:name).freeze
+    STATE_FILES = Hive::Workflows::Registry.default.stages.each_with_object({}) do |stage, state_files|
+      state_files[stage.name] = stage.state_file
+    end.freeze
     PATH_RE = %r{\A(?<root>.+)/(?<state_dir>\.hive-state)/stages/(?<stage_idx>\d+)-(?<stage_name>[a-z][a-z0-9-]*)/(?<slug>[a-z][a-z0-9-]{0,62}[a-z0-9])/?\z}
 
     attr_reader :folder, :project_root, :hive_state_path, :stage_index,

--- a/lib/hive/task.rb
+++ b/lib/hive/task.rb
@@ -7,9 +7,7 @@ require "hive/worktree"
 module Hive
   class Task
     STAGE_NAMES = Hive::Workflows::Registry.default.stages.map(&:name).freeze
-    STATE_FILES = Hive::Workflows::Registry.default.stages.each_with_object({}) do |stage, state_files|
-      state_files[stage.name] = stage.state_file
-    end.freeze
+    STATE_FILES = Hive::Workflows::Registry.default.stages.to_h { |stage| [ stage.name, stage.state_file ] }.freeze
     PATH_RE = %r{\A(?<root>.+)/(?<state_dir>\.hive-state)/stages/(?<stage_idx>\d+)-(?<stage_name>[a-z][a-z0-9-]*)/(?<slug>[a-z][a-z0-9-]{0,62}[a-z0-9])/?\z}
 
     attr_reader :folder, :project_root, :hive_state_path, :stage_index,

--- a/lib/hive/workflow.rb
+++ b/lib/hive/workflow.rb
@@ -1,0 +1,47 @@
+module Hive
+  Workflow = Data.define(:id, :stages) do
+    def initialize(id:, stages:)
+      super(id: id, stages: stages.freeze)
+    end
+  end
+
+  class Workflow
+    Stage = Data.define(
+      :name,
+      :index,
+      :state_file,
+      :advance_verb,
+      :kind,
+      :skill,
+      :status_mode,
+      :budget_usd,
+      :timeout_sec,
+      :capability
+    ) do
+      def initialize(name:, index:, state_file:, advance_verb: nil, kind: nil, skill: nil, status_mode: nil, budget_usd: nil, timeout_sec: nil, capability: nil)
+        super(
+          name: name,
+          index: index,
+          state_file: state_file,
+          advance_verb: advance_verb,
+          kind: kind,
+          skill: skill,
+          status_mode: status_mode,
+          budget_usd: budget_usd,
+          timeout_sec: timeout_sec,
+          capability: capability
+        )
+      end
+
+      def dir
+        "#{index}-#{name}"
+      end
+    end
+
+    AdvanceVerb = Data.define(:name, :force_source, :interactive) do
+      def initialize(name:, force_source: false, interactive: false)
+        super(name: name, force_source: force_source, interactive: interactive)
+      end
+    end
+  end
+end

--- a/lib/hive/workflow.rb
+++ b/lib/hive/workflow.rb
@@ -1,7 +1,7 @@
 module Hive
   Workflow = Data.define(:id, :stages) do
     def initialize(id:, stages:)
-      super(id: id, stages: stages.freeze)
+      super(id: id, stages: stages.dup.freeze)
     end
   end
 
@@ -19,18 +19,7 @@ module Hive
       :capability
     ) do
       def initialize(name:, index:, state_file:, advance_verb: nil, kind: nil, skill: nil, status_mode: nil, budget_usd: nil, timeout_sec: nil, capability: nil)
-        super(
-          name: name,
-          index: index,
-          state_file: state_file,
-          advance_verb: advance_verb,
-          kind: kind,
-          skill: skill,
-          status_mode: status_mode,
-          budget_usd: budget_usd,
-          timeout_sec: timeout_sec,
-          capability: capability
-        )
+        super
       end
 
       def dir
@@ -40,7 +29,7 @@ module Hive
 
     AdvanceVerb = Data.define(:name, :force_source, :interactive) do
       def initialize(name:, force_source: false, interactive: false)
-        super(name: name, force_source: force_source, interactive: interactive)
+        super
       end
     end
   end

--- a/lib/hive/workflow.rb
+++ b/lib/hive/workflow.rb
@@ -5,6 +5,9 @@ module Hive
     end
   end
 
+  # Reopened (not redefined): nested Stage/AdvanceVerb constants must live in a
+  # class body so they resolve as Workflow::Stage — they can't be declared inside
+  # the Data.define block above.
   class Workflow
     Stage = Data.define(
       :name,

--- a/lib/hive/workflow.rb
+++ b/lib/hive/workflow.rb
@@ -1,6 +1,9 @@
 module Hive
   Workflow = Data.define(:id, :stages) do
     def initialize(id:, stages:)
+      # Shallow dup+freeze: the element Stage objects stay shared with the
+      # caller, safe only because Stage is itself frozen. Don't add a mutable
+      # field to Stage on the assumption this dup deep-copies — it does not.
       super(id: id, stages: stages.dup.freeze)
     end
   end

--- a/lib/hive/workflows.rb
+++ b/lib/hive/workflows.rb
@@ -1,13 +1,14 @@
 require "hive/workflows/registry"
 
 module Hive
-  # Single source of truth for the workflow verbs (brainstorm, plan,
-  # develop, open-pr, review, artifacts, finalize, archive). Each verb advances a task from one
-  # stage to the next; `Hive::Commands::StageAction` consumes this map
-  # directly, `Hive::TaskAction` uses it to label the "ready to <verb>"
-  # status bucket per stage, and `Hive::Commands::Approve` /
-  # `FindingToggle` use it to derive the next-action command after a
-  # successful move.
+  # Public source of truth for the workflow verbs (brainstorm, plan,
+  # develop, open-pr, review, artifacts, finalize, archive), derived from
+  # the default workflow descriptor. Each verb advances a task from one
+  # stage to the next; consumers all read from the derived `VERBS` map:
+  # `Hive::Commands::StageAction` consumes it to dispatch the move,
+  # `Hive::TaskAction` uses it to label the "ready to <verb>" status
+  # bucket per stage, and `Hive::Commands::Approve` / `FindingToggle` use
+  # it to derive the next-action command after a successful move.
   #
   # Adding or removing a verb follows the default workflow descriptor.
   module Workflows

--- a/lib/hive/workflows.rb
+++ b/lib/hive/workflows.rb
@@ -1,3 +1,5 @@
+require "hive/workflows/registry"
+
 module Hive
   # Single source of truth for the workflow verbs (brainstorm, plan,
   # develop, open-pr, review, artifacts, finalize, archive). Each verb advances a task from one
@@ -7,7 +9,7 @@ module Hive
   # `FindingToggle` use it to derive the next-action command after a
   # successful move.
   #
-  # Adding or removing a verb is a one-file change here.
+  # Adding or removing a verb follows the default workflow descriptor.
   module Workflows
     # Optional `interactive: true` flag marks verbs that need the user's
     # tty during execution (stdin prompts, interactive `gh pr create`,
@@ -24,16 +26,19 @@ module Hive
     # verb that DOES need stdin (e.g., a manual review prompt) can
     # opt in with one line — without re-introducing foreground
     # takeover for everything.
-    VERBS = {
-      "brainstorm" => { source: "1-inbox", target: "2-brainstorm", force_source: true },
-      "plan"       => { source: "2-brainstorm", target: "3-plan" },
-      "develop"    => { source: "3-plan", target: "4-execute" },
-      "open-pr"    => { source: "4-execute", target: "5-open-pr" },
-      "review"     => { source: "5-open-pr", target: "6-review" },
-      "artifacts"  => { source: "6-review", target: "7-artifacts" },
-      "finalize"   => { source: "7-artifacts", target: "8-finalize" },
-      "archive"    => { source: "8-finalize", target: "9-done" }
-    }.freeze
+    stages = Hive::Workflows::Registry.default.stages
+    VERBS = stages.each_with_index.each_with_object({}) do |(stage, index), verbs|
+      advance_verb = stage.advance_verb
+      next unless advance_verb
+
+      entry = {
+        source: stages.fetch(index - 1).dir,
+        target: stage.dir
+      }
+      entry[:force_source] = true if advance_verb.force_source
+      entry[:interactive] = true if advance_verb.interactive
+      verbs[advance_verb.name] = entry
+    end.freeze
 
     # Reverse lookup by source: verb that advances OUT of stage_dir.
     # nil for `9-done` (no further verb).

--- a/lib/hive/workflows.rb
+++ b/lib/hive/workflows.rb
@@ -7,8 +7,8 @@ module Hive
   # stage to the next; consumers all read from the derived `VERBS` map:
   # `Hive::Commands::StageAction` consumes it to dispatch the move,
   # `Hive::TaskAction` uses it to label the "ready to <verb>" status
-  # bucket per stage, and `Hive::Commands::Approve` / `FindingToggle` use
-  # it to derive the next-action command after a successful move.
+  # bucket per stage, and `Hive::Commands::Approve` uses it to derive
+  # the next-action command after a successful move.
   #
   # Adding or removing a verb follows the default workflow descriptor.
   module Workflows

--- a/lib/hive/workflows/coding.rb
+++ b/lib/hive/workflows/coding.rb
@@ -1,0 +1,94 @@
+require "hive/workflow"
+
+module Hive
+  module Workflows
+    module Coding
+      DESCRIPTOR = Hive::Workflow.new(
+        id: :coding,
+        stages: [
+          Hive::Workflow::Stage.new(
+            name: "inbox",
+            index: 1,
+            state_file: "idea.md",
+            kind: :inert
+          ),
+          Hive::Workflow::Stage.new(
+            name: "brainstorm",
+            index: 2,
+            state_file: "brainstorm.md",
+            advance_verb: Hive::Workflow::AdvanceVerb.new(name: "brainstorm", force_source: true),
+            kind: :agent,
+            skill: "/ce-brainstorm",
+            status_mode: :state_file_marker,
+            budget_usd: 50,
+            timeout_sec: 1800
+          ),
+          Hive::Workflow::Stage.new(
+            name: "plan",
+            index: 3,
+            state_file: "plan.md",
+            advance_verb: Hive::Workflow::AdvanceVerb.new(name: "plan"),
+            kind: :agent,
+            status_mode: :state_file_marker,
+            budget_usd: 100,
+            timeout_sec: 3600
+          ),
+          Hive::Workflow::Stage.new(
+            name: "execute",
+            index: 4,
+            state_file: "task.md",
+            advance_verb: Hive::Workflow::AdvanceVerb.new(name: "develop"),
+            kind: :marker,
+            status_mode: :exit_code_only,
+            budget_usd: 500,
+            timeout_sec: 14400
+          ),
+          Hive::Workflow::Stage.new(
+            name: "open-pr",
+            index: 5,
+            state_file: "pr.md",
+            advance_verb: Hive::Workflow::AdvanceVerb.new(name: "open-pr"),
+            kind: :marker,
+            status_mode: :state_file_marker,
+            budget_usd: 50,
+            timeout_sec: 1800
+          ),
+          Hive::Workflow::Stage.new(
+            name: "review",
+            index: 6,
+            state_file: "task.md",
+            advance_verb: Hive::Workflow::AdvanceVerb.new(name: "review"),
+            kind: :marker
+          ),
+          Hive::Workflow::Stage.new(
+            name: "artifacts",
+            index: 7,
+            state_file: "artifact.md",
+            advance_verb: Hive::Workflow::AdvanceVerb.new(name: "artifacts"),
+            kind: :marker,
+            status_mode: :state_file_marker,
+            budget_usd: 100,
+            timeout_sec: 3600
+          ),
+          Hive::Workflow::Stage.new(
+            name: "finalize",
+            index: 8,
+            state_file: "pr.md",
+            advance_verb: Hive::Workflow::AdvanceVerb.new(name: "finalize"),
+            kind: :marker,
+            status_mode: :state_file_marker,
+            budget_usd: 50,
+            timeout_sec: 1800
+          ),
+          Hive::Workflow::Stage.new(
+            name: "done",
+            index: 9,
+            state_file: "task.md",
+            advance_verb: Hive::Workflow::AdvanceVerb.new(name: "archive"),
+            kind: :inert
+          )
+        ]
+      )
+    end
+  end
+end

--- a/lib/hive/workflows/registry.rb
+++ b/lib/hive/workflows/registry.rb
@@ -1,0 +1,28 @@
+require "hive"
+require "hive/workflows/coding"
+
+module Hive
+  module Workflows
+    class UnknownWorkflow < Hive::Error
+    end
+
+    module Registry
+      WORKFLOWS = {
+        coding: Coding::DESCRIPTOR
+      }.freeze
+
+      module_function
+
+      def fetch(id)
+        WORKFLOWS.fetch(id) do
+          known = WORKFLOWS.keys.map(&:inspect).join(", ")
+          raise UnknownWorkflow, "unknown workflow #{id.inspect}; known workflows: #{known}"
+        end
+      end
+
+      def default
+        fetch(:coding)
+      end
+    end
+  end
+end

--- a/test/unit/workflow_golden_test.rb
+++ b/test/unit/workflow_golden_test.rb
@@ -76,4 +76,25 @@ class WorkflowGoldenTest < Minitest::Test
     end
     assert Hive::Workflows::VERBS.frozen?
   end
+
+  # v1 keeps every verb non-interactive by design (no descriptor sets
+  # `interactive: true`), so the derived map must carry no `:interactive`
+  # key. Locking this against the real VERBS guards the inert path the
+  # descriptor relies on.
+  def test_no_workflow_verb_is_interactive_in_v1
+    Hive::Workflows::VERBS.each do |verb, cfg|
+      refute cfg.key?(:interactive), "#{verb} unexpectedly carries an :interactive key"
+    end
+  end
+
+  # Exercise every reachable branch of the real `interactive?` predicate:
+  # a known non-interactive verb, an unknown verb (nil cfg), nil input,
+  # and a Symbol (coerced via `to_s`). The true return stays unreachable
+  # while v1 ships no interactive verb.
+  def test_interactive_predicate_is_false_for_all_real_verbs
+    assert_equal false, Hive::Workflows.interactive?("review")
+    assert_equal false, Hive::Workflows.interactive?(:review)
+    assert_equal false, Hive::Workflows.interactive?("does-not-exist")
+    assert_equal false, Hive::Workflows.interactive?(nil)
+  end
 end

--- a/test/unit/workflow_golden_test.rb
+++ b/test/unit/workflow_golden_test.rb
@@ -1,0 +1,79 @@
+require "test_helper"
+require "hive/stages"
+require "hive/task"
+require "hive/workflows"
+
+class WorkflowGoldenTest < Minitest::Test
+  EXPECTED_DIRS = %w[
+    1-inbox
+    2-brainstorm
+    3-plan
+    4-execute
+    5-open-pr
+    6-review
+    7-artifacts
+    8-finalize
+    9-done
+  ].freeze
+
+  EXPECTED_STAGE_NAMES = %w[
+    inbox
+    brainstorm
+    plan
+    execute
+    open-pr
+    review
+    artifacts
+    finalize
+    done
+  ].freeze
+
+  EXPECTED_STATE_FILES = {
+    "inbox" => "idea.md",
+    "brainstorm" => "brainstorm.md",
+    "plan" => "plan.md",
+    "execute" => "task.md",
+    "open-pr" => "pr.md",
+    "review" => "task.md",
+    "artifacts" => "artifact.md",
+    "finalize" => "pr.md",
+    "done" => "task.md"
+  }.freeze
+
+  EXPECTED_VERBS = {
+    "brainstorm" => { source: "1-inbox", target: "2-brainstorm", force_source: true },
+    "plan" => { source: "2-brainstorm", target: "3-plan" },
+    "develop" => { source: "3-plan", target: "4-execute" },
+    "open-pr" => { source: "4-execute", target: "5-open-pr" },
+    "review" => { source: "5-open-pr", target: "6-review" },
+    "artifacts" => { source: "6-review", target: "7-artifacts" },
+    "finalize" => { source: "7-artifacts", target: "8-finalize" },
+    "archive" => { source: "8-finalize", target: "9-done" }
+  }.freeze
+
+  def test_stage_dirs_match_original_literal
+    assert_equal EXPECTED_DIRS, Hive::Stages::DIRS
+    assert Hive::Stages::DIRS.frozen?
+  end
+
+  def test_task_stage_names_match_original_literal
+    assert_equal EXPECTED_STAGE_NAMES, Hive::Task::STAGE_NAMES
+    assert Hive::Task::STAGE_NAMES.frozen?
+  end
+
+  def test_task_state_files_match_original_literal
+    assert_equal EXPECTED_STATE_FILES, Hive::Task::STATE_FILES
+    assert_equal EXPECTED_STATE_FILES.to_a, Hive::Task::STATE_FILES.to_a
+    assert Hive::Task::STATE_FILES.frozen?
+  end
+
+  def test_workflow_verbs_match_original_literal
+    assert_equal EXPECTED_VERBS, Hive::Workflows::VERBS
+    assert_equal EXPECTED_VERBS.keys, Hive::Workflows::VERBS.keys
+
+    EXPECTED_VERBS.each do |verb, expected_entry|
+      assert_equal expected_entry.keys, Hive::Workflows::VERBS.fetch(verb).keys
+    end
+    assert Hive::Workflows::VERBS.frozen?
+  end
+end

--- a/test/unit/workflow_test.rb
+++ b/test/unit/workflow_test.rb
@@ -32,6 +32,7 @@ class WorkflowTest < Minitest::Test
     verb = Hive::Workflow::AdvanceVerb.new(name: "manual-review", interactive: true)
 
     assert verb.interactive, "interactive: true must surface on the value object the VERBS derivation reads"
+    assert verb.frozen?
   end
 
   def test_workflow_freezes_stage_array

--- a/test/unit/workflow_test.rb
+++ b/test/unit/workflow_test.rb
@@ -1,0 +1,58 @@
+require "test_helper"
+require "hive/workflow"
+
+class WorkflowTest < Minitest::Test
+  def test_stage_dir_joins_index_and_name
+    stage = Hive::Workflow::Stage.new(name: "execute", index: 4, state_file: "task.md")
+
+    assert_equal "4-execute", stage.dir
+  end
+
+  def test_stage_defaults_optional_descriptor_fields
+    stage = Hive::Workflow::Stage.new(name: "plan", index: 3, state_file: "plan.md")
+
+    assert_nil stage.advance_verb
+    assert_nil stage.kind
+    assert_nil stage.skill
+    assert_nil stage.status_mode
+    assert_nil stage.budget_usd
+    assert_nil stage.timeout_sec
+    assert_nil stage.capability
+  end
+
+  def test_advance_verb_defaults_flags_to_false
+    verb = Hive::Workflow::AdvanceVerb.new(name: "plan")
+
+    assert_equal "plan", verb.name
+    refute verb.force_source
+    refute verb.interactive
+  end
+
+  def test_workflow_freezes_stage_array
+    stages = [
+      Hive::Workflow::Stage.new(name: "inbox", index: 1, state_file: "idea.md")
+    ]
+
+    workflow = Hive::Workflow.new(id: :coding, stages: stages)
+
+    assert workflow.frozen?
+    assert workflow.stages.frozen?
+  end
+
+  def test_value_objects_are_immutable_and_copyable
+    stage = Hive::Workflow::Stage.new(
+      name: "brainstorm",
+      index: 2,
+      state_file: "brainstorm.md",
+      advance_verb: Hive::Workflow::AdvanceVerb.new(name: "brainstorm", force_source: true)
+    )
+
+    assert stage.frozen?
+    assert_raises(FrozenError) { stage.instance_variable_set(:@name, "plan") }
+
+    copy = stage.with(index: 3, name: "plan", state_file: "plan.md")
+
+    assert_equal "3-plan", copy.dir
+    assert_equal "2-brainstorm", stage.dir
+  end
+end

--- a/test/unit/workflow_test.rb
+++ b/test/unit/workflow_test.rb
@@ -28,6 +28,12 @@ class WorkflowTest < Minitest::Test
     refute verb.interactive
   end
 
+  def test_advance_verb_can_flag_interactive
+    verb = Hive::Workflow::AdvanceVerb.new(name: "manual-review", interactive: true)
+
+    assert verb.interactive, "interactive: true must surface on the value object the VERBS derivation reads"
+  end
+
   def test_workflow_freezes_stage_array
     stages = [
       Hive::Workflow::Stage.new(name: "inbox", index: 1, state_file: "idea.md")
@@ -37,6 +43,7 @@ class WorkflowTest < Minitest::Test
 
     assert workflow.frozen?
     assert workflow.stages.frozen?
+    refute stages.frozen?, "the caller's array must stay unfrozen — the workflow freezes its own dup"
   end
 
   def test_value_objects_are_immutable_and_copyable

--- a/test/unit/workflows/coding_test.rb
+++ b/test/unit/workflows/coding_test.rb
@@ -33,4 +33,33 @@ class WorkflowsCodingTest < Minitest::Test
     assert_nil stages_by_name.fetch("review").status_mode
     assert_equal :inert, stages_by_name.fetch("done").kind
   end
+
+  # Pin the *absence* of metadata on the inert/marker stages so a stray
+  # `budget_usd`/`timeout_sec`/`skill` cannot drift in unnoticed. The
+  # current runtime leaves these fields unread, but the golden contract
+  # should still fail loud if the descriptor sprouts spurious config.
+  def test_inert_and_marker_stages_carry_no_spurious_metadata
+    stages_by_name = Hive::Workflows::Coding::DESCRIPTOR.stages.to_h { |stage| [ stage.name, stage ] }
+
+    inbox = stages_by_name.fetch("inbox")
+    assert_nil inbox.advance_verb
+    assert_nil inbox.skill
+    assert_nil inbox.status_mode
+    assert_nil inbox.budget_usd
+    assert_nil inbox.timeout_sec
+    assert_nil inbox.capability
+
+    review = stages_by_name.fetch("review")
+    assert_nil review.skill
+    assert_nil review.budget_usd
+    assert_nil review.timeout_sec
+    assert_nil review.capability
+
+    done = stages_by_name.fetch("done")
+    assert_nil done.skill
+    assert_nil done.status_mode
+    assert_nil done.budget_usd
+    assert_nil done.timeout_sec
+    assert_nil done.capability
+  end
 end

--- a/test/unit/workflows/coding_test.rb
+++ b/test/unit/workflows/coding_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+require "hive/workflows/coding"
+
+class WorkflowsCodingTest < Minitest::Test
+  def test_descriptor_has_coding_id_and_ordered_stages
+    descriptor = Hive::Workflows::Coding::DESCRIPTOR
+
+    assert_equal :coding, descriptor.id
+    assert_equal %w[inbox brainstorm plan execute open-pr review artifacts finalize done],
+                 descriptor.stages.map(&:name)
+    assert_equal (1..9).to_a, descriptor.stages.map(&:index)
+    assert descriptor.stages.frozen?
+  end
+
+  def test_descriptor_carries_transition_verbs
+    verbs = Hive::Workflows::Coding::DESCRIPTOR.stages.map { |stage| stage.advance_verb&.name }
+
+    assert_equal [ nil, "brainstorm", "plan", "develop", "open-pr", "review", "artifacts", "finalize", "archive" ], verbs
+    assert Hive::Workflows::Coding::DESCRIPTOR.stages.fetch(1).advance_verb.force_source
+    refute Hive::Workflows::Coding::DESCRIPTOR.stages.fetch(1).advance_verb.interactive
+  end
+
+  def test_descriptor_carries_inert_stage_metadata
+    stages_by_name = Hive::Workflows::Coding::DESCRIPTOR.stages.to_h { |stage| [ stage.name, stage ] }
+
+    assert_equal :agent, stages_by_name.fetch("brainstorm").kind
+    assert_equal "/ce-brainstorm", stages_by_name.fetch("brainstorm").skill
+    assert_equal :state_file_marker, stages_by_name.fetch("plan").status_mode
+    assert_equal :exit_code_only, stages_by_name.fetch("execute").status_mode
+    assert_equal 500, stages_by_name.fetch("execute").budget_usd
+    assert_equal 14400, stages_by_name.fetch("execute").timeout_sec
+    assert_equal :marker, stages_by_name.fetch("review").kind
+    assert_nil stages_by_name.fetch("review").status_mode
+    assert_equal :inert, stages_by_name.fetch("done").kind
+  end
+end

--- a/test/unit/workflows/registry_test.rb
+++ b/test/unit/workflows/registry_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+require "hive/workflows/registry"
+
+class WorkflowsRegistryTest < Minitest::Test
+  def test_default_returns_coding_workflow
+    assert_same Hive::Workflows::Registry.fetch(:coding), Hive::Workflows::Registry.default
+    assert_equal :coding, Hive::Workflows::Registry.default.id
+  end
+
+  def test_fetch_unknown_workflow_raises_typed_error
+    error = assert_raises(Hive::Workflows::UnknownWorkflow) do
+      Hive::Workflows::Registry.fetch(:nope)
+    end
+
+    assert_includes error.message, ":nope"
+    assert_includes error.message, ":coding"
+  end
+end

--- a/test/unit/workflows/registry_test.rb
+++ b/test/unit/workflows/registry_test.rb
@@ -5,6 +5,7 @@ class WorkflowsRegistryTest < Minitest::Test
   def test_default_returns_coding_workflow
     assert_same Hive::Workflows::Registry.fetch(:coding), Hive::Workflows::Registry.default
     assert_equal :coding, Hive::Workflows::Registry.default.id
+    assert Hive::Workflows::Registry.default.frozen?
   end
 
   def test_fetch_unknown_workflow_raises_typed_error

--- a/wiki/log.d/20260619T102049Z-workflow-descriptor.md
+++ b/wiki/log.d/20260619T102049Z-workflow-descriptor.md
@@ -1,0 +1,21 @@
+---
+date: 2026-06-19
+slug: workflow-descriptor
+pages: [modules/workflows, modules/stages, modules/task]
+---
+
+Introduced the coding workflow descriptor as the source of truth behind the
+legacy stage and verb constants. `Hive::Workflow` now models immutable
+workflow, stage, and advance-verb values; `Hive::Workflows::Coding::DESCRIPTOR`
+declares the current nine-stage coding pipeline; and
+`Hive::Workflows::Registry.default` resolves the implicit coding workflow.
+
+`Hive::Stages::DIRS`, `Hive::Task::STAGE_NAMES`,
+`Hive::Task::STATE_FILES`, and `Hive::Workflows::VERBS` are now derived from
+that descriptor at load time while retaining the exact previous values,
+ordering, frozen-ness, and `VERBS` hash shapes. Updated [[modules/workflows]],
+[[modules/stages]], and [[modules/task]] to document the descriptor-backed
+constant source.
+
+Verified with `bundle exec rake test`, `bundle exec rake coverage` (100.00%
+line coverage), and `bundle exec rubocop`.

--- a/wiki/modules/stages.md
+++ b/wiki/modules/stages.md
@@ -3,15 +3,15 @@ title: Hive::Stages
 type: module
 source: lib/hive/stages.rb
 created: 2026-04-25
-updated: 2026-05-22
+updated: 2026-06-19
 tags: [module, stages, constants]
 ---
 
-**TLDR**: Single source of truth for the nine-stage list. Constants `DIRS`, `NAMES`, `SHORT_TO_FULL`; helpers `next_dir(idx)`, `resolve(name)`, `parse(dir)`. Every consumer (`GitOps`, `Status`, `Run#next_stage_dir`, `Approve`) delegates here so stage changes have one canonical source.
+**TLDR**: Public constants for the nine-stage list. `DIRS` is derived from `Hive::Workflows::Registry.default` at load time, while `NAMES` and `SHORT_TO_FULL` remain derived from `DIRS`; helpers `next_dir(idx)`, `prev_dir(idx)`, `resolve(name)`, and `parse(dir)` keep their existing behavior. Consumers (`GitOps`, `Status`, `Run#next_stage_dir`, `Approve`) still delegate here, so the runtime surface is unchanged even though the backing source is now the workflow descriptor.
 
 ## Constants
 
-- `DIRS = %w[1-inbox 2-brainstorm 3-plan 4-execute 5-open-pr 6-review 7-artifacts 8-finalize 9-done]` — the canonical stage directory names (index + bare name).
+- `DIRS = %w[1-inbox 2-brainstorm 3-plan 4-execute 5-open-pr 6-review 7-artifacts 8-finalize 9-done]` — the canonical stage directory names (index + bare name), derived from the default workflow descriptor.
 - `NAMES = %w[inbox brainstorm plan execute open-pr review artifacts finalize done]` — bare stage names without the index prefix; same as `Hive::Task::STAGE_NAMES`.
 - `SHORT_TO_FULL = { "inbox" => "1-inbox", … }` — frozen hash for short→full resolution.
 
@@ -38,5 +38,5 @@ The values are pure data + pure functions. No state, no construction. `module_fu
 ## Backlinks
 
 - [[state-model]] · [[modules/git_ops]] · [[modules/task]]
-- [[commands/status]] · [[commands/run]] · [[commands/approve]]
+- [[commands/status]] · [[commands/run]] · [[commands/approve]] · [[modules/workflows]]
 - [[cli]]

--- a/wiki/modules/task.md
+++ b/wiki/modules/task.md
@@ -3,7 +3,7 @@ title: Hive::Task
 type: module
 source: lib/hive/task.rb, lib/hive/task_meta.rb, lib/hive/task_counter.rb
 created: 2026-04-25
-updated: 2026-06-18
+updated: 2026-06-19
 tags: [model, task, parsing, task-id, dependencies]
 ---
 
@@ -11,8 +11,8 @@ tags: [model, task, parsing, task-id, dependencies]
 
 ## Constants
 
-- `STAGE_NAMES = %w[inbox brainstorm plan execute open-pr review artifacts finalize done]` — 9 stages post-artifacts insertion. `open-pr` is hyphenated; the dash must be allowed by `PATH_RE`.
-- `STATE_FILES` — maps stage name → state file basename (`idea.md`, `brainstorm.md`, `plan.md`, `task.md`, `pr.md`, `task.md`, `artifact.md`, `pr.md`, `task.md`).
+- `STAGE_NAMES = %w[inbox brainstorm plan execute open-pr review artifacts finalize done]` — 9 stages post-artifacts insertion, derived from `Hive::Workflows::Registry.default`. `open-pr` is hyphenated; the dash must be allowed by `PATH_RE`.
+- `STATE_FILES` — maps stage name → state file basename (`idea.md`, `brainstorm.md`, `plan.md`, `task.md`, `pr.md`, `task.md`, `artifact.md`, `pr.md`, `task.md`), derived from the same ordered workflow descriptor.
 - `PATH_RE = %r{\A(?<root>.+)/(?<state_dir>\.hive-state)/stages/(?<stage_idx>\d+)-(?<stage_name>[a-z][a-z0-9-]*)/(?<slug>[a-z][a-z0-9-]{0,62}[a-z0-9])/?\z}` — the only validator for task paths. The `[a-z][a-z0-9-]*` class for `stage_name` (no `\w+`) is what permits the dash in `5-open-pr`.
 
 ## Constructor (`#initialize(folder)`)
@@ -77,6 +77,6 @@ For stages 4 and later:
 ## Backlinks
 
 - [[modules/markers]] · [[modules/lock]] · [[modules/worktree]]
-- [[modules/task_dependencies]]
+- [[modules/task_dependencies]] · [[modules/workflows]]
 - [[commands/run]] · [[commands/status]]
 - [[state-model]]

--- a/wiki/modules/workflows.md
+++ b/wiki/modules/workflows.md
@@ -19,7 +19,7 @@ tags: [module, workflow, verbs]
 
 ## Constants
 
-- `VERBS` — frozen hash, verb name → `{ source:, target:, force_source? }`. It is derived by walking adjacent stages in `Registry.default`; false `force_source` / `interactive` flags are omitted entirely to preserve the historical hash shape.
+- `VERBS` — frozen hash, verb name → `{ source:, target:, force_source?, interactive? }`. It is derived by walking adjacent stages in `Registry.default`; false `force_source` / `interactive` flags are omitted entirely to preserve the historical hash shape.
 - `VERB_BY_SOURCE` — reverse lookup: source stage_dir → verb. nil for `9-done` (no verb advances out).
 - `VERB_BY_TARGET` — reverse lookup: target stage_dir → verb. nil for `1-inbox` (no verb arrives there; tasks are created via `hive new`).
 

--- a/wiki/modules/workflows.md
+++ b/wiki/modules/workflows.md
@@ -1,17 +1,25 @@
 ---
 title: Hive::Workflows
 type: module
-source: lib/hive/workflows.rb
+source: lib/hive/workflows.rb, lib/hive/workflow.rb, lib/hive/workflows/registry.rb, lib/hive/workflows/coding.rb
 created: 2026-04-26
-updated: 2026-05-22
+updated: 2026-06-19
 tags: [module, workflow, verbs]
 ---
 
-**TLDR**: Single source of truth for the workflow verbs (`brainstorm`, `plan`, `develop`, `open-pr`, `review`, `artifacts`, `finalize`, `archive`). Each verb advances a task from one stage to the next; `Hive::Commands::StageAction` consumes `Hive::Workflows::VERBS` directly, `Hive::TaskAction` uses it to label the next action per stage, and `Hive::Commands::Approve` / `FindingToggle` use it to derive the next-action command after a successful operation.
+**TLDR**: The coding workflow is now described once as `Hive::Workflows::Coding::DESCRIPTOR`: an ordered `Hive::Workflow` value object whose stages carry directory names, state files, and incoming advance verbs. `Hive::Workflows::Registry.default` returns that descriptor, and the legacy public constants (`Hive::Stages::DIRS`, `Hive::Task::STAGE_NAMES` / `STATE_FILES`, `Hive::Workflows::VERBS`) are derived from it at load time. Stage runners and hardcoded stage consumers still read the old constants; this is a behavior-preserving foundation for later workflow-as-data work.
+
+## Descriptor and registry
+
+- `Hive::Workflow` — frozen `Data` value object with `id` and ordered `stages`.
+- `Hive::Workflow::Stage` — frozen stage value object. `#dir` returns `"#{index}-#{name}"`; inert metadata such as `kind`, `skill`, `status_mode`, `budget_usd`, `timeout_sec`, and `capability` is carried for later units but not read by the current runtime.
+- `Hive::Workflow::AdvanceVerb` — frozen value object for the verb that advances into a stage, with `force_source` and `interactive` flags defaulting false.
+- `Hive::Workflows::Coding::DESCRIPTOR` — the only built-in descriptor (`id: :coding`), matching the current nine-stage pipeline exactly.
+- `Hive::Workflows::Registry.fetch(:coding)` / `.default` — descriptor lookup. Unknown ids raise `Hive::Workflows::UnknownWorkflow`.
 
 ## Constants
 
-- `VERBS` — frozen hash, verb name → `{ source:, target:, force_source? }`. Source and target are `Hive::Stages::DIRS` entries.
+- `VERBS` — frozen hash, verb name → `{ source:, target:, force_source? }`. It is derived by walking adjacent stages in `Registry.default`; false `force_source` / `interactive` flags are omitted entirely to preserve the historical hash shape.
 - `VERB_BY_SOURCE` — reverse lookup: source stage_dir → verb. nil for `9-done` (no verb advances out).
 - `VERB_BY_TARGET` — reverse lookup: target stage_dir → verb. nil for `1-inbox` (no verb arrives there; tasks are created via `hive new`).
 
@@ -47,10 +55,11 @@ Hive::Workflows.workflow_verb?("findings") # false (a generic verb, not workflow
 
 ## Why a separate module?
 
-`StageAction` previously owned an `ACTIONS` table; `TaskAction` had its own `ACTIONS` map; `Approve#workflow_command_for` had a hard-coded `{2 => "brainstorm", …}` literal. Three sources of truth for the same five-row map. Renaming `develop` → `execute` would silently leave one of them on the old name. The shared module ensures every consumer stays in lockstep.
+`StageAction` previously owned an `ACTIONS` table; `TaskAction` had its own `ACTIONS` map; `Approve#workflow_command_for` had a hard-coded `{2 => "brainstorm", …}` literal. Three sources of truth for the same map meant renaming a verb could silently leave one consumer on the old value. The shared `VERBS` module-level API fixed that drift class; the descriptor now moves the stage dirs, task state-file map, and verb adjacency behind the same ordered source while keeping the old constants for callers.
 
 ## Backlinks
 
 - [[commands/run]] — workflow verb dispatch via `Hive::Commands::StageAction`
 - [[modules/task_action]] — uses VERBS to build per-state next-action commands
 - [[modules/stages]] — the canonical stage list this module references
+- [[modules/task]] — task stage validation and state-file lookup derived from the descriptor-backed constants


### PR DESCRIPTION
## Summary

The coding pipeline's 9-stage list was triplicated across three files that had to be hand-kept in lockstep: `Stages::DIRS`, `Task::STAGE_NAMES` / `STATE_FILES`, and `Workflows::VERBS`. Renaming or reordering a stage meant editing three literals and hoping none drifted. This PR makes the pipeline a single in-Ruby descriptor and derives all four constants from it at load time, so there is now one place to change a stage.

This is the foundation unit (U1 of 8) of a workflow-as-data inversion. It is deliberately behavior-preserving: every public constant keeps the same name, order, values, and frozen-ness it had before, proven by a golden test that pins each one to its original literal. No call site migrates yet.

```mermaid
graph TB
    D["Coding::DESCRIPTOR<br/>id: :coding · 9 stages"] --> R["Workflows::Registry.default"]
    R --> S["Stages::DIRS"]
    R --> N["Task::STAGE_NAMES"]
    R --> F["Task::STATE_FILES"]
    R --> V["Workflows::VERBS"]
```

### What changed

- `Hive::Workflow`, `Hive::Workflow::Stage`, and `Hive::Workflow::AdvanceVerb` (new `lib/hive/workflow.rb`): frozen `Data` value objects modeling a workflow as an ordered list of stages, each optionally carrying the verb that advances into it.
- `Hive::Workflows::Coding::DESCRIPTOR` (new `lib/hive/workflows/coding.rb`): today's 9-stage pipeline as one pure Ruby literal, `id: :coding`.
- `Hive::Workflows::Registry` (new `lib/hive/workflows/registry.rb`): `fetch(:coding)` / `default`, raising the typed `Hive::Workflows::UnknownWorkflow` on an unknown id.
- `Stages::DIRS`, `Task::STAGE_NAMES`, `Task::STATE_FILES`, and `Workflows::VERBS` now derive from `Registry.default` instead of inline literals. `NAMES`, `SHORT_TO_FULL`, `VERB_BY_SOURCE`, and `VERB_BY_TARGET` keep deriving from those rebuilt constants unchanged.

### Design decisions

- **Byte-identical is the contract.** The rebuilt constants must `==` the old literals exactly, including order and frozen-ness. The sharpest edge is `VERBS`: the original omits the `force_source` key entirely when false and never carries `interactive`, so the derivation adds those keys only when true (`{source:, target:}` and `{source:, target:, force_source: false}` are not equal). The golden test asserts the exact per-entry key set, not just values.
- **One implicit workflow.** Resolution stays implicit via `Registry.default`; no `workflow_id` is added to `Task`. That wiring is deferred.
- **Inert metadata carried, not read.** Each stage also carries `kind`, `skill`, `status_mode`, `budget_usd`, `timeout_sec`, and `capability`, copied faithfully from config and the runners. Nothing reads them in this unit; they are the seam later units consume. Config remains the runtime source of truth and is not restructured.
- **Leaf-file load order.** `workflow.rb`, `coding.rb`, and `registry.rb` never require the constant-holder files, so the new `require`s in `stages.rb` / `task.rb` / `workflows.rb` introduce no cycle.

### Out of scope (later units)

`pick_runner`, `TaskAction#action`, and the ~20 files hardcoding `"N-stage"` literals are untouched — they still read the public constants and migrate in subsequent units.

## Test plan

- `test/unit/workflow_golden_test.rb` pins `DIRS`, `STAGE_NAMES`, `STATE_FILES`, and `VERBS` to their original literals — including key order, per-entry key sets, and frozen-ness — so any future descriptor edit that changes the coding pipeline fails loudly. The reference literals are hard-coded inline (not derived from the descriptor) so the test catches drift in either direction.
- `test/unit/workflow_test.rb`, `test/unit/workflows/coding_test.rb`, and `test/unit/workflows/registry_test.rb` cover the value objects (defaults, `#dir`, immutability), the descriptor shape (9 stages in index order, inert-metadata pins), and the registry (identity, `id`, and the unknown-id raise branch).
- The existing suite — which already exercises every consumer of these four constants — is the behavioral proof.
- Acceptance gates (the same ones CI enforces) all pass: `bundle exec rake test` green, `bundle exec rake coverage` at 100% line coverage, and `bundle exec rubocop` clean. A require-cycle smoke check (`require "hive/stages"; "hive/task"; "hive/workflows"`) loads clean.

## Review summary

Three review passes completed (browser review skipped — no UI surface); **zero user escalations**.

- **Pass 01** — auto-fixed 7 items: a stale self-contradicting `workflows.rb` header, adjacent comment clarity, `Stage`/`AdvanceVerb#initialize` → bare `super`, `Workflow#initialize` → `stages.dup.freeze`, an interactive-verb-derivation test, and an exhaustive inert-metadata pin test.
- **Pass 02** — auto-fixed 2 doc/comment items (a clarifying note on the `class Workflow` reopen; `interactive?` added to the documented `VERBS` shape).
- **Pass 03** — auto-fixed 5 polish items (`STATE_FILES` → `stages.to_h`, a corrected `FindingToggle`-vs-`Approve` consumer comment, a reworded `stages.rb` header, a shallow-dup note, and `frozen?` assertions for `AdvanceVerb` / `Registry.default`).
- **Resolved / no-fix:** the forward-looking hardening Nits (the `VERBS` `fetch(index - 1)` negative-index trap and a structural `Workflow` invariant check) are deliberate deferrals to U2+ per the plan's non-goal guardrail and the 100%-line-coverage gate — they cannot manifest in U1's shipped output. Every codex "High" finding across passes was a **stale two-dot-diff artifact**: `origin/main` advanced 8 commits (a file set disjoint from U1's), so the apparent "deletions/reverts" are diff noise that a real merge takes the union of, not changes by this branch. The `Layout/LineLength 160/150` flag was a verified false positive (the repo's `rubocop-rails-omakase` base disables `Layout/LineLength`).

## Linked task

- **Hive task #1453** — *Hive Workflow Descriptor And Derived Constants* (slug `u1-hive-workflow-descriptor-and-260618-c732`).
- **Unit U1 of 8** in the workflow-as-data inversion: make Hive's stage pipeline data-defined per workflow so non-coding workflows can later run on the same spine. This first unit introduces the descriptor + registry and collapses the triplicated coding-stage definitions into it, with byte-identical behavior as the hard acceptance constraint. Subsequent units migrate the consumers (`pick_runner` → U2, `TaskAction#action` → U4, the hardcoded `"N-stage"` literals → U6).

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_(1M)-D97757?logo=claude&logoColor=white)
