### PR TITLE
Hive patrol: Merged-PR digest wrapper selector lacks coverage

### DIFF
--- a/test/integration/cli_usage_error_json_test.rb
+++ b/test/integration/cli_usage_error_json_test.rb
@@ -79,6 +79,32 @@ class CliUsageErrorJsonTest < Minitest::Test
     end
   end
 
+  def test_merged_pr_digest_json_usage_errors_use_merged_pr_schema
+    schemer = JSONSchemer.schema(JSON.parse(File.read(Hive::Schemas.schema_path("hive-merged-pr-digest"))))
+    cases = [
+      %w[digest --source merged-prs --bad --json],
+      %w[digest --repo owner/repo --bad --json]
+    ]
+
+    with_tmp_global_config do |home|
+      cases.each do |argv|
+        out, _err, status = run_hive(home, *argv)
+
+        refute status.success?, "#{argv.join(' ')} should fail"
+        assert_equal Hive::ExitCodes::USAGE, status.exitstatus
+        payload = JSON.parse(out)
+        assert_equal "hive-merged-pr-digest", payload["schema"]
+        assert_equal Hive::Schemas::SCHEMA_VERSIONS.fetch("hive-merged-pr-digest"), payload["schema_version"]
+        assert_equal false, payload["ok"]
+        assert_equal "InvalidTaskPath", payload["error_class"]
+        assert_equal "usage", payload["error_kind"]
+        assert_equal Hive::ExitCodes::USAGE, payload["exit_code"]
+        assert_empty schemer.validate(payload).map { |e| e["error"] },
+                     "#{argv.join(' ')} envelope must validate against hive-merged-pr-digest schema"
+      end
+    end
+  end
+
   def test_setup_extra_positional_json_usage_error_uses_setup_envelope
     with_tmp_global_config do |home|
       out, err, status = run_hive(home, "setup", "extra", "--json")


### PR DESCRIPTION
## Hive Patrol Finding

Slice: `command-bin-hv`
Category: `test-gap`
Severity: `medium`
Confidence: `high`
Fingerprint: `27083fdae95c26ca934afa979683babb21207bb8793cda15d5a917553ff19179`

bin/hive has wrapper-only logic that must choose the hive-merged-pr-digest schema for Thor usage errors before Hive::Commands::Digest runs. Existing command-level digest tests do not exercise this pre-dispatch selector, so it could regress to the generic hive-digest envelope without failing the current wrapper tests.

## Evidence

- bin/hive:225 def digest_merged_pr_argv?(argv)
- bin/hive:244 return { schema: "hive-merged-pr-digest", error_kind: "usage" }

## Applied Fix

Add wrapper/integration cases for digest --source merged-prs --bad --json and digest --repo owner/repo --bad --json, asserting schema hive-merged-pr-digest, error_kind usage, stdout JSON, and exit 64.

## Validation

- lint: passed (`bundle exec rubocop`)
- test: passed (`bundle exec rake test`)

## Diffstat

```text
 test/integration/cli_usage_error_json_test.rb | 26 ++++++++++++++++++++++++++
 1 file changed, 26 insertions(+)

```
