### PR TITLE
fix(web): managed bundle resolves the hive-cli path gem via HIVE_CLI_ROOT

### DIFF
--- a/lib/hive/commands/web.rb
+++ b/lib/hive/commands/web.rb
@@ -67,7 +67,11 @@ module Hive
           # bundle is replaced wholesale on a version upgrade).
           "HIVEBOX_STORAGE_DIR" => ENV["HIVEBOX_STORAGE_DIR"] ||
             File.join(Hive::Paths.state_home, "web-storage"),
-          "BUNDLE_GEMFILE" => File.join(app_dir, "Gemfile")
+          "BUNDLE_GEMFILE" => File.join(app_dir, "Gemfile"),
+          # The managed bundle's Gemfile resolves the hive-cli path gem via
+          # HIVE_CLI_ROOT (its `..` holds no gem); harmless no-op for a
+          # source checkout, where the default ".." already resolves.
+          "HIVE_CLI_ROOT" => Hive::Web::AppBundle.hive_cli_root
         }
         # The loopback no-auth bypass is opt-out: an operator can set
         # web.local_loopback: false to force GitHub login even on a loopback

--- a/lib/hive/web/app_bundle.rb
+++ b/lib/hive/web/app_bundle.rb
@@ -17,6 +17,15 @@ module Hive
         Hive::Paths.web_app_home
       end
 
+      # Root of the hive-cli gem this code is running from. The managed
+      # bundle's Gemfile resolves `gem "hive-cli"` through HIVE_CLI_ROOT
+      # (there is no gem at its `..`, and hive-cli is not on rubygems), so
+      # every bundler/Rails invocation against the managed app must export
+      # this. Works identically for an installed gem and a source checkout.
+      def hive_cli_root
+        File.expand_path("../../..", __dir__)
+      end
+
       def present?
         File.file?(File.join(app_dir, "config", "application.rb"))
       end
@@ -74,7 +83,9 @@ module Hive
         return dir unless File.file?(File.join(dir, "Gemfile"))
 
         runner ||= ->(argv, env) { system(env, *argv) }
-        ok = runner.call(%w[bundle install], { "BUNDLE_GEMFILE" => File.join(dir, "Gemfile") })
+        ok = runner.call(%w[bundle install],
+                         { "BUNDLE_GEMFILE" => File.join(dir, "Gemfile"),
+                           "HIVE_CLI_ROOT" => hive_cli_root })
         raise Hive::Error, "hive web: bundle install failed in #{dir}" unless ok
 
         output.puts "hive web: installed Rails bundle in #{dir}" if output

--- a/test/unit/web/app_bundle_test.rb
+++ b/test/unit/web/app_bundle_test.rb
@@ -55,9 +55,18 @@ class WebAppBundleTest < Minitest::Test
     with_hive_home do
       source = seed_source_app
       ran = false
+      captured_env = nil
       Hive::Web::AppBundle.ensure!(bundle_url: source, output: nil,
-                                   runner: ->(_argv, _env) { ran = true })
+                                   runner: ->(_argv, env) { captured_env = env; ran = true })
       assert ran, "bundle install runner should have run"
+      # The managed bundle's Gemfile resolves the hive-cli path gem through
+      # HIVE_CLI_ROOT (its ".." holds no gem, and hive-cli is not on
+      # rubygems) — without this export the extracted release asset can never
+      # bundle-install, so `hive setup`/`hive web install` would fail on
+      # every non-source-checkout install.
+      assert_equal Hive::Web::AppBundle.hive_cli_root, captured_env["HIVE_CLI_ROOT"]
+      assert File.file?(File.join(Hive::Web::AppBundle.hive_cli_root, "hive.gemspec")),
+             "HIVE_CLI_ROOT must point at the gem root (hive.gemspec present)"
       assert Hive::Web::AppBundle.present?
       assert_equal Hive::VERSION, Hive::Web::AppBundle.installed_version
       refute Hive::Web::AppBundle.stale?

--- a/test/unit/web/web_command_test.rb
+++ b/test/unit/web/web_command_test.rb
@@ -112,6 +112,10 @@ class WebCommandTest < Minitest::Test
         assert_equal %w[bin/rails server -b], caught.argv[0..2]
         assert caught.env.key?("SECRET_KEY_BASE"), "the persisted session secret must reach Rails"
         assert caught.env.key?("HIVEBOX_STORAGE_DIR")
