### PR TITLE
Fix recovery cutover after an empty v1 skeleton reappears

### DIFF
--- a/lib/hive/recovery/migration.rb
+++ b/lib/hive/recovery/migration.rb
@@ -90,9 +90,11 @@ module Hive
 
       def migrate_attempts!
         if File.exist?(legacy_attempt_root) && File.exist?(current_attempt_root)
-          raise Error,
-                "both legacy and current attempt roots exist; preserve them and resolve " \
-                "#{legacy_attempt_root} versus #{current_attempt_root} before retrying"
+          unless remove_empty_legacy_attempt_skeleton!
+            raise Error,
+                  "both legacy and current attempt roots exist; preserve them and resolve " \
+                  "#{legacy_attempt_root} versus #{current_attempt_root} before retrying"
+          end
         end
 
         if File.exist?(legacy_attempt_root)
@@ -146,6 +148,35 @@ module Hive
           write_json!(path, record.to_h)
         end
         attempt_count_result(migrated: migrated, normalized: normalized, archived: archived)
+      end
+
+      # A pre-cutover reader can recreate the old store's directory skeleton
+      # after v2 has already become authoritative. Remove only a tree made
+      # entirely of empty real directories. Any file, symlink, or concurrent
+      # writer makes rmdir fail closed and preserves the ambiguous root.
+      def remove_empty_legacy_attempt_skeleton!
+        directories = []
+        pending = [ legacy_attempt_root ]
+        until pending.empty?
+          directory = pending.pop
+          return false unless File.lstat(directory).directory?
+
+          directories << directory
+          Dir.children(directory).each do |entry|
+            path = File.join(directory, entry)
+            return false unless File.lstat(path).directory?
+
+            pending << path
+          end
+        end
+
+        directories.sort_by { |path| -path.count(File::SEPARATOR) }.each do |directory|
+          Dir.rmdir(directory)
+        end
+        Hive::AtomicFile.fsync_directory(attempts_parent)
+        true
+      rescue Errno::ENOENT, Errno::ENOTEMPTY
+        !File.exist?(legacy_attempt_root)
       end
 
       # Detached supervisors admitted by the old binary retain an explicit

--- a/test/unit/recovery/migration_test.rb
+++ b/test/unit/recovery/migration_test.rb
@@ -152,7 +152,9 @@ class RecoveryMigrationTest < Minitest::Test
 
   def test_refuses_ambiguous_attempt_roots
     with_tmp_dir do |state_home|
-      FileUtils.mkdir_p(File.join(state_home, "attempts", "v1"))
+      legacy_root = File.join(state_home, "attempts", "v1")
+      FileUtils.mkdir_p(legacy_root)
+      File.write(File.join(legacy_root, "unknown-state"), "preserve me")
       FileUtils.mkdir_p(File.join(state_home, "attempts", "v2"))
 
       error = assert_raises(Hive::Recovery::Migration::Error) do
@@ -160,6 +162,75 @@ class RecoveryMigrationTest < Minitest::Test
       end
 
       assert_includes error.message, "both legacy and current attempt roots exist"
+      assert_equal "preserve me", File.read(File.join(legacy_root, "unknown-state"))
+    end
+  end
+
+  def test_prunes_an_empty_legacy_skeleton_recreated_after_cutover
+    with_tmp_dir do |state_home|
+      current_records = File.join(state_home, "attempts", "v2", "records")
+      FileUtils.mkdir_p(current_records)
+      write_json(
+        File.join(current_records, "current.json"),
+        lost_attempt(current_attempt(attempt_id: "current"))
+      )
+      Hive::Recovery::Migration.ensure!(state_home: state_home, now: NOW)
+
+      legacy_root = File.join(state_home, "attempts", "v1")
+      %w[records logs outputs generation-locks].each do |entry|
+        FileUtils.mkdir_p(File.join(legacy_root, entry))
+      end
+
+      result = Hive::Recovery::Migration.ensure!(state_home: state_home, now: NOW + 60)
+
+      refute_path_exists legacy_root
+      assert_path_exists File.join(current_records, "current.json")
+      assert_equal (NOW + 60).iso8601(6), result.fetch("completed_at")
+    end
+  end
+
+  def test_refuses_a_legacy_root_symlink_beside_the_current_root
+    with_tmp_dir do |state_home|
+      attempts = File.join(state_home, "attempts")
+      legacy_target = File.join(state_home, "legacy-target")
+      FileUtils.mkdir_p(legacy_target)
+      FileUtils.mkdir_p(File.join(attempts, "v2"))
+      File.symlink(legacy_target, File.join(attempts, "v1"))
+
+      error = assert_raises(Hive::Recovery::Migration::Error) do
+        Hive::Recovery::Migration.ensure!(state_home: state_home, now: NOW)
+      end
+
+      assert_includes error.message, "both legacy and current attempt roots exist"
+      assert File.symlink?(File.join(attempts, "v1"))
+    end
+  end
+
+  def test_refuses_an_empty_legacy_skeleton_that_gains_state_during_prune
+    with_tmp_dir do |state_home|
+      legacy_records = File.join(state_home, "attempts", "v1", "records")
+      FileUtils.mkdir_p(legacy_records)
+      FileUtils.mkdir_p(File.join(state_home, "attempts", "v2"))
+
+      original = Dir.method(:rmdir)
+      injected = false
+      Dir.define_singleton_method(:rmdir) do |path|
+        unless injected
+          File.write(File.join(path, "late-state"), "preserve me")
+          injected = true
+        end
+        original.call(path)
+      end
+      begin
+        error = assert_raises(Hive::Recovery::Migration::Error) do
+          Hive::Recovery::Migration.ensure!(state_home: state_home, now: NOW)
+        end
+      ensure
+        Dir.define_singleton_method(:rmdir, original)
+      end
+
+      assert_includes error.message, "both legacy and current attempt roots exist"
+      assert_equal "preserve me", File.read(File.join(legacy_records, "late-state"))
     end
   end
 

