### PR TITLE
Hive patrol: API option values can spoof an explicit GET

### DIFF
--- a/test/unit/babysitter/dry_run_env_test.rb
+++ b/test/unit/babysitter/dry_run_env_test.rb
@@ -1517,6 +1517,21 @@ class BabysitterDryRunEnvTest < Minitest::Test
     end
   end
 
+  def test_gh_api_option_values_cannot_spoof_an_explicit_get
+    with_tmp_dir do |dir|
+      @real_log = File.join(dir, "real.log")
+      env = {
+        "HIVE_BABYSITTER_REAL_GH" => recording_binary(dir, "real-gh"),
+        "HIVE_BABYSITTER_DRY_RUN_LOG" => File.join(dir, "skipped.log")
+      }
+      mutation = "query=mutation { deleteProjectV2(input: {}) { clientMutationId } }"
+
+      %w[--header -H --jq -q --preview -p --template -t].each do |option|
+        assert_stubbed env, "gh", "api", option, "-XGET", "graphql", "-f", mutation
+      end
+    end
+  end
+
   def test_gh_stub_skips_browser_launch_flags
     with_tmp_dir do |dir|
       real_gh = recording_binary(dir, "real-gh")

--- a/wiki/commands/babysit.md
+++ b/wiki/commands/babysit.md
@@ -3,7 +3,7 @@ title: hive babysit
 type: command
 source: lib/hive/cli.rb, lib/hive/commands/babysit.rb, bin/hive-babysitter-stub-git, bin/hive-babysitter-stub-gh
 created: 2026-05-26
-updated: 2026-07-10
+updated: 2026-07-16
 tags: [command, babysitter, daemon, github]
 ---
 
@@ -88,6 +88,8 @@ Pager note (2026-06-19): allowlisted `git` passthrough now also deletes `PAGER` 
 Current source/test coverage also includes `GIT_EXEC_PATH`, `GIT_ASKPASS`, and `SSH_ASKPASS` in the fail-closed git env guard; they are part of the dry-run boundary, not optional hardening. The dry-run overlay and both stubs now scrub dynamic-loader env (`LD_PRELOAD`, `LD_LIBRARY_PATH`, `LD_AUDIT`, `LD_DEBUG_OUTPUT`, `DYLD_INSERT_LIBRARIES`, `DYLD_LIBRARY_PATH`, `DYLD_FRAMEWORK_PATH`, `DYLD_FALLBACK_LIBRARY_PATH`) before the Ruby stub handoff and before real `git` / `gh` passthrough.
 
 For `gh api`, payload-bearing forms are treated as writes unless the command explicitly sets GET. Dry-run skips implicit-POST calls such as `gh api repos/owner/repo/issues/123/comments -f body=hi`, `-F body=@comment.md`, `--raw-field body=hi`, `--field body=hi`, and `--input payload.json`, while still passing explicit GET reads such as `gh api --method GET repos/owner/repo/issues -f state=open`. Explicit GET file/input payloads and cache writes (`-F q=@secret`, glued `-Fq=@secret` / `-F=q=@secret`, `--field=q=@secret`, `--input=payload.json`, `--cache`, and `--cache=<ttl>`) still skip. Browser-launch flags (`--web` and short `-w` parsed as an option flag on read-only PR/repo/run/workflow commands) also skip. The short-option scanner is command-aware and honors value-taking options, so `w` inside values like `gh pr diff 42 -eworkflow.yml`, `gh pr list -lwip`, `gh pr view 42 -qweb`, or `gh pr list --search -wip` passes through instead of being mistaken for a browser launch. For `gh auth status`, `--show-token`, `--show-token=...`, bare `-t`, clustered boolean shorthand forms containing `t` before a value-taking `h` (for example `-at`, `-ta`, and `-ath`), and every host selector (`-h github.com`, `-hgithub.com`, `-ah github.com`, `--hostname`, and `--hostname=...`) skip, while host-default non-token reads such as plain `gh auth status` and `-a` pass through. Before any allowed `gh` read execs the real binary, pager/browser/editor/TTY env is scrubbed, command-local `GH_CONFIG_DIR` / `XDG_CONFIG_HOME` / `HOME` is neutralized, `GH_HOST` / `GH_REPO` / enterprise-token env is deleted, and both `HOME` and `GH_CONFIG_DIR` are pointed at the run-scoped hosts-only auth view. If the trusted handoff is absent or invalid, the stub falls back to a fresh empty writable temp directory rather than caller-controlled config.
