### PR TITLE
refactor(components): establish internal boundary contract

### DIFF
--- a/config/component-boundaries.yml
+++ b/config/component-boundaries.yml
@@ -1,0 +1,300 @@
+schema_version: 1
+
+# Architecture metadata for Hive-first reusable components. This catalog and
+# its test-only contract enforce declared source boundaries; they are not a
+# runtime security sandbox and cannot prevent reflection or monkeypatching.
+components:
+  - id: attempts
+    name: Attempts admission / future RunReceipt
+    state: candidate
+    entrypoint:
+      file: lib/hive/attempts/api.rb
+      require: hive/attempts/api
+      constant: Hive::Attempts::API
+    public_contract:
+      values:
+        - Hive::Attempts::ClientResult
+        - Hive::Attempts::DispatchResult
+      errors:
+        - Hive::Attempts::UnsupportedDetachment
+    owned_paths:
+      - lib/hive/attempts
+    state_contracts:
+      - "$HIVE_HOME/attempts/v1 records, logs, outputs, generation locks, leases, and receipts"
+    schema_contracts:
+      - "hive-attempt v1 remains readable; v2 is the current writer"
+    lock_contracts:
+      - "admission lock before generation lock; record transitions use guarded CAS"
+    component_dependencies: []
+    allowed_hive_dependencies:
+      - hive/agent_limit
+      - hive/atomic_file
+      - hive/conditions/generation_tracker
+      - hive/config
+      - hive/dependency_snapshot
+      - hive/lock
+      - hive/markers
+      - hive/paths
+      - hive/stringify_keys
+      - hive/task
+      - hive/task_projection
+      - hive/task_resolver
+      - hive/workflows
+    internal_collaborators:
+      - Hive::Attempts::Entrypoint
+      - Hive::Attempts::ConfiguredDispatcher
+      - Hive::Attempts::Dispatcher
+      - Hive::Attempts::DetachedLauncher
+      - Hive::Attempts::Client
+      - Hive::Attempts::Store
+      - Hive::Attempts::Supervisor
+      - Hive::Attempts::Reconciler
+    forbidden_constructions:
+      - Hive::Attempts::Entrypoint
+      - Hive::Attempts::ConfiguredDispatcher
+      - Hive::Attempts::Dispatcher
+      - Hive::Attempts::DetachedLauncher
+      - Hive::Attempts::Client
+    hive_consumers:
+      - lib/hive/commands/run.rb
+      - lib/hive/commands/stage_action.rb
+      - lib/hive/commands/daemon.rb
+      - lib/hive/bot/dispatch_request_writer.rb
+    mutation_authority: "Admission accepts an explicit request; internal stores and supervisors retain durable transition authority."
+    recovery_surface: "The facade admits successors; reconciliation, healing, cancellation, and lifecycle policy remain internal."
+    wiki_page: wiki/modules/attempts.md
+    focused_tests:
+      - test/unit/attempts/api_test.rb
+    migration_exceptions: []
+
+  - id: user-service
+    name: UserService
+    state: candidate
+    entrypoint:
+      file: lib/hive/commands/service_installer/base.rb
+      require: hive/commands/service_installer/base
+      constant: Hive::Commands::ServiceInstaller::Base
+    public_contract:
+      values:
+        - Hive::Commands::ServiceInstaller::Outcome
+      errors:
+        - ArgumentError
+    owned_paths:
+      - lib/hive/commands/service_installer
+      - lib/hive/commands/daemon/service_installer.rb
+      - lib/hive/commands/bot/service_installer.rb
+      - lib/hive/commands/web/service_installer.rb
+    state_contracts:
+      - "Per-user systemd unit or launchd plist plus timestamped backups"
+    schema_contracts:
+      - "Hive command JSON and messages remain adapter-owned"
+    lock_contracts:
+      - "No cross-manager transaction; apply revalidates observed file and manager state"
+    component_dependencies: []
+    allowed_hive_dependencies: []
+    internal_collaborators:
+      - Hive::Commands::ServiceInstaller::Base
+    forbidden_constructions: []
+    hive_consumers:
+      - lib/hive/commands/daemon.rb
+      - lib/hive/commands/bot.rb
+      - lib/hive/commands/web.rb
+      - lib/hive/commands/setup.rb
+      - lib/hive/commands/init.rb
+      - lib/hive/commands/uninstall.rb
+    mutation_authority: "Hive command adapters authorize install, force replacement, restart, and remove."
+    recovery_surface: "Typed outcomes report backup paths, final observed state, and partial manager/file failures."
+    wiki_page: wiki/commands/daemon.md
+    focused_tests:
+      - test/unit/commands/service_installer/base_test.rb
+    migration_exceptions: []
+
+  - id: agent-abi
+    name: Agent ABI
+    state: candidate
+    entrypoint:
+      file: lib/hive/agent_profile.rb
+      require: hive/agent_profile
+      constant: Hive::AgentProfile
+    public_contract:
+      values:
+        - Hive::AgentProfile
+        - Hive::AgentProfiles
+      errors:
+        - Hive::AgentError
+    owned_paths:
+      - lib/hive/agent_profile.rb
+      - lib/hive/agent_profiles.rb
+      - lib/hive/agent_profiles
+    state_contracts:
+      - "Provider executable, version, capability, and observable result evidence"
+    schema_contracts:
+      - "Provider profile constructor and registry extension point remain compatible"
+    lock_contracts:
+      - "Version/capability probes are bounded and reap descendant process groups"
+    component_dependencies: []
+    allowed_hive_dependencies: []
+    internal_collaborators:
+      - Hive::AgentProfiles::UsageExtractors
+    forbidden_constructions: []
+    hive_consumers:
+      - lib/hive/agent.rb
+      - lib/hive/stages/base.rb
+    mutation_authority: "Hive orchestration selects profiles and permission policy; adapters only compile and observe."
+    recovery_surface: "Probe and invocation failures return bounded evidence; workflow retry policy stays in Hive."
+    wiki_page: wiki/modules/agent_profile.md
+    focused_tests:
+      - test/unit/agent_profile_test.rb
+    migration_exceptions: []
+
+  - id: agent-artifact-firewall
+    name: Agent Artifact Firewall
+    state: candidate
+    entrypoint:
+      file: lib/hive/protected_files.rb
+      require: hive/protected_files
+      constant: Hive::ProtectedFiles
+    public_contract:
+      values:
+        - Hive::ProtectedFiles
+      errors:
+        - Hive::Error
+        - ArgumentError
+    owned_paths:
+      - lib/hive/protected_files.rb
+      - lib/hive/secret_patterns.rb
+    state_contracts:
+      - "In-memory protected-file capture plus post-spawn custody report"
+    schema_contracts:
+      - "Stage marker and outcome policy remains Hive-owned"
+    lock_contracts:
+      - "No-follow fingerprints and atomic per-file restore; no filesystem transaction claim"
+    component_dependencies: []
+    allowed_hive_dependencies: []
+    internal_collaborators:
+      - Hive::SecretPatterns
+    forbidden_constructions: []
+    hive_consumers:
+      - lib/hive/stages/agent_worktree.rb
+      - lib/hive/stages/agent_report.rb
+    mutation_authority: "Hive stage adapters declare protected, allowed, and required paths."
+    recovery_surface: "Validation and restore report only what application-level custody can prove."
+    wiki_page: wiki/modules/protected_files.md
+    focused_tests:
+      - test/unit/protected_files_test.rb
+    migration_exceptions: []
+
+  - id: skillpack
+    name: Skillpack
+    state: candidate
+    entrypoint:
+      file: lib/hive/agent_skills.rb
+      require: hive/agent_skills
+      constant: Hive::AgentSkills
+    public_contract:
+      values:
+        - Hive::AgentSkills
+      errors:
+        - Hive::AgentSkills::Manifest::ValidationError
+    owned_paths:
+      - lib/hive/agent_skills.rb
+      - lib/hive/agent_skills
+      - config/agent-skills.yml
+    state_contracts:
+      - "Canonical skill source and projected agent-home directories"
+    schema_contracts:
+      - "config/agent-skills.yml manifest and projection provenance"
+    lock_contracts:
+      - "Private staging and complete-directory atomic publication"
+    component_dependencies:
+      - agent-abi
+    allowed_hive_dependencies: []
+    internal_collaborators:
+      - Hive::AgentSkills::DirectoryPublisher
+      - Hive::AgentSkills::Provisioner
+    forbidden_constructions: []
+    hive_consumers:
+      - lib/hive/commands/setup_agents.rb
+    mutation_authority: "Hive setup policy chooses destinations; publisher applies a revalidated projection."
+    recovery_surface: "Foreign trees are refused and prior directories are preserved or restored on failure."
+    wiki_page: wiki/commands/setup-agents.md
+    focused_tests:
+      - test/unit/agent_skills/manifest_test.rb
+    migration_exceptions: []
+
+  - id: safe-agent-git-gate
+    name: Safe Agent Git Gate
+    state: candidate
+    entrypoint:
+      file: lib/hive/managed_git.rb
+      require: hive/managed_git
+      constant: Hive::ManagedGit
+    public_contract:
+      values:
+        - Hive::ManagedGit
+      errors:
+        - ArgumentError
+    owned_paths:
+      - lib/hive/managed_git.rb
+    state_contracts:
+      - "Repository objects, refs, worktrees, and publication receipts"
+    schema_contracts:
+      - "Expected remote object identity and before/after publication receipt"
+    lock_contracts:
+      - "Expected-OID lease is revalidated at publication"
+    component_dependencies: []
+    allowed_hive_dependencies: []
+    internal_collaborators:
+      - Hive::Gh
+    forbidden_constructions: []
+    hive_consumers:
+      - lib/hive/stages/draft_pr_handoff.rb
+      - lib/hive/refactor_patrol/pr_opener.rb
+    mutation_authority: "Hive injects credential, transport, branch, PR, and operator-approval policy."
+    recovery_surface: "Receipts preserve observed identities; publication failure remains explicit and retryable."
+    wiki_page: wiki/modules/git_ops.md
+    focused_tests:
+      - test/unit/managed_git_test.rb
+    migration_exceptions: []
+
+  - id: work-ledger
+    name: WorkLedger
+    state: candidate
+    entrypoint:
+      file: lib/hive/task_journal.rb
+      require: hive/task_journal
+      constant: Hive::TaskJournal
+    public_contract:
+      values:
+        - Hive::TaskJournal::AppendResult
+      errors:
+        - Hive::TaskJournal::Error
+    owned_paths:
+      - lib/hive/task_journal.rb
+      - lib/hive/task_journal
+      - lib/hive/task_projection.rb
+      - lib/hive/task_projection
+      - lib/hive/workflow.rb
+      - lib/hive/workflows
+    state_contracts:
+      - "Task journal, projection, descriptor overlays, and historical fixtures"
+    schema_contracts:
+      - "Hive-owned journal/projection formats remain internal compatibility contracts"
+    lock_contracts:
+      - "Append and projection writes use Hive task/state locks and fsync discipline"
+    component_dependencies: []
+    allowed_hive_dependencies: []
+    internal_collaborators:
+      - Hive::TaskJournal::Validator
+      - Hive::TaskProjection::Store
+      - Hive::Workflows::DescriptorParser
+    forbidden_constructions: []
+    hive_consumers:
+      - lib/hive/task_action.rb
+      - lib/hive/conditions
+    mutation_authority: "Hive event, condition, task-path, transition, Git, and migration policy remains above the seam."
+    recovery_surface: "Replay preserves historical records without rewriting; incompatible events fail closed."
+    wiki_page: wiki/state-model.md
+    focused_tests:
+      - test/unit/task_journal_test.rb
+    migration_exceptions: []

