### PR TITLE
fix(web): make same-version bundle refresh reliable

### DIFF
--- a/lib/hive/cli.rb
+++ b/lib/hive/cli.rb
@@ -1659,10 +1659,11 @@ module Hive
     desc "web [SUBCOMMAND]", "Run or manage the hive web UI"
     option :bind, type: :string, desc: "override web.bind"
     option :port, type: :numeric, desc: "override web.port"
-    option :no_bootstrap, type: :boolean, default: false, desc: "do not install the managed web app if missing"
+    option :no_bootstrap, type: :boolean, default: false, desc: "do not install or refresh the managed web app"
     option :unsafe, type: :boolean, default: false, desc: "allow non-loopback bind without configured owner"
     option :allow_public, type: :boolean, default: false, desc: "alias for --unsafe"
-    option :force, type: :boolean, default: false, desc: "for install: overwrite existing service unit"
+    option :force, type: :boolean, default: false,
+                   desc: "for install: refresh managed bundle and overwrite differing service unit"
     option :detach, type: :boolean, default: false, desc: "for start: start the managed service instead of foreground Rails"
     option :source_root, type: :string, desc: "for capture/capture-server: exact clean source worktree"
     option :runtime_root, type: :string, desc: "for capture-server: isolated private runtime directory"

--- a/lib/hive/commands/web.rb
+++ b/lib/hive/commands/web.rb
@@ -257,11 +257,16 @@ module Hive
       def install_command
         @install_json_emitted = false
         phase = :bootstrap
+        bundle_refreshed = false
         unless @no_bootstrap
-          Hive::Web::AppBundle.ensure!
+          bundle_refreshed = @force ||
+                             !Hive::Web::AppBundle.present? ||
+                             Hive::Web::AppBundle.stale? ||
+                             !Hive::Web::AppBundle.assets_ready?
+          Hive::Web::AppBundle.ensure!(force_refresh: @force)
         end
         phase = :service_install
-        install_service
+        install_service(bundle_refreshed: bundle_refreshed)
       rescue StandardError => e
         error = normalize_install_error(e, phase: phase)
         emit_install_error(error, error_kind: install_error_kind(phase)) if @json && !@install_json_emitted
@@ -337,7 +342,7 @@ module Hive
         Hive::Web::Loopback.address?(bind)
       end
 
-      def install_service
+      def install_service(bundle_refreshed: false)
         require "hive/commands/web/service_installer"
         config = Hive::Config.load_global_web
         installer = Hive::Commands::Web::ServiceInstaller.new(
@@ -345,8 +350,14 @@ module Hive
           environment: @environment,
           config: config
         )
+        was_running = Hive::Web::ServiceStatus.lifecycle_state(installer)["service_running"]
         outcome = installer.install!(autostart: true, force: @force)
-        envelope = service_envelope(installer, outcome, config: config)
+        restarted = outcome.restarted
+        if bundle_refreshed && was_running && outcome.success? && !restarted
+          installer.restart!
+          restarted = true
+        end
+        envelope = service_envelope(installer, outcome, config: config, restarted: restarted)
         if @json
           emit_install_json(envelope)
         else
@@ -414,7 +425,8 @@ module Hive
         end
       end
 
-      def service_envelope(installer, outcome, config: Hive::Config.load_global_web)
+      def service_envelope(installer, outcome, config: Hive::Config.load_global_web,
+                           restarted: outcome.restarted)
         state = Hive::Web::ServiceStatus.snapshot(
           installer: installer, config: config, environment: @environment,
           wait_for_running: true,
@@ -429,7 +441,7 @@ module Hive
           "outcome" => outcome.wire_outcome,
           "target_path" => installer.target_path,
           "backup_path" => outcome.backup_path,
-          "restarted" => outcome.restarted,
+          "restarted" => restarted,
           "messages" => installer.messages.dup,
           "warnings" => environment_warnings
         }.merge(state)

--- a/lib/hive/web/app_bundle.rb
+++ b/lib/hive/web/app_bundle.rb
@@ -137,7 +137,7 @@ module Hive
           begin
             if previous_moved && (File.exist?(backup) || File.symlink?(backup))
               FileUtils.rm_rf(app_dir) if File.exist?(app_dir) || File.symlink?(app_dir)
