### PR TITLE
Hive patrol: C locale bypasses invalid argv detection

### DIFF
--- a/bin/hive
+++ b/bin/hive
@@ -196,7 +196,7 @@ def json_requested?(argv)
 end
 
 def reject_invalid_argv_encoding!(argv)
-  idx = argv.index { |arg| !arg.valid_encoding? }
+  idx = argv.index { |arg| !arg.dup.force_encoding(Encoding::UTF_8).valid_encoding? }
   return unless idx
 
   raise Thor::MalformattedArgumentError, "invalid byte sequence in argument #{idx + 1}"

--- a/bin/hive-e2e
+++ b/bin/hive-e2e
@@ -291,7 +291,7 @@ def json_requested?(argv)
 end
 
 def reject_invalid_argv_encoding!(argv)
-  idx = argv.index { |arg| !arg.valid_encoding? }
+  idx = argv.index { |arg| !arg.dup.force_encoding(Encoding::UTF_8).valid_encoding? }
   return unless idx
 
   raise Thor::MalformattedArgumentError, "invalid byte sequence in argument #{idx + 1}"

--- a/test/e2e/lib/hive_e2e_binary_test.rb
+++ b/test/e2e/lib/hive_e2e_binary_test.rb
@@ -356,8 +356,8 @@ class E2EBinaryTest < Minitest::Test
     assert_match(/run_id must be a safe basename/, payload["message"])
   end
 
-  def test_replay_invalid_byte_name_emits_usage_error_when_json_requested
-    out, err, status = Open3.capture3(hive_e2e, "replay", "--json", "bad\xFF".b, "scenario")
+  def test_run_invalid_byte_pattern_emits_usage_error_in_c_locale
+    out, err, status = Open3.capture3({ "LC_ALL" => "C" }, hive_e2e, "run", "--json", "bad\xFF".b)
     assert_equal 64, status.exitstatus
     assert_empty err
 

--- a/test/integration/cli_usage_error_json_test.rb
+++ b/test/integration/cli_usage_error_json_test.rb
@@ -252,12 +252,16 @@ class CliUsageErrorJsonTest < Minitest::Test
     end
   end
 
-  def test_invalid_byte_json_arg_uses_command_usage_envelope
+  def test_invalid_byte_json_arg_uses_command_usage_envelope_in_c_locale
     with_tmp_global_config do |home|
-      out, err, status = run_hive(home, "run", "--json", "bad\xFF".b)
+      out, err, status = Open3.capture3(
+        { "HIVE_HOME" => home, "LC_ALL" => "C" },
+        RbConfig.ruby, "-Ilib", HIVE_BIN, "run", "--json", "bad\xFF".b
+      )
 
       refute status.success?
       assert_equal Hive::ExitCodes::USAGE, status.exitstatus
+      refute_empty out, "JSON usage errors must emit an envelope"
       refute_match(%r{/thor/}, err)
       payload = JSON.parse(out)
       assert_equal "hive-run", payload["schema"]

--- a/wiki/cli.md
+++ b/wiki/cli.md
@@ -40,10 +40,10 @@ unrecognized `--foo`, and quoted strings containing `--workflow` remain task
 text. When the wrapper itself catches a usage error, JSON-vs-prose mode is
 decided from the last recognized JSON boolean flag in argv, so a trailing false
 form such as `--no-json` or `--json=false` overrides an earlier `--json`.
-Before any wrapper rewrite or Thor dispatch, every `ARGV` entry must have valid
-encoding. Invalid-byte arguments raise through the same usage-error path as
-malformed wrapper options, so JSON callers still receive the command-specific
-error envelope instead of a Ruby/Thor backtrace.
+Before any wrapper rewrite or Thor dispatch, every `ARGV` entry must be valid
+UTF-8 regardless of the process locale. Invalid-byte arguments raise through
+the same usage-error path as malformed wrapper options, so JSON callers still
+receive the command-specific error envelope instead of a Ruby/Thor backtrace.
 
 When a JSON request fails in Thor before the command object runs, `bin/hive`
 uses `JSON_USAGE_ERROR_CONTRACTS` to keep the error shaped like the requested

--- a/wiki/e2e.md
+++ b/wiki/e2e.md
@@ -57,10 +57,10 @@ as `--json=1` or `--json=yes` are usage errors before the value can become the
 default `run` pattern. Wrapper-owned error formatting checks the last
 recognized JSON boolean flag rather than any truthy flag, so duplicate flags
 with a final false form, such as `--json --no-json`, emit the human
-`hive-e2e:` stderr path. Invalid-byte `ARGV` entries are rejected before those
-rewrites and before Thor dispatch, and are reported as usage errors (`64`);
-JSON callers receive the normal `hive-e2e-error` envelope with
-`error_kind: "usage"`.
+`hive-e2e:` stderr path. `ARGV` entries that are not valid UTF-8 are rejected
+before those rewrites and before Thor dispatch, regardless of the process
+locale, and are reported as usage errors (`64`); JSON callers receive the
+normal `hive-e2e-error` envelope with `error_kind: "usage"`.
 
 ## Layout
 

