### PR TITLE
feat(agent-runtime): publish standalone runtime gem

### DIFF
--- a/.github/workflows/agent-cli-runtime-release.yml
+++ b/.github/workflows/agent-cli-runtime-release.yml
@@ -1,0 +1,103 @@
+name: Agent CLI Runtime release
+
+on:
+  push:
+    tags:
+      - "components/agent-cli-runtime/v*.*.*"
+
+permissions:
+  contents: read
+
+jobs:
+  candidate:
+    name: Build and verify exact component candidate
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.0.0
+        with:
+          fetch-depth: 0
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # pinned 2026-07-26
+        with:
+          ruby-version: "3.4"
+      - name: Verify protected-main tag identity
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REF_NAME: ${{ github.ref_name }}
+          EXPECTED_COMMIT: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          test "$(gh api "repos/${GITHUB_REPOSITORY}/branches/main" --jq '.protected')" = "true"
+          components/agent-cli-runtime/bin/release-preflight \
+            "$REF_NAME" "$EXPECTED_COMMIT" refs/remotes/origin/main
+      - name: Build once and verify exact bytes
+        run: |
+          set -euo pipefail
+          components/agent-cli-runtime/bin/build-candidate dist
+          gem_file="$(find dist -maxdepth 1 -name 'agent-cli-runtime-*.gem' -print -quit)"
+          expected_sha="$(awk '{print $1}' dist/SHA256SUMS)"
+          components/agent-cli-runtime/bin/verify-candidate "$gem_file" "$expected_sha"
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: agent-cli-runtime-candidate
+          path: dist
+          if-no-files-found: error
+          retention-days: 3
+
+  install:
+    name: Install exact candidate / ${{ matrix.os }}
+    needs: candidate
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, macos-15]
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.0.0
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: agent-cli-runtime-candidate
+          path: dist
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # pinned 2026-07-26
+        with:
+          ruby-version: "3.4"
+      - name: Install and exercise retained gem
+        run: |
+          set -euo pipefail
+          gem_file="$(find dist -maxdepth 1 -name 'agent-cli-runtime-*.gem' -print -quit)"
+          expected_sha="$(awk '{print $1}' dist/SHA256SUMS)"
+          components/agent-cli-runtime/bin/verify-candidate "$gem_file" "$expected_sha"
+
+  publish:
+    name: Publish exact candidate to RubyGems
+    needs: [candidate, install]
+    runs-on: ubuntu-24.04
+    environment: agent-cli-runtime-release
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: agent-cli-runtime-candidate
+          path: dist
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # pinned 2026-07-26
+        with:
+          ruby-version: "3.4"
+      - name: Revalidate retained checksum
+        run: |
+          set -euo pipefail
+          gem_file="$(find dist -maxdepth 1 -name 'agent-cli-runtime-*.gem' -print -quit)"
+          expected_sha="$(awk '{print $1}' dist/SHA256SUMS)"
+          actual_sha="$(ruby -rdigest -e 'print Digest::SHA256.file(ARGV.fetch(0)).hexdigest' "$gem_file")"
+          test "$actual_sha" = "$expected_sha"
+      - uses: rubygems/configure-rubygems-credentials@dc5a8d8553e6ee01fc26761a49e99e733d17954a # v2.1.0
+      - name: Publish retained gem without rebuilding
+        run: |
+          set -euo pipefail
+          gem_file="$(find dist -maxdepth 1 -name 'agent-cli-runtime-*.gem' -print -quit)"
+          gem push "$gem_file"

--- a/.github/workflows/agent-cli-runtime-release.yml
+++ b/.github/workflows/agent-cli-runtime-release.yml
@@ -12,6 +12,7 @@ jobs:
   candidate:
     name: Build and verify exact component candidate
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:
@@ -44,12 +45,13 @@ jobs:
           name: agent-cli-runtime-candidate
           path: dist
           if-no-files-found: error
-          retention-days: 3
+          retention-days: 30
 
   install:
     name: Install exact candidate / ${{ matrix.os }}
     needs: candidate
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     permissions:
       contents: read
     strategy:
@@ -76,6 +78,7 @@ jobs:
     name: Publish exact candidate to RubyGems
     needs: [candidate, install]
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     environment: agent-cli-runtime-release
     permissions:
       contents: read

--- a/Rakefile
+++ b/Rakefile
@@ -30,6 +30,16 @@ Rake::TestTask.new do |t|
   t.warning = false
 end
 
+Rake::TestTask.new("test:agent_cli_runtime") do |t|
+  t.libs << "components/agent-cli-runtime/test"
+  t.libs << "components/agent-cli-runtime/lib"
+  t.test_files = FileList["components/agent-cli-runtime/test/**/*_test.rb"]
+  t.warning = false
+  t.description = "Run the standalone Agent CLI Runtime package tests"
+end
+
+Rake::Task[:test].enhance([ "test:agent_cli_runtime" ])
+
 desc "Run the default suite with merged stdlib Coverage reporting and a 100% line threshold"
 task :coverage do
   root = File.expand_path(__dir__)

--- a/components/agent-cli-runtime/CHANGELOG.md
+++ b/components/agent-cli-runtime/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.1.0 - 2026-07-26
+
+- Add immutable profiles for Claude Code, Codex CLI, Pi, and Grok CLI.
+- Add provider-neutral invocation compilation, local prerequisite probes,
+  capability evidence, usage extraction, and result normalization.
+- Add the `agent-runtime probe` diagnostic executable with versioned JSON and
+  stable exit statuses.

--- a/components/agent-cli-runtime/CHANGELOG.md
+++ b/components/agent-cli-runtime/CHANGELOG.md
@@ -7,3 +7,8 @@
   capability evidence, usage extraction, and result normalization.
 - Add the `agent-runtime probe` diagnostic executable with versioned JSON and
   stable exit statuses.
+- Keep missing provider usage unknown instead of recording fabricated zero
+  counts, and preserve typed unknown-provider errors through the public facade.
+- Harden local probing around subprocess environments, ambiguous version
+  output, TERM-resistant descendants, custom capability evidence, unused Grok
+  credential paths, and long or JSON-delimited secrets.

--- a/components/agent-cli-runtime/LICENSE.txt
+++ b/components/agent-cli-runtime/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ivan Kuznetsov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/components/agent-cli-runtime/README.md
+++ b/components/agent-cli-runtime/README.md
@@ -42,6 +42,65 @@ Compilation does not execute the returned command. Unsupported requested
 controls raise `AgentCliRuntime::UnsupportedCapability` with typed evidence
 instead of silently widening the request.
 
+`permission_mode: nil` deliberately preserves Hive's existing trusted,
+headless behavior: providers with a bypass flag receive that flag. Consumers
+that do not want this compatibility path should pass `"read-only"` or
+`"workspace-write"` explicitly. A profile raises instead of pretending to
+enforce a mode its CLI cannot represent.
+
+## Public API
+
+- `compile(request)` returns a frozen argv/stdin invocation.
+- `probe(profile)` and `probe_all` report local prerequisite evidence without
+  contacting a provider.
+- `prepare!(profile)` requires that local probe to be ready.
+- `require_capability!(profile, name)` verifies a named CLI capability and
+  returns typed evidence.
+- `extract_usage(profile, event)` normalizes provider usage when present and
+  returns `nil` when usage is absent or malformed.
+- `observe(profile, result)` normalizes bounded, redacted result metadata.
+
+Provider arguments accept a built-in name or an `AgentCliRuntime::Profile`.
+Unknown built-in names raise `AgentCliRuntime::UnknownProvider`; they are not
+converted into generic probe or capability failures.
+
+## Custom profiles
+
+```ruby
+profile = AgentCliRuntime::Profile.new(
+  name: :acme,
+  bin_default: "acme-agent",
+  env_bin_override_keys: ["ACME_AGENT_BIN"],
+  headless_flag: "run",
+  version_flag: "--version",
+  min_version: "1.2.0",
+  prompt_style: :stdin,
+  read_only_flags: ["--sandbox", "read-only"],
+  cli_capabilities: {
+    safe_mode: ["--safe-mode"]
+  },
+  usage_extractor: ->(event) { event["usage"] },
+  auth_configuration_probe: ->(home:, env:) {
+    AgentCliRuntime::AuthConfiguration.new(
+      status: env["ACME_API_KEY"].to_s.empty? ? :missing : :configured,
+      source: "environment"
+    )
+  }
+)
+
+request = AgentCliRuntime::Request.new(
+  profile: profile,
+  prompt: "Inspect the project",
+  permission_mode: "read-only",
+  capabilities: [:safe_mode]
+)
+AgentCliRuntime.compile(request)
+```
+
+Custom capability names cannot shadow the standard capability vocabulary.
+Capability checks use discrete argv, inspect the installed CLI's help, and
+fail closed when a declared option is not advertised.
+
 ## Inspect local prerequisites
 
 ```sh
@@ -82,7 +141,11 @@ bundle exec rake test
 gem build agent-cli-runtime.gemspec
 ```
 
-Release instructions live in the repository’s `docs/RELEASING.md`. Releases
+The root suite includes these package tests plus Hive/package parity coverage;
+run `bundle exec rake test:agent_cli_runtime` from the repository root for the
+standalone component gate alone.
+
+Release instructions live in the repository's `docs/RELEASING.md`. Releases
 use component-scoped tags and publish exact preverified gem bytes through
 RubyGems trusted publishing.
 

--- a/components/agent-cli-runtime/README.md
+++ b/components/agent-cli-runtime/README.md
@@ -1,0 +1,93 @@
+# Agent CLI Runtime
+
+`agent-cli-runtime` is a small Ruby library for tools that need to describe
+and inspect locally installed headless agent CLIs without owning an agent
+orchestration system.
+
+It ships immutable profiles for Claude Code, Codex CLI, Pi, and Grok CLI;
+compiles provider-neutral requests into argv/stdin; reports typed capability
+evidence; extracts usage from provider JSON events; and exposes an honest local
+diagnostic command.
+
+## Install
+
+```ruby
+gem "agent-cli-runtime", "~> 0.1.0"
+```
+
+```ruby
+require "agent_cli_runtime"
+```
+
+Ruby 3.4 or newer is required. Version 0.1.x is tested on Linux and macOS.
+
+## Compile an invocation
+
+```ruby
+profile = AgentCliRuntime::Profiles.fetch(:codex)
+request = AgentCliRuntime::Request.new(
+  profile: profile,
+  prompt: "Review the current diff",
+  permission_mode: "read-only",
+  model: "gpt-5.6-terra",
+  effort: "high"
+)
+
+invocation = AgentCliRuntime.compile(request)
+invocation.argv       # frozen argv; no shell interpolation
+invocation.stdin_data # prompt text for stdin-style providers
+```
+
+Compilation does not execute the returned command. Unsupported requested
+controls raise `AgentCliRuntime::UnsupportedCapability` with typed evidence
+instead of silently widening the request.
+
+## Inspect local prerequisites
+
+```sh
+agent-runtime probe codex
+agent-runtime probe --all --json
+```
+
+The JSON contract is `{"schema_version":1,"probes":[...]}` and always orders
+all-provider output as `claude`, `codex`, `pi`, `grok`.
+
+- Exit `0`: every requested local probe is ready.
+- Exit `1`: at least one requested local prerequisite is unavailable.
+- Exit `64`: invalid usage.
+
+The probe observes only the local executable, version output, authentication
+configuration presence, and declared capabilities. `configured` means a
+recognized local file or environment variable is present. It does not mean the
+credential is valid, the provider is online, or the account has quota.
+
+## Scope and compatibility
+
+The library does not spawn or supervise agents, retry work, run workflows,
+accept artifacts, or interpret Hive state. Provider flags and event formats are
+SemVer-governed public behavior. Additive fields are compatible within 0.1.x;
+removing or changing an existing field or meaning requires a new minor version
+while the gem remains pre-1.0.
+
+Development remains in the Hive monorepo under
+`components/agent-cli-runtime`. Hive is the primary consumer and HiveBench is
+the first named external adopter. The Hive maintainer team owns compatibility,
+security response, and releases for the package.
+
+## Development
+
+```sh
+cd components/agent-cli-runtime
+bundle exec rake test
+gem build agent-cli-runtime.gemspec
+```
+
+Release instructions live in the repository’s `docs/RELEASING.md`. Releases
+use component-scoped tags and publish exact preverified gem bytes through
+RubyGems trusted publishing.
+
+## Security
+
+Diagnostics are bounded and redact common credential forms. The library never
+prints credential file contents or environment values. Report vulnerabilities
+through the Hive repository’s security policy.

--- a/components/agent-cli-runtime/Rakefile
+++ b/components/agent-cli-runtime/Rakefile
@@ -1,0 +1,15 @@
+require "rake/testtask"
+
+Rake::TestTask.new(:test) do |task|
+  task.libs << "test"
+  task.libs << "lib"
+  task.test_files = FileList["test/**/*_test.rb"]
+  task.warning = false
+end
+
+desc "Build agent-cli-runtime"
+task :build do
+  sh "gem", "build", "agent-cli-runtime.gemspec"
+end
+
+task default: :test

--- a/components/agent-cli-runtime/agent-cli-runtime.gemspec
+++ b/components/agent-cli-runtime/agent-cli-runtime.gemspec
@@ -1,0 +1,48 @@
+require_relative "lib/agent_cli_runtime/version"
+
+Gem::Specification.new do |spec|
+  spec.name = "agent-cli-runtime"
+  spec.version = AgentCliRuntime::VERSION
+  spec.authors = [ "Ivan Kuznetsov" ]
+  spec.email = [ "ivan@ikuznetsov.com" ]
+  spec.summary = "Provider-neutral contracts for installed agent CLIs"
+  spec.description = <<~DESC
+    Agent CLI Runtime provides immutable profiles, invocation compilation,
+    local prerequisite probes, capability evidence, usage extraction, and
+    result normalization for Claude Code, Codex CLI, Pi, and Grok CLI. It does
+    not spawn agents or claim live provider health, quota, or credential validity.
+  DESC
+  spec.homepage = "https://github.com/ivankuznetsov/hive"
+  spec.license = "MIT"
+  spec.required_ruby_version = ">= 3.4.0"
+
+  spec.metadata = {
+    "homepage_uri" => spec.homepage,
+    "source_code_uri" =>
+      "https://github.com/ivankuznetsov/hive/tree/main/components/agent-cli-runtime",
+    "changelog_uri" =>
+      "https://github.com/ivankuznetsov/hive/blob/main/components/agent-cli-runtime/CHANGELOG.md",
+    "bug_tracker_uri" => "https://github.com/ivankuznetsov/hive/issues",
+    "documentation_uri" =>
+      "https://github.com/ivankuznetsov/hive/blob/main/components/agent-cli-runtime/README.md",
+    "rubygems_mfa_required" => "true"
+  }
+
+  spec.files = Dir.chdir(__dir__) do
+    Dir[
+      "lib/**/*.rb",
+      "exe/agent-runtime",
+      "README.md",
+      "CHANGELOG.md",
+      "LICENSE.txt",
+      "agent-cli-runtime.gemspec"
+    ]
+  end
+  spec.bindir = "exe"
+  spec.executables = [ "agent-runtime" ]
+  spec.require_paths = [ "lib" ]
+
+  spec.add_dependency "json", ">= 2.7", "< 3.0"
+  spec.add_dependency "open3", "~> 0.2"
+  spec.add_dependency "timeout", ">= 0.4", "< 1.0"
+end

--- a/components/agent-cli-runtime/bin/build-candidate
+++ b/components/agent-cli-runtime/bin/build-candidate
@@ -1,0 +1,59 @@
+#!/usr/bin/env ruby
+
+require "digest"
+require "fileutils"
+require "json"
+require "open3"
+
+ROOT = File.expand_path("..", __dir__)
+$LOAD_PATH.unshift File.join(ROOT, "lib")
+require "agent_cli_runtime/version"
+
+output_dir = File.expand_path(ARGV.fetch(0, File.join(ROOT, "dist")))
+FileUtils.mkdir_p(output_dir)
+
+gem_name = "agent-cli-runtime-#{AgentCliRuntime::VERSION}.gem"
+gem_path = File.join(output_dir, gem_name)
+abort "candidate already exists: #{gem_path}" if File.exist?(gem_path)
+
+source_commit, git_error, git_status = Open3.capture3(
+  "git", "-C", File.expand_path("../..", ROOT), "rev-parse", "HEAD"
+)
+abort git_error unless git_status.success?
+source_commit = source_commit.strip
+source_dirty, git_error, git_status = Open3.capture3(
+  "git", "-C", File.expand_path("../..", ROOT), "status", "--porcelain"
+)
+abort git_error unless git_status.success?
+
+Dir.chdir(ROOT) do
+  success = system(
+    Gem.ruby, "-S", "gem", "build", "agent-cli-runtime.gemspec",
+    "--output", gem_path
+  )
+  abort "gem build failed" unless success
+end
+
+sha256 = Digest::SHA256.file(gem_path).hexdigest
+manifest = {
+  schema_version: 1,
+  gem: File.basename(gem_path),
+  name: "agent-cli-runtime",
+  version: AgentCliRuntime::VERSION,
+  source_commit: source_commit,
+  source_dirty: !source_dirty.empty?,
+  sha256: sha256
+}
+File.write(
+  File.join(output_dir, "candidate.json"),
+  "#{JSON.pretty_generate(manifest)}\n",
+  mode: "w",
+  perm: 0o600
+)
+File.write(
+  File.join(output_dir, "SHA256SUMS"),
+  "#{sha256}  #{gem_name}\n",
+  mode: "w",
+  perm: 0o600
+)
+puts JSON.generate(manifest.merge("gem_path" => gem_path))

--- a/components/agent-cli-runtime/bin/release-preflight
+++ b/components/agent-cli-runtime/bin/release-preflight
@@ -1,0 +1,56 @@
+#!/usr/bin/env ruby
+
+require "json"
+require "open3"
+
+ROOT = File.expand_path("..", __dir__)
+$LOAD_PATH.unshift File.join(ROOT, "lib")
+require "agent_cli_runtime/version"
+
+ref_name = ARGV.fetch(0) {
+  abort "usage: release-preflight TAG EXPECTED_COMMIT [MAIN_REF]"
+}
+expected_commit = ARGV.fetch(1)
+main_ref = ARGV.fetch(2, "origin/main")
+
+match = ref_name.match(
+  %r{\Acomponents/agent-cli-runtime/v(?<version>\d+\.\d+\.\d+)\z}
+)
+abort "invalid component tag: #{ref_name}" unless match
+abort "tag/source version mismatch" unless
+  match[:version] == AgentCliRuntime::VERSION
+abort "expected commit must be a full SHA" unless
+  expected_commit.match?(/\A[0-9a-f]{40}\z/)
+
+repository_root = File.expand_path("../..", ROOT)
+git = lambda do |*arguments|
+  out, err, status = Open3.capture3("git", "-C", repository_root, *arguments)
+  abort err unless status.success?
+  out.strip
+end
+
+head = git.call("rev-parse", "HEAD")
+abort "checkout #{head} does not match expected commit #{expected_commit}" unless
+  head == expected_commit
+
+tag_commit = git.call("rev-parse", "#{ref_name}^{commit}")
+abort "tag #{ref_name} does not resolve to expected commit" unless
+  tag_commit == expected_commit
+
+_out, err, status = Open3.capture3(
+  "git", "-C", repository_root,
+  "merge-base", "--is-ancestor", expected_commit, main_ref
+)
+abort(err.empty? ? "candidate is not reachable from #{main_ref}" : err) unless
+  status.success?
+
+dirty = git.call("status", "--porcelain")
+abort "release checkout is dirty" unless dirty.empty?
+
+puts JSON.generate(
+  schema_version: 1,
+  tag: ref_name,
+  version: AgentCliRuntime::VERSION,
+  commit: expected_commit,
+  main_ref: main_ref
+)

--- a/components/agent-cli-runtime/bin/verify-candidate
+++ b/components/agent-cli-runtime/bin/verify-candidate
@@ -1,0 +1,120 @@
+#!/usr/bin/env ruby
+
+require "digest"
+require "fileutils"
+require "json"
+require "open3"
+require "rubygems/package"
+require "tmpdir"
+
+ROOT = File.expand_path("..", __dir__)
+$LOAD_PATH.unshift File.join(ROOT, "lib")
+require "agent_cli_runtime/version"
+
+gem_path = File.expand_path(ARGV.fetch(0) {
+  abort "usage: verify-candidate PATH_TO_GEM [EXPECTED_SHA256]"
+})
+expected_sha = ARGV[1]
+abort "candidate gem not found: #{gem_path}" unless File.file?(gem_path)
+
+sha256 = Digest::SHA256.file(gem_path).hexdigest
+if expected_sha && sha256 != expected_sha
+  abort "candidate sha256 mismatch: expected #{expected_sha}, got #{sha256}"
+end
+
+package = Gem::Package.new(gem_path)
+spec = package.spec
+abort "wrong gem name: #{spec.name}" unless spec.name == "agent-cli-runtime"
+abort "wrong gem version: #{spec.version}" unless
+  spec.version.to_s == AgentCliRuntime::VERSION
+abort "wrong executable inventory" unless spec.executables == [ "agent-runtime" ]
+abort "wrong Ruby requirement" unless
+  spec.required_ruby_version == Gem::Requirement.new(">= 3.4.0")
+
+required = %w[
+  README.md
+  CHANGELOG.md
+  LICENSE.txt
+  agent-cli-runtime.gemspec
+  exe/agent-runtime
+  lib/agent_cli_runtime.rb
+  lib/agent_cli_runtime/version.rb
+]
+missing = required - spec.files
+abort "candidate missing files: #{missing.join(', ')}" unless missing.empty?
+unexpected = spec.files.grep(%r{\A(?:test|dist)/})
+abort "candidate contains repository-only files: #{unexpected.join(', ')}" unless
+  unexpected.empty?
+
+dependencies = spec.runtime_dependencies.map(&:name).sort
+abort "wrong runtime dependencies: #{dependencies.inspect}" unless
+  dependencies == %w[json open3 timeout]
+
+Dir.mktmpdir("agent-cli-runtime-candidate") do |sandbox|
+  gem_home = File.join(sandbox, "gems")
+  bin_dir = File.join(sandbox, "bin")
+  FileUtils.mkdir_p([ gem_home, bin_dir ])
+  install_env = {
+    "GEM_HOME" => gem_home,
+    "GEM_PATH" => gem_home,
+    "BUNDLE_GEMFILE" => nil,
+    "RUBYLIB" => nil,
+    "RUBYOPT" => nil
+  }
+  install_command = [
+    Gem.ruby, "-S", "gem", "install", gem_path,
+    "--install-dir", gem_home,
+    "--bindir", bin_dir,
+    "--no-document",
+    "--source", "https://rubygems.org"
+  ]
+  install_out, install_err, install_status =
+    Open3.capture3(install_env, *install_command)
+  abort "#{install_out}\n#{install_err}" unless install_status.success?
+
+  runtime_env = install_env.merge(
+    "PATH" => "#{bin_dir}#{File::PATH_SEPARATOR}#{ENV.fetch('PATH', '')}"
+  )
+  require_script = <<~RUBY
+    require "agent_cli_runtime"
+    abort "Hive loaded unexpectedly" if defined?(Hive)
+    abort "wrong version" unless
+      AgentCliRuntime::VERSION == #{AgentCliRuntime::VERSION.dump}
+    abort "wrong providers" unless AgentCliRuntime::Profiles.names == %i[claude codex pi grok]
+  RUBY
+  _out, err, status = Open3.capture3(
+    runtime_env, Gem.ruby, "-e", require_script
+  )
+  abort err unless status.success?
+
+  version_out, version_err, version_status = Open3.capture3(
+    runtime_env, File.join(bin_dir, "agent-runtime"), "--version"
+  )
+  abort version_err unless version_status.success?
+  abort "wrong CLI version: #{version_out.inspect}" unless
+    version_out == "#{AgentCliRuntime::VERSION}\n"
+
+  probe_env = runtime_env.merge(
+    "AGENT_CLI_RUNTIME_CODEX_BIN" => "/missing/codex"
+  )
+  probe_out, probe_err, probe_status = Open3.capture3(
+    probe_env,
+    File.join(bin_dir, "agent-runtime"),
+    "probe", "codex", "--json"
+  )
+  abort probe_err unless probe_err.empty?
+  abort "missing prerequisite probe should exit 1" unless
+    probe_status.exitstatus == 1
+  payload = JSON.parse(probe_out)
+  abort "wrong CLI schema" unless payload["schema_version"] == 1
+  abort "wrong CLI provider" unless
+    payload.fetch("probes").map { |probe| probe["provider"] } == [ "codex" ]
+end
+
+puts JSON.generate(
+  schema_version: 1,
+  gem: gem_path,
+  name: spec.name,
+  version: spec.version.to_s,
+  sha256: sha256
+)

