### PR TITLE
fix(agent-runtime): unblock canonical mirror synchronization

### DIFF
--- a/components/agent-cli-runtime/mirror/mirror-release.yml
+++ b/components/agent-cli-runtime/mirror/mirror-release.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           path: mirror
           fetch-depth: 0
+          ssh-key: ${{ secrets.MIRROR_DEPLOY_KEY }}
 
       - name: Validate the release request
         id: request

--- a/components/agent-cli-runtime/mirror/sync-from-hive.yml
+++ b/components/agent-cli-runtime/mirror/sync-from-hive.yml
@@ -6,7 +6,7 @@ on:
     - cron: "17 */6 * * *"
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: agent-cli-runtime-mirror-sync
@@ -24,6 +24,7 @@ jobs:
         with:
           path: mirror
           fetch-depth: 1
+          ssh-key: ${{ secrets.MIRROR_DEPLOY_KEY }}
 
       - name: Check out canonical Hive main
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.0.0

--- a/components/agent-cli-runtime/test/mirror_test.rb
+++ b/components/agent-cli-runtime/test/mirror_test.rb
@@ -181,7 +181,8 @@ class AgentCliRuntimeMirrorTest < Minitest::Test
     workflow = File.read(WORKFLOW)
 
     assert_includes workflow, "github.repository == 'ivankuznetsov/agent-cli-runtime'"
-    assert_includes workflow, "contents: write"
+    assert_includes workflow, "contents: read"
+    assert_includes workflow, "ssh-key: ${{ secrets.MIRROR_DEPLOY_KEY }}"
     assert_includes workflow, "repository: ivankuznetsov/hive"
     assert_actions_are_pinned(workflow)
     assert_equal 2, workflow.scan("uses: #{CHECKOUT_ACTION}").length
@@ -198,6 +199,10 @@ class AgentCliRuntimeMirrorTest < Minitest::Test
 
     release_workflow = File.read(RELEASE_WORKFLOW)
     assert_includes release_workflow, "contents: write"
+    assert_includes(
+      release_workflow,
+      "ssh-key: ${{ secrets.MIRROR_DEPLOY_KEY }}"
+    )
     assert_actions_are_pinned(release_workflow)
     assert_equal 2, release_workflow.scan("uses: #{CHECKOUT_ACTION}").length
     assert_equal 1, release_workflow.scan("uses: #{RUBY_ACTION}").length

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -90,13 +90,22 @@ The mirror's `main` branch is synchronized one way from
 `components/agent-cli-runtime/` by **Sync from Hive monorepo**, on a six-hour
 schedule or manual dispatch. Each snapshot records its exact canonical
 component commit in `.mirror-source.json`. The sync excludes the component's
-`mirror/` administration directory from the public package tree and preserves
-the mirror-only workflow, contribution, and security files. The workflow
+`mirror/` administration directory from the public package tree and installs
+the canonical workflow, contribution, and security files. The workflow
 executes the projector from the canonical Hive checkout, so projector and
 administration changes take effect atomically.
 New mirror-only administration must first be added to the canonical
 `mirror/` allowlist in Hive; unsourced target-only files are removed. Any
 missing canonical admin file fails before mutating the mirror.
+
+Both mirror workflows use the repository-scoped private deploy key in the
+`MIRROR_DEPLOY_KEY` Actions secret for Git pushes. Its public half must be a
+write-enabled deploy key on `ivankuznetsov/agent-cli-runtime`, and the private
+half must not be reused by any other repository. This credential is required
+because GitHub's generated `GITHUB_TOKEN` cannot update files under
+`.github/workflows`, even with `contents: write`. The sync otherwise keeps its
+generated token read-only; the release workflow uses that short-lived token
+only for ruleset inspection and GitHub release creation.
 
 After an approved component version has been published from Hive, manually run
 **Mirror a component release** in the mirror with `vX.Y.Z`. The workflow checks
@@ -111,12 +120,13 @@ exercises `agent-runtime --version`. Only then does it push the mirror tag and
 create the GitHub release. Existing mirror tags are accepted only when their
 complete tree matches the independently reconstructed canonical snapshot.
 
-The mirror repository must have an active tag ruleset targeting
-`refs/tags/v*` that restricts updates and deletion and blocks non-fast-forward
-movement. Leave initial creation available to the verified workflow; never add
-a bypass that can replace an existing release tag. The workflow checks the live
-ruleset through the GitHub API and refuses to create a local release tag when
-the immutable-tag policy is absent.
+The mirror repository must have the `MIRROR_DEPLOY_KEY` credential described
+above and an active tag ruleset targeting `refs/tags/v*` that restricts updates
+and deletion and blocks non-fast-forward movement. Leave initial creation
+available to the verified workflow; never add a bypass that can replace an
+existing release tag. The workflow checks the live ruleset through the GitHub
+API and refuses to create a local release tag when the immutable-tag policy is
+absent.
 
 The mirror workflow never pushes to Hive or RubyGems and cannot choose or
 publish a version. Do not accept issues, pull requests, independent commits, or

--- a/wiki/component-boundaries.md
+++ b/wiki/component-boundaries.md
@@ -58,10 +58,12 @@ Its public standalone repository is deliberately a one-way distribution
 projection. Scheduled main snapshots and manually requested release snapshots
 record the exact Hive component commit. The canonical checkout owns projection
 logic and the release workflow independently reconstructs the expected tag tree