--- a/wiki/log.d/20260713T195855Z-cli-argv-utf8-locale.md
+++ b/wiki/log.d/20260713T195855Z-cli-argv-utf8-locale.md
@@ -1,0 +1,11 @@
+## [2026-07-13T19:58:55Z] cli - make argv UTF-8 validation locale-independent
+
+**Action:** Updated the pre-dispatch argv guards in `bin/hive` and
+`bin/hive-e2e` to validate a duplicated UTF-8 view of each argument. Raw invalid
+bytes are now rejected under `LC_ALL=C` instead of being accepted as valid
+`ASCII-8BIT` and reaching command dispatch.
+
+**Verified:** Added `LC_ALL=C` raw-byte regressions for both binaries and ran
+`bundle exec ruby -Itest -Ilib test/integration/cli_usage_error_json_test.rb`,
+`bundle exec ruby -Itest -Ilib test/e2e/lib/hive_e2e_binary_test.rb`, and
+`bundle exec rubocop bin/hive bin/hive-e2e test/integration/cli_usage_error_json_test.rb test/e2e/lib/hive_e2e_binary_test.rb`.

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -159,9 +159,9 @@ successful `list --json` / `clean --json` calls, unknown-command JSON errors,
 missing argument errors, top-level version output, command-local help after
 command options (`run --filter tui --help`), leading JSON option normalization,
 malformed JSON assignment rejection, last-JSON-boolean-wins usage-error mode,
-replay path safety, missing, non-executable, and symlinked replay artifact
-validation, cleanup retention validation, and the single-dispatch invariant for
-successful JSON commands.
+locale-independent invalid UTF-8 argv rejection, replay path safety, missing,
+non-executable, and symlinked replay artifact validation, cleanup retention
+validation, and the single-dispatch invariant for successful JSON commands.
 
 The install-smoke workflow's `verify-release.sh (end-to-end behavior)` job
 runs `packaging/verify-release.sh --version=v0.1.0` against the published
@@ -224,7 +224,7 @@ credentials inside a running box.
 
 The live Telegram bot E2E wrapper lives at `test/e2e/tg/run_idea_e2e.sh` and is also opt-in because it uses a real Bot API test token plus a Telethon user session. In default text mode it drives `/idea <nonce>` through the project picker. With `TG_IDEA_MODE=voice`, the wrapper requires the voice fixture and `HIVE_WHISPER_API_KEY`, starts the bot from the current checkout, drives a new voice idea through transcript confirmation/project selection, seeds a temporary `2-brainstorm/<slug>/brainstorm.md` in the scratch project, then sends `/answer <slug>` and answers Q1 with the same voice note. Cleanup resets the scratch state repo to the captured baseline and removes temporary inbox/brainstorm folders.
 
-`test/e2e/lib/hive_e2e_binary_test.rb` is the focused contract suite for the executable itself. It pins `list --json`, `clean --json`, leading JSON option normalization including `--json=true`, duplicate JSON boolean handling where a final false flag chooses prose, malformed `--json=1` / `--json=yes` rejection, error-envelope shapes, help/version handling, replay path validation, missing/non-executable/symlinked replay artifact errors (`missing_repro` / `unusable_repro`, exit `78`), and the usage exit-code contract: unknown commands and missing required arguments exit `64` in both human and `--json` modes. Human usage errors are expected to print a `hive-e2e:`-prefixed prose message on stderr.
+`test/e2e/lib/hive_e2e_binary_test.rb` is the focused contract suite for the executable itself. It pins `list --json`, `clean --json`, leading JSON option normalization including `--json=true`, duplicate JSON boolean handling where a final false flag chooses prose, malformed `--json=1` / `--json=yes` rejection, locale-independent invalid UTF-8 argv rejection, error-envelope shapes, help/version handling, replay path validation, missing/non-executable/symlinked replay artifact errors (`missing_repro` / `unusable_repro`, exit `78`), and the usage exit-code contract: unknown commands and missing required arguments exit `64` in both human and `--json` modes. Human usage errors are expected to print a `hive-e2e:`-prefixed prose message on stderr.
 
 ## Live Claude tmux dogfood
 


### PR DESCRIPTION
## Hive Patrol Finding

Slice: `command-bin-hive`
Category: `bug`
Severity: `medium`
Confidence: `high`
Fingerprint: `4d493dc910dfe73f8486afa69561952134de41081db6528ead0da54db2dede5b`

The boundary check trusts each argument's locale-derived encoding. Under LC_ALL=C, Ruby tags raw argv as ASCII-8BIT, where byte 0xFF is considered valid; malformed input then bypasses both wrappers, causing bin/hive to lose JSON output and bin/hive-e2e to return run_failed/1 instead of usage/64.

## Evidence

- bin/hive:199 idx = argv.index { |arg| !arg.valid_encoding? }
- bin/hive-e2e:294 idx = argv.index { |arg| !arg.valid_encoding? }

## Applied Fix

Validate a duplicate of every argv token after forcing it to UTF-8, reject invalid sequences before option parsing, and add raw-byte regression cases for both binaries under LC_ALL=C.

## Validation

- lint: passed (`bundle exec rubocop`)
- test: passed (`bundle exec rake test`)

## Diffstat

```text
 bin/hive                                            |  2 +-
 bin/hive-e2e                                        |  2 +-
 test/e2e/lib/hive_e2e_binary_test.rb                |  4 ++--
 test/integration/cli_usage_error_json_test.rb       |  8 ++++++--
 wiki/cli.md                                         |  8 ++++----
 wiki/e2e.md                                         |  8 ++++----
 wiki/log.d/20260713T195855Z-cli-argv-utf8-locale.md | 11 +++++++++++
 wiki/testing.md                                     |  8 ++++----
 8 files changed, 33 insertions(+), 18 deletions(-)

```
