### PR TITLE
refactor(proof): extract a pure workflow creator core

### DIFF
--- a/config/component-boundaries.yml
+++ b/config/component-boundaries.yml
@@ -275,6 +275,48 @@ components:
       - reason: "U3 must prove candidate-bound compressed evidence and production qualification before this internal transition boundary can be promoted."
         removal_unit: U3
 
+  - id: workflow-creator-core
+    name: Workflow Creator Proof Core
+    state: candidate
+    entrypoint:
+      file: packaging/live_agent_skills/workflow_creator.rb
+      require: packaging/live_agent_skills/workflow_creator
+      constant: HiveLiveAgentProof::WorkflowCreator
+    public_contract:
+      values:
+        - HiveLiveAgentProof::WorkflowCreator::Vocabulary
+      errors:
+        - HiveLiveAgentProof::WorkflowCreator::Error
+    owned_paths:
+      - packaging/live_agent_skills/proof_primitives.rb
+      - packaging/live_agent_skills/workflow_creator.rb
+      - packaging/live_agent_skills/workflow_creator_contract.rb
+      - packaging/live_agent_skills/workflow_creator_execution_contract.rb
+    state_contracts:
+      - "Pure schema-v1 validation only; no filesystem, process, provider, credential, publication, recovery, or custody authority"
+    schema_contracts:
+      - "Exact failed, primary, installed-closure, and declarative execution-receipt documents with recursively immutable creator vocabulary"
+    lock_contracts:
+      - "None; every operation is deterministic and in-memory"
+    component_dependencies: []
+    allowed_hive_dependencies: []
+    internal_collaborators:
+      - HiveLiveAgentProof::WorkflowCreator::Primitives
+      - HiveLiveAgentProof::WorkflowCreator::Contract
+      - HiveLiveAgentProof::WorkflowCreator::ExecutionContract
+    forbidden_constructions: []
+    authorized_internal_constructions: []
+    hive_consumers: []
+    mutation_authority: "None; validators return admitted input documents and cannot create a passing claim"
+    recovery_surface: "None; U1a2 will own bundle custody and incumbent consumer routing"
+    wiki_page: wiki/component-boundaries.md
+    focused_tests:
+      - test/unit/packaging/workflow_creator_core_test.rb
+      - test/unit/component_boundaries_test.rb
+    migration_exceptions:
+      - reason: "U1a1 stages the pure core with zero production consumers; U1a2 must route proof and release-candidate custody through it or remove it."
+        removal_unit: U1a2
+
   - id: attempts
     name: Attempts admission / future RunReceipt
     state: candidate

--- a/packaging/live_agent_skills/proof_primitives.rb
+++ b/packaging/live_agent_skills/proof_primitives.rb
@@ -3,36 +3,37 @@ module HiveLiveAgentProof
   module WorkflowCreator
     class Error < StandardError; end
     module Primitives
-      SECRET_PATTERNS = [
-        /sk-ant-[A-Za-z0-9_-]{12,}/, /sk-(?:proj-)?[A-Za-z0-9_-]{20,}/,
-        /gh[opsu]_[A-Za-z0-9]{20,}/, /github_pat_[A-Za-z0-9_]{20,}/, /-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----/
-      ].freeze
+      SECRET_PATTERNS = [ /sk-ant-[A-Za-z0-9_-]{12,}/, /sk-(?:proj-)?[A-Za-z0-9_-]{20,}/, /gh[opsu]_[A-Za-z0-9]{20,}/,
+        /github_pat_[A-Za-z0-9_]{20,}/, /-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----/ ].freeze
       MAX_JSON_DEPTH, MAX_JSON_NODES, MAX_JSON_BYTES, MAX_JSON_INTEGER_BITS = 64, 16_384, 16_777_216, 55_732_703
+      RAW_CLASS, RAW_SINGLETON_METHODS = %i[class singleton_methods].map { |name| Object.instance_method(name).freeze }
+      PLAIN = ->(value, type) { RAW_CLASS.bind_call(value).equal?(type) && RAW_SINGLETON_METHODS.bind_call(value, false).empty? }.freeze
       module_function
       def canonical_json(value)
         nodes = projected = 0
         add = ->(size) { (projected += size) <= MAX_JSON_BYTES || raise(TypeError) }
         string_size = lambda do |string|
-          string.instance_of?(String) && string.valid_encoding? && (string.encoding == Encoding::UTF_8 || string.ascii_only?) &&
+          PLAIN.call(string, String) && string.valid_encoding? && (string.encoding == Encoding::UTF_8 || string.ascii_only?) &&
             string.bytesize + 2 <= MAX_JSON_BYTES || raise(TypeError)
-          string.bytesize + 2 + string.count(%Q("\\\b\f\n\r\t)) + (5 * string.count("\x00-\x07\x0B\x0E-\x1F"))
+          string.bytesize + 2 + string.count(%Q("\\\b\f\n\r\t)) + string.count("\\") + (5 * string.count("\x00-\x07\x0B\x0E-\x1F"))
         end
         normalize = lambda do |nested, depth|
           depth <= MAX_JSON_DEPTH && (nodes += 1) <= MAX_JSON_NODES || raise(TypeError)
-          [ Hash, Array, String, Integer, Float, TrueClass, FalseClass, NilClass ].include?(nested.class) || raise(TypeError)
+          [ Hash, Array, String, Integer, Float, TrueClass, FalseClass, NilClass ].any? { |type| PLAIN.call(nested, type) } || raise(TypeError)
           case nested
           when Hash
-            key_sizes = nested.keys.to_h { |key| string_size.call(key).then { |size| [ key.encode(Encoding::UTF_8), [ key, size ] ] } }
-            key_sizes.length == nested.length || raise(TypeError)
-            add.call({ true => 2, false => 4 + (2 * depth) + (2 * (key_sizes.length - 1)) }.fetch(key_sizes.empty?))
-            key_sizes.keys.sort.to_h { |key| key_sizes.fetch(key).then { |original, size|
-              add.call((2 * (depth + 1)) + size + 2).then { [ key, normalize.call(nested.fetch(original), depth + 1) ] } } }
+            count = nested.length; nodes + count <= MAX_JSON_NODES || raise(TypeError)
+            add.call({ true => 2, false => 4 + (2 * depth) + (2 * (count - 1)) }.fetch(count.zero?))
+            key_sizes = nested.each_key.to_h do |key|
+              size = string_size.call(key); add.call((2 * (depth + 1)) + size + 2); [ key.encode(Encoding::UTF_8), key ]
+            end.tap { |sizes| sizes.length == count || raise(TypeError) }
+            key_sizes.keys.sort.to_h { |key| [ key, normalize.call(nested.fetch(key_sizes.fetch(key)), depth + 1) ] }
           when Array
             add.call({ true => 2, false => 4 + (2 * depth) + (2 * (nested.length - 1)) }.fetch(nested.empty?))
             nested.map { |item| add.call(2 * (depth + 1)).then { normalize.call(item, depth + 1) } }
           when String then add.call(string_size.call(nested)).then { nested.encode(Encoding::UTF_8) }
           when Integer then (nested.bit_length <= MAX_JSON_INTEGER_BITS || raise(TypeError)) && add.call(nested.to_s.bytesize).then { nested }
-          when Float then (nested.finite? || raise(TypeError)) && add.call(nested.to_s.bytesize).then { nested }
+          when Float then (nested.finite? || raise(TypeError)) && add.call(JSON.generate(nested).bytesize).then { nested }
           else add.call({ true => 4, false => 5, nil => 4 }.fetch(nested)).then { nested }
           end
         end
@@ -42,10 +43,9 @@ module HiveLiveAgentProof
         raise Error, "cannot canonicalize JSON"
       end
       def safe_relative_path?(value)
-        return false unless value.instance_of?(String) && value.valid_encoding? && (value.encoding == Encoding::UTF_8 || value.ascii_only?)
+        return false unless PLAIN.call(value, String) && value.valid_encoding? && (value.encoding == Encoding::UTF_8 || value.ascii_only?)
         value = value.encode(Encoding::UTF_8)
-        return false if value.empty? || value.start_with?("/") || value.match?(/\A[A-Za-z]:/) || value.include?("\0") || value.include?("\\")
-        value.split("/", -1).none? { |part| part.empty? || part == "." || part == ".." }
+        !value.match?(%r{\A/|\A[A-Za-z]:|\x00|\\|(?:\A|/)\.{0,2}(?=/|\z)})
       end
       def secret_findings(text, exact_secrets: [])
         inspected = text.to_s.encode(Encoding::UTF_8, invalid: :replace, undef: :replace)

--- a/packaging/live_agent_skills/proof_primitives.rb
+++ b/packaging/live_agent_skills/proof_primitives.rb
@@ -1,28 +1,31 @@
 require "json"
-
 module HiveLiveAgentProof
   module WorkflowCreator
     class Error < StandardError; end
     module Primitives
       SECRET_PATTERNS = [
-        /sk-ant-[A-Za-z0-9_-]{12,}/,
-        /sk-(?:proj-)?[A-Za-z0-9_-]{20,}/,
-        /gh[opsu]_[A-Za-z0-9]{20,}/,
-        /github_pat_[A-Za-z0-9_]{20,}/,
+        /sk-ant-[A-Za-z0-9_-]{12,}/, /sk-(?:proj-)?[A-Za-z0-9_-]{20,}/,
+        /gh[opsu]_[A-Za-z0-9]{20,}/, /github_pat_[A-Za-z0-9_]{20,}/,
         /-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----/
       ].freeze
-
+      MAX_JSON_DEPTH = 64
+      MAX_JSON_NODES = 16_384
+      MAX_JSON_BYTES = 16_777_216
       module_function
       def canonical_json(value)
-        normalize = lambda do |nested|
+        nodes = payload_bytes = 0
+        normalize = lambda do |nested, depth|
+          raise TypeError if depth > MAX_JSON_DEPTH || (nodes += 1) > MAX_JSON_NODES
           case nested
           when Hash
-            raise TypeError unless nested.keys.all?(String)
-            nested.keys.sort.to_h { |key| [ key, normalize.call(nested.fetch(key)) ] }
+            raise TypeError unless nested.keys.all? do |key|
+              key.is_a?(String) && key.valid_encoding? && (payload_bytes += key.bytesize) <= MAX_JSON_BYTES
+            end
+            nested.keys.sort.to_h { |key| [ key, normalize.call(nested.fetch(key), depth + 1) ] }
           when Array
-            nested.map { |item| normalize.call(item) }
+            nested.map { |item| normalize.call(item, depth + 1) }
           when String
-            raise TypeError unless nested.valid_encoding?
+            raise TypeError unless nested.valid_encoding? && (payload_bytes += nested.bytesize) <= MAX_JSON_BYTES
             nested
           when Integer, Float, TrueClass, FalseClass, NilClass
             nested
@@ -30,14 +33,15 @@ module HiveLiveAgentProof
             raise TypeError
           end
         end
-        "#{JSON.pretty_generate(normalize.call(value))}\n"
-      rescue JSON::GeneratorError, ArgumentError, TypeError
+        bytes = "#{JSON.pretty_generate(normalize.call(value, 0))}\n"
+        raise TypeError if bytes.bytesize > MAX_JSON_BYTES
+        bytes
+      rescue JSON::GeneratorError, JSON::NestingError, ArgumentError, TypeError
         raise Error, "cannot canonicalize JSON"
       end
       def safe_relative_path?(value)
         return false unless value.is_a?(String) && !value.empty? && value.valid_encoding?
-        return false if value.start_with?("/") || value.include?("\0")
-
+        return false if value.start_with?("/") || value.match?(/\A[A-Za-z]:/) || value.include?("\0") || value.include?("\\")
         value.split("/", -1).none? { |part| part.empty? || part == "." || part == ".." }
       end
       def secret_findings(text, exact_secrets: [])
@@ -51,7 +55,6 @@ module HiveLiveAgentProof
         end
         findings
       end
-
       def secret_safe_text(value, exact_secrets:, limit:)
         text = value.to_s.encode(
           Encoding::UTF_8, invalid: :replace, undef: :replace, replace: "\uFFFD"
@@ -63,7 +66,6 @@ module HiveLiveAgentProof
         SECRET_PATTERNS.each { |pattern| text.gsub!(pattern, "[REDACTED]") }
         text.byteslice(0, limit).force_encoding(Encoding::UTF_8).scrub("")
       end
-
       def deep_freeze(value)
         case value
         when Hash

--- a/packaging/live_agent_skills/proof_primitives.rb
+++ b/packaging/live_agent_skills/proof_primitives.rb
@@ -1,0 +1,78 @@
+require "json"
+
+module HiveLiveAgentProof
+  module WorkflowCreator
+    class Error < StandardError; end
+    module Primitives
+      SECRET_PATTERNS = [
+        /sk-ant-[A-Za-z0-9_-]{12,}/,
+        /sk-(?:proj-)?[A-Za-z0-9_-]{20,}/,
+        /gh[opsu]_[A-Za-z0-9]{20,}/,
+        /github_pat_[A-Za-z0-9_]{20,}/,
+        /-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----/
+      ].freeze
+
+      module_function
+      def canonical_json(value)
+        normalize = lambda do |nested|
+          case nested
+          when Hash
+            raise TypeError unless nested.keys.all?(String)
+            nested.keys.sort.to_h { |key| [ key, normalize.call(nested.fetch(key)) ] }
+          when Array
+            nested.map { |item| normalize.call(item) }
+          when String
+            raise TypeError unless nested.valid_encoding?
+            nested
+          when Integer, Float, TrueClass, FalseClass, NilClass
+            nested
+          else
+            raise TypeError
+          end
+        end
+        "#{JSON.pretty_generate(normalize.call(value))}\n"
+      rescue JSON::GeneratorError, ArgumentError, TypeError
+        raise Error, "cannot canonicalize JSON"
+      end
+      def safe_relative_path?(value)
+        return false unless value.is_a?(String) && !value.empty? && value.valid_encoding?
+        return false if value.start_with?("/") || value.include?("\0")
+
+        value.split("/", -1).none? { |part| part.empty? || part == "." || part == ".." }
+      end
+      def secret_findings(text, exact_secrets: [])
+        inspected = text.to_s.encode(Encoding::UTF_8, invalid: :replace, undef: :replace)
+        findings = SECRET_PATTERNS.filter_map do |pattern|
+          "pattern:#{pattern.source}" if pattern.match?(inspected)
+        end
+        exact_secrets.each_with_index do |secret, index|
+          candidate = secret.to_s.encode(Encoding::UTF_8, invalid: :replace, undef: :replace)
+          findings << "exact-secret:#{index}" if !candidate.empty? && inspected.include?(candidate)
+        end
+        findings
+      end
+
+      def secret_safe_text(value, exact_secrets:, limit:)
+        text = value.to_s.encode(
+          Encoding::UTF_8, invalid: :replace, undef: :replace, replace: "\uFFFD"
+        )
+        exact_secrets.each do |secret|
+          candidate = secret.to_s.encode(Encoding::UTF_8, invalid: :replace, undef: :replace)
+          text.gsub!(candidate, "[REDACTED]") unless candidate.empty?
+        end
+        SECRET_PATTERNS.each { |pattern| text.gsub!(pattern, "[REDACTED]") }
+        text.byteslice(0, limit).force_encoding(Encoding::UTF_8).scrub("")
+      end
+
+      def deep_freeze(value)
+        case value
+        when Hash
+          value.each { |key, nested| deep_freeze(key); deep_freeze(nested) }
+        when Array
+          value.each { |nested| deep_freeze(nested) }
+        end
+        value.freeze
+      end
+    end
+  end
+end

--- a/packaging/live_agent_skills/proof_primitives.rb
+++ b/packaging/live_agent_skills/proof_primitives.rb
@@ -5,74 +5,74 @@ module HiveLiveAgentProof
     module Primitives
       SECRET_PATTERNS = [
         /sk-ant-[A-Za-z0-9_-]{12,}/, /sk-(?:proj-)?[A-Za-z0-9_-]{20,}/,
-        /gh[opsu]_[A-Za-z0-9]{20,}/, /github_pat_[A-Za-z0-9_]{20,}/,
-        /-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----/
+        /gh[opsu]_[A-Za-z0-9]{20,}/, /github_pat_[A-Za-z0-9_]{20,}/, /-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----/
       ].freeze
-      MAX_JSON_DEPTH = 64
-      MAX_JSON_NODES = 16_384
-      MAX_JSON_BYTES = 16_777_216
+      MAX_JSON_DEPTH, MAX_JSON_NODES, MAX_JSON_BYTES, MAX_JSON_INTEGER_BITS = 64, 16_384, 16_777_216, 55_732_703
       module_function
       def canonical_json(value)
-        nodes = payload_bytes = 0
+        nodes = projected = 0
+        add = ->(size) { (projected += size) <= MAX_JSON_BYTES || raise(TypeError) }
+        string_size = lambda do |string|
+          string.instance_of?(String) && string.valid_encoding? && (string.encoding == Encoding::UTF_8 || string.ascii_only?) &&
+            string.bytesize + 2 <= MAX_JSON_BYTES || raise(TypeError)
+          string.bytesize + 2 + string.count(%Q("\\\b\f\n\r\t)) + (5 * string.count("\x00-\x07\x0B\x0E-\x1F"))
+        end
         normalize = lambda do |nested, depth|
-          raise TypeError if depth > MAX_JSON_DEPTH || (nodes += 1) > MAX_JSON_NODES
+          depth <= MAX_JSON_DEPTH && (nodes += 1) <= MAX_JSON_NODES || raise(TypeError)
+          [ Hash, Array, String, Integer, Float, TrueClass, FalseClass, NilClass ].include?(nested.class) || raise(TypeError)
           case nested
           when Hash
-            raise TypeError unless nested.keys.all? do |key|
-              key.is_a?(String) && key.valid_encoding? && (payload_bytes += key.bytesize) <= MAX_JSON_BYTES
-            end
-            nested.keys.sort.to_h { |key| [ key, normalize.call(nested.fetch(key), depth + 1) ] }
+            key_sizes = nested.keys.to_h { |key| string_size.call(key).then { |size| [ key.encode(Encoding::UTF_8), [ key, size ] ] } }
+            key_sizes.length == nested.length || raise(TypeError)
+            add.call({ true => 2, false => 4 + (2 * depth) + (2 * (key_sizes.length - 1)) }.fetch(key_sizes.empty?))
+            key_sizes.keys.sort.to_h { |key| key_sizes.fetch(key).then { |original, size|
+              add.call((2 * (depth + 1)) + size + 2).then { [ key, normalize.call(nested.fetch(original), depth + 1) ] } } }
           when Array
-            nested.map { |item| normalize.call(item, depth + 1) }
-          when String
-            raise TypeError unless nested.valid_encoding? && (payload_bytes += nested.bytesize) <= MAX_JSON_BYTES
-            nested
-          when Integer, Float, TrueClass, FalseClass, NilClass
-            nested
-          else
-            raise TypeError
+            add.call({ true => 2, false => 4 + (2 * depth) + (2 * (nested.length - 1)) }.fetch(nested.empty?))
+            nested.map { |item| add.call(2 * (depth + 1)).then { normalize.call(item, depth + 1) } }
+          when String then add.call(string_size.call(nested)).then { nested.encode(Encoding::UTF_8) }
+          when Integer then (nested.bit_length <= MAX_JSON_INTEGER_BITS || raise(TypeError)) && add.call(nested.to_s.bytesize).then { nested }
+          when Float then (nested.finite? || raise(TypeError)) && add.call(nested.to_s.bytesize).then { nested }
+          else add.call({ true => 4, false => 5, nil => 4 }.fetch(nested)).then { nested }
           end
         end
-        bytes = "#{JSON.pretty_generate(normalize.call(value, 0))}\n"
-        raise TypeError if bytes.bytesize > MAX_JSON_BYTES
-        bytes
-      rescue JSON::GeneratorError, JSON::NestingError, ArgumentError, TypeError
+        normalize.call(value, 0).then { |normalized|
+          add.call(1).then { "#{JSON.pretty_generate(normalized)}\n".tap { |bytes| bytes.bytesize == projected || raise(TypeError) } } }
+      rescue JSON::GeneratorError, JSON::NestingError, ArgumentError, EncodingError, TypeError
         raise Error, "cannot canonicalize JSON"
       end
       def safe_relative_path?(value)
-        return false unless value.is_a?(String) && !value.empty? && value.valid_encoding?
-        return false if value.start_with?("/") || value.match?(/\A[A-Za-z]:/) || value.include?("\0") || value.include?("\\")
+        return false unless value.instance_of?(String) && value.valid_encoding? && (value.encoding == Encoding::UTF_8 || value.ascii_only?)
+        value = value.encode(Encoding::UTF_8)
+        return false if value.empty? || value.start_with?("/") || value.match?(/\A[A-Za-z]:/) || value.include?("\0") || value.include?("\\")
         value.split("/", -1).none? { |part| part.empty? || part == "." || part == ".." }
       end
       def secret_findings(text, exact_secrets: [])
         inspected = text.to_s.encode(Encoding::UTF_8, invalid: :replace, undef: :replace)
-        findings = SECRET_PATTERNS.filter_map do |pattern|
-          "pattern:#{pattern.source}" if pattern.match?(inspected)
-        end
-        exact_secrets.each_with_index do |secret, index|
-          candidate = secret.to_s.encode(Encoding::UTF_8, invalid: :replace, undef: :replace)
-          findings << "exact-secret:#{index}" if !candidate.empty? && inspected.include?(candidate)
-        end
+        findings = SECRET_PATTERNS.filter_map { |pattern| "pattern:#{pattern.source}" if pattern.match?(inspected) }
+        exact_secrets.each_with_index { |secret, index| findings << "exact-secret:#{index}" if !secret.empty? && inspected.include?(secret) }
         findings
       end
-      def secret_safe_text(value, exact_secrets:, limit:)
-        text = value.to_s.encode(
-          Encoding::UTF_8, invalid: :replace, undef: :replace, replace: "\uFFFD"
-        )
+      def secret_safe_text(value, exact_secrets:, limit:, input_limit:)
+        value.instance_of?(String) && value.bytesize <= input_limit || raise(TypeError)
+        text = value.encode(Encoding::UTF_8, invalid: :replace, undef: :replace, replace: "\uFFFD")
+        ranges, append = [], ->(range) { ranges.length < input_limit && ranges << range || raise(TypeError) }
         exact_secrets.each do |secret|
-          candidate = secret.to_s.encode(Encoding::UTF_8, invalid: :replace, undef: :replace)
-          text.gsub!(candidate, "[REDACTED]") unless candidate.empty?
+          text.scan(/(?=#{Regexp.escape(secret)})/) { Regexp.last_match.bytebegin(0).then { |at| append.call([ at, at + secret.bytesize ]) } }
         end
-        SECRET_PATTERNS.each { |pattern| text.gsub!(pattern, "[REDACTED]") }
-        text.byteslice(0, limit).force_encoding(Encoding::UTF_8).scrub("")
+        SECRET_PATTERNS.each { |pattern| text.scan(pattern) { append.call([ Regexp.last_match.bytebegin(0), Regexp.last_match.byteend(0) ]) } }
+        merged = ranges.sort_by!(&:first).each_with_object([]) do |range, union|
+          current = union.last
+          current && range.first <= current.last ? current[1] = [ current.last, range.last ].max : union << range.dup
+        end
+        redacted, cursor = +"", 0
+        merged.each { |first, last| cursor = (redacted << text.byteslice(cursor, first - cursor) << "[REDACTED]" && last) }
+        redacted << text.byteslice(cursor, text.bytesize - cursor)
+        redacted.byteslice(0, limit).force_encoding(Encoding::UTF_8).scrub("")
       end
       def deep_freeze(value)
-        case value
-        when Hash
-          value.each { |key, nested| deep_freeze(key); deep_freeze(nested) }
-        when Array
-          value.each { |nested| deep_freeze(nested) }
-        end
+        value.each { |key, nested| deep_freeze(key); deep_freeze(nested) } if value.is_a?(Hash)
+        value.each { |nested| deep_freeze(nested) } if value.is_a?(Array)
         value.freeze
       end
     end

--- a/packaging/live_agent_skills/workflow_creator.rb
+++ b/packaging/live_agent_skills/workflow_creator.rb
@@ -101,9 +101,9 @@ module HiveLiveAgentProof
       Contract.validate_primary!(row:, manifest:, candidate_sha:, bundle_records:)
     def self.validate_installation!(document:, kind:, manifest:, candidate_sha:) =
       Contract.validate_installation!(document:, kind:, manifest:, candidate_sha:)
-    def self.validate_execution!(receipt:, row:, candidate_sha:, installation_records:,
+    def self.validate_execution!(receipt:, row:, candidate_sha:, manifest:, installation_records:,
                                  receipt_sha256:, candidate_installation:, openclaw_installation:) =
-      ExecutionContract.validate!(receipt:, row:, candidate_sha:, installation_records:,
+      ExecutionContract.validate!(receipt:, row:, candidate_sha:, manifest:, installation_records:,
                                   receipt_sha256:, candidate_installation:, openclaw_installation:)
   end
 end

--- a/packaging/live_agent_skills/workflow_creator.rb
+++ b/packaging/live_agent_skills/workflow_creator.rb
@@ -1,0 +1,109 @@
+require "digest"
+require_relative "proof_primitives"
+module HiveLiveAgentProof
+  module WorkflowCreator
+    request = "Create a three-stage editorial workflow that researches, drafts, and requires approval before publishing."
+    prompt = <<~PROMPT
+      /hive
+      #{request}
+      Use the installed Hive workflow-creator capability in this initialized project.
+      This is creation-only: validate the result, report the defaults, and do not create or run a task.
+    PROMPT
+    task_request = "Research and draft the launch announcement for approval."
+    task_key = "workflow-creator-proof:editorial:live-proof"
+    task_slug = "editorial-live-proof"
+    task_prompt = <<~PROMPT
+      /hive
+      Use the validated editorial workflow to create and run one task for:
+      "#{task_request}"
+      Use idempotency key #{task_key}. In this exact order: create the task,
+      run its first stage once, repeat the same creation command once to prove the retry is a no-op,
+      then query operational status. Do not publish or perform any other external action.
+    PROMPT
+    task_argv = [
+      "new", "workflow-creator-proof", "--workflow", "editorial",
+      "--idempotency-key", task_key, "--json", task_request
+    ]
+    files = %w[
+      .hive-state/workflows/editorial.yml
+      .hive-state/workflows/editorial/draft.md
+      .hive-state/workflows/editorial/research.md
+    ]
+    Vocabulary = Primitives.deep_freeze(
+      "schema_version" => 1,
+      "evidence_schema" => "hive-live-workflow-creator-evidence",
+      "installed_schema" => "hive-live-workflow-creator-installed-manifest",
+      "execution_schema" => "hive-live-workflow-creator-execution-receipt",
+      "execution_plan" => "hive-live-workflow-creator-execution-plan/v1",
+      "scanner" => "hive-live-agent-proof/v1",
+      "request" => request,
+      "prompt" => prompt,
+      "task_request" => task_request,
+      "task_key" => task_key,
+      "task_slug" => task_slug,
+      "task_prompt" => task_prompt,
+      "task_new_argv" => task_argv,
+      "commands" => [
+        [ "version" ], [ "workflow", "list", "--json" ],
+        [ "workflow", "new", "editorial", "--json" ],
+        [ "workflow", "validate", "editorial", "--json" ],
+        [ "workflow", "commit", "editorial" ], task_argv,
+        [ "run", task_slug ], task_argv,
+        [ "status", "--operational", "--json" ]
+      ],
+      "files" => files,
+      "executed_instruction" => files.fetch(2),
+      "native_activation" => { "kind" => "openclaw-skills-info", "invocation" => "/hive" },
+      "graph" => {
+        "valid" => true, "stages" => %w[research draft approval],
+        "automatic_edges" => [ %w[research draft], %w[draft approval] ],
+        "human_outcomes" => [
+          { "stage" => "approval", "name" => "approve", "complete" => true,
+            "artifact" => "draft.md", "to" => nil },
+          { "stage" => "approval", "name" => "reject", "complete" => false,
+            "artifact" => nil, "to" => "draft" }
+        ]
+      },
+      "task" => {
+        "slug" => task_slug, "workflow" => "editorial", "first_created" => true,
+        "retry_created" => false, "run_count" => 1, "current_stage" => "1-research"
+      },
+      "classification" => { "execution_kind" => "authenticated_openclaw", "model_loop" => "executed" },
+      "bundle_files" => %w[
+        openclaw-workflow-creator.json candidate-installed-manifest.json
+        openclaw-installed-manifest.json execution-receipt.json
+      ],
+      "member_roles" => {
+        "candidate" => %w[audit_gateway executable interpreter_or_launcher lock package],
+        "openclaw" => %w[executable interpreter_or_launcher lock package]
+      },
+      "outer_roles" => [
+        { "role" => "workflow-creation-model-loop", "prompt_sha256" => Digest::SHA256.hexdigest(prompt) },
+        { "role" => "authorized-work-model-loop", "prompt_sha256" => Digest::SHA256.hexdigest(task_prompt) }
+      ],
+      "archive_labels" => %w[candidate-package openclaw-package],
+      "archive_policy_sha256" => Digest::SHA256.hexdigest("hive-live-workflow-creator-archive-policy/v1"),
+      "cleanup_labels" => %w[proof-workspace]
+    )
+  end
+end
+require_relative "workflow_creator_contract"
+require_relative "workflow_creator_execution_contract"
+
+module HiveLiveAgentProof
+  module WorkflowCreator
+    private_constant :Primitives, :Contract, :ExecutionContract
+
+    def self.canonical_json(value) = Primitives.canonical_json(value)
+    def self.failure(...) = Contract.failure(...)
+    def self.validate_nonpassing!(row) = Contract.validate_nonpassing!(row)
+    def self.validate_primary!(row:, manifest:, candidate_sha:, bundle_records:) =
+      Contract.validate_primary!(row:, manifest:, candidate_sha:, bundle_records:)
+    def self.validate_installation!(document:, kind:, manifest:, candidate_sha:) =
+      Contract.validate_installation!(document:, kind:, manifest:, candidate_sha:)
+    def self.validate_execution!(receipt:, row:, candidate_sha:, installation_records:,
+                                 receipt_sha256:, candidate_installation:, openclaw_installation:) =
+      ExecutionContract.validate!(receipt:, row:, candidate_sha:, installation_records:,
+                                  receipt_sha256:, candidate_installation:, openclaw_installation:)
+  end
+end

--- a/packaging/live_agent_skills/workflow_creator_contract.rb
+++ b/packaging/live_agent_skills/workflow_creator_contract.rb
@@ -1,0 +1,209 @@
+require "digest"
+require_relative "proof_primitives"
+module HiveLiveAgentProof
+  module WorkflowCreator
+    module Contract
+      PRIMARY_KEYS = Primitives.deep_freeze(%w[
+        schema schema_version platform candidate_sha result prompt_sha256
+        task_prompt_sha256 skill native_activation hive_commands created_files
+        validation creation_only_task_count task_count task external_actions
+        secret_scan execution_kind model_loop executed_instruction evidence_bundle
+        containment teardown cleanup
+      ])
+      FAILURE_KEYS = Primitives.deep_freeze(%w[
+        schema schema_version platform candidate_sha result phase reason detail
+        execution_kind model_loop secret_scan
+      ])
+      MANIFEST_KEYS = Primitives.deep_freeze(%w[
+        canonical_digest candidate_sha files hive_version schema schema_version
+        skill_version
+      ])
+      INSTALLATION_KEYS = Primitives.deep_freeze(%w[
+        schema schema_version candidate_sha kind version closure_sha256
+        required_roles inventory total_size secret_scan
+      ])
+      FILE_KEYS = Primitives.deep_freeze(%w[path sha256 size])
+      ARTIFACT_KEYS = Primitives.deep_freeze(%w[sha256 size])
+      BUNDLE_KEYS = Primitives.deep_freeze(%w[kind path sha256 size])
+      SUMMARY_KEYS = Primitives.deep_freeze(%w[receipt_sha256 status])
+      SHA = /\A[0-9a-f]{40}\z/.freeze
+      DIGEST = /\A[0-9a-f]{64}\z/.freeze
+      FAILURE_PART = /\A[a-z][a-z0-9_]{0,63}\z/.freeze
+      CLASSIFICATIONS = Primitives.deep_freeze([
+        %w[unavailable not_started],
+        %w[deterministic_fixture not_exercised],
+        %w[authenticated_openclaw executed]
+      ])
+      DETAIL_LIMIT = 1_000
+      MAX_INVENTORY_ENTRIES = 512
+      MAX_MEMBER_BYTES = 268_435_456
+      MAX_TOTAL_BYTES = 1_073_741_824
+      ASSERT = ->(condition, message) { raise Error, message unless condition }.freeze
+      module_function
+      def failure(candidate_sha:, phase:, reason:, detail: nil,
+                  execution_kind: "unavailable", model_loop: "not_started",
+                  exact_secrets: [])
+        candidate = candidate_sha.to_s.downcase
+        document = {
+          "schema" => Vocabulary.fetch("evidence_schema"),
+          "schema_version" => Vocabulary.fetch("schema_version"),
+          "platform" => "openclaw",
+          "candidate_sha" => SHA.match?(candidate) ? candidate : "unresolved",
+          "result" => "failed", "phase" => phase.to_s, "reason" => reason.to_s,
+          "detail" => detail.nil? ? nil : Primitives.secret_safe_text(
+            detail, exact_secrets: Array(exact_secrets), limit: DETAIL_LIMIT
+          ),
+          "execution_kind" => execution_kind.to_s, "model_loop" => model_loop.to_s,
+          "secret_scan" => { "status" => "passed", "scanner" => Vocabulary.fetch("scanner") }
+        }
+        validate_nonpassing!(document)
+      rescue TypeError, ArgumentError
+        raise Error, "workflow-creator non-passing evidence is invalid"
+      end
+      def validate_nonpassing!(row)
+        valid = row.is_a?(Hash) && row.keys.sort == FAILURE_KEYS.sort &&
+          row["secret_scan"].is_a?(Hash) && row["secret_scan"].keys.sort == %w[scanner status] &&
+          row["schema"] == Vocabulary.fetch("evidence_schema") &&
+          row["schema_version"].is_a?(Integer) && row["schema_version"] == 1 &&
+          row["platform"] == "openclaw" && row["candidate_sha"].is_a?(String) &&
+          (row["candidate_sha"] == "unresolved" || SHA.match?(row["candidate_sha"])) &&
+          row["result"] == "failed" && row["phase"].is_a?(String) && FAILURE_PART.match?(row["phase"]) &&
+          row["reason"].is_a?(String) && FAILURE_PART.match?(row["reason"]) &&
+          (row["detail"].nil? || (row["detail"].is_a?(String) && row["detail"].valid_encoding? &&
+            row["detail"].bytesize <= DETAIL_LIMIT)) &&
+          CLASSIFICATIONS.include?([ row["execution_kind"], row["model_loop"] ]) &&
+          row["secret_scan"] == { "status" => "passed", "scanner" => Vocabulary.fetch("scanner") }
+        ASSERT.call(valid, "workflow-creator non-passing evidence is invalid")
+        ASSERT.call(Primitives.secret_findings(JSON.generate(row)).empty?,
+                    "workflow-creator non-passing evidence contains secret-shaped material")
+        row
+      rescue TypeError, NoMethodError, ArgumentError, JSON::GeneratorError
+        raise Error, "workflow-creator non-passing evidence is invalid"
+      end
+      def validate_primary!(row:, manifest:, candidate_sha:, bundle_records:)
+        exact = ->(value, keys) { value.is_a?(Hash) && value.keys.sort == keys.sort }
+        file_record = lambda do |record, positive|
+          exact.call(record, FILE_KEYS) && Primitives.safe_relative_path?(record["path"]) &&
+            record["sha256"].is_a?(String) && DIGEST.match?(record["sha256"]) &&
+            record["size"].is_a?(Integer) && (positive ? record["size"].positive? : record["size"] >= 0)
+        end
+        ASSERT.call(exact.call(row, PRIMARY_KEYS), "workflow-creator evidence fields are invalid")
+        ASSERT.call(exact.call(manifest, MANIFEST_KEYS), "artifact manifest fields are invalid")
+        ASSERT.call(valid_manifest?(manifest, candidate_sha), "workflow-creator evidence identity or result is invalid")
+        expected_support = Vocabulary.fetch("bundle_files").drop(1).zip(
+          %w[candidate_installation openclaw_installation execution_receipt]
+        )
+        bundle_list = lambda do |records|
+          records.is_a?(Array) && records.length == 3 && records.each_with_index.all? do |record, index|
+            exact.call(record, BUNDLE_KEYS) &&
+              record.values_at("path", "kind") == expected_support.fetch(index) &&
+              record["sha256"].is_a?(String) && DIGEST.match?(record["sha256"]) &&
+              record["size"].is_a?(Integer) && record["size"].positive?
+          end
+        end
+        bundles_valid = bundle_list.call(bundle_records) && bundle_list.call(row["evidence_bundle"])
+        ASSERT.call(bundles_valid, "workflow-creator evidence bundle is invalid")
+        %w[skill native_activation secret_scan executed_instruction containment teardown cleanup].each do |field|
+          keys = { "skill" => %w[canonical_digest skill_version],
+                   "native_activation" => %w[invocation kind], "secret_scan" => %w[scanner status],
+                   "executed_instruction" => FILE_KEYS }.fetch(field, SUMMARY_KEYS)
+          ASSERT.call(exact.call(row[field], keys), "workflow-creator #{field} fields are invalid")
+        end
+        identity = row["schema"] == Vocabulary.fetch("evidence_schema") &&
+          row["schema_version"].is_a?(Integer) && row["schema_version"] == 1 &&
+          row["platform"] == "openclaw" && row["candidate_sha"] == candidate_sha && row["result"] == "passed" &&
+          row["skill"] == { "skill_version" => manifest["skill_version"],
+                            "canonical_digest" => manifest["canonical_digest"] } &&
+          row["native_activation"] == Vocabulary.fetch("native_activation") &&
+          row["secret_scan"] == { "status" => "passed", "scanner" => Vocabulary.fetch("scanner") } &&
+          row.values_at("execution_kind", "model_loop") == Vocabulary.fetch("classification").values &&
+          Primitives.canonical_json(row["evidence_bundle"]) == Primitives.canonical_json(bundle_records)
+        ASSERT.call(identity, "workflow-creator evidence identity or result is invalid")
+        created = row["created_files"]
+        authored = created&.find { |record| record["path"] == Vocabulary.fetch("executed_instruction") }
+        content = created.is_a?(Array) && created.map { |record| record["path"] } == Vocabulary.fetch("files") &&
+          created.all? { |record| file_record.call(record, true) } && file_record.call(row["executed_instruction"], true) &&
+          row["executed_instruction"] == authored && row["validation"] == Vocabulary.fetch("graph") &&
+          row["creation_only_task_count"].is_a?(Integer) && row["creation_only_task_count"].zero? &&
+          row["task_count"].is_a?(Integer) && row["task_count"] == 1 &&
+          row.dig("task", "run_count").is_a?(Integer) && row["task"] == Vocabulary.fetch("task") &&
+          row["external_actions"] == [] && row["prompt_sha256"] == Digest::SHA256.hexdigest(Vocabulary.fetch("prompt")) &&
+          row["task_prompt_sha256"] == Digest::SHA256.hexdigest(Vocabulary.fetch("task_prompt")) &&
+          row["hive_commands"] == Vocabulary.fetch("commands")
+        ASSERT.call(content, "workflow-creator primary claims are invalid")
+        summary = { "status" => "passed", "receipt_sha256" => bundle_records.fetch(2).fetch("sha256") }
+        ASSERT.call(%w[containment teardown cleanup].all? { |field| row[field] == summary },
+                    "workflow-creator execution claims are not passing")
+        ASSERT.call(Primitives.secret_findings(JSON.generate(row)).empty?,
+                    "workflow-creator evidence contains secret-shaped material")
+        row
+      rescue KeyError, TypeError, NoMethodError, ArgumentError, JSON::GeneratorError
+        raise Error, "workflow-creator contract is invalid"
+      end
+      def valid_manifest?(manifest, candidate_sha)
+        return false unless manifest.is_a?(Hash) && manifest.keys.sort == MANIFEST_KEYS.sort
+        version = manifest["hive_version"]
+        names = [
+          "hive-agent-skills-#{candidate_sha}.tar.gz", "hive-cli-#{version}.gem",
+          "hive-source-#{candidate_sha}.tar.gz"
+        ].sort
+        records = manifest["files"]
+        candidate_sha.is_a?(String) && SHA.match?(candidate_sha) &&
+          manifest["schema"] == "hive-live-agent-candidate-artifacts" &&
+          manifest["schema_version"].is_a?(Integer) && manifest["schema_version"] == 1 &&
+          manifest["candidate_sha"] == candidate_sha && version.is_a?(String) && !version.empty? &&
+          manifest["skill_version"].is_a?(String) && !manifest["skill_version"].empty? &&
+          manifest["canonical_digest"].is_a?(String) && DIGEST.match?(manifest["canonical_digest"]) &&
+          records.is_a?(Hash) && records.keys.sort == names && records.values.all? do |record|
+            record.is_a?(Hash) && record.keys.sort == ARTIFACT_KEYS &&
+              record["sha256"].is_a?(String) && DIGEST.match?(record["sha256"]) &&
+              record["size"].is_a?(Integer) && record["size"].positive?
+          end
+      end
+      def validate_installation!(document:, kind:, manifest:, candidate_sha:)
+        exact = ->(value, keys) { value.is_a?(Hash) && value.keys.sort == keys.sort }
+        record = lambda do |value|
+          exact.call(value, FILE_KEYS) && Primitives.safe_relative_path?(value["path"]) &&
+            value["sha256"].is_a?(String) && DIGEST.match?(value["sha256"]) &&
+            value["size"].is_a?(Integer) && value["size"].between?(0, MAX_MEMBER_BYTES)
+        end
+        ASSERT.call(exact.call(document, INSTALLATION_KEYS), "workflow-creator installed manifest fields are invalid")
+        ASSERT.call(exact.call(manifest, MANIFEST_KEYS), "artifact manifest fields are invalid")
+        ASSERT.call(valid_manifest?(manifest, candidate_sha), "workflow-creator installed manifest identity is invalid")
+        roles = Vocabulary.fetch("member_roles").fetch(kind)
+        inventory = document["inventory"]
+        inventory_valid = inventory.is_a?(Array) && inventory.length.between?(1, MAX_INVENTORY_ENTRIES) &&
+          inventory.all? { |item| record.call(item) } &&
+          inventory.map { |item| item["path"] }.then { |paths| paths == paths.sort && paths.uniq == paths }
+        ASSERT.call(inventory_valid, "workflow-creator #{kind} installed inventory is invalid")
+        required = document["required_roles"]
+        ASSERT.call(exact.call(required, roles), "workflow-creator #{kind} installed required roles are invalid")
+        roles_valid = required.values.all? { |item| record.call(item) && inventory.include?(item) } &&
+          required.values.map { |item| item["path"] }.uniq.length == roles.length
+        ASSERT.call(roles_valid, "workflow-creator #{kind} installed required roles are not inventory-bound")
+        closure = { "required_roles" => required, "inventory" => inventory }
+        total = inventory.sum { |item| item.fetch("size") }
+        version_valid = kind == "candidate" ? document["version"] == manifest["hive_version"] :
+          document["version"].is_a?(String) && !document["version"].empty?
+        valid = candidate_sha.is_a?(String) && SHA.match?(candidate_sha) && document["schema"] == Vocabulary.fetch("installed_schema") &&
+          document["schema_version"].is_a?(Integer) && document["schema_version"] == 1 &&
+          document["candidate_sha"] == candidate_sha && document["kind"] == kind && version_valid &&
+          document["closure_sha256"] == Digest::SHA256.hexdigest(Primitives.canonical_json(closure)) &&
+          document["total_size"].is_a?(Integer) && document["total_size"] == total && total.between?(1, MAX_TOTAL_BYTES) &&
+          document["secret_scan"] == { "status" => "passed", "scanner" => Vocabulary.fetch("scanner") }
+        ASSERT.call(valid, "workflow-creator #{kind} installed manifest identity is invalid")
+        if kind == "candidate"
+          packages = manifest.fetch("files").select { |name, _item| name.match?(/\Ahive-cli-[0-9].*\.gem\z/) }.values
+          package = required.fetch("package")
+          ASSERT.call(packages.one? && package.values_at("sha256", "size") == packages.first.values_at("sha256", "size"),
+                      "workflow-creator candidate installed package does not match the release artifact")
+        end
+        ASSERT.call(Primitives.secret_findings(JSON.generate(document)).empty?,
+                    "workflow-creator installed manifest contains secret-shaped material")
+        document
+      rescue KeyError, TypeError, NoMethodError, ArgumentError, JSON::GeneratorError
+        raise Error, "workflow-creator installed manifest is invalid"
+      end
+    end
+  end
+end

--- a/packaging/live_agent_skills/workflow_creator_contract.rb
+++ b/packaging/live_agent_skills/workflow_creator_contract.rb
@@ -8,20 +8,16 @@ module HiveLiveAgentProof
         task_prompt_sha256 skill native_activation hive_commands created_files
         validation creation_only_task_count task_count task external_actions
         secret_scan execution_kind model_loop executed_instruction evidence_bundle
-        containment teardown cleanup
-      ])
+        containment teardown cleanup])
       FAILURE_KEYS = Primitives.deep_freeze(%w[
         schema schema_version platform candidate_sha result phase reason detail
-        execution_kind model_loop secret_scan
-      ])
+        execution_kind model_loop secret_scan])
       MANIFEST_KEYS = Primitives.deep_freeze(%w[
         canonical_digest candidate_sha files hive_version schema schema_version
-        skill_version
-      ])
+        skill_version])
       INSTALLATION_KEYS = Primitives.deep_freeze(%w[
         schema schema_version candidate_sha kind version closure_sha256
-        required_roles inventory total_size secret_scan
-      ])
+        required_roles inventory total_size secret_scan])
       FILE_KEYS = Primitives.deep_freeze(%w[path sha256 size])
       ARTIFACT_KEYS = Primitives.deep_freeze(%w[sha256 size])
       BUNDLE_KEYS = Primitives.deep_freeze(%w[kind path sha256 size])
@@ -35,6 +31,8 @@ module HiveLiveAgentProof
         %w[authenticated_openclaw executed]
       ])
       DETAIL_LIMIT = 1_000
