### PR TITLE
Hive patrol: E2E artifact capture follows symlinked failure files

### DIFF
--- a/test/e2e/lib/artifact_capture.rb
+++ b/test/e2e/lib/artifact_capture.rb
@@ -103,10 +103,12 @@ module Hive
       # rg'ing through a multi-MB log.
       def copy_logs_with_tails
         source = File.join(@sandbox_dir, ".hive-state", "logs")
-        return unless File.directory?(source)
+        return unless regular_artifact_directory?(source, "logs")
 
         Dir.glob(File.join(source, "**", "*.log")).each do |full_path|
           relative = full_path.sub("#{source}/", "")
+          next unless regular_artifact_file?(full_path, "logs:#{relative}")
+
           dest = File.join(@scenario_dir, "logs", relative)
           FileUtils.mkdir_p(File.dirname(dest))
           FileUtils.cp(full_path, dest)
@@ -122,12 +124,12 @@ module Hive
       # mid-dispatch. Absence of the directory is normal (no TUI invoked, or a
       # non-TUI scenario) — silently skipped.
       def copy_tui_subprocess_diagnostics
-        return unless @tui_log_dir && File.directory?(@tui_log_dir)
+        return unless @tui_log_dir && regular_artifact_directory?(@tui_log_dir, "tui-subprocess-live")
 
         sources = Dir.glob(File.join(@tui_log_dir, "hive-tui-spawn-*.log"))
         %w[hive-tui-subprocess.log hive-tui-subprocess.log.1].each do |name|
           marker_log = File.join(@tui_log_dir, name)
-          sources << marker_log if File.exist?(marker_log)
+          sources << marker_log if artifact_path_present?(marker_log)
         end
         return if sources.empty?
 
@@ -135,12 +137,16 @@ module Hive
         FileUtils.mkdir_p(dest_root)
         sources.each do |source|
           dest = File.join(dest_root, File.basename(source))
-          copy_tui_diagnostic(source, dest)
+          next unless copy_tui_diagnostic(source, dest)
+
           File.write("#{dest}.tail", tail_lines(dest, LOG_TAIL_LINES))
         end
       end
 
       def copy_tui_diagnostic(source, dest)
+        label = "tui-subprocess:#{File.basename(source)}"
+        return false unless regular_artifact_file?(source, label)
+
         if File.basename(source).start_with?("hive-tui-spawn-") &&
            File.size(source) > TUI_SPAWN_CAPTURE_MAX_BYTES
           notice = "[truncated to last #{TUI_SPAWN_CAPTURE_MAX_BYTES} bytes]\n"
@@ -149,6 +155,10 @@ module Hive
         else
           FileUtils.cp(source, dest)
         end
+        true
+      rescue StandardError => e
+        @capture_errors << { "label" => label, "error" => "#{e.class}: #{e.message}" }
+        false
       end
 
       def remove_live_tui_subprocess_diagnostics
@@ -203,11 +213,33 @@ module Hive
       end
 
       def copy_tree(source, dest)
-        return unless File.directory?(source)
+        return unless regular_artifact_directory?(source, "state")
 
         FileUtils.rm_rf(dest)
-        FileUtils.mkdir_p(File.dirname(dest))
-        FileUtils.cp_r(source, dest)
+        FileUtils.mkdir_p(dest)
+        copy_tree_entries(source, dest, source)
+      end
+
+      def copy_tree_entries(source, dest, root)
+        Dir.children(source).sort.each do |entry|
+          source_path = File.join(source, entry)
+          dest_path = File.join(dest, entry)
+          relative = source_path.sub("#{root}/", "")
+          label = "state:#{relative}"
+          stat = File.lstat(source_path)
+
+          if stat.directory? && !stat.symlink?
+            FileUtils.mkdir_p(dest_path)
+            copy_tree_entries(source_path, dest_path, root)
+          elsif stat.file? && !stat.symlink?
+            FileUtils.mkdir_p(File.dirname(dest_path))
+            FileUtils.cp(source_path, dest_path)
+          else
+            record_non_regular_artifact(label, stat)
+          end
+        rescue SystemCallError => e
+          @capture_errors << { "label" => label || "state", "error" => "#{e.class}: #{e.message}" }
+        end
       end
 
       def write(relative, content)
@@ -224,7 +256,7 @@ module Hive
 
       def write_manifest
         files = Dir.glob(File.join(@scenario_dir, "**", "*"), File::FNM_DOTMATCH)
