### PR TITLE
docs(openclaw): document hive-daemon diagnostics and safe repair

### DIFF
--- a/openclaw/skills/hive/SKILL.md
+++ b/openclaw/skills/hive/SKILL.md
@@ -112,6 +112,98 @@ Degrade gracefully: if `systemctl` is unavailable (for example macOS/launchd), r
 If `gh` is missing, unauthenticated, or the task has no PR, report CI as unknown/not applicable.
 If the daemon is stopped or has no live PID, report that plainly instead of failing the bundle.
 
+## Daemon Diagnostics And Repair
+
+Use this when interactive `hive` works but the rootless user-systemd `hive-daemon.service` misbehaves. Run the read-only diagnostics in order before any repair so the operator can see whether the service is using the wrong binary, a missing gem environment, or a Ruby `LoadError`.
+
+Read-only diagnostics — binary alignment:
+
+```bash
+command -v hive
+hive --version
+systemctl --user cat hive-daemon.service
+systemctl --user show hive-daemon.service -p Environment
+hive daemon status --json
+```
+
+Compare the interactive `command -v hive` path with the service `HIVE_BIN`. The expected default is the interactive binary unless the operator intentionally chose another path. A mismatch such as `/usr/bin/hive` versus `~/.local/bin/hive` usually means the daemon is not running the same Hive CLI the shell runs. When `/usr/bin/hive` appears, flag possible Apache Hive shadowing or an unintended system-package path.
+
+Read-only diagnostics — gem and environment validation:
+
+```bash
+ruby -e 'puts Gem.user_dir'
+gem env home
+gem env path
+printf '%s\n' "$PATH"
+systemctl --user show hive-daemon.service -p Environment
+```
+
+Compare the working shell's `PATH`, `GEM_HOME`, and `GEM_PATH` with the unit's `Environment=` lines. The daemon environment is broken when it lacks the user gem dir, lacks the directory containing the intended `hive` binary, points at a different `HIVE_BIN`, or works interactively while the daemon or status path raises a Ruby `LoadError`.
+
+Read-only diagnostics — Arch `ruby-erb` LoadError:
+
+```text
+cannot load such file -- erb (LoadError)
+```
+
+Prefer the system package fix on Arch:
+
+```bash
+sudo pacman -S ruby-erb
+```
+
+If a user-local fallback is required, install the gem and read the actual gem paths from the local Ruby rather than hardcoding a version fragment:
+
+```bash
+gem install --user-install erb
+ruby -e 'puts Gem.user_dir'
+gem env path
+```
+
+These commands print full gem directory paths that already contain the correct Ruby minor-version segment; copy those paths verbatim when adding `GEM_PATH` to the service environment rather than hand-assembling a version fragment.
+
+### Safe repair (mutating)
+
+Prefer a user systemd drop-in override instead of editing the generated unit in place. Inspect first, preserve existing `Environment=` values, and merge only the missing `PATH`, `GEM_HOME`, `GEM_PATH`, or `HIVE_BIN` entries.
+
+`systemctl --user edit hive-daemon.service` and `sudo pacman -S ruby-erb` are interactive/operator-run: the first opens `$SYSTEMD_EDITOR`/`$EDITOR` and the second prompts for a sudo password, so both block (or no-op with no TTY) when an agent runs them non-interactively. When acting non-interactively, write the drop-in override file directly instead of opening the editor, adding only the missing `Environment=` lines:
+
+```bash
+systemctl --user cat hive-daemon.service
+mkdir -p ~/.config/systemd/user/hive-daemon.service.d
+cat > ~/.config/systemd/user/hive-daemon.service.d/override.conf <<'EOF'
+[Service]
+Environment=GEM_PATH=<derived-value>
+# Add only the entries that were actually missing, e.g.:
+# Environment=PATH=<derived-value>
+# Environment=GEM_HOME=<derived-value>
+# Environment=HIVE_BIN=<derived-value>
+EOF
+```
+
+The interactive editor path stays available for an operator running this by hand:
+
+```bash
+systemctl --user edit hive-daemon.service
+```
+
+Reloading and restarting the service stops and restarts background automation, so — like `daemon stop` in `## Safety Boundaries` — restate the effect and get explicit user confirmation before running:
+
+```bash
+systemctl --user daemon-reload
+systemctl --user restart hive-daemon.service
+```
+
+Verify the service is active, responding, and running with the intended binary and environment:
+
+```bash
+systemctl --user status hive-daemon.service --no-pager
+hive daemon status --json
+systemctl --user show hive-daemon.service -p Environment
+```
+
+If the repair changed `HIVE_BIN`, confirm it matches `command -v hive` or the operator's intentional chosen path.
+
 ## Safety Boundaries
 
 Before running destructive admin verbs (`drop`, `uninstall`, `update`, `forget`, `prune`, `migrate`, or `metrics`), restate the effect and get explicit user confirmation. These verbs can kill agents, remove worktrees, close draft PRs, drop registry entries, or rewrite installed software — they are not undoable.

--- a/test/unit/openclaw_skills_test.rb
+++ b/test/unit/openclaw_skills_test.rb
@@ -101,7 +101,7 @@ class OpenClawSkillsTest < Minitest::Test
     _metadata, body = read_skill("hive")
     status_bundle = section(body, "## Status Bundle")
 
