### PR TITLE
Hive patrol: Documented hive new options are captured as task text

### DIFF
--- a/bin/hive
+++ b/bin/hive
@@ -64,36 +64,100 @@ def normalize_leading_json_options!(argv)
   argv.insert(cmd_idx + 1, *leading)
 end
 
-def new_text_start_index(argv)
+def new_value_option?(arg)
+  NEW_VALUE_OPTIONS.include?(arg)
+end
+
+def new_value_assignment?(arg)
+  NEW_VALUE_OPTIONS.any? { |name| arg.start_with?("#{name}=") }
+end
+
+def new_project_index(argv)
   cmd_idx = argv.index { |a| !a.start_with?("-") }
   return nil unless cmd_idx && argv[cmd_idx] == "new"
 
   idx = cmd_idx + 1
-  project_idx = nil
   while idx < argv.length
     arg = argv[idx]
     if JSON_BOOLEAN_OPTIONS.include?(arg)
       idx += 1
       next
     end
-    if NEW_VALUE_OPTIONS.include?(arg)
+    if new_value_option?(arg)
       idx += 2
       next
     end
-    if NEW_VALUE_OPTIONS.any? { |name| arg.start_with?("#{name}=") }
+    if new_value_assignment?(arg)
       idx += 1
       next
     end
-    unless arg.start_with?("-")
-      project_idx = idx
-      break
-    end
+    return idx unless arg.start_with?("-")
 
     idx += 1
   end
+
+  nil
+end
+
+def new_text_start_index(argv)
+  project_idx = new_project_index(argv)
   return nil unless project_idx
 
-  project_idx + 1
+  idx = project_idx + 1
+  while idx < argv.length
+    arg = argv[idx]
+    return idx if arg == "--"
+
+    if new_value_option?(arg)
+      idx += 2
+      next
+    end
+    if new_value_assignment?(arg)
+      idx += 1
+      next
+    end
+
+    return idx
+  end
+
+  nil
+end
+
+def normalize_new_value_options!(argv)
+  project_idx = new_project_index(argv)
+  return unless project_idx
+
+  tail = argv[(project_idx + 1)..] || []
+  explicit_stop_idx = tail.index("--") || tail.length
+  scan_tail = tail[0...explicit_stop_idx]
+  literal_tail = tail[explicit_stop_idx..] || []
+  option_tail = []
+  text_tail = []
+  idx = 0
+
+  while idx < scan_tail.length
+    arg = scan_tail[idx]
+    if new_value_assignment?(arg)
+      option_tail << arg
+      idx += 1
+      next
+    end
+    if new_value_option?(arg)
+      unless idx + 1 < scan_tail.length
+        raise Thor::MalformattedArgumentError, "No value provided for option '#{arg}'"
+      end
+
+      option_tail << arg << scan_tail[idx + 1]
+      idx += 2
+      next
+    end
+
+    text_tail << arg
+    idx += 1
+  end
+  return if option_tail.empty?
+
+  argv.replace(argv[0..project_idx] + option_tail + text_tail + literal_tail)
 end
 
 # Thor only honours `--help` *before* the subcommand name (`hive help approve`);
@@ -184,6 +248,7 @@ end
 begin
   reject_unsupported_json_assignments!(ARGV)
   normalize_leading_json_options!(ARGV)
+  normalize_new_value_options!(ARGV)
   rewrite_help_flag!(ARGV)
   terminate_new_text_options!(ARGV)
   Hive::CLI.start(ARGV, debug: true)

--- a/test/integration/cli_version_test.rb
+++ b/test/integration/cli_version_test.rb
@@ -100,17 +100,33 @@ class CliVersionTest < Minitest::Test
       assert status.success?, "hive new should parse --workflow before PROJECT, stderr was: #{err}"
       assert_includes out, "hive: captured"
       folder = Dir[File.join(dir, ".hive-state", "stages", "1-inbox", "workflow-flag-*")].first
+      assert folder, "expected workflow-flag task to be created"
       assert_equal "coding", Hive::TaskMeta.read(folder)[:workflow]
     end
   end
 
-  def test_bin_hive_new_treats_workflow_option_as_task_text_after_project
+  def test_bin_hive_new_accepts_workflow_option_after_project_before_text
     with_cli_project do |dir, project|
-      out, err, status = run_bin_hive("new", project, "literal", "--workflow", "coding")
+      out, err, status = run_bin_hive("new", project, "--workflow", "coding", "workflow", "flag")
 
-      assert status.success?, "hive new should capture --workflow as text after PROJECT, stderr was: #{err}"
+      assert status.success?, "hive new should parse --workflow after PROJECT, stderr was: #{err}"
       assert_includes out, "hive: captured"
