### PR TITLE
Hive patrol: Wrapper preprocessing treats post-delimiter literals as options

### DIFF
--- a/bin/hive
+++ b/bin/hive
@@ -59,6 +59,10 @@ JSON_USAGE_ERROR_CONTRACTS = {
   end
 ).freeze
 
+def wrapper_option_argv(argv)
+  argv.take(argv.index("--") || argv.length)
+end
+
 # Thor treats a class option before the subcommand as input to its help path.
 # Keep `hive --json status` equivalent to `hive status --json`.
 def normalize_leading_json_options!(argv)
@@ -66,7 +70,7 @@ def normalize_leading_json_options!(argv)
   leading << argv.shift while JSON_BOOLEAN_OPTIONS.include?(argv.first)
   return if leading.empty?
 
-  cmd_idx = argv.index { |a| !a.start_with?("-") }
+  cmd_idx = wrapper_option_argv(argv).index { |a| !a.start_with?("-") }
   return argv.unshift(*leading) unless cmd_idx
 
   argv.insert(cmd_idx + 1, *leading)
@@ -80,13 +84,14 @@ def new_value_assignment?(arg)
 end
 
 def new_text_start_index(argv)
-  cmd_idx = argv.index { |a| !a.start_with?("-") }
+  option_argv = wrapper_option_argv(argv)
+  cmd_idx = option_argv.index { |a| !a.start_with?("-") }
   return nil unless cmd_idx && argv[cmd_idx] == "new"
 
   idx = cmd_idx + 1
   project_idx = nil
-  while idx < argv.length
-    arg = argv[idx]
+  while idx < option_argv.length
+    arg = option_argv[idx]
     if JSON_BOOLEAN_OPTIONS.include?(arg)
       idx += 1
       next
@@ -126,13 +131,14 @@ end
 def rewrite_help_flag!(argv)
   return if argv.empty?
 
-  cmd_idx = argv.index { |a| !a.start_with?("-") }
+  option_argv = wrapper_option_argv(argv)
+  cmd_idx = option_argv.index { |a| !a.start_with?("-") }
   return unless cmd_idx
 
   text_start_idx = new_text_start_index(argv)
-  help_idx = argv.each_index.find do |idx|
+  scan_limit = [ option_argv.length, text_start_idx ].compact.min
+  help_idx = (cmd_idx + 1...scan_limit).find do |idx|
     next false if idx <= cmd_idx
-    next false if text_start_idx && idx >= text_start_idx
 
     argv[idx] == "--help" || argv[idx] == "-h"
   end
@@ -147,7 +153,7 @@ end
 # `new` — before the project, between the project and the task text, or after the
 # text.
 def lift_new_options!(argv)
-  cmd_idx = argv.index { |a| !a.start_with?("-") }
+  cmd_idx = wrapper_option_argv(argv).index { |a| !a.start_with?("-") }
   return unless cmd_idx && argv[cmd_idx] == "new"
 
   lifted = []
@@ -192,7 +198,8 @@ def lift_new_options!(argv)
 end
 
 def json_requested?(argv)
-  JSON_TRUE_OPTIONS.include?(argv.reverse.find { |arg| JSON_BOOLEAN_OPTIONS.include?(arg) })
+  options = wrapper_option_argv(argv)
+  JSON_TRUE_OPTIONS.include?(options.reverse.find { |arg| JSON_BOOLEAN_OPTIONS.include?(arg) })
 end
 
 def reject_invalid_argv_encoding!(argv)
@@ -204,7 +211,7 @@ end
 
 def reject_unsupported_json_assignments!(argv)
   text_start_idx = new_text_start_index(argv)
-  arg = argv.each_with_index.find do |candidate, idx|
+  arg = wrapper_option_argv(argv).each_with_index.find do |candidate, idx|
     next false if text_start_idx && idx >= text_start_idx
 
     candidate.start_with?("--json=") && !JSON_BOOLEAN_OPTIONS.include?(candidate)
@@ -225,7 +232,7 @@ DIGEST_MERGED_PRS_SOURCE = "merged-prs".freeze
 def digest_merged_pr_argv?(argv)
   source = nil
   repo = false
-  argv.each_with_index do |arg, idx|
+  wrapper_option_argv(argv).each_with_index do |arg, idx|
     if arg == "--source"
       source = argv[idx + 1].to_s
     elsif arg.start_with?("--source=")