+      MAX_EXACT_SECRETS = 64
+      MAX_SECRET_BYTES = 4_096
       MAX_INVENTORY_ENTRIES = 512
       MAX_MEMBER_BYTES = 268_435_456
       MAX_TOTAL_BYTES = 1_073_741_824
@@ -43,6 +41,7 @@ module HiveLiveAgentProof
       def failure(candidate_sha:, phase:, reason:, detail: nil,
                   execution_kind: "unavailable", model_loop: "not_started",
                   exact_secrets: [])
+        exact_secrets = exact_secrets!(exact_secrets)
         candidate = candidate_sha.to_s.downcase
         document = {
           "schema" => Vocabulary.fetch("evidence_schema"),
@@ -51,16 +50,17 @@ module HiveLiveAgentProof
           "candidate_sha" => SHA.match?(candidate) ? candidate : "unresolved",
           "result" => "failed", "phase" => phase.to_s, "reason" => reason.to_s,
           "detail" => detail.nil? ? nil : Primitives.secret_safe_text(
-            detail, exact_secrets: Array(exact_secrets), limit: DETAIL_LIMIT
+            detail, exact_secrets:, limit: DETAIL_LIMIT
           ),
           "execution_kind" => execution_kind.to_s, "model_loop" => model_loop.to_s,
           "secret_scan" => { "status" => "passed", "scanner" => Vocabulary.fetch("scanner") }
         }
-        validate_nonpassing!(document)
+        validate_nonpassing!(document, exact_secrets:)
       rescue TypeError, ArgumentError
         raise Error, "workflow-creator non-passing evidence is invalid"
       end
-      def validate_nonpassing!(row)
+      def validate_nonpassing!(row, exact_secrets: [])
+        exact_secrets = exact_secrets!(exact_secrets)
         valid = row.is_a?(Hash) && row.keys.sort == FAILURE_KEYS.sort &&
           row["secret_scan"].is_a?(Hash) && row["secret_scan"].keys.sort == %w[scanner status] &&
           row["schema"] == Vocabulary.fetch("evidence_schema") &&
@@ -74,18 +74,25 @@ module HiveLiveAgentProof
           CLASSIFICATIONS.include?([ row["execution_kind"], row["model_loop"] ]) &&
           row["secret_scan"] == { "status" => "passed", "scanner" => Vocabulary.fetch("scanner") }
         ASSERT.call(valid, "workflow-creator non-passing evidence is invalid")
-        ASSERT.call(Primitives.secret_findings(JSON.generate(row)).empty?,
+        ASSERT.call(Primitives.secret_findings(JSON.generate(row), exact_secrets:).empty?,
                     "workflow-creator non-passing evidence contains secret-shaped material")
         row
       rescue TypeError, NoMethodError, ArgumentError, JSON::GeneratorError
         raise Error, "workflow-creator non-passing evidence is invalid"
       end
+      def exact_secrets!(secrets)
+        valid = secrets.is_a?(Array) && secrets.length <= MAX_EXACT_SECRETS && secrets.all? do |secret|
+          secret.is_a?(String) && secret.valid_encoding? && (secret.encoding == Encoding::UTF_8 || secret.ascii_only?) && secret.bytesize.between?(1, MAX_SECRET_BYTES)
+        end
+        ASSERT.call(valid, "workflow-creator exact secrets are invalid")
+        secrets
+      end
       def validate_primary!(row:, manifest:, candidate_sha:, bundle_records:)
         exact = ->(value, keys) { value.is_a?(Hash) && value.keys.sort == keys.sort }
-        file_record = lambda do |record, positive|
+        file_record = lambda do |record|
           exact.call(record, FILE_KEYS) && Primitives.safe_relative_path?(record["path"]) &&
             record["sha256"].is_a?(String) && DIGEST.match?(record["sha256"]) &&
-            record["size"].is_a?(Integer) && (positive ? record["size"].positive? : record["size"] >= 0)
+            record["size"].is_a?(Integer) && record["size"].positive?
         end
         ASSERT.call(exact.call(row, PRIMARY_KEYS), "workflow-creator evidence fields are invalid")
         ASSERT.call(exact.call(manifest, MANIFEST_KEYS), "artifact manifest fields are invalid")
@@ -122,7 +129,7 @@ module HiveLiveAgentProof
         created = row["created_files"]
         authored = created&.find { |record| record["path"] == Vocabulary.fetch("executed_instruction") }
         content = created.is_a?(Array) && created.map { |record| record["path"] } == Vocabulary.fetch("files") &&
-          created.all? { |record| file_record.call(record, true) } && file_record.call(row["executed_instruction"], true) &&
+          created.all? { |record| file_record.call(record) } && file_record.call(row["executed_instruction"]) &&
           row["executed_instruction"] == authored && row["validation"] == Vocabulary.fetch("graph") &&
           row["creation_only_task_count"].is_a?(Integer) && row["creation_only_task_count"].zero? &&
           row["task_count"].is_a?(Integer) && row["task_count"] == 1 &&
@@ -142,6 +149,7 @@ module HiveLiveAgentProof
       end
       def valid_manifest?(manifest, candidate_sha)
         return false unless manifest.is_a?(Hash) && manifest.keys.sort == MANIFEST_KEYS.sort
+        Primitives.canonical_json(manifest)
         version = manifest["hive_version"]
         names = [
           "hive-agent-skills-#{candidate_sha}.tar.gz", "hive-cli-#{version}.gem",
@@ -159,6 +167,8 @@ module HiveLiveAgentProof
               record["sha256"].is_a?(String) && DIGEST.match?(record["sha256"]) &&
               record["size"].is_a?(Integer) && record["size"].positive?
           end
+      rescue Error
+        false
       end
       def validate_installation!(document:, kind:, manifest:, candidate_sha:)
         exact = ->(value, keys) { value.is_a?(Hash) && value.keys.sort == keys.sort }
@@ -179,7 +189,8 @@ module HiveLiveAgentProof
         required = document["required_roles"]
         ASSERT.call(exact.call(required, roles), "workflow-creator #{kind} installed required roles are invalid")
         roles_valid = required.values.all? { |item| record.call(item) && inventory.include?(item) } &&
-          required.values.map { |item| item["path"] }.uniq.length == roles.length
+          required.values.map { |item| item["path"] }.uniq.length == roles.length &&
+          required.fetch("package").fetch("size").positive?
         ASSERT.call(roles_valid, "workflow-creator #{kind} installed required roles are not inventory-bound")
         closure = { "required_roles" => required, "inventory" => inventory }
         total = inventory.sum { |item| item.fetch("size") }

--- a/packaging/live_agent_skills/workflow_creator_contract.rb
+++ b/packaging/live_agent_skills/workflow_creator_contract.rb
@@ -30,7 +30,7 @@ module HiveLiveAgentProof
         %w[deterministic_fixture not_exercised],
         %w[authenticated_openclaw executed]
       ])
-      DETAIL_LIMIT, MAX_DETAIL_INPUT_BYTES, MAX_EXACT_SECRETS = 1_000, 4_096, 64
+      DETAIL_LIMIT, MAX_DETAIL_INPUT_BYTES, MAX_EXACT_SECRETS, PLAIN = 1_000, 4_096, 64, Primitives::PLAIN
       MAX_SECRET_BYTES, MAX_INVENTORY_ENTRIES, MAX_MEMBER_BYTES, MAX_TOTAL_BYTES = 4_096, 512, 268_435_456, 1_073_741_824
       ASSERT = ->(condition, message) { raise Error, message unless condition }.freeze
       module_function
@@ -38,8 +38,8 @@ module HiveLiveAgentProof
                   execution_kind: "unavailable", model_loop: "not_started",
                   exact_secrets: [])
         inputs = [ candidate_sha, phase, reason, execution_kind, model_loop ]
-        strings_valid = inputs.all? { |value| value.instance_of?(String) && value.encoding == Encoding::UTF_8 && value.valid_encoding? }
-        strings_valid &&= detail.nil? || (detail.instance_of?(String) && detail.encoding == Encoding::UTF_8 && detail.valid_encoding?)
+        strings_valid = inputs.all? { |value| PLAIN.call(value, String) && value.encoding == Encoding::UTF_8 && value.valid_encoding? }
+        strings_valid &&= detail.nil? || (PLAIN.call(detail, String) && detail.encoding == Encoding::UTF_8 && detail.valid_encoding?)
         ASSERT.call(strings_valid, "workflow-creator non-passing evidence is invalid")
         exact_secrets = exact_secrets!(exact_secrets)
         candidate = candidate_sha.downcase
@@ -82,8 +82,8 @@ module HiveLiveAgentProof
         raise Error, "workflow-creator non-passing evidence is invalid"
       end
       def exact_secrets!(secrets)
-        valid = secrets.instance_of?(Array) && secrets.length <= MAX_EXACT_SECRETS && secrets.all? do |secret|
-          secret.instance_of?(String) && secret.encoding == Encoding::UTF_8 && secret.valid_encoding? && secret.bytesize.between?(1, MAX_SECRET_BYTES)
+        valid = PLAIN.call(secrets, Array) && secrets.length <= MAX_EXACT_SECRETS && secrets.all? do |secret|
+          PLAIN.call(secret, String) && secret.encoding == Encoding::UTF_8 && secret.valid_encoding? && secret.bytesize.between?(1, MAX_SECRET_BYTES)
         end
         ASSERT.call(valid, "workflow-creator exact secrets are invalid")
         secrets

--- a/packaging/live_agent_skills/workflow_creator_contract.rb
+++ b/packaging/live_agent_skills/workflow_creator_contract.rb
@@ -30,46 +30,47 @@ module HiveLiveAgentProof
         %w[deterministic_fixture not_exercised],
         %w[authenticated_openclaw executed]
       ])
-      DETAIL_LIMIT = 1_000
-      MAX_EXACT_SECRETS = 64
-      MAX_SECRET_BYTES = 4_096
-      MAX_INVENTORY_ENTRIES = 512
-      MAX_MEMBER_BYTES = 268_435_456
-      MAX_TOTAL_BYTES = 1_073_741_824
+      DETAIL_LIMIT, MAX_DETAIL_INPUT_BYTES, MAX_EXACT_SECRETS = 1_000, 4_096, 64
+      MAX_SECRET_BYTES, MAX_INVENTORY_ENTRIES, MAX_MEMBER_BYTES, MAX_TOTAL_BYTES = 4_096, 512, 268_435_456, 1_073_741_824
       ASSERT = ->(condition, message) { raise Error, message unless condition }.freeze
       module_function
       def failure(candidate_sha:, phase:, reason:, detail: nil,
                   execution_kind: "unavailable", model_loop: "not_started",
                   exact_secrets: [])
+        inputs = [ candidate_sha, phase, reason, execution_kind, model_loop ]
+        strings_valid = inputs.all? { |value| value.instance_of?(String) && value.encoding == Encoding::UTF_8 && value.valid_encoding? }
+        strings_valid &&= detail.nil? || (detail.instance_of?(String) && detail.encoding == Encoding::UTF_8 && detail.valid_encoding?)
+        ASSERT.call(strings_valid, "workflow-creator non-passing evidence is invalid")
         exact_secrets = exact_secrets!(exact_secrets)
-        candidate = candidate_sha.to_s.downcase
+        candidate = candidate_sha.downcase
         document = {
           "schema" => Vocabulary.fetch("evidence_schema"),
           "schema_version" => Vocabulary.fetch("schema_version"),
           "platform" => "openclaw",
           "candidate_sha" => SHA.match?(candidate) ? candidate : "unresolved",
-          "result" => "failed", "phase" => phase.to_s, "reason" => reason.to_s,
+          "result" => "failed", "phase" => phase, "reason" => reason,
           "detail" => detail.nil? ? nil : Primitives.secret_safe_text(
-            detail, exact_secrets:, limit: DETAIL_LIMIT
+            detail, exact_secrets:, limit: DETAIL_LIMIT, input_limit: MAX_DETAIL_INPUT_BYTES
           ),
-          "execution_kind" => execution_kind.to_s, "model_loop" => model_loop.to_s,
+          "execution_kind" => execution_kind, "model_loop" => model_loop,
           "secret_scan" => { "status" => "passed", "scanner" => Vocabulary.fetch("scanner") }
         }
         validate_nonpassing!(document, exact_secrets:)
-      rescue TypeError, ArgumentError
+      rescue TypeError, ArgumentError, EncodingError
         raise Error, "workflow-creator non-passing evidence is invalid"
       end
       def validate_nonpassing!(row, exact_secrets: [])
         exact_secrets = exact_secrets!(exact_secrets)
-        valid = row.is_a?(Hash) && row.keys.sort == FAILURE_KEYS.sort &&
-          row["secret_scan"].is_a?(Hash) && row["secret_scan"].keys.sort == %w[scanner status] &&
+        Primitives.canonical_json(row)
+        valid = row.instance_of?(Hash) && row.keys.sort == FAILURE_KEYS.sort &&
+          row["secret_scan"].instance_of?(Hash) && row["secret_scan"].keys.sort == %w[scanner status] &&
           row["schema"] == Vocabulary.fetch("evidence_schema") &&
-          row["schema_version"].is_a?(Integer) && row["schema_version"] == 1 &&
-          row["platform"] == "openclaw" && row["candidate_sha"].is_a?(String) &&
+          row["schema_version"].instance_of?(Integer) && row["schema_version"] == 1 &&
+          row["platform"] == "openclaw" && row["candidate_sha"].instance_of?(String) &&
           (row["candidate_sha"] == "unresolved" || SHA.match?(row["candidate_sha"])) &&
