### PR TITLE
Hive patrol: hv can hang on a candidate binary that ignores timeout termination

### DIFF
--- a/bin/hv
+++ b/bin/hv
@@ -29,10 +29,14 @@ xdg_bin_home="${XDG_BIN_HOME:-${HOME:+$HOME/.local/bin}}"
 # always close the probe's stdin (</dev/null) and cap each probe so a
 # slow candidate falls through to the next instead of hanging.
 timeout_bin="$(command -v timeout 2>/dev/null || true)"
+timeout_probe_args=(5)
+if [[ -n "$timeout_bin" ]] && "$timeout_bin" -k 1 1 true >/dev/null 2>&1; then
+  timeout_probe_args=(-k 1 5)
+fi
 
 probe_version() {
   if [[ -n "$timeout_bin" ]]; then
-    "$timeout_bin" 5 "$1" --version </dev/null 2>/dev/null
+    "$timeout_bin" "${timeout_probe_args[@]}" "$1" --version </dev/null 2>/dev/null
   else
     local output_file pid status watchdog
     output_file="$(mktemp "${TMPDIR:-/tmp}/hv-version.XXXXXX")" || return

--- a/test/unit/hv_test.rb
+++ b/test/unit/hv_test.rb
@@ -145,6 +145,93 @@ class HvTest < Minitest::Test
     end
   end
 
+  def test_timeout_probe_uses_kill_after_when_supported
+    with_tmp_dir do |dir|
+      override = File.join(dir, "custom", "hive")
+      FileUtils.mkdir_p(File.dirname(override))
+      File.write(override, <<~SH)
+        #!/bin/sh
+        if [ "$1" = "--version" ]; then echo "1.2.3"; exit 0; fi
+        echo override:$1
+      SH
+      FileUtils.chmod(0o755, override)
+
+      log = File.join(dir, "timeout.log")
+      fake_bin = File.join(dir, "bin")
+      FileUtils.mkdir_p(fake_bin)
+      File.write(File.join(fake_bin, "timeout"), <<~SH)
+        #!/bin/sh
+        printf '%s\\n' "$*" >> "#{log}"
+        if [ "$1" != "-k" ]; then
+          exit 125
+        fi
+        shift 2
+        shift
+        exec "$@"
+      SH
+      FileUtils.chmod(0o755, File.join(fake_bin, "timeout"))
+
+      out, err, status = capture_hv_with_timeout(
+        {
+          "HIVE_BIN_OVERRIDE" => override,
+          "XDG_BIN_HOME" => File.join(dir, "empty-xdg"),
+          "HOMEBREW_PREFIX" => File.join(dir, "empty-homebrew"),
+          "PATH" => [ fake_bin, ENV.fetch("PATH", "") ].join(File::PATH_SEPARATOR)
+        },
+        "probe"
+      )
+
+      assert status.success?, err
+      assert_equal "override:probe\n", out
+      lines = File.readlines(log, chomp: true)
+      assert_includes lines, "-k 1 1 true"
+      assert_includes lines, "-k 1 5 #{override} --version"
+    end
+  end
+
+  def test_timeout_probe_falls_back_when_kill_after_is_unsupported
+    with_tmp_dir do |dir|
+      override = File.join(dir, "custom", "hive")
+      FileUtils.mkdir_p(File.dirname(override))
+      File.write(override, <<~SH)
+        #!/bin/sh
+        if [ "$1" = "--version" ]; then echo "1.2.3"; exit 0; fi
+        echo override:$1
+      SH
+      FileUtils.chmod(0o755, override)
+
+      log = File.join(dir, "timeout.log")
+      fake_bin = File.join(dir, "bin")
+      FileUtils.mkdir_p(fake_bin)
+      File.write(File.join(fake_bin, "timeout"), <<~SH)
+        #!/bin/sh
+        printf '%s\\n' "$*" >> "#{log}"
+        if [ "$1" = "-k" ]; then
+          exit 125
+        fi
+        shift
+        exec "$@"
+      SH
+      FileUtils.chmod(0o755, File.join(fake_bin, "timeout"))
+
+      out, err, status = capture_hv_with_timeout(
+        {
+          "HIVE_BIN_OVERRIDE" => override,
+          "XDG_BIN_HOME" => File.join(dir, "empty-xdg"),
+          "HOMEBREW_PREFIX" => File.join(dir, "empty-homebrew"),
+          "PATH" => [ fake_bin, ENV.fetch("PATH", "") ].join(File::PATH_SEPARATOR)
+        },
+        "probe"
+      )
+
+      assert status.success?, err
+      assert_equal "override:probe\n", out
+      lines = File.readlines(log, chomp: true)
+      assert_includes lines, "-k 1 1 true"
+      assert_includes lines, "5 #{override} --version"
+    end
+  end
+
   def test_timed_out_probe_tree_is_group_killed_when_timeout_binary_is_absent
     with_tmp_dir do |dir|
       pidfile = File.join(dir, "probe-child.pid")


### PR DESCRIPTION
## Summary

Patrol fix for **"hv can hang on a candidate binary that ignores timeout termination"** (finding `command-bin-hive-8`).

The `bin/hv` version probe capped each candidate with `timeout 5` but set no kill-after deadline. A candidate binary that ignores `SIGTERM` (or leaves a child running) could outlive the cap and hang `hv` instead of falling through to the next candidate or the Ruby wrapper.

The probe now selects a kill-after form. It detects support once with `timeout -k 1 1 true` and, when available, probes candidates with `timeout -k 1 5` so a stubborn candidate is `SIGKILL`ed ~1s after the 5s cap. When `-k` is unsupported, it falls back to the bare `timeout 5` form. Two new unit tests cover both branches.

Diff vs `main`: 2 files, +92 / -1.

## Test plan

- `bundle exec rubocop` — passed.
- `bundle exec rake test` — passed.
- `ruby -Itest test/unit/hv_test.rb -n '/timeout_probe/'` — 2 runs, 12 assertions, 0 failures (covers the `-k`-supported and `-k`-unsupported branches).
- Manual bounded fall-through: a `SIGTERM`-ignoring override falls through in ~6s (5s cap + 1s kill-after) instead of hanging.

## Review summary

Pass 1 clean. The sole reviewer (`codex-native-review-01.md`) reported **No findings** across High, Medium, and Nit. Nothing was escalated or suppressed.

## Linked task

/home/asterio/Dev/hive/.hive-state/stages/6-review/patrol-command-bin-hive-f00a8abf
