### PR TITLE
Hive patrol: Existing skip logs can remain group- or world-writable

### DIFF
--- a/bin/hive-babysitter-skip-log.rb
+++ b/bin/hive-babysitter-skip-log.rb
@@ -31,6 +31,7 @@ def append_skip_log(path)
     raise IOError, "dry-run skip log is not a regular file" unless stat.file?
     raise IOError, "dry-run skip log is not owned by uid #{Process.uid}" unless stat.uid == Process.uid
     raise IOError, "dry-run skip log link count is not 1" unless stat.nlink == 1
+    raise IOError, "dry-run skip log permissions are not private" unless (stat.mode & 0o077).zero?
   rescue Errno::ENOENT
     # Missing logs are created below; the fstat check still verifies the opened target.
   end
@@ -40,6 +41,7 @@ def append_skip_log(path)
     raise IOError, "dry-run skip log is not a regular file" unless stat.file?
     raise IOError, "dry-run skip log is not owned by uid #{Process.uid}" unless stat.uid == Process.uid
     raise IOError, "dry-run skip log link count is not 1" unless stat.nlink == 1
+    raise IOError, "dry-run skip log permissions are not private" unless (stat.mode & 0o077).zero?
 
     yield file
   end

--- a/test/unit/babysitter/dry_run_env_test.rb
+++ b/test/unit/babysitter/dry_run_env_test.rb
@@ -508,6 +508,29 @@ class BabysitterDryRunEnvTest < Minitest::Test
     end
   end
 
+  def test_stubs_refuse_group_or_world_accessible_skip_logs
+    with_tmp_dir do |dir|
+      [ 0o644, 0o666 ].each do |mode|
+        [
+          [ "git", [ "commit", "-m", "insecure-log" ] ],
+          [ "gh", [ "pr", "comment", "42", "--body", "insecure-log" ] ]
+        ].each do |binary, args|
+          log = File.join(dir, "#{binary}-#{mode.to_s(8)}.log")
+          File.write(log, "existing\n")
+          File.chmod(mode, log)
+
+          _out, err, status = Open3.capture3({ "HIVE_BABYSITTER_DRY_RUN_LOG" => log }, stub_path(binary), *args)
+
+          assert status.success?, err
+          assert_equal "existing\n", File.read(log)
+          assert_equal mode, File.stat(log).mode & 0o777
+          assert_includes err, "dry-run skip log permissions are not private"
+          assert_includes err, "[dry-run] #{binary} #{args.join(' ')} skipped"
+        end
+      end
+    end
+  end
+
   def test_stubs_refuse_fifo_skip_log_without_blocking
     with_tmp_dir do |dir|
       fifo = File.join(dir, "skipped.fifo")

--- a/wiki/commands/babysit.md
+++ b/wiki/commands/babysit.md
@@ -83,6 +83,11 @@ For `gh api`, payload-bearing forms are treated as writes unless the command exp
 
 The dry-run guard is best-effort: an agent that invokes absolute binary paths can bypass the PATH overlay. Use throwaway repos for destructive validation until a stronger sandbox exists. If `HIVE_BABYSITTER_REAL_GIT` is unset or points at an invalid binary, the stub exits 127 with a one-line diagnostic instead of guessing a system path.
 
+Existing skip logs must already be private: both the pre-open and post-open
+checks reject any file with group or world permission bits. The blocked command
+still returns synthetic success and emits the stderr marker plus an audit-write
+warning, but the permissive file is left untouched and receives no new argv.
+
 ## Tests
 
 - `test/unit/commands/babysit_test.rb` covers CLI flag validation, lifecycle helpers, foreground `restart`, detached restart re-exec into `start --detach`, stale-runtime status recommendations, stale-runtime reload warnings, refused-stop failures, PID-file cleanup races, and bounded PID-lock behavior.

--- a/wiki/log.d/20260710T093234Z-babysitter-skip-log-private-permissions.md
+++ b/wiki/log.d/20260710T093234Z-babysitter-skip-log-private-permissions.md
@@ -1,0 +1,18 @@
+## [2026-07-10T09:32:34Z] babysitter - reject non-private existing skip logs
+
+**Action:** Fixed Hive patrol finding `command-bin-hive-3` by extending the
+shared dry-run skip-log helper's existing pre-open and post-open identity checks
+to reject files with any group or world permission bits. The `0600` create mode
+does not alter a pre-existing file, so accepting an existing `0644` or `0666`
+log could disclose skipped argv and let another local user forge the audit
+trail.
+
+**Coverage:** Added a focused regression for both the `git` and `gh` stubs that
+verifies existing `0644` and `0666` logs remain untouched and the skipped
+command still exits successfully with a warning. Verified the full
+`test/unit/babysitter/dry_run_env_test.rb` suite.
+
+**Refreshed pages:**
+- [[commands/babysit]]
+- [[modules/babysitter]]
+- [[testing]]