-          row["result"] == "failed" && row["phase"].is_a?(String) && FAILURE_PART.match?(row["phase"]) &&
-          row["reason"].is_a?(String) && FAILURE_PART.match?(row["reason"]) &&
-          (row["detail"].nil? || (row["detail"].is_a?(String) && row["detail"].valid_encoding? &&
+          row["result"] == "failed" && row["phase"].instance_of?(String) && FAILURE_PART.match?(row["phase"]) &&
+          row["reason"].instance_of?(String) && FAILURE_PART.match?(row["reason"]) &&
+          (row["detail"].nil? || (row["detail"].instance_of?(String) && row["detail"].valid_encoding? &&
             row["detail"].bytesize <= DETAIL_LIMIT)) &&
           CLASSIFICATIONS.include?([ row["execution_kind"], row["model_loop"] ]) &&
           row["secret_scan"] == { "status" => "passed", "scanner" => Vocabulary.fetch("scanner") }
@@ -77,35 +78,34 @@ module HiveLiveAgentProof
         ASSERT.call(Primitives.secret_findings(JSON.generate(row), exact_secrets:).empty?,
                     "workflow-creator non-passing evidence contains secret-shaped material")
         row
-      rescue TypeError, NoMethodError, ArgumentError, JSON::GeneratorError
+      rescue TypeError, NoMethodError, ArgumentError, EncodingError, JSON::GeneratorError
         raise Error, "workflow-creator non-passing evidence is invalid"
       end
       def exact_secrets!(secrets)
-        valid = secrets.is_a?(Array) && secrets.length <= MAX_EXACT_SECRETS && secrets.all? do |secret|
-          secret.is_a?(String) && secret.valid_encoding? && (secret.encoding == Encoding::UTF_8 || secret.ascii_only?) && secret.bytesize.between?(1, MAX_SECRET_BYTES)
+        valid = secrets.instance_of?(Array) && secrets.length <= MAX_EXACT_SECRETS && secrets.all? do |secret|
+          secret.instance_of?(String) && secret.encoding == Encoding::UTF_8 && secret.valid_encoding? && secret.bytesize.between?(1, MAX_SECRET_BYTES)
         end
         ASSERT.call(valid, "workflow-creator exact secrets are invalid")
         secrets
       end
       def validate_primary!(row:, manifest:, candidate_sha:, bundle_records:)
-        exact = ->(value, keys) { value.is_a?(Hash) && value.keys.sort == keys.sort }
+        Primitives.canonical_json([ row, manifest, candidate_sha, bundle_records ])
+        exact = ->(value, keys) { value.instance_of?(Hash) && value.keys.sort == keys.sort }
         file_record = lambda do |record|
           exact.call(record, FILE_KEYS) && Primitives.safe_relative_path?(record["path"]) &&
-            record["sha256"].is_a?(String) && DIGEST.match?(record["sha256"]) &&
-            record["size"].is_a?(Integer) && record["size"].positive?
+            record["sha256"].instance_of?(String) && DIGEST.match?(record["sha256"]) &&
+            record["size"].instance_of?(Integer) && record["size"].positive?
         end
         ASSERT.call(exact.call(row, PRIMARY_KEYS), "workflow-creator evidence fields are invalid")
         ASSERT.call(exact.call(manifest, MANIFEST_KEYS), "artifact manifest fields are invalid")
         ASSERT.call(valid_manifest?(manifest, candidate_sha), "workflow-creator evidence identity or result is invalid")
-        expected_support = Vocabulary.fetch("bundle_files").drop(1).zip(
-          %w[candidate_installation openclaw_installation execution_receipt]
-        )
+        expected_support = Vocabulary.fetch("bundle_files").drop(1).zip(%w[candidate_installation openclaw_installation execution_receipt])
         bundle_list = lambda do |records|
-          records.is_a?(Array) && records.length == 3 && records.each_with_index.all? do |record, index|
+          records.instance_of?(Array) && records.length == 3 && records.each_with_index.all? do |record, index|
             exact.call(record, BUNDLE_KEYS) &&
               record.values_at("path", "kind") == expected_support.fetch(index) &&
-              record["sha256"].is_a?(String) && DIGEST.match?(record["sha256"]) &&
-              record["size"].is_a?(Integer) && record["size"].positive?
+              record["sha256"].instance_of?(String) && DIGEST.match?(record["sha256"]) &&
+              record["size"].instance_of?(Integer) && record["size"].positive?
           end
         end
         bundles_valid = bundle_list.call(bundle_records) && bundle_list.call(row["evidence_bundle"])
@@ -117,7 +117,7 @@ module HiveLiveAgentProof
           ASSERT.call(exact.call(row[field], keys), "workflow-creator #{field} fields are invalid")
         end
         identity = row["schema"] == Vocabulary.fetch("evidence_schema") &&
-          row["schema_version"].is_a?(Integer) && row["schema_version"] == 1 &&
+          row["schema_version"].instance_of?(Integer) && row["schema_version"] == 1 &&
           row["platform"] == "openclaw" && row["candidate_sha"] == candidate_sha && row["result"] == "passed" &&
           row["skill"] == { "skill_version" => manifest["skill_version"],
                             "canonical_digest" => manifest["canonical_digest"] } &&
@@ -128,12 +128,12 @@ module HiveLiveAgentProof
         ASSERT.call(identity, "workflow-creator evidence identity or result is invalid")
         created = row["created_files"]
         authored = created&.find { |record| record["path"] == Vocabulary.fetch("executed_instruction") }
-        content = created.is_a?(Array) && created.map { |record| record["path"] } == Vocabulary.fetch("files") &&
+        content = created.instance_of?(Array) && created.map { |record| record["path"] } == Vocabulary.fetch("files") &&
           created.all? { |record| file_record.call(record) } && file_record.call(row["executed_instruction"]) &&
           row["executed_instruction"] == authored && row["validation"] == Vocabulary.fetch("graph") &&
-          row["creation_only_task_count"].is_a?(Integer) && row["creation_only_task_count"].zero? &&
-          row["task_count"].is_a?(Integer) && row["task_count"] == 1 &&
-          row.dig("task", "run_count").is_a?(Integer) && row["task"] == Vocabulary.fetch("task") &&
+          row["creation_only_task_count"].instance_of?(Integer) && row["creation_only_task_count"].zero? &&
+          row["task_count"].instance_of?(Integer) && row["task_count"] == 1 &&
+          row.dig("task", "run_count").instance_of?(Integer) && row["task"] == Vocabulary.fetch("task") &&
           row["external_actions"] == [] && row["prompt_sha256"] == Digest::SHA256.hexdigest(Vocabulary.fetch("prompt")) &&
           row["task_prompt_sha256"] == Digest::SHA256.hexdigest(Vocabulary.fetch("task_prompt")) &&
           row["hive_commands"] == Vocabulary.fetch("commands")
@@ -144,45 +144,44 @@ module HiveLiveAgentProof
         ASSERT.call(Primitives.secret_findings(JSON.generate(row)).empty?,
                     "workflow-creator evidence contains secret-shaped material")
         row
-      rescue KeyError, TypeError, NoMethodError, ArgumentError, JSON::GeneratorError
+      rescue KeyError, TypeError, NoMethodError, ArgumentError, EncodingError, JSON::GeneratorError
         raise Error, "workflow-creator contract is invalid"
       end
       def valid_manifest?(manifest, candidate_sha)
-        return false unless manifest.is_a?(Hash) && manifest.keys.sort == MANIFEST_KEYS.sort
+        return false unless manifest.instance_of?(Hash) && manifest.keys.sort == MANIFEST_KEYS.sort
         Primitives.canonical_json(manifest)
         version = manifest["hive_version"]
-        names = [
-          "hive-agent-skills-#{candidate_sha}.tar.gz", "hive-cli-#{version}.gem",
-          "hive-source-#{candidate_sha}.tar.gz"
-        ].sort
+        names = [ "hive-agent-skills-#{candidate_sha}.tar.gz", "hive-cli-#{version}.gem",
+                 "hive-source-#{candidate_sha}.tar.gz" ].sort
         records = manifest["files"]
-        candidate_sha.is_a?(String) && SHA.match?(candidate_sha) &&
+        candidate_sha.instance_of?(String) && SHA.match?(candidate_sha) &&
           manifest["schema"] == "hive-live-agent-candidate-artifacts" &&
-          manifest["schema_version"].is_a?(Integer) && manifest["schema_version"] == 1 &&
-          manifest["candidate_sha"] == candidate_sha && version.is_a?(String) && !version.empty? &&
-          manifest["skill_version"].is_a?(String) && !manifest["skill_version"].empty? &&
-          manifest["canonical_digest"].is_a?(String) && DIGEST.match?(manifest["canonical_digest"]) &&
-          records.is_a?(Hash) && records.keys.sort == names && records.values.all? do |record|
-            record.is_a?(Hash) && record.keys.sort == ARTIFACT_KEYS &&
-              record["sha256"].is_a?(String) && DIGEST.match?(record["sha256"]) &&
-              record["size"].is_a?(Integer) && record["size"].positive?
+          manifest["schema_version"].instance_of?(Integer) && manifest["schema_version"] == 1 &&
+          manifest["candidate_sha"] == candidate_sha && version.instance_of?(String) && !version.empty? &&
+          manifest["skill_version"].instance_of?(String) && !manifest["skill_version"].empty? &&
+          manifest["canonical_digest"].instance_of?(String) && DIGEST.match?(manifest["canonical_digest"]) &&
+          records.instance_of?(Hash) && records.keys.sort == names && records.values.all? do |record|
+            record.instance_of?(Hash) && record.keys.sort == ARTIFACT_KEYS &&
+              record["sha256"].instance_of?(String) && DIGEST.match?(record["sha256"]) &&
+              record["size"].instance_of?(Integer) && record["size"].positive?
           end
       rescue Error
         false
       end
       def validate_installation!(document:, kind:, manifest:, candidate_sha:)
-        exact = ->(value, keys) { value.is_a?(Hash) && value.keys.sort == keys.sort }
+        Primitives.canonical_json([ document, kind, manifest, candidate_sha ])
+        exact = ->(value, keys) { value.instance_of?(Hash) && value.keys.sort == keys.sort }
         record = lambda do |value|
           exact.call(value, FILE_KEYS) && Primitives.safe_relative_path?(value["path"]) &&
-            value["sha256"].is_a?(String) && DIGEST.match?(value["sha256"]) &&
-            value["size"].is_a?(Integer) && value["size"].between?(0, MAX_MEMBER_BYTES)
+            value["sha256"].instance_of?(String) && DIGEST.match?(value["sha256"]) &&
+            value["size"].instance_of?(Integer) && value["size"].between?(0, MAX_MEMBER_BYTES)
         end
         ASSERT.call(exact.call(document, INSTALLATION_KEYS), "workflow-creator installed manifest fields are invalid")
         ASSERT.call(exact.call(manifest, MANIFEST_KEYS), "artifact manifest fields are invalid")
         ASSERT.call(valid_manifest?(manifest, candidate_sha), "workflow-creator installed manifest identity is invalid")
         roles = Vocabulary.fetch("member_roles").fetch(kind)
         inventory = document["inventory"]
-        inventory_valid = inventory.is_a?(Array) && inventory.length.between?(1, MAX_INVENTORY_ENTRIES) &&
+        inventory_valid = inventory.instance_of?(Array) && inventory.length.between?(1, MAX_INVENTORY_ENTRIES) &&
           inventory.all? { |item| record.call(item) } &&
           inventory.map { |item| item["path"] }.then { |paths| paths == paths.sort && paths.uniq == paths }
         ASSERT.call(inventory_valid, "workflow-creator #{kind} installed inventory is invalid")
@@ -195,12 +194,12 @@ module HiveLiveAgentProof
         closure = { "required_roles" => required, "inventory" => inventory }
         total = inventory.sum { |item| item.fetch("size") }
         version_valid = kind == "candidate" ? document["version"] == manifest["hive_version"] :
-          document["version"].is_a?(String) && !document["version"].empty?
-        valid = candidate_sha.is_a?(String) && SHA.match?(candidate_sha) && document["schema"] == Vocabulary.fetch("installed_schema") &&
-          document["schema_version"].is_a?(Integer) && document["schema_version"] == 1 &&
+          document["version"].instance_of?(String) && !document["version"].empty?
+        valid = candidate_sha.instance_of?(String) && SHA.match?(candidate_sha) && document["schema"] == Vocabulary.fetch("installed_schema") &&
+          document["schema_version"].instance_of?(Integer) && document["schema_version"] == 1 &&
           document["candidate_sha"] == candidate_sha && document["kind"] == kind && version_valid &&
           document["closure_sha256"] == Digest::SHA256.hexdigest(Primitives.canonical_json(closure)) &&
-          document["total_size"].is_a?(Integer) && document["total_size"] == total && total.between?(1, MAX_TOTAL_BYTES) &&
+          document["total_size"].instance_of?(Integer) && document["total_size"] == total && total.between?(1, MAX_TOTAL_BYTES) &&
           document["secret_scan"] == { "status" => "passed", "scanner" => Vocabulary.fetch("scanner") }
         ASSERT.call(valid, "workflow-creator #{kind} installed manifest identity is invalid")
         if kind == "candidate"
@@ -212,7 +211,7 @@ module HiveLiveAgentProof
         ASSERT.call(Primitives.secret_findings(JSON.generate(document)).empty?,
                     "workflow-creator installed manifest contains secret-shaped material")
         document
-      rescue KeyError, TypeError, NoMethodError, ArgumentError, JSON::GeneratorError
+      rescue KeyError, TypeError, NoMethodError, ArgumentError, EncodingError, JSON::GeneratorError
         raise Error, "workflow-creator installed manifest is invalid"
       end
     end

--- a/packaging/live_agent_skills/workflow_creator_execution_contract.rb
+++ b/packaging/live_agent_skills/workflow_creator_execution_contract.rb
@@ -19,13 +19,13 @@ module HiveLiveAgentProof
       CLEANUP_KEYS = Primitives.deep_freeze(%w[status targets])
       TARGET_KEYS = Primitives.deep_freeze(%w[label path_sha256 device inode created_by_run identity_matched removed])
       LABEL = /\A[a-z][a-z0-9_-]{0,127}\z/.freeze
-      MAX_CAPTURE_BYTES = 1_048_576
-      MAX_ARCHIVE_ENTRIES = 16_384
-      MAX_ARCHIVE_BYTES = 1_073_741_824
+      MAX_CAPTURE_BYTES, MAX_ARCHIVE_ENTRIES, MAX_ARCHIVE_BYTES = 1_048_576, 16_384, 1_073_741_824
       module_function
       def validate!(receipt:, row:, candidate_sha:, manifest:, installation_records:,
                     receipt_sha256:, candidate_installation:, openclaw_installation:)
-        Contract::ASSERT.call(receipt.is_a?(Hash) && receipt.keys.sort == KEYS.sort, "workflow-creator execution receipt fields are invalid")
+        Primitives.canonical_json([ receipt, row, candidate_sha, manifest, installation_records, receipt_sha256,
+                                    candidate_installation, openclaw_installation ])
+        Contract::ASSERT.call(receipt.instance_of?(Hash) && receipt.keys.sort == KEYS.sort, "workflow-creator execution receipt fields are invalid")
         receipt_bytes = Primitives.canonical_json(receipt)
         bundles = installation_records + [ row.fetch("evidence_bundle").fetch(2) ]
         Contract.validate_primary!(row:, manifest:, candidate_sha:, bundle_records: bundles)
@@ -34,20 +34,21 @@ module HiveLiveAgentProof
         validate_identity!(receipt, row, candidate_sha, installation_records, candidate_installation, openclaw_installation)
         labels = validate_processes!(receipt)
         validate_aggregates!(receipt, row, labels, receipt_sha256, receipt_bytes)
-        Contract::ASSERT.call(Primitives.secret_findings(JSON.generate(receipt)).empty?, "workflow-creator execution receipt contains secret-shaped material")
+        Contract::ASSERT.call(Primitives.secret_findings(JSON.generate(receipt)).empty?,
+                              "workflow-creator execution receipt contains secret-shaped material")
         receipt
-      rescue KeyError, TypeError, NoMethodError, ArgumentError, JSON::GeneratorError
+      rescue KeyError, TypeError, NoMethodError, ArgumentError, EncodingError, JSON::GeneratorError
         raise Error, "workflow-creator execution receipt is invalid"
       end
       def validate_identity!(receipt, row, candidate_sha, records, candidate, openclaw)
-        exact = ->(value, keys) { value.is_a?(Hash) && value.keys.sort == keys.sort }
+        exact = ->(value, keys) { value.instance_of?(Hash) && value.keys.sort == keys.sort }
         bundle_record = lambda do |value|
-          exact.call(value, Contract::BUNDLE_KEYS) && value["sha256"].is_a?(String) && Contract::DIGEST.match?(value["sha256"]) &&
-            value["size"].is_a?(Integer) && value["size"].positive?
+          exact.call(value, Contract::BUNDLE_KEYS) && value["sha256"].instance_of?(String) && Contract::DIGEST.match?(value["sha256"]) &&
+            value["size"].instance_of?(Integer) && value["size"].positive?
         end
         expected = %w[candidate-installed-manifest.json openclaw-installed-manifest.json].zip(%w[candidate_installation openclaw_installation])
         record_list = lambda do |items|
-          items.is_a?(Array) && items.length == 2 && items.each_with_index.all? do |item, index|
+          items.instance_of?(Array) && items.length == 2 && items.each_with_index.all? do |item, index|
             bundle_record.call(item) && item.values_at("path", "kind") == expected.fetch(index)
           end
         end
@@ -63,9 +64,9 @@ module HiveLiveAgentProof
         gateway = candidate.fetch("required_roles").fetch("audit_gateway")
         classification = { "outer" => Vocabulary.fetch("classification"), "nested_stage" =>
           { "execution_kind" => "deterministic_fixture", "model_loop" => "not_exercised" } }
-        valid = candidate_sha.is_a?(String) && Contract::SHA.match?(candidate_sha) &&
+        valid = candidate_sha.instance_of?(String) && Contract::SHA.match?(candidate_sha) &&
           receipt["schema"] == Vocabulary.fetch("execution_schema") &&
-          receipt["schema_version"].is_a?(Integer) && receipt["schema_version"] == 1 &&
+          receipt["schema_version"].instance_of?(Integer) && receipt["schema_version"] == 1 &&
           receipt["candidate_sha"] == candidate_sha && receipt["result"] == "passed" &&
           receipt["execution_plan"] == Vocabulary.fetch("execution_plan") &&
           row.slice("execution_kind", "model_loop") == Vocabulary.fetch("classification") &&
@@ -76,34 +77,34 @@ module HiveLiveAgentProof
         Contract::ASSERT.call(valid, "workflow-creator execution receipt identity is invalid")
         packages = [ candidate, openclaw ].map { |item| item.fetch("required_roles").fetch("package") }
         archives = receipt["archive_admissions"]
-        archive_valid = archives.is_a?(Array) && archives.length == 2 && archives.each_with_index.all? do |archive, index|
+        archive_valid = archives.instance_of?(Array) && archives.length == 2 && archives.each_with_index.all? do |archive, index|
           package = packages.fetch(index)
           exact.call(archive, ARCHIVE_KEYS) && archive["label"] == Vocabulary.fetch("archive_labels").fetch(index) &&
-            archive["artifact_sha256"] == package["sha256"] && archive["artifact_size"].is_a?(Integer) &&
+            archive["artifact_sha256"] == package["sha256"] && archive["artifact_size"].instance_of?(Integer) &&
             archive["artifact_size"] == package["size"] && archive["artifact_size"].positive? &&
             archive["policy_sha256"] == Vocabulary.fetch("archive_policy_sha256") &&
-            archive["entry_count"].is_a?(Integer) && archive["entry_count"].between?(1, MAX_ARCHIVE_ENTRIES) &&
-            archive["uncompressed_bytes"].is_a?(Integer) &&
+            archive["entry_count"].instance_of?(Integer) && archive["entry_count"].between?(1, MAX_ARCHIVE_ENTRIES) &&
+            archive["uncompressed_bytes"].instance_of?(Integer) &&
             archive["uncompressed_bytes"].between?(1, MAX_ARCHIVE_BYTES) && archive["status"] == "passed"
         end
         Contract::ASSERT.call(archive_valid, "workflow-creator execution archive admission is invalid")
       end
       def validate_processes!(receipt)
-        exact = ->(value, keys) { value.is_a?(Hash) && value.keys.sort == keys.sort }
+        exact = ->(value, keys) { value.instance_of?(Hash) && value.keys.sort == keys.sort }
         commands = receipt["commands"]
-        valid_commands = commands.is_a?(Array) && commands.length == Vocabulary.fetch("commands").length &&
+        valid_commands = commands.instance_of?(Array) && commands.length == Vocabulary.fetch("commands").length &&
           commands.each_with_index.all? do |command, index|
-            exact.call(command, COMMAND_KEYS) && command["position"].is_a?(Integer) &&
+            exact.call(command, COMMAND_KEYS) && command["position"].instance_of?(Integer) &&
               command["position"] == index + 1 && command["argv"] == Vocabulary.fetch("commands").fetch(index) &&
               valid_process?(command, "attempt_label")
           end
         Contract::ASSERT.call(valid_commands, "workflow-creator execution command receipts are invalid")
         outer = receipt["outer_processes"]
-        valid_outer = outer.is_a?(Array) && outer.length == Vocabulary.fetch("outer_roles").length &&
+        valid_outer = outer.instance_of?(Array) && outer.length == Vocabulary.fetch("outer_roles").length &&
           outer.each_with_index.all? do |process, index|
             exact.call(process, OUTER_KEYS) &&
               process.slice("role", "prompt_sha256") == Vocabulary.fetch("outer_roles").fetch(index) &&
-              process["argv_sha256"].is_a?(String) && Contract::DIGEST.match?(process["argv_sha256"]) &&
+              process["argv_sha256"].instance_of?(String) && Contract::DIGEST.match?(process["argv_sha256"]) &&
               valid_process?(process, "label")
           end
         Contract::ASSERT.call(valid_outer, "workflow-creator execution outer processes are invalid")
@@ -114,20 +115,21 @@ module HiveLiveAgentProof
         labels
       end
       def valid_process?(process, label_key)
-        exact = ->(value, keys) { value.is_a?(Hash) && value.keys.sort == keys.sort }
-        capture = process["capture"]
-        teardown = process["teardown"]
-        limit = capture.is_a?(Hash) ? capture["limit_bytes"] : nil
-        boolean = [ true, false ]
+        exact = ->(value, keys) { value.instance_of?(Hash) && value.keys.sort == keys.sort }
+        capture, teardown = process.values_at("capture", "teardown")
+        limit = capture.instance_of?(Hash) ? capture["limit_bytes"] : nil
+        boolean, empty_digest = [ true, false ], Digest::SHA256.hexdigest("")
+        streams_valid = %w[stdout stderr].all? do |stream|
+          bytes, digest, truncated = capture.values_at("#{stream}_bytes", "#{stream}_sha256", "#{stream}_truncated")
+          bytes.instance_of?(Integer) && bytes.between?(0, limit) && digest.instance_of?(String) &&
+            Contract::DIGEST.match?(digest) && boolean.include?(truncated) && (!bytes.zero? || digest == empty_digest) &&
+            (!truncated || bytes == limit)
+        end
         valid = exact.call(capture, CAPTURE_KEYS) && exact.call(capture["secret_scan"], %w[scanner status]) &&
-          exact.call(teardown, PROCESS_TEARDOWN_KEYS) && process[label_key].is_a?(String) &&
-          LABEL.match?(process[label_key]) && process["exit_code"].is_a?(Integer) && process["exit_code"].zero? &&
-          process["signal"].nil? && process["completed"] == true && limit.is_a?(Integer) &&
-          limit.between?(1, MAX_CAPTURE_BYTES) && %w[stdout_bytes stderr_bytes].all? do |field|
-            capture[field].is_a?(Integer) && capture[field].between?(0, limit)
-          end && %w[stdout_sha256 stderr_sha256].all? do |field|
-            capture[field].is_a?(String) && Contract::DIGEST.match?(capture[field])
-          end && boolean.include?(capture["stdout_truncated"]) && boolean.include?(capture["stderr_truncated"]) &&
+          exact.call(teardown, PROCESS_TEARDOWN_KEYS) && process[label_key].instance_of?(String) &&
+          LABEL.match?(process[label_key]) && process["exit_code"].instance_of?(Integer) && process["exit_code"].zero? &&
+          process["signal"].nil? && process["completed"] == true && limit.instance_of?(Integer) &&
+          limit.between?(1, MAX_CAPTURE_BYTES) && streams_valid &&
           capture["secret_scan"] == { "status" => "passed", "scanner" => Vocabulary.fetch("scanner") } &&
           teardown["status"] == "passed" && boolean.include?(teardown["term_sent"]) &&
           boolean.include?(teardown["kill_sent"]) && (!teardown["kill_sent"] || teardown["term_sent"]) &&
@@ -136,35 +138,34 @@ module HiveLiveAgentProof
         true
       end
       def validate_aggregates!(receipt, row, labels, receipt_sha256, receipt_bytes)
-        exact = ->(value, keys) { value.is_a?(Hash) && value.keys.sort == keys.sort }
+        exact = ->(value, keys) { value.instance_of?(Hash) && value.keys.sort == keys.sort }
         run, containment, teardown, cleanup = receipt.values_at("run", "containment", "teardown", "cleanup")
         Contract::ASSERT.call(exact.call(run, RUN_KEYS) && exact.call(containment, CONTAINMENT_KEYS) &&
                     exact.call(teardown, TEARDOWN_KEYS) && exact.call(cleanup, CLEANUP_KEYS),
                     "workflow-creator execution aggregate fields are invalid")
-        correlation = run["correlation_id"]
-        targets = cleanup["targets"]
-        target_valid = targets.is_a?(Array) && targets.length == Vocabulary.fetch("cleanup_labels").length &&
+        correlation, targets = run["correlation_id"], cleanup["targets"]
+        target_valid = targets.instance_of?(Array) && targets.length == Vocabulary.fetch("cleanup_labels").length &&
           targets.each_with_index.all? do |target, index|
             exact.call(target, TARGET_KEYS) && target["label"] == Vocabulary.fetch("cleanup_labels").fetch(index) &&
-              target["path_sha256"].is_a?(String) && Contract::DIGEST.match?(target["path_sha256"]) &&
-              target["device"].is_a?(Integer) && target["device"] >= 0 && target["inode"].is_a?(Integer) &&
+              target["path_sha256"].instance_of?(String) && Contract::DIGEST.match?(target["path_sha256"]) &&
+              target["device"].instance_of?(Integer) && target["device"] >= 0 && target["inode"].instance_of?(Integer) &&
               target["inode"].positive? && target.values_at("created_by_run", "identity_matched", "removed") == [ true, true, true ]
           end
         instruction = ->(value) do
-          exact.call(value, Contract::FILE_KEYS) && Primitives.safe_relative_path?(value["path"]) && value["sha256"].is_a?(String) &&
-            Contract::DIGEST.match?(value["sha256"]) && value["size"].is_a?(Integer) && value["size"].positive?
+          exact.call(value, Contract::FILE_KEYS) && Primitives.safe_relative_path?(value["path"]) && value["sha256"].instance_of?(String) &&
+            Contract::DIGEST.match?(value["sha256"]) && value["size"].instance_of?(Integer) && value["size"].positive?
         end
         receipt_record = row.fetch("evidence_bundle").fetch(2)
         receipt_identity = [ Digest::SHA256.hexdigest(receipt_bytes), receipt_bytes.bytesize ]
         summary = { "status" => "passed", "receipt_sha256" => receipt_sha256 }
-        valid = correlation.is_a?(String) && LABEL.match?(correlation) && run["expected_labels"] == labels &&
+        valid = correlation.instance_of?(String) && LABEL.match?(correlation) && run["expected_labels"] == labels &&
           receipt["gateway"]["command_labels"] == labels.first(Vocabulary.fetch("commands").length) &&
           containment == { "status" => "passed", "mechanism" => "supervised-process-tree", "established_before_launch" => true,
                            "owner_correlation_id" => correlation,
                            "root_loss_behavior" => "fail-closed" } &&
           teardown == { "status" => "passed", "expected_labels" => labels, "receipt_labels" => labels,
                         "outer_root_reaped" => true, "remaining_descendants" => 0 } &&
-          teardown["remaining_descendants"].is_a?(Integer) && cleanup["status"] == "passed" && target_valid &&
+          cleanup["status"] == "passed" && target_valid &&
           instruction.call(row["executed_instruction"]) && instruction.call(receipt["authored_instruction"]) &&
           instruction.call(receipt["executed_instruction"]) &&
           receipt["authored_instruction"] == row["executed_instruction"] &&

--- a/packaging/live_agent_skills/workflow_creator_execution_contract.rb
+++ b/packaging/live_agent_skills/workflow_creator_execution_contract.rb
@@ -1,0 +1,180 @@
+require_relative "proof_primitives"
+module HiveLiveAgentProof
+  module WorkflowCreator
+    module ExecutionContract
+      KEYS = Primitives.deep_freeze(%w[
+        schema schema_version candidate_sha result execution_plan classification
+        installed_manifests run gateway archive_admissions commands outer_processes
+        authored_instruction executed_instruction external_actions containment teardown cleanup secret_scan
+      ])
+      COMMAND_KEYS = Primitives.deep_freeze(%w[position attempt_label argv exit_code signal completed capture teardown])
+      OUTER_KEYS = Primitives.deep_freeze(%w[label role argv_sha256 prompt_sha256 exit_code signal completed capture teardown])
+      CAPTURE_KEYS = Primitives.deep_freeze(%w[
+        limit_bytes stdout_bytes stderr_bytes stdout_sha256 stderr_sha256 stdout_truncated stderr_truncated secret_scan
+      ])
+      PROCESS_TEARDOWN_KEYS = Primitives.deep_freeze(%w[status term_sent kill_sent reaped descendants owner_complete])
+      ARCHIVE_KEYS = Primitives.deep_freeze(%w[label artifact_sha256 artifact_size policy_sha256 entry_count uncompressed_bytes status])
+      BUNDLE_KEYS = Primitives.deep_freeze(%w[kind path sha256 size])
+      RUN_KEYS = Primitives.deep_freeze(%w[correlation_id expected_labels])
+      GATEWAY_KEYS = Primitives.deep_freeze(%w[identity command_labels status])
+      CONTAINMENT_KEYS = Primitives.deep_freeze(%w[status mechanism established_before_launch owner_correlation_id root_loss_behavior])
+      TEARDOWN_KEYS = Primitives.deep_freeze(%w[status expected_labels receipt_labels outer_root_reaped remaining_descendants])
+      CLEANUP_KEYS = Primitives.deep_freeze(%w[status targets])
+      TARGET_KEYS = Primitives.deep_freeze(%w[label path_sha256 device inode created_by_run identity_matched removed])
+      FILE_KEYS = Primitives.deep_freeze(%w[path sha256 size])
+      SHA = /\A[0-9a-f]{40}\z/.freeze
+      DIGEST = /\A[0-9a-f]{64}\z/.freeze
+      LABEL = /\A[a-z][a-z0-9_-]{0,127}\z/.freeze
+      MAX_CAPTURE_BYTES = 1_048_576
+      MAX_ARCHIVE_ENTRIES = 16_384
+      MAX_ARCHIVE_BYTES = 1_073_741_824
+      ASSERT = ->(condition, message) { raise Error, message unless condition }.freeze
+      module_function
+      def validate!(receipt:, row:, candidate_sha:, installation_records:,
+                    receipt_sha256:, candidate_installation:, openclaw_installation:)
+        ASSERT.call(receipt.is_a?(Hash) && receipt.keys.sort == KEYS.sort,
+                    "workflow-creator execution receipt fields are invalid")
+        validate_identity!(receipt, row, candidate_sha, installation_records, candidate_installation, openclaw_installation)
+        labels = validate_processes!(receipt)
+        validate_aggregates!(receipt, row, labels, receipt_sha256)
+        ASSERT.call(Primitives.secret_findings(JSON.generate(receipt)).empty?, "workflow-creator execution receipt contains secret-shaped material")
+        receipt
+      rescue KeyError, TypeError, NoMethodError, ArgumentError, JSON::GeneratorError
+        raise Error, "workflow-creator execution receipt is invalid"
+      end
+      def validate_identity!(receipt, row, candidate_sha, records, candidate, openclaw)
+        exact = ->(value, keys) { value.is_a?(Hash) && value.keys.sort == keys.sort }
+        bundle_record = lambda do |value|
+          exact.call(value, BUNDLE_KEYS) && value["sha256"].is_a?(String) && DIGEST.match?(value["sha256"]) &&
+            value["size"].is_a?(Integer) && value["size"].positive?
+        end
+        member = lambda do |value|
+          exact.call(value, FILE_KEYS) && Primitives.safe_relative_path?(value["path"]) &&
+            value["sha256"].is_a?(String) && DIGEST.match?(value["sha256"]) &&
+            value["size"].is_a?(Integer) && value["size"] >= 0
+        end
+        expected = %w[candidate-installed-manifest.json openclaw-installed-manifest.json].zip(%w[candidate_installation openclaw_installation])
+        record_list = lambda do |items|
+          items.is_a?(Array) && items.length == 2 && items.each_with_index.all? do |item, index|
+            bundle_record.call(item) && item.values_at("path", "kind") == expected.fetch(index)
+          end
+        end
+        ASSERT.call(record_list.call(records) && record_list.call(receipt["installed_manifests"]) &&
+                    Primitives.canonical_json(receipt["installed_manifests"]) == Primitives.canonical_json(records),
+                    "workflow-creator execution installation records are invalid")
+        ASSERT.call(exact.call(receipt["gateway"], GATEWAY_KEYS), "workflow-creator execution gateway fields are invalid")
+        gateway = candidate.fetch("required_roles").fetch("audit_gateway")
+        classification = { "outer" => Vocabulary.fetch("classification"), "nested_stage" => {
+          "execution_kind" => "deterministic_fixture", "model_loop" => "not_exercised" } }
+        valid = candidate_sha.is_a?(String) && SHA.match?(candidate_sha) &&
+          receipt["schema"] == Vocabulary.fetch("execution_schema") &&
+          receipt["schema_version"].is_a?(Integer) && receipt["schema_version"] == 1 &&
+          receipt["candidate_sha"] == candidate_sha && receipt["result"] == "passed" &&
+          receipt["execution_plan"] == Vocabulary.fetch("execution_plan") &&
+          row.slice("execution_kind", "model_loop") == Vocabulary.fetch("classification") &&
+          receipt["classification"] == classification && member.call(gateway) && member.call(receipt["gateway"]["identity"]) &&
+          Primitives.canonical_json(receipt["gateway"]["identity"]) == Primitives.canonical_json(gateway) &&
+          receipt["gateway"]["status"] == "passed" &&
+          receipt["secret_scan"] == { "status" => "passed", "scanner" => Vocabulary.fetch("scanner") }
+        ASSERT.call(valid, "workflow-creator execution receipt identity is invalid")
+        packages = [ candidate, openclaw ].map { |item| item.fetch("required_roles").fetch("package") }
+        archives = receipt["archive_admissions"]
+        archive_valid = packages.all? { |package| member.call(package) } && archives.is_a?(Array) &&
+          archives.length == 2 && archives.each_with_index.all? do |archive, index|
+          package = packages.fetch(index)
+          exact.call(archive, ARCHIVE_KEYS) && archive["label"] == Vocabulary.fetch("archive_labels").fetch(index) &&
+            archive["artifact_sha256"] == package["sha256"] && archive["artifact_size"].is_a?(Integer) &&
+            archive["artifact_size"] == package["size"] &&
+            archive["policy_sha256"] == Vocabulary.fetch("archive_policy_sha256") &&
+            archive["entry_count"].is_a?(Integer) && archive["entry_count"].between?(1, MAX_ARCHIVE_ENTRIES) &&
+            archive["uncompressed_bytes"].is_a?(Integer) &&
+            archive["uncompressed_bytes"].between?(1, MAX_ARCHIVE_BYTES) && archive["status"] == "passed"
+        end
+        ASSERT.call(archive_valid, "workflow-creator execution archive admission is invalid")
+      end
+      def validate_processes!(receipt)
+        exact = ->(value, keys) { value.is_a?(Hash) && value.keys.sort == keys.sort }
+        commands = receipt["commands"]
+        valid_commands = commands.is_a?(Array) && commands.length == Vocabulary.fetch("commands").length &&
+          commands.each_with_index.all? do |command, index|
+            exact.call(command, COMMAND_KEYS) && command["position"].is_a?(Integer) &&
+              command["position"] == index + 1 && command["argv"] == Vocabulary.fetch("commands").fetch(index) &&
+              valid_process?(command, "attempt_label")
+          end
+        ASSERT.call(valid_commands, "workflow-creator execution command receipts are invalid")
+        outer = receipt["outer_processes"]
+        valid_outer = outer.is_a?(Array) && outer.length == Vocabulary.fetch("outer_roles").length &&
+          outer.each_with_index.all? do |process, index|
+            exact.call(process, OUTER_KEYS) &&
+              process.slice("role", "prompt_sha256") == Vocabulary.fetch("outer_roles").fetch(index) &&
+              process["argv_sha256"].is_a?(String) && DIGEST.match?(process["argv_sha256"]) &&
+              valid_process?(process, "label")
+          end
+        ASSERT.call(valid_outer, "workflow-creator execution outer processes are invalid")
+        ASSERT.call(outer.map { |process| process["argv_sha256"] }.uniq.length == outer.length,
+                    "workflow-creator execution outer argv identities are invalid")
+        labels = commands.map { |command| command.fetch("attempt_label") } + outer.map { |process| process.fetch("label") }
+        ASSERT.call(labels.uniq.length == labels.length, "workflow-creator execution process labels are invalid")
+        labels
+      end
+      def valid_process?(process, label_key)
+        exact = ->(value, keys) { value.is_a?(Hash) && value.keys.sort == keys.sort }
+        capture = process["capture"]
+        teardown = process["teardown"]
+        limit = capture.is_a?(Hash) ? capture["limit_bytes"] : nil
+        boolean = [ true, false ]
+        valid = exact.call(capture, CAPTURE_KEYS) && exact.call(capture["secret_scan"], %w[scanner status]) &&
+          exact.call(teardown, PROCESS_TEARDOWN_KEYS) && process[label_key].is_a?(String) &&
+          LABEL.match?(process[label_key]) && process["exit_code"].is_a?(Integer) && process["exit_code"].zero? &&
+          process["signal"].nil? && process["completed"] == true && limit.is_a?(Integer) &&
+          limit.between?(1, MAX_CAPTURE_BYTES) && %w[stdout_bytes stderr_bytes].all? do |field|
+            capture[field].is_a?(Integer) && capture[field].between?(0, limit)
+          end && %w[stdout_sha256 stderr_sha256].all? do |field|
+            capture[field].is_a?(String) && DIGEST.match?(capture[field])
+          end && boolean.include?(capture["stdout_truncated"]) && boolean.include?(capture["stderr_truncated"]) &&
+          capture["secret_scan"] == { "status" => "passed", "scanner" => Vocabulary.fetch("scanner") } &&
+          teardown["status"] == "passed" && boolean.include?(teardown["term_sent"]) &&
+          boolean.include?(teardown["kill_sent"]) && (!teardown["kill_sent"] || teardown["term_sent"]) &&
+          teardown["reaped"] == true && teardown["descendants"] == "none" && teardown["owner_complete"] == true
+        ASSERT.call(valid, "workflow-creator execution process receipt is invalid")
+        true
+      end
+      def validate_aggregates!(receipt, row, labels, receipt_sha256)
+        exact = ->(value, keys) { value.is_a?(Hash) && value.keys.sort == keys.sort }
+        run, containment, teardown, cleanup = receipt.values_at("run", "containment", "teardown", "cleanup")
+        ASSERT.call(exact.call(run, RUN_KEYS) && exact.call(containment, CONTAINMENT_KEYS) &&
+                    exact.call(teardown, TEARDOWN_KEYS) && exact.call(cleanup, CLEANUP_KEYS),
+                    "workflow-creator execution aggregate fields are invalid")
+        correlation = run["correlation_id"]
+        targets = cleanup["targets"]
+        target_valid = targets.is_a?(Array) && targets.length == Vocabulary.fetch("cleanup_labels").length &&
+          targets.each_with_index.all? do |target, index|
+            exact.call(target, TARGET_KEYS) && target["label"] == Vocabulary.fetch("cleanup_labels").fetch(index) &&
+              target["path_sha256"].is_a?(String) && DIGEST.match?(target["path_sha256"]) &&
+              target["device"].is_a?(Integer) && target["device"] >= 0 && target["inode"].is_a?(Integer) &&
+              target["inode"].positive? && target.values_at("created_by_run", "identity_matched", "removed") == [ true, true, true ]
+          end
+        instruction = ->(value) do
+          exact.call(value, FILE_KEYS) && Primitives.safe_relative_path?(value["path"]) && value["sha256"].is_a?(String) &&
+            DIGEST.match?(value["sha256"]) && value["size"].is_a?(Integer) && value["size"].positive?
+        end
+        summary = { "status" => "passed", "receipt_sha256" => receipt_sha256 }
+        valid = correlation.is_a?(String) && LABEL.match?(correlation) && run["expected_labels"] == labels &&
+          receipt["gateway"]["command_labels"] == labels.first(Vocabulary.fetch("commands").length) &&
+          containment == { "status" => "passed", "mechanism" => "supervised-process-tree", "established_before_launch" => true,
+                           "owner_correlation_id" => correlation,
+                           "root_loss_behavior" => "fail-closed" } &&
+          teardown == { "status" => "passed", "expected_labels" => labels, "receipt_labels" => labels,
+                        "outer_root_reaped" => true, "remaining_descendants" => 0 } &&
+          teardown["remaining_descendants"].is_a?(Integer) && cleanup["status"] == "passed" && target_valid &&
+          instruction.call(row["executed_instruction"]) && instruction.call(receipt["authored_instruction"]) &&
+          instruction.call(receipt["executed_instruction"]) &&
+          receipt["authored_instruction"] == row["executed_instruction"] &&
+          receipt["executed_instruction"] == row["executed_instruction"] &&
+          receipt["external_actions"] == [] && row["external_actions"] == [] && receipt_sha256.is_a?(String) &&
+          DIGEST.match?(receipt_sha256) && %w[containment teardown cleanup].all? { |field| row[field] == summary }
+        ASSERT.call(valid, "workflow-creator execution aggregates are inconsistent")
+      end
+    end
+  end
+end

--- a/packaging/live_agent_skills/workflow_creator_execution_contract.rb
+++ b/packaging/live_agent_skills/workflow_creator_execution_contract.rb
@@ -1,43 +1,40 @@
-require_relative "proof_primitives"
+require_relative "workflow_creator_contract"
 module HiveLiveAgentProof
   module WorkflowCreator
     module ExecutionContract
       KEYS = Primitives.deep_freeze(%w[
         schema schema_version candidate_sha result execution_plan classification
         installed_manifests run gateway archive_admissions commands outer_processes
-        authored_instruction executed_instruction external_actions containment teardown cleanup secret_scan
-      ])
+        authored_instruction executed_instruction external_actions containment teardown cleanup secret_scan])
       COMMAND_KEYS = Primitives.deep_freeze(%w[position attempt_label argv exit_code signal completed capture teardown])
       OUTER_KEYS = Primitives.deep_freeze(%w[label role argv_sha256 prompt_sha256 exit_code signal completed capture teardown])
       CAPTURE_KEYS = Primitives.deep_freeze(%w[
-        limit_bytes stdout_bytes stderr_bytes stdout_sha256 stderr_sha256 stdout_truncated stderr_truncated secret_scan
-      ])
+        limit_bytes stdout_bytes stderr_bytes stdout_sha256 stderr_sha256 stdout_truncated stderr_truncated secret_scan])
       PROCESS_TEARDOWN_KEYS = Primitives.deep_freeze(%w[status term_sent kill_sent reaped descendants owner_complete])
       ARCHIVE_KEYS = Primitives.deep_freeze(%w[label artifact_sha256 artifact_size policy_sha256 entry_count uncompressed_bytes status])
