### PR TITLE
Hive patrol: Optional asciinema can abort TUI scenarios

### DIFF
--- a/test/e2e/lib/asciinema_driver.rb
+++ b/test/e2e/lib/asciinema_driver.rb
@@ -16,7 +16,7 @@ module Hive
       def self.available?
         _out, _err, status = Open3.capture3(binary, "--version")
         status.success?
-      rescue Errno::ENOENT
+      rescue SystemCallError, ArgumentError
         false
       end
 
@@ -26,7 +26,7 @@ module Hive
 
         text = out.split(/\s+/).find { |part| part.match?(/\A\d+\.\d+(?:\.\d+)?/) }
         text ? Gem::Version.new(text) : nil
-      rescue Errno::ENOENT
+      rescue SystemCallError, ArgumentError
         nil
       end
 
@@ -60,6 +60,8 @@ module Hive
           err: File::NULL,
           pgroup: true
         )
+      rescue SystemCallError, ArgumentError => e
+        raise Unavailable, "failed to start asciinema: #{e.message}"
       end
 
       def stop

--- a/test/e2e/lib/asciinema_driver_test.rb
+++ b/test/e2e/lib/asciinema_driver_test.rb
@@ -2,6 +2,22 @@ require_relative "../../test_helper"
 require_relative "asciinema_driver"
 
 class E2EAsciinemaDriverTest < Minitest::Test
+  def test_non_executable_env_override_binary_is_unavailable
+    Dir.mktmpdir("asciinema") do |dir|
+      script = File.join(dir, "asciinema")
+      File.write(script, "not executable\n")
+      File.chmod(0o644, script)
+
+      old = ENV["HIVE_ASCIINEMA_BIN"]
+      ENV["HIVE_ASCIINEMA_BIN"] = script
+
+      refute Hive::E2E::AsciinemaDriver.available?
+      assert_nil Hive::E2E::AsciinemaDriver.version
+    ensure
+      ENV["HIVE_ASCIINEMA_BIN"] = old
+    end
+  end
+
   def test_records_with_env_override_binary
     Dir.mktmpdir("asciinema") do |dir|
       script = File.join(dir, "asciinema")
@@ -29,6 +45,31 @@ class E2EAsciinemaDriverTest < Minitest::Test
       driver.stop
 
       assert_equal :ok, driver.integrity_status
+    ensure
+      ENV["HIVE_ASCIINEMA_BIN"] = old
+    end
+  end
+
+  def test_start_raises_unavailable_when_recorder_spawn_fails
+    Dir.mktmpdir("asciinema") do |dir|
+      script = File.join(dir, "asciinema")
+      cast = File.join(dir, "cast.json")
+      File.write(script, <<~RUBY)
+        #!/usr/bin/env ruby
+        if ARGV == ["--version"]
+          puts "asciinema 3.1.0"
+          exit 0
+        end
+      RUBY
+      File.chmod(0o755, script)
+
+      old = ENV["HIVE_ASCIINEMA_BIN"]
+      ENV["HIVE_ASCIINEMA_BIN"] = script
+      driver = Hive::E2E::AsciinemaDriver.new(socket_name: "fake", session_name: "fake", cast_path: cast)
+      File.chmod(0o644, script)
+
+      error = assert_raises(Hive::E2E::AsciinemaDriver::Unavailable) { driver.start }
+      assert_match(/failed to start asciinema/, error.message)
     ensure
       ENV["HIVE_ASCIINEMA_BIN"] = old
     end


### PR DESCRIPTION
## Summary

Hardens the e2e `AsciinemaDriver` test helper so the *optional* asciinema recorder fails closed instead of aborting a TUI scenario.

- `test/e2e/lib/asciinema_driver.rb`
  - `available?` and `version` now rescue `SystemCallError, ArgumentError` (previously only `Errno::ENOENT`), so a non-executable or stale `HIVE_ASCIINEMA_BIN` disables the recorder rather than raising.
  - `start` wraps `Process.spawn` failures and re-raises them as `AsciinemaDriver::Unavailable`, which the TUI lifecycle already treats as "recording disabled".
- `test/e2e/lib/asciinema_driver_test.rb` — two new cases: a non-executable env-override binary reports unavailable, and `start` raises `Unavailable` when the recorder spawn fails after a successful version probe.

Diff scope: 2 files, +45 / −2.

## Test plan

- `ruby -Itest test/e2e/lib/asciinema_driver_test.rb` → `4 runs, 14 assertions, 0 failures, 0 errors, 0 skips`.

## Review summary

Single reviewer (`codex-native-review-01`) reported no findings across High/Medium/Nit. Triage recorded fix-success with no escalations. No suppressed findings.

## Linked task

- Patrol finding: `test-suite-test-babysitter-acceptance-dry-run-test-rb-2`
- Fingerprint: `4f4a315aa8a32fc76a571cf215671f33eb6649f9a266216370d3716c16500747`
- Task folder: `/home/asterio/Dev/hive/.hive-state/stages/6-review/patrol-test-suite-test-babysitter-acceptance-dry-run-test-rb-4f4`
