### PR TITLE
fix(ci): separate incident timing from functional gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,16 +65,19 @@ jobs:
     needs:
       - test
       - expensive-test-gates
+      - e2e
     runs-on: ubuntu-latest
     steps:
-      - name: Require coverage and expensive proof gates
+      - name: Require coverage, functional e2e, and expensive proof gates
         shell: bash
         env:
           HIVE_COVERAGE_RESULT: ${{ needs.test.result }}
           HIVE_EXPENSIVE_GATES_RESULT: ${{ needs.expensive-test-gates.result }}
+          HIVE_E2E_RESULT: ${{ needs.e2e.result }}
         run: |
           test "$HIVE_COVERAGE_RESULT" = "success"
           test "$HIVE_EXPENSIVE_GATES_RESULT" = "success"
+          test "$HIVE_E2E_RESULT" = "success"
 
   e2e:
     name: real CLI scenario harness
@@ -95,10 +98,10 @@ jobs:
         env:
           HIVE_E2E_RUNS_DIR: ${{ runner.temp }}/hive-e2e-runs
         run: bundle exec rake e2e
-      - name: Enforce incident duration budgets
+      - name: Validate incident report integrity
         env:
           HIVE_E2E_RUNS_DIR: ${{ runner.temp }}/hive-e2e-runs
-        run: bundle exec ruby test/e2e/check_incident_budget.rb "$HIVE_E2E_RUNS_DIR"
+        run: ruby test/e2e/check_incident_budget.rb "$HIVE_E2E_RUNS_DIR" --integrity-only
       - name: Retain e2e reports and failure evidence
         if: always()
         uses: actions/upload-artifact@v7
@@ -108,6 +111,26 @@ jobs:
           include-hidden-files: true
           if-no-files-found: warn
           retention-days: 14
+
+  incident-duration-budget:
+    name: incident duration budget (advisory)
+    needs: e2e
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+      - name: Download e2e report
+        uses: actions/download-artifact@v8
+        with:
+          name: hive-e2e-report
+          path: ${{ runner.temp }}/hive-e2e-runs
+      - name: Check incident duration budgets
+        env:
+          HIVE_E2E_RUNS_DIR: ${{ runner.temp }}/hive-e2e-runs
+        run: ruby test/e2e/check_incident_budget.rb "$HIVE_E2E_RUNS_DIR" --timing-only
 
   web:
     name: Hive web (Rails tests + system)

--- a/test/e2e/check_incident_budget.rb
+++ b/test/e2e/check_incident_budget.rb
@@ -3,9 +3,18 @@
 require "json"
 require_relative "lib/incident_budget"
 
-input = ARGV.fetch(0) do
-  abort "usage: #{$PROGRAM_NAME} REPORT_JSON_OR_RUNS_DIR"
+usage = "usage: #{$PROGRAM_NAME} REPORT_JSON_OR_RUNS_DIR " \
+        "[--all|--integrity-only|--timing-only]"
+input = ARGV.shift
+abort usage unless input
+
+kind = case ARGV.shift || "--all"
+when "--all" then :all
+when "--integrity-only" then :integrity
+when "--timing-only" then :timing
+else abort usage
 end
+abort usage unless ARGV.empty?
 
 report_path = if File.file?(input)
   input
@@ -20,7 +29,7 @@ checked.durations.sort.each do |name, duration|
 end
 puts format("incident total: %.3fs", checked.total_seconds)
 
-unless checked.ok?
-  checked.violations.each { |violation| warn "incident budget: #{violation}" }
+unless checked.ok?(kind)
+  checked.violations_for(kind).each { |violation| warn "incident budget: #{violation}" }
   exit 1
 end

--- a/test/e2e/lib/incident_budget.rb
+++ b/test/e2e/lib/incident_budget.rb
@@ -5,9 +5,22 @@ module Hive
       DEFAULT_AGGREGATE_SECONDS = 30.0
       INCIDENT_TAG = "incident-regression"
 
