### PR TITLE
Fix managed web bootstrap without Bundler on PATH

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     hive-cli (0.6.9)
       base64 (>= 0.2)
       bubbletea (= 0.1.4)
+      bundler (= 2.7.2)
       erb (>= 4.0)
       faraday (>= 2.14.2, < 3.0)
       faraday-multipart (~> 1.0)

--- a/hive.gemspec
+++ b/hive.gemspec
@@ -57,6 +57,10 @@ Gem::Specification.new do |spec|
   # they have no business being installed for end users.
   spec.add_dependency "base64", ">= 0.2"
   spec.add_dependency "bubbletea", "= 0.1.4"
+  # Managed installs isolate GEM_HOME/GEM_PATH from the operator's gems. Keep
+  # the exact web-lock Bundler inside that managed gem home so web bootstrap
+  # can resolve it without relying on a PATH wrapper or a system default gem.
+  spec.add_dependency "bundler", "= 2.7.2"
   # faraday + faraday-multipart are required and used directly by the voice
   # transcriber (Faraday.new, Faraday::Multipart::FilePart). They resolve
   # transitively through telegram-bot-ruby today, but declaring them directly

--- a/lib/hive/web/app_bundle.rb
+++ b/lib/hive/web/app_bundle.rb
@@ -3,6 +3,7 @@ require "fileutils"
 require "json"
 require "open3"
 require "open-uri"
+require "rbconfig"
 require "rubygems/package"
 require "tmpdir"
 require "zlib"
@@ -117,6 +118,7 @@ module Hive
                 "reinstall the hive-cli package before provisioning Hive web"
         end
 
+        command = runner ? %w[bundle install] : bundle_install_argv(dir)
         runner ||= default_runner(output)
         lockfile = File.join(dir, "Gemfile.lock")
         # Bundler rewrites a relative path source (`remote: ..`) to the
@@ -135,7 +137,7 @@ module Hive
           "HIVE_CLI_ROOT" => hive_cli_root
         }
         ok = Dir.chdir(dir) do
-          runner.call(%w[bundle install], env)
+          runner.call(command, env)
         end
         raise Hive::Error, "hive web: bundle install failed in #{dir}" unless ok
 
@@ -149,11 +151,12 @@ module Hive
       end
 
       def prepare!(dir: app_dir, runner: nil, output: $stderr)
-        runner ||= default_runner(output)
+        default_commands = runner.nil?
         lockfile = File.join(dir, "Gemfile.lock")
         lockfile_bytes = File.binread(lockfile) if File.file?(lockfile)
         lockfile_mode = File.stat(lockfile).mode & 0o777 if lockfile_bytes
         bundle_install!(dir: dir, runner: runner, output: nil)
+        runner ||= default_runner(output)
         asset_storage = File.join(dir, "tmp", "assets-build-storage")
         asset_env = {
           "BUNDLE_GEMFILE" => File.join(dir, "Gemfile"),
@@ -165,7 +168,12 @@ module Hive
           "SECRET_KEY_BASE" => "hive-managed-web-assets-build",
           "HIVE_WEB_STORAGE_DIR" => asset_storage
         }
-        ok = Dir.chdir(dir) { runner.call(%w[bin/rails assets:precompile], asset_env) }
+        command = if default_commands
+          [ RbConfig.ruby, File.join(dir, "bin", "rails"), "assets:precompile" ]
+        else
+          %w[bin/rails assets:precompile]
+        end
+        ok = Dir.chdir(dir) { runner.call(command, asset_env) }
         raise Hive::Error, "hive web: asset precompile failed in #{dir}" unless ok
         unless assets_ready?(dir)
           raise Hive::Error, "hive web: asset precompile produced no usable CSS/JavaScript in #{dir}"
@@ -186,6 +194,25 @@ module Hive
           destination = output || File::NULL
           system(env, *argv, out: destination, err: destination)
         end
