### PR TITLE
Hive patrol: Leading JSON breaks top-level help and version

### DIFF
--- a/bin/hive-e2e
+++ b/bin/hive-e2e
@@ -310,7 +310,20 @@ def normalize_leading_global_options!(argv)
   leading = []
   leading << argv.shift while JSON_BOOLEAN_OPTIONS.include?(argv.first)
   return if leading.empty?
-  return if TOP_LEVEL_FLAGS.include?(argv.first)
+
+  # A *bare* top-level flag (`--json --version`, `--json -h`) is handled as
+  # human-only version/help output, so the leading --json is irrelevant and
+  # stays dropped. But when tokens trail the flag (`--json --version --filter
+  # tui`) it is no longer a standalone top-level invocation: Thor consumes it
+  # as a pattern and dispatches into `run_scenarios`, whose body reads
+  # `options[:json]`. Restore --json there so the command honors the caller's
+  # JSON request instead of emitting prose (the outer rescue's json_mode
+  # snapshot only guards Thor-level errors, not the command body).
+  if TOP_LEVEL_FLAGS.include?(argv.first)
+    return if argv.length == 1
+
+    return argv.unshift(*leading)
+  end
 
   commands = Hive::E2E::Binary.all_tasks.keys + [ "run" ]
   cmd_idx = argv.index { |arg| commands.include?(arg) }

--- a/bin/hive-e2e
+++ b/bin/hive-e2e
@@ -306,10 +306,14 @@ def reject_unsupported_json_assignments!(argv)
   raise Thor::MalformattedArgumentError, "invalid boolean value for --json: #{arg.split('=', 2).last.inspect}"
 end
 
+HELP_FLAGS = %w[--help -h].freeze
+
 def normalize_leading_global_options!(argv)
   leading = []
   leading << argv.shift while JSON_BOOLEAN_OPTIONS.include?(argv.first)
   return if leading.empty?
+
+  commands = Hive::E2E::Binary.all_tasks.keys + [ "run" ]
 
   # A *bare* top-level flag (`--json --version`, `--json -h`) is handled as
   # human-only version/help output, so the leading --json is irrelevant and
@@ -322,10 +326,20 @@ def normalize_leading_global_options!(argv)
   if TOP_LEVEL_FLAGS.include?(argv.first)
     return if argv.length == 1
 
+    # `--json --help <command>` / `--json -h <command>` requests that command's
+    # help. Thor renders command help natively when a help flag leads and a
+    # recognized command follows (exactly as `--help run` does) — but only while
+    # the leading --json stays dropped. Restoring --json ahead of --help makes
+    # Thor stop treating --help as the help switch and instead dispatch into
+    # run_scenarios with [--help, <command>], exiting 64. Help output is human
+    # prose, so the now-irrelevant --json can stay dropped. Non-command trailers
+    # (`--json --help missing`, `--json --help --filter tui`) fall through to the
+    # restore path so their usage errors still honor the JSON-envelope contract.
+    return if HELP_FLAGS.include?(argv.first) && commands.include?(argv[1])
+
     return argv.unshift(*leading)
   end
 
-  commands = Hive::E2E::Binary.all_tasks.keys + [ "run" ]
   cmd_idx = argv.index { |arg| commands.include?(arg) }
   return argv.unshift(*leading) unless cmd_idx
 

--- a/bin/hive-e2e
+++ b/bin/hive-e2e
@@ -319,6 +319,14 @@ def normalize_leading_global_options!(argv)
   argv.insert(cmd_idx + 1, *leading)
 end
 
+# Snapshot the caller's JSON request from the pristine ARGV. Normalization can
+# shift a leading `--json` out of ARGV and then return early without restoring
+# it (e.g. `--json --help missing`, `--json --version extra`, where a top-level
+# flag follows the class option). If Thor later raises a usage error, the rescue
+# blocks below would otherwise consult a mutated ARGV that no longer carries the
+# flag and emit prose on stderr instead of honoring the JSON-envelope contract.
+json_mode = json_requested?(ARGV)
+
 begin
   reject_invalid_argv_encoding!(ARGV)
   reject_unsupported_json_assignments!(ARGV)
@@ -334,7 +342,7 @@ begin
   # mapping usage failures to BinaryExit::USAGE.
   Hive::E2E::Binary.start(ARGV, debug: true)
 rescue Hive::E2E::PreflightError => e
-  if json_requested?(ARGV)
+  if json_mode
     puts JSON.pretty_generate(Hive::E2E::JsonError.payload(error_kind: "preflight", message: e.message,
                                                           exit_code: Hive::E2E::BinaryExit::CONFIG))
   else
@@ -342,7 +350,7 @@ rescue Hive::E2E::PreflightError => e
   end
   exit Hive::E2E::BinaryExit::CONFIG
 rescue Thor::Error => e
