### PR TITLE
refactor(packaging): isolate workflow creator values

### DIFF
--- a/config/component-boundaries.yml
+++ b/config/component-boundaries.yml
@@ -379,6 +379,44 @@ components:
       - test/unit/attempts/api_test.rb
     migration_exceptions: []
 
+  - id: workflow-creator-values
+    name: Workflow Creator Values
+    state: candidate
+    entrypoint:
+      file: packaging/live_agent_skills/workflow_creator_values.rb
+      require: packaging/live_agent_skills/workflow_creator_values
+      constant: HiveLiveAgentProof::WorkflowCreator::Values
+    public_contract:
+      values:
+        - HiveLiveAgentProof::WorkflowCreator::Values::Snapshot
+      errors:
+        - HiveLiveAgentProof::WorkflowCreator::Values::Error
+        - HiveLiveAgentProof::WorkflowCreator::TextSafety::Error
+    owned_paths:
+      - packaging/live_agent_skills/workflow_creator_values.rb
+      - packaging/live_agent_skills/workflow_creator_text_safety.rb
+    state_contracts:
+      - "Fresh recursively frozen snapshots and canonical bytes retain no caller-owned container or string"
+    schema_contracts:
+      - "Canonical bytes are sorted-key UTF-8 JSON.pretty_generate-compatible bytes with one trailing newline"
+    lock_contracts:
+      - "No state, lock, mutation, callback, or recovery responsibility"
+    component_dependencies: []
+    allowed_hive_dependencies: []
+    internal_collaborators:
+      - HiveLiveAgentProof::WorkflowCreator::TextSafety
+    forbidden_constructions: []
+    authorized_internal_constructions: []
+    hive_consumers: []
+    mutation_authority: "None; the boundary only copies and projects admitted in-memory values."
+    recovery_surface: "None; rejection is synchronous and leaves no retained state."
+    wiki_page: wiki/component-boundaries.md
+    focused_tests:
+      - test/unit/packaging/workflow_creator_values_test.rb
+    migration_exceptions:
+      - reason: "U1a1c must become the first production consumer before this staged values-only prerequisite can be promoted."
+        removal_unit: U1a1c
+
   - id: user-service
     name: UserService
     state: boundary-ready

