### PR TITLE
fix(workflows): keep managed mapping defaults runnable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes are documented here, newest first. Hive ships frequent micro-releases (see [docs/RELEASING.md](docs/RELEASING.md#versioning-policy)): each `vX.Y.Z` git tag gets a `## X.Y.Z` section with user-facing bullets and, for notable releases, descriptive subsections — no `[Unreleased]` accumulator. Versioning is [SemVer](https://semver.org): PATCH for fixes and small changes (the common case), MINOR for notable features, MAJOR for milestones.
 
+## 0.6.1
+
+- Fixed Honeycomb installation defaults for scoped workflow actors. When a
+  project-default agent cannot enforce a slot's tool scope, Hive now suggests
+  Claude for that slot while preserving fail-closed admission for explicit
+  incompatible mappings.
+
 ## 0.6.0
 
 - Install and update full Honeycomb workflows with immutable per-slot

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hive-cli (0.6.0)
+    hive-cli (0.6.1)
       bubbletea (= 0.1.4)
       erb (>= 4.0)
       faraday (>= 2.14.2, < 3.0)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Hive ships as a rubygem (`hive-cli`) attached to each GitHub Release, signed wit
 | Platform | Channel |
 |----------|---------|
 | macOS arm64 | [`brew install ivankuznetsov/hive/hive`](https://github.com/ivankuznetsov/homebrew-hive) |
-| Ubuntu 22.04+ / glibc Linux x86_64/aarch64 | <code>tmpdir="$(mktemp -d)" && trap 'rm -rf "$tmpdir"' EXIT && curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.6.0/install.sh -o "$tmpdir/hive-install.sh" && bash "$tmpdir/hive-install.sh"</code> |
+| Ubuntu 22.04+ / glibc Linux x86_64/aarch64 | <code>tmpdir="$(mktemp -d)" && trap 'rm -rf "$tmpdir"' EXIT && curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.6.1/install.sh -o "$tmpdir/hive-install.sh" && bash "$tmpdir/hive-install.sh"</code> |
 | Arch Linux x86_64/aarch64 | [`yay -S hive-bin`](https://aur.archlinux.org/packages/hive-bin) |
 
 Prerequisites: **Ruby 3.4** (the gem and its runtime deps install against this), git ≥ 2.40, authenticated `claude` ≥ 2.1.118, `codex` ≥ 0.125.0 for the default execute agent, `grok` ≥ 0.2.90 when selected, authenticated `gh`, `tmux` ≥ 3.0 when the project uses the default `claude.mode: tmux`, and Node.js/npm for managed QMD install/repair. The bash installer reports its own installer-side prereqs (`curl`, `jq`, `gem`, checksum tool) on first run; if npm is missing, Hive still installs and `hive doctor` reports the QMD gap non-fatally.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -93,6 +93,13 @@ manifest metadata binding, static security findings, and runner capabilities
 before asking for confirmation. A managed selection is an atomic lock over an
 immutable catalog-commit generation:
 
+Before consent, Hive shows an agent mapping for every stage, council reviewer,
+and reviser. Suggestions start from the project choices made by `hive init`.
+When one of those agents cannot enforce an actor's non-`yolo` tool scope, Hive
+suggests Claude for that slot instead so accepting all defaults remains
+runnable. An explicit mapping is never rewritten: an incompatible explicit
+choice fails runtime admission before project state changes.
+
 ```text
 .hive-state/workflows/<name>/honeycomb.lock.json
 .hive-state/workflows/<name>/versions/<catalog-commit>/

--- a/install.md
+++ b/install.md
@@ -59,8 +59,8 @@ Ubuntu 22.04+ / glibc Linux fallback (pin to the current release tag, not `main`
 ```bash
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
-# Release maintainers: bump v0.6.0 in both installer URLs when cutting a new stable release.
-curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.6.0/install.sh -o "$tmpdir/hive-install.sh"
+# Release maintainers: bump v0.6.1 in both installer URLs when cutting a new stable release.
+curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.6.1/install.sh -o "$tmpdir/hive-install.sh"
 bash "$tmpdir/hive-install.sh"
 ```
 
@@ -69,8 +69,8 @@ To inspect the installer first, run a dry-run before the real invocation. State 
 ```bash
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
-# Release maintainers: bump v0.6.0 in both installer URLs when cutting a new stable release.
-curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.6.0/install.sh -o "$tmpdir/hive-install.sh"
+# Release maintainers: bump v0.6.1 in both installer URLs when cutting a new stable release.
+curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.6.1/install.sh -o "$tmpdir/hive-install.sh"
 bash "$tmpdir/hive-install.sh" --dry-run
 bash "$tmpdir/hive-install.sh"
 ```

--- a/lib/hive.rb
+++ b/lib/hive.rb
@@ -1,5 +1,5 @@
 module Hive
-  VERSION = "0.6.0".freeze
+  VERSION = "0.6.1".freeze
   MIN_CLAUDE_VERSION = "2.1.118".freeze
   # Canonical GitHub org + repo. Referenced by the release probe
   # (UpdateCheck), the brew tap + installer URL (Commands::Update), etc.

--- a/lib/hive/workflow_package/configuration.rb
+++ b/lib/hive/workflow_package/configuration.rb
@@ -1,6 +1,7 @@
 require "digest"
 require "json"
 require "hive/agent_profiles"
+require "hive/permission_scope"
 require "hive/workflow_package/canonical_json"
 require "hive/workflow_package/input_name"
 require "hive/workflow_package/registry_client"
@@ -31,6 +32,7 @@ module Hive
         mappings = slots.each_with_index.to_h do |slot, index|
           override = normalize_override(normalized_overrides.fetch(slot.id, {}), slot.id)
           suggested = suggested_agent(slot.role, cfg, reviewer_defaults, index)
+          suggested = policy_compatible_suggestion(slot, suggested, cfg) unless override.key?("agent")
           agent = override.fetch("agent", suggested).to_s
           profile = Hive::AgentProfiles.lookup(agent, cfg: cfg)
           model = override.key?("model") ? normalize_optional(override["model"]) : suggested_model(slot.role, cfg, profile)
@@ -213,6 +215,18 @@ module Hive
           when "reviewer" then reviewer_defaults[index % reviewer_defaults.length]
           end
           value.to_s.empty? ? "claude" : value.to_s
+        end
+
+        # Non-yolo actor policies currently require Claude's native tool
+        # scoping. Keep operator-supplied mappings exact (runtime admission
+        # rejects an incompatible explicit choice), but never suggest a
+        # project default that Hive already knows it cannot launch.
+        def policy_compatible_suggestion(slot, suggested, cfg)
+          preset = Hive::PermissionScope.parse_spec(slot.permissions, stage: slot.id).fetch("preset")
+          profile = Hive::AgentProfiles.lookup(suggested, cfg: cfg)
+          return suggested if preset == Hive::PermissionScope::YOLO || profile.name == :claude
+
+          "claude"
         end
 
         def reviewer_agents(cfg)

--- a/test/unit/workflow_package/configuration_test.rb
+++ b/test/unit/workflow_package/configuration_test.rb
@@ -133,14 +133,28 @@ class WorkflowPackageConfigurationTest < Minitest::Test
     )
   end
 
-  def test_reviewer_suggestions_use_configured_review_agents
+  def test_scoped_reviewer_suggestions_fall_back_to_an_enforceable_agent
     configuration = build_configuration(
       overrides: { "stages.draft" => { "agent" => "codex" } },
       cfg: { "review" => { "reviewers" => [ { "agent" => "codex" } ] } }
     )
 
     mapping = configuration.data.fetch("mappings").fetch("stages.review.reviewers.security")
-    assert_equal "codex", mapping.fetch("agent")
+    assert_equal "claude", mapping.fetch("agent")
+  end
+
+  def test_explicit_scoped_mapping_is_preserved_for_runtime_admission
+    configuration = build_configuration(
+      overrides: { "stages.review.reviewers.security" => { "agent" => "codex" } },
+      cfg: {
+        "execute" => { "agent" => "codex" },
+        "review" => { "reviewers" => [ { "agent" => "codex" } ] }
+      }
+    )
+
+    mappings = configuration.data.fetch("mappings")
+    assert_equal "codex", mappings.fetch("stages.draft").fetch("agent")
+    assert_equal "codex", mappings.fetch("stages.review.reviewers.security").fetch("agent")
   end
 
   def test_apply_rejects_mapping_contract_drift

--- a/web/Gemfile.lock
+++ b/web/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    hive-cli (0.6.0)
+    hive-cli (0.6.1)
       bubbletea (= 0.1.4)
       erb (>= 4.0)
       faraday (>= 2.14.2, < 3.0)

--- a/wiki/commands/workflow.md
+++ b/wiki/commands/workflow.md
@@ -76,7 +76,10 @@ produce a misleading "not installed" result.
 Package descriptors cannot select agent/model/effort; immutable installation
 configuration overlays those choices in memory. Planning/development defaults
 follow the project's init choices and reviewer roles cycle configured review
-agents. Updates preserve only slots whose stable ID, role, and
+agents. If a suggested agent cannot enforce a slot's non-`yolo` tool scope,
+the suggestion falls back to Claude; explicit choices remain exact and an
+incompatible explicit mapping fails runtime admission before mutation. Updates
+preserve only slots whose stable ID, role, and
 `mapping_contract` match. Profile drift or contract changes require explicit
 remapping. A non-null model or effort pin is accepted only when the selected
 profile can translate it into native launch arguments; unsupported suggested

--- a/wiki/dependencies.md
+++ b/wiki/dependencies.md
@@ -3,7 +3,7 @@ title: Dependencies
 type: dependencies
 source: Gemfile, hive.gemspec, Gemfile.lock, web/Gemfile, web/Gemfile.lock
 created: 2026-04-25
-updated: 2026-07-18
+updated: 2026-07-19
 tags: [dependencies, gems, runtime]
 ---
 
@@ -11,9 +11,9 @@ tags: [dependencies, gems, runtime]
 
 `hive.gemspec` owns runtime gem constraints; `Gemfile` uses `gemspec`
 to pull those constraints into Bundler, then adds development/test-only
-tools. The v0.6.0 release-prep checkout is `0.6.0`: `lib/hive.rb`, root
+tools. The v0.6.1 release-prep checkout is `0.6.1`: `lib/hive.rb`, root
 `Gemfile.lock`, and `web/Gemfile.lock` all pin the local path gem as
-`hive-cli (0.6.0)`. The release-prep change keeps both lockfiles synchronized
+`hive-cli (0.6.1)`. The release-prep change keeps both lockfiles synchronized
 with public installer URLs and the changelog. Recent root bundle dependency
 commits also bumped RuboCop to 1.88.2, Brakeman from
 8.0.4 to 8.0.5, and `concurrent-ruby` from 1.3.6 to 1.3.7; the separate web

--- a/wiki/log.d/20260719T110846Z-managed-mapping-suggestions.md
+++ b/wiki/log.d/20260719T110846Z-managed-mapping-suggestions.md
@@ -1,0 +1,15 @@
+---
+title: Keep managed workflow mapping defaults runnable
+type: fix
+date: 2026-07-19
+---
+
+- Managed workflow installation now suggests Claude when a project-default
+  agent cannot enforce a stage, reviewer, or reviser's non-`yolo` permission
+  scope.
+- Explicit agent mappings remain unchanged and continue to fail closed during
+  runtime admission when the selected runner cannot enforce the actor policy.
+- Added regression coverage for both automatic fallback and explicit mapping
+  preservation.
+- Prepared the `0.6.1` patch release and synchronized the gem lockfiles,
+  changelog, and public installer references.

--- a/wiki/modules/workflows.md
+++ b/wiki/modules/workflows.md
@@ -113,7 +113,10 @@ weakening owner-authored descriptor compatibility:
   operator-selected agent/model/effort identity, mapping role/contract, profile
   fingerprint, and per-actor policy fingerprint. Snapshot construction rejects
   non-null pins that the selected profile cannot express as native arguments;
-  unsupported project defaults remain nil. Managed council reviewers and
+  unsupported project defaults remain nil. Automatic agent suggestions also
+  fall back to Claude when the project-default profile cannot enforce a
+  non-`yolo` actor scope; explicit mappings are preserved for the existing
+  fail-closed runtime admission check. Managed council reviewers and
   revisers launch exclusively from their child-slot snapshot identity, so a
   nil child model/effort cannot leak the parent stage's provider-specific
   defaults. Owner-authored unmanaged councils retain their historical parent


### PR DESCRIPTION
## Summary

- make Honeycomb installation suggestions respect each executable slot's runtime permission enforceability
- fall back to Claude only for incompatible automatic non-yolo mappings while preserving explicit operator choices for fail-closed admission
- prepare Hive 0.6.1 and synchronize release, installer, workflow docs, and the managed wiki

## Verification

- 220 tests, 1,087 assertions across managed workflow lifecycle, release contract, wiki, schemas, and packaging
- targeted RuboCop: 2 files, no offenses
- built `/tmp/hive-cli-0.6.1.gem`
- fresh-project public dry-runs for `architecture`, `writing`, and `seo-content` succeeded without any `--mapping` flags and reproduced the proven all-Claude configuration digests
- live Honeycomb canaries are running against the released 0.6.0 runtime; Architecture completed a real two-round council revision and Writing completed repository plus web research
