### PR TITLE
fix(release): isolate live proof candidate gem

### DIFF
--- a/.github/workflows/live-agent-skills.yml
+++ b/.github/workflows/live-agent-skills.yml
@@ -162,11 +162,8 @@ jobs:
           set -euo pipefail
           gem_file="$(find candidate-artifacts -maxdepth 1 -type f -name 'hive-cli-*.gem' -print -quit)"
           [[ -n "$gem_file" && -s "$gem_file" ]]
-          mkdir -p "$RUNNER_TEMP/proven-gems"
-          gem install "$gem_file" \
-            --install-dir "$RUNNER_TEMP/proven-gems" \
-            --bindir "$RUNNER_TEMP/proven-gems/bin" \
-            --no-document
+          bash candidate-source/packaging/live_agent_skills/install_candidate_gem.sh \
+            "$gem_file" "$RUNNER_TEMP/proven-gems"
           "$RUNNER_TEMP/proven-gems/bin/hive" --version
           cd candidate-source
           bundle install --jobs 4 --retry 2

--- a/packaging/live_agent_skills/install_candidate_gem.sh
+++ b/packaging/live_agent_skills/install_candidate_gem.sh
@@ -33,7 +33,7 @@ printf -v quoted_rubygems_hive '%q' "$rubygems_bin/hive"
   printf '%s\n' '#!/usr/bin/env bash' 'set -euo pipefail'
   printf '%s\n' 'unset RUBYOPT RUBYLIB BUNDLER_SETUP BUNDLE_GEMFILE BUNDLE_BIN_PATH RUBYGEMS_GEMDEPS'
   printf 'export GEM_HOME=%s\n' "$quoted_install_root"
-  printf '%s\n' 'export GEM_PATH="$GEM_HOME"'
+  printf '%s\n' "export GEM_PATH=\"\$GEM_HOME\""
   printf 'exec %s "$@"\n' "$quoted_rubygems_hive"
 } > "$public_bin/hive"
 chmod 0755 "$public_bin/hive"

