### PR TITLE
Hive patrol: Root bundle locks vulnerable concurrent-ruby

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ GEM
     bundler-audit (0.9.3)
       bundler (>= 1.2.0)
       thor (~> 1.0)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
     drb (2.2.3)
     dry-core (1.2.0)


### PR DESCRIPTION
## Summary

Hive Patrol security relock. The resolved root bundle locked `concurrent-ruby 1.3.6`, which `bundler-audit check` flags for CVE-2026-54904, CVE-2026-54905, and CVE-2026-54906 (including a high-impact `AtomicReference` livelock advisory). All three are fixed in `concurrent-ruby 1.3.7`.

This PR relocks the transitive dependency to `1.3.7` — a one-line change to `Gemfile.lock`, no application code touched.

```text
 Gemfile.lock | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

- Finding slice: `package-gemfile`
- Category: `security` · Severity: `high` · Confidence: `high`
- Fingerprint: `fc6196e59e093861b25107b93d555f39259ba674c29caf64bd8ec7d207e8b564`

## Test plan

- `bundle exec bundler-audit check` — no longer reports CVE-2026-54904/54905/54906 against `concurrent-ruby`
- `bundle exec rubocop` — passed
- `bundle exec rake test` — passed

## Review summary

Automated patrol review (`codex-native-review-01`) reported **No findings** across High, Medium, and Nit. Triage found nothing to escalate and raised no user questions — a pure dependency relock with a clean review.

## Linked task

- Pipeline task: `patrol-package-gemfile-fc6196e5`
- Patrol finding: `package-gemfile-1` (fingerprint `fc6196e59e093861b25107b93d555f39259ba674c29caf64bd8ec7d207e8b564`)
