### PR TITLE
feat(workflow): `workflow new --template` seeds from sample workflows

### DIFF
--- a/lib/hive/cli.rb
+++ b/lib/hive/cli.rb
@@ -317,20 +317,25 @@ module Hive
     desc "workflow SUBCOMMAND [ID]", "Manage per-project workflow descriptors"
     long_desc <<~DESC
       Subcommands:
-        new ID    Scaffold a blank per-project workflow descriptor under
-                  <hive_state_path>/workflows/ID.yml, plus a placeholder
-                  instruction at <hive_state_path>/workflows/ID/work.md.
+        new ID    Scaffold a per-project workflow descriptor under
+                  <hive_state_path>/workflows/ID.yml plus its stage
+                  instruction(s) under <hive_state_path>/workflows/ID/.
 
-      The blank workflow is inbox -> work -> done and is immediately usable
-      with `hive new PROJECT --workflow ID "<your idea>"`.
+      By default `new` scaffolds the blank `inbox -> work -> done` stub. Pass
+      `--template NAME` to seed from a richer sample workflow instead (e.g.
+      writing, research). Either way: edit the scaffolded stage instruction(s),
+      then run `hive new PROJECT --workflow ID "<your idea>"`.
     DESC
+    option :template, type: :string,
+                      desc: "for `new`: seed from a named sample workflow (e.g. writing, research) instead of the blank stub"
     def workflow(subcommand = nil, id = nil)
       require "hive/commands/workflow"
       Hive::Commands::Workflow.new(
         subcommand,
         id,
         project_root: Dir.pwd,
-        json: options[:json]
+        json: options[:json],
+        template: options[:template]
       ).call
     end
 

--- a/lib/hive/commands/workflow.rb
+++ b/lib/hive/commands/workflow.rb
@@ -15,7 +15,8 @@ require "hive/workflows/registry"
 module Hive
   module Commands
     class Workflow
-      TEMPLATE_ROOT = File.expand_path("../../../templates/workflows/blank", __dir__)
+      TEMPLATES_DIR = File.expand_path("../../../templates/workflows", __dir__)
+      DEFAULT_TEMPLATE = "blank".freeze
       WORKFLOW_ID_RE = Hive::Workflows::DescriptorParser::SAFE_SLUG
       SCHEMA = "hive-workflow-new".freeze
       SUBCOMMANDS = %w[new].freeze
@@ -39,8 +40,8 @@ module Hive
         end
       end
 
-      def self.new!(id, project_root: Dir.pwd, json: false, stdout: $stdout)
-        new("new", id, project_root: project_root, json: json, stdout: stdout).call!
+      def self.new!(id, project_root: Dir.pwd, json: false, stdout: $stdout, template: DEFAULT_TEMPLATE)
+        new("new", id, project_root: project_root, json: json, stdout: stdout, template: template).call!
       end
 
       def self.normalize_and_validate_id!(raw)
@@ -49,12 +50,13 @@ module Hive
         id
       end
 
-      def self.scaffold_files!(id_raw, project_root:)
+      def self.scaffold_files!(id_raw, project_root:, template: DEFAULT_TEMPLATE)
         id = normalize_and_validate_id!(id_raw)
-        paths = scaffold_paths(id, project_root: project_root)
+        template_dir = template_dir!(template)
+        paths = scaffold_paths(id, project_root: project_root, template_dir: template_dir)
         refuse_overwrite!(paths)
         begin
-          write_scaffold!(id, paths)
+          write_scaffold!(id, paths, template_dir)
           validate_descriptor!(paths.fetch(:descriptor))
           Hive::Workflows::Project.reset!
         rescue StandardError
@@ -63,6 +65,31 @@ module Hive
         end
         { id: id, paths: paths }
       end
