### PR TITLE
docs(openclaw): add local dogfood workflow to hive skill

### DIFF
--- a/openclaw/skills/hive/SKILL.md
+++ b/openclaw/skills/hive/SKILL.md
@@ -91,6 +91,90 @@ Prefer `--json` when the Hive command supports it and you need structured output
 
 For `hive wiki compile-log`, prefer `--check` when verifying an aggregate wiki changelog. Run the mutating compile command only after merge/rebase or when the user explicitly wants `wiki/log.md` refreshed; feature PRs should add `wiki/log.d/<timestamp>-<slug>.md` fragments instead of editing the compiled log directly.
 
+## Local Dogfood
+
+Use this checklist to dogfood a merged but unreleased Hive PR against the active local runtime. Prefer a clean worktree runtime so the installed gem, package, or standalone binary stays untouched. The goal is to preserve dirty worktree state while proving the merged change locally; do not bump or release during dogfood.
+
+1. Verify the PR is merged and green:
+
+```bash
+gh pr view <number> --json state,mergedAt,baseRefName,statusCheckRollup
+```
+
+Proceed only when `state` is `MERGED`, `mergedAt` is present, `baseRefName` is the expected main branch, and all required checks pass with none required-pending. Hard-stop when the PR is unmerged, red, or still has required checks pending.
+
+2. Identify the active runtime:
+
+```bash
+command -v hive
+readlink -f "$(command -v hive)"
+hive --version
+systemctl --user cat hive-daemon.service
+systemctl --user show hive-daemon.service
+```
+
+Compare the interactive binary with any daemon `HIVE_BIN` or unit override. Handle the install shape that is actually active: gem/rbenv/rvm/bundler, Homebrew Cellar, Arch package, standalone binary, or a user-local wrapper.
+
+3. Guard worktrees:
+
+```bash
+git status --short
+```
+
+Refuse to mutate any worktree with uncommitted changes. Require a separate clean checkout or clean `git worktree` for the merged PR.
+
+4. Apply the change:
+
+First record the prior override so rollback can restore it, not clobber it. Capture the daemon's current `HIVE_BIN` (and any drop-in `Environment=`) from step 2's `systemctl --user show hive-daemon.service` / interactive `command -v hive`; note whether an intentional override already existed and its exact value. Preferred worktree mode points the daemon override or `HIVE_BIN` at the clean merged checkout and leaves the installed binary untouched. See `## Daemon Diagnostics And Repair` for how to set `HIVE_BIN` or the unit `Environment=` via a systemd drop-in override. Patch-in-place is only a tiny single-file emergency fallback: back up the exact installed file first, then copy the changed file from the clean checkout. Do not run broad `git apply` or `cherry-pick` inside an installed package tree.
+
+5. Run checks:
+
+```bash
+ruby -c path/to/changed_file.rb
+bundle exec ruby -Itest test/path/to/focused_test.rb
+```
+
+Use the syntax check and the smallest focused or targeted test set that proves the merged change in the selected runtime.
+
+6. Restart the daemon:
+
+Restart with the command that matches how the override was applied. `hive daemon stop` / `hive daemon start --detach` forks a direct process that reads `HIVE_BIN` from the launching shell, so a drop-in-only `HIVE_BIN` is never picked up by this path — export the intended `HIVE_BIN` in the shell that runs `hive daemon start --detach`:
+
+```bash
+hive daemon stop
+HIVE_BIN=<clean-merged-checkout> hive daemon start --detach
+hive daemon status --json
+systemctl --user status hive-daemon.service --no-pager
+```
+
+For a systemd-managed unit whose override lives in a drop-in `override.conf`, reload and restart the unit instead so the new `Environment=` takes effect (a newly added or edited drop-in requires `daemon-reload` first), following the restart sequence in `## Daemon Diagnostics And Repair`:
+
+```bash
+systemctl --user daemon-reload
+systemctl --user restart hive-daemon.service
+hive daemon status --json
+systemctl --user status hive-daemon.service --no-pager
+```
+
+Stopping or restarting the daemon is guarded by `## Safety Boundaries`; restate the effect and get explicit confirmation before running guarded restart commands. Step 7's `readlink -f` / version / runtime verify confirms the restart actually adopted the intended runtime.
+
+7. Verify behavior:
+
+```bash
+hive --version
+readlink -f "$(command -v hive)"
+hive daemon status --json
+systemctl --user status hive-daemon.service --no-pager
+```
+
+Run one targeted smoke workflow or status check that exercises the changed behavior. Accept only when the daemon is running the intended runtime, the smoke check shows the expected behavior, and status/log output has no new terminal-error marker.
+
+8. Rollback:
+
+The rollback depends on the mode used. For worktree mode, restore the prior daemon override or `HIVE_BIN` captured in step 4 — set it back to the operator's intentional pre-dogfood value, or clear it only when none existed — then restart back to the intended release runtime using the step 6 restart path that matches how the override was applied. For patch-in-place mode, restore the saved backup; if the backup is untrusted, use the package-appropriate repair path such as `gem pristine`, `brew reinstall`, or reinstalling the package or standalone binary. Re-run the version, path, daemon status, and `git status --short` checks to prove the release runtime and worktrees are restored.
+
+Guardrails: preserve dirty worktree state; do not bump or release. Dogfooding must not include `git commit`, version bumps, tag creation, gem release, package publish, destructive cleanup, or release automation.
+
 ## Status Bundle
 
 Use this read-only bundle for a one-shot health overview; these commands need no confirmation, and this section does not weaken confirmation rules for destructive or foreground/streaming commands.

