### PR TITLE
fix(test): sandbox operator state

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -72,7 +72,11 @@ end
 #
 # Per project CLAUDE.md (Ivan's rule "use real APIs, make real requests"):
 # this is the test bed where claude actually gets called.
-Rake::TestTask.new(:smoke) do |t|
+task "test:allow_real_user_environment" do
+  ENV["HIVE_TEST_ALLOW_REAL_USER_ENV"] = "1"
+end
+
+Rake::TestTask.new(smoke: "test:allow_real_user_environment") do |t|
   t.libs << "test"
   t.libs << "lib"
   t.test_files = FileList["test/smoke/**/*_test.rb"]

--- a/test/integration/new_test.rb
+++ b/test/integration/new_test.rb
@@ -741,7 +741,9 @@ class NewTest < Minitest::Test
   end
 
   def test_attachments_accept_absolute_sources_outside_tmpdir
-    source_dir = Dir.mktmpdir("hive-new-src-", Dir.home)
+    # The suite's disposable HOME deliberately lives under Dir.tmpdir, so use
+    # the checkout as this fixture's short-lived non-tmp absolute source.
+    source_dir = Dir.mktmpdir(".hive-new-src-", File.expand_path("../..", __dir__))
     begin
       fixture = File.join(source_dir, "fixture.png")
       File.binwrite(fixture, "outside-tmp".b)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,6 +23,17 @@ require "English"
 require "hive"
 require_relative "support/workflow_helpers"
 
+# Never let a test subprocess inherit the operator's global Git configuration.
+# In particular, `git config --global` prefers an existing XDG config even when
+# a test overrides only HOME. Point Git at one disposable file for the entire
+# process so tests cannot rewrite real credential helpers, hooks, or signing
+# configuration.
+HIVE_TEST_GLOBAL_GIT_CONFIG_ROOT = Dir.mktmpdir("hive-test-git-config").freeze
+ENV["GIT_CONFIG_GLOBAL"] = File.join(HIVE_TEST_GLOBAL_GIT_CONFIG_ROOT, "config")
+Minitest.after_run do
+  FileUtils.rm_rf(HIVE_TEST_GLOBAL_GIT_CONFIG_ROOT)
+end
+
 if ENV.delete("HIVE_REQUIRE_TEST_RUNS") == "1"
   module HiveCiGateRunGuard
     class Reporter < Minitest::StatisticsReporter

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,40 +20,38 @@ require "stringio"
 require "yaml"
 require "shellwords"
 require "English"
-require "hive"
-require_relative "support/workflow_helpers"
 
 # Never let a normal test subprocess inherit the operator's Hive state, home,
 # XDG roots, agent configuration, GitHub configuration, or global Git config.
-# A caller can export any of these into a daemon or terminal; tests must remain
-# hermetic anyway. Authenticated smoke tests opt out explicitly in the Rake
-# task because their purpose is to exercise the operator's real agent login.
+# Set only HOME and remove the optional overrides so production defaults keep
+# following HOME when an individual test replaces it. Authenticated smoke tests
+# opt out explicitly because they exercise the operator's real agent login.
 unless ENV["HIVE_TEST_ALLOW_REAL_USER_ENV"] == "1"
   HIVE_TEST_USER_ROOT = Dir.mktmpdir("hive-test-user").freeze
   test_home = File.join(HIVE_TEST_USER_ROOT, "home")
   FileUtils.mkdir_p(test_home)
