### PR TITLE
chore(review): double the default review wall-clock cap to 8h

### DIFF
--- a/lib/hive/config.rb
+++ b/lib/hive/config.rb
@@ -284,7 +284,7 @@ module Hive
         # review legitimately takes 1-2h. Each reviewer is bounded by its
         # own timeout, NOT by an even split of this budget, so this only
         # needs to cover the sum (raise it if you run more reviewers).
-        "max_wall_clock_sec" => 14_400
+        "max_wall_clock_sec" => 28_800
       },
       # Hive daemon settings (ADR-024). The daemon polls
       # `hive status --json`, dispatches workflow verbs on tasks the

--- a/templates/project_config.yml.erb
+++ b/templates/project_config.yml.erb
@@ -174,8 +174,9 @@ review:
     max_attempts: 2
   max_passes: 2
   # Aggregate wall-clock cap across all phases of one `hive run` on a
-  # 6-review folder. 14400s = 4h, enough for a couple of 1-2h reviewers.
-  max_wall_clock_sec: 14400
+  # 6-review folder. 28800s = 8h — generous headroom so the cap is not hit
+  # on a normal multi-pass review (a couple of 1-2h reviewers + retries).
+  max_wall_clock_sec: 28800
   # Hive's recommended reviewer set: claude /ce-code-review + codex
   # /ce-code-review + claude /pr-review-toolkit:review-pr. Each entry's
   # `name` becomes part of the output filename (`reviews/<name>-<pass>.md`).

--- a/test/integration/init_test.rb
+++ b/test/integration/init_test.rb
@@ -1852,7 +1852,7 @@ class InitTest < Minitest::Test
         # Other defaults present.
         assert_equal "courageous", cfg.dig("review", "triage", "bias")
         assert_equal 2,            cfg.dig("review", "max_passes")
-        assert_equal 14_400,       cfg.dig("review", "max_wall_clock_sec")
+        assert_equal 28_800,       cfg.dig("review", "max_wall_clock_sec")
       end
     end
   end

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -1971,7 +1971,7 @@ class ConfigTest < Minitest::Test
       assert_equal "courageous", cfg.dig("review", "triage", "bias")
       assert_equal false,     cfg.dig("review", "browser_test", "enabled")
       assert_equal 2,         cfg.dig("review", "max_passes")
-      assert_equal 14_400,    cfg.dig("review", "max_wall_clock_sec")
+      assert_equal 28_800,    cfg.dig("review", "max_wall_clock_sec")
       assert_equal "claude",  cfg.dig("agents", "claude", "bin")
       assert_equal "codex",   cfg.dig("agents", "codex", "bin")
       assert_equal "pi",      cfg.dig("agents", "pi", "bin")


### PR DESCRIPTION
## What
Doubles the review `max_wall_clock_sec` default from **14400s (4h) → 28800s (8h)** in:
- `lib/hive/config.rb` `Config::DEFAULTS`
- `templates/project_config.yml.erb` (`hive init` project config)
- the two tests pinning the default (`config_test.rb`, `init_test.rb`)

## Why
The review wall-clock cap is **runaway protection, not a target** — normal multi-pass reviews finish well within it. But the prior 4h default (and tighter per-project overrides like 90 min) was being hit on nearly every review's final verification pass at higher reviewer effort, stranding the task at `REVIEW_STALE` and forcing a manual clear+rerun. A generous default avoids that.

Per-project `review.max_wall_clock_sec` overrides still win as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)