### PR TITLE
fix(drop): accept a bare numeric task id

### DIFF
--- a/lib/hive/commands/drop.rb
+++ b/lib/hive/commands/drop.rb
@@ -75,7 +75,7 @@ module Hive
       end
 
       def resolve_context
-        path_target? ? resolve_path_context : resolve_slug_context
+        (path_target? || numeric_target?) ? resolve_path_context : resolve_slug_context
       end
 
       # Slugs match Stages::SLUG_RE — any /, ~, or . means a path.
@@ -84,6 +84,14 @@ module Hive
         @target.to_s.include?("/") || @target.to_s.start_with?("~", ".")
       end
 
+      # An all-digits target is unambiguously a task id: Stages::SLUG_RE
+      # requires a leading lowercase letter, so no slug can be all digits.
+      def numeric_target?
+        @target.to_s.match?(/\A\d+\z/)
+      end
+
+      # Path/id targets flow through TaskResolver so path validation and
+      # numeric-id lookup stay shared with run/approve/findings.
       def resolve_path_context
         task = Hive::TaskResolver.new(
           @target,
@@ -103,7 +111,7 @@ module Hive
           [ active_stage_dirs, archive_stage_dirs ]
         end
         folders = collect_stage_folders(task.hive_state_path, task.slug, active_dirs)
-        # Mirror resolve_slug_context: if the path target landed on the
+        # Mirror resolve_slug_context: if the path/id target landed on the
         # archive stage (no active folders, but the archive folder exists)
         # surface the archive match so guard_archived! refuses cleanly
         # instead of silently dropping nothing.

--- a/lib/hive/commands/drop.rb
+++ b/lib/hive/commands/drop.rb
@@ -86,6 +86,13 @@ module Hive
 
       # An all-digits target is unambiguously a task id: Stages::SLUG_RE
       # requires a leading lowercase letter, so no slug can be all digits.
+      #
+      # This /\A\d+\z/ predicate is duplicated, deliberately, in
+      # TaskResolver#numeric_target? and the two MUST stay in lockstep: Drop
+      # uses it to route a target onto the resolver path *before* it can build
+      # the resolver, so a shared instance method isn't reachable here. If the
+      # rule ever changes (signs, base, width caps), change BOTH — otherwise a
+      # target routes one way here and resolves the other way there.
       def numeric_target?
         @target.to_s.match?(/\A\d+\z/)
       end
@@ -111,10 +118,14 @@ module Hive
           [ active_stage_dirs, archive_stage_dirs ]
         end
         folders = collect_stage_folders(task.hive_state_path, task.slug, active_dirs)
-        # Mirror resolve_slug_context: if the path/id target landed on the
-        # archive stage (no active folders, but the archive folder exists)
-        # surface the archive match so guard_archived! refuses cleanly
-        # instead of silently dropping nothing.
+        # Same outcome as resolve_slug_context, inverted mechanism: if the
+        # path/id target landed on the archive stage (no active folders, but the
+        # archive folder exists) surface the archive match so guard_archived!
+        # refuses cleanly instead of silently dropping nothing. Here that's an
+        # explicit empty-active fallback (collect against archive_dirs only when
+        # `folders` came back empty); resolve_slug_context reaches the same end
+        # by *not rejecting* the archive folders when no active ones remain
+        # (see 189-192).
         if folders.empty?
           archived = collect_stage_folders(task.hive_state_path, task.slug, archive_dirs)
           folders = archived unless archived.empty?

--- a/lib/hive/commands/drop.rb
+++ b/lib/hive/commands/drop.rb
@@ -125,7 +125,7 @@ module Hive
         # explicit empty-active fallback (collect against archive_dirs only when
         # `folders` came back empty); resolve_slug_context reaches the same end
         # by *not rejecting* the archive folders when no active ones remain
-        # (see 189-192).
+        # (the `@stage_filter.nil?` keep-archive branch in resolve_slug_context).
         if folders.empty?
           archived = collect_stage_folders(task.hive_state_path, task.slug, archive_dirs)
           folders = archived unless archived.empty?

--- a/lib/hive/task_resolver.rb
+++ b/lib/hive/task_resolver.rb
@@ -67,6 +67,9 @@ module Hive
       @target.include?("/") || @target.start_with?("~", ".")
     end
 
+    # Mirrors Hive::Commands::Drop#numeric_target? — keep this /\A\d+\z/ rule in
+    # lockstep with that one (Drop routes onto the resolver path before it can
+    # reach this method, so the predicate is duplicated rather than shared).
     def numeric_target?
       @target.to_s.match?(/\A\d+\z/)
     end

--- a/lib/hive/task_resolver.rb
+++ b/lib/hive/task_resolver.rb
@@ -6,10 +6,11 @@ require "hive/workflows"
 require "hive/workflows/project"
 
 module Hive
-  # Resolve a CLI TARGET (folder path or bare slug) to a `Hive::Task`.
-  # Shared between the agent-callable commands (`approve`, `findings`,
-  # `accept-finding`, `reject-finding`) so the slug-lookup, ambiguity,
-  # realpath, and `--project` mismatch rules are defined in one place.
+  # Resolve a CLI TARGET (folder path, bare slug, or numeric task id) to a
+  # `Hive::Task`. Shared between the agent-callable commands (`approve`,
+  # `findings`, `accept-finding`, `reject-finding`, and `drop` for its numeric-id
+  # targets) so the slug-lookup, numeric-id, ambiguity, realpath, and `--project`
+  # mismatch rules are defined in one place.
   #
   # Resolution rules:
   #   - path-shaped (`/`, `~/`, `./`) → expanded + realpath'd; refused if

--- a/test/integration/drop_command_test.rb
+++ b/test/integration/drop_command_test.rb
@@ -4,6 +4,7 @@ require "open3"
 require "hive/config"
 require "hive/git_ops"
 require "hive/task"
+require "hive/task_meta"
 
 class DropCommandIntegrationTest < Minitest::Test
   include HiveTestHelper
@@ -21,11 +22,33 @@ class DropCommandIntegrationTest < Minitest::Test
     end
   end
 
+  def with_two_cli_projects
+    with_tmp_global_config do |home|
+      with_tmp_git_repo do |dir1|
+        with_tmp_git_repo do |dir2|
+          Hive::GitOps.new(dir1).hive_state_init
+          Hive::GitOps.new(dir2).hive_state_init
+          project1 = "project-one"
+          project2 = "project-two"
+          Hive::Config.register_project(name: project1, path: dir1)
+          Hive::Config.register_project(name: project2, path: dir2)
+          yield(home, dir1, project1, dir2, project2)
+        end
+      end
+    end
+  end
+
   def create_task(dir, stage, slug)
     folder = File.join(dir, ".hive-state", "stages", stage, slug)
     FileUtils.mkdir_p(folder)
     state_name = Hive::Task::STATE_FILES.fetch(stage.split("-", 2).last)
     File.write(File.join(folder, state_name), "# #{slug}\n<!-- WAITING -->\n")
+    folder
+  end
+
+  def create_task_with_id(dir, stage, slug, id)
+    folder = create_task(dir, stage, slug)
+    Hive::TaskMeta.write(folder, id: id, slug: slug, display_name: nil)
     folder
   end
 
@@ -72,6 +95,62 @@ class DropCommandIntegrationTest < Minitest::Test
       assert_equal Hive::ExitCodes::USAGE, status.exitstatus
       assert_equal "already_archived", JSON.parse(out)["error_kind"]
       assert File.directory?(folder)
+    end
+  end
+
+  def test_bin_hive_drop_numeric_id_removes_task_and_emits_json
+    with_cli_project do |home, dir, project|
+      slug = "id-drop-260622-aaaa"
+      folder = create_task_with_id(dir, "2-brainstorm", slug, 7448)
+
+      out, err, status = run_hive(home, "drop", "7448", "--project", project, "--json")
+
+      assert status.success?, err
+      payload = JSON.parse(out)
+      assert_equal "hive-drop", payload["schema"]
+      assert_equal slug, payload["slug"]
+      assert_equal [ "2-brainstorm" ], payload["from_stages"]
+      refute File.directory?(folder)
+    end
+  end
+
+  def test_bin_hive_drop_unknown_numeric_id_exits_usage_with_error_envelope
+    with_cli_project do |home, _dir, project|
+      out, _err, status = run_hive(home, "drop", "9999", "--project", project, "--json")
+
+      refute status.success?
+      assert_equal Hive::ExitCodes::USAGE, status.exitstatus
+      payload = JSON.parse(out)
+      assert_equal "invalid_task_path", payload["error_kind"]
+      assert_includes payload["message"], "no task folder for id 9999"
+    end
+  end
+
+  def test_bin_hive_drop_duplicate_numeric_id_requires_project_and_then_drops_selected_project
+    with_two_cli_projects do |home, dir1, project1, dir2, _project2|
+      slug1 = "duplicate-id-one-260622-aaaa"
+      slug2 = "duplicate-id-two-260622-aaaa"
+      folder1 = create_task_with_id(dir1, "2-brainstorm", slug1, 7448)
+      folder2 = create_task_with_id(dir2, "2-brainstorm", slug2, 7448)
+
+      out, _err, status = run_hive(home, "drop", "7448", "--json")
+
+      refute status.success?
+      assert_equal Hive::ExitCodes::USAGE, status.exitstatus
+      payload = JSON.parse(out)
+      assert_equal "ambiguous_slug", payload["error_kind"]
+      assert_includes payload["message"], "task id 7448 is duplicated"
+      assert File.directory?(folder1)
+      assert File.directory?(folder2)
+
+      out, err, status = run_hive(home, "drop", "7448", "--project", project1, "--json")
+
+      assert status.success?, err
+      payload = JSON.parse(out)
+      assert_equal slug1, payload["slug"]
+      assert_equal project1, payload["project"]
+      refute File.directory?(folder1)
+      assert File.directory?(folder2)
     end
   end
 end

--- a/test/integration/drop_command_test.rb
+++ b/test/integration/drop_command_test.rb
@@ -109,6 +109,7 @@ class DropCommandIntegrationTest < Minitest::Test
       payload = JSON.parse(out)
       assert_equal "hive-drop", payload["schema"]
       assert_equal slug, payload["slug"]
+      assert_equal project, payload["project"]
       assert_equal [ "2-brainstorm" ], payload["from_stages"]
       refute File.directory?(folder)
     end
@@ -123,6 +124,43 @@ class DropCommandIntegrationTest < Minitest::Test
       payload = JSON.parse(out)
       assert_equal "invalid_task_path", payload["error_kind"]
       assert_includes payload["message"], "no task folder for id 9999"
+    end
+  end
+
+  # Leading-zero numeric inputs are parsed with Ruby's Integer(), which reads a
+  # leading zero as octal. `010` therefore parses to decimal 8 (octal 010), so
+  # it does NOT resolve to the decimal id 10. Lock the current behavior: the
+  # id-10 task is preserved and drop refuses with invalid_task_path. (If the
+  # parse is ever switched to base-10, this test will flag the contract change.)
+  def test_bin_hive_drop_leading_zero_id_010_does_not_resolve_to_decimal_id_10
+    with_cli_project do |home, dir, project|
+      slug = "leading-zero-010-260622-aaaa"
+      folder = create_task_with_id(dir, "2-brainstorm", slug, 10)
+
+      out, _err, status = run_hive(home, "drop", "010", "--project", project, "--json")
+
+      refute status.success?, "drop 010 must not succeed against a decimal id-10 task"
+      assert_equal Hive::ExitCodes::USAGE, status.exitstatus
+      assert_equal "invalid_task_path", JSON.parse(out)["error_kind"]
+      assert File.directory?(folder), "id-10 task folder must survive `drop 010`"
+    end
+  end
+
+  # `08` is not a valid octal literal, so Integer("08") raises before any
+  # lookup. Lock the current behavior: drop fails with an internal-error
+  # envelope (exit 70) and drops nothing, rather than treating `08` as
+  # decimal id 8.
+  def test_bin_hive_drop_leading_zero_id_08_errors_and_preserves_task
+    with_cli_project do |home, dir, project|
+      slug = "leading-zero-08-260622-aaaa"
+      folder = create_task_with_id(dir, "2-brainstorm", slug, 8)
+
+      out, _err, status = run_hive(home, "drop", "08", "--project", project, "--json")
+
+      refute status.success?, "drop 08 must not succeed against a decimal id-8 task"
+      assert_equal Hive::ExitCodes::SOFTWARE, status.exitstatus
+      assert_equal "internal", JSON.parse(out)["error_kind"]
+      assert File.directory?(folder), "id-8 task folder must survive `drop 08`"
     end
   end
 

--- a/test/integration/drop_command_test.rb
+++ b/test/integration/drop_command_test.rb
@@ -102,6 +102,7 @@ class DropCommandIntegrationTest < Minitest::Test
     with_cli_project do |home, dir, project|
       slug = "id-drop-260622-aaaa"
       folder = create_task_with_id(dir, "2-brainstorm", slug, 7448)
+      assert File.directory?(folder), "task folder must exist before drop"
 
       out, err, status = run_hive(home, "drop", "7448", "--project", project, "--json")
 
@@ -188,6 +189,20 @@ class DropCommandIntegrationTest < Minitest::Test
       assert_equal slug, payload["slug"]
       assert_equal [ "2-brainstorm" ], payload["from_stages"]
       refute File.directory?(folder), "task folder must be removed when --from matches"
+
+      # A SHORT --from ref (`brainstorm`) must canonicalize to the same
+      # 2-brainstorm dir and route through the resolver stage_filter, so a fresh
+      # id drops by short ref exactly as the long-form ref above did.
+      slug_short = "id-from-short-260622-aaaa"
+      folder_short = create_task_with_id(dir, "2-brainstorm", slug_short, 7452)
+
+      out, err, status = run_hive(home, "drop", "7452", "--project", project, "--from", "brainstorm", "--json")
+
+      assert status.success?, err
+      payload = JSON.parse(out)
+      assert_equal slug_short, payload["slug"]
+      assert_equal [ "2-brainstorm" ], payload["from_stages"]
+      refute File.directory?(folder_short), "task folder must be removed when a short --from matches"
     end
   end
 
@@ -209,9 +224,10 @@ class DropCommandIntegrationTest < Minitest::Test
     end
   end
 
-  # Same id in two stages of ONE project hits the single-project
-  # id_ambiguity_message branch (distinct from the cross-project label). Drop
-  # must refuse with ambiguous_slug and leave both folders intact.
+  # Same id in two stages of ONE project routes through id_ambiguity_message,
+  # which — unlike the slug-side ambiguity_message — emits one fixed "task id <n>
+  # is duplicated" string regardless of project count. Drop must refuse with
+  # ambiguous_slug and leave both folders intact.
   def test_bin_hive_drop_duplicate_numeric_id_within_one_project_is_ambiguous
     with_cli_project do |home, dir, project|
       slug1 = "dup-one-stage-260622-aaaa"

--- a/test/integration/drop_command_test.rb
+++ b/test/integration/drop_command_test.rb
@@ -164,6 +164,73 @@ class DropCommandIntegrationTest < Minitest::Test
     end
   end
 
+  # `drop <id> --from STAGE` forwards the stage as a TaskResolver filter. A
+  # matching stage resolves and drops; a mismatched (but otherwise valid) stage
+  # narrows the id scan to a folder that doesn't hold the id, so it resolves to
+  # nothing and refuses with invalid_task_path (NOT wrong_stage — that exit-4
+  # contract is slug-only; see wiki/commands/drop.md).
+  def test_bin_hive_drop_id_with_from_stage_mismatch_refuses_then_match_drops
+    with_cli_project do |home, dir, project|
+      slug = "id-from-260622-aaaa"
+      folder = create_task_with_id(dir, "2-brainstorm", slug, 7449)
+
+      out, _err, status = run_hive(home, "drop", "7449", "--project", project, "--from", "3-plan", "--json")
+
+      refute status.success?, "id drop with a mismatched --from must not succeed"
+      assert_equal Hive::ExitCodes::USAGE, status.exitstatus
+      assert_equal "invalid_task_path", JSON.parse(out)["error_kind"]
+      assert File.directory?(folder), "task folder must survive a mismatched --from"
+
+      out, err, status = run_hive(home, "drop", "7449", "--project", project, "--from", "2-brainstorm", "--json")
+
+      assert status.success?, err
+      payload = JSON.parse(out)
+      assert_equal slug, payload["slug"]
+      assert_equal [ "2-brainstorm" ], payload["from_stages"]
+      refute File.directory?(folder), "task folder must be removed when --from matches"
+    end
+  end
+
+  # The id path reaches archived tasks through its own empty-active fallback
+  # (drop.rb resolve_path_context), a distinct branch from the slug path's
+  # guard. Dropping a 9-done task by id must still refuse with already_archived
+  # and leave the folder intact — never hard-delete a completed task by id.
+  def test_bin_hive_drop_archived_numeric_id_exits_usage_and_preserves_task
+    with_cli_project do |home, dir, project|
+      slug = "id-done-260622-aaaa"
+      folder = create_task_with_id(dir, "9-done", slug, 7450)
+
+      out, _err, status = run_hive(home, "drop", "7450", "--project", project, "--json")
+
+      refute status.success?, "dropping an archived task by id must not succeed"
+      assert_equal Hive::ExitCodes::USAGE, status.exitstatus
+      assert_equal "already_archived", JSON.parse(out)["error_kind"]
+      assert File.directory?(folder), "archived task folder must survive drop by id"
+    end
+  end
+
+  # Same id in two stages of ONE project hits the single-project
+  # id_ambiguity_message branch (distinct from the cross-project label). Drop
+  # must refuse with ambiguous_slug and leave both folders intact.
+  def test_bin_hive_drop_duplicate_numeric_id_within_one_project_is_ambiguous
+    with_cli_project do |home, dir, project|
+      slug1 = "dup-one-stage-260622-aaaa"
+      slug2 = "dup-two-stage-260622-aaaa"
+      folder1 = create_task_with_id(dir, "2-brainstorm", slug1, 7451)
+      folder2 = create_task_with_id(dir, "3-plan", slug2, 7451)
+
+      out, _err, status = run_hive(home, "drop", "7451", "--project", project, "--json")
+
+      refute status.success?, "a duplicate id within one project must not drop"
+      assert_equal Hive::ExitCodes::USAGE, status.exitstatus
+      payload = JSON.parse(out)
+      assert_equal "ambiguous_slug", payload["error_kind"]
+      assert_includes payload["message"], "task id 7451 is duplicated"
+      assert File.directory?(folder1), "first duplicate folder must survive"
+      assert File.directory?(folder2), "second duplicate folder must survive"
+    end
+  end
+
   def test_bin_hive_drop_duplicate_numeric_id_requires_project_and_then_drops_selected_project
     with_two_cli_projects do |home, dir1, project1, dir2, _project2|
       slug1 = "duplicate-id-one-260622-aaaa"

--- a/wiki/commands/drop.md
+++ b/wiki/commands/drop.md
@@ -13,6 +13,7 @@ tags: [command, task, cleanup, json, tui, web]
 
 ```
 hive drop my-task-260522-abcd
+hive drop 7448
 hive drop 7448 --project demo
 hive drop my-task-260522-abcd --project demo --from 4-execute
 hive drop /path/to/.hive-state/stages/4-execute/my-task-260522-abcd --json
@@ -43,6 +44,8 @@ Tasks at `9-done` are archive records — drop refuses them and leaves the folde
 
 `--from` only raises `wrong_stage` when the slug resolves unambiguously to a single project. For a cross-project slug collision with a mismatched `--from`, the user gets `ambiguous_slug` (or `invalid_task_path` when no project matches) — `--from` is asserted only after the project is pinned.
 
+The exit-4 `wrong_stage` contract is **slug-only**. For numeric-id (and path) targets, `--from` flows through [[modules/task_resolver]] as a stage *filter*, so a mismatched stage means the id resolves to no task there: drop reports `invalid_task_path` (exit 64), not `wrong_stage` (exit 4). This keeps id targets consistent with their `run`/`approve`/`findings` siblings, which share the same resolver.
+
 When a recorded draft PR exists but `gh` is not installed on PATH, draft-PR close is skipped with a warning on stderr (`pr_closed: false`, exit 0). Drop does not require `gh`. In the current v2 JSON contract, `pr_closed` is `true` whenever PR cleanup ends clean — including the common no-PR-recorded case — and `false` strictly means a recorded PR could not be closed (hivebox qualifies its "Dropped" notice on that signal). The v1 schema file remains for consumers pinned to the older no-PR-is-false interpretation.
 
 ## Steps Performed
@@ -55,7 +58,7 @@ When a recorded draft PR exists but `gh` is not installed on PATH, draft-PR clos
 4. Close `pr_url` from `pr.md` frontmatter with `gh pr close <url> --comment "task dropped"` best-effort.
 5. Remove the task worktree from `worktree.yml` or the derived path, retrying with force when needed, then prune stale git worktree metadata.
 6. Delete the task branch (`branch name == slug`) best-effort.
-7. Remove every active-stage folder matching the slug under `1-inbox` through `8-finalize`.
+7. Remove the task folder from each active stage it was found in (`from_stages`), not a fixed `1-inbox`–`8-finalize` coding range — generic workflows have their own active stages.
 8. Remove `.hive-state/logs/<slug>/`.
 9. Commit an audit record on `hive/state` as `hive: dropped/<slug> dropped`.
 

--- a/wiki/commands/drop.md
+++ b/wiki/commands/drop.md
@@ -34,7 +34,7 @@ Tasks at `9-done` are archive records — drop refuses them and leaves the folde
 | Generic failure (uncategorised) | 1 | `error` |
 | `--from` does not match the resolved active stage | 4 | `wrong_stage` |
 | Unknown slug/path/id | 64 | `invalid_task_path` |
-| Ambiguous slug across projects | 64 | `ambiguous_slug` |
+| Ambiguous slug/id across projects | 64 | `ambiguous_slug` |
 | Task is already in `9-done` | 64 | `already_archived` |
 | Git operation failed (e.g. `branch -D`) | 70 | `git` |
 | Worktree operation failed (e.g. `worktree remove`) | 70 | `worktree` |

--- a/wiki/commands/drop.md
+++ b/wiki/commands/drop.md
@@ -3,7 +3,7 @@ title: hive drop
 type: command
 source: lib/hive/commands/drop.rb, lib/hive/web/dispatcher.rb, web/app/controllers/tasks_controller.rb, web/config/routes.rb
 created: 2026-05-22
-updated: 2026-06-12
+updated: 2026-06-23
 tags: [command, task, cleanup, json, tui, web]
 ---
 
@@ -13,11 +13,15 @@ tags: [command, task, cleanup, json, tui, web]
 
 ```
 hive drop my-task-260522-abcd
+hive drop 7448 --project demo
 hive drop my-task-260522-abcd --project demo --from 4-execute
 hive drop /path/to/.hive-state/stages/4-execute/my-task-260522-abcd --json
 ```
 
-Bare slugs use [[modules/task_resolver]] lookup. Pass `--project` to disambiguate cross-project collisions and `--from` to assert the current stage on retry.
+Numeric task ids and path targets use [[modules/task_resolver]] lookup; bare
+slugs use Drop's project/stage scan with the same `--project` and `--from`
+scoping rules. Pass `--project` to disambiguate cross-project collisions and
+`--from` to assert the current stage on retry.
 
 ## Refusals
 
@@ -28,7 +32,7 @@ Tasks at `9-done` are archive records — drop refuses them and leaves the folde
 | Dropped successfully | 0 | — |
 | Generic failure (uncategorised) | 1 | `error` |
 | `--from` does not match the resolved active stage | 4 | `wrong_stage` |
-| Unknown slug/path | 64 | `invalid_task_path` |
+| Unknown slug/path/id | 64 | `invalid_task_path` |
 | Ambiguous slug across projects | 64 | `ambiguous_slug` |
 | Task is already in `9-done` | 64 | `already_archived` |
 | Git operation failed (e.g. `branch -D`) | 70 | `git` |
@@ -45,7 +49,7 @@ When a recorded draft PR exists but `gh` is not installed on PATH, draft-PR clos
 
 `Hive::Commands::Drop#call` runs the cleanup in a fixed, idempotent order:
 
-1. Resolve the task via [[modules/task_resolver]].
+1. Resolve the task target (`TaskResolver` for paths/ids, Drop's project/stage scan for slugs).
 2. Refuse archived-only tasks in `9-done`.
 3. Kill recorded agent PIDs from `.lock` and `AGENT_WORKING pid=...`, guarded by process start time when available.
 4. Close `pr_url` from `pr.md` frontmatter with `gh pr close <url> --comment "task dropped"` best-effort.

--- a/wiki/log.d/20260622T233753Z-drop-numeric-id.md
+++ b/wiki/log.d/20260622T233753Z-drop-numeric-id.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-23
+date: 2026-06-22
 slug: drop-numeric-id
 pages: [commands/drop, modules/task_resolver]
 ---

--- a/wiki/log.d/20260622T233753Z-drop-numeric-id.md
+++ b/wiki/log.d/20260622T233753Z-drop-numeric-id.md
@@ -1,0 +1,14 @@
+---
+date: 2026-06-23
+slug: drop-numeric-id
+pages: [commands/drop, modules/task_resolver]
+---
+
+`hive drop` now treats an all-digits target as a task id and routes it through
+`Hive::TaskResolver`, matching the existing `run`/`approve`/`findings` target
+semantics. The command still uses its bespoke slug context for bare slugs so the
+lock-held active/archive snapshot and cleanup context stay unchanged.
+
+Added integration coverage for successful `drop <id>`, unknown-id JSON errors
+using the resolver's `"no task folder for id <id>"` message, and duplicate-id
+ambiguity across projects with `--project` disambiguating the selected task.

--- a/wiki/modules/task_resolver.md
+++ b/wiki/modules/task_resolver.md
@@ -3,7 +3,7 @@ title: Hive::TaskResolver
 type: module
 source: lib/hive/task_resolver.rb
 created: 2026-04-25
-updated: 2026-06-03
+updated: 2026-06-23
 tags: [module, resolver, slug, task-id]
 ---
 
@@ -46,6 +46,7 @@ When the caller passes both an absolute folder path AND `--project NAME`, the pa
 |------|-----|
 | `lib/hive/commands/run.rb` | Resolves slug, numeric id, or folder targets before dispatching stage runners. |
 | `lib/hive/commands/stage_action.rb` | Resolves workflow-verb targets, using `--from` as stage filter when present. |
+| `lib/hive/commands/drop.rb` | Resolves path-shaped and numeric-id targets before Drop snapshots active/archive stage dirs for deletion/refusal. |
 | `lib/hive/commands/approve.rb` | Resolves approve targets; `--from` can disambiguate same-slug stages while preserving idempotency checks. |
 | `lib/hive/commands/generate_name.rb` | Resolves task targets before display-name generation. |
 | `lib/hive/commands/findings.rb` | Resolves findings targets, with optional `--stage`. |


### PR DESCRIPTION
## Summary

`hive status` tells operators `next: hive run 7448`, and `run`, `approve`, and `findings` all accept that bare numeric id. `hive drop 7448` did not — it treated the digits as a slug and failed with `no task folder for slug '7448'`, forcing a manual slug lookup before the task could be removed. Now `drop` accepts a numeric id like its siblings.

An all-digits target is routed through `Hive::TaskResolver` (the same resolver `run`/`approve`/`findings` use), which scans `meta.yml` ids across projects and honors `--project`/`--from`. A bare id is unambiguous: `Stages::SLUG_RE` requires a leading lowercase letter, so no slug is ever all digits. Bare slugs still flow through Drop's own project/stage scan, so the lock-held active/archive snapshot and cleanup ordering are untouched.

Error envelopes come straight from the resolver: an unknown id returns `invalid_task_path` with `no task folder for id <N>`, and the same id in two projects returns `ambiguous_slug` with `task id <N> is duplicated`, resolvable by passing `--project`.

## Test plan

`test/integration/drop_command_test.rb` adds end-to-end CLI coverage (real `bin/hive` via Open3, no mocks), each case asserting envelope fields **and** filesystem pre/post state:

- **Happy-path id drop** — `drop <id>` resolves to its slug, removes the stage folder(s), and emits the success envelope (`slug`, `project`, `from_stages`).
- **Unknown id** — `drop 9999` fails with exit `USAGE`, `error_kind: invalid_task_path`, message `no task folder for id 9999`.
- **Duplicate id across projects** — unscoped `drop <id>` fails with `ambiguous_slug` and preserves both folders; `--project P` then drops the right one and leaves the other intact.
- **`--from` stage filter** (long and short refs), **archived-id refusal** (`already_archived`, folder survives), **single-project duplicate id**, and **leading-zero id** behavior are all locked.

Verified locally: integration suite green (11 runs, 62 assertions, 0 failures); `bundle exec rubocop lib/hive/commands/drop.rb lib/hive/task_resolver.rb test/integration/drop_command_test.rb` clean. New tests fail against pre-fix `drop.rb` (numeric target → `no task folder for slug '7448'`) and pass after the change.

## Review summary

Three CE passes plus three multi-persona PR-toolkit passes converged on the same verdict: the routing change is **correct, minimal, and faithful to the plan** — dispatch branches (path / numeric / slug) are provably disjoint, every Requirements-Trace item is implemented and exercised, and wiki/comment claims verify against code.

One item was escalated for user gating and intentionally left as-is: a bare leading-zero target (`drop 010`) is parsed by the shared `TaskResolver#resolve_numeric_id` via `Integer()` as **octal** (id 8), and `drop 08`/`drop 09` surface as `internal`/exit 70. The clean fix is a one-line change in `lib/hive/task_resolver.rb`, which the plan explicitly fences out of scope (it would also change `run`/`approve`/`findings`). Real-world likelihood is very low — hive ids from `hive status`/`hive new` are never zero-padded — so the current behavior is locked by regression tests pending a separate decision on the shared resolver. All auto-fixable nits (lockstep comment on the duplicated `numeric_target?` predicate, construct-name comment over a brittle line range, wiki exit-table parity, log-fragment date, resolver docstring sync) were applied.

## Linked task

- Task: `bug-hive-drop-resolves-a-260622-a064` (id **7451**, "Fix Hive Drop Resolution")
- Branch: `bug-hive-drop-resolves-a-260622-a064`
- Pipeline stage: `8-finalize`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![HARNESS](https://img.shields.io/badge/Claude_Code-Opus_4.8_(1M)-D97757?logo=claude&logoColor=white)