+      end
+
+      def bundle_install_argv(dir)
+        version = File.read(File.join(dir, "Gemfile.lock"))[
+          /^BUNDLED WITH\s*\n\s+(\S+)\s*$/m, 1
+        ].to_s
+        unless version.match?(/\A\d+(?:\.\d+){1,3}(?:[.-][0-9A-Za-z]+)*\z/)
+          raise Hive::Error,
+                "hive web: #{File.join(dir, 'Gemfile.lock')} has no valid BUNDLED WITH version"
+        end
+
+        executable = Gem.bin_path("bundler", "bundle", "= #{version}")
+        [ RbConfig.ruby, executable, "install" ]
+      rescue Errno::ENOENT
+        raise Hive::Error, "hive web: downloaded web bundle does not contain a Gemfile.lock"
+      rescue Gem::GemNotFoundException
+        raise Hive::Error,
+              "hive web: locked Bundler #{version} is unavailable; " \
+              "install Bundler #{version} before provisioning Hive web"
       end
 
       def dependency_dir

--- a/lib/hive/web/app_bundle.rb
+++ b/lib/hive/web/app_bundle.rb
@@ -169,7 +169,10 @@ module Hive
           "HIVE_WEB_STORAGE_DIR" => asset_storage
         }
         command = if default_commands
-          [ RbConfig.ruby, File.join(dir, "bin", "rails"), "assets:precompile" ]
+          bundle_argv(
+            dir, "exec", RbConfig.ruby,
+            File.join(dir, "bin", "rails"), "assets:precompile"
+          )
         else
           %w[bin/rails assets:precompile]
         end
@@ -197,6 +200,10 @@ module Hive
       end
 
       def bundle_install_argv(dir)
+        bundle_argv(dir, "install")
+      end
+
+      def bundle_argv(dir, *arguments)
         version = File.read(File.join(dir, "Gemfile.lock"))[
           /^BUNDLED WITH\s*\n\s+(\S+)\s*$/m, 1
         ].to_s
@@ -206,7 +213,7 @@ module Hive
         end
 
         executable = Gem.bin_path("bundler", "bundle", "= #{version}")
-        [ RbConfig.ruby, executable, "install" ]
+        [ RbConfig.ruby, executable, *arguments ]
       rescue Errno::ENOENT
         raise Hive::Error, "hive web: downloaded web bundle does not contain a Gemfile.lock"
       rescue Gem::GemNotFoundException

--- a/test/integration/web_packaged_bootstrap_test.rb
+++ b/test/integration/web_packaged_bootstrap_test.rb
@@ -58,9 +58,16 @@ class WebPackagedBootstrapTest < Minitest::Test
       assert_equal tracked_files.sort, archive_entries.keys.sort,
                    "the release archive must contain every tracked web file exactly once"
 
+      # `gem install hive-cli` installs this exact runtime dependency into the
+      # managed gem home. This fixture keeps the rest of Hive's dependencies
+      # in the parent test bundle, so expose that bundle's gem home explicitly
+      # while still hiding every executable wrapper from PATH.
+      bundler_gem_home = File.expand_path(
+        "../..", Gem.loaded_specs.fetch("bundler").full_gem_path
+      )
       env = {
         "GEM_HOME" => gem_home,
-        "GEM_PATH" => [ gem_home, *Gem.path ].join(File::PATH_SEPARATOR),
+        "GEM_PATH" => [ gem_home, bundler_gem_home, *Gem.path ].uniq.join(File::PATH_SEPARATOR),
         **clean_bundler_environment
       }
 
@@ -76,8 +83,8 @@ class WebPackagedBootstrapTest < Minitest::Test
         "HIVE_PACKAGE_CAPTURE" => capture,
         "HIVE_SETUP_FIXTURE" => preload,
         # A managed install must not depend on the `bundle` wrapper being on
