### PR TITLE
feat(agent-runtime): add read-only distribution mirror

### DIFF
--- a/components/agent-cli-runtime/README.md
+++ b/components/agent-cli-runtime/README.md
@@ -4,6 +4,12 @@
 and inspect locally installed headless agent CLIs without owning an agent
 orchestration system.
 
+> [!NOTE]
+> Canonical development, issues, pull requests, and release authority remain in
+> the [Hive monorepo](https://github.com/ivankuznetsov/hive/tree/main/components/agent-cli-runtime).
+> [`ivankuznetsov/agent-cli-runtime`](https://github.com/ivankuznetsov/agent-cli-runtime)
+> is a read-only distribution mirror for focused discovery and release browsing.
+
 It ships immutable profiles for Claude Code, Codex CLI, Pi, and Grok CLI;
 compiles provider-neutral requests into argv/stdin; reports typed capability
 evidence; extracts usage from provider JSON events; and exposes an honest local
@@ -132,6 +138,10 @@ Development remains in the Hive monorepo under
 `components/agent-cli-runtime`. Hive is the primary consumer and HiveBench is
 the first named external adopter. The Hive maintainer team owns compatibility,
 security response, and releases for the package.
+
+The distribution mirror synchronizes from the canonical component tree and
+cannot become an independent development or release source. Contributions and
+security reports follow the Hive repository links above.
 
 ## Development
 

--- a/components/agent-cli-runtime/README.md
+++ b/components/agent-cli-runtime/README.md
@@ -1,19 +1,10 @@
 # Agent CLI Runtime
 
-`agent-cli-runtime` is a small Ruby library for tools that need to describe
-and inspect locally installed headless agent CLIs without owning an agent
-orchestration system.
-
-> [!NOTE]
-> Canonical development, issues, pull requests, and release authority remain in
-> the [Hive monorepo](https://github.com/ivankuznetsov/hive/tree/main/components/agent-cli-runtime).
-> [`ivankuznetsov/agent-cli-runtime`](https://github.com/ivankuznetsov/agent-cli-runtime)
-> is a read-only distribution mirror for focused discovery and release browsing.
-
-It ships immutable profiles for Claude Code, Codex CLI, Pi, and Grok CLI;
-compiles provider-neutral requests into argv/stdin; reports typed capability
-evidence; extracts usage from provider JSON events; and exposes an honest local
-diagnostic command.
+`agent-cli-runtime` is a small Ruby library for tools that integrate with
+locally installed headless agent CLIs. It ships immutable profiles for Claude
+Code, Codex CLI, Pi, and Grok CLI and compiles provider-neutral requests into
+argv/stdin. It also reports typed capability evidence, extracts usage from
+provider JSON events, and exposes an honest local diagnostic command.
 
 ## Install
 
@@ -48,11 +39,11 @@ Compilation does not execute the returned command. Unsupported requested
 controls raise `AgentCliRuntime::UnsupportedCapability` with typed evidence
 instead of silently widening the request.
 
-`permission_mode: nil` deliberately preserves Hive's existing trusted,
-headless behavior: providers with a bypass flag receive that flag. Consumers
-that do not want this compatibility path should pass `"read-only"` or
-`"workspace-write"` explicitly. A profile raises instead of pretending to
-enforce a mode its CLI cannot represent.
+`permission_mode: nil` selects the profile's default non-interactive permission
+flags, which may include a provider's bypass flag. Pass `"read-only"` or
+`"workspace-write"` explicitly when the integration requires that constraint.
+A profile raises instead of pretending to enforce a mode its CLI cannot
+represent.
 
 ## Public API
 
@@ -109,6 +100,16 @@ fail closed when a declared option is not advertised.
 
 ## Inspect local prerequisites
 
+```ruby
+probe = AgentCliRuntime.probe(:codex)
+probe.ready
+probe.version
+probe.auth_configuration.status
+
+# Returns the ready probe or raises AgentCliRuntime::ProbeError.
+AgentCliRuntime.prepare!(:codex)
+```
+
 ```sh
 agent-runtime probe codex
 agent-runtime probe --all --json
@@ -126,41 +127,45 @@ configuration presence, and declared capabilities. `configured` means a
 recognized local file or environment variable is present. It does not mean the
 credential is valid, the provider is online, or the account has quota.
 
-## Scope and compatibility
+## Normalize provider output
 
-The library does not spawn or supervise agents, retry work, run workflows,
-accept artifacts, or interpret Hive state. Provider flags and event formats are
-SemVer-governed public behavior. Additive fields are compatible within 0.1.x;
-removing or changing an existing field or meaning requires a new minor version
-while the gem remains pre-1.0.
+```ruby
+usage = AgentCliRuntime.extract_usage(
+  :codex,
+  "type" => "turn.completed",
+  "usage" => {
+    "input_tokens" => 120,
+    "output_tokens" => 42
+  }
+)
+# => { input: 120, output: 42, cached: 0, model: nil }
 
-Development remains in the Hive monorepo under
-`components/agent-cli-runtime`. Hive is the primary consumer and HiveBench is
-the first named external adopter. The Hive maintainer team owns compatibility,
-security response, and releases for the package.
-
-The distribution mirror synchronizes from the canonical component tree and
-cannot become an independent development or release source. Contributions and
-security reports follow the Hive repository links above.
-
-## Development
-
-```sh
-cd components/agent-cli-runtime
-bundle exec rake test
-gem build agent-cli-runtime.gemspec
+result = AgentCliRuntime.observe(
+  :codex,
+  exit_code: 0,
+  timed_out: false,
+  status: :completed,
+  usage: usage,
+  final_message: "Review complete"
+)
+result.status # => :completed
+result.usage  # => the normalized usage hash
 ```
 
-The root suite includes these package tests plus Hive/package parity coverage;
-run `bundle exec rake test:agent_cli_runtime` from the repository root for the
-standalone component gate alone.
+Malformed or unrelated events return `nil` from `extract_usage`; they do not
+invent zero-token usage. `observe` returns a frozen
+`AgentCliRuntime::ObservableResult` with bounded, redacted diagnostics.
 
-Release instructions live in the repository's `docs/RELEASING.md`. Releases
-use component-scoped tags and publish exact preverified gem bytes through
-RubyGems trusted publishing.
+## Compatibility
+
+Provider flags, event formats, and public value-object fields are
+SemVer-governed behavior. Additive fields are compatible within 0.1.x; removing
+or changing an existing field or meaning requires a new minor version while the
+gem remains pre-1.0.
 
 ## Security
 
 Diagnostics are bounded and redact common credential forms. The library never
 prints credential file contents or environment values. Report vulnerabilities
-through the Hive repository’s security policy.
+privately through the
+[package security policy](https://github.com/ivankuznetsov/agent-cli-runtime/security/policy).

--- a/components/agent-cli-runtime/agent-cli-runtime.gemspec
+++ b/components/agent-cli-runtime/agent-cli-runtime.gemspec
@@ -12,19 +12,18 @@ Gem::Specification.new do |spec|
     result normalization for Claude Code, Codex CLI, Pi, and Grok CLI. It does
     not spawn agents or claim live provider health, quota, or credential validity.
   DESC
-  spec.homepage = "https://github.com/ivankuznetsov/hive"
+  spec.homepage = "https://github.com/ivankuznetsov/agent-cli-runtime"
   spec.license = "MIT"
   spec.required_ruby_version = ">= 3.4.0"
 
   spec.metadata = {
     "homepage_uri" => spec.homepage,
-    "source_code_uri" =>
-      "https://github.com/ivankuznetsov/hive/tree/main/components/agent-cli-runtime",
+    "source_code_uri" => spec.homepage,
     "changelog_uri" =>
-      "https://github.com/ivankuznetsov/hive/blob/main/components/agent-cli-runtime/CHANGELOG.md",
+      "#{spec.homepage}/blob/main/CHANGELOG.md",
     "bug_tracker_uri" => "https://github.com/ivankuznetsov/hive/issues",
     "documentation_uri" =>
-      "https://github.com/ivankuznetsov/hive/blob/main/components/agent-cli-runtime/README.md",
+      "#{spec.homepage}/blob/main/README.md",
     "rubygems_mfa_required" => "true"
   }
 

--- a/components/agent-cli-runtime/mirror/CONTRIBUTING.md
+++ b/components/agent-cli-runtime/mirror/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing
+
+This repository is a read-only distribution mirror. Canonical development,
+tests, release workflows, issues, and pull requests live in the
+[Hive monorepo](https://github.com/ivankuznetsov/hive).
+
+To propose a change:
+
+1. Open or update the package under
+   `components/agent-cli-runtime/` in the Hive repository.
+2. Run the component tests documented in its README.
+3. Open the pull request against `ivankuznetsov/hive`.
+
+Changes are synchronized here from Hive. Commits or pull requests made only
+against this mirror cannot become the canonical package source.

--- a/components/agent-cli-runtime/mirror/SECURITY.md
+++ b/components/agent-cli-runtime/mirror/SECURITY.md
@@ -1,0 +1,7 @@
+# Security
+
+Do not report vulnerabilities through a public issue in this mirror.
+
+Use the [Hive security policy](https://github.com/ivankuznetsov/hive/security/policy)
+and its private vulnerability-reporting channel. Hive is the canonical source
+and security-response owner for `agent-cli-runtime`.

--- a/components/agent-cli-runtime/mirror/mirror-release.yml
+++ b/components/agent-cli-runtime/mirror/mirror-release.yml
@@ -28,11 +28,26 @@ jobs:
           path: mirror
           fetch-depth: 0
 
+      - name: Validate the release request
+        id: request
+        env:
+          VERSION: ${{ inputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "invalid version: $VERSION" >&2
+            exit 1
+          fi
+          echo "version=${VERSION#v}" >> "$GITHUB_OUTPUT"
+          echo "tag_name=components/agent-cli-runtime/$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag_ref=refs/tags/components/agent-cli-runtime/$VERSION" >> "$GITHUB_OUTPUT"
+
       - name: Check out the canonical component tag
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.0.0
         with:
           repository: ivankuznetsov/hive
-          ref: components/agent-cli-runtime/${{ inputs.version }}
+          ref: ${{ steps.request.outputs.tag_ref }}
           path: hive
           fetch-depth: 0
           persist-credentials: false
@@ -43,42 +58,23 @@ jobs:
         with:
           ruby-version: "3.4"
 
-      - name: Validate release identity
+      - name: Require the exact component tag on canonical main
         id: release
         env:
-          VERSION: ${{ inputs.version }}
-        shell: bash
-        run: |
-          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
-            echo "invalid version: $VERSION" >&2
-            exit 1
-          fi
-          actual="$(
-            ruby -Ihive/components/agent-cli-runtime/lib \
-              -ragent_cli_runtime/version \
-              -e 'print AgentCliRuntime::VERSION'
-          )"
-          if test "v$actual" != "$VERSION"; then
-            echo "tag/source version mismatch: $VERSION != v$actual" >&2
-            exit 1
-          fi
-          source_commit="$(git -C hive rev-parse HEAD)"
-          echo "version=$actual" >> "$GITHUB_OUTPUT"
-          echo "source_commit=$source_commit" >> "$GITHUB_OUTPUT"
-
-      - name: Require the component tag on canonical main
-        env:
-          SOURCE_COMMIT: ${{ steps.release.outputs.source_commit }}
+          EXPECTED_VERSION: ${{ steps.request.outputs.version }}
+          TAG_NAME: ${{ steps.request.outputs.tag_name }}
         shell: bash
         run: |
           set -euo pipefail
+          source_commit="$(git -C hive rev-parse HEAD)"
           git -C hive fetch --no-tags --force origin \
             +refs/heads/main:refs/remotes/origin/main
-          if ! git -C hive merge-base --is-ancestor \
-            "$SOURCE_COMMIT" refs/remotes/origin/main; then
-            echo "component tag is not reachable from canonical main" >&2
-            exit 1
-          fi
+          hive/components/agent-cli-runtime/bin/release-preflight \
+            "$TAG_NAME" \
+            "$source_commit" \
+            refs/remotes/origin/main
+          echo "version=$EXPECTED_VERSION" >> "$GITHUB_OUTPUT"
+          echo "source_commit=$source_commit" >> "$GITHUB_OUTPUT"
 
       - name: Require the exact version on RubyGems
         env:
@@ -101,6 +97,39 @@ jobs:
                 versions.any? { |version| version.fetch("number") == expected }
             ' "$EXPECTED_VERSION"
 
+      - name: Require immutable mirror release tags
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          ruleset_ids="$(
+            gh api "repos/$GITHUB_REPOSITORY/rulesets" \
+              --jq '.[] | select(.target == "tag" and .enforcement == "active") | .id'
+          )"
+          immutable=false
+          while IFS= read -r ruleset_id; do
+            test -n "$ruleset_id" || continue
+            if gh api "repos/$GITHUB_REPOSITORY/rulesets/$ruleset_id" |
+              ruby -rjson -e '
+                ruleset = JSON.parse(STDIN.read)
+                includes = ruleset.dig("conditions", "ref_name", "include") || []
+                types = ruleset.fetch("rules", []).map { |rule| rule.fetch("type") }
+                required = %w[update deletion non_fast_forward]
+                immutable = includes.include?("refs/tags/v*") &&
+                  (required - types).empty?
+                exit(immutable ? 0 : 1)
+              '
+            then
+              immutable=true
+              break
+            fi
+          done <<< "$ruleset_ids"
+          if test "$immutable" != true; then
+            echo "active immutable refs/tags/v* ruleset is required" >&2
+            exit 1
+          fi
+
       - name: Create and compare the exact release snapshot tag locally
         env:
           VERSION: ${{ inputs.version }}
@@ -110,13 +139,23 @@ jobs:
           set -euo pipefail
           sync="$RUNNER_TEMP/agent-cli-runtime-mirror-sync.rb"
           expected="$RUNNER_TEMP/expected-release-snapshot"
-          cp mirror/.github/mirror/sync.rb "$sync"
+          git -C hive show \
+            refs/remotes/origin/main:components/agent-cli-runtime/mirror/sync.rb \
+            > "$sync"
+          mkdir -p "$expected"
+          git -C hive archive \
+            "$SOURCE_COMMIT:components/agent-cli-runtime" |
+            tar -x -C "$expected" --exclude=mirror --exclude='mirror/*'
+          ruby -rjson -e '
+            source_commit, destination = ARGV
+            payload = {
+              repository: "ivankuznetsov/hive",
+              component_path: "components/agent-cli-runtime",
+              source_commit: source_commit
+            }
+            File.write(destination, "#{JSON.pretty_generate(payload)}\n")
+          ' "$SOURCE_COMMIT" "$expected/.mirror-source.json"
           git init -q "$expected"
-          ruby "$sync" \
-            hive/components/agent-cli-runtime \
-            "$expected" \
-            "$SOURCE_COMMIT" \
-            --release
           git -C "$expected" add --all
           expected_tree="$(git -C "$expected" write-tree)"
 

--- a/components/agent-cli-runtime/mirror/mirror-release.yml
+++ b/components/agent-cli-runtime/mirror/mirror-release.yml
@@ -1,0 +1,211 @@
+name: Mirror a component release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Existing component version, including the leading v
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: agent-cli-runtime-mirror-release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    if: github.repository == 'ivankuznetsov/agent-cli-runtime'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out the distribution mirror
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.0.0
+        with:
+          path: mirror
+          fetch-depth: 0
+
+      - name: Check out the canonical component tag
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.0.0
+        with:
+          repository: ivankuznetsov/hive
+          ref: components/agent-cli-runtime/${{ inputs.version }}
+          path: hive
+          fetch-depth: 0
+          persist-credentials: false
+          sparse-checkout: components/agent-cli-runtime
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # pinned 2026-07-26
+        with:
+          ruby-version: "3.4"
+
+      - name: Validate release identity
+        id: release
+        env:
+          VERSION: ${{ inputs.version }}
+        shell: bash
+        run: |
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "invalid version: $VERSION" >&2
+            exit 1
+          fi
+          actual="$(
+            ruby -Ihive/components/agent-cli-runtime/lib \
+              -ragent_cli_runtime/version \
+              -e 'print AgentCliRuntime::VERSION'
+          )"
+          if test "v$actual" != "$VERSION"; then
+            echo "tag/source version mismatch: $VERSION != v$actual" >&2
+            exit 1
+          fi
+          source_commit="$(git -C hive rev-parse HEAD)"
+          echo "version=$actual" >> "$GITHUB_OUTPUT"
+          echo "source_commit=$source_commit" >> "$GITHUB_OUTPUT"
+
+      - name: Require the component tag on canonical main
+        env:
+          SOURCE_COMMIT: ${{ steps.release.outputs.source_commit }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          git -C hive fetch --no-tags --force origin \
+            +refs/heads/main:refs/remotes/origin/main
+          if ! git -C hive merge-base --is-ancestor \
+            "$SOURCE_COMMIT" refs/remotes/origin/main; then
+            echo "component tag is not reachable from canonical main" >&2
+            exit 1
+          fi
+
+      - name: Require the exact version on RubyGems
+        env:
+          EXPECTED_VERSION: ${{ steps.release.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl --fail --silent --show-error --location \
+            --connect-timeout 5 \
+            --max-time 20 \
+            --retry 3 \
+            --retry-delay 2 \
+            --retry-max-time 60 \
+            --retry-all-errors \
+            https://rubygems.org/api/v1/versions/agent-cli-runtime.json |
+            ruby -rjson -e '
+              expected = ARGV.fetch(0)
+              versions = JSON.parse(STDIN.read)
+              abort "RubyGems does not contain exact version #{expected}" unless
+                versions.any? { |version| version.fetch("number") == expected }
+            ' "$EXPECTED_VERSION"
+
+      - name: Create and compare the exact release snapshot tag locally
+        env:
+          VERSION: ${{ inputs.version }}
+          SOURCE_COMMIT: ${{ steps.release.outputs.source_commit }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          sync="$RUNNER_TEMP/agent-cli-runtime-mirror-sync.rb"
+          expected="$RUNNER_TEMP/expected-release-snapshot"
+          cp mirror/.github/mirror/sync.rb "$sync"
+          git init -q "$expected"
+          ruby "$sync" \
+            hive/components/agent-cli-runtime \
+            "$expected" \
+            "$SOURCE_COMMIT" \
+            --release
+          git -C "$expected" add --all
+          expected_tree="$(git -C "$expected" write-tree)"
+
+          if git -C mirror rev-parse --verify --quiet \
+            "refs/tags/$VERSION^{commit}" >/dev/null; then
+            actual_tree="$(
+              git -C mirror rev-parse "refs/tags/$VERSION^{tree}"
+            )"
+            test "$actual_tree" = "$expected_tree"
+            echo "Existing mirror tag $VERSION exactly matches the canonical snapshot."
+            exit 0
+          fi
+
+          git -C mirror config user.name "github-actions[bot]"
+          git -C mirror config user.email \
+            "41898282+github-actions[bot]@users.noreply.github.com"
+          git -C mirror switch --orphan \
+            "mirror-release-${{ steps.release.outputs.version }}"
+          git -C mirror rm -rf --ignore-unmatch .
+          ruby "$sync" \
+            hive/components/agent-cli-runtime \
+            mirror \
+            "$SOURCE_COMMIT" \
+            --release
+          git -C mirror add --all
+          actual_tree="$(git -C mirror write-tree)"
+          test "$actual_tree" = "$expected_tree"
+          git -C mirror commit -m \
+            "Mirror agent-cli-runtime $VERSION"
+          git -C mirror tag "$VERSION"
+          tag_tree="$(
+            git -C mirror rev-parse "refs/tags/$VERSION^{tree}"
+          )"
+          test "$tag_tree" = "$expected_tree"
+
+      - name: Verify the release snapshot
+        env:
+          VERSION: ${{ inputs.version }}
+        shell: bash
+        run: |
+          snapshot="$RUNNER_TEMP/release-snapshot"
+          mkdir -p "$snapshot"
+          git -C mirror archive "$VERSION" | tar -x -C "$snapshot"
+          (
+            cd "$snapshot"
+            gem build agent-cli-runtime.gemspec \
+              --output "$RUNNER_TEMP/agent-cli-runtime.gem"
+          )
+          gem install "$RUNNER_TEMP/agent-cli-runtime.gem" \
+            --install-dir "$RUNNER_TEMP/gem-home" \
+            --no-document
+          GEM_HOME="$RUNNER_TEMP/gem-home" \
+            GEM_PATH="$RUNNER_TEMP/gem-home" \
+            "$RUNNER_TEMP/gem-home/bin/agent-runtime" --version |
+            grep -Fx "${{ steps.release.outputs.version }}"
+
+      - name: Push the verified release snapshot tag
+        env:
+          VERSION: ${{ inputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          git -C mirror push origin "refs/tags/$VERSION"
+
+      - name: Create the mirror GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        shell: bash
+        run: |
+          if gh release view "$VERSION" \
+            --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Mirror release $VERSION already exists."
+            exit 0
+          fi
+          notes="$RUNNER_TEMP/release-notes.md"
+          printf '%s\n' \
+            "Read-only source snapshot of the component release from the Hive monorepo." \
+            "" \
+            "Install from RubyGems:" \
+            "" \
+            '```sh' \
+            "gem install agent-cli-runtime --version ${{ steps.release.outputs.version }}" \
+            '```' \
+            "" \
+            "Canonical development and release authority remain in https://github.com/ivankuznetsov/hive." \
+            > "$notes"
+          gh release create "$VERSION" \
+            --repo "$GITHUB_REPOSITORY" \
+            --verify-tag \
+            --title "agent-cli-runtime $VERSION" \
+            --notes-file "$notes"

--- a/components/agent-cli-runtime/mirror/sync-from-hive.yml
+++ b/components/agent-cli-runtime/mirror/sync-from-hive.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Synchronize the package tree
         shell: bash
         run: |
-          ruby mirror/.github/mirror/sync.rb \
+          ruby hive/components/agent-cli-runtime/mirror/sync.rb \
             hive/components/agent-cli-runtime \
             mirror \
             "${{ steps.source.outputs.commit }}"

--- a/components/agent-cli-runtime/mirror/sync-from-hive.yml
+++ b/components/agent-cli-runtime/mirror/sync-from-hive.yml
@@ -1,0 +1,94 @@
+name: Sync from Hive monorepo
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 */6 * * *"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: agent-cli-runtime-mirror-sync
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    if: github.repository == 'ivankuznetsov/agent-cli-runtime'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out the distribution mirror
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.0.0
+        with:
+          path: mirror
+          fetch-depth: 1
+
+      - name: Check out canonical Hive main
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.0.0
+        with:
+          repository: ivankuznetsov/hive
+          ref: main
+          path: hive
+          fetch-depth: 0
+          persist-credentials: false
+          sparse-checkout: components/agent-cli-runtime
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # pinned 2026-07-26
+        with:
+          ruby-version: "3.4"
+
+      - name: Resolve the exact component source commit
+        id: source
+        shell: bash
+        run: |
+          source_commit="$(
+            git -C hive log -1 --format=%H -- components/agent-cli-runtime
+          )"
+          if [[ ! "$source_commit" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "could not resolve component source commit" >&2
+            exit 1
+          fi
+          echo "commit=$source_commit" >> "$GITHUB_OUTPUT"
+
+      - name: Synchronize the package tree
+        shell: bash
+        run: |
+          ruby mirror/.github/mirror/sync.rb \
+            hive/components/agent-cli-runtime \
+            mirror \
+            "${{ steps.source.outputs.commit }}"
+
+      - name: Verify the synchronized package
+        shell: bash
+        run: |
+          recorded="$(
+            ruby -rjson -e \
+              'print JSON.parse(File.read(ARGV.fetch(0))).fetch("source_commit")' \
+              mirror/.mirror-source.json
+          )"
+          test "$recorded" = "${{ steps.source.outputs.commit }}"
+          ruby -Imirror/lib -ragent_cli_runtime -e \
+            'abort unless AgentCliRuntime::VERSION.match?(/\A\d+\.\d+\.\d+\z/)'
+          (
+            cd mirror
+            gem build agent-cli-runtime.gemspec \
+              --output "$RUNNER_TEMP/agent-cli-runtime.gem"
+          )
+
+      - name: Commit an updated mirror
+        shell: bash
+        working-directory: mirror
+        run: |
+          git add --all
+          if git diff --cached --quiet; then
+            echo "Mirror already matches the canonical component."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m \
+            "Sync from Hive ${{ steps.source.outputs.commit }}"
+          git push origin HEAD:main

--- a/components/agent-cli-runtime/mirror/sync.rb
+++ b/components/agent-cli-runtime/mirror/sync.rb
@@ -10,7 +10,6 @@ module AgentCliRuntimeMirror
   COMPONENT_PATH = "components/agent-cli-runtime"
   SOURCE_SHA = /\A[0-9a-f]{40}\z/
   ADMIN_FILES = {
-    "sync.rb" => ".github/mirror/sync.rb",
     "sync-from-hive.yml" => ".github/workflows/sync-from-hive.yml",
     "mirror-release.yml" => ".github/workflows/mirror-release.yml",
     "CONTRIBUTING.md" => "CONTRIBUTING.md",
@@ -32,16 +31,10 @@ module AgentCliRuntimeMirror
     reject_source_symlinks!(source)
 
     release = mode == "--release"
-    admin_presence = ADMIN_FILES.keys.to_h do |path|
-      [ path, File.file?(File.join(source, "mirror", path)) ]
-    end
-    reject_partial_admin!(admin_presence) unless release
-    admin_available = admin_presence.values.all?
-    preserve = [ ".git" ]
-    preserve.concat([ ".github", "CONTRIBUTING.md", "SECURITY.md" ]) unless release || admin_available
+    require_complete_admin!(source) unless release
 
-    replace_payload(source, destination, preserve:)
-    install_admin_files(source, destination) if !release && admin_available
+    replace_payload(source, destination, preserve: [ ".git" ])
+    install_admin_files(source, destination) unless release
     write_manifest(destination, source_commit)
   end
 
@@ -72,10 +65,12 @@ module AgentCliRuntimeMirror
     abort "destination is not a Git checkout: #{destination}"
   end
 
-  def reject_partial_admin!(admin_presence)
-    return if admin_presence.values.none? || admin_presence.values.all?
+  def require_complete_admin!(source)
+    missing = ADMIN_FILES.keys.reject do |path|
+      File.file?(File.join(source, "mirror", path))
+    end.sort
+    return if missing.empty?
 
-    missing = admin_presence.reject { |_path, present| present }.keys.sort
     abort "source mirror administration is incomplete: missing #{missing.join(", ")}"
   end
 

--- a/components/agent-cli-runtime/mirror/sync.rb
+++ b/components/agent-cli-runtime/mirror/sync.rb
@@ -1,0 +1,131 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "fileutils"
+require "find"
+require "json"
+
+module AgentCliRuntimeMirror
+  SOURCE_REPOSITORY = "ivankuznetsov/hive"
+  COMPONENT_PATH = "components/agent-cli-runtime"
+  SOURCE_SHA = /\A[0-9a-f]{40}\z/
+  ADMIN_FILES = {
+    "sync.rb" => ".github/mirror/sync.rb",
+    "sync-from-hive.yml" => ".github/workflows/sync-from-hive.yml",
+    "mirror-release.yml" => ".github/workflows/mirror-release.yml",
+    "CONTRIBUTING.md" => "CONTRIBUTING.md",
+    "SECURITY.md" => "SECURITY.md"
+  }.freeze
+
+  module_function
+
+  def run(arguments)
+    source_arg, destination_arg, source_commit, mode, *extra = arguments
+    usage! unless source_arg && destination_arg && source_commit && extra.empty?
+    usage! unless mode.nil? || mode == "--release"
+    abort "invalid source commit: #{source_commit.inspect}" unless source_commit.match?(SOURCE_SHA)
+
+    source = verified_directory(source_arg, "source")
+    destination = verified_directory(destination_arg, "destination")
+    verify_distinct_roots!(source, destination)
+    verify_git_checkout!(destination)
+    reject_source_symlinks!(source)
+
+    release = mode == "--release"
+    admin_presence = ADMIN_FILES.keys.to_h do |path|
+      [ path, File.file?(File.join(source, "mirror", path)) ]
+    end
+    reject_partial_admin!(admin_presence) unless release
+    admin_available = admin_presence.values.all?
+    preserve = [ ".git" ]
+    preserve.concat([ ".github", "CONTRIBUTING.md", "SECURITY.md" ]) unless release || admin_available
+
+    replace_payload(source, destination, preserve:)
+    install_admin_files(source, destination) if !release && admin_available
+    write_manifest(destination, source_commit)
+  end
+
+  def usage!
+    abort "usage: sync.rb SOURCE_COMPONENT DESTINATION SOURCE_COMMIT [--release]"
+  end
+
+  def verified_directory(path, label)
+    expanded = File.expand_path(path)
+    abort "#{label} is not a directory: #{expanded}" unless File.directory?(expanded)
+
+    File.realpath(expanded)
+  end
+
+  def verify_distinct_roots!(source, destination)
+    separator = File::SEPARATOR
+    nested = source == destination ||
+             source.start_with?("#{destination}#{separator}") ||
+             destination.start_with?("#{source}#{separator}")
+    abort "source and destination must be separate trees" if nested
+  end
+
+  def verify_git_checkout!(destination)
+    git = File.join(destination, ".git")
+    state = File.lstat(git)
+    abort "destination .git must be a real directory" unless state.directory? && !state.symlink?
+  rescue Errno::ENOENT
+    abort "destination is not a Git checkout: #{destination}"
+  end
+
+  def reject_partial_admin!(admin_presence)
+    return if admin_presence.values.none? || admin_presence.values.all?
+
+    missing = admin_presence.reject { |_path, present| present }.keys.sort
+    abort "source mirror administration is incomplete: missing #{missing.join(", ")}"
+  end
+
+  def reject_source_symlinks!(source)
+    Find.find(source) do |path|
+      abort "source contains a symlink: #{path}" if File.lstat(path).symlink?
+    end
+  end
+
+  def replace_payload(source, destination, preserve:)
+    Dir.children(destination).each do |entry|
+      next if preserve.include?(entry)
+
+      FileUtils.rm_rf(File.join(destination, entry))
+    end
+
+    Dir.children(source).sort.each do |entry|
+      next if entry == "mirror"
+
+      FileUtils.cp_r(
+        File.join(source, entry),
+        destination,
+        preserve: true
+      )
+    end
+  end
+
+  def install_admin_files(source, destination)
+    ADMIN_FILES.each do |source_name, destination_path|
+      target = File.join(destination, destination_path)
+      FileUtils.mkdir_p(File.dirname(target))
+      FileUtils.cp(
+        File.join(source, "mirror", source_name),
+        target,
+        preserve: true
+      )
+    end
+  end
+
+  def write_manifest(destination, source_commit)
+    payload = {
+      repository: SOURCE_REPOSITORY,
+      component_path: COMPONENT_PATH,
+      source_commit: source_commit
+    }
+    File.write(
+      File.join(destination, ".mirror-source.json"),
+      "#{JSON.pretty_generate(payload)}\n"
+    )
+  end
+end
+
+AgentCliRuntimeMirror.run(ARGV)

--- a/components/agent-cli-runtime/test/gemspec_test.rb
+++ b/components/agent-cli-runtime/test/gemspec_test.rb
@@ -26,4 +26,19 @@ class AgentCliRuntimeGemspecTest < Minitest::Test
 
     assert_equal %w[json open3 timeout], spec.runtime_dependencies.map(&:name).sort
   end
+
+  def test_public_links_use_the_distribution_mirror_and_canonical_issue_tracker
+    spec = Gem::Specification.load(GEMSPEC)
+
+    assert_equal "https://github.com/ivankuznetsov/agent-cli-runtime",
+                 spec.homepage
+    assert_equal spec.homepage, spec.metadata.fetch("homepage_uri")
+    assert_equal spec.homepage, spec.metadata.fetch("source_code_uri")
+    assert_equal "#{spec.homepage}/blob/main/CHANGELOG.md",
+                 spec.metadata.fetch("changelog_uri")
+    assert_equal "#{spec.homepage}/blob/main/README.md",
+                 spec.metadata.fetch("documentation_uri")
+    assert_equal "https://github.com/ivankuznetsov/hive/issues",
+                 spec.metadata.fetch("bug_tracker_uri")
+  end
 end

--- a/components/agent-cli-runtime/test/mirror_test.rb
+++ b/components/agent-cli-runtime/test/mirror_test.rb
@@ -1,0 +1,331 @@
+require_relative "test_helper"
+require "rbconfig"
+require "yaml"
+
+class AgentCliRuntimeMirrorTest < Minitest::Test
+  ROOT = File.expand_path("..", __dir__)
+  MIRROR = File.join(ROOT, "mirror")
+  SYNC = File.join(MIRROR, "sync.rb")
+  WORKFLOW = File.join(MIRROR, "sync-from-hive.yml")
+  RELEASE_WORKFLOW = File.join(MIRROR, "mirror-release.yml")
+  SOURCE_SHA = "a" * 40
+  CHECKOUT_ACTION = "actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09"
+  RUBY_ACTION = "ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b"
+
+  def test_sync_materializes_package_at_root_and_preserves_mirror_admin
+    Dir.mktmpdir("agent-cli-runtime-mirror") do |dir|
+      source = File.join(dir, "source")
+      destination = File.join(dir, "destination")
+      build_source(source)
+      build_destination(destination)
+
+      out, err, status = Open3.capture3(
+        RbConfig.ruby, SYNC, source, destination, SOURCE_SHA
+      )
+
+      assert status.success?, "#{out}\n#{err}"
+      assert_equal "package\n", File.read(File.join(destination, "README.md"))
+      assert_equal "runtime\n",
+                   File.read(File.join(destination, "lib", "runtime.rb"))
+      refute_path_exists File.join(destination, "stale.txt")
+      refute_path_exists File.join(destination, "mirror")
+      assert_path_exists File.join(destination, ".git", "keep")
+      assert_equal "workflow\n",
+                   File.read(
+                     File.join(
+                       destination, ".github", "workflows",
+                       "sync-from-hive.yml"
+                     )
+                   )
+      assert_equal "release workflow\n",
+                   File.read(
+                     File.join(
+                       destination, ".github", "workflows",
+                       "mirror-release.yml"
+                     )
+                   )
+      assert_equal "sync\n",
+                   File.read(
+                     File.join(destination, ".github", "mirror", "sync.rb")
+                   )
+      refute_path_exists(
+        File.join(destination, ".github", "workflows", "old.yml")
+      )
+      assert_equal "contributing\n",
+                   File.read(File.join(destination, "CONTRIBUTING.md"))
+      assert_equal "security\n",
+                   File.read(File.join(destination, "SECURITY.md"))
+
+      manifest = JSON.parse(
+        File.read(File.join(destination, ".mirror-source.json"))
+      )
+      assert_equal(
+        {
+          "repository" => "ivankuznetsov/hive",
+          "component_path" => "components/agent-cli-runtime",
+          "source_commit" => SOURCE_SHA
+        },
+        manifest
+      )
+    end
+  end
+
+  def test_sync_rejects_source_symlinks
+    Dir.mktmpdir("agent-cli-runtime-mirror") do |dir|
+      source = File.join(dir, "source")
+      destination = File.join(dir, "destination")
+      build_source(source)
+      build_destination(destination)
+      File.symlink("/tmp", File.join(source, "unsafe"))
+
+      _out, err, status = Open3.capture3(
+        RbConfig.ruby, SYNC, source, destination, SOURCE_SHA
+      )
+
+      refute status.success?
+      assert_match(/source contains a symlink/, err)
+      assert_path_exists File.join(destination, "stale.txt")
+    end
+  end
+
+  def test_sync_preserves_bootstrap_admin_when_source_has_no_admin_files
+    Dir.mktmpdir("agent-cli-runtime-mirror") do |dir|
+      source = File.join(dir, "source")
+      destination = File.join(dir, "destination")
+      build_source(source)
+      FileUtils.rm_r(File.join(source, "mirror"))
+      build_destination(destination)
+      File.write(File.join(destination, "CONTRIBUTING.md"), "existing\n")
+      File.write(File.join(destination, "SECURITY.md"), "existing\n")
+
+      out, err, status = Open3.capture3(
+        RbConfig.ruby, SYNC, source, destination, SOURCE_SHA
+      )
+
+      assert status.success?, "#{out}\n#{err}"
+      assert_equal "package\n", File.read(File.join(destination, "README.md"))
+      assert_equal(
+        "old\n",
+        File.read(
+          File.join(destination, ".github", "workflows", "old.yml")
+        )
+      )
+      assert_equal(
+        "existing\n",
+        File.read(File.join(destination, "CONTRIBUTING.md"))
+      )
+      assert_equal(
+        "existing\n",
+        File.read(File.join(destination, "SECURITY.md"))
+      )
+    end
+  end
+
+  def test_sync_rejects_partial_admin_before_mutating_destination
+    Dir.mktmpdir("agent-cli-runtime-mirror") do |dir|
+      source = File.join(dir, "source")
+      destination = File.join(dir, "destination")
+      build_source(source)
+      FileUtils.rm(File.join(source, "mirror", "SECURITY.md"))
+      build_destination(destination)
+
+      _out, err, status = Open3.capture3(
+        RbConfig.ruby, SYNC, source, destination, SOURCE_SHA
+      )
+
+      refute status.success?
+      assert_match(/source mirror administration is incomplete/, err)
+      assert_match(/SECURITY\.md/, err)
+      assert_path_exists File.join(destination, "stale.txt")
+      assert_path_exists(
+        File.join(destination, ".github", "workflows", "old.yml")
+      )
+    end
+  end
+
+  def test_release_snapshot_omits_mirror_administration
+    Dir.mktmpdir("agent-cli-runtime-mirror") do |dir|
+      source = File.join(dir, "source")
+      destination = File.join(dir, "destination")
+      build_source(source)
+      build_destination(destination)
+
+      out, err, status = Open3.capture3(
+        RbConfig.ruby, SYNC, source, destination, SOURCE_SHA, "--release"
+      )
+
+      assert status.success?, "#{out}\n#{err}"
+      assert_equal "package\n", File.read(File.join(destination, "README.md"))
+      refute_path_exists File.join(destination, "mirror")
+      refute_path_exists File.join(destination, ".github")
+      refute_path_exists File.join(destination, "CONTRIBUTING.md")
+      refute_path_exists File.join(destination, "SECURITY.md")
+      assert_path_exists File.join(destination, ".mirror-source.json")
+    end
+  end
+
+  def test_mirror_files_are_not_packaged_in_the_gem
+    spec = Gem::Specification.load(
+      File.join(ROOT, "agent-cli-runtime.gemspec")
+    )
+
+    refute spec.files.any? { |path| path.start_with?("mirror/") }
+  end
+
+  def test_workflow_is_one_way_and_repository_scoped
+    assert_instance_of Psych::Nodes::Document, YAML.parse_file(WORKFLOW)
+    assert_instance_of(
+      Psych::Nodes::Document,
+      YAML.parse_file(RELEASE_WORKFLOW)
+    )
+
+    workflow = File.read(WORKFLOW)
+
+    assert_includes workflow, "github.repository == 'ivankuznetsov/agent-cli-runtime'"
+    assert_includes workflow, "contents: write"
+    assert_includes workflow, "repository: ivankuznetsov/hive"
+    assert_actions_are_pinned(workflow)
+    assert_equal 2, workflow.scan("uses: #{CHECKOUT_ACTION}").length
+    assert_equal 1, workflow.scan("uses: #{RUBY_ACTION}").length
+    assert_includes workflow, "mirror/.github/mirror/sync.rb"
+    assert_includes workflow, "cd mirror"
+    assert_includes workflow, "fetch-depth: 1"
+    assert_includes workflow, "fetch-depth: 0"
+    assert_includes workflow, "sparse-checkout: components/agent-cli-runtime"
+
+    release_workflow = File.read(RELEASE_WORKFLOW)
+    assert_includes release_workflow, "contents: write"
+    assert_actions_are_pinned(release_workflow)
+    assert_equal 2, release_workflow.scan("uses: #{CHECKOUT_ACTION}").length
+    assert_equal 1, release_workflow.scan("uses: #{RUBY_ACTION}").length
+    assert_includes(
+      release_workflow,
+      "ref: components/agent-cli-runtime/${{ inputs.version }}"
+    )
+    assert_includes release_workflow, "--release"
+    assert_includes release_workflow, 'cd "$snapshot"'
+    assert_includes release_workflow, "rm -rf --ignore-unmatch ."
+    assert_includes(
+      release_workflow,
+      "sparse-checkout: components/agent-cli-runtime"
+    )
+    assert_includes release_workflow, "gh release create"
+    assert_includes release_workflow, '--notes-file "$notes"'
+    assert_includes(
+      release_workflow,
+      "https://rubygems.org/api/v1/versions/agent-cli-runtime.json"
+    )
+    assert_includes release_workflow, "--connect-timeout 5"
+    assert_includes release_workflow, "--max-time 20"
+    assert_includes release_workflow, "--retry 3"
+    assert_includes(
+      release_workflow,
+      "EXPECTED_VERSION: ${{ steps.release.outputs.version }}"
+    )
+    assert_includes(
+      release_workflow,
+      "+refs/heads/main:refs/remotes/origin/main"
+    )
+    assert_includes release_workflow, "merge-base --is-ancestor"
+    assert_includes release_workflow, 'expected_tree="$(git -C "$expected" write-tree)"'
+    assert_includes release_workflow, '"refs/tags/$VERSION^{tree}"'
+    assert_includes release_workflow, 'test "$actual_tree" = "$expected_tree"'
+    assert_includes release_workflow, 'test "$tag_tree" = "$expected_tree"'
+
+    tag_push = 'git -C mirror push origin "refs/tags/$VERSION"'
+    local_tag = 'git -C mirror tag "$VERSION"'
+    assert_before(
+      release_workflow,
+      "https://rubygems.org/api/v1/versions/agent-cli-runtime.json",
+      tag_push
+    )
+    assert_before release_workflow, "merge-base --is-ancestor", tag_push
+    assert_before(
+      release_workflow,
+      "https://rubygems.org/api/v1/versions/agent-cli-runtime.json",
+      local_tag
+    )
+    assert_before release_workflow, "merge-base --is-ancestor", local_tag
+    assert_last_before(
+      release_workflow,
+      'test "$actual_tree" = "$expected_tree"',
+      local_tag
+    )
+    assert_before(
+      release_workflow,
+      'test "$actual_tree" = "$expected_tree"',
+      tag_push
+    )
+    assert_before(
+      release_workflow,
+      'test "$tag_tree" = "$expected_tree"',
+      tag_push
+    )
+    assert_before(
+      release_workflow,
+      "- name: Verify the release snapshot",
+      tag_push
+    )
+  end
+
+  private
+
+  def assert_actions_are_pinned(content)
+    action_refs = content.scan(/^\s*uses:\s+([^\s#]+)/).flatten
+
+    refute_empty action_refs
+    action_refs.each do |action_ref|
+      assert_match(/@[0-9a-f]{40}\z/, action_ref)
+    end
+  end
+
+  def assert_before(content, first, second)
+    first_index = content.index(first)
+    second_index = content.index(second)
+
+    refute_nil first_index, "missing first workflow contract: #{first}"
+    refute_nil second_index, "missing second workflow contract: #{second}"
+    assert_operator first_index, :<, second_index
+  end
+
+  def assert_last_before(content, first, second)
+    first_index = content.rindex(first)
+    second_index = content.index(second)
+
+    refute_nil first_index, "missing first workflow contract: #{first}"
+    refute_nil second_index, "missing second workflow contract: #{second}"
+    assert_operator first_index, :<, second_index
+  end
+
+  def build_source(source)
+    FileUtils.mkdir_p(File.join(source, "lib"))
+    FileUtils.mkdir_p(File.join(source, "mirror"))
+    File.write(File.join(source, "README.md"), "package\n")
+    File.write(File.join(source, "lib", "runtime.rb"), "runtime\n")
+    File.write(
+      File.join(source, "mirror", "sync-from-hive.yml"),
+      "workflow\n"
+    )
+    File.write(
+      File.join(source, "mirror", "mirror-release.yml"),
+      "release workflow\n"
+    )
+    File.write(
+      File.join(source, "mirror", "CONTRIBUTING.md"),
+      "contributing\n"
+    )
+    File.write(File.join(source, "mirror", "SECURITY.md"), "security\n")
+    File.write(File.join(source, "mirror", "sync.rb"), "sync\n")
+  end
+
+  def build_destination(destination)
+    FileUtils.mkdir_p(File.join(destination, ".git"))
+    FileUtils.mkdir_p(File.join(destination, ".github", "workflows"))
+    File.write(File.join(destination, ".git", "keep"), "keep\n")
+    File.write(File.join(destination, "stale.txt"), "stale\n")
+    File.write(
+      File.join(destination, ".github", "workflows", "old.yml"),
+      "old\n"
+    )
+  end
+end

--- a/components/agent-cli-runtime/test/mirror_test.rb
+++ b/components/agent-cli-runtime/test/mirror_test.rb
@@ -12,7 +12,7 @@ class AgentCliRuntimeMirrorTest < Minitest::Test
   CHECKOUT_ACTION = "actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09"
   RUBY_ACTION = "ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b"
 
-  def test_sync_materializes_package_at_root_and_preserves_mirror_admin
+  def test_sync_materializes_package_at_root_and_installs_mirror_admin
     Dir.mktmpdir("agent-cli-runtime-mirror") do |dir|
       source = File.join(dir, "source")
       destination = File.join(dir, "destination")
@@ -44,10 +44,7 @@ class AgentCliRuntimeMirrorTest < Minitest::Test
                        "mirror-release.yml"
                      )
                    )
-      assert_equal "sync\n",
-                   File.read(
-                     File.join(destination, ".github", "mirror", "sync.rb")
-                   )
+      refute_path_exists File.join(destination, ".github", "mirror")
       refute_path_exists(
         File.join(destination, ".github", "workflows", "old.yml")
       )
@@ -88,7 +85,7 @@ class AgentCliRuntimeMirrorTest < Minitest::Test
     end
   end
 
-  def test_sync_preserves_bootstrap_admin_when_source_has_no_admin_files
+  def test_sync_rejects_missing_admin_before_mutating_destination
     Dir.mktmpdir("agent-cli-runtime-mirror") do |dir|
       source = File.join(dir, "source")
       destination = File.join(dir, "destination")
@@ -98,12 +95,14 @@ class AgentCliRuntimeMirrorTest < Minitest::Test
       File.write(File.join(destination, "CONTRIBUTING.md"), "existing\n")
       File.write(File.join(destination, "SECURITY.md"), "existing\n")
 
-      out, err, status = Open3.capture3(
+      _out, err, status = Open3.capture3(
         RbConfig.ruby, SYNC, source, destination, SOURCE_SHA
       )
 
-      assert status.success?, "#{out}\n#{err}"
-      assert_equal "package\n", File.read(File.join(destination, "README.md"))
+      refute status.success?
+      assert_match(/source mirror administration is incomplete/, err)
+      assert_match(/sync-from-hive\.yml/, err)
+      assert_path_exists File.join(destination, "stale.txt")
       assert_equal(
         "old\n",
         File.read(
@@ -187,7 +186,11 @@ class AgentCliRuntimeMirrorTest < Minitest::Test
     assert_actions_are_pinned(workflow)
     assert_equal 2, workflow.scan("uses: #{CHECKOUT_ACTION}").length
     assert_equal 1, workflow.scan("uses: #{RUBY_ACTION}").length
-    assert_includes workflow, "mirror/.github/mirror/sync.rb"
+    assert_includes(
+      workflow,
+      "ruby hive/components/agent-cli-runtime/mirror/sync.rb"
+    )
+    refute_includes workflow, "mirror/.github/mirror/sync.rb"
     assert_includes workflow, "cd mirror"
     assert_includes workflow, "fetch-depth: 1"
     assert_includes workflow, "fetch-depth: 0"
@@ -200,9 +203,19 @@ class AgentCliRuntimeMirrorTest < Minitest::Test
     assert_equal 1, release_workflow.scan("uses: #{RUBY_ACTION}").length
     assert_includes(
       release_workflow,
-      "ref: components/agent-cli-runtime/${{ inputs.version }}"
+      'echo "tag_ref=refs/tags/components/agent-cli-runtime/$VERSION"'
     )
+    assert_includes release_workflow, "ref: ${{ steps.request.outputs.tag_ref }}"
+    assert_before(
+      release_workflow,
+      "- name: Validate the release request",
+      "- name: Check out the canonical component tag"
+    )
+    assert_includes release_workflow, "bin/release-preflight"
     assert_includes release_workflow, "--release"
+    assert_equal 1, release_workflow.scan('ruby "$sync"').length
+    assert_includes release_workflow, "git -C hive archive"
+    assert_includes release_workflow, "--exclude=mirror"
     assert_includes release_workflow, 'cd "$snapshot"'
     assert_includes release_workflow, "rm -rf --ignore-unmatch ."
     assert_includes(
@@ -226,7 +239,8 @@ class AgentCliRuntimeMirrorTest < Minitest::Test
       release_workflow,
       "+refs/heads/main:refs/remotes/origin/main"
     )
-    assert_includes release_workflow, "merge-base --is-ancestor"
+    assert_includes release_workflow, 'includes.include?("refs/tags/v*")'
+    assert_includes release_workflow, "%w[update deletion non_fast_forward]"
     assert_includes release_workflow, 'expected_tree="$(git -C "$expected" write-tree)"'
     assert_includes release_workflow, '"refs/tags/$VERSION^{tree}"'
     assert_includes release_workflow, 'test "$actual_tree" = "$expected_tree"'
@@ -239,13 +253,19 @@ class AgentCliRuntimeMirrorTest < Minitest::Test
       "https://rubygems.org/api/v1/versions/agent-cli-runtime.json",
       tag_push
     )
-    assert_before release_workflow, "merge-base --is-ancestor", tag_push
+    assert_before release_workflow, "bin/release-preflight", tag_push
+    assert_before release_workflow, "Require immutable mirror release tags", tag_push
     assert_before(
       release_workflow,
       "https://rubygems.org/api/v1/versions/agent-cli-runtime.json",
       local_tag
     )
-    assert_before release_workflow, "merge-base --is-ancestor", local_tag
+    assert_before release_workflow, "bin/release-preflight", local_tag
+    assert_before(
+      release_workflow,
+      "git -C hive archive",
+      'expected_tree="$(git -C "$expected" write-tree)"'
+    )
     assert_last_before(
       release_workflow,
       'test "$actual_tree" = "$expected_tree"',

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -91,22 +91,32 @@ The mirror's `main` branch is synchronized one way from
 schedule or manual dispatch. Each snapshot records its exact canonical
 component commit in `.mirror-source.json`. The sync excludes the component's
 `mirror/` administration directory from the public package tree and preserves
-the mirror-only workflow, contribution, and security files.
+the mirror-only workflow, contribution, and security files. The workflow
+executes the projector from the canonical Hive checkout, so projector and
+administration changes take effect atomically.
 New mirror-only administration must first be added to the canonical
-`mirror/` allowlist in Hive; unsourced target-only files are removed. A fully
-absent admin set is preserved only for initial bootstrap compatibility, while a
-partial canonical admin set fails before mutating the mirror.
+`mirror/` allowlist in Hive; unsourced target-only files are removed. Any
+missing canonical admin file fails before mutating the mirror.
 
 After an approved component version has been published from Hive, manually run
 **Mirror a component release** in the mirror with `vX.Y.Z`. The workflow checks
-out the exact protected `components/agent-cli-runtime/vX.Y.Z` tag, requires its
-commit on canonical `main`, verifies its gemspec version is already available
-from RubyGems, and constructs an orphan source snapshot locally. The complete
-snapshot tree must match the canonical projection before the workflow builds
-and installs it and exercises `agent-runtime --version`. Only then does it push
-the mirror tag and create the GitHub release. Existing mirror tags are accepted
-only when their complete tree matches the newly reconstructed canonical
-snapshot.
+out the fully qualified protected
+`refs/tags/components/agent-cli-runtime/vX.Y.Z` ref and runs the component's
+release preflight against canonical `main`. It then verifies the exact version
+is already available from RubyGems and constructs an orphan source snapshot
+locally. An independent Git archive of the canonical tag, excluding only
+`mirror/` and adding the source manifest, defines the expected tree. The
+projected tree must match it before the workflow builds and installs the gem and
+exercises `agent-runtime --version`. Only then does it push the mirror tag and
+create the GitHub release. Existing mirror tags are accepted only when their
+complete tree matches the independently reconstructed canonical snapshot.
+
+The mirror repository must have an active tag ruleset targeting
+`refs/tags/v*` that restricts updates and deletion and blocks non-fast-forward
+movement. Leave initial creation available to the verified workflow; never add
+a bypass that can replace an existing release tag. The workflow checks the live
+ruleset through the GitHub API and refuses to create a local release tag when
+the immutable-tag policy is absent.
 
 The mirror workflow never pushes to Hive or RubyGems and cannot choose or
 publish a version. Do not accept issues, pull requests, independent commits, or

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -78,6 +78,42 @@ never overwrite or reuse it: keep Hive's cutover blocked and prepare a
 separately approved fix-forward version. Yanking or transferring ownership
 requires separate explicit authorization.
 
+### Distribution mirror
+
+[`ivankuznetsov/agent-cli-runtime`](https://github.com/ivankuznetsov/agent-cli-runtime)
+is a public, read-only distribution mirror. It gives the gem a focused
+description, topics, source browser, and release history without splitting
+development across repositories. Hive remains the canonical source, issue
+tracker, pull-request surface, and release authority.
+
+The mirror's `main` branch is synchronized one way from
+`components/agent-cli-runtime/` by **Sync from Hive monorepo**, on a six-hour
+schedule or manual dispatch. Each snapshot records its exact canonical
+component commit in `.mirror-source.json`. The sync excludes the component's
+`mirror/` administration directory from the public package tree and preserves
+the mirror-only workflow, contribution, and security files.
+New mirror-only administration must first be added to the canonical
+`mirror/` allowlist in Hive; unsourced target-only files are removed. A fully
+absent admin set is preserved only for initial bootstrap compatibility, while a
+partial canonical admin set fails before mutating the mirror.
+
+After an approved component version has been published from Hive, manually run
+**Mirror a component release** in the mirror with `vX.Y.Z`. The workflow checks
+out the exact protected `components/agent-cli-runtime/vX.Y.Z` tag, requires its
+commit on canonical `main`, verifies its gemspec version is already available
+from RubyGems, and constructs an orphan source snapshot locally. The complete
+snapshot tree must match the canonical projection before the workflow builds
+and installs it and exercises `agent-runtime --version`. Only then does it push
+the mirror tag and create the GitHub release. Existing mirror tags are accepted
+only when their complete tree matches the newly reconstructed canonical
+snapshot.
+
+The mirror workflow never pushes to Hive or RubyGems and cannot choose or
+publish a version. Do not accept issues, pull requests, independent commits, or
+release decisions there. Changes flow through Hive first; running the mirror
+jobs is a distribution follow-up, not release authority. Both mirror workflows
+pin third-party Actions to reviewed commit SHAs.
+
 A maintainer's explicit `vX.Y.Z` tag triggers `.github/workflows/release.yml`.
 The workflow requires no model-provider credentials. On GitHub-hosted runners,
 it proves the exact tag candidate as follows:

--- a/wiki/component-boundaries.md
+++ b/wiki/component-boundaries.md
@@ -54,6 +54,13 @@ parity tests prevent the temporary publication-window copy from drifting.
 Landing the package does not change Hive's gem dependency graph. See
 [[modules/agent_cli_runtime]] for the public surface and release boundary.
 
+Its public standalone repository is deliberately a one-way distribution
+projection. Scheduled main snapshots and manually requested release snapshots
+record the exact Hive component commit, while development, issues, pull
+requests, version selection, and RubyGems publication remain owned by this
+monorepo. The mirror improves focused discovery without creating a second
+source of truth.
+
 ## Catalog contract
 
 `config/component-boundaries.yml` is the canonical agent-readable inventory.

--- a/wiki/component-boundaries.md
+++ b/wiki/component-boundaries.md
@@ -56,10 +56,12 @@ Landing the package does not change Hive's gem dependency graph. See
 
 Its public standalone repository is deliberately a one-way distribution
 projection. Scheduled main snapshots and manually requested release snapshots
-record the exact Hive component commit, while development, issues, pull
-requests, version selection, and RubyGems publication remain owned by this
-monorepo. The mirror improves focused discovery without creating a second
-source of truth.
+record the exact Hive component commit. The canonical checkout owns projection
+logic and the release workflow independently reconstructs the expected tag tree
+before publication; immutable mirror tag rules protect that verified result.
+Development, issues, pull requests, version selection, and RubyGems publication
+remain owned by this monorepo. The mirror improves focused discovery without
+creating a second source of truth.
 
 ## Catalog contract
 

--- a/wiki/log.d/20260726T211937Z-agent-cli-runtime-distribution-mirror.md
+++ b/wiki/log.d/20260726T211937Z-agent-cli-runtime-distribution-mirror.md
@@ -1,0 +1,26 @@
+# 2026-07-26 — Add a read-only Agent CLI Runtime distribution mirror
+
+**Why:** `agent-cli-runtime` needs a focused public description, source browser,
+and release history for people who discover the gem independently, while Hive
+must remain the single agent-friendly development workspace and release
+authority.
+
+**Change:** Added fail-closed mirror tooling under
+`components/agent-cli-runtime/mirror/`. A scheduled or manually dispatched
+workflow projects the component onto the mirror's `main` branch and records the
+exact canonical component commit in `.mirror-source.json`. A separate manual
+workflow projects an already approved component tag to an orphan mirror tag,
+requires it on canonical main and present on RubyGems, reconstructs and compares
+the complete canonical tree, builds and installs the local snapshot, proves the
+executable version, and only then pushes the tag and creates the mirror GitHub
+release. Third-party Actions are commit-pinned. Tests cover stale-file removal,
+symlink rejection before mutation, absent-versus-partial administration-file
+handling, package exclusion, workflow YAML parsing, repository scoping,
+provenance, and verification-before-publication ordering.
+
+**Boundary:** `ivankuznetsov/agent-cli-runtime` is a read-only distribution
+surface. It cannot push to Hive or RubyGems, choose a version, or become an
+independent contribution path. Canonical development, issues, pull requests,
+component tags, trusted publication, and security ownership remain in Hive.
+The gem version was not changed or republished for this metadata and
+distribution-only addition.

--- a/wiki/log.d/20260726T211937Z-agent-cli-runtime-distribution-mirror.md
+++ b/wiki/log.d/20260726T211937Z-agent-cli-runtime-distribution-mirror.md
@@ -10,13 +10,14 @@ authority.
 workflow projects the component onto the mirror's `main` branch and records the
 exact canonical component commit in `.mirror-source.json`. A separate manual
 workflow projects an already approved component tag to an orphan mirror tag,
-requires it on canonical main and present on RubyGems, reconstructs and compares
-the complete canonical tree, builds and installs the local snapshot, proves the
-executable version, and only then pushes the tag and creates the mirror GitHub
+requires the exact protected tag on canonical main and present on RubyGems,
+independently reconstructs and compares the complete canonical tree, builds and
+installs the local snapshot, proves the executable version, requires immutable
+mirror release tags, and only then pushes the tag and creates the mirror GitHub
 release. Third-party Actions are commit-pinned. Tests cover stale-file removal,
-symlink rejection before mutation, absent-versus-partial administration-file
-handling, package exclusion, workflow YAML parsing, repository scoping,
-provenance, and verification-before-publication ordering.
+symlink rejection before mutation, strict administration completeness, package
+exclusion, workflow YAML parsing, repository scoping, provenance, and
+verification-before-publication ordering.
 
 **Boundary:** `ivankuznetsov/agent-cli-runtime` is a read-only distribution
 surface. It cannot push to Hive or RubyGems, choose a version, or become an

--- a/wiki/log.d/20260727T094500Z-agent-cli-runtime-mirror-integrity.md
+++ b/wiki/log.d/20260727T094500Z-agent-cli-runtime-mirror-integrity.md
@@ -1,0 +1,19 @@
+# 2026-07-27 — Make Agent CLI Runtime mirror provenance fail closed
+
+**Why:** The first mirror implementation let an unqualified release ref prefer
+a same-named branch, executed a stale mirror-side projector, compared two trees
+produced by that same projector, preserved all stale administration when the
+canonical set disappeared, and relied on a mutable live release tag.
+
+**Change:** Mirror sync now executes the projector from canonical Hive and
+requires the complete canonical administration set before mutation. Mirror
+release checkout uses the fully qualified component tag and the component
+release preflight. Its expected tree comes from an independent Git archive of
+the canonical tag, while the actual tree uses the current canonical projector.
+The workflow also refuses release unless the live mirror has an active
+`refs/tags/v*` ruleset blocking updates, deletion, and non-fast-forward
+movement.
+
+**Boundary:** Hive remains the only projection and release authority. The
+mirror may create a verified tag once, but neither a later workflow run nor a
+repository writer may replace or delete that published snapshot.

--- a/wiki/modules/agent_cli_runtime.md
+++ b/wiki/modules/agent_cli_runtime.md
@@ -93,13 +93,16 @@ The public
 repository is a read-only distribution projection, not a second development
 home. Its scheduled or manually dispatched sync copies this component to the
 mirror root and writes `.mirror-source.json` with the exact canonical component
-commit. A separate manual mirror workflow projects an already approved
-component tag to an orphan `vX.Y.Z` source-snapshot tag, verifies the snapshot
-commit is on canonical main and its exact version is already on RubyGems,
-reconstructs and compares the complete canonical tree, verifies that local tag
-as an installable gem, and only then pushes it and creates the focused GitHub
-release. Neither mirror workflow can modify Hive, publish RubyGems bytes, or
-choose a version; issues, pull requests, and release authority stay here.
+commit. The mirror invokes the projector from the canonical checkout and
+requires the complete canonical admin set before mutation. A separate manual
+mirror workflow projects an already approved, fully qualified component tag to
+an orphan `vX.Y.Z` source-snapshot tag. It reuses the component release
+preflight, verifies the exact version is already on RubyGems, compares the
+projected tree with an independently archived canonical tree, requires a live
+immutable `refs/tags/v*` ruleset, verifies the local tag as an installable gem,
+and only then pushes it and creates the focused GitHub release. Neither mirror
+workflow can modify Hive, publish RubyGems bytes, or choose a version; issues,
+pull requests, and release authority stay here.
 
 ## Compatibility
 

--- a/wiki/modules/agent_cli_runtime.md
+++ b/wiki/modules/agent_cli_runtime.md
@@ -1,7 +1,7 @@
 ---
 title: Agent CLI Runtime component
 type: module
-source: components/agent-cli-runtime, .github/workflows/agent-cli-runtime-release.yml
+source: components/agent-cli-runtime, components/agent-cli-runtime/mirror, .github/workflows/agent-cli-runtime-release.yml
 created: 2026-07-26
 updated: 2026-07-26
 tags: [agent, runtime, component, gem, cli]
@@ -87,6 +87,19 @@ survive reviewer delay. Repository operators must separately enforce a
 component-tag ruleset, required reviewers on the release environment, and an
 environment deployment policy restricted to matching component tags. See
 `docs/RELEASING.md`.
+
+The public
+[`ivankuznetsov/agent-cli-runtime`](https://github.com/ivankuznetsov/agent-cli-runtime)
+repository is a read-only distribution projection, not a second development
+home. Its scheduled or manually dispatched sync copies this component to the
+mirror root and writes `.mirror-source.json` with the exact canonical component
+commit. A separate manual mirror workflow projects an already approved
+component tag to an orphan `vX.Y.Z` source-snapshot tag, verifies the snapshot
+commit is on canonical main and its exact version is already on RubyGems,
+reconstructs and compares the complete canonical tree, verifies that local tag
+as an installable gem, and only then pushes it and creates the focused GitHub
+release. Neither mirror workflow can modify Hive, publish RubyGems bytes, or
+choose a version; issues, pull requests, and release authority stay here.
 
 ## Compatibility
 


### PR DESCRIPTION
## Summary

- `agent-cli-runtime` now has a focused public source and release surface without splitting development, issues, or release authority out of Hive. A one-way projection keeps [`ivankuznetsov/agent-cli-runtime`](https://github.com/ivankuznetsov/agent-cli-runtime) synchronized from the canonical component.
- Gem metadata sends package discovery and documentation to the focused mirror while contributions, security reports, and implementation changes continue through Hive.
- Mirror sync executes Hive's canonical projector and requires the complete canonical administration set before mutation.
- Mirror releases accept only a fully qualified protected component tag, reuse the canonical release preflight, require the version on RubyGems, compare the projected snapshot with an independently archived canonical tree, and require immutable live `v*` tags before publication.

Session-settled decisions carried from planning: keep one canonical monorepo (user-approved); keep Hive as the primary consumer (user-directed); use explicit releases (user-approved); ship Agent CLI Runtime first (user-approved).

## Test plan

- [x] Component suite: 43 runs, 407 assertions, 0 failures, 0 errors
- [x] Broad Hive checkpoint: 10,297 runs, 141,489 assertions, 0 failures, 0 errors, 8 skips
- [x] RuboCop on changed Ruby files: 2 files, no offenses
- [x] Workflow YAML parse and embedded Bash syntax checks
- [x] Independent `v0.1.0` reconstruction: expected, projected, and live tag trees all equal `6db8b86a3e8359bdf1c1370564fed5cfa8145944`
- [x] Live immutable mirror tag ruleset: [`19806938`](https://github.com/ivankuznetsov/agent-cli-runtime/rules/19806938), active with no bypass actors
- [x] Earlier live mirror sync and release replay for `v0.1.0`
- [ ] Fresh exact-head hosted CI

## Notes for reviewer

- The public repository is a read-only distribution mirror. Hive remains canonical.
- Every mirror main snapshot records the exact component commit in `.mirror-source.json`.
- Release tags contain only the projected package tree, not mirror-administration workflows.
- The release expected tree is derived independently from the canonical Git tag; it does not trust the projector under test to define both sides of the comparison.
- This does not change the gem version or republish RubyGems. The existing `agent-cli-runtime` 0.1.0 release was only mirrored to GitHub.

## Post-Deploy Monitoring & Validation

- **Signals:** `Sync from Hive monorepo`, `Mirror a component release`, `.mirror-source.json`, and the active immutable-tag ruleset.
- **Healthy:** scheduled syncs stay green; the manifest names the latest canonical component commit; release tags exactly match the independently reconstructed canonical tree; and the installed CLI reports the requested version.
- **Failure and mitigation:** a missing admin file, tag/ref mismatch, non-main source commit, missing RubyGems version, ruleset drift, or tree mismatch blocks distribution. Fix Hive or the mirror settings and rerun; never force or replace an existing release tag.
- **Window and owner:** Hive maintainers check the next six-hour scheduled sync and every component-release follow-up.

## New concepts

### Distribution mirror as a projection

A distribution mirror is a derived public view, not a second source repository. It gives a package focused discovery and release history while preserving one place for development decisions.

```mermaid
flowchart LR
  H[Hive canonical component] -->|scheduled exact projection| M[Mirror main]
  H -->|protected tag and independent tree proof| R[Immutable mirror release tag]
  M -. no reverse sync .-> H
  R -. no version or RubyGems authority .-> H
```

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
