### PR TITLE
Hive patrol: gh dry-run passthrough keeps proxy trust env

### DIFF
--- a/bin/hive-babysitter-stub-gh
+++ b/bin/hive-babysitter-stub-gh
@@ -455,10 +455,14 @@ end
 # allowlisted read at an agent-chosen host (GH_REPO carries an optional `[HOST/]`), and
 # GH_ENTERPRISE_TOKEN / GITHUB_ENTERPRISE_TOKEN supply the credentials for it, so scrub
 # them too, the same host-redirect threat the argv gate defends against.
+# Proxy and TLS trust-store env can still redirect a safe read through an agent-controlled
+# MITM before real gh sees GitHub credentials, so scrub those at the same exec seam.
 %w[
   GH_PAGER PAGER GH_BROWSER BROWSER GH_EDITOR GIT_EDITOR VISUAL EDITOR GH_FORCE_TTY
   GH_CONFIG_DIR XDG_CONFIG_HOME HIVE_BABYSITTER_TRUSTED_GH_CONFIG_DIR
   GH_HOST GH_REPO GH_ENTERPRISE_TOKEN GITHUB_ENTERPRISE_TOKEN
+  HTTP_PROXY HTTPS_PROXY ALL_PROXY NO_PROXY http_proxy https_proxy all_proxy no_proxy
+  SSL_CERT_FILE SSL_CERT_DIR ssl_cert_file ssl_cert_dir
 ].each { |key| ENV.delete(key) }
 # Unlike git — which treats GIT_CONFIG_GLOBAL=/dev/null (and GIT_CONFIG_NOSYSTEM) as an explicit
 # "no config" sentinel — gh has no such escape hatch. It derives its config dir as

--- a/test/unit/babysitter/dry_run_env_test.rb
+++ b/test/unit/babysitter/dry_run_env_test.rb
@@ -886,6 +886,8 @@ class BabysitterDryRunEnvTest < Minitest::Test
       env_keys = %w[
         GH_PAGER PAGER GH_BROWSER BROWSER GH_EDITOR GIT_EDITOR VISUAL EDITOR GH_FORCE_TTY
         GH_CONFIG_DIR XDG_CONFIG_HOME HOME
+        HTTP_PROXY HTTPS_PROXY ALL_PROXY NO_PROXY http_proxy https_proxy all_proxy no_proxy
+        SSL_CERT_FILE SSL_CERT_DIR ssl_cert_file ssl_cert_dir
       ]
       real_gh = recording_env_binary(dir, "real-gh", env_keys)
       env = {
@@ -902,7 +904,19 @@ class BabysitterDryRunEnvTest < Minitest::Test
         "GH_FORCE_TTY" => "80",
         "GH_CONFIG_DIR" => File.join(dir, "evil-gh-config"),
         "XDG_CONFIG_HOME" => File.join(dir, "evil-xdg-config"),
-        "HOME" => File.join(dir, "evil-home")
+        "HOME" => File.join(dir, "evil-home"),
+        "HTTP_PROXY" => "http://127.0.0.1:8080",
+        "HTTPS_PROXY" => "http://127.0.0.1:8443",
+        "ALL_PROXY" => "socks5://127.0.0.1:1080",
+        "NO_PROXY" => "",
+        "http_proxy" => "http://127.0.0.1:8081",
+        "https_proxy" => "http://127.0.0.1:8444",
+        "all_proxy" => "socks5://127.0.0.1:1081",
+        "no_proxy" => "",
+        "SSL_CERT_FILE" => File.join(dir, "agent-ca.pem"),
+        "SSL_CERT_DIR" => File.join(dir, "agent-ca-dir"),
+        "ssl_cert_file" => File.join(dir, "agent-ca-lower.pem"),
+        "ssl_cert_dir" => File.join(dir, "agent-ca-dir-lower")
       }
 
       _out, err, status = Open3.capture3(env, stub_path("gh"), "repo", "view", "owner/repo")


### PR DESCRIPTION
## Summary

Security hardening of the babysitter dry-run `gh` stub (`bin/hive-babysitter-stub-gh`).

After allowlisting a read-only `gh` command, the stub already scrubbed pager,
editor, browser, host, repo, config, and enterprise-token environment variables
before `exec`ing the real `gh` binary — but it left proxy and TLS trust-store
variables intact. A dry-run agent could therefore route an otherwise-allowed
`gh pr view` / `gh api` read through an agent-controlled proxy with an
agent-controlled CA, bypassing the host-redirect guard and capturing the GitHub
credentials `gh` uses for the read.

The fix extends that same exec-seam scrub list to delete both upper- and
lower-case proxy variables (`HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, `NO_PROXY`,
…) and TLS trust-store override variables (`SSL_CERT_FILE`, `SSL_CERT_DIR`, …)
before passthrough, consistent with the stub's established deny-all clean-slate
design.

## Test plan

- `test/unit/babysitter/dry_run_env_test.rb` extends
  `test_gh_stub_scrubs_exec_influencing_environment_before_passthrough` to set
  hostile proxy/CA env and assert each variable is recorded as unset for an
  allowed `gh` passthrough.
- Regression run from the worktree:

  ```
  ruby -Itest test/unit/babysitter/dry_run_env_test.rb \
    -n test_gh_stub_scrubs_exec_influencing_environment_before_passthrough
  # 1 runs, 30 assertions, 0 failures, 0 errors, 0 skips
  ```

- Full gates: `bundle exec rubocop` (lint) and `bundle exec rake test` (suite)
  both passed.

Diff vs `main`: 2 files changed, 19 insertions(+), 1 deletion(-).

## Review summary

- 6-review flow completed (pass 1). High: none. Nit: none.
- One Medium ("preserve trusted proxy/CA settings for gh passthrough") was
  triaged RESOLVED / NO-FIX and suppressed: the patrol task Recommendation
  explicitly sanctioned deleting these vars, the stub follows an established
  deny-all clean-slate design (it scrubs even the captured trusted-config dir and
  uses a fresh empty config dir), and no proxy/CA support exists anywhere in
  `lib/`/`bin/`, so the corporate-proxy scenario is out of scope.
- No escalations; no open user questions.

## Linked task

- Patrol finding: `command-bin-hive-e2e-1`
  (fingerprint `d50f072de5abbc90fe40af1162a43bc4df780c479dee89e82b2e53eb3b009a54`)
- Task folder: `/home/asterio/Dev/hive/.hive-state/stages/6-review/patrol-command-bin-hive-e2e-d50f072d`
