### PR TITLE
Hive patrol: e2e replay trusts a symlinked runs root

### DIFF
--- a/bin/hive-e2e
+++ b/bin/hive-e2e
@@ -147,7 +147,8 @@ module Hive
       def replay(run_id, scenario)
         run_id = PathSafety.safe_basename!(run_id, "run_id")
         scenario = PathSafety.safe_basename!(scenario, "scenario")
-        run_dir = PathSafety.contained_path!(Paths.runs_dir, run_id, "run dir")
+        runs_root = File.expand_path(Paths.runs_dir)
+        run_dir = PathSafety.contained_path!(runs_root, run_id, "run dir")
         scenario_root = PathSafety.contained_path!(run_dir, "scenarios", "scenario root")
         scenario_dir = PathSafety.contained_path!(scenario_root, scenario, "scenario dir")
         script = PathSafety.contained_path!(scenario_dir, "repro.sh", "repro script")
@@ -158,7 +159,7 @@ module Hive
             exit_code: BinaryExit::CONFIG
           )
         end
-        unless artifact_path_without_symlinks?(run_dir, scenario_root, scenario_dir, script) &&
+        unless artifact_path_without_symlinks?(runs_root, run_dir, scenario_root, scenario_dir, script) &&
                File.lstat(script).file? && File.executable?(script)
           exit_with_error(
             "Run ##{run_id} scenario #{scenario} repro.sh is not executable (#{script})",

--- a/test/e2e/lib/hive_e2e_binary_test.rb
+++ b/test/e2e/lib/hive_e2e_binary_test.rb
@@ -277,6 +277,35 @@ class E2EBinaryTest < Minitest::Test
     end
   end
 
+  def test_replay_symlinked_runs_root_emits_json_artifact_error_when_requested
+    Dir.mktmpdir("e2e-replay-target") do |target_runs_dir|
+      Dir.mktmpdir("e2e-replay-link-parent") do |link_parent|
+        runs_link = File.join(link_parent, "runs")
+        File.symlink(target_runs_dir, runs_link)
+
+        script = File.join(target_runs_dir, "run-1", "scenarios", "scenario-1", "repro.sh")
+        FileUtils.mkdir_p(File.dirname(script))
+        File.write(script, "#!/usr/bin/env bash\nexit 42\n")
+        File.chmod(0o755, script)
+
+        out, err, status = Open3.capture3(
+          { "HIVE_E2E_RUNS_DIR" => runs_link },
+          hive_e2e, "replay", "--json", "run-1", "scenario-1"
+        )
+
+        assert_equal 78, status.exitstatus
+        assert_empty err
+
+        payload = JSON.parse(out)
+        assert_equal "hive-e2e-error", payload["schema"]
+        assert_equal false, payload["ok"]
+        assert_equal "unusable_repro", payload["error_kind"]
+        assert_equal 78, payload["exit_code"]
+        assert_match(/not executable/, payload["message"])
+      end
+    end
+  end
+
   def test_replay_dangling_symlinked_repro_emits_unusable_not_missing_when_requested
     Dir.mktmpdir("e2e-replay-test") do |tmp_runs_dir|
       target = File.join(tmp_runs_dir, "deleted-repro.sh")

--- a/wiki/e2e.md
+++ b/wiki/e2e.md
@@ -3,7 +3,7 @@ title: Agentic E2E Suite
 type: reference
 source: test/e2e/, bin/hive-e2e, Rakefile
 created: 2026-04-29
-updated: 2026-06-21
+updated: 2026-07-08
 tags: [test, e2e, tui, artifacts]
 ---
 
@@ -39,10 +39,10 @@ Successful `--json` commands emit exactly one top-level JSON document on stdout,
 resolves the stored `scenarios/<scenario>/repro.sh` under the selected run
 directory, and only `exec`s it when it is both a regular file and executable.
 Missing scripts return `error_kind: missing_repro`; existing but unusable
-scripts, including symlinked repro entries (even dangling symlinks, which are a
-present-but-unusable repro entry rather than a missing one), return
-`error_kind: unusable_repro`. Both are config failures (`78`) and use the
-`hive-e2e-error` envelope in `--json` mode.
+scripts, including symlinked runs roots, scenario directories, and repro
+entries (even dangling symlinks, which are a present-but-unusable repro entry
+rather than a missing one), return `error_kind: unusable_repro`. Both are
+config failures (`78`) and use the `hive-e2e-error` envelope in `--json` mode.
 
 `bin/hive-e2e` is a checkout-only harness entrypoint, not a packaged
 `hive-cli` executable. It handles top-level `--version` / `-v` before Thor

--- a/wiki/log.d/20260708T014124Z-e2e-replay-symlinked-runs-root.md
+++ b/wiki/log.d/20260708T014124Z-e2e-replay-symlinked-runs-root.md
@@ -1,0 +1,5 @@
+## [2026-07-08T01:41:24Z] e2e - reject symlinked replay runs roots
+
+**Action:** Hardened `bin/hive-e2e replay` so the configured `HIVE_E2E_RUNS_DIR` root is part of the symlink-free artifact chain before a stored `repro.sh` can be executed. A symlinked runs root now reports `error_kind: "unusable_repro"` with exit `78` instead of following the root to an executable script outside the intended runs tree.
+
+**Coverage:** Added `test_replay_symlinked_runs_root_emits_json_artifact_error_when_requested` to `test/e2e/lib/hive_e2e_binary_test.rb`, and refreshed [[e2e]] / [[testing]] contract wording. Did not run `qmd update` or `qmd embed`.

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -160,8 +160,8 @@ successful `list --json` / `clean --json` calls, unknown-command JSON errors,
 missing argument errors, top-level version output, command-local help after
 command options (`run --filter tui --help`), leading JSON option normalization,
 malformed JSON assignment rejection, last-JSON-boolean-wins usage-error mode,
-replay path safety, missing, non-executable, and symlinked replay artifact
-validation, cleanup retention validation, and the single-dispatch invariant for
+replay path safety, missing, non-executable, symlinked runs-root, and symlinked
+replay artifact validation, cleanup retention validation, and the single-dispatch invariant for
 successful JSON commands.
 
 The install-smoke workflow's `verify-release.sh (end-to-end behavior)` job
@@ -225,7 +225,7 @@ credentials inside a running box.
 
 The live Telegram bot E2E wrapper lives at `test/e2e/tg/run_idea_e2e.sh` and is also opt-in because it uses a real Bot API test token plus a Telethon user session. In default text mode it drives `/idea <nonce>` through the project picker. With `TG_IDEA_MODE=voice`, the wrapper requires the voice fixture and `HIVE_WHISPER_API_KEY`, starts the bot from the current checkout, drives a new voice idea through transcript confirmation/project selection, seeds a temporary `2-brainstorm/<slug>/brainstorm.md` in the scratch project, then sends `/answer <slug>` and answers Q1 with the same voice note. Cleanup resets the scratch state repo to the captured baseline and removes temporary inbox/brainstorm folders.
 
-`test/e2e/lib/hive_e2e_binary_test.rb` is the focused contract suite for the executable itself. It pins `list --json`, `clean --json`, leading JSON option normalization including `--json=true`, duplicate JSON boolean handling where a final false flag chooses prose, malformed `--json=1` / `--json=yes` rejection, error-envelope shapes, help/version handling, replay path validation, missing/non-executable/symlinked replay artifact errors (`missing_repro` / `unusable_repro`, exit `78`), and the usage exit-code contract: unknown commands and missing required arguments exit `64` in both human and `--json` modes. Human usage errors are expected to print a `hive-e2e:`-prefixed prose message on stderr.
+`test/e2e/lib/hive_e2e_binary_test.rb` is the focused contract suite for the executable itself. It pins `list --json`, `clean --json`, leading JSON option normalization including `--json=true`, duplicate JSON boolean handling where a final false flag chooses prose, malformed `--json=1` / `--json=yes` rejection, error-envelope shapes, help/version handling, replay path validation, missing/non-executable/symlinked runs-root and replay artifact errors (`missing_repro` / `unusable_repro`, exit `78`), and the usage exit-code contract: unknown commands and missing required arguments exit `64` in both human and `--json` modes. Human usage errors are expected to print a `hive-e2e:`-prefixed prose message on stderr.
 
 ## Live Claude tmux dogfood
 


### PR DESCRIPTION
## Hive Patrol Finding

Slice: `command-bin-hive-eval`
Category: `security`
Severity: `medium`
Confidence: `high`
Fingerprint: `ea52a933d8043347123602c7eb1d2af116292d0fddb6f981c3611009d5b18352`

bin/hive-e2e replay validates the run, scenario, and repro entries for symlinks, but it never validates the configured HIVE_E2E_RUNS_DIR root itself. If that root is a symlink, the replay command can execute a repro.sh outside the intended e2e runs tree while passing the existing child-entry symlink checks.

## Evidence

- bin/hive-e2e:150 run_dir = PathSafety.contained_path!(Paths.runs_dir, run_id, "run dir")
- bin/hive-e2e:161 unless artifact_path_without_symlinks?(run_dir, scenario_root, scenario_dir, script) &&

## Applied Fix

Validate Paths.runs_dir with realpath/lstat before resolving replay children, or include the runs root in the symlink-free artifact chain. Add a regression with HIVE_E2E_RUNS_DIR pointing at a symlinked root.

## Validation

- lint: passed (`bundle exec rubocop`)
- test: passed (`bundle exec rake test`)

## Diffstat

```text
 bin/hive-e2e                                       |  5 ++--
 test/e2e/lib/hive_e2e_binary_test.rb               | 29 ++++++++++++++++++++++
 wiki/e2e.md                                        | 10 ++++----
 ...60708T014124Z-e2e-replay-symlinked-runs-root.md |  5 ++++
 wiki/testing.md                                    |  6 ++---
 5 files changed, 45 insertions(+), 10 deletions(-)

```