-before publication; immutable mirror tag rules protect that verified result.
-Development, issues, pull requests, version selection, and RubyGems publication
-remain owned by this monorepo. The mirror improves focused discovery without
-creating a second source of truth.
+before publication. Repository-scoped deploy-key authentication lets canonical
+administration updates include workflow files without granting cross-repository
+access; immutable mirror tag rules protect the verified result. Development,
+issues, pull requests, version selection, and RubyGems publication remain owned
+by this monorepo. The mirror improves focused discovery without creating a
+second source of truth.
 
 ## Catalog contract
 

--- a/wiki/log.d/20260727T101850Z-agent-cli-runtime-mirror-deploy-key.md
+++ b/wiki/log.d/20260727T101850Z-agent-cli-runtime-mirror-deploy-key.md
@@ -1,0 +1,18 @@
+# 2026-07-27 — Give the Agent CLI Runtime mirror a scoped Git writer
+
+**Why:** Live dogfooding showed that GitHub rejects a mirror sync commit when
+the generated Actions token changes `.github/workflows`, even when the workflow
+has `contents: write`. The package projection and build passed, but the final
+push could not install canonical administration.
+
+**Change:** Both mirror workflows now authenticate their mirror checkout with
+the write-enabled, repository-scoped deploy key stored as
+`MIRROR_DEPLOY_KEY`. Sync reduces its generated token to `contents: read`;
+release keeps that short-lived token only for ruleset inspection and GitHub
+release creation. Tests and operator documentation cover the credential
+boundary.
+
+**Boundary:** The deploy key can clone and push only
+`ivankuznetsov/agent-cli-runtime`; it grants no Hive or RubyGems authority and
+must not be reused. Canonical source, administration, version selection, and
+publication remain in Hive.

--- a/wiki/modules/agent_cli_runtime.md
+++ b/wiki/modules/agent_cli_runtime.md
@@ -94,15 +94,18 @@ repository is a read-only distribution projection, not a second development
 home. Its scheduled or manually dispatched sync copies this component to the
 mirror root and writes `.mirror-source.json` with the exact canonical component
 commit. The mirror invokes the projector from the canonical checkout and
-requires the complete canonical admin set before mutation. A separate manual
-mirror workflow projects an already approved, fully qualified component tag to
-an orphan `vX.Y.Z` source-snapshot tag. It reuses the component release
-preflight, verifies the exact version is already on RubyGems, compares the
-projected tree with an independently archived canonical tree, requires a live
-immutable `refs/tags/v*` ruleset, verifies the local tag as an installable gem,
-and only then pushes it and creates the focused GitHub release. Neither mirror
-workflow can modify Hive, publish RubyGems bytes, or choose a version; issues,
-pull requests, and release authority stay here.
+requires the complete canonical admin set before mutation. Mirror Git writes
+use a repository-scoped deploy key because GitHub's generated token cannot
+update workflow files; API reads and release creation retain the shorter-lived
+generated token. A separate manual mirror workflow projects an already
+approved, fully qualified component tag to an orphan `vX.Y.Z` source-snapshot
+tag. It reuses the component release preflight, verifies the exact version is
+already on RubyGems, compares the projected tree with an independently archived
+canonical tree, requires a live immutable `refs/tags/v*` ruleset, verifies the
+local tag as an installable gem, and only then pushes it and creates the focused
+GitHub release. Neither mirror workflow can modify Hive, publish RubyGems
+bytes, or choose a version; issues, pull requests, and release authority stay
+here.
 
 ## Compatibility
 


### PR DESCRIPTION
## Summary

- Restore one-way mirror synchronization when a canonical snapshot changes `.github/workflows`; the first live run after #895 built successfully but GitHub rejected its final push because `GITHUB_TOKEN` has no Workflows permission.
- Confine Git writes to a write-enabled deploy key attached only to `ivankuznetsov/agent-cli-runtime`. Sync reduces its generated token to read-only, while release retains the short-lived token only for ruleset inspection and GitHub release creation.

Related: #895

## Test plan

- [x] `bundle exec rake test:agent_cli_runtime` — 43 runs, 411 assertions, 0 failures or errors
- [x] YAML parsing for both projected workflows
- [x] RuboCop for the changed Ruby contract test
- [x] GitHub accepted and verified repository deploy key `158463063`; `MIRROR_DEPLOY_KEY` is installed as an Actions secret
- [ ] After merge, bootstrap the canonical workflow once, then run the live sync twice to prove the deploy-key push and no-op path
- [ ] Replay the existing `v0.1.0` mirror-release workflow and verify the protected snapshot remains exact

## Notes for reviewer

The failing live run was `ivankuznetsov/agent-cli-runtime` Actions run `30257408055`: projection, manifest verification, and gem build passed; only the workflow-file push was rejected. The deployed workflow cannot consume the new secret until a maintainer performs the one-time canonical bootstrap after this PR merges.

## New concepts

### Repository-scoped deploy keys

A deploy key is an SSH credential attached to one repository, usable for Git clone and push but not for GitHub's REST or GraphQL APIs.

| Credential | Scope | Use here |
|---|---|---|
| `GITHUB_TOKEN` | One repository, one job | Read canonical state, inspect rules, create a release |
| Deploy key | One repository, persistent | Push mirror commits and tags, including workflow-file updates |
| Personal token | Potentially many repositories and APIs | Avoided because its authority is broader than this job needs |

This split keeps the long-lived credential incapable of reaching Hive or RubyGems while preserving a short-lived token for API calls. Do not use a deploy key when the automation needs multi-repository or API authority; use a narrowly installed GitHub App instead.
