### PR TITLE
Hive patrol: JSON mode selection crosses the option terminator

### DIFF
--- a/bin/hive
+++ b/bin/hive
@@ -192,7 +192,8 @@ def lift_new_options!(argv)
 end
 
 def json_requested?(argv)
-  JSON_TRUE_OPTIONS.include?(argv.reverse.find { |arg| JSON_BOOLEAN_OPTIONS.include?(arg) })
+  option_argv = argv.take_while { |arg| arg != "--" }
+  JSON_TRUE_OPTIONS.include?(option_argv.reverse.find { |arg| JSON_BOOLEAN_OPTIONS.include?(arg) })
 end
 
 def reject_invalid_argv_encoding!(argv)

--- a/bin/hive-e2e
+++ b/bin/hive-e2e
@@ -287,7 +287,8 @@ end
 # `--json=<value>` assignments are rejected before Thor can use the value as a
 # command or pattern.
 def json_requested?(argv)
-  JSON_TRUE_OPTIONS.include?(argv.reverse.find { |arg| JSON_BOOLEAN_OPTIONS.include?(arg) })
+  option_argv = argv.take_while { |arg| arg != "--" }
+  JSON_TRUE_OPTIONS.include?(option_argv.reverse.find { |arg| JSON_BOOLEAN_OPTIONS.include?(arg) })
 end
 
 def reject_invalid_argv_encoding!(argv)

--- a/test/e2e/lib/hive_e2e_binary_test.rb
+++ b/test/e2e/lib/hive_e2e_binary_test.rb
@@ -473,6 +473,18 @@ class E2EBinaryTest < Minitest::Test
     end
   end
 
+  def test_usage_error_ignores_json_flags_after_option_terminator
+    out, err, status = Open3.capture3(hive_e2e, "replay", "--json", "--", "--no-json")
+    assert_equal 64, status.exitstatus
+    assert_empty err
+    assert_equal "hive-e2e-error", JSON.parse(out)["schema"]
+
+    out, err, status = Open3.capture3(hive_e2e, "replay", "--", "--json")
+    assert_equal 64, status.exitstatus
+    assert_empty out
+    assert_match(/hive-e2e:/, err)
+  end
+
   def test_missing_required_args_with_json_true_emits_envelope_on_stdout
     out, err, status = Open3.capture3(hive_e2e, "replay", "--json=true")
     refute_equal 0, status.exitstatus

--- a/test/integration/cli_version_test.rb
+++ b/test/integration/cli_version_test.rb
@@ -71,6 +71,21 @@ class CliVersionTest < Minitest::Test
     end
   end
 
+  def test_bin_hive_usage_error_ignores_json_flags_after_option_terminator
+    with_tmp_global_config do
+      out, _err, status = Open3.capture3(
+        RbConfig.ruby, "-Ilib", "bin/hive", "run", "--json", "--", "--no-json", "extra"
+      )
+      assert_equal 64, status.exitstatus
+      assert_equal "hive-run", JSON.parse(out)["schema"]
+
+      out, err, status = Open3.capture3(RbConfig.ruby, "-Ilib", "bin/hive", "run", "--", "--json", "extra")
+      assert_equal 64, status.exitstatus
+      assert_empty out
+      assert_match(/Usage: "hive run TARGET"/, err)
+    end
+  end
+
   def test_bin_hive_new_treats_help_flag_as_task_text_after_project
     with_cli_project do |dir, project|
       out, err, status = run_bin_hive("new", project, "add", "--help", "docs")