+        # The managed bundle's Gemfile resolves the hive-cli path gem via
+        # HIVE_CLI_ROOT; the Rails server re-evaluates the Gemfile at boot,
+        # so the exec env must carry it too (not just bundle install).
+        assert_equal Hive::Web::AppBundle.hive_cli_root, caught.env["HIVE_CLI_ROOT"]
       end
     end
   end

--- a/web/Gemfile
+++ b/web/Gemfile
@@ -70,4 +70,10 @@ end
 # The hive control plane: status payloads, gate approval, daemon dispatch,
 # the GitHub device-flow gate, the agent OAuth relay, and Telegram
 # validation all come from the gem — the web tier adds no pipeline logic.
-gem "hive-cli", path: ".."
+#
+# In a source checkout the gem lives at the repo root (".."). The MANAGED
+# bundle (the extracted hive-web-<version>.tar.gz release asset) has no gem
+# at ".." — and hive-cli is not on rubygems — so `hive web`/`hive setup`
+# export HIVE_CLI_ROOT pointing at the installed gem's own root before
+# running bundler or the Rails server.
+gem "hive-cli", path: ENV.fetch("HIVE_CLI_ROOT", "..")

--- a/wiki/log.d/20260702T084500Z-managed-bundle-gem-path.md
+++ b/wiki/log.d/20260702T084500Z-managed-bundle-gem-path.md
@@ -1,0 +1,16 @@
+# 2026-07-02 — managed web bundle could never bundle-install (release blocker)
+
+Pre-release testing of the 0.3.3 managed-bundle path (with
+`HIVE_WEB_BUNDLE_URL` pointed at a local web/ tree, simulating the release
+asset) exposed that `web/Gemfile`'s `gem "hive-cli", path: ".."` can only
+resolve in a source checkout: the extracted `hive-web-<version>.tar.gz` has
+no gem at `..` and hive-cli is not on rubygems, so `AppBundle.bundle_install!`
+failed on every gem install. The GitHub-release 404 (no asset published yet)
+had masked this — nobody had ever completed the fetch → bundle-install path.
+
+Fix: the Gemfile resolves the path gem via `ENV.fetch("HIVE_CLI_ROOT", "..")`;
+`AppBundle.bundle_install!` and the `hive web` foreground env both export
+`HIVE_CLI_ROOT` = the running gem's root (`AppBundle.hive_cli_root`). Source
+checkouts are unaffected (default `..`; web CI's frozen install unchanged).
+Verified live: full ensure! → real bundle install → db:prepare → Rails 200
+from the managed dir. Pages: [[commands/web]].


### PR DESCRIPTION
**Release blocker for 0.3.3, found by pre-release testing of the managed-bundle path.**

`web/Gemfile` pins `gem "hive-cli", path: ".."` — resolvable only in a source checkout. The extracted `hive-web-<version>.tar.gz` release asset has no gem at `..`, and hive-cli is not on rubygems, so `AppBundle.bundle_install!` fails on **every** gem-channel install:

```
Could not find gem 'hive-cli' in source at `..`. (Bundler::GemNotFound)
```

The GitHub-release 404 (no asset published yet) masked this — the fetch → bundle-install path had never actually completed anywhere. Tagging v0.3.3 would have shipped a broken `hive setup` / `hive web install` for every gem user.

**Fix.** The Gemfile resolves the path via `ENV.fetch("HIVE_CLI_ROOT", "..")`; `AppBundle.bundle_install!` and the `hive web` foreground env (db:prepare **and** the Rails server, which re-evaluates the Gemfile at boot) export `HIVE_CLI_ROOT` = the running gem's own root (`AppBundle.hive_cli_root`). Source checkouts keep the `..` default — the hivebox-web frozen CI install is unchanged.

**Verified live** (sandbox `HIVE_HOME`, `HIVE_WEB_BUNDLE_URL` pointed at a web/ tree to simulate the asset): `ensure!` → staged **real** `bundle install` → version stamp → tamper → stale → auto re-provision; then `hive web` booted **from the managed dir** and served the status page HTTP 200. Unit tests pin `HIVE_CLI_ROOT` in both the bundle-install runner env and the server exec env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)