### PR TITLE
refactor(review): drop the reserved rate_limited enum member

### DIFF
--- a/lib/hive/review_error_reason.rb
+++ b/lib/hive/review_error_reason.rb
@@ -3,19 +3,16 @@ require "hive/agent_limit"
 module Hive
   module ReviewErrorReason
     # The `reason=` vocabulary `mark_review_phase_failure` can stamp onto a
-    # review_error marker, plus one reserved slot. Its limit arm writes
-    # `limits_reached`; `classify` emits the CLASSIFIED subset below (plus the
-    # always-available `unknown` fallback). `rate_limited` is reserved-but-
-    # unemitted: it is accepted on read, but nothing in lib/ ever writes
-    # `reason=rate_limited` (the gate only stamps `limits_reached`) — it is
-    # kept so the enum tolerates the value without tripping the drift guards.
+    # review_error marker. Its limit arm writes `limits_reached`; `classify`
+    # emits the CLASSIFIED subset below (plus the always-available `unknown`
+    # fallback). Every member is written by exactly one live code path — add
+    # a member only together with the code that emits it.
     #
     # This is NOT the complete set of review_error reasons: markers stamped
     # elsewhere in lib/ also carry ci_unrunnable, reviewer_partial_failure,
     # fix_status_check_failed, fix_tampered, and the phase=resume reasons.
     REASONS = %w[
       limits_reached
-      rate_limited
       merge_conflict
       network_timeout
       tool_permission_denied

--- a/wiki/log.d/20260702T004500Z-drop-reserved-rate-limited.md
+++ b/wiki/log.d/20260702T004500Z-drop-reserved-rate-limited.md
@@ -1,0 +1,10 @@
+# 2026-07-02 — drop the reserved `rate_limited` enum member (arch pass)
+
+Architecture review of the review-error-reason PR (#627): `rate_limited`
+was a reserved-but-unemitted member of `Hive::ReviewErrorReason::REASONS`,
+justified as "accepted on read" — but nothing anywhere reads REASONS (the
+healer keys on the literal `limits_reached`; notification_builders keeps
+its own manual-only lists), so the reservation guarded nothing. Removed it:
+every REASONS member is now written by exactly one live code path, and the
+docstring says to add members only together with the code that emits them.
+The wiki ([[stages/review]]) already listed the enum without it.


### PR DESCRIPTION
Architecture-review follow-up for #627, stacked on its branch (review comment posted there). One change, documented in a PR comment below.

`Hive::ReviewErrorReason::REASONS` loses its reserved-but-unemitted `rate_limited` member. Nothing reads `REASONS` anywhere in `lib/`/`web/` — the healer keys on the literal `limits_reached`, `notification_builders` keeps its own manual-only lists, and the wiki's enum table already omits it — so the "accepted on read" reservation guarded nothing while inviting misuse (emitting it would *sound* like a limit but bypass the `limits_reached` cooldown auto-heal).

Verification: review-error-reason, phase-failure-helper, and stale-agent-healer suites green (112 runs); RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)