### PR TITLE
Hive patrol: Eval binary contracts are excluded from CI

### DIFF
--- a/test/integration/hive-eval_binary_test.rb
+++ b/test/integration/hive-eval_binary_test.rb
@@ -1,0 +1,117 @@
+require "test_helper"
+require "fileutils"
+require "json"
+require "open3"
+
+class HiveEvalBinaryTest < Minitest::Test
+  def test_rejects_invalid_arguments_before_launching_eval
+    with_fake_bundle do |env, marker, dir|
+      report = File.join(dir, "report.json")
+      cases = [
+        [ [ "s1_status", "--report", report ], /unexpected argument: s1_status/, true ],
+        [ [ "--scenario", "../s1_status", "--report", report ],
+          /scenario basename must not contain path separators/, false ],
+        [ [ "--bogus", "--report", report ], /invalid option: --bogus/, true ]
+      ]
+
+      cases.each do |argv, error, shows_usage|
+        FileUtils.rm_f(marker)
+        File.write(report, JSON.dump({ "schema" => "hive-eval-report", "stale" => true }))
+        _out, err, status = Open3.capture3(env, "bin/hive-eval", *argv)
+
+        assert_equal 64, status.exitstatus, err
+        assert_match error, err
+        assert_match %r{Usage: bin/hive-eval}, err if shows_usage
+        refute File.exist?(report), "parser errors must not leave stale eval reports behind"
+        refute File.exist?(marker), "invalid arguments must be rejected before launching rake"
+      end
+    end
+  end
+
+  def test_scrubs_ambient_test_and_judge_environment
+    with_fake_bundle do |env, marker, dir|
+      [ [ [], nil ], [ [ "--no-judge" ], "1" ] ].each_with_index do |(flags, expected_no_judge), index|
+        report = File.join(dir, "report-#{index}.json")
+        File.write(report, JSON.dump({ "stale" => true }))
+
+        _out, err, status = Open3.capture3(
+          env.merge("TEST" => "test/unit/config_test.rb", "HIVE_EVAL_NO_JUDGE" => "ambient"),
+          "bin/hive-eval", *flags, "--report", report
+        )
+
+        assert status.success?, err
+        invocation = File.readlines(marker, chomp: true).to_h { |line| line.split("=", 2) }
+        assert_equal "exec rake test:eval", invocation.fetch("argv")
+        assert_empty invocation.fetch("test")
+        if expected_no_judge
+          assert_equal expected_no_judge, invocation.fetch("no_judge")
+        else
+          assert_empty invocation.fetch("no_judge")
+        end
+        assert_equal "1", invocation.fetch("scenarios_only")
+        assert_equal report, invocation.fetch("report")
+        refute File.exist?(report), "hive-eval must clear a stale report before launching rake"
+      end
+    end
+  end
+
+  def test_usage_error_removes_selected_report_without_launching_eval
+    with_fake_bundle do |env, marker, dir|
+      report = File.join(dir, "stale.json")
+      File.write(report, JSON.dump({ "schema" => "hive-eval-report", "stale" => true }))
+
+      _out, err, status = Open3.capture3(
+        env,
+        "bin/hive-eval", "--report", report, "--scenario", "definitely_missing", "--no-judge"
+      )
+
+      assert_equal 64, status.exitstatus, err
+      assert_match(/scenario not found/, err)
+      refute File.exist?(report), "usage errors must not leave stale eval reports behind"
+      refute File.exist?(marker), "missing scenarios must be rejected before launching rake"
+    end
+  end
+
+  def test_help_preserves_selected_report_without_launching_eval
+    with_fake_bundle do |env, marker, dir|
+      report = File.join(dir, "existing.json")
+      contents = JSON.dump({ "schema" => "hive-eval-report", "existing" => true })
+      File.write(report, contents)
+
+      out, err, status = Open3.capture3(env, "bin/hive-eval", "--report", report, "--help")
+
+      assert status.success?, err
+      assert_match %r{Usage: bin/hive-eval}, out
+      assert_equal contents, File.read(report)
+      refute File.exist?(marker), "help must not launch rake"
+    end
+  end
+
+  private
+
+  def with_fake_bundle
+    Dir.mktmpdir("hive-eval-fake-bundle") do |dir|
+      bin_dir = File.join(dir, "bin")
+      marker = File.join(dir, "bundle-called")
+      bundle = File.join(bin_dir, "bundle")
+      FileUtils.mkdir_p(bin_dir)
+      File.write(bundle, <<~'SH')
+        #!/bin/sh
+        {
+          printf 'argv=%s\n' "$*"
+          printf 'test=%s\n' "${TEST-}"
+          printf 'no_judge=%s\n' "${HIVE_EVAL_NO_JUDGE-}"
+          printf 'scenarios_only=%s\n' "${HIVE_EVAL_SCENARIOS_ONLY-}"
+          printf 'report=%s\n' "${HIVE_EVAL_REPORT-}"
+        } > "$HIVE_EVAL_FAKE_BUNDLE_MARKER"
+      SH
+      FileUtils.chmod("+x", bundle)
+
+      env = {
+        "HIVE_EVAL_FAKE_BUNDLE_MARKER" => marker,
+        "PATH" => [ bin_dir, ENV.fetch("PATH") ].join(File::PATH_SEPARATOR)
+      }
+      yield env, marker, dir
+    end
+  end
+end