--- a/docs/plans/2026-07-25-001-refactor-internal-component-boundaries-plan.md
+++ b/docs/plans/2026-07-25-001-refactor-internal-component-boundaries-plan.md
@@ -1,0 +1,433 @@
+---
+title: Internal Component Boundaries - Plan
+type: refactor
+date: 2026-07-25
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-plan-bootstrap
+execution: code
+deepened: 2026-07-25
+---
+
+# Internal Component Boundaries - Plan
+
+## Goal Capsule
+
+- **Objective:** Turn Hive's strongest reusable mechanisms into explicit, enforced in-monorepo component boundaries while keeping Hive as their first and primary consumer.
+- **Authority:** The monorepo and boundary-first decisions in this plan are settled; repository instructions govern wiki maintenance, focused test loops, and final verification.
+- **Execution profile:** Land one component boundary per pull request, beginning with the boundary catalog and UserService; characterize behavior before moving it, migrate Hive consumers before declaring a boundary complete, and wait for exact-head CI before starting the next component.
+- **Stop condition:** Stop when every retained candidate has either passed the internal-boundary contract or has a documented reason to remain coupled; a clean directory alone is not success.
+- **Tail ownership:** Leave each component PR review-ready with focused tests, the broad local checkpoint, hosted CI, and current wiki documentation. Merging, creating package directories, choosing gem names or versions, tagging, publishing, releasing, and splitting repositories are outside this plan.
+
+---
+
+## Product Contract
+
+### Summary
+
+Keep Hive as one agent-friendly Ruby monorepo while making its reusable mechanisms behave like well-owned components.
+Each component gets one supported entry point, an explicit public contract, an allowed dependency direction, documented state and schema ownership, and Hive consumers that use the boundary rather than internal collaborators.
+The work starts from the already-landed `Hive::Attempts::API` precedent and applies the pattern incrementally, with UserService as the next low-coupling boundary.
+
+### Problem Frame
+
+Hive already contains credible standalone mechanisms, but most are reusable by inspection rather than by contract.
+Moving them directly into gems would freeze accidental Hive coupling, multiply release work, and make the repository less useful to agents.
+Leaving the seams implicit has the opposite failure mode: commands, stages, web code, and daemon code can construct internal collaborators directly, so future extraction remains expensive and local refactors can silently widen the dependency graph.
+
+The plan therefore separates three rankings:
+
+1. **Standalone product value:** RunReceipt, UserService, Agent Artifact Firewall, Agent ABI, Skillpack, Safe Agent Git Gate, WorkLedger.
+2. **Internal implementation readiness:** Attempts precedent, UserService, Agent ABI, Agent Artifact Firewall, Skillpack, Safe Agent Git Gate, WorkLedger.
+3. **Publication eligibility:** deliberately unset until a future non-Hive consumer and the gates in `docs/plans/2026-07-25-002-feat-standalone-component-gems-plan.md` exist.
+
+RunReceipt remains the strongest standalone product opportunity, but that does not justify genericizing the full Attempts subsystem now.
+UserService is the safest next internal extraction, but that does not preselect it as the first published gem.
+
+### Actors
+
+- A1. Hive maintainers need refactors that preserve behavior and do not create a multi-repository coordination burden.
+- A2. Coding agents need one canonical place to discover component entry points, ownership, dependencies, state, schemas, and tests.
+- A3. Hive CLI, daemon, bot, web, setup, patrol, and stage code need stable facades instead of knowledge of internal collaborators.
+- A4. Future non-Hive consumers need policy-light mechanisms that do not load Hive commands, workflows, web code, or release configuration.
+- A5. Operators need existing files, locks, service definitions, JSON envelopes, and long-running process behavior to remain compatible throughout internal refactors.
+
+### Requirements
+
+**Monorepo and ownership**
+
+- R1. Hive remains the canonical repository, integration environment, documentation home, and first consumer for every component in this plan; no repository split, gemspec, package directory, or independent version is introduced.
+- R2. Add one canonical component catalog that records each component's supported require path and facade, public values and errors, stability level, owned files and state, lock and schema contracts, allowed dependencies, internal collaborators, Hive consumers, mutation authority, recovery surface, and focused tests.
+- R3. Existing module wiki pages remain the human and agent context source; do not add `.context.md` sidecars or duplicate component narratives across new documentation systems.
+
+**API and dependency boundaries**
+
+- R4. Every component exposes one documented facade or existing module entry point plus structured values and errors; new Hive consumers may not construct or require collaborators declared internal by the catalog.
+- R5. Component dependencies form an acyclic downward graph. Policy-light mechanisms may depend on lower-level primitives such as atomic files or redaction, but may not depend upward on `Hive::Commands`, Thor, web controllers, stages, Hive release constants, or the root CLI aggregate unless the catalog explicitly classifies the dependency as a temporary migration exception.
+- R6. A component entry point must load in a clean Ruby process without loading unrelated commands, web code, stages, or candidate components; temporary exceptions are named, tested, and removed before the component reaches `boundary-ready`.
+- R7. Hive-specific workflow, coding, benchmark, presentation, notification, and release policy stays in Hive adapters. Components own only the mechanism required by their current Hive consumers.
+
+**State, compatibility, and authority**
+
+- R8. Treat Ruby APIs, CLI JSON envelopes, persisted workspace schemas, and service-manager files as separate compatibility layers. A boundary refactor preserves each layer unless a separately approved migration or schema/version change says otherwise.
+- R9. Durable components accept an explicit workspace or state root and use the same records, generations, locks, and receipts as Hive. No component creates a parallel agent-only copy of Hive state.
+- R10. Read-only inspection and planning never mutate files, service managers, Git state, processes, or durable records. Plans bind the content, path identity, and relevant observed state they were derived from, and apply revalidates them. Mutating operations require explicit inputs such as force, expected revision, generation, process identity, or publication lease when stale context could cause damage.
+- R11. Public results use typed statuses, outcomes, errors, schema versions, and bounded redacted diagnostics. Human-readable messages explain outcomes but are not the branching contract.
+- R12. Long-running boundaries preserve operation IDs, request idempotency, accepted/live/terminal/lost states, deadlines, attach and replay behavior, recovery lineage, and the distinction between detaching a client and cancelling an owned process.
+- R13. Historical records and additive newer envelopes remain readable where current Hive behavior promises tolerance; incompatible writers fail closed with actionable restart or upgrade guidance rather than rewriting state.
+
+**Execution and proof**
+
+- R14. Characterize current behavior before relocating it, including rendered bytes, structured outcomes, messages, side effects, error propagation, and adapter-specific hooks that broad tests can miss.
+- R15. Migrate all production Hive consumers through the facade before declaring a component boundary complete, and add enforcement that detects new direct use of internal collaborators.
+- R16. Land one component per pull request in readiness order. Each PR runs focused component and consumer tests during development, `bundle exec rake test` once before handoff, and exact-head hosted CI; exhaustive coverage and packaged merge gates remain CI-owned unless the change specifically affects them.
+- R17. Every component PR updates its module wiki page, the component catalog, affected testing or architecture pages, and one `wiki/log.d/<timestamp>-<slug>.md` fragment without editing compiled `wiki/log.md`.
+- R18. A failed boundary attempt may leave the component internal indefinitely. Remove experimental abstractions and record the coupling that blocked the boundary instead of preserving a misleading facade.
+
+### Key Flows
+
+- F1. **Adopt the boundary contract**
+  - **Trigger:** A mechanism is selected for boundary work.
+  - **Actors:** A1, A2, A3.
+  - **Steps:** Characterize current behavior; record the proposed entry point, public contracts, state, schemas, dependencies, consumers, and authority in the catalog; add clean-load and dependency-direction proof.
+  - **Outcome:** The component has an explicit contract before production consumers move.
+  - **Covered by:** R2-R8, R14.
+- F2. **Migrate Hive first**
+  - **Trigger:** The facade and contracts pass focused tests.
+  - **Actors:** A3, A5.
+  - **Steps:** Route one consumer family at a time through the facade; retain presentation and product policy in its adapter; compare outputs and side effects; remove direct construction of internal collaborators.
+  - **Outcome:** Hive dogfoods the boundary without changing operator-visible behavior.
+  - **Covered by:** R1, R7-R16.
+- F3. **Reject an artificial seam**
+  - **Trigger:** Clean loading, downward dependencies, shared state, or behavior compatibility cannot be achieved without widening scope.
+  - **Actors:** A1, A2.
+  - **Steps:** Remove experimental boundary code; document the concrete coupling and the condition that would justify revisiting it.
+  - **Outcome:** The component remains honestly internal and the monorepo does not accumulate fake modularity.
+  - **Covered by:** R5-R6, R18.
+- F4. **Verify a completed boundary**
+  - **Trigger:** All current Hive consumers have migrated.
+  - **Actors:** A1, A2, A3, A5.
+  - **Steps:** Run clean-load, dependency, focused, cross-consumer, compatibility, broad local, and hosted proofs; update the catalog and wiki from `candidate` to `boundary-ready`.
+  - **Outcome:** The next component may begin without relying on an unproven boundary.
+  - **Covered by:** R15-R17.
+
+### Acceptance Examples
+
+- AE1. Given `Hive::Attempts::API` is the documented admission facade, when a new producer dispatches work, then it calls the facade and does not construct `Entrypoint`, `ConfiguredDispatcher`, `Dispatcher`, `Store`, or launcher classes directly.
+- AE2. Given a UserService definition on Linux, when inspection or planning runs against a temporary home with a fake command runner, then no unit file is written and no `systemctl` command that changes state is invoked.
+- AE3. Given an existing customized service unit, when apply runs without force, then the typed result reports drift, the file remains byte-identical, no manager activation occurs, and Hive's current JSON/message presentation remains unchanged.
+- AE4. Given a force upgrade, when replacement succeeds, then the prior unit is preserved at the reported backup path, the write is atomic, and the result states whether restart was actually invoked. Given the unit or manager state changes after planning, apply refuses the stale plan instead.
+- AE5. Given an agent provider that cannot prove a requested read-only or workspace-write mode, when the Agent ABI compiles the invocation, then it fails closed rather than mapping a similarly named weaker flag.
+- AE6. Given a protected regular file is replaced by a symlink or directory during an agent spawn, when the Artifact Firewall validates custody, then it reports typed tampering and does not claim OS sandboxing or successful restoration it could not prove.
+- AE7. Given a canonical skill and a disposable agent home, when Skillpack plans and applies a projection, then the preview is non-mutating, the complete directory is swapped atomically, and the resulting files and provenance match the canonical source.
+- AE8. Given hostile repository Git configuration, when the Safe Agent Git Gate performs an allowed operation, then forbidden hooks, helpers, diff drivers, fsmonitor, and transports cannot execute, and publication requires the exact expected remote object ID.
+- AE9. Given historical task journal and projection fixtures, when WorkLedger mechanics replay them through the internal boundary, then current Hive state is reproduced without rewriting the source files or silently renaming durable stages.
+
+### Success Criteria
+
+- Every retained component has one discoverable facade, a catalog entry, a module wiki page, clean-process load proof, dependency-direction proof, focused contract tests, and production Hive consumers using the facade.
+- Direct construction of internal collaborators fails a repository contract test or an equivalent enforceable check.
+- Existing CLI JSON, persisted state, service files, agent projections, Git receipts, and workflow fixtures remain compatible.
+- The implementation and publication rankings remain visibly separate; no internal boundary is described as a promise to publish.
+- No package directory, gemspec, version line, tag, release, publication, or repository split is introduced.
+
+### Scope Boundaries
+
+**Included now**
+
+- Boundary catalog and enforcement.
+- Attempts admission as the reference completed slice.
+- UserService, Agent ABI, Agent Artifact Firewall, Skillpack, Safe Agent Git Gate, and WorkLedger internal boundaries in readiness order.
+- Hive-first consumer migrations and compatibility tests.
+
+**Deferred to the standalone-gem plan**
+
+- Generic RunReceipt lifecycle APIs beyond current Hive demand.
+- Neutral product names and namespaces.
+- `components/` or `gems/` package directories, gemspecs, independent versions, changelogs, package CI, and RubyGems publication.
+- Non-Hive CLIs and public migration guarantees.
+
+**Outside the retained extraction set**
+
+- Operational status or Statewatch, layout migration, a standalone capability probe, a separate lease broker, RunCapsule, a generic local agent execution stack, a separate WorkLedger read API, a speculative skill supply chain, ExactBranch as a separate product, and status/TUI rendering.
+- Windows services, OpenRC, or other UserService platforms during the internal boundary refactor.
+- A generic agent loop, OS sandbox, distributed workflow engine, or full Git/GitHub wrapper.
+
+---
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- KTD1. **Keep the monorepo as the product-development unit.** (session-settled: user-approved — chosen over splitting components into separate repositories because one checkout preserves agent navigation, integrated debugging, and cross-component change visibility.)
+- KTD2. **Establish boundaries before packages.** (session-settled: user-approved — chosen over moving candidate code directly into gems because Hive must prove a stable API and real demand before accepting packaging and release costs.)
+- KTD3. **Hive remains the first and primary consumer.** (session-settled: user-directed — chosen over designing for hypothetical external callers because real Hive use supplies compatibility pressure and prevents speculative abstraction.)
+- KTD4. **Use focused component proof plus full Hive integration.** (session-settled: user-approved — chosen over path-only selective verification because component isolation and whole-product behavior are both required.)
+- KTD5. **Implementation order follows readiness, not standalone value.** Record Attempts first, then implement UserService, Agent ABI, Agent Artifact Firewall, Skillpack, Safe Agent Git Gate, and WorkLedger. RunReceipt keeps the highest product-value rank without forcing the largest refactor first.
+- KTD6. **Use one facade and explicit contracts, not a public class collection.** Public callers receive structured value and error types; constructors, stores, launchers, platform runners, parsers, and validators remain internal unless Hive has a concrete need to compose them.
+- KTD7. **Separate policy from mechanism at the adapter boundary.** Components own inspect, plan, validate, persist, reconcile, or apply mechanics. Hive owns task semantics, provider selection, stage policy, command wording, JSON presentation, notifications, release policy, and operator approval.
+- KTD8. **Keep shared durable state singular.** A component receives state roots and lock/process dependencies explicitly and operates on Hive's existing records. Parallel storage or copied agent context is forbidden.
+- KTD9. **Treat security components as different guarantees.** Agent ABI proves invocation capabilities, Artifact Firewall proves application-level artifact custody, and Safe Agent Git Gate hardens a narrow Git publication vocabulary. None is named or documented as a sandbox for the others.
+- KTD10. **Use the managed wiki as agent context.** The component catalog provides the cross-repository map and each existing module page owns the narrative. No competing `.context.md` hierarchy is added.
+- KTD11. **One component per PR.** The Attempts catalog/reference increment and UserService may share the initial foundation PR only if the diff remains reviewable; every later component gets its own exact-head evidence and may be abandoned without blocking the others.
+
+### High-Level Technical Design
+
+```mermaid
+flowchart TB
+  C[Component catalog and contract tests] --> A[Public facade and contracts]
+  A --> M[Policy-light mechanism]
+  H[Hive command, stage, daemon, bot, or web adapter] --> A
+  A --> P[Lower-level approved primitives]
+  M --> S[Existing shared state, locks, schemas, or host resources]
+  I[Internal collaborators] --> M
+  X[Unrelated Hive commands, web, stages, release policy] -. forbidden upward dependency .-> M
+```
+
+Each boundary has four independently recorded compatibility surfaces:
+
+1. Ruby entry point, values, errors, and stability.
+2. CLI JSON envelopes that Hive adapters expose.
+3. Persisted files, schemas, locks, and migration ownership.
+4. Host artifacts such as systemd units, launchd plists, Git refs, or agent-skill projections.
+
+The catalog is machine-checkable metadata, while module wiki pages explain purpose, integration patterns, and limitations.
+The enforcement harness validates catalog completeness, clean loading, the allowed dependency DAG, and selected forbidden namespace edges without pretending a Ruby source scan is a security sandbox.
+
+### Component Boundary Matrix
+
+| Component | Internal entry point and public surface | Mechanism retained below facade | Hive policy retained above facade | Readiness note |
+|---|---|---|---|---|
+| Attempts / future RunReceipt | Existing `Hive::Attempts::API` and contracts | Admission, durable records, leases, supervision, streams, receipts | Task generation, dependency and capacity policy, marker projection, healer decisions | Reference boundary; do not widen lifecycle API without Hive demand |
+| UserService | New `Hive::UserService` entry point, definition, plan/status/result contracts | Drift, backup, atomic replace, systemd-user/launchd inspect, apply, and remove | Templates, binary/channel resolution, wording, JSON, web environment, restart warnings, global uninstall sequencing | Next boundary |
+| Agent ABI | Existing `Hive::AgentProfile` and `Hive::AgentProfiles` plus request/result contract | Provider adapter, capability/version probe, invocation compilation, observable result | Stage orchestration, timeout ownership, artifact acceptance, workflow policy | Mature seam with provider drift |
+| Agent Artifact Firewall | New facade over custody manifest and report | Snapshot, capture, validate, restore, required-output checks, redaction adapter | Which paths are protected/allowed/required and what stage failure means | Security contract must stay narrow |
+| Skillpack | New facade over canonical source, adapter registry, manifest, inspect/plan/apply | Deterministic projection, provenance, foreign-tree refusal, atomic publish | Hive capability selection and canonical Hive skill content | Coherent mechanism; generic schema remains later |
+| Safe Agent Git Gate | New narrow facade over hardened Git and exact-OID publication | Allowed reads, materialization, hostile-config neutralization, lease and receipt | GitHub workflow, credentials, PR policy, branch naming, action approvals | High security maintenance cost |
+| WorkLedger | New internal facade around descriptor structure and journal storage/replay | Structural validation, append durability, replay, projection plumbing | Hive events, conditions, task paths, transitions, Git, migrations | Last; lowest extraction readiness |
+
+### Sequencing
+
+1. Establish the catalog and enforcement using Attempts as the reference.
+2. Extract and migrate UserService, first read-only inspect/plan and then apply, while preserving adapter presentation.
+3. Normalize the Agent ABI before building the Artifact Firewall facade so custody can consume one invocation/result boundary.
+4. Boundary Skillpack after the agent contract is stable.
+5. Boundary the Git gate only with its narrow security vocabulary and exact publication authority.
+6. Attempt WorkLedger last, after every simpler component has exercised the catalog and enforcement pattern.
+7. Run a final dependency and documentation audit; record any candidate intentionally left coupled.
+
+### Sources and Research
+
+- `lib/hive/attempts/api.rb`, `lib/hive/attempts/contracts.rb`, `test/unit/attempts/api_test.rb`, and `wiki/modules/attempts.md` define the existing admission-facade precedent.
+- `lib/hive/commands/service_installer/base.rb`, its three adapters, and `docs/solutions/architecture-patterns/cross-platform-service-installer-base-2026-05-27.md` record the successful base-first service extraction and the missed restart-warning hook.
+- `lib/hive/agent_profile.rb`, `lib/hive/agent_profiles.rb`, and `wiki/modules/agent_profile.md` define the documented provider contract and fail-closed capability behavior.
+- `lib/hive/protected_files.rb`, `lib/hive/secret_patterns.rb`, `wiki/modules/protected_files.md`, and `wiki/modules/secret_patterns.md` define the current custody and redaction guarantees.
+- `lib/hive/agent_skills/`, `config/agent-skills.yml`, and `wiki/commands/setup-agents.md` define canonical source, projections, provenance, preview revalidation, and atomic directory publication.
+- `lib/hive/managed_git.rb`, selected exact-OID behavior in `lib/hive/gh.rb`, and their tests define the current hostile-repository controller boundary.
+- `lib/hive/task_journal.rb`, `lib/hive/task_projection.rb`, `lib/hive/workflow.rb`, `lib/hive/workflows/`, `wiki/state-model.md`, and `wiki/modules/workflows.md` define the WorkLedger opportunity and its compatibility burden.
+- `docs/solutions/architecture-patterns/silent-stage-rename-state-drift.md` records why durable workflow names and producer compatibility cannot change silently.
+
+### System-Wide Impact
+
+- **Require graph:** Component entry points become supported load boundaries. The aggregate Hive load remains available, but component code must not depend on it to pull in unrelated constants accidentally.
+- **Construction ownership:** Commands, stages, daemon services, bot, and web stop constructing component internals. Dependency injection remains available at the facade for tests and host adapters.
+- **State lifecycle:** Attempts, WorkLedger, and any custody records continue using existing Hive roots and locks. No file migration occurs solely to improve directory shape.
+- **Long-running processes:** Daemon, bot, and web can run older loaded code against newer on-disk artifacts. Compatibility fixtures and actionable skew diagnostics remain mandatory.
+- **Agent operation:** Agents discover the same component map and workspace as humans. Read operations do not gain mutation authority, and destructive actions retain explicit approval or revalidation.
+- **Security posture:** Boundary enforcement reduces accidental coupling but is not runtime isolation. Artifact custody, agent capability truth, and Git hardening keep separate threat statements and tests.
+- **Documentation:** The wiki gains a catalog page during U1 and existing module pages gain consistent boundary sections as their components are migrated.
+
+### Risks and Mitigations
+
+| Risk | Mitigation or rejection signal |
+|---|---|
+| A facade merely wraps internals while still loading the whole application | Require clean-process load proof, catalog the actual dependency closure, and reject `boundary-ready` while unrelated commands/web/stages load. |
+| Behavior changes during class movement | Add characterization tests first, compare rendered bytes and messages, and test every relocated adapter hook directly. |
+| The catalog becomes unaudited prose | Back it with schema validation, path/entry-point checks, dependency-cycle checks, and direct-consumer enforcement. |
+| Dependency scanning creates false confidence | Describe it as architecture enforcement, keep runtime/security tests, and allow reviewed migration exceptions with expiry rather than claiming containment. |
+| Newer and older long-running processes disagree on files or schemas | Preserve historical fixtures, additive-read tolerance where already promised, and actionable restart/update errors for incompatible writes. |
+| UserService generalization expands to every init system | Scope the internal boundary to current systemd-user and launchd behavior; reject Windows/OpenRC work from this plan. |
+| Agent security seams collapse into one vague module | Keep Agent ABI, Artifact Firewall, and Safe Git contracts, names, threat statements, and tests separate. |
+| WorkLedger becomes generic machinery without a user | Expose only mechanics already demanded by Hive, preserve Hive formats as internal, and leave the component coupled if policy cannot be separated cleanly. |
+| A multi-component refactor becomes unreviewable | Enforce one component per PR, exact-head CI, and a clean handoff before the next component begins. |
+
+---
+
+## Implementation Units
+
+### U1. Establish the component catalog and enforcement harness
+
+- **Goal:** Make component ownership, entry points, dependencies, state, authority, consumers, and tests discoverable and machine-checkable.
+- **Requirements:** R1-R7, R14-R18; F1, F4; KTD1-KTD4, KTD6, KTD10-KTD11.
+- **Dependencies:** None.
+- **Files:** `config/component-boundaries.yml`, `test/unit/component_boundaries_test.rb`, `test/support/component_boundary_contract.rb`, `wiki/component-boundaries.md`, `wiki/index.md`, `wiki/testing.md`, `wiki/decisions.md`, `wiki/log.d/<timestamp>-component-boundary-contract.md`.
+- **Approach:** Define catalog states such as `candidate` and `boundary-ready`; validate required metadata, existing paths and entry points, unique ownership, acyclic dependencies, declared migration exceptions, clean-process loading, and forbidden upward requires. Use existing module wiki pages for narrative details and add the new catalog page to the wiki index.
+- **Patterns to follow:** `config/agent-skills.yml` and its manifest tests for machine-readable ownership; `test/unit/web/supervisor_test.rb` for a fresh-process require regression; `wiki/modules/attempts.md` for a concise facade/internal-collaborator description.
+- **Test scenarios:**
+  1. A valid Attempts catalog entry resolves its facade, contracts, owned paths, consumers, state/schema surfaces, and focused tests.
+  2. A missing entry point, duplicate owned path, unknown dependency, dependency cycle, or absent wiki page fails with the component ID and offending field.
+  3. A boundary-ready fixture that directly requires `Hive::Commands`, web, stages, or an undeclared component fails dependency enforcement.
+  4. A clean-process load reports the documented constant without loading Thor commands, web, stages, or unrelated candidate entry points.
+  5. A reviewed temporary exception must name its reason and removal unit; an unbounded exception fails validation.
+- **Verification:** Focused catalog tests pass, the wiki index count and links remain correct, and `bundle exec rake test` plus exact-head hosted CI pass before U2.
+
+### U2. Record Attempts as the reference boundary without widening it
+
+- **Goal:** Prove the catalog and enforcement against the already-landed `Hive::Attempts::API` and record which RunReceipt capabilities remain intentionally internal.
+- **Requirements:** R1-R13, R15-R17; F1, F4; AE1; KTD3, KTD5-KTD8.
+- **Dependencies:** U1.
+- **Files:** `config/component-boundaries.yml`, `lib/hive/attempts/api.rb`, `lib/hive/attempts/contracts.rb`, `test/unit/attempts/api_test.rb`, `test/unit/component_boundaries_test.rb`, `wiki/modules/attempts.md`, `wiki/component-boundaries.md`, `wiki/log.d/<timestamp>-attempts-boundary-catalog.md`.
+- **Approach:** Catalog admission as the supported facade and keep launcher, store, dispatcher, client, supervisor, reconciliation, capacity, and loss-policy classes internal. Enumerate durable record and schema ownership, shared store injection, and current Hive consumers. Do not add generic lifecycle, cancellation, export, or non-Hive command APIs merely to make the future RunReceipt idea look complete.
+- **Patterns to follow:** Existing `API` dependency injection and `Contracts` values; the module wiki's explicit statement that this is an in-monorepo seam, not a gem.
+- **Test scenarios:**
+  1. The API facade delegates foreground, queued, and successor admission through one injected store.
+  2. Consumers can interpret dispatch and client results without constructing dispatcher, launcher, client, or store collaborators.
+  3. The documented entry point loads cleanly and the catalog rejects a new direct production construction of an internal Attempts collaborator.
+  4. Existing v1/v2 record, lease, replay, and loss fixtures remain unchanged and readable.
+- **Verification:** Attempts API, store, client, dispatcher, and command-dispatch tests pass; the catalog test proves the reference boundary; broad local and hosted checkpoints are green.
+
+### U3. Extract UserService inspect, plan, apply, status, and remove behind one facade
+
+- **Goal:** Move platform-neutral per-user service mechanics below commands while preserving daemon, bot, web, setup, init, status, and global uninstall behavior.
+- **Requirements:** R1-R11, R14-R18; F1-F4; AE2-AE4; KTD3-KTD8, KTD11.
+- **Dependencies:** U2.
+- **Files:** New files under `lib/hive/user_service/` and `lib/hive/user_service.rb`; `lib/hive/commands/service_installer/{base,outcome,result_presenter}.rb`; `lib/hive/commands/{daemon,bot,web}/service_installer.rb`; service consumers in `lib/hive/commands/{daemon,bot,web,setup,init,uninstall}.rb` and `lib/hive/web/service_status.rb`; new tests under `test/unit/user_service/`; existing service-installer, command, setup, and web tests; `config/component-boundaries.yml`; relevant command wiki pages; `wiki/component-boundaries.md`; `wiki/testing.md`; `wiki/log.d/<timestamp>-user-service-boundary.md`.
+- **Approach:** First characterize current rendered units, lifecycle probes, result values, messages, backups, restart warnings, manager calls, and service removal. Introduce neutral definition and typed plan/status/result contracts; make inspect and plan side-effect-free; bind plans to content/path/manager observations; then place revalidated apply and remove behind the facade. Keep Hive templates, executable and install-channel resolution, service nouns, command messages, JSON envelopes, web environment, daemon drain warning, prompts, and global purge sequencing in adapters. Do not promise transactionality across the filesystem and service manager: return the final observed state, backup, and retry guidance after partial failure. Limit platforms to systemd user services and launchd.
+- **Patterns to follow:** The existing template-method base and its thin daemon/bot/web subclasses; the documented base-first extraction and direct hook coverage learning.
+- **Test scenarios:**
+  1. Linux and macOS definitions render byte-identically before and after migration for daemon, bot, and web.
+  2. Inspect and plan against absent, matching-disabled, matching-enabled-stopped, matching-running, drifted, manager-unavailable, and unsupported states perform no writes or mutating manager calls.
+  3. Apply is idempotent for matching content; refuses drift without force; creates a timestamped backup and atomically replaces on force; refuses a stale content/path/manager observation before mutation.
+  4. Linux reload/start/restart and macOS unload/load partial failures produce typed outcomes with the final observed state and preserve current messages without claiming rollback or success.
+  5. The daemon's 900-second restart warning, bot launchd crash-loop circuit breaker, web environment, WSL degradation, and corrupt-state teardown behavior retain direct tests.
+  6. Remove is idempotent, reports manager/file partial failure truthfully, and leaves Hive's multi-service uninstall ordering, prompts, and data purge outside the component.
+  7. Daemon, bot, web, setup, init, status, and uninstall use the facade or thin Hive adapters and no longer construct the former base directly.
+- **Verification:** New UserService tests and all existing installer/consumer tests pass, RuboCop passes on changed Ruby files, the clean-load/dependency checks pass, and the broad local plus hosted checkpoints are green.
+
+### U4. Stabilize the Agent ABI below Hive orchestration
+
+- **Goal:** Give every agent invocation one provider-neutral request/result contract while preserving the documented `AgentProfile` constructor and registry extension point.
+- **Requirements:** R1-R7, R10-R18; F1-F4; AE5; KTD5-KTD9, KTD11.
+- **Dependencies:** U3.
+- **Files:** `lib/hive/agent_profile.rb`, `lib/hive/agent_profiles.rb`, `lib/hive/agent_profiles/`, new policy-light contract files under `lib/hive/agent_runtime/` if needed, `lib/hive/agent.rb`, affected stage/reviewer/diagnosis/web consumers, agent profile and spawn tests under `test/unit/`, `config/component-boundaries.yml`, `wiki/modules/agent_profile.md`, `wiki/component-boundaries.md`, `wiki/testing.md`, `wiki/log.d/<timestamp>-agent-abi-boundary.md`.
+- **Approach:** Preserve existing profile registration while introducing explicit invocation request, compiled invocation, capability evidence, and observable result values. Move provider-specific argv, prompt transport, model/effort, version, capability, status, and usage behavior behind adapters incrementally. Keep process lifetime, workflow selection, retries, timeouts, artifact acceptance, and stage success policy in Hive.
+- **Patterns to follow:** Existing immutable profiles, optional constructor keywords, fail-closed capability probes, and current provider test matrices. Route `Hive::Agent` or the shared spawn base first, then reviewers, diagnosis, and UI consumers.
+- **Test scenarios:**
+  1. Existing custom profile construction continues to work without new required keywords.
+  2. Positional, stdin, and flag-value prompt styles compile the same argv and input as before for Claude, Codex, Pi, and Grok.
+  3. Unsupported headless, read-only, workspace-write, add-directory, model, effort, or named capability requests fail closed with typed evidence.
+  4. Version and capability probe timeouts terminate descendant process groups and return bounded redacted diagnostics.
+  5. Status evidence and usage extraction normalize into the observable result contract without moving stage success policy into the component.
+  6. Production consumers use the supported registry/runtime boundary and provider-name branches remaining above it are documented as policy rather than hidden ABI gaps.
+- **Verification:** Agent profile, provider, agent spawn, reviewer, diagnosis, and affected web tests pass; clean-load and dependency checks pass; broad local and hosted checkpoints are green.
+
+### U5. Build the Agent Artifact Firewall as an application-level custody boundary
+
+- **Goal:** Consolidate the existing protected-file, required-output, and redaction mechanics into a structured custody manifest and report used around Hive agent spawns.
+- **Requirements:** R1-R7, R9-R18; F1-F4; AE6; KTD5-KTD9, KTD11.
+- **Dependencies:** U4.
+- **Files:** `lib/hive/protected_files.rb`, `lib/hive/secret_patterns.rb`, new files under `lib/hive/artifact_firewall/`, nonce and output validation in affected stage classes, `lib/hive/stages/agent_worktree.rb`, protected-file, secret-pattern, execute, review, open-PR, and finalize tests, `config/component-boundaries.yml`, `wiki/modules/protected_files.md`, `wiki/modules/secret_patterns.md`, `wiki/component-boundaries.md`, `wiki/testing.md`, `wiki/log.d/<timestamp>-artifact-firewall-boundary.md`.
+- **Approach:** Define a policy-neutral manifest for protected anchors, permitted writable roots, required regular outputs, and an injectable redactor. Expose snapshot/capture, post-run validate, bounded report, and safe restore through one facade. Hive adapters decide which paths and outputs apply to a stage and how a failed report becomes a marker or stage result. State explicitly that the guarantee is same-user application-level custody, not OS sandboxing or transactional filesystem isolation.
+- **Patterns to follow:** Existing `ProtectedFiles` no-follow fingerprints, in-memory capture, atomic restore, structured stage failure paths, and `SecretPatterns` redaction.
+- **Test scenarios:**
+  1. Add, change, delete, symlink substitution, directory substitution, mode change, and unchanged protected anchors produce the correct typed custody report.
+  2. Missing, empty, symlinked, non-regular, or outside-root required outputs fail acceptance.
+  3. Safe restoration recreates missing/changed regular files atomically; unreconstructable or failed restoration reports failure without recursive deletion or false success.
+  4. Reports and bounded diagnostics redact credentials, capability values, prompts, and unrestricted environment data.
+  5. Execute, review, open-PR, and finalize consumers supply stage policy through adapters and receive equivalent current markers/outcomes.
+- **Verification:** Firewall, protected-file, secret-pattern, and affected stage tests pass; clean-load and dependency checks pass; broad local and hosted checkpoints are green.
+
+### U6. Boundary Skillpack around canonical compilation and atomic projection
+
+- **Goal:** Expose deterministic render, inspect, plan, and apply operations for canonical agent skills while Hive's skill remains the first source and consumer.
+- **Requirements:** R1-R11, R14-R18; F1-F4; AE7; KTD5-KTD8, KTD10-KTD11.
+- **Dependencies:** U5.
+- **Files:** `lib/hive/agent_skills.rb`, `lib/hive/agent_skills/`, `config/agent-skills.yml`, tests under `test/unit/agent_skills/`, setup-agents command and packaging tests, `config/component-boundaries.yml`, `wiki/commands/setup-agents.md`, `wiki/component-boundaries.md`, `wiki/testing.md`, `wiki/log.d/<timestamp>-skillpack-boundary.md`.
+- **Approach:** Separate canonical source and platform projection/publisher mechanics from Hive configuration and workflow surface resolution. Keep one adapter registry for OpenClaw, Claude, Codex, and Pi; keep inspect and plan non-mutating; require preview revalidation before apply; retain private staging, foreign/symlink/mode refusal, complete-directory atomic swap, provenance, and rollback behavior. Do not design a generic marketplace, signature system, or OCI distribution protocol.
+- **Patterns to follow:** Existing manifest, adapter, filesystem inventory, directory publisher, inspector, provisioner, and exact packaged projection tests.
+- **Test scenarios:**
+  1. One canonical fixture renders deterministic platform projections and provenance manifests for all four supported agents.
+  2. Inspect and plan report missing, matching, drifted, foreign, symlinked, and invalid-mode destinations without mutation.
+  3. Apply revalidates the preview, stages privately, swaps the whole directory atomically, and rolls back or preserves the prior tree on failure.
+  4. Hive configuration resolves targets above the facade while compiler/publisher tests run without Hive workflow or stage loading.
+  5. Packaged Hive projections remain byte-identical to the canonical Hive skill and include every manifest-declared file.
+- **Verification:** All agent-skill, setup-agents, manifest, and packaging contract tests pass; clean-load and dependency checks pass; broad local and hosted checkpoints are green.
+
+### U7. Boundary the Safe Agent Git Gate around a narrow authority vocabulary
+
+- **Goal:** Expose hardened repository reads, exact materialization, and expected-OID publication with a structured receipt, without extracting all of `Hive::Gh`.
+- **Requirements:** R1-R13, R14-R18; F1-F4; AE8; KTD5-KTD11.
+- **Dependencies:** U6.
+- **Files:** `lib/hive/managed_git.rb`, selected behavior in `lib/hive/gh.rb`, new files under `lib/hive/agent_git_gate/`, draft-PR handoff and refactor-patrol publication consumers, managed Git/GitHub/handoff/bare-remote tests, `config/component-boundaries.yml`, relevant Git and PR wiki pages, `wiki/component-boundaries.md`, `wiki/testing.md`, `wiki/log.d/<timestamp>-safe-agent-git-boundary.md`.
+- **Approach:** Keep the supported vocabulary small: hardened reads, immutable remote object materialization, exact expected-OID publication, and a receipt. Inject credential and transport policy; keep GitHub PR workflow, branch naming, configuration lookup, and approval policy in Hive. Preserve hooks/fsmonitor/diff/helper/transport neutralization and durable action authority. Describe the boundary as hardening, not complete Git or OS confinement.
+- **Patterns to follow:** `ManagedGit` command and environment allowlists, exact `--force-with-lease` behavior, immutable worktree materialization, and real bare-remote tests.
+- **Test scenarios:**
+  1. Allowed operations neutralize hostile hooks, helpers, textconv/diff drivers, fsmonitor, pager/help dispatch, and forbidden transports.
+  2. Unknown commands, unsafe options, absolute-path escapes, undeclared environment, and repository-controlled executable helpers fail closed.
+  3. Materialization binds the expected remote and immutable object ID; ref movement after observation cannot silently change the checkout.
+  4. Publication succeeds only when the remote branch still matches the expected object ID and records the before/after identity in a typed receipt.
+  5. Credentials and GitHub policy are injected by Hive and never appear in reports or component-owned persistent state.
+- **Verification:** Managed Git, GitHub wrapper, worktree/handoff, publication, and bare-remote integration tests pass; clean-load and dependency checks pass; broad local and hosted checkpoints are green.
+
+### U8. Isolate WorkLedger mechanics last without publishing a public disk format
+
+- **Goal:** Separate descriptor structure and durable journal storage/replay mechanics from Hive workflow, condition, task-path, transition, Git, and migration policy.
+- **Requirements:** R1-R18; F1-F4; AE9; KTD5-KTD8, KTD10-KTD11.
+- **Dependencies:** U7.
+- **Files:** `lib/hive/task_journal.rb`, `lib/hive/task_projection.rb`, `lib/hive/task_projection/store.rb`, `lib/hive/workflow.rb`, `lib/hive/workflows/`, new policy-light files under `lib/hive/work_ledger/` if the boundary holds, journal/projection/workflow/condition/integration tests, historical fixtures, `config/component-boundaries.yml`, `wiki/state-model.md`, `wiki/modules/workflows.md`, `wiki/component-boundaries.md`, `wiki/testing.md`, `wiki/gaps.md`, `wiki/log.d/<timestamp>-work-ledger-boundary.md`.
+- **Approach:** First split structural descriptor parsing from Hive semantic validation, then split append durability and replay plumbing from Hive event validation and projection rules. Preserve current journal and projection formats as Hive-owned compatibility contracts; do not label them public WorkLedger formats. Keep task folders, condition vocabulary, coding/content/bench policies, Git commits, stage moves, legacy migrations, and operational status above the facade. Abandon the boundary cleanly if the mechanism cannot be isolated without inventing a generic product model.
+- **Patterns to follow:** `TaskJournal::Validator` and writer durability, `TaskProjection` replay, canonical workflow descriptors with derived legacy projections, project overlay synchronization, and direct migration maps.
+- **Test scenarios:**
+  1. Structural descriptors reject malformed identities, duplicate or gapped stages, and invalid topology without loading Hive coding policy.
+  2. Append operations are locked, fsynced, idempotent, and rolled back after partial writes; conflicting idempotency keys fail closed.
+  3. v1/v2 and legacy fixtures replay to equivalent current Hive projections without source rewriting.
+  4. Project overlays remain require-order independent and cannot silently shadow built-ins or leak between projects/tests.
+  5. Direct old-to-current migration maps preserve durable stages and producer warnings; a silent stage rename remains a failing regression.
+  6. Hive conditions, task paths, transitions, Git actions, and operational status remain outside the mechanism and continue to pass integration tests.
+- **Verification:** Focused journal, projection, workflow, condition, migration, and integration tests pass; clean-load and dependency checks pass; broad local and hosted checkpoints are green. If the seam is rejected, the reverted experiment and documented coupling are the passing result for this unit.
+
+### U9. Audit the complete internal boundary graph
+
+- **Goal:** Confirm the monorepo now has honest component boundaries and a current map for agents and future packaging decisions.
+- **Requirements:** R1-R18; F4; KTD1-KTD11.
+- **Dependencies:** U1-U8 complete or explicitly rejected with evidence.
+- **Files:** `config/component-boundaries.yml`, `test/unit/component_boundaries_test.rb`, `wiki/component-boundaries.md`, `wiki/index.md`, affected module pages, `wiki/gaps.md`, `wiki/log.d/<timestamp>-component-boundary-audit.md`.
+- **Approach:** Re-run the graph, clean-load, direct-consumer, state/schema, and documentation audits. Remove expired migration exceptions and dead experimental code. Record which components are boundary-ready, which remain candidates, and the exact reason for any rejection. Do not convert readiness into a publication commitment.
+- **Test scenarios:**
+  - **Test expectation: none —** this unit changes no runtime behavior; any discovered boundary defect returns to the owning unit and its focused test scenarios.
+- **Verification:** Catalog validation, all component clean-load checks, `bundle exec rake test`, RuboCop for changed files, and exact-head hosted CI pass; the wiki and catalog agree and the working tree contains no abandoned extraction code.
+
+---
+
+## Verification Contract
+
+| Gate | Applicability | Command or evidence | Passing signal |
+|---|---|---|---|
+| Component catalog | Every unit | `bundle exec ruby -Itest -Ilib test/unit/component_boundaries_test.rb` | Catalog schema, paths, ownership, dependency DAG, clean loads, and forbidden edges pass. |
+| Attempts | U2 and later graph audits | `bundle exec ruby -Itest -Ilib test/unit/attempts/api_test.rb` plus affected Attempts tests | Admission delegation, contracts, shared store, durable compatibility, and direct-consumer rules pass. |
+| UserService | U3 | New `test/unit/user_service/` tests plus existing service-installer, daemon, bot, web, setup, init, and uninstall tests | Rendering, inspection, planning, apply, outcomes, messages, adapters, and teardown remain compatible. |
+| Agent ABI | U4 | Agent profile, provider, spawn, reviewer, diagnosis, and affected web tests | Provider requests/results normalize honestly and unsupported guarantees fail closed. |
+| Artifact Firewall | U5 | Firewall, protected-file, secret-pattern, and affected stage tests | Custody, required outputs, restoration, redaction, and stage integration pass. |
+| Skillpack | U6 | `test/unit/agent_skills/` plus setup-agents and packaged projection contract tests | Canonical projections, provenance, preview/apply, atomic publication, and packaged bytes pass. |
+| Safe Git Gate | U7 | Managed Git, GitHub, worktree/handoff, publication, and bare-remote tests | Hostile configuration is neutralized and exact-OID authority is enforced. |
+| WorkLedger | U8 | Task journal, task projection, workflow, condition, migration, and relevant integration tests | Durable append/replay, overlays, compatibility fixtures, and Hive policy separation pass. |
+| Style | Every behavior-changing PR | `bundle exec rubocop <changed-ruby-and-test-files>` | No new style violations in the changed surface. |
+| Broad local checkpoint | Once before each component PR handoff | `bundle exec rake test` | The default local suite passes without running exhaustive coverage or CI-only merge gates. |
+| Hosted integration | Every component PR | Exact-head GitHub Actions checks | All required hosted checks are green on the reviewed head before the next component begins. |
+| Documentation | Every component PR | Wiki link/catalog checks and one new `wiki/log.d/` fragment | Component catalog, owning module pages, testing guidance, and log fragment match the code; compiled `wiki/log.md` is untouched. |
+
+---
+
+## Definition of Done
+
+- The monorepo remains the canonical development and release repository, with no package split or repository split.
+- `config/component-boundaries.yml` and `wiki/component-boundaries.md` give agents one current map of supported entry points, public contracts, dependencies, state/schema ownership, consumers, authority, maturity, and tests.
+- Attempts is recorded as the reference admission boundary without speculative lifecycle API expansion.
+- UserService, Agent ABI, Agent Artifact Firewall, Skillpack, and Safe Agent Git Gate are consumed by Hive only through their supported boundaries and retain their documented compatibility and security guarantees.
+- WorkLedger either reaches an honest policy-light internal boundary or is explicitly retained as coupled with the failed experiment removed and the blocking coupling documented.
+- Every boundary-ready component passes clean-process loading, dependency-direction enforcement, direct-consumer enforcement, focused component tests, the broad local checkpoint, and exact-head hosted CI.
+- Ruby APIs, CLI JSON envelopes, persisted workspace schemas, and service/host artifacts remain compatible or carry separately approved migration evidence.
+- Read-only operations remain non-mutating, mutation authority remains explicit and stale-safe, long-running state remains reconnectable, and diagnostics remain typed, bounded, and redacted.
+- Existing module wiki pages and the component catalog are current, every behavior-changing PR has a `wiki/log.d/` fragment, and no `.context.md` shadow documentation or compiled-log edit was added.
+- No abandoned abstraction, duplicate implementation, expired migration exception, dead compatibility shim, or unrelated workspace change remains.
+- No gem name or namespace was chosen, no package directory or gemspec was added, no version was selected or changed, and no tag, publication, release, deployment, or merge was performed by this plan.