-      BUNDLE_KEYS = Primitives.deep_freeze(%w[kind path sha256 size])
       RUN_KEYS = Primitives.deep_freeze(%w[correlation_id expected_labels])
       GATEWAY_KEYS = Primitives.deep_freeze(%w[identity command_labels status])
       CONTAINMENT_KEYS = Primitives.deep_freeze(%w[status mechanism established_before_launch owner_correlation_id root_loss_behavior])
       TEARDOWN_KEYS = Primitives.deep_freeze(%w[status expected_labels receipt_labels outer_root_reaped remaining_descendants])
       CLEANUP_KEYS = Primitives.deep_freeze(%w[status targets])
       TARGET_KEYS = Primitives.deep_freeze(%w[label path_sha256 device inode created_by_run identity_matched removed])
-      FILE_KEYS = Primitives.deep_freeze(%w[path sha256 size])
-      SHA = /\A[0-9a-f]{40}\z/.freeze
-      DIGEST = /\A[0-9a-f]{64}\z/.freeze
       LABEL = /\A[a-z][a-z0-9_-]{0,127}\z/.freeze
       MAX_CAPTURE_BYTES = 1_048_576
       MAX_ARCHIVE_ENTRIES = 16_384
       MAX_ARCHIVE_BYTES = 1_073_741_824
-      ASSERT = ->(condition, message) { raise Error, message unless condition }.freeze
       module_function
