### PR TITLE
Hive patrol: Pre-dispatch JSON errors are missing or use the wrong schema

### DIFF
--- a/bin/hive
+++ b/bin/hive
@@ -38,20 +38,19 @@ JSON_USAGE_ERROR_CONTRACTS = {
     extras: { "operation" => "reject" }
   },
   "markers" => { schema: "hive-markers-clear", error_kind: "invalid_task_path" },
-  "digest" => { schema: "hive-digest", error_kind: "usage" },
-  "pairing" => { schema: "hive-pairing-approve", error_kind: "usage" },
+  "status" => { schema: "hive-status", error_kind: "error" },
+  "prune" => { schema: "hive-prune", error_kind: "usage" },
+  "forget" => { schema: "hive-forget", error_kind: "usage" },
+  "metrics" => {
+    schema: "hive-metrics-rollback-rate",
+    error_kind: "error",
+    omit_error_class: true
+  },
   "answer-digest" => { schema: "hive-answer-digest", error_kind: "usage" },
   # Residual workflow argv-shape errors raised by Thor before command dispatch
   # (for example too many positionals) must ride the same JSON envelope as the
   # command's own UsageError. Bare `hive workflow` is handled in-command.
   "workflow" => { schema: "hive-workflow-new", error_kind: "usage" },
