### PR TITLE
Hive patrol: Replay executes symlinked repro scripts

### DIFF
--- a/bin/hive-e2e
+++ b/bin/hive-e2e
@@ -158,7 +158,7 @@ module Hive
             exit_code: BinaryExit::CONFIG
           )
         end
-        unless File.file?(script) && File.executable?(script)
+        unless File.lstat(script).file? && File.executable?(script)
           exit_with_error(
             "Run ##{run_id} scenario #{scenario} repro.sh is not executable (#{script})",
             error_kind: "unusable_repro",

--- a/test/e2e/lib/hive_e2e_binary_test.rb
+++ b/test/e2e/lib/hive_e2e_binary_test.rb
@@ -185,6 +185,35 @@ class E2EBinaryTest < Minitest::Test
     end
   end
 
+  def test_replay_symlinked_repro_emits_json_artifact_error_when_requested
+    Dir.mktmpdir("e2e-replay-test") do |tmp_runs_dir|
+      Dir.mktmpdir("e2e-replay-target") do |target_dir|
+        target = File.join(target_dir, "outside-repro")
+        File.write(target, "#!/usr/bin/env bash\nexit 0\n")
+        File.chmod(0o755, target)
+
+        script = File.join(tmp_runs_dir, "run-1", "scenarios", "scenario-1", "repro.sh")
+        FileUtils.mkdir_p(File.dirname(script))
+        File.symlink(target, script)
+
+        out, err, status = Open3.capture3(
+          { "HIVE_E2E_RUNS_DIR" => tmp_runs_dir },
+          hive_e2e, "replay", "--json", "run-1", "scenario-1"
+        )
+
+        assert_equal 78, status.exitstatus
+        assert_empty err
+
+        payload = JSON.parse(out)
+        assert_equal "hive-e2e-error", payload["schema"]
+        assert_equal false, payload["ok"]
+        assert_equal "unusable_repro", payload["error_kind"]
+        assert_equal 78, payload["exit_code"]
+        assert_match(/not executable/, payload["message"])
+      end
+    end
+  end
+
   def test_leading_json_replay_dispatches_to_replay
     out, err, status = Open3.capture3(hive_e2e, "--json", "replay", "missing-run", "missing-scenario")
     assert_equal 78, status.exitstatus


### PR DESCRIPTION
## Summary

Security fix to the `hive-e2e replay` CLI command. `replay` is documented to exec only a stored *regular* executable `repro.sh`, but it validated the path with `File.file?`, which follows symlinks. A `repro.sh` symlink could point to an executable outside `HIVE_E2E_RUNS_DIR` and still be exec'd (e.g. a symlink to `/bin/true` would exit `0` instead of returning the documented `unusable_repro` config error).

The guard now uses `File.lstat(script).file?`, which does not follow the final symlink, so a symlinked `repro.sh` fails the regular-file check and is rejected as `unusable_repro` (exit `78`) before any `exec`.

```diff
-        unless File.file?(script) && File.executable?(script)
+        unless File.lstat(script).file? && File.executable?(script)
```

- `bin/hive-e2e` — 1-line guard hardened (`File.file?` → `File.lstat(script).file?`).
- `test/e2e/lib/hive_e2e_binary_test.rb` — new regression covering the symlink rejection path.

## Test plan

- New regression `test_replay_symlinked_repro_emits_json_artifact_error_when_requested`: a `repro.sh` symlinked to an executable *outside* the run tree must emit the `hive-e2e-error` / `unusable_repro` JSON payload with exit `78` and never exec the target.
- Regression re-run during artifact collection: **PASS** — `1 runs, 9 assertions, 0 failures, 0 errors, 0 skips`.

## Review summary

- Review pass 1 (codex-native): no findings across High / Medium / Nit.
- No escalations; no open user questions.
- fix-success recorded for pass 1.

## Linked task

Patrol finding `command-bin-hive-e2e-1` (fingerprint `594ac3bb5be655489261752fcc8d54b7db4833d9b6fa128649cdea02f5b4673b`).

Task folder: `/home/asterio/Dev/hive/.hive-state/stages/8-finalize/patrol-command-bin-hive-e2e-594ac3bb`