-        # PATH. The CLI already runs under the intended Ruby and can resolve
-        # the exact Bundler executable from the authenticated lockfile.
+        # PATH. The CLI already runs under the intended Ruby and resolves its
+        # exact runtime Bundler from the authenticated lockfile.
         "PATH" => "/usr/bin:/bin"
       )
       stdout, setup_stderr, setup_status = Open3.capture3(

--- a/test/integration/web_packaged_bootstrap_test.rb
+++ b/test/integration/web_packaged_bootstrap_test.rb
@@ -74,7 +74,11 @@ class WebPackagedBootstrapTest < Minitest::Test
         "HIVE_WEB_BUNDLE_SHA256" => Digest::SHA256.file(archive).hexdigest,
         "HIVE_EXPECTED_CLI_ROOT" => installed_root,
         "HIVE_PACKAGE_CAPTURE" => capture,
-        "HIVE_SETUP_FIXTURE" => preload
+        "HIVE_SETUP_FIXTURE" => preload,
+        # A managed install must not depend on the `bundle` wrapper being on
+        # PATH. The CLI already runs under the intended Ruby and can resolve
+        # the exact Bundler executable from the authenticated lockfile.
+        "PATH" => "/usr/bin:/bin"
       )
       stdout, setup_stderr, setup_status = Open3.capture3(
         setup_env, File.join(gem_home, "bin", "hive"), "setup", "--no-init", "--yes", "--json",

--- a/test/unit/gemspec_test.rb
+++ b/test/unit/gemspec_test.rb
@@ -72,6 +72,14 @@ class GemspecTest < Minitest::Test
     refute_nil spec.runtime_dependencies.find { |candidate| candidate.name == "base64" }
   end
 
+  def test_runtime_dependencies_include_the_managed_web_locked_bundler
+    spec = Gem::Specification.load(GEMSPEC_PATH)
+    dependency = spec.runtime_dependencies.find { |candidate| candidate.name == "bundler" }
+
+    refute_nil dependency
+    assert_equal Gem::Requirement.new("= 2.7.2"), dependency.requirement
+  end
+
   # The web tier is a Rails app under web/, supported only in the Docker
   # image or a source checkout — the gem must stay a lean CLI and not
   # package the app or its old Sinatra-era assets.

--- a/test/unit/web/app_bundle_test.rb
+++ b/test/unit/web/app_bundle_test.rb
@@ -2,6 +2,7 @@ require "test_helper"
 require "rubygems/package"
 require "zlib"
 require "digest"
+require "rbconfig"
 require "hive/web/app_bundle"
 
 class WebAppBundleTest < Minitest::Test
@@ -405,6 +406,102 @@ class WebAppBundleTest < Minitest::Test
         assert_includes combined, "stdout"
         assert_includes combined, "stderr"
       end
+    end
+  end
+
+  def test_default_bundle_install_uses_locked_bundler_without_path_lookup
+    Dir.mktmpdir("hive-web-app") do |app|
+      version = "2.7.2"
+      File.write(File.join(app, "Gemfile"), "source 'https://rubygems.org'\n")
+      File.write(File.join(app, "Gemfile.lock"), "BUNDLED WITH\n   #{version}\n")
+      captured = nil
+      resolution = nil
+      fake_runner = lambda do |argv, _env|
+        captured = argv
+        true
+      end
+
+      with_replaced_singleton_method(
+        Hive::Web::AppBundle, :default_runner, ->(_output) { fake_runner }
+      ) do
+        with_replaced_singleton_method(
+          Gem, :bin_path, lambda { |*args|
+            resolution = args
+            "/locked/bundler/exe/bundle"
+          }
+        ) do
+          Hive::Web::AppBundle.bundle_install!(dir: app, output: nil)
+        end
+      end
+
+      assert_equal [ "bundler", "bundle", "= 2.7.2" ], resolution
+      assert_equal [ RbConfig.ruby, "/locked/bundler/exe/bundle", "install" ], captured
+    end
+  end
+
+  def test_default_bundle_install_requires_a_valid_locked_bundler
+    Dir.mktmpdir("hive-web-app") do |app|
+      File.write(File.join(app, "Gemfile"), "source 'https://rubygems.org'\n")
+
+      error = assert_raises(Hive::Error) do
+        Hive::Web::AppBundle.bundle_install!(dir: app, output: nil)
+      end
+      assert_match(/does not contain a Gemfile\.lock/, error.message)
+
+      File.write(File.join(app, "Gemfile.lock"), "BUNDLED WITH\n   not/a/version\n")
+      error = assert_raises(Hive::Error) do
+        Hive::Web::AppBundle.bundle_install!(dir: app, output: nil)
+      end
+      assert_match(/has no valid BUNDLED WITH version/, error.message)
+    end
+  end
+
+  def test_default_bundle_install_reports_an_unavailable_locked_bundler
+    Dir.mktmpdir("hive-web-app") do |app|
+      File.write(File.join(app, "Gemfile"), "source 'https://rubygems.org'\n")
+      File.write(File.join(app, "Gemfile.lock"), "BUNDLED WITH\n   9.9.9\n")
+
+      with_replaced_singleton_method(
+        Gem, :bin_path, ->(*_args) { raise Gem::GemNotFoundException }
+      ) do
+        error = assert_raises(Hive::Error) do
+          Hive::Web::AppBundle.bundle_install!(dir: app, output: nil)
+        end
+        assert_match(/locked Bundler 9\.9\.9 is unavailable/, error.message)
+      end
+    end
+  end
+
+  def test_default_prepare_runs_assets_through_the_current_ruby
+    Dir.mktmpdir("hive-web-app") do |app|
+      FileUtils.mkdir_p(File.join(app, "bin"))
+      File.write(File.join(app, "Gemfile"), "source 'https://rubygems.org'\n")
+      File.write(File.join(app, "Gemfile.lock"), "BUNDLED WITH\n   2.7.2\n")
+      File.write(File.join(app, "bin", "rails"), "#!/usr/bin/env ruby\n")
+      calls = []
+      fake_runner = lambda do |argv, _env|
+        calls << argv
+        write_compiled_assets(app) if argv.last == "assets:precompile"
+        true
+      end
+
+      with_replaced_singleton_method(
+        Hive::Web::AppBundle, :default_runner, ->(_output) { fake_runner }
+      ) do
+        with_replaced_singleton_method(
+          Gem, :bin_path, ->(*_args) { "/locked/bundler/exe/bundle" }
+        ) do
+          Hive::Web::AppBundle.prepare!(dir: app, output: nil)
+        end
+      end
+
+      assert_equal(
+        [
+          [ RbConfig.ruby, "/locked/bundler/exe/bundle", "install" ],
+          [ RbConfig.ruby, File.join(app, "bin", "rails"), "assets:precompile" ]
+        ],
+        calls
+      )
     end
   end
 

--- a/test/unit/web/app_bundle_test.rb
+++ b/test/unit/web/app_bundle_test.rb
@@ -498,7 +498,10 @@ class WebAppBundleTest < Minitest::Test
       assert_equal(
         [
           [ RbConfig.ruby, "/locked/bundler/exe/bundle", "install" ],
-          [ RbConfig.ruby, File.join(app, "bin", "rails"), "assets:precompile" ]
+          [
+            RbConfig.ruby, "/locked/bundler/exe/bundle", "exec",
+            RbConfig.ruby, File.join(app, "bin", "rails"), "assets:precompile"
+          ]
         ],
         calls
       )

--- a/web/Gemfile.lock
+++ b/web/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     hive-cli (0.6.9)
       base64 (>= 0.2)
       bubbletea (= 0.1.4)
+      bundler (= 2.7.2)
       erb (>= 4.0)
       faraday (>= 2.14.2, < 3.0)
       faraday-multipart (~> 1.0)

--- a/wiki/architecture.md
+++ b/wiki/architecture.md
@@ -332,8 +332,9 @@ listing and cloning and does not claim ownership. Hivebox is the distinct
 container distribution of the same owner-gated surface. Managed local installs
 stage a locked Bundler install plus a production asset precompile and verify
 the CSS/JavaScript manifest before the atomic bundle swap; both commands run
-through the current Ruby without relying on `bundle` or a matching Ruby shim
-on `PATH`. Same-version installs with missing assets are repaired.
+through the locked Bundler and current Ruby without relying on `bundle` or a
+matching Ruby shim on `PATH`. Same-version installs with missing assets are
+repaired.
 Reads render
 `Commands::Status#json_payload` snapshots; live updates flow over Turbo
 Streams, with production Action Cable accepting same-origin-as-host and

--- a/wiki/architecture.md
+++ b/wiki/architecture.md
@@ -330,9 +330,10 @@ the current owner on every request and evict old sessions when
 ownership rotation. A local GitHub connection remains optional for repository
 listing and cloning and does not claim ownership. Hivebox is the distinct
 container distribution of the same owner-gated surface. Managed local installs
-stage `bundle install` plus a production asset precompile and verify the
-CSS/JavaScript manifest before the atomic bundle swap; same-version installs
-with missing assets are repaired.
+stage a locked Bundler install plus a production asset precompile and verify
+the CSS/JavaScript manifest before the atomic bundle swap; both commands run
+through the current Ruby without relying on `bundle` or a matching Ruby shim
+on `PATH`. Same-version installs with missing assets are repaired.
 Reads render
 `Commands::Status#json_payload` snapshots; live updates flow over Turbo
 Streams, with production Action Cable accepting same-origin-as-host and

--- a/wiki/dependencies.md
+++ b/wiki/dependencies.md
@@ -159,9 +159,10 @@ that exact Bundler through RubyGems, and invokes its absolute executable
 through the current `RbConfig.ruby`. `hive-cli` declares that exact Bundler as
 a runtime dependency so isolated gem, Homebrew, and AUR installations carry it
 inside Hive's managed `GEM_HOME`; a system default gem is not assumed.
-Production asset compilation uses the same Ruby directly. A missing locked
-Bundler is therefore an explicit bootstrap error rather than an ambiguous
-command-not-found failure.
+Production asset compilation runs as locked `bundle exec` over that same Ruby,
+so Rails cannot activate a newer host Bundler while reading the managed lock.
+A missing locked Bundler is therefore an explicit bootstrap error rather than
+an ambiguous command-not-found failure.
 
 ## Ruby version
 

--- a/wiki/dependencies.md
+++ b/wiki/dependencies.md
@@ -3,7 +3,7 @@ title: Dependencies
 type: dependencies
 source: Gemfile, hive.gemspec, Gemfile.lock, web/Gemfile, web/Gemfile.lock, .llm-wiki/post-commit-refresh.sh
 created: 2026-04-25
-updated: 2026-07-22
+updated: 2026-07-26
 tags: [dependencies, gems, runtime]
 ---
 
@@ -26,6 +26,7 @@ as of this refresh.
 |-----|---------|---------|
 | `thor` | `~> 1.3` (locked 1.5.0) | CLI framework — used in `Hive::CLI` (`lib/hive/cli.rb`). Subcommand routing, option parsing, help generation. |
 | `base64` | `>= 0.2` | Explicit runtime dependency for framed durable-attempt output and other binary-safe payloads; Ruby is unbundling it from the default gems. |
+| `bundler` | `= 2.7.2` | Exact installer for the authenticated managed web lock. Hive package managers vendor it into Hive's isolated `GEM_HOME`, and `AppBundle` invokes its absolute executable through the current Ruby without consulting `PATH`. |
 | `telegram-bot-ruby` | `~> 2.7` (locked 2.7.0) | Telegram Bot API client for `hive bot`. Chosen because RubyGems shows an April 3, 2026 release, MFA on publish, Ruby >= 2.7 support, and four direct runtime dependencies (`dry-struct`, `faraday`, `faraday-multipart`, `zeitwerk`). The lockfile review keeps the larger dry/faraday transitive set explicit. |
 | `faraday` | `>= 2.14.2, < 3.0` (locked 2.14.2) | HTTP transport used directly by `Hive::Bot::Transcriber` and indirectly through `telegram-bot-ruby`. The lower bound is the bundler-audit floor for CVE-2026-33637 / GHSA-5rv5-xj5j-3484. |
 | `faraday-multipart` | `~> 1.0` (locked 1.2.0) | Multipart upload support for `Hive::Bot::Transcriber` voice-note POSTs and Telegram Bot API file transport. |
@@ -155,9 +156,12 @@ is a truthful required-capture error, never a silent `not_applicable` result.
 Managed web installation does not require a `bundle` wrapper on `PATH`.
 `Hive::Web::AppBundle` reads the authenticated web `Gemfile.lock`, resolves
 that exact Bundler through RubyGems, and invokes its absolute executable
-through the current `RbConfig.ruby`. Production asset compilation uses the
-same Ruby directly. A missing locked Bundler is therefore an explicit
-bootstrap error rather than an ambiguous command-not-found failure.
+through the current `RbConfig.ruby`. `hive-cli` declares that exact Bundler as
+a runtime dependency so isolated gem, Homebrew, and AUR installations carry it
+inside Hive's managed `GEM_HOME`; a system default gem is not assumed.
+Production asset compilation uses the same Ruby directly. A missing locked
+Bundler is therefore an explicit bootstrap error rather than an ambiguous
+command-not-found failure.
 
 ## Ruby version
 

--- a/wiki/dependencies.md
+++ b/wiki/dependencies.md
@@ -152,6 +152,13 @@ by both root/web lockfile contents plus Ruby engine/version/platform; neither
 linked-worktree lockfile nor its mode may change. Missing browser/media tooling
 is a truthful required-capture error, never a silent `not_applicable` result.
 
+Managed web installation does not require a `bundle` wrapper on `PATH`.
+`Hive::Web::AppBundle` reads the authenticated web `Gemfile.lock`, resolves
+that exact Bundler through RubyGems, and invokes its absolute executable
+through the current `RbConfig.ruby`. Production asset compilation uses the
+same Ruby directly. A missing locked Bundler is therefore an explicit
+bootstrap error rather than an ambiguous command-not-found failure.
+
 ## Ruby version
 
 `Gemfile` declares `ruby "~> 3.4"`. `hive.gemspec` requires Ruby

--- a/wiki/gaps.md
+++ b/wiki/gaps.md
@@ -722,7 +722,9 @@ installing the real Rails bundle and compiling assets. Exact-head CI then
 exposed the second half of the boundary: an isolated candidate `GEM_HOME` did
 not contain Bundler at all. The gemspec now makes the web lock's exact Bundler
 a runtime dependency, while the package fixture exposes that dependency's gem
-home without restoring any executable wrapper. The remaining evidence is one
-installed-main service upgrade from the merged fix, followed by a real
+home without restoring any executable wrapper. Local replay then caught Rails
+activating a newer host Bundler during asset compilation; that phase now runs
+through locked `bundle exec` and the current Ruby too. The remaining evidence
+is one installed-main service upgrade from the merged fix, followed by a real
 worktree capture; keep those operational checks distinct from the packaged
 fixture.

--- a/wiki/gaps.md
+++ b/wiki/gaps.md
@@ -710,3 +710,15 @@ merge and install the exact head, replay the stranded patrol execute task and
 the stale writing workflow pin, and observe at least one daemon tick with the
 local-only registrations present and no merge-reconciliation error. Keep this
 gap open until those three live checks are recorded.
+
+## Managed web Bundler resolution needs installed-main replay (2026-07-26)
+
+Dogfood of merged recovery follow-ups reproduced the artifacts-stage failure
+against an immutable deployment: `hive web install` could run the CLI while
+still failing its internal bare `bundle install` because the Bundler wrapper
+was absent from `PATH`. Unit coverage now pins the exact Ruby/locked-Bundler
+argv, and the packaged-gem bootstrap passes with `PATH=/usr/bin:/bin` while
+installing the real Rails bundle and compiling assets. The remaining evidence
+is one installed-main service upgrade from the merged fix, followed by a real
+worktree capture; keep those operational checks distinct from the packaged
+fixture.

--- a/wiki/gaps.md
+++ b/wiki/gaps.md
@@ -718,7 +718,11 @@ against an immutable deployment: `hive web install` could run the CLI while
 still failing its internal bare `bundle install` because the Bundler wrapper
 was absent from `PATH`. Unit coverage now pins the exact Ruby/locked-Bundler
 argv, and the packaged-gem bootstrap passes with `PATH=/usr/bin:/bin` while
-installing the real Rails bundle and compiling assets. The remaining evidence
-is one installed-main service upgrade from the merged fix, followed by a real
+installing the real Rails bundle and compiling assets. Exact-head CI then
+exposed the second half of the boundary: an isolated candidate `GEM_HOME` did
+not contain Bundler at all. The gemspec now makes the web lock's exact Bundler
+a runtime dependency, while the package fixture exposes that dependency's gem
+home without restoring any executable wrapper. The remaining evidence is one
+installed-main service upgrade from the merged fix, followed by a real
 worktree capture; keep those operational checks distinct from the packaged
 fixture.

--- a/wiki/log.d/20260726T075741Z-managed-web-locked-bundler.md
+++ b/wiki/log.d/20260726T075741Z-managed-web-locked-bundler.md
@@ -1,0 +1,15 @@
+---
+title: Managed web bootstrap uses its locked Bundler directly
+category: fixed
+modules:
+  - web
+  - packaging
+---
+
+- Managed `hive web install` no longer depends on a `bundle` wrapper being on
+  `PATH`; it resolves the authenticated web lockfile's Bundler and invokes it
+  through the current Ruby.
+- Production asset compilation also uses that Ruby directly, preventing a
+  system `ruby` elsewhere on `PATH` from silently taking over.
+- The packaged bootstrap gate now runs with only `/usr/bin:/bin` on `PATH` and
+  still installs the real Rails bundle and compiles its assets.

--- a/wiki/log.d/20260726T075741Z-managed-web-locked-bundler.md
+++ b/wiki/log.d/20260726T075741Z-managed-web-locked-bundler.md
@@ -11,7 +11,7 @@ modules:
   through the current Ruby.
 - `hive-cli` now carries that exact Bundler as a runtime dependency, including
   when its package manager isolates Hive from system gems.
-- Production asset compilation also uses that Ruby directly, preventing a
-  system `ruby` elsewhere on `PATH` from silently taking over.
+- Production asset compilation uses locked `bundle exec` over that Ruby,
+  preventing a system Ruby or newer host Bundler from silently taking over.
 - The packaged bootstrap gate now runs with only `/usr/bin:/bin` on `PATH` and
   still installs the real Rails bundle and compiles its assets.

--- a/wiki/log.d/20260726T075741Z-managed-web-locked-bundler.md
+++ b/wiki/log.d/20260726T075741Z-managed-web-locked-bundler.md
@@ -9,6 +9,8 @@ modules:
 - Managed `hive web install` no longer depends on a `bundle` wrapper being on
   `PATH`; it resolves the authenticated web lockfile's Bundler and invokes it
   through the current Ruby.
+- `hive-cli` now carries that exact Bundler as a runtime dependency, including
+  when its package manager isolates Hive from system gems.
 - Production asset compilation also uses that Ruby directly, preventing a
   system `ruby` elsewhere on `PATH` from silently taking over.
 - The packaged bootstrap gate now runs with only `/usr/bin:/bin` on `PATH` and


### PR DESCRIPTION
## Summary

- resolve the authenticated web lockfile's exact Bundler executable through RubyGems
- vendor that exact Bundler as a `hive-cli` runtime dependency for isolated gem/Homebrew/AUR installs
- compile assets through locked `bundle exec` and the current Ruby instead of PATH shims or a newer host Bundler
- exercise packaged bootstrap with only `/usr/bin:/bin` on PATH
- document the managed install contract and remaining installed-main dogfood proof

## Verification

- `bundle exec ruby -Itest test/unit/web/app_bundle_test.rb` (43 runs, 157 assertions)
- `bundle exec ruby -Itest test/unit/gemspec_test.rb` (11 runs, 53 assertions)
- `bundle exec ruby -Itest test/unit/wiki_log_test.rb` (7 runs, 27 assertions)
- `bundle exec rubocop lib/hive/web/app_bundle.rb test/unit/web/app_bundle_test.rb test/integration/web_packaged_bootstrap_test.rb test/unit/gemspec_test.rb hive.gemspec`
- `bundle exec rake test:packaged_web_bootstrap` (1 run, 644 assertions)
- `bundle exec rake test` before the packaging follow-ups (10,273 runs, 141,055 assertions, 0 failures, 0 errors)
