### PR TITLE
release: prepare v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,89 @@
 # Changelog
 
-All notable changes are documented here, newest first. Hive ships frequent micro-releases (see [docs/RELEASING.md](docs/RELEASING.md#versioning-policy)): each `vX.Y.Z` git tag gets a `## X.Y.Z` section with terse bullets — no `[Unreleased]` accumulator. Versioning is [SemVer](https://semver.org): PATCH for fixes and small changes (the common case), MINOR for notable features, MAJOR for milestones.
+All notable changes are documented here, newest first. Hive ships frequent micro-releases (see [docs/RELEASING.md](docs/RELEASING.md#versioning-policy)): each `vX.Y.Z` git tag gets a `## X.Y.Z` section with user-facing bullets and, for notable releases, descriptive subsections — no `[Unreleased]` accumulator. Versioning is [SemVer](https://semver.org): PATCH for fixes and small changes (the common case), MINOR for notable features, MAJOR for milestones.
 
-## 0.4.3
+## 0.5.0
 
+Hive 0.5.0 makes long-running autonomous work durable, adds a safe lifecycle
+for reusable community workflows, and substantially expands both ordinary and
+architecture patrol. It includes every change merged since v0.4.2; the
+previously prepared but unpublished 0.4.3 changes are included here.
+
+### Community workflows and agent setup
+
+- Added the Honeycomb workflow lifecycle: `hive workflow install`, `list`,
+  `update`, `remove`, and `publish` can manage reviewed community workflows
+  with deterministic manifests, immutable task-pinned generations, semantic
+  and security diffs, crash-safe activation, and explicit consent for
+  permission escalation. Managed workflows fail closed before installation and
+  again before agent launch when their tool, command, path, or network policy
+  cannot be enforced; existing built-in and project-authored workflows keep
+  their previous behavior. (#751)
+- Added evidence-backed diagnosis and provisioning for the enabled Claude,
+  Codex, and Pi skills Hive depends on. `hive doctor` remains read-only,
+  `hive setup-agents` previews and verifies one consented repair plan, and
+  interactive `hive init` can hand unresolved defaults to the same engine
+  without overwriting user-owned aliases or Codex sources. (#750)
 - Added path-qualified `Read(...)` and `Edit(...)` workflow permissions, with
   exact task/repository scope projection and fail-closed portable-path
-  validation. This enables repository-wide reads with writes constrained to
+  validation. Workflows can now read a repository while limiting writes to
   selected files or subtrees. (#769)
 - Added strict repository-aware dependency admission across manual commands,
-  daemon dispatch, and status v5 so missing, ambiguous, or stale cross-project
-  dependencies stop safely with actionable diagnostics.
-- Expanded post-merge architecture patrol into a durable scheduled workflow
-  with bounded discovery, resumable fenced actions, isolated automatic fixes,
-  validated GitHub publication, and persistent lifecycle reconciliation.
+  daemon dispatch, and status. Missing, ambiguous, corrupt, cross-repository,
+  or stale dependencies now hold safely with an explicit reason and correction
+  instead of running against the wrong prerequisite.
+- Fixed upgrades from the former project-local hive-bench workflow. An exact
+  legacy `bench.yml` remains visible and runnable with a migration hint, and
+  `hive init PROJECT --workflow bench` archives it and atomically selects the
+  built-in workflow without disturbing modified or independently authored
+  descriptors. (#747)
+
+### Durable autonomous execution
+
+- Added durable task-stage attempt ownership. Accepted agents run under a
+  detached supervisor with leases, heartbeats, checkpoints, framed logs, and a
+  terminal receipt, so work can survive the CLI, bot/web request, or daemon
+  process that launched it. Daemon restarts adopt live work, duplicate delivery
+  attaches or replays instead of spawning a second agent, and a definitively
+  lost owner preserves evidence for a bounded successor. (#767)
+- Added generation-scoped task conditions backed by an fsynced event journal
+  and rebuildable projection. Execute decisions now use evidence from the
+  current task input, attempt family, and exact HEAD, so an old no-change wait
+  cannot block a repaired attempt that produced a commit; status, daemon, TUI,
+  bot, web, and task actions consume the same reproducible decision. (#768)
+- Added durable implementation identity across execute, PR opening, and review
+  fixes. Retries and restarts keep the selected provider/model, PR opening uses
+  that provider's utility model, review and CI fixes retain the exact execute
+  model, and CLI/JSON/TUI/web status explains the ownership and effort source.
+  (#773)
+- Fixed generic agent stages overwriting provider-limit cooldowns and other
+  agent-authored terminal errors with `agent_preflight_failed`; the daemon can
+  now retain and resume the specific retryable state. (#728)
+
+### Patrol and architecture patrol
+
+- Expanded post-merge architecture patrol into a durable scheduled workflow:
+  immutable merge manifests feed bounded language-neutral discovery, semantic
+  finding families, leverage scoring, resumable fenced actions, isolated
+  automatic fixes, validated GitHub issue/PR publication, and persistent
+  reconciliation after crashes or partial remote success.
+- Raised ordinary patrol signal quality with repository-wide candidate
+  selection, evidence/impact/novelty ranking, component-level deduplication,
+  immutable selection receipts, proof-gated fixes, and shared token, turn,
+  timeout, concurrency, and daily-spend ceilings for ordinary and architecture
+  patrol.
+- Fixed patrol scanning and review handoff so every new or resumed publication
+  proves the current remote default-branch commit and exact patrol head. Failed
+  fetches, unusable saved pins, same-named tags, stalled transports, or an
+  advanced base now fail closed instead of publishing stale review work. (#783)
+- Fixed malformed or unreadable project configuration taking down the global
+  daemon. Patrol now isolates that project, refuses model spend when no
+  validation command can prove a shippable fix, and measures each patch from
+  its immutable pre-agent base. (#758)
 - Hardened patrol and incident-regression CI against option-value spoofing,
-  unsafe repository Git helpers, unbounded logs/work, stale artifacts, and
-  non-hermetic subprocess state.
+  unsafe repository Git helpers, path/symlink/rename escapes, unbounded logs or
+  work, stale artifacts, non-hermetic subprocess state, incomplete retries,
+  corrupt durable state, and publication/reconciliation edge cases.
 
 ## 0.4.2
 
@@ -73,14 +140,6 @@ All notable changes are documented here, newest first. Hive ships frequent micro
 
 ## 0.3.7
 
-- Added manifest-driven diagnosis and consent-safe provisioning for enabled
-  built-in Claude, Codex, and Pi skills. `hive doctor --json` now emits the
-  evidence-rich `hive-doctor.v2` contract; `hive setup-agents` previews,
-  revalidates, provisions through native CLIs, and verifies without clobbering
-  user-owned aliases or Codex sources.
-- Interactive `hive init` can hand unresolved managed skills to the same setup
-  engine after project creation. JSON and non-TTY init remain non-mutating and
-  print standalone remediation instead.
 - Fixed hive failing to start on Arch Linux with `cannot load such file -- erb`:
   erb is now a declared runtime dependency. Distros ship erb as a separate
   package since ruby unbundled it, so every verb (`tui`, `plan`, the daemon)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hive-cli (0.4.3)
+    hive-cli (0.5.0)
       bubbletea (= 0.1.4)
       erb (>= 4.0)
       faraday (>= 2.14.2, < 3.0)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Hive ships as a rubygem (`hive-cli`) attached to each GitHub Release, signed wit
 | Platform | Channel |
 |----------|---------|
 | macOS arm64 | [`brew install ivankuznetsov/hive/hive`](https://github.com/ivankuznetsov/homebrew-hive) |
-| Ubuntu 22.04+ / glibc Linux x86_64/aarch64 | <code>tmpdir="$(mktemp -d)" && trap 'rm -rf "$tmpdir"' EXIT && curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.4.3/install.sh -o "$tmpdir/hive-install.sh" && bash "$tmpdir/hive-install.sh"</code> |
+| Ubuntu 22.04+ / glibc Linux x86_64/aarch64 | <code>tmpdir="$(mktemp -d)" && trap 'rm -rf "$tmpdir"' EXIT && curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.5.0/install.sh -o "$tmpdir/hive-install.sh" && bash "$tmpdir/hive-install.sh"</code> |
 | Arch Linux x86_64/aarch64 | [`yay -S hive-bin`](https://aur.archlinux.org/packages/hive-bin) |
 
 Prerequisites: **Ruby 3.4** (the gem and its runtime deps install against this), git ≥ 2.40, authenticated `claude` ≥ 2.1.118, `codex` ≥ 0.125.0 for the default execute agent, `grok` ≥ 0.2.90 when selected, authenticated `gh`, `tmux` ≥ 3.0 when the project uses the default `claude.mode: tmux`, and Node.js/npm for managed QMD install/repair. The bash installer reports its own installer-side prereqs (`curl`, `jq`, `gem`, checksum tool) on first run; if npm is missing, Hive still installs and `hive doctor` reports the QMD gap non-fatally.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -53,10 +53,11 @@ depends on the gem via `path: ".."`, so a stale web lock fails its frozen
 && git push origin vX.Y.Z`. The tag drives `release.yml` (above). The owner
 bypasses the `v*` tag-protection ruleset.
 
-**CHANGELOG style:** newest-first `## X.Y.Z` sections with terse `-` bullets
-(prefix fixes with "Fixed"); no `[Unreleased]` accumulator, no per-category
-subheadings, no dates — the git tag carries the date. A release with nothing
-user-facing gets a one-line "no user-facing changes" note.
+**CHANGELOG style:** newest-first `## X.Y.Z` sections with user-facing `-`
+bullets (prefix fixes with "Fixed"); no `[Unreleased]` accumulator and no dates
+— the git tag carries the date. Use descriptive `###` category subheadings for
+notable minor/major releases; keep routine patch releases terse. A release with
+nothing user-facing gets a one-line "no user-facing changes" note.
 
 ---
 

--- a/install.md
+++ b/install.md
@@ -59,8 +59,8 @@ Ubuntu 22.04+ / glibc Linux fallback (pin to the current release tag, not `main`
 ```bash
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
-# Release maintainers: bump v0.4.3 in both installer URLs when cutting a new stable release.
-curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.4.3/install.sh -o "$tmpdir/hive-install.sh"
+# Release maintainers: bump v0.5.0 in both installer URLs when cutting a new stable release.
+curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.5.0/install.sh -o "$tmpdir/hive-install.sh"
 bash "$tmpdir/hive-install.sh"
 ```
 
@@ -69,8 +69,8 @@ To inspect the installer first, run a dry-run before the real invocation. State 
 ```bash
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
-# Release maintainers: bump v0.4.3 in both installer URLs when cutting a new stable release.
-curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.4.3/install.sh -o "$tmpdir/hive-install.sh"
+# Release maintainers: bump v0.5.0 in both installer URLs when cutting a new stable release.
+curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.5.0/install.sh -o "$tmpdir/hive-install.sh"
 bash "$tmpdir/hive-install.sh" --dry-run
 bash "$tmpdir/hive-install.sh"
 ```

--- a/lib/hive.rb
+++ b/lib/hive.rb
@@ -1,5 +1,5 @@
 module Hive
-  VERSION = "0.4.3".freeze
+  VERSION = "0.5.0".freeze
   MIN_CLAUDE_VERSION = "2.1.118".freeze
   # Canonical GitHub org + repo. Referenced by the release probe
   # (UpdateCheck), the brew tap + installer URL (Commands::Update), etc.

--- a/web/Gemfile.lock
+++ b/web/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    hive-cli (0.4.3)
+    hive-cli (0.5.0)
       bubbletea (= 0.1.4)
       erb (>= 4.0)
       faraday (>= 2.14.2, < 3.0)

--- a/wiki/active-areas.md
+++ b/wiki/active-areas.md
@@ -3,7 +3,7 @@ title: Active Areas
 type: active-areas
 source: git log + working tree
 created: 2026-04-25
-updated: 2026-07-17
+updated: 2026-07-18
 tags: [roadmap, status]
 ---
 
@@ -13,7 +13,7 @@ tags: [roadmap, status]
 
 Daemon autostart hardening landed on `main` via #189 (2026-05-26): autostart is now install-time/global infrastructure. A Linux host without systemd-user writes the unit and reports the `unsupported` success outcome (exit 0) instead of a spurious failure; `install.sh` captures the real install exit code and carries the verified `hive`/`hv` wrapper through daemon install + `hive init`; `Hive::InvokedBinary` replaces the dead `which` delegators. See log entries 2026-05-26 (21:22Z / 22:55Z / 23:30Z) and ADR-024.
 
-Recent release/dependency/history inspected on 2026-07-17:
+Recent release/dependency/history inspected on 2026-07-18:
 
 | Commit | Area | Notes |
 |--------|------|-------|
@@ -66,7 +66,7 @@ Recent release/dependency/history inspected on 2026-07-17:
 | Telegram bot (ADR-026) | `lib/hive/bot/*`, `lib/hive/commands/bot.rb`, `wiki/commands/bot.md`, `wiki/modules/bot.md` | Mobile human-input surface: long-polls Telegram, notifies on waiting/recovery gates, writes brainstorm answers under lock, and dispatches existing `hive` commands from inline buttons. `hive bot install` adds an opt-in reboot-survivable per-user service (systemd-user/launchd) that runs `hive bot start --foreground` with no inline token; torn down by `hive uninstall`. |
 | Shared service installer | `lib/hive/commands/service_installer/{base,outcome}.rb`, `lib/hive/commands/{daemon,bot}/service_installer.rb`, `schemas/hive-{bot,daemon}-install.v1.json`, `docs/solutions/…cross-platform-service-installer-base…` | `ServiceInstaller::Base` extracted from the daemon installer (daemon behavior byte-identical) and subclassed by daemon + bot, returning a `ServiceInstaller::Outcome` value object. Content-comparison drift detection (`--force` to overwrite), `unsupported` outcome on hosts with no service manager, exit codes 0/64/70, and a read-only `service_state` probe surfaced as `service_installed`/`service_enabled`/`unit_path` in both `bot`/`daemon status --json`. |
 | Testing and eval | `test/unit/`, `test/integration/`, `test/e2e/`, `test/eval/`, `Rakefile`, `bin/hive-eval` | Default `bundle exec rake test`; strict `bundle exec rake coverage`; opt-in e2e and Telegram bot eval layers. |
-| Release/install | `install.sh`, `install.md`, `packaging/`, `.github/workflows/install-smoke.yml`, `.github/workflows/release.yml` | v0.4.3 release prep synchronizes both path-gem locks and public installer pins after path-qualified workflow permissions, repository-aware dependency admission, durable architecture patrol, and incident-CI hardening. Update/uninstall, release artifact verification, install-smoke `jq` provisioning, daemon service install JSON envelopes, hivebox Docker install/smoke flow, and remaining signed-tag/macOS x86_64/live-provider follow-ups are documented in [[operating]], [[commands/web]], [[testing]], and [[gaps]]. |
+| Release/install | `install.sh`, `install.md`, `packaging/`, `.github/workflows/install-smoke.yml`, `.github/workflows/release.yml` | v0.5.0 release prep synchronizes both path-gem locks and public installer pins after Honeycomb workflow lifecycle support, managed agent-skill provisioning, durable attempt/condition/implementation ownership, path-qualified workflow permissions, repository-aware dependency admission, durable architecture patrol, and incident-CI hardening. It supersedes the untagged v0.4.3 prep and includes every change since v0.4.2. Update/uninstall, release artifact verification, install-smoke `jq` provisioning, daemon service install JSON envelopes, hivebox Docker install/smoke flow, and remaining signed-tag/macOS x86_64/live-provider follow-ups are documented in [[operating]], [[commands/web]], [[testing]], and [[gaps]]. |
 | Docs/wiki | `README.md`, `docs/notes/`, `wiki/`, `.llm-wiki/` | Managed llm-wiki context is installed for Codex/Claude/Pi; refresh automation is Codex-owned by `.llm-wiki/config.json`. |
 
 ## Phase 1 deferred work

--- a/wiki/dependencies.md
+++ b/wiki/dependencies.md
@@ -3,7 +3,7 @@ title: Dependencies
 type: dependencies
 source: Gemfile, hive.gemspec, Gemfile.lock, web/Gemfile, web/Gemfile.lock
 created: 2026-04-25
-updated: 2026-07-17
+updated: 2026-07-18
 tags: [dependencies, gems, runtime]
 ---
 
@@ -11,9 +11,9 @@ tags: [dependencies, gems, runtime]
 
 `hive.gemspec` owns runtime gem constraints; `Gemfile` uses `gemspec`
 to pull those constraints into Bundler, then adds development/test-only
-tools. The v0.4.3 release-prep checkout is `0.4.3`: `lib/hive.rb`, root
+tools. The v0.5.0 release-prep checkout is `0.5.0`: `lib/hive.rb`, root
 `Gemfile.lock`, and `web/Gemfile.lock` all pin the local path gem as
-`hive-cli (0.4.3)`. The release-prep change keeps both lockfiles synchronized
+`hive-cli (0.5.0)`. The release-prep change keeps both lockfiles synchronized
 with public installer URLs and the changelog. Recent root bundle dependency
 commits also bumped RuboCop to 1.88.2, Brakeman from
 8.0.4 to 8.0.5, and `concurrent-ruby` from 1.3.6 to 1.3.7; the separate web
@@ -136,7 +136,7 @@ These are not gems but the CLI tools the runtime invokes:
 `Gemfile` declares `ruby "~> 3.4"`. `hive.gemspec` requires Ruby
 `>= 3.4.0` for the packaged gem. `.rubocop.yml` pins
 `TargetRubyVersion: 3.4`. `Gemfile.lock` records Ruby 3.4.7, Bundler
-2.7.2, and the current local path gem as `hive-cli (0.4.3)`.
+2.7.2, and the current local path gem as `hive-cli (0.5.0)`.
 
 ## Backlinks
 

--- a/wiki/gaps.md
+++ b/wiki/gaps.md
@@ -3,7 +3,7 @@ title: Gaps
 type: gaps
 source: wiki/* vs lib/, templates/, test/, bin/
 created: 2026-04-25
-updated: 2026-07-17
+updated: 2026-07-18
 tags: [gap, todo]
 ---
 
@@ -222,16 +222,18 @@ evidence closing the following June 16 gaps.
 
 ## Release install follow-ups
 
-Latest refresh (2026-07-17): v0.4.3 release-prep source is synchronized in
+Latest refresh (2026-07-18): v0.5.0 release-prep source is synchronized in
 `lib/hive.rb`, both lockfiles, README/install URLs, the changelog, and the
 release-facing wiki pages. This source commit does not itself prove the public
 tag, signed gem/assets, Homebrew/AUR updates, or multi-architecture hivebox
 images; those remain the tag-triggered `release.yml` verification boundary.
+The v0.5.0 prep supersedes the untagged v0.4.3 prep and includes every commit
+since the published v0.4.2 tag.
 Historical commit `54fd3455` still provides commit-message evidence for the
 native arm64 GHCR smoke against `ghcr.io/ivankuznetsov/hivebox:0.3.1`.
 Dependency lock uncertainty is unchanged: the root bundle has
 `concurrent-ruby` 1.3.7 and Brakeman 8.0.5, while `web/Gemfile.lock` resolves
-`concurrent-ruby` 1.3.6 and Brakeman 8.0.4; v0.4.3 synchronizes only the local
+`concurrent-ruby` 1.3.6 and Brakeman 8.0.4; v0.5.0 synchronizes only the local
 `hive-cli` path-gem version in that independently resolved web bundle.
 
 1. **Release tag creation is protected, while signed git-tag verification remains deferred.** Homebrew and AUR publishing are implemented and public install docs route macOS users to the tap and Arch users to `yay -S hive-bin` (see ADR-032 in [[decisions]], `docs/RELEASING.md`, `README.md`, and `install.md`). The live repository has an active `v*` tag ruleset restricting creation, update, deletion, and non-fast-forward changes to the configured repository-role bypass. Release automation still publishes the commit selected by an authorized tag without independently verifying a maintainer cryptographic git-tag signature.

--- a/wiki/log.d/20260718T115314Z-release-v050.md
+++ b/wiki/log.d/20260718T115314Z-release-v050.md
@@ -1,0 +1,18 @@
+---
+title: Prepare v0.5.0 minor release
+created: 2026-07-18T11:53:14Z
+tags: [release, packaging, workflows, attempts, patrol]
+---
+
+- Prepared Hive v0.5.0 as the next minor release from the published v0.4.2
+  baseline, superseding the untagged v0.4.3 prep and including every subsequent
+  merged change.
+- Synchronized `Hive::VERSION`, both path-gem lockfiles, and the public pinned
+  installer URLs at `0.5.0` / `v0.5.0`.
+- Replaced the unpublished v0.4.3 changelog section with explicit, grouped
+  v0.5.0 notes focused on Honeycomb workflow lifecycle commands, managed agent
+  skill setup, durable task-stage/condition/implementation ownership, workflow
+  permissions and dependencies, patrol quality, and architecture patrol.
+- Publication remains unproven until the release branch merges, tag-triggered
+  GitHub workflow completes, signed assets and install channels verify, and the
+  released binary is exercised locally.

--- a/wiki/operating.md
+++ b/wiki/operating.md
@@ -3,7 +3,7 @@ title: Operating Hive
 type: operating
 source: README.md, bin/hv, install.sh, lib/hive/commands/daemon.rb, lib/hive/commands/babysit.rb, lib/hive/commands/bot.rb, lib/hive/commands/setup_agents.rb, examples/systemd/, examples/launchd/, openclaw/skills/hive/SKILL.md, openclaw/README.md
 created: 2026-05-07
-updated: 2026-07-17
+updated: 2026-07-18
 tags: [operating, daemon, bot, systemd, launchd, install, skills]
 ---
 
@@ -60,7 +60,7 @@ yay -S hive-bin
 # glibc Linux fallback / Ubuntu 22.04+ (pin to the release tag, not main)
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
-curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.4.3/install.sh -o "$tmpdir/hive-install.sh"
+curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.5.0/install.sh -o "$tmpdir/hive-install.sh"
 bash "$tmpdir/hive-install.sh"
 ```
 
@@ -193,8 +193,8 @@ the published schemas, and asserts no state leaks outside the prefix.
 Local usage:
 
 ```bash
-packaging/verify-release.sh --version=v0.4.3
-packaging/verify-release.sh --version=v0.4.3 --report=json | jq .ok
+packaging/verify-release.sh --version=v0.5.0
+packaging/verify-release.sh --version=v0.5.0 --report=json | jq .ok
 ```
 
 For unreleased packaging fixes, validate against the locally built gem rather


### PR DESCRIPTION
## Summary

Hive 0.5.0 becomes the single public release for every change since v0.4.2, replacing the unpublished 0.4.3 preparation. Reviewers and users get grouped notes for community workflows, durable autonomous execution, and patrol/architecture patrol, while every version and public installer pin agrees on 0.5.0.

This also repairs the changelog history added by PR #750: agent-skill provisioning is described under 0.5.0, not retroactively under the already-tagged 0.3.7 release.

## Verification

- structured correctness and project-standards review: clean after the historical changelog placement fix
- exact-seed full coverage run: 9,306 runs, 131,525 assertions, 100.00% line coverage; four late failures/errors were traced to exhausted temporary storage and every affected test passed after project-native cleanup
- focused release/install/version tests: 30 runs, 133 assertions, 0 failures, 0 errors
- `git diff --check` and Ruby syntax/version checks pass
- built `hive-cli-0.5.0.gem`, installed it with dependencies into an isolated prefix, and verified `hive --version` reports `0.5.0` and `hive help` loads the full CLI

Fresh PR CI remains the authoritative clean-environment merge gate.

## Post-Deploy Monitoring & Validation

- After merge, tag the exact merged `main` SHA as `v0.5.0` and watch the tag-triggered release workflow to completion.
- Verify the GitHub Release notes come from the grouped `0.5.0` changelog section and that the gem, checksums, signatures, installer bundle, and hivebox artifacts are present and valid.
- Run `packaging/verify-release.sh --version=v0.5.0`, verify the public installer path, and confirm Homebrew/AUR/image publication before calling the release complete.
- If any publication gate fails, stop follow-on channel promotion, preserve the workflow evidence, and use the documented release recovery path before retrying or replacing artifacts.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
