### PR TITLE
release: prepare v0.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,64 @@
 
 All notable changes are documented here, newest first. Hive ships frequent micro-releases (see [docs/RELEASING.md](docs/RELEASING.md#versioning-policy)): each `vX.Y.Z` git tag gets a `## X.Y.Z` section with user-facing bullets and, for notable releases, descriptive subsections — no `[Unreleased]` accumulator. Versioning is [SemVer](https://semver.org): PATCH for fixes and small changes (the common case), MINOR for notable features, MAJOR for milestones.
 
+## 0.6.5
+
+Hive 0.6.5 makes autonomous maintenance quieter, sharper, and safer. Patrols
+carry source-backed findings through proof and delivery, Architecture Patrol
+has its own bounded capacity, and scheduled wiki upkeep stays out of developer
+checkouts while respecting the subscription circuit. The release also hardens
+the logs and web surfaces operators depend on when work runs unattended.
+
+### Patrols that produce actionable work
+
+- Added a complete evidence-to-delivery path for ordinary patrol. Reviewers get
+  bounded source context and the exact single-line evidence contract; completed
+  fixes survive token boundaries; shipping cycles reserve validation capacity;
+  and the configured patrol timeout now governs the independent proof. (#805,
+  #808)
+- Gave post-merge Architecture Patrol separate durable launch accounting and a
+  higher 96-run daily safety backstop without weakening shared token budgets or
+  full-lifetime launch locks. Fresh projects enable confined autofix with a
+  reviewable GitHub issue fallback, while existing discovery-only projects do
+  not gain mutation authority silently. (#808)
+- Fixed provider-limit holds waiting until a distant advertised reset date.
+  Hive now keeps that date as an operator-visible estimate while retrying
+  hourly, so account switches, usage resets, and credit top-ups recover without
+  manual marker surgery. (#810)
+
+### Safer unattended operation
+
+- Fixed attempt-log recovery after a torn final write. Reopened stream logs now
+  isolate the incomplete tail before appending, so the first fully written
+  post-restart frame remains replayable. (#807)
+- Fixed the bot logger raising during the failure of both rotation and reopen.
+  Rotation, fallback, and writes are serialized, and events degrade to stderr
+  without losing the in-flight record. (#814)
+- Rebuilt scheduled llm-wiki maintenance around the shared Git queue and the
+  llm-wiki 0.1.15 drain contract. Empty or circuit-blocked runs exit before QMD,
+  worktree creation, or provider launch; real refreshes use a disposable branch
+  instead of modifying any registered checkout; linked worktrees share one
+  recoverable runtime. (#820)
+- Fixed re-enabled Linux wiki timers becoming active with no future trigger.
+  Their first run is now ten minutes after activation, followed by the existing
+  daily cadence. (#821)
+
+### Web and agent setup
+
+- Fixed native `hive web` access behind authenticated loopback proxies and made
+  production asset installation atomic and self-repairing. Source checkouts now
+  compile and validate assets before Rails starts, while Hivebox retains its
+  build-once image path. (#815, #819)
+- Fixed a live-refresh race that could create an idea successfully but leave
+  the submitted text and attachment ready to send again. Only page-wide refresh
+  streams pause during submission; targeted updates and other clients remain
+  live. (#813)
+- Refreshed the public OpenClaw skill with current workflows, bounded status
+  monitoring, subscription-aware patrol guidance, and explicit preview and
+  consent gates. Removed unattended package transactions, runtime patching,
+  direct service overrides, and the embedded polling program. (#813)
+- Updated the repository's tested ERB lock to 6.0.5. (#809)
+
 ## 0.6.4
 
 - Fixed hivebox occasionally retaining a successfully submitted idea in its

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hive-cli (0.6.4)
+    hive-cli (0.6.5)
       bubbletea (= 0.1.4)
       erb (>= 4.0)
       faraday (>= 2.14.2, < 3.0)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Hive ships as a rubygem (`hive-cli`) attached to each GitHub Release, signed wit
 | Platform | Channel |
 |----------|---------|
 | macOS arm64 | [`brew install ivankuznetsov/hive/hive`](https://github.com/ivankuznetsov/homebrew-hive) |
-| Ubuntu 22.04+ / glibc Linux x86_64/aarch64 | <code>tmpdir="$(mktemp -d)" && trap 'rm -rf "$tmpdir"' EXIT && curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.6.4/install.sh -o "$tmpdir/hive-install.sh" && bash "$tmpdir/hive-install.sh"</code> |
+| Ubuntu 22.04+ / glibc Linux x86_64/aarch64 | <code>tmpdir="$(mktemp -d)" && trap 'rm -rf "$tmpdir"' EXIT && curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.6.5/install.sh -o "$tmpdir/hive-install.sh" && bash "$tmpdir/hive-install.sh"</code> |
 | Arch Linux x86_64/aarch64 | [`yay -S hive-bin`](https://aur.archlinux.org/packages/hive-bin) |
 
 Prerequisites: **Ruby 3.4** (the gem and its runtime deps install against this), git ≥ 2.40, authenticated `claude` ≥ 2.1.118, `codex` ≥ 0.125.0 for the default execute agent, `grok` ≥ 0.2.90 when selected, authenticated `gh`, `tmux` ≥ 3.0 when the project uses the default `claude.mode: tmux`, and Node.js/npm for managed QMD install/repair. The bash installer reports its own installer-side prereqs (`curl`, `jq`, `gem`, checksum tool) on first run; if npm is missing, Hive still installs and `hive doctor` reports the QMD gap non-fatally.

--- a/install.md
+++ b/install.md
@@ -59,8 +59,8 @@ Ubuntu 22.04+ / glibc Linux fallback (pin to the current release tag, not `main`
 ```bash
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
-# Release maintainers: bump v0.6.4 in both installer URLs when cutting a new stable release.
-curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.6.4/install.sh -o "$tmpdir/hive-install.sh"
+# Release maintainers: bump v0.6.5 in both installer URLs when cutting a new stable release.
+curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.6.5/install.sh -o "$tmpdir/hive-install.sh"
 bash "$tmpdir/hive-install.sh"
 ```
 
@@ -69,8 +69,8 @@ To inspect the installer first, run a dry-run before the real invocation. State 
 ```bash
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
-# Release maintainers: bump v0.6.4 in both installer URLs when cutting a new stable release.
-curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.6.4/install.sh -o "$tmpdir/hive-install.sh"
+# Release maintainers: bump v0.6.5 in both installer URLs when cutting a new stable release.
+curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.6.5/install.sh -o "$tmpdir/hive-install.sh"
 bash "$tmpdir/hive-install.sh" --dry-run
 bash "$tmpdir/hive-install.sh"
 ```

--- a/lib/hive.rb
+++ b/lib/hive.rb
@@ -1,5 +1,5 @@
 module Hive
-  VERSION = "0.6.4".freeze
+  VERSION = "0.6.5".freeze
   MIN_CLAUDE_VERSION = "2.1.118".freeze
   # Canonical GitHub org + repo. Referenced by the release probe
   # (UpdateCheck), the brew tap + installer URL (Commands::Update), etc.

--- a/web/Gemfile.lock
+++ b/web/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    hive-cli (0.6.4)
+    hive-cli (0.6.5)
       bubbletea (= 0.1.4)
       erb (>= 4.0)
       faraday (>= 2.14.2, < 3.0)

--- a/wiki/dependencies.md
+++ b/wiki/dependencies.md
@@ -11,9 +11,9 @@ tags: [dependencies, gems, runtime]
 
 `hive.gemspec` owns runtime gem constraints; `Gemfile` uses `gemspec`
 to pull those constraints into Bundler, then adds development/test-only
-tools. The v0.6.4 release-prep checkout is `0.6.4`: `lib/hive.rb`, root
+tools. The v0.6.5 release-prep checkout is `0.6.5`: `lib/hive.rb`, root
 `Gemfile.lock`, and `web/Gemfile.lock` all pin the local path gem as
-`hive-cli (0.6.4)`. The release-prep change keeps both lockfiles synchronized
+`hive-cli (0.6.5)`. The release-prep change keeps both lockfiles synchronized
 with public installer URLs and the changelog. Recent root bundle dependency
 commits also bumped RuboCop to 1.88.2, Brakeman from
 8.0.4 to 8.0.5, and `concurrent-ruby` from 1.3.6 to 1.3.7; the separate web
@@ -145,7 +145,7 @@ subscription-safety contract.
 `Gemfile` declares `ruby "~> 3.4"`. `hive.gemspec` requires Ruby
 `>= 3.4.0` for the packaged gem. `.rubocop.yml` pins
 `TargetRubyVersion: 3.4`. `Gemfile.lock` records Ruby 3.4.7, Bundler
-2.7.2, and the current local path gem as `hive-cli (0.6.4)`.
+2.7.2, and the current local path gem as `hive-cli (0.6.5)`.
 
 ## Backlinks
 

--- a/wiki/gaps.md
+++ b/wiki/gaps.md
@@ -542,5 +542,12 @@ found a reachable bot logger crash, independently proved fail-before and
 pass-after, opened pull request 814, and entered 6-review. This closes the local
 delivery-path uncertainty, but the installed package is still v0.6.4 and has
 not exercised the proposed split accounting or default issue-filing behavior;
-keep the rollout portion of this gap until a later explicitly authorized
-release is installed and monitored.
+v0.6.5 packages those changes. Installed v0.6.4 dogfood also exposed a
+separate ordinary-patrol wire-contract gap: reviewers returned meaningful
+source evidence as multiline excerpts or annotated paraphrases, while the
+validator requires every snippet to be an exact substring of one claimed
+source line and therefore rejected the complete finding. v0.6.5 aligns the
+reviewer prompt with that existing fail-closed validator. Retain this gap until
+the installed v0.6.5 package opens meaningful ordinary and Architecture Patrol
+work without dirty-checkout, quota-churn, response-envelope, or evidence-
+contract errors.

--- a/wiki/log.d/20260720T210930Z-release-v065.md
+++ b/wiki/log.d/20260720T210930Z-release-v065.md
@@ -1,0 +1,16 @@
+# Hive v0.6.5 release preparation
+
+**Action:** Prepared Hive v0.6.5 from the complete post-v0.6.4 change set. The
+version constant, root and web lockfiles, installer references, changelog,
+dependency wiki, and remaining dogfood gap now agree on v0.6.5.
+
+The release narrative groups the shipped behavior around three operator-facing
+outcomes: patrol findings that survive validation and reach a fix or reviewable
+issue; durable unattended execution with hourly provider-limit recovery and
+checkout-safe, subscription-bounded wiki maintenance; and reliable native web
+and consent-safe OpenClaw setup. It also records the StreamLog and bot-logger
+recovery fixes and the ERB 6.0.5 dependency update.
+
+Publication remains tag-driven. The release PR must merge and its exact commit
+must pass the release contract, bundle, gem-build, and hosted CI gates before
+the protected `v0.6.5` tag is pushed.


### PR DESCRIPTION
## Summary

- Hive 0.6.5 makes autonomous maintenance more useful without loosening its safety boundaries: ordinary-patrol findings now survive evidence validation and delivery, while Architecture Patrol receives separate durable headroom under the same shared subscription budget.
- Scheduled llm-wiki upkeep now exits before model launch when there is no safe work, refreshes in a disposable branch instead of dirtying developer checkouts, and reliably schedules its first Linux run after activation.
- Unattended operation is sturdier across torn stream logs, bot-log rotation failures, native web startup and proxying, live idea submission, and the consent-safe OpenClaw setup flow.

The changelog covers the complete post-v0.6.4 change set rather than the single patrol fix described by the earlier closed release attempt.

## Test plan

- [x] Release contract, gemspec, and release-verifier tests: 14 runs, 102 assertions, 0 failures or errors
- [x] Root and web bundles resolve from their frozen lockfiles
- [x] Exact-head gem builds, installs in an isolated gem path, and reports 0.6.5
- [x] Release gem SHA-256: `e155891285abad817e36ec31fca5234efb33d1dd6369686c9a5a18e52120e6dd`
- [x] `git diff --check`
- [x] All 16 hosted CI and install-smoke checks pass on this exact PR head

## Notes for reviewer

Publication remains tag-driven. The v0.6.5 tag will be created only from the merged release commit after the exact PR head is green. The source-packaged OpenClaw skill remains independently versioned on ClawHub and is intentionally outside this gem-release metadata update.

## Post-Deploy Monitoring & Validation

- Watch the tag-triggered release workflow through build, Linux and macOS install gates, signed GitHub Release finalization, AUR publication, Hivebox multi-architecture promotion, and post-release verification.
- Healthy means the public v0.6.5 release contains the gem, web bundle, checksums, and signing material; supported install channels report 0.6.5; and the Hivebox 0.6.5 and latest manifests resolve for both architectures.
- Any build, signature, install-channel, image, or version mismatch is a failed release. Do not move or reuse the tag; fix forward with the next patch version.
- Owner: Hive maintainer. Monitoring window: until the release workflow and all enabled downstream channels settle.