-              File.rename(backup, app_dir)
+              renamer.call(backup, app_dir)
               previous_moved = false
             end
           rescue StandardError => rollback_error

--- a/lib/hive/web/app_bundle.rb
+++ b/lib/hive/web/app_bundle.rb
@@ -5,6 +5,7 @@ require "open3"
 require "open-uri"
 require "rbconfig"
 require "rubygems/package"
+require "securerandom"
 require "tmpdir"
 require "zlib"
 
@@ -16,6 +17,7 @@ module Hive
   module Web
     module AppBundle
       VERSION_FILE = ".hive-web-version".freeze
+      REFRESH_LOCK_FILE = ".hive-web-refresh.lock".freeze
       REQUIRED_ASSETS = %w[application.css application.js].freeze
       COSIGN_TIMEOUT_SEC = 60
 
@@ -66,45 +68,92 @@ module Hive
       end
 
       def ensure!(bundle_url: default_bundle_url, bundle_sha256: default_bundle_sha256,
-                  runner: nil, output: $stderr, downloader: nil, verifier: nil)
-        return app_dir if present? && !stale? && assets_ready?
+                  runner: nil, output: $stderr, downloader: nil, verifier: nil,
+                  force_refresh: false, renamer: nil)
+        with_refresh_lock do
+          return app_dir if !force_refresh && present? && !stale? && assets_ready?
 
-        if bundle_url.to_s.empty?
-          raise Hive::Error,
-                "hive web: managed web app is missing. Set HIVE_WEB_BUNDLE_URL or run from a source checkout."
-        end
-
-        tmp = "#{app_dir}.tmp.#{Process.pid}"
-        FileUtils.rm_rf(tmp)
-        FileUtils.mkdir_p(tmp)
-        fetch_and_extract(
-          bundle_url, tmp,
-          bundle_sha256: bundle_sha256,
-          downloader: downloader,
-          verifier: verifier
-        )
-        unless File.file?(File.join(tmp, "config", "application.rb"))
-          nested = Dir.children(tmp).map { |child| File.join(tmp, child) }
-                      .find { |path| File.file?(File.join(path, "config", "application.rb")) }
-          if nested
-            Dir.children(nested).each { |child| FileUtils.mv(File.join(nested, child), tmp) }
+          if bundle_url.to_s.empty?
+            raise Hive::Error,
+                  "hive web: managed web app is missing. Set HIVE_WEB_BUNDLE_URL or run from a source checkout."
           end
+
+          tmp = "#{app_dir}.tmp.#{Process.pid}.#{SecureRandom.hex(6)}"
+          FileUtils.mkdir_p(tmp)
+          fetch_and_extract(
+            bundle_url, tmp,
+            bundle_sha256: bundle_sha256,
+            downloader: downloader,
+            verifier: verifier
+          )
+          unless File.file?(File.join(tmp, "config", "application.rb"))
+            nested = Dir.children(tmp).map { |child| File.join(tmp, child) }
+                        .find { |path| File.file?(File.join(path, "config", "application.rb")) }
+            if nested
+              Dir.children(nested).each { |child| FileUtils.mv(File.join(nested, child), tmp) }
+            end
+          end
+          unless File.file?(File.join(tmp, "config", "application.rb"))
+            raise Hive::Error, "hive web: downloaded web bundle does not contain config/application.rb"
+          end
+
+          # Prepare and stamp the staged bundle before activation. The current
+          # generation is retained as a sibling backup until the staged rename
+          # succeeds, and any activation failure restores it.
+          prepare!(dir: tmp, runner: runner, output: output)
+          File.write(File.join(tmp, VERSION_FILE), "#{Hive::VERSION}\n")
+          activate!(tmp, renamer: renamer)
+        ensure
+          FileUtils.rm_rf(tmp) if tmp
         end
