### PR TITLE
Hive patrol: Manifest omits hidden copied artifacts

### DIFF
--- a/test/e2e/lib/artifact_capture.rb
+++ b/test/e2e/lib/artifact_capture.rb
@@ -221,7 +221,9 @@ module Hive
       end
 
       def write_manifest
-        files = Dir[File.join(@scenario_dir, "**", "*")].select { |path| File.file?(path) }.sort
+        files = Dir.glob(File.join(@scenario_dir, "**", "*"), File::FNM_DOTMATCH)
+          .select { |path| File.file?(path) }
+          .sort
         file_entries = files.filter_map { |path| manifest_entry(path) }
         manifest = {
           "schema" => "hive-e2e-manifest",

--- a/test/e2e/lib/artifact_capture_test.rb
+++ b/test/e2e/lib/artifact_capture_test.rb
@@ -201,6 +201,26 @@ class E2EArtifactCaptureTest < Minitest::Test
     end
   end
 
+  def test_manifest_includes_hidden_state_files
+    with_dirs do |scenario_dir, sandbox, run_home|
+      task_dir = File.join(sandbox, ".hive-state", "stages", "2-brainstorm", "task-1")
+      FileUtils.mkdir_p(task_dir)
+      lock_path = File.join(task_dir, ".lock")
+      File.write(lock_path, "pid: 123\n")
+
+      collect(scenario_dir, sandbox, run_home)
+
+      copied_lock = File.join(scenario_dir, "state", "2-brainstorm", "task-1", ".lock")
+      assert File.exist?(copied_lock), "hidden task lock should be copied into the artifact bundle"
+
+      manifest = JSON.parse(File.read(File.join(scenario_dir, "manifest.json")))
+      lock_entry = manifest.fetch("files").find { |file| file.fetch("path") == "state/2-brainstorm/task-1/.lock" }
+      assert lock_entry, "manifest should include copied hidden state files"
+      assert_equal File.size(copied_lock), lock_entry.fetch("size")
+      assert_equal Digest::SHA256.file(copied_lock).hexdigest, lock_entry.fetch("sha256")
+    end
+  end
+
   def test_env_snapshot_is_json_with_schema_version
     with_dirs do |scenario_dir, sandbox, run_home|
       collect(scenario_dir, sandbox, run_home)


### PR DESCRIPTION
## Summary

Patrol flagged that the e2e `ArtifactCapture` bundle could omit copied hidden files from its manifest. `ArtifactCapture` copies the full state tree into the scenario bundle with `FileUtils.cp_r` — including hidden task files such as `.lock` — but `write_manifest` enumerated files with `Dir["**/*"]`, whose default glob skips dotfiles. A failing run could therefore ship copied hidden artifacts that had no `size` or `sha256` entry in `manifest.json`.

The fix switches enumeration to `Dir.glob(..., File::FNM_DOTMATCH)` so dotfiles are included, while still filtering to regular files only (`.`/`..` and directories are excluded by the existing `File.file?` guard).

- `test/e2e/lib/artifact_capture.rb` — enumerate manifest files with `File::FNM_DOTMATCH` so hidden copied artifacts are recorded.

## Test plan

- Added `test_manifest_includes_hidden_state_files`: copies a state task containing a `.lock` file, then asserts the lock is copied into the bundle **and** appears in `manifest.json` with the correct `size` and `sha256`.
- `bundle exec rake test` — passed.
- `bundle exec rubocop` — passed.

## Review summary

- Automated review (`codex-native-review-01`): no findings across High, Medium, or Nit.
- No escalations; no suppressed findings.

## Linked task

- Finding: `test-suite-test-babysitter-acceptance-dry-run-test-rb-1`
- Fingerprint: `3b147e5e520fafee3da80d3ccf9785403b4e3de850db8856080752cd08e7bedd`
- Task folder: `/home/asterio/Dev/hive/.hive-state/stages/6-review/patrol-test-suite-test-babysitter-acceptance-dry-run-test-rb-3b1`
