### PR TITLE
refactor: idiomatic-Ruby pass on the workflow-as-data architecture

### DIFF
--- a/lib/hive/task_action.rb
+++ b/lib/hive/task_action.rb
@@ -481,7 +481,6 @@ module Hive
         legacy_execute_findings: legacy_execute_findings?,
         stale_agent_reason: stale_agent_reason,
         state_file_mtime: @state_file_mtime,
-        agent_marker_grace_sec: @agent_marker_grace_sec,
         project_name: project_name,
         project_count: @project_count
       )
@@ -597,12 +596,16 @@ module Hive
       log_dirs.any? { |dir| Dir[File.join(dir, "plan-*.log")].any? }
     end
 
-    def log_dirs
+    # The task's log directories. A class method shared with
+    # TaskAction::Diagnostic so the two concerns can't drift on where logs live.
+    def self.log_dirs(task)
       [
         (task.log_dir if task.respond_to?(:log_dir)),
         File.join(task.folder, "logs")
       ].compact.uniq
     end
+
+    def log_dirs = self.class.log_dirs(task)
 
     # Workflow verbs (brainstorm/plan/develop/pr/archive) use --from for
     # the source-stage assertion; coding recovery verbs (findings/accept-

--- a/lib/hive/task_action.rb
+++ b/lib/hive/task_action.rb
@@ -2,11 +2,10 @@ require "shellwords"
 require "digest"
 require "time"
 require "yaml"
-require "hive/execute_waiting_action"
 require "hive/agent_profiles"
-require "hive/secret_patterns"
 require "hive/stages"
 require "hive/workflows"
+require "hive/task_action/diagnostic"
 
 module Hive
   # Classifier that turns a (Task, Marker) pair into a user-facing
@@ -18,23 +17,6 @@ module Hive
   # `hive run` / `hive approve` / `hive accept-finding` JSON
   # `next_action` emission.
   class TaskAction