--- a/packaging/live_agent_skills/workflow_creator_text_safety.rb
+++ b/packaging/live_agent_skills/workflow_creator_text_safety.rb
@@ -5,86 +5,86 @@ module HiveLiveAgentProof
       MAX_INPUT_BYTES, MAX_OUTPUT_BYTES, MAX_SECRET_BYTES, MAX_EXACT_SECRETS = 4_096, 4_096, 4_096, 64
       REDACTED = "[REDACTED]".freeze
       PATTERNS = [
-        [ "pattern:anthropic".freeze, /sk-ant-[A-Za-z0-9_-]{12,}/.freeze ],
-        [ "pattern:openai".freeze, /sk-(?!ant-)(?:proj-)?[A-Za-z0-9_-]{20,}/.freeze ],
-        [ "pattern:github-token".freeze, /gh[opsu]_[A-Za-z0-9]{20,}/.freeze ],
-        [ "pattern:github-pat".freeze, /github_pat_[A-Za-z0-9_]{20,}/.freeze ],
-        [ "pattern:private-key".freeze, /
-          -----BEGIN[ ](?:(?:RSA|EC|OPENSSH|DSA|PGP)[ ])?PRIVATE[ ]KEY(?:[ ]BLOCK)?-----
-          [\s\S]{0,4096}?(?:-----END[ ](?:(?:RSA|EC|OPENSSH|DSA|PGP)[ ])?PRIVATE[ ]KEY(?:[ ]BLOCK)?-----|\z)/x.freeze ]
+        [ "pattern:anthropic".freeze, /sk-ant-[A-Za-z0-9_-]{12,}/.freeze ], [ "pattern:openai".freeze, /sk-(?!ant-)(?:proj-)?[A-Za-z0-9_-]{20,}/.freeze ],
+        [ "pattern:github-token".freeze, /gh[opsu]_[A-Za-z0-9]{20,}/.freeze ], [ "pattern:github-pat".freeze, /github_pat_[A-Za-z0-9_]{20,}/.freeze ],
+        [ "pattern:private-key".freeze, /-----BEGIN[ ](?:(?:RSA|EC|OPENSSH|DSA|PGP|ENCRYPTED)[ ])?PRIVATE[ ]KEY(?:[ ]BLOCK)?-----[\s\S]{0,4096}?(?:-----END[ ](?:(?:RSA|EC|OPENSSH|DSA|PGP|ENCRYPTED)[ ])?PRIVATE[ ]KEY(?:[ ]BLOCK)?-----|\z)/x.freeze ]
       ].each(&:freeze).freeze
       EXACT_FINDINGS = Array.new(MAX_EXACT_SECRETS) { |index| "exact-secret:#{index}".freeze }.freeze
       REDACTION_TRANSITIONS = [ "".freeze, REDACTED, "".freeze, "".freeze ].freeze
       UNSAFE_PATH = %r{\A\z|\A(?:/|[A-Za-z]:|[~-])|[\x00-\x1F\x7F]|\\|//|/\z|(?:\A|/)\.{1,2}(?:/|\z)}.freeze
-      OBJECT_FREEZE, CLASS_ALLOCATE, PROC_CALL, STRING_INITIALIZE =
-        Values::OBJECT_FREEZE, Values::CLASS_ALLOCATE, Values::PROC_CALL, Values::STRING_INITIALIZE
-      REGEXP_LAST_MATCH, METHOD_CALL = Regexp.method(:last_match).freeze, Method.instance_method(:call).freeze
-      MATCH_BEGIN, MATCH_END = %i[bytebegin byteend].map { MatchData.instance_method(_1).freeze }
-      STRING_BYTESIZE, STRING_APPEND, STRING_BYTESLICE, STRING_SCRUB, STRING_MATCH, STRING_BYTEINDEX, STRING_SCAN, STRING_BINARY =
-        Values::STRING_BYTESIZE, Values::STRING_APPEND, *%i[byteslice scrub match? byteindex scan b].map { String.instance_method(_1).freeze }
-      ARRAY_INITIALIZE, ARRAY_EACH, ARRAY_LENGTH, ARRAY_PUSH, ARRAY_GET, ARRAY_SET =
-        %i[initialize each length << [] []=].map { Array.instance_method(_1).freeze }
-      INTEGER_ADD, INTEGER_SUBTRACT, INTEGER_MULTIPLY, INTEGER_GREATER, INTEGER_TIMES, INTEGER_BETWEEN, INTEGER_CLAMP =
-        %i[+ - * > times between? clamp].map { Integer.instance_method(_1).freeze }
+      SEAL = Values.const_get(:SEAL, false)
+      OBJECT_EQUAL, OBJECT_FREEZE, PROC_CALL = Values::OBJECT_EQUAL, Values::OBJECT_FREEZE, Values::PROC_CALL
+      REGEXP_LAST_MATCH = SEAL.call(Regexp.method(:last_match), :call)
+      MATCH_BEGIN, MATCH_END = %i[bytebegin byteend].map { SEAL.call(MatchData.instance_method(_1), :bind_call) }
+      STRING_BYTESIZE, STRING_APPEND, STRING_BYTESLICE, STRING_SCRUB, STRING_MATCH, STRING_BYTEINDEX, STRING_SCAN, STRING_BINARY, HASH_FETCH, HASH_SET = [ Values::STRING_BYTESIZE, Values::STRING_APPEND, *%i[byteslice scrub match? byteindex scan b].map { SEAL.call(String.instance_method(_1), :bind_call) }, *%i[fetch []=].map { SEAL.call(Hash.instance_method(_1), :bind_call) } ]
+      ARRAY_EACH, ARRAY_LENGTH, ARRAY_PUSH, ARRAY_GET, ARRAY_SET, ARRAY_MULTIPLY = %i[each length << [] []= *].map { SEAL.call(Array.instance_method(_1), :bind_call) }
+      INTEGER_ADD, INTEGER_SUBTRACT, INTEGER_MULTIPLY, INTEGER_GREATER, INTEGER_ZERO, INTEGER_COMPARE, INTEGER_TIMES = %i[+ - * > zero? <=> times].map { SEAL.call(Integer.instance_method(_1), :bind_call) }
+      LOWER_MASK, UPPER_MASK = [ 0, 0, 1 ].freeze, [ 0, 1, 0 ].freeze
       MARK_RANGE = lambda do |marks, first, last|
-        ARRAY_SET.bind_call(marks, first, INTEGER_ADD.bind_call(ARRAY_GET.bind_call(marks, first), 1))
-        ARRAY_SET.bind_call(marks, last, INTEGER_SUBTRACT.bind_call(ARRAY_GET.bind_call(marks, last), 1))
+        ARRAY_SET.__invoke__(marks, first, INTEGER_ADD.__invoke__(ARRAY_GET.__invoke__(marks, first), 1))
+        ARRAY_SET.__invoke__(marks, last, INTEGER_SUBTRACT.__invoke__(ARRAY_GET.__invoke__(marks, last), 1))
       end.freeze
+      ERROR_BOUNDARY = SEAL.call(lambda do |&projection|
+        PROC_CALL.__invoke__(projection)
+      rescue Error, EncodingError, TypeError, ArgumentError then raise Error, "workflow-creator text cannot be projected", cause: nil
+      end, :call)
       SECRET_SCAN = lambda do |value, secrets|
-        raise Error if INTEGER_GREATER.bind_call(STRING_BYTESIZE.bind_call(value), MAX_INPUT_BYTES)
-        raise Error if INTEGER_GREATER.bind_call(ARRAY_LENGTH.bind_call(secrets), MAX_EXACT_SECRETS)
-        marks = ARRAY_INITIALIZE.bind_call(CLASS_ALLOCATE.bind_call(Array), INTEGER_ADD.bind_call(STRING_BYTESIZE.bind_call(value), 1), 0)
-        findings, bytes = [], STRING_BINARY.bind_call(value)
-        INTEGER_TIMES.bind_call(ARRAY_LENGTH.bind_call(secrets)) do |index|
-          secret = ARRAY_GET.bind_call(secrets, index)
-          size, needle = STRING_BYTESIZE.bind_call(secret), STRING_BINARY.bind_call(secret)
-          raise Error unless INTEGER_BETWEEN.bind_call(size, 1, MAX_SECRET_BYTES)
-          offset = STRING_BYTEINDEX.bind_call(bytes, needle, 0)
-          ARRAY_PUSH.bind_call(findings, ARRAY_GET.bind_call(EXACT_FINDINGS, index)) if offset
-          while offset
-            PROC_CALL.bind_call(MARK_RANGE, marks, offset, INTEGER_ADD.bind_call(offset, size))
-            offset = STRING_BYTEINDEX.bind_call(bytes, needle, INTEGER_ADD.bind_call(offset, 1))
+        raise Error if INTEGER_GREATER.__invoke__(STRING_BYTESIZE.__invoke__(value), MAX_INPUT_BYTES)
+        raise Error if INTEGER_GREATER.__invoke__(ARRAY_LENGTH.__invoke__(secrets), MAX_EXACT_SECRETS)
+        marks = ARRAY_MULTIPLY.__invoke__([ 0 ], INTEGER_ADD.__invoke__(STRING_BYTESIZE.__invoke__(value), 1))
+        findings, bytes, matches = [], STRING_BINARY.__invoke__(value), {}
+        INTEGER_TIMES.__invoke__(ARRAY_LENGTH.__invoke__(secrets)) do |index|
+          secret = ARRAY_GET.__invoke__(secrets, index)
+          size, needle = STRING_BYTESIZE.__invoke__(secret), STRING_BINARY.__invoke__(secret)
+          raise Error if INTEGER_ZERO.__invoke__(size)
+          raise Error if INTEGER_GREATER.__invoke__(size, MAX_SECRET_BYTES)
+          offset = HASH_FETCH.__invoke__(matches, needle) do
+            first = offset = STRING_BYTEINDEX.__invoke__(bytes, needle, 0)
+            while offset
+              PROC_CALL.__invoke__(MARK_RANGE, marks, offset, INTEGER_ADD.__invoke__(offset, size))
+              offset = STRING_BYTEINDEX.__invoke__(bytes, needle, INTEGER_ADD.__invoke__(offset, 1))
+            end
+            HASH_SET.__invoke__(matches, needle, first)
           end
+          ARRAY_PUSH.__invoke__(findings, ARRAY_GET.__invoke__(EXACT_FINDINGS, index)) if offset
         end
-        ARRAY_EACH.bind_call(PATTERNS) do |label, pattern|
+        ARRAY_EACH.__invoke__(PATTERNS) do |label, pattern|
           found = false
-          STRING_SCAN.bind_call(value, pattern) do
-            match = METHOD_CALL.bind_call(REGEXP_LAST_MATCH)
-            PROC_CALL.bind_call(MARK_RANGE, marks, MATCH_BEGIN.bind_call(match, 0), MATCH_END.bind_call(match, 0))
+          STRING_SCAN.__invoke__(value, pattern) do
+            match = REGEXP_LAST_MATCH.__invoke__
+            PROC_CALL.__invoke__(MARK_RANGE, marks, MATCH_BEGIN.__invoke__(match, 0), MATCH_END.__invoke__(match, 0))
             found = true
           end
-          ARRAY_PUSH.bind_call(findings, label) if found
+          ARRAY_PUSH.__invoke__(findings, label) if found
         end
-        [ OBJECT_FREEZE.bind_call(findings), marks ]
+        [ OBJECT_FREEZE.__invoke__(findings), marks ]
       end.freeze
       class << self
-        def text(value, limit: MAX_OUTPUT_BYTES)
-          raise Error if INTEGER_GREATER.bind_call(STRING_BYTESIZE.bind_call(value), MAX_INPUT_BYTES)
-          bounded = INTEGER_CLAMP.bind_call(limit, 0, MAX_OUTPUT_BYTES)
-          OBJECT_FREEZE.bind_call(STRING_SCRUB.bind_call(STRING_BYTESLICE.bind_call(value, 0, bounded), ""))
+        def text(value, limit: MAX_OUTPUT_BYTES) = ERROR_BOUNDARY.__invoke__ do
+          raise Error if INTEGER_GREATER.__invoke__(STRING_BYTESIZE.__invoke__(value), MAX_INPUT_BYTES)
+          bounded = INTEGER_ADD.__invoke__(limit, INTEGER_MULTIPLY.__invoke__(INTEGER_SUBTRACT.__invoke__(0, limit), ARRAY_GET.__invoke__(LOWER_MASK, INTEGER_COMPARE.__invoke__(limit, 0))))
+          bounded = INTEGER_SUBTRACT.__invoke__(bounded, INTEGER_MULTIPLY.__invoke__(INTEGER_SUBTRACT.__invoke__(bounded, MAX_OUTPUT_BYTES), ARRAY_GET.__invoke__(UPPER_MASK, INTEGER_COMPARE.__invoke__(bounded, MAX_OUTPUT_BYTES))))
+          OBJECT_FREEZE.__invoke__(STRING_SCRUB.__invoke__(STRING_BYTESLICE.__invoke__(value, 0, bounded), ""))
         end
-        def safe_relative_path?(value)
-          INTEGER_GREATER.bind_call(STRING_BYTESIZE.bind_call(value), MAX_INPUT_BYTES) ?
-            false : !STRING_MATCH.bind_call(value, UNSAFE_PATH)
-        end
-        def secret_findings(value, exact_secrets:) = ARRAY_GET.bind_call(PROC_CALL.bind_call(SECRET_SCAN, value, exact_secrets), 0)
-        def redact(value, exact_secrets:, limit: MAX_OUTPUT_BYTES)
-          marks = ARRAY_GET.bind_call(PROC_CALL.bind_call(SECRET_SCAN, value, exact_secrets), 1)
-          output = STRING_INITIALIZE.bind_call(CLASS_ALLOCATE.bind_call(String), encoding: Values::UTF8)
+        def safe_relative_path?(value) = ERROR_BOUNDARY.__invoke__ { INTEGER_GREATER.__invoke__(STRING_BYTESIZE.__invoke__(value), MAX_INPUT_BYTES) ? false : OBJECT_EQUAL.__invoke__(STRING_MATCH.__invoke__(value, UNSAFE_PATH), false) }
+        def secret_findings(value, exact_secrets:) = ERROR_BOUNDARY.__invoke__ { ARRAY_GET.__invoke__(PROC_CALL.__invoke__(SECRET_SCAN, value, exact_secrets), 0) }
+        def redact(value, exact_secrets:, limit: MAX_OUTPUT_BYTES) = ERROR_BOUNDARY.__invoke__ do
+          marks = ARRAY_GET.__invoke__(PROC_CALL.__invoke__(SECRET_SCAN, value, exact_secrets), 1)
+          output = STRING_BYTESLICE.__invoke__("", 0, 0)
           active = inside = 0
-          INTEGER_TIMES.bind_call(STRING_BYTESIZE.bind_call(value)) do |index|
-            active = INTEGER_ADD.bind_call(active, ARRAY_GET.bind_call(marks, index))
-            masked = INTEGER_CLAMP.bind_call(active, 0, 1)
-            transition = INTEGER_ADD.bind_call(INTEGER_MULTIPLY.bind_call(inside, 2), masked)
-            STRING_APPEND.bind_call(output, ARRAY_GET.bind_call(REDACTION_TRANSITIONS, transition))
-            STRING_APPEND.bind_call(output, STRING_BYTESLICE.bind_call(value, index,
-                                                                       INTEGER_SUBTRACT.bind_call(1, masked)))
+          INTEGER_TIMES.__invoke__(STRING_BYTESIZE.__invoke__(value)) do |index|
+            active = INTEGER_ADD.__invoke__(active, ARRAY_GET.__invoke__(marks, index))
+            masked = ARRAY_GET.__invoke__(UPPER_MASK, INTEGER_COMPARE.__invoke__(active, 0))
+            transition = INTEGER_ADD.__invoke__(INTEGER_MULTIPLY.__invoke__(inside, 2), masked)
+            STRING_APPEND.__invoke__(STRING_APPEND.__invoke__(output, ARRAY_GET.__invoke__(REDACTION_TRANSITIONS, transition)),
+                                     STRING_BYTESLICE.__invoke__(value, index, INTEGER_SUBTRACT.__invoke__(1, masked)))
             inside = masked
           end
-          text(STRING_BYTESLICE.bind_call(output, 0, MAX_INPUT_BYTES), limit: limit)
+          text(STRING_BYTESLICE.__invoke__(output, 0, MAX_INPUT_BYTES), limit: limit)
         end
       end
-      Error.freeze
+      private_constant :SEAL
+      [ Error, self ].each { |object| OBJECT_FREEZE.__invoke__(object) }
     end
   end
 end

--- a/packaging/live_agent_skills/workflow_creator_text_safety.rb
+++ b/packaging/live_agent_skills/workflow_creator_text_safety.rb
@@ -1,0 +1,90 @@
+module HiveLiveAgentProof
+  module WorkflowCreator
+    module TextSafety
+      class Error < StandardError; end
+      MAX_INPUT_BYTES, MAX_OUTPUT_BYTES, MAX_SECRET_BYTES, MAX_EXACT_SECRETS = 4_096, 4_096, 4_096, 64
+      REDACTED = "[REDACTED]".freeze
+      PATTERNS = [
+        [ "pattern:anthropic".freeze, /sk-ant-[A-Za-z0-9_-]{12,}/.freeze ],
+        [ "pattern:openai".freeze, /sk-(?!ant-)(?:proj-)?[A-Za-z0-9_-]{20,}/.freeze ],
+        [ "pattern:github-token".freeze, /gh[opsu]_[A-Za-z0-9]{20,}/.freeze ],
+        [ "pattern:github-pat".freeze, /github_pat_[A-Za-z0-9_]{20,}/.freeze ],
+        [ "pattern:private-key".freeze, /
+          -----BEGIN[ ](?:(?:RSA|EC|OPENSSH|DSA|PGP)[ ])?PRIVATE[ ]KEY(?:[ ]BLOCK)?-----
+          [\s\S]{0,4096}?(?:-----END[ ](?:(?:RSA|EC|OPENSSH|DSA|PGP)[ ])?PRIVATE[ ]KEY(?:[ ]BLOCK)?-----|\z)/x.freeze ]
+      ].each(&:freeze).freeze
+      EXACT_FINDINGS = Array.new(MAX_EXACT_SECRETS) { |index| "exact-secret:#{index}".freeze }.freeze
+      REDACTION_TRANSITIONS = [ "".freeze, REDACTED, "".freeze, "".freeze ].freeze
+      UNSAFE_PATH = %r{\A\z|\A(?:/|[A-Za-z]:|[~-])|[\x00-\x1F\x7F]|\\|//|/\z|(?:\A|/)\.{1,2}(?:/|\z)}.freeze
+      OBJECT_FREEZE, CLASS_ALLOCATE, PROC_CALL, STRING_INITIALIZE =
+        Values::OBJECT_FREEZE, Values::CLASS_ALLOCATE, Values::PROC_CALL, Values::STRING_INITIALIZE
+      REGEXP_LAST_MATCH, METHOD_CALL = Regexp.method(:last_match).freeze, Method.instance_method(:call).freeze
+      MATCH_BEGIN, MATCH_END = %i[bytebegin byteend].map { MatchData.instance_method(_1).freeze }
+      STRING_BYTESIZE, STRING_APPEND, STRING_BYTESLICE, STRING_SCRUB, STRING_MATCH, STRING_BYTEINDEX, STRING_SCAN, STRING_BINARY =
+        Values::STRING_BYTESIZE, Values::STRING_APPEND, *%i[byteslice scrub match? byteindex scan b].map { String.instance_method(_1).freeze }
+      ARRAY_INITIALIZE, ARRAY_EACH, ARRAY_LENGTH, ARRAY_PUSH, ARRAY_GET, ARRAY_SET =
+        %i[initialize each length << [] []=].map { Array.instance_method(_1).freeze }
+      INTEGER_ADD, INTEGER_SUBTRACT, INTEGER_MULTIPLY, INTEGER_GREATER, INTEGER_TIMES, INTEGER_BETWEEN, INTEGER_CLAMP =
+        %i[+ - * > times between? clamp].map { Integer.instance_method(_1).freeze }
+      MARK_RANGE = lambda do |marks, first, last|
+        ARRAY_SET.bind_call(marks, first, INTEGER_ADD.bind_call(ARRAY_GET.bind_call(marks, first), 1))
+        ARRAY_SET.bind_call(marks, last, INTEGER_SUBTRACT.bind_call(ARRAY_GET.bind_call(marks, last), 1))
+      end.freeze
+      SECRET_SCAN = lambda do |value, secrets|
+        raise Error if INTEGER_GREATER.bind_call(STRING_BYTESIZE.bind_call(value), MAX_INPUT_BYTES)
+        raise Error if INTEGER_GREATER.bind_call(ARRAY_LENGTH.bind_call(secrets), MAX_EXACT_SECRETS)
+        marks = ARRAY_INITIALIZE.bind_call(CLASS_ALLOCATE.bind_call(Array), INTEGER_ADD.bind_call(STRING_BYTESIZE.bind_call(value), 1), 0)
+        findings, bytes = [], STRING_BINARY.bind_call(value)
+        INTEGER_TIMES.bind_call(ARRAY_LENGTH.bind_call(secrets)) do |index|
+          secret = ARRAY_GET.bind_call(secrets, index)
+          size, needle = STRING_BYTESIZE.bind_call(secret), STRING_BINARY.bind_call(secret)
+          raise Error unless INTEGER_BETWEEN.bind_call(size, 1, MAX_SECRET_BYTES)
+          offset = STRING_BYTEINDEX.bind_call(bytes, needle, 0)
+          ARRAY_PUSH.bind_call(findings, ARRAY_GET.bind_call(EXACT_FINDINGS, index)) if offset
+          while offset
+            PROC_CALL.bind_call(MARK_RANGE, marks, offset, INTEGER_ADD.bind_call(offset, size))
+            offset = STRING_BYTEINDEX.bind_call(bytes, needle, INTEGER_ADD.bind_call(offset, 1))
+          end
+        end
+        ARRAY_EACH.bind_call(PATTERNS) do |label, pattern|
+          found = false
+          STRING_SCAN.bind_call(value, pattern) do
+            match = METHOD_CALL.bind_call(REGEXP_LAST_MATCH)
+            PROC_CALL.bind_call(MARK_RANGE, marks, MATCH_BEGIN.bind_call(match, 0), MATCH_END.bind_call(match, 0))
+            found = true
+          end
+          ARRAY_PUSH.bind_call(findings, label) if found
+        end
+        [ OBJECT_FREEZE.bind_call(findings), marks ]
+      end.freeze
+      class << self
+        def text(value, limit: MAX_OUTPUT_BYTES)
+          raise Error if INTEGER_GREATER.bind_call(STRING_BYTESIZE.bind_call(value), MAX_INPUT_BYTES)
+          bounded = INTEGER_CLAMP.bind_call(limit, 0, MAX_OUTPUT_BYTES)
+          OBJECT_FREEZE.bind_call(STRING_SCRUB.bind_call(STRING_BYTESLICE.bind_call(value, 0, bounded), ""))
+        end
+        def safe_relative_path?(value)
+          INTEGER_GREATER.bind_call(STRING_BYTESIZE.bind_call(value), MAX_INPUT_BYTES) ?
+            false : !STRING_MATCH.bind_call(value, UNSAFE_PATH)
+        end
+        def secret_findings(value, exact_secrets:) = ARRAY_GET.bind_call(PROC_CALL.bind_call(SECRET_SCAN, value, exact_secrets), 0)
+        def redact(value, exact_secrets:, limit: MAX_OUTPUT_BYTES)
+          marks = ARRAY_GET.bind_call(PROC_CALL.bind_call(SECRET_SCAN, value, exact_secrets), 1)
+          output = STRING_INITIALIZE.bind_call(CLASS_ALLOCATE.bind_call(String), encoding: Values::UTF8)
+          active = inside = 0
+          INTEGER_TIMES.bind_call(STRING_BYTESIZE.bind_call(value)) do |index|
+            active = INTEGER_ADD.bind_call(active, ARRAY_GET.bind_call(marks, index))
+            masked = INTEGER_CLAMP.bind_call(active, 0, 1)
+            transition = INTEGER_ADD.bind_call(INTEGER_MULTIPLY.bind_call(inside, 2), masked)
+            STRING_APPEND.bind_call(output, ARRAY_GET.bind_call(REDACTION_TRANSITIONS, transition))
+            STRING_APPEND.bind_call(output, STRING_BYTESLICE.bind_call(value, index,
+                                                                       INTEGER_SUBTRACT.bind_call(1, masked)))
+            inside = masked
+          end
+          text(STRING_BYTESLICE.bind_call(output, 0, MAX_INPUT_BYTES), limit: limit)
+        end
+      end
+      Error.freeze
+    end
+  end
+end

--- a/packaging/live_agent_skills/workflow_creator_values.rb
+++ b/packaging/live_agent_skills/workflow_creator_values.rb
@@ -3,26 +3,31 @@ module HiveLiveAgentProof
   module WorkflowCreator
     module Values
       class Error < StandardError; end
-      Snapshot = Data.define(:value, :canonical_bytes).tap do |type|
-        type.singleton_class.send(:private, :new, :[], :allocate)
-        type.send(:private, :with)
+      Snapshot = Data.define(:value, :canonical_bytes) do
+        private def marshal_dump = raise(TypeError, "workflow-creator snapshots cannot be marshaled")
       end
+      Snapshot.singleton_class.send(:private, :new, :[], :allocate)
+      Snapshot.send(:private, :with)
       MAX_DEPTH, MAX_NODES, MAX_INTEGER_BITS = 64, 8_192, 4_096
       MAX_INPUT_BYTES, MAX_PROJECTED_BYTES, MAX_ALLOCATION_BYTES = 262_144, 1_048_576, 4_194_304
-      OBJECT_CLASS, OBJECT_FREEZE = %i[class freeze].map { Object.instance_method(_1).freeze }
-      OBJECT_EQUAL, OBJECT_ID = %i[equal? __id__].map { BasicObject.instance_method(_1).freeze }
-      CLASS_NEW, CLASS_ALLOCATE, PROC_CALL =
-        [ [ Class, :new ], [ Class, :allocate ], [ Proc, :call ] ].map { |owner, name| owner.instance_method(name).freeze }
+      SEAL = lambda do |operation, invocation|
+        operation.singleton_class.send(:alias_method, :__invoke__, invocation)
+        operation.freeze
+      end.freeze
+      OBJECT_CLASS, OBJECT_FREEZE = %i[class freeze].map { SEAL.call(Object.instance_method(_1), :bind_call) }
+      OBJECT_EQUAL, OBJECT_ID = %i[equal? __id__].map { SEAL.call(BasicObject.instance_method(_1), :bind_call) }
+      CLASS_ALLOCATE, PROC_CALL, DATA_INITIALIZE =
+        [ [ Class, :allocate ], [ Proc, :call ], [ Data, :initialize ] ].map { |owner, name| SEAL.call(owner.instance_method(name), :bind_call) }
       HASH_EACH_PAIR, HASH_KEY, HASH_SET, HASH_DELETE, HASH_LENGTH =
-        %i[each_pair key? []= delete length].map { Hash.instance_method(_1).freeze }
-      ARRAY_EACH, ARRAY_GET, ARRAY_SET, ARRAY_PUSH, ARRAY_INDEX, ARRAY_LENGTH, ARRAY_SORT, ARRAY_SUM =
-        %i[each [] []= << index length sort! sum].map { Array.instance_method(_1).freeze }
-      STRING_INITIALIZE, STRING_ENCODING, STRING_BYTESIZE, STRING_ENCODE, STRING_EACH_BYTE, STRING_TO_JSON, STRING_APPEND, STRING_COMPARE =
-          %i[initialize encoding bytesize encode each_byte to_json << <=>].map { String.instance_method(_1).freeze }
+        %i[each_pair key? []= delete length].map { SEAL.call(Hash.instance_method(_1), :bind_call) }
+      ARRAY_EACH, ARRAY_GET, ARRAY_SET, ARRAY_PUSH, ARRAY_INDEX, ARRAY_LENGTH, ARRAY_SORT =
+        %i[each [] []= << index length sort!].map { SEAL.call(Array.instance_method(_1), :bind_call) }
+      STRING_INITIALIZE, STRING_ENCODING, STRING_BYTESIZE, STRING_ENCODE, STRING_EACH_BYTE, STRING_APPEND, STRING_COMPARE =
+        %i[initialize encoding bytesize encode each_byte << <=>].map { SEAL.call(String.instance_method(_1), :bind_call) }
       INTEGER_ADD, INTEGER_SUBTRACT, INTEGER_MULTIPLY, INTEGER_GREATER, INTEGER_ZERO, INTEGER_BITS, INTEGER_TO_S =
-          %i[+ - * > zero? bit_length to_s].map { Integer.instance_method(_1).freeze }
-      FLOAT_FINITE, FLOAT_TO_JSON = %i[finite? to_json].map { Float.instance_method(_1).freeze }
-      ENCODING_DUMMY, UTF8, BINARY = Encoding.instance_method(:dummy?).freeze, Encoding::UTF_8, Encoding::BINARY
+        %i[+ - * > zero? bit_length to_s].map { SEAL.call(Integer.instance_method(_1), :bind_call) }
+      JSON_GENERATE = SEAL.call(JSON::State.method(:_generate_no_fallback), :call)
+      ENCODING_DUMMY, UTF8, BINARY = SEAL.call(Encoding.instance_method(:dummy?), :bind_call), Encoding::UTF_8, Encoding::BINARY
       TYPES = [ Hash, Array, String, Integer, Float, TrueClass, FalseClass, NilClass ].freeze
       SCALAR_JSON = [ nil, nil, nil, nil, nil, "true".freeze, "false".freeze, "null".freeze ].freeze
       INDENTS = Array.new(MAX_DEPTH + 2) { |depth| ("  " * depth).freeze }.freeze
@@ -32,158 +37,153 @@ module HiveLiveAgentProof
       ESCAPE_EXTRA.freeze
       NODES, INPUT, ALLOCATION, ACTIVE = 0, 1, 2, 3
       COLLECTION_BYTES = lambda do |count, payload, depth|
-        bytes = INTEGER_ADD.bind_call(4, INTEGER_MULTIPLY.bind_call(2, depth))
-        entries = INTEGER_MULTIPLY.bind_call(INTEGER_MULTIPLY.bind_call(count, 2),
-                                             INTEGER_ADD.bind_call(depth, 1))
-        commas = INTEGER_MULTIPLY.bind_call(INTEGER_SUBTRACT.bind_call(count, 1), 2)
-        INTEGER_ADD.bind_call(bytes, INTEGER_ADD.bind_call(entries, INTEGER_ADD.bind_call(commas, payload)))
+        bytes = INTEGER_ADD.__invoke__(4, INTEGER_MULTIPLY.__invoke__(2, depth))
+        entries = INTEGER_MULTIPLY.__invoke__(INTEGER_MULTIPLY.__invoke__(count, 2),
+                                             INTEGER_ADD.__invoke__(depth, 1))
+        commas = INTEGER_MULTIPLY.__invoke__(INTEGER_SUBTRACT.__invoke__(count, 1), 2)
+        INTEGER_ADD.__invoke__(bytes, INTEGER_ADD.__invoke__(entries, INTEGER_ADD.__invoke__(commas, payload)))
       end.freeze
       class << self
         def capture(value)
           state = [ 0, 0, 0, {} ]
           owned, fragment = import(value, state, 0)
-          canonical = STRING_INITIALIZE.bind_call(CLASS_ALLOCATE.bind_call(String), encoding: UTF8)
-          reserve!(state, INTEGER_ADD.bind_call(STRING_BYTESIZE.bind_call(fragment), 1))
-          STRING_APPEND.bind_call(canonical, fragment)
-          STRING_APPEND.bind_call(canonical, "\n")
-          OBJECT_FREEZE.bind_call(canonical)
-          CLASS_NEW.bind_call(Snapshot, value: owned, canonical_bytes: canonical)
+          canonical = STRING_INITIALIZE.__invoke__(CLASS_ALLOCATE.__invoke__(String), encoding: UTF8)
+          reserve!(state, INTEGER_ADD.__invoke__(STRING_BYTESIZE.__invoke__(fragment), 1))
+          STRING_APPEND.__invoke__(STRING_APPEND.__invoke__(canonical, fragment), "\n")
+          OBJECT_FREEZE.__invoke__(canonical)
+          snapshot = CLASS_ALLOCATE.__invoke__(Snapshot)
+          DATA_INITIALIZE.__invoke__(snapshot, value: owned, canonical_bytes: canonical)
+          snapshot
         rescue Error, EncodingError, JSON::GeneratorError, TypeError, ArgumentError
-          raise Error, "workflow-creator value cannot be captured"
+          raise Error, "workflow-creator value cannot be captured", cause: nil
         end
         private
         def import(value, state, depth)
-          raise Error if INTEGER_GREATER.bind_call(depth, MAX_DEPTH)
-          nodes = INTEGER_ADD.bind_call(ARRAY_GET.bind_call(state, NODES), 1)
-          raise Error if INTEGER_GREATER.bind_call(nodes, MAX_NODES)
-          ARRAY_SET.bind_call(state, NODES, nodes)
+          raise Error if INTEGER_GREATER.__invoke__(depth, MAX_DEPTH)
+          nodes = INTEGER_ADD.__invoke__(ARRAY_GET.__invoke__(state, NODES), 1)
+          raise Error if INTEGER_GREATER.__invoke__(nodes, MAX_NODES)
+          ARRAY_SET.__invoke__(state, NODES, nodes)
           reserve!(state, 64)
-          klass = OBJECT_CLASS.bind_call(value)
-          index = ARRAY_INDEX.bind_call(TYPES) { |type| OBJECT_EQUAL.bind_call(klass, type) }
-          handler = ARRAY_GET.bind_call(HANDLERS, index)
+          klass = OBJECT_CLASS.__invoke__(value)
+          index = ARRAY_INDEX.__invoke__(TYPES) { |type| OBJECT_EQUAL.__invoke__(klass, type) }
+          handler = ARRAY_GET.__invoke__(HANDLERS, index)
           raise Error unless handler
-          PROC_CALL.bind_call(handler, value, state, depth)
+          PROC_CALL.__invoke__(handler, value, state, depth)
         end
         def import_hash(value, state, depth)
-          active = ARRAY_GET.bind_call(state, ACTIVE)
-          identity = OBJECT_ID.bind_call(value)
-          raise Error if HASH_KEY.bind_call(active, identity)
-          HASH_SET.bind_call(active, identity, true)
-          minimum_nodes = INTEGER_ADD.bind_call(ARRAY_GET.bind_call(state, NODES), INTEGER_MULTIPLY.bind_call(HASH_LENGTH.bind_call(value), 2))
-          raise Error if INTEGER_GREATER.bind_call(minimum_nodes, MAX_NODES)
+          active = ARRAY_GET.__invoke__(state, ACTIVE)
+          identity = OBJECT_ID.__invoke__(value)
+          raise Error if HASH_KEY.__invoke__(active, identity)
+          HASH_SET.__invoke__(active, identity, true)
+          minimum_nodes = INTEGER_ADD.__invoke__(ARRAY_GET.__invoke__(state, NODES), INTEGER_MULTIPLY.__invoke__(HASH_LENGTH.__invoke__(value), 2))
+          raise Error if INTEGER_GREATER.__invoke__(minimum_nodes, MAX_NODES)
           entries = []
-          seen = {}
-          payload = 0
-          HASH_EACH_PAIR.bind_call(value) do |raw_key, raw_value|
-            entry, entry_bytes = import_hash_entry(raw_key, raw_value, state, depth, seen)
-            payload = INTEGER_ADD.bind_call(payload, entry_bytes)
-            ARRAY_PUSH.bind_call(entries, entry)
+          seen, payload = {}, 0
+          HASH_EACH_PAIR.__invoke__(value) do |raw_key, raw_value|
+            raise Error unless OBJECT_EQUAL.__invoke__(OBJECT_CLASS.__invoke__(raw_key), String)
+            key, key_json = import(raw_key, state, INTEGER_ADD.__invoke__(depth, 1))
+            raise Error if HASH_KEY.__invoke__(seen, key)
+            HASH_SET.__invoke__(seen, key, true)
+            nested, nested_json = import(raw_value, state, INTEGER_ADD.__invoke__(depth, 1))
+            entry_bytes = INTEGER_ADD.__invoke__(STRING_BYTESIZE.__invoke__(key_json),
+                                                 INTEGER_ADD.__invoke__(STRING_BYTESIZE.__invoke__(nested_json), 2))
+            payload = INTEGER_ADD.__invoke__(payload, entry_bytes)
+            ARRAY_PUSH.__invoke__(entries, [ key, key_json, nested, nested_json ])
           end
-          ARRAY_SORT.bind_call(entries) do |left, right|
-            STRING_COMPARE.bind_call(ARRAY_GET.bind_call(left, 0), ARRAY_GET.bind_call(right, 0))
+          ARRAY_SORT.__invoke__(entries) do |left, right|
+            STRING_COMPARE.__invoke__(ARRAY_GET.__invoke__(left, 0), ARRAY_GET.__invoke__(right, 0))
           end
           build_collection({}, entries, payload, state, depth, [ "{", "}", "{}" ], HASH_ENTRY_BUILDER)
         ensure
-          HASH_DELETE.bind_call(active, identity)
-        end
-        def import_hash_entry(raw_key, raw_value, state, depth, seen)
-          raise Error unless OBJECT_EQUAL.bind_call(OBJECT_CLASS.bind_call(raw_key), String)
-          nested_depth = INTEGER_ADD.bind_call(depth, 1)
-          key, key_json = import(raw_key, state, nested_depth)
-          raise Error if HASH_KEY.bind_call(seen, key)
-          HASH_SET.bind_call(seen, key, true)
-          nested, nested_json = import(raw_value, state, nested_depth)
-          bytes = ARRAY_SUM.bind_call([ STRING_BYTESIZE.bind_call(key_json), STRING_BYTESIZE.bind_call(nested_json), 2 ])
-          [ [ key, key_json, nested, nested_json ], bytes ]
+          HASH_DELETE.__invoke__(active, identity)
         end
         def import_array(value, state, depth)
-          active = ARRAY_GET.bind_call(state, ACTIVE)
-          identity = OBJECT_ID.bind_call(value)
-          raise Error if HASH_KEY.bind_call(active, identity)
-          HASH_SET.bind_call(active, identity, true)
-          entries = []
-          payload = 0
-          ARRAY_EACH.bind_call(value) do |nested|
-            owned, fragment = import(nested, state, INTEGER_ADD.bind_call(depth, 1))
-            payload = INTEGER_ADD.bind_call(payload, STRING_BYTESIZE.bind_call(fragment))
-            ARRAY_PUSH.bind_call(entries, [ nil, nil, owned, fragment ])
+          active = ARRAY_GET.__invoke__(state, ACTIVE)
+          identity = OBJECT_ID.__invoke__(value)
+          raise Error if HASH_KEY.__invoke__(active, identity)
+          HASH_SET.__invoke__(active, identity, true)
+          entries, payload = [], 0
+          ARRAY_EACH.__invoke__(value) do |nested|
+            owned, fragment = import(nested, state, INTEGER_ADD.__invoke__(depth, 1))
+            payload = INTEGER_ADD.__invoke__(payload, STRING_BYTESIZE.__invoke__(fragment))
+            ARRAY_PUSH.__invoke__(entries, [ nil, nil, owned, fragment ])
           end
           build_collection([], entries, payload, state, depth, [ "[", "]", "[]" ], ARRAY_ENTRY_BUILDER)
         ensure
-          HASH_DELETE.bind_call(active, identity)
+          HASH_DELETE.__invoke__(active, identity)
         end
         def build_collection(result, entries, payload, state, depth, delimiters, entry_builder)
-          count = ARRAY_LENGTH.bind_call(entries)
-          if INTEGER_ZERO.bind_call(count)
+          count = ARRAY_LENGTH.__invoke__(entries)
+          if INTEGER_ZERO.__invoke__(count)
             reserve!(state, 2)
-            return [ OBJECT_FREEZE.bind_call(result), ARRAY_GET.bind_call(delimiters, 2) ]
+            return [ OBJECT_FREEZE.__invoke__(result), ARRAY_GET.__invoke__(delimiters, 2) ]
           end
-          reserve!(state, PROC_CALL.bind_call(COLLECTION_BYTES, count, payload, depth))
-          output = STRING_INITIALIZE.bind_call(CLASS_ALLOCATE.bind_call(String), encoding: UTF8)
-          STRING_APPEND.bind_call(output, ARRAY_GET.bind_call(delimiters, 0))
-          STRING_APPEND.bind_call(output, "\n")
+          reserve!(state, PROC_CALL.__invoke__(COLLECTION_BYTES, count, payload, depth))
+          output = STRING_INITIALIZE.__invoke__(CLASS_ALLOCATE.__invoke__(String), encoding: UTF8)
+          STRING_APPEND.__invoke__(output, ARRAY_GET.__invoke__(delimiters, 0))
+          STRING_APPEND.__invoke__(output, "\n")
           separator = ""
-          indent = ARRAY_GET.bind_call(INDENTS, INTEGER_ADD.bind_call(depth, 1))
-          ARRAY_EACH.bind_call(entries) do |entry|
-            parts = PROC_CALL.bind_call(entry_builder, result, entry, separator, indent)
-            ARRAY_EACH.bind_call(parts) { |part| STRING_APPEND.bind_call(output, part) }
+          indent = ARRAY_GET.__invoke__(INDENTS, INTEGER_ADD.__invoke__(depth, 1))
+          ARRAY_EACH.__invoke__(entries) do |entry|
+            parts = PROC_CALL.__invoke__(entry_builder, result, entry, separator, indent)
+            ARRAY_EACH.__invoke__(parts) { |part| STRING_APPEND.__invoke__(output, part) }
             separator = ",\n"
           end
-          tail = [ "\n", ARRAY_GET.bind_call(INDENTS, depth), ARRAY_GET.bind_call(delimiters, 1) ]
-          ARRAY_EACH.bind_call(tail) { |part| STRING_APPEND.bind_call(output, part) }
-          [ OBJECT_FREEZE.bind_call(result), output ]
+          tail = [ "\n", ARRAY_GET.__invoke__(INDENTS, depth), ARRAY_GET.__invoke__(delimiters, 1) ]
+          ARRAY_EACH.__invoke__(tail) { |part| STRING_APPEND.__invoke__(output, part) }
+          [ OBJECT_FREEZE.__invoke__(result), output ]
         end
         def import_string(value, state, _depth)
-          encoding = STRING_ENCODING.bind_call(value)
-          raise Error if ENCODING_DUMMY.bind_call(encoding)
-          raise Error if OBJECT_EQUAL.bind_call(encoding, BINARY)
-          raw_size = STRING_BYTESIZE.bind_call(value)
-          input = INTEGER_ADD.bind_call(ARRAY_GET.bind_call(state, INPUT), raw_size)
-          raise Error if INTEGER_GREATER.bind_call(input, MAX_INPUT_BYTES)
-          ARRAY_SET.bind_call(state, INPUT, input)
-          reserve!(state, INTEGER_MULTIPLY.bind_call(raw_size, 4))
-          owned = STRING_ENCODE.bind_call(value, UTF8)
-          token_size = INTEGER_ADD.bind_call(STRING_BYTESIZE.bind_call(owned), 2)
-          STRING_EACH_BYTE.bind_call(owned) do |byte|
-            token_size = INTEGER_ADD.bind_call(token_size, ARRAY_GET.bind_call(ESCAPE_EXTRA, byte))
+          encoding = STRING_ENCODING.__invoke__(value)
+          raise Error if ENCODING_DUMMY.__invoke__(encoding)
+          raise Error if OBJECT_EQUAL.__invoke__(encoding, BINARY)
+          raw_size = STRING_BYTESIZE.__invoke__(value)
+          input = INTEGER_ADD.__invoke__(ARRAY_GET.__invoke__(state, INPUT), raw_size)
+          raise Error if INTEGER_GREATER.__invoke__(input, MAX_INPUT_BYTES)
+          ARRAY_SET.__invoke__(state, INPUT, input)
+          reserve!(state, INTEGER_MULTIPLY.__invoke__(raw_size, 4))
+          owned = STRING_ENCODE.__invoke__(value, UTF8)
+          token_size = INTEGER_ADD.__invoke__(STRING_BYTESIZE.__invoke__(owned), 2)
+          STRING_EACH_BYTE.__invoke__(owned) do |byte|
+            token_size = INTEGER_ADD.__invoke__(token_size, ARRAY_GET.__invoke__(ESCAPE_EXTRA, byte))
           end
           reserve!(state, token_size)
-          token = STRING_TO_JSON.bind_call(owned)
-          [ OBJECT_FREEZE.bind_call(owned), token ]
+          token = JSON_GENERATE.__invoke__(owned, nil, nil)
+          [ OBJECT_FREEZE.__invoke__(owned), token ]
         end
         def reserve!(state, bytes)
-          raise Error if INTEGER_GREATER.bind_call(bytes, MAX_PROJECTED_BYTES)
-          total = INTEGER_ADD.bind_call(ARRAY_GET.bind_call(state, ALLOCATION), bytes)
-          raise Error if INTEGER_GREATER.bind_call(total, MAX_ALLOCATION_BYTES)
-          ARRAY_SET.bind_call(state, ALLOCATION, total)
+          raise Error if INTEGER_GREATER.__invoke__(bytes, MAX_PROJECTED_BYTES)
+          total = INTEGER_ADD.__invoke__(ARRAY_GET.__invoke__(state, ALLOCATION), bytes)
+          raise Error if INTEGER_GREATER.__invoke__(total, MAX_ALLOCATION_BYTES)
+          ARRAY_SET.__invoke__(state, ALLOCATION, total)
         end
       end
       HASH_ENTRY_BUILDER = lambda do |result, entry, separator, indent|
-        HASH_SET.bind_call(result, ARRAY_GET.bind_call(entry, 0), ARRAY_GET.bind_call(entry, 2))
-        [ separator, indent, ARRAY_GET.bind_call(entry, 1), ": ", ARRAY_GET.bind_call(entry, 3) ]
+        HASH_SET.__invoke__(result, ARRAY_GET.__invoke__(entry, 0), ARRAY_GET.__invoke__(entry, 2))
+        [ separator, indent, ARRAY_GET.__invoke__(entry, 1), ": ", ARRAY_GET.__invoke__(entry, 3) ]
       end.freeze
       ARRAY_ENTRY_BUILDER = lambda do |result, entry, separator, indent|
-        ARRAY_PUSH.bind_call(result, ARRAY_GET.bind_call(entry, 2))
-        [ separator, indent, ARRAY_GET.bind_call(entry, 3) ]
+        ARRAY_PUSH.__invoke__(result, ARRAY_GET.__invoke__(entry, 2))
+        [ separator, indent, ARRAY_GET.__invoke__(entry, 3) ]
       end.freeze
       HANDLERS = [
         method(:import_hash).to_proc, method(:import_array).to_proc, method(:import_string).to_proc, lambda do |value, state, _depth|
-          raise Error if INTEGER_GREATER.bind_call(INTEGER_BITS.bind_call(value), MAX_INTEGER_BITS)
-          token = INTEGER_TO_S.bind_call(value)
-          reserve!(state, STRING_BYTESIZE.bind_call(token))
+          raise Error if INTEGER_GREATER.__invoke__(INTEGER_BITS.__invoke__(value), MAX_INTEGER_BITS)
+          token = INTEGER_TO_S.__invoke__(value)
+          reserve!(state, STRING_BYTESIZE.__invoke__(token))
           [ value, token ]
         end,
         lambda do |value, state, _depth|
-          raise Error unless FLOAT_FINITE.bind_call(value)
-          token = FLOAT_TO_JSON.bind_call(value)
-          reserve!(state, STRING_BYTESIZE.bind_call(token))
+          token = JSON_GENERATE.__invoke__(value, nil, nil)
+          reserve!(state, STRING_BYTESIZE.__invoke__(token))
           [ value, token ]
         end,
-        ->(value, _state, _depth) { [ value, ARRAY_GET.bind_call(SCALAR_JSON, 5) ] },
-        ->(value, _state, _depth) { [ value, ARRAY_GET.bind_call(SCALAR_JSON, 6) ] },
-        ->(value, _state, _depth) { [ value, ARRAY_GET.bind_call(SCALAR_JSON, 7) ] }
+        ->(value, _state, _depth) { [ value, ARRAY_GET.__invoke__(SCALAR_JSON, 5) ] },
+        ->(value, _state, _depth) { [ value, ARRAY_GET.__invoke__(SCALAR_JSON, 6) ] },
+        ->(value, _state, _depth) { [ value, ARRAY_GET.__invoke__(SCALAR_JSON, 7) ] }
       ].each(&:freeze).freeze
-      [ Error, Snapshot ].each(&:freeze)
+      private_constant :SEAL, :CLASS_ALLOCATE, :DATA_INITIALIZE, :STRING_INITIALIZE, :JSON_GENERATE
+      [ Error, Snapshot, self ].each { |object| OBJECT_FREEZE.__invoke__(object) }
     end
   end
 end

--- a/packaging/live_agent_skills/workflow_creator_values.rb
+++ b/packaging/live_agent_skills/workflow_creator_values.rb
@@ -1,0 +1,190 @@
+require "json"
+module HiveLiveAgentProof
+  module WorkflowCreator
+    module Values
+      class Error < StandardError; end
+      Snapshot = Data.define(:value, :canonical_bytes).tap do |type|
+        type.singleton_class.send(:private, :new, :[], :allocate)
+        type.send(:private, :with)
+      end
+      MAX_DEPTH, MAX_NODES, MAX_INTEGER_BITS = 64, 8_192, 4_096
+      MAX_INPUT_BYTES, MAX_PROJECTED_BYTES, MAX_ALLOCATION_BYTES = 262_144, 1_048_576, 4_194_304
+      OBJECT_CLASS, OBJECT_FREEZE = %i[class freeze].map { Object.instance_method(_1).freeze }
+      OBJECT_EQUAL, OBJECT_ID = %i[equal? __id__].map { BasicObject.instance_method(_1).freeze }
+      CLASS_NEW, CLASS_ALLOCATE, PROC_CALL =
+        [ [ Class, :new ], [ Class, :allocate ], [ Proc, :call ] ].map { |owner, name| owner.instance_method(name).freeze }
+      HASH_EACH_PAIR, HASH_KEY, HASH_SET, HASH_DELETE, HASH_LENGTH =
+        %i[each_pair key? []= delete length].map { Hash.instance_method(_1).freeze }
+      ARRAY_EACH, ARRAY_GET, ARRAY_SET, ARRAY_PUSH, ARRAY_INDEX, ARRAY_LENGTH, ARRAY_SORT, ARRAY_SUM =
+        %i[each [] []= << index length sort! sum].map { Array.instance_method(_1).freeze }
+      STRING_INITIALIZE, STRING_ENCODING, STRING_BYTESIZE, STRING_ENCODE, STRING_EACH_BYTE, STRING_TO_JSON, STRING_APPEND, STRING_COMPARE =
+          %i[initialize encoding bytesize encode each_byte to_json << <=>].map { String.instance_method(_1).freeze }
+      INTEGER_ADD, INTEGER_SUBTRACT, INTEGER_MULTIPLY, INTEGER_GREATER, INTEGER_ZERO, INTEGER_BITS, INTEGER_TO_S =
+          %i[+ - * > zero? bit_length to_s].map { Integer.instance_method(_1).freeze }
+      FLOAT_FINITE, FLOAT_TO_JSON = %i[finite? to_json].map { Float.instance_method(_1).freeze }
+      ENCODING_DUMMY, UTF8, BINARY = Encoding.instance_method(:dummy?).freeze, Encoding::UTF_8, Encoding::BINARY
+      TYPES = [ Hash, Array, String, Integer, Float, TrueClass, FalseClass, NilClass ].freeze
+      SCALAR_JSON = [ nil, nil, nil, nil, nil, "true".freeze, "false".freeze, "null".freeze ].freeze
+      INDENTS = Array.new(MAX_DEPTH + 2) { |depth| ("  " * depth).freeze }.freeze
+      ESCAPE_EXTRA = Array.new(256, 0)
+      (0..31).each { |byte| ESCAPE_EXTRA[byte] = 5 }
+      [ 8, 9, 10, 12, 13, 34, 92 ].each { |byte| ESCAPE_EXTRA[byte] = 1 }
+      ESCAPE_EXTRA.freeze
+      NODES, INPUT, ALLOCATION, ACTIVE = 0, 1, 2, 3
+      COLLECTION_BYTES = lambda do |count, payload, depth|
+        bytes = INTEGER_ADD.bind_call(4, INTEGER_MULTIPLY.bind_call(2, depth))
+        entries = INTEGER_MULTIPLY.bind_call(INTEGER_MULTIPLY.bind_call(count, 2),
+                                             INTEGER_ADD.bind_call(depth, 1))
+        commas = INTEGER_MULTIPLY.bind_call(INTEGER_SUBTRACT.bind_call(count, 1), 2)
+        INTEGER_ADD.bind_call(bytes, INTEGER_ADD.bind_call(entries, INTEGER_ADD.bind_call(commas, payload)))
+      end.freeze
+      class << self
+        def capture(value)
+          state = [ 0, 0, 0, {} ]
+          owned, fragment = import(value, state, 0)
+          canonical = STRING_INITIALIZE.bind_call(CLASS_ALLOCATE.bind_call(String), encoding: UTF8)
+          reserve!(state, INTEGER_ADD.bind_call(STRING_BYTESIZE.bind_call(fragment), 1))
+          STRING_APPEND.bind_call(canonical, fragment)
+          STRING_APPEND.bind_call(canonical, "\n")
+          OBJECT_FREEZE.bind_call(canonical)
+          CLASS_NEW.bind_call(Snapshot, value: owned, canonical_bytes: canonical)
+        rescue Error, EncodingError, JSON::GeneratorError, TypeError, ArgumentError
+          raise Error, "workflow-creator value cannot be captured"
+        end
+        private
+        def import(value, state, depth)
+          raise Error if INTEGER_GREATER.bind_call(depth, MAX_DEPTH)
+          nodes = INTEGER_ADD.bind_call(ARRAY_GET.bind_call(state, NODES), 1)
+          raise Error if INTEGER_GREATER.bind_call(nodes, MAX_NODES)
+          ARRAY_SET.bind_call(state, NODES, nodes)
+          reserve!(state, 64)
+          klass = OBJECT_CLASS.bind_call(value)
+          index = ARRAY_INDEX.bind_call(TYPES) { |type| OBJECT_EQUAL.bind_call(klass, type) }
+          handler = ARRAY_GET.bind_call(HANDLERS, index)
+          raise Error unless handler
+          PROC_CALL.bind_call(handler, value, state, depth)
+        end
+        def import_hash(value, state, depth)
+          active = ARRAY_GET.bind_call(state, ACTIVE)
+          identity = OBJECT_ID.bind_call(value)
+          raise Error if HASH_KEY.bind_call(active, identity)
+          HASH_SET.bind_call(active, identity, true)
+          minimum_nodes = INTEGER_ADD.bind_call(ARRAY_GET.bind_call(state, NODES), INTEGER_MULTIPLY.bind_call(HASH_LENGTH.bind_call(value), 2))
+          raise Error if INTEGER_GREATER.bind_call(minimum_nodes, MAX_NODES)
+          entries = []
+          seen = {}
+          payload = 0
+          HASH_EACH_PAIR.bind_call(value) do |raw_key, raw_value|
+            entry, entry_bytes = import_hash_entry(raw_key, raw_value, state, depth, seen)
+            payload = INTEGER_ADD.bind_call(payload, entry_bytes)
+            ARRAY_PUSH.bind_call(entries, entry)
+          end
+          ARRAY_SORT.bind_call(entries) do |left, right|
+            STRING_COMPARE.bind_call(ARRAY_GET.bind_call(left, 0), ARRAY_GET.bind_call(right, 0))
+          end
+          build_collection({}, entries, payload, state, depth, [ "{", "}", "{}" ], HASH_ENTRY_BUILDER)
+        ensure
+          HASH_DELETE.bind_call(active, identity)
+        end
+        def import_hash_entry(raw_key, raw_value, state, depth, seen)
+          raise Error unless OBJECT_EQUAL.bind_call(OBJECT_CLASS.bind_call(raw_key), String)
+          nested_depth = INTEGER_ADD.bind_call(depth, 1)
+          key, key_json = import(raw_key, state, nested_depth)
+          raise Error if HASH_KEY.bind_call(seen, key)
+          HASH_SET.bind_call(seen, key, true)
+          nested, nested_json = import(raw_value, state, nested_depth)
+          bytes = ARRAY_SUM.bind_call([ STRING_BYTESIZE.bind_call(key_json), STRING_BYTESIZE.bind_call(nested_json), 2 ])
+          [ [ key, key_json, nested, nested_json ], bytes ]
+        end
+        def import_array(value, state, depth)
+          active = ARRAY_GET.bind_call(state, ACTIVE)
+          identity = OBJECT_ID.bind_call(value)
+          raise Error if HASH_KEY.bind_call(active, identity)
+          HASH_SET.bind_call(active, identity, true)
+          entries = []
+          payload = 0
+          ARRAY_EACH.bind_call(value) do |nested|
+            owned, fragment = import(nested, state, INTEGER_ADD.bind_call(depth, 1))
+            payload = INTEGER_ADD.bind_call(payload, STRING_BYTESIZE.bind_call(fragment))
+            ARRAY_PUSH.bind_call(entries, [ nil, nil, owned, fragment ])
+          end
+          build_collection([], entries, payload, state, depth, [ "[", "]", "[]" ], ARRAY_ENTRY_BUILDER)
+        ensure
+          HASH_DELETE.bind_call(active, identity)
+        end
+        def build_collection(result, entries, payload, state, depth, delimiters, entry_builder)
+          count = ARRAY_LENGTH.bind_call(entries)
+          if INTEGER_ZERO.bind_call(count)
+            reserve!(state, 2)
+            return [ OBJECT_FREEZE.bind_call(result), ARRAY_GET.bind_call(delimiters, 2) ]
+          end
+          reserve!(state, PROC_CALL.bind_call(COLLECTION_BYTES, count, payload, depth))
+          output = STRING_INITIALIZE.bind_call(CLASS_ALLOCATE.bind_call(String), encoding: UTF8)
+          STRING_APPEND.bind_call(output, ARRAY_GET.bind_call(delimiters, 0))
+          STRING_APPEND.bind_call(output, "\n")
+          separator = ""
+          indent = ARRAY_GET.bind_call(INDENTS, INTEGER_ADD.bind_call(depth, 1))
+          ARRAY_EACH.bind_call(entries) do |entry|
+            parts = PROC_CALL.bind_call(entry_builder, result, entry, separator, indent)
+            ARRAY_EACH.bind_call(parts) { |part| STRING_APPEND.bind_call(output, part) }
+            separator = ",\n"
+          end
+          tail = [ "\n", ARRAY_GET.bind_call(INDENTS, depth), ARRAY_GET.bind_call(delimiters, 1) ]
+          ARRAY_EACH.bind_call(tail) { |part| STRING_APPEND.bind_call(output, part) }
+          [ OBJECT_FREEZE.bind_call(result), output ]
+        end
+        def import_string(value, state, _depth)
+          encoding = STRING_ENCODING.bind_call(value)
+          raise Error if ENCODING_DUMMY.bind_call(encoding)
+          raise Error if OBJECT_EQUAL.bind_call(encoding, BINARY)
+          raw_size = STRING_BYTESIZE.bind_call(value)
+          input = INTEGER_ADD.bind_call(ARRAY_GET.bind_call(state, INPUT), raw_size)
+          raise Error if INTEGER_GREATER.bind_call(input, MAX_INPUT_BYTES)
+          ARRAY_SET.bind_call(state, INPUT, input)
+          reserve!(state, INTEGER_MULTIPLY.bind_call(raw_size, 4))
+          owned = STRING_ENCODE.bind_call(value, UTF8)
+          token_size = INTEGER_ADD.bind_call(STRING_BYTESIZE.bind_call(owned), 2)
+          STRING_EACH_BYTE.bind_call(owned) do |byte|
+            token_size = INTEGER_ADD.bind_call(token_size, ARRAY_GET.bind_call(ESCAPE_EXTRA, byte))
+          end
+          reserve!(state, token_size)
+          token = STRING_TO_JSON.bind_call(owned)
+          [ OBJECT_FREEZE.bind_call(owned), token ]
+        end
+        def reserve!(state, bytes)
+          raise Error if INTEGER_GREATER.bind_call(bytes, MAX_PROJECTED_BYTES)
+          total = INTEGER_ADD.bind_call(ARRAY_GET.bind_call(state, ALLOCATION), bytes)
+          raise Error if INTEGER_GREATER.bind_call(total, MAX_ALLOCATION_BYTES)
+          ARRAY_SET.bind_call(state, ALLOCATION, total)
+        end
+      end
+      HASH_ENTRY_BUILDER = lambda do |result, entry, separator, indent|
+        HASH_SET.bind_call(result, ARRAY_GET.bind_call(entry, 0), ARRAY_GET.bind_call(entry, 2))
+        [ separator, indent, ARRAY_GET.bind_call(entry, 1), ": ", ARRAY_GET.bind_call(entry, 3) ]
+      end.freeze
+      ARRAY_ENTRY_BUILDER = lambda do |result, entry, separator, indent|
+        ARRAY_PUSH.bind_call(result, ARRAY_GET.bind_call(entry, 2))
+        [ separator, indent, ARRAY_GET.bind_call(entry, 3) ]
+      end.freeze
+      HANDLERS = [
+        method(:import_hash).to_proc, method(:import_array).to_proc, method(:import_string).to_proc, lambda do |value, state, _depth|
+          raise Error if INTEGER_GREATER.bind_call(INTEGER_BITS.bind_call(value), MAX_INTEGER_BITS)
+          token = INTEGER_TO_S.bind_call(value)
+          reserve!(state, STRING_BYTESIZE.bind_call(token))
+          [ value, token ]
+        end,
+        lambda do |value, state, _depth|
+          raise Error unless FLOAT_FINITE.bind_call(value)
+          token = FLOAT_TO_JSON.bind_call(value)
+          reserve!(state, STRING_BYTESIZE.bind_call(token))
+          [ value, token ]
+        end,
+        ->(value, _state, _depth) { [ value, ARRAY_GET.bind_call(SCALAR_JSON, 5) ] },
+        ->(value, _state, _depth) { [ value, ARRAY_GET.bind_call(SCALAR_JSON, 6) ] },
+        ->(value, _state, _depth) { [ value, ARRAY_GET.bind_call(SCALAR_JSON, 7) ] }
+      ].each(&:freeze).freeze
+      [ Error, Snapshot ].each(&:freeze)
+    end
+  end
+end
+require_relative "workflow_creator_text_safety"

--- a/test/support/component_boundary_contract.rb
+++ b/test/support/component_boundary_contract.rb
@@ -164,7 +164,7 @@ class ComponentBoundaryContract
       next if field == "migration_exceptions"
 
       string_array!(value, "#{component_path}.#{field}",
-                    allow_empty: %w[component_dependencies allowed_hive_dependencies forbidden_constructions].include?(field))
+                    allow_empty: %w[component_dependencies allowed_hive_dependencies forbidden_constructions hive_consumers].include?(field))
     end
     forbidden_allowed = row.fetch("allowed_hive_dependencies").select { |required| forbidden_require?(required) }
     unless forbidden_allowed.empty?
@@ -176,6 +176,11 @@ class ComponentBoundaryContract
     end
     repo_path!(row.fetch("wiki_page"), "#{component_path}.wiki_page")
     validate_migration_exceptions!(row, component_path)
+    if row.fetch("hive_consumers").empty? &&
+        (state != "candidate" || row.fetch("migration_exceptions").empty?)
+      invalid!("#{component_path}.hive_consumers",
+               "may be empty only for a candidate with a bounded migration exception")
+    end
     validate_authorized_internal_constructions!(row, component_path)
     string!(row.fetch("mutation_authority"), "#{component_path}.mutation_authority")
     string!(row.fetch("recovery_surface"), "#{component_path}.recovery_surface")
@@ -190,7 +195,9 @@ class ComponentBoundaryContract
       assert_keys!(exception, %w[reason removal_unit], path)
       string!(exception.fetch("reason"), "#{path}.reason")
       removal_unit = string!(exception.fetch("removal_unit"), "#{path}.removal_unit")
-      invalid!("#{path}.removal_unit", "must name a plan unit such as U3") unless removal_unit.match?(/\AU\d+\z/)
+      unless removal_unit.match?(/\AU\d+(?:[a-z]\d*)*\z/)
+        invalid!("#{path}.removal_unit", "must name a plan unit such as U3 or U1a1c")
+      end
     end
     if row.fetch("state") == "boundary-ready" && !exceptions.empty?
       invalid!("#{component_path}.migration_exceptions", "boundary-ready components cannot retain exceptions")
@@ -371,9 +378,12 @@ class ComponentBoundaryContract
       )
     RUBY
 
