### PR TITLE
Hive patrol: clustered gh api shorthand hides write options

### DIFF
--- a/bin/hive-babysitter-stub-gh
+++ b/bin/hive-babysitter-stub-gh
@@ -151,6 +151,24 @@ def field_uses_file?(value)
   value.to_s.sub(/\A=/, "").split("=", 2).last.to_s.start_with?("@")
 end
 
+GH_API_VALUE_SHORT_OPTIONS = %w[H X F f q t p].freeze
+
+def api_short_option_cluster(arg, rest, index)
+  return nil unless arg.start_with?("-") && !arg.start_with?("--") && arg.length > 1
+
+  chars = arg[1..].chars
+  chars.each_with_index do |char, char_index|
+    next unless GH_API_VALUE_SHORT_OPTIONS.include?(char)
+
+    suffix = chars[(char_index + 1)..].join
+    return [ char, rest[index + 1], 2 ] if suffix.empty?
+
+    return [ char, suffix.sub(/\A=/, ""), 1 ]
+  end
+
+  nil
+end
+
 def api_read_only?(rest)
   return false unless rest.first == "api"
 
@@ -206,7 +224,17 @@ def api_read_only?(rest)
       cache = true
       index += 1
     else
-      index += 1
+      short_option, value, advance = api_short_option_cluster(arg, rest, index)
+      case short_option
+      when "X"
+        method = value
+      when "f"
+        payload = true
+      when "F"
+        payload = true
+        unsafe_payload ||= field_uses_file?(value)
+      end
+      index += advance || 1
     end
   end
 

--- a/test/unit/babysitter/dry_run_env_test.rb
+++ b/test/unit/babysitter/dry_run_env_test.rb
@@ -266,8 +266,12 @@ class BabysitterDryRunEnvTest < Minitest::Test
       assert_stubbed env, "gh", "--repo=owner/repo", "pr", "edit", "42", "--add-label", "ready"
       assert_stubbed env, "gh", "--repo=owner/repo", "pr", "edit", "42", "--add-assignee", "@me"
       assert_stubbed env, "gh", "api", "-X", "POST", "repos/owner/repo/dispatches"
+      assert_stubbed env, "gh", "api", "-iX", "POST", "repos/owner/repo/dispatches"
       assert_stubbed env, "gh", "api", "repos/owner/repo/issues/123/comments", "-f", "body=hi"
+      assert_stubbed env, "gh", "api", "repos/owner/repo/issues/123/comments", "-if", "body=hi"
+      assert_stubbed env, "gh", "api", "repos/owner/repo/issues/123/comments", "-ifbody=hi"
       assert_stubbed env, "gh", "api", "repos/owner/repo/issues/123/comments", "-F", "body=@comment.md"
+      assert_stubbed env, "gh", "api", "repos/owner/repo/issues/123/comments", "-iF", "body=hi"
       assert_stubbed env, "gh", "api", "repos/owner/repo/issues/123/comments", "--raw-field", "body=hi"
       assert_stubbed env, "gh", "api", "repos/owner/repo/issues/123/comments", "--field", "body=hi"
       assert_stubbed env, "gh", "api", "repos/owner/repo/issues/123/comments", "--input", "payload.json"
@@ -338,6 +342,7 @@ class BabysitterDryRunEnvTest < Minitest::Test
       assert_passes env, "gh", "api", "repos/owner/repo"
       assert_passes env, "gh", "api", "--method", "GET", "repos/owner/repo/issues", "-f", "state=open"
       assert_passes env, "gh", "api", "--method", "GET", "repos/owner/repo/issues", "-F", "state=open"
+      assert_passes env, "gh", "api", "-iX", "GET", "repos/owner/repo/issues", "-f", "state=open"
       # The safe positional forms must still reach real gh, so the new positional
       # gate does not over-block: a bare `OWNER/REPO` slug (one slash) on `repo view`,
       # a numeric operand on `pr view`, and a slash-bearing branch ref the pr-URL rule
@@ -516,8 +521,12 @@ class BabysitterDryRunEnvTest < Minitest::Test
       assert_includes skipped, "gh --repo=owner/repo pr edit 42 --add-label ready skipped"
       assert_includes skipped, "gh --repo=owner/repo pr edit 42 --add-assignee @me skipped"
       assert_includes skipped, "gh api -X POST repos/owner/repo/dispatches skipped"