-  # HOME and XDG_CONFIG_HOME contain Git's standard global config files.
-  # Remove an inherited override instead of replacing it: the babysitter
-  # correctly rejects any caller-controlled GIT_CONFIG_GLOBAL passthrough.
-  ENV.delete("GIT_CONFIG_GLOBAL")
-  {
-    "HOME" => test_home,
-    "HIVE_HOME" => File.join(HIVE_TEST_USER_ROOT, "hive"),
-    "XDG_CONFIG_HOME" => File.join(HIVE_TEST_USER_ROOT, "config"),
-    "XDG_DATA_HOME" => File.join(HIVE_TEST_USER_ROOT, "data"),
-    "XDG_STATE_HOME" => File.join(HIVE_TEST_USER_ROOT, "state"),
-    "XDG_CACHE_HOME" => File.join(HIVE_TEST_USER_ROOT, "cache"),
-    "XDG_BIN_HOME" => File.join(HIVE_TEST_USER_ROOT, "bin"),
-    "CLAUDE_CONFIG_DIR" => File.join(test_home, ".claude"),
-    "CODEX_HOME" => File.join(test_home, ".codex"),
-    "PI_CODING_AGENT_DIR" => File.join(test_home, ".pi", "agent"),
-    "GROK_HOME" => File.join(test_home, ".grok"),
-    "GH_CONFIG_DIR" => File.join(HIVE_TEST_USER_ROOT, "gh")
-  }.each { |key, value| ENV[key] = value }
+  ENV["HOME"] = test_home
+  %w[
+    HIVE_HOME
+    XDG_CONFIG_HOME
+    XDG_DATA_HOME
+    XDG_STATE_HOME
+    XDG_CACHE_HOME
+    XDG_BIN_HOME
+    CLAUDE_CONFIG_DIR
+    CODEX_HOME
+    PI_CODING_AGENT_DIR
+    GROK_HOME
+    GH_CONFIG_DIR
+    GIT_CONFIG_GLOBAL
+  ].each { |key| ENV.delete(key) }
   Minitest.after_run do
     FileUtils.rm_rf(HIVE_TEST_USER_ROOT)
   end
 end
+
+require "hive"
+require_relative "support/workflow_helpers"
 
 if ENV.delete("HIVE_REQUIRE_TEST_RUNS") == "1"
   module HiveCiGateRunGuard

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,15 +23,33 @@ require "English"
 require "hive"
 require_relative "support/workflow_helpers"
 
-# Never let a test subprocess inherit the operator's global Git configuration.
-# In particular, `git config --global` prefers an existing XDG config even when
-# a test overrides only HOME. Point Git at one disposable file for the entire
-# process so tests cannot rewrite real credential helpers, hooks, or signing
-# configuration.
-HIVE_TEST_GLOBAL_GIT_CONFIG_ROOT = Dir.mktmpdir("hive-test-git-config").freeze
-ENV["GIT_CONFIG_GLOBAL"] = File.join(HIVE_TEST_GLOBAL_GIT_CONFIG_ROOT, "config")
-Minitest.after_run do
-  FileUtils.rm_rf(HIVE_TEST_GLOBAL_GIT_CONFIG_ROOT)
+# Never let a normal test subprocess inherit the operator's Hive state, home,
+# XDG roots, agent configuration, GitHub configuration, or global Git config.
+# A caller can export any of these into a daemon or terminal; tests must remain
+# hermetic anyway. Authenticated smoke tests opt out explicitly in the Rake
+# task because their purpose is to exercise the operator's real agent login.
+unless ENV["HIVE_TEST_ALLOW_REAL_USER_ENV"] == "1"
+  HIVE_TEST_USER_ROOT = Dir.mktmpdir("hive-test-user").freeze
+  test_home = File.join(HIVE_TEST_USER_ROOT, "home")
+  FileUtils.mkdir_p(test_home)
+  {
+    "HOME" => test_home,
+    "HIVE_HOME" => File.join(HIVE_TEST_USER_ROOT, "hive"),
+    "XDG_CONFIG_HOME" => File.join(HIVE_TEST_USER_ROOT, "config"),
+    "XDG_DATA_HOME" => File.join(HIVE_TEST_USER_ROOT, "data"),
+    "XDG_STATE_HOME" => File.join(HIVE_TEST_USER_ROOT, "state"),
+    "XDG_CACHE_HOME" => File.join(HIVE_TEST_USER_ROOT, "cache"),
+    "XDG_BIN_HOME" => File.join(HIVE_TEST_USER_ROOT, "bin"),
+    "CLAUDE_CONFIG_DIR" => File.join(test_home, ".claude"),
+    "CODEX_HOME" => File.join(test_home, ".codex"),
+    "PI_CODING_AGENT_DIR" => File.join(test_home, ".pi", "agent"),
+    "GROK_HOME" => File.join(test_home, ".grok"),
+    "GH_CONFIG_DIR" => File.join(HIVE_TEST_USER_ROOT, "gh"),
+    "GIT_CONFIG_GLOBAL" => File.join(HIVE_TEST_USER_ROOT, "gitconfig")
+  }.each { |key, value| ENV[key] = value }
+  Minitest.after_run do
+    FileUtils.rm_rf(HIVE_TEST_USER_ROOT)
+  end
 end
 
 if ENV.delete("HIVE_REQUIRE_TEST_RUNS") == "1"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -32,6 +32,10 @@ unless ENV["HIVE_TEST_ALLOW_REAL_USER_ENV"] == "1"
   HIVE_TEST_USER_ROOT = Dir.mktmpdir("hive-test-user").freeze
   test_home = File.join(HIVE_TEST_USER_ROOT, "home")
   FileUtils.mkdir_p(test_home)
