### PR TITLE
Hive patrol: Asciinema 2.4 is accepted but launched with a v3-only flag

### DIFF
--- a/test/e2e/lib/asciinema_driver.rb
+++ b/test/e2e/lib/asciinema_driver.rb
@@ -53,7 +53,7 @@ module Hive
         @pid = Process.spawn(
           self.class.binary, "rec", "--overwrite",
           *recorder_size_args,
-          "--output-format=asciicast-v2",
+          *recorder_output_format_args,
           "--command", command,
           @cast_path,
           out: File::NULL,
@@ -133,6 +133,12 @@ module Hive
         return [ "--window-size", "#{@cols}x#{@rows}" ] if @version.segments.first >= 3
 
         [ "--rows", @rows.to_s, "--cols", @cols.to_s ]
+      end
+
+      def recorder_output_format_args
+        return [ "--output-format=asciicast-v2" ] if @version.segments.first >= 3
+
+        []
       end
     end
   end

--- a/test/e2e/lib/asciinema_driver_test.rb
+++ b/test/e2e/lib/asciinema_driver_test.rb
@@ -67,8 +67,55 @@ class E2EAsciinemaDriverTest < Minitest::Test
       argv = JSON.parse(File.read(args))
       assert_includes argv, "--window-size"
       assert_includes argv, "200x50"
+      assert_includes argv, "--output-format=asciicast-v2"
       refute_includes argv, "--rows"
       refute_includes argv, "--cols"
+    ensure
+      ENV["HIVE_ASCIINEMA_BIN"] = old
+    end
+  end
+
+  def test_omits_output_format_arg_for_v2_binary
+    Dir.mktmpdir("asciinema") do |dir|
+      script = File.join(dir, "asciinema")
+      cast = File.join(dir, "cast.json")
+      args = File.join(dir, "args.json")
+      File.write(script, <<~RUBY)
+        #!/usr/bin/env ruby
+        require "json"
+
+        if ARGV == ["--version"]
+          puts "asciinema 2.4.0"
+          exit 0
+        end
+
+        if ARGV.include?("--output-format=asciicast-v2")
+          exit 64
+        end
+
+        if ARGV.first == "rec"
+          File.write(#{args.inspect}, JSON.dump(ARGV))
+          File.write(ARGV.last, %({"version":2,"width":200,"height":50}\\n))
+          sleep 30
+        end
+      RUBY
+      File.chmod(0o755, script)
+
+      old = ENV["HIVE_ASCIINEMA_BIN"]
+      ENV["HIVE_ASCIINEMA_BIN"] = script
+      driver = Hive::E2E::AsciinemaDriver.new(socket_name: "fake", session_name: "fake", cast_path: cast)
+      driver.start
+      deadline = Time.now + 2
+      sleep 0.05 until File.exist?(args) || Time.now >= deadline
+      driver.stop
+
+      argv = JSON.parse(File.read(args))
+      assert_includes argv, "--rows"
+      assert_includes argv, "50"
+      assert_includes argv, "--cols"
+      assert_includes argv, "200"
+      refute_includes argv, "--window-size"
+      refute_includes argv, "--output-format=asciicast-v2"
     ensure
       ENV["HIVE_ASCIINEMA_BIN"] = old
     end


### PR DESCRIPTION
## Summary

`AsciinemaDriver` accepts any asciinema `>= 2.4.0` and already branches its
terminal-size flags between v2 and v3, but `start` unconditionally passed
`--output-format=asciicast-v2`. That flag only exists on the v3 CLI: a valid
asciinema 2.4 install records asciicast-v2 by default and can reject the unknown
flag, so the recorder exits immediately and TUI failure bundles lose their cast
even though preflight passed.

This change makes the output-format argument version-specific:

- `recorder_output_format_args` now returns `--output-format=asciicast-v2` only
  for asciinema 3.x and an empty argument list for 2.x, so the 2.x recorder is
  launched with `--rows`/`--cols` only.
- `start` builds its argv from `*recorder_output_format_args` instead of the
  hardcoded flag.

## Test plan

- `bundle exec rubocop` — passed
- `bundle exec rake test` — passed
- Added a fake asciinema 2.4.0 test that rejects `--output-format` and asserts
  the v2 command is built without it (size flags only), alongside the existing
  v3 coverage.

## Review summary

Automated review (`codex-native-review-01`) reported no findings across High,
Medium, and Nit tiers. No escalations were raised and no findings were
suppressed.

## Linked task

- Patrol finding: `test-suite-test-babysitter-acceptance-dry-run-test-rb`
  (fingerprint `dba66906c19792f12f4a858a0b1025575231224e7ddbb869b69eb4ccf88aa8a4`)
- Task folder: `/home/asterio/Dev/hive/.hive-state/stages/6-review/patrol-test-suite-test-babysitter-acceptance-dry-run-test-rb-dba`
