### PR TITLE
Fix automatic archive for legacy PR tasks

### DIFF
--- a/lib/hive/daemon/pr_merge_watcher.rb
+++ b/lib/hive/daemon/pr_merge_watcher.rb
@@ -760,23 +760,11 @@ module Hive
       end
 
       def observed_head_for(task, identity, frontmatter)
-        begin
-          pointer = Hive::Worktree.read_owned_pointer(
-            task.folder,
-            project_root: identity.fetch("project_path"),
-            slug: task.slug,
-            expected_root: Hive::Worktree.canonical_root(identity.fetch("project_path"))
-          )
-          head = Hive::GitOps.new(pointer.fetch("path")).head_sha.to_s.downcase
-          return head if head.match?(/\A[a-f0-9]{40,64}\z/)
-        rescue Hive::Error, KeyError, SystemCallError, IOError
-          # A removed owned worktree is expected late in the pipeline. Fall
-          # back to the controller-observed immutable frontmatter binding.
-        end
-        %w[head_sha head_oid headRefOid].filter_map do |field|
-          value = frontmatter[field].to_s.downcase
-          value if value.match?(/\A[a-f0-9]{40,64}\z/)
-        end.first
+        Hive::TaskClosure.local_pr_head_binding(
+          task,
+          frontmatter: frontmatter,
+          project_root: identity.fetch("project_path")
+        )
       end
 
       def stage_dir(task)

--- a/lib/hive/task_closure.rb
+++ b/lib/hive/task_closure.rb
@@ -223,6 +223,30 @@ module Hive
         )
       end
 
+      # One fail-closed local PR-head resolver shared by candidate observation
+      # and the final closure guard. Prefer the exact HEAD of a strictly owned
+      # task worktree; late-stage tasks whose worktree was removed may use the
+      # controller-observed immutable binding persisted in pr.md.
+      def local_pr_head_binding(task, frontmatter:, project_root: task.project_root)
+        begin
+          pointer = Hive::Worktree.read_owned_pointer(
+            task.folder,
+            project_root: project_root,
+            slug: task.slug,
+            expected_root: Hive::Worktree.canonical_root(project_root)
+          )
+          head = Hive::GitOps.new(pointer.fetch("path")).head_sha.to_s.downcase
+          return head if head.match?(FULL_OID_RE)
+        rescue Hive::Error, KeyError, SystemCallError, IOError
+          # Missing or unverifiable legacy worktree falls through to the
+          # immutable controller observation, never an arbitrary git path.
+        end
+        %w[head_oid head_sha headRefOid].filter_map do |field|
+          value = frontmatter[field].to_s.downcase
+          value if value.match?(FULL_OID_RE)
+        end.first
+      end
+
       def validate_active_cas!(task, receipt)
         observation = receipt.fetch("observation")
         current_stage = "#{task.stage_index}-#{task.stage_name}"
@@ -1256,10 +1280,7 @@ module Hive
       evidence = receipt.fetch("evidence").find do |item|
         item["kind"] == "pull_request"
       end
-      head = %w[head_oid head_sha headRefOid].filter_map do |field|
-        value = frontmatter[field].to_s.downcase
-        value if value.match?(FULL_OID_RE)
-      end.first
+      head = self.class.local_pr_head_binding(task, frontmatter: frontmatter)
       unless current && evidence &&
              current.fetch("url") == evidence.fetch("url") &&
              current.fetch("number") == evidence.fetch("number") &&

--- a/test/unit/daemon/pr_merge_watcher_test.rb
+++ b/test/unit/daemon/pr_merge_watcher_test.rb
@@ -450,13 +450,17 @@ class HiveDaemonPrMergeWatcherTest < Minitest::Test
       head = run!("git", "-C", worktree, "rev-parse", "HEAD").strip
       gh = FakeGh.new(state: "MERGED")
       gh.head_oid = head
-      watcher, store = build_watcher(gh: gh)
+      watcher, store = build_watcher(gh: gh, task_closure: Hive::TaskClosure)
 
       watcher.observe([ row_for(task) ], now: T0)
 
       candidate = store.load(identity_for(task.project_root)).fetch("candidates").values.first
       assert_equal head, candidate.dig("pull_request", "observed_head")
-      assert_equal :archived, watcher.tick(now: T0).first.fetch(:status)
+      with_env("HIVE_ATTEMPT_STORE_ROOT" => File.join(home, "attempts")) do
+        assert_equal :archived, watcher.tick(now: T0).first.fetch(:status)
+      end
+      archived = Hive::TaskResolver.new(task.slug, project_filter: "app").resolve
+      assert_equal "9-done", stage_dir(archived)
     end
   end
 

--- a/wiki/log.d/20260726T125300Z-legacy-pr-head-closure.md
+++ b/wiki/log.d/20260726T125300Z-legacy-pr-head-closure.md
@@ -1,0 +1,11 @@
+## Resume automatic closure for pre-head-metadata tasks
+
+- The final daemon closure guard now uses the same fail-closed legacy head
+  recovery as merge candidate observation: when `pr.md` predates immutable
+  head metadata, only the HEAD of the task's strictly owned canonical worktree
+  can bind the task to the verified merged PR.
+- Missing, malformed, relocated, or differently headed worktrees still block
+  automatic archive.
+- The real merge-watcher regression now completes the evidence-bound closure
+  transition and verifies that an older task reaches `9-done`, instead of
+  stopping at a fake closure call.

--- a/wiki/state-model.md
+++ b/wiki/state-model.md
@@ -106,7 +106,12 @@ channel: it may write `authority=remote_merge`, `channel=daemon` only for the
 task's own verified same-repository merged PR after the durable reconciler's
 guards pass. The reconciler's observed head and merge OIDs must still equal
 the closure service's final GitHub read, so architecture-intake delay cannot
-race a changed PR binding. That channel is not accepted by the public confirmation API and
+race a changed PR binding. The final locked PR-binding guard rechecks a
+strictly owned canonical worktree when one exists and otherwise uses the
+controller-observed head in current `pr.md` metadata. For tasks created before
+that field existed, only the owned worktree can supply the binding; an
+arbitrary path, missing worktree, or different HEAD remains unverifiable.
+That channel is not accepted by the public confirmation API and
 cannot take over an operator receipt. `closure.json` is mode 0600 and is
 written/fsynced before the centralized move to `9-done`; a restart resumes the
 same receipt idempotently. Projection overlays only a fully validated receipt


### PR DESCRIPTION
## Summary

- share one fail-closed local PR-head resolver between merge observation and final closure
- let pre-head-metadata tasks bind only through their strictly owned canonical worktree
- upgrade the regression to perform the real closure transition and assert the task reaches 9-done

## Verification

- 10,313 tests, 141,375 assertions, 0 failures, 0 errors
- focused task-closure and merge-watcher suites green
- RuboCop clean on changed Ruby/test files
- git diff --check