### PR TITLE
chore(deps): bump concurrent-ruby to 1.3.7 (CVE-2026-54904/5/6)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ GEM
     bundler-audit (0.9.3)
       bundler (>= 1.2.0)
       thor (~> 1.0)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
     drb (2.2.3)
     dry-core (1.2.0)


### PR DESCRIPTION
Unblocks bundler-audit (required check) across all open PRs — concurrent-ruby 1.3.6 hit three advisories published today, fixed in >= 1.3.7. Conservative lockfile-only bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)