-      assert_new_idea_includes(dir, "literal --workflow coding")
+      folder = Dir[File.join(dir, ".hive-state", "stages", "1-inbox", "workflow-flag-*")].first
+      assert folder, "expected workflow-flag task to be created"
+      assert_equal "coding", Hive::TaskMeta.read(folder)[:workflow]
+    end
+  end
+
+  def test_bin_hive_new_accepts_depends_on_option_after_text
+    with_cli_project do |dir, project|
+      out, err, status = run_bin_hive("new", project, "add", "export", "button", "--depends-on", "42")
+
+      assert status.success?, "hive new should parse --depends-on after TEXT, stderr was: #{err}"
+      assert_includes out, "hive: captured"
+      folder = Dir[File.join(dir, ".hive-state", "stages", "1-inbox", "add-export-button-*")].first
+      assert folder, "expected add-export-button task to be created"
+      assert_equal "42", Hive::TaskMeta.read(folder)[:depends_on]
+      refute_includes File.read(File.join(folder, "idea.md")), "--depends-on"
     end
   end
 

--- a/wiki/commands/new.md
+++ b/wiki/commands/new.md
@@ -3,7 +3,7 @@ title: hive new
 type: command
 source: bin/hive, lib/hive/commands/new.rb, templates/idea.md.erb
 created: 2026-04-25
-updated: 2026-06-20
+updated: 2026-06-23
 tags: [command, capture, slug, task-id, commit-lock, workflow]
 ---
 
@@ -12,19 +12,23 @@ tags: [command, capture, slug, task-id, commit-lock, workflow]
 ## Usage
 
 ```
-hive new [--workflow NAME] PROJECT TEXT...
+hive new [--workflow NAME] [--depends-on ID_OR_SLUG] PROJECT TEXT...
 ```
 
-`PROJECT` must already be registered (via `hive init`); otherwise exit 1 with `"project not initialized"`. `TEXT...` is joined with single spaces and rendered into the workflow entry state's file. Empty text raises `Hive::Error("missing task text")`. `--workflow NAME` is validated against `Hive::Workflows::Registry`; unknown names fail before seeding a task and list valid names.
+`PROJECT` must already be registered (via `hive init`); otherwise exit 1 with `"project not initialized"`. `TEXT...` is joined with single spaces and rendered into the workflow entry state's file. Empty text raises `Hive::Error("missing task text")`. `--workflow NAME` is validated against `Hive::Workflows::Registry`; unknown names fail before seeding a task and list valid names. `--depends-on ID_OR_SLUG` writes `depends_on:` into `meta.yml` after validating the prerequisite selector shape.
 
-After `PROJECT`, the executable wrapper treats the rest of argv as task text
-even when tokens look like wrapper controls. `hive new PROJECT add --help docs`
-captures `add --help docs` instead of rendering help, and
-`hive new PROJECT literal --json=yes text` captures the malformed-looking JSON
-assignment literally instead of failing the wrapper boolean grammar. Wrapper
-options before the project boundary are still parsed normally, including
-`--workflow NAME`; this special case applies only to the text tail after the
-registered project argument.
+After `PROJECT`, the executable wrapper still protects free text from generic
+wrapper controls: `hive new PROJECT add --help docs` captures `add --help docs`
+instead of rendering help, and `hive new PROJECT literal --json=yes text`
+captures the malformed-looking JSON assignment literally instead of failing the
+wrapper boolean grammar. Recognized `hive new` value options are the exception:
+`--workflow`, `--depends-on`, and their `--name=value` forms are normalized
+before the text terminator whether they appear before or after the text, so the
+documented `hive new PROJECT --workflow NAME TEXT...` and
+`hive new PROJECT TEXT... --depends-on ID_OR_SLUG` forms update `meta.yml`
+instead of being swallowed into `idea.md`. Put an explicit `--` immediately
+after `PROJECT` to capture a literal recognized option at the start of the task
+text.
 
 The human stdout surface is still plain text:
 

--- a/wiki/log.d/20260623T010451Z-hive-new-wrapper-options.md
+++ b/wiki/log.d/20260623T010451Z-hive-new-wrapper-options.md
@@ -1,0 +1,12 @@
+---
+date: 2026-06-23
+slug: hive-new-wrapper-options
+pages: [commands/new, testing]
+---
+
+`bin/hive` now normalizes `hive new`'s recognized value options before adding
+the free-text terminator. `--workflow`, `--depends-on`, and their assignment
+forms continue to reach Thor when they appear after `PROJECT` or after the
+task text, while generic control-looking text such as `--help` and malformed
+`--json=yes` remains literal task text. Updated [[commands/new]] and
+[[testing]] to document the wrapper contract and focused regression coverage.

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -3,7 +3,7 @@ title: Testing
 type: reference
 source: test/, Rakefile, bin/hive-eval, .rubocop.yml, .github/workflows/ci.yml, config/brakeman.ignore
 created: 2026-04-25
-updated: 2026-06-21
+updated: 2026-06-23
 tags: [test, minitest, fixtures]
 ---
 
