### PR TITLE
fix(web): compile native assets on startup

### DIFF
--- a/lib/hive/commands/web.rb
+++ b/lib/hive/commands/web.rb
@@ -77,7 +77,8 @@ module Hive
         # bundle-installed against its own ".."; re-pointing the path source
         # at runtime invalidates that prebuilt bundle (the v0.3.4/v0.3.5
         # image-smoke db:prepare failure).
-        env["HIVE_CLI_ROOT"] = Hive::Web::AppBundle.hive_cli_root if app_dir == Hive::Web::AppBundle.app_dir
+        managed_bundle = app_dir == Hive::Web::AppBundle.app_dir
+        env["HIVE_CLI_ROOT"] = Hive::Web::AppBundle.hive_cli_root if managed_bundle
         # The loopback no-auth bypass is opt-out: an operator can set
         # web.local_loopback: false to force GitHub login even on a loopback
         # bind. Only signal the bypass when both the bind is loopback AND the
@@ -86,7 +87,8 @@ module Hive
         FileUtils.mkdir_p(env.fetch("HIVEBOX_STORAGE_DIR"))
 
         Dir.chdir(app_dir) do
-          if env.fetch("RAILS_ENV") == "production" && ENV["HIVEBOX_PRECOMPILED_ASSETS"] != "1"
+          precompiled_assets = managed_bundle || ENV["HIVEBOX_PRECOMPILED_ASSETS"] == "1"
+          if env.fetch("RAILS_ENV") == "production" && !precompiled_assets
             compiled = Dir.mktmpdir("hive-web-assets") do |asset_storage|
               asset_env = env.merge("HIVEBOX_STORAGE_DIR" => asset_storage)
               system(asset_env, "bin/rails", "assets:precompile")

--- a/lib/hive/commands/web.rb
+++ b/lib/hive/commands/web.rb
@@ -1,5 +1,6 @@
 require "fileutils"
 require "json"
+require "tmpdir"
 require "hive/config"
 require "hive/paths"
 require "hive/web/session_secret"
@@ -85,6 +86,17 @@ module Hive
         FileUtils.mkdir_p(env.fetch("HIVEBOX_STORAGE_DIR"))
 
         Dir.chdir(app_dir) do
+          if env.fetch("RAILS_ENV") == "production" && ENV["HIVEBOX_PRECOMPILED_ASSETS"] != "1"
+            compiled = Dir.mktmpdir("hive-web-assets") do |asset_storage|
+              asset_env = env.merge("HIVEBOX_STORAGE_DIR" => asset_storage)
+              system(asset_env, "bin/rails", "assets:precompile")
+            end
+            unless compiled && Hive::Web::AppBundle.assets_ready?(app_dir)
+              raise Hive::Error,
+                    "hive web: asset precompile failed — check that #{app_dir} is writable " \
+                    "and that the web bundle is installed (cd #{app_dir} && bundle install)"
+            end
+          end
           # Idempotent: creates/migrates the solid-stack sqlite databases on
           # first boot, no-ops afterwards. Array form — no shell involved.
           # Typed error so a persistent failure surfaces as guidance, not a

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -8,6 +8,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     XDG_CACHE_HOME=/data/cache \
     HIVEBOX_REPOS_DIR=/data/repos \
     HIVEBOX_WEB_APP_DIR=/app/web \
+    HIVEBOX_PRECOMPILED_ASSETS=1 \
     RAILS_ENV=production
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -42,7 +43,9 @@ RUN bundle install \
        bin/rails assets:precompile \
     && rm -rf /tmp/assets-build \
     # Build steps run as root; the runtime user needs tmp/ + log/ writable
-    # (Rails creates tmp/pids on every server boot).
+    # (Rails creates tmp/pids on every server boot). Hivebox declares these
+    # image-built assets through HIVEBOX_PRECOMPILED_ASSETS above; native
+    # `hive web` retains its separate compile-on-start contract.
     && mkdir -p tmp/pids log \
     && chown -R hive:hive /app/web/tmp /app/web/log
 WORKDIR /app

--- a/test/unit/web/web_command_test.rb
+++ b/test/unit/web/web_command_test.rb
@@ -69,6 +69,13 @@ class WebCommandTest < Minitest::Test
       FileUtils.mkdir_p(File.join(dir, "bin"))
       File.write(File.join(dir, "bin", "rails"), <<~SH)
         #!/usr/bin/env bash
