### PR TITLE
Fix managed web runtime Bundler pin

### DIFF
--- a/lib/hive/commands/web.rb
+++ b/lib/hive/commands/web.rb
@@ -201,6 +201,11 @@ module Hive
           env["HIVE_CLI_ROOT"] = Hive::Web::AppBundle.hive_cli_root
           env["BUNDLE_PATH"] = Hive::Web::AppBundle.dependency_dir
         end
+        rails_argv = if managed_bundle
+          Hive::Web::AppBundle.rails_argv(app_dir)
+        else
+          [ "bin/rails" ]
+        end
         # The loopback no-auth bypass is opt-out: an operator can set
         # web.local_loopback: false to force GitHub login even on a loopback
         # bind. Only signal the bypass when both the bind is loopback AND the
@@ -224,7 +229,7 @@ module Hive
           if env.fetch("RAILS_ENV") == "production" && !precompiled_assets
             compiled = Dir.mktmpdir("hive-web-assets") do |asset_storage|
               asset_env = env.merge("HIVE_WEB_STORAGE_DIR" => asset_storage)
-              system(asset_env, "bin/rails", "assets:precompile")
+              system(asset_env, *rails_argv, "assets:precompile")
             end
             unless compiled && Hive::Web::AppBundle.assets_ready?(app_dir)
               raise Hive::Error,
@@ -236,7 +241,7 @@ module Hive
           # first boot, no-ops afterwards. Array form — no shell involved.
           # Typed error so a persistent failure surfaces as guidance, not a
           # raw backtrace looping on every restart under the service manager.
-          unless system(env, "bin/rails", "db:prepare")
+          unless system(env, *rails_argv, "db:prepare")
             raise Hive::Error,
                   "hive web: db:prepare failed — check that " \
                   "#{env.fetch("HIVE_WEB_STORAGE_DIR")} is writable " \
@@ -245,7 +250,7 @@ module Hive
           puts "hive web: listening on http://#{bind}:#{port}"
           # Replace this process with the Rails server (array form, env hash;
           # Kernel#exec never touches a shell when given an argv list).
-          Kernel.exec env, "bin/rails", "server", "-b", bind, "-p", port.to_s
+          Kernel.exec env, *rails_argv, "server", "-b", bind, "-p", port.to_s
         end
       end
 

--- a/lib/hive/web/app_bundle.rb
+++ b/lib/hive/web/app_bundle.rb
@@ -169,10 +169,7 @@ module Hive
           "HIVE_WEB_STORAGE_DIR" => asset_storage
         }
         command = if default_commands
-          bundle_argv(
-            dir, "exec", RbConfig.ruby,
-            File.join(dir, "bin", "rails"), "assets:precompile"
-          )
+          rails_argv(dir, "assets:precompile")
         else
           %w[bin/rails assets:precompile]
         end
@@ -201,6 +198,13 @@ module Hive
 
       def bundle_install_argv(dir)
         bundle_argv(dir, "install")
+      end
+
+      def rails_argv(dir, *arguments)
+        bundle_argv(
+          dir, "exec", RbConfig.ruby,
+          File.join(dir, "bin", "rails"), *arguments
+        )
       end
 
       def bundle_argv(dir, *arguments)

--- a/test/unit/web/web_command_test.rb
+++ b/test/unit/web/web_command_test.rb
@@ -368,14 +368,29 @@ class WebCommandTest < Minitest::Test
         true
       end
       replacement = ->(env, *argv) { raise ExecCaught.new(env, argv) }
-      caught = with_replaced_singleton_method(Kernel, :exec, replacement) do
-        assert_raises(ExecCaught) { capture_io { command.call } }
+      exact_rails = [
+        "/exact/ruby", "/exact/bundle", "exec", "/exact/ruby",
+        File.join(dir, "bin", "rails")
+      ]
+      rails_argv_calls = []
+      caught = with_replaced_singleton_method(
+        Hive::Web::AppBundle, :rails_argv, ->(actual_dir, *arguments) {
+          rails_argv_calls << [ actual_dir, arguments ]
+          exact_rails
+        }
+      ) do
+        with_replaced_singleton_method(Kernel, :exec, replacement) do
+          assert_raises(ExecCaught) { capture_io { command.call } }
+        end
       end
 
       assert_equal Hive::Web::AppBundle.hive_cli_root, caught.env["HIVE_CLI_ROOT"]
       assert_equal Hive::Web::AppBundle.dependency_dir, caught.env["BUNDLE_PATH"]