--- a/docs/plans/2026-07-25-002-feat-standalone-component-gems-plan.md
+++ b/docs/plans/2026-07-25-002-feat-standalone-component-gems-plan.md
@@ -1,0 +1,471 @@
+---
+title: Standalone Component Gems - Plan
+type: feat
+date: 2026-07-25
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-plan-bootstrap
+execution: code
+deepened: 2026-07-25
+---
+
+# Standalone Component Gems - Plan
+
+## Goal Capsule
+
+- **Objective:** Package and eventually publish only Hive components that have already proven a stable internal boundary and concrete value outside Hive, while retaining one canonical monorepo.
+- **Authority:** `docs/plans/2026-07-25-001-refactor-internal-component-boundaries-plan.md` is a prerequisite. This plan may prepare an exact release candidate, but selecting a public gem name or version, registering ownership, merging a coordinated cutover, tagging, publishing, yanking, releasing Hive, or deploying requires a separate explicit user decision at the named gate.
+- **Execution profile:** Qualify one candidate at a time; land its self-contained package without changing the released Hive dependency graph; prove a stacked Hive dogfood cutover; build and install exact artifacts; then stop at an unpublished release-ready checkpoint unless publication authority is supplied.
+- **Stop condition:** A candidate that lacks non-Hive demand, an independent contract, clean loading, downward dependencies, compatibility ownership, isolated artifact proof, or a maintainer remains internal. That is a successful gate outcome, not a failed plan.
+- **Tail ownership:** Under the authority available from this plan alone, finish at a reviewed, reproducible, unpublished component candidate and a held Hive cutover. With a later explicit release instruction, publish and remotely verify the component first, then land Hive's dependency cutover in a separate PR. Never select a version or trigger public distribution implicitly.
+
+---
+
+## Product Contract
+
+### Summary
+
+Operate a Rails-style multi-gem Ruby monorepo without turning Hive into a collection of repositories or an automatic multi-package release train.
+Each published component remains developed beside Hive, has independent package metadata and versioning, and is consumed from its monorepo path during development.
+Released `hive-cli` artifacts depend on the already-published component version normally, and release proof installs the exact built gems rather than trusting source-checkout load paths.
+
+This plan does not promise that every internally clean component becomes a gem.
+It defines the evidence and release choreography that let one genuinely valuable component cross the package boundary safely.
+
+### Problem Frame
+
+The original extraction analysis found seven retained opportunities:
+
+| Product-value rank | Candidate | Standalone value | Current extraction posture |
+|---|---|---|---|
+| 1 | RunReceipt | Durable local commands, leases, streams, recovery, and terminal receipts without a server | Strongest product; highest subsystem extraction cost |
+| 2 | UserService | Safe plan/apply/status/remove for systemd-user and launchd services | Safest first internal boundary |
+| 3 | Agent Artifact Firewall | Artifact custody and bounded attestation around untrusted agent spawns | Differentiated; security contract still scattered |
+| 4 | Agent ABI | Provider-neutral contract for installed headless agent CLIs | Coherent profile seam; provider churn |
+| 5 | Skillpack | One canonical skill projected safely to multiple agent ecosystems | Coherent mechanism; generic author schema unproven |
+| 6 | Safe Agent Git Gate | Hardened Git operations and exact-object publication authority | Real security need; high maintenance burden |
+| 7 | WorkLedger | Human-readable folder workflows with an append-only evidence ledger | Deepest idea; least ready and most policy-coupled |
+
+Product rank must not become a publication schedule.
+RunReceipt can remain the most valuable idea while UserService is easier to boundary, and either can remain internal if no adopter appears.
+
+Ruby and Bundler already support multiple gemspecs and filesystem path dependencies inside one repository.
+The hard problem is not repository layout; it is preventing a path-resolved development checkout from masquerading as a publishable artifact, and preventing an unpublished component dependency from making the released Hive gem uninstallable.
+
+### Actors
+
+- A1. Hive maintainers need one checkout, one issue and PR history, and one integration suite across every component.
+- A2. Component maintainers need self-contained package tests, documentation, versioning, security ownership, and an explicit release path.
+- A3. Hive contributors and agents need local path dependencies so changes to a component and Hive can be developed and reviewed together.
+- A4. Non-Hive adopters need a normal RubyGems install, one documented require path, direct dependencies, SemVer compatibility, and no hidden `hive-cli` runtime dependency.
+- A5. Release operators need an exact-commit, build-once, install-tested, approval-gated publication chain that cannot trigger Hive's root release by accident.
+- A6. Existing Hive operators need the same workspace, persisted state, schemas, services, and behavior through the package cutover.
+
+### Requirements
+
+**Qualification**
+
+- R1. A candidate is eligible only after its entry in `config/component-boundaries.yml` is `boundary-ready`, all production Hive consumers use the supported facade, and the internal-boundary plan's clean-load, dependency, compatibility, and integration gates pass.
+- R2. Record concrete non-Hive demand: a named adopter, issue, integration, or maintained prototype that uses the boundary for a real job. Hypothetical reuse, a tidy directory, or an internal maintainer preference is insufficient.
+- R3. Record the independent user journey, public Ruby surface, library-versus-CLI decision, supported Ruby and OS matrix, persistence and migration ownership, security posture, maintainer, and maintenance/release burden before choosing a public package identity.
+- R4. Qualification has three honest terminal results: `package-ready`, `deferred-no-demand`, and `deferred-coupled-to-hive`. A deferred result leaves the component internal without creating empty packaging infrastructure.
+- R5. Candidate selection follows current evidence at qualification time; this plan does not preselect UserService, RunReceipt, or any other ranked candidate.
+
+**Monorepo package shape**
+
+- R6. Keep the component in the Hive repository under `components/<gem-name>/` only after it reaches `package-ready`. The package owns its gemspec, `lib/`, tests, README, changelog, license metadata, schemas/templates/assets, and optional executable.
+- R7. Use one documented require path and a neutral public namespace chosen at qualification. The package must not require `hive-cli`, `require "hive"`, Hive commands, stages, web code, task/config/schema constants, or Hive release metadata.
+- R8. Declare every direct runtime dependency in the component gemspec. Do not rely on dependencies arriving transitively or as default gems.
+- R9. Default to a library gem. Add a CLI only when the external operator journey is independently valuable and its argv, exit-status, structured-output, mutation, recovery, and approval contracts are specified and tested.
+- R10. Give each published component independent SemVer and a component changelog. Do not force all packages to share `Hive::VERSION`, and do not add a monorepo package registry or release framework until at least two real gems demonstrate the need.
+
+**Hive dogfood and cutover**
+
+- R11. Develop Hive against the component through a Bundler path dependency while `hive.gemspec` declares a normal compatible released dependency for built Hive artifacts. Update both `Gemfile.lock` and `web/Gemfile.lock` when the real dependency lands.
+- R12. The component package PR and Hive cutover PR remain separate. The package may land without changing Hive's released dependency graph; the cutover remains stacked or held until the component version is publicly available and remotely verified.
+- R13. Temporary duplication between the internal implementation and the package is allowed only across the coordinated publication window, with parity tests and an explicit removal unit. Main must never contain two independently evolving authoritative implementations.
+- R14. Hive and the component use the same state root, records, locks, schemas, service files, and compatibility fixtures. Packaging does not copy durable state or silently migrate it.
+- R15. Path-selected component tests are fast feedback only. Every package or cutover PR still runs the complete relevant Hive integration gate and exact-head hosted CI.
+
+**Artifact and release proof**
+
+- R16. Build the component gem once from an expected protected-main commit and inspect its file manifest, metadata, require path, direct dependencies, executables, schemas, templates, and license/readme/changelog inventory.
+- R17. Install the exact built gem into a clean gem home with no repository load path, no Hive gem, and no Bundler path source; exercise its public library API and CLI when present on the supported Ruby, Linux, and macOS matrix.
+- R18. Prove Hive against the exact built component artifact as well as the development path dependency. Lowest and highest compatible dependency versions must follow the declared compatibility policy.
+- R19. Component publication uses a separate protected tag namespace such as `components/<gem-name>/vX.Y.Z` and a component-specific workflow. It must not match `.github/workflows/release.yml`'s root `v*.*.*` trigger.
+- R20. Path changes may trigger tests but never publication. Publication requires an expected commit, explicitly selected package and version, protected tag or equivalent approval-bearing trigger, package-scoped credentials or trusted publishing, and the already-proven artifact.
+- R21. Publish the exact candidate bytes; do not rebuild between verification and publication. After RubyGems accepts the version, it is immutable: a later failure fixes forward, and yanking requires a separate explicit emergency decision.
+- R22. Remote verification installs the published version from RubyGems in a fresh environment and repeats the public require/CLI smoke plus checksum and metadata checks before the component is considered released.
+- R23. A Hive release may consume the new dependency only after R22 passes. Component publication and the later Hive version/tag/release remain separate explicit decisions.
+
+**Documentation and authority**
+
+- R24. Add component development and release instructions, package-specific changelog rules, compatibility/deprecation policy, rollback guidance, and one wiki log fragment per behavior-changing PR. Do not edit compiled `wiki/log.md`.
+- R25. Choosing or registering the public gem name, selecting a version, changing a public compatibility promise, merging the coordinated cutover, creating or pushing a tag, publishing, yanking, transferring ownership, or releasing Hive stays human-authorized.
+- R26. Execution without R25 authority stops at the release-ready checkpoint with no public or irreversible side effect.
+
+### Key Flows
+
+- F1. **Qualify or defer a candidate**
+  - **Trigger:** An internal component appears useful outside Hive.
+  - **Actors:** A1-A4.
+  - **Steps:** Verify the internal boundary; collect demand; define the external journey and compatibility/security ownership; assess maintenance burden; record `package-ready` or a concrete deferral reason.
+  - **Outcome:** One candidate advances, or it remains internal without packaging scaffolding.
+  - **Covered by:** R1-R5.
+- F2. **Prepare the package and stacked Hive cutover**
+  - **Trigger:** A candidate reaches `package-ready` and its public identity is explicitly approved.
+  - **Actors:** A1-A4, A6.
+  - **Steps:** Create the self-contained component package; keep the package-only PR safe for Hive releases; prepare a separate stacked Hive path-dependency cutover; prove parity, shared state, and compatibility; hold the cutover.
+  - **Outcome:** The package can land and be published without making `hive-cli` depend on an unavailable gem.
+  - **Covered by:** R6-R15.
+- F3. **Build and prove an exact candidate**
+  - **Trigger:** The package PR is on an expected commit.
+  - **Actors:** A2, A5.
+  - **Steps:** Build once; inspect; install in clean environments; exercise public behavior; run Hive against the same artifact; save checksums and provenance.
+  - **Outcome:** An unpublished candidate is release-ready, or the package returns to implementation without registry mutation.
+  - **Covered by:** R16-R18, R24-R26.
+- F4. **Publish the component with explicit authority**
+  - **Trigger:** The user approves the public gem name, exact version, expected protected-main commit, and publication.
+  - **Actors:** A2, A5.
+  - **Steps:** Merge the package-only PR; create the component-scoped protected tag; verify tag/metadata/commit identity; publish the previously proven bytes; install from RubyGems; verify remote metadata and behavior.
+  - **Outcome:** `remotely-verified`, or `registry-published-fix-forward` if post-publication proof fails.
+  - **Covered by:** R19-R22, R25.
+- F5. **Cut Hive over after publication**
+  - **Trigger:** The component version is remotely verified.
+  - **Actors:** A1, A3, A6.
+  - **Steps:** Rebase the held cutover; use the local path for development and the published compatible dependency for built artifacts; remove the internal duplicate; update both lockfiles; rerun artifact and full Hive integration proof; merge separately.
+  - **Outcome:** Hive consumes the published gem while the monorepo remains the canonical development workspace.
+  - **Covered by:** R11-R15, R18, R23-R25.
+
+### Acceptance Examples
+
+- AE1. Given a boundary-ready component with no named non-Hive adopter or maintained prototype, when qualification runs, then the result is `deferred-no-demand` and no `components/` directory, gemspec, or public name is created.
+- AE2. Given a component that loads only after `require "hive"` or imports Hive commands/stages, when qualification runs, then the result is `deferred-coupled-to-hive` even if its focused tests pass.
+- AE3. Given a package-ready candidate, when its package-only PR lands before publication, then current `hive-cli` releases remain installable because `hive.gemspec` has not yet gained the unpublished dependency.
+- AE4. Given a stacked Hive cutover before publication, when CI runs, then Bundler resolves the component by path for development and exact-artifact tests install the locally built component before the Hive candidate; the cutover remains unmergeable.
+- AE5. Given a built component gem, when it is installed into a fresh gem home without the repository or `hive-cli`, then its documented require path and standalone behavior work and every required schema/template is present.
+- AE6. Given a changed component path, when normal CI runs, then focused package tests may be selected but no tag, RubyGems push, GitHub release, or Hive release begins.
+- AE7. Given a component tag `components/example/v1.2.3`, when GitHub evaluates workflows, then the component workflow validates it and Hive's root `v*.*.*` release workflow does not run.
+- AE8. Given no explicit publication instruction or selected version, when the candidate workflow completes, then it stores proof artifacts and stops without creating a tag or contacting RubyGems publication endpoints.
+- AE9. Given RubyGems has accepted a version but the remote-install smoke fails, when the release is handled, then the version is not overwritten or silently yanked; the maintainer records the state and prepares a fix-forward release.
+- AE10. Given the component is remotely verified, when the Hive cutover lands, then source development uses the monorepo path, built `hive-cli` declares the released dependency, both lockfiles are current, and the duplicate internal implementation is gone.
+
+### Success Criteria
+
+- At most one candidate is packaged per execution of this plan, and it passed every qualification gate using current evidence.
+- The component is self-contained, independently installable, directly documented, and free of upward Hive dependencies.
+- Hive path dogfood and exact built-artifact integration both pass against the same public contract and shared state.
+- The component release trigger cannot activate Hive's release workflow, and ordinary path changes cannot publish.
+- Without separate release authority, the terminal state is a proven unpublished candidate and held cutover.
+- With separate release authority, the exact component bytes are remotely verified before Hive's dependency cutover or release.
+
+### Scope Boundaries
+
+**Included**
+
+- Qualification and deferral criteria for all seven retained candidates.
+- One component package under `components/`.
+- Independent gemspec, version file, changelog, documentation, tests, assets, and optional CLI.
+- Path-based monorepo development, exact artifact proof, component-scoped release automation, and a coordinated Hive cutover.
+
+**Deferred until a second real gem**
+
+- A generalized component registry, dependency graph tool, release orchestrator, shared version command, or multi-package changelog system.
+- Cross-component automated release ordering.
+
+**Outside this plan**
+
+- Separate repositories, Git submodules, vendored source copies as a permanent architecture, or npm-oriented monorepo tools.
+- Publishing every retained candidate, synchronizing all package versions, or promising a public extraction roadmap.
+- Auto-publishing based on path changes.
+- A new external composition framework combining RunReceipt, Agent ABI, and Artifact Firewall.
+- Choosing a public name, namespace, version, or registry owner in advance of the qualification and authority gates.
+
+---
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- KTD1. **Keep one canonical monorepo.** (session-settled: user-approved — chosen over one repository per gem because integrated investigation, cross-component changes, and agent navigation are more valuable than repository-level isolation.)
+- KTD2. **Publish only after a proven internal boundary.** (session-settled: user-approved — chosen over package-first extraction because a gem must expose a real contract rather than relocate accidental Hive coupling.)
+- KTD3. **Keep Hive as the primary dogfood consumer.** (session-settled: user-directed — chosen over an external-first rewrite because Hive provides the first compatibility and integration pressure.)
+- KTD4. **Use explicit releases, never path-change publication.** (session-settled: user-approved — chosen over automatic selective publishing because version choice and public registry mutation require deliberate authority.)
+- KTD5. **Do not preselect the first gem.** Qualification re-evaluates demand, coupling, risk, and ownership. Internal readiness and standalone value remain different rankings.
+- KTD6. **Create `components/<gem-name>/` only after qualification.** This keeps package-owned code, tests, metadata, and assets together without creating an empty framework before a real component exists.
+- KTD7. **Give components independent SemVer.** `hive-cli` declares a compatible range; components do not inherit `Hive::VERSION` or require synchronized releases.
+- KTD8. **Use a package-first, publish-first, cutover-last choreography.** Land the self-contained package without changing Hive's released dependency graph, publish and remotely verify it, then land Hive's dependency cutover. This avoids a period where released Hive cannot install.
+- KTD9. **Dogfood both the path and the exact artifact.** Bundler path resolution keeps monorepo development fast, while clean gem installation catches missing files, undeclared dependencies, and repository-only assumptions.
+- KTD10. **Build once and publish the proven bytes.** Component release follows Hive's exact-candidate discipline but uses its own workflow, tag namespace, artifact, and registry credentials.
+- KTD11. **Default to a library gem.** A CLI is earned by a complete independent operator flow; it is not added merely because Hive is a CLI.
+- KTD12. **Delay package-management infrastructure until two packages need it.** One real package uses explicit Rake/workflow targets; duplication pressure from a second package justifies a registry or shared release helper.
+- KTD13. **Treat public registry mutation as human-only.** Candidate automation may build, inspect, install, and attest. Name registration, version selection, tags, publication, yanking, ownership transfer, Hive release, and destructive migration remain explicit operator actions.
+
+### High-Level Technical Design
+
+```mermaid
+flowchart TB
+  B[Boundary-ready Hive component] --> Q{Demand and qualification gates pass?}
+  Q -->|no| D[Remain internal with deferral reason]
+  Q -->|yes| P[Package-only PR under components]
+  P --> C[Exact component candidate]
+  C --> G{Explicit name, version, commit, and publish authority?}
+  G -->|no| H[Stop release-ready and unpublished]
+  G -->|yes| R[Merge package, protected component tag, publish exact bytes]
+  R --> V[Remote RubyGems install verification]
+  V --> X[Separate Hive cutover PR]
+  X --> Y[Path dependency for development and released dependency for artifacts]
+```
+
+The safe dependency transition uses two pull requests:
+
+1. **Package PR:** introduces the self-contained component, release tests, and component workflow without changing `hive.gemspec` to depend on an unpublished gem.
+2. **Hive cutover PR:** dogfoods the component by path, declares the normal compatible runtime dependency, preserves any forwarding compatibility surface, deletes the former internal implementation, and updates both lockfiles. It stays stacked or held until the component is remotely verified.
+
+The package and Hive use one public contract and one shared compatibility fixture set.
+Temporary implementation duplication is bounded to this release window and protected by parity tests; it is never accepted as the final state.
+
+### Qualification Matrix
+
+| Gate | Required evidence | Failure state |
+|---|---|---|
+| Internal boundary | `boundary-ready` catalog entry and all Hive callers behind the facade | `deferred-coupled-to-hive` |
+| External demand | Named adopter, issue, integration, or maintained non-Hive prototype | `deferred-no-demand` |
+| Independent journey | Library or CLI use case with success, error, mutation, and recovery behavior | `deferred-no-demand` |
+| Clean load | Public require works without Hive aggregate or upward constants | `deferred-coupled-to-hive` |
+| Dependency direction | `hive-cli -> component`, never component -> Hive | `deferred-coupled-to-hive` |
+| Compatibility ownership | Public API, persisted format, migration, SemVer, deprecation, Ruby/OS policy | `deferred-coupled-to-hive` |
+| Artifact proof | Built-gem inventory, clean install, standalone smoke, Hive integration | Return to implementation |
+| Maintenance ownership | Named maintainer and release/security response commitment | `deferred-no-demand` |
+
+### Release State Model
+
+```text
+internal
+  -> package-ready
+  -> candidate-proven
+  -> publication-authorized
+  -> registry-published
+  -> remotely-verified
+  -> hive-cutover-merged
+```
+
+`deferred-no-demand` and `deferred-coupled-to-hive` are terminal qualification states.
+Before `registry-published`, failures repair or revert without public side effects.
+After `registry-published`, the version is immutable and failures move to a fix-forward state.
+`remotely-verified` is required before Hive's cutover may merge or a Hive release may consume the dependency.
+
+### Sequencing
+
+1. Run qualification and stop immediately on an honest deferral result.
+2. Obtain explicit approval for the public identity before creating package metadata.
+3. Build the package-only PR and the separately held Hive cutover.
+4. Add exact artifact and release-workflow proof.
+5. Reach the unpublished release-ready checkpoint.
+6. Continue only after explicit package/version/commit/publication authority.
+7. Merge and publish the package; remotely verify RubyGems.
+8. Rebase, verify, and merge the Hive cutover; any later Hive version/tag/release is a separate decision.
+
+### Sources and Research
+
+- `docs/plans/2026-07-25-001-refactor-internal-component-boundaries-plan.md` defines the prerequisite internal contract.
+- `hive.gemspec`, `Gemfile`, `Gemfile.lock`, `web/Gemfile`, and `web/Gemfile.lock` define Hive's current single-gem dependency and packaged-install surfaces.
+- `docs/RELEASING.md` and `.github/workflows/release.yml` provide the build-once, exact-candidate, native install, explicit tag, and no-rebuild publication precedent.
+- `wiki/decisions.md` ADR-031 and `wiki/modules/digest.md` record PRDigest as the existing dependency-first externalization precedent: the standalone package is the engine and Hive remains the adapter.
+- Bundler's official Gemfile reference documents multiple gemspecs in one repository, filesystem `path` dependencies, and the `path 'components'` block: `https://bundler.io/v4.0/man/gemfile.5.html`.
+- RubyGems' official publishing guide defines the normal gem build and push surface: `https://guides.rubygems.org/publishing/`.
+- `hive.gemspec` comments record why direct runtime dependencies and installed-gem file inventories are required instead of relying on source checkout or transitive/default gems.
+
+### System-Wide Impact
+
+- **Repository layout:** The root remains authoritative for shared CI, issues, wiki, and integration. A component owns only its package subtree and referenced shared fixtures.
+- **Dependency resolution:** Development favors the component path; built and remote Hive artifacts use the published dependency. Tests must make the selected source visible so path and artifact proof cannot be confused.
+- **Release topology:** Root `vX.Y.Z` remains exclusively Hive's release trigger. Component tags and workflows are namespaced, independently protected, and separately credentialed.
+- **Lockfiles:** A real Hive cutover changes the root and web lockfiles. Package-only work must not leave locks pointing at an unpublished dependency on main.
+- **Persistent state:** Packaging changes code ownership, not state ownership by fiat. Shared state roots, schema versions, migrations, and older-process behavior stay compatible through the cutover.
+- **Security:** RubyGems credentials or trusted publishing apply only to the selected package workflow. Candidate jobs have read-only registry posture and cannot publish.
+- **Agents:** Agents continue navigating one repo, use package-local README/tests for focused work, and use root wiki/integration tests for cross-component behavior. Nested agent instructions are added only if package workflows materially differ.
+- **Support:** A published component creates a real compatibility and vulnerability-response obligation independent of Hive's release cadence.
+
+### Risks and Mitigations
+
+| Risk | Mitigation or rejection signal |
+|---|---|
+| A neat internal seam is mistaken for market demand | Require a named adopter, issue, integration, or maintained prototype and accept `deferred-no-demand`. |
+| Path tests hide missing files or dependencies | Install the exact built gem in a clean gem home with no repo path or Hive gem, inspect the file manifest, and declare all direct dependencies. |
+| Hive main depends on an unpublished gem | Land package-only first, hold the separate cutover, remotely verify publication, then merge the dependency change. |
+| Temporary duplicate implementations drift | Keep the window short, share/parity-test the contract fixtures, forbid unrelated changes, and delete the internal implementation in the cutover. |
+| A component tag triggers Hive's release chain | Use and test a protected `components/<name>/vX.Y.Z` namespace that cannot match root `v*.*.*`. |
+| Publication starts from an ordinary path change | Give candidate workflows no publish credentials and make publication depend on an explicit protected trigger plus expected commit/version inputs. |
+| Verification and publication use different bytes | Build once, checksum and attest the candidate, and publish the exact retained artifact without rebuilding. |
+| Registry accepted the version but later proof fails | Treat the version as immutable, record the partial release, fix forward, and require separate authority for any yank. |
+| Independent versions create compatibility drift | Declare component SemVer/deprecation policy, test supported dependency bounds, and keep Hive's compatible range explicit. |
+| Persistent formats strand existing Hive workspaces | Keep shared fixtures and migration ownership explicit; reject packaging until old and new consumers interoperate safely. |
+| Release tooling becomes a framework project | Use explicit per-package tasks/workflows for the first gem and defer a registry/orchestrator until a second package produces real duplication. |
+| Public namespace selection causes churn before demand | Choose and register the neutral name only after qualification and explicit approval. |
+
+---
+
+## Implementation Units
+
+### U1. Qualify one component or record an honest deferral
+
+- **Goal:** Decide from current evidence whether exactly one boundary-ready component has earned package work.
+- **Requirements:** R1-R5, R24-R26; F1; AE1-AE2; KTD1-KTD5, KTD13.
+- **Dependencies:** The owning units in `docs/plans/2026-07-25-001-refactor-internal-component-boundaries-plan.md` are complete.
+- **Files:** `config/component-boundaries.yml`, `wiki/component-boundaries.md`, the candidate's module wiki page, a candidate-specific document under `docs/notes/` only when demand evidence needs durable detail, `wiki/gaps.md`, `wiki/log.d/<timestamp>-component-package-qualification.md`.
+- **Approach:** Re-score the retained candidates using the qualification matrix, verify demand and ownership, define the external journey and compatibility/security obligations, and select no more than one. Record `package-ready`, `deferred-no-demand`, or `deferred-coupled-to-hive` with evidence. If package-ready, propose the library/CLI shape and neutral identity for explicit owner approval; do not register a name or select a version automatically.
+- **Patterns to follow:** The component catalog's maturity evidence and ADR-031's separation between a standalone engine and Hive adapter.
+- **Test scenarios:**
+  - **Test expectation: none —** this unit changes no runtime behavior; its evidence is the completed qualification matrix and an explicit terminal state.
+- **Verification:** Catalog validation passes and every qualification claim links to a current contract test, consumer, compatibility fixture, or external demand artifact. A deferred result completes this execution without creating U2-U8 files.
+
+### U2. Create a self-contained package-only component
+
+- **Goal:** Establish the approved component under `components/<gem-name>/` without changing Hive's released dependency graph.
+- **Requirements:** R6-R10, R12-R14, R24-R25; F2; AE3; KTD6-KTD8, KTD11-KTD13.
+- **Dependencies:** U1 returned `package-ready` and the owner explicitly approved the public gem name, namespace, and library-versus-CLI shape.
+- **Files:** `components/<gem-name>/<gem-name>.gemspec`, `components/<gem-name>/lib/`, `components/<gem-name>/test/`, `components/<gem-name>/README.md`, `components/<gem-name>/CHANGELOG.md`, package license/metadata, package-owned schemas/templates/assets, root `Rakefile`, package documentation and wiki log fragment.
+- **Approach:** Move or copy only the policy-light mechanism required by the approved journey, expose one require path, declare direct dependencies, and place package tests beside the source. Keep the current internal Hive implementation authoritative until the published cutover. Share compatibility fixtures or add parity tests so temporary duplication cannot diverge. Do not add the new dependency to `hive.gemspec` in this PR.
+- **Patterns to follow:** Existing gemspec file-inventory and direct-dependency discipline; package-local tests that require the installed-style entry point rather than relative source files.
+- **Test scenarios:**
+  1. The gemspec contains complete metadata, direct dependencies, required Ruby, files, license, README, changelog, schemas/templates, and executable only when approved.
+  2. The documented require path loads without `hive-cli`, root Hive load paths, or upward constants.
+  3. Package behavior and shared compatibility fixtures match the boundary-ready Hive implementation for success, error, state, and security cases.
+  4. The package-only change does not alter `hive.gemspec`, root/web lockfiles, Hive runtime requires, or root release installability.
+- **Verification:** Package-focused tests, gemspec/file-inventory tests, clean-process require smoke, parity tests, root `bundle exec rake test`, and exact-head hosted CI pass in a package-only PR.
+
+### U3. Prepare the held Hive path-dependency cutover
+
+- **Goal:** Prove Hive as the primary consumer of the package while keeping the dependency cutover separate and unmerged until publication.
+- **Requirements:** R11-R15, R18, R23-R26; F2, F5; AE4, AE10; KTD3, KTD8-KTD9, KTD13.
+- **Dependencies:** U2 package-only branch exists.
+- **Files:** `Gemfile`, `hive.gemspec`, `Gemfile.lock`, `web/Gemfile.lock`, Hive facade/compatibility files, former internal implementation, focused Hive consumer tests, package/Hive shared fixtures, affected wiki pages and log fragment.
+- **Approach:** Create a stacked cutover PR. Resolve the component from `components/<gem-name>` for development, declare the approved compatible runtime range in `hive.gemspec`, route Hive through the package entry point, preserve any documented forwarding compatibility surface, and remove the old implementation. Keep the PR held and visibly non-mergeable until U7 remotely verifies the component.
+- **Patterns to follow:** Current root `gemspec` dependency resolution and PRDigest's published-engine/Hive-adapter boundary.
+- **Test scenarios:**
+  1. Bundler selects the component path in the source checkout while `hive.gemspec` records the normal compatible dependency.
+  2. Hive's focused consumers run exclusively through the package and observe the same state, locks, schemas, results, and errors.
+  3. Existing documented Hive constants either forward compatibly or receive an explicit separately approved break; no silent constant disappearance occurs.
+  4. Both root and web lockfiles resolve consistently.
+  5. Removing the component path or locally installed candidate makes the artifact test fail rather than falling back to copied internal code.
+- **Verification:** Component tests, Hive focused consumer/compatibility tests, both frozen Bundler installs, root `bundle exec rake test`, and exact-head hosted CI pass on the stacked PR; the PR remains unmerged.
+
+### U4. Prove exact component and Hive artifacts
+
+- **Goal:** Catch package omissions and repository-only assumptions before any public release.
+- **Requirements:** R8, R14-R18, R24-R26; F3; AE5; KTD9-KTD10, KTD13.
+- **Dependencies:** U2 and U3.
+- **Files:** Package build/install scripts under `components/<gem-name>/`, root packaging helpers where genuinely shared, component artifact tests, Hive candidate install tests, `.github/workflows/ci.yml` or a separate non-publishing component candidate workflow, documentation and wiki log fragment.
+- **Approach:** Build one component candidate from the expected commit, inspect it, and install it into clean environments without repository load paths. Build a Hive candidate from the held cutover and install the exact component artifact before Hive, proving the normal dependency path. Exercise supported Ruby and OS targets and dependency bounds without contacting publication endpoints.
+- **Patterns to follow:** Hive's release candidate build-once and private gem-home install gates; existing `test/unit/gemspec_test.rb` and installed-gem integration tests.
+- **Test scenarios:**
+  1. The built gem contains every declared Ruby file, schema, template, executable, README, changelog, and license and excludes tests or repository-only files as intended.
+  2. A clean gem home requires and exercises the component without Bundler path sources or `hive-cli`.
+  3. A missing direct dependency, omitted asset, accidental root-relative path, or upward Hive require fails the installed smoke.
+  4. The exact component artifact satisfies the built Hive candidate and all shared state/compatibility tests.
+  5. Lowest and highest supported component dependency versions follow the documented compatibility policy.
+- **Verification:** Exact checksums and provenance identify one component artifact, clean install smokes pass on supported Ruby/Linux/macOS targets, the Hive candidate consumes those bytes, and full hosted CI is green.
+
+### U5. Add an isolated component release workflow and runbook
+
+- **Goal:** Make release mechanics explicit, package-scoped, build-once, and unable to trigger from ordinary code changes.
+- **Requirements:** R16-R26; F3-F4; AE6-AE9; KTD4, KTD7-KTD10, KTD13.
+- **Dependencies:** U4.
+- **Files:** `.github/workflows/component-release.yml`, component release verification scripts/tests, `docs/RELEASING.md` or a component-specific release guide, workflow contract tests, package README/changelog, wiki release documentation and log fragment.
+- **Approach:** Define the protected `components/<gem-name>/vX.Y.Z` trigger, validate package/tag/version/expected-main-commit identity, build the candidate once, run U4 proof, retain the exact artifact, and publish only in an approval-bearing job with package-scoped RubyGems authority. Test that root Hive tags cannot enter this workflow and component tags cannot enter `.github/workflows/release.yml`. Document pre-publication, partial-publication, remote verification, fix-forward, and emergency-yank states.
+- **Patterns to follow:** `.github/workflows/release.yml` exact candidate and install gates, but not its Hive web/Homebrew/AUR/GHCR publication chain.
+- **Test scenarios:**
+  1. Only the exact protected component tag shape with matching package version and reachable protected-main commit passes preflight.
+  2. Root `vX.Y.Z`, ordinary branches, pull requests, path changes, malformed tags, and mismatched versions cannot reach publication.
+  3. Candidate and install jobs have no RubyGems publish authority; only the approval-bearing publish job can access package-scoped credentials.
+  4. Publication consumes the exact checksummed candidate artifact and does not rebuild.
+  5. Workflow contracts prove component tags do not match Hive release triggers and vice versa.
+  6. A dry candidate run completes without registry mutation and preserves enough evidence for the release-ready checkpoint.
+- **Verification:** Workflow contract tests, local candidate scripts, component/Hive artifact gates, root `bundle exec rake test`, and exact-head hosted CI pass without publishing.
+
+### U6. Reach the unpublished release-ready checkpoint
+
+- **Goal:** Produce a complete, reviewable candidate and held cutover while preserving the explicit release boundary.
+- **Requirements:** R1-R26; F1-F3; AE1-AE8; KTD1-KTD13.
+- **Dependencies:** U1-U5.
+- **Files:** Package and cutover PR descriptions/evidence, candidate checksums and workflow artifacts, package changelog draft, release checklist, affected wiki pages and `wiki/gaps.md`.
+- **Approach:** Revalidate qualification and maintenance ownership, exact commit and candidate identity, artifact proofs, workflow isolation, package-only PR safety, stacked cutover status, compatibility policy, and rollback/fix-forward instructions. Do not select a version, merge the coordinated changes, tag, or publish without a new explicit instruction.
+- **Patterns to follow:** Hive's explicit release-decision boundary in `docs/RELEASING.md`.
+- **Test scenarios:**
+  - **Test expectation: none —** this unit changes no runtime behavior; any defect returns to its owning implementation unit.
+- **Verification:** Package and cutover PRs are review-ready on exact tested heads, candidate proof is reproducible, no publication credentials were used, RubyGems has no new version, and the next irreversible action is visibly blocked on explicit owner authority.
+
+### U7. Publish and remotely verify the component only when authorized
+
+- **Goal:** Publish the exact candidate and prove the public registry/install surface before Hive depends on it.
+- **Requirements:** R16-R26; F4; AE7-AE9; KTD4, KTD7-KTD10, KTD13.
+- **Dependencies:** U6 plus a new explicit user instruction naming the approved gem, version, expected protected-main commit, and publication authority.
+- **Files:** Component version file and changelog, exact package tag/release metadata, immutable candidate and checksum evidence, remote-install verification record, wiki release log fragment.
+- **Approach:** Merge the package-only PR, confirm the exact protected-main candidate, apply the explicitly selected version, create the protected component tag, let the release workflow publish the already-proven bytes, and install that exact version from RubyGems in fresh environments. If registry mutation occurs and later proof fails, stop Hive cutover and fix forward.
+- **Patterns to follow:** Hive's exact-tag release verification and PRDigest's dependency-before-Hive precedent.
+- **Test scenarios:**
+  1. Remote RubyGems metadata matches the approved name, version, checksum, dependencies, Ruby requirement, source, and MFA/trusted-publishing expectations.
+  2. Fresh remote installs on the supported matrix require and exercise the public API/CLI without the repository or Hive.
+  3. Re-running publication for the same version is rejected; no workflow attempts to overwrite accepted bytes.
+  4. A failed post-publish smoke records `registry-published-fix-forward` and blocks U8.
+- **Verification:** RubyGems serves the exact proven version and all remote smokes pass. No Hive tag or release is created.
+
+### U8. Land the Hive cutover after remote verification
+
+- **Goal:** Make the released component the production dependency while retaining path-based monorepo development.
+- **Requirements:** R11-R15, R18, R23-R25; F5; AE10; KTD1-KTD3, KTD7-KTD9, KTD13.
+- **Dependencies:** U7 is `remotely-verified` and the user explicitly authorizes merging the coordinated Hive cutover. A later Hive version/tag/release still requires separate direction.
+- **Files:** Held U3 files and PR, `Gemfile.lock`, `web/Gemfile.lock`, compatibility shims, former internal source deletion, Hive release/install contract tests, wiki/component docs and log fragment.
+- **Approach:** Rebase the held cutover onto current main, pin the compatible range to the remotely verified component, keep the monorepo path source for development, remove temporary duplication, rerun source and built-artifact integration, and land the cutover separately. Preserve forwarding compatibility where promised and record any restart guidance for long-running Hive processes.
+- **Patterns to follow:** PRDigest as standalone engine with a thin Hive adapter and Hive's dependency/file-inventory tests.
+- **Test scenarios:**
+  1. Source checkout resolves the component path and built `hive-cli` resolves the published dependency.
+  2. Fresh `hive-cli` candidate installation downloads the component normally and runs all affected commands.
+  3. Existing state/schema/service fixtures remain readable and writable under the documented compatibility policy.
+  4. Both lockfiles are current and frozen installs pass.
+  5. No duplicate authoritative implementation or accidental component source copy remains inside the Hive gem.
+- **Verification:** Focused component/Hive tests, both frozen installs, exact built Hive install smoke, root `bundle exec rake test`, and exact-head hosted CI pass. The cutover PR may merge only under the explicit authority above; no Hive version, tag, release, or deployment is implied.
+
+---
+
+## Verification Contract
+
+| Gate | Applicability | Command or evidence | Passing signal |
+|---|---|---|---|
+| Qualification | U1 and final audit | Completed qualification matrix backed by catalog, tests, demand artifact, maintainer, and compatibility policy | Exactly one `package-ready` candidate or an honest terminal deferral with no packaging scaffold. |
+| Package focused tests | U2 onward | Package-local test task executed from `components/<gem-name>/` and from the root Rake integration | Public behavior passes without Hive load paths. |
+| Clean require | U2 onward | Fresh Ruby process with only the installed component gem | The documented require path loads; `hive-cli`, Thor commands, web, stages, and Hive constants are absent. |
+| File/dependency inventory | U2-U7 | Gem specification and built-artifact inspection | All runtime files/assets and direct dependencies are present; repository-only and test files are excluded as intended. |
+| Path dogfood | U3 onward | Root Bundler resolution and focused Hive consumer tests | Development selects `components/<gem-name>` and Hive uses the package facade against shared state. |
+| Exact component artifact | U4-U7 | Build once, checksum, clean private install, public API/CLI smoke | One retained artifact passes supported Ruby/Linux/macOS proof with no repo load path. |
+| Exact Hive artifact | U4 and U8 | Install the exact component gem then the exact Hive candidate in a clean gem home | Hive invokes the packaged component and all affected commands work. |
+| Lockfiles | U3 and U8 | Frozen root and web Bundler installs | `Gemfile.lock` and `web/Gemfile.lock` agree with source path and released dependency policy. |
+| Release workflow contract | U5-U7 | Workflow parser/contract tests and a non-publishing candidate run | Component and Hive tags are disjoint; candidate jobs cannot publish; publish uses the proven bytes. |
+| Broad local checkpoint | Every behavior-changing PR | `bundle exec rake test` | The default Hive suite passes; exhaustive coverage remains CI-owned unless packaging machinery itself changes coverage. |
+| Hosted CI | Every PR and release candidate | Exact-head GitHub Actions checks | All required checks are green on the reviewed commit; full Hive integration remains mandatory. |
+| Remote registry | U7 | Fresh RubyGems metadata lookup and install on supported targets | Name, version, checksum, dependencies, and behavior match the approved candidate. |
+| Documentation | Every behavior-changing PR | Package docs, component wiki, release guide, compatibility policy, and one `wiki/log.d/` fragment | Documentation describes the actual source/artifact/release state and compiled `wiki/log.md` is untouched. |
+
+---
+
+## Definition of Done
+
+### Default completion under this plan's current authority
+
+- Exactly one boundary-ready component was qualified, or the execution ended with `deferred-no-demand` or `deferred-coupled-to-hive` and created no empty package framework.
+- A package-ready candidate has one approved public shape, a self-contained `components/<gem-name>/` subtree, one require path, direct dependencies, package-local tests, documentation, compatibility policy, and named maintenance owner.
+- The package-only PR does not make current Hive releases depend on an unpublished gem.
+- The separate Hive cutover dogfoods the component by path, declares the future released dependency, preserves shared state and compatibility, updates both lockfiles, and remains held.
+- One exact component artifact passes inventory, clean install, supported platform, public API/CLI, dependency-bound, and exact Hive candidate integration proof.
+- Component and Hive release triggers are disjoint, candidate automation has no publication authority, and ordinary path changes cannot publish.
+- Package and cutover PRs are review-ready on exact tested heads, release and rollback/fix-forward instructions are complete, and no public version has been selected or created.
+- No tag, RubyGems publication, yank, ownership change, Hive version, Hive release, deployment, or cutover merge occurred without a separate explicit user instruction.
+
+### Additional completion after explicit publication and cutover authority
+
+- The package-only PR merged to protected main and the approved component tag bound the approved version to the exact tested commit.
+- RubyGems serves the exact proven artifact, remote metadata and clean installs match it, and any partial publication failure is recorded and fixed forward.
+- Only after remote verification, the separate Hive cutover removed temporary duplication, retained path-based monorepo development, declared the compatible released dependency, updated both lockfiles, and passed exact built-artifact plus full Hive integration proof.
+- The component and Hive have independent versions and changelogs; no later Hive tag, release, or deployment is assumed.
+- Package, wiki, release, and compatibility documentation match the final state, and no abandoned scaffold, duplicate implementation, leaked credential, stale candidate artifact, or unrelated workspace change remains.

