### PR TITLE
docs: announce custom workflows + prep 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,58 @@
 
 All notable changes are documented here, newest first. Hive ships frequent micro-releases (see [docs/RELEASING.md](docs/RELEASING.md#versioning-policy)): each `vX.Y.Z` git tag gets a `## X.Y.Z` section with terse bullets — no `[Unreleased]` accumulator. Versioning is [SemVer](https://semver.org): PATCH for fixes and small changes (the common case), MINOR for notable features, MAJOR for milestones.
 
+## 0.3.1
+
+Custom workflows: Hive's pipeline engine is now generic data. Author your own per-project workflow — writing, research, triage, translation, anything — in a few lines of YAML, scaffold it from a sample, and let the daemon run it the same way it runs `coding`. This release also lands a large patrol-driven security-hardening wave, a redesigned daily digest, task dependencies with stacked PRs, and device-flow agent logins in hivebox.
+
+### Custom workflows (workflow-as-data)
+
+- A workflow is now just an ordered list of stages in a YAML descriptor under `.hive-state/workflows/<id>.yml`. The built-in `coding` and `content` pipelines and your own project-authored ones all run through one generic engine — stage `kind:` (`agent`/`terminal`) drives runner, status, and advance behavior. Descriptors validate strictly at author time: `SAFE_SLUG` ids, bare `state_file` basenames, exactly one of `instruction`/`skill` per agent stage, last stage must be terminal.
+- `hive workflow new ID` scaffolds a project-local descriptor plus stage instruction(s), commits them on `hive/state`, and points you at the exact instruction file to edit before the first run.
+- `hive workflow new ID --template NAME` seeds from a curated sample instead of a blank stub — real stage instructions copied in, not placeholders. Ships `blank`, `writing` (inbox → research → draft → edit → done), and `research` (inbox → gather → synthesize → report → done); an unknown name lists what's available.
+- `hive init --new-workflow ID [PATH]` bootstraps a project and binds it to a freshly scaffolded custom workflow as its `default_workflow`, in one command.
+- Workflow selection is a first-class setup step in both `hive init` (CLI) and the hivebox web new-project form — you pick the workflow when you create the project. `--workflow` help advertises project-authored workflows alongside the built-ins.
+- A bare or unknown `hive workflow` subcommand is now a friendly usage error (exit 64), with a structured `expected` array under `--json`.
+- Full guide: https://hivecli.sh/docs/custom-workflows/
+
+### Patrol security hardening
+
+- A large wave of fixes to the `hive patrol` dry-run sandbox, where stubbed `gh`/`git` passthrough could be abused. Closed: auth-token leakage via passthrough and to attacker-controlled hosts; dry-run reads targeting arbitrary hosts or executing repo-configured transport/remote helpers and askpass; skip-log FIFOs hanging stubs or following symlinks; gh-api guard bypass via glued `-F=` fields and short flags; cache writes during dry-run.
+- JSON usage/error envelopes completed across the patrol and eval command surface; scenario-basename validation enforced; non-executable or unusable repro scripts now report precisely instead of as generic failures.
+
+### Pipeline & daemon
+
+- Task dependencies: a `depends_on` gate holds a task until its dependency completes, and dependent PRs stack on their parent's branch.
+- PR numbers now show across all task-list surfaces (TUI, CLI, hivebox).
+- The daemon assigns ids to tasks created outside `hive new`, self-heals non-token error classes, and closes a web/ auto-commit scope gap.
+- Fixed: an AgentLimit false-positive that killed healthy runs; finalize now short-circuits on an already-merged PR and fast-forwards a stale rebase-duplicate worktree instead of looping on `unpushed_commits`.
+- Fixed: transient duplicate rows and `ENOENT` during stage moves; tmux-mode stage completion hardened against missing terminal markers; large pastes settle before submit.
+- Fixed: the babysitter skips PRs owned by an active pipeline task and gitignores dry-run scaffolding so it can't trip clean-exit review.
+- `hive drop` accepts a bare numeric task id; `bin/hive new` lifts recognized options out of the task text.
+
+### Reviewers
+
+- Self-diagnosing review failures, transient-triage retry, and whole-class fixes; triage and fix usage-limit failures now self-heal like reviewers do.
+- Codex-native reviews read codex's real answer instead of the echoed prompt template and normalize native `[Pn]` output so patrol reviews stop failing; the codex session transcript is dropped from published findings.
+- Triage bare timeout/budget fallbacks aligned with `DEFAULTS`; the default review wall-clock cap is doubled to 8h.
+
+### Digest
+
+- Daily shipped digest Telegram message, redesigned with a brand header, summary, per-project sections, and a stats footer. Defaults ON when Telegram is configured (dropped `bot.digest_chat_id`) and loads `~/.config/hive/.env` so the daemon digest can authenticate.
+
+### hivebox & web
+
+- Visual demo capture surfaced in hivebox task artifacts.
+- Operator-ward device-flow logins completed in the Agents UI (codex headless device-auth); binary PTY output scrubbed so the agent-login status page can't 500; the `sanitize_url` splice bug is fixed; honeycomb favicon.
+
+### hive-bench
+
+- `hive bench submit` packages a completed task as a corpus producer for the hive-bench coding-agent benchmark; preflight delegates to hive-bench's canonical SecretScan.
+
+### Dependencies
+
+- Fixed: `concurrent-ruby` 1.3.6 → 1.3.7 (CVE-2026-54904/5/6). Dependabot/action bumps: brakeman 8.0.5, docker/* actions v4, actions/checkout 7.
+
 ## 0.3.0
 
 Hive in a box: one Docker container with a web UI — drop ideas from any browser and get reviewed PRs. First release that publishes the `ghcr.io/ivankuznetsov/hivebox` image.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hive-cli (0.3.0)
+    hive-cli (0.3.1)
       bubbletea (= 0.1.4)
       faraday (>= 2.14.2, < 3.0)
       faraday-multipart (~> 1.0)

--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@
 Community: [join the Hive Discord](https://discord.gg/Qg5E7rMt) for questions,
 feedback, and release discussions.
 
-Hive turns a rough software idea into a merge-ready pull request through a multi-agent pipeline you can watch as it works. You sketch an idea in a few sentences, open the `hive tui` dashboard, and watch the work move forward: brainstorm pins down what you actually want, plan fixes the approach, execute writes the code, review hardens it, and finalize ships the PR. You can step in at any stage with a normal editor — every artefact is a markdown file in a stage folder, inspectable and editable by you or by another agent.
+Hive is an open-source **agent workflow engine and meta-harness**: it orchestrates your coding agents — Claude, Codex, Pi — to run multi-step work as a *folder-as-agent pipeline*. Its flagship **`coding`** workflow turns a rough software idea into a merge-ready pull request: you sketch an idea in a few sentences, open the `hive tui` dashboard, and watch the work move forward — brainstorm pins down what you actually want, plan fixes the approach, execute writes the code, review hardens it, and finalize ships the PR. You can step in at any stage with a normal editor — every artefact is a markdown file in a stage folder, inspectable and editable by you or by another agent. Hive also ships a `content` (research) workflow and runs the ones you author yourself — writing, research, triage, anything (see [Custom Workflows](#custom-workflows)).
 
 The mental model is folders. Every task is a directory; the folder's location is the task state. Moving a task from `2-brainstorm/` to `3-plan/` is the approval gesture, and every stage writes a durable artefact the next stage can trust. That practice — making each step's output strong enough for the next one to run autonomously — is called *compound engineering*. It's how Hive carries work from rough idea to merged PR while letting humans drop in on their own terms instead of a chat thread's.
+
+The `coding` workflow runs nine stages, each a folder:
 
 ```text
 1-inbox  ->  2-brainstorm  ->  3-plan  ->  4-execute  ->  5-open-pr  ->  6-review  ->  7-artifacts  ->  8-finalize  ->  9-done

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Hive ships as a rubygem (`hive-cli`) attached to each GitHub Release, signed wit
 | Platform | Channel |
 |----------|---------|
 | macOS arm64 | [`brew install ivankuznetsov/hive/hive`](https://github.com/ivankuznetsov/homebrew-hive) |
-| Ubuntu 22.04+ / glibc Linux x86_64/aarch64 | <code>tmpdir="$(mktemp -d)" && trap 'rm -rf "$tmpdir"' EXIT && curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.3.0/install.sh -o "$tmpdir/hive-install.sh" && bash "$tmpdir/hive-install.sh"</code> |
+| Ubuntu 22.04+ / glibc Linux x86_64/aarch64 | <code>tmpdir="$(mktemp -d)" && trap 'rm -rf "$tmpdir"' EXIT && curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.3.1/install.sh -o "$tmpdir/hive-install.sh" && bash "$tmpdir/hive-install.sh"</code> |
 | Arch Linux x86_64/aarch64 | [`yay -S hive-bin`](https://aur.archlinux.org/packages/hive-bin) |
 
 Prerequisites: **Ruby 3.4** (the gem and its runtime deps install against this), git ≥ 2.40, authenticated `claude` ≥ 2.1.118, `codex` ≥ 0.125.0 for the default execute agent, authenticated `gh`, `tmux` ≥ 3.0 when the project uses the default `claude.mode: tmux`, and Node.js/npm for managed QMD install/repair. The bash installer reports its own installer-side prereqs (`curl`, `jq`, `gem`, checksum tool) on first run; if npm is missing, Hive still installs and `hive doctor` reports the QMD gap non-fatally.
@@ -197,6 +197,38 @@ Useful prompt shapes once Hive is installed:
 
 The `--json` envelope is stable across versions (schemas live under [schemas/](schemas/)), so agent prompts can rely on field shapes without scraping. `hive tui` is intentionally human-only and rejects `--json` — use the CLI verbs and `hive status --json` for programmatic use. For installation via an agent, point it at [install.md](install.md).
 
+## Custom Workflows
+
+Hive ships two workflows out of the box — `coding` (the nine-stage idea → PR pipeline) and `content` — but the engine underneath is generic. A workflow is just an **ordered list of stages in a YAML descriptor**, so you can author your own per project: writing, research, triage, translation, a weekly-report generator — any task that moves through a sequence of steps where an AI agent does the work at each one. You describe the stages; the daemon runs the pipeline.
+
+Scaffold one from a sample and run it:
+
+```bash
+# Bootstrap a project bound to a new "writing" workflow, seeded from a sample.
+hive init --new-workflow writing ~/Dev/essays
+cd ~/Dev/essays
+
+# Edit the copied-in stage instructions to taste, then drop in an idea.
+hive new essays "an essay on folder-as-agent pipelines"
+hive status            # watch the daemon move it: research → draft → edit → done
+```
+
+A descriptor is short enough to read top to bottom — an entry gate, agent stages that each do one job, an exit gate:
+
+```yaml
+id: "writing"
+stages:
+  - { name: inbox,    kind: terminal, state_file: idea.md }
+  - { name: research, kind: agent,    state_file: research.md, instruction: ./writing/research.md }
+  - { name: draft,    kind: agent,    state_file: draft.md,    instruction: ./writing/draft.md }
+  - { name: edit,     kind: agent,    state_file: edit.md,     instruction: ./writing/edit.md }
+  - { name: done,     kind: terminal, state_file: done.md }
+```
+
+Three commands cover authoring: `hive workflow new ID` (scaffold a blank starter in an existing project), `hive workflow new ID --template writing|research` (seed from a real multi-stage sample), and `hive init --new-workflow ID` (bootstrap a project and bind the workflow as its default in one go). Custom workflows are discovered from `.hive-state/workflows/*.yml` and run through the same surfaces as the built-ins — `hive new --workflow`, `status`, `run`, `approve`, and the daemon.
+
+**Full walkthrough** — mental model, descriptor anatomy, writing stage instructions, advanced options (terminal approval gates, `skill:` stages, per-stage permissions), and gotchas: **[hivecli.sh/docs/custom-workflows](https://hivecli.sh/docs/custom-workflows/)** (also in-repo at [docs/workflows.md](docs/workflows.md)).
+
 ## Power-User / Scripting CLI
 
 The TUI is the recommended human interface and an agent-driven CLI is the recommended automation surface, but every workflow verb is also available directly on `bin/hive` (or the `hv` shim when Apache Hive shadows the name) for scripting, debugging, and recovery. Each verb supports `--json` and returns a typed envelope.
@@ -204,7 +236,7 @@ The TUI is the recommended human interface and an agent-driven CLI is the recomm
 | Group | Verbs | What it's for |
 |---|---|---|
 | Workflow | `hive new`, `hive brainstorm`, `hive plan`, `hive develop`, `hive open-pr`, `hive review`, `hive artifacts`, `hive finalize`, `hive archive`, `hive run`, `hive approve` | Drive a single stage of a single task by hand. `--from <stage>` lets you re-run a stage in place. See [docs/cli.md#day-to-day-workflow](docs/cli.md#day-to-day-workflow). |
-| Workflow authoring | `hive workflow new` | Scaffold a blank per-project workflow descriptor under `.hive-state/workflows/`. See [docs/workflows.md](docs/workflows.md). |
+| Workflow authoring | `hive workflow new` | Scaffold a project-local workflow descriptor under `.hive-state/workflows/` (`--template writing\|research` seeds from a sample). See [Custom Workflows](#custom-workflows) and [docs/workflows.md](docs/workflows.md). |
 | Review findings | `hive findings`, `hive accept-finding`, `hive reject-finding` | Inspect GFM-checkbox findings from the latest review pass and tick which ones should feed the next fix pass. See [docs/cli.md#findings-triage](docs/cli.md#findings-triage). |
 | Patrol | `hive patrol` | Run one opt-in repository patrol cycle: map feature slices, review them, validate fixes, and open PRs for passed fixes only. See [docs/cli.md#patrol](docs/cli.md#patrol). |
 | Daemon | `hive daemon install/enable/start/status/tail/stop/disable` | Manage the global daemon service plus per-project enrollment. The service polls `hive status --json` and dispatches workflow verbs for enrolled projects. Read [wiki/operating.md](wiki/operating.md) before going live. See [docs/cli.md#daemon](docs/cli.md#daemon). |
@@ -222,7 +254,7 @@ Full per-command reference, every flag, every envelope field, and every exit cod
 - **[wiki/commands/tui.md](wiki/commands/tui.md)** — The TUI deep reference: the two-pane layout, red-status detail, log tail, new-idea composer with image paste, the per-mode keybinding map, the terminal-hostility contract (resize, SIGTSTP, SIGHUP, non-tty rejection), and the subprocess-dispatch model. Read this when the TUI does something surprising or you want the full keystroke surface.
 - **[docs/architecture.md](docs/architecture.md)** — The user-facing architecture: the three trees (project checkout, `.hive-state/` orphan branch, feature worktree), the storage layout `hive init` creates, and how stages, agents, configs, and worktrees compose. Read this when you want to know where files live and which process owns what.
 - **[docs/cli.md](docs/cli.md)** — The full command surface exposed by `bin/hive`: every verb, every flag, every `--json` envelope contract, and every exit code. Read this when you're scripting Hive or wiring it into an agent that needs the full CLI map.
-- **[docs/workflows.md](docs/workflows.md)** — How to author a project-local workflow descriptor, use `hive workflow new`, choose `skill:` versus `instruction:`, and scope stage permissions.
+- **[docs/workflows.md](docs/workflows.md)** — How to author a project-local workflow descriptor: `hive workflow new` (with `--template`), `hive init --new-workflow`, `skill:` versus `instruction:`, and per-stage permissions. The full public walkthrough lives at **[hivecli.sh/docs/custom-workflows](https://hivecli.sh/docs/custom-workflows/)**.
 - **[wiki/operating.md](wiki/operating.md)** — Day-2 operations: install matrix, XDG paths, autostart (systemd-user on Linux, launchd on macOS), enrolling existing projects, the mandatory `--dry-run` shakedown, bot setup, tuning concurrency, cost-runaway response, troubleshooting. Read this before running the daemon live and any time you operate Hive across more than one project.
 - **[docs/recipes.md](docs/recipes.md)** — Concrete end-to-end workflows, including the xbookmark dogfood replay (linked to the real PR and a committed transcript of the run). Read this when you want to see what a complete idea-to-PR run looks like before trying it yourself.
 - **[docs/faq.md](docs/faq.md)** — Troubleshooting and design-rationale answers: why folders instead of a database, why per-stage subprocesses instead of a long-running orchestrator, why commit `.hive-state/` to an orphan branch, why project-level daemon enrollment, why no built-in web UI. Read this when you hit a surprise or want to know "why is it like this?".

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -42,8 +42,10 @@ big versions.
   is pre-1.0; `1.0.0` is reserved for when the CLI/JSON contracts are declared
   stable.
 
-**How to cut a release:** bump `VERSION` in `lib/hive.rb`, sync `Gemfile.lock`
-(`hive-cli (X.Y.Z)`), bump the `vX.Y.Z` installer-URL refs in `README.md` /
+**How to cut a release:** bump `VERSION` in `lib/hive.rb`, sync **both**
+`Gemfile.lock` and `web/Gemfile.lock` (`hive-cli (X.Y.Z)` — the hivebox web app
+depends on the gem via `path: ".."`, so a stale web lock fails its frozen
+`bundle install`), bump the `vX.Y.Z` installer-URL refs in `README.md` /
 `install.md`, add a `## X.Y.Z` CHANGELOG section, PR → merge → `git tag vX.Y.Z
 && git push origin vX.Y.Z`. The tag drives `release.yml` (above). The owner
 bypasses the `v*` tag-protection ruleset.

--- a/install.md
+++ b/install.md
@@ -59,8 +59,8 @@ Ubuntu 22.04+ / glibc Linux fallback (pin to the current release tag, not `main`
 ```bash
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
-# Release maintainers: bump v0.3.0 in both installer URLs when cutting a new stable release.
-curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.3.0/install.sh -o "$tmpdir/hive-install.sh"
+# Release maintainers: bump v0.3.1 in both installer URLs when cutting a new stable release.
+curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.3.1/install.sh -o "$tmpdir/hive-install.sh"
 bash "$tmpdir/hive-install.sh"
 ```
 
@@ -69,8 +69,8 @@ To inspect the installer first, run a dry-run before the real invocation. State 
 ```bash
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
-# Release maintainers: bump v0.3.0 in both installer URLs when cutting a new stable release.
-curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.3.0/install.sh -o "$tmpdir/hive-install.sh"
+# Release maintainers: bump v0.3.1 in both installer URLs when cutting a new stable release.
+curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.3.1/install.sh -o "$tmpdir/hive-install.sh"
 bash "$tmpdir/hive-install.sh" --dry-run
 bash "$tmpdir/hive-install.sh"
 ```

--- a/lib/hive.rb
+++ b/lib/hive.rb
@@ -1,5 +1,5 @@
 module Hive
-  VERSION = "0.3.0".freeze
+  VERSION = "0.3.1".freeze
   MIN_CLAUDE_VERSION = "2.1.118".freeze
   # Canonical GitHub org + repo. Referenced by the release probe
   # (UpdateCheck), the brew tap + installer URL (Commands::Update), etc.

--- a/web/Gemfile.lock
+++ b/web/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    hive-cli (0.3.0)
+    hive-cli (0.3.1)
       bubbletea (= 0.1.4)
       faraday (>= 2.14.2, < 3.0)
       faraday-multipart (~> 1.0)


### PR DESCRIPTION
## What

Announces the **custom-workflows** feature set and prepares the **0.3.1** micro-release.

### Custom workflows in the README
A new **Custom Workflows** section right before the Power-User CLI tables: the pitch (the engine under `coding`/`content` is generic), a concrete `writing.yml` descriptor, a copy-pasteable `hive init --new-workflow` → `hive new` → `hive status` run, the three authoring commands, and a link to the full guide. The workflow-authoring table row and the `docs/workflows.md` Documentation entry are refreshed for `--template`, `--new-workflow`, and the public guide.

### Big changelog (`## 0.3.1`)
Custom workflows (workflow-as-data) is the headline, with the rest of the 92 commits since v0.3.0 grouped honestly: the patrol dry-run security-hardening wave, the digest redesign, task dependencies + stacked PRs, reviewer self-heal/codex-native fixes, hivebox device-flow logins, `hive bench submit`, and dependency bumps.

### Release-prep
Per [docs/RELEASING.md](docs/RELEASING.md): `VERSION` 0.3.0 → 0.3.1 (`lib/hive.rb`), **both** `Gemfile.lock` and `web/Gemfile.lock` synced (`hive-cli (0.3.1)` — the hivebox web app depends on the gem via `path: ".."`, so a stale web lock fails its frozen `bundle install`), and the `v0.3.0` → `v0.3.1` installer-URL refs bumped in `README.md` / `install.md`. RELEASING.md now documents the web-lockfile step so the next release doesn't trip it.

## The public guide
The detailed walkthrough (mental model → descriptor anatomy → authoring → worked example → advanced → gotchas) ships on hive-site, already live: **https://hivecli.sh/docs/custom-workflows/**

## Validation
All required checks green on the prior push (rake test, rubocop, brakeman, bundler-audit) plus hivebox web after the web-lockfile fix; re-running on this amend.

## Maintainer note
This is release-prep, not the release. The final `git tag v0.3.1 && git push origin v0.3.1` (which triggers the gem/Homebrew/AUR publish) is left to you. Merge then tag promptly — the bumped installer URLs reference `v0.3.1` and 404 until the tag exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)