### PR TITLE
docs(hive-skill): document custom non-coding workflows

### DIFF
--- a/openclaw/skills/hive/SKILL.md
+++ b/openclaw/skills/hive/SKILL.md
@@ -49,6 +49,16 @@ That listing installs the `/hive` slash command. First run should normally be:
 - `/hive wiki compile-log --check` verifies that `wiki/log.md` matches the fragments in `wiki/log.d/`.
 - `/hive doctor` checks local runtime and skill configuration.
 
+## Custom Workflows
+
+Beyond the default coding pipeline, Hive can run project-authored custom workflows: multi-stage agent work with several stages, agents, and checkpoints for non-coding domains. Teams can use these for writing, feedback triage, research, content pipelines, and other repeatable work that benefits from the same folder-based handoff model.
+
+The `/hive` slash examples below map to the underlying `hive ...` CLI arguments:
+
+- `/hive init . --workflow <id>` chooses the workflow for the whole project at initialization time, so tasks created there use that default.
+- `/hive new . "draft launch notes" --workflow <id>` overrides the workflow for one task when creating it.
+- `hive workflow new <id> [--template <name>]` is the existing scaffold command for creating a project-local workflow descriptor under `<hive_state_path>/workflows/`.
+
 ## CLI Detection
 
 Before running a Hive workflow, check whether the Hive CLI is installed:

--- a/openclaw/skills/hive/SKILL.md
+++ b/openclaw/skills/hive/SKILL.md
@@ -53,7 +53,7 @@ That listing installs the `/hive` slash command. First run should normally be:
 
 Beyond the default coding pipeline, Hive can run project-authored custom workflows: multi-stage agent work with several stages, agents, and checkpoints for non-coding domains. Teams can use these for writing, feedback triage, research, content pipelines, and other repeatable work that benefits from the same folder-based handoff model.
 
-The `/hive` slash examples below map to the underlying `hive ...` CLI arguments:
+These `/hive` commands map to the underlying `hive ...` CLI; the scaffold command is shown in bare CLI form:
 
 - `/hive init . --workflow <id>` chooses the workflow for the whole project at initialization time, so tasks created there use that default.
 - `/hive new . "draft launch notes" --workflow <id>` overrides the workflow for one task when creating it.

--- a/openclaw/skills/hive/SKILL.md
+++ b/openclaw/skills/hive/SKILL.md
@@ -51,12 +51,12 @@ That listing installs the `/hive` slash command. First run should normally be:
 
 ## Custom Workflows
 
-Beyond the default coding pipeline, Hive can run project-authored custom workflows: multi-stage agent work with several stages, agents, and checkpoints for non-coding domains. Teams can use these for writing, feedback triage, research, content pipelines, and other repeatable work that benefits from the same folder-based handoff model.
+Beyond the default coding pipeline, Hive can run project-authored custom workflows: multi-stage agent work with stages, agents, and checkpoints for non-coding domains. Teams can use these for writing, feedback triage, research, content pipelines, and other repeatable work that benefits from the same folder-based handoff model.
 
 These `/hive` commands map to the underlying `hive ...` CLI; the scaffold command is shown in bare CLI form:
 
 - `/hive init . --workflow <id>` chooses the workflow for the whole project at initialization time, so tasks created there use that default.
-- `/hive new . "draft launch notes" --workflow <id>` overrides the workflow for one task when creating it.
+- `/hive new . --workflow <id> "draft launch notes"` overrides the workflow for one task when creating it.
 - `hive workflow new <id> [--template <name>]` is the existing scaffold command for creating a project-local workflow descriptor under `<hive_state_path>/workflows/`.
 
 ## CLI Detection

--- a/openclaw/skills/hive/SKILL.md
+++ b/openclaw/skills/hive/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Run Hive's folder-based coding-agent pipeline from OpenClaw: guided CLI setup,
   project init, task creation, plan/develop/review workflows, status, daemon,
   and guarded admin commands.