-      Result = Data.define(:durations, :total_seconds, :violations) do
-        def ok?
-          violations.empty?
+      Result = Data.define(:durations, :total_seconds, :integrity_violations, :timing_violations) do
+        def violations
+          integrity_violations + timing_violations
+        end
+
+        def violations_for(kind)
+          case kind
+          when :all then violations
+          when :integrity then integrity_violations
+          when :timing then timing_violations
+          else raise ArgumentError, "unknown incident budget check kind: #{kind.inspect}"
+          end
+        end
+
+        def ok?(kind = :all)
+          violations_for(kind).empty?
         end
       end
 
@@ -28,13 +41,14 @@ module Hive
         results = Array(@report["scenarios"])
         results_by_name = results.group_by { |result| result["name"] }
         durations = {}
-        violations = duplicate_violations(metadata, results)
+        integrity_violations = duplicate_violations(metadata, results)
+        timing_violations = []
 
         metadata.each do |entry|
           name = entry["name"]
           matches = results_by_name[name]
           if matches.nil? || matches.empty?
-            violations << "enabled incident #{name.inspect} has no scenario result"
+            integrity_violations << "enabled incident #{name.inspect} has no scenario result"
             next
           end
           next unless matches.one?
@@ -44,24 +58,29 @@ module Hive
           duration = Float(result["duration_seconds"])
           durations[name] = duration
           if duration >= @per_scenario_limit
-            violations << format(
+            timing_violations << format(
               "%s took %.3fs (must be below %.3fs)",
               name, duration, @per_scenario_limit
             )
           end
         rescue ArgumentError, TypeError
-          violations << "enabled incident #{name.inspect} has an invalid duration"
+          integrity_violations << "enabled incident #{name.inspect} has an invalid duration"
         end
 
         total = durations.values.sum
         if total >= @aggregate_limit
-          violations << format(
+          timing_violations << format(
             "incident group took %.3fs (must be below %.3fs)",
             total, @aggregate_limit
           )
         end
 
-        Result.new(durations: durations.freeze, total_seconds: total, violations: violations.freeze)
+        Result.new(
+          durations: durations.freeze,
+          total_seconds: total,
+          integrity_violations: integrity_violations.freeze,
+          timing_violations: timing_violations.freeze
+        )
       end
 
       private

--- a/test/e2e/lib/incident_budget_test.rb
+++ b/test/e2e/lib/incident_budget_test.rb
@@ -1,5 +1,8 @@
 require_relative "../../test_helper"
 require_relative "incident_budget"
+require "json"
+require "open3"
+require "rbconfig"
 
 class E2EIncidentBudgetTest < Minitest::Test
   def report(metadata:, scenarios:)
@@ -30,7 +33,11 @@ class E2EIncidentBudgetTest < Minitest::Test
     )
 
     refute checked.ok?
+    assert checked.ok?(:integrity)
+    refute checked.ok?(:timing)
+    assert_empty checked.integrity_violations
     assert_equal [ "slow took 10.000s (must be below 10.000s)" ], checked.violations
+    assert_equal checked.violations, checked.timing_violations
   end
 
   def test_hosted_runner_variance_above_five_seconds_stays_within_budget
@@ -51,6 +58,8 @@ class E2EIncidentBudgetTest < Minitest::Test
     )
 
     refute checked.ok?
+    assert checked.ok?(:integrity)
+    refute checked.ok?(:timing)
     assert_equal [ "incident group took 30.000s (must be below 30.000s)" ], checked.violations
   end
 
@@ -60,7 +69,11 @@ class E2EIncidentBudgetTest < Minitest::Test
     )
 
     refute checked.ok?
+    refute checked.ok?(:integrity)
+    assert checked.ok?(:timing)
+    assert_empty checked.timing_violations
     assert_equal [ "enabled incident \"missing\" has no scenario result" ], checked.violations
+    assert_equal checked.violations, checked.integrity_violations
   end
 
   def test_duplicate_incident_names_fail_instead_of_undercounting_the_group