--- a/packaging/live_agent_skills/install_candidate_gem.sh
+++ b/packaging/live_agent_skills/install_candidate_gem.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if (( $# != 2 )); then
+  echo "usage: install_candidate_gem.sh GEM_FILE ABSOLUTE_INSTALL_ROOT" >&2
+  exit 64
+fi
+
+gem_file=$1
+install_root=$2
+
+[[ -f "$gem_file" && -s "$gem_file" ]] || {
+  echo "candidate gem is missing or empty: $gem_file" >&2
+  exit 66
+}
+[[ "$install_root" == /* ]] || {
+  echo "candidate gem install root must be absolute: $install_root" >&2
+  exit 64
+}
+
+rubygems_bin="$install_root/rubygems-bin"
+public_bin="$install_root/bin"
+mkdir -p "$rubygems_bin" "$public_bin"
+
+gem install "$gem_file" \
+  --install-dir "$install_root" \
+  --bindir "$rubygems_bin" \
+  --no-document
+
+printf -v quoted_install_root '%q' "$install_root"
+printf -v quoted_rubygems_hive '%q' "$rubygems_bin/hive"
+{
+  printf '%s\n' '#!/usr/bin/env bash' 'set -euo pipefail'
+  printf '%s\n' 'unset RUBYOPT RUBYLIB BUNDLER_SETUP BUNDLE_GEMFILE BUNDLE_BIN_PATH RUBYGEMS_GEMDEPS'
+  printf 'export GEM_HOME=%s\n' "$quoted_install_root"
+  printf '%s\n' 'export GEM_PATH="$GEM_HOME"'
+  printf 'exec %s "$@"\n' "$quoted_rubygems_hive"
+} > "$public_bin/hive"
+chmod 0755 "$public_bin/hive"

--- a/test/unit/live_agent_candidate_gem_installer_test.rb
+++ b/test/unit/live_agent_candidate_gem_installer_test.rb
@@ -1,0 +1,55 @@
+require "test_helper"
+require "open3"
+
+class LiveAgentCandidateGemInstallerTest < Minitest::Test
+  include HiveTestHelper
+
+  INSTALLER = File.expand_path(
+    "../../packaging/live_agent_skills/install_candidate_gem.sh",
+    __dir__
+  )
+
+  def test_private_install_wrapper_restores_its_gem_home
+    with_tmp_dir do |root|
+      source = File.join(root, "fixture-source")
+      executable = File.join(source, "exe", "hive")
+      gem_file = File.join(root, "hive-cli-fixture.gem")
+      install_root = File.join(root, "private gem home")
+      FileUtils.mkdir_p(File.dirname(executable))
+      File.write(executable, "#!/usr/bin/env ruby\nputs 'private-candidate-ok'\n")
+      FileUtils.chmod(0o755, executable)
+      File.write(File.join(source, "fixture.gemspec"), <<~RUBY)
+        Gem::Specification.new do |spec|
+          spec.name = "hive-cli"
+          spec.version = "9.9.9"
+          spec.summary = "Private candidate wrapper fixture"
+          spec.authors = ["Hive tests"]
+          spec.files = ["exe/hive"]
+          spec.bindir = "exe"
+          spec.executables = ["hive"]
+          spec.require_paths = ["lib"]
+        end
+      RUBY
+
+      build_out, build_err, build_status = Open3.capture3(
+        "gem", "build", "fixture.gemspec", "--output", gem_file,
+        chdir: source
+      )
+      assert build_status.success?, "#{build_out}\n#{build_err}"
+
+      install_out, install_err, install_status = Open3.capture3(
+        INSTALLER, gem_file, install_root
+      )
+      assert install_status.success?, "#{install_out}\n#{install_err}"
+
+      wrapper = File.join(install_root, "bin", "hive")
+      assert File.executable?(wrapper)
+      out, err, status = Open3.capture3(
+        { "GEM_HOME" => nil, "GEM_PATH" => nil },
+        wrapper, "--version"
+      )
+      assert status.success?, err
+      assert_equal "private-candidate-ok\n", out
+    end
+  end
+end

--- a/test/unit/release_contract_test.rb
+++ b/test/unit/release_contract_test.rb
@@ -111,6 +111,13 @@ class ReleaseContractTest < Minitest::Test
       step["name"] == "Install the native agent CLI in the ephemeral runner"
     end
     refute install_step.fetch("env").key?("CODEX_API_KEY")
+    candidate_install_step = jobs.fetch("live-agent").fetch("steps").find do |step|
+      step["name"] == "Install the exact candidate gem and test dependencies"
+    end
+    candidate_install_body = candidate_install_step.fetch("run")
+    assert_includes candidate_install_body, "install_candidate_gem.sh"
+    assert_includes candidate_install_body, '"$RUNNER_TEMP/proven-gems/bin/hive" --version'
+    refute_includes candidate_install_body, 'gem install "$gem_file"'
   end
 
   def test_tag_release_consumes_attested_artifacts_without_rebuilding

--- a/wiki/log.d/20260722T035000Z-live-proof-gem-wrapper.md
+++ b/wiki/log.d/20260722T035000Z-live-proof-gem-wrapper.md
@@ -1,0 +1,17 @@
+---
+title: Make the live proof candidate gem self-contained
+date: 2026-07-22
+tags: [release, live-agent, rubygems, ci]
+---
+
+Fixed the four-agent release proof's private gem installation. RubyGems writes
+an executable stub that still needs the non-default install directory on
+`GEM_HOME`/`GEM_PATH`; invoking that stub directly made every matrix job fail
+after installation and before provider access. The workflow now installs the
+raw stub behind a self-contained wrapper that restores the private gem path on
+every invocation and clears inherited Ruby/Bundler startup injection, including
+when the proof harness invokes it from a Bundler-managed test process.
+
+Added an offline regression that builds a dependency-free fixture gem,
+installs it into a path containing spaces, clears inherited RubyGems path
+variables, and proves the public wrapper can still execute the private gem.

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -363,8 +363,10 @@ The protected `live-agent-skills.yml` workflow is the release-readiness owner:
    revision loaded from `refs/heads/main`;
 2. build one gem, one source archive, and one deterministic four-platform skill
    archive from that candidate;
-3. install each native CLI and exact candidate gem in a matrix job with its
-   protected environment credential exposed only to the proof step;
+3. install each native CLI and exact candidate gem in a matrix job, exposing
+   the private gem through a self-contained `GEM_HOME`/`GEM_PATH` wrapper that
+   clears inherited Ruby/Bundler startup injection while keeping its protected
+   environment credential scoped only to the proof step;
 4. place the exact platform projection into a disposable 0700 home and require
    structured native discovery/activation: OpenClaw resolves the exact
    `skills info` path, Codex's model-visible prompt inventory names the exact


### PR DESCRIPTION
## Summary

- install the private candidate gem behind a self-contained wrapper that restores its exact `GEM_HOME`/`GEM_PATH`
- clear inherited Ruby/Bundler startup injection before executing the RubyGems stub
- route all four live-agent proof jobs through the tested installer
- document the release-gate contract in the managed wiki

## Root cause

Run 29889237794 installed `hive-cli-0.6.6` successfully into `$RUNNER_TEMP/proven-gems`, then invoked the generated RubyGems stub without making that non-default gem home visible. All four jobs therefore failed before provider access with `Gem::GemNotFoundException`.

## Verification

- focused installer + release-contract tests: 12 runs, 182 assertions, 0 failures
- regression builds a fixture gem, installs it under a path containing spaces, inherits a Bundler-managed parent, removes inherited gem paths, and executes the private wrapper
- RuboCop: clean
- bash syntax: clean
- `git diff --check`: clean