-          .select { |path| File.file?(path) }
+          .filter_map { |path| manifest_file_path(path) }
           .sort
         file_entries = files.filter_map { |path| manifest_entry(path) }
         manifest = {
@@ -240,8 +272,22 @@ module Hive
         File.rename(tmp, path)
       end
 
+      def manifest_file_path(path)
+        stat = File.lstat(path)
+        return path if stat.file? && !stat.symlink?
+        return nil if stat.directory? && !stat.symlink?
+
+        record_non_regular_artifact("manifest:#{relative_artifact_path(path)}", stat)
+        nil
+      rescue SystemCallError => e
+        @capture_errors << { "label" => "manifest:#{relative_artifact_path(path)}", "error" => "#{e.class}: #{e.message}" }
+        nil
+      end
+
       def manifest_entry(path)
-        relative = path.sub("#{@scenario_dir}/", "")
+        relative = relative_artifact_path(path)
+        return nil unless regular_artifact_file?(path, "manifest:#{relative}")
+
         {
           "path" => relative,
           "size" => File.size(path),
@@ -250,6 +296,42 @@ module Hive
       rescue StandardError => e
         @capture_errors << { "label" => "manifest:#{relative || path}", "error" => "#{e.class}: #{e.message}" }
         nil
+      end
+
+      def relative_artifact_path(path)
+        path.sub("#{@scenario_dir}/", "")
+      end
+
+      def artifact_path_present?(path)
+        File.exist?(path) || File.symlink?(path)
+      end
+
+      def regular_artifact_directory?(path, label)
+        return false unless artifact_path_present?(path)
+
+        stat = File.lstat(path)
+        return true if stat.directory? && !stat.symlink?
+
+        record_non_regular_artifact(label, stat)
+        false
+      rescue SystemCallError => e
+        @capture_errors << { "label" => label, "error" => "#{e.class}: #{e.message}" }
+        false
+      end
+
+      def regular_artifact_file?(path, label)
+        stat = File.lstat(path)
+        return true if stat.file? && !stat.symlink?
+
+        record_non_regular_artifact(label, stat)
+        false
+      rescue SystemCallError => e
+        @capture_errors << { "label" => label, "error" => "#{e.class}: #{e.message}" }
+        false
+      end
+
+      def record_non_regular_artifact(label, stat)
+        @capture_errors << { "label" => label, "error" => "skipped non-regular artifact (#{stat.ftype})" }
       end
     end
   end

--- a/test/e2e/lib/artifact_capture_test.rb
+++ b/test/e2e/lib/artifact_capture_test.rb
@@ -102,6 +102,29 @@ class E2EArtifactCaptureTest < Minitest::Test
     end
   end
 
+  def test_log_capture_skips_symlinked_logs
+    with_dirs do |scenario_dir, sandbox, run_home|
+      Dir.mktmpdir("outside-log") do |outside_dir|
+        outside_log = File.join(outside_dir, "secret.log")
+        File.write(outside_log, "SECRET\n")
+        logs_root = File.join(sandbox, ".hive-state", "logs", "myslug")
+        FileUtils.mkdir_p(logs_root)
+        File.symlink(outside_log, File.join(logs_root, "stage.log"))
+
+        collect(scenario_dir, sandbox, run_home)
+
+        copied_log = File.join(scenario_dir, "logs", "myslug", "stage.log")
+        refute File.exist?(copied_log), "symlinked logs must not be copied into the bundle"
+        refute File.exist?("#{copied_log}.tail"), "symlinked logs must not be tailed"
+
+        manifest = JSON.parse(File.read(File.join(scenario_dir, "manifest.json")))
+        refute_includes manifest.fetch("files").map { |entry| entry.fetch("path") }, "logs/myslug/stage.log"
+        assert manifest.fetch("capture_errors").any? { |entry| entry.fetch("label") == "logs:myslug/stage.log" },
+               "skipped symlinked logs should leave a capture_errors breadcrumb"
+      end
+    end
+  end
+
   def test_pane_before_and_after_both_written_on_tui_failure
     with_dirs do |scenario_dir, sandbox, run_home|
       fake_tmux = Object.new
@@ -162,6 +185,34 @@ class E2EArtifactCaptureTest < Minitest::Test
       paths = manifest.fetch("files").map { |file| file.fetch("path") }
       assert_includes paths, "tui-subprocess/hive-tui-subprocess.log"
       assert_includes paths, "tui-subprocess/hive-tui-subprocess.log.1"
+    end
+  end
+
+  def test_tui_subprocess_diagnostics_skip_symlinked_live_logs
+    with_dirs do |scenario_dir, sandbox, run_home|
+      Dir.mktmpdir("outside-tui-log") do |outside_dir|
+        outside_log = File.join(outside_dir, "secret.log")
+        File.write(outside_log, "SECRET\n")
+        log_dir = File.join(scenario_dir, "tui-live")
+        FileUtils.mkdir_p(log_dir)
+        File.symlink(outside_log, File.join(log_dir, "hive-tui-spawn-FAKE.log"))
+        File.symlink(outside_log, File.join(log_dir, "hive-tui-subprocess.log"))
+
+        collect(scenario_dir, sandbox, run_home, tui_log_dir: log_dir)
+
+        copied_spawn = File.join(scenario_dir, "tui-subprocess", "hive-tui-spawn-FAKE.log")
+        copied_marker = File.join(scenario_dir, "tui-subprocess", "hive-tui-subprocess.log")
+        refute File.exist?(copied_spawn), "symlinked TUI spawn logs must not be copied"
+        refute File.exist?(copied_marker), "symlinked TUI marker logs must not be copied"
+
+        manifest = JSON.parse(File.read(File.join(scenario_dir, "manifest.json")))
+        paths = manifest.fetch("files").map { |entry| entry.fetch("path") }
+        refute_includes paths, "tui-subprocess/hive-tui-spawn-FAKE.log"
+        refute_includes paths, "tui-subprocess/hive-tui-subprocess.log"
+        labels = manifest.fetch("capture_errors").map { |entry| entry.fetch("label") }
+        assert_includes labels, "tui-subprocess:hive-tui-spawn-FAKE.log"
+        assert_includes labels, "tui-subprocess:hive-tui-subprocess.log"
+      end
     end
   end
 
@@ -233,6 +284,29 @@ class E2EArtifactCaptureTest < Minitest::Test
     end
   end
 
+  def test_state_capture_skips_symlinked_state_files
+    with_dirs do |scenario_dir, sandbox, run_home|
+      Dir.mktmpdir("outside-state") do |outside_dir|
+        outside_state = File.join(outside_dir, "task.md")
+        File.write(outside_state, "SECRET\n")
+        task_dir = File.join(sandbox, ".hive-state", "stages", "2-brainstorm", "task-1")
+        FileUtils.mkdir_p(task_dir)
+        File.symlink(outside_state, File.join(task_dir, "task.md"))
+
+        collect(scenario_dir, sandbox, run_home)
+
+        copied_state = File.join(scenario_dir, "state", "2-brainstorm", "task-1", "task.md")
+        refute File.exist?(copied_state), "symlinked state files must not be copied into the bundle"
+
+        manifest = JSON.parse(File.read(File.join(scenario_dir, "manifest.json")))
+        refute_includes manifest.fetch("files").map { |entry| entry.fetch("path") },
+                        "state/2-brainstorm/task-1/task.md"
+        assert manifest.fetch("capture_errors").any? { |entry| entry.fetch("label") == "state:2-brainstorm/task-1/task.md" },
+               "skipped symlinked state should leave a capture_errors breadcrumb"
+      end
+    end
+  end
+
   def test_env_snapshot_is_json_with_schema_version
     with_dirs do |scenario_dir, sandbox, run_home|
       collect(scenario_dir, sandbox, run_home)
@@ -245,6 +319,24 @@ class E2EArtifactCaptureTest < Minitest::Test
       assert_equal 1, payload["schema_version"]
       assert_kind_of String, payload["ruby"]
       assert_kind_of String, payload["platform"]
+    end
+  end
+
+  def test_manifest_skips_preexisting_symlinked_bundle_files
+    with_dirs do |scenario_dir, sandbox, run_home|
+      Dir.mktmpdir("outside-manifest") do |outside_dir|
+        outside_file = File.join(outside_dir, "secret.txt")
+        File.write(outside_file, "SECRET\n")
+        FileUtils.mkdir_p(scenario_dir)
+        File.symlink(outside_file, File.join(scenario_dir, "linked-secret.txt"))
+
+        collect(scenario_dir, sandbox, run_home)
+
+        manifest = JSON.parse(File.read(File.join(scenario_dir, "manifest.json")))
+        refute_includes manifest.fetch("files").map { |entry| entry.fetch("path") }, "linked-secret.txt"
+        assert manifest.fetch("capture_errors").any? { |entry| entry.fetch("label") == "manifest:linked-secret.txt" },
+               "skipped symlinked manifest inputs should leave a capture_errors breadcrumb"
+      end
     end
   end
 


### PR DESCRIPTION
## Hive Patrol Finding

Slice: `test-suite-test-babysitter-acceptance-dry-run-test-rb`
Category: `security`
Severity: `medium`
Confidence: `high`
Fingerprint: `2907d502e03c2d14ac8a54d4592204400a8c6280e8a47fa10e088f6300a13228`

Failure artifact capture copies log files with FileUtils.cp and builds the manifest with File.file?, both of which follow symlinks. A failing scenario or subprocess that leaves a symlink under .hive-state/logs or copied state can cause the artifact bundle or manifest digest pass to read files outside the sandbox, leaking host or CI-local data into retained/shared e2e artifacts.

## Evidence

- test/e2e/lib/artifact_capture.rb:112 FileUtils.cp(full_path, dest)
- test/e2e/lib/artifact_capture.rb:148 FileUtils.cp(source, dest)
- test/e2e/lib/artifact_capture.rb:225 .select { |path| File.file?(path) }

## Applied Fix

Treat sandbox artifacts as untrusted filesystem input: use File.lstat to require regular non-symlink files before copying, tailing, hashing, or manifesting; skip or record capture_errors for symlinks/devices/FIFOs; and add regression tests for symlinked .hive-state/logs, state files, and tui-subprocess-live logs.

## Validation

- lint: passed (`bundle exec rubocop`)
- test: passed (`bundle exec rake test`)

## Diffstat

```text
 test/e2e/lib/artifact_capture.rb      | 100 +++++++++++++++++++++++++++++++---
 test/e2e/lib/artifact_capture_test.rb |  92 +++++++++++++++++++++++++++++++
 2 files changed, 183 insertions(+), 9 deletions(-)

```
