### PR TITLE
chore: re-land orphaned stacked PRs onto main (#645, #646, #642)

### DIFF
--- a/lib/hive/atomic_file.rb
+++ b/lib/hive/atomic_file.rb
@@ -1,0 +1,36 @@
+require "fileutils"
+require "securerandom"
+
+module Hive
+  # The one way to write a small state file atomically: tempfile in the
+  # same directory, then rename over the target. Either the target holds
+  # the old content or the new content; a crash mid-write can never leave
+  # it truncated or torn. The codebase grew several private copies of this
+  # pattern (Markers, Events, Init, ServiceInstaller::Base, review
+  # suppression, …) — new state files should use this helper instead of
+  # adding another.
+  module AtomicFile
+    module_function
+
+    # Write `content` to `path` atomically. `mode:` sets the permissions of
+    # the newly created file (pass 0o600 for owner-private state). `fsync:`
+    # flushes to disk before the rename — keep it on for state that must
+    # survive a crash; a caller that measurably can't afford it may opt out.
+    def write(path, content, mode: 0o644, fsync: true)
+      dir = File.dirname(path)
+      FileUtils.mkdir_p(dir)
+      tmp = File.join(dir, ".#{File.basename(path)}.tmp.#{Process.pid}.#{SecureRandom.hex(4)}")
+      File.open(tmp, File::WRONLY | File::CREAT | File::TRUNC, mode) do |file|
+        file.write(content)
+        if fsync
+          file.flush
+          file.fsync
+        end
+      end
+      File.rename(tmp, path)
+      path
+    ensure
+      FileUtils.rm_f(tmp) if tmp && File.exist?(tmp)
+    end
+  end
+end

--- a/lib/hive/bot/pairing_approval_queue.rb
+++ b/lib/hive/bot/pairing_approval_queue.rb
@@ -1,7 +1,7 @@
 require "json"
-require "fileutils"
 require "securerandom"
 require "time"
+require "hive/atomic_file"
 require "hive/paths"
 require "hive/daemon/queue_directory"
 
@@ -42,17 +42,8 @@ module Hive
 
         dir = directory(state_home: state_home)
         filename = "#{created_at.strftime('%Y%m%dT%H%M%S%6N')}-#{notice_id}.json"
-        final_path = File.join(dir, filename)
-        tmp_path = File.join(dir, ".#{filename}.tmp.#{Process.pid}")
-        File.open(tmp_path, File::WRONLY | File::CREAT | File::TRUNC, 0o644) do |file|
-          file.write(JSON.generate(payload))
-          file.flush
-          file.fsync
-        end
-        File.rename(tmp_path, final_path)
+        Hive::AtomicFile.write(File.join(dir, filename), JSON.generate(payload))
         notice_id
-      ensure
-        FileUtils.rm_f(tmp_path) if tmp_path && File.exist?(tmp_path)
       end
 
       def pending(state_home: Hive::Paths.state_home, bad_handler: nil)

--- a/lib/hive/bot/pairing_store.rb
+++ b/lib/hive/bot/pairing_store.rb
@@ -2,6 +2,7 @@ require "json"
 require "fileutils"
 require "securerandom"
 require "time"
+require "hive/atomic_file"
 require "hive/paths"
 
 module Hive
@@ -168,17 +169,7 @@ module Hive
       end
 
       def write_entries(entries)
-        FileUtils.mkdir_p(File.dirname(@path))
-        tmp_path = File.join(File.dirname(@path), ".#{File.basename(@path)}.tmp.#{Process.pid}.#{SecureRandom.hex(4)}")
-        File.open(tmp_path, File::WRONLY | File::CREAT | File::TRUNC, 0o600) do |file|
-          file.write(JSON.pretty_generate(entries))
-          file.write("\n")
-          file.flush
-          file.fsync
-        end
-        File.rename(tmp_path, @path)
-      ensure
-        FileUtils.rm_f(tmp_path) if tmp_path && File.exist?(tmp_path)
+        Hive::AtomicFile.write(@path, "#{JSON.pretty_generate(entries)}\n", mode: 0o600)
       end
 
       def pruned_entries(entries)

--- a/lib/hive/review_error_reason.rb
+++ b/lib/hive/review_error_reason.rb
@@ -3,19 +3,16 @@ require "hive/agent_limit"
 module Hive
   module ReviewErrorReason
     # The `reason=` vocabulary `mark_review_phase_failure` can stamp onto a
-    # review_error marker, plus one reserved slot. Its limit arm writes
-    # `limits_reached`; `classify` emits the CLASSIFIED subset below (plus the
-    # always-available `unknown` fallback). `rate_limited` is reserved-but-
-    # unemitted: it is accepted on read, but nothing in lib/ ever writes
-    # `reason=rate_limited` (the gate only stamps `limits_reached`) — it is
-    # kept so the enum tolerates the value without tripping the drift guards.
+    # review_error marker. Its limit arm writes `limits_reached`; `classify`
+    # emits the CLASSIFIED subset below (plus the always-available `unknown`
+    # fallback). Every member is written by exactly one live code path — add
+    # a member only together with the code that emits it.
     #
     # This is NOT the complete set of review_error reasons: markers stamped
     # elsewhere in lib/ also carry ci_unrunnable, reviewer_partial_failure,
     # fix_status_check_failed, fix_tampered, and the phase=resume reasons.
     REASONS = %w[
       limits_reached
-      rate_limited
       merge_conflict
       network_timeout
       tool_permission_denied

--- a/openclaw/skills/hive/SKILL.md
+++ b/openclaw/skills/hive/SKILL.md
@@ -89,6 +89,8 @@ Treat `/hive setup`, `/hive install`, and `/hive bootstrap` as requests for the 
 
 Prefer `--json` when the Hive command supports it and you need structured output. Summarize the result, including task slug, stage/action, marker, and next command when present.
 
+OpenClaw installs and enables the Hive daemon by default, so on normal OpenClaw setups ready coding tasks usually auto-advance through stages without asking. A printed `next:` line — the command Hive suggests from command output and status hints — is a manual fallback or recovery command, not a prompt to ask the user before each ordinary stage. For normal enrolled coding tasks with the daemon running, do not ask before ordinary stage advancement; let the daemon auto-advance. Stop and ask only for actual input waits (a `needs_input` state, unanswered questions, or plan content that genuinely needs human judgment), destructive/admin confirmation, or `## Safety Boundaries` actions. When uncertain, confirm daemon state with `hive daemon status --json`; if the daemon is disabled or stopped, the project is not enrolled, the workflow is non-coding or unknown, or the user asks for manual control, present the `next:` line as an optional manual action instead of assuming auto-advance.
+
 For `hive wiki compile-log`, prefer `--check` when verifying an aggregate wiki changelog. Run the mutating compile command only after merge/rebase or when the user explicitly wants `wiki/log.md` refreshed; feature PRs should add `wiki/log.d/<timestamp>-<slug>.md` fragments instead of editing the compiled log directly.
 
 ## Local Dogfood

--- a/test/unit/atomic_file_test.rb
+++ b/test/unit/atomic_file_test.rb
@@ -1,0 +1,46 @@
+require "test_helper"
+require "hive/atomic_file"
+
+class HiveAtomicFileTest < Minitest::Test
+  include HiveTestHelper
+
+  def test_write_creates_parent_dirs_sets_mode_and_returns_path
+    with_tmp_dir do |dir|
+      path = File.join(dir, "nested", "state.json")
+
+      returned = Hive::AtomicFile.write(path, "{\"a\":1}\n", mode: 0o600)
+
+      assert_equal path, returned
+      assert_equal "{\"a\":1}\n", File.read(path)
+      assert_equal 0o600, File.stat(path).mode & 0o777
+      assert_empty Dir.glob(File.join(dir, "nested", ".*tmp*")),
+                   "no tempfile may remain after a successful write"
+    end
+  end
+
+  def test_write_replaces_existing_content_atomically
+    with_tmp_dir do |dir|
+      path = File.join(dir, "state.json")
+      Hive::AtomicFile.write(path, "old")
+
+      Hive::AtomicFile.write(path, "new", fsync: false)
+
+      assert_equal "new", File.read(path)
+    end
+  end
+
+  def test_failed_rename_leaves_target_untouched_and_cleans_tempfile
+    with_tmp_dir do |dir|
+      path = File.join(dir, "state.json")
+      Hive::AtomicFile.write(path, "old")
+
+      with_replaced_singleton_method(File, :rename, ->(*_args) { raise Errno::EACCES, "locked" }) do
+        assert_raises(Errno::EACCES) { Hive::AtomicFile.write(path, "new") }
+      end
+
+      assert_equal "old", File.read(path), "a failed rename must leave the previous content intact"
+      assert_empty Dir.glob(File.join(dir, ".*tmp*")),
+                   "the ensure block must remove the orphaned tempfile"
+    end
+  end
+end

--- a/test/unit/openclaw_skills_test.rb
+++ b/test/unit/openclaw_skills_test.rb
@@ -62,6 +62,23 @@ class OpenClawSkillsTest < Minitest::Test
     assert_includes body, "Pass arguments safely"
   end
 
+  def test_umbrella_skill_documents_daemon_auto_advance
+    _metadata, body = read_skill("hive")
+
+    [
+      "auto-advance",
+      "normal OpenClaw setups",
+      "hive daemon status --json",
+      "next:",
+      "manual fallback or recovery command",
+      "do not ask before ordinary stage advancement",
+      "needs_input",
+      "Safety Boundaries"
+    ].each do |literal|
+      assert_includes body, literal
+    end
+  end
+
   def test_umbrella_skill_guards_destructive_and_blocking_commands
     _metadata, body = read_skill("hive")
 

--- a/wiki/log.d/20260701T211354Z-openclaw-marker-recovery.md
+++ b/wiki/log.d/20260701T211354Z-openclaw-marker-recovery.md
@@ -1,0 +1,5 @@
+## [2026-07-01T21:13:54Z] openclaw — marker recovery guidance
+
+**Action:** Added a `## Marker Recovery` section to the OpenClaw `/hive` skill, placed immediately after Safety Boundaries, so operators inspect with `hive status --json` / `hive daemon status --json`, wait for healer-managed signatures, start a stopped daemon with `hive daemon start --detach`, and ask before guarded manual `hive markers clear` remediation.
+
+**Coverage:** Added `test_umbrella_skill_classifies_recovery_markers` to pin the recovery literals, section ordering, and the existing Safety Boundaries confirmation language. Updated [[operating]] and [[testing]].

--- a/wiki/log.d/20260702T003000Z-atomic-file-helper.md
+++ b/wiki/log.d/20260702T003000Z-atomic-file-helper.md
@@ -1,0 +1,11 @@
+# 2026-07-02 — Hive::AtomicFile (arch pass over the pairing PR)
+
+Architecture review of the Telegram pairing PR (#629): the feature adds two
+more private copies of the tmp+rename(+fsync) atomic-write pattern, joining
+at least five pre-existing ones (`Markers#write_atomic`, `Events`,
+`Commands::Init`, `ServiceInstaller::Base#atomic_write`, review
+suppression). Introduced `lib/hive/atomic_file.rb` (`Hive::AtomicFile.write`
+with `mode:`/`fsync:`) and pointed the two NEW call sites at it
+(`PairingStore#write_entries`, `PairingApprovalQueue.write!`). Migrating the
+legacy copies is deliberately left as a follow-up — noted in [[gaps]]-style
+debt: new state files should use the helper instead of adding another copy.

--- a/wiki/log.d/20260702T004500Z-drop-reserved-rate-limited.md
+++ b/wiki/log.d/20260702T004500Z-drop-reserved-rate-limited.md
@@ -1,0 +1,10 @@
+# 2026-07-02 — drop the reserved `rate_limited` enum member (arch pass)
+
+Architecture review of the review-error-reason PR (#627): `rate_limited`
+was a reserved-but-unemitted member of `Hive::ReviewErrorReason::REASONS`,
+justified as "accepted on read" — but nothing anywhere reads REASONS (the
+healer keys on the literal `limits_reached`; notification_builders keeps
+its own manual-only lists), so the reservation guarded nothing. Removed it:
+every REASONS member is now written by exactly one live code path, and the
+docstring says to add members only together with the code that emits them.
+The wiki ([[stages/review]]) already listed the enum without it.

--- a/wiki/operating.md
+++ b/wiki/operating.md
@@ -163,6 +163,11 @@ version verification, `hive daemon install`, and optional non-interactive
 The skill also documents `/hive wiki compile-log --check` as the read-only
 aggregate-changelog verification path and tells agents to reserve mutating
 `hive wiki compile-log` runs for merge/rebase cleanup or explicit user requests.
+Its marker-recovery guidance mirrors [[modules/daemon]]: inspect first with
+`hive status --json` and `hive daemon status --json`, wait for known
+healer-managed cooldown/retry signatures, start a stopped daemon with
+`hive daemon start --detach`, and treat manual `hive markers clear` as guarded
+mutation under the skill's Safety Boundaries.
 The naked `hive` ClawHub slug is already owned by another publisher, so it is
 intentionally not used.
 


### PR DESCRIPTION
#645, #646, and #642 were **stacked PRs whose bases were other feature branches** (not `main`). Their squash-merges landed on now-deleted intermediate branches, so their content never actually reached `main` (they show "merged" on GitHub but `main` lacks the changes). This re-applies their content directly on `main`:

- **#646** — drop the reserved-but-unemitted `rate_limited` member from `Hive::ReviewErrorReason::REASONS` (nothing reads the enum; every member is now written by a live path).
- **#645** — extract `Hive::AtomicFile` and route `pairing_store` / `pairing_approval_queue` writes through it.
- **#642** — document the daemon auto-advance fallback + marker-recovery guidance in the OpenClaw skill; CI/wiki/test refresh.

Local gate: **100% coverage (30356/30356), 7234 runs, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)