--- a/wiki/log.d/20260717T202926Z-hive-eval-default-contracts.md
+++ b/wiki/log.d/20260717T202926Z-hive-eval-default-contracts.md
@@ -1,0 +1,14 @@
+## [2026-07-17T20:29:26Z] testing - run fast hive-eval contracts in the default suite
+
+**Action:** Added `test/integration/hive-eval_binary_test.rb` so the default
+unit/integration/babysitter task exercises `bin/hive-eval` parser rejection,
+environment isolation, and report lifecycle behavior through a fake `bundle`
+seam. Full eval report and scenario tests remain under the opt-in eval suite.
+Naming the focused test after `hive-eval` also associates it with patrol's
+`command-bin-hive-eval` feature mapping.
+
+**Tests:** Verified the focused file directly and through `bundle exec rake
+test TEST=test/integration/hive-eval_binary_test.rb` (4 runs, 46 assertions),
+ran RuboCop on the new integration test, and passed `bundle exec rake coverage`
+(7,282 runs, 75,224 assertions, 0 failures). The shell-backed fake-bundle
+fixture avoids starting a nested coverage-instrumented Ruby child.

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -136,6 +136,7 @@ task default: :test
 | `daemon_stale_agent_healing_test.rb` | Status-to-healer integration — real `hive status --json` rows feed `Hive::Daemon::StaleAgentHealer`, pinning stale `AGENT_WORKING` classification, on-disk healing, closed logger events (`marker_healed`, `heal_requeued`, `marker_heal_failed`), `daemon.agent_marker_grace_sec` threading, and the `3-plan` terminal-loss healer writing a real allowlisted dispatch request. |
 | `full_flow_test.rb` | End-to-end: idea → brainstorm → plan → execute → open-pr → review → finalize → done. |
 | `cli_version_test.rb`, `cli_usage_error_json_test.rb`, `new_wrapper_argv_test.rb` | `bin/hive` wrapper contract — top-level `--version`, command-local help after option-bearing invocations (`hive approve --from 2-brainstorm --help`), leading `--json=true`, malformed `--json=1` / `--json=yes` assignment rejection before command text/targets, invalid-byte argv rejection before Thor parsing, `hive new PROJECT` preserving post-project `--help` and `--json=yes` as literal task text while lifting allow-listed `new` options (`--workflow`, `--depends-on`, and JSON booleans) from before project, between project and text, or after text, and pre-dispatch JSON usage-error envelopes for missing required arguments on representative command schemas (`hive-run`, `hive-approve`, `hive-markers-clear`, `hive-drop`, `hive-findings`, `hive-rebase-status`, `hive-stage-action`, and the patrol-specific `hive-patrol` / `error_kind: "error"` case). |