+  # HOME and XDG_CONFIG_HOME contain Git's standard global config files.
+  # Remove an inherited override instead of replacing it: the babysitter
+  # correctly rejects any caller-controlled GIT_CONFIG_GLOBAL passthrough.
+  ENV.delete("GIT_CONFIG_GLOBAL")
   {
     "HOME" => test_home,
     "HIVE_HOME" => File.join(HIVE_TEST_USER_ROOT, "hive"),
@@ -44,8 +48,7 @@ unless ENV["HIVE_TEST_ALLOW_REAL_USER_ENV"] == "1"
     "CODEX_HOME" => File.join(test_home, ".codex"),
     "PI_CODING_AGENT_DIR" => File.join(test_home, ".pi", "agent"),
     "GROK_HOME" => File.join(test_home, ".grok"),
-    "GH_CONFIG_DIR" => File.join(HIVE_TEST_USER_ROOT, "gh"),
-    "GIT_CONFIG_GLOBAL" => File.join(HIVE_TEST_USER_ROOT, "gitconfig")
+    "GH_CONFIG_DIR" => File.join(HIVE_TEST_USER_ROOT, "gh")
   }.each { |key, value| ENV[key] = value }
   Minitest.after_run do
     FileUtils.rm_rf(HIVE_TEST_USER_ROOT)

--- a/test/unit/test_helper_isolation_test.rb
+++ b/test/unit/test_helper_isolation_test.rb
@@ -1,0 +1,12 @@
+require "test_helper"
+
+class TestHelperIsolationTest < Minitest::Test
+  def test_global_git_configuration_is_disposable
+    configured = File.expand_path(ENV.fetch("GIT_CONFIG_GLOBAL"))
+    root = File.realpath(HIVE_TEST_GLOBAL_GIT_CONFIG_ROOT)
+
+    assert_equal File.join(root, "config"), configured
+    assert_equal Dir.tmpdir, File.dirname(root)
+    assert_match(/\Ahive-test-git-config/, File.basename(root))
+  end
+end

--- a/test/unit/test_helper_isolation_test.rb
+++ b/test/unit/test_helper_isolation_test.rb
@@ -1,29 +1,27 @@
 require "test_helper"
 
 class TestHelperIsolationTest < Minitest::Test
