### PR TITLE
Hive patrol: CLI driver can hang after parent exits with live descendants

### DIFF
--- a/test/e2e/lib/cli_driver.rb
+++ b/test/e2e/lib/cli_driver.rb
@@ -10,6 +10,7 @@ module Hive
   module E2E
     class CliDriver
       Result = Data.define(:stdout, :stderr, :exit_code, :duration_seconds, :timed_out)
+      READER_JOIN_GRACE_SECONDS = 0.1
 
       class ExitMismatchError < StandardError
         attr_reader :expected, :actual, :stdout, :stderr
@@ -64,6 +65,7 @@ module Hive
       ProcessResult = Data.define(:stdout, :stderr, :exit_code, :timed_out)
 
       def spawn_and_capture(env, args, cwd, timeout)
+        deadline = monotonic_time + timeout
         stdout = +""
         stderr = +""
         timed_out = false
@@ -78,11 +80,28 @@ module Hive
             terminate(wait_thr.pid)
           end
           status = wait_thr.value
-          stdout = out_reader.value.to_s
-          stderr = err_reader.value.to_s
+          readers = [ out_reader, err_reader ]
+          reader_deadline = timed_out ? monotonic_time + READER_JOIN_GRACE_SECONDS : deadline
+          unless readers_finished?(readers, reader_deadline)
+            timed_out = true
+            terminate(wait_thr.pid)
+            readers_finished?(readers, monotonic_time + READER_JOIN_GRACE_SECONDS)
+          end
+          status = nil if timed_out
+          stdout = safe_thread_value(out_reader)
+          stderr = safe_thread_value(err_reader)
         end
 
         ProcessResult.new(stdout: stdout, stderr: stderr, exit_code: status&.exitstatus, timed_out: timed_out)
+      end
+
+      def readers_finished?(readers, deadline)
+        readers.all? do |reader|
+          next true unless reader.alive?
+
+          remaining = deadline - monotonic_time
+          remaining.positive? && reader.join(remaining)
+        end
       end
 
       def read_stream(stream)
@@ -91,14 +110,21 @@ module Hive
         ""
       end
 
+      def safe_thread_value(thread)
+        thread.kill if thread.alive?
+        thread.value.to_s
+      rescue StandardError
+        ""
+      end
+
       # Signal the entire process group (negative pid) so any children spawned by the
-      # CLI under test (editor shims, sub-shells, etc.) are torn down too. Without
-      # pgroup-targeted kills, descendants outlive the timeout and leak.
+      # CLI under test (editor shims, sub-shells, etc.) are torn down too. Open3's
+      # pgroup: true makes the child pid the process-group id, so this still works
+      # after the direct child has exited and only descendants remain.
       def terminate(pid)
-        pgid = Process.getpgid(pid)
-        Process.kill("TERM", -pgid)
+        Process.kill("TERM", -pid)
         sleep 0.5
-        Process.kill("KILL", -pgid)
+        Process.kill("KILL", -pid)
       rescue Errno::ESRCH
         nil
       end

--- a/test/e2e/lib/cli_driver_test.rb
+++ b/test/e2e/lib/cli_driver_test.rb
@@ -97,4 +97,30 @@ class E2ECliDriverTest < Minitest::Test
   rescue StandardError
     nil
   end
+
+  def test_descendant_holding_streams_open_is_bounded_by_timeout
+    Dir.mktmpdir("sandbox") do |sandbox|
+      Dir.mktmpdir("home") do |home|
+        script = File.join(sandbox, "forked_descendant.rb")
+        File.write(script, <<~'RUBY')
+          fork do
+            sleep 2
+          end
+          puts "parent done"
+          warn "parent err"
+          exit 0
+        RUBY
+        driver = Hive::E2E::CliDriver.new(sandbox, home)
+        driver.define_singleton_method(:command) { |_args| [ RbConfig.ruby, script ] }
+
+        error = assert_raises(Hive::E2E::CliDriver::ExitMismatchError) do
+          driver.call([], cwd: sandbox, timeout: 0.2)
+        end
+
+        assert_nil error.actual
+        assert_includes error.stdout, "parent done"
+        assert_includes error.stderr, "parent err"
+      end
+    end
+  end
 end

