### PR TITLE
fix(drop): terminate orphaned descendant processes

### DIFF
--- a/lib/hive/agent.rb
+++ b/lib/hive/agent.rb
@@ -147,7 +147,11 @@ module Hive
         pid
       end
 
-      Hive::Lock.update_task_lock(@task.folder, "claude_pid" => pid)
+      Hive::Lock.update_task_lock(
+        @task.folder,
+        "claude_pid" => pid,
+        "claude_pid_start_time" => Hive::Lock.process_start_time(pid)
+      )
 
       old_int = trap("INT") { kill_group(pgid) }
       old_term = trap("TERM") { kill_group(pgid) }

--- a/lib/hive/claude_launcher.rb
+++ b/lib/hive/claude_launcher.rb
@@ -534,7 +534,11 @@ module Hive
       end
       return unless pid
 
-      Hive::Lock.update_task_lock(task.folder, "claude_pid" => pid)
+      Hive::Lock.update_task_lock(
+        task.folder,
+        "claude_pid" => pid,
+        "claude_pid_start_time" => Hive::Lock.process_start_time(pid)
+      )
     rescue Hive::TmuxError => e
       # Losing the pid means `hive lock` can no longer kill claude
       # cleanly; warn so an operator running interactively sees the

--- a/lib/hive/commands/drop.rb
+++ b/lib/hive/commands/drop.rb
@@ -330,7 +330,7 @@ module Hive
           killed: !killed_pids.empty?,
           pid: candidates.first[:pid],
           killed_pids: killed_pids.uniq,
-          skipped_reason: killed_pids.empty? ? skipped_reasons.compact.first : nil
+          skipped_reason: skipped_reasons.compact.first
         }
       end
 
