### PR TITLE
Hive patrol: CliDriver timeout cleanup path is untested

### DIFF
--- a/test/e2e/lib/cli_driver_test.rb
+++ b/test/e2e/lib/cli_driver_test.rb
@@ -31,4 +31,66 @@ class E2ECliDriverTest < Minitest::Test
       end
     end
   end
+
+  def test_timeout_marks_result_and_kills_process_group
+    Dir.mktmpdir("sandbox") do |sandbox|
+      Dir.mktmpdir("home") do |home|
+        File.write(File.join(sandbox, "Gemfile"), "source \"https://rubygems.org\"\n")
+        marker = File.join(sandbox, "timeout-fixture")
+        command = write_timeout_fixture(sandbox)
+        driver = Hive::E2E::CliDriver.new(sandbox, home)
+        driver.define_singleton_method(:command) { |_args| [ command, marker ] }
+
+        result = driver.call([ "ignored" ], expect_exit: nil, cwd: sandbox, timeout: 0.2)
+
+        assert result.timed_out
+        pgid = Integer(File.read("#{marker}.pgid").strip)
+        refute_process_group_alive pgid
+      ensure
+        kill_process_group(marker)
+      end
+    end
+  end
+
+  def write_timeout_fixture(dir)
+    command = File.join(dir, "timeout-fixture-command")
+    File.write(command, <<~SH)
+      #!/bin/sh
+      marker="$1"
+      (
+        trap '' TERM
+        sleep 30
+      ) >/dev/null 2>&1 &
+      child="$!"
+      printf '%s\\n' "$child" > "$marker.pid"
+      printf '%s\\n' "$$" > "$marker.pgid"
+      wait "$child"
+    SH
+    File.chmod(0o755, command)
+    command
+  end
+
+  def refute_process_group_alive(pgid)
+    deadline = Time.now + 2
+    sleep 0.05 while process_group_alive?(pgid) && Time.now < deadline
+    refute process_group_alive?(pgid), "timeout must terminate the spawned process group"
+  end
+
+  def process_group_alive?(pgid)
+    Process.kill(0, -pgid)
+    true
+  rescue Errno::ESRCH
+    false
+  rescue Errno::EPERM
+    true
+  end
+
+  def kill_process_group(marker)
+    return unless marker && File.exist?("#{marker}.pgid")
+
+    pgid = Integer(File.read("#{marker}.pgid").strip)
+    Process.kill("KILL", -pgid) if process_group_alive?(pgid)
+  rescue StandardError
+    nil
+  end
 end

--- a/test/e2e/lib/cli_driver_test.rb
+++ b/test/e2e/lib/cli_driver_test.rb
@@ -41,7 +41,11 @@ class E2ECliDriverTest < Minitest::Test
         driver = Hive::E2E::CliDriver.new(sandbox, home)
         driver.define_singleton_method(:command) { |_args| [ command, marker ] }
 
-        result = driver.call([ "ignored" ], expect_exit: nil, cwd: sandbox, timeout: 0.2)
+        # Keep the timeout well under the fixture's 30s child sleep, but generous
+        # enough that a slow/loaded CI worker reliably forks the shell and writes
+        # "#{marker}.pgid" before the timeout kills it. A sub-second timeout races
+        # fixture startup and makes the later File.read of the marker raise ENOENT.
+        result = driver.call([ "ignored" ], expect_exit: nil, cwd: sandbox, timeout: 5.0)
 
         assert result.timed_out
         pgid = Integer(File.read("#{marker}.pgid").strip)


### PR DESCRIPTION
## Summary

Closes a test-coverage gap flagged by Hive Patrol: `CliDriver` has a dedicated timeout path (`test/e2e/lib/cli_driver.rb`) that terminates the spawned process group and marks the result as timed out, but the existing suite only exercised a successful command and an exit-code mismatch. A regression in timeout handling could leak child processes or hang e2e scenarios without any test catching it.

This adds `test_timeout_marks_result_and_kills_process_group` to `test/e2e/lib/cli_driver_test.rb`. The test:

- Writes a shell fixture that forks a `TERM`-ignoring child which sleeps 30s, records its own PGID/child PID to marker files, and waits on the child.
- Runs `CliDriver` against the fixture with `expect_exit: nil` and a short timeout.
- Asserts `result.timed_out` is true and that the spawned process group is gone (polling `Process.kill(0, -pgid)` with a bounded deadline), with a guaranteed `KILL` cleanup of the group in an `ensure` block.

## Test plan

- `bundle exec rake test` — full suite passes, including the new timeout case.
- `bundle exec rubocop` — clean.
- The timeout is set to 5.0s: comfortably under the fixture's 30s child sleep, yet generous enough that a slow/loaded CI worker reliably forks the shell and writes `#{marker}.pgid` before the timeout fires. This follows the project rule against hard-coded sub-second timeouts that race process startup and cause flaky `ENOENT` on the later marker read.

## Review summary

Two automated review passes. Pass 01 raised one Medium finding — a sub-second timeout that could race fixture startup on loaded CI workers and make the marker read flaky; it was auto-fixed by raising the timeout to a value well under the child sleep while still allowing startup. Pass 02 reported no findings across High/Medium/Nit. No open findings; nothing suppressed.

## Linked task

- Patrol finding: `test-suite-test-babysitter-acceptance-dry-run-test-rb-3`
- Fingerprint: `8386970e5533734329375d5832acd519d2f11513751ad4b55b8e8596a2e85df1`
- Task folder: `/home/asterio/Dev/hive/.hive-state/stages/8-finalize/patrol-test-suite-test-babysitter-acceptance-dry-run-test-rb-838`
