### PR TITLE
fix(deps): declare erb as a runtime dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     hive-cli (0.3.6)
       bubbletea (= 0.1.4)
+      erb (>= 4.0)
       faraday (>= 2.14.2, < 3.0)
       faraday-multipart (~> 1.0)
       lipgloss (~> 0.2.2)
@@ -71,6 +72,7 @@ GEM
       dry-inflector (~> 1.0)
       dry-logic (~> 1.4)
       zeitwerk (~> 2.6)
+    erb (6.0.4)
     faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
@@ -97,7 +99,6 @@ GEM
     lipgloss (0.2.2-x86_64-linux-gnu)
     lipgloss (0.2.2-x86_64-linux-musl)
     logger (1.7.0)
-    mini_portile2 (2.8.9)
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
@@ -146,8 +147,6 @@ GEM
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
     simpleidn (0.2.3)
-    sqlite3 (2.9.5)
-      mini_portile2 (~> 2.8.0)
     sqlite3 (2.9.5-aarch64-linux-gnu)
     sqlite3 (2.9.5-arm64-darwin)
     sqlite3 (2.9.5-x86_64-linux-gnu)
@@ -169,7 +168,6 @@ GEM
 PLATFORMS
   aarch64-linux-gnu
   arm64-darwin
-  ruby
   x86_64-linux
   x86_64-linux-musl
 

--- a/hive.gemspec
+++ b/hive.gemspec
@@ -58,6 +58,11 @@ Gem::Specification.new do |spec|
   # transitively through telegram-bot-ruby today, but declaring them directly
   # keeps transcription from breaking with a LoadError if an upstream bump
   # drops or re-scopes them.
+  # erb is a bundled-but-unbundling gem: Arch already ships it as a separate
+  # ruby-erb package, and stages/base.rb requires it at load time — without an
+  # explicit dependency, vendored installs (pacman, gem install --install-dir)
+  # crash with LoadError before any stage can run.
+  spec.add_dependency "erb", ">= 4.0"
   spec.add_dependency "faraday", ">= 2.14.2", "< 3.0"
   spec.add_dependency "faraday-multipart", "~> 1.0"
   spec.add_dependency "lipgloss", "~> 0.2.2"

--- a/web/Gemfile.lock
+++ b/web/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     hive-cli (0.3.6)
       bubbletea (= 0.1.4)
+      erb (>= 4.0)
       faraday (>= 2.14.2, < 3.0)
       faraday-multipart (~> 1.0)
       lipgloss (~> 0.2.2)


### PR DESCRIPTION
erb is no longer guaranteed by ruby's default gems (Arch ships it as a separate `ruby-erb` package). hive requires it at load time (`stages/base.rb`, `display_name/generator.rb`, `commands/init.rb`), so vendored installs without the system package crash with `LoadError: cannot load such file -- erb` before any verb runs.

Hit in production today: `/usr/bin/hive plan` (pacman-vendored 0.3.6) crashed on Arch until erb was injected via `GEM_PATH`. This was also pre-diagnosed in the openclaw skill notes (the Arch ruby-erb workaround) — this PR makes the workaround unnecessary by declaring the dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)