@@ -240,7 +247,7 @@ def digest_merged_pr_argv?(argv)
 end
 
 def json_usage_error_contract(argv)
-  command = argv.find { |arg| !arg.start_with?("-") }
+  command = wrapper_option_argv(argv).find { |arg| !arg.start_with?("-") }
   if command == "digest" && digest_merged_pr_argv?(argv)
     return { schema: "hive-merged-pr-digest", error_kind: "usage" }
   end
@@ -282,6 +289,8 @@ rescue Errno::EPIPE, JSON::GeneratorError
   true
 end
 
+original_argv = ARGV.dup
+
 begin
   reject_invalid_argv_encoding!(ARGV)
   reject_unsupported_json_assignments!(ARGV)
@@ -291,7 +300,7 @@ begin
   Hive::CLI.start(ARGV, debug: true)
 rescue Thor::Error => e
   error = Hive::InvalidTaskPath.new(e.message)
-  emitted_json = emit_json_usage_error(ARGV, error)
+  emitted_json = emit_json_usage_error(original_argv, error)
   warn(emitted_json ? "hive: #{error.message}" : error.message)
   exit(error.exit_code)
 rescue Hive::Error => e

--- a/bin/hive-e2e
+++ b/bin/hive-e2e
@@ -251,13 +251,18 @@ module Hive
   end
 end
 
+def wrapper_option_argv(argv)
+  argv.take(argv.index("--") || argv.length)
+end
+
 def rewrite_help_flag!(argv)
   return if argv.empty?
 
-  cmd_idx = argv.index { |arg| !arg.start_with?("-") }
+  option_argv = wrapper_option_argv(argv)
+  cmd_idx = option_argv.index { |arg| !arg.start_with?("-") }
   return unless cmd_idx
 
-  help_idx = argv[(cmd_idx + 1)..]&.index { |arg| arg == "--help" || arg == "-h" }
+  help_idx = option_argv[(cmd_idx + 1)..]&.index { |arg| arg == "--help" || arg == "-h" }
   return unless help_idx
 
   cmd = argv[cmd_idx]
@@ -287,7 +292,8 @@ end
 # `--json=<value>` assignments are rejected before Thor can use the value as a
 # command or pattern.
 def json_requested?(argv)
-  JSON_TRUE_OPTIONS.include?(argv.reverse.find { |arg| JSON_BOOLEAN_OPTIONS.include?(arg) })
+  options = wrapper_option_argv(argv)
+  JSON_TRUE_OPTIONS.include?(options.reverse.find { |arg| JSON_BOOLEAN_OPTIONS.include?(arg) })
 end
 
 def reject_invalid_argv_encoding!(argv)
@@ -298,7 +304,9 @@ def reject_invalid_argv_encoding!(argv)
 end
 
 def reject_unsupported_json_assignments!(argv)
-  arg = argv.find { |candidate| candidate.start_with?("--json=") && !JSON_BOOLEAN_OPTIONS.include?(candidate) }
+  arg = wrapper_option_argv(argv).find do |candidate|
+    candidate.start_with?("--json=") && !JSON_BOOLEAN_OPTIONS.include?(candidate)
+  end
   return unless arg
 
   raise Thor::MalformattedArgumentError, "invalid boolean value for --json: #{arg.split('=', 2).last.inspect}"
@@ -310,11 +318,13 @@ def normalize_leading_global_options!(argv)
   return if leading.empty?
 
   commands = Hive::E2E::Binary.all_tasks.keys + [ "run" ]
-  cmd_idx = argv.index { |arg| commands.include?(arg) }
+  cmd_idx = wrapper_option_argv(argv).index { |arg| commands.include?(arg) }
   return argv.unshift(*leading) unless cmd_idx
 
   argv.insert(cmd_idx + 1, *leading)
 end
+
+original_argv = ARGV.dup
 
 begin
   reject_invalid_argv_encoding!(ARGV)
@@ -327,7 +337,7 @@ begin
   # mapping usage failures to BinaryExit::USAGE.
   Hive::E2E::Binary.start(ARGV, debug: true)
 rescue Hive::E2E::PreflightError => e
-  if json_requested?(ARGV)
+  if json_requested?(original_argv)
     puts JSON.pretty_generate(Hive::E2E::JsonError.payload(error_kind: "preflight", message: e.message,
                                                           exit_code: Hive::E2E::BinaryExit::CONFIG))
   else