-version: 0.1.1
+version: 0.1.2
 user-invocable: true
 metadata:
   openclaw:

--- a/test/unit/openclaw_skills_test.rb
+++ b/test/unit/openclaw_skills_test.rb
@@ -23,7 +23,7 @@ class OpenClawSkillsTest < Minitest::Test
 
     assert_equal "hive", metadata.fetch("name")
     assert_equal CLAWHUB_DESCRIPTION, metadata.fetch("description")
-    assert_equal "0.1.1", metadata.fetch("version")
+    assert_equal "0.1.2", metadata.fetch("version")
     assert_equal true, metadata.fetch("user-invocable")
     assert_equal HOMEPAGE, openclaw_metadata.fetch("homepage")
     assert_equal true, openclaw_metadata.fetch("always"), "umbrella skill must remain visible for setup"
@@ -60,6 +60,16 @@ class OpenClawSkillsTest < Minitest::Test
     assert_includes body, "slash-command text after `/hive` as arguments for `hive_cmd`"
     assert_includes body, '"${hive_cmd}" --help'
     assert_includes body, "Pass arguments safely"
+  end
+
+  def test_umbrella_skill_documents_custom_workflows
+    _metadata, body = read_skill("hive")
+
+    assert_includes body, "Custom Workflows"
+    assert_includes body, "--workflow"
+    assert_includes body, "writing"
+    assert_includes body, "feedback triage"
+    assert_includes body, "hive workflow new"
   end
 
   def test_umbrella_skill_documents_daemon_auto_advance


### PR DESCRIPTION
## Summary

Readers of the OpenClaw Hive skill now learn that Hive is not limited to its default coding pipeline — it can run project-authored custom workflows for non-coding domains like writing, feedback triage, research, and content pipelines. Previously the skill only framed Hive as a coding-agent pipeline, so users had no signal that the same folder-based handoff model powers arbitrary multi-stage work.

A new `## Custom Workflows` section documents the existing CLI surface for selecting and scaffolding workflows: `--workflow <id>` on both `hive init` (whole-project default) and `hive new` (per-task override), plus a one-line mention of `hive workflow new <id> [--template <name>]` as the scaffold command. The section stays deliberately surface-level — no descriptor schema or authoring internals — and is purely additive; existing sections and examples are untouched. The frontmatter version is bumped `0.1.1 → 0.1.2`.

Changed files:

- `openclaw/skills/hive/SKILL.md` — new `## Custom Workflows` section (placed after `## Common Paths`, before `## CLI Detection`) and frontmatter version bump `0.1.1 → 0.1.2`.
- `test/unit/openclaw_skills_test.rb` — new focused `test_umbrella_skill_documents_custom_workflows` locking in the section's key substrings, and the version assertion updated to `0.1.2`.

## Test plan

- `ruby -Itest test/unit/openclaw_skills_test.rb` — 12 runs, 310 assertions, 0 failures. (`bundle exec` was unavailable in the execution environment; the file was run directly.)
- Manual read confirms placement after `## Common Paths` / before `## CLI Detection`, that the change is additive (no existing lines moved except the version bump), and that all four example domains read naturally.

## Review summary

Two independent review passes plus two PR-review-toolkit passes — no High or Medium findings in any pass. All documented CLI claims were verified truthful against `lib/hive/cli.rb` (`--workflow` on `hive init` l.138 and `hive new` l.444; `hive workflow new ID [--template NAME]` l.373+ scaffolding under `<hive_state_path>/workflows/`). Nit-level items (mapping-note wording, redundant "multi-stage" phrasing, option placement consistency) were auto-fixed; one testing nit about the non-unique `"writing"` substring was resolved no-fix (the assertion is plan-mandated and the test stays robust via the other unique substrings). No `lib/` behavior changed and no descriptor internals were documented (R6 met).

## Linked task

Hive task: `update-the-openclaw-hive-skill-260702-9370`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