+        if [ "$1" = "assets:precompile" ]; then
+          mkdir -p public/assets
+          printf 'body {}\n' > public/assets/application-test.css
+          printf 'export {}\n' > public/assets/application-test.js
+          printf '%s\n' '{"application.css":{"digested_path":"application-test.css"},"application.js":{"digested_path":"application-test.js"}}' > public/assets/.manifest.json
+          exit 0
+        fi
         [ "$1" = "db:prepare" ] && exit #{prepare_exit}
         exit 0
       SH
@@ -123,6 +130,136 @@ class WebCommandTest < Minitest::Test
     end
   end
 
+  def test_production_boot_precompiles_assets_before_starting_rails
+    with_tmp_global_config do
+      with_stub_rails_app(prepare_exit: 0) do
+        command = Hive::Commands::Web.new
+        system_calls = []
+        command.define_singleton_method(:system) do |*argv|
+          system_calls << argv
+          true
+        end
+
+        original_exec = Kernel.method(:exec)
+        Kernel.define_singleton_method(:exec) do |env, *argv|
+          raise ExecCaught.new(env, argv)
+        end
+
+        caught = nil
+        begin
+          with_replaced_singleton_method(Hive::Web::AppBundle, :assets_ready?, ->(_dir) { true }) do
+            caught = assert_raises(ExecCaught) { capture_io { command.call } }
+          end
+        ensure
+          Kernel.define_singleton_method(:exec, original_exec)
+        end
+
+        rails_commands = system_calls.map { |call| call.last(2) }
+        assert_equal [ %w[bin/rails assets:precompile], %w[bin/rails db:prepare] ], rails_commands,
+                     "production boot must compile missing assets before preparing the database"
+        precompile_env = system_calls.first.first
+        refute_equal caught.env.fetch("HIVEBOX_STORAGE_DIR"), precompile_env.fetch("HIVEBOX_STORAGE_DIR"),
+                     "asset compilation must not touch the live solid-stack databases"
+        refute_path_exists precompile_env.fetch("HIVEBOX_STORAGE_DIR"),
+                           "temporary asset-build storage must be removed after compilation"
+      end
+    end
+  end
+
+  def test_production_boot_rejects_precompile_without_usable_assets
+    with_tmp_global_config do
+      with_stub_rails_app(prepare_exit: 0) do
+        command = Hive::Commands::Web.new
+        command.define_singleton_method(:system) { |*_argv| true }
+
+        error = with_replaced_singleton_method(Hive::Web::AppBundle, :assets_ready?, ->(_dir) { false }) do
+          assert_raises(Hive::Error) { capture_io { command.call } }
+        end
+
+        assert_match(/asset precompile failed/, error.message)
+      end
+    end
+  end
+
+  def test_production_boot_stops_when_asset_precompile_command_fails
+    with_tmp_global_config do
+      with_stub_rails_app(prepare_exit: 0) do
+        command = Hive::Commands::Web.new
+        system_calls = []
+        command.define_singleton_method(:system) do |*argv|
+          system_calls << argv
+          argv.last(2) != %w[bin/rails assets:precompile]
+        end
+
+        error = with_replaced_singleton_method(Hive::Web::AppBundle, :assets_ready?, ->(_dir) { true }) do
+          assert_raises(Hive::Error) { capture_io { command.call } }
+        end
+
+        assert_match(/asset precompile failed/, error.message)
+        assert_equal [ %w[bin/rails assets:precompile] ], system_calls.map { |call| call.last(2) },
+                     "a failed compiler must stop startup before db:prepare"
+      end
+    end
+  end
+
+  def test_development_boot_skips_asset_precompile
+    with_tmp_global_config do
+      with_stub_rails_app(prepare_exit: 0) do
+        command = Hive::Commands::Web.new
+        system_calls = []
+        command.define_singleton_method(:system) do |*argv|
+          system_calls << argv
+          true
+        end
+
+        original_exec = Kernel.method(:exec)
+        Kernel.define_singleton_method(:exec) do |env, *argv|
+          raise ExecCaught.new(env, argv)
+        end
+
+        begin
+          with_env("RAILS_ENV" => "development") do
+            assert_raises(ExecCaught) { capture_io { command.call } }
+          end
+        ensure
+          Kernel.define_singleton_method(:exec, original_exec)
+        end
+
+        assert_equal [ %w[bin/rails db:prepare] ], system_calls.map { |call| call.last(2) },
+                     "development boot should leave asset compilation to the Rails development server"
+      end
+    end
+  end
+
+  def test_hivebox_boot_uses_assets_precompiled_into_the_image
+    with_tmp_global_config do
+      with_stub_rails_app(prepare_exit: 0) do
+        command = Hive::Commands::Web.new
+        system_calls = []
+        command.define_singleton_method(:system) do |*argv|
+          system_calls << argv
+          true
+        end
+
+        original_exec = Kernel.method(:exec)
+        Kernel.define_singleton_method(:exec) do |env, *argv|
+          raise ExecCaught.new(env, argv)
+        end
+
+        begin
+          with_env("HIVEBOX_PRECOMPILED_ASSETS" => "1") do
+            assert_raises(ExecCaught) { capture_io { command.call } }
+          end
+        ensure
+          Kernel.define_singleton_method(:exec, original_exec)
+        end
+
+        assert_equal [ %w[bin/rails db:prepare] ], system_calls.map { |call| call.last(2) },
+                     "Hivebox should use the asset graph validated while its image is built"
+      end
+    end
+  end
+
   def test_relative_env_override_exec_env_uses_absolute_gemfile
     with_tmp_global_config do
       Dir.mktmpdir("hive-web-parent") do |parent|
