### PR TITLE
Hive patrol: Bare retention flags still run destructive cleanup

### DIFF
--- a/bin/hive-e2e
+++ b/bin/hive-e2e
@@ -304,6 +304,23 @@ def reject_unsupported_json_assignments!(argv)
   raise Thor::MalformattedArgumentError, "invalid boolean value for --json: #{arg.split('=', 2).last.inspect}"
 end
 
+RETENTION_VALUE_OPTIONS = %w[--retain-days --retain-failed-days].freeze
+
+def reject_missing_retention_values!(argv)
+  return unless argv.first == "clean"
+
+  argv.each_index do |idx|
+    arg = argv[idx]
+    break if arg == "--"
+    next unless RETENTION_VALUE_OPTIONS.include?(arg)
+
+    value = argv[idx + 1]
+    next if value && !value.empty? && (!value.start_with?("-") || value.match?(/\A-\d+\z/))
+
+    raise Thor::MalformattedArgumentError, "No value provided for option '#{arg}'"
+  end
+end
+
 def normalize_leading_global_options!(argv)
   leading = []
   leading << argv.shift while JSON_BOOLEAN_OPTIONS.include?(argv.first)
@@ -321,6 +338,7 @@ begin
   reject_unsupported_json_assignments!(ARGV)
   normalize_leading_global_options!(ARGV)
   rewrite_help_flag!(ARGV)
+  reject_missing_retention_values!(ARGV)
   # Thor::Base#start rescues Thor::Error internally and exits 1 when
   # exit_on_failure? is true. Passing `debug: true` makes Thor re-raise
   # instead so the rescue below can preserve human/JSON formatting while

--- a/test/e2e/lib/hive_e2e_binary_test.rb
+++ b/test/e2e/lib/hive_e2e_binary_test.rb
@@ -384,6 +384,34 @@ class E2EBinaryTest < Minitest::Test
     end
   end
 
+  def test_clean_rejects_bare_retention_options_before_cleanup
+    [ "--retain-days", "--retain-failed-days" ].product([ [], [ "--json" ], [ "--dry-run" ] ]).each do |flag, suffix|
+      Dir.mktmpdir("e2e-clean-test") do |tmp_runs_dir|
+        run_dir = File.join(tmp_runs_dir, "2026-04-30T12-00-00Z-1234-abcd")
+        FileUtils.mkdir_p(run_dir)
+        old_time = Time.now - (30 * 86_400)
+        File.utime(old_time, old_time, run_dir)
+
+        out, err, status = Open3.capture3(
+          { "HIVE_E2E_RUNS_DIR" => tmp_runs_dir },
+          hive_e2e, "clean", flag, *suffix
+        )
+
+        assert_equal 64, status.exitstatus, "#{([ flag ] + suffix).inspect}: malformed cleanup must be rejected"
+        assert File.exist?(run_dir), "#{([ flag ] + suffix).inspect}: malformed cleanup must not delete artifacts"
+        if suffix.include?("--json")
+          assert_empty err
+          payload = parse_single_json_document(out)
+          assert_equal "usage", payload["error_kind"]
+          assert_match(/No value provided for option '#{Regexp.escape(flag)}'/, payload["message"])
+        else
+          assert_empty out
+          assert_match(/No value provided for option '#{Regexp.escape(flag)}'/, err)
+        end
+      end
+    end
+  end
+
   def test_clean_json_includes_dry_run_and_audit_arrays
     Dir.mktmpdir("e2e-clean-test") do |tmp_runs_dir|
       out, err, status = Open3.capture3(

--- a/wiki/e2e.md
+++ b/wiki/e2e.md
@@ -62,6 +62,12 @@ rewrites and before Thor dispatch, and are reported as usage errors (`64`);
 JSON callers receive the normal `hive-e2e-error` envelope with
 `error_kind: "usage"`.
 
+`clean` also validates separate-form `--retain-days` and
+`--retain-failed-days` values before Thor dispatch. A bare retention flag, or
+one followed by another option such as `--json` or `--dry-run`, is a usage
+error (`64`) and never reaches artifact cleanup; Thor cannot silently reuse the
+configured retention default for a malformed destructive invocation.
+
 ## Layout
 
 | Path | Purpose |

--- a/wiki/log.d/20260713T014251Z-hive-e2e-bare-retention-validation.md
+++ b/wiki/log.d/20260713T014251Z-hive-e2e-bare-retention-validation.md
@@ -1,0 +1,5 @@
+## [2026-07-13T01:42:51Z] bug - hive-e2e rejects bare cleanup retention flags
+
+**Action:** Added pre-dispatch validation for separate-form `--retain-days` and `--retain-failed-days` options in `bin/hive-e2e`. Thor retains an optional string option's configured default when the flag is terminal or followed by another switch; malformed `clean` calls could therefore reach destructive cleanup with the default window. Bare or option-followed retention flags now raise the existing usage error before Thor dispatch, while explicit negative values still reach the retention-window validator.
+
+**Tests:** Added a six-case binary regression covering both retention flags as the final token and immediately before `--json` or `--dry-run`. Every case must exit `64`, use the expected JSON or human error surface, and preserve an eligible old run directory. Verified the full `test/e2e/lib/hive_e2e_binary_test.rb` suite (38 tests, 305 assertions).


### PR DESCRIPTION
## Hive Patrol Finding

Slice: `command-bin-hive`
Category: `bug`
Severity: `medium`
Confidence: `high`
Fingerprint: `aeae70020bece8569fbbe15e28f0f282717283455b3a592200a001d304e70195`

Thor retains the configured default when --retain-days or --retain-failed-days is supplied without a value. Consequently `bin/hive-e2e clean --retain-days` succeeds and deletes eligible artifacts using the default window instead of rejecting the malformed destructive invocation.

## Evidence

- bin/hive-e2e:176 option :retain_days, type: :string, default: ENV.fetch("RUNS_RETAIN_DAYS", "7")
- bin/hive-e2e:182 result = Sandbox.cleanup_runs(retain_days: retain_days, retain_failed_days: retain_failed_days,

## Applied Fix

Reject either retention option before Thor dispatch when its separate value is absent or option-like. Add tests for each bare flag as the final token and immediately before --json or --dry-run.

## Validation

- lint: passed (`bundle exec rubocop`)
- test: passed (`bundle exec rake test`)

## Diffstat

```text
 bin/hive-e2e                                       | 18 ++++++++++++++
 test/e2e/lib/hive_e2e_binary_test.rb               | 28 ++++++++++++++++++++++
 wiki/e2e.md                                        |  6 +++++
 ...3T014251Z-hive-e2e-bare-retention-validation.md |  5 ++++
 4 files changed, 57 insertions(+)

```