+
+The API classifier consumes every known value-taking option before deriving the method and payload state. In particular, a separate `-XGET` value belonging to `--header`/`-H`, `--jq`/`-q`, `--preview`/`-p`, or `--template`/`-t` is data rather than an explicit method, so a following scalar field remains an implicit POST and is skipped.
 
 The dry-run guard is best-effort: an agent that invokes absolute binary paths can bypass the PATH overlay. Use throwaway repos for destructive validation until a stronger sandbox exists. If `HIVE_BABYSITTER_REAL_GIT` is unset or points at an invalid binary, the stub exits 127 with a one-line diagnostic instead of guessing a system path.
 

--- a/wiki/log.d/20260716T204500Z-babysitter-gh-api-option-values.md
+++ b/wiki/log.d/20260716T204500Z-babysitter-gh-api-option-values.md
@@ -1,0 +1,15 @@
+---
+date: 2026-07-16
+slug: babysitter-gh-api-option-values
+pages: [commands/babysit, modules/babysitter]
+---
+
+The shared pflag-compatible scanner in `bin/hive-babysitter-stub-gh.rb`
+consumes all separate values for known value-taking `gh api` options before
+deriving method and payload state. This fragment adds a focused regression for
+the security boundary: a `-XGET` value belonging to header, jq, preview, or
+template is data, so a following scalar field remains an implicit POST and is
+skipped instead of reaching the authenticated real `gh` binary.
+
+`test/unit/babysitter/dry_run_env_test.rb` now covers both long and short forms
+of those four options with a GraphQL mutation and a recording fake `gh` binary.

--- a/wiki/modules/babysitter.md
+++ b/wiki/modules/babysitter.md
@@ -3,7 +3,7 @@ title: Hive::Babysitter
 type: module
 source: lib/hive/babysitter/, bin/hive-babysitter-stub-git, bin/hive-babysitter-stub-gh, bin/hive-babysitter-skip-log.rb
 created: 2026-05-26
-updated: 2026-07-10
+updated: 2026-07-16
 tags: [babysitter, module, daemon, github, agents]
 ---
 
@@ -85,6 +85,7 @@ Closed outcome enum: `success`, `failure`, `conflict`, `timeout`, `budget_exhaus
 - Current source/test coverage also treats `GIT_EXEC_PATH`, `GIT_ASKPASS`, and `SSH_ASKPASS` as fail-closed git env seams in that same dry-run boundary.
 - Current source/test coverage also scrubs inherited dynamic-loader env (`LD_*` / `DYLD_*`) before generated overlay wrappers hand off to Ruby, and removes the same env family before both dry-run stubs exec real `git` or `gh`.
 - The GH browser-flag scanner is command-aware: it still skips real `--web` / short `-w` browser flags, but treats `w` inside value-taking read-option values as data, so reads such as `pr diff -eworkflow.yml`, `pr list -lwip`, `pr view -qweb`, and `pr list --search -wip` pass through.
+- The `gh api` read/write scanner consumes header, jq, preview, and template values before method detection; an option value equal to `-XGET` cannot spoof an explicit GET for a following payload-bearing request.
 
 - Skip-log FIFO hardening: both dry-run stubs now preflight existing skip-log targets with `File.lstat`, open with `File::NOFOLLOW | File::NONBLOCK`, keep the post-open regular-file/owner check, and warn while still skipping when a FIFO, symlink, device, or non-owned path is configured.
 - Skip-log growth is bounded in the shared helper: escaped argv is limited to 4 KiB, and an exclusive lock serializes the append and 64 KiB size check across concurrent stub processes. When another complete record would exceed the cap, the helper preserves the existing audit history and warns through the best-effort log path. Lock acquisition has a short monotonic deadline so a stalled holder cannot hang a denied command.


### PR DESCRIPTION
## Hive Patrol Finding

Slice: command-bin-hive-babysitter-stub-gh
Category: security
Severity: high
Confidence: high

A value-taking gh api option can consume a following token that looks like a method flag. Without pflag-compatible consumption, a value such as -XGET could be mistaken for an explicit GET and allow a later scalar field to trigger an authenticated implicit POST.

## Integrated Result

Current main already contains the stronger shared pflag-compatible scanner and option metadata, so the rebased PR deliberately retains that implementation. This PR adds the focused security regression proving that separate header, jq, preview, and template values equal to -XGET remain data and that the following GraphQL mutation is skipped before real gh.

## Review

ce-code-review found no actionable source defect. A proposed clustered-option test expansion was independently rejected because existing cluster tests exercise the generic normalizer and the new test covers every newly added option-value consumption branch. Adversarial review passed a 210-case option/payload matrix.

## Validation

- focused dry-run suite: 63 runs, 1,988 assertions, 0 failures, 0 errors
- targeted RuboCop: 1 file, 0 offenses
