### PR TITLE
fix(daemon): stop terminal attempt replay loops

### DIFF
--- a/lib/hive/daemon/concurrency_controller.rb
+++ b/lib/hive/daemon/concurrency_controller.rb
@@ -195,11 +195,13 @@ module Hive
       end
 
       # Update the recorded mtime without consuming a dispatch slot.
-      # Used by the Dispatcher in two flows: (a) when Policy returns
+      # Used by the Dispatcher in three flows: (a) when Policy returns
       # `:record_baseline` on a first-sight `kind: edit` row, the
       # dispatcher seeds the controller with the current mtime so the
-      # next tick has something to compare against; (b) post-child-
-      # completion, the dispatcher refreshes the recorded mtime to the
+      # next tick has something to compare against; (b) when durable
+      # admission returns a successful terminal replay, the dispatcher
+      # records the generation's consumed mtime; (c) post-child-completion,
+      # the dispatcher refreshes the recorded mtime to the
       # current state-file mtime so the agent's own `_WAITING`-marker
       # write (which moves mtime past the at-dispatch value) doesn't
       # trigger a redundant re-dispatch on the next tick.

--- a/lib/hive/daemon/dispatcher.rb
+++ b/lib/hive/daemon/dispatcher.rb
@@ -1306,7 +1306,20 @@ module Hive
           now: now,
           trigger: trigger
         )
-        dispatch_outcome(dispatch_result)
+        outcome = dispatch_outcome(dispatch_result)
+        if outcome == :attempt_terminal_replay
+          # A successful durable attempt already consumed this exact task
+          # generation. Refresh the edit/run baseline just as a locally
+          # reaped child would, so an unchanged waiting marker does not ask
+          # the attempts layer for the same terminal receipt every tick.
+          # The baseline is persisted by the controller, making the brake
+          # survive daemon restarts while a genuine later edit (newer mtime)
+          # remains eligible for dispatch.
+          @controller.observe_state_file_mtime(
+            project: row.project, slug: row.slug, mtime: row.state_file_mtime
+          )
+        end
+        outcome
       end
 
       def dispatch_outcome(result)

--- a/test/unit/daemon/dispatcher_test.rb
+++ b/test/unit/daemon/dispatcher_test.rb
@@ -3650,6 +3650,54 @@ def test_success_completion_then_followup_tick_does_not_redispatch_same_stage
                "follow-up tick must NOT re-dispatch the just-completed stage"
 end
 
+def test_terminal_replay_refreshes_edit_baseline_but_keeps_later_edits_eligible
+  observed_mtime = T0 - 60
+  edit_row = row(
+    stage: "6-review", action: "needs_input", marker: "review_waiting",
+    command: "hive review s1 --from 6-review", mtime: observed_mtime
+  )
+  attempt = Struct.new(:attempt_id, :task_generation, :state)
+                  .new("attempt-terminal", "generation-terminal", "terminal")
+  admissions = 0
+  attempt_dispatcher = Object.new
+  attempt_dispatcher.define_singleton_method(:dispatch_request) do |*_args, **_options|
+    admissions += 1
+    Hive::Attempts::DispatchResult.new(
+      status: :terminal_replay, attempt: attempt, receipt: nil,
+      attach_descriptor: nil, reason: nil
+    )
+  end
+  dispatcher, _supervisor, controller, logger = make_dispatcher(
+    rows: [ edit_row ], attempt_dispatcher: attempt_dispatcher
+  )
+  status = dispatcher.instance_variable_get(:@status_consumer)
+  controller.observe_state_file_mtime(
+    project: "p1", slug: "s1", mtime: T0 - 600
+  )
+
+  dispatcher.tick(now: T0)
+  dispatcher.tick(now: T0 + 30)
+
+  assert_equal 1, admissions,
+               "an unchanged successful generation must not be replayed every daemon tick"
+  assert_equal observed_mtime,
+               controller.last_dispatched_state_file_mtime_for(
+                 project: "p1", slug: "s1"
+               )
+  assert_equal 1, logger.events.count { |name, _attrs| name == :attempt_terminal_replay }
+
+  later_edit = edit_row.dup
+  later_edit.state_file_mtime = T0 + 60
+  status.next_result = Hive::Daemon::StatusConsumer::Result.new(
+    ok: true, rows: [ later_edit ],
+    projects: [ Hive::Daemon::StatusConsumer::ProjectInfo.new(name: "p1", legacy_stage_dirs: []) ],
+    error: nil
+  )
+  dispatcher.tick(now: T0 + 120)
+
+  assert_equal 2, admissions, "a genuinely newer edit must remain eligible"
+end
+
 def test_reaped_success_dispatches_successor_within_2s_wall_budget
   # Plan Unit 2: pin the ≤2s end-to-end latency bound as a single test
   # with an injected clock. The bound is composed of (a) the fast-poll

--- a/wiki/log.d/20260726T134926Z-terminal-replay-baseline.md
+++ b/wiki/log.d/20260726T134926Z-terminal-replay-baseline.md
@@ -1,0 +1,10 @@
+## Stop unchanged terminal attempts from replaying every daemon tick
+
+- When durable dispatch reports that the exact task generation already has a
+  successful terminal attempt, the daemon now records the observed state-file
+  mtime as the persisted dispatch baseline.
+- An unchanged waiting marker is therefore admitted only once after discovery
+  or upgrade instead of querying and logging the same terminal receipt every
+  tick.
+- A later operator or agent edit still has a newer mtime and remains eligible
+  for normal dispatch.

--- a/wiki/modules/daemon.md
+++ b/wiki/modules/daemon.md
@@ -544,8 +544,12 @@ behind a sibling `.lock`, and a **fail-closed** load — a torn / partial /
 corrupt / newer-schema file degrades to an empty map and the daemon boots
 normally (worst case: one task is re-baselined once). The controller
 write-throughs on every baseline mutation — first-sight record, dispatch,
-post-completion refresh, AND prune — so there is no batched loss window
-for the critical value; mtimes are stored at microsecond resolution and
+terminal-attempt replay, post-completion refresh, AND prune — so there is no
+batched loss window for the critical value. A terminal replay means the
+durable attempts layer already completed that exact task generation; recording
+the observed state-file mtime prevents the unchanged waiting marker from being
+readmitted on every daemon tick, while a later edit still becomes eligible.
+Mtimes are stored at microsecond resolution and
 `hive status --json` emits task `mtime` / `folder_mtime` with matching
 microsecond precision. Do not truncate status JSON mtimes: an operator
 answer can land in the same wall-clock second as the daemon baseline, and


### PR DESCRIPTION
## Summary

- persist the observed dispatch baseline when durable admission returns a successful terminal replay
- prevent unchanged waiting markers from re-entering durable admission every daemon tick
- keep genuinely newer task edits eligible and document the daemon invariant

## Verification

- `bundle exec ruby -Itest test/unit/daemon/dispatcher_test.rb` (220 runs, 785 assertions)
- controller + dispatch-baseline unit tests (52 runs, 114 assertions)
- redundant-redispatch integration test (1 run, 10 assertions)
- broad `rake test` checkpoint (10,314 runs, 141,379 assertions, 0 failures/errors, 8 skips)
- RuboCop (3 files, no offenses)
- `git diff --check`