### PR TITLE
fix(web): restore local access and compiled assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,12 +76,18 @@ hive web
 QMD, SQLite, and the Rails bundle. It installs Hive-owned pieces it can
 manage, installs the daemon service, and enrolls the current project. Bare
 `hive web` serves `http://127.0.0.1:4567` in the foreground with
-loopback-only no-auth mode (set `web.local_loopback: false` to require GitHub
-login even on a loopback bind — see [wiki/commands/web.md](wiki/commands/web.md)).
+loopback-only no-auth mode over the same local project registry and workflow
+state as the TUI. GitHub is an optional connection for repository browsing and
+cloning, not a prerequisite or ownership claim. An authenticated, access-
+restricted local reverse proxy such as Tailscale Serve (with tailnet ACLs) can
+forward to that loopback listener. Because Hive trusts the proxy's localhost
+connection, do not expose an unrestricted forwarder to it. Set
+`web.local_loopback: false` to require GitHub login even there (see
+[wiki/commands/web.md](wiki/commands/web.md)).
 For autostart, run `hive setup --service` or
 `hive web install` and `hive web start --detach`; the web service is separate
-from the daemon service. Docker/hivebox remains supported for container-first
-installs.
+from the daemon service. Docker/hivebox is the separate owner-gated,
+container-first deployment mode.
 
 ### Install via a coding agent
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,10 +62,21 @@ The local Rails web UI is a managed runtime dependency, not part of the CLI
 gem payload. `hive web` resolves `HIVEBOX_WEB_APP_DIR`, then
 `${XDG_DATA_HOME}/hive/web`, then a source checkout `web/`. `hive setup` and
 `hive web` can bootstrap the managed app from the versioned web release bundle
-and run its Rails bundle install. The web storage directory remains under
+into a staging directory, install its Rails bundle, precompile production CSS
+and JavaScript, and verify the required entrypoints plus every manifest asset
+before activating it. A current bundle with missing assets is repaired on the
+next setup or launch. The web
+storage directory remains under
 `${XDG_STATE_HOME}/hive/web-storage`, so the TUI, daemon, and web UI operate
 on the same local registry, project `.hive-state/` directories, and task
-folders.
+folders. Local loopback requests use the `hive` identity and do not require
+GitHub; connecting GitHub only enables repository listing and cloning. Because
+the trust check uses the actual socket peer, a reverse proxy that connects over
+localhost (including Tailscale Serve) retains local mode even when it forwards
+the remote client's address. That proxy becomes part of the access boundary
+and must authenticate or restrict its clients; an unrestricted localhost
+forwarder exposes the no-auth UI. Hivebox is the separate owner-gated container
+deployment of the same Rails application.
 
 ## Agents
 

--- a/install.md
+++ b/install.md
@@ -136,9 +136,14 @@ When the user wants the browser UI, prefer the first-class local setup command:
 It runs diagnostics, installs Hive-owned QMD/web pieces, ensures the daemon
 service, enrolls the current project, and leaves the web UI runnable with
 `"$hive_cmd" web` at `http://127.0.0.1:4567`. Bare `hive web` on a loopback
-bind runs no-auth by default; set `web.local_loopback: false` to require
-GitHub login even on loopback. Use `"$hive_cmd" setup --service` when the user
-also wants a managed `hive-web` service.
+bind runs no-auth against the existing local Hive registry and workflow state;
+GitHub connection is optional and does not claim Hivebox ownership. Loopback
+reverse proxies such as Tailscale Serve retain that local behavior, so the
+proxy must authenticate/restrict its clients (for example with tailnet ACLs);
+an unrestricted forwarder would expose the no-auth local UI. Set
+`web.local_loopback: false` to require GitHub login even on loopback. Use
+`"$hive_cmd" setup --service` when the user also wants a managed `hive-web`
+service.
 
 ## Initialize Project
 

--- a/lib/hive/setup/diagnostics.rb
+++ b/lib/hive/setup/diagnostics.rb
@@ -131,6 +131,9 @@ module Hive
           # it automatically, so still a bootstrap candidate.
           Result.new(name: "web_bundle", status: "version_too_old",
                      detail: "managed web bundle is stale", fix_command: nil, bootstrappable: true)
+        elsif !Hive::Web::AppBundle.assets_ready?
+          Result.new(name: "web_bundle", status: "missing",
+                     detail: "managed web bundle assets are missing", fix_command: nil, bootstrappable: true)
         else
           # Installed and current: a real success, NOT a bootstrap candidate
           # (the old code emitted status "ok" with bootstrappable: true — an

--- a/lib/hive/web/app_bundle.rb
+++ b/lib/hive/web/app_bundle.rb
@@ -1,4 +1,5 @@
 require "fileutils"
+require "json"
 require "open-uri"
 require "rubygems/package"
 require "zlib"
@@ -10,6 +11,7 @@ module Hive
   module Web
     module AppBundle
       VERSION_FILE = ".hive-web-version".freeze
+      REQUIRED_ASSETS = %w[application.css application.js].freeze
 
       module_function
 
@@ -39,8 +41,26 @@ module Hive
         present? && installed_version != Hive::VERSION
       end
 
+      def assets_ready?(dir = app_dir)
+        assets_dir = File.join(dir, "public", "assets")
+        assets_root = File.expand_path(assets_dir)
+        manifest = JSON.parse(File.read(File.join(assets_dir, ".manifest.json")))
+        return false unless manifest.is_a?(Hash)
+        return false unless REQUIRED_ASSETS.all? { |logical_path| manifest.key?(logical_path) }
+
+        manifest.values.all? do |entry|
+          digested_path = entry["digested_path"] if entry.is_a?(Hash)
+          next false unless digested_path.is_a?(String) && !digested_path.empty?
+
+          asset_path = File.expand_path(digested_path, assets_dir)
+          asset_path.start_with?("#{assets_root}/") && File.file?(asset_path)
+        end
+      rescue ArgumentError, JSON::ParserError, SystemCallError, TypeError
+        false
+      end
+
       def ensure!(bundle_url: default_bundle_url, runner: nil, output: $stderr)
-        return app_dir if present? && !stale?
+        return app_dir if present? && !stale? && assets_ready?
 
         if bundle_url.to_s.empty?
           raise Hive::Error,
@@ -62,14 +82,11 @@ module Hive
           raise Hive::Error, "hive web: downloaded web bundle does not contain config/application.rb"
         end
 
-        # Run `bundle install` against the staged tmp bundle BEFORE swapping it
-        # into place. A transient Bundler / native-extension failure then leaves
-        # the previous working install untouched instead of replacing it with an
-        # unstamped broken bundle. Only after Bundler succeeds do we swap and
-        # stamp the version (the stamp is last so a crash between swap and stamp
-        # leaves `installed_version` nil → `stale?` true → next `ensure!`
-        # re-bootstraps rather than trusting a half-provisioned bundle).
-        bundle_install!(dir: tmp, runner: runner, output: output)
+        # Prepare dependencies and production assets in the staged bundle
+        # BEFORE swapping it into place. A failed refresh then leaves the
+        # previous working install untouched. The version stamp remains last,
+        # so an interrupted swap is retried rather than trusted.
+        prepare!(dir: tmp, runner: runner, output: output)
         FileUtils.rm_rf(app_dir)
         FileUtils.mkdir_p(File.dirname(app_dir))
         FileUtils.mv(tmp, app_dir)
@@ -79,17 +96,37 @@ module Hive
         FileUtils.rm_rf(tmp) if tmp && File.exist?(tmp)
       end
 