-  # `hive bot` takes a single SUBCOMMAND positional and (unlike `daemon`) has no
-  # `*targets` splat, so an extra positional such as `hive bot status extra` is
-  # rejected by Thor before `Hive::Commands::Bot#call` runs — bypassing the
-  # command-level usage-error emitters. Ride the same hive-bot-status envelope
-  # those emitters use so every `hive bot ... --json` usage error still produces
-  # an ok:false document on stdout instead of bare Thor prose on stderr.
-  "bot" => { schema: "hive-bot-status", error_kind: "extra_arguments" },
   "pr" => {
     schema: "hive-stage-action",
     error_kind: "invalid_task_path",
@@ -220,18 +219,24 @@ end
 
 DIGEST_MERGED_PRS_SOURCE = "merged-prs".freeze
 
+def json_usage_option_region(argv, command_index)
+  argv.drop(command_index + 1).take_while { |arg| arg != "--" }
+end
+
 # Mirror Commands::Digest#normalized_source at the argv level: the merged-PR
 # path is selected by `--source merged-prs` or by any `--repo` with no other
 # --source. A Thor usage error there (e.g. `hive digest --source merged-prs
-# --bad --json`) is raised before the command runs, so without this the static
-# "digest" contract would emit the shipped-digest `hive-digest` schema instead
-# of the `hive-merged-pr-digest` envelope the command itself emits.
+# --bad --json`) is raised before the command runs, so the resolver must select
+# `hive-merged-pr-digest` instead of the shipped-digest `hive-digest` schema.
 def digest_merged_pr_argv?(argv)
   source = nil
   repo = false
   argv.each_with_index do |arg, idx|
+    next unless arg.valid_encoding?
+
     if arg == "--source"
-      source = argv[idx + 1].to_s
+      value = argv[idx + 1]
+      source = value.to_s if value&.valid_encoding?
     elsif arg.start_with?("--source=")
       source = arg.split("=", 2).last
     elsif arg == "--repo" || arg.start_with?("--repo=")
@@ -243,10 +248,63 @@ def digest_merged_pr_argv?(argv)
   source.to_s.strip.empty? && repo
 end
 
+def json_usage_subcommand(argv, command_index, value_options: [])
+  skip_value = false
+  options = true
+  argv.drop(command_index + 1).each do |arg|
+    if skip_value
+      skip_value = false
+      next
+    end
+    return unless arg.valid_encoding?
+
+    if options && arg == "--"
+      options = false
+    elsif options && value_options.include?(arg)
+      skip_value = true
+    elsif options && arg.start_with?("-")
+      next
+    else
+      return arg
+    end
+  end
+  nil
+end
+
 def json_usage_error_contract(argv)
-  command = argv.find { |arg| !arg.start_with?("-") }
-  if command == "digest" && digest_merged_pr_argv?(argv)
-    return { schema: "hive-merged-pr-digest", error_kind: "usage" }
+  command_index = argv.index { |arg| !arg.b.start_with?("-") }
+  return unless command_index
+
+  command = argv.fetch(command_index)
+  return unless command.valid_encoding?
+  option_argv = json_usage_option_region(argv, command_index)
+
+  case command
+  when "status"
+    diagnose = option_argv.any? do |arg|
+      arg.valid_encoding? && (arg == "--diagnose" || arg.start_with?("--diagnose="))
+    end
+    return { schema: "hive-status-diagnose", error_kind: "error" } if diagnose
+  when "web"
+    subcommand = json_usage_subcommand(argv, command_index, value_options: %w[--bind --port])
+    return unless %w[install status].include?(subcommand)
+
+    return {
+      schema: "hive-web-#{subcommand}",
+      error_kind: "invalid_task_path",
+      schema_version: false
+    }
+  when "bot"
+    # hive-bot-status is deliberately the usage-error contract for the whole
+    # bot surface; the stop/reload schemas only describe lifecycle results.
+    return { schema: "hive-bot-status", error_kind: "extra_arguments" }
+  when "pairing"
+    subcommand = json_usage_subcommand(argv, command_index)
+    schema = subcommand == "approve" ? "hive-pairing-approve" : "hive-pairing-list"
+    return { schema: schema, error_kind: "invalid_arguments" }
+  when "digest"
+    schema = digest_merged_pr_argv?(option_argv) ? "hive-merged-pr-digest" : "hive-digest"
+    return { schema: schema, error_kind: "usage" }
   end
 
   JSON_USAGE_ERROR_CONTRACTS[command]
@@ -257,12 +315,14 @@ def json_usage_error_payload(contract, error)
   error_kind = contract.fetch(:error_kind)
   extras = contract.fetch(:extras, {})
   if schema && Hive::Schemas::SCHEMA_VERSIONS.key?(schema)
-    return Hive::Schemas::ErrorEnvelope.build(
+    payload = Hive::Schemas::ErrorEnvelope.build(
       schema: schema,
       error: error,
       error_kind: error_kind,
       extras: extras
     )
+    payload.delete("error_class") if contract[:omit_error_class]
+    return payload
   end
 
   payload = {}

--- a/lib/hive.rb
+++ b/lib/hive.rb
@@ -304,6 +304,7 @@ module Hive
     # other ErrorKind modules so a constant added without a schema-enum
     # update is caught by schema_files_test.
     module ForgetErrorKind
+      USAGE           = "usage".freeze
       MISSING_NAME    = "missing_name".freeze
       UNKNOWN_PROJECT = "unknown_project".freeze
       CONFIG          = "config".freeze

--- a/schemas/hive-forget.v1.json
+++ b/schemas/hive-forget.v1.json
@@ -121,12 +121,13 @@
         "error_kind": {
           "type": "string",
           "enum": [
+            "usage",
             "missing_name",
             "unknown_project",
             "config",
             "internal"
           ],
-          "description": "missing_name = NAME positional was empty/whitespace. unknown_project = NAME does not match any registry entry without --if-exists. config = malformed config.yml or missing $HIVE_HOME (exit 78). internal = uncategorised crash (exit 70)."
+          "description": "usage = malformed invocation rejected before command dispatch (exit 64). missing_name = NAME positional was empty/whitespace. unknown_project = NAME does not match any registry entry without --if-exists. config = malformed config.yml or missing $HIVE_HOME (exit 78). internal = uncategorised crash (exit 70)."
         },
         "exit_code": {
           "type": "integer",

--- a/test/integration/cli_usage_error_json_test.rb
+++ b/test/integration/cli_usage_error_json_test.rb
@@ -24,6 +24,32 @@ class CliUsageErrorJsonTest < Minitest::Test
     Open3.capture3({ "HIVE_HOME" => home }, RbConfig.ruby, "-Ilib", HIVE_BIN, *args)
   end
 
+  def assert_pre_dispatch_error(home, argv, schema:, error_kind:)
+    out, _err, status = run_hive(home, *argv)
+
+    refute status.success?, "#{argv.inspect} should fail"
+    assert_equal Hive::ExitCodes::USAGE, status.exitstatus
+    payload = JSON.parse(out)
+    assert_equal schema, payload["schema"]
+    assert_equal false, payload["ok"]
+    if schema == "hive-metrics-rollback-rate"
+      refute payload.key?("error_class"), "the metrics v1 error schema has no error_class field"
+    else
+      assert_equal "InvalidTaskPath", payload["error_class"]
+    end
+    assert_equal error_kind, payload["error_kind"]
+    assert_equal Hive::ExitCodes::USAGE, payload["exit_code"]
+
+    if Hive::Schemas::SCHEMA_VERSIONS.key?(schema)
+      assert_equal Hive::Schemas::SCHEMA_VERSIONS.fetch(schema), payload["schema_version"]
+      schemer = JSONSchemer.schema(JSON.parse(File.read(Hive::Schemas.schema_path(schema))))
+      assert_empty schemer.validate(payload).map { |error| error["error"] },
+                   "#{argv.inspect} envelope must validate against #{schema}"
+    else
+      refute payload.key?("schema_version"), "#{schema} is an unversioned legacy envelope"
+    end
+  end
+
   def test_json_usage_errors_emit_envelopes_before_command_dispatch
     cases = [
       [ %w[run --json], "hive-run", {} ],
@@ -280,8 +306,8 @@ class CliUsageErrorJsonTest < Minitest::Test
   # command-level usage-error emitters. With --json it must still ride the
   # hive-bot-status envelope via the bin/hive "bot" usage-error contract
   # (error_kind "extra_arguments", error_class "InvalidTaskPath", exit 64), not
-  # bare Thor arity prose on stderr. This is the sole reason the "bot" entry
-  # exists in JSON_USAGE_ERROR_CONTRACTS.
+  # bare Thor arity prose on stderr. This is the sole reason the resolver has a
+  # dedicated `bot` branch in json_usage_error_contract.
   def test_bot_extra_positional_json_usage_error_rides_bot_status_envelope
     schemer = JSONSchemer.schema(JSON.parse(File.read(Hive::Schemas.schema_path("hive-bot-status"))))
     with_tmp_global_config do |home|
@@ -316,6 +342,64 @@ class CliUsageErrorJsonTest < Minitest::Test
       assert_equal Hive::ExitCodes::USAGE, status.exitstatus
       assert_empty out
       assert_match(/was called with arguments \["status", "extra"\]/, err)
+    end
+  end
+
+  def test_documented_json_surfaces_wrap_thor_arity_errors
+    cases = [
+      [ %w[status extra --json], "hive-status", "error" ],
+      [ %w[status --diagnose task extra --json], "hive-status-diagnose", "error" ],
+      [ %w[status --json -- extra --diagnose=task], "hive-status", "error" ],
+      [ %w[prune extra --json], "hive-prune", "usage" ],
+      [ %w[forget project extra --json], "hive-forget", "usage" ],
+      [ %w[metrics rollback-rate extra --json], "hive-metrics-rollback-rate", "error" ],
+      [ %w[web status extra --json], "hive-web-status", "invalid_task_path" ],
+      [ %w[web install extra --json], "hive-web-install", "invalid_task_path" ],
+      [ %w[web --bind install status extra --json], "hive-web-status", "invalid_task_path" ],
+      [ %w[digest extra --json], "hive-digest", "usage" ],
+      [ %w[digest --json -- extra --source merged-prs], "hive-digest", "usage" ],
+      [ %w[digest --source merged-prs extra --json], "hive-merged-pr-digest", "usage" ]
+    ]
+
+    with_tmp_global_config do |home|
+      cases.each do |argv, schema, error_kind|
+        assert_pre_dispatch_error(home, argv, schema: schema, error_kind: error_kind)
+      end
+    end
+  end
+
+  def test_invalid_byte_errors_use_the_selected_json_surface
+    invalid = "bad\xFF".b
+    cases = [
+      [ [ "status", "--diagnose", "task", "--json", invalid ], "hive-status-diagnose", "error" ],
+      [ [ "web", "status", "--json", invalid ], "hive-web-status", "invalid_task_path" ],
+      [ [ "bot", "status", "--json", invalid ], "hive-bot-status", "extra_arguments" ],
+      [ [ "pairing", "list", "--json", invalid ], "hive-pairing-list", "invalid_arguments" ],
+      [ [ "pairing", "unknown", "approve", "--json", invalid ],
+        "hive-pairing-list", "invalid_arguments" ],
+      [ [ "pairing", "approve", "telegram", "CODE", "--json", invalid ],
+        "hive-pairing-approve", "invalid_arguments" ],
+      [ [ "digest", "--json", invalid ], "hive-digest", "usage" ],
+      [ [ "digest", "--source", invalid, "--json" ], "hive-digest", "usage" ],
+      [ [ "digest", "--source", "merged-prs", "--json", invalid ],
+        "hive-merged-pr-digest", "usage" ]
+    ]
+
+    with_tmp_global_config do |home|
+      cases.each do |argv, schema, error_kind|
+        assert_pre_dispatch_error(home, argv, schema: schema, error_kind: error_kind)
+      end
+    end
+  end
+
+  def test_invalid_command_encoding_is_not_attributed_to_a_later_command
+    with_tmp_global_config do |home|
+      out, err, status = run_hive(home, "bad\xFF".b, "status", "--json")
+
+      refute status.success?
+      assert_equal Hive::ExitCodes::USAGE, status.exitstatus
+      assert_empty out
+      assert_match(/invalid byte sequence/, err)
     end
   end
 

--- a/test/unit/schema_files_test.rb
+++ b/test/unit/schema_files_test.rb
@@ -1241,6 +1241,8 @@ class SchemaFilesTest < Minitest::Test
   def test_hive_forget_error_payload_validates_for_every_kind
     schemer = JSONSchemer.schema(JSON.parse(File.read(Hive::Schemas.schema_path("hive-forget"))))
     cases = {
+      Hive::Schemas::ForgetErrorKind::USAGE =>
+        Hive::Commands::Forget::UsageError.new("usage", error_kind: Hive::Schemas::ForgetErrorKind::USAGE),
       Hive::Schemas::ForgetErrorKind::MISSING_NAME =>
         Hive::Commands::Forget::UsageError.new("missing", error_kind: Hive::Schemas::ForgetErrorKind::MISSING_NAME),
       Hive::Schemas::ForgetErrorKind::UNKNOWN_PROJECT =>

--- a/wiki/cli.md
+++ b/wiki/cli.md
@@ -3,7 +3,7 @@ title: CLI Surface
 type: api
 source: bin/hive, bin/hv, lib/hive/cli.rb
 created: 2026-04-25
-updated: 2026-06-30
+updated: 2026-07-10
 tags: [cli, api]
 ---
 
@@ -60,6 +60,15 @@ sibling shape, `setup` keeps the unversioned `hive-setup` shape, and Screenote
 (`pr` maps to `open-pr`), finding toggles include `operation`, and patrol's
 pre-dispatch usage failure uses the `hive-patrol` schema with
 `error_kind: "error"`.
+
+The pre-dispatch resolver is command/subcommand-aware for JSON surfaces whose
+schema varies by argv. It distinguishes status diagnostics, web install/status,
+pairing list/approve, and shipped/merged-PR digest errors; it also covers Thor
+arity failures for status, prune, forget, metrics, bot, and the documented web
+commands. Option values cannot impersonate subcommands, and flags after the
+`--` terminator remain positional data rather than switching the status or
+digest schema. Existing setup, Screenote connect/disconnect, and other static
+contracts retain their established unversioned or schema-less shapes.
 
 `bin/hv` is a bash fallback launcher for Apache Hive name collisions. It deliberately avoids `command -v hive`; instead it probes only `HIVE_BIN_OVERRIDE`, `${XDG_BIN_HOME:-$HOME/.local/bin}/hive`, `${HOMEBREW_PREFIX:-/opt/homebrew}/bin/hive`, and `/usr/local/bin/hive`, skipping a target that resolves back to itself. Each `--version` probe runs in its own process group with temp-file stdout capture and a watchdog/KILL sweep, so a bad candidate cannot keep `hv` blocked by forking a stdout-inheriting child. When the watchdog's timeout elapses it records a sentinel, and `probe_version` forces a non-zero (124, mirroring GNU `timeout`) status regardless of the probe's own exit code — so a candidate that prints a bare semver and then hangs (trapping the watchdog's TERM to exit 0) is rejected rather than exec'd. It does not implicitly exec `/usr/bin/hive` or `/opt/hive/bin/hive`, because those paths may be Apache Hive installs. If no candidate is executable it exits `127` and tells the operator to set `HIVE_BIN_OVERRIDE` or install through the documented channels. `bin/hv` remains in the gem payload for channel installers to copy/read, but it is not listed in `spec.executables`; RubyGems would otherwise generate a Ruby binstub for this bash launcher. See [[operating]] for channel-level `hv` behavior.
 

--- a/wiki/commands/forget.md
+++ b/wiki/commands/forget.md
@@ -78,6 +78,7 @@ For the bulk-of-stale-entries case, prefer `hive prune`. The TUI grid Shift+X ke
 
 | `error_kind` | Exit | Cause |
 |---|---|---|
+| `usage` | 64 | malformed argv rejected before command dispatch |
 | `missing_name` | 64 | NAME positional was empty/whitespace |
 | `unknown_project` | 64 | NAME does not match any registry entry and `--if-exists` was not passed |
 | `config` | 78 | malformed `config.yml` or missing `$HIVE_HOME` |

--- a/wiki/log.d/20260710T084512Z-json-usage-contract-resolution.md
+++ b/wiki/log.d/20260710T084512Z-json-usage-contract-resolution.md
@@ -1,0 +1,25 @@
+---
+title: Variant-aware pre-dispatch JSON usage contracts
+type: log
+created: 2026-07-10
+tags: [cli, json, schemas, thor, argv]
+---
+
+**Action:** Replaced the wrapper's command-only JSON usage lookup with
+variant-aware resolution for status/diagnose, web status/install, pairing
+list/approve, and shipped/merged-PR digest output. Added the previously omitted
+status, prune, forget, and metrics contracts while preserving the established
+whole-bot `hive-bot-status` usage-error schema. The positional resolver consumes
+known option values and fails closed on an invalid command token, preventing a
+later argument from impersonating a command or subcommand. Forget's closed
+error-kind enum now distinguishes wrapper-level `usage` from `internal` faults.
+The resolver also stops option interpretation at `--`, so later flag-looking
+positionals cannot switch the status or digest schema.
+
+**Evidence:** `test/integration/cli_usage_error_json_test.rb` now drives the
+real `bin/hive` subprocess through Thor extra-positional failures and the
+pre-Thor invalid-encoding guard, parses every stdout envelope, and validates
+registered surfaces against their published JSON schemas. Legacy web JSON
+envelopes remain unversioned to match their successful output. Collision cases
+cover web option values, later pairing arguments, invalid digest source values,
+and invalid command-position bytes.

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -3,7 +3,7 @@ title: Testing
 type: reference
 source: test/, Rakefile, bin/hive-eval, .rubocop.yml, .github/workflows/ci.yml, .github/workflows/release.yml, config/brakeman.ignore
 created: 2026-04-25
-updated: 2026-07-09
+updated: 2026-07-10
 tags: [test, minitest, fixtures]
 ---
 
@@ -142,6 +142,11 @@ task default: :test
 | `tui_smoke_test.rb`, `tui_smoke_charm_test.rb` | PTY-driven `bin/hive tui` smokes — boot, first useful paint with a seeded project, clean `q` exit, horizontal and vertical resize handling, and the startup regression gate (a generous 5s bound that catches a revert to the starved-poll loading grid without flaking; the 10s read_until is the hard gate). |
 | `skip_worktree_test.rb` | Verifies hive-state commits on master don't leak into feature worktrees. |
 | `bot/pairing_flow_test.rb` | Telegram pairing flow acceptance — empty-allowlist bootstrap with pairing enabled, unauthorized `/start` reply/throttle, owner approval writing global config and approval notice, reaper-delivered approved DM, reload authorization, and unknown/expired code rejection without allowlist mutation. |
+
+Pre-dispatch JSON integration coverage also exercises variant-aware status,
+web, pairing, bot, and digest error envelopes, including option-value collisions,
+invalid encodings, and `--` terminators that keep later flag-looking positionals
+from changing the selected schema.
 
 ## E2E suite (`test/e2e/`)
 


### PR DESCRIPTION
## Hive Patrol Finding

Slice: `command-bin-hive`
Category: `bug`
Severity: `medium`
Confidence: `high`
Fingerprint: `e05a1313f14ae56102c03c3f3361fdf9c0d4e66914b768889b36e528d672d90f`

The wrapper routes Thor errors through a command-only allowlist. Documented JSON surfaces including status, prune, forget, metrics, and web are absent, so an ordinary arity error such as `hive status extra --json` exits 64 with empty stdout and Thor prose instead of a JSON envelope. The same table hard-codes pairing to `hive-pairing-approve`, so a pre-dispatch error for `hive pairing list --json` emits the approve schema rather than `hive-pairing-list`.

## Evidence

- bin/hive:38 "pairing" => { schema: "hive-pairing-approve", error_kind: "usage" },
- bin/hive:248 JSON_USAGE_ERROR_CONTRACTS[command]
- bin/hive:277 return false unless contract && json_requested?(argv)

## Applied Fix

Replace the partial command-only lookup with a command/subcommand-aware contract resolver covering every documented JSON surface, including dynamic status-diagnose, web, bot, pairing, and digest variants. Add subprocess tests for extra positionals and invalid-encoding argv that parse and schema-validate each emitted error envelope.

## Validation

- lint: passed (`bundle exec rubocop`)
- test: passed (`bundle exec rake test`)

## Diffstat

```text
 bin/hive                                           | 96 +++++++++++++++++-----
 lib/hive.rb                                        |  1 +
 schemas/hive-forget.v1.json                        |  3 +-
 test/integration/cli_usage_error_json_test.rb      | 86 ++++++++++++++++++-
 test/unit/schema_files_test.rb                     |  2 +
 wiki/cli.md                                        | 27 ++++--
 wiki/commands/forget.md                            |  1 +
 ...60710T084512Z-json-usage-contract-resolution.md | 23 ++++++
 wiki/testing.md                                    |  2 +-
 9 files changed, 208 insertions(+), 33 deletions(-)

```