-    assert_operator body.index("## Status Bundle"), :<, body.index("## Safety Boundaries")
+    assert_operator body.index(/^## Status Bundle$/), :<, body.index(/^## Safety Boundaries$/)
 
     [
       "hive daemon status --json",
@@ -126,6 +126,40 @@ class OpenClawSkillsTest < Minitest::Test
     end
 
     assert_includes status_bundle, "read-only"
+  end
+
+  def test_umbrella_skill_documents_daemon_diagnostics_and_repair
+    _metadata, body = read_skill("hive")
+    diagnostics = section(body, "## Daemon Diagnostics And Repair")
+
+    diagnostics_index = body.index(/^## Daemon Diagnostics And Repair$/)
+    safety_index = body.index(/^## Safety Boundaries$/)
+    assert_operator diagnostics_index, :<, safety_index
+    between = body[diagnostics_index...safety_index].sub(/\A## Daemon Diagnostics And Repair\n/, "")
+    refute_match(/^## /, between,
+      "## Daemon Diagnostics And Repair must sit immediately before ## Safety Boundaries")
+
+    [
+      "systemctl --user cat hive-daemon.service",
+      "systemctl --user show hive-daemon.service -p Environment",
+      "command -v hive",
+      "HIVE_BIN",
+      "/usr/bin/hive",
+      "~/.local/bin/hive",
+      "GEM_HOME",
+      "GEM_PATH",
+      "PATH",
+      "cannot load such file -- erb (LoadError)",
+      "ruby-erb",
+      "sudo pacman -S ruby-erb",
+      "gem install --user-install erb",
+      "systemctl --user edit hive-daemon.service",
+      "systemctl --user daemon-reload",
+      "systemctl --user restart hive-daemon.service",
+      "hive daemon status --json"
+    ].each do |literal|
+      assert_includes diagnostics, literal
+    end
   end
 
   def test_openclaw_docs_publish_only_the_single_hive_cli_slug


### PR DESCRIPTION
## Summary

Operators whose interactive `hive` works but whose rootless user-systemd `hive-daemon.service` misbehaves previously had no guidance for the common failure modes: the daemon running a different binary than the shell (`HIVE_BIN` mismatch), a missing gem environment (`PATH`/`GEM_HOME`/`GEM_PATH`), or a Ruby `LoadError`. The Hive umbrella skill now documents how to diagnose and safely repair these.

The new `## Daemon Diagnostics And Repair` section leads with copy-pasteable **read-only** diagnostics — binary alignment, gem/environment validation, and the Arch `ruby-erb` `LoadError` signature — so an operator can see what's wrong before touching anything. A clearly separated **mutating safe-repair** flow then walks through a user systemd drop-in override (`systemctl --user edit`, with a non-interactive `override.conf` path for agent execution) that preserves existing `Environment=` values and merges only what's missing, followed by a verify step confirming the service is active, responding, and running the intended binary.

### Design decisions

- **Read-only before mutating.** All diagnostics run first; the repair subsection is visually and structurally separated (`### Safe repair (mutating)`) so nothing mutates state before the operator understands the failure.
- **Drop-in override, not in-place edit.** Repair uses `systemctl --user edit` so the generated unit stays intact and existing environment entries are preserved; a non-interactive `~/.config/systemd/user/hive-daemon.service.d/override.conf` path is documented for the agent, with commented `Environment=` templates for each mergeable key.
- **Derive, don't hardcode.** The `ruby-erb` user-local fallback instructs deriving the Ruby minor-version gem path from the local Ruby (`ruby -e 'puts Gem.user_dir'` / `gem env`) rather than pasting a stale version segment.
- **Additive only.** The section is inserted immediately before `## Safety Boundaries`; no existing section is restructured and the safety-boundary language is untouched. The mutating repair restates the confirmation the safety model requires before restarting background automation.

## Test plan

Added one focused test, `test_umbrella_skill_documents_daemon_diagnostics_and_repair`, asserting the new section sits immediately before `## Safety Boundaries` (anchored on the real heading, not an inline backtick reference) and contains the required literal command/error/remediation strings. The existing destructive-command safety test is unchanged.

```
LANG=C.UTF-8 ruby -Itest test/unit/openclaw_skills_test.rb
7 runs, 181 assertions, 0 failures, 0 errors, 0 skips
```

## Review summary

Four automated review lanes ran across two passes (`ce-code-review`, `pr-review-toolkit`, and two `codex` passes). No unresolved High or Medium findings remain.

- **Interactive repair command (High).** The mutating block only offered `systemctl --user edit`, which spawns an interactive editor and would hang a non-interactive agent. Fixed by adding a non-interactive drop-in `override.conf` write path while keeping the mandated literal.
- **Safety confirmation (Medium).** The repair flow restarted the daemon without restating the confirmation `## Safety Boundaries` requires; added a confirmation restatement/cross-reference.
- **Placement guard (Medium).** The test's "immediately before `## Safety Boundaries`" assertion matched an inline backtick reference rather than the real heading, making it vacuous. Re-anchored on the real heading and strengthened to reject any intervening `## ` heading; remediation commands (`sudo pacman -S ruby-erb`, `gem install --user-install erb`) are now asserted too.
- **Doc polish (Nit).** Added commented `Environment=` example lines for the other mergeable keys and clarified the derive-don't-hardcode wording.
- **Scope / stale-branch notes (resolved, no fix).** The `## Status Bundle` section and the broad `origin/main..HEAD` deletions are prior-accepted work and a stale merge-base artifact respectively; the branch's own net change is additive to the two plan-named files and resolves at merge-time rebase.

## Linked task

Hive task: `update-the-openclaw-hive-skill-260630-021d`