--- a/wiki/modules/babysitter.md
+++ b/wiki/modules/babysitter.md
@@ -3,7 +3,7 @@ title: Hive::Babysitter
 type: module
 source: lib/hive/babysitter/, bin/hive-babysitter-stub-git, bin/hive-babysitter-stub-gh, bin/hive-babysitter-skip-log.rb
 created: 2026-05-26
-updated: 2026-06-19
+updated: 2026-07-10
 tags: [babysitter, module, daemon, github, agents]
 ---
 
@@ -84,6 +84,11 @@ Closed outcome enum: `success`, `failure`, `conflict`, `timeout`, `budget_exhaus
 
 - Skip-log FIFO hardening: both dry-run stubs now preflight existing skip-log targets with `File.lstat`, open with `File::NOFOLLOW | File::NONBLOCK`, keep the post-open regular-file/owner check, and warn while still skipping when a FIFO, symlink, device, or non-owned path is configured.
 - Git dry-run passthrough skips `--submodule=diff` and the split `--submodule diff` form because expanded submodule diffs can enter nested repositories outside the top-level `--no-ext-diff --no-textconv` hardening. The same submodule mode can also be selected by worktree config (`diff.submodule=diff`/`log`) with no `--submodule` token in argv, so passthrough injects `-c diff.submodule=short` to pin the inert commit-hash summary format.
+
+Skip-log permission checks are fail-closed. Existing `0644`, `0666`, or other
+group/world-accessible targets are rejected both before and after the
+no-follow open; the stubs warn and skip the persistent append while continuing
+to block the command.
 
 ## Backlinks
 

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -116,6 +116,11 @@ task default: :test
 | `tui/clipboard_test.rb` | `Hive::Tui::Clipboard` — Wayland/X11/macOS clipboard-command selection, image-byte/file probes, image signature and size guards, test-only fixture clipboard sequencing, timeout sentinels, and `DefaultShim.capture3` stdout/stderr/timeout behavior. Generic subprocess checks use tiny executable fixture scripts rather than nested `RbConfig.ruby` children so coverage-injected `RUBYOPT` does not dominate unrelated timeout assertions. |
 | `tui/app_test.rb`, `tui/state_source_test.rb` | `Hive::Tui::App` / `StateSource` — charm-only backend selection, synchronous startup snapshot seeding, snapshot-poller dedup/error dispatch, HUP termination hook, WINCH terminal-size seeding/dispatch, unavailable tty-size handling, signal-handler restore failure tolerance, mtime-gated refresh reuse, and liveness-fallback reparsing. |
 
+`babysitter/dry_run_env_test.rb` also pins the private-permission boundary for
+both dry-run stubs: pre-existing `0644` and `0666` audit logs are left unchanged,
+the blocked invocation is not appended, and stderr reports both the permission
+refusal and normal skip marker.
+
 ## Integration suite (`test/integration/`)
 
 | File | Covers |


### PR DESCRIPTION
## Hive Patrol Finding

Slice: `command-bin-hive`
Category: `security`
Severity: `medium`
Confidence: `high`
Fingerprint: `34c563fc5b5af20332897c3456fdc2715d0a52acfa53ba2c3645eae922e32af6`

The skip-log helper verifies that an existing target is regular, current-uid-owned, and single-linked, but never checks or tightens its permission bits. The 0600 mode passed to File.open only applies when creating a new file. A pre-existing 0644/0666 worktree log is therefore accepted unchanged, exposing skipped command arguments and allowing other local users to forge the persistent audit trail.

## Evidence

- bin/hive-babysitter-skip-log.rb:22 raise IOError, "dry-run skip log is not a regular file" unless stat.file?
- bin/hive-babysitter-skip-log.rb:29 File.open(path, File::WRONLY | File::APPEND | File::CREAT | File::NOFOLLOW | File::NONBLOCK, 0o600)

## Applied Fix

After both lstat and fstat, require `stat.mode & 0o077 == 0` or safely chmod the already-open, identity-verified file to 0600 before writing. Add tests for rejecting or repairing 0644 and 0666 existing logs.

## Validation

- lint: passed (`bundle exec rubocop`)
- test: passed (`bundle exec rake test`)

## Diffstat

```text
 bin/hive-babysitter-skip-log.rb                    |  2 ++
 test/unit/babysitter/dry_run_env_test.rb           | 23 ++++++++++++++++++++++
 wiki/commands/babysit.md                           |  6 +++---
 wiki/gaps.md                                       |  4 ++--
 ...234Z-babysitter-skip-log-private-permissions.md | 19 ++++++++++++++++++
 wiki/modules/babysitter.md                         |  6 +++---
 wiki/testing.md                                    |  4 ++--
 7 files changed, 54 insertions(+), 10 deletions(-)

```
