### PR TITLE
release: prepare v0.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes are documented here, newest first. Hive ships frequent micro-releases (see [docs/RELEASING.md](docs/RELEASING.md#versioning-policy)): each `vX.Y.Z` git tag gets a `## X.Y.Z` section with user-facing bullets and, for notable releases, descriptive subsections — no `[Unreleased]` accumulator. Versioning is [SemVer](https://semver.org): PATCH for fixes and small changes (the common case), MINOR for notable features, MAJOR for milestones.
 
+## 0.6.5
+
+- Fixed ordinary patrol discarding source-backed findings when reviewers used
+  multiline excerpts, ellipses, or annotations for evidence snippets. The
+  reviewer prompt now states the validator's exact single-line substring
+  contract without weakening its fail-closed source verification.
+
 ## 0.6.4
 
 - Fixed hivebox occasionally retaining a successfully submitted idea in its

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hive-cli (0.6.4)
+    hive-cli (0.6.5)
       bubbletea (= 0.1.4)
       erb (>= 4.0)
       faraday (>= 2.14.2, < 3.0)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Hive ships as a rubygem (`hive-cli`) attached to each GitHub Release, signed wit
 | Platform | Channel |
 |----------|---------|
 | macOS arm64 | [`brew install ivankuznetsov/hive/hive`](https://github.com/ivankuznetsov/homebrew-hive) |
-| Ubuntu 22.04+ / glibc Linux x86_64/aarch64 | <code>tmpdir="$(mktemp -d)" && trap 'rm -rf "$tmpdir"' EXIT && curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.6.4/install.sh -o "$tmpdir/hive-install.sh" && bash "$tmpdir/hive-install.sh"</code> |
+| Ubuntu 22.04+ / glibc Linux x86_64/aarch64 | <code>tmpdir="$(mktemp -d)" && trap 'rm -rf "$tmpdir"' EXIT && curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.6.5/install.sh -o "$tmpdir/hive-install.sh" && bash "$tmpdir/hive-install.sh"</code> |
 | Arch Linux x86_64/aarch64 | [`yay -S hive-bin`](https://aur.archlinux.org/packages/hive-bin) |
 
 Prerequisites: **Ruby 3.4** (the gem and its runtime deps install against this), git ≥ 2.40, authenticated `claude` ≥ 2.1.118, `codex` ≥ 0.125.0 for the default execute agent, `grok` ≥ 0.2.90 when selected, authenticated `gh`, `tmux` ≥ 3.0 when the project uses the default `claude.mode: tmux`, and Node.js/npm for managed QMD install/repair. The bash installer reports its own installer-side prereqs (`curl`, `jq`, `gem`, checksum tool) on first run; if npm is missing, Hive still installs and `hive doctor` reports the QMD gap non-fatally.

--- a/install.md
+++ b/install.md
@@ -59,8 +59,8 @@ Ubuntu 22.04+ / glibc Linux fallback (pin to the current release tag, not `main`
 ```bash
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
-# Release maintainers: bump v0.6.4 in both installer URLs when cutting a new stable release.
-curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.6.4/install.sh -o "$tmpdir/hive-install.sh"
+# Release maintainers: bump v0.6.5 in both installer URLs when cutting a new stable release.
+curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.6.5/install.sh -o "$tmpdir/hive-install.sh"
 bash "$tmpdir/hive-install.sh"
 ```
 
@@ -69,8 +69,8 @@ To inspect the installer first, run a dry-run before the real invocation. State 
 ```bash
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
-# Release maintainers: bump v0.6.4 in both installer URLs when cutting a new stable release.
-curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.6.4/install.sh -o "$tmpdir/hive-install.sh"
+# Release maintainers: bump v0.6.5 in both installer URLs when cutting a new stable release.
+curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.6.5/install.sh -o "$tmpdir/hive-install.sh"
 bash "$tmpdir/hive-install.sh" --dry-run
 bash "$tmpdir/hive-install.sh"
 ```

--- a/lib/hive.rb
+++ b/lib/hive.rb
@@ -1,5 +1,5 @@
 module Hive
-  VERSION = "0.6.4".freeze
+  VERSION = "0.6.5".freeze
   MIN_CLAUDE_VERSION = "2.1.118".freeze
   # Canonical GitHub org + repo. Referenced by the release probe
   # (UpdateCheck), the brew tap + installer URL (Commands::Update), etc.

--- a/web/Gemfile.lock
+++ b/web/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    hive-cli (0.6.4)
+    hive-cli (0.6.5)
       bubbletea (= 0.1.4)
       erb (>= 4.0)
       faraday (>= 2.14.2, < 3.0)

--- a/wiki/dependencies.md
+++ b/wiki/dependencies.md
@@ -11,9 +11,9 @@ tags: [dependencies, gems, runtime]
 
 `hive.gemspec` owns runtime gem constraints; `Gemfile` uses `gemspec`
 to pull those constraints into Bundler, then adds development/test-only
-tools. The v0.6.4 release-prep checkout is `0.6.4`: `lib/hive.rb`, root
+tools. The v0.6.5 release-prep checkout is `0.6.5`: `lib/hive.rb`, root
 `Gemfile.lock`, and `web/Gemfile.lock` all pin the local path gem as
-`hive-cli (0.6.4)`. The release-prep change keeps both lockfiles synchronized
+`hive-cli (0.6.5)`. The release-prep change keeps both lockfiles synchronized
 with public installer URLs and the changelog. Recent root bundle dependency
 commits also bumped RuboCop to 1.88.2, Brakeman from
 8.0.4 to 8.0.5, and `concurrent-ruby` from 1.3.6 to 1.3.7; the separate web
@@ -138,7 +138,7 @@ These are not gems but the CLI tools the runtime invokes:
 `Gemfile` declares `ruby "~> 3.4"`. `hive.gemspec` requires Ruby
 `>= 3.4.0` for the packaged gem. `.rubocop.yml` pins
 `TargetRubyVersion: 3.4`. `Gemfile.lock` records Ruby 3.4.7, Bundler
-2.7.2, and the current local path gem as `hive-cli (0.6.4)`.
+2.7.2, and the current local path gem as `hive-cli (0.6.5)`.
 
 ## Backlinks
 

--- a/wiki/gaps.md
+++ b/wiki/gaps.md
@@ -532,5 +532,11 @@ meaningful `invert-usage-error-contract-ownership` thesis above the configured
 multi-feature scope, and file/diff limits. Durable architecture review run
 directories still have no automatic retention policy, so long-running
 installations should monitor `.hive-state/refactor_patrol/runs/` growth. Retain
-this gap only until the installed v0.6.4 package repeats both patrol modes
-without dirty-checkout, quota-churn, or response-envelope errors.
+Installed v0.6.4 dogfood then exposed a separate ordinary-patrol wire-contract
+gap: reviewers returned meaningful source evidence as multiline excerpts or
+annotated paraphrases, while the validator requires every snippet to be an
+exact substring of one claimed source line and therefore rejected the complete
+finding. v0.6.5 aligns the reviewer prompt with that existing fail-closed
+validator. Retain this gap until the installed v0.6.5 package opens meaningful
+ordinary and Architecture Patrol PRs without dirty-checkout, quota-churn,
+response-envelope, or evidence-contract errors.

--- a/wiki/log.d/20260719T213300Z-release-v065.md
+++ b/wiki/log.d/20260719T213300Z-release-v065.md
@@ -1,0 +1,10 @@
+# Hive v0.6.5 release preparation
+
+**Action:** Prepared Hive v0.6.5 as a focused patch release for the patrol
+evidence-contract fix. The version constant, both local-path lockfiles,
+installer references, changelog, dependency wiki, and live dogfood gap now
+agree on v0.6.5.
+
+The release keeps the source verifier fail-closed while telling ordinary patrol
+reviewers to provide exact single-line evidence snippets, so meaningful
+source-backed findings can reach ranking, fixing, and PR publication.


### PR DESCRIPTION
## Summary

Publishes v0.6.5 as a focused patch so the supported install channels receive the ordinary-patrol evidence-contract fix from #805. The release preserves fail-closed source verification while allowing reviewers that follow the documented single-line snippet contract to reach ranking, fixing, and PR publication.

## Validation

- release contract — 2 runs, 14 assertions, 0 failures
- root and web bundles resolve from their frozen lockfiles
- gem build — `hive-cli-0.6.5.gem`
- `git diff --check`