+
+      # Sample templates ship as directories under `templates/workflows/` (the
+      # bare `blank` stub plus richer multi-stage samples). A template dir holds
+      # `descriptor.yml.erb` (rendered with the new id) and one `.md` instruction
+      # per agent stage. Only dirs carrying a `descriptor.yml.erb` count, so a
+      # stray file under the templates root is never offered as a template.
+      def self.available_templates
+        Dir.children(TEMPLATES_DIR).select do |name|
+          File.file?(File.join(TEMPLATES_DIR, name, "descriptor.yml.erb"))
+        end.sort
+      end
+
+      def self.template_dir!(template)
+        name = template.to_s.strip
+        name = DEFAULT_TEMPLATE if name.empty?
+        dir = File.join(TEMPLATES_DIR, name)
+        return dir if File.file?(File.join(dir, "descriptor.yml.erb"))
+
+        raise UsageError.new(
+          "unknown workflow template #{name.inspect} (available: #{available_templates.join(', ')})",
+          value: name,
+          expected: available_templates
+        )
+      end
+      private_class_method :template_dir!
 
       # Shared scaffold-commit contract: hive init --new-workflow (fresh and
       # existing) and `hive workflow new` all commit a scaffolded descriptor
@@ -132,15 +159,28 @@ module Hive
       end
       private_class_method :validate_id!
 
-      def self.scaffold_paths(id, project_root:)
+      def self.scaffold_paths(id, project_root:, template_dir:)
         workflows_dir = workflow_dir(project_root)
+        instruction_dir = File.join(workflows_dir, id)
+        instructions = template_instruction_files(template_dir).map { |file| File.join(instruction_dir, file) }
         {
           descriptor: File.join(workflows_dir, "#{id}.yml"),
-          instruction_dir: File.join(workflows_dir, id),
-          instruction: File.join(workflows_dir, id, "work.md")
+          instruction_dir: instruction_dir,
+          instructions: instructions,
+          # The primary instruction (first stage's). Keeps the `instruction_path`
+          # JSON field single-valued for the strict hive-workflow-new schema; the
+          # human output points at the dir when a template has several.
+          instruction: instructions.first
         }
       end
       private_class_method :scaffold_paths
+
+      # Sorted so the copy order — and the `instruction_path`/`next` the payload
+      # reports — are deterministic across runs (golden-output tests).
+      def self.template_instruction_files(template_dir)
+        Dir.children(template_dir).select { |file| file.end_with?(".md") }.sort
+      end
+      private_class_method :template_instruction_files
 
       # Single source of "<hive_state_path>/workflows" — the scaffolder needs the
       # raw config error to surface (no fallback), which Loader.workflow_dir
@@ -151,7 +191,7 @@ module Hive
       private_class_method :workflow_dir
 
       def self.refuse_overwrite!(paths)
-        collisions = [ paths.fetch(:descriptor), paths.fetch(:instruction_dir), paths.fetch(:instruction) ].select do |path|
+        collisions = ([ paths.fetch(:descriptor), paths.fetch(:instruction_dir) ] + paths.fetch(:instructions)).select do |path|
           File.exist?(path)
         end
         return if collisions.empty?
@@ -160,15 +200,17 @@ module Hive
       end
       private_class_method :refuse_overwrite!
 
-      def self.write_scaffold!(id, paths)
+      def self.write_scaffold!(id, paths, template_dir)
         FileUtils.mkdir_p(paths.fetch(:instruction_dir))
-        File.write(paths.fetch(:descriptor), render_descriptor(id))
-        File.write(paths.fetch(:instruction), File.read(File.join(TEMPLATE_ROOT, "work.md")))
+        File.write(paths.fetch(:descriptor), render_descriptor(id, template_dir))
+        template_instruction_files(template_dir).each do |file|
+          File.write(File.join(paths.fetch(:instruction_dir), file), File.read(File.join(template_dir, file)))
+        end
       end
       private_class_method :write_scaffold!
 
-      def self.render_descriptor(id)
-        template = File.read(File.join(TEMPLATE_ROOT, "descriptor.yml.erb"))
+      def self.render_descriptor(id, template_dir)
+        template = File.read(File.join(template_dir, "descriptor.yml.erb"))
         ERB.new(template, trim_mode: "-").result_with_hash(id: id)
       end
       private_class_method :render_descriptor
@@ -199,12 +241,13 @@ module Hive
       end
       private_class_method :warn_failed_scaffold_cleanup
 