@@ -72,7 +85,59 @@ class E2EIncidentBudgetTest < Minitest::Test
     )
 
     refute checked.ok?
+    refute checked.ok?(:integrity)
+    assert checked.ok?(:timing)
+    assert_empty checked.timing_violations
     assert_includes checked.violations, 'enabled incident metadata contains duplicate name "duplicate"'
     assert_includes checked.violations, 'scenario results contain duplicate name "duplicate"'
+  end
+
+  def test_invalid_duration_is_an_integrity_failure
+    checked = Hive::E2E::IncidentBudget.check(
+      report(metadata: [ metadata("invalid") ], scenarios: [ result("invalid", "not-a-number") ])
+    )
+
+    refute checked.ok?(:integrity)
+    assert checked.ok?(:timing)
+    assert_empty checked.timing_violations
+    assert_equal [ 'enabled incident "invalid" has an invalid duration' ], checked.integrity_violations
+  end
+
+  def test_cli_modes_enforce_integrity_and_timing_independently
+    Dir.mktmpdir("incident-budget-cli") do |dir|
+      slow_report = File.join(dir, "slow.json")
+      missing_report = File.join(dir, "missing.json")
+      File.write(
+        slow_report,
+        JSON.generate(report(metadata: [ metadata("slow") ], scenarios: [ result("slow", 10.0) ]))
+      )
+      File.write(
+        missing_report,
+        JSON.generate(report(metadata: [ metadata("missing") ], scenarios: []))
+      )
+
+      _, slow_integrity_error, slow_integrity = run_checker(slow_report, "--integrity-only")
+      _, slow_timing_error, slow_timing = run_checker(slow_report, "--timing-only")
+      _, missing_integrity_error, missing_integrity = run_checker(missing_report, "--integrity-only")
+      _, missing_timing_error, missing_timing = run_checker(missing_report, "--timing-only")
+
+      assert slow_integrity.success?, slow_integrity_error
+      refute slow_timing.success?
+      assert_includes slow_timing_error, "slow took 10.000s"
+      refute missing_integrity.success?
+      assert_includes missing_integrity_error, "has no scenario result"
+      assert missing_timing.success?, missing_timing_error
+    end
+  end
+
+  private
+
+  def run_checker(report_path, mode)
+    Open3.capture3(
+      RbConfig.ruby,
+      File.expand_path("../check_incident_budget.rb", __dir__),
+      report_path,
+      mode
+    )
   end
 end

--- a/test/e2e/scenarios/README.md
+++ b/test/e2e/scenarios/README.md
@@ -23,7 +23,10 @@ unavailable contracts visible without calling the fixture passed. To activate
 one, consume the sibling implementation's exact persisted state and reason
 code, replace the activation guard with terminal-state assertions, and only
 then remove `pending: true`. Enabled incident scenarios must finish below ten
-seconds; their combined duration must remain below thirty seconds.
+seconds; their combined duration must remain below thirty seconds. CI keeps
+missing, duplicate, and invalid incident evidence in the functional E2E gate,
+then reports only those timing targets in a separate advisory job so
+hosted-runner variance cannot block an otherwise functional change.
 
 ## Incident index
 

--- a/test/unit/ci_test_partition_test.rb
+++ b/test/unit/ci_test_partition_test.rb
@@ -75,19 +75,93 @@ class CiTestPartitionTest < Minitest::Test
       required_gate = workflow.fetch("jobs").fetch("required-test-gate")
       assert_equal "rake test (Ruby 3.4)", required_gate.fetch("name")
       assert_equal "${{ always() }}", required_gate.fetch("if")
-      assert_equal %w[test expensive-test-gates], required_gate.fetch("needs")
+      assert_equal %w[test expensive-test-gates e2e], required_gate.fetch("needs")
 
       required_step = required_gate.fetch("steps").fetch(0)