--- a/components/agent-cli-runtime/exe/agent-runtime
+++ b/components/agent-cli-runtime/exe/agent-runtime
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require "agent_cli_runtime"
+
+exit AgentCliRuntime::CLI.run(ARGV)

--- a/components/agent-cli-runtime/lib/agent_cli_runtime.rb
+++ b/components/agent-cli-runtime/lib/agent_cli_runtime.rb
@@ -1,0 +1,47 @@
+require "agent_cli_runtime/version"
+require "agent_cli_runtime/errors"
+require "agent_cli_runtime/values"
+
+module AgentCliRuntime
+  DIAGNOSTIC_BYTES = 512
+end
+
+require "agent_cli_runtime/redactor"
+require "agent_cli_runtime/usage_extractors"
+require "agent_cli_runtime/profile"
+require "agent_cli_runtime/profiles"
+require "agent_cli_runtime/probe"
+require "agent_cli_runtime/runtime"
+require "agent_cli_runtime/cli"
+
+module AgentCliRuntime
+  module_function
+
+  def compile(request)
+    Runtime.compile(request)
+  end
+
+  def prepare!(profile)
+    Runtime.prepare!(profile)
+  end
+
+  def require_capability!(profile, capability)
+    Runtime.require_capability!(profile, capability)
+  end
+
+  def extract_usage(profile, event)
+    Runtime.extract_usage(profile, event)
+  end
+
+  def observe(profile, result)
+    Runtime.observe(profile, result)
+  end
+
+  def probe(profile, home: nil, env: ENV)
+    Probe.call(profile, home: home, env: env)
+  end
+
+  def probe_all(home: nil, env: ENV)
+    Probe.all(home: home, env: env)
+  end
+end

--- a/components/agent-cli-runtime/lib/agent_cli_runtime/cli.rb
+++ b/components/agent-cli-runtime/lib/agent_cli_runtime/cli.rb
@@ -1,0 +1,98 @@
+require "json"
+
+module AgentCliRuntime
+  class CLI
+    USAGE = <<~TEXT.freeze
+      Usage:
+        agent-runtime probe PROVIDER [--json]
+        agent-runtime probe --all [--json]
+        agent-runtime --version
+
+      Providers: #{Profiles.names.join(', ')}
+    TEXT
+
+    class << self
+      def run(argv, out: $stdout, err: $stderr, home: nil, env: ENV)
+        arguments = argv.dup
+        if arguments == [ "--version" ]
+          out.puts VERSION
+          return 0
+        end
+        return usage_error(err) unless arguments.shift == "probe"
+
+        json = arguments.delete("--json")
+        all = arguments.delete("--all")
+        return usage_error(err) if arguments.any? { |arg| arg.start_with?("-") }
+        return usage_error(err) if all && !arguments.empty?
+        return usage_error(err) unless all || arguments.length == 1
+
+        results =
+          if all
+            Probe.all(home: home, env: env)
+          else
+            [ Probe.call(Profiles.fetch(arguments.fetch(0)), home: home, env: env) ]
+          end
+        json ? render_json(results, out) : render_text(results, out)
+        results.all?(&:ready) ? 0 : 1
+      rescue UnknownProvider => e
+        err.puts e.message
+        err.print USAGE
+        64
+      end
+
+      private
+
+      def usage_error(err)
+        err.print USAGE
+        64
+      end
+
+      def render_json(results, out)
+        payload = {
+          schema_version: 1,
+          probes: results.map { |result| probe_hash(result) }
+        }
+        out.puts JSON.generate(payload)
+      end
+
+      def render_text(results, out)
+        results.each do |result|
+          state = result.ready ? "ready" : "unavailable"
+          version = result.version || "unknown"
+          auth = result.auth_configuration.status
+          out.puts(
+            "#{result.provider}: #{state} " \
+            "(installed=#{result.installed} version=#{version} " \
+            "auth_configuration=#{auth})"
+          )
+          out.puts "  #{result.diagnostic}" if result.diagnostic
+        end
+      end
+
+      def probe_hash(result)
+        {
+          provider: result.provider.to_s,
+          ready: result.ready,
+          installed: result.installed,
+          executable: Redactor.diagnostic(result.executable, bytes: 256),
+          version: result.version,
+          minimum_version: result.minimum_version,
+          auth_configuration: {
+            status: result.auth_configuration.status.to_s,
+            source: Redactor.diagnostic(
+              result.auth_configuration.source,
+              bytes: 256
+            )
+          },
+          capabilities: result.capability_evidence.map do |evidence|
+            {
+              capability: evidence.capability.to_s,
+              supported: evidence.supported
+            }
+          end,
+          diagnostic: result.diagnostic
+        }
+      end
+    end
+  end
+end

--- a/components/agent-cli-runtime/lib/agent_cli_runtime/errors.rb
+++ b/components/agent-cli-runtime/lib/agent_cli_runtime/errors.rb
@@ -1,0 +1,17 @@
+module AgentCliRuntime
+  class Error < StandardError
+    attr_reader :evidence
+
+    def initialize(message, evidence: nil)
+      super(message)
+      @evidence = evidence
+    end
+  end
+
+  class BinaryUnavailable < Error; end
+  class VersionError < Error; end
+  class UnsupportedCapability < Error; end
+  class ProbeError < Error; end
+  class CompilationError < Error; end
+  class UnknownProvider < Error; end
+end

--- a/components/agent-cli-runtime/lib/agent_cli_runtime/probe.rb
+++ b/components/agent-cli-runtime/lib/agent_cli_runtime/probe.rb
@@ -1,0 +1,94 @@
+module AgentCliRuntime
+  module Probe
+    module_function
+
+    def call(profile, home: nil, env: ENV)
+      resolved = Profiles.resolve(profile)
+      executable = resolved.bin(env:)
+      installed = resolved.binary_installed?(env:)
+      version = nil
+      diagnostic = nil
+
+      if installed
+        begin
+          version = resolved.check_version!(env:)
+        rescue Error => e
+          diagnostic = Redactor.diagnostic(e)
+        end
+      else
+        diagnostic = Redactor.diagnostic(
+          "#{resolved.name} binary not runnable: #{executable}"
+        )
+      end
+
+      auth =
+        if installed
+          resolved.auth_configuration(home: home, env: env)
+        else
+          AuthConfiguration.new(status: :not_checked)
+        end
+      diagnostic ||= auth.diagnostic
+      ready = installed &&
+              !version.nil? &&
+              auth.status != :missing
+
+      ProbeResult.new(
+        provider: resolved.name,
+        ready: ready,
+        installed: installed,
+        executable: executable,
+        version: version,
+        minimum_version: resolved.min_version,
+        auth_configuration: auth,
+        capability_evidence: capability_evidence(
+          resolved, installed: installed, version: version, auth: auth
+        ),
+        diagnostic: diagnostic
+      )
+    rescue StandardError => e
+      resolved ||= Profiles.resolve(profile)
+      ProbeResult.new(
+        provider: resolved.name,
+        ready: false,
+        installed: false,
+        executable: resolved.bin(env:),
+        version: nil,
+        minimum_version: resolved.min_version,
+        auth_configuration: AuthConfiguration.new(status: :not_checked),
+        capability_evidence: [],
+        diagnostic: Redactor.diagnostic(e)
+      )
+    end
+
+    def all(home: nil, env: ENV)
+      Profiles.names.map do |provider|
+        call(provider, home: home, env: env)
+      end.freeze
+    end
+
+    def capability_evidence(profile, installed:, version:, auth:)
+      capabilities = {
+        headless: true,
+        version: !version.nil?,
+        auth_configuration: auth.status != :missing,
+        add_directory: !profile.add_dir_flag.nil?,
+        allowed_tools: profile.tool_scope_flags.key?(:allowed),
+        disallowed_tools: profile.tool_scope_flags.key?(:disallowed),
+        model: !profile.model_argument_builder.nil?,
+        effort: !profile.effort_argument_builder.nil?,
+        budget: !profile.budget_flag.nil?,
+        raw_cli_arguments: profile.raw_cli_arguments_supported?
+      }
+      capabilities[:installation] = installed
+      capabilities.map do |capability, supported|
+        CapabilityEvidence.new(
+          capability: capability,
+          supported: supported,
+          provider: profile.name,
+          launcher_identity: profile.launcher_identity
+        )
+      end.freeze
+    end
+    private_class_method :capability_evidence
+  end
+end

--- a/components/agent-cli-runtime/lib/agent_cli_runtime/probe.rb
+++ b/components/agent-cli-runtime/lib/agent_cli_runtime/probe.rb
@@ -67,18 +67,15 @@ module AgentCliRuntime
     end
 
     def capability_evidence(profile, installed:, version:, auth:)
+      declared = profile.declared_capability_support
       capabilities = {
-        headless: true,
+        headless: declared.fetch(:headless),
         version: !version.nil?,
-        auth_configuration: auth.status != :missing,
-        add_directory: !profile.add_dir_flag.nil?,
-        allowed_tools: profile.tool_scope_flags.key?(:allowed),
-        disallowed_tools: profile.tool_scope_flags.key?(:disallowed),
-        model: !profile.model_argument_builder.nil?,
-        effort: !profile.effort_argument_builder.nil?,
-        budget: !profile.budget_flag.nil?,
-        raw_cli_arguments: profile.raw_cli_arguments_supported?
+        auth_configuration: auth.status != :missing
       }