@@ -130,7 +130,7 @@ task default: :test
 | `user_workflow_e2e_test.rb` | Project-authored workflow acceptance — `hive workflow new` scaffolds a descriptor, `hive new --workflow` creates a pinned task, generic run/approve drives it from `1-inbox -> 2-work -> 3-done`, and a same-process coding capture still uses the default coding path. |
 | `daemon_stale_agent_healing_test.rb` | Status-to-healer integration — real `hive status --json` rows feed `Hive::Daemon::StaleAgentHealer`, pinning stale `AGENT_WORKING` classification, on-disk healing, closed logger events (`marker_healed`, `heal_requeued`, `marker_heal_failed`), `daemon.agent_marker_grace_sec` threading, and the `3-plan` terminal-loss healer writing a real allowlisted dispatch request. |
 | `full_flow_test.rb` | End-to-end: idea → brainstorm → plan → execute → open-pr → review → finalize → done. |
-| `cli_version_test.rb`, `cli_usage_error_json_test.rb` | `bin/hive` wrapper contract — top-level `--version`, command-local help after option-bearing invocations (`hive approve --from 2-brainstorm --help`), leading `--json=true`, malformed `--json=1` / `--json=yes` assignment rejection before command text/targets, `hive new PROJECT` preserving post-project `--help` and `--json=yes` as literal task text, and pre-dispatch JSON usage-error envelopes for missing required arguments on representative command schemas (`hive-run`, `hive-approve`, `hive-markers-clear`, `hive-drop`, `hive-findings`, `hive-rebase-status`, `hive-stage-action`, and the patrol-specific `hive-patrol` / `error_kind: "error"` case). |
+| `cli_version_test.rb`, `cli_usage_error_json_test.rb` | `bin/hive` wrapper contract — top-level `--version`, command-local help after option-bearing invocations (`hive approve --from 2-brainstorm --help`), leading `--json=true`, malformed `--json=1` / `--json=yes` assignment rejection before command text/targets, `hive new PROJECT` preserving post-project `--help` and `--json=yes` as literal task text while still parsing documented `--workflow` / `--depends-on` positions, and pre-dispatch JSON usage-error envelopes for missing required arguments on representative command schemas (`hive-run`, `hive-approve`, `hive-markers-clear`, `hive-drop`, `hive-findings`, `hive-rebase-status`, `hive-stage-action`, and the patrol-specific `hive-patrol` / `error_kind: "error"` case). |
 | `patrol_command_test.rb` | `hive patrol` — JSON envelope, dry-run behavior, scan-state recording, inbox non-interference, retry/backoff outcomes, and schema validation with fake mapper/reviewer/fixer/PR opener collaborators. |
 | `wiki_command_test.rb` | `hive wiki` — compile-log writes the generated aggregate, `--check` distinguishes stale vs up-to-date output, invalid subcommands/missing wiki dirs raise usage errors, CLI dispatch reaches the command, and help lists the wiki surface. |
 | `tui_smoke_test.rb`, `tui_smoke_charm_test.rb` | PTY-driven `bin/hive tui` smokes — boot, first useful paint with a seeded project, clean `q` exit, horizontal and vertical resize handling, and the startup regression gate (a generous 5s bound that catches a revert to the starved-poll loading grid without flaking; the 10s read_until is the hard gate). |


### PR DESCRIPTION
## Summary

`bin/hive` inserted `--` immediately after the PROJECT argument for `hive new`, so Thor stopped parsing every later token as an option. The documented forms silently swallowed their options into the task idea text:

- `hive new <proj> "add export button" --depends-on 42` → no `depends_on` in `meta.yml`; the option text leaked into `idea.md`.
- `hive new <proj> --workflow my-flow "<idea>"` → the workflow override was ignored.

The fix adds a `normalize_new_value_options!` pass that hoists recognized value options (`--depends-on`, `--workflow`, and their `=` assignment forms) out of the post-PROJECT tail back into real Thor options, and raises a fast `MalformattedArgumentError` when a recognized value option is missing its value. An explicit `--` still forces literal text, so callers who genuinely want option-like text are unaffected.

## Test plan

- `bundle exec rake test` — passed. Regression coverage retargeted/added in `test/integration/cli_version_test.rb`:
  - `--workflow` after PROJECT (before text) now sets `meta.yml[:workflow]` instead of being captured as task text.
  - `--depends-on` after the idea text now sets `meta.yml[:depends_on]` to `42`, and `idea.md` no longer contains the leaked `--depends-on` text.
  - existing `--workflow`-before-PROJECT coverage retained.
- `bundle exec rubocop` — passed (lint clean).

## Review summary

Codex-native review (pass 01) reported no findings — High, Medium, and Nit sections all empty. No correctness, security, or maintainability regressions identified in the diff; nothing to auto-fix, resolve, or escalate.

## Linked task

Hive patrol finding `command-bin-hive-1` (fingerprint `45e0226bff7e57933bd748d64877528b61428a196e1863cdc014c70f3de89b7f`), slug `patrol-command-bin-hive-45e0226b`.
