### PR TITLE
release: 0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,98 @@
 
 All notable changes are documented here, newest first. Hive ships frequent micro-releases (see [docs/RELEASING.md](docs/RELEASING.md#versioning-policy)): each `vX.Y.Z` git tag gets a `## X.Y.Z` section with terse bullets — no `[Unreleased]` accumulator. Versioning is [SemVer](https://semver.org): PATCH for fixes and small changes (the common case), MINOR for notable features, MAJOR for milestones.
 
+## 0.3.3
+
+Hive goes local-first: one `hive setup` command installs and runs the web UI without
+Docker, strangers can pair with the Telegram bot via a one-time code approved from the
+CLI, the daemon auto-retries recoverable failures, and review errors now carry
+classified, actionable reasons. Any GitHub PR can be reviewed ad hoc without a
+pipeline task.
+
+### Local web install & run (non-Docker)
+
+- New `hive setup`: one-command local provisioning — dependency diagnostics with exact
+  fix commands (external CLIs like `gh`/`claude`/`codex` are diagnosed, never silently
+  installed or authenticated), bootstraps qmd and the managed Rails web bundle,
+  installs the daemon service pinned to the invoking binary, and enrolls the current
+  project. `--service` also installs the managed web service; `--no-bootstrap` is
+  diagnose-only; `--json` emits an ordered phase envelope whose `ok` always matches
+  the exit code.
+- `hive web` grows a managed-service lifecycle: `install`, `start --detach`, `stop`,
+  `status [--json]` via systemd-user (Linux) / launchd (macOS). Foreground `hive web`
+  works as before.
+- Loopback binds (default `127.0.0.1:4567`) need no login; `web.local_loopback: false`
+  opts back into GitHub login. Non-loopback binds are refused without a configured
+  owner or an explicit `--unsafe`/`--allow-public`.
+- The managed web bundle is fetched per-version from the release asset, bundle-installed
+  in staging before swap (a failed upgrade can't break the working install), and
+  auto-refreshed when stale after a CLI upgrade.
+- Binary-drift detection: `hive daemon status --json` reports the unit's installed
+  binary vs the expected one (`binary_drift`: path/version/unparseable/unreadable);
+  the web dashboard shows daemon health and a "Repair daemon" button that queues
+  `hive daemon install --force` through the daemon's own maintenance queue.
+
+### Telegram bot: self-service pairing
+
+- With `bot.pairing_enabled`, an unknown chat's `/start` now gets a one-time pairing
+  code instead of silence. The owner approves with
+  `hive pairing approve telegram <CODE>`: the chat lands on the allowlist, a live bot
+  is SIGHUP-reloaded, and the user gets a "✅ Approved" DM. `hive pairing list` shows
+  pending codes; both commands take `--json` (`hive-pairing-list.v1` /
+  `hive-pairing-approve.v1`). The bot can boot with an empty allowlist when pairing
+  is enabled, so a fresh install is reachable before any chat is approved.
+
+### Daemon self-healing
+
+- The daemon auto-retries recoverable terminal error markers (kill switch:
+  `daemon.auto_retry.enabled`, default on).
+- Fixed: Claude stop-hook fix failures are retried instead of parking the task.
+
+### Review pipeline
+
+- `hive review --pr <number|#number|URL>` reviews any GitHub PR ad hoc — no pipeline
+  task needed; fix commits on borrowed PRs stay opt-in.
+- Non-limit triage/fix failures now stamp a classified `reason=` (`merge_conflict`,
+  `network_timeout`, `tool_permission_denied`, `agent_crashed`, `unknown`) instead of
+  flat `triage_failed`/`fix_failed`; the condensed raw cause is preserved in
+  `message=`.
+- Fixed: provider usage-limit failures in 6-review are classified correctly and keep
+  the cooldown-based self-heal.
+- Fixed: `hive diagnose` surfaces on-disk evidence instead of a bare fallback.
+- Fixed: launcher scripts ship in the gem, and the Claude 2.1.179 tmux ready prompt
+  is detected.
+
+### Internals
+
+- Architecture pass over the local web mode: the daemon-status envelope moved to
+  `Hive::Daemon::StatusReport` (CLI and web dashboard share one producer); the
+  daemon/bot/web service installers share one unit-path rule and one renderer pair;
+  `hive setup` phases run through a single failure-recording runner; the unused
+  `--yes` flag was removed before ever shipping.
+- New `Hive::AtomicFile` — the one atomic tempfile+rename write helper; the pairing
+  store and approval queue use it. Dropped the unemitted `rate_limited` enum member.
+
+### CI & testing
+
+- A macOS runner now exercises the real launchd install round-trip for the daemon and
+  web services (previously stub-only).
+- Fixed: `web/Gemfile.lock` path-gem sync restored the hivebox-web CI job after the
+  root lockfile gained `rexml`.
+- The Telegram `/idea` e2e driver handles the bot's file-collection "Done" step.
+
+### Docs
+
+- OpenClaw hive-skill playbooks: status bundle, daemon diagnostics & safe repair,
+  local dogfood workflow, marker recovery, daemon auto-advance fallback, and a task
+  watch recipe.
+
+### Also
+
+- A batch of `hive patrol` hardening fixes: git-grep separator smuggling, asciinema
+  2.4/v3 flag compatibility, hidden copied artifacts in manifests, optional-asciinema
+  TUI aborts, gh Git-trace env scrub, tui_refute tmux preflight, dry-run skip-log
+  dedup.
+
 ## 0.3.2
 
 Setup, the Telegram bot, and TUI performance are the focus of this release. Selected agent backends now persist globally so new projects inherit them; the bot gains idea-by-default capture, a `/waiting` view backed by a daily pending-answer digest, task-id slash commands, and structured JSON errors; and TUI status polling now scales with the number of active tasks instead of the whole archive.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hive-cli (0.3.2)
+    hive-cli (0.3.3)
       bubbletea (= 0.1.4)
       faraday (>= 2.14.2, < 3.0)
       faraday-multipart (~> 1.0)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Hive ships as a rubygem (`hive-cli`) attached to each GitHub Release, signed wit
 | Platform | Channel |
 |----------|---------|
 | macOS arm64 | [`brew install ivankuznetsov/hive/hive`](https://github.com/ivankuznetsov/homebrew-hive) |
-| Ubuntu 22.04+ / glibc Linux x86_64/aarch64 | <code>tmpdir="$(mktemp -d)" && trap 'rm -rf "$tmpdir"' EXIT && curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.3.2/install.sh -o "$tmpdir/hive-install.sh" && bash "$tmpdir/hive-install.sh"</code> |
+| Ubuntu 22.04+ / glibc Linux x86_64/aarch64 | <code>tmpdir="$(mktemp -d)" && trap 'rm -rf "$tmpdir"' EXIT && curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.3.3/install.sh -o "$tmpdir/hive-install.sh" && bash "$tmpdir/hive-install.sh"</code> |
 | Arch Linux x86_64/aarch64 | [`yay -S hive-bin`](https://aur.archlinux.org/packages/hive-bin) |
 
 Prerequisites: **Ruby 3.4** (the gem and its runtime deps install against this), git ≥ 2.40, authenticated `claude` ≥ 2.1.118, `codex` ≥ 0.125.0 for the default execute agent, authenticated `gh`, `tmux` ≥ 3.0 when the project uses the default `claude.mode: tmux`, and Node.js/npm for managed QMD install/repair. The bash installer reports its own installer-side prereqs (`curl`, `jq`, `gem`, checksum tool) on first run; if npm is missing, Hive still installs and `hive doctor` reports the QMD gap non-fatally.

--- a/install.md
+++ b/install.md
@@ -59,8 +59,8 @@ Ubuntu 22.04+ / glibc Linux fallback (pin to the current release tag, not `main`
 ```bash
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
-# Release maintainers: bump v0.3.2 in both installer URLs when cutting a new stable release.
-curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.3.2/install.sh -o "$tmpdir/hive-install.sh"
+# Release maintainers: bump v0.3.3 in both installer URLs when cutting a new stable release.
+curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.3.3/install.sh -o "$tmpdir/hive-install.sh"
 bash "$tmpdir/hive-install.sh"
 ```
 
@@ -69,8 +69,8 @@ To inspect the installer first, run a dry-run before the real invocation. State 
 ```bash
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
-# Release maintainers: bump v0.3.2 in both installer URLs when cutting a new stable release.
-curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.3.2/install.sh -o "$tmpdir/hive-install.sh"
+# Release maintainers: bump v0.3.3 in both installer URLs when cutting a new stable release.
+curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.3.3/install.sh -o "$tmpdir/hive-install.sh"
 bash "$tmpdir/hive-install.sh" --dry-run
 bash "$tmpdir/hive-install.sh"
 ```

--- a/lib/hive.rb
+++ b/lib/hive.rb
@@ -1,5 +1,5 @@
 module Hive
-  VERSION = "0.3.2".freeze
+  VERSION = "0.3.3".freeze
   MIN_CLAUDE_VERSION = "2.1.118".freeze
   # Canonical GitHub org + repo. Referenced by the release probe
   # (UpdateCheck), the brew tap + installer URL (Commands::Update), etc.

--- a/test/unit/setup/diagnostics_test.rb
+++ b/test/unit/setup/diagnostics_test.rb
@@ -73,8 +73,13 @@ class SetupDiagnosticsTest < Minitest::Test
       %w[git tmux gh claude codex node npm sqlite3].each { |name| executable(dir, name) }
       runner = ->(argv) { [ "#{File.basename(argv.first)} 9.9.9", "", Status.new(true) ] }
 
-      row = Hive::Setup::Diagnostics.new(path: dir, runner: runner, ruby_version: "3.4.1")
-                                     .run.results.find { |r| r.name == "qmd" }
+      # check_qmd falls back to the managed install under Paths.data_home, so
+      # isolate HIVE_HOME — on a workstation with a real managed qmd the row
+      # would otherwise read "ok" and this test only passes on qmd-less CI.
+      row = with_env("HIVE_HOME" => File.join(dir, "hive-home")) do
+        Hive::Setup::Diagnostics.new(path: dir, runner: runner, ruby_version: "3.4.1")
+                                .run.results.find { |r| r.name == "qmd" }
+      end
 
       assert_equal "missing", row.status
       assert row.bootstrappable

--- a/web/Gemfile.lock
+++ b/web/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    hive-cli (0.3.2)
+    hive-cli (0.3.3)
       bubbletea (= 0.1.4)
       faraday (>= 2.14.2, < 3.0)
       faraday-multipart (~> 1.0)


### PR DESCRIPTION
Cut 0.3.3 per docs/RELEASING.md:

- `VERSION` → `0.3.3` in `lib/hive.rb`
- Both lockfiles synced (`hive-cli (0.3.3)` in root `Gemfile.lock` **and** `web/Gemfile.lock` — the path-gem consumer)
- Installer-URL refs bumped `v0.3.2` → `v0.3.3` in `README.md` / `install.md`
- `## 0.3.3` CHANGELOG section added (user-facing features first: local web install/run, Telegram pairing, daemon self-healing, review pipeline; then internals/CI/docs/patrol)
- Ride-along: one-line test-hermeticity fix — the qmd-missing diagnostic test now isolates `HIVE_HOME`, so it passes on workstations that have a real managed qmd (it previously only passed on qmd-less CI)

After merge: `git tag v0.3.3 && git push origin v0.3.3` → `release.yml` publishes the signed gem, `SHA256SUMS{,.sig,.pem}`, the `hive-web-0.3.3.tar.gz` bundle asset (first release to carry it — the CLI's `AppBundle` fetch 404s until this tag), and fans out to Homebrew/AUR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)