-  if json_requested?(ARGV)
+  if json_mode
     puts JSON.pretty_generate(Hive::E2E::JsonError.payload(error_kind: "usage", message: e.message,
                                                           exit_code: Hive::E2E::BinaryExit::USAGE))
   else
@@ -350,7 +358,7 @@ rescue Thor::Error => e
   end
   exit Hive::E2E::BinaryExit::USAGE
 rescue StandardError => e
-  if json_requested?(ARGV)
+  if json_mode
     puts JSON.pretty_generate(Hive::E2E::JsonError.payload(error_kind: "error", message: e.message,
                                                           exit_code: Hive::E2E::BinaryExit::FAILURE))
   else

--- a/bin/hive-e2e
+++ b/bin/hive-e2e
@@ -268,6 +268,7 @@ end
 JSON_TRUE_OPTIONS = %w[--json --json=true --json=TRUE --json=t --json=T].freeze
 JSON_FALSE_OPTIONS = %w[--no-json --skip-json --json=false --json=FALSE --json=f --json=F].freeze
 JSON_BOOLEAN_OPTIONS = (JSON_TRUE_OPTIONS + JSON_FALSE_OPTIONS).freeze
+TOP_LEVEL_FLAGS = %w[--help -h --version -v].freeze
 
 def normalize_leading_class_options!(argv)
   return if argv.length < 2
@@ -309,6 +310,7 @@ def normalize_leading_global_options!(argv)
   leading = []
   leading << argv.shift while JSON_BOOLEAN_OPTIONS.include?(argv.first)
   return if leading.empty?
+  return if TOP_LEVEL_FLAGS.include?(argv.first)
 
   commands = Hive::E2E::Binary.all_tasks.keys + [ "run" ]
   cmd_idx = argv.index { |arg| commands.include?(arg) }
@@ -321,6 +323,10 @@ begin
   reject_invalid_argv_encoding!(ARGV)
   reject_unsupported_json_assignments!(ARGV)
   normalize_leading_global_options!(ARGV)
+  if ARGV == [ "--version" ] || ARGV == [ "-v" ]
+    puts Hive::VERSION
+    exit 0
+  end
   rewrite_help_flag!(ARGV)
   # Thor::Base#start rescues Thor::Error internally and exits 1 when
   # exit_on_failure? is true. Passing `debug: true` makes Thor re-raise

--- a/test/e2e/lib/hive_e2e_binary_test.rb
+++ b/test/e2e/lib/hive_e2e_binary_test.rb
@@ -169,6 +169,23 @@ class E2EBinaryTest < Minitest::Test
     end
   end
 
+  # A leading --json followed by a help flag and a recognized command
+  # (`--json --help run`, `--json -h run`) requests that command's help, exactly
+  # like `--help run`. Help is human prose, so the leading --json is dropped and
+  # Thor renders the command's usage with exit 0 — it must not regress into a
+  # run_scenarios usage error (exit 64) as it did when --json was restored ahead
+  # of the help flag.
+  def test_leading_json_help_with_command_shows_command_help
+    %w[--help -h].each do |flag|
+      out, err, status = Open3.capture3(hive_e2e, "--json", flag, "run")
+      assert status.success?, "bin/hive-e2e --json #{flag} run should exit 0, stderr was: #{err}"
+      assert_includes out, "hive-e2e run [PATTERN]"
+      assert_includes out, "Run e2e scenarios"
+      refute_includes out, "hive-e2e-error"
+      refute_includes err, "no scenarios match"
+    end
+  end
+
   # A leading --json followed by a top-level flag plus a trailing token
   # (e.g. `--json --help missing`) must still honor the JSON-envelope
   # contract. Normalization shifts the leading --json out of ARGV and returns

--- a/test/e2e/lib/hive_e2e_binary_test.rb
+++ b/test/e2e/lib/hive_e2e_binary_test.rb
@@ -129,6 +129,14 @@ class E2EBinaryTest < Minitest::Test
     assert_equal "#{Hive::VERSION}\n", out
   end
 
+  def test_leading_json_top_level_version_prints_hive_version
+    %w[--version -v].each do |flag|
+      out, err, status = Open3.capture3(hive_e2e, "--json", flag)
+      assert status.success?, "bin/hive-e2e --json #{flag} should exit 0, stderr was: #{err}"
+      assert_equal "#{Hive::VERSION}\n", out
+    end
+  end
+
   # Thor's default for unknown commands is to print a deprecation warning
   # and exit 0; we override `exit_on_failure?` to true so wrappers / CI
   # see a non-zero status instead. Pin the contract here.