@@ -132,7 +269,16 @@ class WebCommandTest < Minitest::Test
         File.write(File.join(app_dir, "config", "application.rb"), "# rails app marker")
         File.write(File.join(app_dir, "Gemfile"), "# test gemfile")
         FileUtils.mkdir_p(File.join(app_dir, "bin"))
-        File.write(File.join(app_dir, "bin", "rails"), "#!/usr/bin/env bash\nexit 0\n")
+        File.write(File.join(app_dir, "bin", "rails"), <<~SH)
+          #!/usr/bin/env bash
+          if [ "$1" = "assets:precompile" ]; then
+            mkdir -p public/assets
+            printf 'body {}\n' > public/assets/application-test.css
+            printf 'export {}\n' > public/assets/application-test.js
+            printf '%s\n' '{"application.css":{"digested_path":"application-test.css"},"application.js":{"digested_path":"application-test.js"}}' > public/assets/.manifest.json
+          fi
+          exit 0
+        SH
         FileUtils.chmod(0o755, File.join(app_dir, "bin", "rails"))
 
         original = Kernel.method(:exec)

--- a/test/unit/web/web_command_test.rb
+++ b/test/unit/web/web_command_test.rb
@@ -140,18 +140,11 @@ class WebCommandTest < Minitest::Test
           true
         end
 
-        original_exec = Kernel.method(:exec)
-        Kernel.define_singleton_method(:exec) do |env, *argv|
-          raise ExecCaught.new(env, argv)
-        end
-
-        caught = nil
-        begin
+        replacement = ->(env, *argv) { raise ExecCaught.new(env, argv) }
+        caught = with_replaced_singleton_method(Kernel, :exec, replacement) do
           with_replaced_singleton_method(Hive::Web::AppBundle, :assets_ready?, ->(_dir) { true }) do
-            caught = assert_raises(ExecCaught) { capture_io { command.call } }
+            assert_raises(ExecCaught) { capture_io { command.call } }
           end
-        ensure
-          Kernel.define_singleton_method(:exec, original_exec)
         end
 
         rails_commands = system_calls.map { |call| call.last(2) }
@@ -212,17 +205,11 @@ class WebCommandTest < Minitest::Test
           true
         end
 
-        original_exec = Kernel.method(:exec)
-        Kernel.define_singleton_method(:exec) do |env, *argv|
-          raise ExecCaught.new(env, argv)
-        end
-
-        begin
+        replacement = ->(env, *argv) { raise ExecCaught.new(env, argv) }
+        with_replaced_singleton_method(Kernel, :exec, replacement) do
           with_env("RAILS_ENV" => "development") do
             assert_raises(ExecCaught) { capture_io { command.call } }
           end