-      def bundle_install!(dir: app_dir, runner: nil, output: $stderr)
-        return dir unless File.file?(File.join(dir, "Gemfile"))
+      def prepare!(dir: app_dir, runner: nil, output: $stderr)
+        unless File.file?(File.join(dir, "Gemfile"))
+          raise Hive::Error, "hive web: downloaded web bundle does not contain a Gemfile"
+        end
 
         runner ||= ->(argv, env) { system(env, *argv) }
-        ok = runner.call(%w[bundle install],
-                         { "BUNDLE_GEMFILE" => File.join(dir, "Gemfile"),
-                           "HIVE_CLI_ROOT" => hive_cli_root })
-        raise Hive::Error, "hive web: bundle install failed in #{dir}" unless ok
+        env = {
+          "BUNDLE_GEMFILE" => File.join(dir, "Gemfile"),
+          "HIVE_CLI_ROOT" => hive_cli_root
+        }
+        asset_storage = File.join(dir, "tmp", "assets-build-storage")
+        Dir.chdir(dir) do
+          raise Hive::Error, "hive web: bundle install failed in #{dir}" unless runner.call(%w[bundle install], env)
 
-        output.puts "hive web: installed Rails bundle in #{dir}" if output
+          asset_env = env.merge(
+            "RAILS_ENV" => "production",
+            "SECRET_KEY_BASE" => "hive-managed-web-assets-build",
+            "HIVEBOX_STORAGE_DIR" => asset_storage
+          )
+          unless runner.call(%w[bin/rails assets:precompile], asset_env)
+            raise Hive::Error, "hive web: asset precompile failed in #{dir}"
+          end
+        end
+        unless assets_ready?(dir)
+          raise Hive::Error, "hive web: asset precompile produced no usable CSS/JavaScript in #{dir}"
+        end
+
+        output.puts "hive web: installed Rails bundle and compiled assets in #{dir}" if output
         dir
+      ensure
+        FileUtils.rm_rf(asset_storage) if asset_storage
       end
 
       def default_bundle_url

--- a/packaging/docker/smoke.sh
+++ b/packaging/docker/smoke.sh
@@ -70,6 +70,40 @@ case "$body" in
     ;;
 esac
 