-  USER_ENV_PATHS = {
-    "HOME" => "home",
-    "HIVE_HOME" => "hive",
-    "XDG_CONFIG_HOME" => "config",
-    "XDG_DATA_HOME" => "data",
-    "XDG_STATE_HOME" => "state",
-    "XDG_CACHE_HOME" => "cache",
-    "XDG_BIN_HOME" => "bin",
-    "CLAUDE_CONFIG_DIR" => "home/.claude",
-    "CODEX_HOME" => "home/.codex",
-    "PI_CODING_AGENT_DIR" => "home/.pi/agent",
-    "GROK_HOME" => "home/.grok",
-    "GH_CONFIG_DIR" => "gh"
-  }.freeze
+  USER_ENV_OVERRIDES = %w[
+    HIVE_HOME
+    XDG_CONFIG_HOME
+    XDG_DATA_HOME
+    XDG_STATE_HOME
+    XDG_CACHE_HOME
+    XDG_BIN_HOME
+    CLAUDE_CONFIG_DIR
+    CODEX_HOME
+    PI_CODING_AGENT_DIR
+    GROK_HOME
+    GH_CONFIG_DIR
+    GIT_CONFIG_GLOBAL
+  ].freeze
 
   def test_operator_user_environment_is_disposable
     root = File.realpath(HIVE_TEST_USER_ROOT)
 
     assert_equal Dir.tmpdir, File.dirname(root)
     assert_match(/\Ahive-test-user/, File.basename(root))
-    USER_ENV_PATHS.each do |name, relative|
-      assert_equal File.join(root, relative), File.expand_path(ENV.fetch(name)), name
-    end
-    refute ENV.key?("GIT_CONFIG_GLOBAL")
+    assert_equal File.join(root, "home"), File.expand_path(ENV.fetch("HOME"))
+    USER_ENV_OVERRIDES.each { |name| refute ENV.key?(name), name }
   end
 end

--- a/test/unit/test_helper_isolation_test.rb
+++ b/test/unit/test_helper_isolation_test.rb
@@ -13,8 +13,7 @@ class TestHelperIsolationTest < Minitest::Test
     "CODEX_HOME" => "home/.codex",
     "PI_CODING_AGENT_DIR" => "home/.pi/agent",
     "GROK_HOME" => "home/.grok",
-    "GH_CONFIG_DIR" => "gh",
-    "GIT_CONFIG_GLOBAL" => "gitconfig"
+    "GH_CONFIG_DIR" => "gh"
   }.freeze
 
   def test_operator_user_environment_is_disposable
@@ -25,5 +24,6 @@ class TestHelperIsolationTest < Minitest::Test
     USER_ENV_PATHS.each do |name, relative|
       assert_equal File.join(root, relative), File.expand_path(ENV.fetch(name)), name
     end
+    refute ENV.key?("GIT_CONFIG_GLOBAL")
   end
 end

--- a/test/unit/test_helper_isolation_test.rb
+++ b/test/unit/test_helper_isolation_test.rb
@@ -1,12 +1,29 @@
 require "test_helper"
 
 class TestHelperIsolationTest < Minitest::Test
-  def test_global_git_configuration_is_disposable
-    configured = File.expand_path(ENV.fetch("GIT_CONFIG_GLOBAL"))
-    root = File.realpath(HIVE_TEST_GLOBAL_GIT_CONFIG_ROOT)
+  USER_ENV_PATHS = {
+    "HOME" => "home",
+    "HIVE_HOME" => "hive",
+    "XDG_CONFIG_HOME" => "config",
+    "XDG_DATA_HOME" => "data",
+    "XDG_STATE_HOME" => "state",
+    "XDG_CACHE_HOME" => "cache",
+    "XDG_BIN_HOME" => "bin",
+    "CLAUDE_CONFIG_DIR" => "home/.claude",
+    "CODEX_HOME" => "home/.codex",
+    "PI_CODING_AGENT_DIR" => "home/.pi/agent",
+    "GROK_HOME" => "home/.grok",
+    "GH_CONFIG_DIR" => "gh",
+    "GIT_CONFIG_GLOBAL" => "gitconfig"
+  }.freeze
 
-    assert_equal File.join(root, "config"), configured
+  def test_operator_user_environment_is_disposable
+    root = File.realpath(HIVE_TEST_USER_ROOT)
+
     assert_equal Dir.tmpdir, File.dirname(root)
-    assert_match(/\Ahive-test-git-config/, File.basename(root))
+    assert_match(/\Ahive-test-user/, File.basename(root))
+    USER_ENV_PATHS.each do |name, relative|
+      assert_equal File.join(root, relative), File.expand_path(ENV.fetch(name)), name
+    end
   end
 end