--- a/test/support/component_boundary_contract.rb
+++ b/test/support/component_boundary_contract.rb
@@ -1,0 +1,544 @@
+require "json"
+require "open3"
+require "pathname"
+require "rbconfig"
+require "ripper"
+require "yaml"
+
+# Test-only architecture contract for config/component-boundaries.yml.
+#
+# This validates declared source boundaries plus literal require,
+# require_relative, and Constant.new syntax. It is not runtime isolation:
+# dynamic requires, aliases, factory calls, reflection, monkeypatching, and
+# arbitrary same-user code execution remain outside this harness.
+class ComponentBoundaryContract
+  class ValidationError < StandardError; end
+
+  STATES = %w[candidate boundary-ready].freeze
+  REQUIRED_FIELDS = %w[
+    id
+    name
+    state
+    entrypoint
+    public_contract
+    owned_paths
+    state_contracts
+    schema_contracts
+    lock_contracts
+    component_dependencies
+    allowed_hive_dependencies
+    internal_collaborators
+    forbidden_constructions
+    hive_consumers
+    mutation_authority
+    recovery_surface
+    wiki_page
+    focused_tests
+    migration_exceptions
+  ].freeze
+  ARRAY_FIELDS = %w[
+    owned_paths
+    state_contracts
+    schema_contracts
+    lock_contracts
+    component_dependencies
+    allowed_hive_dependencies
+    internal_collaborators
+    forbidden_constructions
+    hive_consumers
+    focused_tests
+    migration_exceptions
+  ].freeze
+  PATH_FIELDS = %w[owned_paths hive_consumers focused_tests].freeze
+  FORBIDDEN_REQUIRE_PREFIXES = %w[
+    hive/cli
+    hive/commands
+    hive/release
+    hive/stages
+    hive/web
+  ].freeze
+  FORBIDDEN_CONSTANTS = %w[Hive::Commands Hive::Stages Hive::Web].freeze
+  SAFE_ID = /\A[a-z][a-z0-9-]*\z/
+  SAFE_CONSTANT = /\A[A-Z]\w*(?:::[A-Z]\w*)*\z/
+
+  attr_reader :components
+
+  def self.load(path:, root:)
+    document = YAML.safe_load_file(path, permitted_classes: [], aliases: false)
+    new(document, root: root)
+  rescue Psych::Exception, Errno::ENOENT, Errno::EACCES => e
+    raise ValidationError, "#{path}: #{e.message}"
+  end
+
+  def initialize(document, root:)
+    @document = document
+    @root = File.realpath(root)
+    @components = []
+  end
+
+  def component(id)
+    ensure_components!
+    @components.find { |entry| entry.fetch("id") == id.to_s } ||
+      raise(ValidationError, "unknown component #{id.inspect}")
+  end
+
+  def validate!
+    validate_catalog!
+    validate_static_boundaries!
+    validate_clean_loads!
+    true
+  end
+
+  def validate_catalog!
+    root = expect_hash(@document, "catalog")
+    assert_keys!(root, %w[schema_version components], "catalog")
+    invalid!("catalog.schema_version", "expected 1") unless root["schema_version"] == 1
+
+    @components = expect_array(root.fetch("components"), "catalog.components").map.with_index do |entry, index|
+      validate_component!(entry, index)
+    end
+    invalid!("catalog.components", "must contain at least one component") if @components.empty?
+
+    index_components!
+    validate_unique_ownership!
+    validate_dependencies!
+    true
+  rescue KeyError => e
+    raise ValidationError, "catalog: missing required key #{e.key.inspect}"
+  end
+
+  def validate_static_boundaries!
+    validate_catalog! if @components.empty?
+
+    boundary_ready_components.each do |entry|
+      validate_requires!(entry)
+      validate_constructions!(entry)
+    end
+    true
+  end
+
+  def validate_clean_loads!
+    validate_catalog! if @components.empty?
+
+    boundary_ready_components.to_h do |entry|
+      [ entry.fetch("id"), clean_load!(entry) ]
+    end
+  end
+
+  private
+
+  def validate_component!(entry, index)
+    path = "catalog.components[#{index}]"
+    row = expect_hash(entry, path)
+    missing = REQUIRED_FIELDS - row.keys
+    invalid!(path, "missing required fields: #{missing.join(', ')}") unless missing.empty?
+
+    id = string!(row.fetch("id"), "#{path}.id")
+    invalid!("#{path}.id", "must match #{SAFE_ID.inspect}") unless id.match?(SAFE_ID)
+    component_path = "component #{id}"
+
+    state = string!(row.fetch("state"), "#{component_path}.state")
+    invalid!("#{component_path}.state", "must be one of #{STATES.join(', ')}") unless STATES.include?(state)
+
+    string!(row.fetch("name"), "#{component_path}.name")
+    entrypoint = expect_hash(row.fetch("entrypoint"), "#{component_path}.entrypoint")
+    assert_keys!(entrypoint, %w[file require constant], "#{component_path}.entrypoint")
+    repo_path!(entrypoint.fetch("file"), "#{component_path}.entrypoint.file")
+    string!(entrypoint.fetch("require"), "#{component_path}.entrypoint.require")
+    constant = string!(entrypoint.fetch("constant"), "#{component_path}.entrypoint.constant")
+    invalid!("#{component_path}.entrypoint.constant", "must be a constant path") unless constant.match?(SAFE_CONSTANT)
+
+    public_contract = expect_hash(row.fetch("public_contract"), "#{component_path}.public_contract")
+    assert_keys!(public_contract, %w[values errors], "#{component_path}.public_contract")
+    %w[values errors].each do |field|
+      string_array!(public_contract.fetch(field), "#{component_path}.public_contract.#{field}",
+                    allow_empty: field == "errors")
+    end
+
+    ARRAY_FIELDS.each do |field|
+      value = expect_array(row.fetch(field), "#{component_path}.#{field}")
+      next if field == "migration_exceptions"
+
+      string_array!(value, "#{component_path}.#{field}",
+                    allow_empty: %w[component_dependencies allowed_hive_dependencies forbidden_constructions].include?(field))
+    end
+    forbidden_allowed = row.fetch("allowed_hive_dependencies").select { |required| forbidden_require?(required) }
+    unless forbidden_allowed.empty?
+      invalid!("#{component_path}.allowed_hive_dependencies",
+               "cannot include forbidden upward dependency #{forbidden_allowed.join(', ')}")
+    end
+    PATH_FIELDS.each do |field|
+      row.fetch(field).each { |value| repo_path!(value, "#{component_path}.#{field}") }
+    end
+    repo_path!(row.fetch("wiki_page"), "#{component_path}.wiki_page")
+    validate_migration_exceptions!(row, component_path)
+    string!(row.fetch("mutation_authority"), "#{component_path}.mutation_authority")
+    string!(row.fetch("recovery_surface"), "#{component_path}.recovery_surface")
+    row
+  end
+
+  def validate_migration_exceptions!(row, component_path)
+    exceptions = expect_array(row.fetch("migration_exceptions"), "#{component_path}.migration_exceptions")
+    exceptions.each_with_index do |entry, index|
+      path = "#{component_path}.migration_exceptions[#{index}]"
+      exception = expect_hash(entry, path)
+      assert_keys!(exception, %w[reason removal_unit], path)
+      string!(exception.fetch("reason"), "#{path}.reason")
+      removal_unit = string!(exception.fetch("removal_unit"), "#{path}.removal_unit")
+      invalid!("#{path}.removal_unit", "must name a plan unit such as U3") unless removal_unit.match?(/\AU\d+\z/)
+    end
+    if row.fetch("state") == "boundary-ready" && !exceptions.empty?
+      invalid!("#{component_path}.migration_exceptions", "boundary-ready components cannot retain exceptions")
+    end
+  end
+
+  def index_components!
+    duplicates = @components.group_by { |entry| entry.fetch("id") }.select { |_id, rows| rows.length > 1 }.keys
+    invalid!("catalog.components", "duplicate component ids: #{duplicates.join(', ')}") unless duplicates.empty?
+    @component_index = @components.to_h { |entry| [ entry.fetch("id"), entry ] }
+  end
+
+  def validate_unique_ownership!
+    ownership = []
+    @components.each do |entry|
+      entry.fetch("owned_paths").each do |relative|
+        owner = entry.fetch("id")
+        conflict = ownership.find do |other_path, _other_owner|
+          relative == other_path ||
+            relative.start_with?("#{other_path}/") ||
+            other_path.start_with?("#{relative}/")
+        end
+        if conflict
+          other_path, other_owner = conflict
+          invalid!("component #{owner}.owned_paths",
+                   "#{relative.inspect} overlaps #{other_path.inspect} owned by #{other_owner}")
+        end
+        ownership << [ relative, owner ]
+      end
+    end
+  end
+
+  def validate_dependencies!
+    @components.each do |entry|
+      id = entry.fetch("id")
+      entry.fetch("component_dependencies").each do |dependency|
+        invalid!("component #{id}.component_dependencies", "unknown component #{dependency.inspect}") unless @component_index.key?(dependency)
+        invalid!("component #{id}.component_dependencies", "cannot depend on itself") if dependency == id
+      end
+    end
+
+    visiting = {}
+    visited = {}
+    visit = lambda do |id, trail|
+      if visiting[id]
+        cycle = (trail + [ id ]).drop_while { |item| item != id }
+        invalid!("component #{id}.component_dependencies", "dependency cycle: #{cycle.join(' -> ')}")
+      end
+      return if visited[id]
+
+      visiting[id] = true
+      @component_index.fetch(id).fetch("component_dependencies").each do |dependency|
+        visit.call(dependency, trail + [ id ])
+      end
+      visiting.delete(id)
+      visited[id] = true
+    end
+    @component_index.each_key { |id| visit.call(id, []) }
+  end
+
+  def validate_requires!(entry)
+    require_owners = component_require_owners
+    allowed_components = entry.fetch("component_dependencies")
+
+    ruby_files(entry.fetch("owned_paths")).each do |relative|
+      ruby_syntax(relative).requires.each do |required|
+        if forbidden_require?(required)
+          invalid!("component #{entry.fetch('id')}.owned_paths",
+                   "#{relative} requires forbidden upward dependency #{required.inspect}")
+        end
+
+        dependency = require_owners[required]
+        next unless dependency && dependency != entry.fetch("id")
+        next if allowed_components.include?(dependency)
+
+        invalid!("component #{entry.fetch('id')}.component_dependencies",
+                 "#{relative} requires undeclared component #{dependency.inspect} via #{required.inspect}")
+      end
+    end
+  end
+
+  def validate_constructions!(entry)
+    forbidden = entry.fetch("forbidden_constructions")
+    return if forbidden.empty?
+
+    owned_files = ruby_files(entry.fetch("owned_paths"))
+    (production_ruby_files - owned_files).each do |relative|
+      constructions = ruby_syntax(relative).constructions
+      invalid_constants = constructions & forbidden
+      next if invalid_constants.empty?
+
+      invalid!("component #{entry.fetch('id')}.forbidden_constructions",
+               "#{relative} directly constructs internal #{invalid_constants.join(', ')}")
+    end
+  end
+
+  def clean_load!(entry)
+    entrypoint = entry.fetch("entrypoint")
+    allowed_components = entry.fetch("component_dependencies")
+    unrelated_owned_features = component_require_owners.filter_map do |required, owner|
+      next if owner == entry.fetch("id") || allowed_components.include?(owner)
+
+      "#{required}.rb"
+    end
+    script = <<~RUBY
+      require "json"
+      require #{entrypoint.fetch("require").dump}
+
+      prefixes = #{FORBIDDEN_REQUIRE_PREFIXES.inspect}
+      unrelated = #{unrelated_owned_features.inspect}
+      loaded = $LOADED_FEATURES.filter_map do |feature|
+        relative = feature.sub(%r{\\A#{Regexp.escape(File.join(@root, "lib"))}/?}, "")
+        next unless prefixes.any? { |prefix| relative == "\#{prefix}.rb" || relative.start_with?("\#{prefix}/") } ||
+                    unrelated.include?(relative)
+        relative
+      end
+      forbidden_constants = #{FORBIDDEN_CONSTANTS.inspect}.select do |name|
+        Object.const_defined?(name, false)
+      end
+      puts JSON.generate(
+        "constant" => #{entrypoint.fetch("constant").dump},
+        "constant_defined" => Object.const_defined?(#{entrypoint.fetch("constant").dump}, false),
+        "forbidden_loaded_features" => loaded.sort,
+        "forbidden_constants" => forbidden_constants.sort
+      )
+    RUBY
+
+    out, err, status = Open3.capture3(
+      RbConfig.ruby,
+      "-I#{File.join(@root, 'lib')}",
+      "-e",
+      script,
+      chdir: @root
+    )
+    invalid!("component #{entry.fetch('id')}.entrypoint",
+             "clean load failed: #{err.strip}") unless status.success?
+    result = JSON.parse(out)
+    invalid!("component #{entry.fetch('id')}.entrypoint.constant",
+             "#{entrypoint.fetch('constant')} was not defined") unless result.fetch("constant_defined")
+    unless result.fetch("forbidden_loaded_features").empty?
+      invalid!("component #{entry.fetch('id')}.entrypoint.require",
+               "clean load pulled forbidden features: #{result.fetch('forbidden_loaded_features').join(', ')}")
+    end
+    unless result.fetch("forbidden_constants").empty?
+      invalid!("component #{entry.fetch('id')}.entrypoint.constant",
+               "clean load defined forbidden constants: #{result.fetch('forbidden_constants').join(', ')}")
+    end
+    result
+  rescue JSON::ParserError => e
+    invalid!("component #{entry.fetch('id')}.entrypoint", "clean load returned invalid JSON: #{e.message}")
+  end
+
+  def boundary_ready_components
+    @components.select { |entry| entry.fetch("state") == "boundary-ready" }
+  end
+
+  def component_require_owners
+    @component_require_owners ||= @component_index.each_with_object({}) do |(id, entry), owners|
+      ruby_files(entry.fetch("owned_paths")).each do |relative|
+        require_path = require_path_for(relative)
+        owners[require_path] = id if require_path
+      end
+    end
+  end
+
+  def production_ruby_files
+    @production_ruby_files ||= ruby_files([ "lib" ])
+  end
+
+  def ruby_files(paths)
+    paths.flat_map do |relative|
+      absolute = File.join(@root, relative)
+      File.directory?(absolute) ? Dir.glob(File.join(absolute, "**", "*.rb")).sort : [ absolute ]
+    end.select { |path| path.end_with?(".rb") }.map { |path| Pathname.new(path).relative_path_from(Pathname.new(@root)).to_s }.uniq
+  end
+
+  def ruby_syntax(relative)
+    @ruby_syntax ||= {}
+    @ruby_syntax[relative] ||= RubySyntax.new(File.read(File.join(@root, relative)), relative)
+  end
+
+  def require_path_for(relative)
+    return unless relative.start_with?("lib/") && relative.end_with?(".rb")
+
+    relative.delete_prefix("lib/").delete_suffix(".rb")
+  end
+
+  def forbidden_require?(required)
+    FORBIDDEN_REQUIRE_PREFIXES.any? do |prefix|
+      required == prefix || required.start_with?("#{prefix}/")
+    end
+  end
+
+  def repo_path!(value, path)
+    relative = string!(value, path)
+    pathname = Pathname.new(relative)
+    invalid!(path, "must be repository-relative") if pathname.absolute? || pathname.each_filename.include?("..")
+
+    absolute = File.expand_path(relative, @root)
+    real = File.realpath(absolute)
+    unless real == @root || real.start_with?("#{@root}/")
+      invalid!(path, "#{relative.inspect} resolves outside the repository")
+    end
+    relative
+  rescue Errno::ENOENT
+    invalid!(path, "#{relative.inspect} does not exist")
+  rescue SystemCallError => e
+    invalid!(path, "#{relative.inspect} could not be resolved: #{e.message}")
+  end
+
+  def ensure_components!
+    validate_catalog! if @components.empty?
+  end
+
+  def expect_hash(value, path)
+    return value if value.is_a?(Hash)
+
+    invalid!(path, "must be a mapping")
+  end
+
+  def expect_array(value, path)
+    return value if value.is_a?(Array)
+
+    invalid!(path, "must be an array")
+  end
+
+  def string!(value, path)
+    return value if value.is_a?(String) && !value.strip.empty?
+
+    invalid!(path, "must be a non-empty string")
+  end
+
+  def string_array!(value, path, allow_empty: false)
+    rows = expect_array(value, path)
+    invalid!(path, "must not be empty") if rows.empty? && !allow_empty
+    rows.each_with_index { |item, index| string!(item, "#{path}[#{index}]") }
+    rows
+  end
+
+  def assert_keys!(hash, allowed, path)
+    missing = allowed - hash.keys
+    extra = hash.keys - allowed
+    invalid!(path, "missing required fields: #{missing.join(', ')}") unless missing.empty?
+    invalid!(path, "unknown fields: #{extra.join(', ')}") unless extra.empty?
+  end
+
+  def invalid!(path, message)
+    raise ValidationError, "#{path}: #{message}"
+  end
+
+  class RubySyntax
+    attr_reader :requires, :constructions
+
+    def initialize(source, path)
+      @requires = []
+      @constructions = []
+      @path = path
+      sexp = Ripper.sexp(source)
+      raise ValidationError, "#{path}: Ruby syntax could not be parsed" unless sexp
+
+      walk(sexp)
+      @requires.uniq!
+      @constructions.uniq!
+    end
+
+    private
+
+    def walk(node)
+      return unless node.is_a?(Array)
+
+      required = require_literal(node)
+      @requires << required if required
+      construction = construction_constant(node)
+      @constructions << construction if construction
+      node.each { |child| walk(child) if child.is_a?(Array) }
+    end
+
+    def require_literal(node)
+      method_name, arguments =
+        if node[0] == :command && identifier(node[1]) == "require"
+          [ "require", node[2] ]
+        elsif node[0] == :command && identifier(node[1]) == "require_relative"
+          [ "require_relative", node[2] ]
+        elsif node[0] == :method_add_arg && %w[require require_relative].include?(fcall_identifier(node[1]))
+          [ fcall_identifier(node[1]), node[2] ]
+        end
+      return unless arguments
+
+      required = literal_string(arguments)
+      return required if required && method_name == "require"
+      relative_require_path(required) if required
+    end
+
+    def construction_constant(node)
+      return unless node[0] == :call && identifier(node[3]) == "new"
+
+      constant_path(node[1])
+    end
+
+    def fcall_identifier(node)
+      return unless node.is_a?(Array) && node[0] == :fcall
+
+      identifier(node[1])
+    end
+
+    def identifier(node)
+      return unless node.is_a?(Array) && %i[@ident @const].include?(node[0])
+
+      node[1]
+    end
+
+    def literal_string(node)
+      return unless node.is_a?(Array)
+      return if contains_type?(node, :string_embexpr)
+
+      if node[0] == :string_literal
+        return node.flatten.each_slice(2).filter_map do |type, value|
+          value if type == :@tstring_content
+        end.join
+      end
+      node.each do |child|
+        next unless child.is_a?(Array)
+
+        value = literal_string(child)
+        return value if value
+      end
+      nil
+    end
+
+    def contains_type?(node, type)
+      node.is_a?(Array) && (node[0] == type || node.any? { |child| contains_type?(child, type) })
+    end
+
+    def relative_require_path(required)
+      relative = Pathname.new(File.join(File.dirname(@path), required)).cleanpath.to_s
+      return unless relative.start_with?("lib/")
+
+      relative.delete_prefix("lib/").delete_suffix(".rb")
+    end
+
+    def constant_path(node)
+      return unless node.is_a?(Array)
+
+      case node[0]
+      when :var_ref, :const_ref
+        identifier(node[1])
+      when :top_const_ref
+        identifier(node[1])
+      when :const_path_ref
+        left = constant_path(node[1])
+        right = identifier(node[2])
+        [ left, right ].compact.join("::") unless left.nil? || right.nil?
+      end
+    end
+  end
+end

--- a/test/unit/component_boundaries_test.rb
+++ b/test/unit/component_boundaries_test.rb
@@ -1,0 +1,476 @@
+require "test_helper"
+require_relative "../support/component_boundary_contract"
+
+class ComponentBoundariesTest < Minitest::Test
+  ROOT = File.expand_path("../..", __dir__)
+  CATALOG = File.join(ROOT, "config", "component-boundaries.yml")
+
+  def setup
+    @document = YAML.safe_load_file(CATALOG, aliases: false)
+  end
+
+  def test_committed_catalog_describes_all_retained_components
+    contract = ComponentBoundaryContract.new(@document, root: ROOT)
+
+    assert contract.validate_catalog!
+    assert contract.validate_static_boundaries!
+    assert_equal %w[
+      agent-abi
+      agent-artifact-firewall
+      attempts
+      safe-agent-git-gate
+      skillpack
+      user-service
+      work-ledger
+    ], contract.components.map { |component| component.fetch("id") }.sort
+
+    attempts = contract.component("attempts")
+    assert_equal "candidate", attempts.fetch("state")
+    assert_equal "hive/attempts/api", attempts.dig("entrypoint", "require")
+    assert_equal "Hive::Attempts::API", attempts.dig("entrypoint", "constant")
+    assert_equal %w[
+      Hive::Attempts::ClientResult
+      Hive::Attempts::DispatchResult
+    ], attempts.dig("public_contract", "values")
+    assert_includes attempts.fetch("internal_collaborators"), "Hive::Attempts::Store"
+    assert_includes attempts.fetch("internal_collaborators"), "Hive::Attempts::Supervisor"
+    assert_includes attempts.fetch("internal_collaborators"), "Hive::Attempts::Reconciler"
+    refute_includes attempts.dig("public_contract", "values"), "Hive::Attempts::Store"
+    refute_includes attempts.dig("public_contract", "values"), "Hive::Attempts::Supervisor"
+    refute_includes attempts.dig("public_contract", "values"), "Hive::Attempts::Reconciler"
+
+    assert contract.components.all? { |component| component.fetch("state") == "candidate" }
+  end
+
+  def test_invalid_catalog_rows_name_the_component_and_field
+    cases = {
+      "missing entry point" => lambda do |document|
+        component(document, "attempts").fetch("entrypoint")["file"] = "lib/hive/missing.rb"
+      end,
+      "duplicate owned path" => lambda do |document|
+        component(document, "user-service").fetch("owned_paths") <<
+          component(document, "attempts").fetch("owned_paths").first
+      end,
+      "unknown dependency" => lambda do |document|
+        component(document, "attempts").fetch("component_dependencies") << "missing"
+      end,
+      "dependency cycle" => lambda do |document|
+        component(document, "attempts").fetch("component_dependencies") << "user-service"
+        component(document, "user-service").fetch("component_dependencies") << "attempts"
+      end,
+      "missing wiki page" => lambda do |document|
+        component(document, "attempts")["wiki_page"] = "wiki/modules/missing.md"
+      end,
+      "unbounded migration exception" => lambda do |document|
+        component(document, "attempts")["migration_exceptions"] = [
+          { "reason" => "temporary upward edge" }
+        ]
+      end
+    }
+
+    cases.each do |label, mutation|
+      document = Marshal.load(Marshal.dump(@document))
+      mutation.call(document)
+
+      error = assert_raises(ComponentBoundaryContract::ValidationError, label) do
+        ComponentBoundaryContract.new(document, root: ROOT).validate_catalog!
+      end
+
+      assert_match(/attempts|user-service/, error.message, label)
+      assert_match(/entrypoint|owned_paths|component_dependencies|wiki_page|migration_exceptions/,
+                   error.message, label)
+    end
+  end
+
+  def test_boundary_ready_component_rejects_bounded_migration_exception
+    with_contract_fixture(
+      entrypoint_source: example_api_source,
+      migration_exceptions: [
+        { "reason" => "temporary upward edge", "removal_unit" => "U3" }
+      ]
+    ) do |contract|
+      error = assert_raises(ComponentBoundaryContract::ValidationError) do
+        contract.validate_catalog!
+      end
+
+      assert_match(/example\.migration_exceptions/, error.message)
+      assert_match(/boundary-ready components cannot retain exceptions/, error.message)
+    end
+  end
+
+  def test_candidate_component_accepts_bounded_migration_exception
+    with_contract_fixture(
+      entrypoint_source: example_api_source,
+      state: "candidate",
+      migration_exceptions: [
+        { "reason" => "temporary upward edge", "removal_unit" => "U3" }
+      ]
+    ) do |contract|
+      assert contract.validate_catalog!
+    end
+  end
+
+  def test_migration_exception_requires_valid_removal_unit
+    with_contract_fixture(
+      entrypoint_source: example_api_source,
+      state: "candidate",
+      migration_exceptions: [
+        { "reason" => "temporary upward edge", "removal_unit" => "later" }
+      ]
+    ) do |contract|
+      error = assert_raises(ComponentBoundaryContract::ValidationError) do
+        contract.validate_catalog!
+      end
+
+      assert_match(/example\.migration_exceptions\[0\]\.removal_unit/, error.message)
+      assert_match(/must name a plan unit such as U3/, error.message)
+    end
+  end
+
+  def test_migration_exception_requires_non_blank_reason
+    with_contract_fixture(
+      entrypoint_source: example_api_source,
+      state: "candidate",
+      migration_exceptions: [
+        { "reason" => " ", "removal_unit" => "U3" }
+      ]
+    ) do |contract|
+      error = assert_raises(ComponentBoundaryContract::ValidationError) do
+        contract.validate_catalog!
+      end
+
+      assert_match(/example\.migration_exceptions\[0\]\.reason/, error.message)
+      assert_match(/must be a non-empty string/, error.message)
+    end
+  end
+
+  def test_boundary_ready_entrypoint_loads_cleanly
+    with_contract_fixture(entrypoint_source: example_api_source) do |contract|
+      result = contract.validate_clean_loads!
+
+      assert_equal [ "example" ], result.keys
+      assert_equal "Example::API", result.fetch("example").fetch("constant")
+      assert_empty result.fetch("example").fetch("forbidden_loaded_features")
+      assert_empty result.fetch("example").fetch("forbidden_constants")
+    end
+  end
+
+  def test_clean_load_rejects_missing_documented_constant
+    with_contract_fixture(entrypoint_source: "module Example; end\n") do |contract|
+      error = assert_raises(ComponentBoundaryContract::ValidationError) do
+        contract.validate_clean_loads!
+      end
+
+      assert_match(/example\.entrypoint\.constant/, error.message)
+      assert_match(/Example::API was not defined/, error.message)
+    end
+  end
+
+  def test_clean_load_reports_entrypoint_failure
+    with_contract_fixture(entrypoint_source: "raise \"fixture boom\"\n") do |contract|
+      error = assert_raises(ComponentBoundaryContract::ValidationError) do
+        contract.validate_clean_loads!
+      end
+
+      assert_match(/example\.entrypoint/, error.message)
+      assert_match(/clean load failed/, error.message)
+      assert_match(/fixture boom/, error.message)
+    end
+  end
+
+  def test_clean_load_rejects_forbidden_constant
+    with_contract_fixture(
+      entrypoint_source: <<~RUBY
+        module Hive
+          module Commands; end
+        end
+        #{example_api_source}
+      RUBY
+    ) do |contract|
+      error = assert_raises(ComponentBoundaryContract::ValidationError) do
+        contract.validate_clean_loads!
+      end
+
+      assert_match(/example\.entrypoint\.constant/, error.message)
+      assert_match(/Hive::Commands/, error.message)
+    end
+  end
+
+  def test_static_enforcement_uses_ruby_syntax_not_comments_or_examples
+    with_contract_fixture(
+      entrypoint_source: <<~RUBY,
+        module Example
+          class API; end
+        end
+      RUBY
+      consumer_source: <<~RUBY
+        # require "hive/commands/run"
+        EXAMPLE = 'Example::Internal.new'
+        Example::API.new
+      RUBY
+    ) do |contract|
+      assert contract.validate_static_boundaries!
+    end
+  end
+
+  def test_boundary_ready_upward_require_fails_with_component_and_file
+    with_contract_fixture(
+      entrypoint_source: <<~RUBY,
+        require "hive/commands/run"
+        module Example
+          class API; end
+        end
+      RUBY
+      consumer_source: "Example::API.new\n"
+    ) do |contract|
+      error = assert_raises(ComponentBoundaryContract::ValidationError) do
+        contract.validate_static_boundaries!
+      end
+
+      assert_match(/example/, error.message)
+      assert_match(/lib\/example\.rb/, error.message)
+      assert_match(/hive\/commands\/run/, error.message)
+    end
+  end
+
+  def test_forbidden_upward_require_cannot_be_allowlisted
+    with_contract_fixture(
+      entrypoint_source: <<~RUBY,
+        require "hive/commands/run"
+        #{example_api_source}
+      RUBY
+      allowed_hive_dependencies: [ "hive/commands/run" ]
+    ) do |contract|
+      error = assert_raises(ComponentBoundaryContract::ValidationError) do
+        contract.validate_catalog!
+      end
+
+      assert_match(/example\.allowed_hive_dependencies/, error.message)
+      assert_match(/forbidden upward dependency/, error.message)
+    end
+  end
+
+  def test_require_relative_upward_edge_in_owned_file_fails
+    with_contract_fixture(
+      entrypoint_source: example_api_source,
+      entrypoint_file: "lib/hive/example/api.rb",
+      entrypoint_require: "hive/example/api",
+      owned_paths: [ "lib/hive/example" ],
+      extra_files: {
+        "lib/hive/example/worker.rb" => "require_relative \"../commands/run\"\n",
+        "lib/hive/commands/run.rb" => "module Hive; module Commands; end; end\n"
+      }
+    ) do |contract|
+      error = assert_raises(ComponentBoundaryContract::ValidationError) do
+        contract.validate_static_boundaries!
+      end
+
+      assert_match(/lib\/hive\/example\/worker\.rb/, error.message)
+      assert_match(/hive\/commands\/run/, error.message)
+    end
+  end
+
+  def test_undeclared_internal_component_require_fails
+    with_support_component do |fixture|
+      with_contract_fixture(
+        entrypoint_source: <<~RUBY,
+          require "support/internal"
+          #{example_api_source}
+        RUBY
+        extra_components: [ fixture.fetch(:component) ],
+        extra_files: fixture.fetch(:files)
+      ) do |contract|
+        error = assert_raises(ComponentBoundaryContract::ValidationError) do
+          contract.validate_static_boundaries!
+        end
+
+        assert_match(/example\.component_dependencies/, error.message)
+        assert_match(/support\/internal/, error.message)
+      end
+    end
+  end
+
+  def test_declared_internal_component_require_passes_static_and_clean_load_checks
+    with_support_component do |fixture|
+      with_contract_fixture(
+        entrypoint_source: <<~RUBY,
+          require "support/internal"
+          #{example_api_source}
+        RUBY
+        component_dependencies: [ "support" ],
+        extra_components: [ fixture.fetch(:component) ],
+        extra_files: fixture.fetch(:files)
+      ) do |contract|
+        assert contract.validate_static_boundaries!
+        assert_equal [ "example" ], contract.validate_clean_loads!.keys
+      end
+    end
+  end
+
+  def test_clean_load_rejects_unrelated_component_owned_feature
+    with_support_component do |fixture|
+      with_contract_fixture(
+        entrypoint_source: <<~RUBY,
+          require "support/internal"
+          #{example_api_source}
+        RUBY
+        extra_components: [ fixture.fetch(:component) ],
+        extra_files: fixture.fetch(:files)
+      ) do |contract|
+        error = assert_raises(ComponentBoundaryContract::ValidationError) do
+          contract.validate_clean_loads!
+        end
+
+        assert_match(/clean load pulled forbidden features/, error.message)
+        assert_match(/support\/internal\.rb/, error.message)
+      end
+    end
+  end
+
+  def test_direct_internal_construction_fails_with_component_and_file
+    with_contract_fixture(
+      entrypoint_source: <<~RUBY,
+        module Example
+          class API; end
+          class Internal; end
+        end
+      RUBY
+      consumer_source: "Example::Internal.new\n"
+    ) do |contract|
+      error = assert_raises(ComponentBoundaryContract::ValidationError) do
+        contract.validate_static_boundaries!
+      end
+
+      assert_match(/example/, error.message)
+      assert_match(/lib\/consumer\.rb/, error.message)
+      assert_match(/Example::Internal/, error.message)
+    end
+  end
+
+  def test_unlisted_consumer_cannot_construct_internal_constant
+    with_contract_fixture(
+      entrypoint_source: <<~RUBY,
+        module Example
+          class API; end
+          class Internal; end
+        end
+      RUBY
+      consumer_source: "Example::API.new\n",
+      extra_files: {
+        "lib/unlisted_consumer.rb" => "Example::Internal.new\n"
+      }
+    ) do |contract|
+      error = assert_raises(ComponentBoundaryContract::ValidationError) do
+        contract.validate_static_boundaries!
+      end
+
+      assert_match(/example/, error.message)
+      assert_match(/lib\/unlisted_consumer\.rb/, error.message)
+      assert_match(/Example::Internal/, error.message)
+    end
+  end
+
+  private
+
+  def component(document, id)
+    document.fetch("components").find { |entry| entry.fetch("id") == id }
+  end
+
+  def example_api_source
+    <<~RUBY
+      module Example
+        class API; end
+      end
+    RUBY
+  end
+
+  def with_support_component
+    component = fixture_component(
+      id: "support",
+      state: "candidate",
+      entrypoint_file: "lib/support.rb",
+      entrypoint_require: "support",
+      entrypoint_constant: "Support::API",
+      owned_paths: [ "lib/support.rb", "lib/support" ]
+    )
+    files = {
+      "lib/support.rb" => "module Support; class API; end; end\n",
+      "lib/support/internal.rb" => "module Support; class Internal; end; end\n"
+    }
+    yield({ component: component, files: files })
+  end
+
+  def with_contract_fixture(entrypoint_source:, consumer_source: "Example::API.new\n",
+                            state: "boundary-ready", entrypoint_file: "lib/example.rb",
+                            entrypoint_require: "example", owned_paths: nil,
+                            component_dependencies: [], allowed_hive_dependencies: [],
+                            migration_exceptions: [], extra_components: [], extra_files: {})
+    Dir.mktmpdir do |root|
+      write_fixture(root, entrypoint_file, entrypoint_source)
+      write_fixture(root, "lib/consumer.rb", consumer_source)
+      write_fixture(root, "wiki/example.md", "# Example\n")
+      write_fixture(root, "test/example_test.rb", "# fixture\n")
+      extra_files.each { |relative, content| write_fixture(root, relative, content) }
+
+      document = {
+        "schema_version" => 1,
+        "components" => [
+          fixture_component(
+            id: "example",
+            state: state,
+            entrypoint_file: entrypoint_file,
+            entrypoint_require: entrypoint_require,
+            entrypoint_constant: "Example::API",
+            owned_paths: owned_paths || [ entrypoint_file ],
+            component_dependencies: component_dependencies,
+            allowed_hive_dependencies: allowed_hive_dependencies,
+            migration_exceptions: migration_exceptions
+          ),
+          *extra_components
+        ]
+      }
+
+      yield ComponentBoundaryContract.new(document, root: root)
+    end
+  end
+
+  def fixture_component(id:, state:, entrypoint_file:, entrypoint_require:, entrypoint_constant:,
+                        owned_paths:, component_dependencies: [], allowed_hive_dependencies: [],
+                        migration_exceptions: [])
+    namespace = entrypoint_constant.split("::").first
+    {
+      "id" => id,
+      "name" => id.split("-").map(&:capitalize).join(" "),
+      "state" => state,
+      "entrypoint" => {
+        "file" => entrypoint_file,
+        "require" => entrypoint_require,
+        "constant" => entrypoint_constant
+      },
+      "public_contract" => {
+        "values" => [ entrypoint_constant ],
+        "errors" => []
+      },
+      "owned_paths" => owned_paths,
+      "state_contracts" => [ "none" ],
+      "schema_contracts" => [ "none" ],
+      "lock_contracts" => [ "none" ],
+      "component_dependencies" => component_dependencies,
+      "allowed_hive_dependencies" => allowed_hive_dependencies,
+      "internal_collaborators" => [ "#{namespace}::Internal" ],
+      "forbidden_constructions" => [ "#{namespace}::Internal" ],
+      "hive_consumers" => [ "lib/consumer.rb" ],
+      "mutation_authority" => "none",
+      "recovery_surface" => "none",
+      "wiki_page" => "wiki/example.md",
+      "focused_tests" => [ "test/example_test.rb" ],
+      "migration_exceptions" => migration_exceptions
+    }
+  end
+
+  def write_fixture(root, relative, content)
+    path = File.join(root, relative)
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, content)
+  end
+end

--- a/wiki/component-boundaries.md
+++ b/wiki/component-boundaries.md
@@ -1,0 +1,92 @@
+---
+title: Component boundaries
+type: reference
+source: config/component-boundaries.yml, test/support/component_boundary_contract.rb
+created: 2026-07-25
+updated: 2026-07-25
+tags: [architecture, components, boundaries, monorepo]
+---
+
+**TLDR**: Hive keeps reusable mechanisms in this monorepo and makes their
+supported Ruby seams explicit before considering gems. The machine-readable
+catalog records ownership, entry points, contracts, dependencies, consumers,
+state and recovery responsibilities, maturity, and focused tests. Hive remains
+the first and primary consumer.
+
+## Current catalog
+
+| Component | State | Current entry point | Narrative context |
+|-----------|-------|---------------------|-------------------|
+| Attempts admission / future RunReceipt | `candidate` | `require "hive/attempts/api"` → `Hive::Attempts::API` | [[modules/attempts]] |
+| UserService | `candidate` | `require "hive/commands/service_installer/base"` → `Hive::Commands::ServiceInstaller::Base` | [[commands/daemon]] |
+| Agent ABI | `candidate` | `require "hive/agent_profile"` → `Hive::AgentProfile` | [[modules/agent_profile]] |
+| Agent Artifact Firewall | `candidate` | `require "hive/protected_files"` → `Hive::ProtectedFiles` | [[modules/protected_files]] |
+| Skillpack | `candidate` | `require "hive/agent_skills"` → `Hive::AgentSkills` | [[commands/setup-agents]] |
+| Safe Agent Git Gate | `candidate` | `require "hive/managed_git"` → `Hive::ManagedGit` | [[modules/git_ops]] |
+| WorkLedger | `candidate` | `require "hive/task_journal"` → `Hive::TaskJournal` | [[state-model]] |
+
+`candidate` means the current code is mapped, but callers, dependencies, or
+policy still need refactoring before the seam is supported. `boundary-ready`
+means the entry point, allowed dependency direction, consumer construction
+rules, and clean-process load are enforced. It does not mean that a component
+has earned a gem, version, repository, or release.
+
+`Hive::Attempts::API` is an existing admission slice, but U1 records Attempts
+as a `candidate`: daemon lifecycle code still constructs its store and
+reconciler internals directly. U2 owns reconciling that construction and may
+promote Attempts only after the completed boundary proof passes.
+
+## Catalog contract
+
+`config/component-boundaries.yml` is the canonical agent-readable inventory.
+Each row names:
+
+- the supported entry point and current public values/errors;
+- owned source paths and explicit component dependencies;
+- state, schema, lock, mutation-authority, and recovery responsibilities;
+- known Hive consumers and internal collaborators;
+- the narrative wiki page and focused tests; and
+- reviewed migration exceptions, if any.
+
+Owned paths cannot overlap between components, component dependencies must form
+an acyclic graph, and every path in the catalog must resolve inside the
+repository. A temporary exception must include both a reason and the
+implementation unit that removes it. A `boundary-ready` component cannot keep
+an exception.
+
+## Enforcement
+
+`test/support/component_boundary_contract.rb` is test-only architecture
+tooling. U1 establishes this catalog and promotion guard; for every
+`boundary-ready` row it:
+
+1. parses literal Ruby `require` and `require_relative` calls and rejects upward
+   dependencies on Hive commands, stages, web, release, or CLI code;
+2. maps every component-owned Ruby file to its require path and rejects
+   undeclared direct component dependencies;
+3. scans production Ruby outside the component's owned paths and rejects
+   literal `Constant.new` construction of listed internals; and
+4. loads the entry point in a fresh Ruby process, verifies the documented
+   constant, and rejects unrelated commands, stages, web code, or files owned
+   by undeclared components.
+
+Run the focused contract with:
+
+```bash
+bundle exec ruby -Itest -Ilib test/unit/component_boundaries_test.rb
+```
+
+The syntax scan is an architecture regression guard, not a Ruby sandbox. Its
+construction rule covers literal `Constant.new`, not aliases or factory
+methods. It does not claim to stop dynamic requires, reflection, monkeypatching,
+or arbitrary same-user code. Those limits must not be weakened into security
+claims.
+
+## Changing a boundary
+
+Change one component per PR. Update its catalog row, focused consumer tests,
+narrative wiki page, this page, and a `wiki/log.d/` fragment together. Promote
+to `boundary-ready` only after clean loading, dependency direction, direct
+consumer routing, focused tests, the broad Hive suite, and exact-head hosted CI
+all pass. Packaging remains a separate, later decision gated by demonstrated
+non-Hive demand and explicit release authority.

--- a/wiki/decisions.md
+++ b/wiki/decisions.md
@@ -3,11 +3,33 @@ title: Architectural Decisions
 type: decisions
 source: code + author's local planning notes (not committed)
 created: 2026-04-25
-updated: 2026-07-23
+updated: 2026-07-25
 tags: [decisions, adr]
 ---
 
-**TLDR**: ADRs below were authored alongside implementation work. ADR-024 records both the PR-first workflow/stage renumbering and daemon autonomy; ADR-026 covers the Telegram bot mobile surface (subprocess caller for non-state-mutating verbs); ADR-027 records the diagnose-then-act surface for red status rows; ADR-029 records the 7-artifacts stage insertion; ADR-030 records the project-global Claude launch mode plus permission/model/effort follow-ups; **ADR-033 supersedes the subprocess-caller portion of ADR-026 for state-mutating verbs — the bot now writes file-backed dispatch requests that the daemon consumes, making the daemon the sole spawner of `hive run`-class children**; ADR-034 records Hive-owned fallback commits for successful fix-agent edits and pre-fix dirty-worktree snapshots; ADR-035 records Hive web's PTY agent-login relay for paste-back and operator-ward device flows, now also used for `gh auth login`, instead of provider-page proxying; ADR-036 records Hive web's switch to GitHub device-flow sign-in, including ownerless first-login claim (no callback URL, no client secret, no required config edit).
+**TLDR**: ADRs below were authored alongside implementation work. ADR-024 records both the PR-first workflow/stage renumbering and daemon autonomy; ADR-026 covers the Telegram bot mobile surface (subprocess caller for non-state-mutating verbs); ADR-027 records the diagnose-then-act surface for red status rows; ADR-029 records the 7-artifacts stage insertion; ADR-030 records the project-global Claude launch mode plus permission/model/effort follow-ups; **ADR-033 supersedes the subprocess-caller portion of ADR-026 for state-mutating verbs — the bot now writes file-backed dispatch requests that the daemon consumes, making the daemon the sole spawner of `hive run`-class children**; ADR-034 records Hive-owned fallback commits for successful fix-agent edits and pre-fix dirty-worktree snapshots; ADR-035 records Hive web's PTY agent-login relay for paste-back and operator-ward device flows, now also used for `gh auth login`, instead of provider-page proxying; ADR-036 records Hive web's switch to GitHub device-flow sign-in, including ownerless first-login claim (no callback URL, no client secret, no required config edit); ADR-038 keeps reusable components in the Hive monorepo, establishes Hive-first internal boundaries before packaging, and makes standalone gem publication conditional on real external demand and an explicit release decision.
+
+## ADR-038: Reusable components stay in the monorepo and earn packaging after Hive-first boundaries
+
+**Status:** Active (strategy recorded 2026-07-25; the component catalog and enforcement harness are implemented, with component refactors following incrementally).
+
+**Context:** Repo-grounded extraction analysis found seven mechanisms with plausible standalone value: RunReceipt, UserService, Agent Artifact Firewall, Agent ABI, Skillpack, Safe Agent Git Gate, and WorkLedger. Splitting them into separate repositories would weaken Hive's most useful maintenance property for humans and agents: one checkout exposes the callers, durable state, compatibility fixtures, integration tests, release machinery, and implementation together. Packaging them immediately inside the monorepo would preserve navigation but still freeze accidental Hive dependencies and create version/release obligations before an external consumer exists.
+
+**Decision:** Hive remains the canonical monorepo and the first and primary consumer of every reusable component. Establish and enforce internal Ruby boundaries first: one supported entry point or facade, structured public values and errors, an acyclic dependency direction, explicit state/schema/lock ownership, clean-process loading, and all Hive production consumers routed through the boundary. Existing module wiki pages plus one component catalog are the canonical agent context; do not add a parallel `.context.md` hierarchy.
+
+Implementation readiness and standalone product value are different rankings. `Hive::Attempts::API` is the existing admission slice, but U1 records Attempts as a candidate while daemon lifecycle code still constructs durable internals directly; U2 owns reconciling that construction before promotion. UserService is the next low-coupling boundary; Agent ABI, Agent Artifact Firewall, Skillpack, Safe Agent Git Gate, and WorkLedger follow in readiness order and may each terminate as deferred when a policy-light seam cannot be proven. RunReceipt remains the strongest standalone opportunity without forcing the largest refactor first. Operational status/Statewatch, layout migration, standalone capability probes, separate lease/capsule products, generic status rendering, and a new local-agent framework remain rejected or folded ideas rather than package commitments.
+
+A component becomes package-eligible only after its internal boundary is stable, a named non-Hive adopter or maintained integration proves demand, the component loads and tests independently without an upward Hive dependency, compatibility and maintenance ownership are explicit, and an exact built gem installs cleanly. A qualifying package stays in this repository under `components/<gem-name>/`, uses independent SemVer, and remains a path dependency for source development while released `hive-cli` declares a normal compatible dependency. Package publication is explicit and component-scoped; path changes may select tests but never publish.
+
+**Consequences:** The immediate work changes module ownership and dependency discipline, not repository layout or release topology. Each component lands in its own reviewable PR with focused tests, a full Hive integration checkpoint, hosted CI, and wiki updates. No gem name, namespace, version, package directory, tag, or publication is implied by reaching an internal boundary.
+
+`config/component-boundaries.yml` is the canonical machine-readable inventory,
+and [[component-boundaries]] explains its states and enforcement. A test-only
+contract validates path ownership, the dependency DAG, bounded exceptions,
+selected forbidden Ruby edges, and clean-process loading without presenting
+source scanning as a security sandbox.
+
+Future package work uses a package-first, publish-first, Hive-cutover-last sequence so protected `main` never releases a Hive gem that depends on an unavailable component. Component release tags or manually approved workflows must be disjoint from Hive's root `v*.*.*` release trigger, build once, install and verify the exact artifact, and require an explicit release decision. The detailed implementation contracts are `docs/plans/2026-07-25-001-refactor-internal-component-boundaries-plan.md` and `docs/plans/2026-07-25-002-feat-standalone-component-gems-plan.md`.
 
 ## ADR-037: Hive web is the shared vanilla Rails 8 + Turbo app for native Hive and Hivebox
 

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -3,7 +3,7 @@ title: hive Wiki
 type: index
 source: wiki/**/*.md
 created: 2026-05-14
-updated: 2026-07-23
+updated: 2026-07-25
 tags: [index, wiki]
 ---
 
@@ -13,8 +13,8 @@ local-first workflow engine for AI agents; software delivery is its flagship
 proof, while built-in content/bench, installable Honeycomb, and owner-authored
 workflows use the same folder-backed execution model.
 
-Page count: 94
-Updated: 2026-07-22
+Page count: 95
+Updated: 2026-07-25
 
 Folder-as-agent workflow engine: a Ruby 3.4 / Thor CLI control plane where descriptor-backed workflows move task folders through filesystem stages, stage agents run via configurable AgentProfile CLIs (`claude` default, `codex`, `pi`, `grok`), and `mv` between directories remains the approval primitive. The built-in `coding` workflow drives the nine-stage PR pipeline (`1-inbox` → `2-brainstorm` → `3-plan` → `4-execute` → `5-open-pr` → `6-review` → `7-artifacts` → `8-finalize` → `9-done`), while the built-in `content` and `bench` workflows and project-authored workflows share the same generic runner/status/action machinery. Agent operation is centered on the additive operational status contract, coherent daemon scheduler snapshots, bounded semantic `hive watch`, and tokenized routine `hive act`; the legacy full JSON graph remains compatible. Hive packages one canonical operating skill projected to OpenClaw `/hive`, Claude `/hive`, Codex `$hive`, and Pi `/skill:hive`, with read-only `hive doctor`, consent-safe setup, and an exact-SHA four-agent pre-release proof.
 
@@ -60,6 +60,7 @@ The public native release surface is the `hive-cli` rubygem plus authenticated m
 - [[commands/web]] — `wiki/commands/web.md`
 - [[commands/wiki]] — `wiki/commands/wiki.md`
 - [[commands/workflow]] — `wiki/commands/workflow.md`
+- [[component-boundaries]] — `wiki/component-boundaries.md`
 - [[decisions]] — `wiki/decisions.md`
 - [[dependencies]] — `wiki/dependencies.md`
 - [[e2e]] — `wiki/e2e.md`

--- a/wiki/log.d/20260725T133931Z-monorepo-component-boundary-strategy.md
+++ b/wiki/log.d/20260725T133931Z-monorepo-component-boundary-strategy.md
@@ -1,0 +1,11 @@
+# 2026-07-25 — Record the Hive-first component boundary and future gem strategy
+
+**Why:** Hive contains reusable mechanisms with plausible value outside the product, but splitting repositories or creating gems before their contracts are proven would reduce agent navigability and freeze accidental coupling.
+
+**Decision:** Added ADR-038 and two implementation-ready plans. Hive remains the canonical monorepo and first consumer; `Hive::Attempts::API` is the reference boundary; UserService is the next internal extraction; later candidates proceed one component per PR and may remain internal. Standalone packaging is gated on a stable boundary, concrete non-Hive demand, independent artifact proof, and maintenance ownership. Any future component stays under `components/`, uses an independent version, and publishes only through an explicit component-scoped release that cannot match Hive's root tag trigger.
+
+**Plans:** `docs/plans/2026-07-25-001-refactor-internal-component-boundaries-plan.md` covers internal API, dependency, state, compatibility, consumer, testing, and wiki boundaries. `docs/plans/2026-07-25-002-feat-standalone-component-gems-plan.md` covers qualification, package layout, path dogfood, exact artifact proof, release authority, remote verification, and the publish-before-Hive-cutover sequence.
+
+**Scope:** This strategy record covers documentation and planning only. It
+does not imply a package directory, gemspec, public name, version, tag,
+publication, release, deployment, or compiled `wiki/log.md` change.

--- a/wiki/log.d/20260725T155021Z-component-boundary-contract.md
+++ b/wiki/log.d/20260725T155021Z-component-boundary-contract.md
@@ -1,0 +1,28 @@
+# 2026-07-25 — Establish the component boundary contract
+
+**Why:** Agents needed one current, machine-checkable map of Hive's reusable
+mechanisms before later refactors could safely route consumers through stable
+internal APIs.
+
+**Change:** Added `config/component-boundaries.yml` with the seven retained
+components, their ownership, entry points, public contracts, dependencies,
+state/schema/lock responsibilities, consumers, authority, recovery surfaces,
+wiki pages, tests, and maturity. U1 establishes the catalog and promotion
+guard: all seven entries remain `candidate`. Attempts admission records the
+existing `Hive::Attempts::API` slice, while U2 owns reconciling direct daemon
+lifecycle construction of durable internals before it can become
+`boundary-ready`.
+
+**Enforcement:** Added a test-only contract that validates catalog metadata,
+repository-local paths, unique ownership, an acyclic dependency graph, bounded
+migration exceptions, forbidden upward requires, direct construction of named
+internals across production Ruby, and clean-process loading for boundary-ready
+entry points. Literal `require_relative` calls and all component-owned Ruby
+files participate in dependency checks. The static scan is explicitly an
+architecture regression guard, not a security sandbox; U1 does not overstate
+it as proof that the existing Attempts lifecycle is already fully routed
+through its admission facade.
+
+**Docs:** Added [[component-boundaries]], linked it from the wiki index, recorded
+the focused command in [[testing]], and updated ADR-038. No component was
+packaged, versioned, tagged, published, or moved to another repository.

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -3,8 +3,8 @@ title: Testing
 type: reference
 source: test/, Rakefile, bin/hive-eval, .rubocop.yml, .github/workflows/{ci,live-agent-skills,release}.yml, packaging/live_agent_skills/, config/brakeman.ignore
 created: 2026-04-25
-updated: 2026-07-24
-tags: [test, minitest, fixtures, honeycomb, agent-skills, release-proof]
+updated: 2026-07-25
+tags: [test, minitest, fixtures, honeycomb, agent-skills, component-boundaries, release-proof]
 ---
 
 **TLDR**: Minitest covers unit/integration behavior; opt-in layers cover outer
@@ -57,6 +57,23 @@ bundle exec rake test:babysitter_dry_run_security_matrix
 The packaged-web gate is commit-bound: it archives `HEAD:web` to reproduce the
 release artifact. Commit relevant web changes before using that task locally;
 otherwise it deliberately tests the previously committed tree.
+
+## Component boundary contract
+
+`config/component-boundaries.yml` is checked by
+`test/unit/component_boundaries_test.rb`. The test validates catalog shape,
+repository-local paths, unique ownership, an acyclic component graph, bounded
+migration exceptions, selected source-level dependency/construction rules, and
+fresh-process loading for every `boundary-ready` component:
+
+```bash
+bundle exec ruby -Itest -Ilib test/unit/component_boundaries_test.rb
+```
+
+The helper uses Ruby syntax rather than comments or string examples for literal
+`require`, `require_relative`, and `Constant.new` checks. It remains an
+architecture guard, not a security sandbox; see [[component-boundaries]] for
+the enforced contract and its limits.
 
 ## Coverage
 


### PR DESCRIPTION
## Summary

Hive now has one machine-checkable map for reusable mechanisms and an executable promotion contract, so agents can inspect ownership, supported entry points, dependency direction, state responsibilities, consumers, and proof requirements without leaving the monorepo.

This is the U1 foundation only. All seven components remain `candidate`; in particular, Attempts is not called boundary-ready while daemon lifecycle code still constructs durable internals directly. U2 owns that reconciliation and promotion after this exact head is green.

The companion plans preserve the longer-term decision: internal boundaries come first, Hive remains the primary consumer, and a separate gem is considered only after stable in-repo use and concrete non-Hive demand. This PR creates no package, version, tag, publication, or repository split.

## Design decisions

| Decision | Consequence |
|---|---|
| Keep one canonical catalog beside the code | Agents get a compact ownership and contract map while existing module wiki pages retain narrative context. |
| Enforce only `boundary-ready` source seams | Candidate metadata can describe current coupling honestly; promotion activates dependency, consumer-construction, and clean-load proofs. |
| Treat source scanning as an architecture guard | Literal `require`, `require_relative`, and `Constant.new` regressions fail without claiming runtime isolation or sandbox security. |
| Gate packaging independently from readiness | Internal modularity does not silently create gem naming, versioning, or release obligations. |

Session-settled decisions carried from planning: keep the monorepo (user-approved, over splitting repositories); establish boundaries before packages (user-approved); keep Hive as first and primary consumer (user-directed).

## Validation

- Component boundary contract: 19 runs, 133 assertions, 0 failures or errors.
- RuboCop: 2 changed Ruby files inspected, no offenses.
- Broad local checkpoint: 10,055 runs, 139,915 assertions, 0 failures, 0 errors, 8 skips.

## Post-Deploy Monitoring & Validation

No runtime deployment or operational monitoring is required because this changes test-only architecture enforcement, metadata, and documentation. The release gate is exact-head hosted CI on this PR; do not begin U2 until every required check is terminal green. If the new catalog or contract fails hosted integration, hold U2 and revert or correct this commit before promotion work starts.

## New concepts

### Executable component boundary

An executable boundary turns an architecture intention into a promotion test: catalog metadata describes the seam, while focused checks prove the dependency direction and clean-load behavior before the seam is marked ready.

```mermaid
flowchart LR
  H[Hive consumer] --> F[Supported facade]
  F --> M[Policy-light mechanism]
  M --> P[Approved primitives]
  X[Commands, web, stages] -. rejected upward edge .-> M
```

Here, candidate rows remain honest documentation; changing one to `boundary-ready` activates the source and fresh-process proofs. This technique is useful for incremental monorepo modularization, but it is not a substitute for runtime isolation, a security sandbox, or demonstrated package demand.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