--- a/test/unit/openclaw_skills_test.rb
+++ b/test/unit/openclaw_skills_test.rb
@@ -97,6 +97,39 @@ class OpenClawSkillsTest < Minitest::Test
     assert_includes body, "hive bot tail"
   end
 
+  def test_umbrella_skill_documents_local_dogfood_workflow
+    _metadata, body = read_skill("hive")
+    dogfood = section(body, "## Local Dogfood")
+    safety = section(body, "## Safety Boundaries")
+
+    assert_operator body.index(/^## Local Dogfood$/), :<, body.index(/^## Safety Boundaries$/)
+
+    [
+      "gh pr view <number> --json state,mergedAt,baseRefName,statusCheckRollup",
+      "command -v hive",
+      'readlink -f "$(command -v hive)"',
+      "hive daemon status --json",
+      "systemctl --user status hive-daemon.service --no-pager",
+      "preserve dirty worktree",
+      "do not bump or release",
+      "rollback",
+      # Pin the numbered Rollback step heading, not just the prose "rollback"
+      # token, so a future prose reword cannot silently drop the section.
+      "8. Rollback:"
+    ].each do |literal|
+      assert_includes dogfood, literal
+    end
+
+    # The dogfood restart guidance must not weaken or relocate the Safety
+    # Boundaries confirmation contract, so pin these literals to that section.
+    [
+      "restate the effect",
+      "daemon stop"
+    ].each do |literal|
+      assert_includes safety, literal
+    end
+  end
+
   def test_umbrella_skill_documents_status_bundle_playbook
     _metadata, body = read_skill("hive")
     status_bundle = section(body, "## Status Bundle")
@@ -183,7 +216,7 @@ class OpenClawSkillsTest < Minitest::Test
   end
 
   def section(body, heading)
-    start_index = body.index(heading)
+    start_index = body.index(/^#{Regexp.escape(heading)}$/)
     refute_nil start_index, "#{heading} section must exist"
 
     remainder = body[start_index..]


### PR DESCRIPTION
## Summary

The OpenClaw Hive skill can now walk an agent through safely dogfooding a **merged-but-unreleased** PR against the local `hive` runtime — something the skill previously gave no guidance for, leaving agents to improvise risky patches against installed packages. The new `## Local Dogfood` section in `openclaw/skills/hive/SKILL.md` is an agent-executable checklist wrapped in short guardrail prose:

- **Hard-stops** unless the PR is merged and all required checks are green (`gh pr view <number> --json state,mergedAt,baseRefName,statusCheckRollup`).
- **Identifies the active runtime** across install shapes (gem/rbenv/rvm/bundler, Homebrew, Arch, standalone) via `command -v hive` and `readlink -f "$(command -v hive)"`, and inspects any daemon `HIVE_BIN`/unit override.
- **Guards worktrees** with `git status --short`, refusing to mutate any worktree that has uncommitted changes — it will **preserve dirty worktree** state and require a clean checkout.
- **Prefers pointing the daemon at a clean worktree** (worktree override) over patch-in-place, which is documented only as a backed-up single-file emergency fallback.
- **Restarts and verifies** with both the direct (`hive daemon status --json`) and systemd (`systemctl --user status hive-daemon.service --no-pager`) paths, then rolls back per mode.
- **Forbids any release action** — the guardrails block literally states **do not bump or release** and prohibits `git commit`, version bumps, tags, gem release, package publish, destructive cleanup, and release automation.

The section sits before `## Safety Boundaries`, which remains the authoritative, byte-unchanged boundary block — the checklist cross-references it rather than duplicating or weakening its confirmation rules. Frontmatter (`version: 0.1.1`) is intentionally left untouched, honoring the "do not bump or release" principle the section documents. This is a documentation + test change only; no runtime/CLI behavior changes.

## Test plan

A dedicated `test_umbrella_skill_documents_local_dogfood_workflow` method in `test/unit/openclaw_skills_test.rb` pins the `## Local Dogfood` heading and its key command literals (scoped to the section via the existing `section()` helper) so the guidance cannot silently regress, and re-asserts — scoped to `## Safety Boundaries` — that the section still pairs a guarded verb with its confirmation requirement.

```
ruby -Itest test/unit/openclaw_skills_test.rb
8 runs, 206 assertions, 0 failures, 0 errors, 0 skips
```

## Review summary

Two rounds of automated review (claude-ce, codex-ce, and pr-review-toolkit personas) — **Ready to merge**, no High or Medium defects on the final pass. All 14 Requirements-Trace items and all 9 test-pinned literals verified present; Safety Boundaries content byte-unchanged and still the final block; frontmatter untouched.

Findings auto-fixed across the passes:

- **Test hardening:** scoped the whole-body `assert_includes` literals (`command -v hive`, `hive daemon status --json`, `systemctl --user ...`, `readlink -f ...`) and the Safety-Boundaries guarded-pairing assertions to their respective sections via the `section()` helper, so gutting the dogfood or Safety Boundaries text would now fail the test.
- **Step 6 restart correctness:** distinguished the direct-fork restart path (`hive daemon stop` / `start --detach`, reads `HIVE_BIN` from the launching shell) from the systemd-managed path (`systemctl --user daemon-reload && systemctl --user restart hive-daemon.service`), and added a `daemon-reload` pointer so a drop-in `HIVE_BIN` actually takes effect.
- **Rollback fidelity:** capture and restore any pre-existing daemon override on rollback rather than clobbering the operator's intentional runtime.
- **Docs polish:** capitalized the `8. Rollback:` heading (keeping the lowercase `rollback` literal in the body), and added a cross-reference to `## Daemon Diagnostics And Repair` for the override mechanism.

No `wiki/log.d` fragment was added — matching the plan's disposition and the two closest prior docs-only SKILL.md PRs (#632, #633), which also shipped without one.

## Linked task

- Slug: `update-the-openclaw-hive-skill-260630-d1c7`
- Branch: `update-the-openclaw-hive-skill-260630-d1c7`
- Plan: Local Dogfood workflow for the OpenClaw Hive skill

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