--- a/wiki/log.d/20260726T105500Z-test-global-git-config-isolation.md
+++ b/wiki/log.d/20260726T105500Z-test-global-git-config-isolation.md
@@ -1,0 +1,10 @@
+---
+title: Isolate the test suite from the operator Git config
+type: fix
+date: 2026-07-26
+---
+
+- Route every test subprocess through a disposable `GIT_CONFIG_GLOBAL` file.
+- Prevent an outer `XDG_CONFIG_HOME` from letting `git config --global` tests
+  rewrite the operator's credential helpers or other global Git controls.
+- Cover the suite-level sandbox contract and clean it after the test process.

--- a/wiki/log.d/20260726T105500Z-test-global-git-config-isolation.md
+++ b/wiki/log.d/20260726T105500Z-test-global-git-config-isolation.md
@@ -1,10 +1,12 @@
 ---
-title: Isolate the test suite from the operator Git config
+title: Isolate the test suite from the operator environment
 type: fix
 date: 2026-07-26
 ---
 
-- Route every test subprocess through a disposable `GIT_CONFIG_GLOBAL` file.
-- Prevent an outer `XDG_CONFIG_HOME` from letting `git config --global` tests
-  rewrite the operator's credential helpers or other global Git controls.
+- Route every normal test subprocess through disposable home, Hive, XDG, agent,
+  GitHub, and global Git configuration roots.
+- Prevent old-code tests from recreating `attempts/v1`, managed setup tests from
+  rewriting real agent skills, and Git tests from changing operator controls.
+- Keep authenticated smoke tests as an explicit real-user-environment opt-out.
 - Cover the suite-level sandbox contract and clean it after the test process.

--- a/wiki/log.d/20260726T105500Z-test-global-git-config-isolation.md
+++ b/wiki/log.d/20260726T105500Z-test-global-git-config-isolation.md
@@ -5,7 +5,9 @@ date: 2026-07-26
 ---
 
 - Route every normal test subprocess through disposable home, Hive, XDG, agent,
-  GitHub, and global Git configuration roots.
+  and GitHub configuration roots. Git global files follow the disposable home
+  and XDG config root after removing the babysitter-sensitive
+  `GIT_CONFIG_GLOBAL` override from the inherited environment.
 - Prevent old-code tests from recreating `attempts/v1`, managed setup tests from
   rewriting real agent skills, and Git tests from changing operator controls.
 - Keep authenticated smoke tests as an explicit real-user-environment opt-out.

--- a/wiki/log.d/20260726T105500Z-test-global-git-config-isolation.md
+++ b/wiki/log.d/20260726T105500Z-test-global-git-config-isolation.md
@@ -4,10 +4,11 @@ type: fix
 date: 2026-07-26
 ---
 
-- Route every normal test subprocess through disposable home, Hive, XDG, agent,
-  and GitHub configuration roots. Git global files follow the disposable home
-  and XDG config root after removing the babysitter-sensitive
-  `GIT_CONFIG_GLOBAL` override from the inherited environment.
+- Route every normal test subprocess through a disposable home before Hive
+  loads, while deleting inherited Hive, XDG, agent, GitHub, and Git global-path
+  overrides. Defaults keep following `HOME` when a test swaps it, and Git
+  global files remain disposable without exposing the babysitter-sensitive
+  `GIT_CONFIG_GLOBAL` override.
 - Prevent old-code tests from recreating `attempts/v1`, managed setup tests from
   rewriting real agent skills, and Git tests from changing operator controls.
 - Keep authenticated smoke tests as an explicit real-user-environment opt-out.

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -131,11 +131,16 @@ task default: :test
 
 ## Test helpers (`test/test_helper.rb`)
 
