### PR TITLE
Hive patrol: hive-e2e replay success exec path is untested

### DIFF
--- a/test/e2e/lib/hive_e2e_binary_test.rb
+++ b/test/e2e/lib/hive_e2e_binary_test.rb
@@ -194,6 +194,33 @@ class E2EBinaryTest < Minitest::Test
     end
   end
 
+  def test_replay_executes_executable_repro_and_preserves_argv0
+    skip "/bin/bash is required to verify argv0 handoff" unless File.executable?("/bin/bash")
+
+    Dir.mktmpdir("e2e-replay-test") do |tmp_runs_dir|
+      script = File.join(tmp_runs_dir, "run-1", "scenarios", "scenario-1", "repro.sh")
+      FileUtils.mkdir_p(File.dirname(script))
+      FileUtils.cp("/bin/bash", script)
+      File.chmod(0o755, script)
+
+      hook = File.join(tmp_runs_dir, "argv0-hook")
+      File.write(hook, <<~BASH)
+        printf 'replay ok\\n'
+        printf 'argv0=%s\\n' "$0"
+        exit 23
+      BASH
+
+      out, err, status = Open3.capture3(
+        { "HIVE_E2E_RUNS_DIR" => tmp_runs_dir, "BASH_ENV" => hook },
+        hive_e2e, "replay", "run-1", "scenario-1"
+      )
+
+      assert_equal 23, status.exitstatus
+      assert_empty err
+      assert_equal "replay ok\nargv0=repro.sh\n", out
+    end
+  end
+
   def test_replay_symlinked_repro_emits_json_artifact_error_when_requested
     Dir.mktmpdir("e2e-replay-test") do |tmp_runs_dir|
       target = File.join(tmp_runs_dir, "outside-repro.sh")


### PR DESCRIPTION
## Hive Patrol Finding

Slice: `command-bin-hv`
Category: `test-gap`
Severity: `medium`
Confidence: `high`
Fingerprint: `3978fceb79762d0cafb1784a26db329e2e5ed5da3b25deceb1824c010d18f9bf`

The replay command has coverage for missing, non-executable, symlinked, dangling, traversal, and invalid-byte repro paths, but not for the successful exec branch. A regression in argv0 handoff or the final exec could break replay while all current failure-path tests still pass.

## Evidence

- bin/hive-e2e:170 exec([ script, File.basename(script) ])
- test/e2e/lib/hive_e2e_binary_test.rb:161 def test_replay_missing_repro_emits_json_error_when_requested
- test/e2e/lib/hive_e2e_binary_test.rb:173 def test_replay_non_executable_repro_emits_json_artifact_error_when_requested

## Applied Fix

Add a replay test that creates an executable non-symlink repro.sh under a temporary HIVE_E2E_RUNS_DIR, runs bin/hive-e2e replay, and asserts the script output, exit status, and argv0.

## Validation

- lint: passed (`bundle exec rubocop`)
- test: passed (`bundle exec rake test`)

## Diffstat

```text
 test/e2e/lib/hive_e2e_binary_test.rb | 27 +++++++++++++++++++++++++++
 1 file changed, 27 insertions(+)

```