-      assert_equal [ %w[bin/rails db:prepare] ], system_calls.map { |call| call.last(2) },
-                   "the validated managed bundle should not recompile assets at every restart"
+      assert_equal [ [ dir, [] ] ], rails_argv_calls
+      assert_equal [ [ *exact_rails, "db:prepare" ] ], system_calls.map { |call| call.drop(1) },
+                   "managed database preparation must run through the locked Bundler"
+      assert_equal [ *exact_rails, "server", "-b", "127.0.0.1", "-p", "4567" ], caught.argv,
+                   "managed Rails server must run through the locked Bundler"
     end
   end
 

--- a/wiki/commands/web.md
+++ b/wiki/commands/web.md
@@ -38,6 +38,10 @@ production `assets:precompile`, requires usable `application.css` and
 `application.js` entrypoints, verifies every Propshaft manifest asset resolves
 to a contained file, and only then atomically activates it. Missing or corrupt
 assets make even a same-version bundle repair itself.
+For a managed bundle, provisioning, `db:prepare`, and the Rails server all run
+through the exact Bundler recorded by the authenticated lockfile and the
+current Ruby. A newer host-default Bundler cannot take over after a successful
+install when systemd starts the service.
 Relative `HIVE_WEB_APP_DIR` values are accepted but normalized before the
 Rails env is built, so `BUNDLE_GEMFILE` points at the real app Gemfile after
 the command changes into the app directory.

--- a/wiki/dependencies.md
+++ b/wiki/dependencies.md
@@ -161,6 +161,9 @@ a runtime dependency so isolated gem, Homebrew, and AUR installations carry it
 inside Hive's managed `GEM_HOME`; a system default gem is not assumed.
 Production asset compilation runs as locked `bundle exec` over that same Ruby,
 so Rails cannot activate a newer host Bundler while reading the managed lock.
+The managed service uses the identical launcher for `db:prepare` and the
+long-running Rails server; provisioning and runtime therefore cannot diverge
+when another Bundler version is the host default.
 A missing locked Bundler is therefore an explicit bootstrap error rather than
 an ambiguous command-not-found failure.
 

--- a/wiki/log.d/20260726T084948Z-managed-web-runtime-bundler.md
+++ b/wiki/log.d/20260726T084948Z-managed-web-runtime-bundler.md
@@ -1,0 +1,17 @@
+---
+title: Managed web runtime uses locked Bundler
+type: log
+created: 2026-07-26
+---
+
+`hive web` now launches managed `db:prepare` and the long-running Rails server
+through the same exact lockfile-selected Bundler and current Ruby used by web
+bundle provisioning. This closes a live systemd failure where installation and
+asset compilation succeeded under Bundler 2.7.2, then direct `bin/rails`
+startup activated host Bundler 4 and rejected `hive-cli`'s runtime dependency.
+Operator-managed source and Hivebox app overrides retain their existing direct
+Rails launch contract.
+
+Focused command coverage pins both managed runtime commands to the canonical
+locked launcher, while AppBundle coverage continues to pin the same launcher
+for production asset compilation.


### PR DESCRIPTION
## Summary

- launch managed `db:prepare` through the Bundler version authenticated by `web/Gemfile.lock`
- launch the long-running managed Rails server through the same exact Bundler/current Ruby path
- retain direct Rails launch behavior for source and Hivebox app overrides
- document the provisioning/runtime contract in the managed web wiki

## Why

A live fresh dogfood install from current `main` successfully installed gems and compiled assets with Bundler 2.7.2, but systemd then invoked `bin/rails` directly. Host Bundler 4.0.16 activated and rejected `hive-cli`'s exact Bundler 2.7.2 runtime dependency, leaving the service in an `active_not_ready` restart loop.

## Verification

- `test/unit/web/app_bundle_test.rb`: 43 runs, 157 assertions
- `test/unit/web/web_command_test.rb`: 40 runs, 139 assertions
- RuboCop: 3 changed Ruby files, no offenses
- real managed app alternate-port smoke: Rails 8.1.3 booted and `/up` returned 200
- real systemd-user install from commit `60c639594`: ready, `NRestarts=0`, `/up` 200, ~132 MB