+| `hive-eval_binary_test.rb` | `bin/hive-eval` fast wrapper contract — parser rejection before dispatch, ambient `TEST` / `HIVE_EVAL_NO_JUDGE` isolation, no-judge forwarding, stale-report cleanup, and read-only help behavior through a fake `bundle` seam. The `hive-eval` filename also associates this suite with the patrol command feature. |
 | `patrol_command_test.rb` | `hive patrol` — JSON envelope, dry-run behavior, scan-state recording, inbox non-interference, retry/backoff outcomes, and schema validation with fake mapper/reviewer/fixer/PR opener collaborators. |
 | `wiki_command_test.rb` | `hive wiki` — compile-log writes the generated aggregate, `--check` distinguishes stale vs up-to-date output, invalid subcommands/missing wiki dirs raise usage errors, CLI dispatch reaches the command, and help lists the wiki surface. |
 | `tui_smoke_test.rb`, `tui_smoke_charm_test.rb` | PTY-driven `bin/hive tui` smokes — boot, first useful paint with a seeded project, clean `q` exit, horizontal and vertical resize handling, and the startup regression gate (a generous 5s bound that catches a revert to the starved-poll loading grid without flaking; the 10s read_until is the hard gate). |
@@ -251,6 +252,11 @@ The Telegram bot eval harness is opt-in and separate from the default suite:
 bundle exec rake test:eval
 bin/hive-eval --scenario s1_status --no-judge --report /tmp/hive-eval.json
 ```
+
+The executable's fast parser, environment-isolation, and report-lifecycle
+contracts live in `test/integration/hive-eval_binary_test.rb`, where a fake
+`bundle` executable keeps them in the default CI suite without running eval
+scenarios. Full report generation and scenario behavior remain opt-in here.
 
 `test/eval/support/` provides an in-process fake Telegram transport, a programmable status watcher, child-supervisor and dispatch-request captures, a scenario DSL, typed-reason contract assertions, scripted/Codex personas, and a Codex prose judge. Scenario files live under `test/eval/scenarios/` and drive the real `Hive::Bot::Supervisor#process_update` / `#status_tick` entrypoints without changing production bot behavior. Queue-routable bot verbs are captured through the fake `DispatchRequestWriter`, and `Harness#dispatched_commands` lets scenarios assert command intent across both queued and child-spawned dispatch paths.
 


### PR DESCRIPTION
## Hive Patrol Finding

Slice: `command-bin-hive-eval`
Category: `test-gap`
Severity: `medium`
Confidence: `high`
Fingerprint: `74600f76ca61ca6d4e4dd78a9328d07060129f1752143264e03cc794d3077de0`

The direct bin/hive-eval contract coverage lives in test/eval/support/reporter_test.rb, but the default test task used by the coverage CI includes only unit, integration, and babysitter tests. The feature's listed associated tests exercise hive-e2e, web bind policy, and invoked-binary resolution rather than hive-eval, so parser, environment-isolation, and report-lifecycle regressions can merge without running the executable's focused suite.

## Evidence

- Rakefile:11 t.test_files = FileList["test/{unit,integration,babysitter}/**/*_test.rb"]
- Rakefile:35 Rake::Task[:test].invoke
- test/eval/support/reporter_test.rb:13 "bin/hive-eval", "s1_status", "--no-judge", "--report", report

## Applied Fix

Move or split the fast bin/hive-eval CLI contract cases into a test/integration binary test that uses the existing fake-bundle seam and therefore runs in the default CI suite; keep the slower full eval scenarios opt-in. Also associate that focused binary test with command-bin-hive-eval.

## Validation

- lint: passed (`bundle exec rubocop`)
- test: passed (`bundle exec rake test`)

## Diffstat

```text
 test/integration/hive-eval_binary_test.rb          | 117 +++++++++++++++++++++
 ...20260717T202926Z-hive-eval-default-contracts.md |  14 +++
 wiki/testing.md                                    |   6 ++
 3 files changed, 137 insertions(+)

```