@@ -335,7 +345,7 @@ rescue Hive::E2E::PreflightError => e
   end
   exit Hive::E2E::BinaryExit::CONFIG
 rescue Thor::Error => e
-  if json_requested?(ARGV)
+  if json_requested?(original_argv)
     puts JSON.pretty_generate(Hive::E2E::JsonError.payload(error_kind: "usage", message: e.message,
                                                           exit_code: Hive::E2E::BinaryExit::USAGE))
   else
@@ -343,7 +353,7 @@ rescue Thor::Error => e
   end
   exit Hive::E2E::BinaryExit::USAGE
 rescue StandardError => e
-  if json_requested?(ARGV)
+  if json_requested?(original_argv)
     puts JSON.pretty_generate(Hive::E2E::JsonError.payload(error_kind: "error", message: e.message,
                                                           exit_code: Hive::E2E::BinaryExit::FAILURE))
   else

--- a/test/e2e/lib/hive_e2e_binary_test.rb
+++ b/test/e2e/lib/hive_e2e_binary_test.rb
@@ -158,6 +158,15 @@ class E2EBinaryTest < Minitest::Test
     refute_includes err, "no scenarios match"
   end
 
+  def test_run_treats_help_after_delimiter_as_literal_pattern
+    out, err, status = Open3.capture3(hive_e2e, "run", "--", "--help")
+
+    assert_equal 64, status.exitstatus
+    assert_empty out
+    assert_match(/no scenarios match --help/, err)
+    refute_match(/Usage:/, err)
+  end
+
   def test_replay_missing_repro_emits_json_error_when_requested
     out, err, status = Open3.capture3(hive_e2e, "replay", "--json", "missing-run", "missing-scenario")
     assert_equal 78, status.exitstatus