-        unless File.file?(File.join(tmp, "config", "application.rb"))
-          raise Hive::Error, "hive web: downloaded web bundle does not contain config/application.rb"
+      end
+
+      def with_refresh_lock
+        parent = File.dirname(app_dir)
+        FileUtils.mkdir_p(parent)
+        path = File.join(parent, REFRESH_LOCK_FILE)
+        File.open(path, File::RDWR | File::CREAT, 0o600) do |lock|
+          lock.flock(File::LOCK_EX)
+          yield
+        ensure
+          lock.flock(File::LOCK_UN)
+        end
+      end
+
+      def activate!(staged_dir, renamer: nil)
+        renamer ||= File.method(:rename)
+        backup = "#{app_dir}.backup.#{Process.pid}.#{SecureRandom.hex(6)}"
+        previous_moved = false
+        activated = false
+
+        begin
+          if File.exist?(app_dir) || File.symlink?(app_dir)
+            renamer.call(app_dir, backup)
+            previous_moved = true
+          end
+          renamer.call(staged_dir, app_dir)
+          activated = true
+        rescue StandardError => activation_error
+          begin
+            if previous_moved && (File.exist?(backup) || File.symlink?(backup))
+              FileUtils.rm_rf(app_dir) if File.exist?(app_dir) || File.symlink?(app_dir)
+              File.rename(backup, app_dir)
+              previous_moved = false
+            end
+          rescue StandardError => rollback_error
+            raise Hive::Error,
+                  "hive web: could not activate prepared web bundle " \
+                  "(#{activation_error.class}: #{activation_error.message}); " \
+                  "rollback failed (#{rollback_error.class}: #{rollback_error.message})"
+          end
+          raise Hive::Error,
+                "hive web: could not activate prepared web bundle " \
+                "(#{activation_error.class}: #{activation_error.message})"
+        ensure
+          FileUtils.rm_rf(backup) if activated && previous_moved
         end
 
-        # Prepare dependencies and production assets in the staged bundle
-        # before swapping it into place. A failed refresh leaves the previous
-        # working install untouched, and the version stamp is written last.
-        prepare!(dir: tmp, runner: runner, output: output)
-        FileUtils.rm_rf(app_dir)
-        FileUtils.mkdir_p(File.dirname(app_dir))
-        FileUtils.mv(tmp, app_dir)
-        File.write(File.join(app_dir, VERSION_FILE), "#{Hive::VERSION}\n")
         app_dir
-      ensure
-        FileUtils.rm_rf(tmp) if tmp
       end
 
       def bundle_install!(dir: app_dir, runner: nil, output: $stderr)

--- a/test/unit/cli_test.rb
+++ b/test/unit/cli_test.rb
@@ -895,6 +895,13 @@ class HiveCliTest < Minitest::Test
   # constant-swap technique web_command_test.rb uses for Puma::Server). This
   # proves the CLI wires bind/port through to the command and invokes #call,
   # without booting a socket.
+  def test_web_help_discloses_force_refresh_and_service_repair
+    out, = capture_io { Hive::CLI.start([ "help", "web" ]) }
+
+    assert_includes out, "refresh managed bundle"
+    assert_includes out, "overwrite differing service unit"
+  end
+
   def test_web_wires_bind_and_port_into_the_web_command
     require "hive/commands/web"
     captured = []

--- a/test/unit/web/app_bundle_test.rb
+++ b/test/unit/web/app_bundle_test.rb
@@ -137,6 +137,73 @@ class WebAppBundleTest < Minitest::Test
     end
   end
 
