### PR TITLE
Hive patrol: Rotated TUI marker log is dropped from failure artifacts

### DIFF
--- a/test/e2e/lib/artifact_capture.rb
+++ b/test/e2e/lib/artifact_capture.rb
@@ -125,8 +125,10 @@ module Hive
         return unless @tui_log_dir && File.directory?(@tui_log_dir)
 
         sources = Dir.glob(File.join(@tui_log_dir, "hive-tui-spawn-*.log"))
-        marker_log = File.join(@tui_log_dir, "hive-tui-subprocess.log")
-        sources << marker_log if File.exist?(marker_log)
+        %w[hive-tui-subprocess.log hive-tui-subprocess.log.1].each do |name|
+          marker_log = File.join(@tui_log_dir, name)
+          sources << marker_log if File.exist?(marker_log)
+        end
         return if sources.empty?
 
         dest_root = File.join(@scenario_dir, "tui-subprocess")

--- a/test/e2e/lib/artifact_capture_test.rb
+++ b/test/e2e/lib/artifact_capture_test.rb
@@ -140,19 +140,28 @@ class E2EArtifactCaptureTest < Minitest::Test
       FileUtils.mkdir_p(log_dir)
       spawn_log = File.join(log_dir, "hive-tui-spawn-FAKE.log")
       marker_log = File.join(log_dir, "hive-tui-subprocess.log")
+      rotated_marker_log = File.join(log_dir, "hive-tui-subprocess.log.1")
       File.write(spawn_log, "FAKE-SPAWN-OUTPUT\n")
       File.write(marker_log, "----- BEGIN[FAKE]: hive plan -----\n")
+      File.write(rotated_marker_log, "----- BEGIN[OLD]: hive run -----\n")
 
       collect(scenario_dir, sandbox, run_home, tui_log_dir: log_dir)
 
       copied_spawn = File.join(scenario_dir, "tui-subprocess", "hive-tui-spawn-FAKE.log")
       copied_marker = File.join(scenario_dir, "tui-subprocess", "hive-tui-subprocess.log")
+      copied_rotated_marker = File.join(scenario_dir, "tui-subprocess", "hive-tui-subprocess.log.1")
       assert File.exist?(copied_spawn), "per-spawn capture file should be copied into the bundle"
       assert File.exist?(copied_marker), "shared TUI marker log should be copied into the bundle"
+      assert File.exist?(copied_rotated_marker), "rotated shared TUI marker log should be copied into the bundle"
       assert_includes File.read(copied_spawn), "FAKE-SPAWN-OUTPUT",
                       "per-spawn capture body should round-trip into the bundle"
       assert File.exist?("#{copied_spawn}.tail"),
              "per-spawn capture should also get a .tail companion (matching log-tails pattern)"
+
+      manifest = JSON.parse(File.read(File.join(scenario_dir, "manifest.json")))
+      paths = manifest.fetch("files").map { |file| file.fetch("path") }
+      assert_includes paths, "tui-subprocess/hive-tui-subprocess.log"
+      assert_includes paths, "tui-subprocess/hive-tui-subprocess.log.1"
     end
   end
 

--- a/wiki/e2e.md
+++ b/wiki/e2e.md
@@ -119,7 +119,7 @@ On failure, the harness writes a scenario bundle containing:
 - copied `.hive-state/stages/` and per-`.log` copies under `logs/<slug>/<basename>.log` plus a sibling `<basename>.tail` (last 200 lines) for fast agent reads
 - `repro.sh`
 - `manifest.json` with size and SHA-256 per artifact
-- TUI failures also include keystroke captures, run-scoped TUI subprocess marker/capture logs under `tui-subprocess/`, plus `pane-before.txt` (snapshot taken just before the most recent `tui_keys`) and `pane-after.txt`. Cast recording is implemented by `AsciinemaDriver`, but depends on local `asciinema >= 2.4`.
+- TUI failures also include keystroke captures, run-scoped TUI subprocess marker/capture logs under `tui-subprocess/` (including the current shared marker log and its single `.log.1` rotation), plus `pane-before.txt` (snapshot taken just before the most recent `tui_keys`) and `pane-after.txt`. Cast recording is implemented by `AsciinemaDriver`, but depends on local `asciinema >= 2.4`.
 
 ## Current Scenarios
 

--- a/wiki/log.d/20260709T162705Z-tui-rotated-marker-artifacts.md
+++ b/wiki/log.d/20260709T162705Z-tui-rotated-marker-artifacts.md
@@ -1,0 +1,5 @@
+## [2026-07-09T16:27:05Z] e2e - preserve rotated TUI marker artifacts
+
+**Action:** `ArtifactCapture` now copies the run-scoped `hive-tui-subprocess.log.1` rotation alongside the current shared TUI marker log when a TUI scenario fails, so marker history is not lost before the live log directory is removed.
+
+**Coverage:** Extended `test/e2e/lib/artifact_capture_test.rb` to seed both `hive-tui-subprocess.log` and `hive-tui-subprocess.log.1` and assert both are copied into `tui-subprocess/` and listed in `manifest.json`. Updated [[e2e]]; did not edit compiled [[log]].


### PR DESCRIPTION
## Hive Patrol Finding

Slice: `test-suite-test-babysitter-acceptance-dry-run-test-rb`
Category: `bug`
Severity: `medium`
Confidence: `high`
Fingerprint: `793111b7c7e7c63e8f01b074667c116687f3d92d5ce1fb9c3b98150144c91045`

ArtifactCapture copies only hive-tui-spawn-*.log and the current hive-tui-subprocess.log, then removes the live tui-subprocess-live directory before manifesting. The TUI subprocess logger rotates oversized marker logs to hive-tui-subprocess.log.1, so a failure after rotation can lose the rotated BEGIN/END marker history from the artifact bundle.

## Evidence

- test/e2e/lib/artifact_capture.rb:127 sources = Dir.glob(File.join(@tui_log_dir, "hive-tui-spawn-*.log"))
- test/e2e/lib/artifact_capture.rb:128 marker_log = File.join(@tui_log_dir, "hive-tui-subprocess.log")
- test/e2e/lib/artifact_capture.rb:154 FileUtils.rm_rf(live_dir)
- lib/hive/tui/subprocess.rb:403 File.rename(path, "#{path}.1")

## Applied Fix

Copy a bounded rotated marker file as well, such as hive-tui-subprocess.log.1 or a constrained hive-tui-subprocess.log* set, and add an artifact_capture_test that seeds both .log and .log.1 and asserts both appear in the bundle and manifest.

## Validation

- lint: passed (`bundle exec rubocop`)
- test: passed (`bundle exec rake test`)

## Diffstat

```text
 test/e2e/lib/artifact_capture.rb                            | 6 ++++--
 test/e2e/lib/artifact_capture_test.rb                       | 9 +++++++++
 wiki/e2e.md                                                 | 2 +-
 wiki/log.d/20260709T162705Z-tui-rotated-marker-artifacts.md | 5 +++++
 4 files changed, 19 insertions(+), 3 deletions(-)

```
