### PR TITLE
fix(web): export HIVE_CLI_ROOT only for the managed bundle

### DIFF
--- a/lib/hive/commands/web.rb
+++ b/lib/hive/commands/web.rb
@@ -67,12 +67,16 @@ module Hive
           # bundle is replaced wholesale on a version upgrade).
           "HIVEBOX_STORAGE_DIR" => ENV["HIVEBOX_STORAGE_DIR"] ||
             File.join(Hive::Paths.state_home, "web-storage"),
-          "BUNDLE_GEMFILE" => File.join(app_dir, "Gemfile"),
-          # The managed bundle's Gemfile resolves the hive-cli path gem via
-          # HIVE_CLI_ROOT (its `..` holds no gem); harmless no-op for a
-          # source checkout, where the default ".." already resolves.
-          "HIVE_CLI_ROOT" => Hive::Web::AppBundle.hive_cli_root
+          "BUNDLE_GEMFILE" => File.join(app_dir, "Gemfile")
         }
+        # Only the MANAGED bundle resolves the hive-cli path gem via
+        # HIVE_CLI_ROOT — its ".." holds no gem, and its bundle was installed
+        # with this same export. A source checkout or a HIVEBOX_WEB_APP_DIR
+        # override (e.g. the hivebox image's baked /app/web) was
+        # bundle-installed against its own ".."; re-pointing the path source
+        # at runtime invalidates that prebuilt bundle (the v0.3.4/v0.3.5
+        # image-smoke db:prepare failure).
+        env["HIVE_CLI_ROOT"] = Hive::Web::AppBundle.hive_cli_root if app_dir == Hive::Web::AppBundle.app_dir
         # The loopback no-auth bypass is opt-out: an operator can set
         # web.local_loopback: false to force GitHub login even on a loopback
         # bind. Only signal the bypass when both the bind is loopback AND the

--- a/test/unit/web/web_command_test.rb
+++ b/test/unit/web/web_command_test.rb
@@ -112,11 +112,47 @@ class WebCommandTest < Minitest::Test
         assert_equal %w[bin/rails server -b], caught.argv[0..2]
         assert caught.env.key?("SECRET_KEY_BASE"), "the persisted session secret must reach Rails"
         assert caught.env.key?("HIVEBOX_STORAGE_DIR")
-        # The managed bundle's Gemfile resolves the hive-cli path gem via
-        # HIVE_CLI_ROOT; the Rails server re-evaluates the Gemfile at boot,
-        # so the exec env must carry it too (not just bundle install).
-        assert_equal Hive::Web::AppBundle.hive_cli_root, caught.env["HIVE_CLI_ROOT"]
+        # A HIVEBOX_WEB_APP_DIR override (like the hivebox image's baked
+        # /app/web) was bundle-installed against its own ".." — exporting
+        # HIVE_CLI_ROOT would re-point the Gemfile's path source and
+        # invalidate that prebuilt bundle (the v0.3.4/v0.3.5 image-smoke
+        # db:prepare failure). Only the managed bundle gets the export.
+        refute caught.env.key?("HIVE_CLI_ROOT"),
+               "an operator-managed app dir must not have its path-gem source re-pointed"
       end
