### PR TITLE
fix(task-action): markerless 3-plan tasks are runnable, not a needs-input gate

### DIFF
--- a/lib/hive/task_action.rb
+++ b/lib/hive/task_action.rb
@@ -438,6 +438,16 @@ module Hive
     def plan_action
       return ACTIONS.fetch(:plan_complete) if marker.name == :complete
       return ACTIONS.fetch(:error) if incomplete_plan_artifact?
+      # Markerless (:none) with no plan run yet is runnable, not an input gate.
+      # incomplete_plan_artifact? above already routes a crashed/empty plan run
+      # to :error, so reaching here with :none means the plan agent simply has
+      # not run (e.g. the task was moved into 3-plan via `hive approve` / a
+      # manual mv / a crash before the run). Classify it ready_to_run so the
+      # daemon dispatches the plan agent instead of skipping it as un-approvable
+      # (plan-approval auto-dispatch requires :waiting/:complete) — without this
+      # it wedges in 3-plan with a misleading "Needs your input" label. Mirrors
+      # finalize_action's :none handling.
+      return ACTIONS.fetch(:generic_ready_to_run) if marker.name == :none
 
       ACTIONS.fetch(:plan_waiting)
     end

--- a/test/integration/run_approve_test.rb
+++ b/test/integration/run_approve_test.rb
@@ -659,11 +659,12 @@ class RunApproveTest < Minitest::Test
         assert_equal Hive::Schemas::NextActionKind::RUN, next_action["kind"]
         assert_includes Hive::Schemas::NextActionKind::ALL, next_action["kind"]
         assert_match(%r{/3-plan/#{slug}\z}, next_action["folder"])
-        # After advancing INTO 3-plan, "next" is "run the plan agent
-        # at 3-plan" — `hive plan <slug> --from 3-plan` hits StageAction's
-        # at-target branch. Emitting a verb that would advance OUT (e.g.
-        # `hive develop`) would refuse on the non-terminal marker.
-        assert_equal "hive plan #{slug} --from 3-plan", next_action["command"]
+        # After advancing INTO 3-plan, "next" is "run the plan agent at
+        # 3-plan". The freshly-approved task is markerless, which now
+        # classifies as ready_to_run, so the command is `hive run <slug>`
+        # (runs the current stage). Emitting a verb that would advance OUT
+        # (e.g. `hive develop`) would refuse on the non-terminal marker.
+        assert_equal "hive run #{slug}", next_action["command"]
       end
     end
   end

--- a/test/unit/bot/notification_builders_test.rb
+++ b/test/unit/bot/notification_builders_test.rb
@@ -3,6 +3,8 @@ require "hive/bot/status_watcher"
 require "hive/bot/notification_builders"
 
 class HiveBotNotificationBuildersTest < Minitest::Test
+  include HiveTestHelper
+
   Row = Hive::Bot::StatusWatcher::Row
 
   def row(action:, marker:, attrs: {}, slug: "slug-260514-abcd", stage: "2-brainstorm",
@@ -320,6 +322,23 @@ class HiveBotNotificationBuildersTest < Minitest::Test
       "rerun:hive:slug-260514-abcd:8-finalize:finalize",
       "details:hive:slug-260514-abcd:8-finalize"
     ], callbacks
+  end
+
+  def test_needs_input_rejects_unexpected_row_action_resolution_kind
+    primary = Hive::Bot::RowActions::Action.new(
+      role: :approve,
+      callback: "approve:run:hive:slug-260514-abcd:3-plan",
+      primary: true
+    )
+    unexpected = Hive::Bot::RowActions::Resolution.new(actions: [ primary ], kind: :stage_approval)
+
+    error = with_replaced_singleton_method(Hive::Bot::RowActions, :resolve, ->(_row) { unexpected }) do
+      assert_raises(ArgumentError) do
+        Hive::Bot::NotificationBuilders.build(row(action: "needs_input", marker: "waiting"))
+      end
+    end
+
+    assert_match(/unexpected resolution kind :stage_approval/, error.message)
   end
 
   def test_none_and_complete_needs_input_rows_are_suppressed

--- a/test/unit/task_action_test.rb
+++ b/test/unit/task_action_test.rb
@@ -61,6 +61,20 @@ class TaskActionTest < Minitest::Test
     assert_equal "ready_to_develop", Hive::TaskAction.for(task, marker(:complete)).key
   end
 
+  def test_markerless_plan_is_ready_to_run_not_needs_input
+    # A task moved into 3-plan without a plan run yet (e.g. via `hive approve`)
+    # must be runnable so the daemon dispatches the plan agent — not classified
+    # as a plan-approval gate, which mislabels it "Needs your input" and leaves
+    # the daemon skipping it (plan-approval auto-dispatch requires :waiting).
+    task = fake_task(stage_name: "plan", stage_index: 3)
+    action = Hive::TaskAction.for(task, marker(:none))
+    assert_equal Hive::Schemas::TaskActionKind::READY_TO_RUN, action.key
+    assert_equal "Ready to run", action.label
+    assert_equal "hive run demo-260426-aaaa", action.command
+    refute_equal Hive::Schemas::TaskActionKind::NEEDS_INPUT, action.key,
+                 "markerless plan must not classify as a needs-input gate"
+  end
+
   def test_plan_missing_or_empty_output_is_error_not_needs_input
     Dir.mktmpdir("task-action-plan") do |dir|
       folder = File.join(dir, ".hive-state", "stages", "3-plan", "demo-260426-aaaa")
@@ -68,9 +82,9 @@ class TaskActionTest < Minitest::Test
       task = Hive::Task.new(folder)
 
       missing = Hive::TaskAction.for(task, marker(:none))
-      assert_equal "needs_input", missing.key,
-                   "freshly approved plan-stage folders start without plan.md and must remain runnable"
-      assert_equal "hive plan demo-260426-aaaa --from 3-plan", missing.command
+      assert_equal "ready_to_run", missing.key,
+                   "freshly approved plan-stage folders start without plan.md and must be runnable, not a needs-input gate"
+      assert_equal "hive run demo-260426-aaaa", missing.command
 
       FileUtils.mkdir_p(File.join(dir, ".hive-state", "logs", task.slug))
       File.write(File.join(dir, ".hive-state", "logs", task.slug, "plan-20260519T221007Z.log"), "spawned\n")
@@ -1123,7 +1137,7 @@ class TaskActionTest < Minitest::Test
       terminal: "ready_to_plan"
     },
     "plan" => {
-      none: "needs_input",
+      none: "ready_to_run",
       waiting: "needs_input",
       terminal: "ready_to_develop"
     },

--- a/test/unit/web/supervisor_test.rb
+++ b/test/unit/web/supervisor_test.rb
@@ -369,6 +369,33 @@ class WebSupervisorTest < Minitest::Test
     end
   end
 
+  def test_reap_with_escalation_force_kills_a_child_after_grace_expires
+    with_tmp_global_config do
+      sup = build
+      pid = Process.spawn(RbConfig.ruby, "-e", "Signal.trap('TERM','IGNORE'); sleep 30", pgroup: true)
+      child = Child.new(name: "web", argv: %w[x], pid: pid, started_at: Time.now)
+
+      sup.send(:reap_with_escalation, child, 0)
+
+      assert_equal true, reaped?(pid), "a child that ignores the grace window must be force-killed and reaped"
+    ensure
+      Process.kill("KILL", -pid) if pid && !reaped?(pid)
+      Process.waitpid(pid) rescue nil
+    end
+  end
+
+  def test_signal_group_treats_a_vanished_pid_as_a_no_op
+    # pgroup: true means the reaped child was its group's leader, so the group
+    # is deterministically gone. No global Process.kill stubbing: the suite
+    # runs tests concurrently and a leaked stub breaks neighbors.
+    pid = Process.spawn("true", pgroup: true)
+    Process.wait(pid)
+    supervisor = Hive::Web::Supervisor.new
+
+    assert_nil supervisor.send(:signal_group, pid, "TERM"),
+               "a child that died before the signal is a clean no-op, not a crash"
+  end
+
   # P0-1: loading hive/web/supervisor WITHOUT a preceding `require "hive"` must
   # not raise NameError (uninitialized Hive::ConfigError). test_helper.rb
   # requires "hive" first and masks this, so assert it in a fresh subprocess.
@@ -439,15 +466,5 @@ class WebSupervisorTest < Minitest::Test
 
       sleep 0.02
     end
-  end
-  def test_signal_group_treats_a_vanished_pid_as_a_no_op
-    # pgroup: true → the reaped child WAS its group's leader, so the group
-    # is deterministically gone. (No global Process.kill stubbing: the
-    # suite runs tests concurrently and a leaked stub breaks neighbors.)
-    pid = Process.spawn("true", pgroup: true)
-    Process.wait(pid)
-    supervisor = Hive::Web::Supervisor.new
-    assert_nil supervisor.send(:signal_group, pid, "TERM"),
-               "a child that died before the signal is a clean no-op, not a crash"
   end
 end

--- a/wiki/log.d/20260627T072555Z-coverage-gate-private-tests.md
+++ b/wiki/log.d/20260627T072555Z-coverage-gate-private-tests.md
@@ -1,0 +1,13 @@
+---
+pages: [testing]
+---
+
+**Action:** Documented the CI coverage-gate failure shape where Minitest reports
+`0 failures, 0 errors` but `bundle exec rake coverage` exits 1 after the merged
+coverage report. Added the debugging reminder to read the `Coverage gate failed`
+section and verify intended `test_*` methods are public, because private test
+methods are not discovered and can silently leave defensive branches uncovered.
+
+**Verification:** `bundle exec ruby -Itest test/unit/bot/notification_builders_test.rb`;
+`bundle exec ruby -Itest test/unit/web/supervisor_test.rb`;
+`bundle exec rake coverage`.

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -25,6 +25,14 @@ The coverage task uses Ruby's stdlib `Coverage` API. It starts line and branch c
 
 `bundle exec rake coverage` is the CI coverage-report path. It fails when an executable source file was never loaded, when a subprocess result file cannot be read, or when line coverage drops below the default 100% threshold. Set `HIVE_COVERAGE_MIN_LINE` to a different numeric percentage only when intentionally loosening or tightening that gate. Visual-artifact and Screenote code paths are part of that 100% gate, including error/default branches such as invalid Screenote JSON, default Net::HTTP transport, manifest upload exceptions, missing media directories, screenote config type errors, and dry-run digest completion failures.
 
+A green Minitest summary does not mean the CI job passed: `rake coverage` runs
+the suite, then fails after the summary if the merged coverage gate is below
+100%. When a GitHub job shows `0 failures, 0 errors` followed by exit 1, read
+the `Coverage gate failed` section and add focused tests for the listed lines.
+Also check that intended `test_*` methods sit above any `private` marker; private
+test methods are not discovered, so they can silently leave defensive lines
+uncovered.
+
 Coverage-included tests that only need a generic stdout/stderr subprocess should avoid `RbConfig.ruby` children unless they are explicitly testing Ruby coverage propagation. Those nested Ruby processes inherit the coverage `RUBYOPT`, which can make startup latency part of otherwise unrelated timeout assertions; use a tiny executable fixture script for generic capture/timeout seams.
 
 In CI (`CI=true`), tests that exercise backgrounding commands must force a foreground path (for example `foreground: true`) or stub daemonization. Otherwise the test process can daemonize before Minitest `after_run` writes `coverage/coverage.json`, leaving the parent coverage task with a missing report while child output keeps streaming. Coverage also reloads `lib/hive.rb`, so self-derived enum constants must exclude `:ALL` to stay reload-safe.


### PR DESCRIPTION
## Problem
A task that ends up **markerless in `3-plan`** (moved in via `hive approve`, a manual `mv`, or a crash before the plan run) was classified as `plan_waiting` → `needs_input`. The daemon can't recover it: its only `3-plan` behavior is plan-*approval* auto-dispatch, which requires a **drafted** plan (`:waiting`/`:complete`). So every tick it logs `plan_approval_invalid: marker=:none; plan-approval auto-dispatch requires :waiting or :complete` and **skips** the task — the plan agent never runs, and the row wedges in `3-plan` with a misleading **"Needs your input"** label.

Found live: 8 tasks advanced into `3-plan` sat stuck this way until each was manually `hive plan`-ed.

## Fix
`plan_action` now classifies a markerless plan task as `ready_to_run` (one line, after the existing `incomplete_plan_artifact?` → `:error` guard, which still catches crashed/empty plan runs). The daemon then dispatches the plan agent (`hive run`) instead of skipping. This mirrors `finalize_action`'s existing `:none → generic_ready_to_run` handling — the plan stage just never got the same treatment.

`:waiting` (a *drafted* plan awaiting approval) is unchanged — that genuinely is the approval gate.

## Tests
- New `test_markerless_plan_is_ready_to_run_not_needs_input`.
- Updated the golden action matrix (`plan` / `none` → `ready_to_run`).
- Updated `test_plan_missing_or_empty_output_is_error_not_needs_input`, whose own assertion message ("must remain runnable") already documented the contradiction it was asserting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)