### PR TITLE
Hive patrol: Security-sensitive glued option branches lack regression tests

### DIFF
--- a/test/unit/babysitter/dry_run_env_test.rb
+++ b/test/unit/babysitter/dry_run_env_test.rb
@@ -610,6 +610,14 @@ class BabysitterDryRunEnvTest < Minitest::Test
       assert_stubbed env, "gh", "api", "repos/owner/repo/issues/123/comments", "--input", "payload.json"
       assert_stubbed env, "gh", "api", "--method", "GET", "repos/owner/repo/issues", "--input", "payload.json"
       assert_stubbed env, "gh", "api", "--method", "GET", "repos/owner/repo/issues", "-F", "q=@secret"
+      [
+        [ "api", "--method=POST", "repos/owner/repo/dispatches" ],
+        [ "api", "-XPOST", "repos/owner/repo/dispatches" ],
+        [ "api", "-X=POST", "repos/owner/repo/dispatches" ],
+        [ "api", "repos/owner/repo/issues/123/comments", "-fbody=hi" ],
+        [ "api", "repos/owner/repo/issues/123/comments", "--raw-field=body=hi" ],
+        [ "auth", "status", "--show-token=true" ]
+      ].each { |args| assert_stubbed env, "gh", *args }
       assert_stubbed env, "gh", "workflow", "run", "release.yml"
       assert_stubbed env, "gh", "totally-new-write-command", "arg"
       assert_stubbed env, "gh", "repo", "view", "--web"
@@ -704,6 +712,9 @@ class BabysitterDryRunEnvTest < Minitest::Test
       assert_passes env, "gh", "api", "-ip", "shadow-cat", "repos/owner/repo"
       assert_passes env, "gh", "api", "--method", "GET", "repos/owner/repo/issues", "-f", "state=open"
       assert_passes env, "gh", "api", "--method", "GET", "repos/owner/repo/issues", "-F", "state=open"
+      %w[--method=GET -XGET -X=GET].each do |method|
+        assert_passes env, "gh", "api", method, "repos/owner/repo/issues"
+      end
       # The safe positional forms must still reach real gh, so the new positional
       # gate does not over-block: a bare `OWNER/REPO` slug (one slash) on `repo view`,
       # a numeric operand on `pr view`, and a slash-bearing branch ref the pr-URL rule


### PR DESCRIPTION
## Hive Patrol Finding

Slice: `command-bin-hive-babysitter-stub-gh`
Category: `test-gap`
Severity: `medium`
Confidence: `high`
Fingerprint: `4da6d5420f401909ffedbe41e7b97af4928a2849396349f55c25f558ec4035d5`

The classifier has separate branches for glued API method and payload forms (`--method=POST`, `-XPOST`, `-X=POST`, `-fbody=...`, and `--raw-field=...`) and for inline token disclosure (`--show-token=...`). The focused suite covers the corresponding separate forms but not these branches, so a regression in their regex handling could allow a mutation or token disclosure while the suite remains green.

## Evidence

- bin/hive-babysitter-stub-gh:240 when /\A--method=(.+)\z/
- bin/hive-babysitter-stub-gh:243 when /\A-X=?(.+)\z/
- bin/hive-babysitter-stub-gh:262 when /\A-f.+\z/, /\A--raw-field=.+\z/
- bin/hive-babysitter-stub-gh:297 return true if arg == "--show-token" || arg.start_with?("--show-token=")
- test/unit/babysitter/dry_run_env_test.rb:519 assert_stubbed env, "gh", "api", "-X", "POST", "repos/owner/repo/dispatches"
- test/unit/babysitter/dry_run_env_test.rb:520 assert_stubbed env, "gh", "api", "repos/owner/repo/issues/123/comments", "-f", "body=hi"
- test/unit/babysitter/dry_run_env_test.rb:532 assert_stubbed env, "gh", "auth", "status", "--show-token"

## Applied Fix

Add table-driven skip cases for each glued POST/payload spelling and `auth status --show-token=true`, paired with passthrough cases for `--method=GET`, `-XGET`, and `-X=GET` to prevent over-blocking.

## Validation

- lint: passed (`bundle exec rubocop`)
- test: passed (`bundle exec rake test`)

## Diffstat

```text
 test/unit/babysitter/dry_run_env_test.rb | 11 +++++++++++
 1 file changed, 11 insertions(+)

```