+      assert_equal "Require coverage, functional e2e, and expensive proof gates",
+                   required_step.fetch("name")
       assert_equal "${{ needs.test.result }}",
                    required_step.fetch("env").fetch("HIVE_COVERAGE_RESULT")
       assert_equal "${{ needs.expensive-test-gates.result }}",
                    required_step.fetch("env").fetch("HIVE_EXPENSIVE_GATES_RESULT")
+      assert_equal "${{ needs.e2e.result }}",
+                   required_step.fetch("env").fetch("HIVE_E2E_RESULT")
       assert_equal "bash", required_step.fetch("shell")
       assert_equal <<~SHELL, required_step.fetch("run")
         test "$HIVE_COVERAGE_RESULT" = "success"
         test "$HIVE_EXPENSIVE_GATES_RESULT" = "success"
+        test "$HIVE_E2E_RESULT" = "success"
       SHELL
     end
+  end
+
+  def test_incident_duration_budget_is_advisory_and_separate_from_functional_e2e
+    workflow = YAML.safe_load_file(File.join(ROOT, ".github", "workflows", "ci.yml"), aliases: true)
+    jobs = workflow.fetch("jobs")
+    e2e = jobs.fetch("e2e")
+    advisory = jobs.fetch("incident-duration-budget")
+    incident_budget_script = "test/e2e/check_incident_budget.rb"
+
+    e2e_steps = e2e.fetch("steps")
+    integrity_steps = e2e_steps.select do |step|
+      step.fetch("run", "").include?(incident_budget_script)
+    end
+    assert_equal 1, integrity_steps.length
+    integrity = integrity_steps.fetch(0)
+    assert_equal(
+      'ruby test/e2e/check_incident_budget.rb "$HIVE_E2E_RUNS_DIR" --integrity-only',
+      integrity.fetch("run")
+    )
+    refute_includes integrity.fetch("run"), "--timing-only"
+    assert_equal "incident duration budget (advisory)", advisory.fetch("name")
+    assert_equal "e2e", advisory.fetch("needs")
+    assert_equal true, advisory.fetch("continue-on-error")
+
+    ruby_setup = advisory.fetch("steps").find { |step| step["uses"] == "ruby/setup-ruby@v1" }
+    assert_equal({ "ruby-version" => "3.4" }, ruby_setup.fetch("with"))
+    refute advisory.fetch("steps").any? { |step| step.fetch("run", "").include?("bundle") }
+
+    download = advisory.fetch("steps").find { |step| step["name"] == "Download e2e report" }
+    assert_equal "actions/download-artifact@v8", download.fetch("uses")
+    assert_equal "hive-e2e-report", download.fetch("with").fetch("name")
+    assert_equal "${{ runner.temp }}/hive-e2e-runs", download.fetch("with").fetch("path")
+
+    enforce_steps = advisory.fetch("steps").select do |step|
+      step.fetch("run", "").include?(incident_budget_script)
+    end
+    assert_equal 1, enforce_steps.length
+    enforce = enforce_steps.fetch(0)
+    assert_equal(
+      'ruby test/e2e/check_incident_budget.rb "$HIVE_E2E_RUNS_DIR" --timing-only',
+      enforce.fetch("run")
+    )
+    refute_includes enforce.fetch("run"), "--integrity-only"
+    assert_equal(
+      "${{ runner.temp }}/hive-e2e-runs",
+      enforce.fetch("env").fetch("HIVE_E2E_RUNS_DIR")
+    )
+
+    scenario = e2e_steps.find { |step| step["name"] == "Run real-subprocess scenarios" }
+    upload = e2e_steps.find { |step| step["uses"] == "actions/upload-artifact@v7" }
+    assert_equal download.fetch("with").fetch("name"), upload.fetch("with").fetch("name")
+    assert_equal(
+      scenario.fetch("env").fetch("HIVE_E2E_RUNS_DIR"),
+      upload.fetch("with").fetch("path")
+    )
+    assert_equal(
+      integrity.fetch("env").fetch("HIVE_E2E_RUNS_DIR"),
+      upload.fetch("with").fetch("path")
+    )
+    assert_equal(
+      enforce.fetch("env").fetch("HIVE_E2E_RUNS_DIR"),
+      download.fetch("with").fetch("path")
+    )
+    assert_operator e2e_steps.index(upload), :>, e2e_steps.index(scenario)
+    assert_operator e2e_steps.index(upload), :>, e2e_steps.index(integrity)
+
+    required_needs = jobs.fetch("required-test-gate").fetch("needs")
+    assert_includes required_needs, "e2e"
+    refute_includes required_needs, "incident-duration-budget"
   end
 
   def test_ci_gate_tasks_fail_when_no_non_skipped_asserting_test_runs

