### PR TITLE
release: prepare v0.6.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes are documented here, newest first. Hive ships frequent micro-releases (see [docs/RELEASING.md](docs/RELEASING.md#versioning-policy)): each `vX.Y.Z` git tag gets a `## X.Y.Z` section with user-facing bullets and, for notable releases, descriptive subsections — no `[Unreleased]` accumulator. Versioning is [SemVer](https://semver.org): PATCH for fixes and small changes (the common case), MINOR for notable features, MAJOR for milestones.
 
+## 0.6.7
+
+- Fixed large llm-wiki backlogs opening a source-pin circuit before any bounded
+  recovery could run. Source refs are now pinned in configurable batches, and
+  crash-left queue records are reconstructed when their commit and diff remain
+  available instead of silently stranding recoverable work. (#836)
+- Fixed an older linked checkout overwriting the repository-shared llm-wiki
+  runner and headless-agent configuration. Hive now keeps the primary checkout
+  authoritative for the shared runtime, preventing a stale worker from
+  restoring unsafe pre-fix behavior. (#836)
+
 ## 0.6.6
 
 - Fixed scheduled llm-wiki refreshes multiplying into thousands of host timers

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hive-cli (0.6.6)
+    hive-cli (0.6.7)
       bubbletea (= 0.1.4)
       erb (>= 4.0)
       faraday (>= 2.14.2, < 3.0)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Hive ships as a rubygem (`hive-cli`) plus a managed Hive web bundle attached to 
 | Platform | Channel |
 |----------|---------|
 | macOS arm64 | [`brew install ivankuznetsov/hive/hive`](https://github.com/ivankuznetsov/homebrew-hive) |
-| Ubuntu 22.04+ / glibc Linux x86_64/aarch64 | <code>tmpdir="$(mktemp -d)" && trap 'rm -rf "$tmpdir"' EXIT && curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.6.6/install.sh -o "$tmpdir/hive-install.sh" && bash "$tmpdir/hive-install.sh"</code> |
+| Ubuntu 22.04+ / glibc Linux x86_64/aarch64 | <code>tmpdir="$(mktemp -d)" && trap 'rm -rf "$tmpdir"' EXIT && curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.6.7/install.sh -o "$tmpdir/hive-install.sh" && bash "$tmpdir/hive-install.sh"</code> |
 | Arch Linux x86_64/aarch64 | [`yay -S hive-bin`](https://aur.archlinux.org/packages/hive-bin) |
 
 Prerequisites: **Ruby 3.4** (the gem and its runtime deps install against this), git ≥ 2.40, authenticated `claude` ≥ 2.1.118, `codex` ≥ 0.125.0 for the default execute agent, `grok` ≥ 0.2.90 when selected, authenticated `gh`, `tmux` ≥ 3.0 when the project uses the default `claude.mode: tmux`, `cosign` for release identity verification, and Node.js/npm for managed QMD install/repair. The bash installer reports its own installer-side prereqs (`curl`, `jq`, `cosign`, `gem`, checksum tool) on first run; if npm is missing, Hive still installs and `hive doctor` reports the QMD gap non-fatally.

--- a/install.md
+++ b/install.md
@@ -69,8 +69,8 @@ Ubuntu 22.04+ / glibc Linux fallback (pin to the current release tag, not `main`
 ```bash
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
-# Release maintainers: bump v0.6.6 in both installer URLs when cutting a new stable release.
-curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.6.6/install.sh -o "$tmpdir/hive-install.sh"
+# Release maintainers: bump v0.6.7 in both installer URLs when cutting a new stable release.
+curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.6.7/install.sh -o "$tmpdir/hive-install.sh"
 bash "$tmpdir/hive-install.sh"
 ```
 
@@ -79,8 +79,8 @@ To inspect the installer first, run a dry-run before the real invocation. State 
 ```bash
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
-# Release maintainers: bump v0.6.6 in both installer URLs when cutting a new stable release.
-curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.6.6/install.sh -o "$tmpdir/hive-install.sh"
+# Release maintainers: bump v0.6.7 in both installer URLs when cutting a new stable release.
+curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.6.7/install.sh -o "$tmpdir/hive-install.sh"
 bash "$tmpdir/hive-install.sh" --dry-run
 bash "$tmpdir/hive-install.sh"
 ```

--- a/lib/hive.rb
+++ b/lib/hive.rb
@@ -1,5 +1,5 @@
 module Hive
-  VERSION = "0.6.6".freeze
+  VERSION = "0.6.7".freeze
   MIN_CLAUDE_VERSION = "2.1.118".freeze
   # Canonical GitHub org + repo. Referenced by the release probe
   # (UpdateCheck), the brew tap + installer URL (Commands::Update), etc.

--- a/openclaw/skills/hive/.hive-skill.json
+++ b/openclaw/skills/hive/.hive-skill.json
@@ -5,13 +5,13 @@
   "platform": "openclaw",
   "invocation": "/hive",
   "skill_version": "0.1.3",
-  "canonical_digest": "94bcade45312ee0eebe246f2b99505e227f7fe1824f99f4bff9d0e58cac8701d",
-  "hive_version": "0.6.6",
+  "canonical_digest": "b30e94110328026f370bde51d123a33dd0caa36739b11cb99627648cf2ed4d04",
+  "hive_version": "0.6.7",
   "files": {
-    "SKILL.md": "40c3c1ef6fc9d6abfd945b77610c5b02f4fe74bfcae1bfe7fa37a5d50d9a57dd",
+    "SKILL.md": "48ba9c2ad41979383a27b09fb0e941ea5174d31d234519dd665f41fbe8153e15",
     "references/recovery.md": "fb7ec513fb2f53183898259ddfc235b6303f2e157c426c8e9e4c991a8802cc27",
     "references/safety.md": "4b420b964a5d729ccafe92bda01738517449f9779e1fe90d184463f461efacd3",
-    "references/setup-and-platforms.md": "c90950d16752e3f0f17e0f62d341965981cc3d37f94183dba673ba5954931ac3",
+    "references/setup-and-platforms.md": "950cfc3ecb8c19528a19c6e1260a19855f94d605e4144e5f36e504728d737c23",
     "references/status-and-watch.md": "5a9c878e347049bee9a7ed14fa98a52fa8428d7d83c21eb8db936696aea0b5aa",
     "references/workflow-actions.md": "e94624d41b1093b2edf1c6e2105b9fd5a17549ef1be46e6260e2cf5178c5ce07"
   }

--- a/openclaw/skills/hive/SKILL.md
+++ b/openclaw/skills/hive/SKILL.md
@@ -17,8 +17,8 @@ metadata:
 platform: openclaw
 invocation: /hive
 skill-version: 0.1.3
-canonical-digest: 94bcade45312ee0eebe246f2b99505e227f7fe1824f99f4bff9d0e58cac8701d
-hive-version: 0.6.6
+canonical-digest: b30e94110328026f370bde51d123a33dd0caa36739b11cb99627648cf2ed4d04
+hive-version: 0.6.7
 -->
 
 Invoke this projection as `/hive`.

--- a/openclaw/skills/hive/references/setup-and-platforms.md
+++ b/openclaw/skills/hive/references/setup-and-platforms.md
@@ -35,7 +35,7 @@ installer into an owner-private temporary directory after approval:
 ```bash
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
-curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.6.6/install.sh \
+curl -fsSL https://raw.githubusercontent.com/ivankuznetsov/hive/v0.6.7/install.sh \
   -o "$tmpdir/hive-install.sh"
 bash "$tmpdir/hive-install.sh"
 ```

--- a/web/Gemfile.lock
+++ b/web/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    hive-cli (0.6.6)
+    hive-cli (0.6.7)
       bubbletea (= 0.1.4)
       erb (>= 4.0)
       faraday (>= 2.14.2, < 3.0)

--- a/wiki/dependencies.md
+++ b/wiki/dependencies.md
@@ -11,9 +11,9 @@ tags: [dependencies, gems, runtime]
 
 `hive.gemspec` owns runtime gem constraints; `Gemfile` uses `gemspec`
 to pull those constraints into Bundler, then adds development/test-only
-tools. The v0.6.6 release-prep checkout is `0.6.6`: `lib/hive.rb`, root
+tools. The v0.6.7 release-prep checkout is `0.6.7`: `lib/hive.rb`, root
 `Gemfile.lock`, and `web/Gemfile.lock` all pin the local path gem as
-`hive-cli (0.6.6)`. The release-prep change keeps both lockfiles synchronized
+`hive-cli (0.6.7)`. The release-prep change keeps both lockfiles synchronized
 with public installer URLs and the changelog. Recent root bundle dependency
 commits also bumped RuboCop to 1.88.2, Brakeman from
 8.0.4 to 8.0.5, and `concurrent-ruby` from 1.3.6 to 1.3.7; the separate web
@@ -147,7 +147,7 @@ subscription-safety contract.
 `Gemfile` declares `ruby "~> 3.4"`. `hive.gemspec` requires Ruby
 `>= 3.4.0` for the packaged gem. `.rubocop.yml` pins
 `TargetRubyVersion: 3.4`. `Gemfile.lock` records Ruby 3.4.7, Bundler
-2.7.2, and the current local path gem as `hive-cli (0.6.6)`.
+2.7.2, and the current local path gem as `hive-cli (0.6.7)`.
 
 ## Backlinks
 

--- a/wiki/gaps.md
+++ b/wiki/gaps.md
@@ -241,7 +241,7 @@ evidence closing the following June 16 gaps.
 ## Release install follow-ups
 
 Latest refresh (2026-07-22): the source version and installer references are
-currently v0.6.6. This feature branch does not itself prove a public tag,
+prepared as v0.6.7. This release-prep branch does not itself prove a public tag,
 signed assets, Homebrew/AUR updates, ClawHub publication, or
 multi-architecture hivebox images. The release boundary uses an exact-tag
 offline candidate gate and does not require provider credentials. The live

--- a/wiki/log.d/20260722T154500Z-release-v067.md
+++ b/wiki/log.d/20260722T154500Z-release-v067.md
@@ -1,0 +1,15 @@
+---
+title: Release v0.6.7
+date: 2026-07-22
+tags: [release, llm-wiki, queue, recovery]
+---
+
+Prepared Hive v0.6.7 with synchronized gem and web lockfile versions, pinned
+installer URLs, canonical agent-skill projections, and user-facing release
+notes. This urgent patch makes large llm-wiki queues recoverable by batching
+source-ref transactions and reconstructing crash-left queue records when their
+source commits remain available.
+
+The release also makes the primary checkout authoritative for the
+repository-shared llm-wiki runner and headless-agent configuration, preventing
+an old linked checkout from replacing the fixed shared runtime.


### PR DESCRIPTION
## Summary

- prepare the urgent `v0.6.7` patch release for the llm-wiki recovery fix merged in #836
- synchronize the gem version, both lockfiles, installer URLs, and canonical OpenClaw projection
- document bounded source-pin batches, crash-left queue reconstruction, and primary-owned shared runtime

## Verification

- `test/unit/release_contract_test.rb`: 11 runs, 205 assertions
- `test/unit/openclaw_skills_test.rb`: 7 runs, 121 assertions
- `test/unit/packaging/verify_release_test.rb` + `live_agent_proof_test.rb`: 17 runs, 174 assertions
- slow `test/integration/cli_version_test.rb` init/version cases passed in bounded runs
- generated OpenClaw projection is byte-identical to `CanonicalSkill.new.render("openclaw")`
- `git diff --check`

Provider-backed live-agent diagnostics are intentionally omitted: they are optional, the release gates require no provider credentials, and none are configured locally.