-      def initialize(subcommand, id = nil, project_root: Dir.pwd, json: false, stdout: $stdout)
+      def initialize(subcommand, id = nil, project_root: Dir.pwd, json: false, stdout: $stdout, template: DEFAULT_TEMPLATE)
         @subcommand = subcommand
         @id = id
         @project_root = File.expand_path(project_root)
         @json = json
         @stdout = stdout
+        @template = template
       end
 
       def call
@@ -246,7 +289,7 @@ module Hive
           )
         end
 
-        scaffold = self.class.scaffold_files!(@id, project_root: @project_root)
+        scaffold = self.class.scaffold_files!(@id, project_root: @project_root, template: @template)
         id = scaffold.fetch(:id)
         paths = scaffold.fetch(:paths)
         begin
@@ -265,7 +308,11 @@ module Hive
           @stdout.puts JSON.generate(payload)
         else
           @stdout.puts "hive: created workflow #{id} at #{paths.fetch(:descriptor)}"
-          @stdout.puts "edit: #{paths.fetch(:instruction)} (the `work` stage instruction — a placeholder until you define it)"
+          if paths.fetch(:instructions).size > 1
+            @stdout.puts "edit: #{paths.fetch(:instruction_dir)}/ (#{paths.fetch(:instructions).size} stage instructions to fill in)"
+          else
+            @stdout.puts "edit: #{paths.fetch(:instruction)} (the `work` stage instruction — a placeholder until you define it)"
+          end
           @stdout.puts "next: #{payload.fetch("next")}"
         end
         payload

--- a/schemas/hive-workflow-new.v1.json
+++ b/schemas/hive-workflow-new.v1.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/ivankuznetsov/hive/blob/main/schemas/hive-workflow-new.v1.json",
   "title": "hive workflow new output (v1)",
