### PR TITLE
test(tg-e2e): drive the /idea file-collection Done step

### DIFF
--- a/test/e2e/tg/_drive.py
+++ b/test/e2e/tg/_drive.py
@@ -80,8 +80,35 @@ def drive(client, bot, project):
         return 1
     target.click()
 
+    # The current /idea text flow has a file-collection step: after picking a
+    # project the bot replies "Send any files now, or press Done." and only
+    # finalizes the capture on Done (or after files). Older/direct flows ack
+    # immediately. Handle both: wait for either the ack or a button message,
+    # and tap Done when the collection keyboard appears.
+    follow = wait_for(
+        client, bot,
+        lambda m: (ACK_MARKER in (m.message or "")) or bool(m.buttons),
+        after_id=picker.id,
+    )
+    after_for_ack = picker.id
+    if follow and ACK_MARKER not in (follow.message or "") and follow.buttons:
+        done = None
+        for row in follow.buttons:
+            for btn in row:
+                if "done" in (btn.text or "").lower():
+                    done = btn
+                    break
+            if done:
+                break
+        if not done:
+            labels = [b.text for row in follow.buttons for b in row]
+            print(f"FAIL file-collection step had no Done button; saw {labels}")
+            return 1
+        done.click()
+        after_for_ack = follow.id
+
     ack = wait_for(client, bot, lambda m: ACK_MARKER in (m.message or ""),
-                   after_id=picker.id)
+                   after_id=after_for_ack)
     if not ack:
         print("FAIL no capture acknowledgment after tapping picker")
         return 1


### PR DESCRIPTION
## Summary

The headless Telegram e2e driver (`test/e2e/tg/_drive.py`) had drifted from the bot's current `/idea` flow. The bot now has a **file-collection step**: after `/idea <text>` and tapping the project picker, it replies *"Send any files now, or press Done."* and only finalizes the capture on **Done** (or after files are sent). The driver still expected an immediate *"Captured your idea"* ack right after the project tap, so `test/e2e/tg/run_idea_e2e.sh` failed with `FAIL no capture acknowledgment after tapping picker`.

This teaches `_drive.py`'s text-`/idea` `drive()` to complete the collection step: after tapping the project, wait for either the ack or a button message, and tap **Done** when the collection keyboard appears. A direct-ack flow (no collection step) still works. `drive_voice()` is unchanged — voice ideas commit directly after the pick.

## Verification

Ran live against the `@BotFather` test bot (`Testivanshive_bot`) via `run_idea_e2e.sh` against a throwaway, daemon-disabled scratch project:

```
PASS /start welcomed with next steps
PASS ack="Captured your idea in <project>. It's in the inbox - move it to 2-brainstorm to start."
```

Found while executing the 0.3.3 non-patrol test plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)