+      declared.each do |capability, supported|
+        capabilities[capability] = supported unless capability == :headless
+      end
       capabilities[:installation] = installed
       capabilities.map do |capability, supported|
         CapabilityEvidence.new(

--- a/components/agent-cli-runtime/lib/agent_cli_runtime/profile.rb
+++ b/components/agent-cli-runtime/lib/agent_cli_runtime/profile.rb
@@ -1,0 +1,330 @@
+require "open3"
+require "timeout"
+require "rubygems/version"
+
+module AgentCliRuntime
+  class Profile
+    PROMPT_STYLES = %i[positional headless_flag_value stdin].freeze
+    WORKSPACE_WRITE_PERMISSION_MODE = "workspace-write".freeze
+    READ_ONLY_PERMISSION_MODE = "read-only".freeze
+    CAPTURE_TIMEOUT_SECONDS = 10
+    CAPTURE_POLL_SECONDS = 0.01
+    CAPTURE_TERM_GRACE_SECONDS = 0.2
+
+    attr_reader :name, :bin_default, :env_bin_override_keys, :headless_flag,
+                :permission_skip_flag, :workspace_write_flags,
+                :read_only_flags, :add_dir_flag, :tool_scope_flags,
+                :budget_flag, :output_format_flags, :version_flag,
+                :min_version, :prompt_style, :model_argument_builder,
+                :effort_argument_builder, :launcher_identity,
+                :cli_capabilities
+
+    def initialize(name:, bin_default:, headless_flag:, version_flag:,
+                   env_bin_override_keys: [], permission_skip_flag: nil,
+                   workspace_write_flags: [], read_only_flags: [],
+                   add_dir_flag: nil, tool_scope_flags: {}, budget_flag: nil,
+                   output_format_flags: [], min_version: nil,
+                   prompt_style: :positional, model_argument_builder: nil,
+                   effort_argument_builder: nil, launcher_identity: nil,
+                   usage_extractor: nil, auth_configuration_probe: nil,
+                   cli_capabilities: {}, raw_cli_arguments_supported: false)
+      normalized_prompt_style = prompt_style.to_sym
+      unless PROMPT_STYLES.include?(normalized_prompt_style)
+        raise ArgumentError,
+              "unknown prompt_style #{prompt_style.inspect}; valid: #{PROMPT_STYLES.inspect}"
+      end
+
+      @name = name.to_sym
+      @bin_default = immutable_string(bin_default)
+      @env_bin_override_keys = immutable_strings(env_bin_override_keys)
+      @headless_flag = immutable_string(headless_flag)
+      @permission_skip_flag =
+        permission_skip_flag.nil? ? nil : immutable_string(permission_skip_flag)
+      @workspace_write_flags = immutable_strings(workspace_write_flags)
+      @read_only_flags = immutable_strings(read_only_flags)
+      @add_dir_flag = add_dir_flag.nil? ? nil : immutable_string(add_dir_flag)
+      @tool_scope_flags = normalize_tool_scope_flags(tool_scope_flags)
+      @budget_flag = budget_flag.nil? ? nil : immutable_string(budget_flag)
+      @output_format_flags = immutable_strings(output_format_flags)
+      @version_flag = immutable_string(version_flag)
+      @min_version = min_version.nil? ? nil : immutable_string(min_version)
+      @prompt_style = normalized_prompt_style
+      @model_argument_builder = model_argument_builder
+      @effort_argument_builder = effort_argument_builder
+      @launcher_identity =
+        immutable_string(launcher_identity || "agent-cli-runtime/v1:#{@name}")
+      @usage_extractor = usage_extractor || ->(_event) { nil }
+      @auth_configuration_probe = auth_configuration_probe
+      @cli_capabilities = normalize_cli_capabilities(cli_capabilities)
+      @raw_cli_arguments_supported = raw_cli_arguments_supported == true
+      freeze
+    end
+
+    def bin(env: ENV)
+      key = @env_bin_override_keys.find do |candidate|
+        !env[candidate].to_s.empty?
+      end
+      key ? env.fetch(key) : @bin_default
+    end
+
+    def permission_flags(permission_mode = nil)
+      if permission_mode == WORKSPACE_WRITE_PERMISSION_MODE
+        return @workspace_write_flags.dup unless @workspace_write_flags.empty?
+
+        raise ArgumentError,
+              "agent profile #{@name.inspect} cannot enforce workspace-write sandboxing"
+      end
+      if permission_mode == READ_ONLY_PERMISSION_MODE
+        return @read_only_flags.dup unless @read_only_flags.empty?
+
+        raise ArgumentError,
+              "agent profile #{@name.inspect} cannot enforce read-only sandboxing"
+      end
+      return [] unless @permission_skip_flag
+      return [ @permission_skip_flag ] unless @name == :claude && permission_mode
+      return [ @permission_skip_flag ] if permission_mode == "bypassPermissions"
+
+      [ "--permission-mode", permission_mode.to_s ]
+    end
+
+    def identity_arguments(model:, effort:, pin_model: true)
+      normalized_model = nonempty_value(model, "model")
+      normalized_effort = effort.nil? ? nil : nonempty_value(effort, "effort")
+      native_arguments = []
+      if pin_model
+        unless @model_argument_builder
+          raise UnsupportedCapability,
+                "agent profile #{@name.inspect} cannot pin a model"
+        end
+        native_arguments.concat(@model_argument_builder.call(normalized_model))
+      end
+
+      effective_effort = nil
+      if normalized_effort
+        unless @effort_argument_builder
+          raise UnsupportedCapability,
+                "agent profile #{@name.inspect} cannot set reasoning effort"
+        end
+        native_arguments.concat(@effort_argument_builder.call(normalized_effort))
+        effective_effort = normalized_effort
+      end
+
+      IdentityArguments.new(
+        model: normalized_model,
+        requested_effort: normalized_effort,
+        effective_effort: effective_effort,
+        effort_supported: !@effort_argument_builder.nil?,
+        model_pinned: pin_model,
+        native_arguments: validate_arguments(native_arguments)
+      )
+    end
+
+    def raw_cli_arguments_supported?
+      @raw_cli_arguments_supported
+    end
+
+    def binary_installed?(env: ENV)
+      executable = bin(env:)
+      return File.file?(executable) && File.executable?(executable) if executable.include?(File::SEPARATOR)
+
+      env.fetch("PATH", "").split(File::PATH_SEPARATOR).any? do |directory|
+        candidate = File.join(directory, executable)
+        File.file?(candidate) && File.executable?(candidate)
+      end
+    rescue ArgumentError
+      false
+    end
+
+    def check_version!(env: ENV)
+      executable = bin(env:)
+      out, _err, status = bounded_capture3(
+        executable, @version_flag, timeout_sec: CAPTURE_TIMEOUT_SECONDS
+      )
+      unless status.success?
+        raise BinaryUnavailable,
+              "#{@name} binary not runnable: #{executable}"
+      end
+
+      version = out[/\d+\.\d+\.\d+/]
+      unless version
+        raise VersionError,
+              "could not parse #{@name} #{@version_flag} output"
+      end
+      if @min_version &&
+         Gem::Version.new(version) < Gem::Version.new(@min_version)
+        raise VersionError,
+              "#{@name} #{version} below minimum #{@min_version}"
+      end
+      version.freeze
+    rescue Errno::ENOENT, Errno::EACCES => e
+      raise BinaryUnavailable,
+            "#{@name} binary not runnable: #{executable} (#{e.class.name.split('::').last})"
+    rescue Timeout::Error
+      raise BinaryUnavailable,
+            "#{@name} version check timed out after #{CAPTURE_TIMEOUT_SECONDS}s: #{executable}"
+    end
+
+    def auth_configuration(home: nil, env: ENV)
+      return AuthConfiguration.new(status: :not_checked) unless @auth_configuration_probe
+
+      result = @auth_configuration_probe.call(home: home, env: env)
+      return result if result.is_a?(AuthConfiguration)
+
+      raise TypeError,
+            "auth_configuration_probe must return AgentCliRuntime::AuthConfiguration"
+    rescue StandardError => e
+      AuthConfiguration.new(
+        status: :missing,
+        diagnostic: Redactor.diagnostic(e)
+      )
+    end
+
+    def extract_usage_event(event)
+      @usage_extractor.call(event)
+    rescue StandardError
+      nil
+    end
+
+    def require_cli_capability!(capability)
+      capability_name = capability.to_sym
+      flags = @cli_capabilities[capability_name]
+      unless flags
+        raise UnsupportedCapability,
+              "agent profile #{@name.inspect} does not declare CLI capability " \
+              "#{capability_name.inspect}"
+      end
+
+      help = capture_help(flags)
+      missing = flags.grep(/\A-/).reject { |flag| flag_advertised?(help, flag) }
+      unless missing.empty?
+        raise UnsupportedCapability,
+              "#{@name} does not advertise required #{capability_name} capability " \
+              "(missing #{missing.join(', ')})"
+      end
+      flags.dup
+    end
+
+    private
+
+    def immutable_string(value)
+      value.to_s.dup.freeze
+    end
+
+    def immutable_strings(values)
+      Array(values).map { |value| immutable_string(value) }.freeze
+    end
+
+    def normalize_tool_scope_flags(flags)
+      unless flags.is_a?(Hash)
+        raise ArgumentError, "tool_scope_flags must be a Hash"
+      end
+
+      flags.each_with_object({}) do |(scope, flag), normalized|
+        name = scope.to_sym
+        unless %i[allowed disallowed].include?(name)
+          raise ArgumentError, "unknown tool scope #{scope.inspect}"
+        end
+        normalized[name] = nonempty_value(flag, "tool scope flag")
+      end.freeze
+    end
+
+    def normalize_cli_capabilities(capabilities)
+      unless capabilities.is_a?(Hash)
+        raise ArgumentError, "cli_capabilities must be a Hash"
+      end
+
+      capabilities.each_with_object({}) do |(name, flags), normalized|
+        values = immutable_strings(flags)
+        raise ArgumentError, "CLI capability #{name.inspect} is empty" if values.empty?
+
+        normalized[name.to_sym] = values
+      end.freeze
+    end
+
+    def nonempty_value(value, label)
+      string = value.to_s
+      if string.empty? || string.include?("\0")
+        raise ArgumentError, "#{label} must be a non-empty string without NUL bytes"
+      end
+      string.freeze
+    end
+
+    def validate_arguments(arguments)
+      Array(arguments).map do |argument|
+        nonempty_value(argument, "native argument")
+      end
+    end
+
+    def capture_help(flags)
+      out, err, status = bounded_capture3(
+        bin, *flags, "--help", timeout_sec: CAPTURE_TIMEOUT_SECONDS
+      )
+      unless status.success?
+        raise UnsupportedCapability,
+              "#{@name} capability check failed"
+      end
+      "#{out}\n#{err}"
+    rescue Errno::ENOENT, Errno::EACCES, Timeout::Error => e
+      raise UnsupportedCapability,
+            "#{@name} capability check could not run (#{e.class.name.split('::').last})"
+    end
+
+    def flag_advertised?(help, flag)
+      help.match?(/(?:\A|[\s,])#{Regexp.escape(flag)}(?:[\s,=\[]|$)/)
+    end
+
+    def bounded_capture3(*argv, timeout_sec:)
+      stdin, stdout, stderr, waiter = Open3.popen3(*argv, pgroup: true)
+      stdin.close
+      readers = [ capture_reader(stdout), capture_reader(stderr) ]
+      deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout_sec
+
+      loop do
+        unless waiter.alive?
+          status = waiter.value
+          return [ readers[0].value, readers[1].value, status ] if readers.none?(&:alive?)
+        end
+
+        remaining = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        raise Timeout::Error if remaining <= 0
+
+        sleep [ CAPTURE_POLL_SECONDS, remaining ].min
+      end
+    rescue Timeout::Error
+      terminate_process_group(waiter) if waiter
+      readers&.each { |reader| reader.kill if reader.alive? }
+      raise
+    ensure
+      [ stdin, stdout, stderr ].each do |io|
+        io.close if io && !io.closed?
+      rescue IOError
+        nil
+      end
+    end
+
+    def capture_reader(io)
+      Thread.new do
+        Thread.current.report_on_exception = false
+        io.read
+      rescue IOError
+        ""
+      end
+    end
+
+    def terminate_process_group(waiter)
+      pid = waiter.pid
+      Process.kill("TERM", -pid)
+      deadline =
+        Process.clock_gettime(Process::CLOCK_MONOTONIC) +
+        CAPTURE_TERM_GRACE_SECONDS
+      while waiter.alive? &&
+            Process.clock_gettime(Process::CLOCK_MONOTONIC) < deadline
+        sleep CAPTURE_POLL_SECONDS
+      end
+      Process.kill("KILL", -pid) if waiter.alive?
+      waiter.join(CAPTURE_TERM_GRACE_SECONDS)
+    rescue Errno::ESRCH, Errno::ECHILD
+      nil
+    end
+  end
+end

--- a/components/agent-cli-runtime/lib/agent_cli_runtime/profile.rb
+++ b/components/agent-cli-runtime/lib/agent_cli_runtime/profile.rb
@@ -10,6 +10,14 @@ module AgentCliRuntime
     CAPTURE_TIMEOUT_SECONDS = 10
     CAPTURE_POLL_SECONDS = 0.01
     CAPTURE_TERM_GRACE_SECONDS = 0.2
+    CAPTURE_REAP_GRACE_SECONDS = 0.2
+    VERSION_TOKEN_PATTERN =
+      /(?<![0-9A-Za-z])v?(\d+\.\d+\.\d+(?:[.-][0-9A-Za-z]+)*)(?![0-9A-Za-z])/
+    RESERVED_CAPABILITY_NAMES = %i[
+      headless version auth_configuration add_directory allowed_tools
+      disallowed_tools model effort budget raw_cli_arguments installation
+    ].freeze
+    private_constant :VERSION_TOKEN_PATTERN, :RESERVED_CAPABILITY_NAMES
 
     attr_reader :name, :bin_default, :env_bin_override_keys, :headless_flag,
                 :permission_skip_flag, :workspace_write_flags,
@@ -17,7 +25,7 @@ module AgentCliRuntime
                 :budget_flag, :output_format_flags, :version_flag,
                 :min_version, :prompt_style, :model_argument_builder,
                 :effort_argument_builder, :launcher_identity,
-                :cli_capabilities
+                :cli_capabilities, :declared_capability_support
 
     def initialize(name:, bin_default:, headless_flag:, version_flag:,
                    env_bin_override_keys: [], permission_skip_flag: nil,
@@ -57,6 +65,7 @@ module AgentCliRuntime
       @auth_configuration_probe = auth_configuration_probe
       @cli_capabilities = normalize_cli_capabilities(cli_capabilities)
       @raw_cli_arguments_supported = raw_cli_arguments_supported == true
+      @declared_capability_support = build_declared_capability_support
       freeze
     end
 
@@ -138,18 +147,24 @@ module AgentCliRuntime
     def check_version!(env: ENV)
       executable = bin(env:)
       out, _err, status = bounded_capture3(
-        executable, @version_flag, timeout_sec: CAPTURE_TIMEOUT_SECONDS
+        executable, @version_flag, timeout_sec: CAPTURE_TIMEOUT_SECONDS, env: env
       )
       unless status.success?
         raise BinaryUnavailable,
               "#{@name} binary not runnable: #{executable}"
       end
 
-      version = out[/\d+\.\d+\.\d+/]
-      unless version
+      versions = out.scan(VERSION_TOKEN_PATTERN).flatten.uniq
+      if versions.empty?
         raise VersionError,
               "could not parse #{@name} #{@version_flag} output"
       end
+      if versions.length > 1
+        raise VersionError,
+              "ambiguous #{@name} #{@version_flag} output: " \
+              "#{versions.join(', ')}"
+      end
+      version = versions.fetch(0)
       if @min_version &&
          Gem::Version.new(version) < Gem::Version.new(@min_version)
         raise VersionError,
@@ -234,11 +249,31 @@ module AgentCliRuntime
       end
 
       capabilities.each_with_object({}) do |(name, flags), normalized|
+        capability_name = name.to_sym
+        if RESERVED_CAPABILITY_NAMES.include?(capability_name)
+          raise ArgumentError,
+                "CLI capability #{name.inspect} collides with a standard capability"
+        end
         values = immutable_strings(flags)
         raise ArgumentError, "CLI capability #{name.inspect} is empty" if values.empty?
 
-        normalized[name.to_sym] = values
+        normalized[capability_name] = values
       end.freeze
+    end
+
+    def build_declared_capability_support
+      support = {
+        headless: true,
+        add_directory: !@add_dir_flag.nil?,
+        allowed_tools: @tool_scope_flags.key?(:allowed),
+        disallowed_tools: @tool_scope_flags.key?(:disallowed),
+        model: !@model_argument_builder.nil?,
+        effort: !@effort_argument_builder.nil?,
+        budget: !@budget_flag.nil?,
+        raw_cli_arguments: @raw_cli_arguments_supported
+      }
+      @cli_capabilities.each_key { |capability| support[capability] = true }
+      support.freeze
     end
 
     def nonempty_value(value, label)
@@ -273,8 +308,10 @@ module AgentCliRuntime
       help.match?(/(?:\A|[\s,])#{Regexp.escape(flag)}(?:[\s,=\[]|$)/)
     end
 
-    def bounded_capture3(*argv, timeout_sec:)
-      stdin, stdout, stderr, waiter = Open3.popen3(*argv, pgroup: true)
+    def bounded_capture3(*argv, timeout_sec:, env: nil)
+      popen_arguments = env ? [ env, *argv ] : argv
+      stdin, stdout, stderr, waiter =
+        Open3.popen3(*popen_arguments, pgroup: true)
       stdin.close
       readers = [ capture_reader(stdout), capture_reader(stderr) ]
       deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout_sec
@@ -292,7 +329,7 @@ module AgentCliRuntime
       end
     rescue Timeout::Error
       terminate_process_group(waiter) if waiter
-      readers&.each { |reader| reader.kill if reader.alive? }
+      stop_capture_readers(readers, stdout, stderr)
       raise
     ensure
       [ stdin, stdout, stderr ].each do |io|
@@ -313,18 +350,41 @@ module AgentCliRuntime
 
     def terminate_process_group(waiter)
       pid = waiter.pid
-      Process.kill("TERM", -pid)
+      signal_process_group("TERM", pid)
       deadline =
         Process.clock_gettime(Process::CLOCK_MONOTONIC) +
         CAPTURE_TERM_GRACE_SECONDS
-      while waiter.alive? &&
+      while process_group_alive?(pid) &&
             Process.clock_gettime(Process::CLOCK_MONOTONIC) < deadline
         sleep CAPTURE_POLL_SECONDS
       end
-      Process.kill("KILL", -pid) if waiter.alive?
-      waiter.join(CAPTURE_TERM_GRACE_SECONDS)
+      signal_process_group("KILL", pid) if process_group_alive?(pid)
+      waiter.join(CAPTURE_REAP_GRACE_SECONDS)
+    end
+
+    def stop_capture_readers(readers, *streams)
+      Array(readers).each { |reader| reader.join(CAPTURE_REAP_GRACE_SECONDS) }
+      streams.each do |stream|
+        stream.close if stream && !stream.closed?
+      rescue IOError
+        nil
+      end
+      Array(readers).each { |reader| reader.kill if reader.alive? }
+    end
+
+    def signal_process_group(signal, pid)
+      Process.kill(signal, -Integer(pid))
     rescue Errno::ESRCH, Errno::ECHILD
       nil
+    end
+
+    def process_group_alive?(pid)
+      Process.kill(0, -Integer(pid))
+      true
+    rescue Errno::ESRCH, Errno::ECHILD
+      false
+    rescue Errno::EPERM
+      true
     end
   end
 end

--- a/components/agent-cli-runtime/lib/agent_cli_runtime/profiles.rb
+++ b/components/agent-cli-runtime/lib/agent_cli_runtime/profiles.rb
@@ -134,7 +134,6 @@ module AgentCliRuntime
       bin_default: "pi",
       env_bin_override_keys: %w[AGENT_CLI_RUNTIME_PI_BIN HIVE_PI_BIN],
       headless_flag: "-p",
-      tool_scope_flags: { allowed: "--tools" },
       output_format_flags: [ "--mode", "json", "--no-session" ],
       version_flag: "--version",
       min_version: "0.70.2",
@@ -172,8 +171,6 @@ module AgentCliRuntime
       usage_extractor: UsageExtractors::GROK,
       auth_configuration_probe: lambda do |home:, env:|
         if env_configured?(env, "XAI_API_KEY", "GROK_CODE_XAI_API_KEY")
-          grok_auth_path(home: home, env: env) if
-            env_configured?(env, "GROK_AUTH_PATH", "GROK_HOME")
           AuthConfiguration.new(status: :configured, source: "environment")
         else
           auth_from_file(

--- a/components/agent-cli-runtime/lib/agent_cli_runtime/profiles.rb
+++ b/components/agent-cli-runtime/lib/agent_cli_runtime/profiles.rb
@@ -1,0 +1,193 @@
+module AgentCliRuntime
+  module Profiles
+    module_function
+
+    def names
+      PROVIDER_ORDER
+    end
+
+    def fetch(name)
+      PROFILES.fetch(name.to_sym) do
+        raise UnknownProvider,
+              "unknown provider #{name.inspect}; expected one of #{PROVIDER_ORDER.join(', ')}"
+      end
+    end
+
+    def resolve(profile)
+      profile.is_a?(Profile) ? profile : fetch(profile)
+    end
+
+    def auth_from_file(path, source:)
+      configured = File.file?(path) &&
+                   !File.read(path).strip.match?(/\A(?:|\{\s*\})\z/m)
+      AuthConfiguration.new(
+        status: configured ? :configured : :missing,
+        source: source
+      )
+    rescue SystemCallError, ArgumentError => e
+      AuthConfiguration.new(
+        status: :missing,
+        source: source,
+        diagnostic: Redactor.diagnostic(e)
+      )
+    end
+
+    def home_path(home, *parts)
+      File.join(home || Dir.home, *parts)
+    end
+
+    def env_configured?(env, *keys)
+      keys.any? { |key| !env[key].to_s.strip.empty? }
+    end
+
+    def grok_auth_path(home:, env:)
+      auth_path = env["GROK_AUTH_PATH"]
+      grok_home = env["GROK_HOME"]
+      if !auth_path.to_s.empty?
+        raise ArgumentError, "GROK_AUTH_PATH must be absolute" unless File.absolute_path?(auth_path)
+
+        return auth_path
+      end
+      if !grok_home.to_s.empty?
+        raise ArgumentError, "GROK_HOME must be absolute" unless File.absolute_path?(grok_home)
+
+        return File.join(grok_home, "auth.json")
+      end
+      home_path(home, ".grok", "auth.json")
+    end
+
+    CLAUDE = Profile.new(
+      name: :claude,
+      bin_default: "claude",
+      env_bin_override_keys: %w[AGENT_CLI_RUNTIME_CLAUDE_BIN HIVE_CLAUDE_BIN],
+      headless_flag: "-p",
+      permission_skip_flag: "--dangerously-skip-permissions",
+      add_dir_flag: "--add-dir",
+      tool_scope_flags: {
+        allowed: "--allowedTools",
+        disallowed: "--disallowedTools"
+      },
+      budget_flag: "--max-budget-usd",
+      output_format_flags: [
+        "--output-format", "stream-json",
+        "--include-partial-messages", "--verbose", "--no-session-persistence"
+      ],
+      version_flag: "--version",
+      min_version: "2.1.118",
+      model_argument_builder: ->(model) { [ "--model", model ] },
+      effort_argument_builder: ->(effort) { [ "--effort", effort ] },
+      launcher_identity: "claude-code/v1",
+      usage_extractor: UsageExtractors::CLAUDE,
+      raw_cli_arguments_supported: true,
+      auth_configuration_probe: lambda do |home:, env:|
+        if env_configured?(env, "ANTHROPIC_API_KEY")
+          AuthConfiguration.new(status: :configured, source: "environment")
+        else
+          auth_from_file(
+            home_path(home, ".claude", ".credentials.json"),
+            source: "~/.claude/.credentials.json"
+          )
+        end
+      end
+    )
+
+    CODEX = Profile.new(
+      name: :codex,
+      bin_default: "codex",
+      env_bin_override_keys: %w[AGENT_CLI_RUNTIME_CODEX_BIN HIVE_CODEX_BIN],
+      headless_flag: "exec",
+      prompt_style: :stdin,
+      permission_skip_flag: "--dangerously-bypass-approvals-and-sandbox",
+      workspace_write_flags: [
+        "--sandbox", "workspace-write",
+        "-c", 'approval_policy="never"',
+        "--ephemeral", "--ignore-user-config", "--ignore-rules"
+      ],
+      read_only_flags: [
+        "--sandbox", "read-only",
+        "-c", 'approval_policy="never"',
+        "--ephemeral", "--ignore-user-config", "--ignore-rules"
+      ],
+      add_dir_flag: "--add-dir",
+      output_format_flags: [ "--json" ],
+      version_flag: "--version",
+      min_version: "0.125.0",
+      model_argument_builder: ->(model) { [ "--model", model ] },
+      effort_argument_builder:
+        ->(effort) { [ "-c", "model_reasoning_effort=#{effort}" ] },
+      launcher_identity: "codex-cli/v1",
+      usage_extractor: UsageExtractors::CODEX,
+      auth_configuration_probe: lambda do |home:, env:|
+        if env_configured?(env, "OPENAI_API_KEY")
+          AuthConfiguration.new(status: :configured, source: "environment")
+        else
+          auth_from_file(
+            home_path(home, ".codex", "auth.json"),
+            source: "~/.codex/auth.json"
+          )
+        end
+      end
+    )
+
+    PI = Profile.new(
+      name: :pi,
+      bin_default: "pi",
+      env_bin_override_keys: %w[AGENT_CLI_RUNTIME_PI_BIN HIVE_PI_BIN],
+      headless_flag: "-p",
+      tool_scope_flags: { allowed: "--tools" },
+      output_format_flags: [ "--mode", "json", "--no-session" ],
+      version_flag: "--version",
+      min_version: "0.70.2",
+      model_argument_builder: ->(model) { [ "--model", model ] },
+      launcher_identity: "pi-coding-agent/v1",
+      usage_extractor: UsageExtractors::PI,
+      auth_configuration_probe: lambda do |home:, env:|
+        directory = env["PI_CODING_AGENT_DIR"]
+        path =
+          if directory.to_s.empty?
+            home_path(home, ".pi", "agent", "auth.json")
+          else
+            raise ArgumentError, "PI_CODING_AGENT_DIR must be absolute" unless File.absolute_path?(directory)
+
+            File.join(directory, "auth.json")
+          end
+        auth_from_file(path, source: "pi auth.json")
+      end
+    )
+
+    GROK = Profile.new(
+      name: :grok,
+      bin_default: "grok",
+      env_bin_override_keys: %w[AGENT_CLI_RUNTIME_GROK_BIN HIVE_GROK_BIN],
+      headless_flag: "-p",
+      prompt_style: :headless_flag_value,
+      permission_skip_flag: "--always-approve",
+      output_format_flags: [ "--output-format", "streaming-json" ],
+      version_flag: "--version",
+      min_version: "0.2.90",
+      model_argument_builder: ->(model) { [ "--model", model ] },
+      effort_argument_builder:
+        ->(effort) { [ "--reasoning-effort", effort ] },
+      launcher_identity: "grok-cli/v1",
+      usage_extractor: UsageExtractors::GROK,
+      auth_configuration_probe: lambda do |home:, env:|
+        if env_configured?(env, "XAI_API_KEY", "GROK_CODE_XAI_API_KEY")
+          grok_auth_path(home: home, env: env) if
+            env_configured?(env, "GROK_AUTH_PATH", "GROK_HOME")
+          AuthConfiguration.new(status: :configured, source: "environment")
+        else
+          auth_from_file(
+            grok_auth_path(home: home, env: env),
+            source: "grok auth.json"
+          )
+        end
+      end
+    )
+
+    PROFILES = [ CLAUDE, CODEX, PI, GROK ].to_h do |profile|
+      [ profile.name, profile ]
+    end.freeze
+    PROVIDER_ORDER = PROFILES.keys.freeze
+    private_constant :PROFILES
+  end
+end

--- a/components/agent-cli-runtime/lib/agent_cli_runtime/redactor.rb
+++ b/components/agent-cli-runtime/lib/agent_cli_runtime/redactor.rb
@@ -5,13 +5,15 @@ module AgentCliRuntime
       openai_api_key: /\bsk-[A-Za-z0-9]{20,}/,
       anthropic_api_key: /\bsk-ant-[A-Za-z0-9_-]{20,}/,
       generic_api_key:
-        /\bapi[_-]?key\b[\s:=]{0,3}['"]?[A-Za-z0-9_-]{20,}['"]?(?=[\s,;]|$)/i,
+        /\bapi[_-]?key\b['"]?[\s:=]{0,3}['"]?[A-Za-z0-9_-]{20,}['"]?(?=[\s,;}\]]|$)/i,
       password:
-        /\b(?:password|passwd|pwd)\b[\s:=]{0,3}['"]?[^\s'"]{6,}['"]?(?=[\s,;]|$)/i,
+        /\b(?:password|passwd|pwd)\b['"]?[\s:=]{0,3}['"]?[^\s'"]{6,}['"]?(?=[\s,;}\]]|$)/i,
       authorization:
         /\bauthorization\s*[:=]\s*['"]?(?:Bearer|Basic|Token)\s+[A-Za-z0-9._+\/=-]{8,}['"]?/i,
       private_key:
-        /-----BEGIN (?:RSA |OPENSSH |EC |DSA |PGP )?PRIVATE KEY(?: BLOCK)?-----[\s\S]{0,4000}/,
+        /-----BEGIN (?:RSA |OPENSSH |EC |DSA |PGP )?PRIVATE KEY(?: BLOCK)?-----.*?-----END (?:RSA |OPENSSH |EC |DSA |PGP )?PRIVATE KEY(?: BLOCK)?-----/m,
+      private_key_header:
+        /-----BEGIN (?:RSA |OPENSSH |EC |DSA |PGP )?PRIVATE KEY(?: BLOCK)?-----[\s\S]*\z/,
       jwt: /\beyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/
     }.freeze
 

--- a/components/agent-cli-runtime/lib/agent_cli_runtime/redactor.rb
+++ b/components/agent-cli-runtime/lib/agent_cli_runtime/redactor.rb
@@ -1,0 +1,40 @@
+module AgentCliRuntime
+  module Redactor
+    PATTERNS = {
+      github_token: /\b(?:github_pat_[A-Za-z0-9_]{20,}|gh[psou]_[A-Za-z0-9]{36,})\b/,
+      openai_api_key: /\bsk-[A-Za-z0-9]{20,}/,
+      anthropic_api_key: /\bsk-ant-[A-Za-z0-9_-]{20,}/,
+      generic_api_key:
+        /\bapi[_-]?key\b[\s:=]{0,3}['"]?[A-Za-z0-9_-]{20,}['"]?(?=[\s,;]|$)/i,
+      password:
+        /\b(?:password|passwd|pwd)\b[\s:=]{0,3}['"]?[^\s'"]{6,}['"]?(?=[\s,;]|$)/i,
+      authorization:
+        /\bauthorization\s*[:=]\s*['"]?(?:Bearer|Basic|Token)\s+[A-Za-z0-9._+\/=-]{8,}['"]?/i,
+      private_key:
+        /-----BEGIN (?:RSA |OPENSSH |EC |DSA |PGP )?PRIVATE KEY(?: BLOCK)?-----[\s\S]{0,4000}/,
+      jwt: /\beyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/
+    }.freeze
+
+    module_function
+
+    def redact(value)
+      output = value.to_s.dup.force_encoding(Encoding::UTF_8).scrub("?")
+      PATTERNS.each do |name, pattern|
+        output.gsub!(pattern, "[REDACTED:#{name}]")
+      end
+      output
+    end
+
+    def diagnostic(value, bytes: AgentCliRuntime::DIAGNOSTIC_BYTES)
+      message = value.respond_to?(:message) ? value.message : value.to_s
+      redacted = redact(message)
+      return nil if redacted.empty?
+      return redacted.freeze if redacted.bytesize <= bytes
+
+      redacted.byteslice(0, bytes).to_s
+              .force_encoding(Encoding::UTF_8)
+              .scrub("?")
+              .freeze
+    end
+  end
+end

--- a/components/agent-cli-runtime/lib/agent_cli_runtime/runtime.rb
+++ b/components/agent-cli-runtime/lib/agent_cli_runtime/runtime.rb
@@ -81,6 +81,8 @@ module AgentCliRuntime
       resolved = Profiles.resolve(profile)
       arguments = resolved.require_cli_capability!(capability)
       supported_evidence(resolved, capability, arguments)
+    rescue UnknownProvider
+      raise
     rescue Error => e
       evidence = unsupported_evidence(
         resolved, capability, Redactor.diagnostic(e)
@@ -94,9 +96,11 @@ module AgentCliRuntime
 
     def extract_usage(profile, event)
       resolved = Profiles.resolve(profile)
-      normalize_usage(resolved.extract_usage_event(event))
-    rescue StandardError
-      nil
+      begin
+        normalize_usage(resolved.extract_usage_event(event))
+      rescue StandardError
+        nil
+      end
     end
 
     def observe(profile, result)

--- a/components/agent-cli-runtime/lib/agent_cli_runtime/runtime.rb
+++ b/components/agent-cli-runtime/lib/agent_cli_runtime/runtime.rb
@@ -1,0 +1,285 @@
+module AgentCliRuntime
+  module Runtime
+    module_function
+
+    def compile(request)
+      unless request.is_a?(Request)
+        raise ArgumentError,
+              "request must be an AgentCliRuntime::Request"
+      end
+
+      profile = Profiles.resolve(request.profile)
+      evidence = [ supported_evidence(profile, :headless) ]
+      argv = [ request.executable || profile.bin ]
+      prompt_style = profile.prompt_style
+      argv << profile.headless_flag
+      argv << request.prompt if prompt_style == :headless_flag_value
+
+      argv.concat(
+        permission_arguments(
+          profile, request.permission_mode, evidence,
+          trusted_arguments: request.permission_arguments
+        )
+      )
+      argv.concat(directory_arguments(profile, request, evidence))
+      argv.concat(tool_scope_arguments(profile, request, evidence))
+      argv.concat(budget_arguments(profile, request.max_budget_usd, evidence))
+      argv.concat(identity_arguments(profile, request, evidence))
+
+      request.capabilities.each do |capability|
+        capability_evidence = require_capability!(profile, capability)
+        evidence << capability_evidence
+        argv.concat(capability_evidence.arguments)
+      end
+
+      unless request.raw_cli_arguments.empty?
+        unless profile.raw_cli_arguments_supported?
+          unsupported!(
+            profile, :raw_cli_arguments,
+            "agent profile #{profile.name.inspect} does not accept raw CLI arguments"
+          )
+        end
+        evidence << supported_evidence(
+          profile, :raw_cli_arguments, request.raw_cli_arguments
+        )
+        argv.concat(request.raw_cli_arguments)
+      end
+      argv.concat(request.trusted_cli_arguments)
+      argv.concat(profile.output_format_flags) if request.include_output_format
+      argv << (prompt_style == :stdin ? "-" : request.prompt) unless
+        prompt_style == :headless_flag_value
+
+      CompiledInvocation.new(
+        argv: request.command_prefix + argv,
+        stdin_data: prompt_style == :stdin ? request.prompt : nil,
+        provider: profile.name,
+        launcher_identity: profile.launcher_identity,
+        capability_evidence: evidence
+      )
+    rescue Error
+      raise
+    rescue StandardError => e
+      profile = Profiles.resolve(request.profile) if request.is_a?(Request)
+      compilation_error!(profile, e)
+    end
+
+    def prepare!(profile)
+      resolved = Profiles.resolve(profile)
+      result = Probe.call(resolved)
+      return result if result.ready
+
+      evidence = unsupported_evidence(
+        resolved, :probe, result.diagnostic || "local prerequisites unavailable"
+      )
+      raise ProbeError.new(
+        "agent profile #{resolved.name.inspect} probe failed: #{evidence.diagnostic}",
+        evidence: evidence
+      )
+    end
+
+    def require_capability!(profile, capability)
+      resolved = Profiles.resolve(profile)
+      arguments = resolved.require_cli_capability!(capability)
+      supported_evidence(resolved, capability, arguments)
+    rescue Error => e
+      evidence = unsupported_evidence(
+        resolved, capability, Redactor.diagnostic(e)
+      )
+      raise UnsupportedCapability.new(
+        "agent profile #{resolved.name.inspect} cannot provide " \
+        "#{capability.to_sym.inspect}: #{evidence.diagnostic}",
+        evidence: evidence
+      ), cause: e
+    end
+
+    def extract_usage(profile, event)
+      resolved = Profiles.resolve(profile)
+      normalize_usage(resolved.extract_usage_event(event))
+    rescue StandardError
+      nil
+    end
+
+    def observe(profile, result)
+      resolved = Profiles.resolve(profile)
+      raw = result.is_a?(Hash) ? result : {}
+      ObservableResult.new(
+        provider: resolved.name,
+        launcher_identity: resolved.launcher_identity,
+        exit_code: raw[:exit_code],
+        timed_out: raw[:timed_out],
+        status: raw[:status],
+        usage: normalize_usage(raw[:usage]),
+        final_message: raw[:final_message],
+        diagnostic: Redactor.diagnostic(
+          raw[:error_message] || raw[:limit_text]
+        )
+      )
+    end
+
+    def supported_evidence(profile, capability, arguments = [])
+      CapabilityEvidence.new(
+        capability: capability,
+        supported: true,
+        provider: profile.name,
+        launcher_identity: profile.launcher_identity,
+        arguments: arguments
+      )
+    end
+
+    def unsupported_evidence(profile, capability, diagnostic)
+      CapabilityEvidence.new(
+        capability: capability,
+        supported: false,
+        provider: profile&.name || :unknown,
+        launcher_identity: profile&.launcher_identity || "unknown",
+        diagnostic: Redactor.diagnostic(diagnostic)
+      )
+    end
+
+    def permission_arguments(profile, permission_mode, evidence,
+                             trusted_arguments: nil)
+      arguments =
+        if trusted_arguments
+          trusted_arguments
+        else
+          profile.permission_flags(permission_mode)
+        end
+      capability =
+        permission_mode&.tr("-", "_")&.to_sym || :permission_bypass
+      evidence << supported_evidence(profile, capability, arguments)
+      arguments
+    rescue ArgumentError => e
+      unsupported!(
+        profile, permission_mode&.tr("-", "_")&.to_sym || :permission, e
+      )
+    end
+    private_class_method :permission_arguments
+
+    def directory_arguments(profile, request, evidence)
+      return [] if request.add_dirs.empty?
+
+      unless profile.add_dir_flag
+        if request.require_add_dirs
+          unsupported!(
+            profile, :add_directory,
+            "agent profile #{profile.name.inspect} cannot constrain additional directories"
+          )
+        end
+        evidence << unsupported_evidence(
+          profile, :add_directory,
+          "unsupported; directories intentionally omitted"
+        )
+        return []
+      end
+
+      arguments =
+        request.add_dirs.flat_map { |directory| [ profile.add_dir_flag, directory ] }
+      evidence << supported_evidence(profile, :add_directory, arguments)
+      arguments
+    end
+    private_class_method :directory_arguments
+
+    def tool_scope_arguments(profile, request, evidence)
+      arguments = []
+      {
+        allowed_tools: [ request.allowed_tools, :allowed ],
+        disallowed_tools: [ request.disallowed_tools, :disallowed ]
+      }.each do |capability, (tools, scope)|
+        value = tool_csv(tools)
+        next unless value
+
+        flag = profile.tool_scope_flags[scope]
+        unless flag
+          unsupported!(
+            profile, capability,
+            "agent profile #{profile.name.inspect} cannot enforce #{scope} tool scope"
+          )
+        end
+        scoped_arguments = [ flag, value ]
+        evidence << supported_evidence(profile, capability, scoped_arguments)
+        arguments.concat(scoped_arguments)
+      end
+      arguments
+    end
+    private_class_method :tool_scope_arguments
+
+    def budget_arguments(profile, max_budget_usd, evidence)
+      return [] if max_budget_usd.nil?
+      unless profile.budget_flag
+        unsupported!(
+          profile, :budget,
+          "agent profile #{profile.name.inspect} cannot enforce a native budget"
+        )
+      end
+
+      arguments = [ profile.budget_flag, max_budget_usd.to_s ]
+      evidence << supported_evidence(profile, :budget, arguments)
+      arguments
+    end
+    private_class_method :budget_arguments
+
+    def identity_arguments(profile, request, evidence)
+      arguments = request.identity_arguments.dup
+      return arguments unless request.model || request.effort
+      unless request.model
+        unsupported!(
+          profile, :effort,
+          "effort requires an explicit model in an invocation request"
+        )
+      end
+
+      identity = profile.identity_arguments(
+        model: request.model,
+        effort: request.effort,
+        pin_model: request.pin_model
+      )
+      evidence << supported_evidence(profile, :model, identity.native_arguments)
+      evidence << supported_evidence(profile, :effort) if request.effort
+      arguments.concat(identity.native_arguments)
+    rescue UnsupportedCapability => e
+      capability = request.effort && !profile.effort_argument_builder ? :effort : :model
+      unsupported!(profile, capability, e)
+    end
+    private_class_method :identity_arguments
+
+    def tool_csv(tools)
+      values = Array(tools).compact.map(&:to_s).reject(&:empty?).uniq
+      values.empty? ? nil : values.join(",")
+    end
+    private_class_method :tool_csv
+
+    def normalize_usage(usage)
+      return nil unless usage.is_a?(Hash)
+
+      input = usage.key?(:input) ? usage[:input] : usage["input"]
+      output = usage.key?(:output) ? usage[:output] : usage["output"]
+      cached = usage.key?(:cached) ? usage[:cached] : usage["cached"]
+      model = usage.key?(:model) ? usage[:model] : usage["model"]
+      {
+        input: [ input.to_i, 0 ].max,
+        output: [ output.to_i, 0 ].max,
+        cached: [ cached.to_i, 0 ].max,
+        model: model&.to_s&.dup&.freeze
+      }.freeze
+    end
+    private_class_method :normalize_usage
+
+    def unsupported!(profile, capability, diagnostic)
+      evidence = unsupported_evidence(profile, capability, diagnostic)
+      raise UnsupportedCapability.new(
+        evidence.diagnostic,
+        evidence: evidence
+      )
+    end
+    private_class_method :unsupported!
+
+    def compilation_error!(profile, error)
+      evidence = unsupported_evidence(profile, :compilation, error)
+      raise CompilationError.new(
+        "agent invocation compilation failed: #{evidence.diagnostic}",
+        evidence: evidence
+      ), cause: error
+    end
+    private_class_method :compilation_error!
+  end
+end

--- a/components/agent-cli-runtime/lib/agent_cli_runtime/usage_extractors.rb
+++ b/components/agent-cli-runtime/lib/agent_cli_runtime/usage_extractors.rb
@@ -1,0 +1,131 @@
+module AgentCliRuntime
+  module UsageExtractors
+    module_function
+
+    CLAUDE = lambda do |event|
+      next nil unless event.is_a?(Hash)
+
+      usage = usage_hash(event)
+      if event["type"] == "result"
+        usage_result(event, usage || {}, model_from(event))
+      elsif event["type"] == "stream_event" && usage
+        usage_result(event, usage, model_from(event))
+      end
+    end
+
+    CODEX = lambda do |event|
+      next nil unless event.is_a?(Hash)
+
+      usage = usage_hash(event)
+      if usage
+        usage_result(event, usage, model_from(event))
+      elsif final_type?(event, %w[turn.completed result response.completed])
+        zero_result(model_from(event))
+      end
+    end
+
+    PI = lambda do |event|
+      next nil unless event.is_a?(Hash)
+
+      usage = usage_hash(event)
+      if usage
+        usage_result(event, usage, model_from(event))
+      elsif final_type?(event, %w[result run.completed task.completed response.completed])
+        zero_result(model_from(event))
+      end
+    end
+
+    GROK = lambda do |event|
+      next nil unless event.is_a?(Hash)
+
+      usage = usage_hash(event)
+      usage_result(event, usage, model_from(event)) if usage
+    end
+
+    def final_type?(event, types)
+      types.include?(event["type"].to_s)
+    end
+
+    def usage_hash(event)
+      candidates = [
+        event["usage"],
+        event["token_usage"],
+        event.dig("event", "usage"),
+        event.dig("event", "message", "usage"),
+        event.dig("info", "usage"),
+        event.dig("info", "total_token_usage"),
+        event.dig("response", "usage"),
+        event.dig("item", "usage")
+      ]
+      candidates.find { |value| value.is_a?(Hash) }
+    end
+
+    def usage_result(event, usage, model)
+      {
+        input: token_count(
+          usage, "input_tokens", "inputTokens", "prompt_tokens", "promptTokens"
+        ),
+        output: token_count(
+          usage, "output_tokens", "outputTokens", "completion_tokens",
+          "completionTokens"
+        ),
+        cached: cached_tokens(usage),
+        model: model || model_from_usage(usage) || model_from(event)
+      }
+    end
+
+    def zero_result(model)
+      { input: 0, output: 0, cached: 0, model: model }
+    end
+
+    def cached_tokens(usage)
+      direct = token_count(
+        usage, "cached", "cached_tokens", "cachedTokens",
+        "cached_input_tokens", "cachedInputTokens"
+      )
+      return direct if direct.positive?
+
+      token_count(usage, "cache_read_input_tokens", "cacheReadInputTokens") +
+        token_count(usage, "cache_creation_input_tokens", "cacheCreationInputTokens") +
+        token_count(
+          nested_hash(usage, "prompt_tokens_details"), "cached_tokens", "cachedTokens"
+        ) +
+        token_count(
+          nested_hash(usage, "input_tokens_details"), "cached_tokens", "cachedTokens"
+        )
+    end
+
+    def token_count(hash, *keys)
+      return 0 unless hash.is_a?(Hash)
+
+      key = keys.find { |candidate| hash.key?(candidate) }
+      key ? hash[key].to_i : 0
+    end
+
+    def nested_hash(hash, key)
+      value = hash[key]
+      value.is_a?(Hash) ? value : {}
+    end
+
+    def model_from(event)
+      model_usage = event["modelUsage"]
+      if model_usage.is_a?(Hash) && !model_usage.empty?
+        return model_usage.keys.first.to_s
+      end
+
+      candidates = [
+        event["model"],
+        event.dig("message", "model"),
+        event.dig("event", "message", "model"),
+        event.dig("response", "model"),
+        event.dig("item", "model")
+      ]
+      candidates.find { |value| !value.to_s.empty? }&.to_s
+    end
+
+    def model_from_usage(usage)
+      value = usage["model"] || usage["model_name"] || usage["modelName"]
+      value.to_s.empty? ? nil : value.to_s
+    end
+  end
+end

--- a/components/agent-cli-runtime/lib/agent_cli_runtime/usage_extractors.rb
+++ b/components/agent-cli-runtime/lib/agent_cli_runtime/usage_extractors.rb
@@ -6,8 +6,8 @@ module AgentCliRuntime
       next nil unless event.is_a?(Hash)
 
       usage = usage_hash(event)
-      if event["type"] == "result"
-        usage_result(event, usage || {}, model_from(event))
+      if event["type"] == "result" && usage
+        usage_result(event, usage, model_from(event))
       elsif event["type"] == "stream_event" && usage
         usage_result(event, usage, model_from(event))
       end
@@ -17,22 +17,14 @@ module AgentCliRuntime
       next nil unless event.is_a?(Hash)
 
       usage = usage_hash(event)
-      if usage
-        usage_result(event, usage, model_from(event))
-      elsif final_type?(event, %w[turn.completed result response.completed])
-        zero_result(model_from(event))
-      end
+      usage_result(event, usage, model_from(event)) if usage
     end
 
     PI = lambda do |event|
       next nil unless event.is_a?(Hash)
 
       usage = usage_hash(event)
-      if usage
-        usage_result(event, usage, model_from(event))
-      elsif final_type?(event, %w[result run.completed task.completed response.completed])
-        zero_result(model_from(event))
-      end
+      usage_result(event, usage, model_from(event)) if usage
     end
 
     GROK = lambda do |event|
@@ -40,10 +32,6 @@ module AgentCliRuntime
 
       usage = usage_hash(event)
       usage_result(event, usage, model_from(event)) if usage
-    end
-
-    def final_type?(event, types)
-      types.include?(event["type"].to_s)
     end
 
     def usage_hash(event)
@@ -72,10 +60,6 @@ module AgentCliRuntime
         cached: cached_tokens(usage),
         model: model || model_from_usage(usage) || model_from(event)
       }
-    end
-
-    def zero_result(model)
-      { input: 0, output: 0, cached: 0, model: model }
     end
 
     def cached_tokens(usage)

--- a/components/agent-cli-runtime/lib/agent_cli_runtime/values.rb
+++ b/components/agent-cli-runtime/lib/agent_cli_runtime/values.rb
@@ -1,0 +1,174 @@
+module AgentCliRuntime
+  module Immutable
+    module_function
+
+    def string(value)
+      string = value.to_s
+      string.frozen? ? string : string.dup.freeze
+    end
+
+    def strings(values)
+      Array(values).map { |value| string(value) }.freeze
+    end
+
+    def symbols(values)
+      Array(values).map(&:to_sym).uniq.freeze
+    end
+  end
+  private_constant :Immutable
+
+  CapabilityEvidence = Data.define(
+    :capability, :supported, :provider, :launcher_identity, :arguments, :diagnostic
+  ) do
+    def initialize(capability:, supported:, provider:, launcher_identity:,
+                   arguments: [], diagnostic: nil)
+      super(
+        capability: capability.to_sym,
+        supported: supported == true,
+        provider: provider.to_sym,
+        launcher_identity: Immutable.string(launcher_identity),
+        arguments: Immutable.strings(arguments),
+        diagnostic: diagnostic.nil? ? nil : Immutable.string(diagnostic)
+      )
+    end
+  end
+
+  IdentityArguments = Data.define(
+    :model, :requested_effort, :effective_effort, :effort_supported,
+    :model_pinned, :native_arguments
+  ) do
+    def initialize(model:, requested_effort:, effective_effort:, effort_supported:,
+                   model_pinned:, native_arguments:)
+      super(
+        model: Immutable.string(model),
+        requested_effort:
+          requested_effort.nil? ? nil : Immutable.string(requested_effort),
+        effective_effort:
+          effective_effort.nil? ? nil : Immutable.string(effective_effort),
+        effort_supported: effort_supported == true,
+        model_pinned: model_pinned == true,
+        native_arguments: Immutable.strings(native_arguments)
+      )
+    end
+  end
+
+  Request = Data.define(
+    :profile, :prompt, :permission_mode, :permission_arguments,
+    :add_dirs, :require_add_dirs,
+    :allowed_tools, :disallowed_tools, :max_budget_usd,
+    :model, :effort, :pin_model, :identity_arguments,
+    :capabilities, :raw_cli_arguments, :trusted_cli_arguments,
+    :executable, :command_prefix, :include_output_format
+  ) do
+    def initialize(profile:, prompt:, permission_mode: nil, permission_arguments: nil,
+                   add_dirs: [], require_add_dirs: false, allowed_tools: nil,
+                   disallowed_tools: nil, max_budget_usd: nil, model: nil,
+                   effort: nil, pin_model: true, identity_arguments: [],
+                   capabilities: [], raw_cli_arguments: [],
+                   trusted_cli_arguments: [], executable: nil,
+                   command_prefix: [], include_output_format: true)
+      super(
+        profile: profile,
+        prompt: Immutable.string(prompt),
+        permission_mode:
+          permission_mode.nil? ? nil : Immutable.string(permission_mode),
+        permission_arguments:
+          permission_arguments.nil? ? nil : Immutable.strings(permission_arguments),
+        add_dirs: Immutable.strings(add_dirs),
+        require_add_dirs: require_add_dirs == true,
+        allowed_tools: Immutable.strings(allowed_tools),
+        disallowed_tools: Immutable.strings(disallowed_tools),
+        max_budget_usd: max_budget_usd,
+        model: model.nil? ? nil : Immutable.string(model),
+        effort: effort.nil? ? nil : Immutable.string(effort),
+        pin_model: pin_model != false,
+        identity_arguments: Immutable.strings(identity_arguments),
+        capabilities: Immutable.symbols(capabilities),
+        raw_cli_arguments: Immutable.strings(raw_cli_arguments),
+        trusted_cli_arguments: Immutable.strings(trusted_cli_arguments),
+        executable: executable.nil? ? nil : Immutable.string(executable),
+        command_prefix: Immutable.strings(command_prefix),
+        include_output_format: include_output_format != false
+      )
+    end
+  end
+
+  CompiledInvocation = Data.define(
+    :argv, :stdin_data, :provider, :launcher_identity, :capability_evidence
+  ) do
+    def initialize(argv:, stdin_data:, provider:, launcher_identity:,
+                   capability_evidence:)
+      super(
+        argv: Immutable.strings(argv),
+        stdin_data: stdin_data.nil? ? nil : Immutable.string(stdin_data),
+        provider: provider.to_sym,
+        launcher_identity: Immutable.string(launcher_identity),
+        capability_evidence: Array(capability_evidence).freeze
+      )
+    end
+  end
+
+  AuthConfiguration = Data.define(:status, :source, :diagnostic) do
+    STATUSES = %i[configured missing not_checked].freeze
+
+    def initialize(status:, source: nil, diagnostic: nil)
+      normalized_status = status.to_sym
+      unless STATUSES.include?(normalized_status)
+        raise ArgumentError,
+              "unknown auth configuration status #{status.inspect}; valid: #{STATUSES.inspect}"
+      end
+
+      super(
+        status: normalized_status,
+        source: source.nil? ? nil : Immutable.string(source),
+        diagnostic: diagnostic.nil? ? nil : Immutable.string(diagnostic)
+      )
+    end
+
+    def configured?
+      status == :configured
+    end
+  end
+
+  ProbeResult = Data.define(
+    :provider, :ready, :installed, :executable, :version, :minimum_version,
+    :auth_configuration, :capability_evidence, :diagnostic
+  ) do
+    def initialize(provider:, ready:, installed:, executable:, version:,
+                   minimum_version:, auth_configuration:, capability_evidence:,
+                   diagnostic:)
+      super(
+        provider: provider.to_sym,
+        ready: ready == true,
+        installed: installed == true,
+        executable: Immutable.string(executable),
+        version: version.nil? ? nil : Immutable.string(version),
+        minimum_version:
+          minimum_version.nil? ? nil : Immutable.string(minimum_version),
+        auth_configuration: auth_configuration,
+        capability_evidence: Array(capability_evidence).freeze,
+        diagnostic: diagnostic.nil? ? nil : Immutable.string(diagnostic)
+      )
+    end
+  end
+
+  ObservableResult = Data.define(
+    :provider, :launcher_identity, :exit_code, :timed_out, :status,
+    :usage, :final_message, :diagnostic
+  ) do
+    def initialize(provider:, launcher_identity:, exit_code:, timed_out:,
+                   status:, usage:, final_message:, diagnostic:)
+      super(
+        provider: provider.to_sym,
+        launcher_identity: Immutable.string(launcher_identity),
+        exit_code: exit_code,
+        timed_out: timed_out == true,
+        status: status&.to_sym,
+        usage: usage&.dup&.freeze,
+        final_message:
+          final_message.nil? ? nil : Immutable.string(final_message),
+        diagnostic: diagnostic.nil? ? nil : Immutable.string(diagnostic)
+      )
+    end
+  end
+end

--- a/components/agent-cli-runtime/lib/agent_cli_runtime/version.rb
+++ b/components/agent-cli-runtime/lib/agent_cli_runtime/version.rb
@@ -1,0 +1,3 @@
+module AgentCliRuntime
+  VERSION = "0.1.0".freeze
+end

--- a/components/agent-cli-runtime/test/cli_test.rb
+++ b/components/agent-cli-runtime/test/cli_test.rb
@@ -1,0 +1,49 @@
+require_relative "test_helper"
+
+class AgentCliRuntimeCliTest < Minitest::Test
+  EXE = File.expand_path("../exe/agent-runtime", __dir__)
+  LIB = File.expand_path("../lib", __dir__)
+
+  def test_json_probe_uses_versioned_envelope_and_unavailable_exit
+    out, err, status = Open3.capture3(
+      {
+        "PATH" => "/usr/bin:/bin",
+        "RUBYLIB" => LIB,
+        "AGENT_CLI_RUNTIME_CODEX_BIN" => "/missing/codex"
+      },
+      Gem.ruby, EXE, "probe", "codex", "--json"
+    )
+
+    assert_equal 1, status.exitstatus
+    assert_empty err
+    payload = JSON.parse(out)
+    assert_equal 1, payload.fetch("schema_version")
+    assert_equal [ "codex" ], payload.fetch("probes").map { |probe| probe.fetch("provider") }
+    assert_equal false, payload.dig("probes", 0, "ready")
+    refute payload.dig("probes", 0).key?("healthy")
+    refute payload.dig("probes", 0).key?("quota")
+    refute payload.dig("probes", 0).key?("credentials_valid")
+  end
+
+  def test_all_json_probe_preserves_provider_order
+    out, _err, status = Open3.capture3(
+      { "PATH" => "/usr/bin:/bin", "RUBYLIB" => LIB },
+      Gem.ruby, EXE, "probe", "--all", "--json"
+    )
+
+    assert_includes [ 0, 1 ], status.exitstatus
+    payload = JSON.parse(out)
+    assert_equal %w[claude codex pi grok],
+                 payload.fetch("probes").map { |probe| probe.fetch("provider") }
+  end
+
+  def test_invalid_usage_exits_64_without_probing
+    _out, err, status = Open3.capture3(
+      { "PATH" => "/usr/bin:/bin", "RUBYLIB" => LIB },
+      Gem.ruby, EXE, "probe", "codex", "--all"
+    )
+
+    assert_equal 64, status.exitstatus
+    assert_match(/Usage:/, err)
+  end
+end

--- a/components/agent-cli-runtime/test/cli_test.rb
+++ b/components/agent-cli-runtime/test/cli_test.rb
@@ -66,10 +66,10 @@ class AgentCliRuntimeCliTest < Minitest::Test
   def test_ready_json_probe_has_the_complete_v1_shape
     Dir.mktmpdir do |dir|
       bin = File.join(dir, "codex")
-      write_executable(bin, <<~RUBY)
-        #!/usr/bin/env ruby
-        puts "codex-cli 0.125.0"
-      RUBY
+      write_executable(bin, <<~SH)
+        #!/bin/sh
+        printf '%s\n' 'codex-cli 0.125.0'
+      SH
       out, err, status = Open3.capture3(
         {
           "PATH" => "/usr/bin:/bin",

--- a/components/agent-cli-runtime/test/cli_test.rb
+++ b/components/agent-cli-runtime/test/cli_test.rb
@@ -46,4 +46,72 @@ class AgentCliRuntimeCliTest < Minitest::Test
     assert_equal 64, status.exitstatus
     assert_match(/Usage:/, err)
   end
+
+  def test_unknown_provider_exits_64_with_typed_message
+    _out, err, status = run_cli("probe", "not-a-provider", "--json")
+
+    assert_equal 64, status.exitstatus
+    assert_match(/unknown provider/, err)
+    assert_match(/claude, codex, pi, grok/, err)
+    assert_match(/Usage:/, err)
+  end
+
+  def test_unknown_option_exits_64
+    _out, err, status = run_cli("probe", "codex", "--yaml")
+
+    assert_equal 64, status.exitstatus
+    assert_match(/Usage:/, err)
+  end
+
+  def test_ready_json_probe_has_the_complete_v1_shape
+    Dir.mktmpdir do |dir|
+      bin = File.join(dir, "codex")
+      write_executable(bin, <<~RUBY)
+        #!/usr/bin/env ruby
+        puts "codex-cli 0.125.0"
+      RUBY
+      out, err, status = Open3.capture3(
+        {
+          "PATH" => "/usr/bin:/bin",
+          "RUBYLIB" => LIB,
+          "OPENAI_API_KEY" => "configured",
+          "AGENT_CLI_RUNTIME_CODEX_BIN" => bin
+        },
+        Gem.ruby, EXE, "probe", "codex", "--json"
+      )
+
+      assert_equal 0, status.exitstatus
+      assert_empty err
+      payload = JSON.parse(out)
+      assert_equal %w[probes schema_version], payload.keys.sort
+      probe = payload.fetch("probes").fetch(0)
+      assert_equal %w[
+        auth_configuration capabilities diagnostic executable installed
+        minimum_version provider ready version
+      ], probe.keys.sort
+      assert_equal %w[source status],
+                   probe.fetch("auth_configuration").keys.sort
+      assert_equal(
+        %w[
+          headless version auth_configuration add_directory allowed_tools
+          disallowed_tools model effort budget raw_cli_arguments installation
+        ],
+        probe.fetch("capabilities").map { |item| item.fetch("capability") }
+      )
+      assert(
+        probe.fetch("capabilities").all? do |item|
+          item.keys.sort == %w[capability supported]
+        end
+      )
+    end
+  end
+
+  private
+
+  def run_cli(*arguments)
+    Open3.capture3(
+      { "PATH" => "/usr/bin:/bin", "RUBYLIB" => LIB },
+      Gem.ruby, EXE, *arguments
+    )
+  end
 end

--- a/components/agent-cli-runtime/test/gemspec_test.rb
+++ b/components/agent-cli-runtime/test/gemspec_test.rb
@@ -1,0 +1,29 @@
+require_relative "test_helper"
+
+class AgentCliRuntimeGemspecTest < Minitest::Test
+  GEMSPEC = File.expand_path("../agent-cli-runtime.gemspec", __dir__)
+
+  def test_public_identity_and_inventory
+    spec = Gem::Specification.load(GEMSPEC)
+
+    assert_equal "agent-cli-runtime", spec.name
+    assert_equal Gem::Version.new("0.1.0"), spec.version
+    assert_equal Gem::Requirement.new(">= 3.4.0"), spec.required_ruby_version
+    assert_equal [ "agent-runtime" ], spec.executables
+    assert_equal "MIT", spec.license
+    %w[
+      README.md
+      CHANGELOG.md
+      LICENSE.txt
+      lib/agent_cli_runtime.rb
+      lib/agent_cli_runtime/version.rb
+      exe/agent-runtime
+    ].each { |path| assert_includes spec.files, path }
+  end
+
+  def test_every_non_core_direct_dependency_is_declared
+    spec = Gem::Specification.load(GEMSPEC)
+
+    assert_equal %w[json open3 timeout], spec.runtime_dependencies.map(&:name).sort
+  end
+end

--- a/components/agent-cli-runtime/test/package_test.rb
+++ b/components/agent-cli-runtime/test/package_test.rb
@@ -1,0 +1,69 @@
+require_relative "test_helper"
+
+class AgentCliRuntimePackageTest < Minitest::Test
+  ROOT = File.expand_path("..", __dir__)
+
+  def test_build_candidate_records_one_exact_gem
+    Dir.mktmpdir do |dir|
+      out, err, status = Open3.capture3(
+        File.join(ROOT, "bin", "build-candidate"),
+        dir
+      )
+
+      assert status.success?, err
+      manifest = JSON.parse(out.lines.last)
+      gem_path = manifest.fetch("gem_path")
+      assert File.file?(gem_path)
+      assert_equal "agent-cli-runtime-0.1.0.gem", File.basename(gem_path)
+      assert_equal Digest::SHA256.file(gem_path).hexdigest,
+                   manifest.fetch("sha256")
+      assert_includes [ true, false ], manifest.fetch("source_dirty")
+      assert_equal "#{manifest.fetch('sha256')}  #{File.basename(gem_path)}\n",
+                   File.read(File.join(dir, "SHA256SUMS"))
+    end
+  end
+
+  def test_release_preflight_accepts_only_the_clean_tagged_main_commit
+    Dir.mktmpdir do |repository|
+      component = File.join(repository, "components", "agent-cli-runtime")
+      FileUtils.mkdir_p(File.dirname(component))
+      FileUtils.cp_r(ROOT, component)
+
+      git!(repository, "init", "--quiet")
+      git!(repository, "checkout", "--quiet", "-b", "main")
+      git!(repository, "add", ".")
+      git!(
+        repository,
+        "-c", "user.name=Agent CLI Runtime Test",
+        "-c", "user.email=agent-cli-runtime@example.invalid",
+        "commit", "--quiet", "-m", "fixture"
+      )
+      commit = git!(repository, "rev-parse", "HEAD").strip
+      tag = "components/agent-cli-runtime/v0.1.0"
+      git!(repository, "tag", tag)
+
+      out, err, status = Open3.capture3(
+        File.join(component, "bin", "release-preflight"),
+        tag, commit, "main"
+      )
+      assert status.success?, err
+      assert_equal commit, JSON.parse(out).fetch("commit")
+
+      File.write(File.join(component, "README.md"), "\ndirty\n", mode: "a")
+      _out, err, status = Open3.capture3(
+        File.join(component, "bin", "release-preflight"),
+        tag, commit, "main"
+      )
+      refute status.success?
+      assert_match(/release checkout is dirty/, err)
+    end
+  end
+
+  private
+
+  def git!(repository, *arguments)
+    out, err, status = Open3.capture3("git", "-C", repository, *arguments)
+    assert status.success?, err
+    out
+  end
+end

--- a/components/agent-cli-runtime/test/package_test.rb
+++ b/components/agent-cli-runtime/test/package_test.rb
@@ -5,6 +5,11 @@ class AgentCliRuntimePackageTest < Minitest::Test
 
   def test_build_candidate_records_one_exact_gem
     Dir.mktmpdir do |dir|
+      dirty, git_error, git_status = Open3.capture3(
+        "git", "-C", File.expand_path("../..", ROOT), "status", "--porcelain"
+      )
+      assert git_status.success?, git_error
+
       out, err, status = Open3.capture3(
         File.join(ROOT, "bin", "build-candidate"),
         dir
@@ -17,13 +22,84 @@ class AgentCliRuntimePackageTest < Minitest::Test
       assert_equal "agent-cli-runtime-0.1.0.gem", File.basename(gem_path)
       assert_equal Digest::SHA256.file(gem_path).hexdigest,
                    manifest.fetch("sha256")
-      assert_includes [ true, false ], manifest.fetch("source_dirty")
+      assert_equal !dirty.empty?, manifest.fetch("source_dirty")
       assert_equal "#{manifest.fetch('sha256')}  #{File.basename(gem_path)}\n",
                    File.read(File.join(dir, "SHA256SUMS"))
     end
   end
 
   def test_release_preflight_accepts_only_the_clean_tagged_main_commit
+    with_release_repository do |repository, component, commit, tag|
+      out, err, status = run_preflight(component, tag, commit, "main")
+      assert status.success?, err
+      assert_equal commit, JSON.parse(out).fetch("commit")
+
+      File.write(File.join(component, "README.md"), "\ndirty\n", mode: "a")
+      _out, err, status = run_preflight(component, tag, commit, "main")
+      refute status.success?
+      assert_match(/release checkout is dirty/, err)
+    end
+  end
+
+  def test_release_preflight_rejects_malformed_identity_inputs
+    with_release_repository do |_repository, component, commit, _tag|
+      {
+        "v0.1.0" => /invalid component tag/,
+        "components/agent-cli-runtime/v0.1.1" => /tag\/source version mismatch/
+      }.each do |tag, message|
+        _out, err, status = run_preflight(component, tag, commit, "main")
+        refute status.success?, tag
+        assert_match message, err
+      end
+
+      _out, err, status = run_preflight(
+        component, "components/agent-cli-runtime/v0.1.0",
+        commit[0, 12], "main"
+      )
+      refute status.success?
+      assert_match(/expected commit must be a full SHA/, err)
+    end
+  end
+
+  def test_release_preflight_rejects_checkout_and_tag_commit_mismatches
+    with_release_repository do |repository, component, commit, tag|
+      File.write(File.join(repository, "second"), "second\n")
+      git!(repository, "add", "second")
+      commit_fixture!(repository, "second")
+      second_commit = git!(repository, "rev-parse", "HEAD").strip
+
+      _out, err, status = run_preflight(component, tag, commit, "main")
+      refute status.success?
+      assert_match(/does not match expected commit/, err)
+
+      _out, err, status = run_preflight(
+        component, tag, second_commit, "main"
+      )
+      refute status.success?
+      assert_match(/does not resolve to expected commit/, err)
+    end
+  end
+
+  def test_release_preflight_rejects_commit_not_reachable_from_main
+    with_release_repository do |repository, component, _commit, tag|
+      git!(repository, "checkout", "--quiet", "-b", "candidate")
+      File.write(File.join(repository, "candidate"), "candidate\n")
+      git!(repository, "add", "candidate")
+      commit_fixture!(repository, "candidate")
+      candidate_commit = git!(repository, "rev-parse", "HEAD").strip
+      git!(repository, "tag", "--force", tag, candidate_commit)
+
+      _out, err, status = run_preflight(
+        component, tag, candidate_commit, "main"
+      )
+      refute status.success?
+      assert_match(/candidate is not reachable from main/, err)
+    end
+  end
+
+  private
+
+  def with_release_repository
     Dir.mktmpdir do |repository|
       component = File.join(repository, "components", "agent-cli-runtime")
       FileUtils.mkdir_p(File.dirname(component))
@@ -32,34 +108,30 @@ class AgentCliRuntimePackageTest < Minitest::Test
       git!(repository, "init", "--quiet")
       git!(repository, "checkout", "--quiet", "-b", "main")
       git!(repository, "add", ".")
-      git!(
-        repository,
-        "-c", "user.name=Agent CLI Runtime Test",
-        "-c", "user.email=agent-cli-runtime@example.invalid",
-        "commit", "--quiet", "-m", "fixture"
-      )
+      commit_fixture!(repository, "fixture")
       commit = git!(repository, "rev-parse", "HEAD").strip
       tag = "components/agent-cli-runtime/v0.1.0"
       git!(repository, "tag", tag)
 
-      out, err, status = Open3.capture3(
-        File.join(component, "bin", "release-preflight"),
-        tag, commit, "main"
-      )
-      assert status.success?, err
-      assert_equal commit, JSON.parse(out).fetch("commit")
-
-      File.write(File.join(component, "README.md"), "\ndirty\n", mode: "a")
-      _out, err, status = Open3.capture3(
-        File.join(component, "bin", "release-preflight"),
-        tag, commit, "main"
-      )
-      refute status.success?
-      assert_match(/release checkout is dirty/, err)
+      yield repository, component, commit, tag
     end
   end
 
-  private
+  def commit_fixture!(repository, message)
+    git!(
+      repository,
+      "-c", "user.name=Agent CLI Runtime Test",
+      "-c", "user.email=agent-cli-runtime@example.invalid",
+      "commit", "--quiet", "-m", message
+    )
+  end
+
+  def run_preflight(component, *arguments)
+    Open3.capture3(
+      File.join(component, "bin", "release-preflight"),
+      *arguments
+    )
+  end
 
   def git!(repository, *arguments)
     out, err, status = Open3.capture3("git", "-C", repository, *arguments)

--- a/components/agent-cli-runtime/test/probe_test.rb
+++ b/components/agent-cli-runtime/test/probe_test.rb
@@ -1,0 +1,57 @@
+require_relative "test_helper"
+
+class AgentCliRuntimeProbeTest < Minitest::Test
+  def test_ready_probe_reports_only_local_observations
+    Dir.mktmpdir do |dir|
+      bin = File.join(dir, "fixture-agent")
+      write_executable(bin, <<~RUBY)
+        #!/usr/bin/env ruby
+        puts "fixture-agent 1.2.3"
+      RUBY
+      profile = AgentCliRuntime::Profile.new(
+        name: :fixture,
+        bin_default: bin,
+        headless_flag: "-p",
+        version_flag: "--version",
+        min_version: "1.0.0",
+        auth_configuration_probe: ->(**) {
+          AgentCliRuntime::AuthConfiguration.new(status: :configured, source: "fixture")
+        }
+      )
+
+      result = AgentCliRuntime.probe(profile)
+
+      assert result.ready
+      assert result.installed
+      assert_equal "1.2.3", result.version
+      assert_equal :configured, result.auth_configuration.status
+      assert_nil result.diagnostic
+      refute_respond_to result, :healthy
+      refute_respond_to result, :quota
+      refute_respond_to result, :credentials_valid
+    end
+  end
+
+  def test_missing_binary_is_fail_soft_and_typed
+    profile = AgentCliRuntime::Profile.new(
+      name: :missing,
+      bin_default: "/definitely/missing/agent",
+      headless_flag: "-p",
+      version_flag: "--version"
+    )
+
+    result = AgentCliRuntime.probe(profile)
+
+    refute result.ready
+    refute result.installed
+    assert_nil result.version
+    assert_equal :not_checked, result.auth_configuration.status
+    assert_match(/not runnable/, result.diagnostic)
+  end
+
+  def test_probe_all_uses_stable_provider_order
+    results = AgentCliRuntime.probe_all
+
+    assert_equal %i[claude codex pi grok], results.map(&:provider)
+  end
+end

--- a/components/agent-cli-runtime/test/probe_test.rb
+++ b/components/agent-cli-runtime/test/probe_test.rb
@@ -1,6 +1,135 @@
 require_relative "test_helper"
 
 class AgentCliRuntimeProbeTest < Minitest::Test
+  def test_version_check_honors_the_supplied_subprocess_environment
+    Dir.mktmpdir do |dir|
+      binary_name = "agent-cli-runtime-env-only-fixture"
+      write_executable(File.join(dir, binary_name), <<~RUBY)
+        #!/usr/bin/env ruby
+        puts "fixture-agent 1.2.3"
+      RUBY
+      profile = fixture_profile(bin: binary_name)
+      env = ENV.to_h.merge(
+        "PATH" => [ dir, ENV.fetch("PATH", "") ].join(File::PATH_SEPARATOR)
+      )
+
+      refute profile.binary_installed?
+      assert profile.binary_installed?(env:)
+      assert_equal "1.2.3", profile.check_version!(env:)
+    end
+  end
+
+  def test_version_check_accepts_prefixed_prerelease_versions
+    Dir.mktmpdir do |dir|
+      bin = File.join(dir, "fixture-agent")
+      write_executable(bin, <<~RUBY)
+        #!/usr/bin/env ruby
+        puts "fixture-agent v1.2.3-beta.1"
+      RUBY
+
+      assert_equal "1.2.3-beta.1", fixture_profile(bin:).check_version!
+    end
+  end
+
+  def test_version_check_rejects_ambiguous_version_output
+    Dir.mktmpdir do |dir|
+      bin = File.join(dir, "fixture-agent")
+      write_executable(bin, <<~RUBY)
+        #!/usr/bin/env ruby
+        puts "wrapper 9.9.9 delegates to fixture-agent 1.2.3"
+      RUBY
+
+      error = assert_raises(AgentCliRuntime::VersionError) do
+        fixture_profile(bin:).check_version!
+      end
+      assert_match(/ambiguous/, error.message)
+      assert_match(/9\.9\.9, 1\.2\.3/, error.message)
+    end
+  end
+
+  def test_timeout_kills_term_ignoring_descendants_that_hold_capture_pipes
+    Dir.mktmpdir do |dir|
+      pid_path = File.join(dir, "child.pid")
+      wrapper = File.join(dir, "wrapper")
+      child_code = <<~'RUBY'
+        File.write(ARGV.fetch(0), Process.pid.to_s)
+        Signal.trap("TERM", "IGNORE")
+        sleep 30
+      RUBY
+      write_executable(wrapper, <<~RUBY)
+        #!/usr/bin/env ruby
+        require "rbconfig"
+        child = Process.spawn(
+          RbConfig.ruby, "-e", #{child_code.dump}, #{pid_path.dump}
+        )
+        100.times do
+          break if File.file?(#{pid_path.dump})
+
+          sleep 0.01
+        end
+        Process.detach(child)
+      RUBY
+      profile = fixture_profile(bin: wrapper)
+
+      started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      assert_raises(Timeout::Error) do
+        profile.send(:bounded_capture3, wrapper, timeout_sec: 1)
+      end
+      elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+
+      assert_operator elapsed, :<, 3
+      assert wait_until(timeout: 1) { File.file?(pid_path) }
+      child_pid = Integer(File.read(pid_path))
+      assert wait_until(timeout: 2) { !process_alive?(child_pid) },
+             "expected timed-out descendant #{child_pid} to be reaped"
+    ensure
+      Process.kill("KILL", child_pid) if child_pid && process_alive?(child_pid)
+    end
+  end
+
+  def test_custom_capabilities_are_visible_in_probe_and_runtime_evidence
+    Dir.mktmpdir do |dir|
+      bin = File.join(dir, "fixture-agent")
+      write_executable(bin, <<~RUBY)
+        #!/usr/bin/env ruby
+        if ARGV == ["--version"]
+          puts "fixture-agent 1.2.3"
+        elsif ARGV.include?("--help")
+          puts "Usage: fixture-agent --safe-mode"
+        else
+          exit 1
+        end
+      RUBY
+      profile = fixture_profile(
+        bin:,
+        cli_capabilities: { safe_mode: [ "--safe-mode" ] }
+      )
+
+      result = AgentCliRuntime.probe(profile)
+      probe_evidence = result.capability_evidence.find do |item|
+        item.capability == :safe_mode
+      end
+      runtime_evidence =
+        AgentCliRuntime.require_capability!(profile, :safe_mode)
+
+      assert result.ready
+      assert probe_evidence.supported
+      assert runtime_evidence.supported
+      assert_equal [ "--safe-mode" ], runtime_evidence.arguments
+    end
+  end
+
+  def test_custom_capabilities_cannot_shadow_standard_capabilities
+    error = assert_raises(ArgumentError) do
+      fixture_profile(
+        bin: Gem.ruby,
+        cli_capabilities: { headless: [ "--not-really-headless" ] }
+      )
+    end
+
+    assert_match(/collides with a standard capability/, error.message)
+  end
+
   def test_ready_probe_reports_only_local_observations
     Dir.mktmpdir do |dir|
       bin = File.join(dir, "fixture-agent")
@@ -53,5 +182,43 @@ class AgentCliRuntimeProbeTest < Minitest::Test
     results = AgentCliRuntime.probe_all
 
     assert_equal %i[claude codex pi grok], results.map(&:provider)
+  end
+
+  private
+
+  def fixture_profile(bin:, cli_capabilities: {})
+    AgentCliRuntime::Profile.new(
+      name: :fixture,
+      bin_default: bin,
+      headless_flag: "-p",
+      version_flag: "--version",
+      min_version: "1.0.0",
+      cli_capabilities:,
+      auth_configuration_probe: ->(**) {
+        AgentCliRuntime::AuthConfiguration.new(
+          status: :configured,
+          source: "fixture"
+        )
+      }
+    )
+  end
+
+  def wait_until(timeout:)
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+    loop do
+      return true if yield
+      return false if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+
+      sleep 0.01
+    end
+  end
+
+  def process_alive?(pid)
+    Process.kill(0, pid)
+    true
+  rescue Errno::ESRCH
+    false
+  rescue Errno::EPERM
+    true
   end
 end

--- a/components/agent-cli-runtime/test/redactor_test.rb
+++ b/components/agent-cli-runtime/test/redactor_test.rb
@@ -1,0 +1,41 @@
+require_relative "test_helper"
+
+class AgentCliRuntimeRedactorTest < Minitest::Test
+  def test_redacts_long_complete_private_keys_without_leaking_the_body
+    body = "A" * 8_000
+    secret = <<~KEY
+      -----BEGIN PRIVATE KEY-----
+      #{body}
+      -----END PRIVATE KEY-----
+    KEY
+
+    redacted = AgentCliRuntime::Redactor.redact("before\n#{secret}after")
+
+    assert_equal "before\n[REDACTED:private_key]\nafter", redacted
+    refute_includes redacted, body
+  end
+
+  def test_redacts_long_truncated_private_keys_through_the_end_of_input
+    body = "B" * 8_000
+
+    redacted = AgentCliRuntime::Redactor.redact(
+      "before\n-----BEGIN OPENSSH PRIVATE KEY-----\n#{body}"
+    )
+
+    assert_equal "before\n[REDACTED:private_key_header]", redacted
+    refute_includes redacted, body
+  end
+
+  def test_redacts_json_secrets_before_object_and_array_delimiters
+    api_key = "api_" + ("a" * 40)
+    password = "b" * 30
+    input = %({"api_key":"#{api_key}","password":"#{password}"})
+
+    redacted = AgentCliRuntime::Redactor.redact(input)
+
+    assert_includes redacted, "[REDACTED:generic_api_key]"
+    assert_includes redacted, "[REDACTED:password]"
+    refute_includes redacted, api_key
+    refute_includes redacted, password
+  end
+end

--- a/components/agent-cli-runtime/test/runtime_test.rb
+++ b/components/agent-cli-runtime/test/runtime_test.rb
@@ -106,6 +106,57 @@ class AgentCliRuntimeRuntimeTest < Minitest::Test
     assert_predicate claude, :frozen?
   end
 
+  def test_terminal_events_without_usage_do_not_invent_zero_token_usage
+    {
+      claude: { "type" => "result" },
+      codex: { "type" => "turn.completed" },
+      pi: { "type" => "result" },
+      grok: { "type" => "end" }
+    }.each do |provider, event|
+      assert_nil AgentCliRuntime.extract_usage(provider, event), provider
+    end
+  end
+
+  def test_facade_preserves_unknown_provider_errors
+    request = AgentCliRuntime::Request.new(
+      profile: :unknown,
+      prompt: "hello"
+    )
+
+    assert_raises(AgentCliRuntime::UnknownProvider) do
+      AgentCliRuntime.compile(request)
+    end
+    assert_raises(AgentCliRuntime::UnknownProvider) do
+      AgentCliRuntime.probe(:unknown)
+    end
+    assert_raises(AgentCliRuntime::UnknownProvider) do
+      AgentCliRuntime.prepare!(:unknown)
+    end
+    assert_raises(AgentCliRuntime::UnknownProvider) do
+      AgentCliRuntime.require_capability!(:unknown, :safe_mode)
+    end
+    assert_raises(AgentCliRuntime::UnknownProvider) do
+      AgentCliRuntime.extract_usage(:unknown, {})
+    end
+    assert_raises(AgentCliRuntime::UnknownProvider) do
+      AgentCliRuntime.observe(:unknown, {})
+    end
+  end
+
+  def test_grok_api_key_ignores_unused_relative_auth_paths
+    env = {
+      "XAI_API_KEY" => "configured",
+      "GROK_AUTH_PATH" => "relative/auth.json",
+      "GROK_HOME" => "relative/home"
+    }
+
+    auth = AgentCliRuntime::Profiles.fetch(:grok).auth_configuration(env:)
+
+    assert auth.configured?
+    assert_equal "environment", auth.source
+    assert_nil auth.diagnostic
+  end
+
   def test_diagnostics_are_bounded_and_redacted
     profile = AgentCliRuntime::Profile.new(
       name: :custom,

--- a/components/agent-cli-runtime/test/runtime_test.rb
+++ b/components/agent-cli-runtime/test/runtime_test.rb
@@ -1,0 +1,139 @@
+require_relative "test_helper"
+
+class AgentCliRuntimeRuntimeTest < Minitest::Test
+  def test_builtin_provider_order_and_profiles_are_immutable
+    assert_equal %i[claude codex pi grok], AgentCliRuntime::Profiles.names
+    assert_predicate AgentCliRuntime::Profiles.names, :frozen?
+    assert AgentCliRuntime::Profiles.names.all? do |name|
+      AgentCliRuntime::Profiles.fetch(name).frozen?
+    end
+  end
+
+  def test_compile_preserves_each_builtin_prompt_transport
+    assert_equal [
+      "claude", "-p", "--dangerously-skip-permissions",
+      "--output-format", "stream-json", "--include-partial-messages",
+      "--verbose", "--no-session-persistence", "hello"
+    ], compile(:claude).argv
+
+    codex = compile(:codex)
+    assert_equal [
+      "codex", "exec", "--dangerously-bypass-approvals-and-sandbox",
+      "--json", "-"
+    ], codex.argv
+    assert_equal "hello", codex.stdin_data
+
+    assert_equal [
+      "pi", "-p", "--mode", "json", "--no-session", "hello"
+    ], compile(:pi).argv
+
+    assert_equal [
+      "grok", "-p", "hello", "--always-approve",
+      "--output-format", "streaming-json"
+    ], compile(:grok).argv
+  end
+
+  def test_compile_translates_models_effort_directories_and_tool_scope
+    invocation = compile(
+      :claude,
+      model: "sonnet",
+      effort: "high",
+      add_dirs: [ "/tmp/work" ],
+      allowed_tools: [ "Read", "Read", "" ],
+      disallowed_tools: [ "Write" ]
+    )
+
+    assert_includes invocation.argv, "--model"
+    assert_includes invocation.argv, "sonnet"
+    assert_includes invocation.argv, "--effort"
+    assert_includes invocation.argv, "high"
+    assert_includes invocation.argv, "--add-dir"
+    assert_includes invocation.argv, "/tmp/work"
+    assert_includes invocation.argv, "--allowedTools"
+    assert_includes invocation.argv, "Read"
+    assert_includes invocation.argv, "--disallowedTools"
+    assert_includes invocation.argv, "Write"
+  end
+
+  def test_compile_fails_closed_for_required_unsupported_capability
+    error = assert_raises(AgentCliRuntime::UnsupportedCapability) do
+      compile(:codex, allowed_tools: [ "Read" ])
+    end
+
+    assert_equal :allowed_tools, error.evidence.capability
+    refute error.evidence.supported
+    assert_equal :codex, error.evidence.provider
+  end
+
+  def test_compile_returns_typed_unsupported_directory_evidence_when_optional
+    invocation = compile(:pi, add_dirs: [ "/tmp/work" ])
+    evidence = invocation.capability_evidence.find do |item|
+      item.capability == :add_directory
+    end
+
+    refute evidence.supported
+    assert_match(/intentionally omitted/, evidence.diagnostic)
+    refute_includes invocation.argv, "/tmp/work"
+  end
+
+  def test_usage_extractors_normalize_provider_streams
+    claude = AgentCliRuntime.extract_usage(
+      :claude,
+      "type" => "result",
+      "usage" => {
+        "input_tokens" => 12,
+        "output_tokens" => 3,
+        "cache_read_input_tokens" => 5
+      },
+      "model" => "claude-sonnet"
+    )
+    codex = AgentCliRuntime.extract_usage(
+      :codex,
+      "type" => "turn.completed",
+      "usage" => { "input_tokens" => 7, "output_tokens" => 4 }
+    )
+    pi = AgentCliRuntime.extract_usage(
+      :pi,
+      "type" => "result",
+      "usage" => { "promptTokens" => 8, "completionTokens" => 2 }
+    )
+    grok = AgentCliRuntime.extract_usage(:grok, "type" => "end")
+
+    assert_equal({ input: 12, output: 3, cached: 5, model: "claude-sonnet" }, claude)
+    assert_equal({ input: 7, output: 4, cached: 0, model: nil }, codex)
+    assert_equal({ input: 8, output: 2, cached: 0, model: nil }, pi)
+    assert_nil grok
+    assert_predicate claude, :frozen?
+  end
+
+  def test_diagnostics_are_bounded_and_redacted
+    profile = AgentCliRuntime::Profile.new(
+      name: :custom,
+      bin_default: Gem.ruby,
+      headless_flag: "-p",
+      version_flag: "--version",
+      auth_configuration_probe: ->(**) {
+        raise "token sk-#{'z' * 80} #{'x' * 1_000}"
+      }
+    )
+
+    result = AgentCliRuntime.probe(profile)
+
+    refute result.ready
+    refute_includes result.diagnostic, "sk-"
+    assert_includes result.diagnostic, "[REDACTED:openai_api_key]"
+    assert_operator result.diagnostic.bytesize, :<=, AgentCliRuntime::DIAGNOSTIC_BYTES
+  end
+
+  private
+
+  def compile(provider, **options)
+    AgentCliRuntime.compile(
+      AgentCliRuntime::Request.new(
+        profile: AgentCliRuntime::Profiles.fetch(provider),
+        prompt: "hello",
+        **options
+      )
+    )
+  end
+end

--- a/components/agent-cli-runtime/test/test_helper.rb
+++ b/components/agent-cli-runtime/test/test_helper.rb
@@ -1,0 +1,21 @@
+require "minitest/autorun"
+require "tmpdir"
+require "fileutils"
+require "json"
+require "open3"
+require "digest"
+
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+
+require "agent_cli_runtime"
+
+module AgentCliRuntimeTestHelpers
+  def write_executable(path, body)
+    File.write(path, body)
+    FileUtils.chmod(0o755, path)
+  end
+end
+
+class Minitest::Test
+  include AgentCliRuntimeTestHelpers
+end

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -9,6 +9,58 @@ gem, and `hive setup` authenticates and installs the matching web bundle:
   [`ivankuznetsov/homebrew-hive`](https://github.com/ivankuznetsov/homebrew-hive) tap.
 - **AUR** — `yay -S hive-bin` (or `paru -S hive-bin`).
 
+## Releasing `agent-cli-runtime`
+
+`agent-cli-runtime` is independently versioned inside this monorepo. Its
+release does not bump, tag, publish, or deploy Hive. Development stays under
+`components/agent-cli-runtime/`; Hive remains the primary consumer, and the
+released package is installed from RubyGems by downstream consumers.
+
+One-time account setup:
+
+1. Create the GitHub environment `agent-cli-runtime-release`.
+2. Before the first publication, configure a RubyGems pending trusted publisher
+   with exactly:
+
+   - gem: `agent-cli-runtime`
+   - repository owner: `ivankuznetsov`
+   - repository name: `hive`
+   - workflow: `agent-cli-runtime-release.yml`
+   - environment: `agent-cli-runtime-release`
+
+The environment and workflow names are part of the OIDC identity. Do not add a
+long-lived RubyGems API key to GitHub.
+
+To publish an approved version:
+
+1. Update
+   `components/agent-cli-runtime/lib/agent_cli_runtime/version.rb` and its
+   package changelog in a package PR. Run the package tests and exact candidate
+   verifier.
+2. Merge the package-only PR while leaving `hive.gemspec`, Hive's lockfiles,
+   and Hive's internal runtime implementation unchanged.
+3. Record the full protected-`main` commit and verify that the version is not
+   already present on RubyGems.
+4. Create and push
+   `components/agent-cli-runtime/vX.Y.Z` at that exact commit. The component
+   workflow rejects malformed tags, version mismatches, dirty candidates, and
+   commits not reachable from `main`.
+5. Watch **candidate → install (Linux and macOS) → publish**. Only `publish`
+   receives an OIDC token. It downloads the previously built candidate,
+   revalidates its checksum, and pushes those exact bytes without rebuilding.
+6. From a fresh gem home, install `agent-cli-runtime` at the exact version,
+   require `agent_cli_runtime`, run `agent-runtime --version`, and exercise a
+   JSON probe. Compare the downloaded gem checksum and metadata with the
+   workflow candidate before allowing a Hive dependency cutover.
+
+Ordinary path changes and Hive `vX.Y.Z` tags cannot publish this package.
+Component tags cannot enter Hive's root release workflow. If the workflow fails
+before `gem push`, fix the source or release machinery and move the component
+tag only while no registry version exists. If RubyGems accepted the version,
+never overwrite or reuse it: keep Hive's cutover blocked and prepare a
+separately approved fix-forward version. Yanking or transferring ownership
+requires separate explicit authorization.
+
 A maintainer's explicit `vX.Y.Z` tag triggers `.github/workflows/release.yml`.
 The workflow requires no model-provider credentials. On GitHub-hosted runners,
 it proves the exact tag candidate as follows:

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -18,8 +18,17 @@ released package is installed from RubyGems by downstream consumers.
 
 One-time account setup:
 
-1. Create the GitHub environment `agent-cli-runtime-release`.
-2. Before the first publication, configure a RubyGems pending trusted publisher
+1. Create an active GitHub tag ruleset targeting
+   `components/agent-cli-runtime/v*`. Restrict tag creation, update, and
+   deletion to the release maintainers, keep the bypass list equally narrow,
+   and do not rely on the broader Hive `v*` rule to cover component tags.
+2. Create the GitHub environment `agent-cli-runtime-release`. Require at least
+   one release-maintainer reviewer, prevent self-review where the repository
+   plan supports it, and restrict deployments to tags matching
+   `components/agent-cli-runtime/v*`. Those tags are separately protected by
+   the component tag ruleset. This environment is the final human approval
+   boundary before RubyGems OIDC is issued.
+3. Before the first publication, configure a RubyGems pending trusted publisher
    with exactly:
 
    - gem: `agent-cli-runtime`
@@ -29,7 +38,9 @@ One-time account setup:
    - environment: `agent-cli-runtime-release`
 
 The environment and workflow names are part of the OIDC identity. Do not add a
-long-lived RubyGems API key to GitHub.
+long-lived RubyGems API key to GitHub. Before accepting the first component
+release as ready, verify the component tag ruleset and environment protection
+in repository settings; a protected `main` branch alone is insufficient.
 
 To publish an approved version:
 
@@ -37,10 +48,14 @@ To publish an approved version:
    `components/agent-cli-runtime/lib/agent_cli_runtime/version.rb` and its
    package changelog in a package PR. Run the package tests and exact candidate
    verifier.
-2. Merge the package-only PR while leaving `hive.gemspec`, Hive's lockfiles,
-   and Hive's internal runtime implementation unchanged.
+2. Merge the package PR while leaving `hive.gemspec`, Hive's lockfiles, and
+   Hive's dependency loading unchanged. During the temporary duplication
+   window, any contract correction shared with Hive's internal implementation
+   must land in lockstep and remain covered by package/Hive parity tests.
 3. Record the full protected-`main` commit and verify that the version is not
-   already present on RubyGems.
+   already present on RubyGems. Confirm the component tag ruleset is active and
+   that `agent-cli-runtime-release` still requires the intended reviewers and
+   permits only matching component tags.
 4. Create and push
    `components/agent-cli-runtime/vX.Y.Z` at that exact commit. The component
    workflow rejects malformed tags, version mismatches, dirty candidates, and
@@ -48,6 +63,8 @@ To publish an approved version:
 5. Watch **candidate → install (Linux and macOS) → publish**. Only `publish`
    receives an OIDC token. It downloads the previously built candidate,
    revalidates its checksum, and pushes those exact bytes without rebuilding.
+   The candidate is retained for 30 days so an approval delay does not silently
+   replace it with rebuilt bytes; every job has a 15-minute execution timeout.
 6. From a fresh gem home, install `agent-cli-runtime` at the exact version,
    require `agent_cli_runtime`, run `agent-runtime --version`, and exercise a
    JSON probe. Compare the downloaded gem checksum and metadata with the

--- a/lib/hive/agent_profile.rb
+++ b/lib/hive/agent_profile.rb
@@ -41,6 +41,9 @@ module Hive
     CAPTURE_POLL_INTERVAL_SEC = 0.01
     CAPTURE_TERM_GRACE_SEC = 0.2
     CAPTURE_REAP_GRACE_SEC = 0.2
+    VERSION_TOKEN_PATTERN =
+      /(?<![0-9A-Za-z])v?(\d+\.\d+\.\d+(?:[.-][0-9A-Za-z]+)*)(?![0-9A-Za-z])/
+    private_constant :VERSION_TOKEN_PATTERN
 
     attr_reader :prompt_style
     attr_reader :name, :bin_default, :env_bin_override_key,
@@ -422,8 +425,16 @@ module Hive
       end
       raise Hive::AgentError, "#{@name} binary not runnable: #{bin}" unless status.success?
 
-      version = out[/\d+\.\d+\.\d+/]
-      raise Hive::AgentError, "could not parse #{@name} #{@version_flag} output: #{out.inspect}" unless version
+      versions = out.scan(VERSION_TOKEN_PATTERN).flatten.uniq
+      if versions.empty?
+        raise Hive::AgentError,
+              "could not parse #{@name} #{@version_flag} output: #{out.inspect}"
+      end
+      if versions.length > 1
+        raise Hive::AgentError,
+              "ambiguous #{@name} #{@version_flag} output: #{versions.join(', ')}"
+      end
+      version = versions.fetch(0)
 
       if @min_version
         cmp = version_tuple(version) <=> version_tuple(@min_version)

--- a/lib/hive/agent_profiles.rb
+++ b/lib/hive/agent_profiles.rb
@@ -85,11 +85,6 @@ module Hive
           api_key = [ ENV["XAI_API_KEY"], ENV["GROK_CODE_XAI_API_KEY"] ].any? do |value|
             !value.to_s.strip.empty?
           end
-          explicit_path = [ ENV["GROK_AUTH_PATH"], ENV["GROK_HOME"] ].any? do |value|
-            !value.to_s.strip.empty?
-          end
-
-          grok_auth_path(home:) if api_key && explicit_path
           return true if api_key
 
           credential_present?(grok_auth_path(home:))

--- a/lib/hive/agent_profiles/grok.rb
+++ b/lib/hive/agent_profiles/grok.rb
@@ -30,13 +30,9 @@ module Hive
       api_key = [ ENV["XAI_API_KEY"], ENV["GROK_CODE_XAI_API_KEY"] ].find do |value|
         !value.to_s.strip.empty?
       end
-      explicit_path = [ ENV["GROK_AUTH_PATH"], ENV["GROK_HOME"] ].any? do |value|
-        !value.to_s.strip.empty?
-      end
-
       auth_path =
         begin
-          Hive::AgentProfiles.grok_auth_path if explicit_path || !api_key
+          Hive::AgentProfiles.grok_auth_path unless api_key
         rescue ArgumentError => e
           raise Hive::AgentError,
                 "grok profile preflight failed: cannot resolve auth path (#{e.message}). " \

--- a/lib/hive/agent_profiles/usage_extractors.rb
+++ b/lib/hive/agent_profiles/usage_extractors.rb
@@ -6,10 +6,11 @@ module Hive
       CLAUDE = lambda do |event|
         next nil unless event.is_a?(Hash)
 
-        if event["type"] == "result"
-          usage_result(event, usage_hash(event) || {}, model_from(event))
-        elsif event["type"] == "stream_event" && usage_hash(event)
-          usage_result(event, usage_hash(event), model_from(event))
+        usage = usage_hash(event)
+        if event["type"] == "result" && usage
+          usage_result(event, usage, model_from(event))
+        elsif event["type"] == "stream_event" && usage
+          usage_result(event, usage, model_from(event))
         else
           nil
         end
@@ -19,11 +20,7 @@ module Hive
         next nil unless event.is_a?(Hash)
 
         usage = usage_hash(event)
-        if usage
-          usage_result(event, usage, model_from(event))
-        elsif final_type?(event, %w[turn.completed result response.completed])
-          zero_result(model_from(event))
-        end
+        usage_result(event, usage, model_from(event)) if usage
       end
 
       # Grok's streaming-json currently carries no usage counts. Preserve
@@ -40,15 +37,7 @@ module Hive
         next nil unless event.is_a?(Hash)
 
         usage = usage_hash(event)
-        if usage
-          usage_result(event, usage, model_from(event))
-        elsif final_type?(event, %w[result run.completed task.completed response.completed])
-          zero_result(model_from(event))
-        end
-      end
-
-      def final_type?(event, types)
-        types.include?(event["type"].to_s)
+        usage_result(event, usage, model_from(event)) if usage
       end
 
       def usage_hash(event)
@@ -72,10 +61,6 @@ module Hive
           cached: cached_tokens(usage),
           model: model || model_from_usage(usage) || model_from(event)
         }
-      end
-
-      def zero_result(model)
-        { input: 0, output: 0, cached: 0, model: model }
       end
 
       def cached_tokens(usage)

--- a/lib/hive/secret_patterns.rb
+++ b/lib/hive/secret_patterns.rb
@@ -20,7 +20,7 @@ module Hive
       # assignments (`API_KEY=abcdef...`) also trip; the trailing
       # lookahead requires a token boundary so we don't run past the
       # secret into adjacent text.
-      generic_api_key:       /\bapi[_\-]?key\b[\s:=]{0,3}['"]?[A-Za-z0-9_\-]{20,}['"]?(?=[\s,;]|$)/i,
+      generic_api_key:       /\bapi[_\-]?key\b['"]?[\s:=]{0,3}['"]?[A-Za-z0-9_\-]{20,}['"]?(?=[\s,;}\]]|$)/i,
       # PEM-encoded private keys. Block form (/m flag) so the regex
       # spans the full BEGIN ... END envelope including the base64
       # body. The previous header-only regex left the key body in
@@ -30,15 +30,15 @@ module Hive
       # fixed byte budget (DIAGNOSTIC_DETAIL_MAX = 4000) so most leaks
       # appear as BEGIN + partial body with no matching END. The
       # block-form pattern above fails on these; this fallback redacts
-      # BEGIN through up to 4000 trailing bytes so the partial body is
+      # BEGIN through the end of the diagnostic so a long partial body is
       # not surfaced. Ordering matters: the full-block pattern runs
       # first via PATTERNS-iteration so complete PEMs are replaced
       # before this fallback can see them. Resolves issue #88.
-      pem_private_key_header: /-----BEGIN (?:RSA |OPENSSH |EC |DSA |PGP )?PRIVATE KEY( BLOCK)?-----[\s\S]{0,4000}/,
+      pem_private_key_header: /-----BEGIN (?:RSA |OPENSSH |EC |DSA |PGP )?PRIVATE KEY( BLOCK)?-----[\s\S]*\z/,
       # `password=`, `passwd=`, `PASSWORD=` style assignments. Same
       # token-boundary shape as generic_api_key so unquoted shell/env
       # values trip without running past the secret.
-      password_assignment:   /\b(?:password|passwd|pwd)\b[\s:=]{0,3}['"]?[^\s'"]{6,}['"]?(?=[\s,;]|$)/i,
+      password_assignment:   /\b(?:password|passwd|pwd)\b['"]?[\s:=]{0,3}['"]?[^\s'"]{6,}['"]?(?=[\s,;}\]]|$)/i,
       # HTTP Authorization headers with Bearer / Basic / Token scheme.
       # Catches the header value regardless of surrounding format
       # (curl output, header dumps, framework log lines).

--- a/test/unit/agent_cli_runtime_component_test.rb
+++ b/test/unit/agent_cli_runtime_component_test.rb
@@ -1,0 +1,102 @@
+require "test_helper"
+
+component_root = File.expand_path("../../components/agent-cli-runtime", __dir__)
+$LOAD_PATH.unshift File.join(component_root, "lib")
+require "agent_cli_runtime"
+
+class AgentCliRuntimeComponentTest < Minitest::Test
+  COMPONENT_ROOT =
+    File.expand_path("../../components/agent-cli-runtime", __dir__)
+
+  def test_public_package_clean_loads_without_hive
+    script = <<~'RUBY'
+      require "agent_cli_runtime"
+      abort "loaded Hive unexpectedly" if defined?(Hive)
+      abort "wrong version" unless AgentCliRuntime::VERSION == "0.1.0"
+      puts AgentCliRuntime::Profiles.names.join(",")
+    RUBY
+    out, err, status = Bundler.with_unbundled_env do
+      Open3.capture3(
+        Gem.ruby,
+        "-I#{File.join(COMPONENT_ROOT, 'lib')}",
+        "-e",
+        script
+      )
+    end
+
+    assert status.success?, err
+    assert_equal "claude,codex,pi,grok\n", out
+  end
+
+  def test_builtin_compile_transport_matches_hive_boundary
+    %i[claude codex pi grok].each do |provider|
+      public_invocation = AgentCliRuntime.compile(
+        AgentCliRuntime::Request.new(
+          profile: AgentCliRuntime::Profiles.fetch(provider),
+          prompt: "inspect"
+        )
+      )
+      hive_invocation = Hive::AgentRuntime.compile(
+        Hive::AgentRuntime::Request.new(
+          profile: Hive::AgentProfiles.lookup(provider),
+          prompt: "inspect"
+        )
+      )
+
+      assert_equal hive_invocation.argv, public_invocation.argv, provider
+      if hive_invocation.stdin_data.nil?
+        assert_nil public_invocation.stdin_data, provider
+      else
+        assert_equal hive_invocation.stdin_data, public_invocation.stdin_data, provider
+      end
+      assert_equal hive_invocation.provider, public_invocation.provider, provider
+      assert_equal hive_invocation.launcher_identity,
+                   public_invocation.launcher_identity,
+                   provider
+    end
+  end
+
+  def test_builtin_usage_extraction_matches_hive_boundary
+    events = {
+      claude: {
+        "type" => "result",
+        "usage" => {
+          "input_tokens" => 3,
+          "output_tokens" => 2,
+          "cache_read_input_tokens" => 1
+        },
+        "model" => "claude-sonnet"
+      },
+      codex: {
+        "type" => "turn.completed",
+        "usage" => { "input_tokens" => 4, "output_tokens" => 3 }
+      },
+      pi: {
+        "type" => "result",
+        "usage" => { "promptTokens" => 5, "completionTokens" => 4 }
+      },
+      grok: { "type" => "end" }
+    }
+
+    events.each do |provider, event|
+      expected = Hive::AgentRuntime.extract_usage(
+        Hive::AgentProfiles.lookup(provider),
+        event
+      )
+      actual = AgentCliRuntime.extract_usage(provider, event)
+      expected.nil? ? assert_nil(actual, provider) : assert_equal(expected, actual, provider)
+    end
+  end
+
+  def test_package_only_change_does_not_enter_hive_dependency_graph
+    spec = Gem::Specification.load(File.expand_path("../../hive.gemspec", __dir__))
+
+    refute(
+      spec.runtime_dependencies.any? do |dependency|
+        dependency.name == "agent-cli-runtime"
+      end
+    )
+    refute File.read(File.expand_path("../../lib/hive.rb", __dir__))
+               .include?('require "agent_cli_runtime"')
+  end
+end

--- a/test/unit/agent_cli_runtime_component_test.rb
+++ b/test/unit/agent_cli_runtime_component_test.rb
@@ -5,8 +5,34 @@ $LOAD_PATH.unshift File.join(component_root, "lib")
 require "agent_cli_runtime"
 
 class AgentCliRuntimeComponentTest < Minitest::Test
+  include HiveTestHelper
+
   COMPONENT_ROOT =
     File.expand_path("../../components/agent-cli-runtime", __dir__)
+  COMPILE_OPTIONS = {
+    claude: {
+      permission_mode: "bypassPermissions",
+      model: "claude-sonnet",
+      effort: "high",
+      add_dirs: [ "/tmp/work" ],
+      allowed_tools: [ "Read" ],
+      disallowed_tools: [ "Write" ],
+      max_budget_usd: 1.5
+    },
+    codex: {
+      permission_mode: "read-only",
+      model: "gpt-5.6-terra",
+      effort: "high",
+      add_dirs: [ "/tmp/work" ]
+    },
+    pi: {
+      model: "provider/model"
+    },
+    grok: {
+      model: "grok-code",
+      effort: "high"
+    }
+  }.freeze
 
   def test_public_package_clean_loads_without_hive
     script = <<~'RUBY'
@@ -28,18 +54,20 @@ class AgentCliRuntimeComponentTest < Minitest::Test
     assert_equal "claude,codex,pi,grok\n", out
   end
 
-  def test_builtin_compile_transport_matches_hive_boundary
-    %i[claude codex pi grok].each do |provider|
+  def test_non_default_builtin_compile_transport_matches_hive_boundary
+    COMPILE_OPTIONS.each do |provider, options|
       public_invocation = AgentCliRuntime.compile(
         AgentCliRuntime::Request.new(
           profile: AgentCliRuntime::Profiles.fetch(provider),
-          prompt: "inspect"
+          prompt: "inspect",
+          **options
         )
       )
       hive_invocation = Hive::AgentRuntime.compile(
         Hive::AgentRuntime::Request.new(
           profile: Hive::AgentProfiles.lookup(provider),
-          prompt: "inspect"
+          prompt: "inspect",
+          **options
         )
       )
 
@@ -47,7 +75,9 @@ class AgentCliRuntimeComponentTest < Minitest::Test
       if hive_invocation.stdin_data.nil?
         assert_nil public_invocation.stdin_data, provider
       else
-        assert_equal hive_invocation.stdin_data, public_invocation.stdin_data, provider
+        assert_equal hive_invocation.stdin_data,
+                     public_invocation.stdin_data,
+                     provider
       end
       assert_equal hive_invocation.provider, public_invocation.provider, provider
       assert_equal hive_invocation.launcher_identity,
@@ -56,35 +86,213 @@ class AgentCliRuntimeComponentTest < Minitest::Test
     end
   end
 
-  def test_builtin_usage_extraction_matches_hive_boundary
+  def test_builtin_usage_variants_match_hive_boundary
     events = {
-      claude: {
-        "type" => "result",
-        "usage" => {
-          "input_tokens" => 3,
-          "output_tokens" => 2,
-          "cache_read_input_tokens" => 1
+      claude: [
+        {
+          "type" => "result",
+          "usage" => {
+            "input_tokens" => 3,
+            "output_tokens" => 2,
+            "cache_read_input_tokens" => 1
+          },
+          "model" => "claude-sonnet"
         },
-        "model" => "claude-sonnet"
-      },
-      codex: {
-        "type" => "turn.completed",
-        "usage" => { "input_tokens" => 4, "output_tokens" => 3 }
-      },
-      pi: {
-        "type" => "result",
-        "usage" => { "promptTokens" => 5, "completionTokens" => 4 }
-      },
-      grok: { "type" => "end" }
+        {
+          "type" => "stream_event",
+          "event" => {
+            "message" => {
+              "usage" => { "inputTokens" => 6, "outputTokens" => 4 },
+              "model" => "claude-opus"
+            }
+          }
+        },
+        { "type" => "result" }
+      ],
+      codex: [
+        {
+          "type" => "turn.completed",
+          "usage" => { "input_tokens" => 4, "output_tokens" => 3 }
+        },
+        {
+          "response" => {
+            "usage" => {
+              "prompt_tokens" => 8,
+              "completion_tokens" => 5,
+              "prompt_tokens_details" => { "cached_tokens" => 2 }
+            },
+            "model" => "gpt-5.6-terra"
+          }
+        },
+        { "type" => "turn.completed" }
+      ],
+      pi: [
+        {
+          "type" => "result",
+          "usage" => { "promptTokens" => 5, "completionTokens" => 4 }
+        },
+        {
+          "info" => {
+            "total_token_usage" => {
+              "inputTokens" => 9,
+              "outputTokens" => 6,
+              "cachedTokens" => 3
+            }
+          },
+          "modelUsage" => { "provider/model" => {} }
+        },
+        { "type" => "result" }
+      ],
+      grok: [
+        {
+          "type" => "end",
+          "token_usage" => { "input_tokens" => 7, "output_tokens" => 2 }
+        },
+        { "type" => "end" }
+      ]
     }
 
-    events.each do |provider, event|
-      expected = Hive::AgentRuntime.extract_usage(
+    events.each do |provider, variants|
+      variants.each do |event|
+        expected = Hive::AgentRuntime.extract_usage(
+          Hive::AgentProfiles.lookup(provider),
+          event
+        )
+        actual = AgentCliRuntime.extract_usage(provider, event)
+        expected.nil? ? assert_nil(actual, provider) :
+          assert_equal(expected, actual, provider)
+      end
+    end
+  end
+
+  def test_observation_normalization_and_redaction_match_hive_boundary
+    raw = {
+      exit_code: 1,
+      timed_out: true,
+      status: "error",
+      usage: {
+        input: "12",
+        output: -4,
+        cached: nil,
+        model: "provider/model"
+      },
+      final_message: "stopped",
+      error_message: "api_key=abcdefghijklmnopqrstuvwxyz"
+    }
+
+    %i[claude codex pi grok].each do |provider|
+      expected = Hive::AgentRuntime.observe(
         Hive::AgentProfiles.lookup(provider),
-        event
+        raw
       )
-      actual = AgentCliRuntime.extract_usage(provider, event)
-      expected.nil? ? assert_nil(actual, provider) : assert_equal(expected, actual, provider)
+      actual = AgentCliRuntime.observe(provider, raw)
+
+      assert_equal expected.to_h, actual.to_h, provider
+      assert_includes(
+        actual.diagnostic,
+        "[REDACTED:generic_api_key]",
+        provider
+      )
+    end
+  end
+
+  def test_local_builtin_probe_outcomes_match_hive_boundary
+    with_tmp_dir do |home|
+      FileUtils.mkdir_p(File.join(home, ".pi", "agent"))
+      File.write(
+        File.join(home, ".pi", "agent", "auth.json"),
+        '{"provider":"configured"}'
+      )
+      overrides = {
+        "HOME" => home,
+        "ANTHROPIC_API_KEY" => "configured",
+        "OPENAI_API_KEY" => "configured",
+        "XAI_API_KEY" => "configured"
+      }
+      {
+        claude: "HIVE_CLAUDE_BIN",
+        codex: "HIVE_CODEX_BIN",
+        pi: "HIVE_PI_BIN",
+        grok: "HIVE_GROK_BIN"
+      }.each do |provider, env_key|
+        binary = File.join(home, "#{provider}-fixture")
+        File.write(binary, <<~SH)
+          #!/bin/sh
+          printf '%s\n' '#{provider} 99.0.0'
+        SH
+        FileUtils.chmod(0o755, binary)
+        overrides[env_key] = binary
+      end
+
+      Hive::AgentProfile.reset_version_cache!
+      with_env(overrides) do
+        %i[claude codex pi grok].each do |provider|
+          public_result =
+            AgentCliRuntime.probe(provider, home:, env: ENV.to_h)
+          hive_result =
+            Hive::AgentRuntime.prepare!(Hive::AgentProfiles.lookup(provider))
+
+          assert public_result.ready, public_result.diagnostic
+          assert_equal hive_result.version, public_result.version, provider
+          assert_equal hive_result.provider, public_result.provider, provider
+          assert_equal(
+            hive_result.launcher_identity,
+            AgentCliRuntime::Profiles.fetch(provider).launcher_identity,
+            provider
+          )
+        end
+      end
+    end
+  ensure
+    Hive::AgentProfile.reset_version_cache!
+  end
+
+  def test_named_capability_evidence_matches_hive_boundary
+    with_tmp_dir do |dir|
+      binary = File.join(dir, "capable-agent")
+      File.write(binary, <<~SH)
+        #!/bin/sh
+        if [ "$1" = "--version" ]; then
+          echo "capable-agent 1.2.3"
+        elif [ "$1" = "--safe-mode" ] && [ "$2" = "--help" ]; then
+          echo "Usage: capable-agent --safe-mode"
+        else
+          exit 1
+        fi
+      SH
+      FileUtils.chmod(0o755, binary)
+      public_profile = AgentCliRuntime::Profile.new(
+        name: :fixture,
+        bin_default: binary,
+        headless_flag: "-p",
+        version_flag: "--version",
+        min_version: "1.0.0",
+        cli_capabilities: { safe_mode: [ "--safe-mode" ] }
+      )
+      hive_profile = Hive::AgentProfile.new(
+        name: :fixture,
+        bin_default: binary,
+        headless_flag: "-p",
+        version_flag: "--version",
+        min_version: "1.0.0",
+        skill_syntax_format: "/%{skill}",
+        cli_capabilities: { safe_mode: [ "--safe-mode" ] }
+      )
+
+      expected =
+        Hive::AgentRuntime.require_capability!(hive_profile, :safe_mode)
+      actual =
+        AgentCliRuntime.require_capability!(public_profile, :safe_mode)
+      public_probe = AgentCliRuntime.probe(public_profile)
+      probe_evidence = public_probe.capability_evidence.find do |evidence|
+        evidence.capability == :safe_mode
+      end
+
+      assert_equal expected.capability, actual.capability
+      assert_equal expected.supported, actual.supported
+      assert_equal expected.provider, actual.provider
+      assert_equal expected.arguments, actual.arguments
+      assert probe_evidence.supported
     end
   end
 

--- a/test/unit/agent_cli_runtime_release_contract_test.rb
+++ b/test/unit/agent_cli_runtime_release_contract_test.rb
@@ -32,6 +32,19 @@ class AgentCliRuntimeReleaseContractTest < Minitest::Test
     end
   end
 
+  def test_every_job_is_bounded_and_candidate_survives_approval_delay
+    workflow = YAML.safe_load_file(WORKFLOW, aliases: true)
+    jobs = workflow.fetch("jobs")
+
+    assert jobs.values.all? { |job| job.fetch("timeout-minutes") == 15 }
+    candidate = jobs.fetch("candidate")
+    upload = candidate.fetch("steps").find do |step|
+      step.fetch("uses", "").start_with?("actions/upload-artifact@")
+    end
+
+    assert_equal 30, upload.fetch("with").fetch("retention-days")
+  end
+
   def test_publish_uses_pinned_oidc_action_and_does_not_rebuild
     content = File.read(WORKFLOW)
 

--- a/test/unit/agent_cli_runtime_release_contract_test.rb
+++ b/test/unit/agent_cli_runtime_release_contract_test.rb
@@ -1,0 +1,57 @@
+require "test_helper"
+
+class AgentCliRuntimeReleaseContractTest < Minitest::Test
+  WORKFLOW =
+    File.expand_path("../../.github/workflows/agent-cli-runtime-release.yml", __dir__)
+  ROOT_RELEASE =
+    File.expand_path("../../.github/workflows/release.yml", __dir__)
+
+  def test_component_and_hive_release_tags_are_disjoint
+    component = File.read(WORKFLOW)
+    hive = File.read(ROOT_RELEASE)
+
+    assert_includes component, '"components/agent-cli-runtime/v*.*.*"'
+    refute_includes component, '- "v*.*.*"'
+    assert_includes hive, '- "v*.*.*"'
+    refute_includes hive, "components/agent-cli-runtime/"
+  end
+
+  def test_only_publish_job_has_oidc_and_environment_authority
+    workflow = YAML.safe_load_file(WORKFLOW, aliases: true)
+    jobs = workflow.fetch("jobs")
+
+    jobs.each do |name, job|
+      permissions = job.fetch("permissions", {})
+      if name == "publish"
+        assert_equal "write", permissions.fetch("id-token")
+        assert_equal "agent-cli-runtime-release", job.fetch("environment")
+      else
+        refute_equal "write", permissions["id-token"], name
+        refute job.key?("environment"), name
+      end
+    end
+  end
+
+  def test_publish_uses_pinned_oidc_action_and_does_not_rebuild
+    content = File.read(WORKFLOW)
+
+    assert_includes content,
+                    "rubygems/configure-rubygems-credentials@" \
+                    "dc5a8d8553e6ee01fc26761a49e99e733d17954a"
+    publish = content.split(/^  publish:\n/, 2).fetch(1)
+    assert_includes publish, "gem push \"$gem_file\""
+    refute_includes publish, "gem build"
+    refute_includes publish, "build-candidate"
+  end
+
+  def test_every_action_is_pinned_to_a_commit
+    uses = File.readlines(WORKFLOW).filter_map do |line|
+      line[/uses:\s+([^\s#]+)/, 1]
+    end
+
+    refute_empty uses
+    uses.each do |action|
+      assert_match(/@[0-9a-f]{40}\z/, action, action)
+    end
+  end
+end

--- a/test/unit/agent_profile_test.rb
+++ b/test/unit/agent_profile_test.rb
@@ -213,6 +213,16 @@ class AgentProfileTest < Minitest::Test
     assert_match(/9\.9\.9, 2\.0\.0/, err.message)
   end
 
+  def test_check_version_rejects_output_without_a_version
+    profile = make_profile(min_version: "1.0.0")
+    ENV["HIVE_FAKE_CLAUDE_VERSION"] = "version unavailable"
+
+    err = assert_raises(Hive::AgentError) { profile.check_version! }
+
+    assert_match(/could not parse/, err.message)
+    assert_match(/version unavailable/, err.message)
+  end
+
   def test_check_version_raises_when_binary_not_runnable
     profile = make_profile(bin_default: "/this/does/not/exist", env_bin_override_key: nil)
     err = assert_raises(Hive::AgentError) { profile.check_version! }

--- a/test/unit/agent_profile_test.rb
+++ b/test/unit/agent_profile_test.rb
@@ -202,6 +202,17 @@ class AgentProfileTest < Minitest::Test
     assert_match(/below minimum/, err.message)
   end
 
+  def test_check_version_rejects_ambiguous_version_output
+    profile = make_profile(min_version: "1.0.0")
+    ENV["HIVE_FAKE_CLAUDE_VERSION"] =
+      "wrapper 9.9.9 delegates to claude 2.0.0"
+
+    err = assert_raises(Hive::AgentError) { profile.check_version! }
+
+    assert_match(/ambiguous/, err.message)
+    assert_match(/9\.9\.9, 2\.0\.0/, err.message)
+  end
+
   def test_check_version_raises_when_binary_not_runnable
     profile = make_profile(bin_default: "/this/does/not/exist", env_bin_override_key: nil)
     err = assert_raises(Hive::AgentError) { profile.check_version! }

--- a/test/unit/agent_profiles_test.rb
+++ b/test/unit/agent_profiles_test.rb
@@ -276,9 +276,13 @@ class AgentProfilesTest < Minitest::Test
     end
   end
 
-  def test_grok_logged_in_rejects_relative_auth_path_even_with_api_key
-    with_env("GROK_AUTH_PATH" => "auth.json", "XAI_API_KEY" => "test-key") do
-      refute Hive::AgentProfiles.logged_in?(:grok)
+  def test_grok_logged_in_ignores_unused_relative_paths_with_api_key
+    with_env(
+      "GROK_AUTH_PATH" => "auth.json",
+      "GROK_HOME" => "relative/grok-home",
+      "XAI_API_KEY" => "test-key"
+    ) do
+      assert Hive::AgentProfiles.logged_in?(:grok)
     end
   end
 

--- a/test/unit/grok_preflight_test.rb
+++ b/test/unit/grok_preflight_test.rb
@@ -72,12 +72,10 @@ class GrokPreflightTest < Minitest::Test
     assert_match(/GROK_AUTH_PATH must be absolute/, err.message)
   end
 
-  def test_rejects_relative_grok_auth_path_even_with_api_key
-    err = with_env("GROK_AUTH_PATH" => "relative/auth.json", "XAI_API_KEY" => "test-key") do
-      assert_raises(Hive::AgentError) { Hive::AgentProfiles::GROK_PREFLIGHT.call }
+  def test_ignores_unused_relative_grok_auth_path_with_api_key
+    with_env("GROK_AUTH_PATH" => "relative/auth.json", "XAI_API_KEY" => "test-key") do
+      assert_nil Hive::AgentProfiles::GROK_PREFLIGHT.call
     end
-
-    assert_match(/GROK_AUTH_PATH must be absolute/, err.message)
   end
 
   def test_rejects_relative_grok_home
@@ -88,20 +86,13 @@ class GrokPreflightTest < Minitest::Test
     assert_match(/GROK_HOME must be absolute/, err.message)
   end
 
-  def test_rejects_relative_grok_home_when_auth_path_and_api_key_are_set
-    Dir.mktmpdir do |dir|
-      auth_path = File.join(dir, "auth.json")
-      File.write(auth_path, '{"access_token":"x"}')
-
-      err = with_env(
-        "GROK_AUTH_PATH" => auth_path,
-        "GROK_HOME" => "relative/grok-home",
-        "XAI_API_KEY" => "test-key"
-      ) do
-        assert_raises(Hive::AgentError) { Hive::AgentProfiles::GROK_PREFLIGHT.call }
-      end
-
-      assert_match(/GROK_HOME must be absolute/, err.message)
+  def test_ignores_unused_relative_grok_home_with_api_key
+    with_env(
+      "GROK_AUTH_PATH" => "relative/auth.json",
+      "GROK_HOME" => "relative/grok-home",
+      "XAI_API_KEY" => "test-key"
+    ) do
+      assert_nil Hive::AgentProfiles::GROK_PREFLIGHT.call
     end
   end
 

--- a/test/unit/secret_patterns_test.rb
+++ b/test/unit/secret_patterns_test.rb
@@ -40,6 +40,13 @@ class SecretPatternsTest < Minitest::Test
     assert_match_name("API_KEY=abcdefghijklmnopqrstuvwxyz", :generic_api_key)
   end
 
+  def test_generic_api_key_before_json_delimiter_is_detected
+    assert_match_name(
+      '{"api_key":"abcdefghijklmnopqrstuvwxyz"}',
+      :generic_api_key
+    )
+  end
+
   def test_short_api_key_value_does_not_match
     refute_match_any("api_key = 'short'")
   end
@@ -94,6 +101,28 @@ class SecretPatternsTest < Minitest::Test
     assert_includes redacted, "noisy log tail"
   end
 
+  def test_long_private_key_bodies_are_fully_redacted
+    complete_body = "A" * 8_000
+    complete = <<~PEM
+      -----BEGIN PRIVATE KEY-----
+      #{complete_body}
+      -----END PRIVATE KEY-----
+    PEM
+    complete_redacted = Hive::SecretPatterns.redact(complete)
+    refute_includes complete_redacted, complete_body
+    assert_includes complete_redacted, "[REDACTED:pem_private_key]"
+
+    truncated_body = "B" * 8_000
+    truncated =
+      "-----BEGIN OPENSSH PRIVATE KEY-----\n#{truncated_body}"
+    truncated_redacted = Hive::SecretPatterns.redact(truncated)
+    refute_includes truncated_redacted, truncated_body
+    assert_includes(
+      truncated_redacted,
+      "[REDACTED:pem_private_key_header]"
+    )
+  end
+
   def test_truncated_pem_header_alone_with_no_body_is_redacted
     # Edge case: truncation cut at the BEGIN line itself, leaving no
     # body. Still redact — the header signal alone is meaningful and
@@ -127,6 +156,13 @@ class SecretPatternsTest < Minitest::Test
 
   def test_password_assignment_yaml_style_is_detected
     assert_match_name("password: s3cretpassphrase42", :password_assignment)
+  end
+
+  def test_password_before_json_delimiter_is_detected
+    assert_match_name(
+      '{"password":"s3cretpassphrase42"}',
+      :password_assignment
+    )
   end
 
   def test_short_password_value_does_not_match

--- a/test/unit/usage_extractors_test.rb
+++ b/test/unit/usage_extractors_test.rb
@@ -101,10 +101,10 @@ class UsageExtractorsTest < Minitest::Test
     assert_equal({ input: 1000, output: 200, cached: 300, model: "gpt-5-codex" }, result)
   end
 
-  def test_codex_final_event_without_usage_zero_fills
+  def test_codex_final_event_without_usage_remains_unknown
     result = CODEX.call(event("type" => "turn.completed", "model" => "gpt-5-codex"))
 
-    assert_equal({ input: 0, output: 0, cached: 0, model: "gpt-5-codex" }, result)
+    assert_nil result
   end
 
   def test_pi_usage_shape
@@ -121,9 +121,9 @@ class UsageExtractorsTest < Minitest::Test
     assert_equal({ input: 40, output: 20, cached: 10, model: "pi-model" }, result)
   end
 
-  def test_pi_final_event_without_usage_zero_fills
+  def test_pi_final_event_without_usage_remains_unknown
     result = PI.call(event("type" => "task.completed"))
 
-    assert_equal({ input: 0, output: 0, cached: 0, model: nil }, result)
+    assert_nil result
   end
 end

--- a/wiki/component-boundaries.md
+++ b/wiki/component-boundaries.md
@@ -3,7 +3,7 @@ title: Component boundaries
 type: reference
 source: config/component-boundaries.yml, test/support/component_boundary_contract.rb
 created: 2026-07-25
-updated: 2026-07-25
+updated: 2026-07-26
 tags: [architecture, components, boundaries, monorepo]
 ---
 
@@ -19,7 +19,7 @@ the first and primary consumer.
 |-----------|-------|---------------------|-------------------|
 | Attempts admission / future RunReceipt | `candidate` | `require "hive/attempts/api"` → `Hive::Attempts::API` | [[modules/attempts]] |
 | UserService | `candidate` | `require "hive/commands/service_installer/base"` → `Hive::Commands::ServiceInstaller::Base` | [[commands/daemon]] |
-| Agent ABI | `boundary-ready` | `require "hive/agent_runtime"` → `Hive::AgentRuntime` | [[modules/agent_profile]] |
+| Agent ABI | `boundary-ready`; standalone package candidate | `require "hive/agent_runtime"` → `Hive::AgentRuntime` | [[modules/agent_cli_runtime]], [[modules/agent_profile]] |
 | Agent Artifact Firewall | `candidate` | `require "hive/protected_files"` → `Hive::ProtectedFiles` | [[modules/protected_files]] |
 | Skillpack | `candidate` | `require "hive/agent_skills"` → `Hive::AgentSkills` | [[commands/setup-agents]] |
 | Safe Agent Git Gate | `candidate` | `require "hive/managed_git"` → `Hive::ManagedGit` | [[modules/git_ops]] |
@@ -45,6 +45,14 @@ lifetime, timeouts, retries, workflow selection, artifact acceptance, and
 stage success. `Hive::SecretPatterns` remains shared Hive infrastructure rather
 than component-owned state: both the ABI's bounded diagnostics and the future
 artifact firewall consume it.
+
+The package-only extraction lives at `components/agent-cli-runtime/` and
+publishes the neutral `AgentCliRuntime` namespace plus the bounded
+`agent-runtime` diagnostic executable. Until the separately held Hive cutover,
+`Hive::AgentRuntime` remains Hive's authoritative implementation and package
+parity tests prevent the temporary publication-window copy from drifting.
+Landing the package does not change Hive's gem dependency graph. See
+[[modules/agent_cli_runtime]] for the public surface and release boundary.
 
 ## Catalog contract
 
@@ -98,5 +106,7 @@ Change one component per PR. Update its catalog row, focused consumer tests,
 narrative wiki page, this page, and a `wiki/log.d/` fragment together. Promote
 to `boundary-ready` only after clean loading, dependency direction, direct
 consumer routing, focused tests, the broad Hive suite, and exact-head hosted CI
-all pass. Packaging remains a separate, later decision gated by demonstrated
-non-Hive demand and explicit release authority.
+all pass. Packaging remains a separate decision gated by demonstrated non-Hive
+demand and explicit release authority. Agent CLI Runtime has passed that gate
+with HiveBench as the named adopter; no other catalog row inherits that
+decision.

--- a/wiki/decisions.md
+++ b/wiki/decisions.md
@@ -3,7 +3,7 @@ title: Architectural Decisions
 type: decisions
 source: code + author's local planning notes (not committed)
 created: 2026-04-25
-updated: 2026-07-25
+updated: 2026-07-26
 tags: [decisions, adr]
 ---
 
@@ -21,7 +21,21 @@ Implementation readiness and standalone product value are different rankings. `H
 
 A component becomes package-eligible only after its internal boundary is stable, a named non-Hive adopter or maintained integration proves demand, the component loads and tests independently without an upward Hive dependency, compatibility and maintenance ownership are explicit, and an exact built gem installs cleanly. A qualifying package stays in this repository under `components/<gem-name>/`, uses independent SemVer, and remains a path dependency for source development while released `hive-cli` declares a normal compatible dependency. Package publication is explicit and component-scoped; path changes may select tests but never publish.
 
-**Consequences:** The immediate work changes module ownership and dependency discipline, not repository layout or release topology. Each component lands in its own reviewable PR with focused tests, a full Hive integration checkpoint, hosted CI, and wiki updates. No gem name, namespace, version, package directory, tag, or publication is implied by reaching an internal boundary.
+**Consequences:** The initial work changes module ownership and dependency
+discipline before release topology. Each component lands in its own reviewable
+PR with focused tests, a full Hive integration checkpoint, hosted CI, and wiki
+updates. No gem name, namespace, version, package directory, tag, or publication
+is implied by reaching an internal boundary.
+
+Agent ABI is the first component to pass the later package gate. It has the
+approved public identity `agent-cli-runtime` 0.1.0, namespace
+`AgentCliRuntime`, require path `agent_cli_runtime`, and executable
+`agent-runtime`, with HiveBench as its named non-Hive adopter. The package
+remains under `components/agent-cli-runtime/`; its package-only landing does not
+change Hive's dependency graph. Publication uses the disjoint
+`components/agent-cli-runtime/vX.Y.Z` tag and exact-artifact trusted publishing.
+Hive's dependency cutover remains separate and follows only after remote
+RubyGems verification.
 
 `config/component-boundaries.yml` is the canonical machine-readable inventory,
 and [[component-boundaries]] explains its states and enforcement. A test-only

--- a/wiki/gaps.md
+++ b/wiki/gaps.md
@@ -11,6 +11,14 @@ tags: [gap, todo, release-proof, agent-skills]
 
 ## Current release gap
 
+- `agent-cli-runtime` 0.1.0 has a self-contained package, exact-artifact
+  verifier, Linux/macOS install matrix, and component-scoped trusted-publishing
+  workflow. Until the package PR is merged, the RubyGems pending publisher is
+  configured, the component tag workflow succeeds, and a fresh remote install
+  matches the retained checksum, this is release-ready source evidence rather
+  than proof of a public gem. Hive intentionally keeps its internal
+  implementation authoritative and does not depend on the unpublished package;
+  the separately authorized cutover follows remote verification.
 - Native package-layout integration now proves that an installed gem plus
   authenticated, real `git archive` managed bundle resolves `hive-cli` from
   the package root and reaches the setup service seam without a parent

--- a/wiki/gaps.md
+++ b/wiki/gaps.md
@@ -13,12 +13,23 @@ tags: [gap, todo, release-proof, agent-skills]
 
 - `agent-cli-runtime` 0.1.0 has a self-contained package, exact-artifact
   verifier, Linux/macOS install matrix, and component-scoped trusted-publishing
-  workflow. Until the package PR is merged, the RubyGems pending publisher is
-  configured, the component tag workflow succeeds, and a fresh remote install
-  matches the retained checksum, this is release-ready source evidence rather
-  than proof of a public gem. Hive intentionally keeps its internal
+  workflow. Repository-hosted controls remain operator work: the
+  `components/agent-cli-runtime/v*` tag ruleset must restrict creation, update,
+  deletion, and bypass; the `agent-cli-runtime-release` environment must
+  require release reviewers and permit only matching component tags; and the
+  RubyGems pending publisher must match that environment identity. Until the
+  package PR is merged, those controls are verified, the component tag workflow
+  succeeds, and a fresh remote install matches the retained checksum, this is
+  release-ready source evidence rather than proof of a public gem. Hive
+  intentionally keeps its internal
   implementation authoritative and does not depend on the unpublished package;
   the separately authorized cutover follows remote verification.
+  Candidate/install/publish jobs have a 15-minute job timeout and retain the
+  exact candidate for 30 days. The install verifier does not add a second,
+  per-subprocess timeout around each gem command; a hung child can therefore
+  consume the remainder of its bounded job before cancellation. This narrow
+  operational risk is accepted for 0.1.0 rather than duplicating process
+  supervision in release shell.
 - Native package-layout integration now proves that an installed gem plus
   authenticated, real `git archive` managed bundle resolves `hive-cli` from
   the package root and reaches the setup service seam without a parent

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -3,7 +3,7 @@ title: hive Wiki
 type: index
 source: wiki/**/*.md
 created: 2026-05-14
-updated: 2026-07-25
+updated: 2026-07-26
 tags: [index, wiki]
 ---
 
@@ -13,8 +13,8 @@ local-first workflow engine for AI agents; software delivery is its flagship
 proof, while built-in content/bench, installable Honeycomb, and owner-authored
 workflows use the same folder-backed execution model.
 
-Page count: 95
-Updated: 2026-07-25
+Page count: 96
+Updated: 2026-07-26
 
 Folder-as-agent workflow engine: a Ruby 3.4 / Thor CLI control plane where descriptor-backed workflows move task folders through filesystem stages, stage agents compile provider-neutral invocations through `Hive::AgentRuntime` and configurable AgentProfile adapters (`claude` default, `codex`, `pi`, `grok`), and `mv` between directories remains the approval primitive. The built-in `coding` workflow drives the nine-stage PR pipeline (`1-inbox` → `2-brainstorm` → `3-plan` → `4-execute` → `5-open-pr` → `6-review` → `7-artifacts` → `8-finalize` → `9-done`), while the built-in `content` and `bench` workflows and project-authored workflows share the same generic runner/status/action machinery. Agent operation is centered on the additive operational status contract, coherent daemon scheduler snapshots, bounded semantic `hive watch`, and tokenized routine `hive act`; the legacy full JSON graph remains compatible. Hive packages one canonical operating skill projected to OpenClaw `/hive`, Claude `/hive`, Codex `$hive`, and Pi `/skill:hive`, with read-only `hive doctor`, consent-safe setup, and an exact-SHA four-agent pre-release proof.
 

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -69,6 +69,7 @@ The public native release surface is the `hive-cli` rubygem plus authenticated m
 - [[index]] — `wiki/index.md`
 - [[log]] — `wiki/log.md`
 - [[modules/agent]] — `wiki/modules/agent.md`
+- [[modules/agent_cli_runtime]] — `wiki/modules/agent_cli_runtime.md`
 - [[modules/agent_profile]] — `wiki/modules/agent_profile.md`
 - [[modules/attempts]] — `wiki/modules/attempts.md`
 - [[modules/atomic_file]] — `wiki/modules/atomic_file.md`

--- a/wiki/log.d/20260726T154459Z-agent-cli-runtime-package.md
+++ b/wiki/log.d/20260726T154459Z-agent-cli-runtime-package.md
@@ -1,0 +1,25 @@
+# 2026-07-26 — Package Agent CLI Runtime inside the Hive monorepo
+
+**Why:** HiveBench duplicates the same provider profile, preflight, argv, and
+stream-decoding mechanisms, giving the boundary-ready Agent ABI a concrete
+non-Hive adopter without justifying a separate repository.
+
+**Change:** Added the self-contained `agent-cli-runtime` 0.1.0 component under
+`components/agent-cli-runtime/`. It exposes `AgentCliRuntime`, the
+`agent_cli_runtime` require path, immutable provider-neutral contracts for
+Claude Code, Codex CLI, Pi, and Grok CLI, and the bounded `agent-runtime probe`
+executable. Package and root parity tests prove clean loading, fail-closed
+capabilities, usage extraction, stable local-probe output, and that Hive's
+current dependency graph is unchanged.
+
+**Release:** Added build-once candidate and private-install verification plus a
+disjoint `components/agent-cli-runtime/vX.Y.Z` workflow. Only its
+`agent-cli-runtime-release` environment receives RubyGems OIDC authority, after
+Linux and macOS install the exact retained bytes. The pending publisher identity
+and fix-forward procedure are documented in `docs/RELEASING.md`.
+
+**Boundary:** Hive remains the canonical source repository, primary consumer,
+and current authoritative implementation during the publication window. This
+package-only change does not add a Hive runtime dependency, tag or release
+Hive, publish the gem, merge the later Hive cutover, or make any other catalog
+component package-eligible.

--- a/wiki/log.d/20260726T154459Z-agent-cli-runtime-package.md
+++ b/wiki/log.d/20260726T154459Z-agent-cli-runtime-package.md
@@ -9,14 +9,22 @@ non-Hive adopter without justifying a separate repository.
 `agent_cli_runtime` require path, immutable provider-neutral contracts for
 Claude Code, Codex CLI, Pi, and Grok CLI, and the bounded `agent-runtime probe`
 executable. Package and root parity tests prove clean loading, fail-closed
-capabilities, usage extraction, stable local-probe output, and that Hive's
-current dependency graph is unchanged.
+capabilities, non-default compile parity, local probes, custom capability
+evidence, nested and absent usage variants, observable redaction, stable
+local-probe output, and that Hive's current dependency graph is unchanged.
+Probe hardening forwards the caller's environment, rejects ambiguous versions,
+and bounds TERM/KILL cleanup for descendant-held pipes. Missing usage remains
+unknown rather than a fabricated zero; Grok API-key auth ignores unused path
+overrides; long and JSON-delimited secrets stay redacted.
 
 **Release:** Added build-once candidate and private-install verification plus a
 disjoint `components/agent-cli-runtime/vX.Y.Z` workflow. Only its
 `agent-cli-runtime-release` environment receives RubyGems OIDC authority, after
 Linux and macOS install the exact retained bytes. The pending publisher identity
-and fix-forward procedure are documented in `docs/RELEASING.md`.
+and fix-forward procedure are documented in `docs/RELEASING.md`, together with
+the required component-tag ruleset and release-environment reviewers. Release
+jobs are bounded to 15 minutes and the candidate is retained for 30 days across
+approval delays.
 
 **Boundary:** Hive remains the canonical source repository, primary consumer,
 and current authoritative implementation during the publication window. This

--- a/wiki/modules/agent_cli_runtime.md
+++ b/wiki/modules/agent_cli_runtime.md
@@ -27,6 +27,24 @@ cannot represent them. Provider profiles and extractors are public,
 SemVer-governed behavior; orchestration policy stays injectable or outside the
 package.
 
+The public facade includes `compile`, `prepare!`, `require_capability!`,
+`extract_usage`, `observe`, `probe`, and `probe_all`. It accepts built-in names
+or custom `Profile` objects, preserves `UnknownProvider` as a typed caller
+error, exposes custom CLI capabilities in static probe evidence, and rejects
+custom names that collide with the standard capability vocabulary. Missing
+usage stays `nil`; terminal events without counters do not become measured
+zero-token events.
+
+For compatibility with Hive's trusted headless launches,
+`permission_mode: nil` still selects a provider's bypass flag. Independent
+consumers should pass `read-only` or `workspace-write` when they require those
+restrictions; unsupported enforcement fails closed. Version probes execute
+with their supplied environment, reject output containing multiple distinct
+version tokens, and terminate the full process group with a TERM/KILL and
+bounded-reader cleanup path on timeout. Grok environment authentication ignores
+unused file-path overrides, while file-backed authentication still validates
+absolute paths.
+
 The `agent-runtime probe [PROVIDER|--all] [--json]` executable checks only
 locally observable executable installation, version output, authentication
 configuration presence, and declared capabilities. Its JSON envelope has
@@ -54,14 +72,21 @@ internal copy only after RubyGems verification and separate merge authority.
 Package tests run directly from the subtree and through the root `rake test`
 task. Candidate tooling builds one gem, records its source commit and dirty
 state, checksums it, installs it into a private gem home, proves a clean require,
-and exercises the executable.
+and exercises the executable. Root parity fixtures cover non-default
+compilation, local probes, named capability evidence, provider usage variants,
+and observable normalization/redaction across all four built-ins.
 
 Only `components/agent-cli-runtime/vX.Y.Z` tags can trigger the component
 workflow. The tag, package version, exact main commit, and clean checkout must
 agree. Candidate and platform-install jobs have no publication identity; the
 `agent-cli-runtime-release` environment grants OIDC only to the publish job,
 which pushes the previously verified bytes without rebuilding. Hive root tags
-use a separate workflow and release surface. See `docs/RELEASING.md`.
+use a separate workflow and release surface. Every component release job has a
+15-minute execution timeout and the exact candidate is retained for 30 days to
+survive reviewer delay. Repository operators must separately enforce a
+component-tag ruleset, required reviewers on the release environment, and an
+environment deployment policy restricted to matching component tags. See
+`docs/RELEASING.md`.
 
 ## Compatibility
 

--- a/wiki/modules/agent_cli_runtime.md
+++ b/wiki/modules/agent_cli_runtime.md
@@ -1,0 +1,75 @@
+---
+title: Agent CLI Runtime component
+type: module
+source: components/agent-cli-runtime, .github/workflows/agent-cli-runtime-release.yml
+created: 2026-07-26
+updated: 2026-07-26
+tags: [agent, runtime, component, gem, cli]
+---
+
+**TLDR**: `agent-cli-runtime` is the first independently versioned gem kept in
+the Hive monorepo. It exposes provider-neutral profiles, invocation
+compilation, local prerequisite evidence, usage extraction, and normalized
+results for Claude Code, Codex CLI, Pi, and Grok CLI. Hive remains the primary
+consumer; the gem does not own orchestration or Hive policy.
+
+## Public surface
+
+The package lives at `components/agent-cli-runtime/`, loads with
+`require "agent_cli_runtime"`, and exposes the `AgentCliRuntime` namespace.
+Its built-in profiles are ordered `claude`, `codex`, `pi`, `grok`. Callers
+construct immutable requests and receive immutable compiled invocations,
+capability evidence, probe results, and observable results.
+
+Compilation returns argv and optional stdin without executing a process.
+Requested controls fail closed with `UnsupportedCapability` when a profile
+cannot represent them. Provider profiles and extractors are public,
+SemVer-governed behavior; orchestration policy stays injectable or outside the
+package.
+
+The `agent-runtime probe [PROVIDER|--all] [--json]` executable checks only
+locally observable executable installation, version output, authentication
+configuration presence, and declared capabilities. Its JSON envelope has
+`schema_version: 1` and a `probes` array. Exit 0 means every requested local
+prerequisite is ready, 1 means at least one is unavailable, and 64 means invalid
+usage. `configured` never claims credential validity, provider health, or
+account quota.
+
+## Ownership boundary
+
+The package does not spawn or supervise agents, select workflows, retry work,
+interpret stages or markers, accept artifacts, decide success, own provider
+budgets, or contain Hive defaults and skills. It can load and run without
+`hive-cli` or Hive constants. Direct standard-library gem dependencies are
+declared in its gemspec.
+
+Until the post-publication cutover, `Hive::AgentRuntime` remains authoritative
+inside Hive and focused parity tests compare the package against it. This
+temporary duplication is bounded to the publish-first window; the held cutover
+will preserve promised Hive constants as forwarding adapters and remove the
+internal copy only after RubyGems verification and separate merge authority.
+
+## Development and release
+
+Package tests run directly from the subtree and through the root `rake test`
+task. Candidate tooling builds one gem, records its source commit and dirty
+state, checksums it, installs it into a private gem home, proves a clean require,
+and exercises the executable.
+
+Only `components/agent-cli-runtime/vX.Y.Z` tags can trigger the component
+workflow. The tag, package version, exact main commit, and clean checkout must
+agree. Candidate and platform-install jobs have no publication identity; the
+`agent-cli-runtime-release` environment grants OIDC only to the publish job,
+which pushes the previously verified bytes without rebuilding. Hive root tags
+use a separate workflow and release surface. See `docs/RELEASING.md`.
+
+## Compatibility
+
+The initial public line is 0.1.x on Ruby 3.4 or newer, tested on Linux and
+macOS. Additive fields are compatible within 0.1.x. Removing or changing an
+existing public field, flag mapping, event meaning, or executable contract
+requires a new minor release while pre-1.0. A published bad version is fixed
+forward; yanking or ownership changes are separate operator decisions.
+
+Related context: [[component-boundaries]], [[modules/agent_profile]], and
+ADR-038 in [[decisions]].

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -3,7 +3,7 @@ title: Testing
 type: reference
 source: test/, Rakefile, bin/hive-eval, .rubocop.yml, .github/workflows/{ci,live-agent-skills,release}.yml, packaging/live_agent_skills/, config/brakeman.ignore
 created: 2026-04-25
-updated: 2026-07-25
+updated: 2026-07-26
 tags: [test, minitest, fixtures, honeycomb, agent-skills, component-boundaries, release-proof]
 ---
 
@@ -57,6 +57,21 @@ bundle exec rake test:babysitter_dry_run_security_matrix
 The packaged-web gate is commit-bound: it archives `HEAD:web` to reproduce the
 release artifact. Commit relevant web changes before using that task locally;
 otherwise it deliberately tests the previously committed tree.
+
+The standalone Agent CLI Runtime component suite is part of the root `test`
+dependency graph and also has an explicit task:
+
+```bash
+bundle exec rake test:agent_cli_runtime
+bundle exec ruby -Itest -Ilib test/unit/agent_cli_runtime_component_test.rb
+bundle exec ruby -Itest -Ilib test/unit/agent_cli_runtime_release_contract_test.rb
+```
+
+The first command runs the package's own tests. The two root files pin
+Hive/package behavioral parity and the component release workflow contract.
+Parity covers non-default compilation, successful local probes, custom named
+capabilities, nested/missing usage variants, and observable redaction across
+Claude, Codex, Pi, and Grok.
 
 ## Component boundary contract
 


### PR DESCRIPTION
## Summary

- add the public `agent-cli-runtime` 0.1.0 component gem while keeping Hive as its primary monorepo consumer
- expose `AgentCliRuntime` through `require "agent_cli_runtime"` and the `agent-runtime` executable for deterministic install, version, auth, capability, and usage probing across Claude, Codex, Pi, and Grok
- add build-once candidate verification and an OIDC trusted-publishing workflow for component tags
- keep the Hive dependency cutover explicitly out of this PR while enforcing package/Hive behavior parity
- harden bounded process cleanup, output validation, secret redaction, unknown-usage semantics, and custom provider capabilities

## Verification

- `bundle exec rake test`: 10,350 runs, 141,663 assertions, 0 failures, 0 errors, 8 skips
- component suite across seeds 1, 2, 3, and 4: 35 runs, 227 assertions each, all green
- focused parity/release/profile/provider/redaction/usage/wiki suites: all green
- changed-file RuboCop: 22 files inspected, 0 offenses
- clean candidate verification: 19,456 bytes, SHA-256 `088ceeb63503c26812e5b60f7349956b69196818d194bb6a28dfee30529295d3`

## Release contract

After merge, tag the exact merge commit as `components/agent-cli-runtime/v0.1.0`. The workflow builds once, installs that exact artifact on Linux and macOS, then publishes the same bytes through the `agent-cli-runtime-release` GitHub environment and RubyGems OIDC trusted publishing.

The pending RubyGems publisher must match owner `ivankuznetsov`, repository `hive`, workflow `agent-cli-runtime-release.yml`, and environment `agent-cli-runtime-release` before the tag is pushed.