### PR TITLE
release: prepare v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes are documented here, newest first. Hive ships frequent micro-releases (see [docs/RELEASING.md](docs/RELEASING.md#versioning-policy)): each `vX.Y.Z` git tag gets a `## X.Y.Z` section with user-facing bullets and, for notable releases, descriptive subsections — no `[Unreleased]` accumulator. Versioning is [SemVer](https://semver.org): PATCH for fixes and small changes (the common case), MINOR for notable features, MAJOR for milestones.
 
+## 0.6.2
+
+- Fixed ordinary patrol exhausting its launch allowance without advancing past
+  source-verified clean features. Review batches now fit the remaining launch
+  headroom, preserve clean-prefix progress, and keep one fixer launch available
+  when the quota permits it.
+- Fixed Architecture Patrol depending on the registered developer checkout.
+  Discovery and retry now use a detached exact worktree pinned to committed
+  default-branch source, so local branches and uncommitted edits cannot block or
+  contaminate analysis.
+- Fixed Architecture Patrol quota churn and lost reviewer evidence. Bounded
+  runs stop after the first failed slice, back off until the next UTC budget
+  window when daily headroom is exhausted, accept a strict whole-message JSON
+  fence, and retain raw reviewer responses with their job context.
+
 ## 0.6.1
 
 - Fixed Honeycomb installation defaults for scoped workflow actors. When a

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hive-cli (0.6.1)
+    hive-cli (0.6.2)
       bubbletea (= 0.1.4)
       erb (>= 4.0)
       faraday (>= 2.14.2, < 3.0)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Hive ships as a rubygem (`hive-cli`) attached to each GitHub Release, signed wit
 | Platform | Channel |
 |----------|---------|
 | macOS arm64 | [`brew install ivankuznetsov/hive/hive`](https://github.com/ivankuznetsov/homebrew-hive) |
-| Ubuntu 22.04+ / glibc Linux x86_64/aarch64 | <code>tmpdir="$(mktemp -d)" && trap 'rm -rf "$tmpdir"' EXIT && curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.6.1/install.sh -o "$tmpdir/hive-install.sh" && bash "$tmpdir/hive-install.sh"</code> |
+| Ubuntu 22.04+ / glibc Linux x86_64/aarch64 | <code>tmpdir="$(mktemp -d)" && trap 'rm -rf "$tmpdir"' EXIT && curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.6.2/install.sh -o "$tmpdir/hive-install.sh" && bash "$tmpdir/hive-install.sh"</code> |
 | Arch Linux x86_64/aarch64 | [`yay -S hive-bin`](https://aur.archlinux.org/packages/hive-bin) |
 
 Prerequisites: **Ruby 3.4** (the gem and its runtime deps install against this), git ≥ 2.40, authenticated `claude` ≥ 2.1.118, `codex` ≥ 0.125.0 for the default execute agent, `grok` ≥ 0.2.90 when selected, authenticated `gh`, `tmux` ≥ 3.0 when the project uses the default `claude.mode: tmux`, and Node.js/npm for managed QMD install/repair. The bash installer reports its own installer-side prereqs (`curl`, `jq`, `gem`, checksum tool) on first run; if npm is missing, Hive still installs and `hive doctor` reports the QMD gap non-fatally.

--- a/install.md
+++ b/install.md
@@ -59,8 +59,8 @@ Ubuntu 22.04+ / glibc Linux fallback (pin to the current release tag, not `main`
 ```bash
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
-# Release maintainers: bump v0.6.1 in both installer URLs when cutting a new stable release.
-curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.6.1/install.sh -o "$tmpdir/hive-install.sh"
+# Release maintainers: bump v0.6.2 in both installer URLs when cutting a new stable release.
+curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.6.2/install.sh -o "$tmpdir/hive-install.sh"
 bash "$tmpdir/hive-install.sh"
 ```
 
@@ -69,8 +69,8 @@ To inspect the installer first, run a dry-run before the real invocation. State 
 ```bash
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
-# Release maintainers: bump v0.6.1 in both installer URLs when cutting a new stable release.
-curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.6.1/install.sh -o "$tmpdir/hive-install.sh"
+# Release maintainers: bump v0.6.2 in both installer URLs when cutting a new stable release.
+curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.6.2/install.sh -o "$tmpdir/hive-install.sh"
 bash "$tmpdir/hive-install.sh" --dry-run
 bash "$tmpdir/hive-install.sh"
 ```

--- a/lib/hive.rb
+++ b/lib/hive.rb
@@ -1,5 +1,5 @@
 module Hive
-  VERSION = "0.6.1".freeze
+  VERSION = "0.6.2".freeze
   MIN_CLAUDE_VERSION = "2.1.118".freeze
   # Canonical GitHub org + repo. Referenced by the release probe
   # (UpdateCheck), the brew tap + installer URL (Commands::Update), etc.

--- a/web/Gemfile.lock
+++ b/web/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    hive-cli (0.6.1)
+    hive-cli (0.6.2)
       bubbletea (= 0.1.4)
       erb (>= 4.0)
       faraday (>= 2.14.2, < 3.0)

--- a/wiki/dependencies.md
+++ b/wiki/dependencies.md
@@ -11,9 +11,9 @@ tags: [dependencies, gems, runtime]
 
 `hive.gemspec` owns runtime gem constraints; `Gemfile` uses `gemspec`
 to pull those constraints into Bundler, then adds development/test-only
-tools. The v0.6.1 release-prep checkout is `0.6.1`: `lib/hive.rb`, root
+tools. The v0.6.2 release-prep checkout is `0.6.2`: `lib/hive.rb`, root
 `Gemfile.lock`, and `web/Gemfile.lock` all pin the local path gem as
-`hive-cli (0.6.1)`. The release-prep change keeps both lockfiles synchronized
+`hive-cli (0.6.2)`. The release-prep change keeps both lockfiles synchronized
 with public installer URLs and the changelog. Recent root bundle dependency
 commits also bumped RuboCop to 1.88.2, Brakeman from
 8.0.4 to 8.0.5, and `concurrent-ruby` from 1.3.6 to 1.3.7; the separate web
@@ -138,7 +138,7 @@ These are not gems but the CLI tools the runtime invokes:
 `Gemfile` declares `ruby "~> 3.4"`. `hive.gemspec` requires Ruby
 `>= 3.4.0` for the packaged gem. `.rubocop.yml` pins
 `TargetRubyVersion: 3.4`. `Gemfile.lock` records Ruby 3.4.7, Bundler
-2.7.2, and the current local path gem as `hive-cli (0.5.3)`.
+2.7.2, and the current local path gem as `hive-cli (0.6.2)`.
 
 ## Backlinks
 

--- a/wiki/gaps.md
+++ b/wiki/gaps.md
@@ -233,19 +233,21 @@ evidence closing the following June 16 gaps.
 
 ## Release install follow-ups
 
-Latest refresh (2026-07-18): v0.5.3 release-prep source is synchronized in
+Latest refresh (2026-07-19): v0.6.2 release-prep source is synchronized in
 `lib/hive.rb`, both lockfiles, README/install URLs, the changelog, and the
 release-facing wiki pages. This source commit does not itself prove the public
 tag, signed gem/assets, Homebrew/AUR updates, or multi-architecture hivebox
 images; those remain the tag-triggered `release.yml` verification boundary.
-The v0.5.3 prep packages the bounded Architecture Patrol merged-PR intake fix
-after its focused gateway/daemon tests and exact-head pull-request CI gates
-passed.
+The v0.6.2 prep packages quota-bounded ordinary/architecture patrol progress,
+durable architecture reviewer evidence, and detached exact-source analysis
+after their focused tests and exact-head pull-request CI gates passed. The live
+post-release dogfood evidence tracked below remains intentionally open until the
+published release is installed and both patrol modes complete a real run.
 Historical commit `54fd3455` still provides commit-message evidence for the
 native arm64 GHCR smoke against `ghcr.io/ivankuznetsov/hivebox:0.3.1`.
 Dependency lock uncertainty is unchanged: the root bundle has
 `concurrent-ruby` 1.3.7 and Brakeman 8.0.5, while `web/Gemfile.lock` resolves
-`concurrent-ruby` 1.3.6 and Brakeman 8.0.4; v0.5.3 synchronizes only the local
+`concurrent-ruby` 1.3.6 and Brakeman 8.0.4; v0.6.2 synchronizes only the local
 `hive-cli` path-gem version in that independently resolved web bundle.
 
 1. **Release tag creation is protected, while signed git-tag verification remains deferred.** Homebrew and AUR publishing are implemented and public install docs route macOS users to the tap and Arch users to `yay -S hive-bin` (see ADR-032 in [[decisions]], `docs/RELEASING.md`, `README.md`, and `install.md`). The live repository has an active `v*` tag ruleset restricting creation, update, deletion, and non-fast-forward changes to the configured repository-role bypass. Release automation still publishes the commit selected by an authorized tag without independently verifying a maintainer cryptographic git-tag signature.

--- a/wiki/log.d/20260719T124726Z-release-v062.md
+++ b/wiki/log.d/20260719T124726Z-release-v062.md
@@ -1,0 +1,9 @@
+---
+title: Prepare v0.6.2 patrol reliability fixes
+date: 2026-07-19
+tags: [release, patrol, refactor-patrol, worktree, quota]
+---
+
+- Prepared Hive v0.6.2 from the merged patrol quota-progress and Architecture Patrol isolated-analysis fixes.
+- Synchronized `Hive::VERSION`, both path-gem lockfiles, public installer references, and the changelog.
+- Kept the post-release patrol dogfood gap open until the published build is installed and ordinary plus architecture patrol produce live evidence.


### PR DESCRIPTION
## Summary

- Prepare Hive v0.6.2 with the merged ordinary-patrol quota-progress fix and Architecture Patrol detached exact-source analysis fix.
- Synchronize `Hive::VERSION`, both path-gem lockfiles, public installer URLs, the changelog, and release-facing wiki context.
- Keep the live patrol dogfood gap open until the published build is installed and both patrol modes are proven end to end.

## Test plan

- [x] Release contract: 2 runs, 14 assertions, 0 failures or errors.
- [x] CLI unit tests: 38 runs, 198 assertions, 0 failures or errors.
- [x] CLI version integration: 13 runs, 85 assertions, 0 failures or errors.
- [x] The CI-failed permanent-composer system test passes locally four consecutive times on this exact head (84 assertions total); its first hosted failure is an unrelated timing flake and will be retried after the run completes.
- [x] `bundle check` succeeds and `bin/hive --version` prints `0.6.2`.
- [x] `gem build hive.gemspec` produces `hive-cli-0.6.2.gem`.
- [x] `git diff --check` passes.

## Release follow-up

After merge, tag `v0.6.2`, watch the full release workflow, install the published stable build, reset only today's eight real Hive patrol quota rows with a fresh database backup, and dogfood ordinary plus architecture patrol.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