--- a/wiki/e2e.md
+++ b/wiki/e2e.md
@@ -3,7 +3,7 @@ title: Agentic E2E Suite
 type: reference
 source: test/e2e/, bin/hive-e2e, Rakefile
 created: 2026-04-29
-updated: 2026-07-22
+updated: 2026-07-24
 tags: [test, e2e, tui, incidents, artifacts]
 ---
 
@@ -100,7 +100,7 @@ variable from silently overriding the harness-specific cleanup policy.
 | `test/e2e/fixtures/gh` | Run-global, default-deny GitHub CLI shim with no host-binary fallback. |
 | `test/e2e/sample-project/` | Tiny Ruby fixture copied into each scenario sandbox. Vendored gems keep bootstrap offline. |
 | `test/e2e/runs/` | Gitignored run artifacts. Each run has `report.json` and per-scenario artifact directories. |
-| `test/e2e/check_incident_budget.rb` | Report-driven below-10s-per-incident and below-30s-aggregate CI gate. |
+| `test/e2e/check_incident_budget.rb` | Report-integrity gate plus below-10s-per-incident and below-30s-aggregate advisory check. |
 | `bin/hive-e2e` | Thor shell for run/list/replay/clean. |
 
 ## Scenario DSL
@@ -241,10 +241,14 @@ The harness prepends repo `bin/` to the tmux environment PATH because TUI rows d
 `CliDriver` starts CLI subprocesses in their own process group and applies the step timeout to both the direct child and stdout/stderr reader threads, so descendants that inherit the capture pipes cannot hold an e2e step open after their parent exits.
 
 Routine pull-request CI runs `e2e:lib_test` and `rake e2e` in a separate job,
-retains the run directory even after failure, and then reads enabled incident
-durations from `report.json`. Durations include sandbox bootstrap; each enabled
-incident must be below ten seconds and the group below thirty seconds. This job does not fold e2e into the default
-`rake test` task.
+retains the run directory even after failure, and feeds that functional job
+into the protected `rake test (Ruby 3.4)` aggregate. A downstream advisory job
+downloads the artifact and reads enabled incident durations from `report.json`.
+Durations include sandbox bootstrap; each enabled incident targets below ten
+seconds and the group targets below thirty seconds. Timing failures remain
+visible without blocking a merge. Missing enabled results, duplicate
+metadata/results, and invalid durations remain functional failures in the E2E
+job. Neither job folds e2e into the local default `rake test` task.
 
 `tmux` is required for TUI scenarios. `asciinema` is test-time optional: when
 it is unavailable or too old, TUI scenarios run without cast capture while the

--- a/wiki/log.d/20260724T082832Z-advisory-incident-duration-gate.md
+++ b/wiki/log.d/20260724T082832Z-advisory-incident-duration-gate.md
@@ -1,0 +1,18 @@
+## [2026-07-24T08:28:32Z] CI — separate functional E2E from incident timing
+
+**Action:** Kept the real CLI harness as a functional merge gate by adding its
+result to the protected `rake test (Ruby 3.4)` aggregate. Moved the
+report-driven incident duration check into a downstream `continue-on-error`
+job that downloads the retained E2E artifact, so hosted-runner timing variance
+stays visible without blocking a functional change. Kept report-integrity
+checks in the functional E2E job.
+
+**Contract:** Functional harness/library/scenario failures still fail the
+protected aggregate, including missing enabled results, duplicate
+metadata/results, and invalid durations. The advisory check retains only the
+ten-second per-incident and thirty-second group targets, reuses the existing
+report artifact, and does not repeat the E2E run or install the root bundle.
+
+**Verification:** Added workflow-structure assertions for the required E2E
+dependency, blocking integrity mode, advisory timing mode, artifact handoff,
+and exclusion of timing from the protected aggregate.

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -3,7 +3,7 @@ title: Testing
 type: reference
 source: test/, Rakefile, bin/hive-eval, .rubocop.yml, .github/workflows/{ci,live-agent-skills,release}.yml, packaging/live_agent_skills/, config/brakeman.ignore
 created: 2026-04-25