-      def validate!(receipt:, row:, candidate_sha:, installation_records:,
+      def validate!(receipt:, row:, candidate_sha:, manifest:, installation_records:,
                     receipt_sha256:, candidate_installation:, openclaw_installation:)
-        ASSERT.call(receipt.is_a?(Hash) && receipt.keys.sort == KEYS.sort,
-                    "workflow-creator execution receipt fields are invalid")
+        Contract::ASSERT.call(receipt.is_a?(Hash) && receipt.keys.sort == KEYS.sort, "workflow-creator execution receipt fields are invalid")
+        receipt_bytes = Primitives.canonical_json(receipt)
+        bundles = installation_records + [ row.fetch("evidence_bundle").fetch(2) ]
+        Contract.validate_primary!(row:, manifest:, candidate_sha:, bundle_records: bundles)
+        Contract.validate_installation!(document: candidate_installation, kind: "candidate", manifest:, candidate_sha:)
+        Contract.validate_installation!(document: openclaw_installation, kind: "openclaw", manifest:, candidate_sha:)
         validate_identity!(receipt, row, candidate_sha, installation_records, candidate_installation, openclaw_installation)
         labels = validate_processes!(receipt)
-        validate_aggregates!(receipt, row, labels, receipt_sha256)
-        ASSERT.call(Primitives.secret_findings(JSON.generate(receipt)).empty?, "workflow-creator execution receipt contains secret-shaped material")
+        validate_aggregates!(receipt, row, labels, receipt_sha256, receipt_bytes)
+        Contract::ASSERT.call(Primitives.secret_findings(JSON.generate(receipt)).empty?, "workflow-creator execution receipt contains secret-shaped material")
         receipt
       rescue KeyError, TypeError, NoMethodError, ArgumentError, JSON::GeneratorError
         raise Error, "workflow-creator execution receipt is invalid"
@@ -45,13 +42,8 @@ module HiveLiveAgentProof
       def validate_identity!(receipt, row, candidate_sha, records, candidate, openclaw)
         exact = ->(value, keys) { value.is_a?(Hash) && value.keys.sort == keys.sort }
         bundle_record = lambda do |value|
-          exact.call(value, BUNDLE_KEYS) && value["sha256"].is_a?(String) && DIGEST.match?(value["sha256"]) &&
+          exact.call(value, Contract::BUNDLE_KEYS) && value["sha256"].is_a?(String) && Contract::DIGEST.match?(value["sha256"]) &&
             value["size"].is_a?(Integer) && value["size"].positive?
-        end
-        member = lambda do |value|
-          exact.call(value, FILE_KEYS) && Primitives.safe_relative_path?(value["path"]) &&
-            value["sha256"].is_a?(String) && DIGEST.match?(value["sha256"]) &&
-            value["size"].is_a?(Integer) && value["size"] >= 0
         end
         expected = %w[candidate-installed-manifest.json openclaw-installed-manifest.json].zip(%w[candidate_installation openclaw_installation])
         record_list = lambda do |items|
@@ -59,38 +51,42 @@ module HiveLiveAgentProof
             bundle_record.call(item) && item.values_at("path", "kind") == expected.fetch(index)
           end
         end
-        ASSERT.call(record_list.call(records) && record_list.call(receipt["installed_manifests"]) &&
+        Contract::ASSERT.call(record_list.call(records) && record_list.call(receipt["installed_manifests"]) &&
                     Primitives.canonical_json(receipt["installed_manifests"]) == Primitives.canonical_json(records),
                     "workflow-creator execution installation records are invalid")
-        ASSERT.call(exact.call(receipt["gateway"], GATEWAY_KEYS), "workflow-creator execution gateway fields are invalid")
+        documents = [ candidate, openclaw ].map { |document| Primitives.canonical_json(document) }
+        bound = documents.each_with_index.all? do |bytes, index|
+          records.fetch(index).values_at("sha256", "size") == [ Digest::SHA256.hexdigest(bytes), bytes.bytesize ]
+        end
+        Contract::ASSERT.call(bound, "workflow-creator execution installation bytes are invalid")
+        Contract::ASSERT.call(exact.call(receipt["gateway"], GATEWAY_KEYS), "workflow-creator execution gateway fields are invalid")
         gateway = candidate.fetch("required_roles").fetch("audit_gateway")
-        classification = { "outer" => Vocabulary.fetch("classification"), "nested_stage" => {
-          "execution_kind" => "deterministic_fixture", "model_loop" => "not_exercised" } }
-        valid = candidate_sha.is_a?(String) && SHA.match?(candidate_sha) &&
+        classification = { "outer" => Vocabulary.fetch("classification"), "nested_stage" =>
+          { "execution_kind" => "deterministic_fixture", "model_loop" => "not_exercised" } }
+        valid = candidate_sha.is_a?(String) && Contract::SHA.match?(candidate_sha) &&
           receipt["schema"] == Vocabulary.fetch("execution_schema") &&
           receipt["schema_version"].is_a?(Integer) && receipt["schema_version"] == 1 &&
           receipt["candidate_sha"] == candidate_sha && receipt["result"] == "passed" &&
           receipt["execution_plan"] == Vocabulary.fetch("execution_plan") &&
           row.slice("execution_kind", "model_loop") == Vocabulary.fetch("classification") &&
-          receipt["classification"] == classification && member.call(gateway) && member.call(receipt["gateway"]["identity"]) &&
+          receipt["classification"] == classification &&
           Primitives.canonical_json(receipt["gateway"]["identity"]) == Primitives.canonical_json(gateway) &&
           receipt["gateway"]["status"] == "passed" &&
           receipt["secret_scan"] == { "status" => "passed", "scanner" => Vocabulary.fetch("scanner") }
-        ASSERT.call(valid, "workflow-creator execution receipt identity is invalid")
+        Contract::ASSERT.call(valid, "workflow-creator execution receipt identity is invalid")
         packages = [ candidate, openclaw ].map { |item| item.fetch("required_roles").fetch("package") }
         archives = receipt["archive_admissions"]
-        archive_valid = packages.all? { |package| member.call(package) } && archives.is_a?(Array) &&
-          archives.length == 2 && archives.each_with_index.all? do |archive, index|
+        archive_valid = archives.is_a?(Array) && archives.length == 2 && archives.each_with_index.all? do |archive, index|
           package = packages.fetch(index)
           exact.call(archive, ARCHIVE_KEYS) && archive["label"] == Vocabulary.fetch("archive_labels").fetch(index) &&
             archive["artifact_sha256"] == package["sha256"] && archive["artifact_size"].is_a?(Integer) &&
-            archive["artifact_size"] == package["size"] &&
+            archive["artifact_size"] == package["size"] && archive["artifact_size"].positive? &&
             archive["policy_sha256"] == Vocabulary.fetch("archive_policy_sha256") &&
             archive["entry_count"].is_a?(Integer) && archive["entry_count"].between?(1, MAX_ARCHIVE_ENTRIES) &&
             archive["uncompressed_bytes"].is_a?(Integer) &&
             archive["uncompressed_bytes"].between?(1, MAX_ARCHIVE_BYTES) && archive["status"] == "passed"
         end
-        ASSERT.call(archive_valid, "workflow-creator execution archive admission is invalid")
+        Contract::ASSERT.call(archive_valid, "workflow-creator execution archive admission is invalid")
       end
       def validate_processes!(receipt)
         exact = ->(value, keys) { value.is_a?(Hash) && value.keys.sort == keys.sort }
@@ -101,20 +97,20 @@ module HiveLiveAgentProof
               command["position"] == index + 1 && command["argv"] == Vocabulary.fetch("commands").fetch(index) &&
               valid_process?(command, "attempt_label")
           end
-        ASSERT.call(valid_commands, "workflow-creator execution command receipts are invalid")
+        Contract::ASSERT.call(valid_commands, "workflow-creator execution command receipts are invalid")
         outer = receipt["outer_processes"]
         valid_outer = outer.is_a?(Array) && outer.length == Vocabulary.fetch("outer_roles").length &&
           outer.each_with_index.all? do |process, index|
             exact.call(process, OUTER_KEYS) &&
               process.slice("role", "prompt_sha256") == Vocabulary.fetch("outer_roles").fetch(index) &&
-              process["argv_sha256"].is_a?(String) && DIGEST.match?(process["argv_sha256"]) &&
+              process["argv_sha256"].is_a?(String) && Contract::DIGEST.match?(process["argv_sha256"]) &&
               valid_process?(process, "label")
           end
-        ASSERT.call(valid_outer, "workflow-creator execution outer processes are invalid")
-        ASSERT.call(outer.map { |process| process["argv_sha256"] }.uniq.length == outer.length,
+        Contract::ASSERT.call(valid_outer, "workflow-creator execution outer processes are invalid")
+        Contract::ASSERT.call(outer.map { |process| process["argv_sha256"] }.uniq.length == outer.length,
                     "workflow-creator execution outer argv identities are invalid")
         labels = commands.map { |command| command.fetch("attempt_label") } + outer.map { |process| process.fetch("label") }
-        ASSERT.call(labels.uniq.length == labels.length, "workflow-creator execution process labels are invalid")
+        Contract::ASSERT.call(labels.uniq.length == labels.length, "workflow-creator execution process labels are invalid")
         labels
       end
       def valid_process?(process, label_key)
@@ -130,19 +126,19 @@ module HiveLiveAgentProof
           limit.between?(1, MAX_CAPTURE_BYTES) && %w[stdout_bytes stderr_bytes].all? do |field|
             capture[field].is_a?(Integer) && capture[field].between?(0, limit)
           end && %w[stdout_sha256 stderr_sha256].all? do |field|
-            capture[field].is_a?(String) && DIGEST.match?(capture[field])
+            capture[field].is_a?(String) && Contract::DIGEST.match?(capture[field])
           end && boolean.include?(capture["stdout_truncated"]) && boolean.include?(capture["stderr_truncated"]) &&
           capture["secret_scan"] == { "status" => "passed", "scanner" => Vocabulary.fetch("scanner") } &&
           teardown["status"] == "passed" && boolean.include?(teardown["term_sent"]) &&
           boolean.include?(teardown["kill_sent"]) && (!teardown["kill_sent"] || teardown["term_sent"]) &&
           teardown["reaped"] == true && teardown["descendants"] == "none" && teardown["owner_complete"] == true
-        ASSERT.call(valid, "workflow-creator execution process receipt is invalid")
+        Contract::ASSERT.call(valid, "workflow-creator execution process receipt is invalid")
         true
       end
-      def validate_aggregates!(receipt, row, labels, receipt_sha256)
+      def validate_aggregates!(receipt, row, labels, receipt_sha256, receipt_bytes)
         exact = ->(value, keys) { value.is_a?(Hash) && value.keys.sort == keys.sort }
         run, containment, teardown, cleanup = receipt.values_at("run", "containment", "teardown", "cleanup")
-        ASSERT.call(exact.call(run, RUN_KEYS) && exact.call(containment, CONTAINMENT_KEYS) &&
+        Contract::ASSERT.call(exact.call(run, RUN_KEYS) && exact.call(containment, CONTAINMENT_KEYS) &&
                     exact.call(teardown, TEARDOWN_KEYS) && exact.call(cleanup, CLEANUP_KEYS),
                     "workflow-creator execution aggregate fields are invalid")
         correlation = run["correlation_id"]
@@ -150,14 +146,16 @@ module HiveLiveAgentProof
         target_valid = targets.is_a?(Array) && targets.length == Vocabulary.fetch("cleanup_labels").length &&
           targets.each_with_index.all? do |target, index|
             exact.call(target, TARGET_KEYS) && target["label"] == Vocabulary.fetch("cleanup_labels").fetch(index) &&
-              target["path_sha256"].is_a?(String) && DIGEST.match?(target["path_sha256"]) &&
+              target["path_sha256"].is_a?(String) && Contract::DIGEST.match?(target["path_sha256"]) &&
               target["device"].is_a?(Integer) && target["device"] >= 0 && target["inode"].is_a?(Integer) &&
               target["inode"].positive? && target.values_at("created_by_run", "identity_matched", "removed") == [ true, true, true ]
           end
         instruction = ->(value) do
-          exact.call(value, FILE_KEYS) && Primitives.safe_relative_path?(value["path"]) && value["sha256"].is_a?(String) &&
-            DIGEST.match?(value["sha256"]) && value["size"].is_a?(Integer) && value["size"].positive?
+          exact.call(value, Contract::FILE_KEYS) && Primitives.safe_relative_path?(value["path"]) && value["sha256"].is_a?(String) &&
+            Contract::DIGEST.match?(value["sha256"]) && value["size"].is_a?(Integer) && value["size"].positive?
         end
+        receipt_record = row.fetch("evidence_bundle").fetch(2)
+        receipt_identity = [ Digest::SHA256.hexdigest(receipt_bytes), receipt_bytes.bytesize ]
         summary = { "status" => "passed", "receipt_sha256" => receipt_sha256 }
         valid = correlation.is_a?(String) && LABEL.match?(correlation) && run["expected_labels"] == labels &&
           receipt["gateway"]["command_labels"] == labels.first(Vocabulary.fetch("commands").length) &&
@@ -171,9 +169,10 @@ module HiveLiveAgentProof
           instruction.call(receipt["executed_instruction"]) &&
           receipt["authored_instruction"] == row["executed_instruction"] &&
           receipt["executed_instruction"] == row["executed_instruction"] &&
-          receipt["external_actions"] == [] && row["external_actions"] == [] && receipt_sha256.is_a?(String) &&
-          DIGEST.match?(receipt_sha256) && %w[containment teardown cleanup].all? { |field| row[field] == summary }
-        ASSERT.call(valid, "workflow-creator execution aggregates are inconsistent")
+          receipt["external_actions"] == [] && row["external_actions"] == [] &&
+          receipt_record.values_at("sha256", "size") == receipt_identity && receipt_sha256 == receipt_identity.first &&
+          %w[containment teardown cleanup].all? { |field| row[field] == summary }
+        Contract::ASSERT.call(valid, "workflow-creator execution aggregates are inconsistent")
       end
     end
   end

--- a/packaging/live_agent_skills/workflow_creator_execution_contract.rb
+++ b/packaging/live_agent_skills/workflow_creator_execution_contract.rb
@@ -122,7 +122,7 @@ module HiveLiveAgentProof
         streams_valid = %w[stdout stderr].all? do |stream|
           bytes, digest, truncated = capture.values_at("#{stream}_bytes", "#{stream}_sha256", "#{stream}_truncated")
           bytes.instance_of?(Integer) && bytes.between?(0, limit) && digest.instance_of?(String) &&
-            Contract::DIGEST.match?(digest) && boolean.include?(truncated) && (!bytes.zero? || digest == empty_digest) &&
+            Contract::DIGEST.match?(digest) && boolean.include?(truncated) && (bytes.zero? == (digest == empty_digest)) &&
             (!truncated || bytes == limit)
         end
         valid = exact.call(capture, CAPTURE_KEYS) && exact.call(capture["secret_scan"], %w[scanner status]) &&
@@ -165,7 +165,7 @@ module HiveLiveAgentProof
                            "root_loss_behavior" => "fail-closed" } &&
           teardown == { "status" => "passed", "expected_labels" => labels, "receipt_labels" => labels,
                         "outer_root_reaped" => true, "remaining_descendants" => 0 } &&
-          cleanup["status"] == "passed" && target_valid &&
+          teardown["remaining_descendants"].instance_of?(Integer) && cleanup["status"] == "passed" && target_valid &&
           instruction.call(row["executed_instruction"]) && instruction.call(receipt["authored_instruction"]) &&
           instruction.call(receipt["executed_instruction"]) &&
           receipt["authored_instruction"] == row["executed_instruction"] &&

--- a/test/support/component_boundary_contract.rb
+++ b/test/support/component_boundary_contract.rb
@@ -178,9 +178,11 @@ class ComponentBoundaryContract
     repo_path!(row.fetch("wiki_page"), "#{component_path}.wiki_page")
     validate_migration_exceptions!(row, component_path)
     if row.fetch("hive_consumers").empty? &&
-        !(state == "candidate" && !row.fetch("migration_exceptions").empty?)
+        !(id == "workflow-creator-core" && state == "candidate" &&
+          row.fetch("migration_exceptions").one? &&
+          row.dig("migration_exceptions", 0, "removal_unit") == "U1a2")
       invalid!("#{component_path}.hive_consumers",
-               "candidate components without consumers require a staged removal exception")
+               "zero consumers are reserved for candidate workflow-creator-core with exactly one U1a2 removal exception")
     end
     validate_authorized_internal_constructions!(row, component_path)
     string!(row.fetch("mutation_authority"), "#{component_path}.mutation_authority")

--- a/test/support/component_boundary_contract.rb
+++ b/test/support/component_boundary_contract.rb
@@ -163,8 +163,9 @@ class ComponentBoundaryContract
       value = expect_array(row.fetch(field), "#{component_path}.#{field}")
       next if field == "migration_exceptions"
 
-      string_array!(value, "#{component_path}.#{field}",
-                    allow_empty: %w[component_dependencies allowed_hive_dependencies forbidden_constructions].include?(field))
+      allow_empty = %w[component_dependencies allowed_hive_dependencies forbidden_constructions].include?(field) ||
+        field == "hive_consumers"
+      string_array!(value, "#{component_path}.#{field}", allow_empty: allow_empty)
     end
     forbidden_allowed = row.fetch("allowed_hive_dependencies").select { |required| forbidden_require?(required) }
     unless forbidden_allowed.empty?
@@ -176,6 +177,11 @@ class ComponentBoundaryContract
     end
     repo_path!(row.fetch("wiki_page"), "#{component_path}.wiki_page")
     validate_migration_exceptions!(row, component_path)
+    if row.fetch("hive_consumers").empty? &&
+        !(state == "candidate" && !row.fetch("migration_exceptions").empty?)
+      invalid!("#{component_path}.hive_consumers",
+               "candidate components without consumers require a staged removal exception")
+    end
     validate_authorized_internal_constructions!(row, component_path)
     string!(row.fetch("mutation_authority"), "#{component_path}.mutation_authority")
     string!(row.fetch("recovery_surface"), "#{component_path}.recovery_surface")
@@ -190,7 +196,8 @@ class ComponentBoundaryContract
       assert_keys!(exception, %w[reason removal_unit], path)
       string!(exception.fetch("reason"), "#{path}.reason")
       removal_unit = string!(exception.fetch("removal_unit"), "#{path}.removal_unit")
-      invalid!("#{path}.removal_unit", "must name a plan unit such as U3") unless removal_unit.match?(/\AU\d+\z/)
+      invalid!("#{path}.removal_unit", "must name a plan unit such as U3 or U1a2") unless
+        removal_unit.match?(/\AU\d+(?:[a-z]\d*)*\z/)
     end
     if row.fetch("state") == "boundary-ready" && !exceptions.empty?
       invalid!("#{component_path}.migration_exceptions", "boundary-ready components cannot retain exceptions")
@@ -355,7 +362,8 @@ class ComponentBoundaryContract
       prefixes = #{FORBIDDEN_REQUIRE_PREFIXES.inspect}
       unrelated = #{unrelated_owned_features.inspect}
       loaded = $LOADED_FEATURES.filter_map do |feature|
-        relative = feature.sub(%r{\\A#{Regexp.escape(File.join(@root, "lib"))}/?}, "")
+        relative = feature.delete_prefix(#{"#{@root}/".dump})
+        relative = relative.delete_prefix("lib/")
         next unless prefixes.any? { |prefix| relative == "\#{prefix}.rb" || relative.start_with?("\#{prefix}/") } ||
                     unrelated.include?(relative)
         relative
@@ -373,6 +381,7 @@ class ComponentBoundaryContract
 
     out, err, status = Open3.capture3(
       RbConfig.ruby,
+      "-I#{@root}",
       "-I#{File.join(@root, 'lib')}",
       "-e",
       script,
@@ -426,9 +435,11 @@ class ComponentBoundaryContract
   end
 
   def require_path_for(relative)
-    return unless relative.start_with?("lib/") && relative.end_with?(".rb")
+    return unless relative.end_with?(".rb")
+    return relative.delete_prefix("lib/").delete_suffix(".rb") if relative.start_with?("lib/")
+    return relative.delete_suffix(".rb") if relative.start_with?("packaging/")
 
-    relative.delete_prefix("lib/").delete_suffix(".rb")
+    nil
   end
 
   def forbidden_require?(required)
@@ -612,9 +623,10 @@ class ComponentBoundaryContract
 
     def relative_require_path(required)
       relative = Pathname.new(File.join(File.dirname(@path), required)).cleanpath.to_s
-      return unless relative.start_with?("lib/")
+      return relative.delete_prefix("lib/").delete_suffix(".rb") if relative.start_with?("lib/")
+      return relative.delete_suffix(".rb") if relative.start_with?("packaging/")
 
-      relative.delete_prefix("lib/").delete_suffix(".rb")
+      nil
     end
 
     def constant_path(node)

--- a/test/unit/component_boundaries_test.rb
+++ b/test/unit/component_boundaries_test.rb
@@ -655,18 +655,17 @@ class ComponentBoundariesTest < Minitest::Test
     end
   end
 
-  def test_boundary_ready_component_rejects_zero_consumers_even_with_a_fence
+  def test_boundary_ready_component_rejects_zero_consumers_at_the_named_branch
     with_contract_fixture(
       entrypoint_source: example_api_source,
       hive_consumers: [],
-      migration_exceptions: [
-        { "reason" => "not a ready-state exception", "removal_unit" => "U1a2" }
-      ]
+      migration_exceptions: []
     ) do |contract|
       error = assert_raises(ComponentBoundaryContract::ValidationError) do
         contract.validate_catalog!
       end
-      assert_match(/example\.(?:hive_consumers|migration_exceptions)/, error.message)
+      assert_match(/example\.hive_consumers/, error.message)
+      assert_match(/candidate components without consumers require a staged removal exception/, error.message)
     end
   end
 

--- a/test/unit/component_boundaries_test.rb
+++ b/test/unit/component_boundaries_test.rb
@@ -22,6 +22,7 @@ class ComponentBoundariesTest < Minitest::Test
       skillpack
       user-service
       work-ledger
+      workflow-creator-core
     ], contract.components.map { |component| component.fetch("id") }.sort
 
     attempts = contract.component("attempts")
@@ -74,6 +75,22 @@ class ComponentBoundariesTest < Minitest::Test
         [ entry.fetch("constant"), entry.fetch("files") ]
       end
     )
+    workflow_creator = contract.component("workflow-creator-core")
+    assert_equal "candidate", workflow_creator.fetch("state")
+    assert_equal "packaging/live_agent_skills/workflow_creator",
+                 workflow_creator.dig("entrypoint", "require")
+    assert_equal "HiveLiveAgentProof::WorkflowCreator",
+                 workflow_creator.dig("entrypoint", "constant")
+    assert_equal %w[
+      packaging/live_agent_skills/proof_primitives.rb
+      packaging/live_agent_skills/workflow_creator.rb
+      packaging/live_agent_skills/workflow_creator_contract.rb
+      packaging/live_agent_skills/workflow_creator_execution_contract.rb
+    ], workflow_creator.fetch("owned_paths").sort
+    assert_empty workflow_creator.fetch("hive_consumers")
+    assert_empty workflow_creator.fetch("component_dependencies")
+    assert_equal [ "U1a2" ], workflow_creator.fetch("migration_exceptions")
+      .map { |entry| entry.fetch("removal_unit") }
     user_service = contract.component("user-service")
     assert_equal "boundary-ready", user_service.fetch("state")
     assert_equal "hive/user_service", user_service.dig("entrypoint", "require")
@@ -248,7 +265,7 @@ class ComponentBoundariesTest < Minitest::Test
     remaining_candidates = contract.components.reject do |component|
       ready_components.include?(component)
     end
-    assert_equal %w[attempts patrol-effects],
+    assert_equal %w[attempts patrol-effects workflow-creator-core],
                  remaining_candidates.map { |entry| entry.fetch("id") }.sort
     assert remaining_candidates.all? { |component| component.fetch("state") == "candidate" }
 
@@ -290,6 +307,11 @@ class ComponentBoundariesTest < Minitest::Test
                  patrol_effects_load.fetch("constant")
     assert_empty patrol_effects_load.fetch("forbidden_loaded_features")
     assert_empty patrol_effects_load.fetch("forbidden_constants")
+    workflow_creator_load = contract.validate_clean_load!("workflow-creator-core")
+    assert_equal "HiveLiveAgentProof::WorkflowCreator",
+                 workflow_creator_load.fetch("constant")
+    assert_empty workflow_creator_load.fetch("forbidden_loaded_features")
+    assert_empty workflow_creator_load.fetch("forbidden_constants")
   end
 
   def test_final_graph_and_wiki_inventory_agree_with_the_catalog
@@ -313,8 +335,12 @@ class ComponentBoundariesTest < Minitest::Test
       assert_includes row, "[[#{wiki_link}]]"
       assert_includes wiki_index, "[[#{wiki_link}]]"
       exceptions = component.fetch("migration_exceptions")
-      if component.fetch("id") == "patrol-effects"
-        assert_equal [ "U3" ],
+      expected_exception = {
+        "patrol-effects" => [ "U3" ],
+        "workflow-creator-core" => [ "U1a2" ]
+      }[component.fetch("id")]
+      if expected_exception
+        assert_equal expected_exception,
                      exceptions.map { |entry| entry.fetch("removal_unit") }
       else
         assert_empty exceptions,
@@ -591,14 +617,56 @@ class ComponentBoundariesTest < Minitest::Test
   end
 
   def test_candidate_component_accepts_bounded_migration_exception
+    %w[U3 U3a U3b U3c U1a2].each do |removal_unit|
+      with_contract_fixture(
+        entrypoint_source: example_api_source,
+        state: "candidate",
+        migration_exceptions: [
+          { "reason" => "temporary upward edge", "removal_unit" => removal_unit }
+        ]
+      ) do |contract|
+        assert contract.validate_catalog!, removal_unit
+      end
+    end
+  end
+
+  def test_candidate_only_zero_consumer_state_requires_a_valid_staged_removal_fence
     with_contract_fixture(
       entrypoint_source: example_api_source,
       state: "candidate",
+      hive_consumers: [],
       migration_exceptions: [
-        { "reason" => "temporary upward edge", "removal_unit" => "U3" }
+        { "reason" => "U1a1 is staged before its production consumer", "removal_unit" => "U1a2" }
       ]
     ) do |contract|
       assert contract.validate_catalog!
+    end
+
+    with_contract_fixture(
+      entrypoint_source: example_api_source,
+      state: "candidate",
+      hive_consumers: []
+    ) do |contract|
+      error = assert_raises(ComponentBoundaryContract::ValidationError) do
+        contract.validate_catalog!
+      end
+      assert_match(/example\.hive_consumers/, error.message)
+      assert_match(/candidate components without consumers require a staged removal exception/, error.message)
+    end
+  end
+
+  def test_boundary_ready_component_rejects_zero_consumers_even_with_a_fence
+    with_contract_fixture(
+      entrypoint_source: example_api_source,
+      hive_consumers: [],
+      migration_exceptions: [
+        { "reason" => "not a ready-state exception", "removal_unit" => "U1a2" }
+      ]
+    ) do |contract|
+      error = assert_raises(ComponentBoundaryContract::ValidationError) do
+        contract.validate_catalog!
+      end
+      assert_match(/example\.(?:hive_consumers|migration_exceptions)/, error.message)
     end
   end
 
@@ -1127,7 +1195,7 @@ class ComponentBoundariesTest < Minitest::Test
                             entrypoint_require: "example", owned_paths: nil,
                             component_dependencies: [], allowed_hive_dependencies: [],
                             migration_exceptions: [], authorized_internal_constructions: [],
-                            internal_collaborators: nil,
+                            internal_collaborators: nil, hive_consumers: [ "lib/consumer.rb" ],
                             extra_components: [], extra_files: {})
     Dir.mktmpdir do |root|
       write_fixture(root, entrypoint_file, entrypoint_source)
@@ -1150,7 +1218,8 @@ class ComponentBoundariesTest < Minitest::Test
             allowed_hive_dependencies: allowed_hive_dependencies,
             migration_exceptions: migration_exceptions,
             authorized_internal_constructions: authorized_internal_constructions,
-            internal_collaborators: internal_collaborators
+            internal_collaborators: internal_collaborators,
+            hive_consumers: hive_consumers
           ),
           *extra_components
         ]
@@ -1163,7 +1232,7 @@ class ComponentBoundariesTest < Minitest::Test
   def fixture_component(id:, state:, entrypoint_file:, entrypoint_require:, entrypoint_constant:,
                         owned_paths:, component_dependencies: [], allowed_hive_dependencies: [],
                         migration_exceptions: [], authorized_internal_constructions: [],
-                        internal_collaborators: nil)
+                        internal_collaborators: nil, hive_consumers: [ "lib/consumer.rb" ])
     namespace = entrypoint_constant.split("::").first
     internal_collaborators ||= [ "#{namespace}::Internal" ]
     {
@@ -1188,7 +1257,7 @@ class ComponentBoundariesTest < Minitest::Test
       "internal_collaborators" => internal_collaborators,
       "forbidden_constructions" => [ "#{namespace}::Internal" ],
       "authorized_internal_constructions" => authorized_internal_constructions,
-      "hive_consumers" => [ "lib/consumer.rb" ],
+      "hive_consumers" => hive_consumers,
       "mutation_authority" => "none",
       "recovery_surface" => "none",
       "wiki_page" => "wiki/example.md",

--- a/test/unit/component_boundaries_test.rb
+++ b/test/unit/component_boundaries_test.rb
@@ -630,18 +630,7 @@ class ComponentBoundariesTest < Minitest::Test
     end
   end
 
-  def test_candidate_only_zero_consumer_state_requires_a_valid_staged_removal_fence
-    with_contract_fixture(
-      entrypoint_source: example_api_source,
-      state: "candidate",
-      hive_consumers: [],
-      migration_exceptions: [
-        { "reason" => "U1a1 is staged before its production consumer", "removal_unit" => "U1a2" }
-      ]
-    ) do |contract|
-      assert contract.validate_catalog!
-    end
-
+  def test_candidate_rejects_zero_consumers_without_a_staged_removal_fence
     with_contract_fixture(
       entrypoint_source: example_api_source,
       state: "candidate",
@@ -651,8 +640,63 @@ class ComponentBoundariesTest < Minitest::Test
         contract.validate_catalog!
       end
       assert_match(/example\.hive_consumers/, error.message)
-      assert_match(/candidate components without consumers require a staged removal exception/, error.message)
+      assert_match(/zero consumers are reserved for candidate workflow-creator-core with exactly one U1a2 removal exception/, error.message)
     end
+  end
+
+  def test_patrol_effects_cannot_reuse_its_u3_exception_with_zero_consumers
+    document = Marshal.load(Marshal.dump(@document))
+    component(document, "patrol-effects")["hive_consumers"] = []
+
+    error = assert_raises(ComponentBoundaryContract::ValidationError) do
+      ComponentBoundaryContract.new(document, root: ROOT).validate_catalog!
+    end
+
+    assert_match(/patrol-effects\.hive_consumers/, error.message)
+  end
+
+  def test_attempts_cannot_claim_the_u1a2_zero_consumer_exception
+    document = Marshal.load(Marshal.dump(@document))
+    attempts = component(document, "attempts")
+    attempts["hive_consumers"] = []
+    attempts["migration_exceptions"] = [
+      { "reason" => "temporary staged component", "removal_unit" => "U1a2" }
+    ]
+
+    error = assert_raises(ComponentBoundaryContract::ValidationError) do
+      ComponentBoundaryContract.new(document, root: ROOT).validate_catalog!
+    end
+
+    assert_match(/attempts\.hive_consumers/, error.message)
+  end
+
+  def test_workflow_creator_zero_consumer_exception_must_name_u1a2
+    document = Marshal.load(Marshal.dump(@document))
+    workflow_creator = component(document, "workflow-creator-core")
+    workflow_creator["migration_exceptions"] = [
+      { "reason" => "temporary staged component", "removal_unit" => "U3" }
+    ]
+
+    error = assert_raises(ComponentBoundaryContract::ValidationError) do
+      ComponentBoundaryContract.new(document, root: ROOT).validate_catalog!
+    end
+
+    assert_match(/workflow-creator-core\.hive_consumers/, error.message)
+  end
+
+  def test_workflow_creator_zero_consumer_exception_must_be_unique
+    document = Marshal.load(Marshal.dump(@document))
+    workflow_creator = component(document, "workflow-creator-core")
+    workflow_creator["migration_exceptions"] = [
+      { "reason" => "first staged component fence", "removal_unit" => "U1a2" },
+      { "reason" => "second staged component fence", "removal_unit" => "U1a2" }
+    ]
+
+    error = assert_raises(ComponentBoundaryContract::ValidationError) do
+      ComponentBoundaryContract.new(document, root: ROOT).validate_catalog!
+    end
+
+    assert_match(/workflow-creator-core\.hive_consumers/, error.message)
   end
 
   def test_boundary_ready_component_rejects_zero_consumers_at_the_named_branch
@@ -665,7 +709,7 @@ class ComponentBoundariesTest < Minitest::Test
         contract.validate_catalog!
       end
       assert_match(/example\.hive_consumers/, error.message)
-      assert_match(/candidate components without consumers require a staged removal exception/, error.message)
+      assert_match(/zero consumers are reserved for candidate workflow-creator-core with exactly one U1a2 removal exception/, error.message)
     end
   end
 

--- a/test/unit/packaging/live_agent_proof_test.rb
+++ b/test/unit/packaging/live_agent_proof_test.rb
@@ -104,6 +104,274 @@ class LiveAgentProofTest < Minitest::Test
     end
   end
 
+  def test_workflow_creator_schema_v1_vocabulary_and_bytes_are_exact
+    with_tmp_dir do |dir|
+      artifacts = prepare_artifacts(dir)
+      creator_evidence = prepare_creator_evidence(dir, artifacts)
+      path = File.join(creator_evidence, "openclaw-workflow-creator.json")
+      row = JSON.parse(File.read(path))
+
+      assert_equal(
+        %w[
+          candidate_sha cleanup created_files creation_only_task_count
+          external_actions hive_commands native_activation platform
+          prompt_sha256 result schema schema_version secret_scan skill task
+          task_count task_prompt_sha256 validation
+        ],
+        row.keys.sort
+      )
+      assert_equal(
+        <<~PROMPT,
+          /hive
+          Create a three-stage editorial workflow that researches, drafts, and requires approval before publishing.
+          Use the installed Hive workflow-creator capability in this initialized project.
+          This is creation-only: validate the result, report the defaults, and do not create or run a task.
+        PROMPT
+        HiveLiveAgentProof::WORKFLOW_CREATOR_PROMPT
+      )
+      assert_equal(
+        <<~PROMPT,
+          /hive
+          Use the validated editorial workflow to create and run one task for:
+          "Research and draft the launch announcement for approval."
+          Use idempotency key workflow-creator-proof:editorial:live-proof. In this exact order: create the task,
+          run its first stage once, repeat the same creation command once to prove the retry is a no-op,
+          then query operational status. Do not publish or perform any other external action.
+        PROMPT
+        HiveLiveAgentProof::WORKFLOW_CREATOR_TASK_PROMPT
+      )
+      assert_equal(
+        [
+          [ "version" ],
+          [ "workflow", "list", "--json" ],
+          [ "workflow", "new", "editorial", "--json" ],
+          [ "workflow", "validate", "editorial", "--json" ],
+          [ "workflow", "commit", "editorial" ],
+          [ "new", "workflow-creator-proof", "--workflow", "editorial",
+            "--idempotency-key", "workflow-creator-proof:editorial:live-proof",
+            "--json", "Research and draft the launch announcement for approval." ],
+          [ "run", "editorial-live-proof" ],
+          [ "new", "workflow-creator-proof", "--workflow", "editorial",
+            "--idempotency-key", "workflow-creator-proof:editorial:live-proof",
+            "--json", "Research and draft the launch announcement for approval." ],
+          [ "status", "--operational", "--json" ]
+        ],
+        HiveLiveAgentProof::WORKFLOW_CREATOR_COMMANDS
+      )
+      assert_equal(
+        %w[
+          .hive-state/workflows/editorial.yml
+          .hive-state/workflows/editorial/draft.md
+          .hive-state/workflows/editorial/research.md
+        ],
+        HiveLiveAgentProof::WORKFLOW_CREATOR_FILES
+      )
+      assert_equal "#{JSON.pretty_generate(row)}\n", File.binread(path)
+    end
+  end
+
+  def test_attestor_and_verifier_preserve_public_and_unrelated_proof_bytes
+    with_tmp_dir do |dir|
+      artifacts = prepare_artifacts(dir)
+      evidence = prepare_evidence(dir, artifacts)
+      creator_evidence = prepare_creator_evidence(dir, artifacts)
+      creator_path = File.join(
+        creator_evidence,
+        "openclaw-workflow-creator.json"
+      )
+      creator_bytes = File.binread(creator_path)
+      creator_row = JSON.parse(creator_bytes)
+      platform_rows = HiveLiveAgentProof::PLATFORMS.to_h do |platform|
+        [ platform, JSON.parse(File.read(File.join(evidence, "#{platform}.json"))) ]
+      end
+      manifest = JSON.parse(File.read(File.join(artifacts, "artifact-manifest.json")))
+      proof = File.join(dir, "proof")
+
+      result = attest(artifacts, evidence, creator_evidence, proof)
+      attestation = result.fetch("attestation")
+
+      assert_equal creator_row, attestation.fetch("workflow_creator")
+      assert_equal creator_bytes,
+                   File.binread(File.join(proof, "evidence", "openclaw-workflow-creator.json"))
+      assert_equal manifest, attestation.fetch("artifacts")
+      assert_equal platform_rows, attestation.fetch("platforms")
+      assert_equal 6, attestation.dig("secret_scan", "files_scanned")
+      assert_equal(
+        "#{result.fetch("sha256")}  attestation.json\n",
+        File.binread(File.join(proof, "attestation.sha256"))
+      )
+
+      FileUtils.rm_rf(creator_evidence)
+      verified = verifier(proof, result.fetch("sha256")).call
+      assert_match(/hive-cli-1\.2\.3\.gem\z/, verified.fetch("gem"))
+    end
+  end
+
+  def test_current_creator_failures_have_exact_public_messages
+    with_tmp_dir do |dir|
+      artifacts = prepare_artifacts(dir)
+      evidence = prepare_evidence(dir, artifacts)
+      cases = {
+        "missing-inventory" => [
+          ->(root, _row) { FileUtils.rm_f(File.join(root, "openclaw-workflow-creator.json")) },
+          "workflow-creator evidence must contain exactly openclaw-workflow-creator.json"
+        ],
+        "extra-inventory" => [
+          ->(root, _row) { HiveLiveAgentProof.write_json(File.join(root, "extra.json"), {}) },
+          "workflow-creator evidence must contain exactly openclaw-workflow-creator.json"
+        ],
+        "identity" => [
+          ->(_root, row) { row["schema"] = "wrong" },
+          "workflow-creator evidence identity or result is invalid"
+        ],
+        "provenance" => [
+          ->(_root, row) { row["skill"]["canonical_digest"] = "0" * 64 },
+          "workflow-creator evidence canonical provenance mismatch"
+        ],
+        "activation" => [
+          ->(_root, row) { row["native_activation"]["kind"] = "generic-file-read" },
+          "workflow-creator native activation evidence is invalid"
+        ],
+        "missing-command" => [
+          ->(_root, row) { row["hive_commands"].pop },
+          "workflow-creator prompt or command sequence is invalid"
+        ],
+        "reordered-command" => [
+          lambda do |_root, row|
+            row["hive_commands"][0], row["hive_commands"][1] =
+              row["hive_commands"][1], row["hive_commands"][0]
+          end,
+          "workflow-creator prompt or command sequence is invalid"
+        ],
+        "duplicate-command" => [
+          ->(_root, row) { row["hive_commands"].insert(1, row["hive_commands"].first) },
+          "workflow-creator prompt or command sequence is invalid"
+        ],
+        "extra-command" => [
+          ->(_root, row) { row["hive_commands"] << [ "doctor", "--json" ] },
+          "workflow-creator prompt or command sequence is invalid"
+        ],
+        "missing-created-file" => [
+          ->(_root, row) { row["created_files"].pop },
+          "workflow-creator created files are incomplete"
+        ],
+        "invalid-file" => [
+          ->(_root, row) { row["created_files"].first["size"] = 0 },
+          "workflow-creator created-file records are invalid"
+        ],
+        "missing-validation" => [
+          ->(_root, row) { row["validation"] = nil },
+          "workflow-creator normalized graph is invalid"
+        ],
+        "graph-drift" => [
+          ->(_root, row) { row["validation"]["stages"] << "publish" },
+          "workflow-creator normalized graph is invalid"
+        ],
+        "unauthorized-task" => [
+          ->(_root, row) { row["task_count"] = 2 },
+          "workflow-creator proof contains an unauthorized side effect"
+        ],
+        "unauthorized-effect" => [
+          ->(_root, row) { row["external_actions"] << "publish" },
+          "workflow-creator proof contains an unauthorized side effect"
+        ],
+        "secret-scan-status" => [
+          ->(_root, row) { row["secret_scan"]["status"] = "failed" },
+          "workflow-creator evidence lacks secret-scan or cleanup proof"
+        ],
+        "cleanup-status" => [
+          ->(_root, row) { row["cleanup"]["status"] = "failed" },
+          "workflow-creator evidence lacks secret-scan or cleanup proof"
+        ],
+        "secret-content" => [
+          ->(_root, row) { row["diagnostic"] = [ "sk", "ant", "abcdefghijkl" ].join("-") },
+          "workflow-creator evidence secret scan failed: pattern:sk-ant-[A-Za-z0-9_-]{12,}"
+        ]
+      }
+
+      cases.each do |label, (mutation, expected_message)|
+        creator = prepare_creator_evidence(File.join(dir, label), artifacts)
+        path = File.join(creator, "openclaw-workflow-creator.json")
+        row = JSON.parse(File.read(path))
+        mutation.call(creator, row)
+        HiveLiveAgentProof.write_json(path, row) if File.exist?(path)
+
+        error = assert_raises(HiveLiveAgentProof::Error, label) do
+          attest(artifacts, evidence, creator, File.join(dir, "proof-#{label}"))
+        end
+        assert_equal expected_message, error.message, label
+      end
+
+      creator = prepare_creator_evidence(File.join(dir, "verifier-source"), artifacts)
+      source_proof = File.join(dir, "verifier-source-proof")
+      attest(artifacts, evidence, creator, source_proof)
+      verifier_cases = {
+        "identity" => [
+          ->(row) { row["platform"] = "wrong" },
+          "workflow-creator attested evidence is incomplete"
+        ],
+        "activation" => [
+          ->(row) { row["native_activation"]["kind"] = "generic-file-read" },
+          "workflow-creator attested native activation evidence is invalid"
+        ],
+        "contract" => [
+          ->(row) { row["prompt_sha256"] = "0" * 64 },
+          "workflow-creator attested contract is invalid"
+        ]
+      }
+      verifier_cases.each do |label, (mutation, expected_message)|
+        proof = File.join(dir, "verifier-proof-#{label}")
+        FileUtils.cp_r(source_proof, proof)
+        attestation_path = File.join(proof, "attestation.json")
+        attestation = JSON.parse(File.read(attestation_path))
+        mutation.call(attestation.fetch("workflow_creator"))
+        HiveLiveAgentProof.write_json(attestation_path, attestation)
+
+        error = assert_raises(HiveLiveAgentProof::Error, label) do
+          verifier(proof, HiveLiveAgentProof.sha256(attestation_path)).call
+        end
+        assert_equal expected_message, error.message, label
+      end
+    end
+  end
+
+  # These accepted mutations are characterization of the current duplicated
+  # verifier. They are tightening targets for U1a1/U1a2, not compatibility promises.
+  def test_current_verifier_acceptance_gaps_are_explicit
+    with_tmp_dir do |dir|
+      artifacts = prepare_artifacts(dir)
+      evidence = prepare_evidence(dir, artifacts)
+      creator_evidence = prepare_creator_evidence(dir, artifacts)
+      source_proof = File.join(dir, "source-proof")
+      attest(artifacts, evidence, creator_evidence, source_proof)
+      cases = {
+        "extra-field" => ->(row) { row["unexpected"] = true },
+        "schema-version" => ->(row) { row["schema_version"] = 999 },
+        "skill-version" => ->(row) { row["skill"]["skill_version"] = "wrong" },
+        "created-file" => lambda do |row|
+          row["created_files"].first["sha256"] = "0" * 64
+          row["created_files"].first["size"] = 0
+        end,
+        "graph" => ->(row) { row["validation"]["stages"] << "publish" }
+      }
+
+      cases.each do |label, mutation|
+        proof = File.join(dir, "proof-#{label}")
+        FileUtils.cp_r(source_proof, proof)
+        attestation_path = File.join(proof, "attestation.json")
+        attestation = JSON.parse(File.read(attestation_path))
+        mutation.call(attestation.fetch("workflow_creator"))
+        HiveLiveAgentProof.write_json(attestation_path, attestation)
+
+        verified = verifier(
+          proof,
+          HiveLiveAgentProof.sha256(attestation_path)
+        ).call
+        assert_match(/hive-cli-1\.2\.3\.gem\z/, verified.fetch("gem"), label)
+      end
+    end
+  end
+
   def test_attestor_rejects_missing_skipped_or_unsafe_platform_evidence
     with_tmp_dir do |dir|
       artifacts = prepare_artifacts(dir)

--- a/test/unit/packaging/live_agent_proof_test.rb
+++ b/test/unit/packaging/live_agent_proof_test.rb
@@ -468,8 +468,8 @@ class LiveAgentProofTest < Minitest::Test
   end
 
   def test_secret_scanner_rejects_provider_and_private_key_shapes
-    refute_empty HiveLiveAgentProof.secret_findings("sk-ant-abcdefghijklmnopqrstuvwxyz")
-    refute_empty HiveLiveAgentProof.secret_findings("-----BEGIN PRIVATE KEY-----")
+    refute_empty HiveLiveAgentProof.secret_findings(%w[sk ant abcdefghijklmnopqrstuvwxyz].join("-"))
+    refute_empty HiveLiveAgentProof.secret_findings([ "-----BEGIN", "PRIVATE", "KEY-----" ].join(" "))
     refute_empty HiveLiveAgentProof.secret_findings("prefix exact-value suffix", exact_secrets: [ "exact-value" ])
     assert_empty HiveLiveAgentProof.secret_findings('{"result":"passed","sha256":"abc"}')
   end

--- a/test/unit/packaging/workflow_creator_core_test.rb
+++ b/test/unit/packaging/workflow_creator_core_test.rb
@@ -208,6 +208,56 @@ class WorkflowCreatorCoreTest < Minitest::Test
     end
   end
 
+  def test_canonical_json_stops_before_encoding_keys_past_resource_bounds
+    json_limit = CREATOR.const_get(:Primitives, false).const_get(:MAX_JSON_BYTES, false)
+    oversized_key = ("z" * (json_limit - 2)).freeze
+    late_key = "late-key".freeze
+    node_bound_hash = 16_384.times.to_h { |index| [ format("key-%05d", index).freeze, 0 ] }
+    cases = {
+      "byte-ceiling" => { oversized_key => 0, late_key => 0 },
+      "remaining-value-nodes" => node_bound_hash
+    }
+    observed = cases.to_h do |label, value|
+      encode_calls = 0
+      trace = TracePoint.new(:c_call) { |event| encode_calls += 1 if event.method_id == :encode }
+      trace.enable { assert_raises(CREATOR::Error, label) { CREATOR.canonical_json(value) } }
+      [ label, encode_calls ]
+    end
+
+    assert_equal({ "byte-ceiling" => 0, "remaining-value-nodes" => 0 }, observed)
+  end
+
+  def test_canonical_json_uses_generator_accurate_finite_float_tokens
+    values = [ 1e20, 1e-6, 1e-7 ]
+    documents = values.flat_map { |value| [ value, { "nested" => [ value ] } ] }
+    actual = documents.map do |document|
+      CREATOR.canonical_json(document)
+    rescue CREATOR::Error => error
+      "#{error.class}: #{error.message}"
+    end
+
+    assert_equal documents.map { |document| "#{JSON.pretty_generate(document)}\n" }, actual
+    [ Float::NAN, Float::INFINITY, -Float::INFINITY ].each do |value|
+      assert_raises(CREATOR::Error) { CREATOR.canonical_json(value) }
+    end
+  end
+
+  def test_canonical_json_projects_backslash_escapes_exactly
+    value = {
+      "array" => [ "C:\\tmp", "one\\two\\three" ],
+      "controls" => "line one\nline two\t\x01",
+      "path" => "runtime\\dependency.rb",
+      "quote" => "quoted \"value\""
+    }
+    actual = begin
+      CREATOR.canonical_json(value)
+    rescue CREATOR::Error => error
+      "#{error.class}: #{error.message}"
+    end
+
+    assert_equal "#{JSON.pretty_generate(value)}\n", actual
+  end
+
   def test_public_validation_boundaries_reject_json_subclasses
     hostile_hash = Class.new(Hash) { def keys = [] }
     hostile_array = Class.new(Array) { def map = [] }
@@ -258,6 +308,72 @@ class WorkflowCreatorCoreTest < Minitest::Test
       nil
     end
     assert_empty accepted, "subclass-backed evidence admitted: #{accepted.join(', ')}"
+  end
+
+  def test_public_validation_rejects_deceptive_class_and_singleton_dispatch
+    deceptive_hash = Class.new(Hash) do
+      def class = Hash
+      def keys = []
+      def length = 0
+    end
+    singleton_hash = { "hidden" => true }
+    singleton_hash.define_singleton_method(:keys) { [] }
+    singleton_hash.define_singleton_method(:length) { 0 }
+    singleton_array = [ "hidden" ]
+    singleton_array.define_singleton_method(:empty?) { true }
+    singleton_array.define_singleton_method(:map) { [] }
+    singleton_string = +"hidden"
+    singleton_string.define_singleton_method(:bytesize) { 0 }
+    singleton_string.define_singleton_method(:count) { |*| 0 }
+    singleton_string.define_singleton_method(:encode) { |*| "" }
+    singleton_secret = +"fixture-secret"
+    singleton_secret.define_singleton_method(:bytesize) { 1 }
+    deceptive_argument = Class.new(String) do
+      def instance_of?(_type) = true
+      def downcase = raise(Minitest::Assertion, "failure argument dispatched before admission")
+    end
+    singleton_detail = +"detail"
+    singleton_detail.define_singleton_method(:encode) { |*| raise Minitest::Assertion, "detail dispatched before admission" }
+    deceptive_secrets = Class.new(Array) do
+      def instance_of?(_type) = true
+      def length = 0
+      def all? = true
+    end
+    singleton_secrets = [ "fixture-secret" ]
+    singleton_secrets.define_singleton_method(:length) { 0 }
+    singleton_secrets.define_singleton_method(:all?) { true }
+    cases = {
+      "deceptive-hash-class" => -> { CREATOR.canonical_json(deceptive_hash["hidden" => true]) },
+      "exact-hash-singleton" => -> { CREATOR.canonical_json(singleton_hash) },
+      "exact-array-singleton" => -> { CREATOR.canonical_json(singleton_array) },
+      "exact-string-singleton" => -> { CREATOR.canonical_json(singleton_string) },
+      "deceptive-failure-argument" => lambda do
+        CREATOR.failure(candidate_sha: deceptive_argument.new(SHA), phase: "preflight", reason: "not_started")
+      end,
+      "exact-detail-singleton" => lambda do
+        CREATOR.failure(candidate_sha: SHA, phase: "preflight", reason: "not_started", detail: singleton_detail)
+      end,
+      "exact-secret-singleton" => lambda do
+        CREATOR.failure(candidate_sha: SHA, phase: "preflight", reason: "not_started",
+                        exact_secrets: [ singleton_secret ])
+      end,
+      "deceptive-secret-array" => lambda do
+        CREATOR.failure(candidate_sha: SHA, phase: "preflight", reason: "not_started",
+                        exact_secrets: deceptive_secrets["fixture-secret"])
+      end,
+      "exact-secret-array-singleton" => lambda do
+        CREATOR.failure(candidate_sha: SHA, phase: "preflight", reason: "not_started",
+                        exact_secrets: singleton_secrets)
+      end
+    }
+    accepted = cases.filter_map do |label, action|
+      action.call
+      label
+    rescue CREATOR::Error
+      nil
+    end
+
+    assert_empty accepted, "dispatch-backed evidence admitted: #{accepted.join(', ')}"
   end
 
   def test_failure_redaction_merges_overlapping_original_ranges
@@ -504,6 +620,26 @@ class WorkflowCreatorCoreTest < Minitest::Test
     assert_empty accepted, "incoherent capture tuples admitted: #{accepted.join(', ')}"
   end
 
+  def test_execution_capture_rejects_positive_bytes_with_empty_digest_after_rebinding
+    fixture = valid_fixture
+    capture = fixture.fetch(:receipt).fetch("commands").first.fetch("capture")
+    capture["stdout_bytes"] = 1
+    capture["stdout_sha256"] = Digest::SHA256.hexdigest("")
+    rebind_execution_receipt!(fixture)
+
+    error = assert_raises(CREATOR::Error) { validate_execution(fixture) }
+    assert_equal "workflow-creator execution process receipt is invalid", error.message
+  end
+
+  def test_execution_teardown_rejects_float_zero_after_rebinding
+    fixture = valid_fixture
+    fixture.fetch(:receipt).fetch("teardown")["remaining_descendants"] = 0.0
+    rebind_execution_receipt!(fixture)
+
+    error = assert_raises(CREATOR::Error) { validate_execution(fixture) }
+    assert_equal "workflow-creator execution aggregates are inconsistent", error.message
+  end
+
   def test_execution_contract_binds_all_canonical_document_bytes_and_kinds
     cases = {
       "swapped-documents" => lambda do |item|
@@ -606,6 +742,23 @@ class WorkflowCreatorCoreTest < Minitest::Test
     end
   end
 
+  def test_relative_path_scanning_preserves_results_without_component_allocation
+    primitives = CREATOR.const_get(:Primitives, false)
+    separator_heavy = ([ "segment" ] * 20_000).join("/")
+    safe = [ "file", "dir/file", "dir/.hidden", "...", "Cfile", "utf8/é", separator_heavy ]
+    unsafe = [ "", ".", "..", "/absolute", "../escape", "dir/../escape", "./file",
+               "dir//file", "dir/", "C:/escape", "C:relative", "C:\\escape", "dir\\escape", "nul\0path" ]
+    split_calls = 0
+    trace = TracePoint.new(:c_call) do |event|
+      split_calls += 1 if event.method_id == :split
+    end
+    observed_safe = trace.enable { safe.to_h { |path| [ path, primitives.safe_relative_path?(path) ] } }
+
+    assert observed_safe.values.all?, observed_safe.inspect
+    assert unsafe.none? { |path| primitives.safe_relative_path?(path) }
+    assert_equal 0, split_calls
+  end
+
   def test_schema_v1_vocabulary_is_bound_to_the_incumbent_proof
     require_relative "../../../packaging/live_agent_skills/proof"
     keys = %w[schema_version request prompt task_request task_key task_slug task_prompt task_new_argv commands files]
@@ -696,7 +849,7 @@ class WorkflowCreatorCoreTest < Minitest::Test
     { lines: 590, methods: 22, branches: 28 }.each do |metric, hard_limit|
       assert_operator totals.fetch(metric), :<=, hard_limit, "aggregate hard #{metric}"
     end
-    { lines: 588, methods: 22, branches: 19 }.each do |metric, target|
+    { lines: 588, methods: 22, branches: 15 }.each do |metric, target|
       assert_operator totals.fetch(metric), :<=, target, "aggregate target #{metric}"
     end
   end
@@ -836,16 +989,16 @@ class WorkflowCreatorCoreTest < Minitest::Test
       "proof_primitives.rb" => {
         requires: [ %w[require json] ],
         calls: %w[
-          ascii_only? bit_length bytebegin byteend bytesize byteslice call class count deep_freeze dup each
-          each_with_index each_with_object empty? encode encoding escape fetch filter_map finite? first
-          force_encoding freeze include? instance_of? is_a? keys lambda last last_match length map match?
-          max module_function none? pretty_generate raise require scan scrub sort sort_by! source split
-          start_with? tap then to_h to_s valid_encoding?
+          any? ascii_only? bind_call bit_length bytebegin byteend bytesize byteslice call count deep_freeze dup each
+          each_key each_with_index each_with_object empty? encode encoding equal? escape fetch filter_map finite? first
+          force_encoding freeze generate include? instance_method instance_of? is_a? keys lambda last last_match
+          length map match? max module_function pretty_generate raise require scan scrub sort sort_by! source tap then
+          to_h to_s valid_encoding? zero?
         ],
         constants: %w[
           ArgumentError Array Encoding EncodingError Error FalseClass Float GeneratorError Hash HiveLiveAgentProof
-          Integer JSON MAX_JSON_BYTES MAX_JSON_DEPTH MAX_JSON_INTEGER_BITS MAX_JSON_NODES NestingError NilClass Primitives Regexp
-          SECRET_PATTERNS StandardError String TrueClass TypeError UTF_8 WorkflowCreator
+          Integer JSON MAX_JSON_BYTES MAX_JSON_DEPTH MAX_JSON_INTEGER_BITS MAX_JSON_NODES NestingError NilClass Object PLAIN Primitives
+          RAW_CLASS RAW_SINGLETON_METHODS Regexp SECRET_PATTERNS StandardError String TrueClass TypeError UTF_8 WorkflowCreator
         ]
       },
       "workflow_creator.rb" => {
@@ -873,7 +1026,7 @@ class WorkflowCreatorCoreTest < Minitest::Test
           ARTIFACT_KEYS ASSERT ArgumentError Array BUNDLE_KEYS CLASSIFICATIONS Contract DETAIL_LIMIT DIGEST Digest Encoding EncodingError Error
           FAILURE_KEYS FAILURE_PART FILE_KEYS GeneratorError Hash HiveLiveAgentProof INSTALLATION_KEYS Integer JSON
           KeyError MANIFEST_KEYS MAX_DETAIL_INPUT_BYTES MAX_EXACT_SECRETS MAX_INVENTORY_ENTRIES MAX_MEMBER_BYTES MAX_SECRET_BYTES
-          MAX_TOTAL_BYTES NoMethodError PRIMARY_KEYS Primitives SHA SHA256 SUMMARY_KEYS String TypeError UTF_8 Vocabulary
+          MAX_TOTAL_BYTES NoMethodError PLAIN PRIMARY_KEYS Primitives SHA SHA256 SUMMARY_KEYS String TypeError UTF_8 Vocabulary
           WorkflowCreator
         ]
       },

--- a/test/unit/packaging/workflow_creator_core_test.rb
+++ b/test/unit/packaging/workflow_creator_core_test.rb
@@ -3,6 +3,7 @@ require "digest"
 require "json"
 require "open3"
 require "rbconfig"
+require "ripper"
 require_relative "../../../packaging/live_agent_skills/workflow_creator"
 
 class WorkflowCreatorCoreTest < Minitest::Test
@@ -20,6 +21,9 @@ class WorkflowCreatorCoreTest < Minitest::Test
       CREATOR.singleton_methods(false).sort
     )
     assert CREATOR::Error < StandardError
+    assert_includes CREATOR.method(:validate_execution!).parameters, [ :keyreq, :manifest ]
+    execution_contract = CREATOR.const_get(:ExecutionContract, false)
+    assert_includes execution_contract.method(:validate!).parameters, [ :keyreq, :manifest ]
     assert_equal %w[
       schema_version evidence_schema installed_schema execution_schema
       execution_plan scanner request prompt task_request task_key task_slug
@@ -118,6 +122,16 @@ class WorkflowCreatorCoreTest < Minitest::Test
       error = assert_raises(CREATOR::Error) { CREATOR.canonical_json(value) }
       assert_equal "cannot canonicalize JSON", error.message
     end
+    deeply_nested = []
+    128.times { deeply_nested = [ deeply_nested ] }
+    assert_raises(CREATOR::Error) { CREATOR.canonical_json(deeply_nested) }
+    assert_raises(CREATOR::Error) { CREATOR.canonical_json(Array.new(16_385, 0)) }
+    json_limit = CREATOR.const_get(:Primitives, false).const_get(:MAX_JSON_BYTES, false)
+    assert_raises(CREATOR::Error) { CREATOR.canonical_json("x" * (json_limit + 1)) }
+    assert_raises(CREATOR::Error) { CREATOR.canonical_json({ "x" * (json_limit + 1) => 0 }) }
+    assert_raises(CREATOR::Error) do
+      CREATOR.canonical_json([ "x" * (json_limit / 2), "y" * (json_limit / 2) ])
+    end
 
     row = CREATOR.failure(
       candidate_sha: SHA, phase: "preflight", reason: "provider_unavailable",
@@ -152,6 +166,26 @@ class WorkflowCreatorCoreTest < Minitest::Test
       assert_raises(CREATOR::Error) { CREATOR.validate_nonpassing!(invalid) }
     end
     assert_raises(CREATOR::Error) { CREATOR.validate_nonpassing!(nil) }
+
+    %i[phase reason].each do |field|
+      secret = "databasepassword0123456789"
+      arguments = { candidate_sha: SHA, phase: "preflight", reason: "provider_unavailable",
+                    exact_secrets: [ secret ] }
+      arguments[field] = secret
+      assert_raises(CREATOR::Error, field.to_s) { CREATOR.failure(**arguments) }
+    end
+    [ "databasepassword0123456789", { "api_key" => "databasepassword0123456789" } ].each do |secrets|
+      assert_raises(CREATOR::Error) do
+        CREATOR.failure(candidate_sha: SHA, phase: "preflight", reason: "provider_unavailable",
+                        detail: "databasepassword0123456789", exact_secrets: secrets)
+      end
+    end
+    [ Array.new(65) { |index| "absent-secret-#{index}" }, [ "x" * 4_097 ], [ "" ], [ "\xFF".b ] ].each do |secrets|
+      assert_raises(CREATOR::Error) do
+        CREATOR.failure(candidate_sha: SHA, phase: "preflight", reason: "provider_unavailable",
+                        exact_secrets: secrets)
+      end
+    end
   end
 
   def test_primary_contract_accepts_exact_claims_and_rejects_key_type_order_and_binding_drift
@@ -233,6 +267,30 @@ class WorkflowCreatorCoreTest < Minitest::Test
       CREATOR.validate_installation!(document: openclaw, kind: "openclaw",
                                      manifest: fixture.fetch(:manifest), candidate_sha: SHA)
     end
+
+    zero_package = deep_dup(fixture.fetch(:installations).fetch("openclaw"))
+    package = zero_package.fetch("required_roles").fetch("package")
+    package["size"] = 0
+    zero_package.fetch("inventory").find { |item| item["path"] == package["path"] }["size"] = 0
+    refresh_installation!(zero_package)
+    assert_raises(CREATOR::Error) do
+      CREATOR.validate_installation!(document: zero_package, kind: "openclaw",
+                                     manifest: fixture.fetch(:manifest), candidate_sha: SHA)
+    end
+  end
+
+  def test_artifact_manifests_reject_invalid_utf8_before_identity_use
+    fixture = valid_fixture
+    fixture.fetch(:manifest)["skill_version"] = "\xFF".b
+    fixture.fetch(:row).fetch("skill")["skill_version"] = "\xFF".b
+
+    assert_raises(CREATOR::Error) { validate_primary(fixture) }
+    assert_raises(CREATOR::Error) do
+      CREATOR.validate_installation!(
+        document: fixture.fetch(:installations).fetch("openclaw"), kind: "openclaw",
+        manifest: fixture.fetch(:manifest), candidate_sha: SHA
+      )
+    end
   end
 
   def test_execution_contract_is_a_closed_declarative_transaction
@@ -287,7 +345,126 @@ class WorkflowCreatorCoreTest < Minitest::Test
     assert_raises(CREATOR::Error) { validate_execution(invalid) }
   end
 
-  def test_core_loads_cleanly_in_both_proof_orders_and_has_no_io_or_back_edge
+  def test_execution_contract_binds_all_canonical_document_bytes_and_kinds
+    cases = {
+      "swapped-documents" => lambda do |item|
+        candidate = item[:installations].fetch("candidate")
+        item[:installations]["candidate"] = item[:installations].fetch("openclaw")
+        item[:installations]["openclaw"] = candidate
+      end,
+      "duplicated-candidate-document" => lambda do |item|
+        item[:installations]["openclaw"] = deep_dup(item[:installations].fetch("candidate"))
+        rebind_installation_record!(item, 1, "openclaw")
+        package = item[:installations].fetch("candidate").dig("required_roles", "package")
+        item[:receipt].fetch("archive_admissions")[1]["artifact_sha256"] = package.fetch("sha256")
+        item[:receipt].fetch("archive_admissions")[1]["artifact_size"] = package.fetch("size")
+      end,
+      "stale-candidate-identity" => lambda do |item|
+        item[:installations]["openclaw"]["candidate_sha"] = "c" * 40
+        rebind_installation_record!(item, 1, "openclaw")
+      end,
+      "tampered-gateway-bytes" => lambda do |item|
+        gateway = item[:installations].fetch("candidate").fetch("required_roles").fetch("audit_gateway")
+        gateway["sha256"] = DIGEST
+        inventory = item[:installations].fetch("candidate").fetch("inventory")
+        inventory.find { |record| record["path"] == gateway["path"] }["sha256"] = DIGEST
+        refresh_installation!(item[:installations].fetch("candidate"))
+        item[:receipt].fetch("gateway")["identity"] = deep_dup(gateway)
+      end,
+      "record-bytes-mismatch" => lambda do |item|
+        record = item[:bundle_records].fetch(0)
+        record["sha256"] = DIGEST
+        record["size"] += 1
+        item[:receipt].fetch("installed_manifests")[0] = deep_dup(record)
+      end,
+      "primary-record-cross-binding" => lambda do |item|
+        record = item[:bundle_records].fetch(0)
+        record["sha256"] = DIGEST
+        item[:receipt].fetch("installed_manifests")[0] = deep_dup(record)
+      end,
+      "stale-execution-receipt-bytes" => lambda do |item|
+        item[:receipt].fetch("run")["correlation_id"] = "different-run"
+        item[:receipt].fetch("containment")["owner_correlation_id"] = "different-run"
+      end,
+      "execution-receipt-size-mismatch" => lambda do |item|
+        record = item[:bundle_records].fetch(2)
+        record["size"] += 1
+        item[:row].fetch("evidence_bundle")[2] = deep_dup(record)
+      end,
+      "zero-byte-openclaw-package-and-archive" => lambda do |item|
+        document = item[:installations].fetch("openclaw")
+        package = document.fetch("required_roles").fetch("package")
+        package["size"] = 0
+        document.fetch("inventory").find { |entry| entry["path"] == package["path"] }["size"] = 0
+        refresh_installation!(document)
+        rebind_installation_record!(item, 1, "openclaw")
+        item[:receipt].fetch("archive_admissions")[1]["artifact_size"] = 0
+      end
+    }
+
+    accepted = cases.filter_map do |label, mutation|
+      invalid = valid_fixture
+      mutation.call(invalid)
+      validate_execution(invalid)
+      label
+    rescue CREATOR::Error
+      nil
+    end
+    assert_empty accepted, "execution admitted unbound cases: #{accepted.join(', ')}"
+  end
+
+  def test_primary_installation_and_execution_reject_unsafe_relative_paths
+    unsafe_paths = [
+      "", ".", "..", "/absolute", "../escape", "dir/../escape", "./file",
+      "dir//file", "dir/", "C:/escape", "C:relative", "C:\\escape", "dir\\escape",
+      "nul\0path", "\xFF".b
+    ]
+
+    unsafe_paths.each do |path|
+      primary = valid_fixture
+      primary.fetch(:row).fetch("created_files").first["path"] = path
+      assert_raises(CREATOR::Error, "primary #{path.inspect}") { validate_primary(primary) }
+
+      installed = valid_fixture
+      document = installed.fetch(:installations).fetch("openclaw")
+      dependency = document.fetch("inventory").last
+      dependency["path"] = path
+      begin
+        refresh_installation!(document)
+      rescue CREATOR::Error
+        nil
+      end
+      assert_raises(CREATOR::Error, "installation #{path.inspect}") do
+        CREATOR.validate_installation!(document:, kind: "openclaw",
+                                       manifest: installed.fetch(:manifest), candidate_sha: SHA)
+      end
+
+      execution = valid_fixture
+      execution.fetch(:row).fetch("executed_instruction")["path"] = path
+      execution.fetch(:receipt)["authored_instruction"]["path"] = path
+      execution.fetch(:receipt)["executed_instruction"]["path"] = path
+      assert_raises(CREATOR::Error, "execution #{path.inspect}") { validate_execution(execution) }
+    end
+  end
+
+  def test_schema_v1_vocabulary_is_bound_to_the_incumbent_proof
+    require_relative "../../../packaging/live_agent_skills/proof"
+    keys = %w[schema_version request prompt task_request task_key task_slug task_prompt task_new_argv commands files]
+    constants = %i[
+      SCHEMA_VERSION WORKFLOW_CREATOR_REQUEST WORKFLOW_CREATOR_PROMPT WORKFLOW_CREATOR_TASK_REQUEST
+      WORKFLOW_CREATOR_TASK_KEY WORKFLOW_CREATOR_TASK_SLUG WORKFLOW_CREATOR_TASK_PROMPT
+      WORKFLOW_CREATOR_TASK_NEW_ARGV WORKFLOW_CREATOR_COMMANDS WORKFLOW_CREATOR_FILES]
+    keys.zip(constants).each do |key, name|
+      assert_equal HiveLiveAgentProof.const_get(name), vocabulary.fetch(key), key
+    end
+    assert_equal({ "kind" => HiveLiveAgentProof::NATIVE_ACTIVATION_KINDS.fetch("openclaw"),
+                   "invocation" => HiveLiveAgentProof::INVOCATIONS.fetch("openclaw") },
+                 vocabulary.fetch("native_activation"))
+    patterns = CREATOR.const_get(:Primitives, false).const_get(:SECRET_PATTERNS, false)
+    assert_equal HiveLiveAgentProof::SECRET_PATTERNS.map(&:source), patterns.map(&:source)
+  end
+
+  def test_core_loads_cleanly_in_both_proof_orders_and_has_pure_dependencies
     core = "packaging/live_agent_skills/workflow_creator"
     proof = "packaging/live_agent_skills/proof"
     [ [ core ], [ core, proof ], [ proof, core ] ].each do |order|
@@ -315,13 +492,16 @@ class WorkflowCreatorCoreTest < Minitest::Test
       [ name, File.read(File.join(ROOT, "packaging", "live_agent_skills", name)) ]
     end
     sources.each do |name, source|
-      refute_match(/\b(?:File|Dir|IO|Open3|Process|Pathname|Zlib|Gem::Package)\b|`|\bsystem\s*\(/,
-                   source, name)
       refute_match(/require_relative ["'](?:proof|workflow_creator_bundle)["']/, source, name)
     end
     assert_match(/require_relative "proof_primitives"/, sources.fetch("workflow_creator.rb"))
     assert_match(/require_relative "workflow_creator_contract"/, sources.fetch("workflow_creator.rb"))
     assert_match(/require_relative "workflow_creator_execution_contract"/, sources.fetch("workflow_creator.rb"))
+    assert_pure_source_surface(sources)
+    poisoned = sources.merge(
+      "proof_primitives.rb" => "#{sources.fetch('proof_primitives.rb')}\ndef dormant_io\n  require 'socket'\n  TCPSocket.open('localhost', 9)\nend\n"
+    )
+    assert_raises(Minitest::Assertion) { assert_pure_source_surface(poisoned) }
   end
 
   def test_production_files_stay_inside_r43_line_method_and_branch_budgets
@@ -349,7 +529,7 @@ class WorkflowCreatorCoreTest < Minitest::Test
     { lines: 590, methods: 22, branches: 28 }.each do |metric, hard_limit|
       assert_operator totals.fetch(metric), :<=, hard_limit, "aggregate hard #{metric}"
     end
-    { lines: 576, methods: 21, branches: 27 }.each do |metric, target|
+    { lines: 588, methods: 22, branches: 19 }.each do |metric, target|
       assert_operator totals.fetch(metric), :<=, target, "aggregate target #{metric}"
     end
   end
@@ -373,7 +553,10 @@ class WorkflowCreatorCoreTest < Minitest::Test
       load path
       puts Coverage.peek_result.fetch(path).fetch(:branches).length
     RUBY
-    out, err, status = Open3.capture3(RbConfig.ruby, "-e", script, path)
+    clean_env = %w[HIVE_COVERAGE HIVE_COVERAGE_ROOT HIVE_COVERAGE_RUN_ID RUBYOPT].to_h do |key|
+      [ key, nil ]
+    end
+    out, err, status = Open3.capture3(clean_env, RbConfig.ruby, "-e", script, path)
     assert status.success?, "#{name} branch coverage: #{out}#{err}"
     assert_empty err, name
     Integer(out, 10)
@@ -381,13 +564,14 @@ class WorkflowCreatorCoreTest < Minitest::Test
 
   def valid_fixture
     manifest = artifact_manifest
-    records = bundle_records
     installations = {
       "candidate" => installation("candidate", manifest),
       "openclaw" => installation("openclaw", manifest)
     }
+    records = bundle_records(installations)
     row = primary_row(manifest, records)
     receipt = execution_receipt(row, records, installations)
+    bind_execution_record!(row, records, receipt)
     {
       manifest:, bundle_records: records, installations:, row:, receipt:,
       receipt_sha256: records.fetch(2).fetch("sha256")
@@ -405,7 +589,7 @@ class WorkflowCreatorCoreTest < Minitest::Test
     CREATOR.validate_execution!(
       receipt: fixture.fetch(:receipt), row: fixture.fetch(:row), candidate_sha: SHA,
       installation_records: fixture.fetch(:bundle_records).first(2),
-      receipt_sha256: fixture.fetch(:receipt_sha256),
+      receipt_sha256: fixture.fetch(:receipt_sha256), manifest: fixture.fetch(:manifest),
       candidate_installation: fixture.fetch(:installations).fetch("candidate"),
       openclaw_installation: fixture.fetch(:installations).fetch("openclaw")
     )
@@ -427,15 +611,159 @@ class WorkflowCreatorCoreTest < Minitest::Test
     }
   end
 
-  def bundle_records
-    %w[
-      candidate-installed-manifest.json openclaw-installed-manifest.json
-      execution-receipt.json
-    ].each_with_index.map do |path, index|
+  def bundle_records(installations)
+    documents = [ installations.fetch("candidate"), installations.fetch("openclaw") ]
+    %w[candidate-installed-manifest.json openclaw-installed-manifest.json].each_with_index.map do |path, index|
+      bytes = CREATOR.canonical_json(documents.fetch(index))
       {
         "kind" => %w[candidate_installation openclaw_installation execution_receipt].fetch(index),
-        "path" => path, "sha256" => Digest::SHA256.hexdigest(path), "size" => path.bytesize
+        "path" => path, "sha256" => Digest::SHA256.hexdigest(bytes), "size" => bytes.bytesize
       }
+    end << {
+      "kind" => "execution_receipt", "path" => "execution-receipt.json",
+      "sha256" => Digest::SHA256.hexdigest("execution-receipt.json"), "size" => 22
+    }
+  end
+
+  def rebind_installation_record!(fixture, index, kind)
+    bytes = CREATOR.canonical_json(fixture.fetch(:installations).fetch(kind))
+    record = fixture.fetch(:bundle_records).fetch(index)
+    record["sha256"] = Digest::SHA256.hexdigest(bytes)
+    record["size"] = bytes.bytesize
+    fixture.fetch(:row).fetch("evidence_bundle")[index] = deep_dup(record)
+    fixture.fetch(:receipt).fetch("installed_manifests")[index] = deep_dup(record)
+  end
+
+  def bind_execution_record!(row, records, receipt)
+    bytes = CREATOR.canonical_json(receipt)
+    record = records.fetch(2)
+    record["sha256"] = Digest::SHA256.hexdigest(bytes)
+    record["size"] = bytes.bytesize
+    row.fetch("evidence_bundle")[2] = deep_dup(record)
+    summary = { "status" => "passed", "receipt_sha256" => record.fetch("sha256") }
+    %w[containment teardown cleanup].each { |field| row[field] = deep_dup(summary) }
+  end
+
+  def refresh_installation!(document)
+    closure = {
+      "required_roles" => document.fetch("required_roles"),
+      "inventory" => document.fetch("inventory")
+    }
+    document["closure_sha256"] = Digest::SHA256.hexdigest(CREATOR.canonical_json(closure))
+    document["total_size"] = document.fetch("inventory").sum { |record| record.fetch("size") }
+  end
+
+  def assert_pure_source_surface(sources)
+    script = "require 'json'; require 'digest'; before=$LOADED_FEATURES.dup; " \
+      "require 'packaging/live_agent_skills/workflow_creator'; puts(($LOADED_FEATURES-before).join(\"\\n\"))"
+    out, err, status = Open3.capture3(RbConfig.ruby, "-I#{ROOT}", "-e", script)
+    assert status.success?, err
+    allowed = %r{\A#{Regexp.escape(ROOT)}/packaging/live_agent_skills/(?:proof_primitives|workflow_creator(?:_contract|_execution_contract)?)\.rb\z|/(?:digest/sha2(?:/loader)?\.rb|digest/sha2\.[^/]+)\z}
+    assert out.lines.map(&:chomp).all? { |path| allowed.match?(path) }, out
+    expected = {
+      "proof_primitives.rb" => {
+        requires: [ %w[require json] ],
+        calls: %w[
+          all? bytesize byteslice call deep_freeze each each_with_index empty? encode fetch filter_map
+          force_encoding freeze gsub! include? is_a? keys lambda map match? module_function none?
+          pretty_generate raise require scrub sort source split start_with? to_h to_s valid_encoding?
+        ],
+        constants: %w[
+          ArgumentError Array Encoding Error FalseClass Float GeneratorError Hash HiveLiveAgentProof Integer JSON
+          MAX_JSON_BYTES MAX_JSON_DEPTH MAX_JSON_NODES NestingError NilClass Primitives SECRET_PATTERNS
+          StandardError String TrueClass TypeError UTF_8 WorkflowCreator
+        ]
+      },
+      "workflow_creator.rb" => {
+        requires: [ %w[require digest], %w[require_relative proof_primitives],
+                    %w[require_relative workflow_creator_contract],
+                    %w[require_relative workflow_creator_execution_contract] ],
+        calls: %w[
+          canonical_json deep_freeze failure fetch hexdigest private_constant require require_relative
+          validate! validate_installation! validate_nonpassing! validate_primary!
+        ],
+        constants: %w[
+          Contract Digest ExecutionContract HiveLiveAgentProof Primitives SHA256 Vocabulary WorkflowCreator
+        ]
+      },
+      "workflow_creator_contract.rb" => {
+        requires: [ %w[require digest], %w[require_relative proof_primitives] ],
+        calls: %w[
+          all? ascii_only? between? bytesize call canonical_json deep_freeze dig downcase drop each each_with_index empty? encoding
+          exact_secrets! fetch find first freeze generate hexdigest include? is_a? keys lambda length map match?
+          module_function nil? one? positive? raise require require_relative safe_relative_path? secret_findings
+          secret_safe_text select sort sum then to_s uniq valid_encoding? valid_manifest? validate_nonpassing!
+          values values_at zero? zip
+        ],
+        constants: %w[
+          ARTIFACT_KEYS ASSERT ArgumentError Array BUNDLE_KEYS CLASSIFICATIONS Contract DETAIL_LIMIT DIGEST Digest Encoding Error
+          FAILURE_KEYS FAILURE_PART FILE_KEYS GeneratorError Hash HiveLiveAgentProof INSTALLATION_KEYS Integer JSON
+          KeyError MANIFEST_KEYS MAX_EXACT_SECRETS MAX_INVENTORY_ENTRIES MAX_MEMBER_BYTES MAX_SECRET_BYTES
+          MAX_TOTAL_BYTES NoMethodError PRIMARY_KEYS Primitives SHA SHA256 SUMMARY_KEYS String TypeError UTF_8 Vocabulary
+          WorkflowCreator
+        ]
+      },
+      "workflow_creator_execution_contract.rb" => {
+        requires: [ %w[require_relative workflow_creator_contract] ],
+        calls: %w[
+          all? between? bytesize call canonical_json deep_freeze each_with_index empty? fetch first freeze generate
+          hexdigest include? is_a? keys lambda length map match? module_function nil? positive? raise require_relative
+          safe_relative_path? secret_findings slice sort uniq valid_process? validate_aggregates! validate_identity!
+          validate_installation! validate_primary! validate_processes! values_at zero? zip
+        ],
+        constants: %w[
+          ARCHIVE_KEYS ASSERT ArgumentError Array BUNDLE_KEYS CAPTURE_KEYS CLEANUP_KEYS COMMAND_KEYS CONTAINMENT_KEYS
+          Contract DIGEST Digest Error ExecutionContract FILE_KEYS GATEWAY_KEYS GeneratorError Hash HiveLiveAgentProof
+          Integer JSON KEYS KeyError LABEL MAX_ARCHIVE_BYTES MAX_ARCHIVE_ENTRIES MAX_CAPTURE_BYTES NoMethodError
+          OUTER_KEYS PROCESS_TEARDOWN_KEYS Primitives RUN_KEYS SHA SHA256 String TARGET_KEYS TEARDOWN_KEYS TypeError
+          Vocabulary WorkflowCreator
+        ]
+      }
+    }
+    sources.each do |name, source|
+      syntax = Ripper.sexp(source)
+      refute_nil syntax, name
+      nodes = []
+      walk = lambda do |node|
+        next unless node.is_a?(Array)
+        nodes << node
+        node.each { |child| walk.call(child) }
+      end
+      walk.call(syntax)
+      calls = nodes.filter_map do |node|
+        case node.first
+        when :vcall, :fcall, :command then node.dig(1, 1)
+        when :call, :command_call, :field then node.dig(3, 1)
+        end
+      end
+      requires = nodes.filter_map do |node|
+        invocation, arguments = case node.first
+        when :command then [ node[1], node[2] ]
+        when :command_call then [ node[3], node[4] ]
+        when :method_add_arg
+          call = node[1]
+          [ call&.first == :fcall ? call[1] : call&.[](3), node[2] ]
+        end
+        next unless invocation && %w[require require_relative].include?(invocation[1])
+        parts = []
+        dynamic = false
+        inspect_argument = lambda do |argument|
+          next unless argument.is_a?(Array)
+          parts << argument[1] if argument.first == :@tstring_content
+          dynamic = true if argument.first == :string_embexpr
+          argument.each { |child| inspect_argument.call(child) }
+        end
+        inspect_argument.call(arguments)
+        [ invocation[1], !dynamic && parts.one? ? parts.first : "<dynamic>" ]
+      end
+      expected_surface = expected.fetch(name)
+      assert_equal calls.count { |call| %w[require require_relative].include?(call) }, requires.length, name
+      assert_equal expected_surface.fetch(:requires), requires, name
+      assert_equal expected_surface.fetch(:calls), calls.uniq.sort, name
+      tokens = Ripper.lex(source)
+      constants = tokens.filter_map { |_position, type, text| text if type == :on_const }.uniq.sort
+      assert_equal expected_surface.fetch(:constants), constants, name
+      assert_empty tokens.select { |_position, type, _text| %i[on_backtick on_gvar].include?(type) }, name
     end
   end
 

--- a/test/unit/packaging/workflow_creator_core_test.rb
+++ b/test/unit/packaging/workflow_creator_core_test.rb
@@ -1,0 +1,653 @@
+require "test_helper"
+require "digest"
+require "json"
+require "open3"
+require "rbconfig"
+require_relative "../../../packaging/live_agent_skills/workflow_creator"
+
+class WorkflowCreatorCoreTest < Minitest::Test
+  ROOT = File.expand_path("../../..", __dir__)
+  SHA = "a" * 40
+  DIGEST = "b" * 64
+  CREATOR = HiveLiveAgentProof::WorkflowCreator
+
+  def test_public_api_and_schema_v1_vocabulary_are_exact
+    assert_equal(
+      %i[
+        canonical_json failure validate_execution! validate_installation!
+        validate_nonpassing! validate_primary!
+      ],
+      CREATOR.singleton_methods(false).sort
+    )
+    assert CREATOR::Error < StandardError
+    assert_equal %w[
+      schema_version evidence_schema installed_schema execution_schema
+      execution_plan scanner request prompt task_request task_key task_slug
+      task_prompt task_new_argv commands files executed_instruction
+      native_activation graph task classification bundle_files member_roles
+      outer_roles archive_labels archive_policy_sha256 cleanup_labels
+    ], vocabulary.keys
+    assert_equal 1, vocabulary.fetch("schema_version")
+    assert_equal "hive-live-workflow-creator-evidence",
+                 vocabulary.fetch("evidence_schema")
+    assert_equal "hive-live-workflow-creator-installed-manifest",
+                 vocabulary.fetch("installed_schema")
+    assert_equal "hive-live-workflow-creator-execution-receipt",
+                 vocabulary.fetch("execution_schema")
+    assert_equal "hive-live-workflow-creator-execution-plan/v1",
+                 vocabulary.fetch("execution_plan")
+    assert_equal expected_prompt, vocabulary.fetch("prompt")
+    assert_equal expected_task_prompt, vocabulary.fetch("task_prompt")
+    assert_equal expected_commands, vocabulary.fetch("commands")
+    assert_equal expected_commands.fetch(5), vocabulary.fetch("task_new_argv")
+    assert_equal expected_files, vocabulary.fetch("files")
+    assert_equal expected_files.fetch(2), vocabulary.fetch("executed_instruction")
+    assert_equal({ "kind" => "openclaw-skills-info", "invocation" => "/hive" },
+                 vocabulary.fetch("native_activation"))
+    assert_equal expected_graph, vocabulary.fetch("graph")
+    assert_equal expected_task, vocabulary.fetch("task")
+    assert_equal(
+      { "execution_kind" => "authenticated_openclaw", "model_loop" => "executed" },
+      vocabulary.fetch("classification")
+    )
+    assert_equal %w[
+      openclaw-workflow-creator.json candidate-installed-manifest.json
+      openclaw-installed-manifest.json execution-receipt.json
+    ], vocabulary.fetch("bundle_files")
+    assert_equal(
+      {
+        "candidate" => %w[audit_gateway executable interpreter_or_launcher lock package],
+        "openclaw" => %w[executable interpreter_or_launcher lock package]
+      },
+      vocabulary.fetch("member_roles")
+    )
+    assert_equal(
+      [
+        { "role" => "workflow-creation-model-loop", "prompt_sha256" => Digest::SHA256.hexdigest(expected_prompt) },
+        { "role" => "authorized-work-model-loop", "prompt_sha256" => Digest::SHA256.hexdigest(expected_task_prompt) }
+      ],
+      vocabulary.fetch("outer_roles")
+    )
+    assert_equal %w[candidate-package openclaw-package], vocabulary.fetch("archive_labels")
+    assert_equal Digest::SHA256.hexdigest("hive-live-workflow-creator-archive-policy/v1"),
+                 vocabulary.fetch("archive_policy_sha256")
+    assert_equal %w[proof-workspace], vocabulary.fetch("cleanup_labels")
+  end
+
+  def test_vocabulary_is_recursively_immutable_including_computed_digests
+    leaves = []
+    walk = lambda do |value, path|
+      assert_predicate value, :frozen?, path
+      case value
+      when Hash
+        assert_raises(FrozenError, path) { value["mutation"] = true }
+        value.each do |key, nested|
+          walk.call(key, "#{path}{key:#{key}}")
+          walk.call(nested, "#{path}.#{key}")
+        end
+      when Array
+        assert_raises(FrozenError, path) { value << "mutation" }
+        value.each_with_index { |nested, index| walk.call(nested, "#{path}[#{index}]") }
+      when String
+        leaves << [ path, value ]
+        assert_raises(FrozenError, path) { value.replace("mutation") }
+      end
+    end
+
+    walk.call(vocabulary, "Vocabulary")
+    digest_paths = leaves.filter_map { |path, value| path if value.match?(/\A[0-9a-f]{64}\z/) }
+    assert_includes digest_paths, "Vocabulary.outer_roles[0].prompt_sha256"
+    assert_includes digest_paths, "Vocabulary.outer_roles[1].prompt_sha256"
+    assert_includes digest_paths, "Vocabulary.archive_policy_sha256"
+    assert_equal expected_commands, vocabulary.fetch("commands")
+    classifications = CREATOR.const_get(:Contract, false).const_get(:CLASSIFICATIONS, false)
+    walk.call(classifications, "Contract.CLASSIFICATIONS")
+  end
+
+  def test_canonical_json_and_nonpassing_documents_are_bounded_and_secret_safe
+    left = { "z" => { "b" => 2, "a" => 1 }, "a" => [ { "d" => 4, "c" => 3 } ] }
+    right = { "a" => [ { "c" => 3, "d" => 4 } ], "z" => { "a" => 1, "b" => 2 } }
+    assert_equal CREATOR.canonical_json(left), CREATOR.canonical_json(right)
+    assert_equal <<~JSON, CREATOR.canonical_json({ "b" => 2, "a" => 1 })
+      {
+        "a": 1,
+        "b": 2
+      }
+    JSON
+    [ { invalid: true }, "\xFF".b, Object.new, Float::NAN ].each do |value|
+      error = assert_raises(CREATOR::Error) { CREATOR.canonical_json(value) }
+      assert_equal "cannot canonicalize JSON", error.message
+    end
+
+    row = CREATOR.failure(
+      candidate_sha: SHA, phase: "preflight", reason: "provider_unavailable",
+      detail: "exact-fixture-secret #{secret_shape}#{'x' * 1_100}",
+      exact_secrets: [ "exact-fixture-secret" ]
+    )
+    assert_equal %w[
+      candidate_sha detail execution_kind model_loop phase platform reason
+      result schema schema_version secret_scan
+    ], row.keys.sort
+    assert_equal "failed", row.fetch("result")
+    assert_equal 2, row.fetch("detail").scan("[REDACTED]").length
+    assert_operator row.fetch("detail").bytesize, :<=, 1_000
+    assert_same row, CREATOR.validate_nonpassing!(row)
+    unresolved = CREATOR.failure(candidate_sha: "unknown", phase: "preflight", reason: "not_started")
+    assert_equal "unresolved", unresolved.fetch("candidate_sha")
+    assert_nil unresolved.fetch("detail")
+
+    [
+      ->(value) { value["unexpected"] = true },
+      ->(value) { value["schema_version"] = 1.0 },
+      ->(value) { value["result"] = "passed" },
+      ->(value) { value["candidate_sha"] = ("1" * 40).to_i },
+      ->(value) { value["phase"] = :preflight },
+      ->(value) { value["phase"] = "not-valid!" },
+      ->(value) { value["model_loop"] = "executed" },
+      ->(value) { value["detail"] = secret_shape },
+      ->(value) { value["detail"] = "\xFF".b }
+    ].each do |mutation|
+      invalid = deep_dup(row)
+      mutation.call(invalid)
+      assert_raises(CREATOR::Error) { CREATOR.validate_nonpassing!(invalid) }
+    end
+    assert_raises(CREATOR::Error) { CREATOR.validate_nonpassing!(nil) }
+  end
+
+  def test_primary_contract_accepts_exact_claims_and_rejects_key_type_order_and_binding_drift
+    fixture = valid_fixture
+    assert_same fixture.fetch(:row), validate_primary(fixture)
+    cases = {
+      "extra-key" => ->(item) { item[:row]["unexpected"] = true },
+      "schema-float" => ->(item) { item[:row]["schema_version"] = 1.0 },
+      "manifest-schema-float" => ->(item) { item[:manifest]["schema_version"] = 1.0 },
+      "manifest-record-float" => ->(item) { item[:manifest]["files"].values.first["size"] = 10.0 },
+      "manifest-record-extra" => ->(item) { item[:manifest]["files"].values.first["path"] = "x" },
+      "prompt" => ->(item) { item[:row]["prompt_sha256"] = DIGEST },
+      "command-order" => ->(item) { item[:row]["hive_commands"].reverse! },
+      "created-order" => ->(item) { item[:row]["created_files"].reverse! },
+      "created-size-float" => ->(item) { item[:row]["created_files"][0]["size"] = 10.0 },
+      "graph" => ->(item) { item[:row]["validation"]["stages"] << "publish" },
+      "task-count-float" => ->(item) { item[:row]["task_count"] = 1.0 },
+      "run-count-float" => ->(item) { item[:row]["task"]["run_count"] = 1.0 },
+      "authored" => ->(item) { item[:row]["executed_instruction"]["sha256"] = DIGEST },
+      "bundle-order" => ->(item) { item[:row]["evidence_bundle"].reverse! },
+      "bundle-size-float" => ->(item) { item[:row]["evidence_bundle"][0]["size"] = 12.0 },
+      "argument-bundle-float" => ->(item) { item[:bundle_records][0]["size"] = 12.0 },
+      "summary" => ->(item) { item[:row]["cleanup"]["receipt_sha256"] = DIGEST },
+      "classification" => ->(item) { item[:row]["model_loop"] = "not_exercised" },
+      "external-effect" => ->(item) { item[:row]["external_actions"] << "publish" }
+    }
+    cases.each do |label, mutation|
+      invalid = valid_fixture
+      mutation.call(invalid)
+      assert_raises(CREATOR::Error, label) { validate_primary(invalid) }
+    end
+    %i[row manifest bundle_records].each do |field|
+      invalid = valid_fixture.merge(field => nil)
+      assert_raises(CREATOR::Error, field.to_s) { validate_primary(invalid) }
+    end
+  end
+
+  def test_installed_closure_contract_is_exact_typed_ordered_and_manifest_bound
+    fixture = valid_fixture
+    %w[candidate openclaw].each do |kind|
+      document = fixture.fetch(:installations).fetch(kind)
+      assert_same document, CREATOR.validate_installation!(
+        document:, kind:, manifest: fixture.fetch(:manifest), candidate_sha: SHA
+      )
+    end
+    cases = {
+      "extra-key" => ->(item) { item[:document]["unexpected"] = true },
+      "schema-float" => ->(item) { item[:document]["schema_version"] = 1.0 },
+      "inventory-order" => ->(item) { item[:document]["inventory"].reverse! },
+      "inventory-duplicate" => ->(item) { item[:document]["inventory"] << deep_dup(item[:document]["inventory"].last) },
+      "inventory-size-float" => ->(item) { item[:document]["inventory"][0]["size"] = 1.0 },
+      "missing-role" => ->(item) { item[:document]["required_roles"].delete("executable") },
+      "role-not-inventory" => ->(item) { item[:document]["required_roles"]["executable"]["sha256"] = DIGEST },
+      "duplicate-role-path" => lambda do |item|
+        item[:document]["required_roles"]["executable"] = deep_dup(item[:document]["required_roles"]["lock"])
+      end,
+      "closure" => ->(item) { item[:document]["closure_sha256"] = DIGEST },
+      "total-float" => ->(item) { item[:document]["total_size"] = item[:document]["total_size"].to_f },
+      "secret" => ->(item) { item[:document]["version"] = secret_shape },
+      "package" => ->(item) { item[:document]["required_roles"]["package"]["sha256"] = DIGEST },
+      "manifest-nil" => ->(item) { item[:manifest] = nil },
+      "manifest-files" => ->(item) { item[:manifest]["files"] = nil },
+      "manifest-candidate" => ->(item) { item[:manifest]["candidate_sha"] = "c" * 40 }
+    }
+    cases.each do |label, mutation|
+      item = {
+        document: deep_dup(fixture.fetch(:installations).fetch("candidate")),
+        manifest: deep_dup(fixture.fetch(:manifest))
+      }
+      mutation.call(item)
+      assert_raises(CREATOR::Error, label) do
+        CREATOR.validate_installation!(document: item[:document], kind: "candidate",
+                                       manifest: item[:manifest], candidate_sha: SHA)
+      end
+    end
+    openclaw = deep_dup(fixture.fetch(:installations).fetch("openclaw"))
+    openclaw["version"] = ""
+    assert_raises(CREATOR::Error) do
+      CREATOR.validate_installation!(document: openclaw, kind: "openclaw",
+                                     manifest: fixture.fetch(:manifest), candidate_sha: SHA)
+    end
+  end
+
+  def test_execution_contract_is_a_closed_declarative_transaction
+    fixture = valid_fixture
+    assert_same fixture.fetch(:receipt), validate_execution(fixture)
+    cases = {
+      "extra-key" => ->(item) { item[:receipt]["unexpected"] = true },
+      "schema-float" => ->(item) { item[:receipt]["schema_version"] = 1.0 },
+      "classification" => ->(item) { item[:receipt]["classification"]["outer"]["model_loop"] = "not_exercised" },
+      "installed-size-float" => ->(item) { item[:receipt]["installed_manifests"][0]["size"] = 10.0 },
+      "gateway-size-float" => ->(item) { item[:receipt]["gateway"]["identity"]["size"] = 10.0 },
+      "archive-order" => ->(item) { item[:receipt]["archive_admissions"].reverse! },
+      "archive-size-float" => ->(item) { item[:receipt]["archive_admissions"][0]["artifact_size"] = 10.0 },
+      "archive-policy" => ->(item) { item[:receipt]["archive_admissions"][0]["policy_sha256"] = DIGEST },
+      "command-order" => ->(item) { item[:receipt]["commands"].reverse! },
+      "command-position-float" => ->(item) { item[:receipt]["commands"][0]["position"] = 1.0 },
+      "command-argv" => ->(item) { item[:receipt]["commands"][0]["argv"] = [ "doctor" ] },
+      "capture-limit-float" => ->(item) { item[:receipt]["commands"][0]["capture"]["limit_bytes"] = 4_096.0 },
+      "capture-bound" => ->(item) { item[:receipt]["commands"][0]["capture"]["stdout_bytes"] = 4_097 },
+      "kill-before-term" => lambda do |item|
+        item[:receipt]["commands"][0]["teardown"]["kill_sent"] = true
+        item[:receipt]["commands"][0]["teardown"]["term_sent"] = false
+      end,
+      "outer-order" => ->(item) { item[:receipt]["outer_processes"].reverse! },
+      "outer-alias" => lambda do |item|
+        item[:receipt]["outer_processes"][1]["argv_sha256"] = item[:receipt]["outer_processes"][0]["argv_sha256"]
+      end,
+      "duplicate-label" => lambda do |item|
+        item[:receipt]["outer_processes"][0]["label"] = item[:receipt]["commands"][0]["attempt_label"]
+      end,
+      "run-order" => ->(item) { item[:receipt]["run"]["expected_labels"].reverse! },
+      "containment" => ->(item) { item[:receipt]["containment"]["established_before_launch"] = false },
+      "teardown-float" => ->(item) { item[:receipt]["teardown"]["remaining_descendants"] = 0.0 },
+      "cleanup-inode-float" => ->(item) { item[:receipt]["cleanup"]["targets"][0]["inode"] = 2.0 },
+      "cleanup-custody" => ->(item) { item[:receipt]["cleanup"]["targets"][0]["identity_matched"] = false },
+      "authored-size-float" => ->(item) { item[:receipt]["authored_instruction"]["size"] = 10.0 },
+      "row-instruction-float" => ->(item) { item[:row]["executed_instruction"]["size"] = 10.0 },
+      "executed-binding" => ->(item) { item[:receipt]["executed_instruction"]["sha256"] = DIGEST },
+      "external-effect" => ->(item) { item[:receipt]["external_actions"] << "publish" },
+      "summary" => ->(item) { item[:row]["cleanup"]["receipt_sha256"] = DIGEST },
+      "secret" => lambda do |item|
+        item[:receipt]["run"]["correlation_id"] = secret_shape
+        item[:receipt]["containment"]["owner_correlation_id"] = secret_shape
+      end
+    }
+    cases.each do |label, mutation|
+      invalid = valid_fixture
+      mutation.call(invalid)
+      assert_raises(CREATOR::Error, label) { validate_execution(invalid) }
+    end
+    invalid = valid_fixture.merge(receipt: nil)
+    assert_raises(CREATOR::Error) { validate_execution(invalid) }
+  end
+
+  def test_core_loads_cleanly_in_both_proof_orders_and_has_no_io_or_back_edge
+    core = "packaging/live_agent_skills/workflow_creator"
+    proof = "packaging/live_agent_skills/proof"
+    [ [ core ], [ core, proof ], [ proof, core ] ].each do |order|
+      script = order.map { |feature| "require #{feature.dump}" }.join("\n")
+      script << "\n"
+      script << <<~RUBY
+        names = HiveLiveAgentProof.constants(false).map(&:to_s)
+        forbidden = (names & %w[SCHEMA_VERSION SAFE_SHA SECRET_PATTERNS Error]) + names.grep(/\AWORKFLOW_CREATOR_/)
+        if #{order == [ core ]} && !forbidden.empty?
+          abort "forbidden root constant"
+        end
+        abort "missing facade" unless defined?(HiveLiveAgentProof::WorkflowCreator)
+      RUBY
+      out, err, status = Open3.capture3(RbConfig.ruby, "-w", "-I#{ROOT}", "-e", script)
+      assert status.success?, "#{order.join(' -> ')}: #{out}#{err}"
+      assert_empty err, order.join(" -> ")
+    end
+    %i[Primitives Contract ExecutionContract].each do |name|
+      assert_raises(NameError) { eval("HiveLiveAgentProof::WorkflowCreator::#{name}") }
+    end
+    sources = %w[
+      proof_primitives.rb workflow_creator.rb workflow_creator_contract.rb
+      workflow_creator_execution_contract.rb
+    ].to_h do |name|
+      [ name, File.read(File.join(ROOT, "packaging", "live_agent_skills", name)) ]
+    end
+    sources.each do |name, source|
+      refute_match(/\b(?:File|Dir|IO|Open3|Process|Pathname|Zlib|Gem::Package)\b|`|\bsystem\s*\(/,
+                   source, name)
+      refute_match(/require_relative ["'](?:proof|workflow_creator_bundle)["']/, source, name)
+    end
+    assert_match(/require_relative "proof_primitives"/, sources.fetch("workflow_creator.rb"))
+    assert_match(/require_relative "workflow_creator_contract"/, sources.fetch("workflow_creator.rb"))
+    assert_match(/require_relative "workflow_creator_execution_contract"/, sources.fetch("workflow_creator.rb"))
+  end
+
+  def test_production_files_stay_inside_r43_line_method_and_branch_budgets
+    caps = {
+      "proof_primitives.rb" => { lines: 80 },
+      "workflow_creator.rb" => { lines: 110 },
+      "workflow_creator_contract.rb" => { lines: 220, methods: 10, branches: 12 },
+      "workflow_creator_execution_contract.rb" => { lines: 180, methods: 8, branches: 10 }
+    }
+    observed = caps.to_h do |name, limits|
+      source = File.read(File.join(ROOT, "packaging", "live_agent_skills", name))
+      counts = {
+        lines: source.lines.length,
+        methods: source.scan(/^\s*def\b/).length,
+        branches: coverage_branch_sites(name)
+      }
+      limits.each do |metric, limit|
+        assert_operator counts.fetch(metric), :<=, limit, "#{name} #{metric}"
+      end
+      [ name, counts ]
+    end
+    totals = observed.values.each_with_object(Hash.new(0)) do |counts, sum|
+      counts.each { |metric, value| sum[metric] += value }
+    end
+    { lines: 590, methods: 22, branches: 28 }.each do |metric, hard_limit|
+      assert_operator totals.fetch(metric), :<=, hard_limit, "aggregate hard #{metric}"
+    end
+    { lines: 576, methods: 21, branches: 27 }.each do |metric, target|
+      assert_operator totals.fetch(metric), :<=, target, "aggregate target #{metric}"
+    end
+  end
+
+  private
+
+  def deep_dup(value)
+    Marshal.load(Marshal.dump(value))
+  end
+
+  def secret_shape
+    %w[sk ant abcdefghijklmnopqrstuvwxyz].join("-")
+  end
+
+  def coverage_branch_sites(name)
+    path = File.join(ROOT, "packaging", "live_agent_skills", name)
+    script = <<~'RUBY'
+      require "coverage"
+      Coverage.start(branches: true)
+      path = File.expand_path(ARGV.fetch(0))
+      load path
+      puts Coverage.peek_result.fetch(path).fetch(:branches).length
+    RUBY
+    out, err, status = Open3.capture3(RbConfig.ruby, "-e", script, path)
+    assert status.success?, "#{name} branch coverage: #{out}#{err}"
+    assert_empty err, name
+    Integer(out, 10)
+  end
+
+  def valid_fixture
+    manifest = artifact_manifest
+    records = bundle_records
+    installations = {
+      "candidate" => installation("candidate", manifest),
+      "openclaw" => installation("openclaw", manifest)
+    }
+    row = primary_row(manifest, records)
+    receipt = execution_receipt(row, records, installations)
+    {
+      manifest:, bundle_records: records, installations:, row:, receipt:,
+      receipt_sha256: records.fetch(2).fetch("sha256")
+    }
+  end
+
+  def validate_primary(fixture)
+    CREATOR.validate_primary!(
+      row: fixture.fetch(:row), manifest: fixture.fetch(:manifest),
+      candidate_sha: SHA, bundle_records: fixture.fetch(:bundle_records)
+    )
+  end
+
+  def validate_execution(fixture)
+    CREATOR.validate_execution!(
+      receipt: fixture.fetch(:receipt), row: fixture.fetch(:row), candidate_sha: SHA,
+      installation_records: fixture.fetch(:bundle_records).first(2),
+      receipt_sha256: fixture.fetch(:receipt_sha256),
+      candidate_installation: fixture.fetch(:installations).fetch("candidate"),
+      openclaw_installation: fixture.fetch(:installations).fetch("openclaw")
+    )
+  end
+
+  def artifact_manifest
+    version = "1.2.3"
+    names = [
+      "hive-agent-skills-#{SHA}.tar.gz", "hive-cli-#{version}.gem",
+      "hive-source-#{SHA}.tar.gz"
+    ]
+    {
+      "schema" => "hive-live-agent-candidate-artifacts", "schema_version" => 1,
+      "candidate_sha" => SHA, "hive_version" => version,
+      "skill_version" => "2026.8.2", "canonical_digest" => Digest::SHA256.hexdigest("canonical"),
+      "files" => names.sort.to_h do |name|
+        [ name, { "sha256" => Digest::SHA256.hexdigest(name), "size" => name.bytesize } ]
+      end
+    }
+  end
+
+  def bundle_records
+    %w[
+      candidate-installed-manifest.json openclaw-installed-manifest.json
+      execution-receipt.json
+    ].each_with_index.map do |path, index|
+      {
+        "kind" => %w[candidate_installation openclaw_installation execution_receipt].fetch(index),
+        "path" => path, "sha256" => Digest::SHA256.hexdigest(path), "size" => path.bytesize
+      }
+    end
+  end
+
+  def installation(kind, manifest)
+    roles = vocabulary.fetch("member_roles").fetch(kind).to_h do |role|
+      path = if role == "package"
+        kind == "candidate" ? "packages/hive-cli-1.2.3.gem" : "packages/openclaw.tgz"
+      else
+        "#{role}/fixture"
+      end
+      artifact = manifest.fetch("files").fetch("hive-cli-1.2.3.gem") if kind == "candidate" && role == "package"
+      [
+        role,
+        {
+          "path" => path,
+          "sha256" => artifact&.fetch("sha256") || Digest::SHA256.hexdigest(path),
+          "size" => artifact&.fetch("size") || path.bytesize
+        }
+      ]
+    end
+    dependency = {
+      "path" => "runtime/dependency.rb", "sha256" => Digest::SHA256.hexdigest("runtime/dependency.rb"),
+      "size" => 21
+    }
+    inventory = [ *roles.values.map { |record| deep_dup(record) }, dependency ].sort_by { |record| record.fetch("path") }
+    closure = { "required_roles" => roles, "inventory" => inventory }
+    {
+      "schema" => vocabulary.fetch("installed_schema"), "schema_version" => 1,
+      "candidate_sha" => SHA, "kind" => kind,
+      "version" => kind == "candidate" ? manifest.fetch("hive_version") : "fixture-openclaw",
+      "closure_sha256" => Digest::SHA256.hexdigest(CREATOR.canonical_json(closure)),
+      "required_roles" => roles, "inventory" => inventory,
+      "total_size" => inventory.sum { |record| record.fetch("size") },
+      "secret_scan" => { "status" => "passed", "scanner" => vocabulary.fetch("scanner") }
+    }
+  end
+
+  def primary_row(manifest, records)
+    created = expected_files.map do |path|
+      { "path" => path, "sha256" => Digest::SHA256.hexdigest(path), "size" => path.bytesize }
+    end
+    instruction = deep_dup(created.fetch(2))
+    summary = { "status" => "passed", "receipt_sha256" => records.fetch(2).fetch("sha256") }
+    {
+      "schema" => vocabulary.fetch("evidence_schema"), "schema_version" => 1,
+      "platform" => "openclaw", "candidate_sha" => SHA, "result" => "passed",
+      "prompt_sha256" => Digest::SHA256.hexdigest(expected_prompt),
+      "task_prompt_sha256" => Digest::SHA256.hexdigest(expected_task_prompt),
+      "skill" => {
+        "skill_version" => manifest.fetch("skill_version"),
+        "canonical_digest" => manifest.fetch("canonical_digest")
+      },
+      "native_activation" => deep_dup(vocabulary.fetch("native_activation")),
+      "hive_commands" => deep_dup(expected_commands), "created_files" => created,
+      "validation" => deep_dup(expected_graph), "creation_only_task_count" => 0,
+      "task_count" => 1, "task" => deep_dup(expected_task), "external_actions" => [],
+      "secret_scan" => { "status" => "passed", "scanner" => vocabulary.fetch("scanner") },
+      "execution_kind" => "authenticated_openclaw", "model_loop" => "executed",
+      "executed_instruction" => instruction, "evidence_bundle" => deep_dup(records),
+      "containment" => deep_dup(summary), "teardown" => deep_dup(summary), "cleanup" => deep_dup(summary)
+    }
+  end
+
+  def execution_receipt(row, records, installations)
+    command_labels = expected_commands.each_index.map { |index| format("command-%02d", index + 1) }
+    commands = expected_commands.each_with_index.map do |argv, index|
+      process_receipt("attempt_label" => command_labels.fetch(index)).merge(
+        "position" => index + 1, "argv" => deep_dup(argv)
+      )
+    end
+    outer = vocabulary.fetch("outer_roles").each_with_index.map do |identity, index|
+      process_receipt("label" => %w[outer-workflow-creator outer-authorized-work].fetch(index)).merge(
+        deep_dup(identity), "argv_sha256" => Digest::SHA256.hexdigest("outer-argv-#{index}")
+      )
+    end
+    labels = command_labels + outer.map { |process| process.fetch("label") }
+    correlation = "workflow-creator-proof-run"
+    packages = installations.values.map { |document| document.dig("required_roles", "package") }
+    archives = packages.each_with_index.map do |package, index|
+      {
+        "label" => vocabulary.fetch("archive_labels").fetch(index),
+        "artifact_sha256" => package.fetch("sha256"), "artifact_size" => package.fetch("size"),
+        "policy_sha256" => vocabulary.fetch("archive_policy_sha256"),
+        "entry_count" => 5, "uncompressed_bytes" => 1_024, "status" => "passed"
+      }
+    end
+    instruction = deep_dup(row.fetch("executed_instruction"))
+    {
+      "schema" => vocabulary.fetch("execution_schema"), "schema_version" => 1,
+      "candidate_sha" => SHA, "result" => "passed", "execution_plan" => vocabulary.fetch("execution_plan"),
+      "classification" => {
+        "outer" => deep_dup(vocabulary.fetch("classification")),
+        "nested_stage" => { "execution_kind" => "deterministic_fixture", "model_loop" => "not_exercised" }
+      },
+      "installed_manifests" => deep_dup(records.first(2)),
+      "run" => { "correlation_id" => correlation, "expected_labels" => labels },
+      "gateway" => {
+        "identity" => deep_dup(installations.fetch("candidate").dig("required_roles", "audit_gateway")),
+        "command_labels" => command_labels, "status" => "passed"
+      },
+      "archive_admissions" => archives, "commands" => commands, "outer_processes" => outer,
+      "authored_instruction" => deep_dup(instruction), "executed_instruction" => deep_dup(instruction),
+      "external_actions" => [],
+      "containment" => {
+        "status" => "passed", "mechanism" => "supervised-process-tree",
+        "established_before_launch" => true, "owner_correlation_id" => correlation,
+        "root_loss_behavior" => "fail-closed"
+      },
+      "teardown" => {
+        "status" => "passed", "expected_labels" => labels, "receipt_labels" => deep_dup(labels),
+        "outer_root_reaped" => true, "remaining_descendants" => 0
+      },
+      "cleanup" => {
+        "status" => "passed",
+        "targets" => [
+          {
+            "label" => "proof-workspace", "path_sha256" => Digest::SHA256.hexdigest("workspace"),
+            "device" => 1, "inode" => 2, "created_by_run" => true,
+            "identity_matched" => true, "removed" => true
+          }
+        ]
+      },
+      "secret_scan" => { "status" => "passed", "scanner" => vocabulary.fetch("scanner") }
+    }
+  end
+
+  def process_receipt(label)
+    label.merge(
+      "exit_code" => 0, "signal" => nil, "completed" => true,
+      "capture" => {
+        "limit_bytes" => 4_096, "stdout_bytes" => 0, "stderr_bytes" => 0,
+        "stdout_sha256" => Digest::SHA256.hexdigest(""), "stderr_sha256" => Digest::SHA256.hexdigest(""),
+        "stdout_truncated" => false, "stderr_truncated" => false,
+        "secret_scan" => { "status" => "passed", "scanner" => vocabulary.fetch("scanner") }
+      },
+      "teardown" => {
+        "status" => "passed", "term_sent" => false, "kill_sent" => false,
+        "reaped" => true, "descendants" => "none", "owner_complete" => true
+      }
+    )
+  end
+
+  def vocabulary
+    CREATOR::Vocabulary
+  end
+
+  def expected_prompt
+    <<~PROMPT
+      /hive
+      Create a three-stage editorial workflow that researches, drafts, and requires approval before publishing.
+      Use the installed Hive workflow-creator capability in this initialized project.
+      This is creation-only: validate the result, report the defaults, and do not create or run a task.
+    PROMPT
+  end
+
+  def expected_task_prompt
+    <<~PROMPT
+      /hive
+      Use the validated editorial workflow to create and run one task for:
+      "Research and draft the launch announcement for approval."
+      Use idempotency key workflow-creator-proof:editorial:live-proof. In this exact order: create the task,
+      run its first stage once, repeat the same creation command once to prove the retry is a no-op,
+      then query operational status. Do not publish or perform any other external action.
+    PROMPT
+  end
+
+  def expected_commands
+    task_argv = [
+      "new", "workflow-creator-proof", "--workflow", "editorial",
+      "--idempotency-key", "workflow-creator-proof:editorial:live-proof",
+      "--json", "Research and draft the launch announcement for approval."
+    ]
+    [
+      [ "version" ],
+      [ "workflow", "list", "--json" ],
+      [ "workflow", "new", "editorial", "--json" ],
+      [ "workflow", "validate", "editorial", "--json" ],
+      [ "workflow", "commit", "editorial" ],
+      task_argv,
+      [ "run", "editorial-live-proof" ],
+      task_argv,
+      [ "status", "--operational", "--json" ]
+    ]
+  end
+
+  def expected_files
+    %w[
+      .hive-state/workflows/editorial.yml
+      .hive-state/workflows/editorial/draft.md
+      .hive-state/workflows/editorial/research.md
+    ]
+  end
+
+  def expected_graph
+    {
+      "valid" => true,
+      "stages" => %w[research draft approval],
+      "automatic_edges" => [ %w[research draft], %w[draft approval] ],
+      "human_outcomes" => [
+        { "stage" => "approval", "name" => "approve", "complete" => true,
+          "artifact" => "draft.md", "to" => nil },
+        { "stage" => "approval", "name" => "reject", "complete" => false,
+          "artifact" => nil, "to" => "draft" }
+      ]
+    }
+  end
+
+  def expected_task
+    {
+      "slug" => "editorial-live-proof", "workflow" => "editorial",
+      "first_created" => true, "retry_created" => false,
+      "run_count" => 1, "current_stage" => "1-research"
+    }
+  end
+end

--- a/test/unit/packaging/workflow_creator_core_test.rb
+++ b/test/unit/packaging/workflow_creator_core_test.rb
@@ -188,6 +188,141 @@ class WorkflowCreatorCoreTest < Minitest::Test
     end
   end
 
+  def test_canonical_json_rejects_projected_expansion_before_pretty_serialization
+    json_limit = CREATOR.const_get(:Primitives, false).const_get(:MAX_JSON_BYTES, false)
+    adversarial = {
+      "nul-expansion" => "\0" * json_limit,
+      "oversized-integer" => 1 << (json_limit * 4)
+    }
+
+    adversarial.each do |label, value|
+      serializer = ->(*) { raise Minitest::Assertion, "pretty serializer reached for #{label}" }
+      original = JSON.method(:pretty_generate)
+      JSON.define_singleton_method(:pretty_generate, serializer)
+      begin
+        error = assert_raises(CREATOR::Error, label) { CREATOR.canonical_json(value) }
+        assert_equal "cannot canonicalize JSON", error.message
+      ensure
+        JSON.define_singleton_method(:pretty_generate, original)
+      end
+    end
+  end
+
+  def test_public_validation_boundaries_reject_json_subclasses
+    hostile_hash = Class.new(Hash) { def keys = [] }
+    hostile_array = Class.new(Array) { def map = [] }
+    hostile_string = Class.new(String) do
+      def ==(_other) = true
+      def bytesize = 0
+      def valid_encoding? = true
+    end
+    plain_hash = Class.new(Hash)
+    plain_array = Class.new(Array)
+    plain_string = Class.new(String)
+
+    cases = {
+      "canonical-hash-enumeration" => -> { CREATOR.canonical_json(hostile_hash["hidden" => true]) },
+      "canonical-array-enumeration" => -> { CREATOR.canonical_json(hostile_array["hidden"]) },
+      "canonical-string-accounting" => -> { CREATOR.canonical_json(hostile_string.new("passed")) },
+      "failure-candidate-string" => lambda do
+        CREATOR.failure(candidate_sha: plain_string.new(SHA), phase: "preflight", reason: "not_started")
+      end,
+      "nonpassing-equality" => lambda do
+        row = CREATOR.failure(candidate_sha: SHA, phase: "preflight", reason: "not_started")
+        row["result"] = hostile_string.new("passed")
+        CREATOR.validate_nonpassing!(row)
+      end,
+      "primary-hash" => lambda do
+        fixture = valid_fixture
+        fixture[:row] = plain_hash.new.merge!(fixture.fetch(:row))
+        validate_primary(fixture)
+      end,
+      "installation-array" => lambda do
+        fixture = valid_fixture
+        document = fixture.fetch(:installations).fetch("openclaw")
+        document["inventory"] = plain_array.new.concat(document.fetch("inventory"))
+        CREATOR.validate_installation!(document:, kind: "openclaw",
+                                       manifest: fixture.fetch(:manifest), candidate_sha: SHA)
+      end,
+      "execution-label-string" => lambda do
+        fixture = valid_fixture
+        label = fixture.fetch(:receipt).fetch("commands").first.fetch("attempt_label")
+        fixture.fetch(:receipt).fetch("commands").first["attempt_label"] = plain_string.new(label)
+        validate_execution(fixture)
+      end
+    }
+    accepted = cases.filter_map do |label, action|
+      action.call
+      label
+    rescue CREATOR::Error
+      nil
+    end
+    assert_empty accepted, "subclass-backed evidence admitted: #{accepted.join(', ')}"
+  end
+
+  def test_failure_redaction_merges_overlapping_original_ranges
+    cases = {
+      "exact-exact" => [ "token=abcdefghij", %w[abc abcdefghij] ],
+      "exact-pattern" => [ "token=#{secret_shape}", [ "sk-ant-abc" ] ]
+    }
+    cases.each do |label, (detail, exact_secrets)|
+      row = CREATOR.failure(candidate_sha: SHA, phase: "preflight", reason: "provider_unavailable",
+                            detail:, exact_secrets:)
+      assert_equal "token=[REDACTED]", row.fetch("detail"), label
+      refute_match(/defghij/, row.fetch("detail"), label)
+    end
+  end
+
+  def test_failure_rejects_raw_detail_above_the_documented_work_ceiling
+    contract = CREATOR.const_get(:Contract, false)
+    assert_equal 4_096, contract.const_get(:MAX_DETAIL_INPUT_BYTES, false)
+    exact_secrets = 64.times.map { |index| format("absent-secret-%02d", index) }
+    assert_raises(CREATOR::Error) do
+      CREATOR.failure(candidate_sha: SHA, phase: "preflight", reason: "provider_unavailable",
+                      detail: "x" * 4_097, exact_secrets:)
+    end
+  end
+
+  def test_public_strings_reject_non_utf8_with_domain_errors
+    utf16_sha = SHA.encode(Encoding::UTF_16LE)
+    cases = {
+      "canonical-key" => -> { CREATOR.canonical_json({ "key".encode(Encoding::UTF_16LE) => true }) },
+      "failure-candidate-sha" => lambda do
+        CREATOR.failure(candidate_sha: utf16_sha, phase: "preflight", reason: "not_started")
+      end,
+      "failure-phase" => lambda do
+        CREATOR.failure(candidate_sha: SHA, phase: "preflight".encode(Encoding::UTF_16LE), reason: "not_started")
+      end,
+      "primary-candidate-sha" => lambda do
+        fixture = valid_fixture
+        CREATOR.validate_primary!(row: fixture.fetch(:row), manifest: fixture.fetch(:manifest),
+                                  candidate_sha: utf16_sha, bundle_records: fixture.fetch(:bundle_records))
+      end,
+      "installation-path" => lambda do
+        fixture = valid_fixture
+        document = fixture.fetch(:installations).fetch("openclaw")
+        document.fetch("inventory").last["path"] = "runtime/dependency.rb".encode(Encoding::UTF_16LE)
+        CREATOR.validate_installation!(document:, kind: "openclaw",
+                                       manifest: fixture.fetch(:manifest), candidate_sha: SHA)
+      end,
+      "execution-label" => lambda do
+        fixture = valid_fixture
+        fixture.fetch(:receipt).fetch("commands").first["attempt_label"] =
+          "command-01".encode(Encoding::UTF_16LE)
+        validate_execution(fixture)
+      end
+    }
+    boundary_leaks = cases.filter_map do |label, action|
+      action.call
+      "#{label}:accepted"
+    rescue CREATOR::Error
+      nil
+    rescue EncodingError => error
+      "#{label}:#{error.class}"
+    end
+    assert_empty boundary_leaks, "non-UTF-8 boundary leaks: #{boundary_leaks.join(', ')}"
+  end
+
   def test_primary_contract_accepts_exact_claims_and_rejects_key_type_order_and_binding_drift
     fixture = valid_fixture
     assert_same fixture.fetch(:row), validate_primary(fixture)
@@ -345,6 +480,30 @@ class WorkflowCreatorCoreTest < Minitest::Test
     assert_raises(CREATOR::Error) { validate_execution(invalid) }
   end
 
+  def test_execution_capture_tuples_bind_counts_digests_and_truncation
+    cases = {
+      "zero-byte-stdout-digest" => lambda do |capture|
+        capture["stdout_sha256"] = DIGEST
+      end,
+      "short-truncated-stderr" => lambda do |capture|
+        capture["stderr_bytes"] = capture.fetch("limit_bytes") - 1
+        capture["stderr_sha256"] = DIGEST
+        capture["stderr_truncated"] = true
+      end
+    }
+    accepted = cases.filter_map do |label, mutation|
+      fixture = valid_fixture
+      mutation.call(fixture.fetch(:receipt).fetch("commands").first.fetch("capture"))
+      rebind_execution_receipt!(fixture)
+      validate_execution(fixture)
+      label
+    rescue CREATOR::Error => error
+      assert_equal "workflow-creator execution process receipt is invalid", error.message, label
+      nil
+    end
+    assert_empty accepted, "incoherent capture tuples admitted: #{accepted.join(', ')}"
+  end
+
   def test_execution_contract_binds_all_canonical_document_bytes_and_kinds
     cases = {
       "swapped-documents" => lambda do |item|
@@ -472,7 +631,7 @@ class WorkflowCreatorCoreTest < Minitest::Test
       script << "\n"
       script << <<~RUBY
         names = HiveLiveAgentProof.constants(false).map(&:to_s)
-        forbidden = (names & %w[SCHEMA_VERSION SAFE_SHA SECRET_PATTERNS Error]) + names.grep(/\AWORKFLOW_CREATOR_/)
+        forbidden = (names & %w[SCHEMA_VERSION SAFE_SHA SECRET_PATTERNS Error]) + names.grep(/\\AWORKFLOW_CREATOR_/)
         if #{order == [ core ]} && !forbidden.empty?
           abort "forbidden root constant"
         end
@@ -481,6 +640,14 @@ class WorkflowCreatorCoreTest < Minitest::Test
       out, err, status = Open3.capture3(RbConfig.ruby, "-w", "-I#{ROOT}", "-e", script)
       assert status.success?, "#{order.join(' -> ')}: #{out}#{err}"
       assert_empty err, order.join(" -> ")
+      next unless order == [ core ]
+
+      poisoned = script.sub("names = ", "HiveLiveAgentProof::WORKFLOW_CREATOR_POISON = true\nnames = ")
+      poison_out, poison_err, poison_status = Open3.capture3(
+        RbConfig.ruby, "-w", "-I#{ROOT}", "-e", poisoned
+      )
+      refute poison_status.success?, "root constant poison was not detected: #{poison_out}#{poison_err}"
+      assert_includes poison_err, "forbidden root constant"
     end
     %i[Primitives Contract ExecutionContract].each do |name|
       assert_raises(NameError) { eval("HiveLiveAgentProof::WorkflowCreator::#{name}") }
@@ -644,6 +811,11 @@ class WorkflowCreatorCoreTest < Minitest::Test
     %w[containment teardown cleanup].each { |field| row[field] = deep_dup(summary) }
   end
 
+  def rebind_execution_receipt!(fixture)
+    bind_execution_record!(fixture.fetch(:row), fixture.fetch(:bundle_records), fixture.fetch(:receipt))
+    fixture[:receipt_sha256] = fixture.fetch(:bundle_records).fetch(2).fetch("sha256")
+  end
+
   def refresh_installation!(document)
     closure = {
       "required_roles" => document.fetch("required_roles"),
@@ -664,14 +836,16 @@ class WorkflowCreatorCoreTest < Minitest::Test
       "proof_primitives.rb" => {
         requires: [ %w[require json] ],
         calls: %w[
-          all? bytesize byteslice call deep_freeze each each_with_index empty? encode fetch filter_map
-          force_encoding freeze gsub! include? is_a? keys lambda map match? module_function none?
-          pretty_generate raise require scrub sort source split start_with? to_h to_s valid_encoding?
+          ascii_only? bit_length bytebegin byteend bytesize byteslice call class count deep_freeze dup each
+          each_with_index each_with_object empty? encode encoding escape fetch filter_map finite? first
+          force_encoding freeze include? instance_of? is_a? keys lambda last last_match length map match?
+          max module_function none? pretty_generate raise require scan scrub sort sort_by! source split
+          start_with? tap then to_h to_s valid_encoding?
         ],
         constants: %w[
-          ArgumentError Array Encoding Error FalseClass Float GeneratorError Hash HiveLiveAgentProof Integer JSON
-          MAX_JSON_BYTES MAX_JSON_DEPTH MAX_JSON_NODES NestingError NilClass Primitives SECRET_PATTERNS
-          StandardError String TrueClass TypeError UTF_8 WorkflowCreator
+          ArgumentError Array Encoding EncodingError Error FalseClass Float GeneratorError Hash HiveLiveAgentProof
+          Integer JSON MAX_JSON_BYTES MAX_JSON_DEPTH MAX_JSON_INTEGER_BITS MAX_JSON_NODES NestingError NilClass Primitives Regexp
+          SECRET_PATTERNS StandardError String TrueClass TypeError UTF_8 WorkflowCreator
         ]
       },
       "workflow_creator.rb" => {
@@ -689,16 +863,16 @@ class WorkflowCreatorCoreTest < Minitest::Test
       "workflow_creator_contract.rb" => {
         requires: [ %w[require digest], %w[require_relative proof_primitives] ],
         calls: %w[
-          all? ascii_only? between? bytesize call canonical_json deep_freeze dig downcase drop each each_with_index empty? encoding
-          exact_secrets! fetch find first freeze generate hexdigest include? is_a? keys lambda length map match?
+          all? between? bytesize call canonical_json deep_freeze dig downcase drop each each_with_index empty? encoding
+          exact_secrets! fetch find first freeze generate hexdigest include? instance_of? keys lambda length map match?
           module_function nil? one? positive? raise require require_relative safe_relative_path? secret_findings
-          secret_safe_text select sort sum then to_s uniq valid_encoding? valid_manifest? validate_nonpassing!
+          secret_safe_text select sort sum then uniq valid_encoding? valid_manifest? validate_nonpassing!
           values values_at zero? zip
         ],
         constants: %w[
-          ARTIFACT_KEYS ASSERT ArgumentError Array BUNDLE_KEYS CLASSIFICATIONS Contract DETAIL_LIMIT DIGEST Digest Encoding Error
+          ARTIFACT_KEYS ASSERT ArgumentError Array BUNDLE_KEYS CLASSIFICATIONS Contract DETAIL_LIMIT DIGEST Digest Encoding EncodingError Error
           FAILURE_KEYS FAILURE_PART FILE_KEYS GeneratorError Hash HiveLiveAgentProof INSTALLATION_KEYS Integer JSON
-          KeyError MANIFEST_KEYS MAX_EXACT_SECRETS MAX_INVENTORY_ENTRIES MAX_MEMBER_BYTES MAX_SECRET_BYTES
+          KeyError MANIFEST_KEYS MAX_DETAIL_INPUT_BYTES MAX_EXACT_SECRETS MAX_INVENTORY_ENTRIES MAX_MEMBER_BYTES MAX_SECRET_BYTES
           MAX_TOTAL_BYTES NoMethodError PRIMARY_KEYS Primitives SHA SHA256 SUMMARY_KEYS String TypeError UTF_8 Vocabulary
           WorkflowCreator
         ]
@@ -707,13 +881,13 @@ class WorkflowCreatorCoreTest < Minitest::Test
         requires: [ %w[require_relative workflow_creator_contract] ],
         calls: %w[
           all? between? bytesize call canonical_json deep_freeze each_with_index empty? fetch first freeze generate
-          hexdigest include? is_a? keys lambda length map match? module_function nil? positive? raise require_relative
+          hexdigest include? instance_of? keys lambda length map match? module_function nil? positive? raise require_relative
           safe_relative_path? secret_findings slice sort uniq valid_process? validate_aggregates! validate_identity!
           validate_installation! validate_primary! validate_processes! values_at zero? zip
         ],
         constants: %w[
           ARCHIVE_KEYS ASSERT ArgumentError Array BUNDLE_KEYS CAPTURE_KEYS CLEANUP_KEYS COMMAND_KEYS CONTAINMENT_KEYS
-          Contract DIGEST Digest Error ExecutionContract FILE_KEYS GATEWAY_KEYS GeneratorError Hash HiveLiveAgentProof
+          Contract DIGEST Digest EncodingError Error ExecutionContract FILE_KEYS GATEWAY_KEYS GeneratorError Hash HiveLiveAgentProof
           Integer JSON KEYS KeyError LABEL MAX_ARCHIVE_BYTES MAX_ARCHIVE_ENTRIES MAX_CAPTURE_BYTES NoMethodError
           OUTER_KEYS PROCESS_TEARDOWN_KEYS Primitives RUN_KEYS SHA SHA256 String TARGET_KEYS TEARDOWN_KEYS TypeError
           Vocabulary WorkflowCreator

--- a/wiki/component-boundaries.md
+++ b/wiki/component-boundaries.md
@@ -3,7 +3,7 @@ title: Component boundaries
 type: reference
 source: config/component-boundaries.yml, test/support/component_boundary_contract.rb
 created: 2026-07-25
-updated: 2026-07-30
+updated: 2026-08-02
 tags: [architecture, components, boundaries, monorepo]
 ---
 
@@ -18,6 +18,7 @@ the first and primary consumer.
 | Component | State | Current entry point | Narrative context |
 |-----------|-------|---------------------|-------------------|
 | Patrol Effect Evidence | `candidate` (U3 qualification pending) | `require "hive/modules/migration/patrol_evidence"` → `Hive::Modules::Migration::PatrolEvidence` | [[modules/patrol]] |
+| Workflow Creator Proof Core | `candidate` (U1a2 consumer fence) | `require "packaging/live_agent_skills/workflow_creator"` → `HiveLiveAgentProof::WorkflowCreator` | [[component-boundaries]] |
 | Attempts admission / future RunReceipt | `candidate` (guarded reference) | `require "hive/attempts/api"` → `Hive::Attempts::API` | [[modules/attempts]] |
 | UserService | `boundary-ready` | `require "hive/user_service"` → `Hive::UserService` | [[modules/user_service]] |
 | Agent ABI | `boundary-ready`; standalone package candidate | `require "hive/agent_runtime"` → `Hive::AgentRuntime` | [[modules/agent_cli_runtime]], [[modules/agent_profile]] |
@@ -34,8 +35,9 @@ has earned a gem, version, repository, or release.
 
 ## Final graph audit
 
-The final U2 resolution on 2026-07-29 retains eight components: six are
-`boundary-ready`; Attempts and Patrol Effect Evidence remain `candidate`.
+The final U2 resolution plus the staged U1a1 prerequisite retain nine
+components: six are `boundary-ready`; Attempts, Patrol Effect Evidence, and
+Workflow Creator Proof Core remain `candidate`.
 Patrol retains one bounded U3 exception for compressed evidence qualification
 and cutover proof. Every retained entry point has a focused clean-process load
 proof, every catalog-owned path and focused test resolves inside this
@@ -48,6 +50,7 @@ The component dependency graph has one edge:
 flowchart LR
   skillpack[Skillpack] --> agent_abi[Agent ABI]
   patrol_effects[Patrol Effect Evidence - candidate]
+  workflow_creator[Workflow Creator Proof Core - candidate]
   attempts[Attempts admission - candidate]
   user_service[UserService]
   artifact_firewall[Agent Artifact Firewall]
@@ -56,11 +59,26 @@ flowchart LR
 ```
 
 All other cataloged components depend only on explicitly allowed lower-level
-Hive primitives. The source audit found no retained experimental facade outside
+primitives. The source audit found no retained experimental facade outside
 the catalog: each promoted facade is owned by a catalog row and used by Hive,
 while Attempts and Patrol Effect Evidence are deliberately retained as guarded
 candidates rather than being promoted ahead of their remaining lifecycle or
 qualification proof.
+
+`HiveLiveAgentProof::WorkflowCreator` is the sole staged-prerequisite
+exception. Its four-file core is pure and namespaced: it exports one deeply
+frozen schema-v1 `Vocabulary`, a nested `Error`, canonical JSON, and validators
+for failed, primary, installed-closure, and declarative execution-receipt
+documents. It performs no filesystem, archive, process, provider, credential,
+publication, recovery, or bundle-custody work. The dependency direction is
+facade to primitives/contracts only; the core cannot require `proof.rb` or
+`workflow_creator_bundle.rb`.
+
+This candidate truthfully has zero current production consumers. Its non-empty
+U1a2 migration exception is an executable removal fence: U1a2 must route the
+incumbent proof and release-candidate custody consumers through the core or
+remove the staged component. It cannot become `boundary-ready` with zero
+consumers or retain that exception.
 
 This is an internal architecture verdict, not a packaging verdict. None of the
 six ready components currently has the named non-Hive adopter and independent
@@ -266,8 +284,10 @@ Each row names:
 Owned paths cannot overlap between components, component dependencies must form
 an acyclic graph, and every path in the catalog must resolve inside the
 repository. A temporary exception must include both a reason and the
-implementation unit that removes it. A `boundary-ready` component cannot keep
-an exception or depend on a `candidate` component.
+implementation unit that removes it. A candidate may have zero current Hive
+consumers only while a valid, non-empty staged removal exception records that
+unit. A `boundary-ready` component cannot have zero consumers, keep an
+exception, or depend on a `candidate` component.
 
 ## Enforcement
 

--- a/wiki/component-boundaries.md
+++ b/wiki/component-boundaries.md
@@ -81,16 +81,23 @@ primitives/contracts only; `ExecutionContract` reuses `Contract` primitives,
 while the core cannot require `proof.rb` or `workflow_creator_bundle.rb`.
 
 Every public validator now admits only an exact plain JSON tree; subclasses
-cannot override equality, enumeration, or path behavior. External strings and
-keys must be valid UTF-8, with deterministic UTF-8 normalization limited to
-ASCII-only strings. Canonical JSON projects the complete pretty-printed byte
-size—including escaping, indentation, punctuation, numerics, and its trailing
-newline—before invoking the serializer, while retaining the final exact-size
-check. Failure detail has a 4,096-byte raw work ceiling, finds exact and pattern
-matches against the original normalized text, merges overlapping intervals,
-and replaces each merged range once before its 1,000-byte output truncation.
-Execution capture tuples bind zero captured bytes to the empty SHA-256 digest,
-and a true truncation flag requires the captured count to equal its limit.
+cannot override equality, enumeration, or path behavior. Exact-class
+inspection bypasses input dispatch and rejects per-object singleton overrides;
+global core monkeypatching remains outside this boundary. External strings,
+keys, and exact secrets must be plain valid UTF-8 values, with deterministic
+UTF-8 normalization limited to ASCII-only strings. Canonical JSON projects the
+complete pretty-printed byte size—including backslash escaping, indentation,
+punctuation, generator-accurate finite numerics, and its trailing newline—while
+rejecting NaN and Infinity. Hash admission rejects impossible remaining value
+nodes before key preprocessing, charges aggregate and per-key bytes before
+encoding or retaining each key, and retains the final exact-size check.
+Relative-path validation scans without allocating a separator-proportional
+component array. Failure detail has a 4,096-byte raw work ceiling, finds exact
+and pattern matches against the original normalized text, merges overlapping
+intervals, and replaces each merged range once before its 1,000-byte output
+truncation. Execution capture tuples bind the empty SHA-256 digest if and only
+if captured bytes are zero, a true truncation flag requires the captured count
+to equal its limit, and teardown admits only integer zero remaining descendants.
 
 This candidate truthfully has zero current production consumers. Its non-empty
 U1a2 migration exception is an executable removal fence: U1a2 must route the

--- a/wiki/component-boundaries.md
+++ b/wiki/component-boundaries.md
@@ -80,11 +80,24 @@ recovery, or bundle-custody work. The dependency direction is facade to
 primitives/contracts only; `ExecutionContract` reuses `Contract` primitives,
 while the core cannot require `proof.rb` or `workflow_creator_bundle.rb`.
 
+Every public validator now admits only an exact plain JSON tree; subclasses
+cannot override equality, enumeration, or path behavior. External strings and
+keys must be valid UTF-8, with deterministic UTF-8 normalization limited to
+ASCII-only strings. Canonical JSON projects the complete pretty-printed byte
+size—including escaping, indentation, punctuation, numerics, and its trailing
+newline—before invoking the serializer, while retaining the final exact-size
+check. Failure detail has a 4,096-byte raw work ceiling, finds exact and pattern
+matches against the original normalized text, merges overlapping intervals,
+and replaces each merged range once before its 1,000-byte output truncation.
+Execution capture tuples bind zero captured bytes to the empty SHA-256 digest,
+and a true truncation flag requires the captured count to equal its limit.
+
 This candidate truthfully has zero current production consumers. Its non-empty
 U1a2 migration exception is an executable removal fence: U1a2 must route the
 incumbent proof and release-candidate custody consumers through the core or
 remove the staged component. It cannot become `boundary-ready` with zero
-consumers or retain that exception.
+consumers or retain that exception. No other catalog row may use a migration
+exception to declare zero consumers.
 
 This is an internal architecture verdict, not a packaging verdict. None of the
 six ready components currently has the named non-Hive adopter and independent
@@ -290,10 +303,12 @@ Each row names:
 Owned paths cannot overlap between components, component dependencies must form
 an acyclic graph, and every path in the catalog must resolve inside the
 repository. A temporary exception must include both a reason and the
-implementation unit that removes it. A candidate may have zero current Hive
-consumers only while a valid, non-empty staged removal exception records that
-unit. A `boundary-ready` component cannot have zero consumers, keep an
-exception, or depend on a `candidate` component.
+implementation unit that removes it. The sole zero-consumer fence is the
+`workflow-creator-core` row while it is a `candidate` with exactly one
+migration exception whose removal unit is `U1a2`. All other rows require real
+consumers even when a candidate has a valid migration exception. A
+`boundary-ready` component cannot have zero consumers, keep an exception, or
+depend on a `candidate` component.
 
 ## Enforcement
 

--- a/wiki/component-boundaries.md
+++ b/wiki/component-boundaries.md
@@ -67,12 +67,18 @@ qualification proof.
 
 `HiveLiveAgentProof::WorkflowCreator` is the sole staged-prerequisite
 exception. Its four-file core is pure and namespaced: it exports one deeply
-frozen schema-v1 `Vocabulary`, a nested `Error`, canonical JSON, and validators
-for failed, primary, installed-closure, and declarative execution-receipt
-documents. It performs no filesystem, archive, process, provider, credential,
-publication, recovery, or bundle-custody work. The dependency direction is
-facade to primitives/contracts only; the core cannot require `proof.rb` or
-`workflow_creator_bundle.rb`.
+frozen schema-v1 `Vocabulary`, a nested `Error`, resource-bounded canonical
+JSON, and validators for failed, primary, installed-closure, and declarative
+execution-receipt documents. Failure admission accepts only a bounded array of
+unambiguous exact-secret strings, and relative document paths reject both
+traversal and drive-qualified forms. Execution admission composes the primary
+and installation validators, binds canonical candidate/OpenClaw installation
+bytes to the matching primary and receipt records, and binds the canonical
+execution receipt to the third bundle record and supplied receipt digest. It
+performs no filesystem, archive, process, provider, credential, publication,
+recovery, or bundle-custody work. The dependency direction is facade to
+primitives/contracts only; `ExecutionContract` reuses `Contract` primitives,
+while the core cannot require `proof.rb` or `workflow_creator_bundle.rb`.
 
 This candidate truthfully has zero current production consumers. Its non-empty
 U1a2 migration exception is an executable removal fence: U1a2 must route the

--- a/wiki/gaps.md
+++ b/wiki/gaps.md
@@ -122,12 +122,15 @@ tags: [gap, todo, release-proof, agent-skills]
 
 ## Internal component boundary gap
 
-- The final internal graph audit retains eight catalog rows: UserService, Agent
+- The internal graph audit plus staged U1a1 retain nine catalog rows: UserService, Agent
   ABI, Agent Artifact Firewall, Skillpack, Safe Agent Git Gate, and WorkLedger
   are `boundary-ready`; Attempts admission and Patrol Effect Evidence remain
-  `candidate`. Skillpack to Agent ABI is the only component dependency. Patrol
-  retains one bounded U3 exception for compressed candidate evidence and
-  production qualification; Attempts remains unready because Hive has no
+  `candidate`, joined by the pure Workflow Creator Proof Core. Skillpack to
+  Agent ABI is the only component dependency. The creator core has zero
+  production consumers and a bounded U1a2 removal fence: U1a2 must route the
+  incumbent proof/custody consumers through it or remove it. Patrol retains one
+  bounded U3 exception for compressed candidate evidence and production
+  qualification; Attempts remains unready because Hive has no
   demonstrated need for a supported reconciliation, supervision, capacity,
   loss-processing, cancellation, export, or raw-store lifecycle API.
 - No ready component has yet earned standalone packaging. There is no named

--- a/wiki/gaps.md
+++ b/wiki/gaps.md
@@ -128,7 +128,11 @@ tags: [gap, todo, release-proof, agent-skills]
   `candidate`, joined by the pure Workflow Creator Proof Core. Skillpack to
   Agent ABI is the only component dependency. The creator core has zero
   production consumers and a bounded U1a2 removal fence: U1a2 must route the
-  incumbent proof/custody consumers through it or remove it. Patrol retains one
+  incumbent proof/custody consumers through it or remove it. Its execution
+  validator now closes candidate/OpenClaw kind, bounded canonical-byte,
+  primary-row, installation-record, and execution-receipt-record binding, but
+  this remains source-level validation rather than retained custody or
+  installed/live proof. Patrol retains one
   bounded U3 exception for compressed candidate evidence and production
   qualification; Attempts remains unready because Hive has no
   demonstrated need for a supported reconciliation, supervision, capacity,

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -3,7 +3,7 @@ title: hive Wiki
 type: index
 source: wiki/**/*.md
 created: 2026-05-14
-updated: 2026-07-30
+updated: 2026-08-02
 tags: [index, wiki]
 ---
 
@@ -14,18 +14,19 @@ proof, while built-in content/bench, installable Honeycomb, and owner-authored
 workflows use the same folder-backed execution model.
 
 Page count: 98
-Updated: 2026-07-30
+Updated: 2026-08-02
 
 Folder-as-agent workflow engine: a Ruby 3.4 / Thor CLI control plane where descriptor-backed workflows move task folders through filesystem stages, stage agents compile provider-neutral invocations through `Hive::AgentRuntime` and configurable AgentProfile adapters (`claude` default, `codex`, `pi`, `grok`), and `mv` between directories remains the approval primitive. The built-in `coding` workflow drives the nine-stage PR pipeline (`1-inbox` → `2-brainstorm` → `3-plan` → `4-execute` → `5-open-pr` → `6-review` → `7-artifacts` → `8-finalize` → `9-done`), while the built-in `content` and `bench` workflows and project-authored workflows share the same generic runner/status/action machinery. Agent operation is centered on the additive operational status contract, coherent daemon scheduler snapshots, bounded semantic `hive watch`, tokenized routine `hive act`, and stable-ID semantic E2E profiles; the legacy full JSON graph remains compatible. Hive packages one canonical operating skill projected to OpenClaw `/hive`, Claude `/hive`, Codex `$hive`, and Pi `/skill:hive`, with read-only `hive doctor`, consent-safe setup, deterministic trusted pre-release proof, and optional four-agent live diagnostics.
 
 Reusable mechanisms remain in this monorepo behind the canonical
-[[component-boundaries]] catalog. The final internal graph has six
-`boundary-ready` facades—UserService, Agent ABI, Agent Artifact Firewall,
-Skillpack, Safe Agent Git Gate, and WorkLedger—and one guarded `candidate`,
-Attempts admission. Skillpack's downward dependency on the Agent ABI is the
-only component-to-component edge; no migration exceptions remain. Hive is the
-first and primary consumer, and internal readiness does not imply a gem,
-version, repository, or release.
+[[component-boundaries]] catalog. The internal graph has six `boundary-ready`
+facades—UserService, Agent ABI, Agent Artifact Firewall, Skillpack, Safe Agent
+Git Gate, and WorkLedger—and three guarded candidates: Attempts admission,
+Patrol Effect Evidence, and the pure Workflow Creator Proof Core. Skillpack's
+downward dependency on the Agent ABI is the only component-to-component edge.
+The creator core truthfully has zero production consumers behind an explicit
+U1a2 removal fence; internal readiness does not imply a gem, version,
+repository, or release.
 
 Agent spawns that own controller artifacts use the boundary-ready
 `Hive::ArtifactFirewall` for same-user protected-anchor custody, required

--- a/wiki/log.d/20260802T135918Z-workflow-creator-core.md
+++ b/wiki/log.d/20260802T135918Z-workflow-creator-core.md
@@ -18,3 +18,12 @@
   clean/co-load, purity/back-edge, and executable line/method/branch budget
   proofs. U1a2 still owns edits to incumbent proof/custody consumers; no live
   provider, release, publication, deployment, or remote mutation occurred.
+- Resolution 01 composes primary and installation validation into execution
+  admission; binds canonical candidate/OpenClaw bytes to their record views;
+  binds canonical receipt bytes, size, and supplied digest to the third bundle
+  record; bounds canonical depth, nodes, strings, and output; rejects kind
+  substitution, stale/tampered bytes, zero-byte required packages,
+  non-array/oversized/ambiguous exact-secret inputs, and drive-qualified or
+  traversal paths; replaces the negative purity blocklist with exact
+  Ripper-derived require/call/constant admission; reuses contract primitives;
+  and isolates branch-budget subprocess coverage bootstrap state.

--- a/wiki/log.d/20260802T135918Z-workflow-creator-core.md
+++ b/wiki/log.d/20260802T135918Z-workflow-creator-core.md
@@ -1,0 +1,20 @@
+## 2026-08-02 — Stage the pure workflow-creator proof core
+
+- Added `HiveLiveAgentProof::WorkflowCreator` as a four-file, namespaced,
+  in-memory schema-v1 core. Its recursively frozen `Vocabulary` preserves the
+  exact creator prompts, argv, files, graph, task, schema, classification, and
+  computed digest identities without redefining incumbent `proof.rb` constants.
+- Added strict, secret-safe validators for failed evidence, primary passing
+  documents, installed inventory closure, and declarative execution receipts.
+  The core validates process/archive/containment/teardown/cleanup claims but
+  performs no I/O, execution, custody, publication, recovery, provider, or
+  credential orchestration.
+- Cataloged the core honestly as a `candidate` with zero current production
+  consumers and an explicit U1a2 removal fence. The test-only boundary helper
+  now admits that state only for a valid staged exception, keeps
+  `boundary-ready` zero-consumer rows invalid, maps `packaging/` require
+  ownership, and clean-loads packaged entry points from the repository root.
+- Added focused exact-key/type/order/cross-binding, recursive mutation,
+  clean/co-load, purity/back-edge, and executable line/method/branch budget
+  proofs. U1a2 still owns edits to incumbent proof/custody consumers; no live
+  provider, release, publication, deployment, or remote mutation occurred.

--- a/wiki/log.d/20260802T135918Z-workflow-creator-core.md
+++ b/wiki/log.d/20260802T135918Z-workflow-creator-core.md
@@ -27,3 +27,16 @@
   traversal paths; replaces the negative purity blocklist with exact
   Ripper-derived require/call/constant admission; reuses contract primitives;
   and isolates branch-budget subprocess coverage bootstrap state.
+- Resolution 02 rejects adversarial pretty-JSON expansion before serializer
+  entry with exact projected-byte accounting, admits only exact plain JSON
+  trees with deterministic UTF-8 strings, merges overlapping secret ranges
+  under a 4,096-byte raw-detail ceiling, binds empty/truncated capture digests
+  coherently to byte counts, and activates the anchored root-constant poison
+  control. These remain pure validation changes with no custody, I/O, process,
+  provider, credential, publication, or live behavior.
+- Resolution 02 finding 8 narrows the zero-consumer catalog fence to the
+  `workflow-creator-core` candidate with exactly one `U1a2` migration
+  exception. Other candidates still accept valid exceptions when they have
+  real consumers, but Patrol's `U3` exception, a borrowed `U1a2` exception,
+  the wrong removal unit, and duplicate `U1a2` entries cannot excuse zero
+  consumers.

--- a/wiki/log.d/20260802T135918Z-workflow-creator-core.md
+++ b/wiki/log.d/20260802T135918Z-workflow-creator-core.md
@@ -40,3 +40,12 @@
   real consumers, but Patrol's `U3` exception, a borrowed `U1a2` exception,
   the wrong removal unit, and duplicate `U1a2` entries cannot excuse zero
   consumers.
+- Resolution 03 bypasses deceptive class dispatch and rejects per-object
+  singleton overrides, including exact-secret inputs; enforces Hash node and
+  byte ceilings before avoidable key encoding/retention; projects backslashes
+  and finite Float tokens exactly like the JSON generator; scans relative paths
+  without separator-proportional component allocation; and requires coherent
+  captured-byte/digest tuples plus integer-zero teardown descendants. These are
+  still pure source-level admission rules and add no production consumer,
+  custody, filesystem/archive I/O, process, provider, credential, publication,
+  recovery, OpenClaw setup, or live behavior.

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -50,9 +50,17 @@ staged U1a1 semantic core with no live provider or filesystem fixture. It pins
 the exact prompt, argv, file, graph, task, schema, and classification bytes;
 recursively attempts to mutate every exported `Vocabulary` container, key, and
 string (including computed digests); and exercises strict failed, primary,
-installed-closure, and declarative execution-transaction matrices. It also
-loads the core alone and before/after untouched `proof.rb` under Ruby warnings,
-and statically rejects I/O/process dependencies or proof/bundle back-edges.
+installed-closure, and declarative execution-transaction matrices. Canonical
+JSON has explicit depth, node, string, and output-byte ceilings; failure
+redaction rejects scalar, mapping, oversized, ambiguous-encoding, and
+over-count exact-secret inputs; and document paths reject drive-qualified as
+well as traversal forms. Execution validation composes the primary and
+installation contracts, then binds both canonical installation documents and
+the canonical execution receipt by digest and byte size before consuming their
+records. The test also loads the core alone and before/after untouched
+`proof.rb` under Ruby warnings, admits an exact Ripper-derived
+require/call/constant surface, rejects dormant I/O additions, and rejects
+proof/bundle back-edges.
 This is core-only proof, not bundle custody or an activated production
 consumer; U1a2 owns that routing.
 
@@ -179,6 +187,10 @@ transport, manifest upload exceptions, missing media directories, screenote
 config type errors, and dry-run digest completion failures.
 
 Coverage-included tests that only need a generic stdout/stderr subprocess should avoid `RbConfig.ruby` children unless they are explicitly testing Ruby coverage propagation. Those nested Ruby processes inherit the coverage `RUBYOPT`, which can make startup latency part of otherwise unrelated timeout assertions; use a tiny executable fixture script for generic capture/timeout seams.
+The workflow-creator branch-budget probe is intentionally different: its child
+clears the inherited coverage bootstrap variables before starting an isolated
+Ruby `Coverage` branch measurement, avoiding a double-start while preserving
+the exact production branch-site count.
 
 In CI (`CI=true`), tests that exercise backgrounding commands must force a foreground path (for example `foreground: true`) or stub daemonization. Otherwise the test process can daemonize before Minitest `after_run` writes `coverage/coverage.json`, leaving the parent coverage task with a missing report while child output keeps streaming. Bundler evaluates the gemspec before coverage starts, so the bootstrap reloads the preloaded `lib/hive/version.rb`, `lib/hive/errors.rb`, and `lib/hive.rb` files in dependency order. Reloaded code must therefore be idempotent; for example, self-derived enum constants must exclude `:ALL` to stay reload-safe.
 

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -64,14 +64,22 @@ proof/bundle back-edges.
 
 The resource regressions stub the pretty serializer and prove that NUL-heavy
 strings and oversized integers fail on projected output size before serializer
-entry. Hostile `Hash`, `Array`, and `String` subclasses, UTF-16LE keys and
-public identities, overlapping exact/pattern secrets, and a 4,097-byte failure
-detail with all 64 exact-secret slots fail closed. Capture regressions rebind
-the complete execution-receipt identity after inner mutation, so zero-byte
-digest and short-truncated-count rejection cannot pass merely because an outer
-receipt digest became stale. The clean-load guard also injects a root
-`WORKFLOW_CREATOR_*` poison constant to prove its anchored leak detector is
-live.
+entry. TracePoint-backed cases prove impossible Hash value-node cardinality
+rejects before key preprocessing and an aggregate-byte overflow charges a key
+before encoding it. Representative backslash strings and finite exponent/fixed
+Floats must match `JSON.pretty_generate` plus its canonical newline, while NaN
+and Infinity fail closed. Hostile `Hash`, `Array`, and `String` subclasses,
+deceptive `class` overrides, exact-class values with singleton overrides,
+singleton-backed exact secrets, UTF-16LE keys and public identities,
+overlapping exact/pattern secrets, and a 4,097-byte failure detail with all 64
+exact-secret slots fail closed. Relative-path characterization preserves the
+safe/unsafe matrix and proves separator-heavy input does not call `split`.
+Capture and teardown regressions rebind the complete execution-receipt identity
+after inner mutation, so positive bytes with the empty digest, zero-byte digest,
+short-truncated counts, and Float zero remaining descendants cannot pass merely
+because an outer receipt digest became stale. The clean-load guard also injects
+a root `WORKFLOW_CREATOR_*` poison constant to prove its anchored leak detector
+is live.
 
 This is core-only proof, not bundle custody or an activated production
 consumer; U1a2 owns that routing.

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -3,7 +3,7 @@ title: Testing
 type: reference
 source: test/, Rakefile, bin/hive-eval, .rubocop.yml, .github/workflows/{ci,live-agent-skills,release-candidate,release}.yml, packaging/{live_agent_skills,release_candidate}/, config/brakeman.ignore
 created: 2026-04-25
-updated: 2026-07-30
+updated: 2026-08-02
 tags: [test, minitest, fixtures, honeycomb, agent-skills, component-boundaries, release-proof]
 ---
 
@@ -44,6 +44,17 @@ then one created-and-run slug plus a no-op retry with the same idempotency key,
 operational status, no external actions, secret scanning, and cleanup. Missing
 provider credentials make this live gate explicitly unavailable; they never
 turn a skipped test into release evidence.
+
+`test/unit/packaging/workflow_creator_core_test.rb` independently proves the
+staged U1a1 semantic core with no live provider or filesystem fixture. It pins
+the exact prompt, argv, file, graph, task, schema, and classification bytes;
+recursively attempts to mutate every exported `Vocabulary` container, key, and
+string (including computed digests); and exercises strict failed, primary,
+installed-closure, and declarative execution-transaction matrices. It also
+loads the core alone and before/after untouched `proof.rb` under Ruby warnings,
+and statically rejects I/O/process dependencies or proof/bundle back-edges.
+This is core-only proof, not bundle custody or an activated production
+consumer; U1a2 owns that routing.
 
 ## Local feedback loop
 
@@ -129,6 +140,14 @@ Ready components cannot depend on candidates. Forbidden-construction rules
 also apply to guarded candidates, and the helper can run a named focused
 clean-load proof for a candidate such as Attempts without representing the
 whole component graph as ready.
+
+The helper also admits the narrow staged-prerequisite state used by Workflow
+Creator Proof Core: a `candidate` may list zero current Hive consumers only
+with a non-empty, valid migration exception naming its removal unit. Plan IDs
+include nested units such as `U1a2`. `boundary-ready` rows still require a
+consumer and reject all exceptions. Clean-load ownership maps both `lib/` and
+`packaging/` require paths and launches with the repository root plus `lib/` on
+the load path.
 
 The helper uses Ruby syntax rather than comments or string examples for literal
 `require`, `require_relative`, and `Constant.new` checks. It remains an

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -61,6 +61,18 @@ records. The test also loads the core alone and before/after untouched
 `proof.rb` under Ruby warnings, admits an exact Ripper-derived
 require/call/constant surface, rejects dormant I/O additions, and rejects
 proof/bundle back-edges.
+
+The resource regressions stub the pretty serializer and prove that NUL-heavy
+strings and oversized integers fail on projected output size before serializer
+entry. Hostile `Hash`, `Array`, and `String` subclasses, UTF-16LE keys and
+public identities, overlapping exact/pattern secrets, and a 4,097-byte failure
+detail with all 64 exact-secret slots fail closed. Capture regressions rebind
+the complete execution-receipt identity after inner mutation, so zero-byte
+digest and short-truncated-count rejection cannot pass merely because an outer
+receipt digest became stale. The clean-load guard also injects a root
+`WORKFLOW_CREATOR_*` poison constant to prove its anchored leak detector is
+live.
+
 This is core-only proof, not bundle custody or an activated production
 consumer; U1a2 owns that routing.
 
@@ -150,12 +162,14 @@ clean-load proof for a candidate such as Attempts without representing the
 whole component graph as ready.
 
 The helper also admits the narrow staged-prerequisite state used by Workflow
-Creator Proof Core: a `candidate` may list zero current Hive consumers only
-with a non-empty, valid migration exception naming its removal unit. Plan IDs
-include nested units such as `U1a2`. `boundary-ready` rows still require a
-consumer and reject all exceptions. Clean-load ownership maps both `lib/` and
-`packaging/` require paths and launches with the repository root plus `lib/` on
-the load path.
+Creator Proof Core: only the `workflow-creator-core` row may list zero current
+Hive consumers, and only while its state is `candidate` and it has exactly one
+valid migration exception whose removal unit is `U1a2`. Other candidates may
+retain valid migration exceptions when they have real consumers, but cannot
+borrow this zero-consumer fence; the wrong removal unit and duplicate U1a2
+exceptions also fail. `boundary-ready` rows still require a consumer and reject
+all exceptions. Clean-load ownership maps both `lib/` and `packaging/` require
+paths and launches with the repository root plus `lib/` on the load path.
 
 The helper uses Ruby syntax rather than comments or string examples for literal
 `require`, `require_relative`, and `Constant.new` checks. It remains an


### PR DESCRIPTION
## Summary

- Freeze the workflow-creator evidence vocabulary, canonical bytes, and public failure surface before extracting it from the packaging proof hotspot.
- Record the current duplicated verifier's accepted mutations as explicit tightening targets, not compatibility promises.
- Keep this draft at the U1a1 boundary: the forthcoming core is pure and namespaced; production consumers and retained custody remain follow-up work.

## Test plan

- [x] `ruby -Itest test/unit/packaging/live_agent_proof_test.rb` — 12 runs, 139 assertions, zero failures/errors/skips
- [x] focused creator coverage — 53/53 executable lines and 34/34 branch edges
- [x] focused RuboCop — one file inspected, no offenses
- [x] diff secret-pattern scan — no findings
- [ ] U1a1 core, component-boundary, require-order, and recursive-immutability tests
- [ ] broad local checkpoint and exact-head hosted CI after implementation

## Notes for reviewer

U1a1 is the sole staged-prerequisite exception in the architecture program: it introduces no active production consumer. Its core must stay under 590 lines / 22 methods / 28 branch points, and U1a2 must consume it from merged `main` before the combined hotspot-reduction claim can complete.

Related: #920