-        ensure
-          Kernel.define_singleton_method(:exec, original_exec)
         end
 
         assert_equal [ %w[bin/rails db:prepare] ], system_calls.map { |call| call.last(2) },
@@ -241,17 +228,11 @@ class WebCommandTest < Minitest::Test
           true
         end
 
-        original_exec = Kernel.method(:exec)
-        Kernel.define_singleton_method(:exec) do |env, *argv|
-          raise ExecCaught.new(env, argv)
-        end
-
-        begin
+        replacement = ->(env, *argv) { raise ExecCaught.new(env, argv) }
+        with_replaced_singleton_method(Kernel, :exec, replacement) do
           with_env("HIVEBOX_PRECOMPILED_ASSETS" => "1") do
             assert_raises(ExecCaught) { capture_io { command.call } }
           end
-        ensure
-          Kernel.define_singleton_method(:exec, original_exec)
         end
 
         assert_equal [ %w[bin/rails db:prepare] ], system_calls.map { |call| call.last(2) },
@@ -330,22 +311,20 @@ class WebCommandTest < Minitest::Test
         )
       )
 
-      original = Kernel.method(:exec)
-      Kernel.define_singleton_method(:exec) do |env, *argv|
-        raise ExecCaught.new(env, argv)
+      command = Hive::Commands::Web.new
+      system_calls = []
+      command.define_singleton_method(:system) do |*argv|
+        system_calls << argv
+        true
+      end
+      replacement = ->(env, *argv) { raise ExecCaught.new(env, argv) }
+      caught = with_replaced_singleton_method(Kernel, :exec, replacement) do
+        assert_raises(ExecCaught) { capture_io { command.call } }
       end
 
-      caught = nil
-      begin
-        capture_io { Hive::Commands::Web.new.call }
-      rescue ExecCaught => e
-        caught = e
-      ensure
-        Kernel.define_singleton_method(:exec, original)
-      end
-
-      refute_nil caught, "the command must end in Kernel.exec of the rails server"
       assert_equal Hive::Web::AppBundle.hive_cli_root, caught.env["HIVE_CLI_ROOT"]
+      assert_equal [ %w[bin/rails db:prepare] ], system_calls.map { |call| call.last(2) },
+                   "the validated managed bundle should not recompile assets at every restart"
     end
   end
 

--- a/wiki/commands/web.md
+++ b/wiki/commands/web.md
@@ -48,11 +48,13 @@ recreation), `HIVEBOX_ORIGIN` (extra Action Cable origin allow; same-origin
 host traffic is accepted without config), and
 `HIVEBOX_STORAGE_DIR` (the solid-stack sqlite files, under
 `Hive::Paths.state_home/web-storage` so they live on the `/data` mount). In
-production it runs `bin/rails assets:precompile` on every start and refuses to
-boot unless the resulting manifest and application CSS/JavaScript entrypoints
-are usable; compilation uses temporary build storage rather than the live
-solid-stack databases. This keeps direct source checkouts and updated managed
-bundles from serving stale or missing fingerprinted assets. It then runs
+production it guarantees a usable fingerprinted asset graph before Rails
+starts. Versioned managed bundles compile and validate assets while they are
+provisioned; direct source checkouts and operator-managed app overrides run
+`bin/rails assets:precompile` at startup and refuse to boot unless the resulting
+manifest and application CSS/JavaScript entrypoints are usable. Startup
+compilation uses temporary build storage rather than the live solid-stack
+databases. It then runs
 `bin/rails db:prepare` and execs `bin/rails server`. Outside the container,
 a source checkout, or a bootstrapped managed bundle the command exits 1 with
 guidance — the gem itself does not package the Rails app

--- a/wiki/commands/web.md
+++ b/wiki/commands/web.md
@@ -47,11 +47,21 @@ It exports `SECRET_KEY_BASE` (derived from the same persisted
 recreation), `HIVEBOX_ORIGIN` (extra Action Cable origin allow; same-origin
 host traffic is accepted without config), and
 `HIVEBOX_STORAGE_DIR` (the solid-stack sqlite files, under
-`Hive::Paths.state_home/web-storage` so they live on the `/data` mount), runs
-`bin/rails db:prepare`, then execs `bin/rails server`. Outside the container,
+`Hive::Paths.state_home/web-storage` so they live on the `/data` mount). In
+production it runs `bin/rails assets:precompile` on every start and refuses to
+boot unless the resulting manifest and application CSS/JavaScript entrypoints
+are usable; compilation uses temporary build storage rather than the live
+solid-stack databases. This keeps direct source checkouts and updated managed
+bundles from serving stale or missing fingerprinted assets. It then runs
+`bin/rails db:prepare` and execs `bin/rails server`. Outside the container,
 a source checkout, or a bootstrapped managed bundle the command exits 1 with
 guidance — the gem itself does not package the Rails app
 (`test/unit/gemspec_test.rb` pins that).