+    load_paths = [ "-I#{File.join(@root, 'lib')}" ]
+    load_paths.unshift("-I#{@root}") unless entrypoint.fetch("file").start_with?("lib/")
+
     out, err, status = Open3.capture3(
       RbConfig.ruby,
-      "-I#{File.join(@root, 'lib')}",
+      *load_paths,
       "-e",
       script,
       chdir: @root

--- a/test/unit/component_boundaries_test.rb
+++ b/test/unit/component_boundaries_test.rb
@@ -22,7 +22,12 @@ class ComponentBoundariesTest < Minitest::Test
       skillpack
       user-service
       work-ledger
+      workflow-creator-values
     ], contract.components.map { |component| component.fetch("id") }.sort
+    assert_equal [ "workflow-creator-values" ],
+                 contract.components.filter_map { |component|
+                   component.fetch("id") if component.fetch("hive_consumers").empty?
+                 }
 
     attempts = contract.component("attempts")
     assert_equal "candidate", attempts.fetch("state")
@@ -74,6 +79,23 @@ class ComponentBoundariesTest < Minitest::Test
         [ entry.fetch("constant"), entry.fetch("files") ]
       end
     )
+    creator_values = contract.component("workflow-creator-values")
+    assert_equal "candidate", creator_values.fetch("state")
+    assert_equal "packaging/live_agent_skills/workflow_creator_values",
+                 creator_values.dig("entrypoint", "require")
+    assert_equal "HiveLiveAgentProof::WorkflowCreator::Values",
+                 creator_values.dig("entrypoint", "constant")
+    assert_equal %w[
+      packaging/live_agent_skills/workflow_creator_text_safety.rb
+      packaging/live_agent_skills/workflow_creator_values.rb
+    ], creator_values.fetch("owned_paths").sort
+    assert_empty creator_values.fetch("hive_consumers")
+    assert_empty creator_values.fetch("component_dependencies")
+    assert_equal [ "U1a1c" ], creator_values.fetch("migration_exceptions").map { |entry| entry.fetch("removal_unit") }
+    creator_values_load = contract.validate_clean_load!("workflow-creator-values")
+    assert_equal "HiveLiveAgentProof::WorkflowCreator::Values", creator_values_load.fetch("constant")
+    assert_empty creator_values_load.fetch("forbidden_loaded_features")
+    assert_empty creator_values_load.fetch("forbidden_constants")
     user_service = contract.component("user-service")
     assert_equal "boundary-ready", user_service.fetch("state")
     assert_equal "hive/user_service", user_service.dig("entrypoint", "require")