--- a/wiki/commands/migrate.md
+++ b/wiki/commands/migrate.md
@@ -3,7 +3,7 @@ title: hive migrate
 type: command
 source: lib/hive/commands/migrate.rb, lib/hive/stages.rb
 created: 2026-05-21
-updated: 2026-07-23
+updated: 2026-07-26
 tags: [command, migration, config, reviewers, stages, task-id, display-name, recovery]
 ---
 
@@ -103,11 +103,15 @@ active document is current.
 
 Final compatibility leases are moved to
 `$HIVE_HOME/attempts/legacy-v1-records/` as audit history. A live compatibility
-lease, any other live attempt in the old tree, or simultaneous `attempts/v1`
-and `attempts/v2` trees fails closed with an actionable error. An old detached
-supervisor retains the explicit v1 path until it terminalizes, so Hive never
-moves storage underneath live work or guesses which process owns it. The
-migration is idempotent, and runtime readers contain no legacy-schema branches.
+lease, any other live attempt in the old tree, or simultaneous populated
+`attempts/v1` and `attempts/v2` trees fails closed with an actionable error. A
+pre-cutover reader can recreate only the empty v1 directory skeleton after v2
+is authoritative; migrate removes that inert tree with empty-directory-only
+`rmdir` operations. Any file, symlink, or concurrent writer preserves the
+fail-closed dual-root error. An old detached supervisor retains the explicit v1
+path until it terminalizes, so Hive never moves storage underneath live work or
+guesses which process owns it. The migration is idempotent, and runtime readers
+contain no legacy-schema branches.
 
 ## Registered repository identity backfill
 
@@ -142,7 +146,7 @@ A rerun after successful migration prints that there is nothing to move and keep
   counter seeding.
 - `test/unit/recovery/migration_test.rb` covers the global schema cutover,
   receipt idempotency, archived final compatibility records, queue upgrades,
-  and live/ambiguous-state refusal.
+  empty post-cutover v1 skeleton cleanup, and live/ambiguous-state refusal.
 - Status integration scenarios prove hidden legacy tasks surface before migrate and disappear after migration.
 
 ## Backlinks

--- a/wiki/log.d/20260726T063024Z-recovery-empty-v1-skeleton.md
+++ b/wiki/log.d/20260726T063024Z-recovery-empty-v1-skeleton.md
@@ -1,0 +1,17 @@
+---
+title: Recovery migration prunes inert post-cutover v1 skeletons
+type: fix
+date: 2026-07-26
+tags: [recovery, migration, attempts, dogfood]
+---
+
+Fresh-main dogfood found that a still-running pre-cutover web reader could
+recreate the empty `attempts/v1` directory skeleton after v2 became
+authoritative. That left no records to migrate, but the dual-root guard still
+blocked daemon startup.
+
+`Hive::Recovery::Migration` now removes a legacy tree only when every entry is
+an empty real directory. It uses bottom-up `rmdir`, so a file, symlink, or
+concurrent writer fails closed and preserves the ambiguous root for operator
+inspection. Regression tests cover successful inert cleanup plus file,
+symlink, and concurrent-write refusal.

--- a/wiki/modules/attempts.md
+++ b/wiki/modules/attempts.md
@@ -3,7 +3,7 @@ title: Durable task attempts
 type: module
 source: lib/hive/attempts/
 created: 2026-07-16
-updated: 2026-07-25
+updated: 2026-07-26
 tags: [attempts, ownership, leases, daemon, recovery]
 ---
 
@@ -100,9 +100,13 @@ compatibility flag, and leaves a receipt in the state home. Final compatibility
 leases are archived outside the active store. Any live attempt in the old tree
 blocks the rename because its detached old-binary supervisor still owns the v1
 path; a live compatibility lease is likewise never guessed into the new
-ownership model. Old schema files and in-memory normalization paths are removed. Every condition event must
-name a durable attempt whose task/stage ownership matches the record. Retry and
-adoption reuse the numeric epoch when accepted inputs are unchanged.
+ownership model. If an old reader recreates only empty directories beside the
+current v2 tree, migration prunes them with empty-only `rmdir`; a file, symlink,
+or concurrent writer remains an ambiguous dual root and fails closed. Old
+schema files and in-memory normalization paths are removed. Every condition
+event must name a durable attempt whose task/stage ownership matches the
+record. Retry and adoption reuse the numeric epoch when accepted inputs are
+unchanged.
 
 ## State protocol
 


### PR DESCRIPTION
## Summary

- prune a recreated legacy attempt root only when it contains empty real directories
- preserve the fail-closed dual-root error for files, symlinks, and concurrent writers
- document and regress the fresh-main dogfood failure found after the v2-only cutover

## Why

After PR #870 cut over the live store to attempts/v2, the still-running old web process recreated an empty attempts/v1 directory skeleton during status reads. The new daemon correctly refused simultaneous roots, but that meant an inert directory-only remnant blocked startup even though all 674 authoritative records were already valid v2 records.

## Verification

- recovery migration tests: 17 runs, 80 assertions, 0 failures
- wiki log tests: 7 runs, 27 assertions, 0 failures
- RuboCop 1.88.2: 2 files, no offenses
- git diff --check