+
+Hivebox keeps a separate asset lifecycle: its container image compiles and
+validates the Rails asset graph during the image build, then exports the
+internal `HIVEBOX_PRECOMPILED_ASSETS=1` marker so the shared launcher does not
+repeat native web preparation at container startup.
 
 `hive web install [--force] [--json]` installs the separate `hive-web` autostart
 service using the invoked user-facing binary path; `hive web start --detach`

--- a/wiki/log.d/20260720T163900Z-web-start-precompile-assets.md
+++ b/wiki/log.d/20260720T163900Z-web-start-precompile-assets.md
@@ -1,0 +1,13 @@
+# Compile production web assets during startup
+
+- Made production `hive web` precompile fingerprinted CSS and JavaScript before
+  Rails starts, including when assets from an older source revision already
+  exist, while isolating the build from the live web databases.
+- Made startup fail closed when precompilation does not produce a usable
+  Propshaft manifest and application entrypoints, preventing an apparently
+  healthy web service from returning 404s for its advertised assets.
+- Kept Hivebox's separate image lifecycle unchanged: its image build compiles
+  and validates assets once, then marks them precompiled so container startup
+  does not repeat the native web preparation step.
+- Added command-level regression coverage for successful compilation and for
+  unusable compiler output.

--- a/wiki/log.d/20260720T163900Z-web-start-precompile-assets.md
+++ b/wiki/log.d/20260720T163900Z-web-start-precompile-assets.md
@@ -1,8 +1,9 @@
 # Compile production web assets during startup
 
-- Made production `hive web` precompile fingerprinted CSS and JavaScript before
-  Rails starts, including when assets from an older source revision already
-  exist, while isolating the build from the live web databases.
+- Made production `hive web` guarantee fingerprinted CSS and JavaScript before
+  Rails starts: managed bundles compile and validate during provisioning, while
+  source checkouts and operator overrides compile at startup using storage
+  isolated from the live web databases.
 - Made startup fail closed when precompilation does not produce a usable
   Propshaft manifest and application entrypoints, preventing an apparently
   healthy web service from returning 404s for its advertised assets.


### PR DESCRIPTION
## Summary

- Make native production `hive web` compile and validate fingerprinted CSS/JavaScript automatically before Rails starts, so a source checkout or updated bundle cannot advertise missing assets.
- Isolate asset compilation from the live Solid Queue/Cache/Cable databases and fail startup with actionable guidance when compilation is unusable.
- Preserve Hivebox as a separate lifecycle: its container image still compiles assets at build time and marks them precompiled so container startup does not repeat native preparation.

## Test plan

- [x] `test/unit/web/web_command_test.rb` — 31 runs, 75 assertions
- [x] `test/unit/web/app_bundle_test.rb` — 21 runs, 75 assertions
- [x] `test/unit/setup/diagnostics_test.rb` — 18 runs, 59 assertions
- [x] RuboCop clean for changed Ruby files
- [x] Native `hive-web.service` restarted from this branch; all 12 CSS/JS URLs referenced by `https://hivebox.mellori-lime.ts.net/` return HTTP 200
- [x] Separate Hivebox image build and `packaging/docker/smoke.sh` pass

## Notes for reviewer

The Tailscale hostname contains `hivebox`, but the dogfood service is native `hive web` under systemd; Docker is not involved in serving it. `HIVEBOX_PRECOMPILED_ASSETS` is an internal image marker solely to preserve Hivebox's existing build-time asset lifecycle.

A broader suite run reached 8,921 tests before being interrupted, with five failures in unrelated local plugin-version/skill expectations and no errors in this changed path. The focused web/setup coverage and both real runtime paths pass.