+    end
+  end
+
+  # The MANAGED bundle is the one place whose Gemfile can only resolve the
+  # hive-cli path gem through HIVE_CLI_ROOT (its ".." holds no gem, and its
+  # bundle was installed with the same export). The Rails server re-evaluates
+  # the Gemfile at boot, so the exec env must carry it there — and only there.
+  def test_managed_bundle_exec_env_carries_hive_cli_root
+    with_tmp_global_config do
+      dir = Hive::Web::AppBundle.app_dir
+      FileUtils.mkdir_p(File.join(dir, "config"))
+      File.write(File.join(dir, "config", "application.rb"), "# rails app marker")
+      File.write(File.join(dir, Hive::Web::AppBundle::VERSION_FILE), "#{Hive::VERSION}\n")
+      FileUtils.mkdir_p(File.join(dir, "bin"))
+      File.write(File.join(dir, "bin", "rails"), "#!/usr/bin/env bash\nexit 0\n")
+      FileUtils.chmod(0o755, File.join(dir, "bin", "rails"))
+
+      original = Kernel.method(:exec)
+      Kernel.define_singleton_method(:exec) do |env, *argv|
+        raise ExecCaught.new(env, argv)
+      end
+
+      caught = nil
+      begin
+        capture_io { Hive::Commands::Web.new.call }
+      rescue ExecCaught => e
+        caught = e
+      ensure
+        Kernel.define_singleton_method(:exec, original)
+      end
+
+      refute_nil caught, "the command must end in Kernel.exec of the rails server"
+      assert_equal Hive::Web::AppBundle.hive_cli_root, caught.env["HIVE_CLI_ROOT"]
     end
   end
 

--- a/wiki/log.d/20260703T090500Z-hive-cli-root-scope.md
+++ b/wiki/log.d/20260703T090500Z-hive-cli-root-scope.md
@@ -1,0 +1,12 @@
+# 2026-07-03 — scope HIVE_CLI_ROOT to the managed bundle (image-smoke fix)
+
+The v0.3.4/v0.3.5 hivebox image smoke failed at `db:prepare`: the runtime
+HIVE_CLI_ROOT export (added for the managed bundle) re-pointed the web
+Gemfile's hive-cli path source under the image's PREBUILT /app/web bundle
+(built against ".." = /app, while the runtime hive is the installed gem, so
+its root differs). `hive web` now exports HIVE_CLI_ROOT only when serving
+the managed bundle (`app_dir == AppBundle.app_dir`); source checkouts and
+HIVEBOX_WEB_APP_DIR overrides keep their build-time ".." resolution.
+Verified by running the release job's exact sequence locally: gem build →
+image build → `packaging/docker/smoke.sh` → PASS (first pass since v0.3.2).
+Pages: [[commands/web]].


### PR DESCRIPTION
**Fixes the hivebox image smoke that failed on v0.3.4 and v0.3.5** (and, for a different reason since fixed, v0.3.3) — the image has not published since v0.3.2.

## Failure

`packaging/docker/smoke.sh` → `FAIL /health never came up`, container loops on:

```
hive: hive web: db:prepare failed — check that /data/state/hive/web-storage is writable and that the web bundle is installed (cd /app/web …)
```

## Root cause

#654 made `hive web` export `HIVE_CLI_ROOT` (the running gem's root) unconditionally so the **managed** bundle's Gemfile can resolve the hive-cli path gem. But the hivebox image serves a **prebuilt** bundle: `/app/web` was bundle-installed at build time against `path: ".."` = `/app` (the baked source), while the runtime `hive` is the *gem-installed* copy (`gem install hive-cli-*.gem`) whose root is the gem dir. The runtime export re-points the Gemfile's path source under that prebuilt bundle → bundler rejects it → `db:prepare` fails → the supervisor's web child crash-loops.

## Fix

Export `HIVE_CLI_ROOT` only when `app_dir == AppBundle.app_dir` (the managed bundle — the one place whose `..` holds no gem and whose bundle was installed with the same export). Source checkouts and `HIVEBOX_WEB_APP_DIR` overrides keep the `..` resolution their bundles were actually built against. `AppBundle.bundle_install!` is unchanged (it only ever targets managed/staged dirs).

## Verification

- Ran the release job's exact sequence locally: `gem build hive.gemspec` → `docker build -f packaging/docker/Dockerfile` → `packaging/docker/smoke.sh` → **PASS** (health, claimable login, owner gate) — the smoke's first pass since v0.3.2.
- Managed-bundle regression coverage kept: new test pins `HIVE_CLI_ROOT` in the exec env when serving the managed dir; the override-dir test now pins its **absence**.

After merge this needs a patch tag (0.3.6) to actually publish the image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)