### PR TITLE
fix(release): stabilize hivebox and AUR verification

### DIFF
--- a/lib/hive/web/supervisor.rb
+++ b/lib/hive/web/supervisor.rb
@@ -18,6 +18,12 @@ module Hive
       # A run shorter than this counts as a fast failure and earns a backoff.
       FAST_FAILURE_SEC = 10
 
+      # The container binds all interfaces by design: hivebox's front door is
+      # the GitHub device-flow gate (an ownerless box is claimable; first login
+      # pins the owner), not the CLI's ownerless-bind refusal. Actual network
+      # exposure remains the operator's compose port-mapping choice.
+      WEB_CHILD_ARGV = %w[hive web --bind 0.0.0.0 --allow-public].freeze
+
       def initialize
         @children = []
         @stopping = false
@@ -34,7 +40,7 @@ module Hive
         ENV["HIVEBOX_SUPERVISOR_PID"] = Process.pid.to_s
         previous_signal_handlers = trap_signals
         start_child("daemon", %w[hive daemon start])
-        start_child("web", %w[hive web --bind 0.0.0.0])
+        start_child("web", WEB_CHILD_ARGV)
         start_child("bot", %w[hive bot start --foreground]) if bot_enabled?
         loop do
           break if @stopping

--- a/packaging/verify-channel.sh
+++ b/packaging/verify-channel.sh
@@ -75,6 +75,24 @@ ok()   { printf '  ok   %s\n' "$*"; PASS=$((PASS + 1)); }
 fail() { printf '  FAIL %s\n' "$*" >&2; FAIL=$((FAIL + 1)); }
 log()  { printf '[verify-channel:%s] %s\n' "$CHANNEL" "$*"; }
 
+git_clone_retry() {
+  local url="$1"
+  local dest="$2"
+  local attempt rc
+  for attempt in 1 2 3; do
+    rm -rf "$dest"
+    if git clone --depth 1 "$url" "$dest"; then
+      return 0
+    fi
+    rc=$?
+    if [[ "$attempt" -eq 3 ]]; then
+      return "$rc"
+    fi
+    log "git clone failed (attempt ${attempt}/3, rc=${rc}); retrying"
+    sleep $((attempt * 2))
+  done
+}
+
 # Resolve the channel's install command, expected binary, and marker path.
 HIVE_BIN=""
 MARKER_PATH=""
@@ -109,7 +127,7 @@ install_aur() {
     command -v makepkg >/dev/null 2>&1 || { echo "neither yay/paru nor makepkg found" >&2; exit 3; }
     local build
     build="$(mktemp -d)"
-    git clone --depth 1 "https://aur.archlinux.org/hive-bin.git" "$build/hive-bin"
+    git_clone_retry "https://aur.archlinux.org/hive-bin.git" "$build/hive-bin"
     ( cd "$build/hive-bin" && makepkg -si --noconfirm --needed )
   fi
   HIVE_BIN="/usr/bin/hive"

--- a/test/unit/web/supervisor_test.rb
+++ b/test/unit/web/supervisor_test.rb
@@ -207,8 +207,8 @@ class WebSupervisorTest < Minitest::Test
       with_tmp_global_config do
         sup = build
         started = []
-        sup.define_singleton_method(:start_child) do |name, _argv|
-          started << name
+        sup.define_singleton_method(:start_child) do |name, argv|
+          started << [ name, argv ]
           published_pids << ENV["HIVEBOX_SUPERVISOR_PID"]
         end
         # Make the loop exit on its first iteration and turn terminate_all into a
@@ -220,8 +220,11 @@ class WebSupervisorTest < Minitest::Test
 
         sup.run
 
-        assert_includes started, "daemon", "run must start the daemon child"
-        assert_includes started, "web", "run must start the web child"
+        assert_includes started.map(&:first), "daemon", "run must start the daemon child"
+        assert_includes started.map(&:first), "web", "run must start the web child"
+        web = started.find { |name, _argv| name == "web" }
+        assert_equal %w[hive web --bind 0.0.0.0 --allow-public], web.last,
+                     "container web child must opt into public bind; owner gate still protects UI"
         assert_equal [ Process.pid.to_s, Process.pid.to_s ], published_pids,
                      "run must publish its pid before children are spawned"
         assert sup.instance_variable_get(:@terminated), "run must terminate_all on exit"


### PR DESCRIPTION
## Summary
- start hivebox web with `--allow-public` so the container can bind `0.0.0.0` while GitHub owner-gate still protects the UI
- pin the container supervisor argv in a unit test
- retry the AUR fallback clone in channel verification to absorb transient AUR SSL EOF failures

## Tests
- `ruby -c lib/hive/web/supervisor.rb`
- `bash -n packaging/verify-channel.sh`
- `mise exec ruby@3.4.7 -- ruby -Itest test/unit/web/supervisor_test.rb`
- `mise exec ruby@3.4.7 -- ruby -Itest test/unit/web/web_command_test.rb`
- `mise exec ruby@3.4.7 -- ruby -Itest test/unit/openclaw_skills_test.rb`