--- a/wiki/cli.md
+++ b/wiki/cli.md
@@ -38,8 +38,10 @@ forms, and JSON booleans lifted only in their exact accepted forms (`--json`,
 as `--help`, unsupported-looking `--json=...` assignments after `PROJECT`,
 unrecognized `--foo`, and quoted strings containing `--workflow` remain task
 text. When the wrapper itself catches a usage error, JSON-vs-prose mode is
-decided from the last recognized JSON boolean flag in argv, so a trailing false
-form such as `--no-json` or `--json=false` overrides an earlier `--json`.
+decided from the last recognized JSON boolean flag before the first `--` option
+terminator, so a trailing false form such as `--no-json` or `--json=false`
+overrides an earlier `--json` only while it remains in the option-parsed region.
+JSON-looking positional literals after `--` never change the output mode.
 Before any wrapper rewrite or Thor dispatch, every `ARGV` entry must have valid
 encoding. Invalid-byte arguments raise through the same usage-error path as
 malformed wrapper options, so JSON callers still receive the command-specific

--- a/wiki/commands.md
+++ b/wiki/commands.md
@@ -72,8 +72,9 @@ command argument or task target. `hive new` is the wrapper-level text-tail
 exception: after `hive new PROJECT`, later `--help`, `-h`, or malformed
 `--json=...` tokens are treated as literal task text, with `bin/hive` inserting
 `--` before the tail so Thor leaves the idea text alone. Wrapper-owned usage
-errors use the last recognized JSON boolean flag, so `--json --no-json` and
-`--json --json=false` choose human prose instead of an error envelope.
+errors use the last recognized JSON boolean flag before the first `--` option
+terminator, so `--json --no-json` and `--json --json=false` choose human prose,
+while JSON-looking positional literals after `--` do not affect output mode.
 
 `bin/hv` is the Apache Hive collision fallback entrypoint. It probes only the
 owned Hive CLI locations and `HIVE_BIN_OVERRIDE`; it intentionally does not

--- a/wiki/e2e.md
+++ b/wiki/e2e.md
@@ -55,9 +55,11 @@ grammar as `bin/hive`: bare `--json`, exact truthy assignments
 assignments are moved behind a recognized command. Unsupported assignments such
 as `--json=1` or `--json=yes` are usage errors before the value can become the
 default `run` pattern. Wrapper-owned error formatting checks the last
-recognized JSON boolean flag rather than any truthy flag, so duplicate flags
-with a final false form, such as `--json --no-json`, emit the human
-`hive-e2e:` stderr path. Invalid-byte `ARGV` entries are rejected before those
+recognized JSON boolean flag before the first `--` option terminator rather
+than any truthy flag anywhere in argv, so duplicate option flags with a final
+false form, such as `--json --no-json`, emit the human `hive-e2e:` stderr path,
+while JSON-looking positional literals after `--` do not change output mode.
+Invalid-byte `ARGV` entries are rejected before those
 rewrites and before Thor dispatch, and are reported as usage errors (`64`);
 JSON callers receive the normal `hive-e2e-error` envelope with
 `error_kind: "usage"`.

--- a/wiki/log.d/20260717T040107Z-json-wrapper-option-terminator.md
+++ b/wiki/log.d/20260717T040107Z-json-wrapper-option-terminator.md
@@ -1,0 +1,21 @@
+## [2026-07-17T04:01:07Z] wiki — bound JSON wrapper mode to parsed options
+
+**Action:** Updated the `bin/hive` and `bin/hive-e2e` wrapper contracts after
+their error-mode scanners were changed to stop at the first `--` option
+terminator. Wrapper-owned errors still honor the last recognized JSON boolean
+in the option-parsed region, but JSON-looking positional literals after the
+terminator no longer enable or disable structured output. Added focused
+entrypoint regressions for both a literal `--json` and a literal `--no-json`
+after `--`; [[testing]] records the expanded executable contract. The existing
+pages were sufficient, so [[index]] did not need a catalog update. Did not edit
+the compiled [[log]] or run `qmd update`/`qmd embed`.
+
+**Tests:**
+- `bundle exec ruby -Itest test/integration/cli_version_test.rb -n /option_terminator/`
+- `bundle exec ruby -Itest test/e2e/lib/hive_e2e_binary_test.rb -n /option_terminator/`
+
+**Refreshed pages:**
+- [[cli]]
+- [[commands]]
+- [[e2e]]
+- [[testing]]

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -159,6 +159,8 @@ successful `list --json` / `clean --json` calls, unknown-command JSON errors,
 missing argument errors, top-level version output, command-local help after
 command options (`run --filter tui --help`), leading JSON option normalization,
 malformed JSON assignment rejection, last-JSON-boolean-wins usage-error mode,
+JSON-looking literals after the `--` option terminator being ignored for mode
+selection,
 replay path safety, missing, non-executable, and symlinked replay artifact
 validation, cleanup retention validation, and the single-dispatch invariant for
 successful JSON commands.


### PR DESCRIPTION
## Hive Patrol Finding

Slice: `command-bin-hive`
Category: `bug`
Severity: `medium`
Confidence: `high`
Fingerprint: `5e619825ab6dfaa0d6fa610ae9777c23dda87b9f97264b5ed0bba10bd7804ee6`

json_requested? chooses the last recognized JSON boolean anywhere in argv, including literal arguments after --. Thus a trailing literal --json turns structured error output on, while a trailing literal --no-json suppresses an explicit pre-terminator --json. Reproductions against both entrypoints returned prose with empty stdout for `--json -- --no-json`, violating their machine-readable error contract.

## Evidence

- bin/hive:194 def json_requested?(argv)
- bin/hive-e2e:289 def json_requested?(argv)

## Applied Fix

Determine JSON mode only from the option-parsed region before -- (and before bin/hive's protected new task text), preferably through one shared argv scanner, then cover both enable and disable flags after the terminator in entrypoint tests.

## Validation

- lint: passed (`bundle exec rubocop`)
- test: passed (`bundle exec rake test`)

## Diffstat

```text
 bin/hive                                            |  3 ++-
 bin/hive-e2e                                        |  3 ++-
 test/e2e/lib/hive_e2e_binary_test.rb                | 12 ++++++++++++
 test/integration/cli_version_test.rb                | 15 +++++++++++++++
 wiki/cli.md                                         |  6 ++++--
 wiki/commands.md                                    |  5 +++--
 wiki/e2e.md                                         |  8 +++++---
 ...260717T040107Z-json-wrapper-option-terminator.md | 21 +++++++++++++++++++++
 wiki/testing.md                                     |  2 ++
 9 files changed, 66 insertions(+), 9 deletions(-)

```
