### PR TITLE
Hive patrol: Dry-run test can pass with the wrong agent cwd

### DIFF
--- a/test/babysitter/acceptance/dry_run_test.rb
+++ b/test/babysitter/acceptance/dry_run_test.rb
@@ -15,15 +15,18 @@ class BabysitterAcceptanceDryRunTest < Minitest::Test
       install_tripwire_binary(tripwire_bin, "gh", tripwire_log)
       pr = babysitter_pr
       command_results = []
+      assert_equal_method = method(:assert_equal)
 
       with_env("PATH" => [ tripwire_bin, ENV.fetch("PATH", "") ].join(File::PATH_SEPARATOR)) do
         with_non_green_babysitter_context(project, worktree_path, pr) do
           with_replaced_singleton_method(Hive::Stages::Base, :spawn_agent, lambda { |_task, **kwargs|
+            assert_equal_method.call(worktree_path, kwargs.fetch(:cwd))
+            assert_equal_method.call([ worktree_path ], kwargs.fetch(:add_dirs))
             Dir.chdir(kwargs.fetch(:cwd)) do
               command_results << system("git", "push", "origin", "HEAD:feature", "--force-with-lease", out: File::NULL, err: File::NULL)
               command_results << system("gh", "pr", "comment", "42", "--body", "would comment", out: File::NULL, err: File::NULL)
               command_results << system("gh", "--repo=owner/repo", "pr", "close", "42", out: File::NULL, err: File::NULL)
-              File.write(File.join(worktree_path, ".babysitter-dry-run-plan.md"), "would repair PR 42\n")
+              File.write(".babysitter-dry-run-plan.md", "would repair PR 42\n")
               { status: :ok }
             end
           }) do


### PR DESCRIPTION
## Summary

Tightens the babysitter dry-run acceptance test so it actually pins the agent's working directory and add-dirs.

Previously the stub `chdir`'d into `kwargs[:cwd]`, but then wrote and asserted the dry-run plan at the closed-over `worktree_path`. That meant the test would still pass even if `PrFixer` regressed to launch the agent from the project root or dropped the worktree from `add_dirs` — the real failure mode where the agent's `git`/`gh` commands run against the wrong repository context.

The stub now:

- Asserts `kwargs[:cwd] == worktree_path`.
- Asserts `kwargs[:add_dirs] == [worktree_path]`.
- Writes the dry-run plan relative to `Dir.pwd` (the `chdir`'d cwd) instead of the closed-over `worktree_path`, so an incorrect `cwd` fails the test.

This is a test-only change; no production behavior changes.

## Test plan

- `bundle exec rake test` — full suite passes.
- Focused: `bundle exec ruby -Itest test/babysitter/acceptance/dry_run_test.rb` — the dry-run acceptance test still passes with the tightened assertions.
- `bundle exec rubocop` — lint passes.

## Review summary

- `codex-native-review-01`: no findings under High, Medium, or Nit.
- Triage (pass 01): nothing to auto-fix, resolve, or escalate; no user questions.

## Linked task

Patrol finding `test-suite-test-babysitter-acceptance-dry-run-test-rb-3` (fingerprint `93e904d476d68255badc718d1c919ba4ad45ace34b69ef2aa5b28d4190bcec57`).