+# A rendered page is not a usable UI when its Propshaft manifest points at
+# files missing from the image. Require the entrypoints, then fetch every
+# digest-stamped stylesheet/module advertised by Rails so the smoke exercises
+# the same initial asset graph as a browser.
+stylesheet_path="$(printf '%s\n' "$body" | sed -n 's/.*<link rel="stylesheet" href="\([^"]*\)".*/\1/p' | head -1)"
+javascript_path="$(printf '%s\n' "$body" | sed -n 's/.*<link rel="modulepreload" href="\([^"]*application-[^"]*\.js\)".*/\1/p' | head -1)"
+case "$stylesheet_path:$javascript_path" in
+  /assets/*.css:/assets/*.js) ;;
+  *)
+    echo "FAIL login page did not advertise compiled CSS and JavaScript"
+    exit 1
+    ;;
+esac
+asset_paths="$(printf '%s\n' "$body" | sed -n \
+  -e 's/.*href="\([^"]*\/assets\/[^"]*\.css\)".*/\1/p' \
+  -e 's/.*href="\([^"]*\/assets\/[^"]*\.js\)".*/\1/p' \
+  -e 's/.*src="\([^"]*\/assets\/[^"]*\.js\)".*/\1/p' | sort -u)"
+for asset_path in $asset_paths; do
+  case "$asset_path" in
+    /assets/*.css|/assets/*.js) ;;
+    *)
+      echo "FAIL login page advertised an unexpected asset path: $asset_path"
+      exit 1
+      ;;
+  esac
+  smoke_curl -fsS "http://127.0.0.1:${PORT}${asset_path}" >/dev/null
+done
+
+# Exercise the exact managed-install readiness predicate against the real
+# Propshaft manifest produced by this image build. Unit fixtures alone cannot
+# protect the release from a manifest-format drift.
+docker exec "$NAME" ruby -rhive/web/app_bundle -e \
+  'abort "managed web asset manifest is not ready" unless Hive::Web::AppBundle.assets_ready?("/app/web")'
+
 # Everything else is owner-gated.
 code="$(smoke_curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:${PORT}/")"
 if [ "$code" != "302" ]; then

--- a/test/unit/packaging/verify_release_test.rb
+++ b/test/unit/packaging/verify_release_test.rb
@@ -34,6 +34,17 @@ class PackagingVerifyReleaseTest < Minitest::Test
     assert_operator body.rindex("/health?deep=1"), :>, body.index("unauthenticated / expected 302")
   end
 
+  def test_hivebox_smoke_fetches_every_stylesheet_and_javascript_advertised_by_login
+    body = File.read(HIVEBOX_SMOKE)
+
+    assert_includes body, "stylesheet_path="
+    assert_includes body, "javascript_path="
+    assert_includes body, "asset_paths="
+    assert_includes body, "for asset_path in $asset_paths"
+    assert_includes body, 'smoke_curl -fsS "http://127.0.0.1:${PORT}${asset_path}"'
+    assert_includes body, 'Hive::Web::AppBundle.assets_ready?("/app/web")'
+  end
+
   def test_release_promotes_only_the_two_native_smoked_digests
     body = File.read(RELEASE_WORKFLOW)
 

--- a/test/unit/setup/diagnostics_test.rb
+++ b/test/unit/setup/diagnostics_test.rb
@@ -143,12 +143,30 @@ class SetupDiagnosticsTest < Minitest::Test
     diag = Hive::Setup::Diagnostics.new(ruby_version: "3.4.1")
     with_replaced_singleton_method(Hive::Web::AppBundle, :present?, -> { true }) do
       with_replaced_singleton_method(Hive::Web::AppBundle, :stale?, -> { false }) do
-        with_replaced_singleton_method(Hive::Web::AppBundle, :app_dir, -> { "/managed/web" }) do
+        with_replaced_singleton_method(Hive::Web::AppBundle, :assets_ready?, -> { true }) do
+          with_replaced_singleton_method(Hive::Web::AppBundle, :app_dir, -> { "/managed/web" }) do
+            row = diag.check_web_bundle
+
+            assert_equal "ok", row.status
+            assert_equal "/managed/web", row.detail
+            refute row.bootstrappable, "a present+current bundle must not be a bootstrap candidate"
+          end
+        end
+      end
+    end
+  end
+
+  def test_web_bundle_with_missing_assets_is_bootstrappable
+    diag = Hive::Setup::Diagnostics.new(ruby_version: "3.4.1")
+    with_replaced_singleton_method(Hive::Web::AppBundle, :present?, -> { true }) do
+      with_replaced_singleton_method(Hive::Web::AppBundle, :stale?, -> { false }) do
+        with_replaced_singleton_method(Hive::Web::AppBundle, :assets_ready?, -> { false }) do
           row = diag.check_web_bundle
 
-          assert_equal "ok", row.status
-          assert_equal "/managed/web", row.detail
-          refute row.bootstrappable, "a present+current bundle must not be a bootstrap candidate"
+          assert_equal "missing", row.status
+          assert_equal "managed web bundle assets are missing", row.detail
+          assert row.bootstrappable, "hive setup repairs a current bundle whose compiled assets are absent"
+          assert_nil row.fix_command
         end
       end
     end

--- a/test/unit/web/app_bundle_test.rb
+++ b/test/unit/web/app_bundle_test.rb
@@ -56,8 +56,16 @@ class WebAppBundleTest < Minitest::Test
       source = seed_source_app
       ran = false
       captured_env = nil
-      Hive::Web::AppBundle.ensure!(bundle_url: source, output: nil,
-                                   runner: ->(_argv, env) { captured_env = env; ran = true })
+      Hive::Web::AppBundle.ensure!(
+        bundle_url: source,
+        output: nil,
+        runner: lambda do |argv, env|
+          captured_env = env
+          ran = true
+          write_compiled_assets(Dir.pwd) if argv == %w[bin/rails assets:precompile]
+          true
+        end
+      )
       assert ran, "bundle install runner should have run"
       # The managed bundle's Gemfile resolves the hive-cli path gem through
       # HIVE_CLI_ROOT (its ".." holds no gem, and hive-cli is not on
@@ -70,6 +78,149 @@ class WebAppBundleTest < Minitest::Test
       assert Hive::Web::AppBundle.present?
       assert_equal Hive::VERSION, Hive::Web::AppBundle.installed_version
       refute Hive::Web::AppBundle.stale?
+    end
+  end
+
+  def test_ensure_precompiles_and_validates_managed_assets_before_installing
+    with_hive_home do
+      source = seed_source_app
+      calls = []
+      runner = lambda do |argv, env|
+        calls << { argv: argv, env: env, dir: Dir.pwd }
+        write_compiled_assets(Dir.pwd) if argv == %w[bin/rails assets:precompile]
+        true
+      end
+
+      Hive::Web::AppBundle.ensure!(bundle_url: source, output: nil, runner: runner)
+
+      assert_equal [ %w[bundle install], %w[bin/rails assets:precompile] ], calls.map { |call| call[:argv] }
+      assert calls.all? { |call| call[:dir].include?(".tmp.") },
+             "dependencies and assets must be prepared in the staged bundle before the atomic swap"
+      asset_env = calls.last.fetch(:env)
+      assert_equal "production", asset_env["RAILS_ENV"]
+      assert asset_env["SECRET_KEY_BASE"].to_s != ""
+      assert asset_env["HIVEBOX_STORAGE_DIR"].to_s != ""
+      assert Hive::Web::AppBundle.assets_ready?,
+             "a successfully installed managed bundle must contain fetchable CSS and JavaScript"
+    end
+  end
+
+  def test_same_version_bundle_with_missing_assets_is_repaired
+    with_hive_home do
+      app = Hive::Web::AppBundle.app_dir
+      FileUtils.mkdir_p(File.join(app, "config"))
+      File.write(File.join(app, "config", "application.rb"), "# broken installed app\n")
+      File.write(File.join(app, Hive::Web::AppBundle::VERSION_FILE), "#{Hive::VERSION}\n")
+      refute Hive::Web::AppBundle.assets_ready?, "precondition: the installed bundle has no compiled assets"
+
+      calls = []
+      runner = lambda do |argv, _env|
+        calls << argv
+        write_compiled_assets(Dir.pwd) if argv == %w[bin/rails assets:precompile]
+        true
+      end
+      Hive::Web::AppBundle.ensure!(bundle_url: seed_source_app, output: nil, runner: runner)
+
+      assert_includes calls, %w[bin/rails assets:precompile],
+                      "a matching version stamp must not hide a broken asset installation"
+      assert Hive::Web::AppBundle.assets_ready?
+    end
+  end
+
+  def test_assets_ready_rejects_manifest_paths_outside_the_asset_directory
+    Dir.mktmpdir("hive-web-assets") do |app|
+      assets = File.join(app, "public", "assets")
+      FileUtils.mkdir_p(assets)
+      File.write(File.join(app, "public", "escape.css"), "body {}\n")
+      File.write(File.join(app, "public", "escape.js"), "export {}\n")
+      File.write(
+        File.join(assets, ".manifest.json"),
+        JSON.generate(
+          "application.css" => { "digested_path" => "../escape.css" },
+          "application.js" => { "digested_path" => "../escape.js" }
+        )
+      )
+
+      refute Hive::Web::AppBundle.assets_ready?(app)
+    end
+  end
+
+  def test_assets_ready_rejects_a_missing_controller_module
+    Dir.mktmpdir("hive-web-assets") do |app|
+      write_compiled_assets(app)
+      manifest_path = File.join(app, "public", "assets", ".manifest.json")
+      manifest = JSON.parse(File.read(manifest_path))
+      manifest["controllers/status_controller.js"] = {
+        "digested_path" => "controllers/status_controller-missing.js"
+      }
+      File.write(manifest_path, JSON.generate(manifest))
+
+      refute Hive::Web::AppBundle.assets_ready?(app),
+             "every module named by the production manifest must exist before activation"
+    end
+  end
+
+  def test_assets_ready_treats_a_null_byte_path_as_missing
+    Dir.mktmpdir("hive-web-assets") do |app|
+      write_compiled_assets(app)
+      manifest_path = File.join(app, "public", "assets", ".manifest.json")
+      manifest = JSON.parse(File.read(manifest_path))
+      manifest["application.css"]["digested_path"] = "application\0.css"
+      File.write(manifest_path, JSON.generate(manifest))
+
+      refute Hive::Web::AppBundle.assets_ready?(app)
+    end
+  end
+
+  def test_assets_ready_treats_non_object_json_as_missing
+    Dir.mktmpdir("hive-web-assets") do |app|
+      assets = File.join(app, "public", "assets")
+      FileUtils.mkdir_p(assets)
+      File.write(File.join(assets, ".manifest.json"), "null\n")
+
+      refute Hive::Web::AppBundle.assets_ready?(app)
+    end
+  end
+
+  def test_asset_precompile_failure_preserves_the_previous_bundle
+    with_hive_home do
+      app = Hive::Web::AppBundle.app_dir
+      FileUtils.mkdir_p(File.join(app, "config"))
+      File.write(File.join(app, "config", "application.rb"), "# old app\n")
+      File.write(File.join(app, Hive::Web::AppBundle::VERSION_FILE), "0.0.0-old\n")
+
+      error = assert_raises(Hive::Error) do
+        Hive::Web::AppBundle.ensure!(
+          bundle_url: seed_source_app,
+          output: nil,
+          runner: ->(argv, _env) { argv == %w[bundle install] }
+        )
+      end
+
+      assert_match(/asset precompile failed/, error.message)
+      assert_equal "# old app\n", File.read(File.join(app, "config", "application.rb"))
+      assert_equal "0.0.0-old", Hive::Web::AppBundle.installed_version
+    end
+  end
+
+  def test_asset_precompile_without_output_preserves_the_previous_bundle
+    with_hive_home do
+      app = Hive::Web::AppBundle.app_dir
+      FileUtils.mkdir_p(File.join(app, "config"))
+      File.write(File.join(app, "config", "application.rb"), "# old app\n")
+      File.write(File.join(app, Hive::Web::AppBundle::VERSION_FILE), "0.0.0-old\n")
+
+      error = assert_raises(Hive::Error) do
+        Hive::Web::AppBundle.ensure!(
+          bundle_url: seed_source_app,
+          output: nil,
+          runner: ->(_argv, _env) { true }
+        )
+      end
+
+      assert_match(/asset precompile produced no usable CSS\/JavaScript/, error.message)
+      assert_equal "# old app\n", File.read(File.join(app, "config", "application.rb"))
+      assert_equal "0.0.0-old", Hive::Web::AppBundle.installed_version
     end
   end
 
@@ -87,7 +238,7 @@ class WebAppBundleTest < Minitest::Test
         Hive::Web::AppBundle.ensure!(bundle_url: source, output: nil,
                                      runner: ->(_argv, _env) { false })
       end
-      # bundle_install! now runs against the staged tmp dir BEFORE the swap, so
+      # prepare! now runs against the staged tmp dir BEFORE the swap, so
       # a Bundler failure never reaches FileUtils.mv — the previous working app
       # (and its stamp) is left untouched instead of being replaced with an
       # unstamped broken bundle.
@@ -120,8 +271,14 @@ class WebAppBundleTest < Minitest::Test
       # dir (hive-web-X.Y.Z/) around config/application.rb. ensure! must
       # detect that layout and hoist the wrapper's children to the app root.
       source = seed_nested_source_app
-      Hive::Web::AppBundle.ensure!(bundle_url: source, output: nil,
-                                   runner: ->(_argv, _env) { true })
+      Hive::Web::AppBundle.ensure!(
+        bundle_url: source,
+        output: nil,
+        runner: lambda do |argv, _env|
+          write_compiled_assets(Dir.pwd) if argv == %w[bin/rails assets:precompile]
+          true
+        end
+      )
       assert Hive::Web::AppBundle.present?,
              "a bundle wrapped in a single versioned dir must unwrap to the app root"
       assert_equal "# app\n",
@@ -156,6 +313,21 @@ class WebAppBundleTest < Minitest::Test
     end
   end
 
+  def test_ensure_raises_when_bundle_lacks_gemfile
+    with_hive_home do
+      src = Dir.mktmpdir("hive-web-no-gemfile")
+      FileUtils.mkdir_p(File.join(src, "config"))
+      File.write(File.join(src, "config", "application.rb"), "# app\n")
+
+      error = assert_raises(Hive::Error) do
+        Hive::Web::AppBundle.ensure!(bundle_url: src, output: nil, runner: ->(_argv, _env) { true })
+      end
+
+      assert_match(/does not contain a Gemfile/, error.message)
+      refute Hive::Web::AppBundle.present?, "a bundle without dependencies must not be installed or stamped"
+    end
+  end
+
   def test_default_bundle_url_prefers_env_override_then_falls_back_to_release_url
     with_env("HIVE_WEB_BUNDLE_URL" => "https://example.test/custom-bundle.tar.gz") do
       assert_equal "https://example.test/custom-bundle.tar.gz", Hive::Web::AppBundle.default_bundle_url
@@ -182,7 +354,11 @@ class WebAppBundleTest < Minitest::Test
         StringIO.new(gz_bytes)
       }) do
         Hive::Web::AppBundle.ensure!(bundle_url: "https://example.test/bundle.tar.gz",
-                                     output: nil, runner: ->(_argv, _env) { ran = true })
+                                     output: nil, runner: lambda { |argv, _env|
+                                       ran = true
+                                       write_compiled_assets(Dir.pwd) if argv == %w[bin/rails assets:precompile]
+                                       true
+                                     })
       end
 
       assert_equal "https://example.test/bundle.tar.gz", opened_url,
@@ -221,7 +397,7 @@ class WebAppBundleTest < Minitest::Test
   end
 
   # Build a minimal "source checkout" the directory branch of
-  # fetch_and_extract copies verbatim, including a Gemfile so bundle_install!
+  # fetch_and_extract copies verbatim, including a Gemfile so prepare!
   # invokes the injected runner.
   def seed_source_app
     src = Dir.mktmpdir("hive-web-src")
@@ -229,6 +405,20 @@ class WebAppBundleTest < Minitest::Test
     File.write(File.join(src, "config", "application.rb"), "# app\n")
     File.write(File.join(src, "Gemfile"), "source 'https://rubygems.org'\n")
     src
+  end
+
+  def write_compiled_assets(dir)
+    assets = File.join(dir, "public", "assets")
+    FileUtils.mkdir_p(assets)
+    File.write(File.join(assets, "application-test.css"), "body {}\n")
+    File.write(File.join(assets, "application-test.js"), "export {}\n")
+    File.write(
+      File.join(assets, ".manifest.json"),
+      JSON.generate(
+        "application.css" => { "digested_path" => "application-test.css" },
+        "application.js" => { "digested_path" => "application-test.js" }
+      )
+    )
   end
 
   def with_hive_home

--- a/test/unit/web/web_command_test.rb
+++ b/test/unit/web/web_command_test.rb
@@ -172,6 +172,17 @@ class WebCommandTest < Minitest::Test
       FileUtils.mkdir_p(File.join(dir, "bin"))
       File.write(File.join(dir, "bin", "rails"), "#!/usr/bin/env bash\nexit 0\n")
       FileUtils.chmod(0o755, File.join(dir, "bin", "rails"))
+      assets = File.join(dir, "public", "assets")
+      FileUtils.mkdir_p(assets)
+      File.write(File.join(assets, "application-test.css"), "body {}\n")
+      File.write(File.join(assets, "application-test.js"), "export {}\n")
+      File.write(
+        File.join(assets, ".manifest.json"),
+        JSON.generate(
+          "application.css" => { "digested_path" => "application-test.css" },
+          "application.js" => { "digested_path" => "application-test.js" }
+        )
+      )
 
       original = Kernel.method(:exec)
       Kernel.define_singleton_method(:exec) do |env, *argv|

--- a/web/app/controllers/application_controller.rb
+++ b/web/app/controllers/application_controller.rb
@@ -11,7 +11,8 @@ class ApplicationController < ActionController::Base
 
   before_action :require_login
 
-  helper_method :current_login, :operator_access?, :operator_label
+  helper_method :current_login, :operator_access?, :operator_label,
+                :local_web_mode?, :web_product_name
 
   # Hive's typed errors are operator-readable by design ("task not in stage",
   # "invalid clone URL"). Render them on an error page instead of a blank
@@ -60,6 +61,14 @@ class ApplicationController < ActionController::Base
     current_login.presence || "Local"
   end
 
+  def local_web_mode?
+    ENV["HIVEBOX_LOCAL_LOOPBACK"] == "1"
+  end
+
+  def web_product_name
+    local_web_mode? ? "hive" : "hivebox"
+  end
+
   def require_login
     return if local_loopback_request?
     return redirect_to login_path unless current_login
@@ -81,9 +90,13 @@ class ApplicationController < ActionController::Base
   # "which addresses count as loopback" rule can't drift between the tier
   # that sets HIVEBOX_LOCAL_LOOPBACK and the tier that honors it.
   def local_loopback_request?
-    return false unless ENV["HIVEBOX_LOCAL_LOOPBACK"] == "1"
+    return false unless local_web_mode?
 
-    Hive::Web::Loopback.address?(request.remote_ip)
+    # Trust the socket peer, not ActionDispatch's proxy-expanded remote_ip.
+    # Tailscale Serve connects from localhost but forwards the tailnet client's
+    # address; treating that forwarded address as the peer wrongly turns the
+    # local control plane into hivebox's GitHub owner gate.
+    Hive::Web::Loopback.address?(request.get_header("REMOTE_ADDR"))
   end
 
   def registered_projects

--- a/web/app/controllers/sessions_controller.rb
+++ b/web/app/controllers/sessions_controller.rb
@@ -80,7 +80,7 @@ class SessionsController < ApplicationController
 
   def destroy
     reset_session
-    redirect_to login_path
+    redirect_to local_web_mode? ? root_path : login_path
   end
 
   # Dev/test auth seam — the route only exists in local envs, and the action
@@ -98,10 +98,12 @@ class SessionsController < ApplicationController
 
   def admit!(result)
     login = result[:login]
-    claim_ownership!(login) if github_auth.claimable?
-    unless github_auth.owner?(login)
-      return render "errors/show", status: :forbidden,
-                    locals: { heading: "Not allowed", message: "#{login} is not the configured owner." }
+    unless local_loopback_request?
+      claim_ownership!(login) if github_auth.claimable?
+      unless github_auth.owner?(login)
+        return render "errors/show", status: :forbidden,
+                      locals: { heading: "Not allowed", message: "#{login} is not the configured owner." }
+      end
     end
 
     # Rotate the session at the auth boundary; carry the grant into the

--- a/web/app/views/agents/index.html.erb
+++ b/web/app/views/agents/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:title, "hivebox — agents") %>
+<% content_for(:title, "#{web_product_name} — agents") %>
 <h1>Agents</h1>
 <p class="muted">Authenticate the agents the pipeline runs. Credentials persist in Hive's data home on this machine.</p>
 

--- a/web/app/views/errors/show.html.erb
+++ b/web/app/views/errors/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:title, "hivebox — #{heading.downcase}") %>
+<% content_for(:title, "#{web_product_name} — #{heading.downcase}") %>
 <div class="card auth-card">
   <h1><%= heading %></h1>
   <p><%= message %></p>

--- a/web/app/views/layouts/application.html.erb
+++ b/web/app/views/layouts/application.html.erb
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title><%= content_for(:title) || "hivebox" %></title>
+    <title><%= content_for(:title) || web_product_name %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta name="application-name" content="hivebox">
+    <meta name="application-name" content="<%= web_product_name %>">
     <meta name="mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
@@ -23,7 +23,7 @@
   <body>
     <header class="topbar">
       <div class="topbar-inner">
-        <%= link_to "hivebox", root_path, class: "brand" %>
+        <%= link_to web_product_name, root_path, class: "brand" %>
         <% if operator_access? %>
           <nav aria-label="Primary">
             <%= link_to "Status", root_path, class: nav_class(:status) %>

--- a/web/app/views/repos/index.html.erb
+++ b/web/app/views/repos/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:title, "hivebox — repos") %>
+<% content_for(:title, "#{web_product_name} — repos") %>
 <h1>Repos</h1>
 
 <h2>Registered</h2>

--- a/web/app/views/repos/new.html.erb
+++ b/web/app/views/repos/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:title, "hivebox — project setup") %>
+<% content_for(:title, "#{web_product_name} — project setup") %>
 <h1>Project setup</h1>
 <% if @project_name %>
   <p class="muted">Re-running setup for <strong><%= @project_name %></strong> — the same questions <code>hive init</code> asks, applied to the existing checkout.</p>

--- a/web/app/views/sessions/new.html.erb
+++ b/web/app/views/sessions/new.html.erb
@@ -1,7 +1,19 @@
-<% content_for(:title, "hivebox — sign in") %>
+<% content_for(:title, "#{web_product_name} — #{local_web_mode? ? "connect GitHub" : "sign in"}") %>
 <div class="card auth-card">
-  <h1>hivebox</h1>
-  <% if @configured %>
+  <% if local_web_mode? %>
+    <h1>Connect GitHub</h1>
+    <% if @configured %>
+      <p>Optional — Hive already works with your existing local projects and workflows.</p>
+      <p class="muted">Connect GitHub only to browse or clone repositories from the Repos page.
+        You'll get a short code to type at github.com/login/device.</p>
+      <%= form_with url: auth_github_path do |f| %>
+        <%= f.submit "Connect GitHub", data: { turbo_submits_with: "Contacting GitHub…" } %>
+      <% end %>
+    <% else %>
+      <p>Optional GitHub connection is unavailable: <code>web.github.client_id</code> is empty.</p>
+    <% end %>
+  <% elsif @configured %>
+    <h1>hivebox</h1>
     <% if @claimable %>
       <p>Fresh box — the first GitHub sign-in becomes its owner.</p>
       <p class="muted">You'll get a short code to type at github.com/login/device
@@ -13,6 +25,7 @@
       <%= f.submit "Continue with GitHub", data: { turbo_submits_with: "Contacting GitHub…" } %>
     <% end %>
   <% else %>
+    <h1>hivebox</h1>
     <p>Sign-in is unavailable: <code>web.github.client_id</code> is empty in the
       box's <code>config.yml</code>. The default ships with the shared hivebox
       OAuth app — restore it or set your own device-flow-enabled client id.</p>

--- a/web/app/views/sessions/wait.html.erb
+++ b/web/app/views/sessions/wait.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:title, "hivebox — finish signing in") %>
+<% content_for(:title, "#{web_product_name} — finish connecting GitHub") %>
 <%# Native timed refresh — each render polls GitHub at most once. %>
 <% content_for(:head) { tag.meta("http-equiv": "refresh", content: @device["interval"].to_i.clamp(1, 60)) } %>
 <div class="card auth-card">
@@ -10,7 +10,11 @@
   <p class="device-code"><%= @device["user_code"] %></p>
   <p class="muted">
     Waiting for GitHub to confirm — this page refreshes itself.
-    Approve as the configured owner account.
+    <% if local_web_mode? %>
+      This optional connection only unlocks GitHub-backed repository actions.
+    <% else %>
+      Approve as the configured owner account.
+    <% end %>
   </p>
   <p><%= link_to "Start over", login_path %></p>
 </div>

--- a/web/app/views/status/index.html.erb
+++ b/web/app/views/status/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:title, "hivebox — status") %>
+<% content_for(:title, "#{web_product_name} — status") %>
 <%# The status channel delivers BOTH a targeted #projects replace and a page
     refresh signal (task pages need the latter). Without these metas the
     refresh falls back to a full-body replace — which resets window scroll to

--- a/web/app/views/tasks/diff.html.erb
+++ b/web/app/views/tasks/diff.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:title, "hivebox — diff #{@row["slug"]}") %>
+<% content_for(:title, "#{web_product_name} — diff #{@row["slug"]}") %>
 <div class="task-header">
   <h1>Diff</h1>
   <%= stage_badge(@row["stage"]) %>

--- a/web/app/views/tasks/show.html.erb
+++ b/web/app/views/tasks/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:title, "hivebox — #{task_title(@row)}") %>
+<% content_for(:title, "#{web_product_name} — #{task_title(@row)}") %>
 
 <div class="task-header">
   <h1><%= task_title(@row) %></h1>

--- a/web/app/views/telegram/show.html.erb
+++ b/web/app/views/telegram/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:title, "hivebox — telegram") %>
+<% content_for(:title, "#{web_product_name} — telegram") %>
 <h1>Telegram</h1>
 <p class="muted">Connect the hive bot so you can drive the pipeline from Telegram. The token is validated against the real API before anything is saved.</p>
 

--- a/web/app/views/workflows/index.html.erb
+++ b/web/app/views/workflows/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:title, "hivebox — workflows") %>
+<% content_for(:title, "#{web_product_name} — workflows") %>
 <h1>Workflows</h1>
 <p class="muted">Choose how each project turns an idea into a deliverable. Built-ins, project-authored workflows, and reviewed Honeycomb packages all use Hive's real workflow registry.</p>
 

--- a/web/test/integration/local_loopback_auth_test.rb
+++ b/web/test/integration/local_loopback_auth_test.rb
@@ -34,6 +34,23 @@ class LocalLoopbackAuthTest < ActionDispatch::IntegrationTest
     assert_select "a", text: "Connect GitHub"
     assert_select "form[action='/logout']", 0,
                   "a tokenless local session must not offer a meaningless logout action"
+    assert_select "a.brand", text: "hive"
+    assert_select "title", text: "hive — status"
+    refute_includes response.body, "hivebox",
+                    "local Hive Web must not present itself as the separate hivebox appliance"
+  end
+
+  test "loopback proxy remains local when it forwards the Tailscale client IP" do
+    ENV["HIVEBOX_LOCAL_LOOPBACK"] = "1"
+
+    get "/", headers: {
+      "REMOTE_ADDR" => "127.0.0.1",
+      "HTTP_X_FORWARDED_FOR" => "100.105.122.109"
+    }
+
+    assert_response :success,
+                    "a localhost Tailscale Serve proxy must not turn Hive Web into a GitHub login gate"
+    assert_select "nav[aria-label='Primary']", 1
   end
 
   test "bypass enabled but a non-loopback remote still requires login" do

--- a/web/test/integration/sessions_flow_test.rb
+++ b/web/test/integration/sessions_flow_test.rb
@@ -32,11 +32,17 @@ class SessionsFlowTest < ActionDispatch::IntegrationTest
   )
 
   setup do
+    @prior_local_loopback = ENV.delete("HIVEBOX_LOCAL_LOOPBACK")
     configure_owner!(owner: "alice")
   end
 
   teardown do
     SessionsController.http_client = Net::HTTP
+    if @prior_local_loopback.nil?
+      ENV.delete("HIVEBOX_LOCAL_LOOPBACK")
+    else
+      ENV["HIVEBOX_LOCAL_LOOPBACK"] = @prior_local_loopback
+    end
   end
 
   def http_ok(body)
@@ -162,6 +168,35 @@ class SessionsFlowTest < ActionDispatch::IntegrationTest
                   "the claim path must be one button, not a config-editing instruction"
   end
 
+  test "local Hive Web presents GitHub as an optional connection, not box ownership" do
+    ENV["HIVEBOX_LOCAL_LOOPBACK"] = "1"
+    configure_owner!(owner: "")
+
+    get "/login"
+
+    assert_response :success
+    assert_select "h1", text: "Connect GitHub"
+    assert_match(/optional/i, response.body)
+    refute_match(/Fresh box|becomes its owner/, response.body)
+    refute_includes response.body, "hivebox"
+  end
+
+  test "local GitHub connection retains the token without claiming box ownership" do
+    ENV["HIVEBOX_LOCAL_LOOPBACK"] = "1"
+    configure_owner!(owner: "")
+    install_auth(login: "local-operator")
+    begin_device_flow
+
+    get "/auth/github/wait"
+
+    assert_redirected_to "/"
+    assert_equal "local-operator", session[:github_login]
+    assert_equal "gho_test", session[:github_token]
+    config = YAML.safe_load_file(File.join(ENV["HIVE_HOME"], "config.yml"))
+    assert_nil config.dig("web", "github", "owner"),
+               "connecting GitHub in local mode must not turn Hive Web into a claimed hivebox"
+  end
+
   test "non-owner login is denied (U2)" do
     install_auth(login: "mallory")
     begin_device_flow
@@ -193,5 +228,18 @@ class SessionsFlowTest < ActionDispatch::IntegrationTest
     assert_redirected_to "/login"
     get "/"
     assert_redirected_to "/login", "the session must be gone after logout"
+  end
+
+  test "disconnecting GitHub in local mode returns to Hive instead of the login gate" do
+    ENV["HIVEBOX_LOCAL_LOOPBACK"] = "1"
+    sign_in!(token: "gho_test")
+
+    post "/logout"
+
+    assert_redirected_to "/"
+    follow_redirect!
+    assert_response :success
+    assert_nil session[:github_token]
+    assert_select ".session-login", text: "Local"
   end
 end

--- a/web/test/system/pipeline_flow_test.rb
+++ b/web/test/system/pipeline_flow_test.rb
@@ -70,8 +70,8 @@ class PipelineFlowTest < ApplicationSystemTestCase
     JS
     submit_idea
     assert_selector ".flash-notice", text: "Idea added", wait: 5
-    assert_equal "", find("textarea[aria-label='New idea']").value,
-                 "a submitted permanent composer must not retain a duplicate-ready draft"
+    assert page.has_field?("New idea", with: "", wait: 5),
+           "a submitted permanent composer must not retain a duplicate-ready draft"
     assert_no_selector ".chip", wait: 0
     assert_equal 0, page.evaluate_script("document.querySelector('[data-composer-target=\"files\"]').files.length"),
                  "successful submission must release the staged upload transport"

--- a/wiki/architecture.md
+++ b/wiki/architecture.md
@@ -3,7 +3,7 @@ title: Architecture
 type: architecture
 source: lib/hive/, bin/hive, templates/
 created: 2026-04-25
-updated: 2026-07-16
+updated: 2026-07-20
 tags: [architecture, overview]
 ---
 
@@ -297,16 +297,24 @@ sends the next question. The earlier "Codex draft-assist" flow — where
 Path A spawned Codex to draft an answer with write-draft/edit/cancel
 buttons — has been retired; see [[modules/bot]] and [[state-model]].
 
-## Hivebox web pipeline
+## Hive Web and Hivebox pipeline
 
 `hive web` serves a vanilla Rails 8 + Turbo app from `web/` (ADR-037; the
-original Sinatra/Puma + SSE tier is gone). Auth is the GitHub device flow
-(ADR-036): a configured `web.github.owner` gates entry, while an ownerless
-fresh box is claimable and the first successful login writes
+original Sinatra/Puma + SSE tier is gone). Local Hive Web is a browser control
+plane over the same registry and workflow state as the CLI/TUI; loopback
+requests use the `hive` identity without mandatory sign-in, including through
+a local reverse proxy whose socket peer is loopback. GitHub is an optional
+connection for repository listing and cloning and does not claim ownership.
+Hivebox is the distinct owner-gated container mode. Its auth is the GitHub
+device flow (ADR-036): a configured `web.github.owner` gates entry, while an
+ownerless fresh box is claimable and the first successful login writes
 `web.github.owner` under the global config lock. Owner-gated requests re-check
 the current owner on every request and evict old sessions when
 `web.github.owner` changes, so a repo-scoped session token cannot survive an
-ownership rotation. Reads render
+ownership rotation. Managed local installs stage `bundle install` plus a
+production asset precompile and verify the CSS/JavaScript manifest before the
+atomic bundle swap; same-version installs with missing assets are repaired.
+Reads render
 `Commands::Status#json_payload` snapshots; live updates flow over Turbo
 Streams, with production Action Cable accepting same-origin-as-host and
 `HIVEBOX_ORIGIN` only as an extra allow for split-origin deployments:

--- a/wiki/commands/web.md
+++ b/wiki/commands/web.md
@@ -3,13 +3,16 @@ title: hive web
 type: command
 source: lib/hive/commands/web.rb, lib/hive/web/, web/, packaging/docker/, .github/workflows/release.yml
 created: 2026-06-04
-updated: 2026-07-19
+updated: 2026-07-20
 tags: [command, web, hivebox, rails, turbo]
 ---
 
-**TLDR**: `hive web` boots the hivebox web UI — a vanilla **Rails 8** app
-(importmap, Turbo, Stimulus, propshaft, solid_cable) living in `web/` at the
-repo root, shipped in the Docker image at `/app/web`. The web tier adds no
+**TLDR**: `hive web` boots the local Hive browser UI — a vanilla **Rails 8**
+app (importmap, Turbo, Stimulus, propshaft, solid_cable) living in `web/` at
+the repo root. It is an advanced browser counterpart to the TUI over the same
+local registry and workflow state, with no mandatory sign-in. Hivebox is the
+separate owner-gated container deployment of this shared app at `/app/web`.
+The web tier adds no
 pipeline logic: status reads call `Hive::Commands::Status#json_payload` (via
 `Hive::Web::StatusFeed`), gate approval calls `Hive::Commands::Approve`
 in-process, task Drop calls `Hive::Commands::Drop` in-process, stage runs go
@@ -31,6 +34,11 @@ points at a real Rails app, the managed version-stamped app under
 `Hive::Paths.web_app_home` (refreshed when stale unless `--no-bootstrap` is
 passed), then a source checkout `web/` next to `lib/`; if none exists and
 bootstrap is allowed, it downloads/extracts the versioned web release bundle.
+Managed installation prepares a staging directory with `bundle install` and a
+production `assets:precompile`, requires usable `application.css` and
+`application.js` entrypoints, verifies every Propshaft manifest asset resolves
+to a contained file, and only then atomically activates it. Missing or corrupt
+assets make even a same-version bundle repair itself.
 Relative `HIVEBOX_WEB_APP_DIR` values are accepted but normalized before the
 Rails env is built, so `BUNDLE_GEMFILE` points at the real app Gemfile after
 the command changes into the app directory.
@@ -52,10 +60,10 @@ while systemd-user was unavailable becomes visible. Foreground
 `hive web start` is equivalent to `hive web`. `status --json` emits
 `hive-web-status`; `install --json` emits `hive-web-install`.
 
-## Auth
+## Access and GitHub connection
 
-GitHub **device flow** (RFC 8628, see [[decisions]] ADR-036), owner-only.
-An ownerless box is CLAIMABLE: the first successful device-flow login writes
+Hivebox uses an owner-only GitHub **device flow** (RFC 8628, see [[decisions]]
+ADR-036). An ownerless box is CLAIMABLE: the first successful device-flow login writes
 itself into `web.github.owner` (config-lock-guarded so concurrent first
 logins race safely; the claim is logged loudly) — the install path has no
 config-editing step.
@@ -77,11 +85,17 @@ usable. The local dev/test seam is exempt only for tokenless local sessions.
 Local loopback mode is a deliberate no-auth bypass for local foreground use:
 when the CLI bind address is `localhost`, `::1`, or any `127.0.0.0/8` address
 and `web.local_loopback` is not `false`, it exports `HIVEBOX_LOCAL_LOOPBACK=1`.
-Rails still checks that the request peer is loopback before skipping login.
+Rails still checks that the actual socket peer in `REMOTE_ADDR` is loopback
+before skipping login; it deliberately ignores proxy-expanded `remote_ip` for
+this decision. A local reverse proxy such as Tailscale Serve therefore retains
+local access even when it forwards the tailnet client's address. The proxy is
+part of the security boundary: restrict/authenticate clients (for example with
+tailnet ACLs), because an unrestricted forwarder exposes the no-auth local UI.
 That connection-authenticated operator sees the complete primary navigation
-and is labelled `Local`; GitHub-dependent repository browsing stays behind an
-explicit **Connect GitHub** action instead of making the rest of hivebox look
-signed out.
+under the `hive` product identity and is labelled `Local`; GitHub-dependent
+repository browsing stays behind an explicit **Connect GitHub** action.
+Completing that optional connection stores the login/token in the browser
+session but never claims or changes `web.github.owner`.
 Non-loopback binds require either `--unsafe` or a configured `web.github.owner`;
 when an owner gate authorizes a non-loopback bind, the CLI warns that
 `web.github.owner` is the only login gate, and `0.0.0.0` without an HTTPS
@@ -317,8 +331,10 @@ Typed `Hive::Error`s render a readable error page (422; `InvalidTaskPath` →
 writing a daemon request, and `Hive::Web::Dispatcher#dispatch` wraps queue
 writer `ArgumentError`s (for example the queue's stricter slug grammar) as
 typed 422s instead of surfacing an opaque 500. CSRF is Rails-default (per-form
-tokens); every route except `/health`, `/up`, `/login`, `/logout`,
-`/auth/github*`, and the dev/test-only `/dev_login` is behind the owner gate.
+tokens). In Hivebox mode every route except `/health`, `/up`, `/login`,
+`/logout`, `/auth/github*`, and the dev/test-only `/dev_login` is behind the
+owner gate; a verified local loopback request bypasses that gate for the
+complete local UI.
 
 ## Tests
 
@@ -330,8 +346,13 @@ and the real `Commands::New`/`Approve`/`Drop` plus web recovery queue writes
 against a sandboxed `HIVE_HOME` (the suite NEVER touches the developer's real
 config — `test_helper.rb` sets the sandbox before the app loads). It pins that
 a loopback-authenticated local operator gets the full navigation and an
-explicit GitHub connection action, and that repository setup always invokes
-the CLI init adapter with non-TTY provisioning input. It also pins that
+explicit GitHub connection action. It also covers Tailscale-style forwarded
+client addresses over a loopback socket, local `hive` branding, optional
+GitHub connection without owner claim, and local logout returning to the
+usable dashboard. Managed-bundle tests pin staged dependency/asset preparation,
+same-version missing-asset repair, and preservation of the previous bundle on
+precompile failure. Repository setup always invokes the CLI init adapter with
+non-TTY provisioning input. It also pins that
 a red task page shows the diagnostic banner and Retry button, and that the
 route queues the marker-clear command plus the hidden rerun sequence. It also
 pins the Telegram first-run guide shape, strict token/chat-ID validation,
@@ -432,7 +453,10 @@ Colima cannot boot a Linux VM there. Current `.github/workflows/ci.yml` does
 not run a push/PR Docker image smoke; it covers Rails web tests, the
 golden-path browser E2E, and the Windows installer harness. The smoke covers
 web and daemon health plus the front door (`/health`, `/health?deep=1`,
-claimable `/login`, owner-gated `/`). The Windows workflow cannot run Linux
+claimable `/login`, owner-gated `/`) and fetches the exact digest-stamped CSS
+and JavaScript graph advertised by that page, then runs the managed-install
+manifest predicate against the real precompile output. The Windows workflow
+cannot run Linux
 containers on hosted runners, so it syntax-checks `install-box.ps1` and runs
 `packaging/docker/test-install-box.ps1` against a stubbed Docker CLI to pin the
 installer's diagnostics and pull/run argv shape.

--- a/wiki/decisions.md
+++ b/wiki/decisions.md
@@ -3,15 +3,15 @@ title: Architectural Decisions
 type: decisions
 source: code + author's local planning notes (not committed)
 created: 2026-04-25
-updated: 2026-06-16
+updated: 2026-07-20
 tags: [decisions, adr]
 ---
 
 **TLDR**: ADRs below were authored alongside implementation work. ADR-024 records both the PR-first workflow/stage renumbering and daemon autonomy; ADR-026 covers the Telegram bot mobile surface (subprocess caller for non-state-mutating verbs); ADR-027 records the diagnose-then-act surface for red status rows; ADR-029 records the 7-artifacts stage insertion; ADR-030 records the project-global Claude launch mode plus permission/model/effort follow-ups; **ADR-033 supersedes the subprocess-caller portion of ADR-026 for state-mutating verbs — the bot now writes file-backed dispatch requests that the daemon consumes, making the daemon the sole spawner of `hive run`-class children**; ADR-034 records Hive-owned fallback commits for successful fix-agent edits and pre-fix dirty-worktree snapshots; ADR-035 records hivebox's PTY agent-login relay for paste-back and operator-ward device flows, now also used for `gh auth login`, instead of provider-page proxying; ADR-036 records hivebox's switch to GitHub device-flow sign-in, including ownerless first-login claim (no callback URL, no client secret, no required config edit).
 
-## ADR-037: Hivebox web tier is a vanilla Rails 8 + Turbo app, replacing the Sinatra tier
+## ADR-037: Hive Web and Hivebox share a vanilla Rails 8 + Turbo app
 
-**Status:** Active (replaced the Sinatra/Puma tier during PR #300, 2026-06-10).
+**Status:** Active (replaced the Sinatra/Puma tier during PR #300, 2026-06-10; amended for the managed local runtime during PR #622 and its 2026-07-20 follow-up).
 
 **Context:** The first web tier was Sinatra + hand-rolled SSE + hand-written
 DOM-reconciliation JS. It worked, but live updates needed a bespoke
@@ -31,12 +31,26 @@ execs `bin/rails server` from the app dir; the gem does not package the app
 claude.com: warm ivory/charcoal surfaces, terracotta accent, serif display
 headings, hairline borders, calm dark mode.
 
+The Rails application has two deployment identities. `hive web` is a local
+browser/TUI counterpart over existing Hive state: verified loopback requests
+need no sign-in, use `hive` branding, and may optionally connect GitHub for
+repository actions without claiming an owner. Hivebox is the container-first,
+owner-gated product governed by ADR-036. Release installs stage the versioned
+web bundle outside the gem, install its dependencies, precompile production
+assets, verify the required entrypoints and full manifest graph, and atomically
+activate it.
+
 **Consequences:** SSE limiter, custom reconciliation JS, and the Sinatra
 route/view tree are gone (−sinatra, −rack-protection, −puma gem deps). The
 image gains a second bundle + asset precompile. Browser-level coverage moved
 to Capybara + Playwright system tests with a dev/test-only login seam.
 Authorization, device flow, and the no-new-pipeline-logic constraint are
-unchanged (ADR-036 still applies).
+unchanged for Hivebox (ADR-036 still applies). The local listener trusts the
+actual loopback socket peer rather than a reverse proxy's forwarded client IP,
+so localhost proxies do not accidentally switch the application into Hivebox.
+That makes the proxy part of the access boundary: Tailscale Serve must remain
+tailnet-restricted, and a generic forwarder must authenticate/restrict clients
+or local no-auth mode must be disabled.
 
 ## ADR-036: Hivebox operator sign-in uses GitHub OAuth device flow, not the callback web flow
 
@@ -77,6 +91,10 @@ secret. The UX cost is one extra step (entering a short code at
 github.com/login/device) — symmetrical with the agent relay. Operators
 overriding `client_id` must check "Enable Device Flow" on their app. Route
 behavior and tests: [[commands/web]].
+
+This owner-claim decision applies only to Hivebox. Local `hive web` loopback
+access requires no GitHub identity, and its optional repository connection
+must not write `web.github.owner`.
 
 ## ADR-035: Hivebox agent OAuth uses a PTY login relay, not provider-page proxying
 

--- a/wiki/log.d/20260720T103442Z-local-hive-web-proxy-assets.md
+++ b/wiki/log.d/20260720T103442Z-local-hive-web-proxy-assets.md
@@ -1,0 +1,16 @@
+# Restore local Hive Web access and assets
+
+- Kept `hive web` as a local browser control plane over the same registry and
+  workflow state as the CLI/TUI, distinct from the owner-gated Hivebox product.
+- Made loopback authentication use the real socket peer so Tailscale Serve and
+  similar localhost proxies do not turn forwarded tailnet addresses into a
+  Hivebox login gate. The proxy remains part of the access boundary and must
+  restrict/authenticate its clients. Local GitHub connection remains optional
+  and never claims `web.github.owner`.
+- Made managed web installation precompile and verify production CSS/JavaScript
+  manifest graph before atomically activating a bundle, repair same-version
+  installs whose assets are missing, and preserve the last working bundle on
+  build failure.
+- Extended integration, unit, and Docker smoke coverage for forwarded local
+  access, product copy/branding, optional GitHub sessions, missing-asset repair,
+  and fetching every digest-stamped asset advertised by the login page.

--- a/wiki/modules/config.md
+++ b/wiki/modules/config.md
@@ -3,7 +3,7 @@ title: Hive::Config
 type: module
 source: lib/hive/config.rb
 created: 2026-04-25
-updated: 2026-07-19
+updated: 2026-07-20
 tags: [config, yaml, validation]
 ---
 
@@ -342,17 +342,23 @@ Global web settings are validated separately for [[commands/web]]:
 `web.github` must be a hash, optional `web.github.owner` and
 `web.github.client_id` must be non-empty strings when set, and
 `web.session_secret_file` must be a non-empty string when set. A blank/missing
-`web.github.owner` is valid and means the first successful hivebox GitHub
+`web.github.owner` is valid and means the first successful Hivebox GitHub
 device-flow login claims the box by writing that owner under the global config
-lock; pre-setting the owner keeps the older pinned-owner gate. GitHub sign-in
+lock; a local Hive Web GitHub connection never claims it. Pre-setting the owner
+keeps the older pinned-owner gate. GitHub sign-in
 uses the OAuth device flow (see [[decisions]] ADR-036), so no client secret
 exists anywhere; `web.github.client_id` defaults to the shared hivebox OAuth
 app — public by design, since device flow is a public-client grant.
 `web.local_loopback: true` is the local foreground default: when `hive web`
 binds `localhost`, `::1`, or `127.0.0.0/8`, the CLI exports
 `HIVEBOX_LOCAL_LOOPBACK=1` and Rails skips GitHub login only for requests whose
-peer IP is also loopback. Setting it to `false` forces the normal GitHub owner
-gate even on a loopback bind.
+actual socket peer (`REMOTE_ADDR`, not proxy-expanded `remote_ip`) is also
+loopback. This preserves local mode through Tailscale Serve and similar
+localhost reverse proxies without trusting arbitrary forwarded headers. The
+proxy must authenticate/restrict its clients because Rails trusts its loopback
+socket connection; use `false` when that boundary cannot be guaranteed.
+Setting it to `false` forces the normal GitHub owner gate even on a loopback
+bind.
 
 The current `hive init` JSON summary envelope (`schemas/hive-init.v2.json`) carries the chosen architecture-patrol discovery value as `refactor_patrol_enabled`, alongside the launch and permission-mode choices. The retained v1 schema is a compatibility artifact. See [[commands/init]].
 


### PR DESCRIPTION
## Summary

Opening `hive web` through a trusted local or Tailscale proxy now lands directly in the styled `hive` control plane backed by the machine's existing registry, projects, and workflows. GitHub is an optional connection for repository browsing and cloning; first-login ownership and the `hivebox` identity remain exclusive to the separate Hivebox deployment.

Managed release installs now build production assets in staging, require the complete Propshaft manifest graph before activation, repair same-version installs with missing assets, and preserve the last working bundle when preparation fails. The image promotion smoke exercises both the browser-advertised asset graph and that same managed-install predicate against real precompile output.

Local no-auth mode deliberately trusts the actual loopback socket peer so Tailscale Serve works even when it forwards the tailnet client's address. The proxy therefore remains part of the access boundary: it must authenticate or restrict clients, or operators should set `web.local_loopback: false`.

## Related

Related: #622

## Verification

- Production-mode browser with a forwarded tailnet client address: dashboard returned 200 without GitHub auth, rendered `hive` branding and full navigation, loaded both stylesheets and JavaScript modules, established Turbo's WebSocket, and reported no console errors.
- Managed bundle/release regression tests: 21 runs, 75 assertions, 0 failures.
- Rails model/integration: 130 runs, 715 assertions, 0 failures.
- Rails Playwright system: 20 runs, 155 assertions, 0 failures.
- Golden browser/daemon workflow: 1 run, 13 assertions, 0 failures.
- Clean production Docker build and Hivebox smoke, including every advertised CSS/JavaScript asset and the real Propshaft manifest predicate.
- RuboCop: root 1,052 files and web 62 files clean; Zeitwerk clean.
- Bundler audit: no vulnerabilities. Brakeman reported only the two pre-existing weak `TasksController` file-path warnings and no new warning in this change.

## Review

A structured correctness, standards, testing, maintainability, security, and reliability pass was followed by an independent Claude Opus adversarial review. All validated findings were fixed. A proposed manifest-shape blocker was disproved against the clean image's real Propshaft 1.3.2 output, then permanently guarded by running the production parser in Docker smoke.
