### PR TITLE
Hive patrol: gh passthrough preserves agent-controlled PATH

### DIFF
--- a/test/unit/babysitter/dry_run_env_test.rb
+++ b/test/unit/babysitter/dry_run_env_test.rb
@@ -1193,6 +1193,37 @@ class BabysitterDryRunEnvTest < Minitest::Test
     end
   end
 
+  def test_gh_stub_pins_path_before_allowlisted_pr_view_passthrough
+    with_tmp_dir do |dir|
+      poison_dir = File.join(dir, "poison-bin")
+      FileUtils.mkdir_p(poison_dir)
+      poison_marker = File.join(dir, "poison-git-ran")
+      executable_touch_binary(poison_dir, "git", poison_marker)
+
+      marker_path = File.join(dir, "real-gh-ran")
+      real_gh = File.join(dir, "real-gh")
+      File.write(real_gh, <<~RUBY)
+        #!#{RbConfig.ruby}
+        File.write(#{marker_path.dump}, ARGV.join(" "))
+        ok = system("git", "--version", out: File::NULL, err: File::NULL)
+        exit(ok ? 0 : 1)
+      RUBY
+      FileUtils.chmod("+x", real_gh)
+
+      env = {
+        "HIVE_BABYSITTER_REAL_GH" => real_gh,
+        "HIVE_BABYSITTER_DRY_RUN_LOG" => File.join(dir, "skipped.log"),
+        "PATH" => [ poison_dir, ENV.fetch("PATH", "") ].join(File::PATH_SEPARATOR)
+      }
+
+      _out, err, status = Open3.capture3(env, stub_path("gh"), "pr", "view", "42")
+
+      assert status.success?, err
+      assert_equal "pr view 42", File.read(marker_path)
+      refute_path_exists poison_marker, "real gh child git resolved from caller-controlled PATH"
+    end
+  end
+
   def test_gh_stub_scrubs_host_repo_and_enterprise_token_environment_before_passthrough
     with_tmp_dir do |dir|
       # The argv gate inspects argv only; gh also reads the target host/repo and enterprise

--- a/wiki/log.d/20260703T094219Z-babysitter-gh-path-pinning.md
+++ b/wiki/log.d/20260703T094219Z-babysitter-gh-path-pinning.md
@@ -1,0 +1,20 @@
+---
+date: 2026-07-03T09:42:19Z
+slug: babysitter-gh-path-pinning
+pages: [modules/babysitter, testing]
+---
+
+## babysitter - pin PATH before gh dry-run passthrough
+
+Fixed patrol finding `command-bin-hive-babysitter-stub-gh-1` by pinning
+`PATH=/usr/bin:/bin` before `bin/hive-babysitter-stub-gh` execs an
+allowlisted real `gh` read. The stub already scrubbed Git child-process env
+seams; the new PATH pin prevents real `gh` repository probes from resolving a
+caller-controlled `git` binary while credentials and passthrough environment are
+still available.
+
+Added focused `test/unit/babysitter/dry_run_env_test.rb` coverage where fake
+real `gh` shells out to `git --version` while PATH points first at a poisoned
+`git`. The test now proves the poisoned child `git` is not executed.
+
+Updated [[modules/babysitter]] and [[testing]].


### PR DESCRIPTION
## Hive Patrol Finding

Slice: `command-bin-hive-babysitter-stub-gh`
Category: `security`
Severity: `high`
Confidence: `high`
Fingerprint: `5d304069d8b91c490f839a06947b25f2e48a66909fa161c2f3cfb213b0b8a482`

Allowlisted dry-run gh reads scrub Git-specific environment variables, but then exec the real gh binary without replacing PATH. Real gh can spawn git for repository probes, so a command that reaches this stub with PATH pointing at an agent-controlled directory can make that child git execute arbitrary code while gh credentials and process environment are still available. A temp repro with a fake real-gh that runs git --version executed a poisoned git from PATH during `gh pr view 42`.

## Evidence

- bin/hive-babysitter-stub-gh:466 # Real gh can also invoke git for repo probes; scrub git's trace, config, and helper-command
- bin/hive-babysitter-stub-gh:492 exec real, *argv

## Applied Fix

Before execing real gh, set PATH to trusted system directories or another immutable git wrapper path, and add a regression test that poisons PATH while fake real-gh shells out to git. Keep the existing Git env scrubbing, but ensure child git lookup cannot resolve from the worktree or caller-controlled PATH.

## Validation

- lint: passed (`bundle exec rubocop`)
- test: passed (`bundle exec rake test`)

## Diffstat

```text
 bin/hive-babysitter-stub-gh                        |  3 +++
 test/unit/babysitter/dry_run_env_test.rb           | 31 ++++++++++++++++++++++
 .../20260703T094219Z-babysitter-gh-path-pinning.md | 20 ++++++++++++++
 wiki/modules/babysitter.md                         |  2 +-
 wiki/testing.md                                    |  2 +-
 5 files changed, 56 insertions(+), 2 deletions(-)

```