@@ -149,6 +157,16 @@ class E2EBinaryTest < Minitest::Test
     assert status.success?, "bin/hive-e2e run --help should exit 0, stderr was: #{err}"
     assert_includes out, "Run e2e scenarios"
     refute_includes err, "no scenarios match"
+  end
+
+  def test_leading_json_top_level_help_shows_usage
+    %w[--help -h].each do |flag|
+      out, err, status = Open3.capture3(hive_e2e, "--json", flag)
+      assert status.success?, "bin/hive-e2e --json #{flag} should exit 0, stderr was: #{err}"
+      assert_includes out, "Commands:"
+      refute_includes out, "hive-e2e-error"
+      refute_includes err, "no scenarios match"
+    end
   end
 
   def test_run_help_after_option_value_shows_usage

--- a/test/e2e/lib/hive_e2e_binary_test.rb
+++ b/test/e2e/lib/hive_e2e_binary_test.rb
@@ -198,6 +198,27 @@ class E2EBinaryTest < Minitest::Test
     assert_equal 64, payload["exit_code"]
   end
 
+  # A leading --json followed by a top-level flag AND a recognized option
+  # (e.g. `--json --version --filter tui`) does not raise a Thor error: Thor
+  # consumes the flag as the run pattern and dispatches into run_scenarios,
+  # whose body reads options[:json]. The stripped --json must be restored so
+  # the command honors the JSON contract instead of printing prose on stderr;
+  # the outer rescue's json_mode snapshot cannot cover this dispatch path.
+  def test_leading_json_top_level_flag_then_option_emits_envelope_on_stdout
+    %w[--version -v --help -h].each do |flag|
+      out, err, status = Open3.capture3(hive_e2e, "--json", flag, "--filter", "tui")
+      assert_equal 64, status.exitstatus, "#{flag}: usage error must exit 64"
+      assert_empty err, "#{flag}: human prose must not leak to stderr when --json leads"
+
+      payload = JSON.parse(out)
+      assert_equal "hive-e2e-error", payload["schema"]
+      assert_equal false, payload["ok"]
+      assert_equal "no_scenarios", payload["error_kind"]
+      assert_equal 64, payload["exit_code"]
+      assert_match(/no scenarios match #{Regexp.escape(flag)}/, payload["message"])
+    end
+  end
+
   def test_run_help_after_option_value_shows_usage
     out, err, status = Open3.capture3(hive_e2e, "run", "--filter", "tui", "--help")
     assert status.success?, "bin/hive-e2e run --filter tui --help should exit 0, stderr was: #{err}"

--- a/test/e2e/lib/hive_e2e_binary_test.rb
+++ b/test/e2e/lib/hive_e2e_binary_test.rb
@@ -169,6 +169,35 @@ class E2EBinaryTest < Minitest::Test
     end
   end
 
+  # A leading --json followed by a top-level flag plus a trailing token
+  # (e.g. `--json --help missing`) must still honor the JSON-envelope
+  # contract. Normalization shifts the leading --json out of ARGV and returns
+  # early on the top-level flag without restoring it, so the rescue path must
+  # consult the caller's original JSON request rather than the mutated ARGV.
+  def test_leading_json_help_with_trailing_token_emits_envelope_on_stdout
+    out, err, status = Open3.capture3(hive_e2e, "--json", "--help", "missing")
+    assert_equal 64, status.exitstatus
+    assert_empty err, "human prose must not leak to stderr when --json precedes --help"
+
+    payload = JSON.parse(out)
+    assert_equal "hive-e2e-error", payload["schema"]
+    assert_equal false, payload["ok"]
+    assert_equal "usage", payload["error_kind"]
+    assert_equal 64, payload["exit_code"]
+  end
+
+  def test_leading_json_version_with_trailing_token_emits_envelope_on_stdout
+    out, err, status = Open3.capture3(hive_e2e, "--json", "--version", "extra")
+    assert_equal 64, status.exitstatus
+    assert_empty err, "human prose must not leak to stderr when --json precedes --version"
+
+    payload = JSON.parse(out)
+    assert_equal "hive-e2e-error", payload["schema"]
+    assert_equal false, payload["ok"]
+    assert_equal "usage", payload["error_kind"]
+    assert_equal 64, payload["exit_code"]
+  end
+
   def test_run_help_after_option_value_shows_usage
     out, err, status = Open3.capture3(hive_e2e, "run", "--filter", "tui", "--help")
     assert status.success?, "bin/hive-e2e run --filter tui --help should exit 0, stderr was: #{err}"

--- a/wiki/e2e.md
+++ b/wiki/e2e.md
@@ -52,9 +52,11 @@ options precede the help flag, e.g. `bin/hive-e2e run --filter tui --help`.
 Leading JSON class options are normalized with the same Thor-style boolean
 grammar as `bin/hive`: bare `--json`, exact truthy assignments
 (`--json=true`/`TRUE`/`t`/`T`), bare negative forms, and exact false
-assignments are moved behind a recognized command. Unsupported assignments such
-as `--json=1` or `--json=yes` are usage errors before the value can become the
-default `run` pattern. Wrapper-owned error formatting checks the last
+assignments are moved behind a recognized command, or stripped before top-level
+`--help` / `-h` / `--version` / `-v` so those flags remain wrapper requests.
+Unsupported assignments such as `--json=1` or `--json=yes` are usage errors
+before the value can become the default `run` pattern. Wrapper-owned error
+formatting checks the last
 recognized JSON boolean flag rather than any truthy flag, so duplicate flags
 with a final false form, such as `--json --no-json`, emit the human
 `hive-e2e:` stderr path. Invalid-byte `ARGV` entries are rejected before those

--- a/wiki/log.d/20260707-094033-hive-e2e-leading-json-help-version.md
+++ b/wiki/log.d/20260707-094033-hive-e2e-leading-json-help-version.md
@@ -1,0 +1,7 @@
+## [2026-07-07T09:40:33Z] e2e — leading JSON top-level help/version
+
+**Action:** Fixed `bin/hive-e2e` wrapper normalization so recognized leading JSON boolean flags are stripped before top-level `--help` / `-h` / `--version` / `-v`; those invocations now print usage or the version instead of falling into default scenario selection with `no_scenarios`. Added focused `test/e2e/lib/hive_e2e_binary_test.rb` coverage for `--json --help`, `--json -h`, `--json --version`, and `--json -v`.
+
+**Refreshed pages:**
+- [[e2e]]
+- [[testing]]

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -158,7 +158,8 @@ The current scenarios copy `test/e2e/sample-project/` into a per-run sandbox, se
 scenario inventory JSON, cleanup JSON, the single-document stdout invariant for
 successful `list --json` / `clean --json` calls, unknown-command JSON errors,
 missing argument errors, top-level version output, command-local help after
-command options (`run --filter tui --help`), leading JSON option normalization,
+command options (`run --filter tui --help`), leading JSON option normalization
+for commands and top-level help/version flags,
 malformed JSON assignment rejection, last-JSON-boolean-wins usage-error mode,
 replay path safety, missing, non-executable, symlinked runs-root, and symlinked
 replay artifact validation, cleanup retention validation, and the single-dispatch invariant for


### PR DESCRIPTION
## Summary

Patrol finding `command-bin-hive-e2e-2`: a leading `--json` flag broke top-level `--help`/`--version` on `bin/hive-e2e`. The flag was stripped during argument normalization but the top-level flag that followed was never recognized, so the invocation fell into the default scenario runner and exited 64 with `no_scenarios` instead of printing help or the version string.

This fixes `bin/hive-e2e` argument normalization so a leading `--json` is handled correctly for top-level flags:

- `--json --version` / `--json -v` print the version and exit 0.
- `--json --help` / `--json -h` print top-level help and exit 0.
- `--json --help <command>` (e.g. `--json --help run`) resolves that command's help through the leading flag and exits 0, mirroring `--help run`.
- Genuine junk forms still emit the documented JSON usage envelope with exit 64 (`--json --version extra`, `--json --help missing`, `--json --help --filter tui`).

The caller's JSON request is now snapshotted from the pristine `ARGV` before normalization can shift a leading `--json` out, so the Thor-level rescue blocks keep honoring the JSON-envelope contract even when the flag was dropped during normalization.

## Test plan

- `ruby -Itest -Itest/e2e/lib test/e2e/lib/hive_e2e_binary_test.rb` → 43 runs, 353 assertions, 0 failures, 0 errors, 0 skips (adds 85 lines of coverage for the mixed `--json` + help/version forms).
- `bundle exec rubocop` → passed.
- `bundle exec rake test` → passed.
- Live runs confirm the fixed behaviors: `--json --version` → version string (exit 0); `--json --help` → command list (exit 0); `--json --help run` → run usage (exit 0).

## Review summary

Three codex-native review passes (fix → reviewers → triage across passes 01–03). No High findings in any pass. Each pass surfaced a single Medium finding, all auto-fixed:

- Pass 01: preserve JSON mode when top-level flag parsing fails (`--json --help missing`, `--json --version extra`) — snapshot the JSON request before normalization strips it.
- Pass 02: preserve JSON mode after stripping leading flags for `--json --version --filter tui` / `--json -v --filter tui`.
- Pass 03: preserve command help after leading JSON so `--json --help run` shows the `run` command's help (exit 0) instead of regressing to exit 64.

No open findings remain.

## Linked task

/home/asterio/Dev/hive/.hive-state/stages/6-review/patrol-command-bin-hive-e2e-08bcbd64