+  def test_force_refresh_reprovisions_a_healthy_same_version_bundle
+    with_hive_home do
+      app = Hive::Web::AppBundle.app_dir
+      FileUtils.mkdir_p(File.join(app, "config"))
+      File.write(File.join(app, "config", "application.rb"), "# old app\n")
+      File.write(File.join(app, Hive::Web::AppBundle::VERSION_FILE), "#{Hive::VERSION}\n")
+      write_compiled_assets(app)
+
+      calls = []
+      runner = lambda do |argv, _env|
+        calls << argv
+        write_compiled_assets(Dir.pwd) if argv == %w[bin/rails assets:precompile]
+        true
+      end
+      source = seed_source_app
+
+      Hive::Web::AppBundle.ensure!(bundle_url: source, output: nil, runner: runner)
+      assert_empty calls, "ordinary startup must keep a healthy current bundle"
+      assert_equal "# old app\n", File.read(File.join(app, "config", "application.rb"))
+
+      Hive::Web::AppBundle.ensure!(
+        bundle_url: source,
+        output: nil,
+        runner: runner,
+        force_refresh: true
+      )
+
+      assert_equal [ %w[bundle install], %w[bin/rails assets:precompile] ], calls
+      assert_equal "# app\n", File.read(File.join(app, "config", "application.rb"))
+      assert_equal Hive::VERSION, Hive::Web::AppBundle.installed_version
+    end
+  end
+
+  def test_force_refresh_restores_the_previous_bundle_when_activation_fails
+    with_hive_home do
+      app = Hive::Web::AppBundle.app_dir
+      FileUtils.mkdir_p(File.join(app, "config"))
+      File.write(File.join(app, "config", "application.rb"), "# old app\n")
+      File.write(File.join(app, Hive::Web::AppBundle::VERSION_FILE), "#{Hive::VERSION}\n")
+      write_compiled_assets(app)
+
+      renamer = lambda do |source, destination|
+        if source.start_with?("#{app}.tmp.") && destination == app
+          raise Errno::EIO, "synthetic activation failure"
+        end
+
+        File.rename(source, destination)
+      end
+
+      error = assert_raises(Hive::Error) do
+        Hive::Web::AppBundle.ensure!(
+          bundle_url: seed_source_app,
+          output: nil,
+          runner: successful_prepare_runner,
+          force_refresh: true,
+          renamer: renamer
+        )
+      end
+
+      assert_match(/could not activate prepared web bundle/, error.message)
+      assert_equal "# old app\n", File.read(File.join(app, "config", "application.rb"))
+      assert_equal Hive::VERSION, Hive::Web::AppBundle.installed_version
+      assert Hive::Web::AppBundle.assets_ready?
+      assert_empty Dir.glob("#{app}.backup.*")
+    end
+  end
+
   def test_assets_ready_rejects_manifest_paths_outside_the_asset_directory
     Dir.mktmpdir("hive-web-assets") do |app|
       assets = File.join(app, "public", "assets")

--- a/test/unit/web/app_bundle_test.rb
+++ b/test/unit/web/app_bundle_test.rb
@@ -204,6 +204,42 @@ class WebAppBundleTest < Minitest::Test
     end
   end
 
+  def test_force_refresh_reports_activation_and_rollback_failures
+    with_hive_home do
+      app = Hive::Web::AppBundle.app_dir
+      FileUtils.mkdir_p(File.join(app, "config"))
+      File.write(File.join(app, "config", "application.rb"), "# old app\n")
+      File.write(File.join(app, Hive::Web::AppBundle::VERSION_FILE), "#{Hive::VERSION}\n")
+      write_compiled_assets(app)
+
+      renamer = lambda do |source, destination|
+        if source.start_with?("#{app}.tmp.") && destination == app
+          raise Errno::EIO, "synthetic activation failure"
+        end
+        if source.start_with?("#{app}.backup.") && destination == app
+          raise Errno::EIO, "synthetic rollback failure"
+        end
+
+        File.rename(source, destination)
+      end
+
+      error = assert_raises(Hive::Error) do
+        Hive::Web::AppBundle.ensure!(
+          bundle_url: seed_source_app,
+          output: nil,
+          runner: successful_prepare_runner,
+          force_refresh: true,
+          renamer: renamer
+        )
+      end
+
+      assert_match(/synthetic activation failure/, error.message)
+      assert_match(/rollback failed .*synthetic rollback failure/, error.message)
+      refute File.exist?(app)
+      assert_equal 1, Dir.glob("#{app}.backup.*").length
+    end
+  end
+
   def test_assets_ready_rejects_manifest_paths_outside_the_asset_directory
     Dir.mktmpdir("hive-web-assets") do |app|
       assets = File.join(app, "public", "assets")

--- a/test/unit/web/web_command_test.rb
+++ b/test/unit/web/web_command_test.rb
@@ -399,10 +399,14 @@ class WebCommandTest < Minitest::Test
   # a drifted unit → InvalidTaskPath (retry with --force), a failed install →
   # Hive::Error, and --json emits the hive-web-install envelope. Swap in a fake
   # installer so the mapping is asserted without touching launchctl/systemctl.
-  def with_fake_web_installer(outcome_kind, state: nil, install_error: nil)
+  def with_fake_web_installer(outcome_kind, state: nil, install_error: nil,
+                              outcome_restarted: false, restart_calls: nil)
     require "hive/commands/web/service_installer"
     require "hive/commands/service_installer/outcome"