--- a/wiki/e2e.md
+++ b/wiki/e2e.md
@@ -143,6 +143,7 @@ On failure, the harness writes a scenario bundle containing:
 ## Operational Notes
 
 The harness prepends repo `bin/` to the tmux environment PATH because TUI rows dispatch commands like `hive plan ...`. `tui_keys` with `text:` sends literal text one character at a time by default for deterministic slow typing; `paste: true` sends the full `text:` value as one literal tmux chunk to exercise the TUI paste-aware runner.
+`CliDriver` starts CLI subprocesses in their own process group and applies the step timeout to both the direct child and stdout/stderr reader threads, so descendants that inherit the capture pipes cannot hold an e2e step open after their parent exits.
 
 `tmux` is required for TUI scenarios. `asciinema` is test-time optional until a TUI failure needs a cast, but missing/corrupt casts are recorded in artifacts instead of crashing unrelated CLI scenarios. If `asciinema` is installed outside PATH, set `HIVE_ASCIINEMA_BIN=/absolute/path/to/asciinema`.
 

--- a/wiki/log.d/20260707T012802Z-cli-driver-reader-timeout.md
+++ b/wiki/log.d/20260707T012802Z-cli-driver-reader-timeout.md
@@ -1,0 +1,10 @@
+# 2026-07-07 — bound e2e CLI stream readers after parent exit
+
+`test/e2e/lib/cli_driver.rb` now treats stdout/stderr reader threads as part
+of the CLI step timeout. If the direct `bin/hive` child exits but a descendant
+keeps inherited capture pipes open, the driver marks the run timed out, signals
+the spawned process group by `-pid`, and returns a nil exit code so normal
+`expect_exit` validation fails instead of hanging the e2e suite. The regression
+coverage in `test/e2e/lib/cli_driver_test.rb` uses a temporary Ruby fixture that
+forks a sleeping child and exits immediately while keeping stdout/stderr open.
+Pages: [[e2e]].


### PR DESCRIPTION
## Summary

Fixes a hang in the e2e test helper `CliDriver` when the CLI under test exits but a forked descendant keeps its stdout/stderr pipes open.

- The stdout/stderr reader threads previously blocked on `.value` waiting for EOF. If a descendant (editor shim, sub-shell, etc.) inherited the pipes and outlived the parent, those reads never returned and the driver hung indefinitely — past the configured timeout.
- Reader-thread joins are now bounded by the run's timeout deadline. If the readers don't finish in time, the run is marked timed out, the process group is terminated, and a short grace period (`READER_JOIN_GRACE_SECONDS`) is allowed before the reader threads are killed via `safe_thread_value`.
- Process-group teardown now signals `-pid` directly instead of resolving `Process.getpgid(pid)` first. Open3's `pgroup: true` makes the child pid the process-group id, so teardown still reaches lingering descendants even after the direct child has already exited.

## Test plan

- Added `test_descendant_holding_streams_open_is_bounded_by_timeout` in `test/e2e/lib/cli_driver_test.rb`: spawns a script whose parent exits immediately while a `fork`ed child sleeps holding the streams open, and asserts the driver raises `ExitMismatchError` within the timeout with `actual` nil and the parent's captured stdout/stderr preserved.
- Existing `CliDriver` e2e suite continues to pass.

## Review summary

Codex native review (pass 01) reported **No findings** across High, Medium, and Nit. No escalations and no open user questions. The diff bounds `CliDriver` reader joins, adds focused coverage, and updates `wiki/e2e.md`; no branch-introduced correctness issues were identified.

## Linked task

Patrol finding `test-suite-test-babysitter-acceptance-dry-run-test-rb-1` (fingerprint `06adaf1964e5654c622593e739b784da2db98aa9ad66ba92529d20b322bf8afa`).

Task folder: `/home/asterio/Dev/hive/.hive-state/stages/6-review/patrol-test-suite-test-babysitter-acceptance-dry-run-test-rb-06a`