@@ -248,7 +270,7 @@ class ComponentBoundariesTest < Minitest::Test
     remaining_candidates = contract.components.reject do |component|
       ready_components.include?(component)
     end
-    assert_equal %w[attempts patrol-effects],
+    assert_equal %w[attempts patrol-effects workflow-creator-values],
                  remaining_candidates.map { |entry| entry.fetch("id") }.sort
     assert remaining_candidates.all? { |component| component.fetch("state") == "candidate" }
 
@@ -313,12 +335,16 @@ class ComponentBoundariesTest < Minitest::Test
       assert_includes row, "[[#{wiki_link}]]"
       assert_includes wiki_index, "[[#{wiki_link}]]"
       exceptions = component.fetch("migration_exceptions")
-      if component.fetch("id") == "patrol-effects"
-        assert_equal [ "U3" ],
-                     exceptions.map { |entry| entry.fetch("removal_unit") }
-      else
+      expected_exception = {
+        "patrol-effects" => [ "U3" ],
+        "workflow-creator-values" => [ "U1a1c" ]
+      }.fetch(component.fetch("id"), [])
+      if expected_exception.empty?
         assert_empty exceptions,
                      "#{component.fetch('id')} retained an expired migration exception"
+      else
+        assert_equal expected_exception,
+                     exceptions.map { |entry| entry.fetch("removal_unit") }
       end
 
       component_dependencies = component.fetch("component_dependencies")