@@ -340,7 +340,7 @@ module Hive
           lock = lock_payload(File.join(entry[:folder], ".lock"))
           if integer_like?(lock["claude_pid"])
             register_candidate(by_pid, lock["claude_pid"].to_i,
-                               process_start_time: nil, group: true)
+                               process_start_time: lock["claude_pid_start_time"], group: true)
           end
           if integer_like?(lock["pid"])
             register_candidate(by_pid, lock["pid"].to_i,

--- a/lib/hive/process_kill.rb
+++ b/lib/hive/process_kill.rb
@@ -1,10 +1,12 @@
 require "hive/lock"
+require "open3"
 
 module Hive
   module ProcessKill
     TERM_GRACE_SECONDS = 2.0
     KILL_GRACE_SECONDS = 0.2
     POLL_INTERVAL_SECONDS = 0.05
+    SYSTEM_PS_PATHS = [ "/bin/ps", "/usr/bin/ps" ].freeze
 
     Result = Struct.new(:pid, :killed, :skipped_reason, keyword_init: true)
 
@@ -84,21 +86,156 @@ module Hive
         return Result.new(pid: pid, killed: false, skipped_reason: "pid_reuse_guard")
       end
 
-      pgid = Process.getpgid(pid)
-      safe_kill("TERM", -pgid)
-      wait_until_dead(pid, grace_seconds)
-      if pid_alive?(pid)
-        safe_kill("KILL", -pgid)
-        wait_until_dead(pid, KILL_GRACE_SECONDS)
+      targets = process_tree_snapshot(pid)
+      unless targets
+        best_effort_terminate_root(pid, recorded_start_time, grace_seconds)
+        return Result.new(pid: pid, killed: false, skipped_reason: "process_tree_unavailable")
       end
-      killed = !pid_alive?(pid)
-      Result.new(pid: pid, killed: killed, skipped_reason: killed ? nil : "kill_failed")
+      if targets.empty?
+        return Result.new(pid: pid, killed: false, skipped_reason: "not_alive") unless pid_alive?(pid)
+
+        best_effort_terminate_root(pid, recorded_start_time, grace_seconds)
+        return Result.new(pid: pid, killed: false, skipped_reason: "process_tree_unavailable")
+      end
+
+      root_target = targets.find { |target| target.fetch(:pid) == pid }
+      if !recorded_start_time.to_s.empty? && root_target[:start_time].to_s != recorded_start_time.to_s
+        return Result.new(pid: pid, killed: false, skipped_reason: "pid_reuse_guard")
+      end
+
+      permission_denied = signal_captured_processes("TERM", targets)
+      killed = wait_until_process_tree_dead(pid, targets, grace_seconds)
+      unless killed
+        kill_permission_denied = signal_captured_processes("KILL", targets, require_identity: true)
+        permission_denied ||= kill_permission_denied
+        killed = wait_until_process_tree_dead(pid, targets, KILL_GRACE_SECONDS)
+      end
+      reason = permission_denied ? "permission_denied" : "kill_failed"
+      Result.new(pid: pid, killed: killed, skipped_reason: killed ? nil : reason)
     rescue ArgumentError, TypeError
       Result.new(pid: nil, killed: false, skipped_reason: "invalid_pid")
     rescue Errno::ESRCH
       Result.new(pid: pid, killed: false, skipped_reason: "not_alive")
+    end
+
+    # Agents may launch tool commands in their own process groups. Snapshot the
+    # full descendant tree before signalling so those processes remain
+    # addressable after their parent exits and init adopts them. Signal PIDs,
+    # not process groups: a descendant can join a group containing unrelated
+    # processes, and a PGID can be reused during TERM-to-KILL escalation.
+    def process_tree_snapshot(pid)
+      table = process_table
+      return nil unless table
+      return [] unless table.key?(pid)
+
+      children = Hash.new { |hash, parent| hash[parent] = [] }
+      table.each { |child_pid, row| children[row.fetch(:ppid)] << child_pid }
+
+      pending = [ pid ]
+      depths = { pid => 0 }
+      cursor = 0
+      while (parent = pending[cursor])
+        cursor += 1
+        children.fetch(parent, []).each do |child|
+          depths[child] = depths.fetch(parent) + 1
+          pending << child
+        end
+      end
+
+      pending.filter_map do |target_pid|
+        row = table[target_pid]
+        next unless row && valid_target_pid?(target_pid)
+
+        row.merge(pid: target_pid, start_time: process_start_time(target_pid), depth: depths.fetch(target_pid))
+      end.sort_by { |target| [ -target.fetch(:depth), target.fetch(:pid) ] }
+    end
+
+    def process_table
+      ps_path = SYSTEM_PS_PATHS.find { |path| File.file?(path) && File.executable?(path) }
+      return nil unless ps_path
+
+      out, _err, status = Open3.capture3(ps_path, "-axo", "pid=,ppid=,pgid=")
+      return nil unless status.success?
+
+      rows = {}
+      out.each_line do |line|
+        fields = line.split
+        next if fields.empty?
+        return nil unless fields.length == 3
+
+        pid, ppid, pgid = fields.map { |value| Integer(value, 10) }
+        rows[pid] = { ppid: ppid, pgid: pgid }
+      rescue ArgumentError
+        return nil
+      end
+      rows
+    rescue SystemCallError
+      nil
+    end
+
+    def signal_captured_processes(signal, targets, require_identity: false)
+      permission_denied = false
+      targets.each do |target|
+        next unless captured_process_current?(target, require_identity: require_identity)
+
+        begin
+          safe_kill(signal, target.fetch(:pid))
+        rescue Errno::EPERM
+          permission_denied = true
+        end
+      end
+      permission_denied
+    end
+
+    def captured_process_current?(target, require_identity: false)
+      expected = target[:start_time]
+      return !require_identity && pid_alive?(target.fetch(:pid)) if expected.to_s.empty?
+
+      live = process_start_time(target.fetch(:pid))
+      !live.to_s.empty? && live.to_s == expected.to_s
+    end
+
+    def captured_process_alive?(target)
+      expected = target[:start_time]
+      return pid_alive?(target.fetch(:pid)) if expected.to_s.empty?
+
+      live = process_start_time(target.fetch(:pid))
+      return pid_alive?(target.fetch(:pid)) if live.to_s.empty?
+
+      live.to_s == expected.to_s
+    end
+
+    def wait_until_process_tree_dead(pid, targets, seconds)
+      deadline = Time.now + seconds
+      while Time.now < deadline
+        reap_if_child_exited(pid)
+        return true unless targets.any? { |target| captured_process_alive?(target) }
+
+        sleep POLL_INTERVAL_SECONDS
+      end
+      reap_if_child_exited(pid)
+      targets.none? { |target| captured_process_alive?(target) }
+    end
+
+    def best_effort_terminate_root(pid, recorded_start_time, grace_seconds)
+      expected = recorded_start_time
+      expected = process_start_time(pid) if expected.to_s.empty?
+      return if !expected.to_s.empty? && process_start_time(pid).to_s != expected.to_s
+
+      begin
+        safe_kill("TERM", pid)
+      rescue Errno::EPERM
+        return
+      end
+      wait_until_dead(pid, grace_seconds)
+      return unless pid_alive?(pid)
+      return if expected.to_s.empty?
+      return unless process_start_time(pid).to_s == expected.to_s
+
+      safe_kill("KILL", pid)
+      wait_until_dead(pid, KILL_GRACE_SECONDS)
     rescue Errno::EPERM
-      Result.new(pid: pid, killed: false, skipped_reason: "permission_denied")
+      nil
     end
 
     def safe_kill(signal, target)

--- a/lib/hive/process_kill.rb
+++ b/lib/hive/process_kill.rb
@@ -98,7 +98,20 @@ module Hive
         return Result.new(pid: pid, killed: false, skipped_reason: "process_tree_unavailable")
       end
 
+      targets = confirm_process_tree_snapshot(pid, targets)
+      unless targets
+        best_effort_terminate_root(pid, recorded_start_time, grace_seconds)
+        return Result.new(pid: pid, killed: false, skipped_reason: "process_tree_unavailable")
+      end
+      if targets.empty?
+        return Result.new(pid: pid, killed: false, skipped_reason: "not_alive") unless pid_alive?(pid)
+
+        return Result.new(pid: pid, killed: false, skipped_reason: "pid_reuse_guard")
+      end
+
       root_target = targets.find { |target| target.fetch(:pid) == pid }
+      return Result.new(pid: pid, killed: false, skipped_reason: "pid_reuse_guard") unless root_target
+
       if !recorded_start_time.to_s.empty? && root_target[:start_time].to_s != recorded_start_time.to_s
         return Result.new(pid: pid, killed: false, skipped_reason: "pid_reuse_guard")
       end
@@ -148,6 +161,23 @@ module Hive
 
         row.merge(pid: target_pid, start_time: process_start_time(target_pid), depth: depths.fetch(target_pid))
       end.sort_by { |target| [ -target.fetch(:depth), target.fetch(:pid) ] }
+    end
+
+    # `process_tree_snapshot` reads ancestry from one ps snapshot and process
+    # identity immediately afterward. A PID can be recycled between those two
+    # reads, producing a row with the old process's parent and the replacement
+    # process's start time. Require a second full snapshot to reproduce the
+    # same ancestry + identity tuple before TERM; mismatched descendants are
+    # omitted and a mismatched root fails closed.
+    def confirm_process_tree_snapshot(pid, targets)
+      confirmation = process_tree_snapshot(pid)
+      return nil unless confirmation
+
+      by_pid = confirmation.to_h { |target| [ target.fetch(:pid), target ] }
+      targets.select do |target|
+        current = by_pid[target.fetch(:pid)]
+        current && %i[ppid pgid start_time].all? { |key| current[key].to_s == target[key].to_s }
+      end
     end
 
     def process_table

--- a/test/unit/agent_test.rb
+++ b/test/unit/agent_test.rb
@@ -621,6 +621,39 @@ class AgentTest < Minitest::Test
     end
   end
 
+  def test_spawn_records_agent_pid_and_start_time_in_one_lock_update
+    with_tmp_dir do |dir|
+      task = make_task(dir)
+      File.write(task.state_file, "<!-- WAITING -->\n")
+      ENV["HIVE_FAKE_CLAUDE_WRITE_FILE"] = task.state_file
+      ENV["HIVE_FAKE_CLAUDE_WRITE_CONTENT"] = "## Round 1\n<!-- WAITING -->\n"
+      updates = []
+      start_time_pids = []
+
+      with_replaced_singleton_method(Hive::Lock, :process_start_time, lambda { |pid|
+        start_time_pids << pid
+        "spawn-start-time"
+      }) do
+        with_replaced_singleton_method(Hive::Lock, :update_task_lock, lambda { |folder, additions|
+          updates << [ folder, additions ]
+        }) do
+          result = Hive::Agent.new(task: task, prompt: "x", max_budget_usd: 1, timeout_sec: 5).run!
+
+          assert_equal [ result[:pid] ], start_time_pids
+          assert_equal [
+            [
+              task.folder,
+              {
+                "claude_pid" => result[:pid],
+                "claude_pid_start_time" => "spawn-start-time"
+              }
+            ]
+          ], updates
+        end
+      end
+    end
+  end
+
   def test_signaled_subprocess_reports_negative_exit_code
     with_tmp_dir do |dir|
       task = make_task(dir)

--- a/test/unit/commands/drop_test.rb
+++ b/test/unit/commands/drop_test.rb
@@ -80,7 +80,17 @@ class DropCommandTest < Minitest::Test
       File.write(File.join(log_dir, "execute.log"), "running\n")
       commit_hive_state(ops, "4-execute", slug)
 
-      pid = Process.spawn("sleep", "60", pgroup: true, out: File::NULL, err: File::NULL)
+      child_pid_path = File.join(dir, "nested-agent-child.pid")
+      pid = Process.spawn(
+        RbConfig.ruby, "-e", <<~'RUBY', child_pid_path,
+          child = Process.spawn("sleep", "60", pgroup: true, out: File::NULL, err: File::NULL)
+          File.write(ARGV.fetch(0), child)
+          sleep 60
+        RUBY
+        pgroup: true, out: File::NULL, err: File::NULL
+      )
+      nested_pid = wait_for_pid_file(child_pid_path)
+      nested_pgid = Process.getpgid(nested_pid)
       begin
         File.write(File.join(folder, ".lock"), { "claude_pid" => pid }.to_yaml)
 
@@ -95,6 +105,10 @@ class DropCommandTest < Minitest::Test
         assert_equal [ "4-execute" ], payload["from_stages"]
         assert_equal true, payload["agent_killed"]
         assert_includes payload["agent_killed_pids"], pid
+        refute Hive::ProcessKill.pid_alive?(pid),
+               "the recorded agent root must not survive drop"
+        refute process_group_alive?(nested_pgid),
+               "a nested tool subprocess in its own process group must not survive drop"
         assert_equal true, payload["worktree_removed"]
         assert_equal true, payload["branch_deleted"]
         refute File.directory?(folder)
@@ -104,8 +118,10 @@ class DropCommandTest < Minitest::Test
         log = `git -C #{File.join(dir, ".hive-state")} log --format=%s -1`.strip
         assert_equal "hive: dropped/#{slug} dropped", log
       ensure
-        # Reap the helper sleep so a failed assertion doesn't leak a
-        # 60s child until the test runner exits.
+        # Reap the helper tree so a failed assertion doesn't leak a
+        # nested 60s child until the test runner exits.
+        kill_process_group(nested_pgid)
+        kill_process_group(pid)
         reap_spawn(pid)
       end
     end
@@ -305,6 +321,62 @@ class DropCommandTest < Minitest::Test
         assert_equal Process.pid, payload["agent_pid"]
         assert_equal "pid_reuse_guard", payload["agent_kill_skipped_reason"]
       end
+    end
+  end
+
+  def test_drop_reports_partial_multi_candidate_cleanup_and_passes_group_start_time
+    with_drop_project do |dir, _ops, project|
+      slug = "partial-agent-cleanup-260709-aaaa"
+      folder = create_task(dir, "4-execute", slug)
+      group_pid = 81_001
+      runner_pid = 81_002
+      File.write(
+        File.join(folder, ".lock"),
+        {
+          "claude_pid" => group_pid,
+          "claude_pid_start_time" => "recorded-group-start",
+          "pid" => runner_pid,
+          "process_start_time" => "recorded-runner-start"
+        }.to_yaml
+      )
+
+      group_calls = []
+      runner_calls = []
+      group_result = Hive::ProcessKill::Result.new(pid: group_pid, killed: true, skipped_reason: nil)
+      runner_result = Hive::ProcessKill::Result.new(
+        pid: runner_pid, killed: false, skipped_reason: "pid_reuse_guard"
+      )
+
+      with_replaced_singleton_method(
+        Hive::ProcessKill, :terminate_process_group,
+        lambda do |pid, recorded_start_time: nil, **_kwargs|
+          group_calls << [ pid, recorded_start_time ]
+          group_result
+        end
+      ) do
+        with_replaced_singleton_method(
+          Hive::ProcessKill, :terminate_process,
+          lambda do |pid, recorded_start_time: nil, **_kwargs|
+            runner_calls << [ pid, recorded_start_time ]
+            runner_result
+          end
+        ) do
+          out, _err = capture_io do
+            Hive::Commands::Drop.new(slug, project: project, json: true).call
+          end
+          payload = JSON.parse(out)
+
+          assert_equal true, payload["agent_killed"],
+                       "one successful candidate must keep the aggregate cleanup successful"
+          assert_equal [ group_pid ], payload["agent_killed_pids"]
+          assert_equal "pid_reuse_guard", payload["agent_kill_skipped_reason"],
+                       "partial cleanup must retain the failed candidate's reason"
+        end
+      end
+
+      assert_equal [ [ group_pid, "recorded-group-start" ] ], group_calls,
+                   "drop must pass claude_pid_start_time to group cleanup"
+      assert_equal [ [ runner_pid, "recorded-runner-start" ] ], runner_calls
     end
   end
 
@@ -541,6 +613,25 @@ class DropCommandTest < Minitest::Test
     rescue Errno::ECHILD
       # already reaped
     end
+  end
+
+  def wait_for_pid_file(path)
+    deadline = Time.now + 2
+    sleep 0.01 until File.exist?(path) || Time.now >= deadline
+    Integer(File.read(path))
+  end
+
+  def process_group_alive?(pgid)
+    Process.kill(0, -pgid)
+    true
+  rescue Errno::ESRCH
+    false
+  end
+
+  def kill_process_group(pgid)
+    Process.kill("KILL", -pgid) if pgid && process_group_alive?(pgid)
+  rescue Errno::ESRCH, Errno::EPERM
+    nil
   end
 
   def test_drop_path_target_refuses_archived_task

--- a/test/unit/process_kill_test.rb
+++ b/test/unit/process_kill_test.rb
@@ -111,6 +111,53 @@ class ProcessKillTest < Minitest::Test
     end
   end
 
+  def test_terminate_process_group_kills_recursive_descendants_that_ignore_term
+    with_tmp_dir do |dir|
+      wrapper_pid_path = File.join(dir, "wrapper.pid")
+      grandchild_pid_path = File.join(dir, "grandchild.pid")
+      grandchild_term_path = File.join(dir, "grandchild.term")
+      root_pid = Process.spawn(
+        RbConfig.ruby, "-e", <<~'RUBY', wrapper_pid_path, grandchild_pid_path, grandchild_term_path,
+          wrapper = Process.spawn(
+            RbConfig.ruby, "-e", <<~'CHILD', ARGV.fetch(1), ARGV.fetch(2),
+              grandchild = Process.spawn(
+                RbConfig.ruby, "-e", <<~'GRANDCHILD', ARGV.fetch(0), ARGV.fetch(1),
+                  trap("TERM") { File.write(ARGV.fetch(1), "received") }
+                  File.write(ARGV.fetch(0), Process.pid)
+                  sleep 30
+                GRANDCHILD
+                pgroup: true, out: File::NULL, err: File::NULL
+              )
+              Process.wait(grandchild)
+            CHILD
+            out: File::NULL, err: File::NULL
+          )
+          File.write(ARGV.fetch(0), wrapper)
+          sleep 30
+        RUBY
+        pgroup: true, out: File::NULL, err: File::NULL
+      )
+      wrapper_pid = wait_for_pid_file(wrapper_pid_path)
+      grandchild_pid = wait_for_pid_file(grandchild_pid_path)
+
+      assert_equal root_pid, Process.getpgid(wrapper_pid), "wrapper must remain in the root process group"
+      assert_equal grandchild_pid, Process.getpgid(grandchild_pid), "grandchild must create a nested process group"
+
+      result = Hive::ProcessKill.terminate_process_group(root_pid, grace_seconds: 0.2)
+
+      assert result.killed, "the recorded root process must be terminated"
+      assert File.exist?(grandchild_term_path), "grandchild must receive and ignore TERM before KILL escalation"
+      refute process_alive?(grandchild_pid), "a recursive tool subprocess must not survive the recorded agent"
+    ensure
+      [ grandchild_pid, wrapper_pid, root_pid ].compact.each { |pid| kill_process_if_alive(pid) }
+      begin
+        Process.waitpid(root_pid, Process::WNOHANG) if root_pid
+      rescue Errno::ECHILD
+        nil
+      end
+    end
+  end
+
   def test_pid_alive_treats_permission_denied_as_alive
     with_replaced_singleton_method(Process, :kill, lambda { |_signal, _pid| raise Errno::EPERM }) do
       assert Hive::ProcessKill.pid_alive?(1234)
@@ -168,17 +215,28 @@ class ProcessKillTest < Minitest::Test
   end
 
   def test_terminate_process_group_escalates_to_kill_when_term_does_not_stop_process
-    alive_sequence = [ true, true, false ]
-    signals = []
-    with_replaced_singleton_method(Hive::ProcessKill, :pid_alive?, lambda { |_pid| alive_sequence.shift }) do
-      with_replaced_singleton_method(Process, :getpgid, lambda { |pid| pid }) do
-        with_replaced_singleton_method(Hive::ProcessKill, :safe_kill, lambda { |signal, target| signals << [ signal, target ] }) do
-          with_replaced_singleton_method(Hive::ProcessKill, :wait_until_dead, lambda { |_pid, _seconds| false }) do
-            result = Hive::ProcessKill.terminate_process_group(1234, grace_seconds: 0)
+    target = { pid: 1234, ppid: 1, pgid: 1234, start_time: "original", depth: 0 }
+    signal_calls = []
+    wait_results = [ false, true ]
+    with_replaced_singleton_method(Hive::ProcessKill, :pid_alive?, ->(_pid) { true }) do
+      with_replaced_singleton_method(Hive::ProcessKill, :process_tree_snapshot, ->(_pid) { [ target ] }) do
+        with_replaced_singleton_method(Hive::ProcessKill, :signal_captured_processes,
+                                       lambda { |signal, targets, require_identity: false|
+                                         signal_calls << [ signal, targets, require_identity ]
+                                         false
+                                       }) do
+          with_replaced_singleton_method(Hive::ProcessKill, :wait_until_process_tree_dead,
+                                         ->(_pid, _targets, _seconds) { wait_results.shift }) do
+            with_process_start_time_stub("original") do
+              result = Hive::ProcessKill.terminate_process_group(1234, grace_seconds: 0)
 
-            assert_equal [ [ "TERM", -1234 ], [ "KILL", -1234 ] ], signals
-            assert result.killed
-            assert_nil result.skipped_reason
+              assert_equal [
+                [ "TERM", [ target ], false ],
+                [ "KILL", [ target ], true ]
+              ], signal_calls
+              assert result.killed
+              assert_nil result.skipped_reason
+            end
           end
         end
       end
@@ -186,8 +244,9 @@ class ProcessKillTest < Minitest::Test
   end
 
   def test_terminate_process_group_reports_not_alive_when_group_disappears
-    with_replaced_singleton_method(Hive::ProcessKill, :pid_alive?, lambda { |_pid| true }) do
-      with_replaced_singleton_method(Process, :getpgid, lambda { |_pid| raise Errno::ESRCH }) do
+    alive_results = [ true, false ]
+    with_replaced_singleton_method(Hive::ProcessKill, :pid_alive?, lambda { |_pid| alive_results.shift }) do
+      with_replaced_singleton_method(Hive::ProcessKill, :process_tree_snapshot, ->(_pid) { [] }) do
         result = Hive::ProcessKill.terminate_process_group(1234, grace_seconds: 0)
 
         refute result.killed
@@ -197,16 +256,127 @@ class ProcessKillTest < Minitest::Test
   end
 
   def test_terminate_process_group_reports_permission_denied_when_signal_fails
+    target = { pid: 1234, ppid: 1, pgid: 1234, start_time: "original", depth: 0 }
     with_replaced_singleton_method(Hive::ProcessKill, :pid_alive?, lambda { |_pid| true }) do
-      with_replaced_singleton_method(Process, :getpgid, lambda { |pid| pid }) do
+      with_replaced_singleton_method(Hive::ProcessKill, :process_tree_snapshot, ->(_pid) { [ target ] }) do
         with_replaced_singleton_method(Hive::ProcessKill, :safe_kill, lambda { |_signal, _target| raise Errno::EPERM }) do
-          result = Hive::ProcessKill.terminate_process_group(1234, grace_seconds: 0)
+          with_replaced_singleton_method(Hive::ProcessKill, :wait_until_process_tree_dead,
+                                         ->(_pid, _targets, _seconds) { false }) do
+            with_process_start_time_stub("original") do
+              result = Hive::ProcessKill.terminate_process_group(1234, grace_seconds: 0)
 
-          refute result.killed
-          assert_equal "permission_denied", result.skipped_reason
+              refute result.killed
+              assert_equal "permission_denied", result.skipped_reason
+            end
+          end
         end
       end
     end
+  end
+
+  def test_process_tree_snapshot_and_signalling_order_descendants_first
+    table = {
+      1001 => { ppid: 1, pgid: 1001 },
+      1002 => { ppid: 1001, pgid: 1001 },
+      1003 => { ppid: 1002, pgid: 1003 }
+    }
+    signals = []
+    with_replaced_singleton_method(Hive::ProcessKill, :process_table, -> { table }) do
+      with_replaced_singleton_method(Hive::ProcessKill, :process_start_time, ->(pid) { "start-#{pid}" }) do
+        targets = Hive::ProcessKill.process_tree_snapshot(1001)
+
+        assert_equal [ 1003, 1002, 1001 ], targets.map { |target| target.fetch(:pid) }
+        with_replaced_singleton_method(Hive::ProcessKill, :safe_kill,
+                                       lambda { |signal, pid| signals << [ signal, pid ] }) do
+          refute Hive::ProcessKill.signal_captured_processes("TERM", targets)
+        end
+      end
+    end
+
+    assert_equal [ [ "TERM", 1003 ], [ "TERM", 1002 ], [ "TERM", 1001 ] ], signals
+  end
+
+  def test_process_tree_unavailable_on_nonzero_ps_exit_still_attempts_root_cleanup
+    status = Object.new
+    status.define_singleton_method(:success?) { false }
+    assert_process_tree_failure_reports_unavailable(->(*_args) { [ "", "ps failed", status ] })
+  end
+
+  def test_process_tree_unavailable_on_ps_system_error_still_attempts_root_cleanup
+    assert_process_tree_failure_reports_unavailable(->(*_args) { raise Errno::ENOENT })
+  end
+
+  def test_process_table_invokes_an_absolute_trusted_ps_path
+    command = nil
+    status = Object.new
+    status.define_singleton_method(:success?) { true }
+    with_system_ps_available do
+      with_replaced_singleton_method(Open3, :capture3, lambda { |*args|
+        command = args
+        [ "4321 1 4321\n", "", status ]
+      }) do
+        assert_equal({ 4321 => { ppid: 1, pgid: 4321 } }, Hive::ProcessKill.process_table)
+      end
+    end
+
+    assert_equal Hive::ProcessKill::SYSTEM_PS_PATHS.first, command.first
+    assert command.first.start_with?("/"), "process discovery must not resolve ps through PATH"
+    refute_equal "ps", command.first
+    assert_equal [ "-axo", "pid=,ppid=,pgid=" ], command.drop(1)
+  end
+
+  def test_malformed_nonblank_ps_row_makes_the_whole_process_tree_unavailable
+    status = Object.new
+    status.define_singleton_method(:success?) { true }
+    capture3 = lambda do |*_args|
+      [ "4321 1 4321\nmalformed row\n9999 4321 9999\n", "", status ]
+    end
+
+    with_system_ps_available do
+      with_replaced_singleton_method(Open3, :capture3, capture3) do
+        assert_nil Hive::ProcessKill.process_table,
+                   "a partial process snapshot is unsafe when even one nonblank row is malformed"
+      end
+      assert_process_tree_failure_reports_unavailable(capture3)
+    end
+  end
+
+  def test_kill_skips_captured_pid_when_identity_changed
+    targets = [
+      { pid: 2002, ppid: 2001, pgid: 2002, start_time: "original-child", depth: 1 },
+      { pid: 2001, ppid: 1, pgid: 2001, start_time: "original-root", depth: 0 }
+    ]
+    signals = []
+    live_starts = { 2002 => "reused-child", 2001 => "original-root" }
+    with_replaced_singleton_method(Hive::ProcessKill, :process_start_time, ->(pid) { live_starts.fetch(pid) }) do
+      with_replaced_singleton_method(Hive::ProcessKill, :safe_kill,
+                                     lambda { |signal, pid| signals << [ signal, pid ] }) do
+        refute Hive::ProcessKill.signal_captured_processes("KILL", targets, require_identity: true)
+      end
+    end
+
+    assert_equal [ [ "KILL", 2001 ] ], signals,
+                 "a PID reused during the TERM grace period must never receive KILL"
+  end
+
+  def test_permission_denied_for_one_captured_target_does_not_skip_later_targets
+    targets = [
+      { pid: 3003, ppid: 3002, pgid: 3003, start_time: "three", depth: 2 },
+      { pid: 3002, ppid: 3001, pgid: 3001, start_time: "two", depth: 1 },
+      { pid: 3001, ppid: 1, pgid: 3001, start_time: "one", depth: 0 }
+    ]
+    signals = []
+    with_replaced_singleton_method(Hive::ProcessKill, :captured_process_current?,
+                                   ->(_target, require_identity: false) { !require_identity }) do
+      with_replaced_singleton_method(Hive::ProcessKill, :safe_kill, lambda { |signal, pid|
+        signals << [ signal, pid ]
+        raise Errno::EPERM if pid == 3003
+      }) do
+        assert Hive::ProcessKill.signal_captured_processes("TERM", targets)
+      end
+    end
+
+    assert_equal [ [ "TERM", 3003 ], [ "TERM", 3002 ], [ "TERM", 3001 ] ], signals
   end
 
   def test_safe_kill_ignores_missing_targets
@@ -235,6 +405,50 @@ class ProcessKillTest < Minitest::Test
 
 
   private
+
+  def wait_for_pid_file(path)
+    deadline = Time.now + 2
+    sleep 0.01 until File.exist?(path) || Time.now >= deadline
+    Integer(File.read(path))
+  end
+
+  def process_alive?(pid)
+    Process.kill(0, pid)
+    true
+  rescue Errno::ESRCH
+    false
+  end
+
+  def kill_process_if_alive(pid)
+    Process.kill("KILL", pid) if process_alive?(pid)
+  rescue Errno::ESRCH
+    nil
+  end
+
+  def assert_process_tree_failure_reports_unavailable(capture3_replacement)
+    root_cleanup_calls = []
+    with_replaced_singleton_method(Open3, :capture3, capture3_replacement) do
+      with_replaced_singleton_method(Hive::ProcessKill, :pid_alive?, ->(_pid) { true }) do
+        with_replaced_singleton_method(Hive::ProcessKill, :best_effort_terminate_root,
+                                       lambda { |*args| root_cleanup_calls << args }) do
+          result = Hive::ProcessKill.terminate_process_group(4321, grace_seconds: 0.25)
+
+          refute result.killed
+          assert_equal "process_tree_unavailable", result.skipped_reason
+        end
+      end
+    end
+    assert_equal [ [ 4321, nil, 0.25 ] ], root_cleanup_calls
+  end
+
+  def with_system_ps_available
+    trusted_paths = Hive::ProcessKill::SYSTEM_PS_PATHS
+    with_replaced_singleton_method(File, :file?, ->(path) { trusted_paths.include?(path) }) do
+      with_replaced_singleton_method(File, :executable?, ->(path) { trusted_paths.include?(path) }) do
+        yield
+      end
+    end
+  end
 
   # Temporarily replace ProcessKill.process_start_time so we can pin
   # the pid-reuse-guard branches deterministically. Restores the

--- a/test/unit/process_kill_test.rb
+++ b/test/unit/process_kill_test.rb
@@ -296,6 +296,39 @@ class ProcessKillTest < Minitest::Test
     assert_equal [ [ "TERM", 1003 ], [ "TERM", 1002 ], [ "TERM", 1001 ] ], signals
   end
 
+  def test_terminate_process_group_skips_pid_reused_between_ancestry_and_identity_reads
+    first = [
+      { pid: 2002, ppid: 2001, pgid: 2002, start_time: "replacement", depth: 1 },
+      { pid: 2001, ppid: 1, pgid: 2001, start_time: "root", depth: 0 }
+    ]
+    confirmation = [
+      { pid: 2001, ppid: 1, pgid: 2001, start_time: "root", depth: 0 }
+    ]
+    snapshots = [ first, confirmation ]
+    signals = []
+
+    with_replaced_singleton_method(Hive::ProcessKill, :pid_alive?, ->(_pid) { true }) do
+      with_replaced_singleton_method(Hive::ProcessKill, :process_tree_snapshot, ->(_pid) { snapshots.shift }) do
+        with_replaced_singleton_method(Hive::ProcessKill, :process_start_time, ->(_pid) { "root" }) do
+          with_replaced_singleton_method(Hive::ProcessKill, :safe_kill,
+                                         ->(signal, pid) { signals << [ signal, pid ] }) do
+            with_replaced_singleton_method(Hive::ProcessKill, :wait_until_process_tree_dead,
+                                           ->(_pid, _targets, _seconds) { true }) do
+              result = Hive::ProcessKill.terminate_process_group(
+                2001, recorded_start_time: "root", grace_seconds: 0
+              )
+
+              assert result.killed
+            end
+          end
+        end
+      end
+    end
+
+    assert_equal [ [ "TERM", 2001 ] ], signals,
+                 "a replacement PID whose ancestry changed must not receive TERM"
+  end
+
   def test_process_tree_unavailable_on_nonzero_ps_exit_still_attempts_root_cleanup
     status = Object.new
     status.define_singleton_method(:success?) { false }
@@ -304,6 +337,86 @@ class ProcessKillTest < Minitest::Test
 
   def test_process_tree_unavailable_on_ps_system_error_still_attempts_root_cleanup
     assert_process_tree_failure_reports_unavailable(->(*_args) { raise Errno::ENOENT })
+  end
+
+  def test_empty_process_tree_with_live_root_attempts_root_cleanup
+    cleanup = []
+    with_replaced_singleton_method(Hive::ProcessKill, :pid_alive?, ->(_pid) { true }) do
+      with_replaced_singleton_method(Hive::ProcessKill, :process_tree_snapshot, ->(_pid) { [] }) do
+        with_replaced_singleton_method(Hive::ProcessKill, :best_effort_terminate_root,
+                                       ->(*args) { cleanup << args }) do
+          result = Hive::ProcessKill.terminate_process_group(4321, grace_seconds: 0.25)
+
+          refute result.killed
+          assert_equal "process_tree_unavailable", result.skipped_reason
+        end
+      end
+    end
+
+    assert_equal [ [ 4321, nil, 0.25 ] ], cleanup
+  end
+
+  def test_process_tree_confirmation_failure_attempts_root_cleanup
+    target = { pid: 4321, ppid: 1, pgid: 4321, start_time: "root", depth: 0 }
+    snapshots = [ [ target ], nil ]
+    cleanup = []
+    with_replaced_singleton_method(Hive::ProcessKill, :pid_alive?, ->(_pid) { true }) do
+      with_replaced_singleton_method(Hive::ProcessKill, :process_tree_snapshot, ->(_pid) { snapshots.shift }) do
+        with_replaced_singleton_method(Hive::ProcessKill, :best_effort_terminate_root,
+                                       ->(*args) { cleanup << args }) do
+          result = Hive::ProcessKill.terminate_process_group(4321, grace_seconds: 0.25)
+
+          refute result.killed
+          assert_equal "process_tree_unavailable", result.skipped_reason
+        end
+      end
+    end
+
+    assert_equal [ [ 4321, nil, 0.25 ] ], cleanup
+  end
+
+  def test_process_tree_confirmation_refuses_reused_root
+    target = { pid: 4321, ppid: 1, pgid: 4321, start_time: "old", depth: 0 }
+    replacement = target.merge(ppid: 99, start_time: "replacement")
+    snapshots = [ [ target ], [ replacement ] ]
+    with_replaced_singleton_method(Hive::ProcessKill, :pid_alive?, ->(_pid) { true }) do
+      with_replaced_singleton_method(Hive::ProcessKill, :pid_owned_by_recorded_start?, ->(*) { true }) do
+        with_replaced_singleton_method(Hive::ProcessKill, :process_tree_snapshot, ->(_pid) { snapshots.shift }) do
+          result = Hive::ProcessKill.terminate_process_group(4321, grace_seconds: 0)
+
+          refute result.killed
+          assert_equal "pid_reuse_guard", result.skipped_reason
+        end
+      end
+    end
+  end
+
+  def test_process_tree_confirmation_checks_recorded_root_identity_again
+    target = { pid: 4321, ppid: 1, pgid: 4321, start_time: "replacement", depth: 0 }
+    with_replaced_singleton_method(Hive::ProcessKill, :pid_alive?, ->(_pid) { true }) do
+      with_replaced_singleton_method(Hive::ProcessKill, :pid_owned_by_recorded_start?, ->(*) { true }) do
+        with_replaced_singleton_method(Hive::ProcessKill, :process_tree_snapshot, ->(_pid) { [ target ] }) do
+          result = Hive::ProcessKill.terminate_process_group(
+            4321, recorded_start_time: "original", grace_seconds: 0
+          )
+
+          refute result.killed
+          assert_equal "pid_reuse_guard", result.skipped_reason
+        end
+      end
+    end
+  end
+
+  def test_terminate_process_group_treats_disappearing_snapshot_as_not_alive
+    with_replaced_singleton_method(Hive::ProcessKill, :pid_alive?, ->(_pid) { true }) do
+      with_replaced_singleton_method(Hive::ProcessKill, :process_tree_snapshot,
+                                     ->(_pid) { raise Errno::ESRCH }) do
+        result = Hive::ProcessKill.terminate_process_group(4321, grace_seconds: 0)
+
+        refute result.killed
+        assert_equal "not_alive", result.skipped_reason
+      end
+    end
   end
 
   def test_process_table_invokes_an_absolute_trusted_ps_path
@@ -323,6 +436,22 @@ class ProcessKillTest < Minitest::Test
     assert command.first.start_with?("/"), "process discovery must not resolve ps through PATH"
     refute_equal "ps", command.first
     assert_equal [ "-axo", "pid=,ppid=,pgid=" ], command.drop(1)
+  end
+
+  def test_process_table_returns_nil_when_no_trusted_ps_exists
+    with_replaced_singleton_method(File, :file?, ->(_path) { false }) do
+      assert_nil Hive::ProcessKill.process_table
+    end
+  end
+
+  def test_process_table_rejects_nonnumeric_rows
+    status = Object.new
+    status.define_singleton_method(:success?) { true }
+    with_system_ps_available do
+      with_replaced_singleton_method(Open3, :capture3, ->(*_args) { [ "pid 1 1\n", "", status ] }) do
+        assert_nil Hive::ProcessKill.process_table
+      end
+    end
   end
 
   def test_malformed_nonblank_ps_row_makes_the_whole_process_tree_unavailable
@@ -388,6 +517,77 @@ class ProcessKillTest < Minitest::Test
   def test_safe_kill_propagates_permission_denied
     with_replaced_singleton_method(Process, :kill, lambda { |_signal, _target| raise Errno::EPERM }) do
       assert_raises(Errno::EPERM) { Hive::ProcessKill.safe_kill("TERM", 1234) }
+    end
+  end
+
+  def test_best_effort_root_cleanup_refuses_reused_pid_before_term
+    signals = []
+    with_replaced_singleton_method(Hive::ProcessKill, :process_start_time, ->(_pid) { "replacement" }) do
+      with_replaced_singleton_method(Hive::ProcessKill, :safe_kill,
+                                     ->(signal, pid) { signals << [ signal, pid ] }) do
+        Hive::ProcessKill.best_effort_terminate_root(1234, "original", 0)
+      end
+    end
+
+    assert_empty signals
+  end
+
+  def test_best_effort_root_cleanup_terms_and_kills_same_pid
+    signals = []
+    with_replaced_singleton_method(Hive::ProcessKill, :process_start_time, ->(_pid) { "original" }) do
+      with_replaced_singleton_method(Hive::ProcessKill, :pid_alive?, ->(_pid) { true }) do
+        with_replaced_singleton_method(Hive::ProcessKill, :wait_until_dead, ->(_pid, _seconds) { false }) do
+          with_replaced_singleton_method(Hive::ProcessKill, :safe_kill,
+                                         ->(signal, pid) { signals << [ signal, pid ] }) do
+            Hive::ProcessKill.best_effort_terminate_root(1234, "original", 0)
+          end
+        end
+      end
+    end
+
+    assert_equal [ [ "TERM", 1234 ], [ "KILL", 1234 ] ], signals
+  end
+
+  def test_best_effort_root_cleanup_never_kills_without_identity
+    signals = []
+    with_replaced_singleton_method(Hive::ProcessKill, :process_start_time, ->(_pid) { nil }) do
+      with_replaced_singleton_method(Hive::ProcessKill, :pid_alive?, ->(_pid) { true }) do
+        with_replaced_singleton_method(Hive::ProcessKill, :wait_until_dead, ->(_pid, _seconds) { false }) do
+          with_replaced_singleton_method(Hive::ProcessKill, :safe_kill,
+                                         ->(signal, pid) { signals << [ signal, pid ] }) do
+            Hive::ProcessKill.best_effort_terminate_root(1234, nil, 0)
+          end
+        end
+      end
+    end
+
+    assert_equal [ [ "TERM", 1234 ] ], signals
+  end
+
+  def test_best_effort_root_cleanup_handles_permission_denied_during_kill
+    signals = []
+    with_replaced_singleton_method(Hive::ProcessKill, :process_start_time, ->(_pid) { "original" }) do
+      with_replaced_singleton_method(Hive::ProcessKill, :pid_alive?, ->(_pid) { true }) do
+        with_replaced_singleton_method(Hive::ProcessKill, :wait_until_dead, ->(_pid, _seconds) { false }) do
+          with_replaced_singleton_method(Hive::ProcessKill, :safe_kill, lambda { |signal, pid|
+            signals << [ signal, pid ]
+            raise Errno::EPERM if signal == "KILL"
+          }) do
+            assert_nil Hive::ProcessKill.best_effort_terminate_root(1234, "original", 0)
+          end
+        end
+      end
+    end
+
+    assert_equal [ [ "TERM", 1234 ], [ "KILL", 1234 ] ], signals
+  end
+
+  def test_best_effort_root_cleanup_handles_permission_denied_during_term
+    with_replaced_singleton_method(Hive::ProcessKill, :process_start_time, ->(_pid) { "original" }) do
+      with_replaced_singleton_method(Hive::ProcessKill, :safe_kill,
+                                     ->(_signal, _pid) { raise Errno::EPERM }) do
+        assert_nil Hive::ProcessKill.best_effort_terminate_root(1234, "original", 0)
+      end
     end
   end
 

--- a/test/unit/stages/brainstorm_tmux_sentinel_test.rb
+++ b/test/unit/stages/brainstorm_tmux_sentinel_test.rb
@@ -307,10 +307,13 @@ class BrainstormTmuxSentinelTest < Minitest::Test
     with_tmp_task_folder do |task|
       Hive::Lock.acquire_task_lock(task.folder, "stage" => "2-brainstorm")
 
-      Hive::ClaudeLauncher.record_claude_pid(task, FakePidRunner.new(12_345))
+      with_replaced_singleton_method(Hive::Lock, :process_start_time, ->(pid) { "start-time-#{pid}" }) do
+        Hive::ClaudeLauncher.record_claude_pid(task, FakePidRunner.new(12_345))
+      end
 
       lock = YAML.safe_load(File.read(File.join(task.folder, ".lock")))
       assert_equal 12_345, lock.fetch("claude_pid")
+      assert_equal "start-time-12345", lock.fetch("claude_pid_start_time")
     ensure
       Hive::Lock.release_task_lock(task.folder)
     end

--- a/wiki/commands/drop.md
+++ b/wiki/commands/drop.md
@@ -3,11 +3,11 @@ title: hive drop
 type: command
 source: lib/hive/commands/drop.rb, lib/hive/web/dispatcher.rb, web/app/controllers/tasks_controller.rb, web/config/routes.rb
 created: 2026-05-22
-updated: 2026-06-23
+updated: 2026-07-09
 tags: [command, task, cleanup, json, tui, web]
 ---
 
-**TLDR**: `hive drop TARGET [--project NAME] [--from STAGE] [--json]` hard-deletes an active task. It kills any recorded agent process, closes the draft PR best-effort, removes the task's worktree and branch, deletes the task folder from every active stage, removes per-slug logs, and records an audit commit on `hive/state`. There is no dropped bucket, archive, undo, reason prompt, or confirmation.
+**TLDR**: `hive drop TARGET [--project NAME] [--from STAGE] [--json]` hard-deletes an active task. It identity-checks the recorded agent with `.lock` start-time metadata (including `claude_pid_start_time`), kills that process plus descendant tool processes present in a successful process-tree snapshot, closes the draft PR best-effort, removes the task's worktree and branch, deletes the task folder from every active stage, removes per-slug logs, and records an audit commit on `hive/state`. There is no dropped bucket, archive, undo, reason prompt, or confirmation.
 
 ## Usage
 
@@ -54,7 +54,7 @@ When a recorded draft PR exists but `gh` is not installed on PATH, draft-PR clos
 
 1. Resolve the task target (`TaskResolver` for paths/ids, Drop's project/stage scan for slugs).
 2. Refuse archived-only tasks in `9-done`.
-3. Kill recorded agent PIDs from `.lock` and `AGENT_WORKING pid=...`, guarded by process start time when available.
+3. Kill recorded agent PIDs from `.lock` and `AGENT_WORKING pid=...`, guarded by process start time when available. In particular, `.lock`'s `claude_pid_start_time` verifies the recorded `claude_pid` identity before cleanup. Before signalling that root PID, snapshot its descendants and terminate the verified PIDs present in that snapshot too. If process-tree discovery fails, cleanup falls back to the recorded root PID only and reports `process_tree_unavailable` instead of claiming a complete tree cleanup.
 4. Close `pr_url` from `pr.md` frontmatter with `gh pr close <url> --comment "task dropped"` best-effort.
 5. Remove the task worktree from `worktree.yml` or the derived path, retrying with force when needed, then prune stale git worktree metadata.
 6. Delete the task branch (`branch name == slug`) best-effort.
@@ -63,6 +63,20 @@ When a recorded draft PR exists but `gh` is not installed on PATH, draft-PR clos
 9. Commit an audit record on `hive/state` as `hive: dropped/<slug> dropped`.
 
 Re-running after an interrupted cleanup converges: already-missing processes, folders, worktrees, PRs, and branches are treated as complete.
+
+`agent_killed_pids` reports the recorded root candidates whose cleanup
+succeeded. It does not enumerate the descendant PIDs terminated as part of that
+root's process tree. `agent_killed` is true when
+at least one recorded candidate was cleaned up, so
+`agent_kill_skipped_reason` can be non-null alongside it when another candidate
+was skipped or only received incomplete cleanup. A
+`process_tree_unavailable` reason means the recorded root cleanup was attempted
+but descendant discovery could not be completed.
+
+The descendant set is a one-time snapshot. A process forked after discovery can
+escape that cleanup window; closing that residual race requires durable
+OS-level containment (for example, a cgroup or equivalent process-lifetime
+boundary), not another assertion around the snapshot algorithm.
 
 ## JSON Contract
 

--- a/wiki/commands/drop.md
+++ b/wiki/commands/drop.md
@@ -54,7 +54,7 @@ When a recorded draft PR exists but `gh` is not installed on PATH, draft-PR clos
 
 1. Resolve the task target (`TaskResolver` for paths/ids, Drop's project/stage scan for slugs).
 2. Refuse archived-only tasks in `9-done`.
-3. Kill recorded agent PIDs from `.lock` and `AGENT_WORKING pid=...`, guarded by process start time when available. In particular, `.lock`'s `claude_pid_start_time` verifies the recorded `claude_pid` identity before cleanup. Before signalling that root PID, snapshot its descendants and terminate the verified PIDs present in that snapshot too. If process-tree discovery fails, cleanup falls back to the recorded root PID only and reports `process_tree_unavailable` instead of claiming a complete tree cleanup.
+3. Kill recorded agent PIDs from `.lock` and `AGENT_WORKING pid=...`, guarded by process start time when available. In particular, `.lock`'s `claude_pid_start_time` verifies the recorded `claude_pid` identity before cleanup. Before signalling that root PID, snapshot its descendants, take a second full snapshot, and retain only PIDs whose parent, process group, and start-time identity match across both reads. This prevents PID reuse between process-table and identity reads from combining an old process's ancestry with a replacement process's identity. If either process-tree discovery fails, cleanup falls back to the recorded root PID only and reports `process_tree_unavailable` instead of claiming a complete tree cleanup.
 4. Close `pr_url` from `pr.md` frontmatter with `gh pr close <url> --comment "task dropped"` best-effort.
 5. Remove the task worktree from `worktree.yml` or the derived path, retrying with force when needed, then prune stale git worktree metadata.
 6. Delete the task branch (`branch name == slug`) best-effort.
@@ -73,8 +73,9 @@ was skipped or only received incomplete cleanup. A
 `process_tree_unavailable` reason means the recorded root cleanup was attempted
 but descendant discovery could not be completed.
 
-The descendant set is a one-time snapshot. A process forked after discovery can
-escape that cleanup window; closing that residual race requires durable
+The descendant set is captured and identity-confirmed across two consecutive
+snapshots. A process forked after confirmation can escape that cleanup window;
+closing that residual race requires durable
 OS-level containment (for example, a cgroup or equivalent process-lifetime
 boundary), not another assertion around the snapshot algorithm.
 

--- a/wiki/gaps.md
+++ b/wiki/gaps.md
@@ -157,7 +157,7 @@ records; and isolates concurrent report generation before atomic publication.
 The remaining gap is still a real judge-enabled run, not structural report
 integrity.
 
-54. **Drop's descendant cleanup still has a snapshot/concurrent-fork race.** `Hive::ProcessKill` can terminate the agent and every verified descendant PID present in a successful process-table snapshot, and it reports `process_tree_unavailable` when discovery cannot support that claim. A child created after the snapshot can still escape before the captured processes are stopped. Fully closing this race requires durable OS-level containment such as a cgroup (or an equivalent cross-platform process-lifetime boundary); repeated best-effort snapshots can narrow but cannot remove the race.
+54. **Drop's descendant cleanup still has a snapshot/concurrent-fork race.** `Hive::ProcessKill` can terminate the agent and every descendant whose parent, process group, and start-time identity agree across two successful process-tree snapshots, and it reports `process_tree_unavailable` when discovery cannot support that claim. The second snapshot closes the PID-reuse window between ancestry and identity reads, but a child created after confirmation can still escape before the captured processes are stopped. Fully closing this race requires durable OS-level containment such as a cgroup (or an equivalent cross-platform process-lifetime boundary); repeated best-effort snapshots can narrow but cannot remove the race.
 
 ## 2026-06-16/17 refresh uncertainty
 

--- a/wiki/gaps.md
+++ b/wiki/gaps.md
@@ -157,6 +157,8 @@ records; and isolates concurrent report generation before atomic publication.
 The remaining gap is still a real judge-enabled run, not structural report
 integrity.
 
+54. **Drop's descendant cleanup still has a snapshot/concurrent-fork race.** `Hive::ProcessKill` can terminate the agent and every verified descendant PID present in a successful process-table snapshot, and it reports `process_tree_unavailable` when discovery cannot support that claim. A child created after the snapshot can still escape before the captured processes are stopped. Fully closing this race requires durable OS-level containment such as a cgroup (or an equivalent cross-platform process-lifetime boundary); repeated best-effort snapshots can narrow but cannot remove the race.
+
 ## 2026-06-16/17 refresh uncertainty
 
 The 2026-06-17 audit rechecked recent source, tests, git history, project wiki

--- a/wiki/log.d/20260709T221000Z-drop-descendant-process-groups.md
+++ b/wiki/log.d/20260709T221000Z-drop-descendant-process-groups.md
@@ -1,14 +1,19 @@
 # Drop terminates descendant processes
 
 `hive drop` now snapshots the recorded agent's descendant processes before
-termination and signals the verified PIDs present in a successful snapshot
-through TERM/KILL escalation. Both headless and tmux launchers now record
+termination, confirms each PID's parent, process group, and start time in a
+second full snapshot, and signals only the verified PIDs present in both reads
+through TERM/KILL escalation. This prevents a PID reused between the ancestry
+and identity reads from inheriting an old process's trusted ancestry. Both
+headless and tmux launchers now record
 `.lock` `claude_pid_start_time` alongside `claude_pid`, and drop compares that
 identity before signalling the child. A process-tree discovery failure falls
 back to root-PID-only cleanup and is reported as incomplete with
 `process_tree_unavailable` rather than as a complete tree kill.
 
-A real-process regression test covers an agent process with a nested tool process.
-The one-shot snapshot still has a concurrent-fork race: a descendant created
-after discovery can escape, and fully closing that gap requires durable
+A real-process regression test covers an agent process with a nested tool process,
+and focused unit coverage pins snapshot failure, PID-reuse, fallback cleanup, and
+permission-denied paths at 100% line coverage for `Hive::ProcessKill`.
+The confirmed snapshot still has a concurrent-fork race: a descendant created
+after confirmation can escape, and fully closing that gap requires durable
 OS-level containment.

--- a/wiki/log.d/20260709T221000Z-drop-descendant-process-groups.md
+++ b/wiki/log.d/20260709T221000Z-drop-descendant-process-groups.md
@@ -1,0 +1,14 @@
+# Drop terminates descendant processes
+
+`hive drop` now snapshots the recorded agent's descendant processes before
+termination and signals the verified PIDs present in a successful snapshot
+through TERM/KILL escalation. Both headless and tmux launchers now record
+`.lock` `claude_pid_start_time` alongside `claude_pid`, and drop compares that
+identity before signalling the child. A process-tree discovery failure falls
+back to root-PID-only cleanup and is reported as incomplete with
+`process_tree_unavailable` rather than as a complete tree kill.
+
+A real-process regression test covers an agent process with a nested tool process.
+The one-shot snapshot still has a concurrent-fork race: a descendant created
+after discovery can escape, and fully closing that gap requires durable
+OS-level containment.

--- a/wiki/modules/agent.md
+++ b/wiki/modules/agent.md
@@ -3,7 +3,7 @@ title: Hive::Agent
 type: module
 source: lib/hive/agent.rb, lib/hive/agent_limit.rb, lib/hive/claude_launcher.rb, lib/hive/scripts/interactive_claude_wrapper.sh
 created: 2026-04-25
-updated: 2026-06-30
+updated: 2026-07-09
 tags: [agent, claude, subprocess]
 ---
 
@@ -131,7 +131,10 @@ tmux-backed Claude sessions, and the shell wrapper forwards `--model` and
 2. `IO.pipe` for child stdout/stderr.
 3. `Process.spawn(*cmd, chdir: cwd, pgroup: true, out: w, err: w)` — `pgroup: true` puts the child in its own process group so we can kill the entire group on signal/timeout.
 4. Capture `pgid` (with `Errno::ESRCH` fallback to pid).
-5. `Hive::Lock.update_task_lock(task.folder, "claude_pid" => pid)` — `hive status` uses this to detect stale agents.
+5. `Hive::Lock.update_task_lock` records both `claude_pid` and
+   `claude_pid_start_time = Hive::Lock.process_start_time(pid)`. `hive status`
+   uses the PID for liveness, and drop cleanup uses the start time to reject a
+   reused PID before signalling the recorded child.
 6. Trap `INT`/`TERM` to forward `kill -TERM -<pgid>`. Old handlers are restored in `ensure`.
 7. Reader thread: `r.each_line` writes timestamped lines to the log, captures the last structured agent final message it recognizes, and captures the first raw stream line whose text matches `Hive::AgentLimit`. Claude-style `result` / `assistant` events and Codex-style `item.completed` assistant messages set `result[:final_message_source] = :structured`; non-JSON output is retained as a bounded plain tail with `:plain` source.
 8. Polling loop: `Process.wait(pid, WNOHANG)` every `[remaining, 0.2].min` seconds until the deadline.
@@ -141,6 +144,11 @@ tmux-backed Claude sessions, and the shell wrapper forwards `--model` and
 12. Return `{pid, pgid, exit_code, timed_out, log_file, final_message, final_message_source, status: nil}`.
 
 `final_message` is for orchestrators that need a human-readable agent answer even when the agent does not edit the state file. 4-execute writes this into `task.md` under `## Execute Output`; only structured final messages satisfy research-mode completion.
+
+Claude/tmux launches record the managed pane PID in the same per-task lock.
+`Hive::ClaudeLauncher#record_claude_pid` waits for `pane_pid`, then writes both
+`claude_pid` and its `claude_pid_start_time`; this gives tmux-backed cleanup the
+same PID-reuse identity guard as headless `Hive::Agent` spawns.
 
 Claude/tmux launches that use `status_mode: :output_file_exists` (reviewers, triage/browser helpers) poll the expected artifact and the managed tmux session together. If the session disappears before the expected file exists and is non-empty, `Hive::ClaudeLauncher` returns `status: :error` with `tmux_session_terminated...` instead of waiting for the full reviewer timeout. If the expected artifact is non-empty and Claude's Stop hook already wrote `.done`, the result is accepted as `:ok`; a non-empty artifact without `.done` is treated as partial and retried rather than being promoted as a successful review. Claude/tmux pane tails are also scanned for provider-limit UI such as Claude's "Stop and wait for limit to reset" / "Add funds to continue with usage credits" menu. When that appears, marker-owned waits stamp `ERROR reason=limits_reached` and expected-output waits return an error message beginning `limits reached for claude:` instead of surfacing generic readiness, timeout, or tmux-session-death errors.
 

--- a/wiki/modules/lock.md
+++ b/wiki/modules/lock.md
@@ -3,7 +3,7 @@ title: Hive::Lock
 type: module
 source: lib/hive/lock.rb
 created: 2026-04-25
-updated: 2026-06-14
+updated: 2026-07-09
 tags: [lock, concurrency, flock, commit-lock]
 ---
 
@@ -27,7 +27,14 @@ tags: [lock, concurrency, flock, commit-lock]
 }
 ```
 
-The runner adds `slug:` and `stage:` to the payload. `Hive::Agent` later injects `claude_pid` via `update_task_lock`, used by `hive status` to detect stale agents.
+The runner adds `slug:` and `stage:` to the payload. After launch, both the
+headless `Hive::Agent` writer and the tmux-backed `Hive::ClaudeLauncher` writer
+inject `claude_pid` plus `claude_pid_start_time` through `update_task_lock`.
+`hive status` uses the child PID for liveness, while cleanup commands compare
+the recorded start time with the live process before signalling it so a reused
+PID cannot target an unrelated process. If the platform cannot read a start
+time, the field is nil and that child-specific PID-reuse guard degrades to its
+existing PID-only behavior.
 
 ## Stale-lock detection (`stale_lock?`)
 
@@ -38,7 +45,9 @@ The runner adds `slug:` and `stage:` to the payload. `Hive::Agent` later injects
    - `EPERM` → process exists but we can't signal → not stale (live).
 4. Read `process_start_time` from the lock and the live `/proc/<pid>/stat` field 22. If recorded ≠ live → PID was reused after we locked → stale.
 
-This is the PID-reuse defence: a fresh process with the same PID would have a different start time.
+This is the runner PID-reuse defence: a fresh process with the same PID would
+have a different start time. The optional `claude_pid_start_time` applies the
+same identity principle to the recorded agent child during cleanup.
 
 ## `process_start_time(pid)`
 

--- a/wiki/state-model.md
+++ b/wiki/state-model.md
@@ -3,7 +3,7 @@ title: State Model
 type: data-model
 source: lib/hive/task.rb, lib/hive/markers.rb, lib/hive/config.rb, lib/hive/lock.rb, lib/hive/worktree.rb, lib/hive/metrics.rb, lib/hive/usage_db.rb, lib/hive/bot/*, lib/hive/patrol/review_handoff.rb, lib/hive/daemon/display_name_backfiller.rb, lib/hive/daemon/dispatch_request_queue.rb, lib/hive/web/status_feed.rb, web/app/models/status_broadcaster.rb
 created: 2026-04-25
-updated: 2026-07-01
+updated: 2026-07-09
 tags: [state, filesystem, model, architecture, review, task-id, display-name, archive, web]
 ---
 
@@ -116,7 +116,7 @@ Recovery from a stale or error marker is agent-callable via `hive markers clear 
 
 ## Concurrency files
 
-- **Per-task lock**: `<task folder>/.lock` — YAML payload `{pid, started_at, process_start_time, claude_pid?, slug?, stage?}`. Acquired EXCL by `Hive::Lock.acquire_task_lock` (`lib/hive/lock.rb:18`). Stale check uses `Process.kill(0, pid)` plus `/proc/<pid>/stat` field-22 cross-check to defeat PID reuse.
+- **Per-task lock**: `<task folder>/.lock` — YAML payload `{pid, started_at, process_start_time, claude_pid?, claude_pid_start_time?, slug?, stage?}`. Acquired EXCL by `Hive::Lock.acquire_task_lock` (`lib/hive/lock.rb:18`). Stale check uses `Process.kill(0, pid)` plus `/proc/<pid>/stat` field-22 cross-check to defeat runner PID reuse. After spawning, both headless `Hive::Agent` and tmux-backed `Hive::ClaudeLauncher` write the child `claude_pid` and its `claude_pid_start_time`; cleanup compares that identity metadata with the live process before signalling so PID reuse cannot target an unrelated child.
 - **Per-project commit lock**: `<project>/.hive-state/.commit-lock` — short flock around the `git add && git commit` in the hive-state worktree to serialize concurrent writers. See [[modules/lock]].
 
 ## Runtime dispatch queue and web snapshots


### PR DESCRIPTION
## Summary

Dropping a running task could report success while a tool subprocess survived: once the recorded agent exited, a subprocess in its own process group was reparented and escaped Hive's root-group cleanup.

`hive drop` now snapshots the agent's descendant PIDs before termination, signals only captured processes rather than broadcasting to potentially shared process groups, and revalidates process start identities before SIGKILL escalation. Headless and tmux launches record `claude_pid_start_time` so stale locks cannot expand cleanup across a reused agent PID. If discovery is unavailable or one of several recorded candidates cannot be cleaned up, the JSON result preserves `agent_kill_skipped_reason` instead of claiming complete cleanup.

The snapshot closes the observed orphan path without pretending to be kernel-level containment: a process forked after the snapshot remains a documented residual race.

## Test plan

- Real process-tree regression: root -> wrapper -> separate-PGID grandchild that ignores SIGTERM and requires SIGKILL escalation
- `bundle exec rake test` — 7,422 runs, 76,038 assertions, 0 failures, 0 errors
- Focused drop integration — 11 runs, 67 assertions, 0 failures
- Focused RuboCop on all changed Ruby files — no offenses

## Post-Deploy Monitoring & Validation

- Exercise `hive drop <task> --json` on a running agent with a nested tool process and verify the recorded root and captured descendants are gone.
- Treat a non-null `agent_kill_skipped_reason`, especially `process_tree_unavailable`, as incomplete cleanup requiring operator verification.
- Watch for surviving harness/container processes after successful drops. Any recurrence means the snapshot boundary is insufficient for that launcher and the change should be rolled back while durable process containment is designed.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