-  "description": "Stable contract emitted by `hive workflow new ID --json`. Scaffolds a blank per-project workflow descriptor (inbox -> work -> done) under <hive_state_path>/workflows/ID.yml plus a placeholder instruction at <hive_state_path>/workflows/ID/work.md, then records a hive/state commit. The error arm routes through Hive::Schemas::ErrorEnvelope so its keys match every other hive-* command's error envelope; the success arm builds its hash directly. A missing/invalid/reserved id or a missing/unknown subcommand is a USAGE error (64); commit-lock contention is a retryable TEMPFAIL (75).",
+  "description": "Stable contract emitted by `hive workflow new ID --json`. Scaffolds a per-project workflow descriptor under <hive_state_path>/workflows/ID.yml plus its stage instruction(s) under <hive_state_path>/workflows/ID/, then records a hive/state commit. Defaults to the blank inbox -> work -> done stub; `--template NAME` seeds from a richer sample workflow instead (the payload shape is identical). The error arm routes through Hive::Schemas::ErrorEnvelope so its keys match every other hive-* command's error envelope; the success arm builds its hash directly. A missing/invalid/reserved id or a missing/unknown subcommand is a USAGE error (64); commit-lock contention is a retryable TEMPFAIL (75).",
   "oneOf": [
     {
       "$ref": "#/$defs/SuccessPayload"
@@ -44,7 +44,7 @@
         },
         "instruction_path": {
           "type": "string",
-          "description": "Absolute path to the written placeholder instruction (<id>/work.md)."
+          "description": "Absolute path to the primary (first stage's) scaffolded instruction under <id>/. For the blank default this is <id>/work.md; a --template seed names its first agent stage's instruction. Multi-stage templates scaffold additional instructions alongside it in the same <id>/ directory (see the descriptor)."
         },
         "next": {
           "type": "string",

--- a/templates/workflows/research/descriptor.yml.erb
+++ b/templates/workflows/research/descriptor.yml.erb
@@ -1,0 +1,21 @@
+<%# Sample workflow: a gather -> synthesize -> report research pipeline. -%>
+id: "<%= id %>"
+stages:
+  - name: inbox
+    kind: terminal
+    state_file: idea.md
+  - name: gather
+    kind: agent
+    state_file: gather.md
+    instruction: ./<%= id %>/gather.md
+  - name: synthesize
+    kind: agent
+    state_file: synthesize.md
+    instruction: ./<%= id %>/synthesize.md
+  - name: report
+    kind: agent
+    state_file: report.md
+    instruction: ./<%= id %>/report.md
+  - name: done
+    kind: terminal
+    state_file: done.md

--- a/templates/workflows/research/gather.md
+++ b/templates/workflows/research/gather.md
@@ -1,0 +1,11 @@
+You are the **gather** stage of a research pipeline.
+
+Read `idea.md` (the question to investigate). Produce `gather.md`:
+
+- Restate the question precisely, and list the sub-questions it breaks into.
+- Collect the relevant evidence — facts, data, sources, prior art, quotes.
+  For each item, note the source and a one-line relevance.
+- Flag contradictions, gaps, and anything you could not verify.
+
+Gather broadly and cite as you go. Do not draw conclusions yet — that is the
+synthesize stage's job.

--- a/templates/workflows/research/report.md
+++ b/templates/workflows/research/report.md
@@ -1,0 +1,12 @@
+You are the **report** stage of a research pipeline.
+
+Using `idea.md`, `gather.md`, and `synthesize.md`, produce `report.md` — the
+final deliverable:
+
+- Lead with the answer / bottom line in 2–3 sentences.
+- Support it with the themes and evidence from `synthesize.md`, structured for a
+  reader who has not seen the working files.
+- Keep claims tied to evidence; carry the confidence caveats through.
+- End with open questions and any recommended next steps.
+
+Output the full report in `report.md`. This is what the requester reads.

--- a/templates/workflows/research/synthesize.md
+++ b/templates/workflows/research/synthesize.md
@@ -1,0 +1,12 @@
+You are the **synthesize** stage of a research pipeline.
+
+Using `idea.md` and `gather.md` (the evidence), produce `synthesize.md`:
+
+- Group the evidence into the few themes that actually answer the question.
+- For each theme, state what the evidence supports and how strongly (note where
+  it is thin or contradictory).
+- Draw the conclusions the evidence justifies — and name the ones it does not.
+- List the open questions a reader would still have.
+
+Reason from `gather.md`; do not introduce unsourced claims. The report stage
+turns this into the deliverable.

--- a/templates/workflows/writing/descriptor.yml.erb
+++ b/templates/workflows/writing/descriptor.yml.erb
@@ -1,0 +1,23 @@
+<%# Sample workflow: a research -> draft -> edit writing pipeline. Each agent -%>
+<%# stage reads the prior stages' outputs and produces its own. Quoted id for -%>
+<%# the same YAML-coercion reason as the blank template. -%>
+id: "<%= id %>"
+stages:
+  - name: inbox
+    kind: terminal
+    state_file: idea.md
+  - name: research
+    kind: agent
+    state_file: research.md
+    instruction: ./<%= id %>/research.md
+  - name: draft
+    kind: agent
+    state_file: draft.md
+    instruction: ./<%= id %>/draft.md
+  - name: edit
+    kind: agent
+    state_file: edit.md
+    instruction: ./<%= id %>/edit.md
+  - name: done
+    kind: terminal
+    state_file: done.md

--- a/templates/workflows/writing/draft.md
+++ b/templates/workflows/writing/draft.md
@@ -1,0 +1,14 @@
+You are the **draft** stage of a writing pipeline.
+
+Using `idea.md` (the brief) and `research.md` (framing, outline, key points),
+write a complete first draft in `draft.md`.
+
+- Follow the outline from `research.md`, improving it where the material calls
+  for it.
+- Write the full piece — real prose, not notes or bullet stubs.
+- Keep the single takeaway from the research framing front and centre.
+- Plain, direct voice. No filler, no throat-clearing ("In today's fast-paced
+  world…").
+
+Aim for a strong, complete draft — the edit stage will polish. Do not
+self-edit to death here.

--- a/templates/workflows/writing/edit.md
+++ b/templates/workflows/writing/edit.md
@@ -1,0 +1,12 @@
+You are the **edit** stage of a writing pipeline.
+
+Revise `draft.md` into a final, publishable version in `edit.md`.
+
+- Tighten every sentence; cut whatever doesn't earn its place.
+- Fix structure, transitions, and flow; make the opening earn the read and the
+  ending land.
+- Correct grammar, consistency, and tone — keep the author's voice.
+- Verify the piece delivers the single takeaway from `research.md` clearly.
+
+Output the full final text in `edit.md` — the version a reader sees — not a
+list of edits.

--- a/templates/workflows/writing/research.md
+++ b/templates/workflows/writing/research.md
@@ -1,0 +1,13 @@
+You are the **research** stage of a writing pipeline.
+
+Read `idea.md` (the topic or brief). Produce `research.md` with:
+
+- **Framing** — one paragraph: who the audience is, the angle, and the single
+  takeaway the finished piece must land.
+- **Key points** — 5–8 concrete facts, examples, or arguments worth including,
+  each with a one-line note on why it matters.
+- **Outline** — the section headings, in order.
+- **Open questions** — anything the draft stage must resolve or look up.
+
+Be specific to the brief. Do not write the piece itself — that is the draft
+stage's job.

--- a/test/unit/cli_test.rb
+++ b/test/unit/cli_test.rb
@@ -206,7 +206,7 @@ class HiveCliTest < Minitest::Test
       Hive::CLI.start([ "workflow", "new", "my-flow", "--json" ])
 
       assert_equal [ "new", "my-flow" ], calls.first.fetch(:args)
-      assert_equal({ project_root: Dir.pwd, json: true }, calls.first.fetch(:kwargs))
+      assert_equal({ project_root: Dir.pwd, json: true, template: nil }, calls.first.fetch(:kwargs))
       assert_equal :call, calls.last
     end
   end

--- a/test/unit/commands/workflow_new_test.rb
+++ b/test/unit/commands/workflow_new_test.rb
@@ -80,6 +80,55 @@ class WorkflowNewTest < Minitest::Test
     end
   end
 
+  def test_scaffolds_from_a_named_template
+    with_initialized_project do |project_root|
+      stdout = StringIO.new
+
+      payload = Hive::Commands::Workflow.new!(
+        "article", project_root: project_root, stdout: stdout, template: "writing"
+      )
+
+      workflows = File.join(project_root, ".hive-state", "workflows")
+      assert_equal "article", payload.fetch("id")
+
+      # The descriptor carries the SAMPLE's multi-stage shape, renamed to the id.
+      workflow = Hive::Workflows::DescriptorParser.parse_file(File.join(workflows, "article.yml"))
+      assert_equal %w[inbox research draft edit done], workflow.stage_names
+      assert_equal %i[inert agent agent agent inert], workflow.stages.map(&:kind)
+
+      # Every stage instruction is copied verbatim from the sample — real
+      # content, not the blank placeholder — and named per stage.
+      %w[research draft edit].each do |stage|
+        path = File.join(workflows, "article", "#{stage}.md")
+        assert File.file?(path), "#{stage}.md should be scaffolded"
+        refute_includes File.read(path), "Edit this file",
+                        "#{stage}.md must be the sample instruction, not the blank stub"
+      end
+      assert_equal File.join(workflows, "article", "research.md"),
+                   workflow.stages.find { |s| s.name == "research" }.instruction
+
+      # A multi-stage template points the operator at the directory of stage
+      # instructions to fill in, not a single file.
+      assert_includes stdout.string, "edit: #{File.join(workflows, 'article')}/"
+      assert_includes stdout.string, "3 stage instructions"
+    end
+  end
+
+  def test_unknown_template_is_a_usage_error_listing_available
+    with_initialized_project do |project_root|
+      error = assert_raises(Hive::Commands::Workflow::UsageError) do
+        Hive::Commands::Workflow.new!("x", project_root: project_root, stdout: StringIO.new, template: "bogus")
+      end
+
+      assert_equal Hive::ExitCodes::USAGE, error.exit_code
+      assert_includes error.message, %(unknown workflow template "bogus")
+      assert_includes error.expected, "blank"
+      assert_includes error.expected, "writing"
+      # An invalid template is rejected before any scaffold is written.
+      refute File.exist?(File.join(project_root, ".hive-state", "workflows", "x.yml"))
+    end
+  end
+
   def test_json_success_payload
     with_initialized_project do |project_root|
       out, err, status = with_captured_exit do

--- a/wiki/commands/workflow.md
+++ b/wiki/commands/workflow.md
@@ -1,7 +1,7 @@
 ---
 title: hive workflow
 type: command
-source: lib/hive/cli.rb, lib/hive/commands/workflow.rb, templates/workflows/blank/
+source: lib/hive/cli.rb, lib/hive/commands/workflow.rb, templates/workflows/
 created: 2026-06-21
 updated: 2026-06-23
 tags: [command, workflow, authoring]
@@ -13,6 +13,7 @@ tags: [command, workflow, authoring]
 
 ```bash
 hive workflow new my-flow
+hive workflow new my-flow --template writing
 hive workflow new my-flow --json
 ```
 
@@ -77,6 +78,24 @@ The placeholder `work.md` says:
 ```text
 Edit this file to define what the `work` stage should do.
 ```
+
+## Templates
+
+`new` scaffolds the blank `inbox -> work -> done` stub by default. Pass
+`--template NAME` to seed from a curated sample workflow instead: the
+descriptor is rewritten to your `ID` and the sample's stage instructions are
+copied verbatim — real content, not a placeholder — into `<id>/`. Available
+templates are the directories under `templates/workflows/` that carry a
+`descriptor.yml.erb`:
+
+- `blank` (default) — `inbox -> work -> done`, one placeholder instruction.
+- `writing` — `inbox -> research -> draft -> edit -> done`.
+- `research` — `inbox -> gather -> synthesize -> report -> done`.
+
+A multi-stage template prints `edit: <id>/ (N stage instructions to fill in)`
+pointing at the directory of instructions to define (the single-stage blank
+still names its one `work.md`). An unknown `--template` is a USAGE error
+listing the available names; with `--json` they ride the `expected` array.
 
 ## Backlinks
 

--- a/wiki/log.d/20260623T124710Z-workflow-new-templates.md
+++ b/wiki/log.d/20260623T124710Z-workflow-new-templates.md
@@ -1,0 +1,19 @@
+## hive workflow new --template (sample workflow seeds)
+
+`hive workflow new ID` previously always scaffolded the bare `blank`
+inbox->work->done stub with a placeholder `work.md`. Generalized the scaffolder
+to named templates: a template is a directory under `templates/workflows/`
+carrying `descriptor.yml.erb` plus one `.md` instruction per agent stage. The
+new `--template NAME` flag seeds from a sample instead of the stub — the
+descriptor is rendered with the user's ID and every stage instruction is copied
+verbatim (real content, not "Edit this file").
+
+Shipped two samples: `writing` (inbox->research->draft->edit->done) and
+`research` (inbox->gather->synthesize->report->done). Unknown templates are a
+USAGE error listing the available names (also in the `--json` `expected`
+array). The blank default, `hive init --new-workflow` (which shares the
+scaffolder), and the `hive-workflow-new` JSON schema (single `instruction_path`
+= the first stage's instruction) are unchanged. Multi-stage templates print
+`edit: <id>/ (N stage instructions to fill in)` pointing at the directory.
+
+Refreshed [[commands/workflow]].


### PR DESCRIPTION
Generalizes `hive workflow new` from the single hardcoded `blank` stub to named templates, and adds `--template NAME` to seed a custom workflow from a curated sample instead of a bare "Edit this file" placeholder.

**Samples shipped:** `writing` (research→draft→edit) and `research` (gather→synthesize→report) — real, complete stage instructions.

**Mechanism:** a template = a dir under `templates/workflows/` with `descriptor.yml.erb` + one `.md` per agent stage. `--template` renders the descriptor with the user's ID and copies the instructions verbatim. Unknown templates → USAGE error listing available names (and `--json` `expected`).

**Unchanged:** the `blank` default, `hive init --new-workflow` (shares the scaffolder), the #578 `edit:` hint, and the `hive-workflow-new` schema (single `instruction_path` = first stage's). Multi-stage templates point at the `<id>/` instruction dir.

Found dogfooding custom-workflow onboarding — the bare stub left new users with no example to start from. Tests: workflow-new 23/0 (2 new), init 76/0, full gate 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)