-- The test process unconditionally points `GIT_CONFIG_GLOBAL` at a disposable
-  `hive-test-git-config*` directory and removes it after the suite. This keeps
-  subprocesses hermetic even when the caller exports a real
-  `XDG_CONFIG_HOME`: `git config --global` cannot rewrite the operator's
-  credential helpers, hooks, signing settings, or other global controls.
+- Normal test processes replace `HOME`, `HIVE_HOME`, every persisted XDG root,
+  the Claude/Codex/Pi/Grok config roots, `GH_CONFIG_DIR`, and
+  `GIT_CONFIG_GLOBAL` with paths under one disposable `hive-test-user*`
+  directory, then remove it after the suite. This keeps subprocesses hermetic
+  even when the caller is a daemon exporting real user paths: tests cannot
+  recreate legacy attempt roots, rewrite managed agent skills, consume real
+  GitHub configuration, or change credential helpers, hooks, and signing
+  settings. The authenticated `rake smoke` task explicitly opts out because it
+  exists to exercise real operator logins; direct smoke-file runs must set
+  `HIVE_TEST_ALLOW_REAL_USER_ENV=1` deliberately.
 - `with_tmp_dir` — `Dir.mktmpdir("hive-test", &block)`.
 - `with_tmp_git_repo` — `git init -b master`, configures user/email and disables GPG signing, makes one initial commit, yields the path.
 - `with_tmp_global_config(home: nil)` — overrides `ENV["HIVE_HOME"]` to a tmp dir, writes an empty `registered_projects: []` YAML, and defaults `HOME` to the same tmp dir so subprocesses and service-installer tests do not touch the operator's real home. Pass `home:` when a test intentionally installs fake user-level skills or plugins under a separate fake HOME.

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -131,6 +131,11 @@ task default: :test
 
 ## Test helpers (`test/test_helper.rb`)
 
+- The test process unconditionally points `GIT_CONFIG_GLOBAL` at a disposable
+  `hive-test-git-config*` directory and removes it after the suite. This keeps
+  subprocesses hermetic even when the caller exports a real
+  `XDG_CONFIG_HOME`: `git config --global` cannot rewrite the operator's
+  credential helpers, hooks, signing settings, or other global controls.
 - `with_tmp_dir` — `Dir.mktmpdir("hive-test", &block)`.
 - `with_tmp_git_repo` — `git init -b master`, configures user/email and disables GPG signing, makes one initial commit, yields the path.
 - `with_tmp_global_config(home: nil)` — overrides `ENV["HIVE_HOME"]` to a tmp dir, writes an empty `registered_projects: []` YAML, and defaults `HOME` to the same tmp dir so subprocesses and service-installer tests do not touch the operator's real home. Pass `home:` when a test intentionally installs fake user-level skills or plugins under a separate fake HOME.

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -131,14 +131,15 @@ task default: :test
 
 ## Test helpers (`test/test_helper.rb`)
 
-- Normal test processes replace `HOME`, `HIVE_HOME`, every persisted XDG root,
-  the Claude/Codex/Pi/Grok config roots, and `GH_CONFIG_DIR` with paths under
-  one disposable `hive-test-user*` directory, then remove it after the suite.
-  Git's standard global files follow the temporary `HOME` and
-  `XDG_CONFIG_HOME`; tests explicitly remove any inherited
-  `GIT_CONFIG_GLOBAL`, because the babysitter correctly rejects that
-  caller-controlled execution channel. This keeps subprocesses hermetic even
-  when the caller is a daemon
+- Normal test processes replace `HOME` with a disposable
+  `hive-test-user*/home` directory before loading Hive, then remove it after
+  the suite. They delete inherited Hive, XDG, Claude/Codex/Pi/Grok, GitHub, and
+  Git global-path overrides instead of pinning them to fixed paths. Production
+  defaults therefore keep following `HOME` when an individual test swaps it,
+  while Git's standard global files remain under that test's disposable home.
+  `GIT_CONFIG_GLOBAL` is removed rather than replaced because the babysitter
+  correctly rejects that caller-controlled execution channel. This keeps
+  subprocesses hermetic even when the caller is a daemon
   exporting real user paths: tests cannot recreate legacy attempt roots,
   rewrite managed agent skills, consume real GitHub configuration, or change
   credential helpers, hooks, and signing settings. The authenticated

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -132,14 +132,18 @@ task default: :test
 ## Test helpers (`test/test_helper.rb`)
 
 - Normal test processes replace `HOME`, `HIVE_HOME`, every persisted XDG root,