-updated: 2026-07-23
+updated: 2026-07-24
 tags: [test, minitest, fixtures, honeycomb, agent-skills, release-proof]
 ---
 
@@ -283,12 +283,16 @@ remains visible in `report.json#scenario_metadata` with `pending: true`, while
 its steps and ordinary result row remain absent. CI runs
 `bundle exec rake e2e:lib_test` and `bundle exec rake e2e` in a dedicated
 pull-request job, uploads the configured `HIVE_E2E_RUNS_DIR` on success or
-failure, and uses `test/e2e/check_incident_budget.rb` to enforce below ten
-seconds per enabled incident (including sandbox bootstrap) and below thirty
-seconds for the group. The #9771 dependency-gate and repository-routing
-incidents are enabled; four sibling-gated fixtures remain pending. The
-incident index and activation rules live in
-`test/e2e/scenarios/README.md`.
+failure, and feeds the functional job result into the protected
+`rake test (Ruby 3.4)` aggregate. That job treats missing enabled results,
+duplicate metadata/results, and invalid durations as functional failures. A
+separate `continue-on-error` job downloads the retained report and runs only
+the timing mode of `test/e2e/check_incident_budget.rb`, flagging enabled
+incidents at or above ten seconds (including sandbox bootstrap) or a group
+total at or above thirty seconds without blocking the merge. The #9771
+dependency-gate and repository-routing incidents are enabled; four
+sibling-gated fixtures remain pending. The incident index and activation rules
+live in `test/e2e/scenarios/README.md`.
 
 `durable_attempt_1849_replay.yml` is the ownership acceptance replay. It starts
 a foreground develop attachment, makes three provider commits, kills the


### PR DESCRIPTION
## Summary

- Functional E2E evidence remains merge-blocking, including missing enabled results, duplicate metadata/results, and invalid durations.
- Hosted-runner timing variance no longer blocks an otherwise functional change: the 10-second per-scenario and 30-second aggregate targets run once in a downstream advisory job using the retained E2E artifact.
- The protected `rake test (Ruby 3.4)` aggregate now includes the functional E2E result, so existing branch protection covers that contract.

## Test plan

- [x] `ruby -Itest test/e2e/lib/incident_budget_test.rb` — 8 runs, 45 assertions
- [x] `ruby -Itest test/unit/ci_test_partition_test.rb` — 4 runs, 57 assertions
- [x] RuboCop on all four changed Ruby files — no offenses
- [x] Workflow YAML parse and `git diff --check`
- [x] Hosted CI proves the cross-job artifact handoff and advisory conclusion

## Notes for reviewer

The advisory job installs only Ruby, downloads the existing report artifact, and runs the standard-library checker; it does not install the root bundle or repeat the E2E scenarios. The checker's default `--all` behavior remains available for local use.

## Post-Deploy Monitoring & Validation

- Window: the first pull-request run and the first `main` run after merge.
- Expected: `real CLI scenario harness` and the protected `rake test (Ruby 3.4)` context are green; `incident duration budget (advisory)` emits timing results without becoming a required dependency.
- Failure signal: a red functional E2E/protected context blocks the change; a missing artifact or absent timing output in the advisory job requires repair before relying on its signal.
- Owner: PR author/operator.
- Rollback: revert this workflow commit to restore the combined blocking check.