-    outcome = Hive::Commands::ServiceInstaller::Outcome.new(outcome_kind)
+    outcome = Hive::Commands::ServiceInstaller::Outcome.new(
+      outcome_kind,
+      restarted: outcome_restarted
+    )
     service_state = state || {
       "platform" => "macos", "unit_path" => "/tmp/local.hive-web.plist",
       "service_installed" => true, "service_enabled" => true,
@@ -415,6 +419,11 @@ class WebCommandTest < Minitest::Test
         raise install_error if install_error
 
         outcome
+      end
+      define_method(:service_lifecycle_state) { service_state }
+      define_method(:restart!) do
+        restart_calls << true if restart_calls
+        true
       end
       define_method(:messages) { [ "installed note" ] }
       define_method(:target_path) { "/tmp/local.hive-web.plist" }
@@ -481,6 +490,50 @@ class WebCommandTest < Minitest::Test
                            "a failed install is a hard error, not a retry-with-force drift"
       end
     end
+  end
+
+  def test_force_install_forces_managed_bundle_refresh
+    observed = nil
+    restart_calls = []
+    replacement = lambda do |**kwargs|
+      observed = kwargs
+      Hive::Web::AppBundle.app_dir
+    end
+
+    with_tmp_global_config do
+      with_fake_web_installer(:unchanged, restart_calls: restart_calls) do
+        with_replaced_singleton_method(Hive::Web::AppBundle, :ensure!, replacement) do
+          out, = capture_io { Hive::Commands::Web.new("install", force: true, json: true).call }
+          assert_equal true, JSON.parse(out).fetch("restarted")
+        end
+      end
+    end
+
+    assert_equal true, observed.fetch(:force_refresh)
+    assert_equal [ true ], restart_calls
+  end
+
+  def test_force_install_does_not_restart_twice_after_unit_upgrade_restart
+    restart_calls = []
+
+    with_tmp_global_config do
+      with_fake_web_installer(
+        :upgraded,
+        outcome_restarted: true,
+        restart_calls: restart_calls
+      ) do
+        with_replaced_singleton_method(
+          Hive::Web::AppBundle,
+          :ensure!,
+          ->(**) { Hive::Web::AppBundle.app_dir }
+        ) do
+          out, = capture_io { Hive::Commands::Web.new("install", force: true, json: true).call }
+          assert_equal true, JSON.parse(out).fetch("restarted")
+        end
+      end
+    end
+
+    assert_empty restart_calls
   end
 
   def test_install_service_json_envelope_shape

--- a/wiki/commands/web.md
+++ b/wiki/commands/web.md
@@ -3,7 +3,7 @@ title: hive web
 type: command
 source: lib/hive/commands/web.rb, lib/hive/web/, web/, packaging/docker/, .github/workflows/release.yml
 created: 2026-06-04
-updated: 2026-07-25
+updated: 2026-07-26
 tags: [command, web, rails, turbo, hivebox-container]
 ---
 
@@ -36,8 +36,10 @@ bootstrap is allowed, it downloads/extracts the versioned web release bundle.
 Managed installation prepares a staging directory with `bundle install` and a
 production `assets:precompile`, requires usable `application.css` and
 `application.js` entrypoints, verifies every Propshaft manifest asset resolves
-to a contained file, and only then atomically activates it. Missing or corrupt
-assets make even a same-version bundle repair itself.
+to a contained file, and only then activates it under a refresh lock. Activation
+keeps the previous generation as a sibling backup until the staged rename
+succeeds; a failed rename restores that generation. Missing or corrupt assets
+make even a same-version bundle repair itself.
 For a managed bundle, provisioning, `db:prepare`, and the Rails server all run
 through the exact Bundler recorded by the authenticated lockfile and the
 current Ruby. A newer host-default Bundler cannot take over after a successful
@@ -70,9 +72,27 @@ internal `HIVEBOX_PRECOMPILED_ASSETS=1` marker so the shared launcher does not
 repeat native web preparation at container startup.
 
 `hive web install [--force] [--json]` installs the separate `hive-web` autostart
-service using the invoked user-facing binary path; `hive web start --detach`
-starts that service and reloads systemd-user first on Linux so a unit written
-while systemd-user was unavailable becomes visible. Foreground
+service using the invoked user-facing binary path. `--force` also forces an
+authenticated, rollback-safe managed-bundle reprovision before replacing the
+service, even when the installed bundle has a current version stamp and healthy
+assets. This matters when separately merged dependencies or web content change
+without a Hive version bump; ordinary foreground/start bootstrap remains a
+no-op for a healthy current bundle. If the service was already running, a
+successful refresh restarts it exactly once even when the unit file itself is
+unchanged. A service-unit upgrade that already restarted it is not restarted a
+second time.
+
+The default managed source is the signed release bundle, so a forced refresh can
+require network access and `cosign`; verification or preparation failure occurs
+before any service-unit mutation and leaves the current bundle and service
+intact. Source-checkout dogfood must set `HIVE_WEB_BUNDLE_URL` to that checkout's
+`web/` directory when it needs unreleased web content. `--no-bootstrap` is
+authoritative and suppresses both managed installation and refresh, including
+when combined with `--force`.
+
+`hive web start --detach` starts that service and reloads
+systemd-user first on Linux so a unit written while systemd-user was unavailable
+becomes visible. Foreground
 `hive web start` is equivalent to `hive web`. `status --json` emits
 `hive-web-status.v1`; `install --json` emits `hive-web-install.v1`. Both carry
 `mode: "managed_service"`, deduplicated environment migration warnings, and
@@ -583,9 +603,15 @@ explicit GitHub connection action. It also covers Tailscale-style forwarded
 client addresses over a loopback socket, arbitrary proxy hostnames reaching
 the GitHub login instead of a Host-authorization 403, mutation rejection before
 side effects, local `hive` branding, optional GitHub connection without owner
-claim, and local logout returning to the usable dashboard. Managed-bundle tests pin staged dependency/asset preparation,
-same-version missing-asset repair, and preservation of the previous bundle on
-precompile failure. Repository setup always invokes the CLI init adapter with
+claim, and local logout returning to the usable dashboard. Managed-bundle tests
+pin staged dependency/asset preparation,
+same-version missing-asset repair, explicit force refresh of a healthy
+same-version bundle, the ordinary-start no-op, install-command propagation, and
+preservation of the previous bundle on preparation or activation failure.
+Command tests additionally pin exactly-once restart after refreshing an
+unchanged running service, no duplicate restart after a unit upgrade, and help
+text that discloses the refresh and service-repair scope. Repository setup
+always invokes the CLI init adapter with
 non-TTY provisioning input. It also pins that
 a red task page shows the diagnostic banner and Retry button, and that the
   route submits the current row to the durable recovery coordinator and renders

--- a/wiki/gaps.md
+++ b/wiki/gaps.md
@@ -247,7 +247,27 @@ completed real GitHub/Codex/Claude provider login plus a daemon-owned PR push.
 
 51. **Ad-hoc PR review is source/test-pinned but not live-smoked.** `hive review --pr PR` runs through `Hive::Commands::AdhocReview`, `Hive::Gh.pr_metadata`, `Hive::Pr.identifier_to_number`, and `Hive::Worktree.materialize_pr`. Focused unit/integration tests pin PR identifier parsing, project-scoped `gh pr view` lookup via `chdir:`, synthetic `6-review/adhoc-review-pr-N` task creation/reuse/collision behavior, PR-head materialization, head-SHA verification, cleanup after partial creation, reviewer selection, and default fix-off behavior (`review.adhoc.fix: false`). This refresh did not find an in-tree artifact showing a real registered project running `hive review --pr <github-pr>`, materializing the PR head from GitHub, completing review with real reviewer agents, and surfacing the ad-hoc task through `hive status`/TUI/bot. The 2026-06-30 cleanup audit for `make-the-hive-daemon-automatically-260629-223d` rechecked the branch commit, current source/tests, and configured main-wiki context and found no new live ad-hoc PR review evidence closing this gap.
 
-52. **Local setup/web install repair is source/test-pinned but not live-smoked.** Branch `add-local-hive-web-install-260629-f4ca` documents `hive setup`, managed web-bundle refresh/install safety, daemon/web same-binary service install, web loopback/no-auth gating, and `hive web start --detach` systemd reload behavior. Focused tests cover phase-exit semantics, AppBundle extraction/stamping, service-installer rendering/parsing, and queue allowlisting, but this refresh did not find an in-tree artifact showing a real Homebrew/AUR/install.sh local install running setup, repairing stale daemon/web services, downloading the release web bundle, and serving the updated local web UI after a CLI upgrade. The 2026-07-20 agent-first setup change restored `--yes` as the explicit unattended consent boundary, added the agent-skills-first phase, and pinned zero mutation for JSON/non-TTY runs without consent. The native-default work adds default-on web-service setup, versioned service/readiness schemas, release-layout dependency resolution, signed-manifest/digest enforcement, and a package-layout integration fixture. These close the source/package simulation gap but not the missing live published-release smoke on real systemd-user and launchd hosts.
+52. **Local setup/web install repair is source/test-pinned, with a real
+systemd-user source-deployment smoke but no published-release/launchd proof.**
+Branch `add-local-hive-web-install-260629-f4ca` documents `hive setup`, managed
+web-bundle refresh/install safety, daemon/web same-binary service install, web
+loopback/no-auth gating, and `hive web start --detach` systemd reload behavior.
+The 2026-07-26 current-main dogfood installed the exact checkout binary and
+managed Rails app through real systemd-user, served `/up`, and held zero
+restarts, but exposed that a healthy `0.6.9` version stamp could hide newer web
+content after another same-version merge. Explicit `hive web install --force`
+now bypasses only that healthy-bundle early return and reuses the existing
+staged dependency/asset preparation plus rollback-safe activation path; ordinary
+bootstrap stays a no-op. Focused tests cover that split, phase-exit semantics,
+AppBundle extraction/stamping, service-installer rendering/parsing, and queue
+allowlisting. The remaining release gap is a real Homebrew/AUR/install.sh
+published archive running setup and same-version forced repair on systemd-user,
+plus equivalent launchd evidence. The 2026-07-20 agent-first setup change
+restored `--yes` as the explicit unattended consent boundary, added the
+agent-skills-first phase, and pinned zero mutation for JSON/non-TTY runs without
+consent. The native-default work adds default-on web-service setup, versioned
+service/readiness schemas, release-layout dependency resolution,
+signed-manifest/digest enforcement, and a package-layout integration fixture.
 
 53. **Daemon status `unreadable` drift is source/test-pinned but schema-unpinned.** Branch `arch-review-local-web-install` extracts the daemon-status envelope into `Hive::Daemon::StatusReport`; that producer now owns `BINARY_DRIFT_STATES` / `BINARY_DRIFT_ACTIONABLE`, can emit `binary_drift: "unreadable"` when an installed same-path binary cannot answer `--version`, and the hivebox `_daemon` view treats that value as actionable through `StatusReport::BINARY_DRIFT_ACTIONABLE`. Focused daemon tests cover `StatusReport#safe_payload`, `binary_state`, `binary_version`, and the `unreadable` drift branch. However, `schemas/hive-daemon-status.v1.json` still enumerates only `none`, `path`, `version`, `unparseable`, and `not_applicable`, so an actual `unreadable` payload would not validate against the published daemon-status schema. A follow-up should add `unreadable` to the schema enum/description and pin a schema validation test for that payload shape. The 2026-07-01 post-commit audit for `arch-review-local-web-install` rechecked the branch diff, `Hive::Daemon::StatusReport`, daemon CLI wiring, hivebox `_daemon` rendering, the daemon-status schema, and focused daemon tests; it found no schema update or live repair artifact closing this gap.
 
@@ -758,3 +778,12 @@ through locked `bundle exec` and the current Ruby too. The remaining evidence
 is one installed-main service upgrade from the merged fix, followed by a real
 worktree capture; keep those operational checks distinct from the packaged
 fixture.
+
+Latest refresh (2026-07-26): same-version dogfood also showed that a successful
+forced reprovision did not restart an already-running service when its unit was
+unchanged. The implementation now serializes refreshes, restores the previous
+bundle if activation fails, and restarts a running service exactly once after a
+successful refresh. Focused tests cover those contracts. The remaining evidence
+is still the installed-main replay: use an explicit checkout bundle URL for
+unreleased dogfood, verify the unchanged-unit restart receipt, then confirm the
+managed lockfile and live service both identify the merged generation.

--- a/wiki/log.d/20260726T175106Z-managed-web-force-refresh.md
+++ b/wiki/log.d/20260726T175106Z-managed-web-force-refresh.md
@@ -1,0 +1,33 @@
+---
+title: Forced web install refreshes same-version bundles
+type: log
+tags: [web, install, systemd, dogfood, bugfix]
+---
+
+# Forced web install refreshes same-version bundles
+
+A current-main dogfood deployment exposed an identity gap in managed Hive web:
+the service binary could advance while the web bundle retained the same
+`Hive::VERSION` stamp. `AppBundle.ensure!` then treated healthy compiled assets
+as proof that the older app and lockfile were current, so the replacement
+service booted against stale dependencies.
+
+`hive web install --force` now forces the existing staged dependency and asset
+preparation path before rollback-safe bundle activation, even when version and
+asset checks pass. A persistent parent-directory lock serializes refreshes. The
+prepared generation receives its version stamp before activation, the previous
+generation remains available as a sibling backup until activation succeeds,
+and a failed activation restores it. Ordinary web startup still avoids all
+provisioning work for a healthy current bundle.
+
+If a successful refresh leaves the service unit unchanged, install now restarts
+an already-running service exactly once so it consumes the new bundle. A unit
+upgrade's existing restart is not duplicated. The CLI help discloses both the
+bundle refresh and service-unit overwrite scope. `--no-bootstrap` remains
+authoritative, and the signed-release default fails closed before service
+mutation if download, verification, or preparation fails.
+
+Focused tests pin the no-op/forced split, activation rollback, restart
+coordination, help text, and force propagation. The remaining release proof is
+an installed-main same-version repair on real systemd-user plus equivalent
+launchd coverage.

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -495,6 +495,14 @@ one gem/source/four-platform skill candidate; verifies manifest digests and
 every archive projection byte against `skills/hive/`; and invokes the privately
 installed candidate binary. The same job then exercises the exact managed web
 archive. Later jobs consume those artifacts without rebuilding them.
+Focused managed-web unit coverage additionally distinguishes ordinary healthy
+same-version bootstrap (no work) from explicit `hive web install --force`
+(staged dependency/asset reprovision plus rollback-safe activation), pins that
+an activation failure restores the previous bundle, and proves the command
+forwards force intent into `Hive::Web::AppBundle.ensure!`. It also proves a
+refresh restarts an unchanged running service exactly once, does not duplicate
+the restart already performed by a unit upgrade, and advertises the mutation
+scope in `hive help web`.
 
 `test/smoke/live_hive_operating_skill_smoke_test.rb` is the four-platform
 OpenClaw/Claude/Codex/Pi harness. It is disabled by default and skips with a


### PR DESCRIPTION
## Summary

- A forced web install now refreshes a healthy same-version managed Rails bundle, so a newly installed Hive binary cannot keep serving an older web app and lockfile merely because both carry the same Hive version stamp.
- Refresh activation is serialized and rollback-safe. A running service consumes the new bundle via exactly one restart, including when its unit is unchanged, while unit upgrades that already restarted are not restarted twice.
- CLI help and the managed wiki now disclose the refresh, service-repair, fail-closed verification, and `--no-bootstrap` boundaries.

## Test plan

- [x] Exact final head: app-bundle regression suite — 46 runs, 178 assertions, 0 failures
- [x] Exact final head: `bundle exec rake coverage` — 10,358 runs, 141,701 assertions, 0 failures, 0 errors, 8 skips; 100.00% lines (59,085/59,085)
- [x] Focused web command, CLI, and wiki-log suites — 96 runs, 412 assertions, 0 failures
- [x] RuboCop on all changed Ruby/test files — 0 offenses
- [x] Structured correctness, reliability, API-contract, agent-native, testing, standards, and independent Claude Opus review; all three validated findings fixed
- [x] Hosted exact-head CI and install smoke — 22/22 contexts passed, including coverage, packaged web bootstrap, Rails/system tests, and launchd service install
- [ ] Post-merge installed-main same-version systemd-user replay

## Notes for reviewer

Current-main dogfood reproduced the bug with a `0.6.9` service binary containing the new PRDigest integration while the healthy managed web bundle still held the older lockfile. Clearing the stamp forced reprovision and immediately restored the service, proving that version-only freshness was the broken boundary.

The default forced refresh still downloads and verifies the signed release bundle before touching the service unit. Unreleased source dogfood must set `HIVE_WEB_BUNDLE_URL=<checkout>/web`; download, signature, preparation, or activation failure leaves the previous bundle and service intact.
