### PR TITLE
release: v0.4.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,7 +188,7 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
           REPO: ${{ github.repository }}
         run: |
-          content="🚀 **hive ${REF_NAME}** is out — \`gem install hive-cli\`"$'\n'"Release notes: https://github.com/${REPO}/releases/tag/${REF_NAME}"
+          content="🚀 **Hive ${REF_NAME}** is out — update with \`hive update\`"$'\n'"Release notes: https://github.com/${REPO}/releases/tag/${REF_NAME}"
           jq -nc --arg c "$content" '{content: $c, allowed_mentions: {parse: []}}' \
             | curl -sSf -X POST -H 'Content-Type: application/json' -d @- "$DISCORD_RELEASE_WEBHOOK" >/dev/null
           echo "discord: announced ${REF_NAME}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes are documented here, newest first. Hive ships frequent micro-releases (see [docs/RELEASING.md](docs/RELEASING.md#versioning-policy)): each `vX.Y.Z` git tag gets a `## X.Y.Z` section with terse bullets — no `[Unreleased]` accumulator. Versioning is [SemVer](https://semver.org): PATCH for fixes and small changes (the common case), MINOR for notable features, MAJOR for milestones.
 
+## 0.4.2
+
+- Added `bench` as a third built-in workflow for reproducible coding-agent
+  campaigns. `hive init PATH --workflow bench` installs the self-contained,
+  versioned `extract -> generate -> judge -> publish` harness without requiring
+  a separate hive-bench checkout. (#734)
+- Made long-running benchmark and other generic agent stages quota-aware, so
+  provider-limit failures retain cooldown metadata and can resume after reset
+  while malformed results and non-limit failures still stop for review. (#734)
+- Fixed daemon child logging to write bounded per-task captures under Hive's XDG
+  state directory instead of shared `/tmp`, preventing temporary-directory quota
+  exhaustion from crashing dispatch and keeping logs out of tracked state. (#718)
+
 ## 0.4.1
 
 - Fixed Grok auth overrides so explicit `GROK_AUTH_PATH` and `GROK_HOME`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hive-cli (0.4.1)
+    hive-cli (0.4.2)
       bubbletea (= 0.1.4)
       erb (>= 4.0)
       faraday (>= 2.14.2, < 3.0)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Hive ships as a rubygem (`hive-cli`) attached to each GitHub Release, signed wit
 | Platform | Channel |
 |----------|---------|
 | macOS arm64 | [`brew install ivankuznetsov/hive/hive`](https://github.com/ivankuznetsov/homebrew-hive) |
-| Ubuntu 22.04+ / glibc Linux x86_64/aarch64 | <code>tmpdir="$(mktemp -d)" && trap 'rm -rf "$tmpdir"' EXIT && curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.4.1/install.sh -o "$tmpdir/hive-install.sh" && bash "$tmpdir/hive-install.sh"</code> |
+| Ubuntu 22.04+ / glibc Linux x86_64/aarch64 | <code>tmpdir="$(mktemp -d)" && trap 'rm -rf "$tmpdir"' EXIT && curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.4.2/install.sh -o "$tmpdir/hive-install.sh" && bash "$tmpdir/hive-install.sh"</code> |
 | Arch Linux x86_64/aarch64 | [`yay -S hive-bin`](https://aur.archlinux.org/packages/hive-bin) |
 
 Prerequisites: **Ruby 3.4** (the gem and its runtime deps install against this), git ≥ 2.40, authenticated `claude` ≥ 2.1.118, `codex` ≥ 0.125.0 for the default execute agent, `grok` ≥ 0.2.90 when selected, authenticated `gh`, `tmux` ≥ 3.0 when the project uses the default `claude.mode: tmux`, and Node.js/npm for managed QMD install/repair. The bash installer reports its own installer-side prereqs (`curl`, `jq`, `gem`, checksum tool) on first run; if npm is missing, Hive still installs and `hive doctor` reports the QMD gap non-fatally.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -19,6 +19,9 @@ A push of a `vX.Y.Z` tag triggers `.github/workflows/release.yml`, which:
    the released gem, renders `PKGBUILD` from `packaging/aur/PKGBUILD.template`
    via `packaging/render.rb`, regenerates `.SRCINFO` with
    `makepkg --printsrcinfo`, and pushes a version bump to the AUR package.
+5. Announces the release on Discord with the supported `hive update` command
+   when `DISCORD_RELEASE_WEBHOOK` is configured. Announcement failures are
+   non-fatal and do not block package publication.
 
 Both channel templates render through one helper (`packaging/render.rb`), so a
 release's version/sha is substituted identically everywhere.

--- a/install.md
+++ b/install.md
@@ -59,8 +59,8 @@ Ubuntu 22.04+ / glibc Linux fallback (pin to the current release tag, not `main`
 ```bash
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
-# Release maintainers: bump v0.4.1 in both installer URLs when cutting a new stable release.
-curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.4.1/install.sh -o "$tmpdir/hive-install.sh"
+# Release maintainers: bump v0.4.2 in both installer URLs when cutting a new stable release.
+curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.4.2/install.sh -o "$tmpdir/hive-install.sh"
 bash "$tmpdir/hive-install.sh"
 ```
 
@@ -69,8 +69,8 @@ To inspect the installer first, run a dry-run before the real invocation. State 
 ```bash
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
-# Release maintainers: bump v0.4.1 in both installer URLs when cutting a new stable release.
-curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.4.1/install.sh -o "$tmpdir/hive-install.sh"
+# Release maintainers: bump v0.4.2 in both installer URLs when cutting a new stable release.
+curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.4.2/install.sh -o "$tmpdir/hive-install.sh"
 bash "$tmpdir/hive-install.sh" --dry-run
 bash "$tmpdir/hive-install.sh"
 ```

--- a/lib/hive.rb
+++ b/lib/hive.rb
@@ -1,5 +1,5 @@
 module Hive
-  VERSION = "0.4.1".freeze
+  VERSION = "0.4.2".freeze
   MIN_CLAUDE_VERSION = "2.1.118".freeze
   # Canonical GitHub org + repo. Referenced by the release probe
   # (UpdateCheck), the brew tap + installer URL (Commands::Update), etc.

--- a/test/unit/release_contract_test.rb
+++ b/test/unit/release_contract_test.rb
@@ -1,0 +1,35 @@
+require "test_helper"
+
+class ReleaseContractTest < Minitest::Test
+  ROOT = File.expand_path("../..", __dir__)
+  RELEASE_WORKFLOW = File.join(ROOT, ".github/workflows/release.yml")
+
+  def test_release_metadata_matches_runtime_version
+    version = Regexp.escape(Hive::VERSION)
+
+    assert_match(/^    hive-cli \(#{version}\)$/, read("Gemfile.lock"))
+    assert_match(/^    hive-cli \(#{version}\)$/, read("web/Gemfile.lock"))
+    assert_equal 1, read("CHANGELOG.md").scan(/^## #{version}$/).size
+    assert_equal 1, read("README.md").scan(%r{/v#{version}/install\.sh}).size
+    assert_equal 2, read("install.md").scan(%r{/v#{version}/install\.sh}).size
+  end
+
+  def test_discord_announcement_uses_supported_update_command
+    workflow = YAML.safe_load_file(RELEASE_WORKFLOW, aliases: true)
+    step = workflow.fetch("jobs").fetch("release-finalize").fetch("steps").find do |candidate|
+      candidate["name"] == "Announce release on Discord"
+    end
+
+    refute_nil step
+    assert_equal "${{ env.DISCORD_RELEASE_WEBHOOK != '' }}", step.fetch("if")
+    assert_equal true, step.fetch("continue-on-error")
+    assert_includes step.fetch("run"), "\\`hive update\\`"
+    refute_includes step.fetch("run"), "gem install hive-cli"
+  end
+
+  private
+
+  def read(path)
+    File.read(File.join(ROOT, path))
+  end
+end

--- a/web/Gemfile.lock
+++ b/web/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    hive-cli (0.4.1)
+    hive-cli (0.4.2)
       bubbletea (= 0.1.4)
       erb (>= 4.0)
       faraday (>= 2.14.2, < 3.0)

--- a/wiki/active-areas.md
+++ b/wiki/active-areas.md
@@ -3,7 +3,7 @@ title: Active Areas
 type: active-areas
 source: git log + working tree
 created: 2026-04-25
-updated: 2026-07-10
+updated: 2026-07-14
 tags: [roadmap, status]
 ---
 
@@ -13,7 +13,7 @@ tags: [roadmap, status]
 
 Daemon autostart hardening landed on `main` via #189 (2026-05-26): autostart is now install-time/global infrastructure. A Linux host without systemd-user writes the unit and reports the `unsupported` success outcome (exit 0) instead of a spurious failure; `install.sh` captures the real install exit code and carries the verified `hive`/`hv` wrapper through daemon install + `hive init`; `Hive::InvokedBinary` replaces the dead `which` delegators. See log entries 2026-05-26 (21:22Z / 22:55Z / 23:30Z) and ADR-024.
 
-Recent release/dependency/history inspected on 2026-07-10:
+Recent release/dependency/history inspected on 2026-07-14:
 
 | Commit | Area | Notes |
 |--------|------|-------|
@@ -66,7 +66,7 @@ Recent release/dependency/history inspected on 2026-07-10:
 | Telegram bot (ADR-026) | `lib/hive/bot/*`, `lib/hive/commands/bot.rb`, `wiki/commands/bot.md`, `wiki/modules/bot.md` | Mobile human-input surface: long-polls Telegram, notifies on waiting/recovery gates, writes brainstorm answers under lock, and dispatches existing `hive` commands from inline buttons. `hive bot install` adds an opt-in reboot-survivable per-user service (systemd-user/launchd) that runs `hive bot start --foreground` with no inline token; torn down by `hive uninstall`. |
 | Shared service installer | `lib/hive/commands/service_installer/{base,outcome}.rb`, `lib/hive/commands/{daemon,bot}/service_installer.rb`, `schemas/hive-{bot,daemon}-install.v1.json`, `docs/solutions/…cross-platform-service-installer-base…` | `ServiceInstaller::Base` extracted from the daemon installer (daemon behavior byte-identical) and subclassed by daemon + bot, returning a `ServiceInstaller::Outcome` value object. Content-comparison drift detection (`--force` to overwrite), `unsupported` outcome on hosts with no service manager, exit codes 0/64/70, and a read-only `service_state` probe surfaced as `service_installed`/`service_enabled`/`unit_path` in both `bot`/`daemon status --json`. |
 | Testing and eval | `test/unit/`, `test/integration/`, `test/e2e/`, `test/eval/`, `Rakefile`, `bin/hive-eval` | Default `bundle exec rake test`; strict `bundle exec rake coverage`; opt-in e2e and Telegram bot eval layers. |
-| Release/install | `install.sh`, `install.md`, `packaging/`, `.github/workflows/install-smoke.yml`, `.github/workflows/release.yml` | v0.4.1 release prep synchronizes both path-gem locks and public installer pins after the Grok-auth, daemon-reload, JSON-schema, babysitter, eval-integrity, and descendant-cleanup hardening pass. Update/uninstall, release artifact verification, install-smoke `jq` provisioning, daemon service install JSON envelopes, hivebox Docker install/smoke flow, and remaining tag-trust/macOS x86_64/live-provider follow-ups are documented in [[operating]], [[commands/web]], [[testing]], and [[gaps]]. |
+| Release/install | `install.sh`, `install.md`, `packaging/`, `.github/workflows/install-smoke.yml`, `.github/workflows/release.yml` | v0.4.2 release prep synchronizes both path-gem locks and public installer pins after the built-in benchmark workflow, quota-aware generic-stage recovery, and daemon child-log isolation changes. Update/uninstall, release artifact verification, install-smoke `jq` provisioning, daemon service install JSON envelopes, hivebox Docker install/smoke flow, and remaining tag-trust/macOS x86_64/live-provider follow-ups are documented in [[operating]], [[commands/web]], [[testing]], and [[gaps]]. |
 | Docs/wiki | `README.md`, `docs/notes/`, `wiki/`, `.llm-wiki/` | Managed llm-wiki context is installed for Codex/Claude/Pi; refresh automation is Codex-owned by `.llm-wiki/config.json`. |
 
 ## Phase 1 deferred work

--- a/wiki/dependencies.md
+++ b/wiki/dependencies.md
@@ -3,7 +3,7 @@ title: Dependencies
 type: dependencies
 source: Gemfile, hive.gemspec, Gemfile.lock, web/Gemfile, web/Gemfile.lock
 created: 2026-04-25
-updated: 2026-07-10
+updated: 2026-07-14
 tags: [dependencies, gems, runtime]
 ---
 
@@ -11,9 +11,9 @@ tags: [dependencies, gems, runtime]
 
 `hive.gemspec` owns runtime gem constraints; `Gemfile` uses `gemspec`
 to pull those constraints into Bundler, then adds development/test-only
-tools. The v0.4.1 release-prep checkout is `0.4.1`: `lib/hive.rb`, root
+tools. The v0.4.2 release-prep checkout is `0.4.2`: `lib/hive.rb`, root
 `Gemfile.lock`, and `web/Gemfile.lock` all pin the local path gem as
-`hive-cli (0.4.1)`. The release-prep change keeps both lockfiles synchronized
+`hive-cli (0.4.2)`. The release-prep change keeps both lockfiles synchronized
 with public installer URLs and the changelog. Recent root bundle dependency
 commits also bumped RuboCop to 1.88.2, Brakeman from
 8.0.4 to 8.0.5, and `concurrent-ruby` from 1.3.6 to 1.3.7; the separate web
@@ -136,7 +136,7 @@ These are not gems but the CLI tools the runtime invokes:
 `Gemfile` declares `ruby "~> 3.4"`. `hive.gemspec` requires Ruby
 `>= 3.4.0` for the packaged gem. `.rubocop.yml` pins
 `TargetRubyVersion: 3.4`. `Gemfile.lock` records Ruby 3.4.7, Bundler
-2.7.2, and the current local path gem as `hive-cli (0.4.1)`.
+2.7.2, and the current local path gem as `hive-cli (0.4.2)`.
 
 ## Backlinks
 

--- a/wiki/gaps.md
+++ b/wiki/gaps.md
@@ -3,7 +3,7 @@ title: Gaps
 type: gaps
 source: wiki/* vs lib/, templates/, test/, bin/
 created: 2026-04-25
-updated: 2026-07-13
+updated: 2026-07-14
 tags: [gap, todo]
 ---
 
@@ -189,7 +189,7 @@ evidence closing the following June 16 gaps.
 
 ## Release install follow-ups
 
-Latest refresh (2026-07-10): v0.4.1 release-prep source is synchronized in
+Latest refresh (2026-07-14): v0.4.2 release-prep source is synchronized in
 `lib/hive.rb`, both lockfiles, README/install URLs, the changelog, and the
 release-facing wiki pages. This source commit does not itself prove the public
 tag, signed gem/assets, Homebrew/AUR updates, or multi-architecture hivebox
@@ -198,7 +198,7 @@ Historical commit `54fd3455` still provides commit-message evidence for the
 native arm64 GHCR smoke against `ghcr.io/ivankuznetsov/hivebox:0.3.1`.
 Dependency lock uncertainty is unchanged: the root bundle has
 `concurrent-ruby` 1.3.7 and Brakeman 8.0.5, while `web/Gemfile.lock` resolves
-`concurrent-ruby` 1.3.6 and Brakeman 8.0.4; v0.4.1 synchronizes only the local
+`concurrent-ruby` 1.3.6 and Brakeman 8.0.4; v0.4.2 synchronizes only the local
 `hive-cli` path-gem version in that independently resolved web bundle.
 
 1. **Release tag trust remains the main release-channel hardening gap.** Homebrew and AUR publishing are implemented and public install docs now route macOS users to the tap and Arch users to `yay -S hive-bin` (see ADR-032 in [[decisions]], `docs/RELEASING.md`, `README.md`, and `install.md`). The remaining trust gap is that release automation signs and publishes whatever a `vX.Y.Z` tag points at; a GitHub `v*` tag-protection ruleset and/or signed git-tag verification remains the compensating control to record before considering the release chain fully hardened.

--- a/wiki/log.d/20260714T142127Z-release-v042.md
+++ b/wiki/log.d/20260714T142127Z-release-v042.md
@@ -1,0 +1,18 @@
+# 2026-07-14 — Prepare Hive v0.4.2
+
+**Action:** Bumped the CLI and both local path-gem locks to `0.4.2`, pinned the
+public installer snippets to `v0.4.2`, and added the matching patch changelog.
+The release collects the built-in benchmark workflow, quota-aware generic-stage
+recovery, and daemon child-log isolation changes merged after v0.4.1. Release
+announcements now direct existing users to the channel-preserving `hive update`
+command instead of an unsupported direct `gem install` invocation that cannot
+resolve Hive's GitHub-release-only gem.
+
+**Docs:** Release-facing operating, dependency, active-area, and gaps pages now
+record the synchronized v0.4.2 source state and the remaining tag-triggered
+publication boundary.
+
+**Verification boundary:** Source checks can prove version/reference parity,
+gem construction, and the existing focused regressions before merge. Signed
+artifacts, the GitHub Release, Homebrew/AUR updates, and hivebox images are
+verified only after the public `v0.4.2` tag triggers the release workflow.

--- a/wiki/operating.md
+++ b/wiki/operating.md
@@ -3,7 +3,7 @@ title: Operating Hive
 type: operating
 source: README.md, bin/hv, install.sh, lib/hive/commands/daemon.rb, lib/hive/commands/babysit.rb, lib/hive/commands/bot.rb, examples/systemd/, examples/launchd/, openclaw/skills/hive/SKILL.md, openclaw/README.md
 created: 2026-05-07
-updated: 2026-07-10
+updated: 2026-07-14
 tags: [operating, daemon, bot, systemd, launchd, install]
 ---
 
@@ -60,7 +60,7 @@ yay -S hive-bin
 # glibc Linux fallback / Ubuntu 22.04+ (pin to the release tag, not main)
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
-curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.4.1/install.sh -o "$tmpdir/hive-install.sh"
+curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.4.2/install.sh -o "$tmpdir/hive-install.sh"
 bash "$tmpdir/hive-install.sh"
 ```
 
@@ -190,8 +190,8 @@ the published schemas, and asserts no state leaks outside the prefix.
 Local usage:
 
 ```bash
-packaging/verify-release.sh --version=v0.4.1
-packaging/verify-release.sh --version=v0.4.1 --report=json | jq .ok
+packaging/verify-release.sh --version=v0.4.2
+packaging/verify-release.sh --version=v0.4.2 --report=json | jq .ok
 ```
 
 For unreleased packaging fixes, validate against the locally built gem rather


### PR DESCRIPTION
## Summary

Hive v0.4.2 makes the built-in benchmark workflow, quota-aware generic-stage recovery, and daemon child-log isolation available through the supported release channels. The release metadata and public installer pins now agree on `0.4.2`, and release announcements direct existing users to the channel-preserving `hive update` command instead of a gem command that cannot resolve Hive's GitHub-release-only package.

## Validation

- The default test suite passed 7,501 runs and 117,085 assertions with no failures or errors; the added release-contract regression separately passed 2 runs and 14 assertions.
- RuboCop inspected 803 files with no offenses.
- Built `hive-cli-0.4.2.gem`, verified `bin/hive --version`, and confirmed that the package includes the complete 52-file built-in benchmark workflow.
- Confirmed version parity across the runtime constant, both path-gem lockfiles, changelog, and all public installer references; the release workflow also parses as valid YAML and `git diff --check` is clean.

## Post-Deploy Monitoring & Validation

- Watch the tag-triggered Release workflow through native gem-install gates, signed assets, checksums, GitHub Release publication, AUR, Homebrew dispatch, post-release install checks, multi-architecture GHCR publication, and the native ARM64 image smoke.
- Healthy signals: all required jobs succeed; the v0.4.2 asset set is complete and verifies; Homebrew and AUR report 0.4.2; and the `v0.4.2`/`latest` image manifests contain both amd64 and arm64.
- Failure signals: missing or signature-invalid assets, channel version skew after propagation, a failed native install, or an incomplete image manifest. Do not move or reuse the public tag; fix forward with v0.4.3 if a published artifact is bad.
- Discord and Homebrew dispatch are intentionally non-fatal, so verify both manually. The announcement can briefly precede downstream channel propagation, during which `hive update` may still observe v0.4.1.
- Validation window/owner: release operator, from the v0.4.2 tag push through all publication and downstream verification jobs (normally about 35 minutes).

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
