### PR TITLE
docs(boundaries): audit final component graph

### DIFF
--- a/test/unit/component_boundaries_test.rb
+++ b/test/unit/component_boundaries_test.rb
@@ -229,6 +229,36 @@ class ComponentBoundariesTest < Minitest::Test
     assert_empty work_ledger_load.fetch("forbidden_constants")
   end
 
+  def test_final_graph_and_wiki_inventory_agree_with_the_catalog
+    contract = ComponentBoundaryContract.new(@document, root: ROOT)
+    assert contract.validate_catalog!
+
+    component_page = File.read(File.join(ROOT, "wiki", "component-boundaries.md"))
+    wiki_index = File.read(File.join(ROOT, "wiki", "index.md"))
+    dependencies = {}
+
+    contract.components.each do |component|
+      row = component_page.lines.find do |line|
+        line.start_with?("| #{component.fetch('name')} |")
+      end
+      refute_nil row, "wiki inventory is missing #{component.fetch('name')}"
+      assert_includes row, "`#{component.fetch('state')}`"
+      assert_includes row, "`require \"#{component.dig('entrypoint', 'require')}\"`"
+      assert_includes row, "`#{component.dig('entrypoint', 'constant')}`"
+
+      wiki_link = component.fetch("wiki_page").delete_prefix("wiki/").delete_suffix(".md")
+      assert_includes row, "[[#{wiki_link}]]"
+      assert_includes wiki_index, "[[#{wiki_link}]]"
+      assert_empty component.fetch("migration_exceptions"),
+                   "#{component.fetch('id')} retained an expired migration exception"
+
+      component_dependencies = component.fetch("component_dependencies")
+      dependencies[component.fetch("id")] = component_dependencies unless component_dependencies.empty?
+    end
+
+    assert_equal({ "skillpack" => [ "agent-abi" ] }, dependencies)
+  end
+
   def test_production_consumers_do_not_bypass_artifact_firewall
     allowed = %w[
       lib/hive/artifact_firewall.rb

--- a/wiki/component-boundaries.md
+++ b/wiki/component-boundaries.md
@@ -31,6 +31,37 @@ means the entry point, allowed dependency direction, consumer construction
 rules, and clean-process load are enforced. It does not mean that a component
 has earned a gem, version, repository, or release.
 
+## Final graph audit
+
+The U9 audit on 2026-07-26 retained seven components: six are
+`boundary-ready`, Attempts remains the sole `candidate`, and no migration
+exceptions remain. Every retained entry point has a focused clean-process load
+proof, every catalog-owned path and focused test resolves inside this
+repository, and the direct-construction guards pass against all production
+Ruby sources.
+
+The component dependency graph has one edge:
+
+```mermaid
+flowchart LR
+  skillpack[Skillpack] --> agent_abi[Agent ABI]
+  attempts[Attempts admission - candidate]
+  user_service[UserService]
+  artifact_firewall[Agent Artifact Firewall]
+  git_gate[Safe Agent Git Gate]
+  work_ledger[WorkLedger]
+```
+
+All other cataloged components depend only on explicitly allowed lower-level
+Hive primitives. The source audit found no retained experimental facade outside
+the catalog: each promoted facade is owned by a catalog row and used by Hive,
+while Attempts is deliberately retained as a guarded candidate rather than
+misrepresented as a complete lifecycle API.
+
+This is an internal architecture verdict, not a packaging verdict. None of the
+six ready components currently has the named non-Hive adopter and independent
+package proof required by the standalone-gem plan.
+
 `Hive::Attempts::API` is the guarded reference admission slice. Its public
 result contracts, focused clean-load proof, and exact internal construction
 sites are enforced while it remains a `candidate`. U8 removed its former

--- a/wiki/decisions.md
+++ b/wiki/decisions.md
@@ -11,13 +11,26 @@ tags: [decisions, adr]
 
 ## ADR-038: Reusable components stay in the monorepo and earn packaging after Hive-first boundaries
 
-**Status:** Active (strategy recorded 2026-07-25; the component catalog and enforcement harness are implemented, with component refactors following incrementally).
+**Status:** Active (strategy recorded 2026-07-25; the internal-boundary graph was audited on 2026-07-26).
 
 **Context:** Repo-grounded extraction analysis found seven mechanisms with plausible standalone value: RunReceipt, UserService, Agent Artifact Firewall, Agent ABI, Skillpack, Safe Agent Git Gate, and WorkLedger. Splitting them into separate repositories would weaken Hive's most useful maintenance property for humans and agents: one checkout exposes the callers, durable state, compatibility fixtures, integration tests, release machinery, and implementation together. Packaging them immediately inside the monorepo would preserve navigation but still freeze accidental Hive dependencies and create version/release obligations before an external consumer exists.
 
 **Decision:** Hive remains the canonical monorepo and the first and primary consumer of every reusable component. Establish and enforce internal Ruby boundaries first: one supported entry point or facade, structured public values and errors, an acyclic dependency direction, explicit state/schema/lock ownership, clean-process loading, and all Hive production consumers routed through the boundary. Existing module wiki pages plus one component catalog are the canonical agent context; do not add a parallel `.context.md` hierarchy.
 
-Implementation readiness and standalone product value are different rankings. `Hive::Attempts::API` is the guarded reference admission candidate: its focused clean-load behavior, result contracts, and exact internal composition/compatibility sites are enforced without adding generic lifecycle, cancellation, export, or raw-store APIs. It is not `boundary-ready` while Attempts reads WorkLedger projections and WorkLedger-owned `lib/hive/task_projection/store.rb` reaches back into `Hive::Attempts::Store`; the bounded catalog exception assigns removal of that reciprocal edge to U8. UserService is the next low-coupling boundary; Agent ABI, Agent Artifact Firewall, Skillpack, Safe Agent Git Gate, and WorkLedger follow in readiness order and may each terminate as deferred when a policy-light seam cannot be proven. RunReceipt remains the strongest standalone opportunity without forcing the largest refactor first. Operational status/Statewatch, layout migration, standalone capability probes, separate lease/capsule products, generic status rendering, and a new local-agent framework remain rejected or folded ideas rather than package commitments.
+Implementation readiness and standalone product value are different rankings.
+The final audit retains six `boundary-ready` components: UserService, Agent ABI,
+Agent Artifact Firewall, Skillpack, Safe Agent Git Gate, and WorkLedger.
+`Hive::Attempts::API` remains the sole guarded `candidate`: its focused
+clean-load behavior, result contracts, and exact internal composition and
+compatibility sites are enforced without adding generic lifecycle,
+cancellation, export, or raw-store APIs. U8 removed the former reciprocal
+Attempts/WorkLedger catalog edge by keeping `TaskProjection::Store` as a
+Hive-owned adapter rather than WorkLedger-owned source, so the final catalog has
+no migration exceptions. RunReceipt remains the strongest standalone
+opportunity without forcing the largest refactor first. Operational
+status/Statewatch, layout migration, standalone capability probes, separate
+lease/capsule products, generic status rendering, and a new local-agent
+framework remain rejected or folded ideas rather than package commitments.
 
 A component becomes package-eligible only after its internal boundary is stable, a named non-Hive adopter or maintained integration proves demand, the component loads and tests independently without an upward Hive dependency, compatibility and maintenance ownership are explicit, and an exact built gem installs cleanly. A qualifying package stays in this repository under `components/<gem-name>/`, uses independent SemVer, and remains a path dependency for source development while released `hive-cli` declares a normal compatible dependency. Package publication is explicit and component-scoped; path changes may select tests but never publish.
 

--- a/wiki/gaps.md
+++ b/wiki/gaps.md
@@ -100,6 +100,26 @@ tags: [gap, todo, release-proof, agent-skills]
   Sol `ce-code-review` policy, and combined Sol-runner selection are locally
   test-pinned but still need their first paid end-to-end cell.
 
+## Internal component boundary gap
+
+- The final internal graph audit retains seven catalog rows: UserService, Agent
+  ABI, Agent Artifact Firewall, Skillpack, Safe Agent Git Gate, and WorkLedger
+  are `boundary-ready`; Attempts admission remains the sole `candidate`.
+  Skillpack to Agent ABI is the only component dependency, and no migration
+  exceptions remain. Attempts is not ready because Hive has no demonstrated
+  need for a supported reconciliation, supervision, capacity, loss-processing,
+  cancellation, export, or raw-store lifecycle API.
+- No ready component has yet earned standalone packaging. There is no named
+  non-Hive adopter, independently installed component artifact, separate
+  compatibility promise, or explicit release decision. Those proofs belong to
+  `docs/plans/2026-07-25-002-feat-standalone-component-gems-plan.md`; internal
+  readiness must not be reported as RubyGems publication eligibility.
+- The catalog guard parses literal `require`, `require_relative`, and
+  `Constant.new` edges. Dynamic loading, aliases, reflection, factories, and
+  same-user monkeypatching remain outside that test-only architecture check.
+  A future package candidate still needs an independent package harness and
+  security claims grounded in its own runtime tests.
+
 ## Source-file coverage (representative map)
 
 | Area / file set | Page |

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -18,6 +18,15 @@ Updated: 2026-07-26
 
 Folder-as-agent workflow engine: a Ruby 3.4 / Thor CLI control plane where descriptor-backed workflows move task folders through filesystem stages, stage agents compile provider-neutral invocations through `Hive::AgentRuntime` and configurable AgentProfile adapters (`claude` default, `codex`, `pi`, `grok`), and `mv` between directories remains the approval primitive. The built-in `coding` workflow drives the nine-stage PR pipeline (`1-inbox` → `2-brainstorm` → `3-plan` → `4-execute` → `5-open-pr` → `6-review` → `7-artifacts` → `8-finalize` → `9-done`), while the built-in `content` and `bench` workflows and project-authored workflows share the same generic runner/status/action machinery. Agent operation is centered on the additive operational status contract, coherent daemon scheduler snapshots, bounded semantic `hive watch`, and tokenized routine `hive act`; the legacy full JSON graph remains compatible. Hive packages one canonical operating skill projected to OpenClaw `/hive`, Claude `/hive`, Codex `$hive`, and Pi `/skill:hive`, with read-only `hive doctor`, consent-safe setup, and an exact-SHA four-agent pre-release proof.
 
+Reusable mechanisms remain in this monorepo behind the canonical
+[[component-boundaries]] catalog. The final internal graph has six
+`boundary-ready` facades—UserService, Agent ABI, Agent Artifact Firewall,
+Skillpack, Safe Agent Git Gate, and WorkLedger—and one guarded `candidate`,
+Attempts admission. Skillpack's downward dependency on the Agent ABI is the
+only component-to-component edge; no migration exceptions remain. Hive is the
+first and primary consumer, and internal readiness does not imply a gem,
+version, repository, or release.
+
 Agent spawns that own controller artifacts use the boundary-ready
 `Hive::ArtifactFirewall` for same-user protected-anchor custody, required
 regular-output admission, bounded redacted reports, and verified safe restore;

--- a/wiki/log.d/20260726T083744Z-component-boundary-audit.md
+++ b/wiki/log.d/20260726T083744Z-component-boundary-audit.md
@@ -1,0 +1,23 @@
+# 2026-07-26 — Audit the complete internal component graph
+
+**Verdict:** Hive retains seven cataloged mechanisms. UserService, Agent ABI,
+Agent Artifact Firewall, Skillpack, Safe Agent Git Gate, and WorkLedger are
+`boundary-ready`; Attempts admission remains the sole guarded `candidate`.
+Skillpack to Agent ABI is the only component-to-component dependency, and the
+catalog contains no migration exceptions.
+
+**Audit:** Re-ran catalog schema, repository-path, ownership, dependency-cycle,
+clean-load, forbidden-upward-edge, and direct-internal-construction checks.
+Added an executable agreement check between the catalog, the current component
+table, and the wiki index. The retained facades are catalog-owned and
+Hive-consumed; no abandoned experimental facade or shadow `.context.md`
+documentation was retained.
+
+**Correction:** Updated ADR-038, which still described the former reciprocal
+Attempts/WorkLedger edge and U8-bounded exception after WorkLedger moved
+`TaskProjection::Store` back to explicit Hive adapter ownership.
+
+**Scope:** This is an internal architecture audit only. No package directory,
+gemspec, independent version, tag, release, publication, deployment, or
+repository split was introduced. Standalone packaging remains gated by a named
+non-Hive adopter, independent package proof, and explicit release authority.


### PR DESCRIPTION
## Summary

- records the final seven-component graph: six boundary-ready facades, Attempts as the sole candidate, one Skillpack to Agent ABI dependency, and zero migration exceptions
- corrects ADR-038 after U8 removed the former Attempts and WorkLedger reciprocal edge
- makes the catalog table and wiki index agree through an executable architecture check
- records remaining standalone-package proof gaps without creating a package or publication commitment

## Verification

- current-main component boundary contract: 30 runs, 379 assertions, 0 failures
- RuboCop on the changed Ruby test: no offenses
- diff whitespace check: clean
- exact-head hosted CI: pending

## Scope

Documentation and architecture-test only; no runtime behavior, package directory, gemspec, version, tag, release, deployment, publication, or repository split.