-    DIAGNOSTIC_SUMMARY_MAX = 120
-    DIAGNOSTIC_DETAIL_MAX = 4_000
-    DIAGNOSTIC_TAIL_BYTES = 8_192
-    # Cap on artifact_paths reported in the diagnostic payload. The schema
-    # pins maxItems=20; this constant is the producer-side enforcement so
-    # a marker with hundreds of matching artifacts (legacy reviews/ dirs)
-    # cannot blow past the contract.
-    ARTIFACT_PATHS_MAX = 20
-    # Cap on .log files probed per task per status invocation. Bounds the
-    # File.mtime cost when a task accumulated many agent-run logs over a
-    # long-lived branch (saw 50+ on auto-rebase test fixtures).
-    LOG_GLOB_CAP = 20
-    # Cap on diagnostic_frontmatter scan window. Real frontmatter is < 1KB;
-    # 16KB is generous for human-written artifacts and tight enough to
-    # reject a runaway file masquerading as frontmatter.
-    FRONTMATTER_SCAN_BYTES = 16_384
-
     ACTIONS = {
       inbox: {
         key: Hive::Schemas::TaskActionKind::READY_TO_BRAINSTORM,
@@ -472,375 +454,37 @@ module Hive
     public
 
     def diagnostic
-      synthesized = synthetic_stale_agent_diagnostic
-      return synthesized if synthesized
-      return nil unless diagnostic_action?
-
-      artifacts = diagnostic_artifacts.select { |path| safe_diagnostic_artifact?(path) }
-      primary = incomplete_plan_artifact? ? nil : artifacts.first
-      updated_at = diagnostic_updated_at(primary)
-      detail = primary ? artifact_detail(primary) : marker_detail
-      generator = diagnostic_generated_by(primary)
-
-      {
-        "summary" => truncate(redact(marker_summary), DIAGNOSTIC_SUMMARY_MAX),
-        "detail" => truncate(redact(detail), DIAGNOSTIC_DETAIL_MAX),
-        "source" => primary ? "artifact" : "marker",
-        "source_path" => primary,
-        "artifact_paths" => artifacts.uniq.first(ARTIFACT_PATHS_MAX),
-        "generated_by" => generator,
-        "marker_signature" => marker_signature,
-        "suggested_next_action" => suggested_next_action_payload,
-        "updated_at" => updated_at.utc.iso8601
-      }
+      diagnostic_builder.to_h
     end
 
     def next_action
-      return nil unless execute_waiting_input?
-
-      Hive::ExecuteWaitingAction.build(task, marker, rerun_with: command)
+      diagnostic_builder.next_action
     end
 
     private
 
-    # Diagnostic synthesized purely from liveness signal — the on-disk
-    # marker is still AGENT_WORKING (no artifact, no diagnosis pass),
-    # so the existing diagnostic_artifacts pipeline has nothing to chew
-    # on. Once the daemon's StaleAgentHealer rewrites the marker to
-    # ERROR reason=..., the normal generic_error_artifacts path takes
-    # over and this synthesized shape is no longer produced.
-    def synthetic_stale_agent_diagnostic
-      reason = stale_agent_reason
-      return nil unless reason
-
-      summary =
-        case reason
-        when :agent_died
-          recorded_pid = marker.attrs["pid"]
-          if recorded_pid && !recorded_pid.empty?
-            "agent process not alive (recorded pid=#{recorded_pid})"
-          else
-            "agent process not alive"
-          end
-        when :agent_orphaned
-          age_min = ((Time.now - @state_file_mtime) / 60).to_i
-          "agent never attached (marker placeholder is #{age_min} min old)"
-        end
-
-      {
-        "summary" => summary,
-        "detail" => "AGENT_WORKING marker is stale. The daemon's StaleAgentHealer will rewrite it to ERROR reason=#{reason} on its next tick (typically within 30 seconds). Once healed, re-read `hive status --json` or use the standard red-status flow, then run the reported suggested_next_action.command so the current ERROR marker guard is included. If the daemon is not running, start it with `systemctl --user start hive-daemon` (or your platform equivalent).",
-        "source" => "marker",
-        "source_path" => nil,
-        "artifact_paths" => [],
-        "generated_by" => "local",
-        "marker_signature" => marker_signature,
-        "suggested_next_action" => suggested_next_action_payload,
-        "updated_at" => Time.now.utc.iso8601
-      }
-    end
-
-    # The diagnostic shape exists for ALL three recovery action keys per
-    # ADR-027 and wiki/commands/status.md — recover_review, error, AND
-    # recover_execute (EXECUTE_STALE). The TUI's red_status_detail view
-    # renders all three under a unified [Enter] Recover / [o] Open in
-    # agent contract; recover_execute rows surface the Risk-#3 mitigation
-    # flash when [Enter] Recover is pressed (no auto-retry recipe), then
-    # the screen closes. Bot, daemon, and external `--json` consumers
-    # also rely on this field for EXECUTE_STALE rows the autofix path
-    # cannot resolve; emitting nil would defeat the diagnose-then-act
-    # feature for one of the three red states it covers.
-    def diagnostic_action?
-      %w[recover_execute recover_review error].include?(key.to_s)
-    end
-
-    def diagnostic_artifacts
-      return latest_log_artifacts if incomplete_plan_artifact?
-      return fresh_diagnosis_artifact + execute_stale_artifacts if legacy_execute_findings?
-
-      case marker.name
-      when :review_error
-        fresh_diagnosis_artifact + review_error_artifacts
-      when :review_ci_stale
-        fresh_diagnosis_artifact + review_ci_artifacts
-      when :review_stale
-        fresh_diagnosis_artifact + review_stale_artifacts
-      when :execute_stale
-        fresh_diagnosis_artifact + execute_stale_artifacts
-      when :error
-        fresh_diagnosis_artifact + generic_error_artifacts
-      else
-        []
-      end
-    end
-
-    def fresh_diagnosis_artifact
-      path = task_artifact("diagnostics", "red-status.md")
-      return [] unless File.exist?(path)
-      return [] unless safe_diagnostic_artifact?(path)
-
-      metadata = diagnostic_frontmatter(path)
-      return [] unless trusted_diagnostic_generator?(metadata["generated_by"])
-      return [] unless metadata["marker_signature"].to_s == marker_signature
-      # marker_signature is SHA-256(marker_name + sorted_attr_pairs), so a
-      # red → green → same-shape red rotation cycle produces an identical
-      # signature across episodes. Without an ordering check the second
-      # episode would silently reuse the first's artifact. Compare mtimes:
-      # the state_file is touched on every marker rotation, so an artifact
-      # older than the state_file is from a previous episode. See #89.
-      return [] if artifact_predates_marker?(path)
-
-      [ path ]
-    end
-
-    def artifact_predates_marker?(artifact_path)
-      artifact_mtime = safe_mtime(artifact_path)
-      state_mtime = safe_mtime(task.state_file)
-      return false if artifact_mtime.nil? || state_mtime.nil?
-
-      artifact_mtime < state_mtime
-    end
-
-    def review_error_artifacts
-      pass = pass_suffix
-      phase = marker.attrs["phase"].to_s
-      reason = marker.attrs["reason"].to_s
-      paths = []
-      paths.concat(paths_from_marker_files)
-      paths << task_artifact("reviews", "errors-#{pass}.md") if pass
-      paths << task_artifact("reviews", "fix-guardrail-#{pass}.md") if pass && reason == "fix_guardrail"
-      paths << task_artifact("reviews", "escalations-#{pass}.md") if pass
-      paths.concat(review_phase_logs(phase, pass))
-      paths.concat(latest_log_artifacts)
-      paths
-    end
-
-    def review_ci_artifacts
-      [
-        task_artifact("reviews", "ci-blocked.md"),
-        *glob_task_artifacts("logs", "review-ci-fix-attempt*.log"),
-        *latest_log_artifacts
-      ]
-    end
-
-    def review_stale_artifacts
-      pass = pass_suffix
-      paths = []
-      paths << task_artifact("reviews", "escalations-#{pass}.md") if pass
-      paths.concat(glob_task_artifacts("reviews", "*-#{pass}.md")) if pass
-      paths.concat(latest_log_artifacts)
-      paths
-    end
-
-    # EXECUTE_STALE artifacts: the previous-pass review files (the user
-    # needs to inspect findings the agent could not satisfy) plus the
-    # last few agent logs. Cap the review-md glob at the most recent
-    # entries by filename so a long-lived task with dozens of review
-    # files doesn't blow past the schema's artifact_paths maxItems.
-    def execute_stale_artifacts
-      review_md = glob_task_artifacts("reviews", "*.md").sort.last(3)
-      [ *review_md, *latest_log_artifacts ]
-    end
-
-    def generic_error_artifacts
-      [
-        *latest_log_artifacts,
-        task.state_file
-      ]
-    end
-
-    def review_phase_logs(phase, pass)
-      return [] unless pass
-
-      case phase
-      when "fix"
-        glob_task_artifacts("logs", "review-fix-pass#{pass}*.log")
-      when "triage"
-        glob_task_artifacts("logs", "review-triage-pass#{pass}*.log")
-      when "browser"
-        glob_task_artifacts("logs", "review-browser-pass#{pass}*.log")
-      when "reviewers"
-        glob_task_artifacts("logs", "review-*-pass#{pass}*.log")
-      else
-        []
-      end
-    end
-
-    def paths_from_marker_files
-      marker.attrs.fetch("files", "").to_s.split(/[,\s]+/).filter_map do |relative|
-        next if relative.empty? || relative.include?("..") || relative.start_with?("/")
-
-        File.join(task.folder, relative)
-      end
-    end
-
-    # Cap the candidate set (LOG_GLOB_CAP) before sorting by mtime so a
-    # long-lived task with 100+ retained logs doesn't pay an O(N) stat
-    # sweep on every status poll. The cap is the most recent N by
-    # filename-suffix timestamp (hive's log filenames embed an ISO
-    # timestamp), which is a good proxy for mtime ordering and avoids
-    # the stat. Final sort-by-mtime over the capped set still produces
-    # the freshest 3.
-    def latest_log_artifacts
-      candidates = log_dirs.flat_map { |dir| Dir[File.join(dir, "*.log")] }
-      return [] if candidates.empty?
-
-      head = candidates.sort.last(LOG_GLOB_CAP)
-      head.sort_by { |path| safe_mtime(path) || Time.at(0) }.last(3).reverse
-    end
-
-    def log_dirs
-      [
-        (task.log_dir if task.respond_to?(:log_dir)),
-        File.join(task.folder, "logs")
-      ].compact.uniq
-    end
-
-    def glob_task_artifacts(*parts)
-      Dir[task_artifact(*parts)]
-    end
-
-    def task_artifact(*parts)
-      File.join(task.folder, *parts)
-    end
-
-    def pass_suffix
-      raw = marker.attrs["pass"].to_s
-      return nil unless raw.match?(/\A[1-9]\d*\z/)
-
-      format("%02d", raw.to_i)
-    end
-
-    def marker_summary
-      return "PLAN_MISSING_OUTPUT" if incomplete_plan_artifact?
-      return "FINALIZE_MISSING_PR_MD" if finalize_missing_pr_md?
-      return "FINALIZE_MISSING_PR_URL" if finalize_missing_pr_url?
-      return "FINALIZE_PR_URL_MISMATCH" if finalize_pr_url_mismatch?
-
-      attrs = Hive::Markers.display_attrs(marker.attrs)
-                           .map { |key, value| "#{key}=#{value}" }.join(" ")
-      marker_name = marker.name.to_s.upcase
-      attrs.empty? ? marker_name : "#{marker_name} #{attrs}"
-    end
-
-    def marker_detail
-      if incomplete_plan_artifact?
-        return [
-          "PLAN_MISSING_OUTPUT",
-          "Plan is incomplete because #{task.state_file} is missing or empty.",
-          "Rerun the plan stage to regenerate plan.md."
-        ].join("\n")
-      end
-
-      if finalize_missing_pr_md?
-        return [
-          "FINALIZE_MISSING_PR_MD",
-          "Finalize cannot run because #{task.state_file} is missing.",
-          "Move the task back to 5-open-pr or recreate pr.md with pr_url frontmatter."
-        ].join("\n")
-      end
-
-      if finalize_missing_pr_url?
-        return [
-          "FINALIZE_MISSING_PR_URL",
-          "Finalize cannot archive because #{task.state_file} is missing pr_url metadata.",
-          "Repair pr.md or move the task back to 5-open-pr so the PR metadata can be recreated."
-        ].join("\n")
-      end
-
-      if finalize_pr_url_mismatch?
-        return [
-          "FINALIZE_PR_URL_MISMATCH",
-          "Finalize cannot archive because the COMPLETE marker pr_url does not match pr.md frontmatter.",
-          "Rerun finalize or repair pr.md so both PR URLs match."
-        ].join("\n")
-      end
-
-      if auto_commit_scope_failure?
-        return [
-          marker_summary,
-          "Hive rejected the fix-agent fallback commit because staged paths were outside review.fix.auto_commit.scope_check.",
-          "Inspect the listed files, remove or revert rejected worktree changes, or adjust review.fix.auto_commit.scope_check before clearing REVIEW_ERROR."
-        ].join("\n")
-      end
-
-      if auto_commit_signing_failure?
-        return [
-          marker_summary,
-          "Hive could not create the fix-agent fallback commit because commit signing policy or signing execution blocked it.",
-          "Inspect the worktree changes, manually commit or revert remaining changes, fix signing config or set review.fix.auto_commit.sign_policy to inherit/bypass/fail as appropriate, then clear REVIEW_ERROR and re-run."
-        ].join("\n")
-      end
-
-      if fix_status_check_failure?
-        return [
-          marker_summary,
-          "Hive could not read the task worktree Git status before or after running the review fix agent.",
-          "Repair the worktree or repository state, then clear REVIEW_ERROR and re-run the review."
-        ].join("\n")
-      end
-
-      lines = [ marker_summary ]
-      lines << "No diagnostic artifact was found under #{task.folder}."
-      lines.join("\n")
-    end
-
-    def artifact_detail(path)
-      body = tail_file(path)
-      "#{path}:\n#{body}"
-    rescue SystemCallError => e
-      "#{path}: #{e.class}: #{e.message}"
-    end
-
-    def tail_file(path)
-      raw = File.open(path, "rb") do |file|
-        begin
-          file.seek(-DIAGNOSTIC_TAIL_BYTES, IO::SEEK_END)
-        rescue Errno::EINVAL
-          file.rewind
-        end
-        file.read.to_s
-      end
-      # Coerce to UTF-8 with invalid byte replacement so downstream
-      # redact / truncate / JSON.generate never raises
-      # Encoding::CompatibilityError on a binary log tail. A single
-      # corrupt byte in one task's log used to abort the entire
-      # `hive status --json` snapshot, breaking every downstream
-      # consumer (bot, daemon, TUI). See PR #84 review finding #4.
-      raw.encode("UTF-8", invalid: :replace, undef: :replace, replace: "?")
-    end
-
-    def diagnostic_updated_at(primary)
-      safe_mtime(primary) || safe_mtime(task.state_file) || Time.now
-    end
-
-    def diagnostic_generated_by(primary)
-      return "local" unless primary && File.basename(primary) == "red-status.md"
-
-      diagnostic_frontmatter(primary)["generated_by"].to_s.tap do |value|
-        return value unless value.empty?
-      end
-      "local"
-    end
-
-    # Scan up to FRONTMATTER_SCAN_BYTES of the artifact head looking for
-    # the closing `---` boundary. A fixed 4KB head used to silently parse
-    # frontmatter blocks larger than 4KB as empty (no closing match) —
-    # widening the window to 16KB keeps the cost bounded while accepting
-    # real-world artifact frontmatter.
-    def diagnostic_frontmatter(path)
-      body = File.read(path, FRONTMATTER_SCAN_BYTES)
-      match = body.match(/\A---\n(.*?)\n---\n/m)
-      return {} unless match
-
-      parsed = YAML.safe_load(match[1], permitted_classes: [ Time ]) || {}
-      parsed.is_a?(Hash) ? parsed.transform_keys(&:to_s) : {}
-    rescue Psych::Exception, SystemCallError
-      {}
-    end
-
-    def trusted_diagnostic_generator?(name)
-      Hive::Schemas::DIAGNOSTIC_GENERATORS.include?(name.to_s)
+    # The diagnostics concern lives in the Diagnostic collaborator; it's a
+    # pure function of (task, marker) plus the classification context the
+    # diagnostic depends on (this action's key, its rerun command, and the
+    # state predicates that also drive classification). Memoized so a single
+    # `hive status` row builds it once.
+    def diagnostic_builder
+      @diagnostic_builder ||= Diagnostic.new(
+        task: task,
+        marker: marker,
+        action_key: key,
+        rerun_command: command,
+        incomplete_plan_artifact: incomplete_plan_artifact?,
+        finalize_missing_pr_md: finalize_missing_pr_md?,
+        finalize_missing_pr_url: finalize_missing_pr_url?,
+        finalize_pr_url_mismatch: finalize_pr_url_mismatch?,
+        legacy_execute_findings: legacy_execute_findings?,
+        stale_agent_reason: stale_agent_reason,
+        state_file_mtime: @state_file_mtime,
+        agent_marker_grace_sec: @agent_marker_grace_sec,
+        project_name: project_name,
+        project_count: @project_count
+      )
     end
 
     public
@@ -868,86 +512,6 @@ module Hive
       ::Digest::SHA256.hexdigest(([ marker.name.to_s ] + attrs).join("\n"))
     end
 
-    def marker_signature
-      self.class.marker_signature(marker)
-    end
-
-    private
-
-    # Recovery hint surfaced inside the diagnostic JSON so agents and
-    # external consumers don't have to re-derive the next move from
-    # marker shape alone. `kind` mirrors the operator gesture:
-    #   - "retry" — Enter-in-detail-view runs the existing recover_review
-    #     / recover_error path, or a markerless synthetic-error direct
-    #     rerun such as PLAN_MISSING_OUTPUT; `command` is the copy-
-    #     paste shell form.
-    #   - "manual_fix" — max_passes-hit REVIEW_STALE; the operator must
-    #     edit `reviews/escalations-NN.md` before retry. command stays
-    #     null because there's nothing safe to dispatch.
-    #   - "clear_marker" — kept reserved for future expansion; not yet
-    #     emitted because the in-tree heuristics route everything else
-    #     through retry or manual_fix.
-    def suggested_next_action_payload
-      return nil unless diagnostic_action?
-
-      if incomplete_plan_artifact?
-        return { "kind" => "retry", "command" => workflow_command("plan") }
-      end
-
-      if finalize_missing_pr_md? || finalize_missing_metadata_error?
-        return { "kind" => "manual_fix", "command" => nil }
-      end
-
-      if finalize_missing_pr_url? || finalize_pr_url_mismatch?
-        return { "kind" => "manual_fix", "command" => nil }
-      end
-
-      if max_passes_review_stale_with_escalations?
-        return { "kind" => "manual_fix", "command" => nil }
-      end
-
-      # EXECUTE_STALE rows have no auto-retry recipe: the operator must
-      # review findings and either edit the worktree or lower the pass
-      # counter. Emit manual_fix with command:null instead of falling
-      # through to a nil payload so agents reading hive-status JSON
-      # see an explicit "do not auto-retry" signal rather than the
-      # absence of data. See PR #84 review finding #9.
-      if marker.name == :execute_stale || legacy_execute_findings?
-        return { "kind" => "manual_fix", "command" => nil }
-      end
-
-      if fix_status_check_failure?
-        return { "kind" => "manual_fix", "command" => nil }
-      end
-
-      if auto_commit_manual_failure?
-        return { "kind" => "manual_fix", "command" => nil }
-      end
-
-      # CleanExit's `ensure_clean_on_exit_failed` is operator-resolves-
-      # the-worktree territory: scope-violating or signing-failed
-      # residue needs human inspection. Emit `manual_fix` with
-      # `command:null` so polling agents see the explicit
-      # "do not auto-retry" signal (the bot's manual-only routing in
-      # `RecoverySequence` already refuses to dispatch a retry verb
-      # for this reason; the JSON payload mirrors that decision so
-      # CLI-driven consumers don't try to construct one themselves).
-      if clean_exit_manual_failure?
-        return { "kind" => "manual_fix", "command" => nil }
-      end
-
-      cmd = retry_command_string
-      return nil if cmd.nil?
-
-      { "kind" => "retry", "command" => cmd }
-    end
-
-    def max_passes_review_stale_with_escalations?
-      self.class.max_passes_review_stale_with_escalations?(
-        folder: task.folder, marker_name: marker.name, attrs: marker.attrs
-      )
-    end
-
     # Class-level predicate so TUI consumers (KeyMap#red_detail_row?,
     # BubbleModel#red_status_autofix_force?) share the exact same logic
     # as the JSON producer here. Previously the rule lived in three
@@ -963,46 +527,6 @@ module Hive
       File.exist?(File.join(folder.to_s, "reviews", "escalations-#{format('%02d', pass.to_i)}.md"))
     end
 
-    # `hive markers clear` accepts --match-attr KEY=VALUE or comma-separated
-    # KEY=VALUE pairs; pick the most-identifying guard per marker shape. The
-    # recipe stays a copy-pasteable one-liner so external agents and humans can
-    # run it from a shell unchanged.
-    def retry_command_string
-      attrs = marker.attrs || {}
-      case marker.name
-      when :review_error, :review_ci_stale
-        attr_pair = priority_match_attr(attrs, %w[pass phase reason])
-        clear_argv = [ "hive", "markers", "clear", task.folder,
-                       "--name", marker.name.to_s.upcase, *attr_pair ]
-        "#{clear_argv.shelljoin} && #{[ 'hive', 'run', task.folder ].shelljoin}"
-      when :review_stale
-        attr_pair = priority_match_attr(attrs, %w[pass reason])
-        clear_argv = [ "hive", "markers", "clear", task.folder,
-                       "--name", "REVIEW_STALE", *attr_pair ]
-        "#{clear_argv.shelljoin} && #{[ 'hive', 'run', task.folder ].shelljoin}"
-      when :error
-        match_attr = Hive::Markers.error_recovery_match_attr(attrs)
-        attr_pair = match_attr ? [ "--match-attr", match_attr ] : []
-        clear_argv = [ "hive", "markers", "clear", task.folder,
-                       "--name", "ERROR", *attr_pair ]
-        "#{clear_argv.shelljoin} && #{[ 'hive', 'run', task.folder ].shelljoin}"
-      end
-    end
-
-    def priority_match_attr(attrs, keys)
-      keys.each do |key|
-        value = attrs[key]
-        return [ "--match-attr", "#{key}=#{value}" ] if value && !value.to_s.empty?
-      end
-      []
-    end
-
-    def workflow_command(verb)
-      parts = command_prefix(verb)
-      parts.concat([ "--from", stage_dir ])
-      parts.shelljoin
-    end
-
     # Shared prefix for every `hive <verb> <slug>` builder: the verb, the
     # slug, and the `--project` qualifier added only when more than one
     # project is in view (a single-project status never needs it). Callers
@@ -1011,109 +535,6 @@ module Hive
       parts = [ "hive", verb, task.slug ]
       parts.concat([ "--project", project_name ]) if project_name && @project_count > 1
       parts
-    end
-
-    def safe_mtime(path)
-      return nil if path.nil? || path.to_s.empty?
-
-      File.mtime(path)
-    rescue SystemCallError
-      nil
-    end
-
-    def safe_diagnostic_artifact?(path)
-      return false if path.nil? || path.to_s.empty? || !File.file?(path)
-
-      real = File.realpath(path)
-      diagnostic_roots.any? { |root| path_inside?(real, root) }
-    rescue Errno::ENOENT
-      false
-    rescue SystemCallError => e
-      # EACCES / ELOOP / ENAMETOOLONG / EIO: the artifact may exist but
-      # we cannot determine its realpath. Returning false silently
-      # invisibles a paid-for agent verdict (operator sees "no diagnostic
-      # available" while the file exists). Surface via $stderr so support
-      # threads have a breadcrumb; still return false so the local-marker
-      # fallback wins and the snapshot does not crash.
-      warn "[diagnose] cannot realpath #{path}: #{e.class}: #{e.message}"
-      false
-    end
-
-    def diagnostic_roots
-      # task.folder + any log_dirs are the legitimate roots an artifact
-      # may live under. We deliberately do NOT add a project_root
-      # containment filter: when .hive-state is a symlink to a separate
-      # volume (a legitimate deployment pattern), task.folder.realpath
-      # lands outside project_root.realpath and every diagnostic gets
-      # silently dropped. The symlink-escape guard is already provided
-      # by checking that the artifact's realpath is inside the (also
-      # realpath'd) task.folder / log_dir.
-      ([ task.folder ] + log_dirs).filter_map { |root| realpath_or_expand(root) }.uniq
-    end
-
-    def realpath_or_expand(path)
-      return nil if path.nil? || path.to_s.empty?
-
-      File.realpath(path)
-    rescue Errno::ENOENT
-      File.expand_path(path)
-    end
-
-    def path_inside?(path, root)
-      path == root || path.start_with?(root + File::SEPARATOR)
-    end
-
-    def redact(text)
-      Hive::SecretPatterns.redact(text)
-    end
-
-    def truncate(text, max)
-      return text if text.length <= max
-
-      "#{text[0, max - 1]}…"
-    end
-
-    def execute_waiting_input?
-      task.stage_name == "execute" &&
-        marker.name == :execute_waiting &&
-        !legacy_execute_findings?
-    end
-
-    AUTO_COMMIT_MANUAL_FAILURE_REASONS = %w[
-      fix_auto_commit_scope_failed
-      fix_auto_commit_sign_policy_failed
-      fix_auto_commit_signing_failed
-    ].freeze
-    FIX_STATUS_CHECK_MANUAL_FAILURE_REASON = "fix_status_check_failed".freeze
-
-    def auto_commit_scope_failure?
-      marker.name == :review_error && marker.attrs["reason"].to_s == "fix_auto_commit_scope_failed"
-    end
-
-    def auto_commit_signing_failure?
-      marker.name == :review_error && %w[
-        fix_auto_commit_sign_policy_failed
-        fix_auto_commit_signing_failed
-      ].include?(marker.attrs["reason"].to_s)
-    end
-
-    def auto_commit_manual_failure?
-      marker.name == :review_error && AUTO_COMMIT_MANUAL_FAILURE_REASONS.include?(marker.attrs["reason"].to_s)
-    end
-
-    def fix_status_check_failure?
-      marker.name == :review_error &&
-        marker.attrs["reason"].to_s == FIX_STATUS_CHECK_MANUAL_FAILURE_REASON
-    end
-
-    # `:error reason=ensure_clean_on_exit_failed` is the CleanExit
-    # invariant refusing to auto-commit residue: either the staged
-    # paths fell outside `review.fix.auto_commit.scope_check`, or
-    # `git add` / `git commit` / `git status` failed or timed out.
-    # Operator must inspect the worktree before any retry; there is
-    # no safe automated command to dispatch.
-    def clean_exit_manual_failure?
-      marker.name == :error && marker.attrs["reason"].to_s == "ensure_clean_on_exit_failed"
     end
 
     def legacy_execute_findings?
@@ -1142,12 +563,6 @@ module Hive
         task.state_file.to_s.end_with?("/pr.md") &&
         !frontmatter_pr_url.empty? &&
         marker.attrs["pr_url"].to_s != frontmatter_pr_url
-    end
-
-    def finalize_missing_metadata_error?
-      task.stage_name == "finalize" &&
-        marker.name == :error &&
-        %w[missing_pr_md missing_pr_url].include?(marker.attrs["reason"].to_s)
     end
 
     def frontmatter_pr_url
@@ -1180,6 +595,13 @@ module Hive
 
     def plan_run_started?
       log_dirs.any? { |dir| Dir[File.join(dir, "plan-*.log")].any? }
+    end
+
+    def log_dirs
+      [
+        (task.log_dir if task.respond_to?(:log_dir)),
+        File.join(task.folder, "logs")
+      ].compact.uniq
     end
 
     # Workflow verbs (brainstorm/plan/develop/pr/archive) use --from for

--- a/lib/hive/task_action/diagnostic.rb
+++ b/lib/hive/task_action/diagnostic.rb
@@ -1,7 +1,9 @@
 require "digest"
+require "shellwords"
 require "time"
 require "yaml"
 require "hive/execute_waiting_action"
+require "hive/markers"
 require "hive/secret_patterns"
 
 module Hive
@@ -44,7 +46,7 @@ module Hive
                      incomplete_plan_artifact:, finalize_missing_pr_md:,
                      finalize_missing_pr_url:, finalize_pr_url_mismatch:,
                      legacy_execute_findings:, stale_agent_reason:,
-                     state_file_mtime: nil, agent_marker_grace_sec: nil,
+                     state_file_mtime: nil,
                      project_name: nil, project_count: 1)
         @task = task
         @marker = marker
@@ -57,7 +59,6 @@ module Hive
         @legacy_execute_findings = legacy_execute_findings
         @stale_agent_reason = stale_agent_reason
         @state_file_mtime = state_file_mtime
-        @agent_marker_grace_sec = agent_marker_grace_sec
         @project_name = project_name
         @project_count = project_count
       end
@@ -278,12 +279,8 @@ module Hive
         head.sort_by { |path| safe_mtime(path) || Time.at(0) }.last(3).reverse
       end
 
-      def log_dirs
-        [
-          (task.log_dir if task.respond_to?(:log_dir)),
-          File.join(task.folder, "logs")
-        ].compact.uniq
-      end
+      # Shared with the classifier so the artifact-root check can't drift from it.
+      def log_dirs = Hive::TaskAction.log_dirs(task)
 
       def glob_task_artifacts(*parts)
         Dir[task_artifact(*parts)]

--- a/lib/hive/task_action/diagnostic.rb
+++ b/lib/hive/task_action/diagnostic.rb
@@ -1,0 +1,646 @@
+require "digest"
+require "time"
+require "yaml"
+require "hive/execute_waiting_action"
+require "hive/secret_patterns"
+
+module Hive
+  class TaskAction
+    # Builds the red-status diagnostic payload for a (Task, Marker) pair:
+    # the summary/detail an operator reads, the on-disk artifact paths
+    # backing it, and the suggested next action. Surfaced by `hive status
+    # --json`, the TUI's red-status detail view, the bot, and the daemon.
+    #
+    # Constructed by `TaskAction` with the classification context the
+    # diagnostic depends on (the action `key`, the rerun `command`, and the
+    # handful of state predicates that also drive classification) so this
+    # object stays a pure function of its inputs and never reaches back into
+    # the classifier.
+    class Diagnostic
+      SUMMARY_MAX = 120
+      DETAIL_MAX = 4_000
+      TAIL_BYTES = 8_192
+      # The schema pins artifact_paths maxItems=20; this is the producer-side
+      # enforcement so a marker with hundreds of matching artifacts (legacy
+      # reviews/ dirs) cannot blow past the contract.
+      ARTIFACT_PATHS_MAX = 20
+      # Cap on .log files probed per task per status invocation. Bounds the
+      # File.mtime cost when a task accumulated many agent-run logs over a
+      # long-lived branch (saw 50+ on auto-rebase test fixtures).
+      LOG_GLOB_CAP = 20
+      # Real frontmatter is < 1KB; 16KB is generous for human-written
+      # artifacts and tight enough to reject a runaway file masquerading as
+      # frontmatter.
+      FRONTMATTER_SCAN_BYTES = 16_384
+
+      AUTO_COMMIT_MANUAL_FAILURE_REASONS = %w[
+        fix_auto_commit_scope_failed
+        fix_auto_commit_sign_policy_failed
+        fix_auto_commit_signing_failed
+      ].freeze
+      FIX_STATUS_CHECK_MANUAL_FAILURE_REASON = "fix_status_check_failed".freeze
+
+      def initialize(task:, marker:, action_key:, rerun_command:,
+                     incomplete_plan_artifact:, finalize_missing_pr_md:,
+                     finalize_missing_pr_url:, finalize_pr_url_mismatch:,
+                     legacy_execute_findings:, stale_agent_reason:,
+                     state_file_mtime: nil, agent_marker_grace_sec: nil,
+                     project_name: nil, project_count: 1)
+        @task = task
+        @marker = marker
+        @action_key = action_key
+        @rerun_command = rerun_command
+        @incomplete_plan_artifact = incomplete_plan_artifact
+        @finalize_missing_pr_md = finalize_missing_pr_md
+        @finalize_missing_pr_url = finalize_missing_pr_url
+        @finalize_pr_url_mismatch = finalize_pr_url_mismatch
+        @legacy_execute_findings = legacy_execute_findings
+        @stale_agent_reason = stale_agent_reason
+        @state_file_mtime = state_file_mtime
+        @agent_marker_grace_sec = agent_marker_grace_sec
+        @project_name = project_name
+        @project_count = project_count
+      end
+
+      def to_h
+        synthesized = synthetic_stale_agent_diagnostic
+        return synthesized if synthesized
+        return nil unless diagnostic_action?
+
+        artifacts = diagnostic_artifacts.select { |path| safe_diagnostic_artifact?(path) }
+        primary = incomplete_plan_artifact? ? nil : artifacts.first
+        updated_at = diagnostic_updated_at(primary)
+        detail = primary ? artifact_detail(primary) : marker_detail
+
+        {
+          "summary" => truncate(redact(marker_summary), SUMMARY_MAX),
+          "detail" => truncate(redact(detail), DETAIL_MAX),
+          "source" => primary ? "artifact" : "marker",
+          "source_path" => primary,
+          "artifact_paths" => artifacts.uniq.first(ARTIFACT_PATHS_MAX),
+          "generated_by" => diagnostic_generated_by(primary),
+          "marker_signature" => marker_signature,
+          "suggested_next_action" => suggested_next_action_payload,
+          "updated_at" => updated_at.utc.iso8601
+        }
+      end
+
+      def next_action
+        return nil unless execute_waiting_input?
+
+        Hive::ExecuteWaitingAction.build(task, marker, rerun_with: rerun_command)
+      end
+
+      private
+
+      attr_reader :task, :marker, :rerun_command
+
+      # Synthesized purely from liveness signal — the on-disk marker is still
+      # AGENT_WORKING (no artifact, no diagnosis pass), so the normal
+      # diagnostic_artifacts pipeline has nothing to chew on. Once the
+      # daemon's StaleAgentHealer rewrites the marker to ERROR reason=..., the
+      # generic_error_artifacts path takes over and this shape is no longer
+      # produced.
+      def synthetic_stale_agent_diagnostic
+        reason = @stale_agent_reason
+        return nil unless reason
+
+        {
+          "summary" => stale_agent_summary(reason),
+          "detail" => "AGENT_WORKING marker is stale. The daemon's StaleAgentHealer will rewrite it to ERROR reason=#{reason} on its next tick (typically within 30 seconds). Once healed, re-read `hive status --json` or use the standard red-status flow, then run the reported suggested_next_action.command so the current ERROR marker guard is included. If the daemon is not running, start it with `systemctl --user start hive-daemon` (or your platform equivalent).",
+          "source" => "marker",
+          "source_path" => nil,
+          "artifact_paths" => [],
+          "generated_by" => "local",
+          "marker_signature" => marker_signature,
+          "suggested_next_action" => suggested_next_action_payload,
+          "updated_at" => Time.now.utc.iso8601
+        }
+      end
+
+      def stale_agent_summary(reason)
+        case reason
+        when :agent_died
+          recorded_pid = marker.attrs["pid"]
+          if recorded_pid && !recorded_pid.empty?
+            "agent process not alive (recorded pid=#{recorded_pid})"
+          else
+            "agent process not alive"
+          end
+        when :agent_orphaned
+          age_min = ((Time.now - @state_file_mtime) / 60).to_i
+          "agent never attached (marker placeholder is #{age_min} min old)"
+        end
+      end
+
+      # The diagnostic shape exists for ALL three recovery action keys per
+      # ADR-027 and wiki/commands/status.md — recover_review, error, AND
+      # recover_execute (EXECUTE_STALE). The TUI's red_status_detail view
+      # renders all three under a unified [Enter] Recover / [o] Open in agent
+      # contract; recover_execute rows surface the Risk-#3 mitigation flash
+      # when [Enter] Recover is pressed (no auto-retry recipe), then the
+      # screen closes. Bot, daemon, and external `--json` consumers also rely
+      # on this field for EXECUTE_STALE rows the autofix path cannot resolve;
+      # emitting nil would defeat the diagnose-then-act feature for one of the
+      # three red states it covers.
+      def diagnostic_action?
+        %w[recover_execute recover_review error].include?(@action_key.to_s)
+      end
+
+      def diagnostic_artifacts
+        return latest_log_artifacts if incomplete_plan_artifact?
+        return fresh_diagnosis_artifact + execute_stale_artifacts if legacy_execute_findings?
+
+        case marker.name
+        when :review_error
+          fresh_diagnosis_artifact + review_error_artifacts
+        when :review_ci_stale
+          fresh_diagnosis_artifact + review_ci_artifacts
+        when :review_stale
+          fresh_diagnosis_artifact + review_stale_artifacts
+        when :execute_stale
+          fresh_diagnosis_artifact + execute_stale_artifacts
+        when :error
+          fresh_diagnosis_artifact + generic_error_artifacts
+        else
+          []
+        end
+      end
+
+      def fresh_diagnosis_artifact
+        path = task_artifact("diagnostics", "red-status.md")
+        return [] unless File.exist?(path)
+        return [] unless safe_diagnostic_artifact?(path)
+
+        metadata = diagnostic_frontmatter(path)
+        return [] unless trusted_diagnostic_generator?(metadata["generated_by"])
+        return [] unless metadata["marker_signature"].to_s == marker_signature
+        # marker_signature is SHA-256(marker_name + sorted_attr_pairs), so a
+        # red → green → same-shape red rotation cycle produces an identical
+        # signature across episodes. Without an ordering check the second
+        # episode would silently reuse the first's artifact. Compare mtimes:
+        # the state_file is touched on every marker rotation, so an artifact
+        # older than the state_file is from a previous episode. See #89.
+        return [] if artifact_predates_marker?(path)
+
+        [ path ]
+      end
+
+      def artifact_predates_marker?(artifact_path)
+        artifact_mtime = safe_mtime(artifact_path)
+        state_mtime = safe_mtime(task.state_file)
+        return false if artifact_mtime.nil? || state_mtime.nil?
+
+        artifact_mtime < state_mtime
+      end
+
+      def review_error_artifacts
+        pass = pass_suffix
+        phase = marker.attrs["phase"].to_s
+        reason = marker.attrs["reason"].to_s
+        paths = []
+        paths.concat(paths_from_marker_files)
+        paths << task_artifact("reviews", "errors-#{pass}.md") if pass
+        paths << task_artifact("reviews", "fix-guardrail-#{pass}.md") if pass && reason == "fix_guardrail"
+        paths << task_artifact("reviews", "escalations-#{pass}.md") if pass
+        paths.concat(review_phase_logs(phase, pass))
+        paths.concat(latest_log_artifacts)
+        paths
+      end
+
+      def review_ci_artifacts
+        [
+          task_artifact("reviews", "ci-blocked.md"),
+          *glob_task_artifacts("logs", "review-ci-fix-attempt*.log"),
+          *latest_log_artifacts
+        ]
+      end
+
+      def review_stale_artifacts
+        pass = pass_suffix
+        paths = []
+        paths << task_artifact("reviews", "escalations-#{pass}.md") if pass
+        paths.concat(glob_task_artifacts("reviews", "*-#{pass}.md")) if pass
+        paths.concat(latest_log_artifacts)
+        paths
+      end
+
+      # The previous-pass review files (the user needs to inspect findings the
+      # agent could not satisfy) plus the last few agent logs. Cap the
+      # review-md glob at the most recent entries by filename so a long-lived
+      # task with dozens of review files doesn't blow past the schema's
+      # artifact_paths maxItems.
+      def execute_stale_artifacts
+        review_md = glob_task_artifacts("reviews", "*.md").sort.last(3)
+        [ *review_md, *latest_log_artifacts ]
+      end
+
+      def generic_error_artifacts
+        [ *latest_log_artifacts, task.state_file ]
+      end
+
+      def review_phase_logs(phase, pass)
+        return [] unless pass
+
+        case phase
+        when "fix"
+          glob_task_artifacts("logs", "review-fix-pass#{pass}*.log")
+        when "triage"
+          glob_task_artifacts("logs", "review-triage-pass#{pass}*.log")
+        when "browser"
+          glob_task_artifacts("logs", "review-browser-pass#{pass}*.log")
+        when "reviewers"
+          glob_task_artifacts("logs", "review-*-pass#{pass}*.log")
+        else
+          []
+        end
+      end
+
+      def paths_from_marker_files
+        marker.attrs.fetch("files", "").to_s.split(/[,\s]+/).filter_map do |relative|
+          next if relative.empty? || relative.include?("..") || relative.start_with?("/")
+
+          File.join(task.folder, relative)
+        end
+      end
+
+      # Cap the candidate set (LOG_GLOB_CAP) before sorting by mtime so a
+      # long-lived task with 100+ retained logs doesn't pay an O(N) stat sweep
+      # on every status poll. The cap is the most recent N by filename-suffix
+      # timestamp (hive's log filenames embed an ISO timestamp), a good proxy
+      # for mtime ordering that avoids the stat. The final sort-by-mtime over
+      # the capped set still produces the freshest 3.
+      def latest_log_artifacts
+        candidates = log_dirs.flat_map { |dir| Dir[File.join(dir, "*.log")] }
+        return [] if candidates.empty?
+
+        head = candidates.sort.last(LOG_GLOB_CAP)
+        head.sort_by { |path| safe_mtime(path) || Time.at(0) }.last(3).reverse
+      end
+
+      def log_dirs
+        [
+          (task.log_dir if task.respond_to?(:log_dir)),
+          File.join(task.folder, "logs")
+        ].compact.uniq
+      end
+
+      def glob_task_artifacts(*parts)
+        Dir[task_artifact(*parts)]
+      end
+
+      def task_artifact(*parts)
+        File.join(task.folder, *parts)
+      end
+
+      def pass_suffix
+        raw = marker.attrs["pass"].to_s
+        return nil unless raw.match?(/\A[1-9]\d*\z/)
+
+        format("%02d", raw.to_i)
+      end
+
+      def marker_summary
+        return "PLAN_MISSING_OUTPUT" if incomplete_plan_artifact?
+        return "FINALIZE_MISSING_PR_MD" if finalize_missing_pr_md?
+        return "FINALIZE_MISSING_PR_URL" if finalize_missing_pr_url?
+        return "FINALIZE_PR_URL_MISMATCH" if finalize_pr_url_mismatch?
+
+        attrs = Hive::Markers.display_attrs(marker.attrs)
+                             .map { |key, value| "#{key}=#{value}" }.join(" ")
+        marker_name = marker.name.to_s.upcase
+        attrs.empty? ? marker_name : "#{marker_name} #{attrs}"
+      end
+
+      def marker_detail
+        if incomplete_plan_artifact?
+          return [
+            "PLAN_MISSING_OUTPUT",
+            "Plan is incomplete because #{task.state_file} is missing or empty.",
+            "Rerun the plan stage to regenerate plan.md."
+          ].join("\n")
+        end
+
+        if finalize_missing_pr_md?
+          return [
+            "FINALIZE_MISSING_PR_MD",
+            "Finalize cannot run because #{task.state_file} is missing.",
+            "Move the task back to 5-open-pr or recreate pr.md with pr_url frontmatter."
+          ].join("\n")
+        end
+
+        if finalize_missing_pr_url?
+          return [
+            "FINALIZE_MISSING_PR_URL",
+            "Finalize cannot archive because #{task.state_file} is missing pr_url metadata.",
+            "Repair pr.md or move the task back to 5-open-pr so the PR metadata can be recreated."
+          ].join("\n")
+        end
+
+        if finalize_pr_url_mismatch?
+          return [
+            "FINALIZE_PR_URL_MISMATCH",
+            "Finalize cannot archive because the COMPLETE marker pr_url does not match pr.md frontmatter.",
+            "Rerun finalize or repair pr.md so both PR URLs match."
+          ].join("\n")
+        end
+
+        if auto_commit_scope_failure?
+          return [
+            marker_summary,
+            "Hive rejected the fix-agent fallback commit because staged paths were outside review.fix.auto_commit.scope_check.",
+            "Inspect the listed files, remove or revert rejected worktree changes, or adjust review.fix.auto_commit.scope_check before clearing REVIEW_ERROR."
+          ].join("\n")
+        end
+
+        if auto_commit_signing_failure?
+          return [
+            marker_summary,
+            "Hive could not create the fix-agent fallback commit because commit signing policy or signing execution blocked it.",
+            "Inspect the worktree changes, manually commit or revert remaining changes, fix signing config or set review.fix.auto_commit.sign_policy to inherit/bypass/fail as appropriate, then clear REVIEW_ERROR and re-run."
+          ].join("\n")
+        end
+
+        if fix_status_check_failure?
+          return [
+            marker_summary,
+            "Hive could not read the task worktree Git status before or after running the review fix agent.",
+            "Repair the worktree or repository state, then clear REVIEW_ERROR and re-run the review."
+          ].join("\n")
+        end
+
+        [ marker_summary, "No diagnostic artifact was found under #{task.folder}." ].join("\n")
+      end
+
+      def artifact_detail(path)
+        "#{path}:\n#{tail_file(path)}"
+      rescue SystemCallError => e
+        "#{path}: #{e.class}: #{e.message}"
+      end
+
+      def tail_file(path)
+        raw = File.open(path, "rb") do |file|
+          begin
+            file.seek(-TAIL_BYTES, IO::SEEK_END)
+          rescue Errno::EINVAL
+            file.rewind
+          end
+          file.read.to_s
+        end
+        # Coerce to UTF-8 with invalid byte replacement so downstream redact /
+        # truncate / JSON.generate never raises Encoding::CompatibilityError on
+        # a binary log tail. A single corrupt byte in one task's log used to
+        # abort the entire `hive status --json` snapshot, breaking every
+        # downstream consumer (bot, daemon, TUI). See PR #84 review finding #4.
+        raw.encode("UTF-8", invalid: :replace, undef: :replace, replace: "?")
+      end
+
+      def diagnostic_updated_at(primary)
+        safe_mtime(primary) || safe_mtime(task.state_file) || Time.now
+      end
+
+      def diagnostic_generated_by(primary)
+        return "local" unless primary && File.basename(primary) == "red-status.md"
+
+        diagnostic_frontmatter(primary)["generated_by"].to_s.tap do |value|
+          return value unless value.empty?
+        end
+        "local"
+      end
+
+      # Scan up to FRONTMATTER_SCAN_BYTES of the artifact head looking for the
+      # closing `---` boundary. A fixed 4KB head used to silently parse
+      # frontmatter blocks larger than 4KB as empty (no closing match);
+      # widening the window to 16KB keeps the cost bounded while accepting
+      # real-world artifact frontmatter.
+      def diagnostic_frontmatter(path)
+        body = File.read(path, FRONTMATTER_SCAN_BYTES)
+        match = body.match(/\A---\n(.*?)\n---\n/m)
+        return {} unless match
+
+        parsed = YAML.safe_load(match[1], permitted_classes: [ Time ]) || {}
+        parsed.is_a?(Hash) ? parsed.transform_keys(&:to_s) : {}
+      rescue Psych::Exception, SystemCallError
+        {}
+      end
+
+      def trusted_diagnostic_generator?(name)
+        Hive::Schemas::DIAGNOSTIC_GENERATORS.include?(name.to_s)
+      end
+
+      def marker_signature
+        Hive::TaskAction.marker_signature(marker)
+      end
+
+      # Recovery hint surfaced inside the diagnostic JSON so agents and
+      # external consumers don't have to re-derive the next move from marker
+      # shape alone. `kind` mirrors the operator gesture:
+      #   - "retry" — Enter-in-detail-view runs the existing recover_review /
+      #     recover_error path, or a markerless synthetic-error direct rerun
+      #     such as PLAN_MISSING_OUTPUT; `command` is the copy-paste shell form.
+      #   - "manual_fix" — max_passes-hit REVIEW_STALE; the operator must edit
+      #     `reviews/escalations-NN.md` before retry. command stays null
+      #     because there's nothing safe to dispatch.
+      #   - "clear_marker" — reserved for future expansion; not yet emitted
+      #     because the in-tree heuristics route everything else through retry
+      #     or manual_fix.
+      def suggested_next_action_payload
+        return nil unless diagnostic_action?
+
+        return { "kind" => "retry", "command" => workflow_command("plan") } if incomplete_plan_artifact?
+
+        return manual_fix if finalize_missing_pr_md? || finalize_missing_metadata_error?
+        return manual_fix if finalize_missing_pr_url? || finalize_pr_url_mismatch?
+        return manual_fix if max_passes_review_stale_with_escalations?
+
+        # EXECUTE_STALE rows have no auto-retry recipe: the operator must
+        # review findings and either edit the worktree or lower the pass
+        # counter. Emit manual_fix with command:null instead of falling
+        # through to a nil payload so agents reading hive-status JSON see an
+        # explicit "do not auto-retry" signal rather than the absence of data.
+        # See PR #84 review finding #9.
+        return manual_fix if marker.name == :execute_stale || legacy_execute_findings?
+        return manual_fix if fix_status_check_failure?
+        return manual_fix if auto_commit_manual_failure?
+
+        # CleanExit's `ensure_clean_on_exit_failed` is operator-resolves-the-
+        # worktree territory: scope-violating or signing-failed residue needs
+        # human inspection. Emit `manual_fix` with `command:null` so polling
+        # agents see the explicit "do not auto-retry" signal (the bot's
+        # manual-only routing in `RecoverySequence` already refuses to dispatch
+        # a retry verb for this reason; the JSON payload mirrors that decision
+        # so CLI-driven consumers don't try to construct one themselves).
+        return manual_fix if clean_exit_manual_failure?
+
+        cmd = retry_command_string or return nil
+
+        { "kind" => "retry", "command" => cmd }
+      end
+
+      def manual_fix
+        { "kind" => "manual_fix", "command" => nil }
+      end
+
+      def max_passes_review_stale_with_escalations?
+        Hive::TaskAction.max_passes_review_stale_with_escalations?(
+          folder: task.folder, marker_name: marker.name, attrs: marker.attrs
+        )
+      end
+
+      # `hive markers clear` accepts --match-attr KEY=VALUE or comma-separated
+      # KEY=VALUE pairs; pick the most-identifying guard per marker shape. The
+      # recipe stays a copy-pasteable one-liner so external agents and humans
+      # can run it from a shell unchanged.
+      def retry_command_string
+        attrs = marker.attrs || {}
+        case marker.name
+        when :review_error, :review_ci_stale
+          attr_pair = priority_match_attr(attrs, %w[pass phase reason])
+          clear_argv = [ "hive", "markers", "clear", task.folder,
+                         "--name", marker.name.to_s.upcase, *attr_pair ]
+          "#{clear_argv.shelljoin} && #{[ 'hive', 'run', task.folder ].shelljoin}"
+        when :review_stale
+          attr_pair = priority_match_attr(attrs, %w[pass reason])
+          clear_argv = [ "hive", "markers", "clear", task.folder,
+                         "--name", "REVIEW_STALE", *attr_pair ]
+          "#{clear_argv.shelljoin} && #{[ 'hive', 'run', task.folder ].shelljoin}"
+        when :error
+          match_attr = Hive::Markers.error_recovery_match_attr(attrs)
+          attr_pair = match_attr ? [ "--match-attr", match_attr ] : []
+          clear_argv = [ "hive", "markers", "clear", task.folder,
+                         "--name", "ERROR", *attr_pair ]
+          "#{clear_argv.shelljoin} && #{[ 'hive', 'run', task.folder ].shelljoin}"
+        end
+      end
+
+      def priority_match_attr(attrs, keys)
+        keys.each do |key|
+          value = attrs[key]
+          return [ "--match-attr", "#{key}=#{value}" ] if value && !value.to_s.empty?
+        end
+        []
+      end
+
+      def workflow_command(verb)
+        parts = [ "hive", verb, task.slug ]
+        parts.concat([ "--project", @project_name ]) if @project_name && @project_count > 1
+        parts.concat([ "--from", stage_dir ])
+        parts.shelljoin
+      end
+
+      def stage_dir
+        "#{task.stage_index}-#{task.stage_name}"
+      end
+
+      def safe_mtime(path)
+        return nil if path.nil? || path.to_s.empty?
+
+        File.mtime(path)
+      rescue SystemCallError
+        nil
+      end
+
+      def safe_diagnostic_artifact?(path)
+        return false if path.nil? || path.to_s.empty? || !File.file?(path)
+
+        real = File.realpath(path)
+        diagnostic_roots.any? { |root| path_inside?(real, root) }
+      rescue Errno::ENOENT
+        false
+      rescue SystemCallError => e
+        # EACCES / ELOOP / ENAMETOOLONG / EIO: the artifact may exist but we
+        # cannot determine its realpath. Returning false silently invisibles a
+        # paid-for agent verdict (operator sees "no diagnostic available" while
+        # the file exists). Surface via $stderr so support threads have a
+        # breadcrumb; still return false so the local-marker fallback wins and
+        # the snapshot does not crash.
+        warn "[diagnose] cannot realpath #{path}: #{e.class}: #{e.message}"
+        false
+      end
+
+      def diagnostic_roots
+        # task.folder + any log_dirs are the legitimate roots an artifact may
+        # live under. We deliberately do NOT add a project_root containment
+        # filter: when .hive-state is a symlink to a separate volume (a
+        # legitimate deployment pattern), task.folder.realpath lands outside
+        # project_root.realpath and every diagnostic gets silently dropped. The
+        # symlink-escape guard is already provided by checking that the
+        # artifact's realpath is inside the (also realpath'd) task.folder /
+        # log_dir.
+        ([ task.folder ] + log_dirs).filter_map { |root| realpath_or_expand(root) }.uniq
+      end
+
+      def realpath_or_expand(path)
+        return nil if path.nil? || path.to_s.empty?
+
+        File.realpath(path)
+      rescue Errno::ENOENT
+        File.expand_path(path)
+      end
+
+      def path_inside?(path, root)
+        path == root || path.start_with?(root + File::SEPARATOR)
+      end
+
+      def redact(text)
+        Hive::SecretPatterns.redact(text)
+      end
+
+      def truncate(text, max)
+        return text if text.length <= max
+
+        "#{text[0, max - 1]}…"
+      end
+
+      def execute_waiting_input?
+        task.stage_name == "execute" &&
+          marker.name == :execute_waiting &&
+          !legacy_execute_findings?
+      end
+
+      def auto_commit_scope_failure?
+        marker.name == :review_error && marker.attrs["reason"].to_s == "fix_auto_commit_scope_failed"
+      end
+
+      def auto_commit_signing_failure?
+        marker.name == :review_error && %w[
+          fix_auto_commit_sign_policy_failed
+          fix_auto_commit_signing_failed
+        ].include?(marker.attrs["reason"].to_s)
+      end
+
+      def auto_commit_manual_failure?
+        marker.name == :review_error && AUTO_COMMIT_MANUAL_FAILURE_REASONS.include?(marker.attrs["reason"].to_s)
+      end
+
+      def fix_status_check_failure?
+        marker.name == :review_error &&
+          marker.attrs["reason"].to_s == FIX_STATUS_CHECK_MANUAL_FAILURE_REASON
+      end
+
+      # `:error reason=ensure_clean_on_exit_failed` is the CleanExit invariant
+      # refusing to auto-commit residue: either the staged paths fell outside
+      # `review.fix.auto_commit.scope_check`, or `git add` / `git commit` /
+      # `git status` failed or timed out. Operator must inspect the worktree
+      # before any retry; there is no safe automated command to dispatch.
+      def clean_exit_manual_failure?
+        marker.name == :error && marker.attrs["reason"].to_s == "ensure_clean_on_exit_failed"
+      end
+
+      def finalize_missing_metadata_error?
+        task.stage_name == "finalize" &&
+          marker.name == :error &&
+          %w[missing_pr_md missing_pr_url].include?(marker.attrs["reason"].to_s)
+      end
+
+      # The five state predicates below also drive action classification;
+      # TaskAction computes them once and passes the result in so this object
+      # and the classifier can never disagree about a (task, marker) pair.
+      def incomplete_plan_artifact? = @incomplete_plan_artifact
+      def finalize_missing_pr_md? = @finalize_missing_pr_md
+      def finalize_missing_pr_url? = @finalize_missing_pr_url
+      def finalize_pr_url_mismatch? = @finalize_pr_url_mismatch
+      def legacy_execute_findings? = @legacy_execute_findings
+    end
+  end
+end

--- a/lib/hive/workflow.rb
+++ b/lib/hive/workflow.rb
@@ -1,188 +1,111 @@
 module Hive
   Workflow = Data.define(:id, :stages) do
     def initialize(id:, stages:)
-      # Shallow dup+freeze: the element Stage objects stay shared with the
-      # caller, safe only because Stage is itself frozen. Don't add a mutable
-      # field to Stage on the assumption this dup deep-copies — it does not.
+      # Shallow freeze: the element Stages stay shared with the caller, which is
+      # safe only because Stage is itself frozen. This dup does NOT deep-copy.
       super(id: id, stages: stages.dup.freeze)
       validate_structure!
     end
   end
 
-  # Reopened (not redefined): nested Stage/AdvanceVerb constants must live in a
-  # class body so they resolve as Workflow::Stage — they can't be declared inside
-  # the Data.define block above.
+  # Reopened (not redefined) so the nested Stage/AdvanceVerb constants resolve as
+  # Workflow::Stage — Data.define's block can't host constant declarations.
   class Workflow
-    # Behaviorally significant stage kinds: `:agent` selects the agent runner,
-    # `:inert` auto-advances with no runner, `:marker` is a coding marker-gated
-    # stage, and `nil` is the unspecified default. A typo'd kind
-    # (`Stage.new(kind: :agnet)`) would otherwise construct cleanly and only
-    # strand the task at run time (Resolver raises StageError); the
-    # construction-time check below turns it into a load-time error.
+    include Enumerable
+
+    # :agent selects the agent runner, :inert auto-advances with no runner,
+    # :marker is a coding marker-gated stage, nil is the unspecified default.
     KNOWN_KINDS = [ nil, :agent, :inert, :marker ].freeze
 
-    # Structural invariants every "ordered, unique pipeline" consumer
-    # (next_stage_after, the VERBS derivation, validate_workflow_stage!)
-    # silently assumes but never enforces on its own. Checking them once at
-    # construction converts five runtime-stranding modes — empty stage list,
-    # gapped/unordered indices, duplicate names or dirs, an unknown kind, and a
-    # first stage that carries an advance_verb — into a single load-time
-    # ArgumentError at the descriptor that introduced the typo, instead of a
-    # mis-route far from the cause. Valid descriptors (coding + every test
-    # fixture) satisfy it with no behavior change.
-    def validate_structure!
-      raise ArgumentError, "workflow #{id.inspect} must declare at least one stage" if stages.empty?
+    def each(&) = stages.each(&)
 
-      indices = stages.map(&:index)
-      expected = (1..stages.length).to_a
-      unless indices == expected
-        raise ArgumentError,
-              "workflow #{id.inspect} stage indices must be #{expected.inspect} in order, got #{indices.inspect}"
-      end
+    def stage_named(name) = find { |stage| stage.name == name }
+    def stage_for_dir(dir) = find { |stage| stage.dir == dir }
 
-      names = stages.map(&:name)
-      unless names.uniq.length == names.length
-        raise ArgumentError, "workflow #{id.inspect} has duplicate stage names: #{names.inspect}"
-      end
-
-      dirs = stages.map(&:dir)
-      unless dirs.uniq.length == dirs.length
-        raise ArgumentError, "workflow #{id.inspect} has duplicate stage dirs: #{dirs.inspect}"
-      end
-
-      stages.each do |stage|
-        next if KNOWN_KINDS.include?(stage.kind)
-
-        raise ArgumentError,
-              "workflow #{id.inspect} stage #{stage.name.inspect} has unknown kind #{stage.kind.inspect} " \
-              "(known: #{KNOWN_KINDS.map(&:inspect).join(', ')})"
-      end
-
-      return if stages.first.advance_verb.nil?
-
-      raise ArgumentError,
-            "workflow #{id.inspect} first stage #{stages.first.name.inspect} must not declare an advance_verb " \
-            "(no stage precedes it to advance from)"
-    end
-    private :validate_structure!
-
-    # Soft lookup: returns the Stage or nil so callers can decide how to handle
-    # an unknown name (Task#validate_workflow_stage! raises its own message).
-    def stage_named(name)
-      stages.find { |stage| stage.name == name }
-    end
-
-    # Descriptor-scoped sequence lookup. Verb/sequence resolution is
-    # data-driven from the workflow descriptor; the coding-only TaskAction
-    # action map remains a separate bespoke gate.
-    #
-    # Soft lookup: returns nil for BOTH the terminal stage (no successor) and an
-    # unknown name. Callers can't distinguish the two from the return value — a
-    # typo'd `name` collapses into the same "no next stage" signal as the real
-    # final stage. The terminal-nil is handled differently per caller:
-    # Approve#resolve_destination raises FinalStageReached, while Run#next_stage_dir
-    # and New#call fall back to a `hive run` hint, and Approve#json_next_action
-    # emits a NO_OP/final_stage signal. All four callers (approve.rb
-    # resolve_destination + json_next_action, run.rb next_stage_dir, new.rb call)
-    # pass a `Task#validate_workflow_stage!`-validated `task.stage_name` or the
-    # descriptor's own `entry_stage.name`, so the unknown-name arm is unreachable
-    # on every live path today — it can only surface if a future caller feeds an
-    # unvalidated name.
+    # The next stage in sequence, or nil at the terminal stage. (An unknown name
+    # also folds into nil; every live caller passes a validated name, so only the
+    # terminal-nil arm is reachable today.)
     def next_stage_after(name)
-      index = stages.index { |stage| stage.name == name }
+      index = find_index { |stage| stage.name == name }
       index && stages[index + 1]
     end
 
-    # Returns the verb that ARRIVES AT this stage (the descriptor's inbound
-    # advance verb), not the verb that advances OUT of it — the bare name reads
-    # the opposite way.
-    # Soft lookup: nil means EITHER the stage advances by bare mv (no incoming
-    # verb in the descriptor) OR the name is unknown — both fold into one nil.
-    def advance_verb_for(name)
-      stage_named(name)&.advance_verb&.name
-    end
+    # The verb that ARRIVES AT this stage, not the one that advances out of it.
+    # nil means bare-mv advance (no inbound verb) or an unknown name.
+    def advance_verb_for(name) = stage_named(name)&.advance_verb&.name
 
-    # Soft lookup: returns nil if no stage has this dir.
-    def stage_for_dir(dir)
-      stages.find { |stage| stage.dir == dir }
-    end
+    # A full dir ("3-plan") or a short name ("plan") → the canonical Stage#dir, so
+    # callers (rename targets, commit messages) get the descriptor's dir.
+    def resolve_stage_ref(ref) = (stage_for_dir(ref) || stage_named(ref))&.dir
+    def has_stage?(ref) = !resolve_stage_ref(ref).nil?
 
-    # Accepts a full dir (`3-plan`) or a short name (`plan`) and returns the
-    # canonical `Stage#dir` (or nil if neither matches). Deriving the return from
-    # the matched Stage on both arms keeps the provenance workflow-canonical —
-    # callers (File.rename targets, commit messages) get the descriptor's dir,
-    # not the caller's raw string.
-    def resolve_stage_ref(ref)
-      (stage_for_dir(ref) || stage_named(ref))&.dir
-    end
-
-    def has_stage?(ref)
-      !resolve_stage_ref(ref).nil?
-    end
-
-    # Hard resolve: raises KeyError on an unknown name — used where a missing
-    # stage is a programmer error, not a recoverable condition.
+    # Hard resolve: a missing stage here is a programmer error, not recoverable.
+    # (Returns the matched stage's state_file verbatim — only an unknown NAME
+    # raises, matching the original; a found stage's nil state_file would not.)
     def state_file_for(name)
-      stage = stage_named(name)
-      return stage.state_file if stage
-
-      raise KeyError, "unknown stage #{name.inspect} for workflow #{id.inspect}"
+      stage = stage_named(name) or
+        raise KeyError, "unknown stage #{name.inspect} for workflow #{id.inspect}"
+      stage.state_file
     end
 
-    def stage_names
-      # Frozen to match the parallel frozen Task::STAGE_NAMES constant — a
-      # uniform immutability contract across both sources of truth. A fresh
-      # array is built each call, so freezing it is safe (callers don't mutate).
-      stages.map(&:name).freeze
-    end
-
-    def stage_dirs
-      # Frozen for the same reason as stage_names: a uniform immutability
-      # contract across descriptor-derived lists. A fresh array is built each
-      # call, so freezing it is safe (callers don't mutate).
-      stages.map(&:dir).freeze
-    end
+    # Frozen to match Task::STAGE_NAMES's immutability contract; a fresh array is
+    # built each call, so freezing it can't surprise a caller.
+    def stage_names = map(&:name).freeze
+    def stage_dirs = map(&:dir).freeze
 
     Stage = Data.define(
-      :name,
-      :index,
-      :state_file,
-      :advance_verb,
-      :kind,
-      :skill,
-      :instruction,
-      :permissions,
-      :status_mode,
-      :budget_usd,
-      :timeout_sec,
-      :capability
+      :name, :index, :state_file, :advance_verb, :kind, :skill, :instruction,
+      :permissions, :status_mode, :budget_usd, :timeout_sec, :capability
     ) do
-      def initialize(
-        name:,
-        index:,
-        state_file:,
-        advance_verb: nil,
-        kind: nil,
-        skill: nil,
-        instruction: nil,
-        permissions: nil,
-        status_mode: nil,
-        budget_usd: nil,
-        timeout_sec: nil,
-        capability: nil
-      )
+      def initialize(name:, index:, state_file:, advance_verb: nil, kind: nil,
+                     skill: nil, instruction: nil, permissions: nil,
+                     status_mode: nil, budget_usd: nil, timeout_sec: nil,
+                     capability: nil)
         super
       end
 
-      def dir
-        "#{index}-#{name}"
-      end
+      def dir = "#{index}-#{name}"
     end
 
     AdvanceVerb = Data.define(:name, :force_source, :interactive) do
-      def initialize(name:, force_source: false, interactive: false)
-        super
+      def initialize(name:, force_source: false, interactive: false) = super
+    end
+
+    private
+
+    # Turn five runtime-stranding modes — empty list, gapped/unordered indices,
+    # duplicate names or dirs, an unknown kind, and a leading advance_verb — into
+    # one load-time error at the descriptor that introduced the typo. Coding and
+    # every test fixture satisfy it with no behavior change.
+    def validate_structure!
+      raise ArgumentError, "workflow #{id.inspect} must declare at least one stage" if stages.empty?
+
+      expected = (1..stages.length).to_a
+      actual = map(&:index)
+      actual == expected or
+        raise ArgumentError,
+              "workflow #{id.inspect} stage indices must be #{expected.inspect} in order, got #{actual.inspect}"
+
+      reject_duplicates!(map(&:name), "stage names")
+      reject_duplicates!(map(&:dir), "stage dirs")
+
+      each do |stage|
+        KNOWN_KINDS.include?(stage.kind) or
+          raise ArgumentError,
+                "workflow #{id.inspect} stage #{stage.name.inspect} has unknown kind #{stage.kind.inspect} " \
+                "(known: #{KNOWN_KINDS.map(&:inspect).join(', ')})"
       end
+
+      stages.first.advance_verb.nil? or
+        raise ArgumentError,
+              "workflow #{id.inspect} first stage #{stages.first.name.inspect} must not declare an " \
+              "advance_verb (no stage precedes it to advance from)"
+    end
+
+    def reject_duplicates!(values, label)
+      return if values.uniq.length == values.length
+
+      raise ArgumentError, "workflow #{id.inspect} has duplicate #{label}: #{values.inspect}"
     end
   end
 end

--- a/lib/hive/workflow.rb
+++ b/lib/hive/workflow.rb
@@ -34,7 +34,7 @@ module Hive
     # nil means bare-mv advance (no inbound verb) or an unknown name.
     def advance_verb_for(name) = stage_named(name)&.advance_verb&.name
 
-    # A full dir ("3-plan") or a short name ("plan") → the canonical Stage#dir, so
+    # A full dir (`3-plan`) or a short name (`plan`) → the canonical Stage#dir, so
     # callers (rename targets, commit messages) get the descriptor's dir.
     def resolve_stage_ref(ref) = (stage_for_dir(ref) || stage_named(ref))&.dir
     def has_stage?(ref) = !resolve_stage_ref(ref).nil?

--- a/lib/hive/workflows/descriptor_parser.rb
+++ b/lib/hive/workflows/descriptor_parser.rb
@@ -4,7 +4,12 @@ require "hive/workflow"
 
 module Hive
   module Workflows
-    module DescriptorParser
+    # Parses + validates ONE owner-authored YAML workflow descriptor into a
+    # `Hive::Workflow`. An instance carries the source `@path` so every check
+    # can build a path-attributed `ConfigError` without threading it through
+    # each signature; `label:` (per-stage/field context) and `id:` (parsed
+    # mid-flight) stay as arguments because they vary within a single parse.
+    class DescriptorParser
       SAFE_SLUG = /\A[a-z0-9][a-z0-9-]*\z/
       TOP_LEVEL_KEYS = %w[id stages].freeze
       STAGE_KEYS = %w[
@@ -17,27 +22,34 @@ module Hive
         permissions
       ].freeze
 
-      module_function
+      def self.parse_file(path) = new(path).parse_file
+      def self.parse_hash(data, path:) = new(path).parse_hash(data)
 
-      def parse_file(path)
-        parsed = YAML.safe_load(File.read(path))
-        parse_hash(parsed, path: path)
+      def initialize(path)
+        @path = path
+      end
+
+      def parse_file
+        parsed = YAML.safe_load(File.read(@path))
+        parse_hash(parsed)
       rescue Psych::Exception => e
-        raise descriptor_error(path, "is not valid YAML: #{e.message}")
+        raise descriptor_error("is not valid YAML: #{e.message}")
       rescue SystemCallError, IOError => e
-        raise descriptor_error(path, "is not readable: #{e.message}")
+        raise descriptor_error("is not readable: #{e.message}")
       end
 
-      def parse_hash(data, path:)
-        descriptor = stringify_hash(data, path: path, label: "descriptor")
-        reject_unknown_keys!(descriptor, TOP_LEVEL_KEYS, path: path, label: "descriptor")
-        id = parse_id(descriptor["id"], path: path)
-        validate_filename_id!(id, path)
-        stages = parse_stages(descriptor["stages"], id: id, path: path)
-        validate_terminal_last_stage!(stages, path: path)
+      def parse_hash(data)
+        descriptor = stringify_hash(data, label: "descriptor")
+        reject_unknown_keys!(descriptor, TOP_LEVEL_KEYS, label: "descriptor")
+        id = parse_id(descriptor["id"])
+        validate_filename_id!(id)
+        stages = parse_stages(descriptor["stages"], id: id)
+        validate_terminal_last_stage!(stages)
 
-        build_workflow(id, stages, path: path)
+        build_workflow(id, stages)
       end
+
+      private
 
       # A project workflow's last stage must be terminal (kind: terminal →
       # :inert). `Hive::Workflows.all_terminal_stage_dirs` treats every workflow's
@@ -49,14 +61,13 @@ module Hive
       # inert; content's terminal stage is intentionally an agent), so the rule is
       # scoped to owner-authored YAML descriptors. Skip the empty case — Workflow.new
       # raises its own "at least one stage" error.
-      def validate_terminal_last_stage!(stages, path:)
+      def validate_terminal_last_stage!(stages)
         return if stages.empty?
 
         last = stages.last
         return if last.kind == :inert
 
         raise descriptor_error(
-          path,
           "last stage #{last.name.inspect} must be a terminal stage (kind: terminal); a task at the " \
           "final stage cannot advance, so a non-terminal last stage would be undroppable"
         )
@@ -71,53 +82,53 @@ module Hive
       # Wrapping the whole parse body (as before) would mislabel an unrelated
       # wrong-kwarg bug in a future Stage.new/Workflow.new signature change as a
       # descriptor error, hiding a genuine code bug from the maintainer.
-      def build_workflow(id, stages, path:)
+      def build_workflow(id, stages)
         Hive::Workflow.new(id: id.to_sym, stages: stages)
       rescue ArgumentError => e
-        raise descriptor_error(path, e.message)
+        raise descriptor_error(e.message)
       end
 
-      def parse_id(value, path:)
-        id = required_string(value, path: path, label: "id")
+      def parse_id(value)
+        id = required_string(value, label: "id")
         return id if SAFE_SLUG.match?(id)
 
-        raise descriptor_error(path, "id #{id.inspect} must match #{SAFE_SLUG.source}")
+        raise descriptor_error("id #{id.inspect} must match #{SAFE_SLUG.source}")
       end
 
-      def validate_filename_id!(id, path)
-        expected = File.basename(path, File.extname(path))
+      def validate_filename_id!(id)
+        expected = File.basename(@path, File.extname(@path))
         return if id == expected
 
-        raise descriptor_error(path, "id #{id.inspect} must match filename #{expected.inspect}")
+        raise descriptor_error("id #{id.inspect} must match filename #{expected.inspect}")
       end
 
-      def parse_stages(data, id:, path:)
+      def parse_stages(data, id:)
         unless data.is_a?(Array)
-          raise descriptor_error(path, "stages must be an array")
+          raise descriptor_error("stages must be an array")
         end
 
         data.each_with_index.map do |stage_data, offset|
-          parse_stage(stage_data, id: id, path: path, index: offset + 1)
+          parse_stage(stage_data, id: id, index: offset + 1)
         end
       end
 
-      def parse_stage(data, id:, path:, index:)
+      def parse_stage(data, id:, index:)
         label = "stage #{index}"
-        stage = stringify_hash(data, path: path, label: label)
-        reject_unknown_keys!(stage, STAGE_KEYS, path: path, label: label)
-        name = parse_stage_name(stage["name"], path: path, label: label)
-        kind = parse_kind(stage["kind"], path: path, label: label)
-        reject_agent_only_fields!(stage, kind: kind, path: path, label: label)
-        skill = optional_string(stage["skill"], path: path, label: "#{label} skill")
-        instruction = parse_instruction(stage["instruction"], path: path, label: label)
-        permissions = parse_permissions(stage, id: id, stage_name: name, path: path, label: label)
-        validate_agent_instruction!(skill: skill, instruction: instruction, path: path, label: label) if kind == :agent
+        stage = stringify_hash(data, label: label)
+        reject_unknown_keys!(stage, STAGE_KEYS, label: label)
+        name = parse_stage_name(stage["name"], label: label)
+        kind = parse_kind(stage["kind"], label: label)
+        reject_agent_only_fields!(stage, kind: kind, label: label)
+        skill = optional_string(stage["skill"], label: "#{label} skill")
+        instruction = parse_instruction(stage["instruction"], label: label)
+        permissions = parse_permissions(stage, id: id, stage_name: name, label: label)
+        validate_agent_instruction!(skill: skill, instruction: instruction, label: label) if kind == :agent
 
         Hive::Workflow::Stage.new(
           name: name,
           index: index,
-          state_file: parse_state_file(stage["state_file"], path: path, label: label),
-          advance_verb: parse_advance_verb(stage, name: name, index: index, path: path, label: label),
+          state_file: parse_state_file(stage["state_file"], label: label),
+          advance_verb: parse_advance_verb(stage, name: name, index: index, label: label),
           kind: kind,
           skill: skill,
           instruction: instruction,
@@ -125,11 +136,11 @@ module Hive
         )
       end
 
-      def parse_stage_name(value, path:, label:)
-        name = required_string(value, path: path, label: "#{label} name")
+      def parse_stage_name(value, label:)
+        name = required_string(value, label: "#{label} name")
         return name if SAFE_SLUG.match?(name)
 
-        raise descriptor_error(path, "#{label} name #{name.inspect} must match #{SAFE_SLUG.source}")
+        raise descriptor_error("#{label} name #{name.inspect} must match #{SAFE_SLUG.source}")
       end
 
       # `state_file` is joined onto `task.folder` at run time
@@ -145,55 +156,54 @@ module Hive
       # all use bare basenames (idea.md, work.md, …), so this matches the contract
       # the rest of the runner assumes and removes the nested-dir fragility in the
       # agent runner's output path.
-      def parse_state_file(value, path:, label:)
-        file = required_string(value, path: path, label: "#{label} state_file")
+      def parse_state_file(value, label:)
+        file = required_string(value, label: "#{label} state_file")
         return file if file == File.basename(file) && ![ ".", ".." ].include?(file)
 
         raise descriptor_error(
-          path,
           "#{label} state_file #{file.inspect} must be a bare filename inside the task folder " \
           "(no '/' path separator, not '.' or '..'); built-in stages use basenames like 'idea.md'"
         )
       end
 
-      def parse_kind(value, path:, label:)
-        raw = required_string(value, path: path, label: "#{label} kind")
+      def parse_kind(value, label:)
+        raw = required_string(value, label: "#{label} kind")
         case raw
         when "agent" then :agent
         when "terminal" then :inert
         when "council"
-          raise descriptor_error(path, "#{label} kind 'council' is not yet supported (reserved for a future release)")
+          raise descriptor_error("#{label} kind 'council' is not yet supported (reserved for a future release)")
         else
-          raise descriptor_error(path, "#{label} kind #{raw.inspect} must be agent or terminal")
+          raise descriptor_error("#{label} kind #{raw.inspect} must be agent or terminal")
         end
       end
 
-      def parse_instruction(value, path:, label:)
-        raw = optional_string(value, path: path, label: "#{label} instruction")
+      def parse_instruction(value, label:)
+        raw = optional_string(value, label: "#{label} instruction")
         return nil if raw.nil?
 
-        resolved = File.expand_path(raw, File.dirname(path))
+        resolved = File.expand_path(raw, File.dirname(@path))
         return resolved if File.file?(resolved) && File.readable?(resolved)
 
-        raise descriptor_error(path, "#{label} instruction #{raw.inspect} must reference a readable file (#{resolved})")
+        raise descriptor_error("#{label} instruction #{raw.inspect} must reference a readable file (#{resolved})")
       end
 
-      def parse_permissions(stage, id:, stage_name:, path:, label:)
+      def parse_permissions(stage, id:, stage_name:, label:)
         return nil unless stage.key?("permissions")
 
         value = stage["permissions"]
         Hive::PermissionScope.validate!(value, stage: "#{id}.#{stage_name}")
         deep_freeze(value)
       rescue Hive::ConfigError => e
-        raise descriptor_error(path, "#{label} #{e.message}")
+        raise descriptor_error("#{label} #{e.message}")
       end
 
-      def parse_advance_verb(stage, name:, index:, path:, label:)
+      def parse_advance_verb(stage, name:, index:, label:)
         return nil if index == 1 && !stage.key?("advance_verb")
 
         verb_name =
           if stage.key?("advance_verb")
-            optional_string(stage["advance_verb"], path: path, label: "#{label} advance_verb")
+            optional_string(stage["advance_verb"], label: "#{label} advance_verb")
           else
             name
           end
@@ -208,61 +218,60 @@ module Hive
       # trap. Reject them at parse time (fail-fast, consistent with the parser's
       # other strict checks) so a typo'd-kind or misplaced field surfaces at load
       # rather than vanishing at run time.
-      def reject_agent_only_fields!(stage, kind:, path:, label:)
+      def reject_agent_only_fields!(stage, kind:, label:)
         return if kind == :agent
 
         present = %w[skill instruction permissions].select { |key| stage.key?(key) }
         return if present.empty?
 
         raise descriptor_error(
-          path,
           "#{label} #{present.inspect} #{present.one? ? 'is' : 'are'} only valid on an agent stage " \
           "(kind: agent), not a #{stage['kind'].inspect} stage"
         )
       end
 
-      def validate_agent_instruction!(skill:, instruction:, path:, label:)
+      def validate_agent_instruction!(skill:, instruction:, label:)
         # Exactly one of skill/instruction must be present. `optional_string`
         # already normalized blanks to nil, so `compact.one?` reads more
         # plainly than an XOR over the two `nil?` results.
         return if [ skill, instruction ].compact.one?
 
-        raise descriptor_error(path, "#{label} agent stages must declare exactly one of skill or instruction")
+        raise descriptor_error("#{label} agent stages must declare exactly one of skill or instruction")
       end
 
-      def stringify_hash(data, path:, label:)
+      def stringify_hash(data, label:)
         unless data.is_a?(Hash)
-          raise descriptor_error(path, "#{label} must be a map")
+          raise descriptor_error("#{label} must be a map")
         end
 
         data.each_with_object({}) do |(key, value), out|
           unless key.is_a?(String) || key.is_a?(Symbol)
-            raise descriptor_error(path, "#{label} contains non-string key #{key.inspect}")
+            raise descriptor_error("#{label} contains non-string key #{key.inspect}")
           end
 
           out[key.to_s] = value
         end
       end
 
-      def reject_unknown_keys!(data, allowed, path:, label:)
+      def reject_unknown_keys!(data, allowed, label:)
         unknown = data.keys - allowed
         return if unknown.empty?
 
-        raise descriptor_error(path, "#{label} contains unknown key(s) #{unknown.inspect}")
+        raise descriptor_error("#{label} contains unknown key(s) #{unknown.inspect}")
       end
 
-      def required_string(value, path:, label:)
-        string = optional_string(value, path: path, label: label)
+      def required_string(value, label:)
+        string = optional_string(value, label: label)
         return string unless string.nil?
 
-        raise descriptor_error(path, "#{label} must be a non-empty string")
+        raise descriptor_error("#{label} must be a non-empty string")
       end
 
-      def optional_string(value, path:, label:)
+      def optional_string(value, label:)
         return nil if value.nil?
         return value.strip if value.is_a?(String) && !value.strip.empty?
 
-        raise descriptor_error(path, "#{label} must be a non-empty string")
+        raise descriptor_error("#{label} must be a non-empty string")
       end
 
       def deep_freeze(value)
@@ -276,8 +285,8 @@ module Hive
         end
       end
 
-      def descriptor_error(path, message)
-        Hive::ConfigError.new("workflow descriptor #{path}: #{message}")
+      def descriptor_error(message)
+        Hive::ConfigError.new("workflow descriptor #{@path}: #{message}")
       end
     end
   end

--- a/test/unit/task_action_test.rb
+++ b/test/unit/task_action_test.rb
@@ -28,6 +28,13 @@ class TaskActionTest < Minitest::Test
     Marker.new(name: name, attrs: attrs, raw: nil)
   end
 
+  # The diagnostics concern lives in Hive::TaskAction::Diagnostic. Build it the
+  # way the classifier does so the predicate context it receives matches
+  # production exactly.
+  def diagnostic_for(task, marker, **)
+    Hive::TaskAction.for(task, marker, **).send(:diagnostic_builder)
+  end
+
   # ── classification matrix ─────────────────────────────────────────────
 
   def test_inbox_marker_waiting_is_ready_to_brainstorm
@@ -764,7 +771,7 @@ class TaskActionTest < Minitest::Test
       # the middle of the credential — pre-redaction truncation would
       # leave the leading half intact in the emitted summary.
       gh_token = "ghp_#{'A' * 40}"
-      summary_max = Hive::TaskAction::DIAGNOSTIC_SUMMARY_MAX
+      summary_max = Hive::TaskAction::Diagnostic::SUMMARY_MAX
       # The marker_summary is "REVIEW_ERROR phase=fix pass=4 reason=<padding><token>".
       # We need the cut point to fall inside the token bytes — choose a
       # padding that leaves the token spanning the cut.
@@ -1265,29 +1272,29 @@ class TaskActionTest < Minitest::Test
       reviewer = File.join(logs, "review-claude-pass03.log")
       File.write(browser, "browser log\n")
       File.write(reviewer, "reviewer log\n")
-      action = Hive::TaskAction.for(task, marker(:review_error, "pass" => "3"))
+      diagnostic = diagnostic_for(task, marker(:review_error, "pass" => "3"))
 
-      assert_equal [ browser ], action.send(:review_phase_logs, "browser", "03")
-      assert_equal [ browser, reviewer ].sort, action.send(:review_phase_logs, "reviewers", "03").sort
-      assert_empty action.send(:review_phase_logs, "unknown", "03")
+      assert_equal [ browser ], diagnostic.send(:review_phase_logs, "browser", "03")
+      assert_equal [ browser, reviewer ].sort, diagnostic.send(:review_phase_logs, "reviewers", "03").sort
+      assert_empty diagnostic.send(:review_phase_logs, "unknown", "03")
     end
   end
 
   def test_paths_from_marker_files_filters_unsafe_entries
     task = fake_task(stage_name: "review", stage_index: 6)
-    action = Hive::TaskAction.for(
+    diagnostic = diagnostic_for(
       task,
       marker(:review_error, "files" => "reviews/a.md ../escape /tmp/rooted logs/b.log")
     )
 
     assert_equal [ File.join(task.folder, "reviews/a.md"), File.join(task.folder, "logs/b.log") ],
-                 action.send(:paths_from_marker_files)
+                 diagnostic.send(:paths_from_marker_files)
   end
 
   def test_artifact_detail_reports_read_errors
     task = fake_task(stage_name: "review", stage_index: 6)
-    action = Hive::TaskAction.for(task, marker(:review_error))
-    detail = action.send(:artifact_detail, File.join(task.folder, "missing.md"))
+    diagnostic = diagnostic_for(task, marker(:review_error))
+    detail = diagnostic.send(:artifact_detail, File.join(task.folder, "missing.md"))
 
     assert_includes detail, "Errno::ENOENT"
   end
@@ -1298,9 +1305,9 @@ class TaskActionTest < Minitest::Test
       path = File.join(task.folder, "diagnostics", "red-status.md")
       FileUtils.mkdir_p(File.dirname(path))
       File.write(path, "---\nmarker_signature: abc\n---\nbody\n")
-      action = Hive::TaskAction.for(task, marker(:review_error))
+      diagnostic = diagnostic_for(task, marker(:review_error))
 
-      assert_equal "local", action.send(:diagnostic_generated_by, path)
+      assert_equal "local", diagnostic.send(:diagnostic_generated_by, path)
     end
   end
 
@@ -1310,10 +1317,10 @@ class TaskActionTest < Minitest::Test
       path = File.join(task.folder, "diagnostics", "red-status.md")
       FileUtils.mkdir_p(File.dirname(path))
       File.write(path, "---\n: bad\n---\nbody\n")
-      action = Hive::TaskAction.for(task, marker(:review_error))
+      diagnostic = diagnostic_for(task, marker(:review_error))
 
-      assert_equal({}, action.send(:diagnostic_frontmatter, path))
-      assert_equal({}, action.send(:diagnostic_frontmatter, File.join(task.folder, "missing.md")))
+      assert_equal({}, diagnostic.send(:diagnostic_frontmatter, path))
+      assert_equal({}, diagnostic.send(:diagnostic_frontmatter, File.join(task.folder, "missing.md")))
     end
   end
 
@@ -1519,27 +1526,27 @@ class TaskActionTest < Minitest::Test
 
   def test_private_path_helpers_cover_missing_and_empty_inputs
     task = fake_task(stage_name: "review", stage_index: 6)
-    action = Hive::TaskAction.for(task, marker(:review_error))
+    diagnostic = diagnostic_for(task, marker(:review_error))
 
-    assert_nil action.send(:realpath_or_expand, nil)
+    assert_nil diagnostic.send(:realpath_or_expand, nil)
     assert_equal File.expand_path(File.join(task.folder, "missing")),
-                 action.send(:realpath_or_expand, File.join(task.folder, "missing"))
+                 diagnostic.send(:realpath_or_expand, File.join(task.folder, "missing"))
   end
 
   def test_safe_diagnostic_artifact_handles_realpath_failures
     task = fake_task(stage_name: "review", stage_index: 6)
-    action = Hive::TaskAction.for(task, marker(:review_error))
+    diagnostic = diagnostic_for(task, marker(:review_error))
     original_file = File.method(:file?)
     original_realpath = File.method(:realpath)
 
     with_replaced_singleton_method(File, :file?, ->(_path) { true }) do
       with_replaced_singleton_method(File, :realpath, ->(_path) { raise Errno::ENOENT }) do
-        refute action.send(:safe_diagnostic_artifact?, File.join(task.folder, "gone.md"))
+        refute diagnostic.send(:safe_diagnostic_artifact?, File.join(task.folder, "gone.md"))
       end
 
       with_replaced_singleton_method(File, :realpath, ->(_path) { raise Errno::EACCES }) do
         _out, err = capture_io do
-          refute action.send(:safe_diagnostic_artifact?, File.join(task.folder, "blocked.md"))
+          refute diagnostic.send(:safe_diagnostic_artifact?, File.join(task.folder, "blocked.md"))
         end
         assert_includes err, "cannot realpath"
       end


### PR DESCRIPTION
Stacked on #562. Iterative, behavior-preserving refactor of the workflow-as-data architecture toward idiomatic, expressive Ruby (DHH / Kieran-Klassen sensibility) — each step live-tested + autoreviewed. Tracking in `/tmp/refactor-multi-worflow.md`.

## S1 — `workflow.rb` (188→120)
Crispened the central `Workflow`/`Stage` value objects: stripped *what*-comments (kept *why*), endless defs, `Enumerable` over stages, extracted `reject_duplicates!`, kept `Data` structural `==` (no gratuitous `Comparable`). Workflow/coding/content tests green, rubocop clean, live exercise of the real coding descriptor green. Autoreview (simplicity): "idiomatic, behavior-preserving, ship it."

More steps to follow (S2: decompose the 1212-line `task_action.rb` — extract the diagnostics collaborator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)