### PR TITLE
Hive patrol: Capture failure test never forces a capture failure

### DIFF
--- a/test/e2e/lib/artifact_capture_test.rb
+++ b/test/e2e/lib/artifact_capture_test.rb
@@ -45,21 +45,24 @@ class E2EArtifactCaptureTest < Minitest::Test
 
   def test_capture_failures_dont_mask_original_error
     with_dirs do |scenario_dir, sandbox, run_home|
-      # Stub ENV["TERM"] to nil and force git -C $sandbox to fail by using a
-      # sandbox without .git. The capture step that depends on it raises,
-      # but the original RuntimeError is still the surfaced scenario error.
+      fake_tmux = Object.new
+      fake_tmux.define_singleton_method(:keystrokes) do
+        raise RuntimeError, "FORCED_CAPTURE_FAILURE"
+      end
+      fake_tmux.define_singleton_method(:capture_pane) { "PANE_TEXT\n" }
       original_error = RuntimeError.new("ORIGINAL_ERROR_TEXT")
-      collect(scenario_dir, sandbox, run_home, error: original_error)
+      collect(scenario_dir, sandbox, run_home, error: original_error, tmux_driver: fake_tmux)
 
       exception_text = File.read(File.join(scenario_dir, "exception.txt"))
       assert_includes exception_text, "ORIGINAL_ERROR_TEXT",
         "original error must surface in exception.txt regardless of capture failures"
 
       manifest = JSON.parse(File.read(File.join(scenario_dir, "manifest.json")))
-      # capture_errors may or may not be empty (sandbox-tree.txt + git status
-      # both succeed against an empty dir); the contract is that the manifest
-      # is well-formed and the original error is preserved.
-      assert manifest.key?("capture_errors")
+      capture_error = manifest.fetch("capture_errors").find do |entry|
+        entry["label"] == "keystrokes.log"
+      end
+      assert capture_error, "manifest should record the guarded artifact writer failure"
+      assert_includes capture_error.fetch("error"), "RuntimeError: FORCED_CAPTURE_FAILURE"
     end
   end
 


### PR DESCRIPTION
## Hive Patrol Finding

Slice: `test-suite-test-babysitter-acceptance-dry-run-test-rb`
Category: `test-gap`
Severity: `medium`
Confidence: `high`
Fingerprint: `7eea7f3bb84dc1f18076d9fd4c650a9e2f05b3584899c46d2a8a7e0d51277541`

test_capture_failures_dont_mask_original_error claims to cover guarded artifact-writer failures, but it only calls collect with a plain RuntimeError and checks that the manifest has a capture_errors key. The supposed git failure is converted into text by capture instead of raising, so the guard rescue path can regress without this test failing.

## Evidence

- test/e2e/lib/artifact_capture_test.rb:48 # Stub ENV["TERM"] to nil and force git -C $sandbox to fail by using a
- test/e2e/lib/artifact_capture_test.rb:62 assert manifest.key?("capture_errors")
- test/e2e/lib/artifact_capture.rb:183 out, err, status = Open3.capture3(*cmd)
- test/e2e/lib/artifact_capture.rb:217 def guard(label)

## Applied Fix

Force a specific guarded artifact writer to raise, then assert exception.txt still contains ORIGINAL_ERROR_TEXT and manifest["capture_errors"] records the failing label and error.

## Validation

- lint: passed (`bundle exec rubocop`)
- test: passed (`bundle exec rake test`)

## Diffstat

```text
 test/e2e/lib/artifact_capture_test.rb | 19 +++++++++++--------
 1 file changed, 11 insertions(+), 8 deletions(-)

```