+      assert_includes skipped, "gh api -iX POST repos/owner/repo/dispatches skipped"
       assert_includes skipped, "gh api repos/owner/repo/issues/123/comments -f body=hi skipped"
+      assert_includes skipped, "gh api repos/owner/repo/issues/123/comments -if body=hi skipped"
+      assert_includes skipped, "gh api repos/owner/repo/issues/123/comments -ifbody=hi skipped"
       assert_includes skipped, "gh api repos/owner/repo/issues/123/comments -F body=@comment.md skipped"
+      assert_includes skipped, "gh api repos/owner/repo/issues/123/comments -iF body=hi skipped"
       assert_includes skipped, "gh api repos/owner/repo/issues/123/comments --raw-field body=hi skipped"
       assert_includes skipped, "gh api repos/owner/repo/issues/123/comments --field body=hi skipped"
       assert_includes skipped, "gh api repos/owner/repo/issues/123/comments --input payload.json skipped"
@@ -587,6 +596,7 @@ class BabysitterDryRunEnvTest < Minitest::Test
       assert_includes real_invocations, "real-gh pr view feature/topic/branch"
       assert_includes real_invocations, "real-gh api --method GET repos/owner/repo/issues -f state=open"
       assert_includes real_invocations, "real-gh api --method GET repos/owner/repo/issues -F state=open"
+      assert_includes real_invocations, "real-gh api -iX GET repos/owner/repo/issues -f state=open"
       assert_includes real_invocations, expected_real_invocation("git", "-C", dir, "status", "--short")
       assert_includes real_invocations, expected_real_invocation("git", "config", "--get", "remote.origin.url")
       assert_includes real_invocations, expected_real_invocation("git", "config", "--get-all", "remote.origin.fetch")


### PR DESCRIPTION
## Summary

The dry-run `gh` stub (`bin/hive-babysitter-stub-gh`) classified `gh api` calls
as read-only by recognizing write flags only as standalone (`-X`, `-f`, `-F`) or
directly-attached (`-XPOST`, `-fkey`) tokens. `gh` also supports clustered
short-option shorthand, so write calls like `gh api -iX POST …` and
`gh api … -ifbody=hi` slipped through the classifier and were forwarded to real
`gh` during a dry run — performing writes that should have been blocked.

This change parses `gh api` short-option clusters with gh/pflag semantics before
classification. A new `GH_API_VALUE_SHORT_OPTIONS` set (`H X F f q t p`) and the
`api_short_option_cluster` helper resolve value-taking shorthands that consume
either the cluster's suffix or the next argument, then mark the `X`/`f`/`F`
payload forms as unsafe. Clustered writes are now skipped, while clustered reads
(e.g. `gh api -iX GET …`) still reach real `gh`.

Two files changed (39 insertions, 1 deletion):

- `bin/hive-babysitter-stub-gh` — cluster-aware short-option parsing for `gh api`.
- `test/unit/babysitter/dry_run_env_test.rb` — coverage for the clustered forms.

## Test plan

- `ruby -Itest test/unit/babysitter/dry_run_env_test.rb` → 23 runs, 1314
  assertions, 0 failures / 0 errors / 0 skips.
- `bundle exec rake test` → passed.
- `bundle exec rubocop` → passed.

New assertions verify that clustered writes (`-iX POST`, `-if body=hi`,
`-ifbody=hi`, `-iF body=hi`) are skipped, while a clustered read
(`-iX GET … -f state=open`) is forwarded to real `gh`.

## Review summary

- Review pass 01: codex native review reported no findings across all tiers
  (High / Medium / Nit).
- Triage: clean — nothing to auto-fix, resolve, or escalate; no user questions.
- Browser review: skipped (CLI/dry-run change with no UI surface).

## Linked task

- Patrol finding: `command-bin-hive-2` — "clustered gh api shorthand hides write options"
- Fingerprint: `a43b6ca78c59a145370554d8f3eea6a1ad94f4ec3409d763ca6f62290a582bdb`
- Task slug: `patrol-command-bin-hive-a43b6ca7`
