### PR TITLE
fix(workflow): point `workflow new` at the stub instruction to edit

### DIFF
--- a/lib/hive/commands/workflow.rb
+++ b/lib/hive/commands/workflow.rb
@@ -265,6 +265,7 @@ module Hive
           @stdout.puts JSON.generate(payload)
         else
           @stdout.puts "hive: created workflow #{id} at #{paths.fetch(:descriptor)}"
+          @stdout.puts "edit: #{paths.fetch(:instruction)} (the `work` stage instruction — a placeholder until you define it)"
           @stdout.puts "next: #{payload.fetch("next")}"
         end
         payload

--- a/test/unit/commands/workflow_new_test.rb
+++ b/test/unit/commands/workflow_new_test.rb
@@ -33,6 +33,7 @@ class WorkflowNewTest < Minitest::Test
       assert_equal descriptor_path, payload.fetch("descriptor_path")
       assert_equal instruction_path, payload.fetch("instruction_path")
       assert_includes stdout.string, "hive: created workflow my-flow"
+      assert_includes stdout.string, "edit: #{instruction_path}"
       assert_includes stdout.string, "hive new #{File.basename(project_root)} --workflow my-flow"
 
       assert File.file?(descriptor_path)


### PR DESCRIPTION
First-time-user dogfood of custom-workflow onboarding surfaced this: `hive init`'s tip points users to `hive workflow new <id>`, but that command never told them the scaffolded `work`-stage instruction is a placeholder to edit — so following the hint verbatim runs a silent no-op workflow (agent instruction = "Edit this file…").

Adds one human-output `edit:` line naming the stub path, matching the `hive init --new-workflow` flow which already says "edit the descriptor above, then …". The `--json` payload (agent contract) is unchanged.

**Evidence:** clean-project onboarding now completes uninterrupted on visible guidance alone — init → `hive workflow new` (now shows `edit:`) → edit stub → `hive new --workflow` → task bound to the custom workflow with the real instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)