-  the Claude/Codex/Pi/Grok config roots, `GH_CONFIG_DIR`, and
-  `GIT_CONFIG_GLOBAL` with paths under one disposable `hive-test-user*`
-  directory, then remove it after the suite. This keeps subprocesses hermetic
-  even when the caller is a daemon exporting real user paths: tests cannot
-  recreate legacy attempt roots, rewrite managed agent skills, consume real
-  GitHub configuration, or change credential helpers, hooks, and signing
-  settings. The authenticated `rake smoke` task explicitly opts out because it
-  exists to exercise real operator logins; direct smoke-file runs must set
+  the Claude/Codex/Pi/Grok config roots, and `GH_CONFIG_DIR` with paths under
+  one disposable `hive-test-user*` directory, then remove it after the suite.
+  Git's standard global files follow the temporary `HOME` and
+  `XDG_CONFIG_HOME`; tests explicitly remove any inherited
+  `GIT_CONFIG_GLOBAL`, because the babysitter correctly rejects that
+  caller-controlled execution channel. This keeps subprocesses hermetic even
+  when the caller is a daemon
+  exporting real user paths: tests cannot recreate legacy attempt roots,
+  rewrite managed agent skills, consume real GitHub configuration, or change
+  credential helpers, hooks, and signing settings. The authenticated
+  `rake smoke` task explicitly opts out because it exists to exercise real
+  operator logins; direct smoke-file runs must set
   `HIVE_TEST_ALLOW_REAL_USER_ENV=1` deliberately.
 - `with_tmp_dir` — `Dir.mktmpdir("hive-test", &block)`.
 - `with_tmp_git_repo` — `git init -b master`, configures user/email and disables GPG signing, makes one initial commit, yields the path.


### PR DESCRIPTION
## Summary

- sandbox every normal test process behind a disposable `HOME` before Hive loads
- remove inherited Hive, XDG, agent, GitHub, and Git global-path overrides so per-test `HOME` swaps still work
- protect the operator's global Git controls and persisted Hive/agent state from mutating tests
- keep authenticated smoke tests as the explicit real-user-environment opt-out
- adapt the non-temp attachment fixture to the checkout because the suite home is intentionally under `Dir.tmpdir`
- document the suite-level isolation contract in the managed wiki

## Why

A dogfood `rake test` inherited the daemon's real `XDG_CONFIG_HOME` and executed `git config --global credential.helper attacker` from a negative-path agent test. It also recreated legacy attempt state and republished managed agent skills. Normal tests must never be able to mutate operator state, regardless of the launching shell or daemon environment.

The first sandbox revision pinned every alternate config root. Hosted coverage exposed that existing tests intentionally swap `HOME`; pinned agent/XDG paths prevented those tests from exercising their fake homes. The corrected boundary sets only disposable `HOME` and deletes optional overrides, so production resolution continues to follow each test's active home without exposing real state or the babysitter-sensitive `GIT_CONFIG_GLOBAL` channel.

## Verification

- `bundle exec rake test`: 10,313 runs, 141,374 assertions, 0 failures, 0 errors, 8 skips
- `test/unit/test_helper_isolation_test.rb`: 1 run, 16 assertions
- `test/unit/skill_check_test.rb`: 68 runs, 185 assertions
- `test/unit/pi_preflight_test.rb`: 7 runs, 23 assertions
- `test/unit/commands/web/service_installer_test.rb`: 11 runs, 77 assertions
- `test/unit/stages/agent_test.rb`: 61 runs, 274 assertions
- `test/unit/babysitter/dry_run_env_test.rb`: 67 runs, 756 assertions, 1 skip
- focused non-temp attachment regression: 1 run, 3 assertions
- RuboCop: 3 files, no offenses
- post-suite real-state checks: operator credential helper absent; `~/.local/state/hive/attempts/v1` absent
