### PR TITLE
Hive patrol: gh passthrough can execute git from caller PATH

### DIFF
--- a/bin/hive-babysitter-stub-gh
+++ b/bin/hive-babysitter-stub-gh
@@ -464,7 +464,8 @@ end
 # Proxy and TLS trust-store env can still redirect a safe read through an agent-controlled
 # MITM before real gh sees GitHub credentials, so scrub those at the same exec seam.
 # Real gh can also invoke git for repo probes; scrub git's trace, config, and helper-command
-# env seams before those child git processes can inherit them.
+# env seams before those child git processes can inherit them. Pin PATH too, so those child
+# git probes cannot resolve an agent-controlled git binary from the caller's PATH.
 %w[
   GH_PAGER PAGER GH_BROWSER BROWSER GH_EDITOR GIT_EDITOR VISUAL EDITOR GH_FORCE_TTY
   GH_CONFIG_DIR XDG_CONFIG_HOME HIVE_BABYSITTER_TRUSTED_GH_CONFIG_DIR
@@ -488,6 +489,7 @@ ENV["PATH"] = "/usr/bin:/bin"
 config_home = make_gh_config_home
 ENV["HOME"] = config_home
 ENV["GH_CONFIG_DIR"] = config_home
+ENV["PATH"] = "/usr/bin:/bin"
 
 begin
   exec real, *argv

--- a/test/unit/babysitter/dry_run_env_test.rb
+++ b/test/unit/babysitter/dry_run_env_test.rb
@@ -1095,10 +1095,14 @@ class BabysitterDryRunEnvTest < Minitest::Test
     end
   end
 
-  def test_gh_stub_scrubs_git_trace_env_before_allowlisted_pr_view_passthrough
+  def test_gh_stub_scrubs_git_trace_env_and_pins_path_before_allowlisted_pr_view_passthrough
     with_tmp_git_repo do |dir|
       trace_path = File.join(dir, "gh-git-trace.log")
       marker_path = File.join(dir, "real-gh-ran")
+      poison_dir = File.join(dir, "poison-bin")
+      poison_marker = File.join(dir, "poison-git-ran")
+      FileUtils.mkdir_p(poison_dir)
+      executable_touch_binary(poison_dir, "git", poison_marker)
       real_gh = File.join(dir, "real-gh")
       File.write(real_gh, <<~RUBY)
         #!#{RbConfig.ruby}
@@ -1111,7 +1115,8 @@ class BabysitterDryRunEnvTest < Minitest::Test
       env = {
         "HIVE_BABYSITTER_REAL_GH" => real_gh,
         "HIVE_BABYSITTER_DRY_RUN_LOG" => File.join(dir, "skipped.log"),
-        "GIT_TRACE" => trace_path
+        "GIT_TRACE" => trace_path,
+        "PATH" => [ poison_dir, ENV.fetch("PATH", "") ].join(File::PATH_SEPARATOR)
       }
 
       _out, err, status = Open3.capture3(env, stub_path("gh"), "pr", "view", "42")
@@ -1120,6 +1125,7 @@ class BabysitterDryRunEnvTest < Minitest::Test
       assert_equal "pr view 42", File.read(marker_path)
       refute_path_exists File.join(dir, "skipped.log")
       refute_path_exists trace_path
+      refute_path_exists poison_marker, "real gh resolved child git from the caller-controlled PATH"
     end
   end
 


### PR DESCRIPTION
## Hive Patrol Finding

Slice: `command-bin-hv`
Category: `security`
Severity: `high`
Confidence: `high`
Fingerprint: `2dcd955b514dc7a26733757442b4070eb4633a19869a1b93d3aa1ab5d3971f5b`

The dry-run gh stub recognizes that real gh can invoke git for repository probes, but it scrubs only Git-specific environment variables and then execs real gh with the caller-controlled PATH still intact. An allowlisted command such as `gh repo view owner/repo` can therefore run an agent-supplied `git` binary from PATH while the dry-run gate treats the command as read-only.

## Evidence

- bin/hive-babysitter-stub-gh:466 # Real gh can also invoke git for repo probes; scrub git's trace, config, and helper-command
- bin/hive-babysitter-stub-gh:468 %w[
- bin/hive-babysitter-stub-gh:492 exec real, *argv
- bin/hive-babysitter-stub-git:384 ENV["PATH"] = "/usr/bin:/bin"

## Applied Fix

Before execing real gh, pin PATH to trusted system directories or to a dedicated safe git wrapper, mirroring the git stub's PATH hardening. Add a regression where a fake real gh shells out to git while PATH points at a marker-writing fake git.

## Validation

- lint: passed (`bundle exec rubocop`)
- test: passed (`bundle exec rake test`)

## Diffstat

```text
 bin/hive-babysitter-stub-gh              |  4 +++-
 test/unit/babysitter/dry_run_env_test.rb | 10 ++++++++--
 2 files changed, 11 insertions(+), 3 deletions(-)

```
