### PR TITLE
Hive patrol: StreamLog reopen after torn write silently drops the first appended frame on replay

### DIFF
--- a/lib/hive/attempts/stream_log.rb
+++ b/lib/hive/attempts/stream_log.rb
@@ -49,6 +49,7 @@ module Hive
         File.chmod(0o700, File.dirname(@path))
         @io = File.open(@path, File::WRONLY | File::CREAT | File::APPEND, 0o600)
         @io.chmod(0o600)
+        seal_torn_tail
         @sequence = self.class.read(@path).last&.sequence.to_i
       end
 
@@ -84,6 +85,24 @@ module Hive
       end
 
       def closed? = @io.closed?
+
+      private
+
+      # A crash mid-append can leave a torn final line with no trailing newline.
+      # Terminate it before the first post-reopen append so the torn bytes stay
+      # an isolated unparseable line instead of fusing with the next frame.
+      def seal_torn_tail
+        return if File.size(@path).zero?
+
+        last_byte = File.open(@path, "rb") do |file|
+          file.seek(-1, IO::SEEK_END)
+          file.read(1)
+        end
+        return if last_byte == "\n"
+
+        @io.syswrite("\n")
+        @io.flush
+      end
     end
   end
 end

--- a/test/unit/attempts/stream_log_test.rb
+++ b/test/unit/attempts/stream_log_test.rb
@@ -78,6 +78,37 @@ class AttemptsStreamLogTest < Minitest::Test
     end
   end
 
+  def test_reopen_after_torn_write_preserves_the_first_post_recovery_frame
+    with_tmp_dir do |root|
+      path = File.join(root, "logs", "attempt.frames")
+      log = Hive::Attempts::StreamLog.new(path, clock: -> { NOW })
+      log.append(:stdout, "a")
+      log.close
+      File.open(path, "ab") { |file| file.write('{"sequence":2,"timestamp":"2026-') }
+
+      reopened = Hive::Attempts::StreamLog.new(path, clock: -> { NOW })
+      assert_equal 2, reopened.append(:stdout, "b")
+      reopened.close
+
+      frames = Hive::Attempts::StreamLog.read(path)
+      assert_equal [ 1, 2 ], frames.map(&:sequence)
+      assert_equal "b", frames.last.bytes
+    end
+  end
+
+  def test_reopen_of_a_log_ending_at_a_frame_boundary_leaves_the_file_unchanged
+    with_tmp_dir do |root|
+      path = File.join(root, "logs", "attempt.frames")
+      log = Hive::Attempts::StreamLog.new(path, clock: -> { NOW })
+      log.append(:stdout, "a")
+      log.close
+      before = File.binread(path)
+
+      Hive::Attempts::StreamLog.new(path, clock: -> { NOW }).close
+      assert_equal before, File.binread(path)
+    end
+  end
+
   def test_reader_ignores_malformed_frames_and_read_errors
     with_tmp_dir do |root|
       path = File.join(root, "bad.frames")


### PR DESCRIPTION
## Hive Patrol Finding

Slice: `architecture-lib-hive-attempts-part-5`
Category: `bug`
Severity: `medium`
Confidence: `medium`
Alpha: `77`
Scope: `feature`
Fingerprint: `7860433fbaccdde0cd911f8e7d855202064aa3487a1c23b059c21c442eb823bc`

StreamLog.append writes each frame with a loop of syswrite calls, so a crash (SIGKILL, power loss) between partial writes leaves a torn final line with no trailing newline. StreamLog#initialize explicitly supports reopening an existing log (it opens with File::APPEND and resumes @sequence from the last parseable frame), but it never repairs the torn tail. The first frame appended by the reopened writer is written directly after the torn partial bytes, producing one physical line of the form '<partial-junk>{valid frame JSON}\n'. StreamLog.read parses per line, so JSON.parse fails on that merged line and the rescue silently discards it, dropping a fully written, sequence-published frame from every subsequent replay.

## Contract and impact

**Contract:** Per the class comment, each frame is written completely before its sequence is published so stdout/stderr ordering can be replayed; a frame whose append returned a sequence must be returned by StreamLog.read.

