### PR TITLE
release: prepare v0.6.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes are documented here, newest first. Hive ships frequent micro-releases (see [docs/RELEASING.md](docs/RELEASING.md#versioning-policy)): each `vX.Y.Z` git tag gets a `## X.Y.Z` section with user-facing bullets and, for notable releases, descriptive subsections — no `[Unreleased]` accumulator. Versioning is [SemVer](https://semver.org): PATCH for fixes and small changes (the common case), MINOR for notable features, MAJOR for milestones.
 
+## 0.6.6
+
+- Fixed scheduled llm-wiki refreshes multiplying into thousands of host timers
+  from disposable repositories. Hive now installs one bounded timer per
+  primary repository, removes catch-up stampedes, reconciles old units, and
+  serializes refreshes behind a machine-wide lock and memory limit. Scheduled
+  updates publish through `llm-wiki/refresh` without dirtying protected
+  checkouts. (#828)
+- Added managed draft-PR handoff for agent work, with bounded branch publication
+  and recovery evidence when an agent reaches a review boundary. (#827)
+- Made native Hive web the default experience and added the workflow-derived
+  Kanban board, mobile status improvements, and clearer first-run launch paths.
+  (#796, #817, #822, #826)
+- Made Hive operations agent-native across Claude, Codex, Pi, and OpenClaw with
+  fresh status/action contracts and canonical managed skill projections. (#824)
+- Fixed generic approve binding to the task's actual stage and simplified the
+  workflow, Rails, and patrol architecture around value-bearing work. (#799,
+  #816, #825)
+
 ## 0.6.5
 
 Hive 0.6.5 makes autonomous maintenance quieter, sharper, and safer. Patrols

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hive-cli (0.6.5)
+    hive-cli (0.6.6)
       bubbletea (= 0.1.4)
       erb (>= 4.0)
       faraday (>= 2.14.2, < 3.0)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Hive ships as a rubygem (`hive-cli`) plus a managed Hive web bundle attached to 
 | Platform | Channel |
 |----------|---------|
 | macOS arm64 | [`brew install ivankuznetsov/hive/hive`](https://github.com/ivankuznetsov/homebrew-hive) |
-| Ubuntu 22.04+ / glibc Linux x86_64/aarch64 | <code>tmpdir="$(mktemp -d)" && trap 'rm -rf "$tmpdir"' EXIT && curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.6.5/install.sh -o "$tmpdir/hive-install.sh" && bash "$tmpdir/hive-install.sh"</code> |
+| Ubuntu 22.04+ / glibc Linux x86_64/aarch64 | <code>tmpdir="$(mktemp -d)" && trap 'rm -rf "$tmpdir"' EXIT && curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.6.6/install.sh -o "$tmpdir/hive-install.sh" && bash "$tmpdir/hive-install.sh"</code> |
 | Arch Linux x86_64/aarch64 | [`yay -S hive-bin`](https://aur.archlinux.org/packages/hive-bin) |
 
 Prerequisites: **Ruby 3.4** (the gem and its runtime deps install against this), git ≥ 2.40, authenticated `claude` ≥ 2.1.118, `codex` ≥ 0.125.0 for the default execute agent, `grok` ≥ 0.2.90 when selected, authenticated `gh`, `tmux` ≥ 3.0 when the project uses the default `claude.mode: tmux`, `cosign` for release identity verification, and Node.js/npm for managed QMD install/repair. The bash installer reports its own installer-side prereqs (`curl`, `jq`, `cosign`, `gem`, checksum tool) on first run; if npm is missing, Hive still installs and `hive doctor` reports the QMD gap non-fatally.

--- a/install.md
+++ b/install.md
@@ -69,8 +69,8 @@ Ubuntu 22.04+ / glibc Linux fallback (pin to the current release tag, not `main`
 ```bash
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
-# Release maintainers: bump v0.6.5 in both installer URLs when cutting a new stable release.
-curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.6.5/install.sh -o "$tmpdir/hive-install.sh"
+# Release maintainers: bump v0.6.6 in both installer URLs when cutting a new stable release.
+curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.6.6/install.sh -o "$tmpdir/hive-install.sh"
 bash "$tmpdir/hive-install.sh"
 ```
 
@@ -79,8 +79,8 @@ To inspect the installer first, run a dry-run before the real invocation. State 
 ```bash
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
-# Release maintainers: bump v0.6.5 in both installer URLs when cutting a new stable release.
-curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.6.5/install.sh -o "$tmpdir/hive-install.sh"
+# Release maintainers: bump v0.6.6 in both installer URLs when cutting a new stable release.
+curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.6.6/install.sh -o "$tmpdir/hive-install.sh"
 bash "$tmpdir/hive-install.sh" --dry-run
 bash "$tmpdir/hive-install.sh"
 ```

--- a/lib/hive.rb
+++ b/lib/hive.rb
@@ -1,5 +1,5 @@
 module Hive
-  VERSION = "0.6.5".freeze
+  VERSION = "0.6.6".freeze
   MIN_CLAUDE_VERSION = "2.1.118".freeze
   # Canonical GitHub org + repo. Referenced by the release probe
   # (UpdateCheck), the brew tap + installer URL (Commands::Update), etc.

--- a/openclaw/skills/hive/.hive-skill.json
+++ b/openclaw/skills/hive/.hive-skill.json
@@ -5,13 +5,13 @@
   "platform": "openclaw",
   "invocation": "/hive",
   "skill_version": "0.1.3",
-  "canonical_digest": "3a76d4f4b65543a1d0110969039f6d74a25c841da67aa5535adf9893bb03c26e",
-  "hive_version": "0.6.5",
+  "canonical_digest": "94bcade45312ee0eebe246f2b99505e227f7fe1824f99f4bff9d0e58cac8701d",
+  "hive_version": "0.6.6",
   "files": {
-    "SKILL.md": "cf204f3c0380fe2c15c8802aca5b5bbd8a1f12629b3521b223115d1cd738252b",
+    "SKILL.md": "40c3c1ef6fc9d6abfd945b77610c5b02f4fe74bfcae1bfe7fa37a5d50d9a57dd",
     "references/recovery.md": "fb7ec513fb2f53183898259ddfc235b6303f2e157c426c8e9e4c991a8802cc27",
     "references/safety.md": "4b420b964a5d729ccafe92bda01738517449f9779e1fe90d184463f461efacd3",
-    "references/setup-and-platforms.md": "f65f15652f59d5bce4a0d17fbe11b61870dcd60683e2de539b0a7ebf06830c6f",
+    "references/setup-and-platforms.md": "c90950d16752e3f0f17e0f62d341965981cc3d37f94183dba673ba5954931ac3",
     "references/status-and-watch.md": "5a9c878e347049bee9a7ed14fa98a52fa8428d7d83c21eb8db936696aea0b5aa",
     "references/workflow-actions.md": "e94624d41b1093b2edf1c6e2105b9fd5a17549ef1be46e6260e2cf5178c5ce07"
   }

--- a/openclaw/skills/hive/SKILL.md
+++ b/openclaw/skills/hive/SKILL.md
@@ -17,8 +17,8 @@ metadata:
 platform: openclaw
 invocation: /hive
 skill-version: 0.1.3
-canonical-digest: 3a76d4f4b65543a1d0110969039f6d74a25c841da67aa5535adf9893bb03c26e
-hive-version: 0.6.5
+canonical-digest: 94bcade45312ee0eebe246f2b99505e227f7fe1824f99f4bff9d0e58cac8701d
+hive-version: 0.6.6
 -->
 
 Invoke this projection as `/hive`.

--- a/openclaw/skills/hive/references/setup-and-platforms.md
+++ b/openclaw/skills/hive/references/setup-and-platforms.md
@@ -35,7 +35,7 @@ installer into an owner-private temporary directory after approval:
 ```bash
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
-curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.6.5/install.sh \
+curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.6.6/install.sh \
   -o "$tmpdir/hive-install.sh"
 bash "$tmpdir/hive-install.sh"
 ```

--- a/web/Gemfile.lock
+++ b/web/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    hive-cli (0.6.5)
+    hive-cli (0.6.6)
       bubbletea (= 0.1.4)
       erb (>= 4.0)
       faraday (>= 2.14.2, < 3.0)

--- a/wiki/dependencies.md
+++ b/wiki/dependencies.md
@@ -3,7 +3,7 @@ title: Dependencies
 type: dependencies
 source: Gemfile, hive.gemspec, Gemfile.lock, web/Gemfile, web/Gemfile.lock, .llm-wiki/post-commit-refresh.sh
 created: 2026-04-25
-updated: 2026-07-20
+updated: 2026-07-22
 tags: [dependencies, gems, runtime]
 ---
 
@@ -11,9 +11,9 @@ tags: [dependencies, gems, runtime]
 
 `hive.gemspec` owns runtime gem constraints; `Gemfile` uses `gemspec`
 to pull those constraints into Bundler, then adds development/test-only
-tools. The v0.6.5 release-prep checkout is `0.6.5`: `lib/hive.rb`, root
+tools. The v0.6.6 release-prep checkout is `0.6.6`: `lib/hive.rb`, root
 `Gemfile.lock`, and `web/Gemfile.lock` all pin the local path gem as
-`hive-cli (0.6.5)`. The release-prep change keeps both lockfiles synchronized
+`hive-cli (0.6.6)`. The release-prep change keeps both lockfiles synchronized
 with public installer URLs and the changelog. Recent root bundle dependency
 commits also bumped RuboCop to 1.88.2, Brakeman from
 8.0.4 to 8.0.5, and `concurrent-ruby` from 1.3.6 to 1.3.7; the separate web
@@ -147,7 +147,7 @@ subscription-safety contract.
 `Gemfile` declares `ruby "~> 3.4"`. `hive.gemspec` requires Ruby
 `>= 3.4.0` for the packaged gem. `.rubocop.yml` pins
 `TargetRubyVersion: 3.4`. `Gemfile.lock` records Ruby 3.4.7, Bundler
-2.7.2, and the current local path gem as `hive-cli (0.6.5)`.
+2.7.2, and the current local path gem as `hive-cli (0.6.6)`.
 
 ## Backlinks
 

--- a/wiki/log.d/20260722T015340Z-release-v066.md
+++ b/wiki/log.d/20260722T015340Z-release-v066.md
@@ -1,0 +1,16 @@
+---
+title: Release v0.6.6
+date: 2026-07-22
+tags: [release, llm-wiki, scheduler, web, agent-skills]
+---
+
+Prepared Hive v0.6.6 with synchronized gem and web lockfile versions, pinned
+installer URLs, canonical agent-skill projections, and user-facing release
+notes. This urgent patch includes the llm-wiki scheduler safety fix: one
+bounded timer per primary repository, no persistent catch-up stampede,
+machine-wide serialization and memory limits, startup reconciliation, and
+refresh-branch publication that does not dirty protected checkouts.
+
+The release also packages the managed agent draft-PR handoff, native Hive web
+and workflow-derived Kanban defaults, current multi-agent operating skill, and
+the latest workflow, patrol, mobile, and stage-approval fixes.


### PR DESCRIPTION
## Summary

- bump Hive and both lockfiles to 0.6.6
- publish the urgent llm-wiki scheduler/OOM fix from #828
- refresh pinned install URLs, OpenClaw projection metadata, changelog, and managed wiki release notes

## Verification

- `release_contract_test.rb`, `openclaw_skills_test.rb`, and `gemspec_test.rb`: 27 runs, 344 assertions, 0 failures
- `gem build hive.gemspec`: built `hive-cli-0.6.6.gem`
- `git diff --check`: clean

The release commit is based directly on merged main commit `5581a0cd1`.