@@ -590,15 +616,33 @@ class ComponentBoundariesTest < Minitest::Test
     end
   end
 
-  def test_candidate_component_accepts_bounded_migration_exception
+  def test_zero_consumers_require_a_candidate_with_a_bounded_migration_exception
+    { "user-service" => "boundary-ready", "attempts" => "candidate" }.each do |id, state|
+      document = Marshal.load(Marshal.dump(@document))
+      entry = component(document, id)
+      entry["state"] = state
+      entry["hive_consumers"] = []
+      entry["migration_exceptions"] = []
+
+      error = assert_raises(ComponentBoundaryContract::ValidationError, id) do
+        ComponentBoundaryContract.new(document, root: ROOT).validate_catalog!
+      end
+
+      assert_match(/#{id}\.hive_consumers/, error.message)
+      assert_match(/candidate with a bounded migration exception/, error.message)
+    end
+  end
+
+  def test_candidate_component_accepts_actual_nested_plan_unit
     with_contract_fixture(
       entrypoint_source: example_api_source,
       state: "candidate",
       migration_exceptions: [
-        { "reason" => "temporary upward edge", "removal_unit" => "U3" }
+        { "reason" => "temporary upward edge", "removal_unit" => "U1a1c" }
       ]
     ) do |contract|
       assert contract.validate_catalog!
+      assert_equal "U1a1c", contract.component("example").fetch("migration_exceptions").first.fetch("removal_unit")
     end
   end
 
@@ -631,7 +675,7 @@ class ComponentBoundariesTest < Minitest::Test
       end
 
       assert_match(/example\.migration_exceptions\[0\]\.removal_unit/, error.message)
-      assert_match(/must name a plan unit such as U3/, error.message)
+      assert_match(/must name a plan unit such as U3 or U1a1c/, error.message)
     end
   end
 
@@ -683,6 +727,25 @@ class ComponentBoundariesTest < Minitest::Test
       assert_match(/example\.entrypoint/, error.message)
       assert_match(/clean load failed/, error.message)
       assert_match(/fixture boom/, error.message)
+    end
+  end
+
+  def test_clean_load_does_not_expose_root_owned_packaging_features_to_lib_entrypoints
+    with_contract_fixture(
+      entrypoint_source: <<~RUBY,
+        require "packaging/unrelated"
+        #{example_api_source}
+      RUBY
+      extra_files: {
+        "packaging/unrelated.rb" => "module Packaging; module Unrelated; end; end\n"
+      }
+    ) do |contract|
+      error = assert_raises(ComponentBoundaryContract::ValidationError) do
+        contract.validate_clean_loads!
+      end
+
+      assert_match(/clean load failed/, error.message)
+      assert_match(/cannot load such file -- packaging\/unrelated/, error.message)
     end
   end
 

--- a/test/unit/packaging/workflow_creator_values_test.rb
+++ b/test/unit/packaging/workflow_creator_values_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "bundler"
 require "json"
 require "open3"
 require "rbconfig"
@@ -10,6 +11,8 @@ class WorkflowCreatorValuesTest < Minitest::Test
   ROOT = File.expand_path("../../..", __dir__)
   Values = HiveLiveAgentProof::WorkflowCreator::Values
   TextSafety = HiveLiveAgentProof::WorkflowCreator::TextSafety
+  POISONED_CHILD_ENV = %w[HIVE_COVERAGE HIVE_COVERAGE_ROOT HIVE_COVERAGE_RUN_ID RUBYOPT]
+    .to_h { |name| [ name, nil ] }.freeze
   DECISION_NODES = %i[
     if unless elsif if_mod unless_mod ifop when in rescue rescue_mod
     while until for while_mod until_mod
@@ -43,6 +46,15 @@ class WorkflowCreatorValuesTest < Minitest::Test
     assert_raises(NoMethodError) { type[value: [], canonical_bytes: +"mutable"] }
     assert_raises(NoMethodError) { type.allocate }
     assert_raises(NoMethodError) { snapshot.with(value: []) }
+    assert_raises(NameError) { Values::CLASS_ALLOCATE }
+    assert_raises(NameError) { Values::DATA_INITIALIZE }
+    assert_raises(NameError) { Values::STRING_INITIALIZE }
+    assert_raises(NameError) { TextSafety::CLASS_ALLOCATE }
+    assert_raises(NameError) { TextSafety::ARRAY_INITIALIZE }
+    assert_raises(NameError) { TextSafety::STRING_INITIALIZE }
+    assert_raises(TypeError) { Marshal.dump(snapshot) }
+    assert Values.frozen?
+    assert TextSafety.frozen?
   end
 
   def test_ascii_only_canonical_bytes_are_utf8_and_can_be_captured_again
@@ -187,7 +199,7 @@ class WorkflowCreatorValuesTest < Minitest::Test
       captured = HiveLiveAgentProof::WorkflowCreator::Values.capture({ "b" => ["value"], "a" => 1 })
       STDOUT.write(captured.canonical_bytes)
     RUBY
-    out, err, status = Open3.capture3(RbConfig.ruby, "-e", script, values_path)
+    out, err, status = poisoned_capture3(script, values_path)
 
     assert status.success?, err
     assert_equal "{\n  \"a\": 1,\n  \"b\": [\n    \"value\"\n  ]\n}\n", out
@@ -227,7 +239,7 @@ class WorkflowCreatorValuesTest < Minitest::Test
       io_write.bind_call(STDOUT, redacted)
       io_write.bind_call(STDOUT, initialized.canonical_bytes)
     RUBY
-    out, err, status = Open3.capture3(RbConfig.ruby, "-e", script, values_path)
+    out, err, status = poisoned_capture3(script, values_path)
 
     assert status.success?, err
     canonical = <<~JSON
@@ -240,6 +252,71 @@ class WorkflowCreatorValuesTest < Minitest::Test
       }
     JSON
     assert_equal canonical + "value=[REDACTED]" + canonical, out
+  end
+
+  def test_each_captured_invocation_resists_post_load_invocation_replacement
+    values_path = File.expand_path("../../../packaging/live_agent_skills/workflow_creator_values", __dir__)
+    script = <<~'RUBY'
+      require ARGV.fetch(0)
+      writer = IO.instance_method(:write)
+      writer.singleton_class.send(:alias_method, :invoke, :bind_call)
+      writer.freeze
+      UnboundMethod.class_eval { define_method(:bind_call) { |*| raise "intercepted UnboundMethod#bind_call" } }
+      Method.class_eval { define_method(:call) { |*| raise "intercepted Method#call" } }
+      values = HiveLiveAgentProof::WorkflowCreator::Values
+      safety = HiveLiveAgentProof::WorkflowCreator::TextSafety
+      captured = values.capture({ "key" => "sk-ant-abcdefghijklmnopqrstuvwxyz" })
+      redacted = safety.redact(captured.value.fetch("key"), exact_secrets: values.capture([]).value)
+      writer.invoke(STDOUT, captured.canonical_bytes)
+      writer.invoke(STDOUT, redacted)
+    RUBY
+    out, err, status = poisoned_capture3(script, values_path)
+
+    assert status.success?, err
+    assert_equal "{\n  \"key\": \"sk-ant-abcdefghijklmnopqrstuvwxyz\"\n}\n[REDACTED]", out
+  end
+
+  def test_captured_leaf_operations_resist_composite_core_replacement
+    values_path = File.expand_path("../../../packaging/live_agent_skills/workflow_creator_values", __dir__)
+    script = <<~'RUBY'
+      require ARGV.fetch(0)
+      writer = IO.instance_method(:write)
+      writer.singleton_class.send(:alias_method, :invoke, :bind_call)
+      writer.freeze
+      if ARGV.fetch(1) == "noop"
+        Data.class_eval { define_method(:initialize) { |*| nil } }
+      else
+        Data.class_eval { define_method(:initialize) { |*| raise "intercepted Data#initialize" } }
+      end
+      JSON::State.define_singleton_method(:_generate_no_fallback) { |*| "\"forged\"" }
+      Float.define_singleton_method(:===) { |*| raise "intercepted Float.===" }
+      Integer.class_eval { define_method(:<=>) { |*| raise "intercepted Integer#<=>" } }
+      values = HiveLiveAgentProof::WorkflowCreator::Values
+      safety = HiveLiveAgentProof::WorkflowCreator::TextSafety
+      captured = values.capture({ "float" => 1.5, "string" => "safe" })
+      writer.invoke(STDOUT, captured.canonical_bytes)
+      writer.invoke(STDOUT, safety.text(captured.value.fetch("string"), limit: 4))
+      writer.invoke(STDOUT, safety.redact(values.capture("secret").value,
+                                          exact_secrets: values.capture(["secret"]).value))
+    RUBY
+    expected = "{\n  \"float\": 1.5,\n  \"string\": \"safe\"\n}\nsafe[REDACTED]"
+
+    %w[noop raise].each do |mode|
+      out, err, status = poisoned_capture3(script, values_path, mode)
+      assert status.success?, "#{mode}: #{err}"
+      assert_equal expected, out, mode
+    end
+  end
+
+  def test_capture_errors_suppress_secret_bearing_causes
+    sentinel = "u1a1v-rejected-secret"
+    invalid = "#{sentinel}\xFF".dup.force_encoding(Encoding::UTF_8)
+
+    error = assert_raises(Values::Error) { Values.capture(invalid) }
+
+    assert_equal "workflow-creator value cannot be captured", error.message
+    assert_nil error.cause
+    refute_includes error.full_message, sentinel
   end
 
   def test_encoding_normalization_collision_and_numeric_limits_fail_closed
@@ -304,6 +381,8 @@ class WorkflowCreatorValuesTest < Minitest::Test
   def test_text_safety_projects_only_captured_values
     captured = Values.capture("prefix secret-token suffix")
     secret = Values.capture([ "secret-token" ])
+    safe = Values.capture("safe report")
+    no_secrets = Values.capture([])
 
     assert_equal "prefix", TextSafety.text(captured.value, limit: 6)
     assert TextSafety.safe_relative_path?(Values.capture("dir/file.json").value)
@@ -314,6 +393,50 @@ class WorkflowCreatorValuesTest < Minitest::Test
     unicode = Values.capture("é secret-token suffix").value
     assert_equal "é [REDACTED] suffix",
                  TextSafety.redact(unicode, exact_secrets: secret.value, limit: 1_000)
+    assert_equal "safe report", TextSafety.redact(safe.value, exact_secrets: no_secrets.value)
+  end
+
+  def test_text_safety_normalizes_its_four_public_error_surfaces
+    value = Values.capture("safe").value
+    non_string = Values.capture(1).value
+    non_string_secrets = Values.capture([ 1 ]).value
+    projections = {
+      text: -> { TextSafety.text(non_string) },
+      path_predicate: -> { TextSafety.safe_relative_path?(non_string) },
+      secret_findings: -> { TextSafety.secret_findings(value, exact_secrets: non_string_secrets) },
+      redact: -> { TextSafety.redact(value, exact_secrets: Values.capture([]).value, limit: "invalid") }
+    }
+
+    projections.each do |name, projection|
+      error = assert_raises(TextSafety::Error) { projection.call }
+      assert_equal "workflow-creator text cannot be projected", error.message, name
+      assert_nil error.cause, name
+    end
+    assert TextSafety.safe_relative_path?(value)
+    refute TextSafety.safe_relative_path?(Values.capture("../unsafe").value)
+  end
+
+  def test_text_safety_normalizes_encoding_errors_across_all_public_projections
+    incompatible = "safe".encode(Encoding::UTF_16LE)
+    no_secrets = Values.capture([]).value
+    projections = {
+      text: -> { TextSafety.text(incompatible) },
+      path_predicate: -> { TextSafety.safe_relative_path?(incompatible) },
+      secret_findings: -> { TextSafety.secret_findings(incompatible, exact_secrets: no_secrets) },
+      redact: -> { TextSafety.redact(incompatible, exact_secrets: no_secrets) }
+    }
+    errors = projections.transform_values do |projection|
+      projection.call
+      nil
+    rescue StandardError => error
+      error
+    end
+
+    assert_equal projections.keys.to_h { |name| [ name, TextSafety::Error ] }, errors.transform_values(&:class)
+    errors.each do |name, error|
+      assert_equal "workflow-creator text cannot be projected", error.message, name
+      assert_nil error.cause, name
+    end
   end
 
   def test_text_and_path_limits_are_utf8_safe_and_separator_bounded
@@ -362,6 +485,27 @@ class WorkflowCreatorValuesTest < Minitest::Test
     assert expanded.valid_encoding?
   end
 
+  def test_duplicate_exact_secrets_scan_each_unique_needle_once
+    value = Values.capture("a" * 4_096).value
+    one_secret = Values.capture([ "a" * 2_048 ]).value
+    duplicate_secrets = Values.capture(Array.new(64, "a" * 2_048)).value
+    measurements = [ one_secret, duplicate_secrets ].map do |exact_secrets|
+      calls = 0
+      findings = nil
+      trace = TracePoint.new(:c_call) do |event|
+        calls += 1 if event.defined_class == String && event.method_id == :byteindex
+      end
+      trace.enable { findings = TextSafety.secret_findings(value, exact_secrets: exact_secrets) }
+      [ calls, findings ]
+    end
+
+    assert_equal measurements.first.first, measurements.last.first,
+                 "exact-secret byte searches must scale with unique needles"
+    assert_equal 64, measurements.last.last.length
+    assert_equal "exact-secret:0", measurements.last.last.first
+    assert_equal "exact-secret:63", measurements.last.last.last
+  end
+
   def test_supported_token_patterns_detect_and_redact_to_utf8
     tokens = {
       "pattern:openai" => [ "sk-#{"a" * 20}", "sk-proj-#{"b" * 20}" ],
@@ -382,7 +526,7 @@ class WorkflowCreatorValuesTest < Minitest::Test
   end
 
   def test_private_key_patterns_redact_complete_and_truncated_envelopes
-    envelopes = [ "PRIVATE KEY", "RSA PRIVATE KEY", "EC PRIVATE KEY", "OPENSSH PRIVATE KEY",
+    envelopes = [ "PRIVATE KEY", "ENCRYPTED PRIVATE KEY", "RSA PRIVATE KEY", "EC PRIVATE KEY", "OPENSSH PRIVATE KEY",
                   "DSA PRIVATE KEY", "PGP PRIVATE KEY BLOCK" ]
     no_exact_secrets = Values.capture([]).value
 
@@ -455,7 +599,29 @@ class WorkflowCreatorValuesTest < Minitest::Test
     end
   end
 
+  def test_poisoned_children_drop_coverage_and_ruby_startup_instrumentation
+    inherited = {
+      "HIVE_COVERAGE" => "1", "HIVE_COVERAGE_ROOT" => "/sensitive/root",
+      "HIVE_COVERAGE_RUN_ID" => "sensitive-run", "RUBYOPT" => "-W0"
+    }
+    script = <<~'RUBY'
+      forbidden = %w[HIVE_COVERAGE HIVE_COVERAGE_ROOT HIVE_COVERAGE_RUN_ID RUBYOPT]
+      STDOUT.write(forbidden.filter_map { |name| "#{name}=#{ENV[name]}" if ENV.key?(name) }.join("\n"))
+    RUBY
+
+    out, err, status = poisoned_capture3(script, child_env: inherited)
+
+    assert status.success?, err
+    assert_equal "", out
+  end
+
   private
+
+  def poisoned_capture3(script, *arguments, child_env: {})
+    Bundler.with_unbundled_env do
+      Open3.capture3(child_env.merge(POISONED_CHILD_ENV), RbConfig.ruby, "-e", script, *arguments)
+    end
+  end
 
   def assert_deeply_frozen(value)
     assert value.frozen?

--- a/test/unit/packaging/workflow_creator_values_test.rb
+++ b/test/unit/packaging/workflow_creator_values_test.rb
@@ -1,0 +1,494 @@
+require "test_helper"
+require "json"
+require "open3"
+require "rbconfig"
+require "ripper"
+require_relative "../../../packaging/live_agent_skills/workflow_creator_values"
+require_relative "../../../packaging/live_agent_skills/workflow_creator_text_safety"
+
+class WorkflowCreatorValuesTest < Minitest::Test
+  ROOT = File.expand_path("../../..", __dir__)
+  Values = HiveLiveAgentProof::WorkflowCreator::Values
+  TextSafety = HiveLiveAgentProof::WorkflowCreator::TextSafety
+  DECISION_NODES = %i[
+    if unless elsif if_mod unless_mod ifop when in rescue rescue_mod
+    while until for while_mod until_mod
+  ].freeze
+
+  def test_capture_returns_a_fresh_frozen_snapshot_and_canonical_bytes
+    input = { "z" => [ true, nil ], "a" => { "count" => 2 } }
+    captured = Values.capture(input)
+
+    assert_equal({ "a" => { "count" => 2 }, "z" => [ true, nil ] }, captured.value)
+    assert_equal "#{JSON.pretty_generate(captured.value)}\n", captured.canonical_bytes
+    refute_same input, captured.value
+    assert captured.frozen?
+    assert_deeply_frozen captured.value
+    assert captured.canonical_bytes.frozen?
+  end
+
+  def test_snapshot_construction_and_update_bypasses_are_non_public
+    snapshot = Values.capture("safe")
+    type = Values::Snapshot
+
+    refute_respond_to type, :new
+    refute_respond_to type, :[]
+    refute_respond_to type, :allocate
+    refute_respond_to snapshot, :with
+    assert type.singleton_class.private_method_defined?(:new)
+    assert type.singleton_class.private_method_defined?(:[])
+    assert type.singleton_class.private_method_defined?(:allocate)
+    assert type.private_method_defined?(:with)
+    assert_raises(NoMethodError) { type.new(value: [], canonical_bytes: +"mutable") }
+    assert_raises(NoMethodError) { type[value: [], canonical_bytes: +"mutable"] }
+    assert_raises(NoMethodError) { type.allocate }
+    assert_raises(NoMethodError) { snapshot.with(value: []) }
+  end
+
+  def test_ascii_only_canonical_bytes_are_utf8_and_can_be_captured_again
+    captured = Values.capture({ "ascii" => [ "only", true ] })
+
+    assert_equal Encoding::UTF_8, captured.canonical_bytes.encoding
+    recaptured = Values.capture(captured.canonical_bytes)
+    assert_equal captured.canonical_bytes, recaptured.value
+    assert_equal Encoding::UTF_8, recaptured.value.encoding
+    assert_equal captured.canonical_bytes, Values.capture(JSON.parse(captured.canonical_bytes)).canonical_bytes
+  end
+
+  def test_capture_covers_every_json_type_and_generator_boundary
+    values = [
+      {}, [], "", 0, -7, 0.0, -0.0, 1e20, 1e-6, 1e-7,
+      true, false, nil,
+      { "quote" => "\"", "slash" => "\\", "controls" => "\0\b\f\n\r\t\x1f", "unicode" => "é😀" }
+    ]
+
+    values.each do |value|
+      captured = Values.capture(value)
+      assert_equal "#{JSON.pretty_generate(captured.value)}\n", captured.canonical_bytes, value.inspect
+    end
+  end
+
+  def test_canonical_bytes_match_pretty_generate_for_a_deterministic_property_corpus
+    random = Random.new(0xC0FFEE)
+
+    200.times do |index|
+      captured = Values.capture(property_value(random))
+      assert_equal "#{JSON.pretty_generate(captured.value)}\n", captured.canonical_bytes, "case #{index}"
+    end
+  end
+
+  def test_capture_rejects_subclasses_cycles_and_non_json_scalars
+    subclass_values = [
+      Class.new(Hash)["key" => "value"],
+      Class.new(Array)["value"],
+      Class.new(String).new("value"),
+      Class.new(Integer),
+      Object.new,
+      :symbol
+    ]
+    subclass_values.each { |value| assert_raises(Values::Error) { Values.capture(value) } }
+
+    array_cycle = []
+    array_cycle << array_cycle
+    hash_cycle = {}
+    hash_cycle["self"] = hash_cycle
+    assert_raises(Values::Error) { Values.capture(array_cycle) }
+    assert_raises(Values::Error) { Values.capture(hash_cycle) }
+  end
+
+  def test_exact_values_with_direct_and_module_hooks_cannot_interpose
+    exploding = Module.new do
+      def class = raise("class dispatched")
+      def each = raise("each dispatched")
+      def each_pair = raise("each_pair dispatched")
+      def encode(*) = raise("encode dispatched")
+      def bytesize = raise("bytesize dispatched")
+      def to_json(*) = raise("to_json dispatched")
+      def respond_to_missing?(*) = raise("respond_to_missing dispatched")
+      def method_missing(*) = raise("method_missing dispatched")
+
+      protected :bytesize
+      private :method_missing, :respond_to_missing?
+    end
+    hooked_key = +"key"
+    hooked_key.extend(exploding)
+    hooked_value = +"value"
+    hooked_value.define_singleton_method(:valid_encoding?) { raise "valid_encoding dispatched" }
+    hooked_value.singleton_class.undef_method(:to_json)
+    hooked_array = [ hooked_value ]
+    hooked_array.extend(exploding)
+    hooked_hash = { hooked_key => hooked_array }
+    hooked_hash.extend(exploding)
+
+    captured = Values.capture(hooked_hash)
+
+    assert_equal({ "key" => [ "value" ] }, captured.value)
+    assert_equal "#{JSON.pretty_generate(captured.value)}\n", captured.canonical_bytes
+  end
+
+  def test_singleton_class_include_and_prepend_hooks_cannot_interpose
+    poison = Module.new do
+      def each_pair = raise("each_pair dispatched")
+      def each = raise("each dispatched")
+      def encode(*) = raise("encode dispatched")
+      def ==(*) = raise("equality dispatched")
+
+      private :each_pair, :==
+      protected :each
+    end
+    value = +"value"
+    value.singleton_class.prepend(poison)
+    list = [ value ]
+    list.singleton_class.include(poison)
+    input = { "key" => list }
+    input.singleton_class.prepend(poison)
+
+    captured = Values.capture(input)
+
+    assert_equal({ "key" => [ "value" ] }, captured.value)
+    assert_equal "#{JSON.pretty_generate(captured.value)}\n", captured.canonical_bytes
+  end
+
+  def test_capture_is_stable_after_caller_and_extension_module_mutation
+    extension = Module.new do
+      def to_json(*) = "\"forged\""
+    end
+    child = { "message" => +"original" }
+    child.extend(extension)
+    input = [ child, child ]
+    captured = Values.capture(input)
+
+    child["message"].replace("changed")
+    child["new"] = true
+    extension.module_eval { define_method(:each_pair) { raise "late interposition" } }
+
+    assert_equal [ { "message" => "original" }, { "message" => "original" } ], captured.value
+    refute_same captured.value.fetch(0), captured.value.fetch(1), "shared acyclic nodes are copied per occurrence"
+    assert_equal "#{JSON.pretty_generate(captured.value)}\n", captured.canonical_bytes
+  end
+
+  def test_ruby_refinements_are_a_negative_control
+    values_path = File.expand_path("../../../packaging/live_agent_skills/workflow_creator_values", __dir__)
+    script = <<~'RUBY'
+      module Poison
+        refine Hash do
+          def each_pair = raise("refined Hash#each_pair")
+        end
+        refine Array do
+          def each = raise("refined Array#each")
+        end
+        refine String do
+          def encode(*) = raise("refined String#encode")
+          def to_json(*) = raise("refined String#to_json")
+        end
+      end
+      using Poison
+      require ARGV.fetch(0)
+      captured = HiveLiveAgentProof::WorkflowCreator::Values.capture({ "b" => ["value"], "a" => 1 })
+      STDOUT.write(captured.canonical_bytes)
+    RUBY
+    out, err, status = Open3.capture3(RbConfig.ruby, "-e", script, values_path)
+
+    assert status.success?, err
+    assert_equal "{\n  \"a\": 1,\n  \"b\": [\n    \"value\"\n  ]\n}\n", out
+  end
+
+  def test_load_captured_operations_resist_post_load_core_replacement
+    values_path = File.expand_path("../../../packaging/live_agent_skills/workflow_creator_values", __dir__)
+    script = <<~'RUBY'
+      require ARGV.fetch(0)
+      values = { "z" => [1e20, "value"], "a" => -7 }
+      token = "sk-" + "ant-abcdefghijklmnopqrstuvwxyz"
+      text = HiveLiveAgentProof::WorkflowCreator::Values.capture("value=#{token}").value
+      secrets = HiveLiveAgentProof::WorkflowCreator::Values.capture([token]).value
+      io_write = IO.instance_method(:write)
+      Array.define_singleton_method(:new) { |*| raise "post-load Array.new" }
+      Regexp.define_singleton_method(:last_match) { |*| raise "post-load Regexp.last_match" }
+      poisons = {
+        Hash => %i[each_pair key? []= delete],
+        Array => %i[initialize each [] []= << index length sort! each_with_index],
+        String => %i[initialize valid_encoding? encoding bytesize encode each_byte to_json << <=> == hash eql?
+                     byteslice scrub match? include? byteindex scan b],
+        Integer => %i[+ - * > === zero? bit_length to_s hash eql? times between? clamp],
+        Float => %i[finite? to_json], Encoding => %i[dummy?], MatchData => %i[bytebegin byteend],
+        Object => %i[class freeze], BasicObject => %i[equal? __id__], Class => %i[new allocate],
+        Proc => %i[call], Method => %i[call]
+      }
+      poisons.to_a.reverse_each do |owner, names|
+        names.reverse_each do |name|
+          owner.define_method(name) { |*| raise "post-load #{owner}##{name}" }
+        end
+      end
+      captured = HiveLiveAgentProof::WorkflowCreator::Values.capture(values)
+      redacted = HiveLiveAgentProof::WorkflowCreator::TextSafety.redact(text, exact_secrets: secrets)
+      String.class_eval { define_method(:initialize) { |*| raise "post-load String#initialize" } }
+      initialized = HiveLiveAgentProof::WorkflowCreator::Values.capture(values)
+      io_write.bind_call(STDOUT, captured.canonical_bytes)
+      io_write.bind_call(STDOUT, redacted)
+      io_write.bind_call(STDOUT, initialized.canonical_bytes)
+    RUBY
+    out, err, status = Open3.capture3(RbConfig.ruby, "-e", script, values_path)
+
+    assert status.success?, err
+    canonical = <<~JSON
+      {
+        "a": -7,
+        "z": [
+          1e+20,
+          "value"
+        ]
+      }
+    JSON
+    assert_equal canonical + "value=[REDACTED]" + canonical, out
+  end
+
+  def test_encoding_normalization_collision_and_numeric_limits_fail_closed
+    latin = "é".encode(Encoding::ISO_8859_1)
+    normalized = Values.capture(latin)
+    assert_equal "é", normalized.value
+    assert_equal Encoding::UTF_8, normalized.value.encoding
+
+    collision = { "é" => 1, latin => 2 }
+    invalid_utf8 = "\xFF".dup.force_encoding(Encoding::UTF_8)
+    ambiguous = "\xFE\xFF\0a".b.force_encoding(Encoding::UTF_16)
+    binary = "\xFF".b
+    ascii_binary = "ascii".b
+    [ collision, invalid_utf8, ambiguous, binary, ascii_binary ].each do |value|
+      assert_raises(Values::Error) { Values.capture(value) }
+    end
+
+    max_integer = (1 << (Values::MAX_INTEGER_BITS - 1)) - 1
+    assert_equal max_integer, Values.capture(max_integer).value
+    assert_raises(Values::Error) { Values.capture(1 << Values::MAX_INTEGER_BITS) }
+    [ Float::NAN, Float::INFINITY, -Float::INFINITY ].each do |value|
+      assert_raises(Values::Error) { Values.capture(value) }
+    end
+  end
+
+  def test_graph_and_projection_resource_ceilings_are_enforced_before_serialization
+    at_input_limit = "x" * Values::MAX_INPUT_BYTES
+    assert_equal at_input_limit, Values.capture(at_input_limit).value
+    assert_raises(Values::Error) { Values.capture("x" * (Values::MAX_INPUT_BYTES + 1)) }
+    assert_raises(Values::Error) { Values.capture("\0" * Values::MAX_INPUT_BYTES) }
+
+    too_many_nodes = Array.new(Values::MAX_NODES, nil)
+    assert_raises(Values::Error) { Values.capture(too_many_nodes) }
+
+    near_limit_hash = (0...((Values::MAX_NODES / 2) - 1)).to_h { |index| [ "key-#{index}", nil ] }
+    assert_equal near_limit_hash.length, Values.capture(near_limit_hash).value.length
+
+    impossible_hash = (0...(Values::MAX_NODES / 2)).to_h { |index| [ "key-#{index}", nil ] }
+    encode_calls = 0
+    trace = TracePoint.new(:c_call) do |event|
+      encode_calls += 1 if event.defined_class == String && event.method_id == :encode
+    end
+    trace.enable { assert_raises(Values::Error) { Values.capture(impossible_hash) } }
+    assert_equal 0, encode_calls, "impossible direct cardinality must fail before key encoding"
+
+    nested = nil
+    (Values::MAX_DEPTH + 1).times { nested = [ nested ] }
+    assert_raises(Values::Error) { Values.capture(nested) }
+  end
+
+  def test_allocation_ceiling_is_distinct_from_input_output_node_and_depth_ceilings
+    within = "x" * 50_000
+    Values::MAX_DEPTH.times { within = [ within ] }
+    captured = Values.capture(within)
+    assert_operator captured.canonical_bytes.bytesize, :<, Values::MAX_PROJECTED_BYTES
+
+    over = "x" * 55_000
+    Values::MAX_DEPTH.times { over = [ over ] }
+    assert_raises(Values::Error) { Values.capture(over) }
+  end
+
+  def test_text_safety_projects_only_captured_values
+    captured = Values.capture("prefix secret-token suffix")
+    secret = Values.capture([ "secret-token" ])
+
+    assert_equal "prefix", TextSafety.text(captured.value, limit: 6)
+    assert TextSafety.safe_relative_path?(Values.capture("dir/file.json").value)
+    assert_equal [ "exact-secret:0" ],
+                 TextSafety.secret_findings(captured.value, exact_secrets: secret.value)
+    assert_equal "prefix [REDACTED] suffix",
+                 TextSafety.redact(captured.value, exact_secrets: secret.value, limit: 1_000)
+    unicode = Values.capture("é secret-token suffix").value
+    assert_equal "é [REDACTED] suffix",
+                 TextSafety.redact(unicode, exact_secrets: secret.value, limit: 1_000)
+  end
+
+  def test_text_and_path_limits_are_utf8_safe_and_separator_bounded
+    assert_equal "é", TextSafety.text(Values.capture("éé").value, limit: 3)
+    assert_equal "x" * 4_096, TextSafety.text(Values.capture("x" * 4_096).value, limit: 4_096)
+    assert_raises(TextSafety::Error) do
+      TextSafety.text(Values.capture("x" * 4_097).value, limit: 4_096)
+    end
+    assert_raises(TextSafety::Error) do
+      TextSafety.text(Values.capture("x" * 100_000).value, limit: 4_096)
+    end
+
+    safe = [ "file", "dir/file", "dir/.hidden", "...", ([ "a" ] * 1_000).join("/") ]
+    unsafe = [ "", ".", "..", "/root", "C:/root", "C:root", "~", "~/x", "-rf", "dir//file", "dir/../file",
+               "./file", "dir/", "dir\\file", "nul\0file", "line\nbreak", "tab\tpath", "del\x7Fpath",
+               ([ "a" ] * 2_100).join("/") ]
+    assert safe.all? { |path| TextSafety.safe_relative_path?(Values.capture(path).value) }
+    assert unsafe.none? { |path| TextSafety.safe_relative_path?(Values.capture(path).value) }
+  end
+
+  def test_secret_findings_and_redaction_merge_original_overlaps_at_high_frequency
+    token = "sk-" + "ant-abcdefghijklmnopqrstuvwxyz"
+    text = Values.capture("token=#{token} suffix").value
+    secrets = Values.capture([ "sk-ant-abc", "ant-abcdefghijklmnopqrstuvwxyz" ]).value
+    assert_equal %w[exact-secret:0 exact-secret:1 pattern:anthropic],
+                 TextSafety.secret_findings(text, exact_secrets: secrets)
+    assert_equal "token=[REDACTED] suffix", TextSafety.redact(text, exact_secrets: secrets, limit: 1_000)
+
+    repeated = Values.capture("a" * 4_096).value
+    overlaps = Values.capture(%w[aa aaa aaaa]).value
+    assert_equal "[REDACTED]", TextSafety.redact(repeated, exact_secrets: overlaps, limit: 1_000)
+    assert_equal %w[exact-secret:0 exact-secret:1 exact-secret:2],
+                 TextSafety.secret_findings(repeated, exact_secrets: overlaps)
+
+    multibyte = Values.capture("ééé").value
+    multibyte_overlap = Values.capture([ "éé" ]).value
+    assert_equal [ "exact-secret:0" ], TextSafety.secret_findings(multibyte, exact_secrets: multibyte_overlap)
+    assert_equal "[REDACTED]", TextSafety.redact(multibyte, exact_secrets: multibyte_overlap)
+
+    long_overlaps = Values.capture(Array.new(64, "a" * 2_048)).value
+    assert_equal "[REDACTED]", TextSafety.redact(repeated, exact_secrets: long_overlaps)
+
+    separated = Values.capture("a." * 2_048).value
+    expanded = TextSafety.redact(separated, exact_secrets: Values.capture([ "a" ]).value)
+    assert_operator expanded.bytesize, :<=, TextSafety::MAX_OUTPUT_BYTES
+    assert expanded.valid_encoding?
+  end
+
+  def test_supported_token_patterns_detect_and_redact_to_utf8
+    tokens = {
+      "pattern:openai" => [ "sk-#{"a" * 20}", "sk-proj-#{"b" * 20}" ],
+      "pattern:github-token" => %w[ghp_ ghs_ gho_ ghu_].map { |prefix| "#{prefix}#{"c" * 36}" },
+      "pattern:github-pat" => [ "github_pat_#{"d" * 20}" ]
+    }
+    no_exact_secrets = Values.capture([]).value
+
+    tokens.each do |label, examples|
+      examples.each do |token|
+        text = Values.capture("before #{token} after").value
+        assert_equal [ label ], TextSafety.secret_findings(text, exact_secrets: no_exact_secrets), token
+        redacted = TextSafety.redact(text, exact_secrets: no_exact_secrets)
+        assert_equal "before [REDACTED] after", redacted, token
+        assert_equal Encoding::UTF_8, redacted.encoding, token
+      end
+    end
+  end
+
+  def test_private_key_patterns_redact_complete_and_truncated_envelopes
+    envelopes = [ "PRIVATE KEY", "RSA PRIVATE KEY", "EC PRIVATE KEY", "OPENSSH PRIVATE KEY",
+                  "DSA PRIVATE KEY", "PGP PRIVATE KEY BLOCK" ]
+    no_exact_secrets = Values.capture([]).value
+
+    envelopes.each do |envelope|
+      body = "sensitive-body-#{envelope.delete(" ")}"
+      footer = "-----END #{envelope}-----"
+      complete = Values.capture("before\n-----BEGIN #{envelope}-----\n#{body}\n#{footer}\nafter").value
+      truncated_footer = "-----END #{envelope}"
+      truncated = Values.capture("before\n-----BEGIN #{envelope}-----\n#{body}\n#{truncated_footer}").value
+
+      [ [ complete, "before\n[REDACTED]\nafter" ], [ truncated, "before\n[REDACTED]" ] ].each do |text, expected|
+        assert_equal [ "pattern:private-key" ], TextSafety.secret_findings(text, exact_secrets: no_exact_secrets), envelope
+        redacted = TextSafety.redact(text, exact_secrets: no_exact_secrets)
+        assert_equal expected, redacted, envelope
+        refute_includes redacted, body, envelope
+        refute_includes redacted, "-----END", envelope
+      end
+    end
+  end
+
+  def test_exact_secret_count_and_byte_ceilings_are_exact
+    value = Values.capture("a" * 4_096).value
+    sixty_four = Values.capture(Array.new(64, "a")).value
+    findings = TextSafety.secret_findings(value, exact_secrets: sixty_four)
+    assert_equal 64, findings.length
+    assert_equal "exact-secret:0", findings.first
+    assert_equal "exact-secret:63", findings.last
+
+    sixty_five = Values.capture(Array.new(65, "a")).value
+    assert_raises(TextSafety::Error) { TextSafety.secret_findings(value, exact_secrets: sixty_five) }
+    max_secret = Values.capture([ "a" * 4_096 ]).value
+    assert_equal [ "exact-secret:0" ], TextSafety.secret_findings(value, exact_secrets: max_secret)
+    too_long = Values.capture([ "a" * 4_097 ]).value
+    assert_raises(TextSafety::Error) { TextSafety.secret_findings(value, exact_secrets: too_long) }
+  end
+
+  def test_static_decision_counter_counts_every_budgeted_form
+    fixtures = {
+      conditional: "if flag\n  true\nend\n",
+      modifier: "work if flag\n",
+      case_arm: "case value\nwhen 1\n  true\nend\n",
+      ternary: "flag ? true : false\n",
+      rescue_clause: "begin\n  work\nrescue Error\n  false\nend\n",
+      loop: "while flag\n  work\nend\n",
+      boolean_and: "left && right\n",
+      boolean_or: "left || right\n"
+    }
+
+    fixtures.each do |name, source|
+      assert_equal 1, static_metrics(source).fetch(:decisions), name
+    end
+  end
+
+  def test_production_files_stay_inside_u1a1v_hard_caps
+    caps = {
+      "workflow_creator_values.rb" => { lines: 190, methods: 8, decisions: 22 },
+      "workflow_creator_text_safety.rb" => { lines: 90, methods: 4, decisions: 10 }
+    }
+    observed = caps.to_h do |name, limits|
+      source = File.read(File.join(ROOT, "packaging", "live_agent_skills", name))
+      metrics = static_metrics(source).merge(lines: source.lines.length)
+      limits.each { |metric, limit| assert_operator metrics.fetch(metric), :<=, limit, "#{name} #{metric}" }
+      [ name, metrics ]
+    end
+    totals = observed.values.each_with_object(Hash.new(0)) do |metrics, sum|
+      metrics.each { |metric, value| sum[metric] += value }
+    end
+    { lines: 280, methods: 12, decisions: 32 }.each do |metric, limit|
+      assert_operator totals.fetch(metric), :<=, limit, "aggregate #{metric}"
+    end
+  end
+
+  private
+
+  def assert_deeply_frozen(value)
+    assert value.frozen?
+    value.each { |key, nested| assert_deeply_frozen(key); assert_deeply_frozen(nested) } if value.instance_of?(Hash)
+    value.each { |nested| assert_deeply_frozen(nested) } if value.instance_of?(Array)
+  end
+
+  def property_value(random, depth = 0)
+    strings = [ "", "plain", "quote=\" slash=\\ control=\0\n", "é😀" ]
+    floats = [ 0.0, -0.0, 1e20, 1e-6, 1e-7, 3.141592653589793 ]
+    scalars = [ nil, true, false, random.rand(-1_000_000..1_000_000),
+                floats.fetch(random.rand(floats.length)), strings.fetch(random.rand(strings.length)) ]
+    return scalars.fetch(random.rand(scalars.length)) if depth >= 3 || random.rand(3).zero?
+
+    return Array.new(random.rand(5)) { property_value(random, depth + 1) } if random.rand(2).zero?
+
+    Array.new(random.rand(5)) do |index|
+      [ "k#{depth}-#{index}-#{random.rand(1_000_000)}", property_value(random, depth + 1) ]
+    end.to_h
+  end
+
+  def static_metrics(source)
+    syntax = Ripper.sexp(source) or raise "invalid Ruby fixture"
+    counts = { methods: 0, decisions: 0 }
+    walk = lambda do |node|
+      next unless node.instance_of?(Array)
+      type = node.first
+      counts[:methods] += 1 if %i[def defs].include?(type)
+      counts[:decisions] += 1 if DECISION_NODES.include?(type)
+      counts[:decisions] += 1 if type == :binary && %i[&& ||].include?(node[2])
+      node.each { |child| walk.call(child) }
+    end
+    walk.call(syntax)
+    counts
+  end
+end

--- a/wiki/component-boundaries.md
+++ b/wiki/component-boundaries.md
@@ -173,19 +173,28 @@ than component-owned state. Both the Agent ABI and Artifact Firewall use it for
 bounded diagnostics, while the firewall also accepts an injected redactor.
 
 `HiveLiveAgentProof::WorkflowCreator::Values` is a packaging-owned leaf
-candidate. It captures the core operations it needs at load, imports exact
+candidate. It captures the core operations it needs at load and seals each
+bound or unbound operation behind an object-local invocation alias before the
+component is frozen, so later replacement of generic `call` or `bind_call`
+dispatch cannot redirect the importer. It imports exact
 JSON-shaped Ruby values into fresh recursively frozen containers and strings,
 rejects cycles, type subclasses, ambiguous binary encodings, normalized-key
 collisions, non-finite numbers, impossible direct hash cardinality, and
 resource overruns, and emits sorted pretty UTF-8 JSON bytes with one trailing
-newline. `Values.capture` is the sole ordinary `Snapshot` factory: alternate
-`Data` constructors and copy/update APIs are non-public. Collision admission
+newline. Snapshot allocation and `Data` initialization are captured
+separately, scalar canonical tokens come from a sealed JSON generator leaf,
+and rejected values expose one cause-free typed error. `Values.capture` is the
+sole ordinary `Snapshot` factory: alternate constructors and copy/update APIs
+are non-public, and snapshots reject Marshal transport. Collision admission
 uses a bounded linear index, while `WorkflowCreator::TextSafety` records
 overlapping exact-secret and token matches into one fixed-size difference mask
-before emitting merged UTF-8 redactions. Exact-secret searches use byte copies
-so multibyte overlaps cannot split a character boundary; complete and
-truncated PEM envelopes redact through their body, and relative paths reject
-root-expanding, option-like, and control-byte forms.
+before emitting merged UTF-8 redactions. Exact-secret searches deduplicate
+equal byte needles before scanning, retain every original finding label, and
+use byte copies so multibyte overlaps cannot split a character boundary; complete and
+truncated PEM envelopes, including encrypted PKCS#8 keys, redact through their
+body, and relative paths reject root-expanding, option-like, and control-byte
+forms. Text projections use the same sealed-operation discipline and normalize
+their public rejection surface to a cause-free typed error.
 The boundary owns no creator vocabulary or schema, retained evidence,
 mutation, recovery, process, credential, provider, or live behavior. Pre-load
 core mutation is explicitly outside this same-process boundary; captured

--- a/wiki/component-boundaries.md
+++ b/wiki/component-boundaries.md
@@ -3,7 +3,7 @@ title: Component boundaries
 type: reference
 source: config/component-boundaries.yml, test/support/component_boundary_contract.rb
 created: 2026-07-25
-updated: 2026-07-30
+updated: 2026-08-02
 tags: [architecture, components, boundaries, monorepo]
 ---
 
@@ -19,6 +19,7 @@ the first and primary consumer.
 |-----------|-------|---------------------|-------------------|
 | Patrol Effect Evidence | `candidate` (U3 qualification pending) | `require "hive/modules/migration/patrol_evidence"` → `Hive::Modules::Migration::PatrolEvidence` | [[modules/patrol]] |
 | Attempts admission / future RunReceipt | `candidate` (guarded reference) | `require "hive/attempts/api"` → `Hive::Attempts::API` | [[modules/attempts]] |
+| Workflow Creator Values | `candidate` (U1a1c consumer pending) | `require "packaging/live_agent_skills/workflow_creator_values"` → `HiveLiveAgentProof::WorkflowCreator::Values` | [[component-boundaries]] |
 | UserService | `boundary-ready` | `require "hive/user_service"` → `Hive::UserService` | [[modules/user_service]] |
 | Agent ABI | `boundary-ready`; standalone package candidate | `require "hive/agent_runtime"` → `Hive::AgentRuntime` | [[modules/agent_cli_runtime]], [[modules/agent_profile]] |
 | Agent Artifact Firewall | `boundary-ready` | `require "hive/artifact_firewall"` → `Hive::ArtifactFirewall` | [[modules/protected_files]] |
@@ -34,13 +35,15 @@ has earned a gem, version, repository, or release.
 
 ## Final graph audit
 
-The final U2 resolution on 2026-07-29 retains eight components: six are
-`boundary-ready`; Attempts and Patrol Effect Evidence remain `candidate`.
-Patrol retains one bounded U3 exception for compressed evidence qualification
-and cutover proof. Every retained entry point has a focused clean-process load
-proof, every catalog-owned path and focused test resolves inside this
-repository, and the direct-construction guards pass against all production
-Ruby sources.
+The catalog currently retains nine components: six are `boundary-ready`;
+Attempts, Patrol Effect Evidence, and Workflow Creator Values remain
+`candidate`. Patrol retains a bounded U3 exception for compressed evidence
+qualification and cutover proof. Workflow Creator Values retains the sole
+zero-consumer staged-prerequisite exception, removed by U1a1c when that unit
+becomes its first production consumer. Every retained entry point has a
+focused clean-process load proof, every catalog-owned path and focused test
+resolves inside this repository, and the direct-construction guards pass
+against all production Ruby sources.
 
 The component dependency graph has one edge:
 
@@ -49,18 +52,20 @@ flowchart LR
   skillpack[Skillpack] --> agent_abi[Agent ABI]
   patrol_effects[Patrol Effect Evidence - candidate]
   attempts[Attempts admission - candidate]
+  creator_values[Workflow Creator Values - candidate]
   user_service[UserService]
   artifact_firewall[Agent Artifact Firewall]
   git_gate[Safe Agent Git Gate]
   work_ledger[WorkLedger]
 ```
 
-All other cataloged components depend only on explicitly allowed lower-level
-Hive primitives. The source audit found no retained experimental facade outside
-the catalog: each promoted facade is owned by a catalog row and used by Hive,
-while Attempts and Patrol Effect Evidence are deliberately retained as guarded
-candidates rather than being promoted ahead of their remaining lifecycle or
-qualification proof.
+All other cataloged components have no component dependency. The source audit
+found no retained experimental facade outside the catalog: each promoted
+facade is owned by a catalog row and used by Hive, while Attempts and Patrol
+Effect Evidence remain guarded pending lifecycle or qualification proof.
+Workflow Creator Values is the one explicitly staged exception: it has no
+production consumer until U1a1c and is program-incomplete if that successor is
+abandoned.
 
 This is an internal architecture verdict, not a packaging verdict. None of the
 six ready components currently has the named non-Hive adopter and independent
@@ -166,6 +171,26 @@ transaction, or the Safe Agent Git Gate.
 `Hive::SecretPatterns` remains shared lower-level Hive infrastructure rather
 than component-owned state. Both the Agent ABI and Artifact Firewall use it for
 bounded diagnostics, while the firewall also accepts an injected redactor.
+
+`HiveLiveAgentProof::WorkflowCreator::Values` is a packaging-owned leaf
+candidate. It captures the core operations it needs at load, imports exact
+JSON-shaped Ruby values into fresh recursively frozen containers and strings,
+rejects cycles, type subclasses, ambiguous binary encodings, normalized-key
+collisions, non-finite numbers, impossible direct hash cardinality, and
+resource overruns, and emits sorted pretty UTF-8 JSON bytes with one trailing
+newline. `Values.capture` is the sole ordinary `Snapshot` factory: alternate
+`Data` constructors and copy/update APIs are non-public. Collision admission
+uses a bounded linear index, while `WorkflowCreator::TextSafety` records
+overlapping exact-secret and token matches into one fixed-size difference mask
+before emitting merged UTF-8 redactions. Exact-secret searches use byte copies
+so multibyte overlaps cannot split a character boundary; complete and
+truncated PEM envelopes redact through their body, and relative paths reject
+root-expanding, option-like, and control-byte forms.
+The boundary owns no creator vocabulary or schema, retained evidence,
+mutation, recovery, process, credential, provider, or live behavior. Pre-load
+core mutation is explicitly outside this same-process boundary; captured
+allocation, initialization, traversal, and projection operations prevent later
+replacement from redirecting import dispatch.
 
 The package-only extraction lives at `components/agent-cli-runtime/` and
 publishes the neutral `AgentCliRuntime` namespace plus the bounded

--- a/wiki/gaps.md
+++ b/wiki/gaps.md
@@ -122,14 +122,17 @@ tags: [gap, todo, release-proof, agent-skills]
 
 ## Internal component boundary gap
 
-- The final internal graph audit retains eight catalog rows: UserService, Agent
+- The current internal graph retains nine catalog rows: UserService, Agent
   ABI, Agent Artifact Firewall, Skillpack, Safe Agent Git Gate, and WorkLedger
-  are `boundary-ready`; Attempts admission and Patrol Effect Evidence remain
-  `candidate`. Skillpack to Agent ABI is the only component dependency. Patrol
-  retains one bounded U3 exception for compressed candidate evidence and
-  production qualification; Attempts remains unready because Hive has no
-  demonstrated need for a supported reconciliation, supervision, capacity,
-  loss-processing, cancellation, export, or raw-store lifecycle API.
+  are `boundary-ready`; Attempts admission, Patrol Effect Evidence, and
+  Workflow Creator Values remain `candidate`. Skillpack to Agent ABI is the
+  only component dependency. Patrol retains a bounded U3 exception for
+  compressed candidate evidence and production qualification. Workflow Creator
+  Values is a zero-consumer staged prerequisite with one U1a1c removal fence;
+  it must be consumed and promoted by that immediate successor or removed.
+  Attempts remains unready because Hive has no demonstrated need for a
+  supported reconciliation, supervision, capacity, loss-processing,
+  cancellation, export, or raw-store lifecycle API.
 - No ready component has yet earned standalone packaging. There is no named
   non-Hive adopter, independently installed component artifact, separate
   compatibility promise, or explicit release decision. Those proofs belong to

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -3,7 +3,7 @@ title: hive Wiki
 type: index
 source: wiki/**/*.md
 created: 2026-05-14
-updated: 2026-07-30
+updated: 2026-08-02
 tags: [index, wiki]
 ---
 
@@ -14,18 +14,20 @@ proof, while built-in content/bench, installable Honeycomb, and owner-authored
 workflows use the same folder-backed execution model.
 
 Page count: 98
-Updated: 2026-07-30
+Updated: 2026-08-02
 
 Folder-as-agent workflow engine: a Ruby 3.4 / Thor CLI control plane where descriptor-backed workflows move task folders through filesystem stages, stage agents compile provider-neutral invocations through `Hive::AgentRuntime` and configurable AgentProfile adapters (`claude` default, `codex`, `pi`, `grok`), and `mv` between directories remains the approval primitive. The built-in `coding` workflow drives the nine-stage PR pipeline (`1-inbox` → `2-brainstorm` → `3-plan` → `4-execute` → `5-open-pr` → `6-review` → `7-artifacts` → `8-finalize` → `9-done`), while the built-in `content` and `bench` workflows and project-authored workflows share the same generic runner/status/action machinery. Agent operation is centered on the additive operational status contract, coherent daemon scheduler snapshots, bounded semantic `hive watch`, tokenized routine `hive act`, and stable-ID semantic E2E profiles; the legacy full JSON graph remains compatible. Hive packages one canonical operating skill projected to OpenClaw `/hive`, Claude `/hive`, Codex `$hive`, and Pi `/skill:hive`, with read-only `hive doctor`, consent-safe setup, deterministic trusted pre-release proof, and optional four-agent live diagnostics.
 
 Reusable mechanisms remain in this monorepo behind the canonical
-[[component-boundaries]] catalog. The final internal graph has six
+[[component-boundaries]] catalog. The current internal graph has six
 `boundary-ready` facades—UserService, Agent ABI, Agent Artifact Firewall,
-Skillpack, Safe Agent Git Gate, and WorkLedger—and one guarded `candidate`,
-Attempts admission. Skillpack's downward dependency on the Agent ABI is the
-only component-to-component edge; no migration exceptions remain. Hive is the
-first and primary consumer, and internal readiness does not imply a gem,
-version, repository, or release.
+Skillpack, Safe Agent Git Gate, and WorkLedger—and three guarded candidates:
+Attempts admission, Patrol Effect Evidence, and the zero-consumer Workflow
+Creator Values staged prerequisite. Skillpack's downward dependency on the
+Agent ABI is the only component-to-component edge. Patrol retains its U3
+qualification fence and Workflow Creator Values retains its U1a1c consumer
+fence. Internal readiness does not imply a gem, version, repository, or
+release.
 
 Agent spawns that own controller artifacts use the boundary-ready
 `Hive::ArtifactFirewall` for same-user protected-anchor custody, required

--- a/wiki/log.d/20260802T214142Z-workflow-creator-values.md
+++ b/wiki/log.d/20260802T214142Z-workflow-creator-values.md
@@ -1,0 +1,23 @@
+# 2026-08-02 — Bound workflow-creator values
+
+- Added a packaging-owned candidate that copies hostile JSON-shaped Ruby
+  graphs through load-captured core operations into fresh recursively frozen
+  snapshots and sorted UTF-8 canonical bytes. Alternate `Data` factories are
+  non-public, so `Values.capture` remains the sole ordinary snapshot factory.
+- Added bounded text, relative-path, exact-secret, and token-pattern
+  projections over snapshot-owned values; collision checks are linear and
+  overlapping redactions use one fixed-size difference mask instead of
+  rescanning or filling every matched span. Multibyte exact-secret overlaps are
+  searched through byte-semantic copies; complete and truncated PEM bodies are
+  fully redacted, and unsafe tilde, option-like, and control-byte paths fail.
+- Added deterministic canonical-property, direct/module/refinement dispatch,
+  post-load core replacement, exact resource boundary, and high-frequency
+  secret proofs. Impossible direct Hash cardinality now fails before any key
+  encoding, ambiguous `ASCII-8BIT` input fails closed, and captured allocation
+  plus initialization resists post-load constructor replacement.
+- Registered the zero-consumer U1a1v staged prerequisite with its single
+  `U1a1c` removal fence and candidate clean-load proof. Catalog validation now
+  permits zero consumers only for such a fenced candidate, while focused graph
+  proof pins it as the sole current exception. Clean-load proof exposes the
+  repository root only to non-`lib` entrypoints; creator schemas, consumers,
+  custody, mutation, process, and live behavior remain unchanged.

--- a/wiki/log.d/20260802T214142Z-workflow-creator-values.md
+++ b/wiki/log.d/20260802T214142Z-workflow-creator-values.md
@@ -7,14 +7,25 @@
 - Added bounded text, relative-path, exact-secret, and token-pattern
   projections over snapshot-owned values; collision checks are linear and
   overlapping redactions use one fixed-size difference mask instead of
-  rescanning or filling every matched span. Multibyte exact-secret overlaps are
-  searched through byte-semantic copies; complete and truncated PEM bodies are
-  fully redacted, and unsafe tilde, option-like, and control-byte paths fail.
+  filling every matched span. Equal exact-secret byte needles are scanned once
+  while retaining every original finding label; multibyte overlaps use
+  byte-semantic copies. Complete and truncated PEM bodies are fully redacted,
+  and unsafe tilde, option-like, and control-byte paths fail.
 - Added deterministic canonical-property, direct/module/refinement dispatch,
   post-load core replacement, exact resource boundary, and high-frequency
   secret proofs. Impossible direct Hash cardinality now fails before any key
   encoding, ambiguous `ASCII-8BIT` input fails closed, and captured allocation
   plus initialization resists post-load constructor replacement.
+- Sealed every captured bound and unbound operation behind its own frozen
+  invocation alias, captured `Data` initialization and the JSON scalar
+  generator as leaf operations, made construction handles private, and denied
+  Snapshot Marshal transport. Rejections now suppress secret-bearing causes,
+  TextSafety normalizes its four public error surfaces, and encrypted PKCS#8
+  private-key envelopes are covered alongside the existing PEM forms.
+- Isolated adversarial child processes from inherited coverage and Ruby startup
+  instrumentation. Post-load operation poisoning now proves the product path
+  without letting the coverage reporter execute through deliberately replaced
+  core methods during child teardown.
 - Registered the zero-consumer U1a1v staged prerequisite with its single
   `U1a1c` removal fence and candidate clean-load proof. Catalog validation now
   permits zero consumers only for such a fenced candidate, while focused graph

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -127,8 +127,17 @@ bundle exec ruby -Itest -Ilib test/unit/component_boundaries_test.rb
 
 Ready components cannot depend on candidates. Forbidden-construction rules
 also apply to guarded candidates, and the helper can run a named focused
-clean-load proof for a candidate such as Attempts without representing the
-whole component graph as ready.
+clean-load proof for a candidate such as Attempts or Workflow Creator Values
+without representing the whole component graph as ready. Candidate migration
+units accept nested plan identifiers such as `U1a1c`; malformed or free-form
+labels still fail catalog validation. An empty `hive_consumers` list is valid
+only for a `candidate` that also carries a non-empty bounded migration
+exception; boundary-ready and unfenced candidate rows must name a real Hive
+consumer. The current graph also pins Workflow Creator Values as the sole
+zero-consumer row, so the staged exception cannot spread to another candidate.
+Clean-load subprocesses expose the repository root only to catalog entrypoints
+outside `lib/`; ordinary `lib` components retain the production-like `-Ilib`
+surface and cannot silently import root-owned packaging code.
 
 The helper uses Ruby syntax rather than comments or string examples for literal
 `require`, `require_relative`, and `Constant.new` checks. It remains an


### PR DESCRIPTION
## Summary

- **This draft is frozen and will not be merged.** It proved useful hostile-value import and bounded projection behavior, but exact-head Review 02 found that the combined boundary reached its old size ceiling through complexity compression while still failing Snapshot ownership and supported clean-Ruby loading.
- The replacement is now two independently reviewable successors: U1a1vi owns immutable hostile-value import and canonical bytes; U1a1vt later owns bounded text/path/secret projection. Each starts from refreshed merged main and inherits the complete finding history rather than treating this branch as a base.
- PR #924 remains open only as append-only evidence and a selective code donor. There will be no Resolution 02, in-place repair, rebase, merge, release, publication, deployment, or live activation from this branch.

## Test plan

- [x] Local bundled Values/TextSafety proof: 29 runs, 494 assertions, 0 failures/errors/skips.
- [x] Local component boundaries: 35 runs, 522 assertions, 0 failures/errors/skips.
- [x] Local bundled broad checkpoint: 11,735 runs, 151,848 assertions, 0 failures/errors, 8 expected skips.
- [x] Project-config RuboCop 1.88.2: 3 changed Ruby files, no offenses; `git diff --check` passed.
- [ ] Required R43 metrics: `import_hash` ABC 37.79/25 and `build_collection` ABC 25.1/25; 2 offenses, exit 1.
- [ ] Clean standard-Ruby load: fails at private `JSON::State._generate_no_fallback` capture.
- [ ] Hosted exact-head CI: 20 checks green / 2 red; the suite has 4 clean-load failures.
- [ ] Clean final review: Review 02 retains 3 P1 and 2 P2 actionable findings.

## Notes for reviewer

- Exact base: `c470e343161b2158a30fad97768c799683f3cae1`; exact frozen head: `feb32bc8c3a374cc10a42524e511551f4e974727`.
- Review 02: https://github.com/ivankuznetsov/hive/pull/924#issuecomment-5162056235.
- Blocked / re-scope checkpoint: https://github.com/ivankuznetsov/hive/pull/924#issuecomment-5162235816.
- Audited plan amendment: https://github.com/ivankuznetsov/hive/pull/924#issuecomment-5162241350, plan SHA-256 `596165f6113a52836f451fabe0fa9cc000327cd1b7e04be28f60035b2b3742e9`.
- Reopened P1 `U1A1V-R01-COR-001`: a supplied Marshal payload reconstructs a frozen outer Snapshot with mutable nested fields.
- Open P1 `U1A1V-R02-REL-001`: the component does not clean-load against stock Ruby/json.
- Open P1 `U1A1V-R02-ARCH-002`: the repository RuboCop configuration disables the R43 metric cops, while the exact required configuration fails. U1a1vi must prove its import half; U1a1vt is the sole final closer after exact combined metrics pass.
- Open P2s `U1A1V-R02-COR-001` and `U1A1V-R02-TEST-001`: public Snapshot copy paths contradict the documented factory claim, and three TextSafety privacy assertions name constants that never exist.
- Same-process reflection remains outside KTD18; the successor does not turn this leaf into a Ruby sandbox. PR #921 and this branch remain evidence/code donors, never successor bases.

Session-settled decisions carried from planning: KTD3 (user-directed one U-ID per PR); KTD16, KTD18, and KTD19 (user-authorized R11 re-scope into the U1a1vi → U1a1vt chain and owned immutable snapshots rather than another compressed repair).

## Related

Related: #921

## New concepts

### Sealed load-captured operations

Ruby normally resolves `call` and `bind_call` when they execute. Capturing an `UnboundMethod` alone therefore does not help if that generic invocation method is replaced later.

This boundary gives every captured operation its own invocation alias before freezing it:

```ruby
# Invoke the operation through the alias captured with that object.
operation.singleton_class.alias_method(:__invoke__, :bind_call)
operation.freeze
operation.__invoke__(owned_value)
```

The technique fits a small, security-sensitive leaf boundary that must avoid caller dispatch. It is not a Ruby sandbox and should not be used as a substitute for process isolation or executable custody.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