**Impact:** After a crash mid-append followed by reopening the same log path, the first post-recovery frame is permanently unreadable: attempt stdout/stderr replay (e.g. the tail loop in lib/hive/attempts/client.rb using StreamLog.read) silently omits that output chunk, with no error surfaced. The corrupted merged line persists in the log file, so the loss is permanent wrong user-visible output, not a transient glitch.

## Root cause

Append-only recovery assumes the existing file ends at a frame boundary. initialize resumes the sequence counter from the last complete frame but does not detect or seal a newline-less tail before appending, so torn bytes and the next valid frame share one line in the line-oriented format.

## Reproduction

1) log = StreamLog.new(path); log.append("stdout", "a"). 2) Simulate a crash between syswrite iterations: File.open(path, "ab") { |f| f.write('{"sequence":2,"timestamp":"2026-') } (partial frame, no newline). 3) log2 = StreamLog.new(path) — @sequence resumes as 1; log2.append("stdout", "b") returns published sequence 2. 4) StreamLog.read(path) returns only the frame with sequence 1; the published frame 2 carrying "b" is absent because its JSON is fused with the torn bytes into one unparseable line.

## Evidence

- lib/hive/attempts/stream_log.rb:50 @io = File.open(@path, File::WRONLY | File::CREAT | File::APPEND, 0o600)
- lib/hive/attempts/stream_log.rb:52 @sequence = self.class.read(@path).last&.sequence.to_i
- lib/hive/attempts/stream_log.rb:69 written = @io.syswrite(frame.byteslice(offset, frame.bytesize - offset))
- lib/hive/attempts/stream_log.rb:37 rescue JSON::ParserError, KeyError, ArgumentError

## Applied Fix

In StreamLog#initialize, after opening the file, seal any torn tail before the first append: if the file is non-empty and its last byte is not "\n", append a single "\n" so the torn bytes become an isolated unparseable line that read already skips. Compute @sequence after sealing. This preserves the append-only format and protects every reopen path (supervisor restarts and any future callers) rather than one call site.

**Targeted validation:** Add a test performing the reproduction above and asserting StreamLog.read(path).map(&:sequence) == [1, 2] and that frame 2's bytes are "b". It fails on the current checkout (returns [1]) and passes after the fix. Broader checks: existing append/read round-trip tests still pass, a file ending exactly at a newline is unchanged, and a torn tail with no subsequent append still yields only the complete frames.

## Observed fix proof

**Agent-reported root cause:** StreamLog#initialize reopened an existing log in append mode and resumed @sequence from the last complete frame, but never sealed a torn tail left by a crash mid-append. A final line without a trailing newline fused with the next appended frame into one unparseable physical line, so StreamLog.read silently dropped a frame whose sequence had already been published. Fixed by sealing any newline-less tail in initialize (appending a single "\n" so the torn bytes stay an isolated unparseable line that read already skips) before computing @sequence, protecting every reopen path.

**Audited paths:**
- `lib/hive/attempts/stream_log.rb`
- `test/unit/attempts/stream_log_test.rb`

**Targeted command:** `ruby -Ilib -Itest test/integration/cli_version_test.rb -n /hive_accepts_/ && TESTOPTS='--exclude=/hive_accepts_/' ruby -rbundler/setup -rrake -e 'load "Rakefile"; Rake::Task[:test].invoke'`

**Before:** exit=1 timed_out=false

**After:** exit=0 timed_out=false

## Validation

- test: passed (`ruby -Ilib -Itest test/integration/cli_version_test.rb -n /hive_accepts_/ && TESTOPTS='--exclude=/hive_accepts_/' ruby -rbundler/setup -rrake -e 'load "Rakefile"; Rake::Task[:test].invoke'`)

## Diffstat

```text
 lib/hive/attempts/stream_log.rb       | 19 +++++++++++++++++++
 test/unit/attempts/stream_log_test.rb | 31 +++++++++++++++++++++++++++++++
 2 files changed, 50 insertions(+)

```