@@ -307,6 +316,15 @@ class E2EBinaryTest < Minitest::Test
       assert_match(/invalid boolean value for --json/, err)
       refute_match(/no scenarios match #{Regexp.escape(value)}/, err)
     end
+  end
+
+  def test_run_treats_unsupported_json_assignment_after_delimiter_as_literal_pattern
+    out, err, status = Open3.capture3(hive_e2e, "run", "--", "--json=bogus")
+
+    assert_equal 64, status.exitstatus
+    assert_empty out
+    assert_match(/no scenarios match --json=bogus/, err)
+    refute_match(/invalid boolean value for --json/, err)
   end
 
   def test_run_no_match_emits_json_error_when_requested
@@ -471,6 +489,20 @@ class E2EBinaryTest < Minitest::Test
       assert_empty out, "#{flags.join(" ")}: final false JSON flag must force prose output"
       assert_match(/hive-e2e:/, err)
     end
+  end
+
+  def test_usage_error_ignores_json_booleans_after_delimiter
+    out, err, status = Open3.capture3(hive_e2e, "run", "--json", "pattern", "--", "--no-json")
+
+    assert_equal 64, status.exitstatus
+    assert_equal "hive-e2e-error", JSON.parse(out)["schema"]
+    assert_empty err
+
+    out, err, status = Open3.capture3(hive_e2e, "run", "--no-json", "pattern", "--", "--json")
+
+    assert_equal 64, status.exitstatus
+    assert_empty out
+    assert_match(/hive-e2e:/, err)
   end
 
   def test_missing_required_args_with_json_true_emits_envelope_on_stdout

--- a/test/integration/cli_version_test.rb
+++ b/test/integration/cli_version_test.rb
@@ -25,6 +25,15 @@ class CliVersionTest < Minitest::Test
     refute_includes err, "No value provided for required arguments"
   end
 
+  def test_bin_hive_treats_help_after_delimiter_as_literal_target
+    out, err, status = Open3.capture3(RbConfig.ruby, "-Ilib", "bin/hive", "run", "--", "--help")
+
+    assert_equal 64, status.exitstatus
+    assert_empty out
+    assert_match(/no task folder for slug '--help'/, err)
+    refute_match(/Usage:/, err)
+  end
+
   def test_bin_hive_accepts_json_before_status_command
     with_tmp_global_config do
       leading = JSON.parse(run!(RbConfig.ruby, "-Ilib", "bin/hive", "--json", "status"))
@@ -56,6 +65,19 @@ class CliVersionTest < Minitest::Test
     end
   end
 
+  def test_bin_hive_treats_unsupported_json_assignment_after_delimiter_as_literal_target
+    with_tmp_global_config do
+      out, err, status = Open3.capture3(
+        RbConfig.ruby, "-Ilib", "bin/hive", "run", "--", "--json=bogus"
+      )
+
+      assert_equal 64, status.exitstatus
+      assert_empty out
+      assert_match(/no task folder for slug '--json=bogus'/, err)
+      refute_match(/invalid boolean value for --json/, err)
+    end
+  end
+
   def test_bin_hive_usage_error_respects_last_json_boolean_flag
     with_tmp_global_config do
       [
@@ -68,6 +90,26 @@ class CliVersionTest < Minitest::Test
         assert_empty out, "#{flags.join(" ")}: final false JSON flag must force prose output"
         assert_match(/Usage: "hive run TARGET"/, err)
       end
+    end
+  end
+
+  def test_bin_hive_usage_error_ignores_json_booleans_after_delimiter
+    with_tmp_global_config do
+      out, err, status = Open3.capture3(
+        RbConfig.ruby, "-Ilib", "bin/hive", "run", "--json", "target", "--", "--no-json"
+      )
+
+      assert_equal 64, status.exitstatus
+      assert_equal "hive-run", JSON.parse(out)["schema"]
+      assert_match(/hive:/, err)
+
+      out, err, status = Open3.capture3(
+        RbConfig.ruby, "-Ilib", "bin/hive", "run", "--no-json", "target", "--", "--json"
+      )
+
+      assert_equal 64, status.exitstatus
+      assert_empty out
+      assert_match(/Usage: "hive run TARGET"/, err)
     end
   end
 

--- a/wiki/cli.md
+++ b/wiki/cli.md
@@ -3,7 +3,7 @@ title: CLI Surface
 type: api
 source: bin/hive, bin/hv, lib/hive/cli.rb
 created: 2026-04-25
-updated: 2026-06-30
+updated: 2026-07-15
 tags: [cli, api]
 ---
 
@@ -40,6 +40,13 @@ unrecognized `--foo`, and quoted strings containing `--workflow` remain task
 text. When the wrapper itself catches a usage error, JSON-vs-prose mode is
 decided from the last recognized JSON boolean flag in argv, so a trailing false
 form such as `--no-json` or `--json=false` overrides an earlier `--json`.
+Wrapper-owned option scans stop at the first explicit `--`: later `--help`,
+JSON booleans, and unsupported `--json=VALUE` tokens remain literal command
+arguments. Usage-error formatting reads an argv snapshot captured before
+wrapper rewrites and Thor dispatch, so parser mutation cannot change which
+pre-delimiter JSON boolean wins. `hive new` retains its earlier task-text
+boundary for help and unsupported-assignment scans while still lifting
+recognized options only until an explicit delimiter.
 Before any wrapper rewrite or Thor dispatch, every `ARGV` entry must have valid
 encoding. Invalid-byte arguments raise through the same usage-error path as
 malformed wrapper options, so JSON callers still receive the command-specific

--- a/wiki/e2e.md
+++ b/wiki/e2e.md
@@ -3,7 +3,7 @@ title: Agentic E2E Suite
 type: reference
 source: test/e2e/, bin/hive-e2e, Rakefile
 created: 2026-04-29
-updated: 2026-06-21
+updated: 2026-07-15
 tags: [test, e2e, tui, artifacts]
 ---
 
@@ -57,7 +57,11 @@ as `--json=1` or `--json=yes` are usage errors before the value can become the
 default `run` pattern. Wrapper-owned error formatting checks the last
 recognized JSON boolean flag rather than any truthy flag, so duplicate flags
 with a final false form, such as `--json --no-json`, emit the human
-`hive-e2e:` stderr path. Invalid-byte `ARGV` entries are rejected before those
+`hive-e2e:` stderr path. Every wrapper-level help and JSON scan stops at the
+first explicit `--`, leaving later option-looking tokens as literal patterns or
+arguments. Outer error formatting uses an argv snapshot from before wrapper
+rewrites and Thor dispatch, so a post-delimiter literal cannot override the
+actual pre-delimiter JSON mode. Invalid-byte `ARGV` entries are rejected before those
 rewrites and before Thor dispatch, and are reported as usage errors (`64`);
 JSON callers receive the normal `hive-e2e-error` envelope with
 `error_kind: "usage"`.

--- a/wiki/gaps.md
+++ b/wiki/gaps.md
@@ -3,7 +3,7 @@ title: Gaps
 type: gaps
 source: wiki/* vs lib/, templates/, test/, bin/
 created: 2026-04-25
-updated: 2026-07-01
+updated: 2026-07-15
 tags: [gap, todo]
 ---
 
@@ -13,7 +13,7 @@ tags: [gap, todo]
 
 | Area / file set | Page |
 |-----------------|------|
-| `bin/hive`, `lib/hive/cli.rb`, command registration | ✓ [[cli]], [[commands]] cover command registration plus the wrapper-level `--version`, command-local help rewrite, leading JSON boolean grammar contracts, last-recognized-JSON-boolean error-mode semantics, and the `hive new PROJECT` lift-and-rebuild contract that lifts recognized `--workflow`/`--depends-on` (and their `=VALUE`/JSON-boolean forms) from anywhere outside an explicit `--`, rebuilds the `PROJECT TEXT...` tail behind a protective `--`, and leaves a trailing/value-less value option as literal task text. |
+| `bin/hive`, `lib/hive/cli.rb`, command registration | ✓ [[cli]], [[commands]] cover command registration plus the wrapper-level `--version`, command-local help rewrite, leading JSON boolean grammar contracts, first-`--` option-scan termination, snapshot-based last-recognized-JSON-boolean error-mode semantics, and the `hive new PROJECT` lift-and-rebuild contract that lifts recognized `--workflow`/`--depends-on` (and their `=VALUE`/JSON-boolean forms) from anywhere outside an explicit `--`, rebuilds the `PROJECT TEXT...` tail behind a protective `--`, and leaves a trailing/value-less value option as literal task text. |
 | `bin/hive`, `lib/hive/cli.rb`, command registration | ✓ [[cli]], [[commands]] cover command registration plus the wrapper-level `--version`, command-local help rewrite, leading JSON boolean grammar, and pre-dispatch JSON usage-error contracts for required-argument command surfaces. |
 | `lib/hive/commands/*.rb` | ✓ `wiki/commands/*` pages cover the active command surface, including setup, daemon, bot, web, init, new, generate-name, status/archive listing, run, stage-action, markers, migrate, findings, metrics, update, uninstall, wiki, bench-submit, and rebase-status. |
 | `bin/hive`, `lib/hive/cli.rb`, command registration | ✓ [[cli]], [[commands]] cover command registration plus the wrapper-level `--version`, command-local help rewrite, and leading JSON boolean grammar contracts. |

--- a/wiki/log.d/20260715T050824Z-wrapper-delimiter-options.md
+++ b/wiki/log.d/20260715T050824Z-wrapper-delimiter-options.md
@@ -1,0 +1,19 @@
+---
+title: Wrapper option scans respect the end-of-options delimiter
+type: log
+created: 2026-07-15
+tags: [cli, e2e, argv, json, help]
+---
+
+**Action:** Fixed `bin/hive` and `bin/hive-e2e` wrapper preprocessing so the
+first explicit `--` ends wrapper-owned help and JSON option scans. Tokens after
+the delimiter now remain literal arguments, including `--help`, JSON booleans,
+and unsupported `--json=VALUE` assignments. Both wrappers snapshot argv before
+rewrites and Thor dispatch, and wrapper-owned error formatting derives JSON mode
+from recognized pre-delimiter options in that snapshot.
+
+**Evidence:** `test/integration/cli_version_test.rb` and
+`test/e2e/lib/hive_e2e_binary_test.rb` cover literal post-delimiter help and
+invalid JSON assignments plus both true/false JSON precedence directions.
+Focused wrapper suites, adjacent `hive new` and JSON usage-error suites,
+targeted RuboCop, and the full 7,281-test suite pass.

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -3,7 +3,7 @@ title: Testing
 type: reference
 source: test/, Rakefile, bin/hive-eval, .rubocop.yml, .github/workflows/ci.yml, .github/workflows/release.yml, config/brakeman.ignore
 created: 2026-04-25
-updated: 2026-07-01
+updated: 2026-07-15
 tags: [test, minitest, fixtures]
 ---
 
@@ -159,6 +159,7 @@ successful `list --json` / `clean --json` calls, unknown-command JSON errors,
 missing argument errors, top-level version output, command-local help after
 command options (`run --filter tui --help`), leading JSON option normalization,
 malformed JSON assignment rejection, last-JSON-boolean-wins usage-error mode,
+post-`--` help/JSON literal handling and pre-delimiter JSON-mode precedence,
 replay path safety, missing, non-executable, and symlinked replay artifact
 validation, cleanup retention validation, and the single-dispatch invariant for
 successful JSON commands.
@@ -225,6 +226,10 @@ credentials inside a running box.
 The live Telegram bot E2E wrapper lives at `test/e2e/tg/run_idea_e2e.sh` and is also opt-in because it uses a real Bot API test token plus a Telethon user session. In default text mode it drives `/idea <nonce>` through the project picker. With `TG_IDEA_MODE=voice`, the wrapper requires the voice fixture and `HIVE_WHISPER_API_KEY`, starts the bot from the current checkout, drives a new voice idea through transcript confirmation/project selection, seeds a temporary `2-brainstorm/<slug>/brainstorm.md` in the scratch project, then sends `/answer <slug>` and answers Q1 with the same voice note. Cleanup resets the scratch state repo to the captured baseline and removes temporary inbox/brainstorm folders.
 
 `test/e2e/lib/hive_e2e_binary_test.rb` is the focused contract suite for the executable itself. It pins `list --json`, `clean --json`, leading JSON option normalization including `--json=true`, duplicate JSON boolean handling where a final false flag chooses prose, malformed `--json=1` / `--json=yes` rejection, error-envelope shapes, help/version handling, replay path validation, missing/non-executable/symlinked replay artifact errors (`missing_repro` / `unusable_repro`, exit `78`), and the usage exit-code contract: unknown commands and missing required arguments exit `64` in both human and `--json` modes. Human usage errors are expected to print a `hive-e2e:`-prefixed prose message on stderr.
+The same suite and `test/integration/cli_version_test.rb` pin the explicit
+end-of-options contract for both wrappers: help and unsupported JSON
+assignments after `--` are literal arguments, and post-delimiter JSON booleans
+cannot change wrapper-owned usage-error formatting.
 
 ## Live Claude tmux dogfood
 


### PR DESCRIPTION
## Hive Patrol Finding

Slice: `command-bin-hive`
Category: `bug`
Severity: `medium`
Confidence: `high`
Fingerprint: `2843686e084a1e14cc69b0acc6bbed5076331a57cb84fecb6057110ac2b0f8a2`

Both wrappers scan tokens after the end-of-options delimiter for help and JSON controls. As a result, bin/hive run -- --help and bin/hive-e2e run -- --help exit 0 with help instead of dispatching the literal argument; post-delimiter --json=bogus is rejected as an option; and a literal --no-json after -- can override a real pre-delimiter --json when formatting usage errors. The inverse also occurs in hive-e2e, where a literal --json after a real --no-json switches the error to JSON.

## Evidence

- bin/hive:133 help_idx = argv.each_index.find do |idx|
- bin/hive:195 JSON_TRUE_OPTIONS.include?(argv.reverse.find { |arg| JSON_BOOLEAN_OPTIONS.include?(arg) })
- bin/hive-e2e:260 help_idx = argv[(cmd_idx + 1)..]&.index { |arg| arg == "--help" || arg == "-h" }
- bin/hive-e2e:301 arg = argv.find { |candidate| candidate.start_with?("--json=") && !JSON_BOOLEAN_OPTIONS.include?(candidate) }

## Applied Fix

Snapshot argv before Thor mutates it and make every wrapper-level option scan stop at the command-appropriate first -- (while retaining the existing new-command text boundary). Derive error formatting only from actual option positions in that snapshot. Add delimiter regressions for help, true/false JSON precedence, and invalid JSON assignments in both binaries.

## Validation

- lint: passed (`bundle exec rubocop`)
- test: passed (`bundle exec rake test`)

## Diffstat

```text
 bin/hive                                           | 35 +++++++++++-------
 bin/hive-e2e                                       | 26 +++++++++-----
 test/e2e/lib/hive_e2e_binary_test.rb               | 32 +++++++++++++++++
 test/integration/cli_version_test.rb               | 42 ++++++++++++++++++++++
 wiki/cli.md                                        |  9 ++++-
 wiki/e2e.md                                        |  8 +++--
 wiki/gaps.md                                       |  4 +--
 .../20260715T050824Z-wrapper-delimiter-options.md  | 19 ++++++++++
 wiki/testing.md                                    |  7 +++-
 9 files changed, 155 insertions(+), 27 deletions(-)

```
