### PR TITLE
chore(release): 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,51 @@
 
 All notable changes are documented here, newest first. Hive ships frequent micro-releases (see [docs/RELEASING.md](docs/RELEASING.md#versioning-policy)): each `vX.Y.Z` git tag gets a `## X.Y.Z` section with terse bullets — no `[Unreleased]` accumulator. Versioning is [SemVer](https://semver.org): PATCH for fixes and small changes (the common case), MINOR for notable features, MAJOR for milestones.
 
+## 0.4.0
+
+A security-hardening release. A second wave of fixes to the `hive patrol` dry-run sandbox — where the stubbed `gh`/`git` passthrough is exposed to agent-controlled input — closes pre-guard code-execution and host-gate-bypass vectors. Alongside it, the Telegram bot gains idea-by-default capture, a `/waiting` view backed by a daily pending-answer digest, task-id slash commands, and structured JSON errors, plus pipeline, status, and TUI refinements.
+
+### Patrol security hardening
+
+- Fixed: the dry-run `gh`/`git` stubs honored caller-controlled Ruby startup hooks (`RUBYOPT`, `RUBYLIB`) and could run attacker code before the allowlist guard; the dry-run launcher now scrubs Ruby/Bundler/Gem startup env before invoking the stubs.
+- Fixed: clustered `-R`/short-flag selectors slipped the `gh` host gate, letting a dry-run read target an arbitrary host.
+- Fixed: dry-run stubs could exec a relative real-binary path resolved from the worktree.
+- Fixed: skip-log writes followed hard links and could append outside the worktree.
+- Fixed: `gh` dry-run passthrough leaked proxy-trust environment to the real binary.
+- Fixed: replay followed symlinked parent directories.
+- Fixed: invalid-UTF-8 / invalid-byte argv crashed the stub or bypassed the strict usage contract.
+- Fixed: the `gh` stub emitted a raw backtrace when the real binary was missing.
+- Fixed: detached background cleanup could signal a reused process group.
+- Fixed: a missing `--report` value could swallow `--no-judge` and run evals unintentionally.
+
+### Telegram bot
+
+- Bare text sent to the bot is now captured as an idea by default instead of erroring.
+- New `/waiting` command lists tasks awaiting your input, backed by a daily pending-answer digest so nothing stalls unseen.
+- Slash commands accept a bare task id (e.g. `/approve 42`).
+- Added log severity levels and quieted routine `bot.log` noise.
+- `--json` usage errors now return a structured `hive-bot-status` envelope instead of prose.
+- Fixed: every needs-input row now gets a working action button or is suppressed — no dead buttons.
+- Fixed: "Show details" always renders row content.
+- Fixed: stuck-task alerts are suppressed for healthy live-agent retries.
+
+### Pipeline & status
+
+- Fixed: markerless `3-plan` tasks are runnable instead of being parked behind a needs-input gate.
+- Needs-input status labels now differentiate by the reason a task paused.
+
+### Performance
+
+- TUI status polling cost now scales with the number of active tasks rather than the full archive.
+
+### Setup
+
+- Selected agent backends now persist globally, so new projects inherit your choice.
+
+### Packaging
+
+- Fixed: the published arm64 hivebox image is smoke-tested on native arm64 Linux instead of macOS/colima.
+
 ## 0.3.1
 
 Custom workflows: Hive's pipeline engine is now generic data. Author your own per-project workflow — writing, research, triage, translation, anything — in a few lines of YAML, scaffold it from a sample, and let the daemon run it the same way it runs `coding`. This release also lands a large patrol-driven security-hardening wave, a redesigned daily digest, task dependencies with stacked PRs, and device-flow agent logins in hivebox.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hive-cli (0.3.1)
+    hive-cli (0.4.0)
       bubbletea (= 0.1.4)
       faraday (>= 2.14.2, < 3.0)
       faraday-multipart (~> 1.0)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Hive ships as a rubygem (`hive-cli`) attached to each GitHub Release, signed wit
 | Platform | Channel |
 |----------|---------|
 | macOS arm64 | [`brew install ivankuznetsov/hive/hive`](https://github.com/ivankuznetsov/homebrew-hive) |
-| Ubuntu 22.04+ / glibc Linux x86_64/aarch64 | <code>tmpdir="$(mktemp -d)" && trap 'rm -rf "$tmpdir"' EXIT && curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.3.1/install.sh -o "$tmpdir/hive-install.sh" && bash "$tmpdir/hive-install.sh"</code> |
+| Ubuntu 22.04+ / glibc Linux x86_64/aarch64 | <code>tmpdir="$(mktemp -d)" && trap 'rm -rf "$tmpdir"' EXIT && curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.4.0/install.sh -o "$tmpdir/hive-install.sh" && bash "$tmpdir/hive-install.sh"</code> |
 | Arch Linux x86_64/aarch64 | [`yay -S hive-bin`](https://aur.archlinux.org/packages/hive-bin) |
 
 Prerequisites: **Ruby 3.4** (the gem and its runtime deps install against this), git ≥ 2.40, authenticated `claude` ≥ 2.1.118, `codex` ≥ 0.125.0 for the default execute agent, authenticated `gh`, `tmux` ≥ 3.0 when the project uses the default `claude.mode: tmux`, and Node.js/npm for managed QMD install/repair. The bash installer reports its own installer-side prereqs (`curl`, `jq`, `gem`, checksum tool) on first run; if npm is missing, Hive still installs and `hive doctor` reports the QMD gap non-fatally.

--- a/install.md
+++ b/install.md
@@ -59,8 +59,8 @@ Ubuntu 22.04+ / glibc Linux fallback (pin to the current release tag, not `main`
 ```bash
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
-# Release maintainers: bump v0.3.1 in both installer URLs when cutting a new stable release.
-curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.3.1/install.sh -o "$tmpdir/hive-install.sh"
+# Release maintainers: bump v0.4.0 in both installer URLs when cutting a new stable release.
+curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.4.0/install.sh -o "$tmpdir/hive-install.sh"
 bash "$tmpdir/hive-install.sh"
 ```
 
@@ -69,8 +69,8 @@ To inspect the installer first, run a dry-run before the real invocation. State 
 ```bash
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
-# Release maintainers: bump v0.3.1 in both installer URLs when cutting a new stable release.
-curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.3.1/install.sh -o "$tmpdir/hive-install.sh"
+# Release maintainers: bump v0.4.0 in both installer URLs when cutting a new stable release.
+curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.4.0/install.sh -o "$tmpdir/hive-install.sh"
 bash "$tmpdir/hive-install.sh" --dry-run
 bash "$tmpdir/hive-install.sh"
 ```

--- a/lib/hive.rb
+++ b/lib/hive.rb
@@ -1,5 +1,5 @@
 module Hive
-  VERSION = "0.3.1".freeze
+  VERSION = "0.4.0".freeze
   MIN_CLAUDE_VERSION = "2.1.118".freeze
   # Canonical GitHub org + repo. Referenced by the release probe
   # (UpdateCheck), the brew tap + installer URL (Commands::Update), etc.

--- a/web/Gemfile.lock
+++ b/web/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    hive-cli (0.3.1)
+    hive-cli (0.4.0)
       bubbletea (= 0.1.4)
       faraday (>= 2.14.2, < 3.0)
       faraday-multipart (~> 1.0)


### PR DESCRIPTION
Minor release cutting **v0.4.0** (from v0.3.1). Follows the `docs/RELEASING.md` cut procedure: `VERSION` bump, both `Gemfile.lock`s synced, installer-URL refs bumped, and a `## 0.4.0` CHANGELOG section that `release.yml` extracts verbatim as the GitHub release notes.

## What's in 0.4.0

A security-hardening release covering 27 user-facing PRs merged since v0.3.1.

- **Patrol security hardening** — a second wave on the dry-run `gh`/`git` sandbox: closes `RUBYOPT`/`RUBYLIB` pre-guard code execution, clustered `-R` host-gate bypass, relative real-binary exec, hard-link/symlink skip-log and replay escapes, proxy-trust env leakage, invalid-byte argv crashes, and more.
- **Telegram bot** — bare text → idea capture by default; `/waiting` + daily pending-answer digest; task-id slash commands; log severity levels; `--json` usage errors now return a structured `hive-bot-status` envelope; dead-button and stuck-alert fixes.
- **Pipeline & status** — markerless `3-plan` tasks are runnable; needs-input labels differentiate by pause reason.
- **Performance** — TUI poll cost scales with active tasks, not the archive.
- **Setup / packaging** — agent backends persist globally; published arm64 hivebox image smoke-tested on native arm64 Linux.

## Verification

- `hive --version` → `0.4.0`
- `bundle check` passes for root **and** `web/` (frozen-install safe)
- `rubocop lib/hive.rb` clean
- `release.yml` notes extraction yields the full `## 0.4.0` section (44 lines)
- No stray `0.3.1` refs outside the historical changelog/wiki

## After merge

Tagging is the irreversible public trigger (gem + Homebrew + AUR + hivebox image) and is **not** done here — once this merges, cut it with `git tag v0.4.0 && git push origin v0.4.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)