### PR TITLE
fix(web): harden project capture provider custody

### DIFF
--- a/lib/hive.rb
+++ b/lib/hive.rb
@@ -8,6 +8,10 @@ module Hive
   # One place to change on a repository rename.
   REPO_OWNER = "ivankuznetsov".freeze
   REPO_NAME = "hive".freeze
+  ARTIFACT_CAPTURE_MANIFEST_MAX_BYTES = 256 * 1024
+  ARTIFACT_CAPTURE_MANIFEST_PRODUCER_MAX_BYTES = 240 * 1024
+  PROJECT_CAPTURE_PROVIDER_MAX_COMMAND_BYTES = 16 * 1024
+  PROJECT_CAPTURE_PROVIDER_MAX_EVIDENCE_BYTES = 64 * 1024
 
   module Schemas
     # JSON schema versions for the agent-callable contracts emitted by the
@@ -28,7 +32,7 @@ module Hive
       "hive-web-install" => 1,
       "hive-capture-requirement" => 1,
       "hive-web-capture-runtime" => 1,
-      "hive-artifact-capture" => 1,
+      "hive-artifact-capture" => 2,
       "hive-doctor" => 2,
       "hive-status-diagnose" => 2,
       "hive-run" => 2,

--- a/lib/hive/artifacts/capture_policy.rb
+++ b/lib/hive/artifacts/capture_policy.rb
@@ -23,7 +23,7 @@ module Hive
       SCHEMA_VERSION = 1
       CLASSIFIER_VERSION = "visual-paths-v1".freeze
       FILE_NAME = "capture-requirement.json".freeze
-      CAPTURE_MANIFEST_MAX_BYTES = 256 * 1024
+      CAPTURE_MANIFEST_MAX_BYTES = Hive::ARTIFACT_CAPTURE_MANIFEST_MAX_BYTES
       CAPTURE_MEDIA_FILE = /\A[\w.-]+\.(?:png|jpe?g|gif|webp|webm|mp4)\z/i
       VISUAL_PATH = %r{
         \A(?:
@@ -236,30 +236,63 @@ module Hive
       end
 
       def valid_capture_manifest?(manifest, receipt)
-        return false unless capture_manifest_schemer.valid?(manifest)
+        return false unless manifest.is_a?(Hash)
+
+        version = Integer(manifest["schema_version"], exception: false)
+        return false unless [ 1, 2 ].include?(version)
+        return false unless capture_manifest_schemer(version).valid?(manifest)
         return false unless manifest["status"] == "captured"
         return false unless manifest["task"].to_s == @task.slug.to_s
         return false unless manifest["source_sha"].to_s == receipt["implementation_head"].to_s
-        return false unless manifest["environment_keys"] ==
-                            Hive::Web::CaptureRuntime::DISCLOSED_ENV_KEYS.sort
-        return false if Array(manifest["command"]).empty?
-        return false if Array(manifest["fixture_ids"]).empty?
-        return false if Array(manifest["accessibility_assertions"]).empty?
         return false unless manifest["diagnostic"].nil?
         return false unless manifest["cleanup"] == {
           "port" => "released", "processes" => "clean", "runtime" => "cleaned"
         }
         return false unless valid_capture_times?(manifest)
         return false if Hive::SecretPatterns.match?(JSON.generate(manifest))
+        evidence_valid = if version == 1
+          valid_v1_capture_evidence?(manifest)
+        else
+          valid_v2_capture_evidence?(manifest)
+        end
+        return false unless evidence_valid
 
         artifacts = Array(manifest["artifacts"])
         artifacts.any? && artifacts.all? { |artifact| valid_capture_artifact?(artifact) }
       end
 
-      def capture_manifest_schemer
-        @capture_manifest_schemer ||= JSONSchemer.schema(
-          Pathname.new(Hive::Schemas.schema_path("hive-artifact-capture"))
+      def capture_manifest_schemer(version)
+        @capture_manifest_schemers ||= {}
+        @capture_manifest_schemers[version] ||= JSONSchemer.schema(
+          Pathname.new(Hive::Schemas.schema_path("hive-artifact-capture", version: version))
         )
+      end
+
+      def valid_v1_capture_evidence?(manifest)
+        manifest["environment_keys"] == Hive::Web::CaptureRuntime::DISCLOSED_ENV_KEYS.sort &&
+          !Array(manifest["command"]).empty? &&
+          !Array(manifest["fixture_ids"]).empty? &&
+          !Array(manifest["accessibility_assertions"]).empty?
+      end
+
+      def valid_v2_capture_evidence?(manifest)
+        recorder = manifest["recorder"]
+        evidence = manifest["evidence"]
+        return false unless recorder.is_a?(Hash) && evidence.is_a?(Hash)
+        return false if Array(recorder["command"]).empty?
+        return false if Array(manifest["environment_keys"]).empty?
+
+        case recorder["kind"]
+        when "built_in"
+          evidence["type"] == "hivebox" &&
+            manifest["environment_keys"] == Hive::Web::CaptureRuntime::DISCLOSED_ENV_KEYS.sort &&
+            !Array(evidence["fixture_ids"]).empty? &&
+            !Array(evidence["accessibility_assertions"]).empty?
+        when "project_provider"
+          evidence["type"] == "project_provider" && evidence["details"].is_a?(Hash)
+        else
+          false
+        end
       end
 
       def valid_capture_times?(manifest)

--- a/lib/hive/config.rb
+++ b/lib/hive/config.rb
@@ -118,7 +118,10 @@ module Hive
         "stages" => {}
       },
       "open_pr" => {},
-      "artifacts" => { "agent" => "claude" },
+      "artifacts" => {
+        "agent" => "claude",
+        "capture" => { "provider" => nil }
+      },
       "finalize" => { "agent" => "claude" },
       # Per-CLI agent profiles. Each project may override `bin`,
       # `env_override`, or `min_version` to pin to a different binary or
@@ -2042,6 +2045,7 @@ module Hive
       validate_review_attempts!(cfg, source_path)
       validate_attempt_timers!(cfg, source_path)
       validate_conditions!(cfg, source_path)
+      validate_artifact_capture!(cfg, source_path)
       validate_daemon!(cfg, source_path)
       validate_web_config!(cfg, source_path)
       validate_screenote!(cfg, source_path)
@@ -2300,6 +2304,74 @@ module Hive
           raise ConfigError, "conditions.stages.#{stage} in #{describe_source(source_path)}: #{e.message}"
         end
       end
+    end
+
+    def validate_artifact_capture!(cfg, source_path)
+      capture = cfg.dig("artifacts", "capture")
+      unless capture.is_a?(Hash)
+        raise ConfigError,
+              "artifacts.capture in #{describe_source(source_path)} must be a Hash; " \
+              "got #{capture.inspect} (#{capture.class})"
+      end
+
+      unknown_capture = capture.keys - %w[provider]
+      unless unknown_capture.empty?
+        raise ConfigError,
+              "artifacts.capture in #{describe_source(source_path)} has unknown keys: " \
+              "#{unknown_capture.map(&:inspect).sort.join(', ')}"
+      end
+
+      provider = capture["provider"]
+      return if provider.nil?
+
+      unless provider.is_a?(Hash)
+        raise ConfigError,
+              "artifacts.capture.provider in #{describe_source(source_path)} must be a Hash or nil; " \
+              "got #{provider.inspect} (#{provider.class})"
+      end
+
+      unknown_provider = provider.keys - %w[name command timeout_sec]
+      unless unknown_provider.empty?
+        raise ConfigError,
+              "artifacts.capture.provider in #{describe_source(source_path)} has unknown keys: " \
+              "#{unknown_provider.map(&:inspect).sort.join(', ')}"
+      end
+
+      name = provider["name"]
+      unless name.is_a?(String) && name.match?(/\A[a-z][a-z0-9_-]{0,63}\z/)
+        raise ConfigError,
+              "artifacts.capture.provider.name in #{describe_source(source_path)} must match " \
+              "[a-z][a-z0-9_-]{0,63}"
+      end
+
+      command = provider["command"]
+      unless command.is_a?(Array) && command.length.between?(1, 32) &&
+             command.all? { |part| part.is_a?(String) && !part.empty? && part.bytesize <= 4096 && !part.include?("\0") }
+        raise ConfigError,
+              "artifacts.capture.provider.command in #{describe_source(source_path)} must be an " \
+              "Array of 1..32 non-empty String argv values"
+      end
+      command_bytes = command.sum { |part| part.bytesize + 1 }
+      if command_bytes > Hive::PROJECT_CAPTURE_PROVIDER_MAX_COMMAND_BYTES
+        raise ConfigError,
+              "artifacts.capture.provider.command total argv in #{describe_source(source_path)} " \
+              "must not exceed #{Hive::PROJECT_CAPTURE_PROVIDER_MAX_COMMAND_BYTES} bytes"
+      end
+      executable = command.first.tr("\\", "/")
+      segments = executable.split("/", -1)
+      if executable.start_with?("/") || executable.match?(/\A[A-Za-z]:\//) ||
+         segments.any? { |segment| segment.empty? || segment == "." || segment == ".." }
+        raise ConfigError,
+              "artifacts.capture.provider.command[0] in #{describe_source(source_path)} must be a " \
+              "project-relative executable path without traversal"
+      end
+
+      timeout = provider.fetch("timeout_sec", 120)
+      return if timeout.is_a?(Integer) && timeout.between?(1, 600)
+
+      raise ConfigError,
+            "artifacts.capture.provider.timeout_sec in #{describe_source(source_path)} must be an " \
+            "integer between 1 and 600"
     end
 
     def validate_stage_skill_by_agent!(cfg, source_path)

--- a/lib/hive/web/capture_runtime.rb
+++ b/lib/hive/web/capture_runtime.rb
@@ -22,7 +22,7 @@ module Hive
       SCHEMA = "hive-web-capture-runtime".freeze
       SCHEMA_VERSION = 1
       ARTIFACT_SCHEMA = "hive-artifact-capture".freeze
-      ARTIFACT_SCHEMA_VERSION = 1
+      ARTIFACT_SCHEMA_VERSION = 2
       BIND = "127.0.0.1".freeze
       READY_TIMEOUT_SEC = 60
       CLEANUP_TIMEOUT_SEC = 5
@@ -195,45 +195,64 @@ module Hive
         raise OwnershipError, "refusing stale capture cleanup: lifecycle receipt is invalid"
       end
 
-      def capture_manifest(task:, source_sha:, lock_digests:, cache_key:, command:,
-                           fixture_ids:, media_paths:, status:, cleanup:,
+      def capture_manifest(task:, source_sha:, status:, cleanup:,
+                           recorder: nil, environment_keys: nil, evidence: nil,
+                           media_paths: [], artifacts: nil,
+                           lock_digests: nil, cache_key: nil, command: nil,
+                           fixture_ids: [],
                            viewport: { "width" => 1280, "height" => 800 },
                            accessibility_assertions: [], diagnostic: nil,
                            started_at: nil, finished_at: nil)
         now = @clock.call
         started_at ||= now
         finished_at ||= now
-        artifacts = Array(media_paths).sort_by { |path| File.basename(path) }.map do |path|
+        artifact_records = artifacts || Array(media_paths).sort_by { |path| File.basename(path) }.map do |path|
           {
             "file" => File.basename(path),
             "bytes" => File.size(path),
             "sha256" => ::Digest::SHA256.file(path).hexdigest
           }
         end
+        recorder ||= {
+          "kind" => "built_in",
+          "name" => "hivebox",
+          "command" => Array(command).map(&:to_s)
+        }
+        evidence ||= {
+          "type" => "hivebox",
+          "lock_digests" => lock_digests.to_h.sort.to_h,
+          "cache_key" => cache_key.to_s,
+          "fixture_ids" => Array(fixture_ids).map(&:to_s).sort,
+          "viewport" => viewport.to_h.sort.to_h,
+          "accessibility_assertions" => Array(accessibility_assertions).map(&:to_s).sort
+        }
         {
           "schema" => ARTIFACT_SCHEMA,
           "schema_version" => ARTIFACT_SCHEMA_VERSION,
           "status" => status.to_s,
           "task" => task.to_s,
           "source_sha" => source_sha.to_s,
-          "lock_digests" => lock_digests.to_h.sort.to_h,
-          "cache_key" => cache_key.to_s,
-          "command" => Array(command).map(&:to_s),
-          "environment_keys" => DISCLOSED_ENV_KEYS.sort,
-          "fixture_ids" => Array(fixture_ids).map(&:to_s).sort,
+          "recorder" => recorder.to_h,
+          "environment_keys" => Array(environment_keys || DISCLOSED_ENV_KEYS).map(&:to_s).sort,
           "started_at" => iso_time(started_at),
           "finished_at" => iso_time(finished_at),
-          "viewport" => viewport.to_h.sort.to_h,
-          "accessibility_assertions" => Array(accessibility_assertions).map(&:to_s).sort,
-          "artifacts" => artifacts,
+          "artifacts" => Array(artifact_records).map do |artifact|
+            artifact.to_h.slice("file", "bytes", "sha256")
+          end.sort_by { |artifact| artifact.fetch("file") },
           "cleanup" => cleanup.to_h.sort.to_h,
-          "diagnostic" => redacted(diagnostic)
+          "diagnostic" => redacted(diagnostic),
+          "evidence" => evidence.to_h
         }
       end
 
       def publish_manifest!(task_folder:, manifest:)
         media_root = File.join(File.expand_path(task_folder), "media")
         FileUtils.mkdir_p(media_root, mode: 0o700)
+        bytes = JSON.generate(manifest).bytesize + 1
+        if bytes > Hive::ARTIFACT_CAPTURE_MANIFEST_MAX_BYTES
+          raise OwnershipError,
+                "capture manifest exceeds the shared #{Hive::ARTIFACT_CAPTURE_MANIFEST_MAX_BYTES}-byte consumer ceiling"
+        end
         write_json_atomic(
           File.join(media_root, "capture-manifest.json"),
           manifest

--- a/lib/hive/web/capture_runtime.rb
+++ b/lib/hive/web/capture_runtime.rb
@@ -226,6 +226,12 @@ module Hive
           "viewport" => viewport.to_h.sort.to_h,
           "accessibility_assertions" => Array(accessibility_assertions).map(&:to_s).sort
         }
+        disclosed_environment_keys =
+          Array(environment_keys || DISCLOSED_ENV_KEYS).map(&:to_s).sort
+        if disclosed_environment_keys.empty?
+          raise OwnershipError,
+                "capture manifest environment_keys must contain at least one key"
+        end
         {
           "schema" => ARTIFACT_SCHEMA,
           "schema_version" => ARTIFACT_SCHEMA_VERSION,
@@ -233,7 +239,7 @@ module Hive
           "task" => task.to_s,
           "source_sha" => source_sha.to_s,
           "recorder" => recorder.to_h,
-          "environment_keys" => Array(environment_keys || DISCLOSED_ENV_KEYS).map(&:to_s).sort,
+          "environment_keys" => disclosed_environment_keys,
           "started_at" => iso_time(started_at),
           "finished_at" => iso_time(finished_at),
           "artifacts" => Array(artifact_records).map do |artifact|

--- a/lib/hive/web/project_capture_provider.rb
+++ b/lib/hive/web/project_capture_provider.rb
@@ -46,6 +46,24 @@ module Hive
 
       class ProviderError < Hive::Error; end
 
+      # TaskCapture's source-attestation Git probes need the same bounded
+      # process-tree custody as the configured provider itself. Keep that
+      # boundary here so detached helpers cannot outlive either caller.
+      def self.capture_command_with_custody(argv:, source_root:, environment:, deadline:,
+                                            stdout_consumer: nil)
+        remaining = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        allocate.send(
+          :supervise_provider,
+          Array(argv),
+          request: nil,
+          source_root: source_root,
+          environment: environment,
+          timeout_sec: [ remaining, 0 ].max,
+          deadline: deadline,
+          stdout_consumer: stdout_consumer
+        )
+      end
+
       def initialize(config:, environment: ENV, clock: -> { Time.now.utc })
         @config = config
         @environment = environment.to_h
@@ -82,9 +100,11 @@ module Hive
         document = parse_result(stdout)
         validate_result_shape!(document)
         if document.fetch("status") != "captured"
+          diagnostic = document["diagnostic"]
+          diagnostic = "provider reported failure" if diagnostic.to_s.strip.empty?
           raise ProviderError,
                 "project capture provider #{@config.fetch('name')} failed: " \
-                "#{bounded_diagnostic(document['diagnostic'] || 'provider reported failure')}"
+                "#{bounded_diagnostic(diagnostic)}"
         end
         artifacts = validate_artifacts!(document.fetch("artifacts"), staging_root)
         validate_staging_inventory!(staging_root, artifacts)
@@ -200,7 +220,88 @@ module Hive
         raise ProviderError, "project capture provider could not start: #{bounded_diagnostic(e)}"
       end
 
-      def supervise_provider(argv, request:, source_root:, environment:, timeout_sec:)
+      def supervise_provider(argv, request:, source_root:, environment:, timeout_sec:,
+                             deadline: nil, stdout_consumer: nil)
+        reader = writer = result_thread = custody_pid = custody_target = nil
+        result = primary_error = custody_error = nil
+        begin
+          reader, writer = IO.pipe
+          custody_pid = Process.fork do
+            reader.close
+            payload = begin
+              Process.setsid
+              encode_supervisor_result(
+                supervise_provider_in_custody(
+                  argv,
+                  request: request,
+                  source_root: source_root,
+                  environment: environment,
+                  timeout_sec: timeout_sec,
+                  deadline: deadline,
+                  stdout_consumer: stdout_consumer
+                )
+              )
+            rescue Exception => e # rubocop:disable Lint/RescueException -- trusted custody root must report before exit!
+              { "internal_error" => "#{e.class}: #{e.message}" }
+            end
+            write_supervisor_result(writer, payload)
+          ensure
+            writer.close unless writer.closed?
+            exit! 0
+          end
+          writer.close
+          custody_target = recorded_process_target!(custody_pid, "custody root")
+          result_thread = Thread.new { read_supervisor_result(reader) }
+          result_thread.report_on_exception = false
+          outer_runtime = deadline ? [ deadline - monotonic_now, 0 ].max : timeout_sec
+          outer_limit = outer_runtime + (2 * (CUSTODY_TERM_GRACE_SEC + CUSTODY_KILL_GRACE_SEC)) + 2
+          custody_status = wait_for_supervisor_status!(
+            custody_target,
+            deadline: monotonic_now + outer_limit,
+            label: "custody root"
+          )
+          unless custody_status.success?
+            raise ProviderError,
+                  "project capture provider custody root failed " \
+                  "(#{serialized_exit_detail(custody_status)})"
+          end
+          raw = begin
+            Timeout.timeout(0.5) { result_thread.value }
+          rescue Timeout::Error
+            raise ProviderError,
+                  "project capture provider custody result exceeded its read deadline"
+          end
+          result = decode_supervisor_result(raw)
+        rescue StandardError => e
+          primary_error = e
+        ensure
+          begin
+            cleanup_command_custody_tree!(custody_target)
+          rescue StandardError => e
+            custody_error = e
+          end
+          reader&.close unless reader&.closed?
+          writer&.close unless writer&.closed?
+          result_thread&.join(0.1)
+        end
+
+        if primary_error && custody_error
+          raise ProviderError,
+                "#{bounded_diagnostic(primary_error)}; command custody also failed: " \
+                "#{bounded_diagnostic(custody_error)}"
+        end
+        raise primary_error if primary_error
+        raise custody_error if custody_error
+
+        result
+      end
+
+      # The caller is never made a subreaper and is never scanned for children.
+      # This freshly forked custody root owns only the nested supervisor and the
+      # command subtree, so even abnormal supervisor death cannot transfer an
+      # unrelated caller process into cleanup custody.
+      def supervise_provider_in_custody(argv, request:, source_root:, environment:,
+                                        timeout_sec:, deadline:, stdout_consumer:)
         reader = writer = result_thread = supervisor_pid = supervisor_target = nil
         parent_was_subreaper = nil
         parent_custody_active = false
@@ -225,7 +326,9 @@ module Hive
                 request: request,
                 source_root: source_root,
                 environment: environment,
-                timeout_sec: timeout_sec
+                timeout_sec: timeout_sec,
+                deadline: deadline,
+                stdout_consumer: stdout_consumer
               )
             rescue Exception => e # rubocop:disable Lint/RescueException -- trusted supervisor must report before exit!
               { "internal_error" => "#{e.class}: #{e.message}" }
@@ -239,7 +342,8 @@ module Hive
           supervisor_target = recorded_process_target!(supervisor_pid, "supervisor")
           result_thread = Thread.new { read_supervisor_result(reader) }
           result_thread.report_on_exception = false
-          outer_limit = timeout_sec + CUSTODY_TERM_GRACE_SEC + CUSTODY_KILL_GRACE_SEC + 1
+          outer_runtime = deadline ? [ deadline - monotonic_now, 0 ].max : timeout_sec
+          outer_limit = outer_runtime + CUSTODY_TERM_GRACE_SEC + CUSTODY_KILL_GRACE_SEC + 1
           supervisor_status = wait_for_supervisor_status!(
             supervisor_target,
             deadline: monotonic_now + outer_limit
@@ -287,6 +391,61 @@ module Hive
         result
       end
 
+      def cleanup_command_custody_tree!(custody_target)
+        return unless custody_target &&
+                      Hive::ProcessKill.captured_process_alive?(custody_target)
+
+        deadline = monotonic_now + CUSTODY_TERM_GRACE_SEC + CUSTODY_KILL_GRACE_SEC
+        term_deadline = [ monotonic_now + CUSTODY_TERM_GRACE_SEC, deadline ].min
+        owned_targets = command_custody_targets(custody_target)
+        signal_targets("TERM", owned_targets)
+        remaining = wait_for_command_custody_exit(
+          custody_target, owned_targets, deadline: term_deadline, signal: "TERM"
+        )
+        unless remaining.empty?
+          signal_targets("KILL", remaining)
+          remaining = wait_for_command_custody_exit(
+            custody_target, owned_targets, deadline: deadline, signal: "KILL"
+          )
+        end
+        return if remaining.empty?
+
+        raise ProviderError,
+              "project capture provider could not terminate its command custody subtree"
+      end
+
+      def wait_for_command_custody_exit(custody_target, owned_targets, deadline:, signal:)
+        loop do
+          if Hive::ProcessKill.captured_process_alive?(custody_target)
+            owned_targets.concat(command_custody_targets(custody_target))
+          end
+          owned_targets.uniq! { |target| [ target.fetch(:pid), target.fetch(:start_time) ] }
+          reap_command_custody_root(custody_target)
+          remaining = owned_targets.select do |target|
+            Hive::ProcessKill.captured_process_alive?(target)
+          end
+          return [] if remaining.empty?
+          return remaining if monotonic_now >= deadline
+
+          signal_targets(signal, remaining)
+          sleep CUSTODY_POLL_SEC
+        end
+      end
+
+      def command_custody_targets(custody_target)
+        targets = confirmed_descendants(custody_target.fetch(:pid))
+        if Hive::ProcessKill.captured_process_alive?(custody_target)
+          targets << custody_target
+        end
+        targets.sort_by { |target| [ -target.fetch(:depth), target.fetch(:pid) ] }
+      end
+
+      def reap_command_custody_root(custody_target)
+        Process.waitpid(custody_target.fetch(:pid), Process::WNOHANG)
+      rescue Errno::ECHILD
+        nil
+      end
+
       def recorded_process_target!(pid, label)
         start_time = Hive::ProcessKill.process_start_time(pid)
         if start_time.to_s.empty?
@@ -296,20 +455,20 @@ module Hive
         { pid: pid, start_time: start_time, depth: 0 }
       end
 
-      def wait_for_supervisor_status!(target, deadline:)
+      def wait_for_supervisor_status!(target, deadline:, label: "supervisor")
         pid = target.fetch(:pid)
         loop do
           waited = Process.waitpid2(pid, Process::WNOHANG)
           if waited
             unless waited.fetch(0) == pid
-              raise ProviderError, "project capture provider supervisor identity changed"
+              raise ProviderError, "project capture provider #{label} identity changed"
             end
 
             return waited.fetch(1)
           end
           if monotonic_now >= deadline
             raise ProviderError,
-                  "project capture provider supervisor exceeded its custody deadline"
+                  "project capture provider #{label} exceeded its custody deadline"
           end
 
           live_start_time = Hive::ProcessKill.process_start_time(pid)
@@ -317,13 +476,13 @@ module Hive
             waited = Process.waitpid2(pid, Process::WNOHANG)
             return waited.fetch(1) if waited&.fetch(0) == pid
 
-            raise ProviderError, "project capture provider supervisor identity changed"
+            raise ProviderError, "project capture provider #{label} identity changed"
           end
           sleep CUSTODY_POLL_SEC
         end
       rescue Errno::ECHILD
         raise ProviderError,
-              "project capture provider supervisor exit status custody was lost"
+              "project capture provider #{label} exit status custody was lost"
       end
 
       def cleanup_parent_provider_tree!(supervisor_target)
@@ -382,15 +541,17 @@ module Hive
         "exit #{status.exitstatus.inspect}"
       end
 
-      def supervise_provider_child(argv, request:, source_root:, environment:, timeout_sec:)
+      def supervise_provider_child(argv, request:, source_root:, environment:,
+                                    timeout_sec:, deadline: nil, stdout_consumer: nil)
         stdin_reader, stdin_writer = IO.pipe
         stdout_reader, stdout_writer = IO.pipe
         stderr_reader, stderr_writer = IO.pipe
         unless supervisor_descendants.empty?
           raise ProviderError, "provider supervisor has unexpected pre-existing descendants"
         end
+        executable = argv.fetch(0)
         provider_pid = Process.spawn(
-          environment, *argv,
+          environment, [ executable, executable ], *argv.drop(1),
           chdir: source_root,
           in: stdin_reader,
           out: stdout_writer,
@@ -399,13 +560,19 @@ module Hive
           unsetenv_others: true
         )
         [ stdin_reader, stdout_writer, stderr_writer ].each(&:close)
-        stdin_writer.write("#{JSON.generate(request)}\n")
+        stdin_writer.write("#{JSON.generate(request)}\n") if request
         stdin_writer.close
         streams = {
-          stdout_reader => { data: +"".b, limit: MAX_OUTPUT_BYTES, overflow: false, open: true },
-          stderr_reader => { data: +"".b, limit: MAX_DIAGNOSTIC_BYTES, overflow: false, open: true }
+          stdout_reader => {
+            data: +"".b, limit: MAX_OUTPUT_BYTES, overflow: false, open: true,
+            consumer: stdout_consumer, consumer_error: nil
+          },
+          stderr_reader => {
+            data: +"".b, limit: MAX_DIAGNOSTIC_BYTES, overflow: false, open: true,
+            consumer: nil, consumer_error: nil
+          }
         }
-        deadline = monotonic_now + timeout_sec
+        deadline ||= monotonic_now + timeout_sec
         status = nil
         timed_out = false
 
@@ -440,6 +607,8 @@ module Hive
           "stderr" => Base64.strict_encode64(streams.fetch(stderr_reader).fetch(:data)),
           "stdout_overflow" => streams.fetch(stdout_reader).fetch(:overflow),
           "stderr_overflow" => streams.fetch(stderr_reader).fetch(:overflow),
+          "stdout_consumer_error" =>
+            streams.fetch(stdout_reader).fetch(:consumer_error),
           "timed_out" => timed_out,
           "leftover_processes" => !!leftover_processes,
           "cleanup_failed" => cleanup_failed,
@@ -474,21 +643,44 @@ module Hive
             chunk = io.read_nonblock(8192, exception: false)
             break if chunk == :wait_readable
             if chunk.nil?
+              finish_provider_stream_consumer(stream)
               stream[:open] = false
               io.close
               break
             end
 
-            remaining = stream.fetch(:limit) - stream.fetch(:data).bytesize
-            stream.fetch(:data) << chunk.byteslice(0, remaining) if remaining.positive?
-            if chunk.bytesize > remaining
-              stream[:overflow] = true
-              break
-            end
+            consume_provider_stream_chunk(stream, chunk)
+            break if stream.fetch(:overflow)
           end
         rescue IOError, Errno::EBADF
           stream[:open] = false
         end
+      end
+
+      def consume_provider_stream_chunk(stream, chunk)
+        return if stream.fetch(:consumer_error)
+
+        consumer = stream.fetch(:consumer)
+        if consumer
+          consumer.write(chunk)
+          return
+        end
+
+        remaining = stream.fetch(:limit) - stream.fetch(:data).bytesize
+        stream.fetch(:data) << chunk.byteslice(0, remaining) if remaining.positive?
+        stream[:overflow] = true if chunk.bytesize > remaining
+      rescue StandardError => e
+        stream[:consumer_error] = e.message
+        stream[:overflow] = true
+      end
+
+      def finish_provider_stream_consumer(stream)
+        return if stream.fetch(:consumer_error)
+
+        stream.fetch(:consumer)&.finish
+      rescue StandardError => e
+        stream[:consumer_error] = e.message
+        stream[:overflow] = true
       end
 
       def terminate_supervised_tree!(provider_pid, status, deadline:)
@@ -527,8 +719,12 @@ module Hive
       end
 
       def supervisor_descendants
-        first = linux_descendant_snapshot(Process.pid)
-        confirmation = linux_descendant_snapshot(Process.pid).to_h do |target|
+        confirmed_descendants(Process.pid)
+      end
+
+      def confirmed_descendants(root_pid)
+        first = linux_descendant_snapshot(root_pid)
+        confirmation = linux_descendant_snapshot(root_pid).to_h do |target|
           [ target.fetch(:pid), target ]
         end
         first.select do |target|
@@ -656,6 +852,15 @@ module Hive
         payload
       rescue JSON::ParserError, ArgumentError, KeyError
         raise ProviderError, "project capture provider supervisor returned an invalid result"
+      end
+
+      def encode_supervisor_result(payload)
+        return payload if payload["internal_error"]
+
+        payload.merge(
+          "stdout" => Base64.strict_encode64(payload.fetch("stdout")),
+          "stderr" => Base64.strict_encode64(payload.fetch("stderr"))
+        )
       end
 
       def enable_child_subreaper!

--- a/lib/hive/web/project_capture_provider.rb
+++ b/lib/hive/web/project_capture_provider.rb
@@ -1,0 +1,931 @@
+require "digest"
+require "base64"
+require "fileutils"
+require "fiddle"
+require "json"
+require "timeout"
+require "time"
+require "hive"
+require "hive/invoked_binary"
+require "hive/process_kill"
+require "hive/secret_patterns"
+
+module Hive
+  module Web
+    # Runs a project-owned capture recorder as a bounded, credential-free
+    # subprocess. Hive accepts provider artifacts only from its private
+    # staging directory and validates every declaration before publication.
+    class ProjectCaptureProvider
+      REQUEST_SCHEMA = "hive-project-capture-request".freeze
+      REQUEST_SCHEMA_VERSION = 1
+      RESULT_SCHEMA = "hive-project-capture-result".freeze
+      RESULT_SCHEMA_VERSION = 1
+      MAX_OUTPUT_BYTES = 256 * 1024
+      MAX_DIAGNOSTIC_BYTES = 16 * 1024
+      MAX_COMMAND_BYTES = Hive::PROJECT_CAPTURE_PROVIDER_MAX_COMMAND_BYTES
+      MAX_EVIDENCE_BYTES = Hive::PROJECT_CAPTURE_PROVIDER_MAX_EVIDENCE_BYTES
+      MAX_ARTIFACTS = 32
+      MAX_ARTIFACT_BYTES = 256 * 1024 * 1024
+      MAX_TOTAL_ARTIFACT_BYTES = 512 * 1024 * 1024
+      CUSTODY_TERM_GRACE_SEC = 0.35
+      CUSTODY_KILL_GRACE_SEC = 0.35
+      CUSTODY_POLL_SEC = 0.01
+      SUPERVISOR_RESULT_MAX_BYTES = 512 * 1024
+      PR_SET_CHILD_SUBREAPER = 36
+      PR_GET_CHILD_SUBREAPER = 37
+      MEDIA_FILE = /\A[\w.-]+\.(?:png|jpe?g|gif|webp|webm|mp4)\z/i
+      SAFE_AMBIENT_KEYS = %w[PATH LANG LC_ALL LC_CTYPE TZ SSL_CERT_FILE SSL_CERT_DIR].freeze
+      CLEANUP = {
+        "port" => "released", "processes" => "clean", "runtime" => "cleaned"
+      }.freeze
+
+      Result = Data.define(
+        :name, :command, :environment_keys, :artifacts, :evidence,
+        :cleanup, :diagnostic, :started_at, :finished_at
+      )
+
+      class ProviderError < Hive::Error; end
+
+      def initialize(config:, environment: ENV, clock: -> { Time.now.utc })
+        @config = config
+        @environment = environment.to_h
+        @clock = clock
+      end
+
+      def call(task:, source_root:, source_sha:, staging_root:, runtime_root:)
+        source_root = File.realpath(source_root)
+        staging_root = File.realpath(staging_root)
+        ensure_private_directory!(staging_root, "provider staging root")
+        FileUtils.mkdir_p(runtime_root, mode: 0o700)
+        runtime_root = File.realpath(runtime_root)
+        ensure_private_directory!(runtime_root, "provider runtime root")
+        command = @config.fetch("command").map(&:to_s)
+        validate_command_budget!(command)
+        executable = provider_executable(source_root, command.fetch(0))
+        request = {
+          "schema" => REQUEST_SCHEMA,
+          "schema_version" => REQUEST_SCHEMA_VERSION,
+          "task" => task.to_s,
+          "source_root" => source_root,
+          "source_sha" => source_sha.to_s,
+          "staging_root" => staging_root
+        }
+        started_at = @clock.call
+        stdout, stderr = execute!(
+          [ executable, *command.drop(1) ],
+          request: request,
+          source_root: source_root,
+          environment: provider_environment(runtime_root),
+          timeout_sec: @config.fetch("timeout_sec", 120)
+        )
+        reject_secret_shaped_output!(stdout, stderr)
+        document = parse_result(stdout)
+        validate_result_shape!(document)
+        if document.fetch("status") != "captured"
+          raise ProviderError,
+                "project capture provider #{@config.fetch('name')} failed: " \
+                "#{bounded_diagnostic(document['diagnostic'] || 'provider reported failure')}"
+        end
+        artifacts = validate_artifacts!(document.fetch("artifacts"), staging_root)
+        validate_staging_inventory!(staging_root, artifacts)
+
+        Result.new(
+          name: @config.fetch("name"),
+          command: command.freeze,
+          environment_keys: provider_environment(runtime_root).keys.sort.freeze,
+          artifacts: artifacts.freeze,
+          evidence: document.fetch("evidence").freeze,
+          cleanup: document.fetch("cleanup").freeze,
+          diagnostic: document["diagnostic"],
+          started_at: started_at,
+          finished_at: @clock.call
+        )
+      rescue KeyError, JSON::GeneratorError, JSON::ParserError, SystemCallError, TypeError => e
+        raise ProviderError, bounded_diagnostic(e)
+      end
+
+      private
+
+      def provider_executable(source_root, relative)
+        candidate = File.expand_path(relative, source_root)
+        unless candidate.start_with?("#{source_root}#{File::SEPARATOR}")
+          raise ProviderError, "project capture provider executable escapes the source root"
+        end
+        stat = File.lstat(candidate)
+        unless stat.file? && !stat.symlink? && File.executable?(candidate)
+          raise ProviderError,
+                "project capture provider executable must be a regular executable file: #{relative}"
+        end
+        real = File.realpath(candidate)
+        unless real.start_with?("#{source_root}#{File::SEPARATOR}")
+          raise ProviderError, "project capture provider executable escapes the source root"
+        end
+
+        real
+      rescue Errno::ENOENT, Errno::ENOTDIR
+        raise ProviderError, "project capture provider executable is unavailable: #{relative}"
+      end
+
+      def validate_command_budget!(command)
+        bytes = command.sum { |part| part.bytesize + 1 }
+        return if bytes <= MAX_COMMAND_BYTES
+
+        raise ProviderError,
+              "project capture provider command argv exceeded #{MAX_COMMAND_BYTES} bytes"
+      end
+
+      def provider_environment(runtime_root)
+        home = private_dir(runtime_root, "home")
+        xdg = private_dir(runtime_root, "xdg")
+        tmp = private_dir(runtime_root, "tmp")
+        safe = SAFE_AMBIENT_KEYS.each_with_object({}) do |key, allowed|
+          value = @environment[key]
+          allowed[key] = value if value && !value.empty?
+        end
+        safe["PATH"] ||= "/usr/local/bin:/usr/bin:/bin"
+        safe.merge(
+          "HOME" => home,
+          "XDG_CONFIG_HOME" => private_dir(xdg, "config"),
+          "XDG_CACHE_HOME" => private_dir(xdg, "cache"),
+          "XDG_DATA_HOME" => private_dir(xdg, "data"),
+          "XDG_STATE_HOME" => private_dir(xdg, "state"),
+          "TMPDIR" => tmp
+        )
+      end
+
+      def private_dir(root, name)
+        path = File.join(root, name)
+        FileUtils.mkdir_p(path, mode: 0o700)
+        FileUtils.chmod(0o700, path)
+        path
+      end
+
+      def execute!(argv, request:, source_root:, environment:, timeout_sec:)
+        result = supervise_provider(
+          argv,
+          request: request,
+          source_root: source_root,
+          environment: environment,
+          timeout_sec: Integer(timeout_sec)
+        )
+        raise ProviderError, bounded_diagnostic(result.fetch("internal_error")) if result["internal_error"]
+        if result.fetch("cleanup_failed")
+          raise ProviderError, "project capture provider descendants could not be terminated"
+        end
+        raise ProviderError, "project capture provider timed out after #{timeout_sec}s" if result.fetch("timed_out")
+        if result.fetch("stdout_overflow")
+          raise ProviderError, "project capture provider stdout exceeded #{MAX_OUTPUT_BYTES} bytes"
+        end
+        if result.fetch("stderr_overflow")
+          raise ProviderError, "project capture provider stderr exceeded #{MAX_DIAGNOSTIC_BYTES} bytes"
+        end
+
+        status = result.fetch("status")
+        unless status.fetch("success")
+          exit_detail = if status.fetch("signaled")
+            "signal #{status.fetch('termsig').inspect}"
+          else
+            "exit #{status.fetch('exitstatus').inspect}"
+          end
+          detail = bounded_diagnostic(result.fetch("stderr"))
+          suffix = detail.empty? ? "" : ": #{detail}"
+          raise ProviderError, "project capture provider failed (#{exit_detail})#{suffix}"
+        end
+        if result.fetch("leftover_processes")
+          raise ProviderError, "project capture provider left child processes running"
+        end
+
+        [ result.fetch("stdout"), result.fetch("stderr") ]
+      rescue Errno::ENOENT, Errno::EACCES => e
+        raise ProviderError, "project capture provider could not start: #{bounded_diagnostic(e)}"
+      end
+
+      def supervise_provider(argv, request:, source_root:, environment:, timeout_sec:)
+        reader = writer = result_thread = supervisor_pid = supervisor_target = nil
+        parent_was_subreaper = nil
+        parent_custody_active = false
+        result = primary_error = custody_error = nil
+        begin
+          parent_was_subreaper = child_subreaper_enabled?
+          enable_child_subreaper! unless parent_was_subreaper
+          unless supervisor_descendants.empty?
+            raise ProviderError,
+                  "project capture provider parent has unexpected pre-existing descendants"
+          end
+          parent_custody_active = true
+
+          reader, writer = IO.pipe
+          supervisor_pid = Process.fork do
+            reader.close
+            payload = begin
+              Process.setsid
+              enable_child_subreaper!
+              supervise_provider_child(
+                argv,
+                request: request,
+                source_root: source_root,
+                environment: environment,
+                timeout_sec: timeout_sec
+              )
+            rescue Exception => e # rubocop:disable Lint/RescueException -- trusted supervisor must report before exit!
+              { "internal_error" => "#{e.class}: #{e.message}" }
+            end
+            write_supervisor_result(writer, payload)
+          ensure
+            writer.close unless writer.closed?
+            exit! 0
+          end
+          writer.close
+          supervisor_target = recorded_process_target!(supervisor_pid, "supervisor")
+          result_thread = Thread.new { read_supervisor_result(reader) }
+          result_thread.report_on_exception = false
+          outer_limit = timeout_sec + CUSTODY_TERM_GRACE_SEC + CUSTODY_KILL_GRACE_SEC + 1
+          supervisor_status = wait_for_supervisor_status!(
+            supervisor_target,
+            deadline: monotonic_now + outer_limit
+          )
+          unless supervisor_status.success?
+            raise ProviderError,
+                  "project capture provider supervisor failed " \
+                  "(#{serialized_exit_detail(supervisor_status)})"
+          end
+          raw = begin
+            Timeout.timeout(0.5) { result_thread.value }
+          rescue Timeout::Error
+            raise ProviderError,
+                  "project capture provider supervisor result exceeded its read deadline"
+          end
+          result = decode_supervisor_result(raw)
+        rescue StandardError => e
+          primary_error = e
+        ensure
+          begin
+            cleanup_parent_provider_tree!(supervisor_target) if parent_custody_active
+          rescue StandardError => e
+            custody_error = e
+          end
+          reader&.close unless reader&.closed?
+          writer&.close unless writer&.closed?
+          result_thread&.join(0.1)
+          if parent_was_subreaper == false && custody_error.nil?
+            begin
+              disable_child_subreaper!
+            rescue StandardError => e
+              custody_error = e
+            end
+          end
+        end
+
+        if primary_error && custody_error
+          raise ProviderError,
+                "#{bounded_diagnostic(primary_error)}; parent provider custody also failed: " \
+                "#{bounded_diagnostic(custody_error)}"
+        end
+        raise primary_error if primary_error
+        raise custody_error if custody_error
+
+        result
+      end
+
+      def recorded_process_target!(pid, label)
+        start_time = Hive::ProcessKill.process_start_time(pid)
+        if start_time.to_s.empty?
+          raise ProviderError, "project capture provider #{label} identity is unavailable"
+        end
+
+        { pid: pid, start_time: start_time, depth: 0 }
+      end
+
+      def wait_for_supervisor_status!(target, deadline:)
+        pid = target.fetch(:pid)
+        loop do
+          waited = Process.waitpid2(pid, Process::WNOHANG)
+          if waited
+            unless waited.fetch(0) == pid
+              raise ProviderError, "project capture provider supervisor identity changed"
+            end
+
+            return waited.fetch(1)
+          end
+          if monotonic_now >= deadline
+            raise ProviderError,
+                  "project capture provider supervisor exceeded its custody deadline"
+          end
+
+          live_start_time = Hive::ProcessKill.process_start_time(pid)
+          unless live_start_time.to_s == target.fetch(:start_time).to_s
+            waited = Process.waitpid2(pid, Process::WNOHANG)
+            return waited.fetch(1) if waited&.fetch(0) == pid
+
+            raise ProviderError, "project capture provider supervisor identity changed"
+          end
+          sleep CUSTODY_POLL_SEC
+        end
+      rescue Errno::ECHILD
+        raise ProviderError,
+              "project capture provider supervisor exit status custody was lost"
+      end
+
+      def cleanup_parent_provider_tree!(supervisor_target)
+        deadline = monotonic_now + CUSTODY_TERM_GRACE_SEC + CUSTODY_KILL_GRACE_SEC
+        term_deadline = [ monotonic_now + CUSTODY_TERM_GRACE_SEC, deadline ].min
+        remaining = parent_provider_targets(supervisor_target)
+        signal_targets("TERM", remaining)
+        remaining = wait_for_parent_provider_exit(
+          supervisor_target, deadline: term_deadline, signal: "TERM"
+        )
+        unless remaining.empty?
+          signal_targets("KILL", remaining)
+          remaining = wait_for_parent_provider_exit(
+            supervisor_target, deadline: deadline, signal: "KILL"
+          )
+        end
+        return if remaining.empty?
+
+        raise ProviderError,
+              "project capture provider parent could not terminate and verify every descendant"
+      end
+
+      def wait_for_parent_provider_exit(supervisor_target, deadline:, signal:)
+        loop do
+          targets = parent_provider_targets(supervisor_target)
+          reap_parent_provider_children(targets)
+          targets = parent_provider_targets(supervisor_target)
+          return [] if targets.empty?
+          return targets if monotonic_now >= deadline
+
+          signal_targets(signal, targets)
+          sleep CUSTODY_POLL_SEC
+        end
+      end
+
+      def parent_provider_targets(supervisor_target)
+        targets = supervisor_descendants
+        if supervisor_target && Hive::ProcessKill.captured_process_alive?(supervisor_target)
+          targets << supervisor_target
+        end
+        targets.uniq { |target| [ target.fetch(:pid), target.fetch(:start_time) ] }
+               .sort_by { |target| [ -target.fetch(:depth), target.fetch(:pid) ] }
+      end
+
+      def reap_parent_provider_children(targets)
+        targets.each do |target|
+          Process.waitpid(target.fetch(:pid), Process::WNOHANG)
+        rescue Errno::ECHILD
+          nil
+        end
+      end
+
+      def serialized_exit_detail(status)
+        return "signal #{status.termsig.inspect}" if status.signaled?
+
+        "exit #{status.exitstatus.inspect}"
+      end
+
+      def supervise_provider_child(argv, request:, source_root:, environment:, timeout_sec:)
+        stdin_reader, stdin_writer = IO.pipe
+        stdout_reader, stdout_writer = IO.pipe
+        stderr_reader, stderr_writer = IO.pipe
+        unless supervisor_descendants.empty?
+          raise ProviderError, "provider supervisor has unexpected pre-existing descendants"
+        end
+        provider_pid = Process.spawn(
+          environment, *argv,
+          chdir: source_root,
+          in: stdin_reader,
+          out: stdout_writer,
+          err: stderr_writer,
+          pgroup: true,
+          unsetenv_others: true
+        )
+        [ stdin_reader, stdout_writer, stderr_writer ].each(&:close)
+        stdin_writer.write("#{JSON.generate(request)}\n")
+        stdin_writer.close
+        streams = {
+          stdout_reader => { data: +"".b, limit: MAX_OUTPUT_BYTES, overflow: false, open: true },
+          stderr_reader => { data: +"".b, limit: MAX_DIAGNOSTIC_BYTES, overflow: false, open: true }
+        }
+        deadline = monotonic_now + timeout_sec
+        status = nil
+        timed_out = false
+
+        loop do
+          status ||= wait_status(provider_pid)
+          break if status
+          if streams.values.any? { |stream| stream.fetch(:overflow) }
+            break
+          end
+          if monotonic_now >= deadline
+            timed_out = true
+            break
+          end
+
+          drain_provider_streams(streams, [ deadline - monotonic_now, CUSTODY_POLL_SEC ].min)
+        end
+
+        descendants = supervisor_descendants
+        leftover_processes = status && descendants.any? do |target|
+          target.fetch(:pid) != provider_pid
+        end
+        cleanup_deadline = monotonic_now + CUSTODY_TERM_GRACE_SEC + CUSTODY_KILL_GRACE_SEC
+        status, cleanup_failed = terminate_supervised_tree!(
+          provider_pid, status, deadline: cleanup_deadline
+        )
+        drain_provider_streams_until(streams, cleanup_deadline)
+        streams.each_key { |io| io.close unless io.closed? }
+        status ||= wait_status(provider_pid)
+
+        {
+          "stdout" => Base64.strict_encode64(streams.fetch(stdout_reader).fetch(:data)),
+          "stderr" => Base64.strict_encode64(streams.fetch(stderr_reader).fetch(:data)),
+          "stdout_overflow" => streams.fetch(stdout_reader).fetch(:overflow),
+          "stderr_overflow" => streams.fetch(stderr_reader).fetch(:overflow),
+          "timed_out" => timed_out,
+          "leftover_processes" => !!leftover_processes,
+          "cleanup_failed" => cleanup_failed,
+          "status" => serialize_status(status)
+        }
+      rescue StandardError
+        emergency_terminate_provider!(provider_pid) if provider_pid
+        raise
+      ensure
+        [ stdin_reader, stdin_writer, stdout_reader, stdout_writer,
+          stderr_reader, stderr_writer ].each do |io|
+          io&.close unless io&.closed?
+        rescue IOError
+          nil
+        end
+      end
+
+      def drain_provider_streams_until(streams, deadline)
+        while monotonic_now < deadline && streams.values.any? { |stream| stream.fetch(:open) }
+          drain_provider_streams(streams, [ deadline - monotonic_now, CUSTODY_POLL_SEC ].min)
+        end
+      end
+
+      def drain_provider_streams(streams, wait_seconds)
+        open_ios = streams.filter_map { |io, stream| io if stream.fetch(:open) }
+        return if open_ios.empty?
+
+        ready = IO.select(open_ios, nil, nil, [ wait_seconds, 0 ].max)&.first || []
+        ready.each do |io|
+          stream = streams.fetch(io)
+          loop do
+            chunk = io.read_nonblock(8192, exception: false)
+            break if chunk == :wait_readable
+            if chunk.nil?
+              stream[:open] = false
+              io.close
+              break
+            end
+
+            remaining = stream.fetch(:limit) - stream.fetch(:data).bytesize
+            stream.fetch(:data) << chunk.byteslice(0, remaining) if remaining.positive?
+            if chunk.bytesize > remaining
+              stream[:overflow] = true
+              break
+            end
+          end
+        rescue IOError, Errno::EBADF
+          stream[:open] = false
+        end
+      end
+
+      def terminate_supervised_tree!(provider_pid, status, deadline:)
+        term_deadline = [ monotonic_now + CUSTODY_TERM_GRACE_SEC, deadline ].min
+        signal_supervisor_descendants("TERM")
+        status = wait_for_supervised_exit(provider_pid, status, term_deadline)
+        remaining = supervisor_descendants
+        unless remaining.empty?
+          signal_targets("KILL", remaining)
+          status = wait_for_supervised_exit(provider_pid, status, deadline, signal: "KILL")
+        end
+        [ status, supervisor_descendants.any? ]
+      end
+
+      def wait_for_supervised_exit(provider_pid, status, deadline, signal: "TERM")
+        loop do
+          status ||= wait_status(provider_pid)
+          reap_supervised_children if status
+          remaining = supervisor_descendants
+          return status if remaining.empty?
+          return status if monotonic_now >= deadline
+
+          signal_targets(signal, remaining)
+          sleep CUSTODY_POLL_SEC
+        end
+      end
+
+      def signal_supervisor_descendants(signal)
+        signal_targets(signal, supervisor_descendants)
+      end
+
+      def signal_targets(signal, targets)
+        Hive::ProcessKill.signal_captured_processes(
+          signal, targets, require_identity: signal == "KILL"
+        )
+      end
+
+      def supervisor_descendants
+        first = linux_descendant_snapshot(Process.pid)
+        confirmation = linux_descendant_snapshot(Process.pid).to_h do |target|
+          [ target.fetch(:pid), target ]
+        end
+        first.select do |target|
+          current = confirmation[target.fetch(:pid)]
+          current && current.fetch(:start_time) == target.fetch(:start_time)
+        end
+      end
+
+      def linux_descendant_snapshot(root_pid)
+        pending = linux_child_pids(root_pid, required: true).map { |pid| [ pid, 1 ] }
+        seen = { root_pid => true }
+        targets = []
+        until pending.empty?
+          pid, depth = pending.shift
+          next if seen[pid]
+
+          seen[pid] = true
+          start_time = Hive::ProcessKill.process_start_time(pid)
+          if start_time.to_s.empty?
+            next unless Hive::ProcessKill.pid_alive?(pid)
+
+            raise ProviderError, "provider process identity custody is unavailable"
+          end
+          targets << { pid: pid, start_time: start_time, depth: depth }
+          linux_child_pids(pid, required: false).each do |child_pid|
+            pending << [ child_pid, depth + 1 ]
+          end
+        end
+        targets.sort_by { |target| [ -target.fetch(:depth), target.fetch(:pid) ] }
+      end
+
+      def linux_child_pids(pid, required:)
+        task_root = "/proc/#{pid}/task"
+        task_ids = Dir.children(task_root)
+        task_ids.flat_map do |task_id|
+          File.read(File.join(task_root, task_id, "children")).split.filter_map do |value|
+            child_pid = Integer(value, 10)
+            child_pid if Hive::ProcessKill.valid_target_pid?(child_pid)
+          end
+        rescue Errno::ENOENT
+          []
+        end.uniq
+      rescue Errno::ENOENT
+        raise ProviderError, "provider process-tree custody is unavailable" if required
+
+        []
+      rescue Errno::EACCES, Errno::EIO, ArgumentError
+        raise ProviderError, "provider process-tree custody is unavailable"
+      end
+
+      def emergency_terminate_provider!(provider_pid)
+        deadline = monotonic_now + CUSTODY_TERM_GRACE_SEC + CUSTODY_KILL_GRACE_SEC
+        terminate_supervised_tree!(provider_pid, wait_status(provider_pid), deadline: deadline)
+      rescue ProviderError
+        signal_provider_group("TERM", provider_pid)
+        sleep CUSTODY_POLL_SEC
+        signal_provider_group("KILL", provider_pid)
+      ensure
+        reap_supervised_children
+      end
+
+      def signal_provider_group(signal, provider_pid)
+        Process.kill(signal, -provider_pid)
+        Process.kill(signal, provider_pid)
+      rescue Errno::ESRCH
+        nil
+      end
+
+      def wait_status(pid)
+        waited = Process.waitpid2(pid, Process::WNOHANG)
+        waited&.last
+      rescue Errno::ECHILD
+        nil
+      end
+
+      def reap_supervised_children
+        loop do
+          break unless Process.waitpid(-1, Process::WNOHANG)
+        end
+      rescue Errno::ECHILD
+        nil
+      end
+
+      def serialize_status(status)
+        return { "success" => false, "signaled" => false, "exitstatus" => nil, "termsig" => nil } unless status
+
+        {
+          "success" => status.success?,
+          "signaled" => status.signaled?,
+          "exitstatus" => status.exitstatus,
+          "termsig" => status.termsig
+        }
+      end
+
+      def write_supervisor_result(writer, payload)
+        bytes = JSON.generate(payload)
+        offset = 0
+        while offset < bytes.bytesize
+          offset += writer.write(bytes.byteslice(offset, bytes.bytesize - offset))
+        end
+      rescue SystemCallError, IOError
+        nil
+      end
+
+      def read_supervisor_result(reader)
+        data = +"".b
+        loop do
+          chunk = reader.readpartial(8192)
+          if data.bytesize + chunk.bytesize > SUPERVISOR_RESULT_MAX_BYTES
+            raise ProviderError, "project capture provider supervisor result exceeded its limit"
+          end
+          data << chunk
+        end
+      rescue EOFError
+        data
+      end
+
+      def decode_supervisor_result(raw)
+        payload = JSON.parse(raw)
+        raise ProviderError, "project capture provider supervisor returned an invalid result" unless payload.is_a?(Hash)
+        return payload if payload["internal_error"]
+
+        payload["stdout"] = Base64.strict_decode64(payload.fetch("stdout"))
+        payload["stderr"] = Base64.strict_decode64(payload.fetch("stderr"))
+        payload
+      rescue JSON::ParserError, ArgumentError, KeyError
+        raise ProviderError, "project capture provider supervisor returned an invalid result"
+      end
+
+      def enable_child_subreaper!
+        unless RUBY_PLATFORM.include?("linux")
+          raise ProviderError,
+                "project capture provider custody requires Linux child-subreaper support"
+        end
+
+        prctl = Fiddle::Function.new(
+          Fiddle::Handle::DEFAULT["prctl"],
+          [ Fiddle::TYPE_INT, Fiddle::TYPE_LONG, Fiddle::TYPE_LONG,
+            Fiddle::TYPE_LONG, Fiddle::TYPE_LONG ],
+          Fiddle::TYPE_INT
+        )
+        result = prctl.call(PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0)
+        raise ProviderError, "provider child-subreaper custody is unavailable" unless result.zero?
+      rescue Fiddle::DLError
+        raise ProviderError, "provider child-subreaper custody is unavailable"
+      end
+
+      def disable_child_subreaper!
+        prctl = Fiddle::Function.new(
+          Fiddle::Handle::DEFAULT["prctl"],
+          [ Fiddle::TYPE_INT, Fiddle::TYPE_LONG, Fiddle::TYPE_LONG,
+            Fiddle::TYPE_LONG, Fiddle::TYPE_LONG ],
+          Fiddle::TYPE_INT
+        )
+        result = prctl.call(PR_SET_CHILD_SUBREAPER, 0, 0, 0, 0)
+        raise ProviderError, "provider child-subreaper custody could not be restored" unless result.zero?
+      rescue Fiddle::DLError
+        raise ProviderError, "provider child-subreaper custody could not be restored"
+      end
+
+      def child_subreaper_enabled?
+        unless RUBY_PLATFORM.include?("linux")
+          raise ProviderError,
+                "project capture provider custody requires Linux child-subreaper support"
+        end
+
+        value = Fiddle::Pointer.malloc(Fiddle::SIZEOF_INT)
+        value[0, Fiddle::SIZEOF_INT] = [ 0 ].pack("i")
+        prctl = Fiddle::Function.new(
+          Fiddle::Handle::DEFAULT["prctl"],
+          [ Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_LONG,
+            Fiddle::TYPE_LONG, Fiddle::TYPE_LONG ],
+          Fiddle::TYPE_INT
+        )
+        result = prctl.call(PR_GET_CHILD_SUBREAPER, value, 0, 0, 0)
+        raise ProviderError, "provider child-subreaper custody is unavailable" unless result.zero?
+
+        value[0, Fiddle::SIZEOF_INT].unpack1("i") == 1
+      rescue Fiddle::DLError
+        raise ProviderError, "provider child-subreaper custody is unavailable"
+      end
+
+      def monotonic_now
+        Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      end
+
+      def parse_result(stdout)
+        document = JSON.parse(stdout)
+        raise ProviderError, "project capture provider result must be a JSON object" unless document.is_a?(Hash)
+
+        document
+      rescue JSON::ParserError => e
+        raise ProviderError,
+              "project capture provider returned malformed JSON: #{bounded_diagnostic(e)}"
+      end
+
+      def validate_result_shape!(document)
+        allowed = %w[schema schema_version status artifacts evidence cleanup diagnostic]
+        unknown = document.keys - allowed
+        missing = allowed - document.keys
+        raise ProviderError, "project capture provider result has unknown keys: #{unknown.sort.join(', ')}" unless unknown.empty?
+        raise ProviderError, "project capture provider result is missing keys: #{missing.sort.join(', ')}" unless missing.empty?
+        unless document["schema"] == RESULT_SCHEMA &&
+               document["schema_version"] == RESULT_SCHEMA_VERSION
+          raise ProviderError, "project capture provider returned an unsupported result schema"
+        end
+        unless %w[captured failed].include?(document["status"])
+          raise ProviderError, "project capture provider result has an invalid status"
+        end
+        unless document["artifacts"].is_a?(Array) && document["evidence"].is_a?(Hash) &&
+               document["cleanup"].is_a?(Hash)
+          raise ProviderError, "project capture provider result has invalid artifacts, evidence, or cleanup"
+        end
+        evidence_bytes = JSON.generate(document.fetch("evidence")).bytesize
+        if evidence_bytes > MAX_EVIDENCE_BYTES
+          raise ProviderError,
+                "project capture provider evidence exceeded #{MAX_EVIDENCE_BYTES} bytes"
+        end
+        unless document["cleanup"] == CLEANUP
+          raise ProviderError, "project capture provider did not report complete cleanup"
+        end
+        diagnostic = document["diagnostic"]
+        unless diagnostic.nil? || (diagnostic.is_a?(String) && diagnostic.bytesize <= MAX_DIAGNOSTIC_BYTES)
+          raise ProviderError, "project capture provider diagnostic is invalid or too large"
+        end
+        if document["status"] == "captured" && !diagnostic.nil?
+          raise ProviderError, "captured provider result must have a null diagnostic"
+        end
+      end
+
+      def validate_artifacts!(entries, staging_root)
+        unless entries.length.between?(1, MAX_ARTIFACTS)
+          raise ProviderError,
+                "project capture provider must return between 1 and #{MAX_ARTIFACTS} artifacts"
+        end
+        seen = {}
+        total = 0
+        entries.map.with_index do |entry, index|
+          unless entry.is_a?(Hash) && entry.keys.sort == %w[bytes file sha256]
+            raise ProviderError, "project capture provider artifact #{index} has an invalid shape"
+          end
+          filename = entry["file"].to_s
+          unless File.basename(filename) == filename && filename.match?(MEDIA_FILE)
+            raise ProviderError, "project capture provider artifact #{index} has an unsafe filename"
+          end
+          raise ProviderError, "project capture provider returned duplicate artifact #{filename}" if seen[filename]
+          seen[filename] = true
+          path = File.join(staging_root, filename)
+          stat = File.lstat(path)
+          unless stat.file? && !stat.symlink? && stat.uid == Process.uid
+            raise ProviderError, "project capture provider artifact #{filename} is not an owned regular file"
+          end
+          unless stat.size.positive? && stat.size <= MAX_ARTIFACT_BYTES
+            raise ProviderError, "project capture provider artifact #{filename} has an invalid size"
+          end
+          unless File.realpath(path).start_with?("#{staging_root}#{File::SEPARATOR}")
+            raise ProviderError, "project capture provider artifact #{filename} escapes staging"
+          end
+          unless entry["bytes"] == stat.size
+            raise ProviderError, "project capture provider artifact #{filename} size does not match"
+          end
+          digest = ::Digest::SHA256.file(path).hexdigest
+          unless entry["sha256"].to_s.match?(/\A[0-9a-f]{64}\z/) && entry["sha256"] == digest
+            raise ProviderError, "project capture provider artifact #{filename} digest does not match"
+          end
+          validate_media_content!(path, filename, staging_root)
+          total += stat.size
+          raise ProviderError, "project capture provider artifacts exceed the total size limit" if
+            total > MAX_TOTAL_ARTIFACT_BYTES
+
+          {
+            "file" => filename,
+            "bytes" => stat.size,
+            "sha256" => digest,
+            "source_path" => path
+          }.freeze
+        rescue Errno::ENOENT, Errno::ENOTDIR
+          raise ProviderError, "project capture provider artifact #{filename} is missing"
+        end
+      end
+
+      def validate_media_content!(path, filename, staging_root)
+        ffprobe = Hive::InvokedBinary.which("ffprobe", env: @environment)
+        ffmpeg = Hive::InvokedBinary.which("ffmpeg", env: @environment)
+        raise ProviderError, "ffprobe is required to validate project capture media" unless ffprobe
+        raise ProviderError, "ffmpeg is required to decode project capture media" unless ffmpeg
+
+        probe = media_tool_result(
+          [
+            ffprobe, "-v", "error", "-show_entries",
+            "format=format_name,duration:stream=codec_name,codec_type",
+            "-of", "json", path
+          ],
+          source_root: staging_root,
+          timeout_sec: 10
+        )
+        document = if !probe["internal_error"] && !probe.fetch("timed_out") &&
+                      !probe.fetch("cleanup_failed") && probe.fetch("status").fetch("success")
+          JSON.parse(probe.fetch("stdout"))
+        end
+        extension = File.extname(filename).downcase
+        stream = Array(document&.fetch("streams", nil)).find do |candidate|
+          candidate.is_a?(Hash) && candidate["codec_type"] == "video"
+        end
+        codec = stream&.fetch("codec_name", nil)
+        valid = case extension
+        when ".png" then codec == "png"
+        when ".jpg", ".jpeg" then codec == "mjpeg"
+        when ".gif" then codec == "gif"
+        when ".webp" then codec == "webp"
+        when ".webm"
+          playable_video?(document, stream, /(?:\A|,)matroska,webm(?:,|\z)|\Awebm\z/)
+        when ".mp4"
+          playable_video?(document, stream, /(?:\A|,)(?:mov|mp4)(?:,|\z)/)
+        else
+          false
+        end
+        decoded = media_tool_result(
+          [
+            ffmpeg, "-nostdin", "-v", "error", "-i", path, "-map", "0:v:0",
+            "-frames:v", "1", "-f", "null", "-"
+          ],
+          source_root: staging_root,
+          timeout_sec: 10
+        )
+        return if valid && decoded.fetch("status").fetch("success") &&
+                  !decoded.fetch("timed_out") && !decoded.fetch("cleanup_failed")
+
+        label = extension.delete_prefix(".").upcase
+        raise ProviderError,
+              "project capture provider artifact #{filename} is not valid decodable #{label} media"
+      rescue JSON::ParserError, KeyError, TypeError
+        label = File.extname(filename).delete_prefix(".").upcase
+        raise ProviderError,
+              "project capture provider artifact #{filename} is not valid decodable #{label} media"
+      end
+
+      def playable_video?(document, stream, format_pattern)
+        return false unless stream
+
+        format = document&.fetch("format", nil)
+        return false unless format.is_a?(Hash)
+        return false unless format.fetch("format_name", "").match?(format_pattern)
+
+        Float(format["duration"], exception: false)&.positive? == true
+      end
+
+      def media_probe_environment
+        SAFE_AMBIENT_KEYS.each_with_object({}) do |key, allowed|
+          value = @environment[key]
+          allowed[key] = value if value && !value.empty?
+        end.tap { |allowed| allowed["PATH"] ||= "/usr/local/bin:/usr/bin:/bin" }
+      end
+
+      def media_tool_result(argv, source_root:, timeout_sec:)
+        supervise_provider(
+          argv,
+          request: {},
+          source_root: source_root,
+          environment: media_probe_environment,
+          timeout_sec: timeout_sec
+        )
+      end
+
+      def validate_staging_inventory!(staging_root, artifacts)
+        expected = artifacts.map { |artifact| artifact.fetch("file") }.sort
+        actual = Dir.children(staging_root).sort
+        return if actual == expected
+
+        raise ProviderError,
+              "project capture provider left undeclared or incomplete staging entries"
+      end
+
+      def reject_secret_shaped_output!(*values)
+        hits = Hive::SecretPatterns.scan(values.join("\n"))
+        return if hits.empty?
+
+        names = hits.map { |hit| hit.fetch(:name) }.uniq.join(", ")
+        raise ProviderError,
+              "project capture provider output contains secret-shaped content: #{names}"
+      end
+
+      def ensure_private_directory!(path, label)
+        stat = File.lstat(path)
+        unless stat.directory? && !stat.symlink? && stat.uid == Process.uid
+          raise ProviderError, "#{label} must be an owned regular directory"
+        end
+        FileUtils.chmod(0o700, path)
+      end
+
+      def bounded_diagnostic(value)
+        text = value.respond_to?(:message) ? value.message : value.to_s
+        Hive::SecretPatterns.redact(
+          text.to_s.b.byteslice(0, MAX_DIAGNOSTIC_BYTES).to_s
+              .force_encoding(Encoding::UTF_8).scrub
+        )
+      end
+    end
+  end
+end

--- a/lib/hive/web/task_capture.rb
+++ b/lib/hive/web/task_capture.rb
@@ -36,6 +36,10 @@ module Hive
       PROVIDER_SOURCE_SNAPSHOT_MAX_BYTES = 1024 * 1024 * 1024
       PROVIDER_SOURCE_SNAPSHOT_TIMEOUT_SEC = 30
       PROVIDER_SOURCE_HASH_CHUNK_BYTES = 1024 * 1024
+      PROVIDER_SOURCE_GIT_STDOUT_MAX_BYTES =
+        Hive::Web::ProjectCaptureProvider::MAX_OUTPUT_BYTES
+      PROVIDER_SOURCE_GIT_STDERR_MAX_BYTES =
+        Hive::Web::ProjectCaptureProvider::MAX_DIAGNOSTIC_BYTES
       PNG_SIGNATURE = "\x89PNG\r\n\x1a\n".b.freeze
       BUILT_IN_RECORDER_INPUTS = %w[
         Gemfile.lock
@@ -52,6 +56,54 @@ module Hive
       ].freeze
 
       class CaptureError < Hive::Error; end
+
+      class GitIndexFlagConsumer
+        def initialize(max_entries:, max_record_bytes:)
+          @max_entries = max_entries
+          @max_record_bytes = max_record_bytes
+          @entries = 0
+          @buffer = +"".b
+        end
+
+        def write(chunk)
+          @buffer << chunk.b
+          while (separator = @buffer.index("\0".b))
+            record = @buffer.slice!(0, separator)
+            @buffer.slice!(0)
+            validate_record!(record)
+          end
+          return if @buffer.bytesize <= @max_record_bytes
+
+          raise CaptureError,
+                "provider capture source Git index record exceeded its custody limit"
+        end
+
+        def finish
+          validate_record!(@buffer) unless @buffer.empty?
+        end
+
+        private
+
+        def validate_record!(record)
+          @entries += 1
+          if @entries > @max_entries
+            raise CaptureError,
+                  "provider capture source Git index exceeded the " \
+                  "#{@max_entries}-entry custody limit"
+          end
+          match = /\A([A-Za-z?]) (.*)\z/m.match(record)
+          unless match
+            raise CaptureError,
+                  "provider capture source Git index flags have an unsupported representation"
+          end
+          return if match[1] == "H"
+
+          raise CaptureError,
+                "provider capture source has non-default Git index flags " \
+                "(assume-unchanged or skip-worktree)"
+        end
+      end
+      private_constant :GitIndexFlagConsumer
 
       attr_reader :task
 
@@ -285,6 +337,12 @@ module Hive
         return { kind: :built_in } if @source_bundle
         return { kind: :built_in } if built_in_recorder_compatible?(source_root)
 
+        unless project_provider_supported?
+          raise CaptureError,
+                "project-provider capture is unavailable on #{RUBY_PLATFORM}: " \
+                "project capture provider custody requires Linux child-subreaper support"
+        end
+
         provider = @project_config.dig("artifacts", "capture", "provider")
         return { kind: :provider, config: provider } if provider
 
@@ -301,6 +359,10 @@ module Hive
         BUILT_IN_RECORDER_INPUTS.all? do |relative|
           regular_file?(File.join(source_root, relative))
         end
+      end
+
+      def project_provider_supported?
+        RUBY_PLATFORM.include?("linux")
       end
 
       def regular_file?(path)
@@ -352,31 +414,36 @@ module Hive
 
       def verify_provider_source!(source_root, expected_head, provider_executable:,
                                   expected_snapshot: nil)
+        deadline = provider_custody_monotonic_now + PROVIDER_SOURCE_SNAPSHOT_TIMEOUT_SEC
         stat = File.lstat(source_root)
         if stat.symlink? || !stat.directory? || stat.uid != Process.uid
           raise CaptureError, "provider capture source must be an owned Git worktree directory"
         end
-        top = capture_git!(source_root, "rev-parse", "--show-toplevel").strip
+        top = capture_git!(
+          source_root, "rev-parse", "--show-toplevel", deadline: deadline
+        ).strip
         unless File.realpath(top) == File.realpath(source_root)
           raise CaptureError, "provider capture source does not match the Git worktree top level"
         end
-        head = capture_git!(source_root, "rev-parse", "HEAD").strip
+        head = capture_git!(source_root, "rev-parse", "HEAD", deadline: deadline).strip
         unless head == expected_head
           raise CaptureError,
                 "capture source HEAD #{head} does not match requirement #{expected_head}"
         end
         dirty = capture_git!(
           source_root, "status", "--porcelain=v1", "--untracked-files=all",
-          "--ignore-submodules=none"
+          "--ignore-submodules=none", deadline: deadline
         )
         unless dirty.empty?
           raise CaptureError,
                 "source HEAD or cleanliness changed during project provider capture"
         end
         capture_git!(
-          source_root, "ls-files", "--error-unmatch", "--", provider_executable
+          source_root, "ls-files", "--error-unmatch", "--", provider_executable,
+          deadline: deadline
         )
-        snapshot = provider_source_snapshot!(source_root)
+        verify_provider_source_index_flags!(source_root, deadline: deadline)
+        snapshot = provider_source_snapshot!(source_root, deadline: deadline)
         if expected_snapshot && snapshot != expected_snapshot
           raise CaptureError,
                 "source custody changed during project provider capture, including ignored paths"
@@ -386,10 +453,10 @@ module Hive
         raise CaptureError, "provider capture source is unavailable: #{bounded_diagnostic(e)}"
       end
 
-      def provider_source_snapshot!(source_root)
+      def provider_source_snapshot!(source_root, deadline: nil)
         records = []
         logical_bytes = 0
-        deadline = provider_custody_monotonic_now + PROVIDER_SOURCE_SNAPSHOT_TIMEOUT_SEC
+        deadline ||= provider_custody_monotonic_now + PROVIDER_SOURCE_SNAPSHOT_TIMEOUT_SEC
         Find.find(source_root) do |path|
           enforce_provider_source_snapshot_deadline!(deadline)
           relative = path.delete_prefix("#{source_root}#{File::SEPARATOR}")
@@ -516,26 +583,84 @@ module Hive
         end
       end
 
-      def capture_git!(source_root, *args)
+      def verify_provider_source_index_flags!(source_root, deadline:)
+        consumer = GitIndexFlagConsumer.new(
+          max_entries: PROVIDER_SOURCE_SNAPSHOT_MAX_ENTRIES,
+          max_record_bytes: PROVIDER_SOURCE_GIT_STDOUT_MAX_BYTES
+        )
+        capture_git!(
+          source_root, "ls-files", "-v", "-f", "-z", deadline: deadline,
+          stdout_consumer: consumer
+        )
+        nil
+      end
+
+      def capture_git!(source_root, *args, deadline: nil, stdout_consumer: nil)
+        deadline ||= provider_custody_monotonic_now + PROVIDER_SOURCE_SNAPSHOT_TIMEOUT_SEC
+        enforce_provider_source_snapshot_deadline!(deadline)
         env = {
           "PATH" => @environment.fetch("PATH", "/usr/local/bin:/usr/bin:/bin"),
           "LANG" => @environment["LANG"],
           "LC_ALL" => @environment["LC_ALL"],
           "GIT_CONFIG_NOSYSTEM" => "1",
+          "GIT_LITERAL_PATHSPECS" => "1",
           "GIT_OPTIONAL_LOCKS" => "0",
           "GIT_TERMINAL_PROMPT" => "0"
         }.compact
-        stdout, stderr, status = Open3.capture3(
-          env,
-          "git", "-c", "core.hooksPath=/dev/null", "-c", "diff.external=",
-          "-C", source_root, *args,
-          unsetenv_others: true
+        result = Hive::Web::ProjectCaptureProvider.capture_command_with_custody(
+          argv: [
+            "git", "-c", "core.hooksPath=/dev/null", "-c", "diff.external=",
+            "-c", "core.fsmonitor=false", "-C", source_root, *args
+          ],
+          source_root: source_root,
+          environment: env,
+          deadline: deadline,
+          stdout_consumer: stdout_consumer
         )
-        unless status.success?
+        if result["internal_error"]
           raise CaptureError,
-                "provider capture Git check failed: #{bounded_diagnostic(stderr)}"
+                "provider capture Git custody failed: " \
+                "#{bounded_diagnostic(result.fetch('internal_error'))}"
         end
-        stdout
+        if result.fetch("cleanup_failed")
+          raise CaptureError,
+                "provider capture Git helper descendants could not be terminated"
+        end
+        if result["stdout_consumer_error"]
+          raise CaptureError,
+                bounded_diagnostic(result.fetch("stdout_consumer_error"))
+        end
+        enforce_provider_source_snapshot_deadline!(deadline) if result.fetch("timed_out")
+        if result.fetch("stdout_overflow")
+          raise CaptureError,
+                "provider capture Git check stdout exceeded " \
+                "#{PROVIDER_SOURCE_GIT_STDOUT_MAX_BYTES} bytes"
+        end
+        if result.fetch("stderr_overflow")
+          raise CaptureError,
+                "provider capture Git check stderr exceeded " \
+                "#{PROVIDER_SOURCE_GIT_STDERR_MAX_BYTES} bytes"
+        end
+        if result.fetch("leftover_processes")
+          raise CaptureError,
+                "provider capture Git check left child processes running"
+        end
+
+        status = result.fetch("status")
+        unless status.fetch("success")
+          exit_detail = if status.fetch("signaled")
+            "signal #{status.fetch('termsig').inspect}"
+          else
+            "exit #{status.fetch('exitstatus').inspect}"
+          end
+          detail = bounded_diagnostic(result.fetch("stderr"))
+          suffix = detail.empty? ? "" : ": #{detail}"
+          raise CaptureError,
+                "provider capture Git check failed (#{exit_detail})#{suffix}"
+        end
+        result.fetch("stdout")
+      rescue Hive::Web::ProjectCaptureProvider::ProviderError => e
+        raise CaptureError, "provider capture Git custody failed: #{bounded_diagnostic(e)}"
       end
 
       def provider_publication_plan(artifacts, media_root:, source_sha:)

--- a/lib/hive/web/task_capture.rb
+++ b/lib/hive/web/task_capture.rb
@@ -463,7 +463,6 @@ module Hive
           next if relative.empty?
           if relative == ".git"
             Find.prune
-            next
           end
 
           stat = File.lstat(path)

--- a/lib/hive/web/task_capture.rb
+++ b/lib/hive/web/task_capture.rb
@@ -1,5 +1,6 @@
 require "digest"
 require "fileutils"
+require "find"
 require "json"
 require "open3"
 require "rbconfig"
@@ -11,11 +12,13 @@ require "uri"
 require "hive"
 require "hive/artifacts/capture_policy"
 require "hive/commands/web/capture_server"
+require "hive/config"
 require "hive/invoked_binary"
 require "hive/secret_patterns"
 require "hive/task"
 require "hive/web/browser_bundle"
 require "hive/web/capture_runtime"
+require "hive/web/project_capture_provider"
 require "hive/web/source_bundle"
 require "hive/worktree"
 
@@ -29,7 +32,24 @@ module Hive
       START_TIMEOUT_SEC = 600
       COMMAND_TIMEOUT_SEC = 120
       DIAGNOSTIC_MAX_BYTES = 16 * 1024
+      PROVIDER_SOURCE_SNAPSHOT_MAX_ENTRIES = 250_000
+      PROVIDER_SOURCE_SNAPSHOT_MAX_BYTES = 1024 * 1024 * 1024
+      PROVIDER_SOURCE_SNAPSHOT_TIMEOUT_SEC = 30
+      PROVIDER_SOURCE_HASH_CHUNK_BYTES = 1024 * 1024
       PNG_SIGNATURE = "\x89PNG\r\n\x1a\n".b.freeze
+      BUILT_IN_RECORDER_INPUTS = %w[
+        Gemfile.lock
+        web/Gemfile
+        web/Gemfile.lock
+        web/package.json
+        web/package-lock.json
+        web/script/capture_task_page.cjs
+        web/config/application.rb
+        web/bin/rails
+        web/Rakefile
+        bin/hive
+        lib/hive.rb
+      ].freeze
 
       class CaptureError < Hive::Error; end
 
@@ -38,7 +58,8 @@ module Hive
       def initialize(task_folder:, source_root: nil, output: $stdout,
                      error: $stderr, environment: ENV,
                      source_bundle: nil, browser_bundle: nil,
-                     runtime_factory: nil, server_factory: nil)
+                     runtime_factory: nil, server_factory: nil,
+                     project_config: nil, provider_factory: nil)
         @task = Hive::Task.new(File.expand_path(task_folder))
         @source_root_override = source_root && File.expand_path(source_root)
         @output = output
@@ -48,6 +69,8 @@ module Hive
         @browser_bundle = browser_bundle
         @runtime_factory = runtime_factory
         @server_factory = server_factory
+        @project_config = project_config || Hive::Config.load(@task.project_root)
+        @provider_factory = provider_factory
       end
 
       def call
@@ -60,6 +83,26 @@ module Hive
         unless expected_head.match?(/\A[0-9a-f]{40,64}\z/)
           raise CaptureError, "capture requirement has no immutable implementation HEAD"
         end
+        recorder = select_recorder(source_root)
+        if recorder.fetch(:kind) == :built_in
+          return capture_with_builtin(source_root: source_root, expected_head: expected_head)
+        end
+
+        capture_with_provider(
+          source_root: source_root,
+          expected_head: expected_head,
+          provider_config: recorder.fetch(:config)
+        )
+      rescue Hive::Web::ProjectCaptureProvider::ProviderError => e
+        raise CaptureError, bounded_diagnostic(e)
+      rescue KeyError, JSON::ParserError, Timeout::Error, SystemCallError => e
+        raise CaptureError, bounded_diagnostic(e)
+      end
+
+      private
+
+      def capture_with_builtin(source_root:, expected_head:)
+        session = staging = runtime_root = nil
         source_entry = source_bundle(source_root).ensure!
         unless source_entry.source_sha == expected_head
           raise CaptureError,
@@ -120,13 +163,23 @@ module Hive
         manifest = runtime.capture_manifest(
           task: task.slug,
           source_sha: expected_head,
-          lock_digests: source_entry.lock_digests,
-          cache_key: source_entry.cache_key,
-          command: [
-            "hive", "web", "capture", "--task-folder", task.folder,
-            "--source-root", source_root
-          ],
-          fixture_ids: [ seed.fetch("project"), seed.fetch("task") ],
+          recorder: {
+            "kind" => "built_in",
+            "name" => "hivebox",
+            "command" => [
+              "hive", "web", "capture", "--task-folder", task.folder,
+              "--source-root", source_root
+            ]
+          },
+          environment_keys: Hive::Web::CaptureRuntime::DISCLOSED_ENV_KEYS,
+          evidence: {
+            "type" => "hivebox",
+            "lock_digests" => source_entry.lock_digests,
+            "cache_key" => source_entry.cache_key,
+            "fixture_ids" => [ seed.fetch("project"), seed.fetch("task") ],
+            "viewport" => { "width" => 1280, "height" => 800 },
+            "accessibility_assertions" => browser_result.fetch("accessibility_assertions")
+          },
           media_paths: final_paths,
           status: "captured",
           cleanup: {
@@ -134,11 +187,11 @@ module Hive
             "port" => "released",
             "runtime" => "cleaned"
           },
-          accessibility_assertions: browser_result.fetch("accessibility_assertions"),
           started_at: started_at,
           finished_at: Time.now.utc
         )
         reject_manifest_secrets!(manifest)
+        validate_manifest_budget!(manifest)
         runtime.publish_manifest!(task_folder: task.folder, manifest: manifest)
         manifest
       rescue KeyError, JSON::ParserError, Timeout::Error, SystemCallError => e
@@ -149,7 +202,434 @@ module Hive
         FileUtils.rm_rf(runtime_root) if runtime_root && File.exist?(runtime_root)
       end
 
-      private
+      def capture_with_provider(source_root:, expected_head:, provider_config:)
+        staging = runtime_root = nil
+        published_paths = []
+        previous_provider_paths = []
+        manifest_published = false
+        provider_executable = provider_config.fetch("command").fetch(0)
+        source_snapshot = verify_provider_source!(
+          source_root, expected_head, provider_executable: provider_executable
+        )
+        media_root = validated_media_root
+        previous_provider_paths = retained_provider_media_paths(media_root)
+        staging = Dir.mktmpdir(".capture-", media_root)
+        runtime_root = Dir.mktmpdir("hive-project-capture-")
+        provider = if @provider_factory
+          @provider_factory.call(
+            config: provider_config,
+            environment: @environment
+          )
+        else
+          Hive::Web::ProjectCaptureProvider.new(
+            config: provider_config,
+            environment: @environment
+          )
+        end
+        result = call_provider_with_source_custody(
+          provider,
+          source_root: source_root,
+          expected_head: expected_head,
+          provider_executable: provider_executable,
+          source_snapshot: source_snapshot,
+          staging: staging,
+          runtime_root: runtime_root
+        )
+        publication = provider_publication_plan(
+          result.artifacts,
+          media_root: media_root,
+          source_sha: expected_head
+        )
+        runtime = capture_runtime(
+          source_root: source_root,
+          runtime_root: runtime_root,
+          lifecycle_token: "provider-capture-#{SecureRandom.hex(12)}"
+        )
+        manifest = runtime.capture_manifest(
+          task: task.slug,
+          source_sha: expected_head,
+          recorder: {
+            "kind" => "project_provider",
+            "name" => result.name,
+            "command" => result.command
+          },
+          environment_keys: result.environment_keys,
+          evidence: {
+            "type" => "project_provider",
+            "details" => result.evidence
+          },
+          artifacts: publication.map { |entry| entry.fetch("manifest") },
+          status: "captured",
+          cleanup: result.cleanup,
+          diagnostic: result.diagnostic,
+          started_at: result.started_at,
+          finished_at: result.finished_at
+        )
+        reject_manifest_secrets!(manifest)
+        validate_manifest_budget!(manifest)
+        published_paths = publish_provider_media!(publication, staging: staging)
+        runtime.publish_manifest!(task_folder: task.folder, manifest: manifest)
+        manifest_published = true
+        cleanup_superseded_provider_media!(
+          previous_provider_paths,
+          keep: publication.map { |entry| entry.fetch("destination") }
+        )
+        manifest
+      ensure
+        published_paths.each { |path| FileUtils.rm_f(path) } unless manifest_published
+        FileUtils.rm_rf(staging) if staging && File.exist?(staging)
+        FileUtils.rm_rf(runtime_root) if runtime_root && File.exist?(runtime_root)
+      end
+
+      def select_recorder(source_root)
+        return { kind: :built_in } if @source_bundle
+        return { kind: :built_in } if built_in_recorder_compatible?(source_root)
+
+        provider = @project_config.dig("artifacts", "capture", "provider")
+        return { kind: :provider, config: provider } if provider
+
+        root_lock = regular_file?(File.join(source_root, "Gemfile.lock"))
+        layout = root_lock ? "a conventional project root" : "a non-Hivebox project root"
+        raise CaptureError,
+              "no supported artifact capture provider is available for #{layout}: " \
+              "the built-in recorder capability is absent and no project provider is configured. " \
+              "Declare artifacts.capture.provider in #{File.join(task.project_root, '.hive-state', 'config.yml')} " \
+              "with a project-owned recorder command."
+      end
+
+      def built_in_recorder_compatible?(source_root)
+        BUILT_IN_RECORDER_INPUTS.all? do |relative|
+          regular_file?(File.join(source_root, relative))
+        end
+      end
+
+      def regular_file?(path)
+        stat = File.lstat(path)
+        stat.file? && !stat.symlink?
+      rescue SystemCallError
+        false
+      end
+
+      def call_provider_with_source_custody(provider, source_root:, expected_head:,
+                                            provider_executable:, source_snapshot:,
+                                            staging:, runtime_root:)
+        result = nil
+        provider_error = nil
+        custody_error = nil
+        begin
+          result = provider.call(
+            task: task.slug,
+            source_root: source_root,
+            source_sha: expected_head,
+            staging_root: staging,
+            runtime_root: runtime_root
+          )
+        rescue StandardError => e
+          provider_error = e
+        ensure
+          begin
+            verify_provider_source!(
+              source_root,
+              expected_head,
+              provider_executable: provider_executable,
+              expected_snapshot: source_snapshot
+            )
+          rescue StandardError => e
+            custody_error = e
+          end
+        end
+
+        if provider_error && custody_error
+          raise CaptureError,
+                "#{bounded_diagnostic(provider_error)}; source custody also failed: " \
+                "#{bounded_diagnostic(custody_error)}"
+        end
+        raise provider_error if provider_error
+        raise custody_error if custody_error
+
+        result
+      end
+
+      def verify_provider_source!(source_root, expected_head, provider_executable:,
+                                  expected_snapshot: nil)
+        stat = File.lstat(source_root)
+        if stat.symlink? || !stat.directory? || stat.uid != Process.uid
+          raise CaptureError, "provider capture source must be an owned Git worktree directory"
+        end
+        top = capture_git!(source_root, "rev-parse", "--show-toplevel").strip
+        unless File.realpath(top) == File.realpath(source_root)
+          raise CaptureError, "provider capture source does not match the Git worktree top level"
+        end
+        head = capture_git!(source_root, "rev-parse", "HEAD").strip
+        unless head == expected_head
+          raise CaptureError,
+                "capture source HEAD #{head} does not match requirement #{expected_head}"
+        end
+        dirty = capture_git!(
+          source_root, "status", "--porcelain=v1", "--untracked-files=all",
+          "--ignore-submodules=none"
+        )
+        unless dirty.empty?
+          raise CaptureError,
+                "source HEAD or cleanliness changed during project provider capture"
+        end
+        capture_git!(
+          source_root, "ls-files", "--error-unmatch", "--", provider_executable
+        )
+        snapshot = provider_source_snapshot!(source_root)
+        if expected_snapshot && snapshot != expected_snapshot
+          raise CaptureError,
+                "source custody changed during project provider capture, including ignored paths"
+        end
+        snapshot
+      rescue Errno::ENOENT, Errno::ENOTDIR => e
+        raise CaptureError, "provider capture source is unavailable: #{bounded_diagnostic(e)}"
+      end
+
+      def provider_source_snapshot!(source_root)
+        records = []
+        logical_bytes = 0
+        deadline = provider_custody_monotonic_now + PROVIDER_SOURCE_SNAPSHOT_TIMEOUT_SEC
+        Find.find(source_root) do |path|
+          enforce_provider_source_snapshot_deadline!(deadline)
+          relative = path.delete_prefix("#{source_root}#{File::SEPARATOR}")
+          next if relative.empty?
+          if relative == ".git"
+            Find.prune
+            next
+          end
+
+          stat = File.lstat(path)
+          if stat.file?
+            remaining = PROVIDER_SOURCE_SNAPSHOT_MAX_BYTES - logical_bytes
+            if stat.size > remaining
+              raise CaptureError,
+                    "provider capture source custody exceeds the " \
+                    "#{PROVIDER_SOURCE_SNAPSHOT_MAX_BYTES}-byte logical-file limit; " \
+                    "remove generated or ignored source files before capture"
+            end
+            logical_bytes += stat.size
+          end
+          records << provider_source_record(path, relative, stat, deadline: deadline)
+          if records.length > PROVIDER_SOURCE_SNAPSHOT_MAX_ENTRIES
+            raise CaptureError,
+                  "provider capture source exceeds the #{PROVIDER_SOURCE_SNAPSHOT_MAX_ENTRIES}-entry custody limit"
+          end
+        end
+        enforce_provider_source_snapshot_deadline!(deadline)
+        digest = ::Digest::SHA256.new
+        records.sort.each do |record|
+          enforce_provider_source_snapshot_deadline!(deadline)
+          digest << [ record.bytesize ].pack("Q>") << record
+        end
+        {
+          count: records.length,
+          logical_bytes: logical_bytes,
+          digest: digest.hexdigest
+        }.freeze
+      rescue Errno::EACCES, Errno::EIO, Errno::ELOOP, Errno::ENAMETOOLONG => e
+        raise CaptureError, "provider capture source could not be inventoried: #{bounded_diagnostic(e)}"
+      end
+
+      def provider_source_record(path, relative, stat, deadline:)
+        fields = [
+          relative.b,
+          stat.ftype,
+          stat.mode,
+          stat.uid,
+          stat.gid,
+          stat.ino,
+          stat.size,
+          stat.mtime.to_i,
+          stat.mtime.nsec,
+          stat.ctime.to_i,
+          stat.ctime.nsec
+        ]
+        case stat.ftype
+        when "file"
+          digest = provider_source_file_digest!(path, stat.size, deadline: deadline)
+          after = File.lstat(path)
+          unless provider_source_stat_identity(stat) == provider_source_stat_identity(after)
+            raise CaptureError, "provider capture source changed while custody was inventoried"
+          end
+          fields << digest
+        when "link"
+          fields << File.readlink(path).b
+        when "directory", "fifo", "socket", "characterSpecial", "blockSpecial"
+          fields << stat.rdev
+        else
+          raise CaptureError,
+                "provider capture source contains an unsupported #{stat.ftype} entry"
+        end
+        length_framed_record(fields)
+      end
+
+      def provider_source_file_digest!(path, expected_size, deadline:)
+        digest = ::Digest::SHA256.new
+        bytes_read = 0
+        File.open(path, "rb") do |file|
+          loop do
+            enforce_provider_source_snapshot_deadline!(deadline)
+            chunk = file.read(PROVIDER_SOURCE_HASH_CHUNK_BYTES)
+            break unless chunk
+
+            bytes_read += chunk.bytesize
+            if bytes_read > expected_size
+              raise CaptureError,
+                    "provider capture source changed while custody was inventoried"
+            end
+            digest << chunk
+          end
+        end
+        enforce_provider_source_snapshot_deadline!(deadline)
+        unless bytes_read == expected_size
+          raise CaptureError, "provider capture source changed while custody was inventoried"
+        end
+
+        digest.hexdigest
+      end
+
+      def enforce_provider_source_snapshot_deadline!(deadline)
+        return if provider_custody_monotonic_now < deadline
+
+        raise CaptureError,
+              "provider capture source custody exceeded the " \
+              "#{PROVIDER_SOURCE_SNAPSHOT_TIMEOUT_SEC}-second monotonic inventory deadline; " \
+              "reduce the source tree before capture"
+      end
+
+      def provider_custody_monotonic_now
+        Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      end
+
+      def provider_source_stat_identity(stat)
+        [
+          stat.ftype, stat.mode, stat.uid, stat.gid, stat.ino, stat.size,
+          stat.mtime.to_i, stat.mtime.nsec, stat.ctime.to_i, stat.ctime.nsec
+        ]
+      end
+
+      def length_framed_record(fields)
+        fields.each_with_object(+"".b) do |field, record|
+          bytes = field.to_s.b
+          record << [ bytes.bytesize ].pack("Q>") << bytes
+        end
+      end
+
+      def capture_git!(source_root, *args)
+        env = {
+          "PATH" => @environment.fetch("PATH", "/usr/local/bin:/usr/bin:/bin"),
+          "LANG" => @environment["LANG"],
+          "LC_ALL" => @environment["LC_ALL"],
+          "GIT_CONFIG_NOSYSTEM" => "1",
+          "GIT_OPTIONAL_LOCKS" => "0",
+          "GIT_TERMINAL_PROMPT" => "0"
+        }.compact
+        stdout, stderr, status = Open3.capture3(
+          env,
+          "git", "-c", "core.hooksPath=/dev/null", "-c", "diff.external=",
+          "-C", source_root, *args,
+          unsetenv_others: true
+        )
+        unless status.success?
+          raise CaptureError,
+                "provider capture Git check failed: #{bounded_diagnostic(stderr)}"
+        end
+        stdout
+      end
+
+      def provider_publication_plan(artifacts, media_root:, source_sha:)
+        artifacts.sort_by { |artifact| artifact.fetch("file") }.map do |artifact|
+          original_name = artifact.fetch("file")
+          extension = File.extname(original_name).downcase
+          name_digest = ::Digest::SHA256.hexdigest(original_name)
+          destination_name =
+            "capture-provider-#{source_sha}-#{artifact.fetch('sha256')}-#{name_digest}#{extension}"
+          {
+            "source" => artifact.fetch("source_path"),
+            "destination" => File.join(media_root, destination_name),
+            "manifest" => {
+              "file" => destination_name,
+              "bytes" => artifact.fetch("bytes"),
+              "sha256" => artifact.fetch("sha256")
+            }
+          }
+        end
+      end
+
+      def retained_provider_media_paths(media_root)
+        manifest_path = File.join(media_root, "capture-manifest.json")
+        stat = File.lstat(manifest_path)
+        return [] unless stat.file? && !stat.symlink?
+        return [] if stat.size > Hive::ARTIFACT_CAPTURE_MANIFEST_MAX_BYTES
+
+        manifest = JSON.parse(
+          File.binread(manifest_path, Hive::ARTIFACT_CAPTURE_MANIFEST_MAX_BYTES)
+        )
+        return [] unless manifest.is_a?(Hash)
+        return [] unless manifest["schema"] == "hive-artifact-capture"
+        return [] unless manifest["schema_version"] == 2
+        recorder = manifest["recorder"]
+        return [] unless recorder.is_a?(Hash)
+        return [] unless recorder["kind"] == "project_provider"
+
+        Array(manifest["artifacts"]).filter_map do |artifact|
+          next unless artifact.is_a?(Hash)
+
+          filename = artifact["file"].to_s
+          next unless File.basename(filename) == filename
+          next unless filename.start_with?("capture-provider-")
+          next unless filename.match?(Hive::Web::ProjectCaptureProvider::MEDIA_FILE)
+
+          File.join(media_root, filename)
+        end
+      rescue JSON::ParserError, SystemCallError
+        []
+      end
+
+      def cleanup_superseded_provider_media!(previous_paths, keep:)
+        (Array(previous_paths) - Array(keep)).each do |path|
+          FileUtils.rm_f(path)
+        rescue SystemCallError => e
+          @error.puts(
+            "hive: retained superseded provider media #{File.basename(path)}: " \
+            "#{bounded_diagnostic(e)}"
+          )
+        end
+      end
+
+      def publish_provider_media!(publication, staging:)
+        published = []
+        publication.each do |entry|
+          destination = entry.fetch("destination")
+          manifest = entry.fetch("manifest")
+          if File.exist?(destination) || File.symlink?(destination)
+            stat = File.lstat(destination)
+            reusable = stat.file? && !stat.symlink? && stat.uid == Process.uid &&
+                       stat.size == manifest.fetch("bytes") &&
+                       ::Digest::SHA256.file(destination).hexdigest == manifest.fetch("sha256")
+            raise CaptureError, "capture artifact destination collision: #{destination}" unless reusable
+            next
+          end
+
+          staged = File.join(staging, ".publish-#{File.basename(destination)}")
+          File.open(staged, File::WRONLY | File::CREAT | File::EXCL, 0o600) do |output|
+            File.open(entry.fetch("source"), "rb") do |input|
+              IO.copy_stream(input, output)
+            end
+            output.flush
+            output.fsync
+          end
+          File.rename(staged, destination)
+          published << destination
+        ensure
+          FileUtils.rm_f(staged) if staged
+        end
+        published
+      rescue StandardError
+        published.each { |path| FileUtils.rm_f(path) }
+        raise
+      end
 
       def capture_requirement
         Hive::Artifacts::CapturePolicy.for_task(
@@ -443,6 +923,19 @@ module Hive
 
         names = hits.map { |hit| hit.fetch(:name) }.uniq.join(", ")
         raise CaptureError, "capture manifest contains secret-shaped content: #{names}"
+      end
+
+      def validate_manifest_budget!(manifest)
+        bytes = JSON.generate(manifest).bytesize + 1
+        return bytes if bytes <= Hive::ARTIFACT_CAPTURE_MANIFEST_PRODUCER_MAX_BYTES
+
+        raise CaptureError,
+              "capture manifest is #{bytes} bytes and exceeds the producer limit of " \
+              "#{Hive::ARTIFACT_CAPTURE_MANIFEST_PRODUCER_MAX_BYTES} bytes below the shared " \
+              "consumer ceiling of #{Hive::ARTIFACT_CAPTURE_MANIFEST_MAX_BYTES} bytes; " \
+              "reduce artifacts.capture.provider command or evidence data"
+      rescue JSON::GeneratorError, TypeError => e
+        raise CaptureError, "capture manifest could not be serialized: #{bounded_diagnostic(e)}"
       end
 
       def capture_runtime(source_root:, runtime_root:, lifecycle_token:)

--- a/schemas/hive-artifact-capture.v2.json
+++ b/schemas/hive-artifact-capture.v2.json
@@ -32,6 +32,7 @@
     },
     "environment_keys": {
       "type": "array",
+      "minItems": 1,
       "uniqueItems": true,
       "items": { "type": "string", "minLength": 1 }
     },

--- a/schemas/hive-artifact-capture.v2.json
+++ b/schemas/hive-artifact-capture.v2.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/ivankuznetsov/hive/blob/main/schemas/hive-artifact-capture.v2.json",
+  "title": "Hive retained local artifact capture (v2)",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema", "schema_version", "status", "task", "source_sha", "recorder",
+    "environment_keys", "started_at", "finished_at", "artifacts", "cleanup",
+    "diagnostic", "evidence"
+  ],
+  "properties": {
+    "schema": { "const": "hive-artifact-capture" },
+    "schema_version": { "const": 2 },
+    "status": { "enum": ["captured", "failed"] },
+    "task": { "type": "string", "minLength": 1 },
+    "source_sha": { "type": "string", "pattern": "^[0-9a-f]{40,64}$" },
+    "recorder": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "name", "command"],
+      "properties": {
+        "kind": { "enum": ["built_in", "project_provider"] },
+        "name": { "type": "string", "pattern": "^[a-z][a-z0-9_-]{0,63}$" },
+        "command": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 32,
+          "items": { "type": "string", "minLength": 1, "maxLength": 4096 }
+        }
+      }
+    },
+    "environment_keys": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "started_at": { "type": "string", "format": "date-time" },
+    "finished_at": { "type": "string", "format": "date-time" },
+    "artifacts": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 32,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["file", "bytes", "sha256"],
+        "properties": {
+          "file": { "type": "string", "minLength": 1 },
+          "bytes": { "type": "integer", "minimum": 1 },
+          "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+        }
+      }
+    },
+    "cleanup": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["port", "processes", "runtime"],
+      "properties": {
+        "port": { "const": "released" },
+        "processes": { "const": "clean" },
+        "runtime": { "const": "cleaned" }
+      }
+    },
+    "diagnostic": { "type": ["string", "null"], "maxLength": 16384 },
+    "evidence": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "type", "lock_digests", "cache_key", "fixture_ids", "viewport",
+            "accessibility_assertions"
+          ],
+          "properties": {
+            "type": { "const": "hivebox" },
+            "lock_digests": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["root", "web"],
+              "properties": {
+                "root": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+                "web": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+              }
+            },
+            "cache_key": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+            "fixture_ids": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": { "type": "string", "minLength": 1 }
+            },
+            "viewport": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["width", "height"],
+              "properties": {
+                "width": { "type": "integer", "minimum": 1 },
+                "height": { "type": "integer", "minimum": 1 }
+              }
+            },
+            "accessibility_assertions": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "type": "string", "minLength": 1 }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["type", "details"],
+          "properties": {
+            "type": { "const": "project_provider" },
+            "details": { "type": "object" }
+          }
+        }
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": { "recorder": { "properties": { "kind": { "const": "built_in" } } } }
+      },
+      "then": {
+        "properties": { "evidence": { "properties": { "type": { "const": "hivebox" } } } }
+      }
+    },
+    {
+      "if": {
+        "properties": { "recorder": { "properties": { "kind": { "const": "project_provider" } } } }
+      },
+      "then": {
+        "properties": { "evidence": { "properties": { "type": { "const": "project_provider" } } } }
+      }
+    }
+  ]
+}

--- a/templates/artifacts_prompt.md.erb
+++ b/templates/artifacts_prompt.md.erb
@@ -31,24 +31,31 @@ started and is authoritative for this generation.
 
 ## Required local capture
 
-Use the project's supported recorder. For Hive's own web UI, run:
+Use the public capture command for the owned worktree:
 
 ```sh
 hive web capture --task-folder <%= task_folder %> --source-root <%= worktree_path %>
 ```
 
-That public command owns the supervised capture server, pinned browser cache,
-synthetic fixture, PNG/WebM recording, teardown, and manifest publication. Do
-not call `hive web capture-server` directly, construct an ambient
-`BUNDLE_GEMFILE`, reuse a long-lived web service, or install dependencies into
-the linked worktree.
+That command automatically selects the built-in Hivebox recorder or the
+configured project provider before constructing recorder-specific resources.
+The built-in path owns the supervised capture server, pinned browser cache,
+synthetic fixture, PNG/WebM recording, teardown, and manifest publication. A
+configured project provider receives the exact task, source root, source HEAD,
+and private staging root; Hive validates its media and publishes the manifest.
+Do not call `hive web capture-server` directly, construct an ambient
+`BUNDLE_GEMFILE`, reuse a long-lived web service, install dependencies into the
+linked worktree, or invoke a provider outside the public command.
 
 Capture must use deterministic synthetic or explicitly sanitized data. Keep
-media small and task-local. A success manifest must be
-`hive-artifact-capture` v1 and bind the exact clean source HEAD, lockfile
-digests, cache key, command, fixture IDs, viewport, accessibility assertions,
-artifact byte sizes and SHA-256 hashes, and teardown outcome. Do not claim
-success for partial output.
+media small and task-local. Every new success manifest must use
+`hive-artifact-capture` v2 and bind the exact clean source HEAD, recorder kind,
+recorder argv, disclosed environment-key names, artifact byte sizes and SHA-256
+hashes, typed recorder evidence, and teardown outcome. Built-in evidence carries
+Hivebox lock/cache/fixture/viewport/accessibility fields; configured providers
+carry bounded provider-neutral details. v1 manifests are retained compatibility
+evidence only, not output for a new capture. Do not claim success for partial
+output.
 
 Required media remains local. Do not call Screenote or any external upload tool,
 do not upload to a signed URL, and do not add a remote URL. External publication

--- a/templates/project_config.yml.erb
+++ b/templates/project_config.yml.erb
@@ -130,6 +130,16 @@ conditions:
 open_pr: {}
 artifacts:
   agent: claude
+  # Hive checkouts use the built-in locked Hivebox recorder automatically.
+  # Conventional projects declare a project-owned executable instead; Hive
+  # passes a JSON request on stdin and accepts only a bounded JSON result whose
+  # media files stay inside Hive's private staging directory. The complete argv
+  # is limited to 16 KiB; provider evidence is limited to 64 KiB.
+  # capture:
+  #   provider:
+  #     name: rails
+  #     command: [bin/hive-capture]
+  #     timeout_sec: 120
 finalize:
   agent: claude
 

--- a/test/hive_coverage_boot.rb
+++ b/test/hive_coverage_boot.rb
@@ -3,3 +3,17 @@ $LOAD_PATH.unshift(File.join(root, "lib"))
 require_relative "support/coverage"
 HiveTestCoverage.start!(root: root)
 at_exit { HiveTestCoverage.dump_process_result! }
+
+# Production process supervisors use `exit!` so forked children cannot run
+# inherited application/test at-exit hooks. Coverage still needs each child's
+# hits, so flush a sparse result and then retain the same immediate-exit path.
+module HiveCoverageExitFlush
+  private
+
+  def exit!(status = false)
+    HiveTestCoverage.dump_process_result!(sparse: true)
+    super
+  end
+end
+
+Kernel.prepend(HiveCoverageExitFlush)

--- a/test/support/coverage.rb
+++ b/test/support/coverage.rb
@@ -107,14 +107,16 @@ module HiveTestCoverage
     Warning.define_singleton_method(:warn, original_warn) if original_warn
   end
 
-  def dump_process_result!
+  def dump_process_result!(sparse: false)
     return unless @started
     return if @dumped
 
     FileUtils.mkdir_p(@resultset_dir)
     path = File.join(@resultset_dir, "#{Process.pid}-#{object_id}.marshal")
     tmp_path = "#{path}.tmp"
-    File.binwrite(tmp_path, Marshal.dump(Coverage.result))
+    result = Coverage.result
+    result = sparse_process_result(result) if sparse
+    File.binwrite(tmp_path, Marshal.dump(result))
     File.rename(tmp_path, path)
     @dumped = true
   rescue RuntimeError => e
@@ -130,6 +132,15 @@ module HiveTestCoverage
     # silently producing a too-low coverage number.
     record_dump_error!(e)
     @dumped = true
+  end
+
+  def sparse_process_result(result)
+    result.select do |_path, entry|
+      Array(entry[:lines]).any? { |count| count.to_i.positive? } ||
+        (entry[:branches] || {}).any? do |_decision, outcomes|
+          outcomes.values.any? { |count| count.to_i.positive? }
+        end
+    end
   end
 
   def record_dump_error!(error)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -216,6 +216,45 @@ module HiveTestHelper
     end
   end
 
+  # Project capture delegates content validation to ffprobe and ffmpeg, but
+  # those optional runtime tools are not present on every test host. Keep the
+  # provider tests hermetic with tiny stand-ins that accept the fixture's known
+  # PNG and reject corrupt bytes while preserving the real argv/process path.
+  def with_fake_png_media_tools
+    Dir.mktmpdir("hive-test-media-tools") do |root|
+      fake_bin = File.join(root, "bin")
+      FileUtils.mkdir_p(fake_bin)
+      tool = <<~RUBY
+        #!#{RbConfig.ruby}
+        require "json"
+
+        path = if File.basename($PROGRAM_NAME) == "ffmpeg"
+          ARGV.fetch(ARGV.index("-i") + 1)
+        else
+          ARGV.last
+        end
+        signature = File.binread(path, 8)
+        valid = signature == [ 137, 80, 78, 71, 13, 10, 26, 10 ].pack("C*")
+        exit 1 unless valid
+
+        if File.basename($PROGRAM_NAME) == "ffprobe"
+          puts JSON.generate(
+            "streams" => [ { "codec_name" => "png", "codec_type" => "video" } ],
+            "format" => { "format_name" => "png_pipe", "duration" => "0" }
+          )
+        end
+      RUBY
+      %w[ffprobe ffmpeg].each do |name|
+        path = File.join(fake_bin, name)
+        File.write(path, tool)
+        FileUtils.chmod(0o755, path)
+      end
+      with_env(
+        "PATH" => [ fake_bin, ENV.fetch("PATH", "") ].join(File::PATH_SEPARATOR)
+      ) { yield fake_bin }
+    end
+  end
+
   # Tests run real `git` inside the tmpdir; pack-objects renames internal
   # state like `bitmap-ref-tips_*` between scan and unlink, so `Dir.mktmpdir`'s
   # built-in cleanup (which uses `FileUtils.remove_entry`) intermittently

--- a/test/unit/artifacts/capture_policy_test.rb
+++ b/test/unit/artifacts/capture_policy_test.rb
@@ -145,6 +145,121 @@ class ArtifactsCapturePolicyTest < Minitest::Test
     end
   end
 
+  def test_retained_v1_capture_manifest_remains_satisfactory_after_v2_migration
+    with_task do |task|
+      policy = Hive::Artifacts::CapturePolicy.new(
+        task: task, project: "demo", changed_paths: [ "web/app.css" ],
+        task_generation: "g", base_sha: "a" * 40, head_sha: "b" * 40
+      )
+      policy.ensure!
+      media = File.join(task.folder, "media")
+      FileUtils.mkdir_p(media)
+      image = File.join(media, "legacy.png")
+      File.binwrite(image, "legacy-png")
+      manifest = {
+        "schema" => "hive-artifact-capture",
+        "schema_version" => 1,
+        "status" => "captured",
+        "task" => task.slug,
+        "source_sha" => "b" * 40,
+        "lock_digests" => { "root" => "c" * 64, "web" => "d" * 64 },
+        "cache_key" => "e" * 64,
+        "command" => [ "hive", "web", "capture" ],
+        "environment_keys" => Hive::Web::CaptureRuntime::DISCLOSED_ENV_KEYS.sort,
+        "fixture_ids" => [ "legacy-fixture" ],
+        "started_at" => "2026-07-26T03:00:00Z",
+        "finished_at" => "2026-07-26T03:01:00Z",
+        "viewport" => { "width" => 1280, "height" => 800 },
+        "accessibility_assertions" => [ "heading visible" ],
+        "artifacts" => [
+          {
+            "file" => File.basename(image),
+            "bytes" => File.size(image),
+            "sha256" => Digest::SHA256.file(image).hexdigest
+          }
+        ],
+        "cleanup" => {
+          "port" => "released", "processes" => "clean", "runtime" => "cleaned"
+        },
+        "diagnostic" => nil
+      }
+      File.write(File.join(media, "capture-manifest.json"), JSON.generate(manifest))
+
+      assert policy.capture_satisfied?
+    end
+  end
+
+  def test_capture_manifest_consumer_ceiling_accepts_just_below_and_rejects_just_above
+    with_task do |task|
+      policy = Hive::Artifacts::CapturePolicy.new(
+        task: task, project: "demo", changed_paths: [ "web/app.css" ],
+        task_generation: "g", base_sha: "a" * 40, head_sha: "b" * 40
+      )
+      policy.ensure!
+      media = File.join(task.folder, "media")
+      FileUtils.mkdir_p(media)
+      image = File.join(media, "provider.png")
+      File.binwrite(image, "png")
+      runtime = Hive::Web::CaptureRuntime.new(
+        source_root: "/source", runtime_root: File.join(task.folder, "runtime"),
+        environment: {}, lifecycle_token: "token-123"
+      )
+      manifest = runtime.capture_manifest(
+        task: task.slug,
+        source_sha: "b" * 40,
+        recorder: {
+          "kind" => "project_provider", "name" => "fixture",
+          "command" => [ "bin/provider" ]
+        },
+        environment_keys: [ "PATH" ],
+        evidence: { "type" => "project_provider", "details" => {} },
+        media_paths: [ image ],
+        status: "captured",
+        cleanup: {
+          "port" => "released", "processes" => "clean", "runtime" => "cleaned"
+        }
+      )
+      path = File.join(media, "capture-manifest.json")
+      encoded = JSON.generate(manifest)
+      limit = Hive::ARTIFACT_CAPTURE_MANIFEST_MAX_BYTES
+
+      File.binwrite(path, encoded + (" " * (limit - 1 - encoded.bytesize)))
+      assert_equal limit - 1, File.size(path)
+      assert policy.capture_satisfied?
+
+      File.binwrite(path, encoded + (" " * (limit + 1 - encoded.bytesize)))
+      assert_equal limit + 1, File.size(path)
+      refute policy.capture_satisfied?
+    end
+  end
+
+  def test_non_object_capture_manifests_fail_closed
+    with_task do |task|
+      policy = Hive::Artifacts::CapturePolicy.new(
+        task: task, project: "demo", changed_paths: [ "web/app.css" ],
+        task_generation: "g", base_sha: "a" * 40, head_sha: "b" * 40
+      )
+      policy.ensure!
+      media = File.join(task.folder, "media")
+      FileUtils.mkdir_p(media)
+      path = File.join(media, "capture-manifest.json")
+      invalid_manifests = {
+        "array" => [],
+        "null" => nil,
+        "scalar recorder" => {
+          "schema" => "hive-artifact-capture",
+          "schema_version" => 2,
+          "recorder" => "not-an-object"
+        }
+      }
+
+      invalid_manifests.each do |shape, manifest|
+        File.binwrite(path, JSON.generate(manifest))
+        refute policy.capture_satisfied?, "#{shape} manifest must fail closed"
+      end
+    end
+  end
+
   def test_for_task_collects_committed_staged_unstaged_and_untracked_paths
     with_task do |task|
       base = "a" * 40

--- a/test/unit/artifacts/capture_policy_test.rb
+++ b/test/unit/artifacts/capture_policy_test.rb
@@ -161,6 +161,10 @@ class ArtifactsCapturePolicyTest < Minitest::Test
     refute policy.send(
       :valid_v2_capture_evidence?, manifest.merge("environment_keys" => [])
     )
+    refute policy.send(
+      :valid_v2_capture_evidence?,
+      manifest.merge("recorder" => manifest.fetch("recorder").merge("kind" => "unknown"))
+    )
   end
 
   def test_retained_v1_capture_manifest_remains_satisfactory_after_v2_migration

--- a/test/unit/artifacts/capture_policy_test.rb
+++ b/test/unit/artifacts/capture_policy_test.rb
@@ -145,6 +145,24 @@ class ArtifactsCapturePolicyTest < Minitest::Test
     end
   end
 
+  def test_v2_capture_policy_requires_nonempty_environment_keys
+    policy = Hive::Artifacts::CapturePolicy.allocate
+    manifest = {
+      "recorder" => {
+        "kind" => "project_provider",
+        "name" => "fixture",
+        "command" => [ "bin/provider" ]
+      },
+      "environment_keys" => [ "PATH" ],
+      "evidence" => { "type" => "project_provider", "details" => {} }
+    }
+
+    assert policy.send(:valid_v2_capture_evidence?, manifest)
+    refute policy.send(
+      :valid_v2_capture_evidence?, manifest.merge("environment_keys" => [])
+    )
+  end
+
   def test_retained_v1_capture_manifest_remains_satisfactory_after_v2_migration
     with_task do |task|
       policy = Hive::Artifacts::CapturePolicy.new(

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -1460,6 +1460,103 @@ class ConfigTest < Minitest::Test
                    "artifacts timeout must default to 3600 seconds per plan U1"
       assert_equal "claude", cfg.dig("artifacts", "agent"),
                    "artifacts agent must default to claude per plan U1"
+      assert_nil cfg.dig("artifacts", "capture", "provider")
+    end
+  end
+
+  def test_load_accepts_a_closed_project_capture_provider_declaration
+    with_tmp_dir do |dir|
+      FileUtils.mkdir_p(File.join(dir, ".hive-state"))
+      File.write(File.join(dir, ".hive-state", "config.yml"), <<~YAML)
+        artifacts:
+          capture:
+            provider:
+              name: rails
+              command: [bin/hive-capture, --format, hive-v1]
+              timeout_sec: 90
+      YAML
+
+      provider = Hive::Config.load(dir).dig("artifacts", "capture", "provider")
+
+      assert_equal "rails", provider.fetch("name")
+      assert_equal [ "bin/hive-capture", "--format", "hive-v1" ], provider.fetch("command")
+      assert_equal 90, provider.fetch("timeout_sec")
+    end
+  end
+
+  def test_load_rejects_malformed_or_open_ended_capture_provider_declarations
+    cases = {
+      "capture must be a mapping" => "artifacts:\n  capture: provider",
+      "capture keys are closed" => "artifacts:\n  capture:\n    mystery: true",
+      "provider must be a mapping" => "artifacts:\n  capture:\n    provider: bin/capture",
+      "provider keys are closed" => <<~YAML,
+        artifacts:
+          capture:
+            provider:
+              name: rails
+              command: [bin/capture]
+              shell: true
+      YAML
+      "name is required" => <<~YAML,
+        artifacts:
+          capture:
+            provider:
+              command: [bin/capture]
+      YAML
+      "command must be argv" => <<~YAML,
+        artifacts:
+          capture:
+            provider:
+              name: rails
+              command: bin/capture --unsafe
+      YAML
+      "executable cannot traverse" => <<~YAML,
+        artifacts:
+          capture:
+            provider:
+              name: rails
+              command: [../bin/capture]
+      YAML
+      "timeout is bounded" => <<~YAML
+        artifacts:
+          capture:
+            provider:
+              name: rails
+              command: [bin/capture]
+              timeout_sec: 0
+      YAML
+    }
+
+    cases.each do |label, yaml|
+      with_tmp_dir do |dir|
+        FileUtils.mkdir_p(File.join(dir, ".hive-state"))
+        File.write(File.join(dir, ".hive-state", "config.yml"), yaml)
+
+        assert_raises(Hive::ConfigError, label) { Hive::Config.load(dir) }
+      end
+    end
+  end
+
+  def test_load_rejects_capture_provider_argv_over_the_total_budget
+    with_tmp_dir do |dir|
+      FileUtils.mkdir_p(File.join(dir, ".hive-state"))
+      File.write(
+        File.join(dir, ".hive-state", "config.yml"),
+        {
+          "artifacts" => {
+            "capture" => {
+              "provider" => {
+                "name" => "rails",
+                "command" => [ "bin/capture", *Array.new(4, "x" * 4096) ]
+              }
+            }
+          }
+        }.to_yaml
+      )
+
+      error = assert_raises(Hive::ConfigError) { Hive::Config.load(dir) }
+
+      assert_match(/total argv.*16384 bytes/, error.message)
     end
   end
 

--- a/test/unit/coverage_test.rb
+++ b/test/unit/coverage_test.rb
@@ -82,6 +82,26 @@ class HiveTestCoverageTest < Minitest::Test
     end
   end
 
+  def test_sparse_process_results_keep_only_files_with_observed_hits
+    result = {
+      "/zero.rb" => {
+        lines: [ nil, 0 ],
+        branches: { [ :if, 0, 1, 0, 1, 1 ] => { [ :then, 1, 1, 0, 1, 1 ] => 0 } }
+      },
+      "/line.rb" => { lines: [ nil, 1 ], branches: {} },
+      "/branch.rb" => {
+        lines: [ nil, 0 ],
+        branches: { [ :if, 0, 1, 0, 1, 1 ] => { [ :then, 1, 1, 0, 1, 1 ] => 1 } }
+      }
+    }
+
+    sparse = HiveTestCoverage.sparse_process_result(result)
+
+    assert_equal [ "/branch.rb", "/line.rb" ], sparse.keys.sort
+    assert_same result.fetch("/line.rb"), sparse.fetch("/line.rb")
+    assert_same result.fetch("/branch.rb"), sparse.fetch("/branch.rb")
+  end
+
   def test_reload_preloaded_entrypoint_filters_constant_redefinition_warnings_only
     with_tmp_dir do |dir|
       lib = File.join(dir, "lib")

--- a/test/unit/schema_files_test.rb
+++ b/test/unit/schema_files_test.rb
@@ -42,6 +42,38 @@ class SchemaFilesTest < Minitest::Test
     assert_equal 1, doc.dig("$defs", "SuccessPayload", "properties", "schema_version", "const")
   end
 
+  def test_artifact_capture_v2_requires_nonempty_environment_keys
+    schemer = JSONSchemer.schema(
+      JSON.parse(File.read(Hive::Schemas.schema_path("hive-artifact-capture")))
+    )
+    manifest = {
+      "schema" => "hive-artifact-capture",
+      "schema_version" => 2,
+      "status" => "captured",
+      "task" => "demo-task",
+      "source_sha" => "a" * 40,
+      "recorder" => {
+        "kind" => "project_provider",
+        "name" => "fixture",
+        "command" => [ "bin/provider" ]
+      },
+      "environment_keys" => [ "PATH" ],
+      "started_at" => "2026-08-03T00:00:00Z",
+      "finished_at" => "2026-08-03T00:00:01Z",
+      "artifacts" => [
+        { "file" => "proof.png", "bytes" => 1, "sha256" => "b" * 64 }
+      ],
+      "cleanup" => {
+        "port" => "released", "processes" => "clean", "runtime" => "cleaned"
+      },
+      "diagnostic" => nil,
+      "evidence" => { "type" => "project_provider", "details" => {} }
+    }
+
+    assert schemer.valid?(manifest)
+    refute schemer.valid?(manifest.merge("environment_keys" => []))
+  end
+
   def test_native_web_schema_files_accept_versioned_success_and_error_shapes
     service = {
       "platform" => "linux", "unit_path" => "/tmp/hive-web.service",

--- a/test/unit/stages/artifacts_prompt_test.rb
+++ b/test/unit/stages/artifacts_prompt_test.rb
@@ -14,6 +14,13 @@ class StagesArtifactsPromptTest < Minitest::Test
       assert_includes prompt, "Capture requirement: not_applicable"
       assert_includes prompt, "media/capture-manifest.json"
       assert_includes prompt, "hive-artifact-capture"
+      assert_includes prompt, "`hive-artifact-capture` v2"
+      assert_match(
+        /automatically selects the built-in Hivebox recorder or the\s+configured project provider/,
+        prompt
+      )
+      assert_match(/v1 manifests are retained compatibility\s+evidence only/, prompt)
+      refute_match(/success manifest must be\s+`hive-artifact-capture` v1/, prompt)
       assert_match(/Do not call Screenote or any external upload tool/, prompt)
       refute_includes prompt, "create_screenshot_upload"
       assert_includes prompt, "Completion — REQUIRED",

--- a/test/unit/web/capture_runtime_test.rb
+++ b/test/unit/web/capture_runtime_test.rb
@@ -69,6 +69,36 @@ class WebCaptureRuntimeTest < Minitest::Test
     end
   end
 
+  def test_manifest_requires_nonempty_environment_keys
+    Dir.mktmpdir("capture-runtime") do |root|
+      runtime = Hive::Web::CaptureRuntime.new(
+        source_root: "/source", runtime_root: root,
+        environment: {}, lifecycle_token: "token-123"
+      )
+      attributes = {
+        task: "demo",
+        source_sha: "a" * 40,
+        status: "failed",
+        cleanup: {},
+        recorder: {
+          "kind" => "project_provider",
+          "name" => "fixture",
+          "command" => [ "bin/provider" ]
+        },
+        evidence: { "type" => "project_provider", "details" => {} },
+        diagnostic: "fixture"
+      }
+
+      error = assert_raises(Hive::Web::CaptureRuntime::OwnershipError) do
+        runtime.capture_manifest(**attributes, environment_keys: [])
+      end
+      assert_match(/environment_keys must contain at least one key/, error.message)
+
+      manifest = runtime.capture_manifest(**attributes, environment_keys: [ "PATH" ])
+      assert_equal [ "PATH" ], manifest.fetch("environment_keys")
+    end
+  end
+
   def test_stale_runtime_pid_is_never_killed_with_the_wrong_token
     Dir.mktmpdir("capture-runtime") do |root|
       File.write(File.join(root, "lifecycle.json"), JSON.generate(

--- a/test/unit/web/capture_runtime_test.rb
+++ b/test/unit/web/capture_runtime_test.rb
@@ -353,4 +353,32 @@ class WebCaptureRuntimeTest < Minitest::Test
       assert_instance_of Hive::Web::SourceBundle, runtime.send(:source_bundle)
     end
   end
+
+  def test_readiness_serialization_and_manifest_consumer_ceiling_are_explicit
+    readiness = Hive::Web::CaptureRuntime::Readiness.new(
+      lifecycle_id: "capture-123", pid: 123, process_start_time: "456",
+      process_group: 123, port: 4567,
+      readiness_url: "http://127.0.0.1:4567/health",
+      source_sha: "a" * 40, cache_key: "b" * 64,
+      lock_digests: { "root" => "c" * 64 }, runtime_root: "/runtime",
+      storage_root: "/storage", started_at: "2026-08-03T12:00:00Z"
+    )
+    assert_equal Hive::Web::CaptureRuntime::SCHEMA, readiness.to_h.fetch("schema")
+
+    Dir.mktmpdir("capture-runtime") do |root|
+      runtime = Hive::Web::CaptureRuntime.new(
+        source_root: "/source", runtime_root: root,
+        environment: {}, lifecycle_token: "token-123"
+      )
+      oversized = {
+        "blob" => "x" * Hive::ARTIFACT_CAPTURE_MANIFEST_MAX_BYTES
+      }
+
+      error = assert_raises(Hive::Web::CaptureRuntime::OwnershipError) do
+        runtime.publish_manifest!(task_folder: root, manifest: oversized)
+      end
+      assert_match(/consumer ceiling/, error.message)
+      refute File.exist?(File.join(root, "media", "capture-manifest.json"))
+    end
+  end
 end

--- a/test/unit/web/capture_runtime_test.rb
+++ b/test/unit/web/capture_runtime_test.rb
@@ -61,6 +61,9 @@ class WebCaptureRuntimeTest < Minitest::Test
       )
 
       assert_equal JSON.generate(first), JSON.generate(second)
+      assert_equal 2, first.fetch("schema_version")
+      assert_equal "built_in", first.dig("recorder", "kind")
+      assert_equal "hivebox", first.dig("evidence", "type")
       assert_equal %w[a.png b.png], first.fetch("artifacts").map { |item| item.fetch("file") }
       assert first.fetch("artifacts").all? { |item| item.fetch("sha256").match?(/\A[0-9a-f]{64}\z/) }
     end

--- a/test/unit/web/project_capture_provider_coverage_test.rb
+++ b/test/unit/web/project_capture_provider_coverage_test.rb
@@ -1,0 +1,744 @@
+require "test_helper"
+require "hive/web/project_capture_provider"
+
+class WebProjectCaptureProviderCoverageTest < Minitest::Test
+  include HiveTestHelper
+
+  FakeStatus = Data.define(:success_value, :signaled_value, :exitstatus, :termsig) do
+    def success? = success_value
+    def signaled? = signaled_value
+  end
+
+  def test_call_and_executable_validation_errors_are_bounded
+    Dir.mktmpdir("capture-provider-validation") do |root|
+      source = File.join(root, "source")
+      staging = File.join(root, "staging")
+      runtime = File.join(root, "runtime")
+      outside = File.join(root, "outside")
+      FileUtils.mkdir_p([ source, staging, outside ])
+
+      missing_config = provider(config: { "name" => "fixture" })
+      error = assert_raises(error_class) do
+        missing_config.call(
+          task: "demo", source_root: source, source_sha: "a" * 40,
+          staging_root: staging, runtime_root: runtime
+        )
+      end
+      assert_match(/key not found.*command/, error.message)
+
+      escape = assert_raises(error_class) do
+        provider.send(:provider_executable, source, "../outside/provider")
+      end
+      assert_match(/escapes the source root/, escape.message)
+
+      directory = File.join(source, "directory")
+      FileUtils.mkdir_p(directory)
+      invalid = assert_raises(error_class) do
+        provider.send(:provider_executable, source, "directory")
+      end
+      assert_match(/regular executable file/, invalid.message)
+
+      escaped_dir = File.join(source, "escaped")
+      outside_executable = File.join(outside, "provider")
+      File.write(outside_executable, "#!/bin/sh\n")
+      FileUtils.chmod(0o755, outside_executable)
+      File.symlink(outside, escaped_dir)
+      realpath_escape = assert_raises(error_class) do
+        provider.send(:provider_executable, source, "escaped/provider")
+      end
+      assert_match(/escapes the source root/, realpath_escape.message)
+
+      missing = assert_raises(error_class) do
+        provider.send(:provider_executable, source, "missing")
+      end
+      assert_match(/is unavailable/, missing.message)
+    end
+  end
+
+  def test_execute_translates_every_process_result_boundary
+    cases = [
+      [ { "cleanup_failed" => true }, /descendants could not be terminated/ ],
+      [ { "stderr_overflow" => true }, /stderr exceeded/ ],
+      [
+        {
+          "status" => {
+            "success" => false, "signaled" => true,
+            "exitstatus" => nil, "termsig" => 9
+          }
+        },
+        /signal 9/
+      ]
+    ]
+    cases.each do |override, expected|
+      subject = provider
+      result = base_result.merge(override)
+      subject.define_singleton_method(:supervise_provider) { |*, **| result }
+      error = assert_raises(error_class) do
+        subject.send(
+          :execute!, [ "/bin/true" ], request: {}, source_root: "/tmp",
+          environment: {}, timeout_sec: 1
+        )
+      end
+      assert_match expected, error.message
+    end
+
+    subject = provider
+    subject.define_singleton_method(:supervise_provider) { |*, **| raise Errno::EACCES, "blocked" }
+    error = assert_raises(error_class) do
+      subject.send(
+        :execute!, [ "/bin/true" ], request: {}, source_root: "/tmp",
+        environment: {}, timeout_sec: 1
+      )
+    end
+    assert_match(/could not start.*blocked/, error.message)
+  end
+
+  def test_outer_custody_combines_primary_and_cleanup_failures
+    subject = provider
+    result = base_result
+    provider_error = error_class
+    subject.define_singleton_method(:supervise_provider_in_custody) { |*, **| result }
+    subject.define_singleton_method(:read_supervisor_result) { |_reader| "" }
+    subject.define_singleton_method(:wait_for_supervisor_status!) do |target, **|
+      Process.waitpid(target.fetch(:pid))
+      FakeStatus.new(false, true, nil, 9)
+    end
+    subject.define_singleton_method(:cleanup_command_custody_tree!) do |_target|
+      raise provider_error, "cleanup exploded"
+    end
+
+    error = assert_raises(error_class) do
+      subject.send(
+        :supervise_provider, [ "/bin/true" ], request: {}, source_root: "/tmp",
+        environment: {}, timeout_sec: 1
+      )
+    end
+    assert_match(/custody root failed.*command custody also failed.*cleanup exploded/, error.message)
+  end
+
+  def test_outer_custody_bounds_result_pipe_reads
+    subject = provider
+    result = base_result
+    subject.define_singleton_method(:supervise_provider_in_custody) { |*, **| result }
+    error = with_blocked_result_reader(subject) do
+      assert_raises(error_class) do
+        subject.send(
+          :supervise_provider, [ "/bin/true" ], request: {}, source_root: "/tmp",
+          environment: {}, timeout_sec: 1
+        )
+      end
+    end
+    assert_match(/custody result exceeded its read deadline/, error.message)
+  end
+
+  def test_inner_custody_rejects_preexisting_descendants_and_serializes_child_errors
+    subject = provider
+    subject.define_singleton_method(:child_subreaper_enabled?) { true }
+    subject.define_singleton_method(:supervisor_descendants) do
+      [ { pid: 123, start_time: "1", depth: 1 } ]
+    end
+    error = assert_raises(error_class) do
+      subject.send(
+        :supervise_provider_in_custody, [ "/bin/true" ], request: {},
+        source_root: "/tmp", environment: {}, timeout_sec: 1,
+        deadline: nil, stdout_consumer: nil
+      )
+    end
+    assert_match(/unexpected pre-existing descendants/, error.message)
+
+    subject = provider
+    subject.define_singleton_method(:child_subreaper_enabled?) { true }
+    subject.define_singleton_method(:supervisor_descendants) { [] }
+    subject.define_singleton_method(:enable_child_subreaper!) { raise "child setup exploded" }
+    subject.define_singleton_method(:cleanup_parent_provider_tree!) { |_target| nil }
+    result = subject.send(
+      :supervise_provider_in_custody, [ "/bin/true" ], request: {},
+      source_root: "/tmp", environment: {}, timeout_sec: 1,
+      deadline: nil, stdout_consumer: nil
+    )
+    assert_match(/child setup exploded/, result.fetch("internal_error"))
+  end
+
+  def test_inner_custody_bounds_reads_and_combines_cleanup_failures
+    timeout_subject = provider
+    result = base_result
+    timeout_subject.define_singleton_method(:child_subreaper_enabled?) { true }
+    timeout_subject.define_singleton_method(:supervisor_descendants) { [] }
+    timeout_subject.define_singleton_method(:enable_child_subreaper!) { nil }
+    timeout_subject.define_singleton_method(:supervise_provider_child) { |*, **| result }
+    timeout_subject.define_singleton_method(:cleanup_parent_provider_tree!) { |_target| nil }
+    error = with_blocked_result_reader(timeout_subject) do
+      assert_raises(error_class) do
+        timeout_subject.send(
+          :supervise_provider_in_custody, [ "/bin/true" ], request: {},
+          source_root: "/tmp", environment: {}, timeout_sec: 1,
+          deadline: nil, stdout_consumer: nil
+        )
+      end
+    end
+    assert_match(/supervisor result exceeded its read deadline/, error.message)
+
+    combined = provider
+    provider_error = error_class
+    combined.define_singleton_method(:child_subreaper_enabled?) { true }
+    combined.define_singleton_method(:supervisor_descendants) { [] }
+    combined.define_singleton_method(:enable_child_subreaper!) { nil }
+    combined.define_singleton_method(:supervise_provider_child) { |*, **| result }
+    combined.define_singleton_method(:wait_for_supervisor_status!) do |target, **|
+      Process.waitpid(target.fetch(:pid))
+      FakeStatus.new(false, true, nil, 9)
+    end
+    combined.define_singleton_method(:cleanup_parent_provider_tree!) do |_target|
+      raise provider_error, "parent cleanup exploded"
+    end
+    error = assert_raises(error_class) do
+      combined.send(
+        :supervise_provider_in_custody, [ "/bin/true" ], request: {},
+        source_root: "/tmp", environment: {}, timeout_sec: 1,
+        deadline: nil, stdout_consumer: nil
+      )
+    end
+    assert_match(/supervisor failed.*parent provider custody also failed/, error.message)
+  end
+
+  def test_inner_custody_reports_subreaper_restore_failures
+    subject = provider
+    result = base_result
+    subject.define_singleton_method(:child_subreaper_enabled?) { false }
+    subject.define_singleton_method(:enable_child_subreaper!) { nil }
+    subject.define_singleton_method(:disable_child_subreaper!) { raise "restore exploded" }
+    subject.define_singleton_method(:supervisor_descendants) { [] }
+    subject.define_singleton_method(:supervise_provider_child) { |*, **| result }
+    subject.define_singleton_method(:cleanup_parent_provider_tree!) { |_target| nil }
+
+    error = assert_raises(RuntimeError) do
+      subject.send(
+        :supervise_provider_in_custody, [ "/bin/true" ], request: {},
+        source_root: "/tmp", environment: {}, timeout_sec: 1,
+        deadline: nil, stdout_consumer: nil
+      )
+    end
+    assert_match(/restore exploded/, error.message)
+  end
+
+  def test_command_custody_cleanup_exercises_term_kill_and_failure_paths
+    target = { pid: 123, start_time: "1", depth: 0 }
+    success = provider
+    success.define_singleton_method(:command_custody_targets) { |_target| [ target ] }
+    success.define_singleton_method(:signal_targets) { |*, **| nil }
+    success.define_singleton_method(:wait_for_command_custody_exit) { |*, **| [] }
+    with_replaced_singleton_method(
+      Hive::ProcessKill, :captured_process_alive?, ->(_target) { true }
+    ) { assert_nil success.send(:cleanup_command_custody_tree!, target) }
+
+    failure = provider
+    signals = []
+    failure.define_singleton_method(:command_custody_targets) { |_target| [ target ] }
+    failure.define_singleton_method(:signal_targets) { |signal, _targets| signals << signal }
+    failure.define_singleton_method(:wait_for_command_custody_exit) { |*, **| [ target ] }
+    error = with_replaced_singleton_method(
+      Hive::ProcessKill, :captured_process_alive?, ->(_target) { true }
+    ) do
+      assert_raises(error_class) { failure.send(:cleanup_command_custody_tree!, target) }
+    end
+    assert_match(/could not terminate/, error.message)
+    assert_equal %w[TERM KILL], signals
+  end
+
+  def test_command_custody_wait_and_target_inventory_are_identity_bound
+    custody = { pid: 10, start_time: "1", depth: 0 }
+    child = { pid: 11, start_time: "2", depth: 1 }
+    subject = provider
+    subject.define_singleton_method(:command_custody_targets) { |_target| [ child ] }
+    subject.define_singleton_method(:reap_command_custody_root) { |_target| nil }
+    subject.define_singleton_method(:signal_targets) { |*, **| nil }
+    subject.define_singleton_method(:sleep) { |_seconds| nil }
+    times = [ 0.0, 2.0 ]
+    subject.define_singleton_method(:monotonic_now) { times.shift || 2.0 }
+    alive = ->(target) { [ 10, 11 ].include?(target.fetch(:pid)) }
+    remaining = with_replaced_singleton_method(
+      Hive::ProcessKill, :captured_process_alive?, alive
+    ) do
+      subject.send(
+        :wait_for_command_custody_exit, custody, [ child, child.dup ],
+        deadline: 1.0, signal: "TERM"
+      )
+    end
+    assert_equal [ 11 ], remaining.map { |entry| entry.fetch(:pid) }
+
+    inventory_subject = provider
+    inventory_subject.define_singleton_method(:confirmed_descendants) { |_pid| [ child ] }
+    targets = with_replaced_singleton_method(
+      Hive::ProcessKill, :captured_process_alive?, ->(_target) { true }
+    ) { inventory_subject.send(:command_custody_targets, custody) }
+    assert_equal [ 11, 10 ], targets.map { |entry| entry.fetch(:pid) }
+
+    with_replaced_singleton_method(Process, :waitpid, ->(*) { raise Errno::ECHILD }) do
+      assert_nil inventory_subject.send(:reap_command_custody_root, custody)
+    end
+  end
+
+  def test_process_target_and_wait_status_fail_closed_on_identity_loss
+    subject = provider
+    error = with_replaced_singleton_method(
+      Hive::ProcessKill, :process_start_time, ->(_pid) { nil }
+    ) do
+      assert_raises(error_class) { subject.send(:recorded_process_target!, 123, "worker") }
+    end
+    assert_match(/identity is unavailable/, error.message)
+
+    target = { pid: 123, start_time: "1", depth: 0 }
+    wrong_wait = with_replaced_singleton_method(
+      Process, :waitpid2, ->(*) { [ 999, FakeStatus.new(true, false, 0, nil) ] }
+    ) do
+      assert_raises(error_class) do
+        subject.send(:wait_for_supervisor_status!, target, deadline: Float::INFINITY)
+      end
+    end
+    assert_match(/identity changed/, wrong_wait.message)
+
+    subject.define_singleton_method(:monotonic_now) { 2.0 }
+    timeout = with_replaced_singleton_method(Process, :waitpid2, ->(*) { nil }) do
+      assert_raises(error_class) do
+        subject.send(:wait_for_supervisor_status!, target, deadline: 1.0)
+      end
+    end
+    assert_match(/exceeded its custody deadline/, timeout.message)
+
+    waits = [ nil, [ 123, FakeStatus.new(true, false, 0, nil) ] ]
+    subject.define_singleton_method(:monotonic_now) { 0.0 }
+    status = with_replaced_singleton_method(Process, :waitpid2, ->(*) { waits.shift }) do
+      with_replaced_singleton_method(
+        Hive::ProcessKill, :process_start_time, ->(_pid) { "changed" }
+      ) do
+        subject.send(:wait_for_supervisor_status!, target, deadline: 1.0)
+      end
+    end
+    assert status.success?
+
+    waits = [ nil, nil ]
+    changed = with_replaced_singleton_method(Process, :waitpid2, ->(*) { waits.shift }) do
+      with_replaced_singleton_method(
+        Hive::ProcessKill, :process_start_time, ->(_pid) { "changed" }
+      ) do
+        assert_raises(error_class) do
+          subject.send(:wait_for_supervisor_status!, target, deadline: 1.0)
+        end
+      end
+    end
+    assert_match(/identity changed/, changed.message)
+
+    lost = with_replaced_singleton_method(Process, :waitpid2, ->(*) { raise Errno::ECHILD }) do
+      assert_raises(error_class) do
+        subject.send(:wait_for_supervisor_status!, target, deadline: 1.0)
+      end
+    end
+    assert_match(/exit status custody was lost/, lost.message)
+  end
+
+  def test_parent_cleanup_and_status_serialization_cover_remaining_boundaries
+    target = { pid: 10, start_time: "1", depth: 0 }
+    subject = provider
+    subject.define_singleton_method(:parent_provider_targets) { |_target| [ target ] }
+    subject.define_singleton_method(:signal_targets) { |*, **| nil }
+    subject.define_singleton_method(:wait_for_parent_provider_exit) { |*, **| [ target ] }
+    error = assert_raises(error_class) { subject.send(:cleanup_parent_provider_tree!, target) }
+    assert_match(/could not terminate and verify/, error.message)
+
+    subject = provider
+    subject.define_singleton_method(:supervisor_descendants) { [] }
+    targets = with_replaced_singleton_method(
+      Hive::ProcessKill, :captured_process_alive?, ->(_target) { true }
+    ) { subject.send(:parent_provider_targets, target) }
+    assert_equal [ target ], targets
+    assert_equal "exit 7", subject.send(
+      :serialized_exit_detail, FakeStatus.new(false, false, 7, nil)
+    )
+  end
+
+  def test_supervisor_child_rejects_dirty_parent_and_emergency_cleans_after_spawn
+    subject = provider
+    subject.define_singleton_method(:supervisor_descendants) do
+      [ { pid: 123, start_time: "1", depth: 1 } ]
+    end
+    error = assert_raises(error_class) do
+      subject.send(
+        :supervise_provider_child, [ "/bin/true" ], request: {},
+        source_root: "/tmp", environment: {}, timeout_sec: 1
+      )
+    end
+    assert_match(/unexpected pre-existing descendants/, error.message)
+
+    subject = provider
+    subject.define_singleton_method(:supervisor_descendants) { [] }
+    emergency = []
+    subject.define_singleton_method(:emergency_terminate_provider!) { |pid| emergency << pid }
+    circular = []
+    circular << circular
+    with_replaced_singleton_method(Process, :spawn, ->(*) { 321 }) do
+      assert_raises(JSON::NestingError) do
+        subject.send(
+          :supervise_provider_child, [ "/bin/true" ], request: circular,
+          source_root: "/tmp", environment: {}, timeout_sec: 1
+        )
+      end
+    end
+    assert_equal [ 321 ], emergency
+  end
+
+  def test_stream_and_io_error_paths_fail_closed
+    subject = provider
+    io = Object.new
+    io.define_singleton_method(:read_nonblock) { |*, **| raise IOError, "closed" }
+    io.define_singleton_method(:close) { nil }
+    stream = { data: +"".b, limit: 10, overflow: false, open: true, consumer: nil,
+               consumer_error: nil }
+    with_replaced_singleton_method(IO, :select, ->(*) { [ [ io ], [], [] ] }) do
+      subject.send(:drain_provider_streams, { io => stream }, 0)
+    end
+    refute stream.fetch(:open)
+
+    consumer = Object.new
+    consumer.define_singleton_method(:finish) { raise "finish exploded" }
+    stream = { consumer: consumer, consumer_error: nil, overflow: false }
+    subject.send(:finish_provider_stream_consumer, stream)
+    assert_equal "finish exploded", stream.fetch(:consumer_error)
+    assert stream.fetch(:overflow)
+  end
+
+  def test_supervisor_cleanup_ignores_a_pipe_already_closed_by_another_thread
+    bad_reader = Object.new
+    bad_reader.define_singleton_method(:closed?) { false }
+    bad_reader.define_singleton_method(:close) { raise IOError, "closed concurrently" }
+    writer = Object.new
+    writer.define_singleton_method(:closed?) { false }
+    writer.define_singleton_method(:close) { nil }
+    pipe_calls = 0
+    pipe = lambda do
+      pipe_calls += 1
+      raise RuntimeError, "pipe setup failed" if pipe_calls > 1
+
+      [ bad_reader, writer ]
+    end
+
+    error = with_replaced_singleton_method(IO, :pipe, pipe) do
+      assert_raises(RuntimeError) do
+        provider.send(
+          :supervise_provider_child, [ "/bin/true" ], request: {},
+          source_root: "/tmp", environment: {}, timeout_sec: 1
+        )
+      end
+    end
+
+    assert_equal "pipe setup failed", error.message
+  end
+
+  def test_linux_process_inventory_handles_disappearance_and_permission_failures
+    subject = provider
+    subject.define_singleton_method(:linux_child_pids) do |pid, required:|
+      pid == 1 && required ? [ 2 ] : []
+    end
+    with_replaced_singleton_method(
+      Hive::ProcessKill, :process_start_time, ->(_pid) { nil }
+    ) do
+      with_replaced_singleton_method(Hive::ProcessKill, :pid_alive?, ->(_pid) { false }) do
+        assert_empty subject.send(:linux_descendant_snapshot, 1)
+      end
+      with_replaced_singleton_method(Hive::ProcessKill, :pid_alive?, ->(_pid) { true }) do
+        error = assert_raises(error_class) { subject.send(:linux_descendant_snapshot, 1) }
+        assert_match(/identity custody is unavailable/, error.message)
+      end
+    end
+
+    subject = provider
+    with_replaced_singleton_method(Dir, :children, ->(_path) { [ "1" ] }) do
+      with_replaced_singleton_method(File, :read, ->(_path) { raise Errno::ENOENT }) do
+        assert_empty subject.send(:linux_child_pids, 1, required: true)
+      end
+    end
+    with_replaced_singleton_method(Dir, :children, ->(_path) { raise Errno::ENOENT }) do
+      assert_empty subject.send(:linux_child_pids, 1, required: false)
+      assert_raises(error_class) { subject.send(:linux_child_pids, 1, required: true) }
+    end
+    with_replaced_singleton_method(Dir, :children, ->(_path) { raise Errno::EACCES }) do
+      assert_raises(error_class) { subject.send(:linux_child_pids, 1, required: false) }
+    end
+  end
+
+  def test_emergency_group_signaling_wait_and_pipe_errors_are_bounded
+    subject = provider
+    calls = []
+    subject.define_singleton_method(:terminate_supervised_tree!) { |*, **| calls << :terminated }
+    subject.define_singleton_method(:wait_status) { |_pid| nil }
+    subject.define_singleton_method(:reap_supervised_children) { calls << :reaped }
+    subject.send(:emergency_terminate_provider!, 123)
+    assert_equal %i[terminated reaped], calls
+
+    subject = provider
+    calls = []
+    provider_error = error_class
+    subject.define_singleton_method(:terminate_supervised_tree!) do |*, **|
+      raise provider_error, "fail"
+    end
+    subject.define_singleton_method(:wait_status) { |_pid| nil }
+    subject.define_singleton_method(:signal_provider_group) { |signal, _pid| calls << signal }
+    subject.define_singleton_method(:sleep) { |_seconds| nil }
+    subject.define_singleton_method(:reap_supervised_children) { calls << "reaped" }
+    subject.send(:emergency_terminate_provider!, 123)
+    assert_equal %w[TERM KILL reaped], calls
+
+    subject = provider
+    signals = []
+    with_replaced_singleton_method(Process, :kill, ->(signal, pid) { signals << [ signal, pid ] }) do
+      subject.send(:signal_provider_group, "TERM", 123)
+    end
+    assert_equal [ [ "TERM", -123 ], [ "TERM", 123 ] ], signals
+    with_replaced_singleton_method(Process, :kill, ->(*) { raise Errno::ESRCH }) do
+      assert_nil subject.send(:signal_provider_group, "TERM", 123)
+    end
+    with_replaced_singleton_method(Process, :waitpid2, ->(*) { raise Errno::ECHILD }) do
+      assert_nil subject.send(:wait_status, 123)
+    end
+
+    writer = Object.new
+    writer.define_singleton_method(:write) { |_bytes| raise IOError, "closed" }
+    assert_nil subject.send(:write_supervisor_result, writer, { "ok" => true })
+  end
+
+  def test_supervisor_result_size_and_decode_validation_are_bounded
+    subject = provider
+    reader = StringIO.new("x" * (described_class::SUPERVISOR_RESULT_MAX_BYTES + 1))
+    error = assert_raises(error_class) { subject.send(:read_supervisor_result, reader) }
+    assert_match(/exceeded its limit/, error.message)
+
+    [ "{", "[]", '{"stdout":"!","stderr":""}', "{}" ].each do |raw|
+      error = assert_raises(error_class) { subject.send(:decode_supervisor_result, raw) }
+      assert_match(/invalid result/, error.message)
+    end
+  end
+
+  def test_subreaper_platform_failures_are_actionable
+    subject = provider
+    original_platform = RUBY_PLATFORM
+    original_verbose = $VERBOSE
+    $VERBOSE = nil
+    Object.send(:remove_const, :RUBY_PLATFORM)
+    Object.const_set(:RUBY_PLATFORM, "arm64-darwin26")
+    %i[enable_child_subreaper! child_subreaper_enabled?].each do |method|
+      error = assert_raises(error_class) { subject.send(method) }
+      assert_match(/requires Linux/, error.message)
+    end
+  ensure
+    Object.send(:remove_const, :RUBY_PLATFORM)
+    Object.const_set(:RUBY_PLATFORM, original_platform)
+    $VERBOSE = original_verbose
+  end
+
+  def test_subreaper_dynamic_link_failures_are_actionable
+    subject = provider
+    failing_function = ->(*) { raise Fiddle::DLError, "missing prctl" }
+    with_replaced_singleton_method(Fiddle::Function, :new, failing_function) do
+      %i[enable_child_subreaper! disable_child_subreaper! child_subreaper_enabled?].each do |method|
+        error = assert_raises(error_class) { subject.send(method) }
+        assert_match(/subreaper custody/, error.message)
+      end
+    end
+  end
+
+  def test_result_shape_artifact_and_inventory_validation_fail_closed
+    base = {
+      "schema" => described_class::RESULT_SCHEMA,
+      "schema_version" => described_class::RESULT_SCHEMA_VERSION,
+      "status" => "captured",
+      "artifacts" => [],
+      "evidence" => {},
+      "cleanup" => described_class::CLEANUP,
+      "diagnostic" => nil
+    }
+    cases = [
+      [ base.merge("schema_version" => 99), /unsupported result schema/ ],
+      [ base.merge("status" => "unknown"), /invalid status/ ],
+      [ base.merge("artifacts" => {}), /invalid artifacts/ ],
+      [ base.merge("diagnostic" => 123), /diagnostic is invalid/ ],
+      [ base.merge("diagnostic" => "unexpected"), /must have a null diagnostic/ ]
+    ]
+    cases.each do |document, expected|
+      error = assert_raises(error_class) { provider.send(:validate_result_shape!, document) }
+      assert_match expected, error.message
+    end
+
+    assert_raises(error_class) { provider.send(:validate_artifacts!, [], "/tmp") }
+    invalid = assert_raises(error_class) do
+      provider.send(:validate_artifacts!, [ { "file" => "x.png" } ], "/tmp")
+    end
+    assert_match(/invalid shape/, invalid.message)
+
+    Dir.mktmpdir("provider-artifacts") do |root|
+      empty = File.join(root, "empty.png")
+      File.write(empty, "")
+      invalid = assert_raises(error_class) do
+        provider.send(:validate_artifacts!, [ artifact_entry(empty) ], root)
+      end
+      assert_match(/invalid size/, invalid.message)
+
+      Dir.mktmpdir("provider-outside") do |outside|
+        outside_path = File.join(outside, "proof.png")
+        File.write(outside_path, "png")
+        linked_root = File.join(root, "linked")
+        File.symlink(outside, linked_root)
+        escaped = assert_raises(error_class) do
+          provider.send(:validate_artifacts!, [ artifact_entry(outside_path) ], linked_root)
+        end
+        assert_match(/escapes staging/, escaped.message)
+      end
+
+      sized = File.join(root, "sized.png")
+      File.write(sized, "png")
+      entry = artifact_entry(sized).merge("bytes" => 99)
+      mismatch = assert_raises(error_class) do
+        provider.send(:validate_artifacts!, [ entry ], root)
+      end
+      assert_match(/size does not match/, mismatch.message)
+    end
+
+    mismatch = assert_raises(error_class) do
+      provider.send(:validate_staging_inventory!, "/tmp", [ { "file" => "missing.png" } ])
+    end
+    assert_match(/undeclared or incomplete/, mismatch.message)
+  end
+
+  def test_media_validation_covers_supported_formats_and_malformed_probe_results
+    formats = {
+      "proof.jpg" => [ "mjpeg", {} ],
+      "proof.jpeg" => [ "mjpeg", {} ],
+      "proof.gif" => [ "gif", {} ],
+      "proof.webp" => [ "webp", {} ],
+      "proof.webm" => [ "vp9", { "format_name" => "matroska,webm", "duration" => "1.0" } ],
+      "proof.mp4" => [ "h264", { "format_name" => "mov,mp4", "duration" => "1.0" } ]
+    }
+    formats.each do |filename, (codec, format)|
+      subject = provider
+      results = [
+        base_result.merge(
+          "stdout" => JSON.generate(
+            "streams" => [ { "codec_type" => "video", "codec_name" => codec } ],
+            "format" => format
+          )
+        ),
+        base_result
+      ]
+      subject.define_singleton_method(:media_tool_result) { |*, **| results.shift }
+      with_replaced_singleton_method(
+        Hive::InvokedBinary, :which, ->(name, **) { "/bin/#{name}" }
+      ) do
+        assert_nil subject.send(:validate_media_content!, "/tmp/media", filename, "/tmp")
+      end
+    end
+
+    subject = provider
+    results = [ base_result.merge("stdout" => "{"), base_result ]
+    subject.define_singleton_method(:media_tool_result) { |*, **| results.shift }
+    error = with_replaced_singleton_method(
+      Hive::InvokedBinary, :which, ->(name, **) { "/bin/#{name}" }
+    ) do
+      assert_raises(error_class) do
+        subject.send(:validate_media_content!, "/tmp/media", "proof.png", "/tmp")
+      end
+    end
+    assert_match(/not valid decodable PNG/, error.message)
+
+    subject = provider
+    results = [
+      base_result.merge(
+        "stdout" => JSON.generate(
+          "streams" => [ { "codec_type" => "video", "codec_name" => "unknown" } ]
+        )
+      ),
+      base_result
+    ]
+    subject.define_singleton_method(:media_tool_result) { |*, **| results.shift }
+    error = with_replaced_singleton_method(
+      Hive::InvokedBinary, :which, ->(name, **) { "/bin/#{name}" }
+    ) do
+      assert_raises(error_class) do
+        subject.send(:validate_media_content!, "/tmp/media", "proof.avi", "/tmp")
+      end
+    end
+    assert_match(/not valid decodable AVI/, error.message)
+
+    assert_equal false, provider.send(:playable_video?, {}, nil, /webm/)
+    assert_equal false, provider.send(
+      :playable_video?, { "format" => "webm" }, {}, /webm/
+    )
+    assert_equal false, provider.send(
+      :playable_video?, { "format" => { "format_name" => "mov", "duration" => "1" } },
+      {}, /webm/
+    )
+    assert_equal false, provider.send(
+      :playable_video?, { "format" => { "format_name" => "webm", "duration" => "0" } },
+      {}, /webm/
+    )
+  end
+
+  def test_private_directory_rejects_non_directories
+    Dir.mktmpdir("provider-private-dir") do |root|
+      path = File.join(root, "file")
+      File.write(path, "x")
+      error = assert_raises(error_class) do
+        provider.send(:ensure_private_directory!, path, "fixture")
+      end
+      assert_match(/owned regular directory/, error.message)
+    end
+  end
+
+  private
+
+  def described_class
+    Hive::Web::ProjectCaptureProvider
+  end
+
+  def error_class
+    described_class::ProviderError
+  end
+
+  def provider(config: nil)
+    described_class.new(
+      config: config || {
+        "name" => "fixture", "command" => [ "bin/provider" ], "timeout_sec" => 1
+      },
+      environment: { "PATH" => ENV.fetch("PATH", "") }
+    )
+  end
+
+  def base_result
+    {
+      "stdout" => "",
+      "stderr" => "",
+      "stdout_overflow" => false,
+      "stderr_overflow" => false,
+      "stdout_consumer_error" => nil,
+      "timed_out" => false,
+      "leftover_processes" => false,
+      "cleanup_failed" => false,
+      "status" => {
+        "success" => true, "signaled" => false, "exitstatus" => 0, "termsig" => nil
+      }
+    }
+  end
+
+  def artifact_entry(path)
+    {
+      "file" => File.basename(path),
+      "bytes" => File.size(path),
+      "sha256" => Digest::SHA256.file(path).hexdigest
+    }
+  end
+
+  def with_blocked_result_reader(subject)
+    gate = Queue.new
+    subject.define_singleton_method(:read_supervisor_result) { |_reader| gate.pop }
+    yield
+  ensure
+    gate << ""
+  end
+end

--- a/test/unit/web/project_capture_provider_test.rb
+++ b/test/unit/web/project_capture_provider_test.rb
@@ -479,7 +479,7 @@ class WebProjectCaptureProviderTest < Minitest::Test
         end
       RUBY
       FileUtils.chmod(0o755, executable)
-      yield root, source, executable
+      with_fake_png_media_tools { yield root, source, executable }
     end
   end
 end

--- a/test/unit/web/project_capture_provider_test.rb
+++ b/test/unit/web/project_capture_provider_test.rb
@@ -1,0 +1,389 @@
+require "test_helper"
+require "base64"
+require "hive/process_kill"
+require "hive/web/project_capture_provider"
+
+class WebProjectCaptureProviderTest < Minitest::Test
+  include HiveTestHelper
+
+  HOSTILE_CASES = {
+    "nonzero" => /failed \(exit 7\)/,
+    "timeout" => /timed out/,
+    "malformed" => /malformed JSON/,
+    "oversized" => /stdout exceeded/,
+    "traversal" => /unsafe filename/,
+    "symlink" => /not an owned regular file/,
+    "special" => /not an owned regular file/,
+    "missing" => /is missing/,
+    "tampered" => /digest does not match/,
+    "corrupt" => /valid decodable PNG/,
+    "corrupt-video" => /valid decodable WEBM/,
+    "evidence" => /evidence exceeded/,
+    "secret" => /secret-shaped content/,
+    "cleanup" => /complete cleanup/,
+    "orphan" => /left child processes/
+  }.freeze
+
+  def test_hostile_provider_results_fail_closed_before_publication
+    with_provider_fixture do |root, source, executable|
+      HOSTILE_CASES.each do |mode, expected|
+        staging = File.join(root, "staging-#{mode}")
+        runtime = File.join(root, "runtime-#{mode}")
+        FileUtils.mkdir_p(staging)
+        provider = Hive::Web::ProjectCaptureProvider.new(
+          config: {
+            "name" => "fixture",
+            "command" => [ "bin/provider", mode ],
+            "timeout_sec" => mode == "timeout" ? 1 : 5
+          },
+          environment: {
+            "PATH" => ENV.fetch("PATH", ""),
+            "GH_TOKEN" => "must-not-leak"
+          }
+        )
+
+        error = assert_raises(
+          Hive::Web::ProjectCaptureProvider::ProviderError,
+          "#{mode} provider result must fail closed"
+        ) do
+          provider.call(
+            task: "demo-task",
+            source_root: source,
+            source_sha: "a" * 40,
+            staging_root: staging,
+            runtime_root: runtime
+          )
+        end
+
+        assert_match expected, error.message, mode
+        refute_includes error.message, "ghp_", mode
+        refute File.exist?(File.join(root, "capture-manifest.json")), mode
+      ensure
+        FileUtils.rm_rf(staging) if staging
+        FileUtils.rm_rf(runtime) if runtime
+      end
+      assert File.executable?(executable)
+    end
+  end
+
+  def test_provider_receives_exact_context_without_ambient_credentials
+    with_provider_fixture do |root, source, _executable|
+      staging = File.join(root, "staging-success")
+      runtime = File.join(root, "runtime-success")
+      FileUtils.mkdir_p(staging)
+      provider = Hive::Web::ProjectCaptureProvider.new(
+        config: {
+          "name" => "fixture",
+          "command" => [ "bin/provider", "success" ],
+          "timeout_sec" => 5
+        },
+        environment: {
+          "PATH" => ENV.fetch("PATH", ""),
+          "GH_TOKEN" => "must-not-leak"
+        }
+      )
+
+      result = provider.call(
+        task: "demo-task",
+        source_root: source,
+        source_sha: "a" * 40,
+        staging_root: staging,
+        runtime_root: runtime
+      )
+
+      assert_equal "demo-task", result.evidence.fetch("task")
+      assert_equal File.realpath(source), result.evidence.fetch("source_root")
+      assert_equal "a" * 40, result.evidence.fetch("source_sha")
+      assert_nil result.evidence.fetch("gh_token")
+      refute_includes result.environment_keys, "GH_TOKEN"
+      assert_equal [ "proof.png" ], result.artifacts.map { |artifact| artifact.fetch("file") }
+    end
+  end
+
+  def test_setsid_descendant_holding_output_pipes_is_killed_within_the_deadline
+    with_provider_fixture do |root, source, _executable|
+      staging = File.join(root, "staging-detached")
+      runtime = File.join(root, "runtime-detached")
+      pid_path = File.join(root, "detached.pid")
+      FileUtils.mkdir_p(staging)
+      provider = Hive::Web::ProjectCaptureProvider.new(
+        config: {
+          "name" => "fixture",
+          "command" => [ "bin/provider", "detached", pid_path ],
+          "timeout_sec" => 1
+        },
+        environment: { "PATH" => ENV.fetch("PATH", "") }
+      )
+      started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+      error = assert_raises(Hive::Web::ProjectCaptureProvider::ProviderError) do
+        provider.call(
+          task: "demo-task",
+          source_root: source,
+          source_sha: "a" * 40,
+          staging_root: staging,
+          runtime_root: runtime
+        )
+      end
+      elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+      detached_pid = Integer(File.read(pid_path))
+
+      assert_match(/left child processes running/, error.message)
+      assert_operator elapsed, :<, 2.5,
+                      "provider call exceeded timeout_sec plus bounded custody grace"
+      refute Hive::ProcessKill.pid_alive?(detached_pid),
+             "detached descendant #{detached_pid} survived provider return"
+    ensure
+      if defined?(detached_pid) && Hive::ProcessKill.pid_alive?(detached_pid)
+        Hive::ProcessKill.terminate_process(detached_pid, grace_seconds: 0.1)
+      end
+    end
+  end
+
+  def test_abnormal_supervisor_death_kills_the_exact_provider_tree_before_return
+    with_provider_fixture do |root, source, _executable|
+      staging = File.join(root, "staging-supervisor-death")
+      runtime = File.join(root, "runtime-supervisor-death")
+      provider_pid_path = File.join(root, "provider.pid")
+      descendant_pid_path = File.join(root, "descendant.pid")
+      FileUtils.mkdir_p(staging)
+      provider = Hive::Web::ProjectCaptureProvider.new(
+        config: {
+          "name" => "fixture",
+          "command" => [
+            "bin/provider", "supervisor-death", provider_pid_path,
+            descendant_pid_path
+          ],
+          "timeout_sec" => 1
+        },
+        environment: { "PATH" => ENV.fetch("PATH", "") }
+      )
+
+      error = assert_raises(Hive::Web::ProjectCaptureProvider::ProviderError) do
+        provider.call(
+          task: "demo-task",
+          source_root: source,
+          source_sha: "a" * 40,
+          staging_root: staging,
+          runtime_root: runtime
+        )
+      end
+      provider_pid = Integer(File.read(provider_pid_path))
+      descendant_pid = Integer(File.read(descendant_pid_path))
+
+      assert_match(/supervisor.*signal 9/i, error.message)
+      refute Hive::ProcessKill.pid_alive?(provider_pid),
+             "provider #{provider_pid} survived abnormal supervisor death"
+      refute Hive::ProcessKill.pid_alive?(descendant_pid),
+             "descendant #{descendant_pid} survived abnormal supervisor death"
+    ensure
+      [ provider_pid, descendant_pid ].compact.each do |pid|
+        next unless Hive::ProcessKill.pid_alive?(pid)
+
+        Hive::ProcessKill.terminate_process(pid, grace_seconds: 0.1)
+      end
+    end
+  end
+
+  def test_total_provider_argv_is_bounded_before_execution
+    with_provider_fixture do |root, source, _executable|
+      staging = File.join(root, "staging-argv")
+      runtime = File.join(root, "runtime-argv")
+      FileUtils.mkdir_p(staging)
+      provider = Hive::Web::ProjectCaptureProvider.new(
+        config: {
+          "name" => "fixture",
+          "command" => [ "bin/provider", "success", "x" * (16 * 1024) ],
+          "timeout_sec" => 5
+        },
+        environment: { "PATH" => ENV.fetch("PATH", "") }
+      )
+
+      error = assert_raises(Hive::Web::ProjectCaptureProvider::ProviderError) do
+        provider.call(
+          task: "demo-task",
+          source_root: source,
+          source_sha: "a" * 40,
+          staging_root: staging,
+          runtime_root: runtime
+        )
+      end
+
+      assert_match(/command argv exceeded/, error.message)
+      assert_empty Dir.children(staging)
+    end
+  end
+
+  private
+
+  def with_provider_fixture
+    Dir.mktmpdir("project-capture-provider") do |root|
+      source = File.join(root, "source")
+      executable = File.join(source, "bin", "provider")
+      FileUtils.mkdir_p(File.dirname(executable))
+      File.write(executable, <<~'RUBY')
+        #!/usr/bin/env ruby
+        require "digest"
+        require "base64"
+        require "json"
+        require "rbconfig"
+
+        request = JSON.parse($stdin.read)
+        staging = request.fetch("staging_root")
+        mode = ARGV.fetch(0)
+        clean = { "port" => "released", "processes" => "clean", "runtime" => "cleaned" }
+        result = lambda do |artifacts:, cleanup: clean, status: "captured", diagnostic: nil|
+          puts JSON.generate(
+            "schema" => "hive-project-capture-result",
+            "schema_version" => 1,
+            "status" => status,
+            "artifacts" => artifacts,
+            "evidence" => {},
+            "cleanup" => cleanup,
+            "diagnostic" => diagnostic
+          )
+        end
+        artifact = lambda do |name, path, sha: nil|
+          {
+            "file" => name,
+            "bytes" => File.size(path),
+            "sha256" => sha || Digest::SHA256.file(path).hexdigest
+          }
+        end
+        write_png = lambda do |path|
+          File.binwrite(
+            path,
+            Base64.decode64(
+              "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="
+            )
+          )
+        end
+
+        case mode
+        when "success"
+          path = File.join(staging, "proof.png")
+          write_png.call(path)
+          puts JSON.generate(
+            "schema" => "hive-project-capture-result",
+            "schema_version" => 1,
+            "status" => "captured",
+            "artifacts" => [ artifact.call("proof.png", path) ],
+            "evidence" => {
+              "task" => request.fetch("task"),
+              "source_root" => request.fetch("source_root"),
+              "source_sha" => request.fetch("source_sha"),
+              "gh_token" => ENV["GH_TOKEN"]
+            },
+            "cleanup" => clean,
+            "diagnostic" => nil
+          )
+        when "nonzero"
+          warn "provider exploded"
+          exit 7
+        when "timeout"
+          sleep 3
+        when "malformed"
+          print "{"
+        when "oversized"
+          print "x" * 300_000
+        when "traversal"
+          result.call(artifacts: [ { "file" => "../escape.png", "bytes" => 1, "sha256" => "0" * 64 } ])
+        when "symlink"
+          path = File.join(staging, "link.png")
+          File.symlink(__FILE__, path)
+          result.call(artifacts: [ artifact.call("link.png", path) ])
+        when "special"
+          path = File.join(staging, "special.png")
+          Dir.mkdir(path)
+          result.call(artifacts: [ { "file" => "special.png", "bytes" => 1, "sha256" => "0" * 64 } ])
+        when "missing"
+          result.call(artifacts: [ { "file" => "missing.png", "bytes" => 1, "sha256" => "0" * 64 } ])
+        when "tampered"
+          path = File.join(staging, "tampered.png")
+          write_png.call(path)
+          result.call(artifacts: [ artifact.call("tampered.png", path, sha: "0" * 64) ])
+        when "corrupt"
+          path = File.join(staging, "corrupt.png")
+          File.binwrite(path, "not an image")
+          result.call(artifacts: [ artifact.call("corrupt.png", path) ])
+        when "corrupt-video"
+          path = File.join(staging, "corrupt.webm")
+          File.binwrite(path, "not a video")
+          result.call(artifacts: [ artifact.call("corrupt.webm", path) ])
+        when "evidence"
+          path = File.join(staging, "evidence.png")
+          write_png.call(path)
+          puts JSON.generate(
+            "schema" => "hive-project-capture-result",
+            "schema_version" => 1,
+            "status" => "captured",
+            "artifacts" => [ artifact.call("evidence.png", path) ],
+            "evidence" => { "blob" => "x" * 70_000 },
+            "cleanup" => clean,
+            "diagnostic" => nil
+          )
+        when "secret"
+          result.call(
+            artifacts: [],
+            status: "failed",
+            diagnostic: "ghp_abcdefghijklmnopqrstuvwxyz1234567890"
+          )
+        when "cleanup"
+          path = File.join(staging, "cleanup.png")
+          write_png.call(path)
+          result.call(
+            artifacts: [ artifact.call("cleanup.png", path) ],
+            cleanup: clean.merge("runtime" => "dirty")
+          )
+        when "orphan"
+          path = File.join(staging, "orphan.png")
+          write_png.call(path)
+          Process.spawn(RbConfig.ruby, "-e", "sleep 30")
+          result.call(artifacts: [ artifact.call("orphan.png", path) ])
+        when "detached"
+          path = File.join(staging, "detached.png")
+          write_png.call(path)
+          child_code = <<~'CHILD'
+            Process.setsid
+            File.write(ARGV.fetch(0), Process.pid.to_s)
+            trap("TERM") {}
+            sleep 5
+          CHILD
+          Process.spawn(
+            RbConfig.ruby, "-e", child_code, ARGV.fetch(1),
+            out: $stdout, err: $stderr
+          )
+          deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 2
+          until File.file?(ARGV.fetch(1))
+            abort "detached child did not start" if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+            sleep 0.01
+          end
+          result.call(artifacts: [ artifact.call("detached.png", path) ])
+        when "supervisor-death"
+          supervisor_pid = Process.ppid
+          File.write(ARGV.fetch(1), Process.pid.to_s)
+          trap("TERM") {}
+          child_code = <<~'CHILD'
+            Process.setsid
+            File.write(ARGV.fetch(0), Process.pid.to_s)
+            trap("TERM") {}
+            sleep 30
+          CHILD
+          Process.spawn(RbConfig.ruby, "-e", child_code, ARGV.fetch(2))
+          deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 2
+          until File.file?(ARGV.fetch(2))
+            abort "supervisor-death descendant did not start" if
+              Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+            sleep 0.01
+          end
+          Process.kill("KILL", supervisor_pid)
+          sleep 30
+        else
+          abort "unknown mode"
+        end
+      RUBY
+      FileUtils.chmod(0o755, executable)
+      yield root, source, executable
+    end
+  end
+end

--- a/test/unit/web/project_capture_provider_test.rb
+++ b/test/unit/web/project_capture_provider_test.rb
@@ -214,6 +214,93 @@ class WebProjectCaptureProviderTest < Minitest::Test
     end
   end
 
+  def test_one_item_command_executes_a_tracked_punctuation_filename_literally
+    Dir.mktmpdir("project-capture-punctuation") do |root|
+      source = File.join(root, "source")
+      staging = File.join(root, "staging")
+      runtime = File.join(root, "runtime")
+      executable = File.join(source, "bin", "capture;literal")
+      FileUtils.mkdir_p(File.dirname(executable))
+      FileUtils.mkdir_p(staging, mode: 0o700)
+      File.write(executable, <<~RUBY)
+        #!#{RbConfig.ruby}
+        require "json"
+        $stdin.read
+        puts JSON.generate(
+          "schema" => "hive-project-capture-result",
+          "schema_version" => 1,
+          "status" => "failed",
+          "artifacts" => [],
+          "evidence" => {},
+          "cleanup" => {
+            "port" => "released", "processes" => "clean", "runtime" => "cleaned"
+          },
+          "diagnostic" => "literal executable ran"
+        )
+      RUBY
+      FileUtils.chmod(0o755, executable)
+      run!("git", "-C", source, "init", "--quiet")
+      run!("git", "-C", source, "add", "--", "bin/capture;literal")
+      assert_equal "bin/capture;literal",
+                   run!("git", "-C", source, "ls-files", "--", "bin/capture;literal").strip
+      provider = Hive::Web::ProjectCaptureProvider.new(
+        config: {
+          "name" => "punctuation",
+          "command" => [ "bin/capture;literal" ],
+          "timeout_sec" => 2
+        },
+        environment: { "PATH" => ENV.fetch("PATH", "") }
+      )
+
+      error = assert_raises(Hive::Web::ProjectCaptureProvider::ProviderError) do
+        provider.call(
+          task: "demo-task",
+          source_root: source,
+          source_sha: "a" * 40,
+          staging_root: staging,
+          runtime_root: runtime
+        )
+      end
+
+      assert_match(/literal executable ran/, error.message)
+    end
+  end
+
+  def test_blank_failed_diagnostics_use_the_actionable_fallback
+    with_provider_fixture do |root, source, _executable|
+      expectations = {
+        "failed-empty" => "provider reported failure",
+        "failed-whitespace" => "provider reported failure",
+        "failed-actionable" => "retry after fixing the fixture"
+      }
+      expectations.each do |mode, expected|
+        staging = File.join(root, "staging-#{mode}")
+        runtime = File.join(root, "runtime-#{mode}")
+        FileUtils.mkdir_p(staging, mode: 0o700)
+        provider = Hive::Web::ProjectCaptureProvider.new(
+          config: {
+            "name" => "fixture",
+            "command" => [ "bin/provider", mode ],
+            "timeout_sec" => 2
+          },
+          environment: { "PATH" => ENV.fetch("PATH", "") }
+        )
+
+        error = assert_raises(Hive::Web::ProjectCaptureProvider::ProviderError, mode) do
+          provider.call(
+            task: "demo-task",
+            source_root: source,
+            source_sha: "a" * 40,
+            staging_root: staging,
+            runtime_root: runtime
+          )
+        end
+
+        assert_match(/failed: #{Regexp.escape(expected)}\z/, error.message, mode)
+      end
+    end
+  end
+
   private
 
   def with_provider_fixture
@@ -334,6 +421,15 @@ class WebProjectCaptureProviderTest < Minitest::Test
           result.call(
             artifacts: [ artifact.call("cleanup.png", path) ],
             cleanup: clean.merge("runtime" => "dirty")
+          )
+        when "failed-empty"
+          result.call(artifacts: [], status: "failed", diagnostic: "")
+        when "failed-whitespace"
+          result.call(artifacts: [], status: "failed", diagnostic: "   ")
+        when "failed-actionable"
+          result.call(
+            artifacts: [], status: "failed",
+            diagnostic: "retry after fixing the fixture"
           )
         when "orphan"
           path = File.join(staging, "orphan.png")

--- a/test/unit/web/task_capture_coverage_test.rb
+++ b/test/unit/web/task_capture_coverage_test.rb
@@ -1,0 +1,312 @@
+require "test_helper"
+require "hive/web/task_capture"
+
+class WebTaskCaptureCoverageTest < Minitest::Test
+  include HiveTestHelper
+
+  def test_git_index_flag_consumer_rejects_every_bounded_invalid_shape
+    consumer_class = Hive::Web::TaskCapture.const_get(:GitIndexFlagConsumer, false)
+
+    overlong = consumer_class.new(max_entries: 2, max_record_bytes: 3)
+    error = assert_raises(capture_error) { overlong.write("xxxx") }
+    assert_match(/record exceeded/, error.message)
+
+    too_many = consumer_class.new(max_entries: 1, max_record_bytes: 20)
+    error = assert_raises(capture_error) { too_many.write("H one\0H two\0") }
+    assert_match(/entry custody limit/, error.message)
+
+    malformed = consumer_class.new(max_entries: 1, max_record_bytes: 20)
+    error = assert_raises(capture_error) { malformed.write("malformed\0") }
+    assert_match(/unsupported representation/, error.message)
+  end
+
+  def test_call_translates_provider_failures
+    with_capture do |capture, source, _task_folder|
+      provider_error = Hive::Web::ProjectCaptureProvider::ProviderError
+      capture.define_singleton_method(:capture_requirement) do
+        { "result" => "required", "implementation_head" => "a" * 40 }
+      end
+      capture.define_singleton_method(:owned_source_root) { source }
+      capture.define_singleton_method(:select_recorder) do |_source_root|
+        { kind: :project_provider, config: {} }
+      end
+      capture.define_singleton_method(:capture_with_provider) do |**|
+        raise provider_error, "provider failed"
+      end
+
+      error = assert_raises(capture_error) { capture.call }
+      assert_match(/provider failed/, error.message)
+    end
+  end
+
+  def test_builtin_capture_translates_structural_failures
+    source_bundle = Object.new
+    source_bundle.define_singleton_method(:ensure!) { raise Errno::EIO, "bundle failed" }
+
+    with_capture(source_bundle: source_bundle) do |capture, source, _task_folder|
+      error = assert_raises(capture_error) do
+        capture.send(:capture_with_builtin, source_root: source, expected_head: "a" * 40)
+      end
+      assert_match(/bundle failed/, error.message)
+    end
+  end
+
+  def test_provider_source_identity_checks_fail_closed
+    with_capture do |capture, source, _task_folder|
+      file = File.join(source, "not-a-directory")
+      File.write(file, "x")
+      error = assert_raises(capture_error) do
+        capture.send(
+          :verify_provider_source!, file, "a" * 40,
+          provider_executable: "bin/provider"
+        )
+      end
+      assert_match(/owned Git worktree directory/, error.message)
+
+      other = File.join(File.dirname(source), "other")
+      FileUtils.mkdir_p(other)
+      top_mismatch = task_capture(capture.task.folder)
+      top_mismatch.define_singleton_method(:capture_git!) { |*| other }
+      error = assert_raises(capture_error) do
+        top_mismatch.send(
+          :verify_provider_source!, source, "a" * 40,
+          provider_executable: "bin/provider"
+        )
+      end
+      assert_match(/does not match the Git worktree top level/, error.message)
+
+      head_mismatch = task_capture(capture.task.folder)
+      responses = [ source, "b" * 40 ]
+      head_mismatch.define_singleton_method(:capture_git!) { |*| responses.shift }
+      error = assert_raises(capture_error) do
+        head_mismatch.send(
+          :verify_provider_source!, source, "a" * 40,
+          provider_executable: "bin/provider"
+        )
+      end
+      assert_match(/does not match requirement/, error.message)
+
+      missing = File.join(source, "missing")
+      error = assert_raises(capture_error) do
+        capture.send(
+          :verify_provider_source!, missing, "a" * 40,
+          provider_executable: "bin/provider"
+        )
+      end
+      assert_match(/source is unavailable/, error.message)
+    end
+  end
+
+  def test_provider_source_snapshot_bounds_entry_count_and_inventory_errors
+    with_capture do |capture, source, _task_folder|
+      File.write(File.join(source, "one"), "1")
+      File.write(File.join(source, "two"), "2")
+      original = Hive::Web::TaskCapture::PROVIDER_SOURCE_SNAPSHOT_MAX_ENTRIES
+      original_verbose = $VERBOSE
+      $VERBOSE = nil
+      Hive::Web::TaskCapture.send(:remove_const, :PROVIDER_SOURCE_SNAPSHOT_MAX_ENTRIES)
+      Hive::Web::TaskCapture.const_set(:PROVIDER_SOURCE_SNAPSHOT_MAX_ENTRIES, 1)
+      begin
+        error = assert_raises(capture_error) do
+          capture.send(:provider_source_snapshot!, source)
+        end
+        assert_match(/1-entry custody limit/, error.message)
+      ensure
+        Hive::Web::TaskCapture.send(:remove_const, :PROVIDER_SOURCE_SNAPSHOT_MAX_ENTRIES)
+        Hive::Web::TaskCapture.const_set(
+          :PROVIDER_SOURCE_SNAPSHOT_MAX_ENTRIES, original
+        )
+        $VERBOSE = original_verbose
+      end
+
+      error = with_replaced_singleton_method(
+        Find, :find, ->(*) { raise Errno::EACCES, "denied" }
+      ) do
+        assert_raises(capture_error) do
+          capture.send(:provider_source_snapshot!, source)
+        end
+      end
+      assert_match(/could not be inventoried/, error.message)
+    end
+  end
+
+  def test_provider_source_records_detect_identity_and_entry_type_changes
+    with_capture do |capture, source, _task_folder|
+      file = File.join(source, "file")
+      File.binwrite(file, "before")
+      original_stat = File.lstat(file)
+      capture.define_singleton_method(:provider_source_file_digest!) do |path, *, **|
+        File.binwrite(path, "after-change")
+        "digest"
+      end
+      error = assert_raises(capture_error) do
+        capture.send(
+          :provider_source_record, file, "file", original_stat,
+          deadline: Float::INFINITY
+        )
+      end
+      assert_match(/changed while custody was inventoried/, error.message)
+
+      target = File.join(source, "target")
+      link = File.join(source, "link")
+      File.write(target, "target")
+      File.symlink("target", link)
+      record = task_capture(capture.task.folder).send(
+        :provider_source_record, link, "link", File.lstat(link),
+        deadline: Float::INFINITY
+      )
+      refute_empty record
+
+      fake_stat = Struct.new(
+        :ftype, :mode, :uid, :gid, :ino, :size, :mtime, :ctime
+      ).new("mystery", 0, Process.uid, Process.gid, 1, 0, Time.now, Time.now)
+      error = assert_raises(capture_error) do
+        capture.send(
+          :provider_source_record, file, "file", fake_stat,
+          deadline: Float::INFINITY
+        )
+      end
+      assert_match(/unsupported mystery entry/, error.message)
+    end
+  end
+
+  def test_provider_source_digest_detects_growth_and_shrinkage
+    with_capture do |capture, source, _task_folder|
+      file = File.join(source, "changing")
+      File.binwrite(file, "ab")
+      assert_raises(capture_error) do
+        capture.send(
+          :provider_source_file_digest!, file, 1, deadline: Float::INFINITY
+        )
+      end
+
+      File.binwrite(file, "a")
+      assert_raises(capture_error) do
+        capture.send(
+          :provider_source_file_digest!, file, 2, deadline: Float::INFINITY
+        )
+      end
+    end
+  end
+
+  def test_capture_git_translates_custody_and_signal_failures
+    with_capture do |capture, source, _task_folder|
+      cases = [
+        [ git_result.merge("internal_error" => "internal"), /custody failed.*internal/ ],
+        [ git_result.merge("cleanup_failed" => true), /descendants could not be terminated/ ],
+        [
+          git_result.merge(
+            "status" => {
+              "success" => false, "signaled" => true,
+              "exitstatus" => nil, "termsig" => 9
+            }
+          ),
+          /failed \(signal 9\)/
+        ]
+      ]
+      cases.each do |result, message|
+        error = with_replaced_singleton_method(
+          Hive::Web::ProjectCaptureProvider, :capture_command_with_custody,
+          ->(**) { result }
+        ) do
+          assert_raises(capture_error) { capture.send(:capture_git!, source, "status") }
+        end
+        assert_match message, error.message
+      end
+
+      provider_error = Hive::Web::ProjectCaptureProvider::ProviderError
+      error = with_replaced_singleton_method(
+        Hive::Web::ProjectCaptureProvider, :capture_command_with_custody,
+        ->(**) { raise provider_error, "provider boundary" }
+      ) do
+        assert_raises(capture_error) { capture.send(:capture_git!, source, "status") }
+      end
+      assert_match(/custody failed.*provider boundary/, error.message)
+    end
+  end
+
+  def test_provider_media_cleanup_reports_retention_and_rolls_back_partial_publish
+    output = StringIO.new
+    with_capture(error: output) do |capture, source, task_folder|
+      error = with_replaced_singleton_method(
+        FileUtils, :rm_f, ->(*) { raise Errno::EACCES, "denied" }
+      ) do
+        capture.send(
+          :cleanup_superseded_provider_media!, [ "/tmp/old.png" ], keep: []
+        )
+        output.string
+      end
+      assert_match(/retained superseded provider media old.png/, error)
+
+      staging = File.join(task_folder, "staging")
+      media = File.join(task_folder, "media")
+      FileUtils.mkdir_p([ staging, media ])
+      first_source = File.join(source, "first.png")
+      first_destination = File.join(media, "first.png")
+      File.binwrite(first_source, "first")
+      publication = [
+        {
+          "source" => first_source, "destination" => first_destination,
+          "manifest" => { "bytes" => 5, "sha256" => Digest::SHA256.hexdigest("first") }
+        },
+        {
+          "source" => File.join(source, "missing.png"),
+          "destination" => File.join(media, "second.png"),
+          "manifest" => { "bytes" => 1, "sha256" => "a" * 64 }
+        }
+      ]
+
+      assert_raises(Errno::ENOENT) do
+        capture.send(:publish_provider_media!, publication, staging: staging)
+      end
+      refute File.exist?(first_destination)
+    end
+  end
+
+  def test_manifest_budget_translates_serialization_failures
+    with_capture do |capture, _source, _task_folder|
+      error = assert_raises(capture_error) do
+        capture.send(:validate_manifest_budget!, { "invalid" => Float::NAN })
+      end
+      assert_match(/could not be serialized/, error.message)
+    end
+  end
+
+  private
+
+  def capture_error
+    Hive::Web::TaskCapture::CaptureError
+  end
+
+  def task_capture(task_folder, **options)
+    Hive::Web::TaskCapture.new(
+      task_folder: task_folder,
+      environment: { "PATH" => ENV.fetch("PATH", "") },
+      **options
+    )
+  end
+
+  def with_capture(**options)
+    Dir.mktmpdir("hive-task-capture-coverage") do |root|
+      source = File.join(root, "source")
+      task_folder = File.join(
+        root, ".hive-state", "stages", "7-artifacts", "demo-task"
+      )
+      FileUtils.mkdir_p([ source, task_folder ])
+      yield task_capture(task_folder, **options), source, task_folder
+    end
+  end
+
+  def git_result
+    {
+      "stdout" => "", "stderr" => "", "internal_error" => nil,
+      "cleanup_failed" => false, "stdout_consumer_error" => nil,
+      "timed_out" => false, "stdout_overflow" => false,
+      "stderr_overflow" => false, "leftover_processes" => false,
+      "status" => {
+        "success" => true, "signaled" => false,
+        "exitstatus" => 0, "termsig" => nil
+      }
+    }
+  end
+end

--- a/test/unit/web/task_capture_test.rb
+++ b/test/unit/web/task_capture_test.rb
@@ -229,8 +229,13 @@ class WebTaskCaptureTest < Minitest::Test
         assert_raises(Hive::Web::TaskCapture::CaptureError) { capture.call }
       end
 
-      assert_match(/no supported artifact capture provider/i, error.message)
-      assert_includes error.message, "artifacts.capture.provider"
+      assert_equal(
+        "no supported artifact capture provider is available for a conventional project root: " \
+        "the built-in recorder capability is absent and no project provider is configured. " \
+        "Declare artifacts.capture.provider in #{File.join(root, '.hive-state', 'config.yml')} " \
+        "with a project-owned recorder command.",
+        error.message
+      )
       refute_includes error.message, "web/Gemfile"
       refute_includes error.message, "web/Gemfile.lock"
       assert_equal 0, source_bundle_calls
@@ -238,6 +243,50 @@ class WebTaskCaptureTest < Minitest::Test
       assert_equal 0, server_calls
       refute File.exist?(File.join(task_folder, "media"))
       assert_equal root, File.dirname(File.dirname(File.dirname(File.dirname(task_folder))))
+    end
+  end
+
+  def test_non_linux_selection_reports_project_provider_unavailability
+    with_capture_task do |_root, task_folder, source|
+      File.write(File.join(source, "Gemfile.lock"), "GEM\n")
+      original_platform = RUBY_PLATFORM
+      original_verbose = $VERBOSE
+      $VERBOSE = nil
+      Object.send(:remove_const, :RUBY_PLATFORM)
+      Object.const_set(:RUBY_PLATFORM, "arm64-darwin26")
+      begin
+        [
+          {},
+          {
+            "artifacts" => {
+              "capture" => {
+                "provider" => {
+                  "name" => "fixture", "command" => [ "bin/provider" ],
+                  "timeout_sec" => 2
+                }
+              }
+            }
+          }
+        ].each do |project_config|
+          capture = Hive::Web::TaskCapture.new(
+            task_folder: task_folder,
+            project_config: project_config
+          )
+
+          error = assert_raises(Hive::Web::TaskCapture::CaptureError) do
+            capture.send(:select_recorder, source)
+          end
+
+          assert_match(/project-provider capture is unavailable on arm64-darwin26/i,
+                       error.message)
+          assert_match(/Linux child-subreaper support/, error.message)
+          refute_includes error.message, "Declare artifacts.capture.provider"
+        end
+      ensure
+        Object.send(:remove_const, :RUBY_PLATFORM)
+        Object.const_set(:RUBY_PLATFORM, original_platform)
+        $VERBOSE = original_verbose
+      end
     end
   end
 
@@ -252,6 +301,7 @@ class WebTaskCaptureTest < Minitest::Test
   end
 
   def test_configured_conventional_provider_publishes_valid_v2_evidence_without_hivebox
+    unrelated_child = start_unrelated_caller_child
     with_capture_task do |_root, task_folder, source|
       FileUtils.mkdir_p([ File.join(source, "app"), File.join(source, "bin") ])
       File.write(File.join(source, "Gemfile.lock"), "GEM\n")
@@ -350,9 +400,13 @@ class WebTaskCaptureTest < Minitest::Test
       policy.ensure!
       assert policy.capture_satisfied?
     end
+    assert_unrelated_caller_child_alive(unrelated_child)
+  ensure
+    stop_unrelated_caller_child(unrelated_child)
   end
 
   def test_provider_target_mutation_is_detected_before_any_media_is_published
+    unrelated_child = start_unrelated_caller_child
     with_capture_task do |_root, task_folder, source|
       FileUtils.mkdir_p([ File.join(source, "app"), File.join(source, "bin") ])
       lockfile = File.join(source, "Gemfile.lock")
@@ -420,9 +474,13 @@ class WebTaskCaptureTest < Minitest::Test
       assert_empty Dir.children(media)
       refute File.exist?(File.join(media, "capture-manifest.json"))
     end
+    assert_unrelated_caller_child_alive(unrelated_child)
+  ensure
+    stop_unrelated_caller_child(unrelated_child)
   end
 
   def test_real_provider_failures_revalidate_source_and_preserve_both_errors
+    unrelated_child = start_unrelated_caller_child
     failures = {
       "nonzero" => /failed \(exit 7\)/,
       "timeout" => /timed out after 1s/,
@@ -465,6 +523,9 @@ class WebTaskCaptureTest < Minitest::Test
         assert_empty Dir.children(File.join(task_folder, "media")), failure
       end
     end
+    assert_unrelated_caller_child_alive(unrelated_child)
+  ensure
+    stop_unrelated_caller_child(unrelated_child)
   end
 
   def test_provider_ignored_path_mutation_is_detected_before_publication
@@ -508,6 +569,286 @@ class WebTaskCaptureTest < Minitest::Test
       assert File.file?(File.join(source, "tmp", "ignored.txt")),
              "custody detection must not hide or restore the provider mutation"
       assert_empty Dir.children(File.join(task_folder, "media"))
+    end
+  end
+
+  def test_provider_source_rejects_hidden_index_flags_before_execution
+    {
+      "assume-unchanged" => "--assume-unchanged",
+      "skip-worktree" => "--skip-worktree"
+    }.each do |name, flag|
+      with_capture_task do |_root, task_folder, source|
+        head = prepare_conventional_provider_source(source)
+        run!("git", "-C", source, "update-index", flag, "--", "Gemfile.lock")
+        File.write(File.join(source, "Gemfile.lock"), "hidden #{name} mutation\n")
+        capture = Hive::Web::TaskCapture.new(
+          task_folder: task_folder,
+          environment: { "PATH" => ENV.fetch("PATH", "") }
+        )
+
+        error = assert_raises(Hive::Web::TaskCapture::CaptureError, name) do
+          capture.send(
+            :verify_provider_source!, source, head,
+            provider_executable: "bin/provider"
+          )
+        end
+
+        assert_match(/non-default Git index flags/i, error.message, name)
+      end
+    end
+  end
+
+  def test_provider_source_requires_the_literal_executable_path_to_be_tracked
+    with_capture_task do |_root, task_folder, source|
+      prepare_conventional_provider_source(source, ignored: "bin/capture*\n")
+      tracked_match = File.join(source, "bin", "capture-safe")
+      File.binwrite(tracked_match, "tracked decoy\n")
+      run!("git", "-C", source, "add", "-f", "--", "bin/capture-safe")
+      run!("git", "-C", source, "commit", "-m", "track decoy", "--quiet")
+      head = run!("git", "-C", source, "rev-parse", "HEAD").strip
+      write_executable(File.join(source, "bin", "capture*"), "#!/bin/sh\nexit 0\n")
+      capture = Hive::Web::TaskCapture.new(
+        task_folder: task_folder,
+        environment: { "PATH" => ENV.fetch("PATH", "") }
+      )
+
+      error = assert_raises(Hive::Web::TaskCapture::CaptureError) do
+        capture.send(
+          :verify_provider_source!, source, head,
+          provider_executable: "bin/capture*"
+        )
+      end
+
+      assert_match(/Git check failed/i, error.message)
+    end
+  end
+
+  def test_provider_source_rejects_hidden_index_flags_after_execution
+    {
+      "assume-unchanged" => "--assume-unchanged",
+      "skip-worktree" => "--skip-worktree"
+    }.each do |name, flag|
+      with_capture_task do |root, task_folder, source|
+        head = prepare_conventional_provider_source(source)
+        capture = Hive::Web::TaskCapture.new(
+          task_folder: task_folder,
+          environment: { "PATH" => ENV.fetch("PATH", "") }
+        )
+        snapshot = capture.send(
+          :verify_provider_source!, source, head,
+          provider_executable: "bin/provider"
+        )
+        runner = method(:run!)
+        provider = Object.new
+        provider.define_singleton_method(:call) do |**|
+          runner.call("git", "-C", source, "update-index", flag, "--", "Gemfile.lock")
+          :provider_result
+        end
+
+        error = assert_raises(Hive::Web::TaskCapture::CaptureError, name) do
+          capture.send(
+            :call_provider_with_source_custody,
+            provider,
+            source_root: source,
+            expected_head: head,
+            provider_executable: "bin/provider",
+            source_snapshot: snapshot,
+            staging: File.join(root, "staging"),
+            runtime_root: File.join(root, "runtime")
+          )
+        end
+
+        assert_match(/non-default Git index flags/i, error.message, name)
+      end
+    end
+  end
+
+  def test_provider_git_checks_share_one_monotonic_deadline
+    with_capture_task do |root, task_folder, source|
+      fake_bin = File.join(root, "fake-bin")
+      git_path = File.join(fake_bin, "git")
+      FileUtils.mkdir_p(fake_bin)
+      FileUtils.mkdir_p(File.join(source, "bin"))
+      File.binwrite(File.join(source, "bin", "provider"), "provider\n")
+      write_executable(git_path, <<~RUBY)
+        #!#{RbConfig.ruby}
+        sleep 0.06
+        marker = ARGV.index("-C")
+        source = ARGV.fetch(marker + 1)
+        command = ARGV.drop(marker + 2)
+        case command
+        when [ "rev-parse", "--show-toplevel" ]
+          puts source
+        when [ "rev-parse", "HEAD" ]
+          puts "#{'a' * 40}"
+        when [ "status", "--porcelain=v1", "--untracked-files=all", "--ignore-submodules=none" ]
+        when [ "ls-files", "-v", "-f", "-z" ]
+          STDOUT.write("H bin/provider\\0")
+        else
+          puts "bin/provider"
+        end
+      RUBY
+      capture = Hive::Web::TaskCapture.new(
+        task_folder: task_folder,
+        environment: { "PATH" => fake_bin }
+      )
+      original_timeout = Hive::Web::TaskCapture::PROVIDER_SOURCE_SNAPSHOT_TIMEOUT_SEC
+      original_verbose = $VERBOSE
+      $VERBOSE = nil
+      Hive::Web::TaskCapture.send(:remove_const, :PROVIDER_SOURCE_SNAPSHOT_TIMEOUT_SEC)
+      Hive::Web::TaskCapture.const_set(:PROVIDER_SOURCE_SNAPSHOT_TIMEOUT_SEC, 0.1)
+      started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      begin
+        error = assert_raises(Hive::Web::TaskCapture::CaptureError) do
+          capture.send(
+            :verify_provider_source!, source, "a" * 40,
+            provider_executable: "bin/provider"
+          )
+        end
+        elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+
+        assert_match(/source custody exceeded the 0.1-second monotonic (?:inventory )?deadline/i,
+                     error.message)
+        assert_operator elapsed, :<, 1.0
+      ensure
+        Hive::Web::TaskCapture.send(:remove_const, :PROVIDER_SOURCE_SNAPSHOT_TIMEOUT_SEC)
+        Hive::Web::TaskCapture.const_set(
+          :PROVIDER_SOURCE_SNAPSHOT_TIMEOUT_SEC, original_timeout
+        )
+        $VERBOSE = original_verbose
+      end
+    end
+  end
+
+  def test_provider_git_checks_bound_stdout_and_stderr_while_streaming
+    with_capture_task do |root, task_folder, source|
+      fake_bin = File.join(root, "fake-bin")
+      git_path = File.join(fake_bin, "git")
+      FileUtils.mkdir_p(fake_bin)
+      capture = Hive::Web::TaskCapture.new(
+        task_folder: task_folder,
+        environment: { "PATH" => fake_bin }
+      )
+
+      { "stdout" => "STDOUT", "stderr" => "STDERR" }.each do |stream, constant|
+        write_executable(git_path, <<~RUBY)
+          #!#{RbConfig.ruby}
+          #{constant}.write("x" * (2 * 1024 * 1024))
+        RUBY
+
+        error = assert_raises(Hive::Web::TaskCapture::CaptureError, stream) do
+          capture.send(:capture_git!, source, "status")
+        end
+
+        assert_match(/Git check #{stream} exceeded/i, error.message, stream)
+      end
+    end
+  end
+
+  def test_provider_index_flag_attestation_streams_large_valid_listing
+    with_capture_task do |root, task_folder, source|
+      fake_bin = File.join(root, "fake-bin")
+      git_path = File.join(fake_bin, "git")
+      FileUtils.mkdir_p(fake_bin)
+      write_executable(git_path, <<~RUBY)
+        #!#{RbConfig.ruby}
+        70_000.times { |index| STDOUT.write("H f\#{index}\\0") }
+      RUBY
+      capture = Hive::Web::TaskCapture.new(
+        task_folder: task_folder,
+        environment: { "PATH" => fake_bin }
+      )
+      deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 5
+
+      assert_nil capture.send(
+        :verify_provider_source_index_flags!, source, deadline: deadline
+      )
+    end
+  end
+
+  def test_provider_git_check_receives_closed_empty_stdin
+    with_capture_task do |root, task_folder, source|
+      fake_bin = File.join(root, "fake-bin")
+      git_path = File.join(fake_bin, "git")
+      FileUtils.mkdir_p(fake_bin)
+      write_executable(git_path, <<~RUBY)
+        #!#{RbConfig.ruby}
+        STDOUT.write(STDIN.read.bytesize.to_s)
+      RUBY
+      capture = Hive::Web::TaskCapture.new(
+        task_folder: task_folder,
+        environment: { "PATH" => fake_bin }
+      )
+
+      assert_equal "0", capture.send(:capture_git!, source, "status")
+    end
+  end
+
+  def test_provider_git_check_owns_only_its_command_subtree
+    with_capture_task do |_root, task_folder, source|
+      head = prepare_conventional_provider_source(source)
+      capture = Hive::Web::TaskCapture.new(
+        task_folder: task_folder,
+        environment: { "PATH" => ENV.fetch("PATH", "") }
+      )
+      unrelated_child = start_unrelated_caller_child
+
+      assert_equal head, capture.send(:capture_git!, source, "rev-parse", "HEAD").strip
+      snapshot = capture.send(
+        :verify_provider_source!, source, head,
+        provider_executable: "bin/provider"
+      )
+      refute_empty snapshot
+      assert_unrelated_caller_child_alive(unrelated_child)
+    ensure
+      stop_unrelated_caller_child(unrelated_child)
+    end
+  end
+
+  def test_provider_git_check_terminates_and_reaps_a_setsid_descendant
+    with_capture_task do |root, task_folder, source|
+      fake_bin = File.join(root, "fake-bin")
+      git_path = File.join(fake_bin, "git")
+      pid_path = File.join(root, "detached.pid")
+      FileUtils.mkdir_p(fake_bin)
+      write_executable(git_path, <<~RUBY)
+        #!#{RbConfig.ruby}
+        child = fork do
+          Process.setsid
+          STDIN.reopen(File::NULL)
+          STDOUT.reopen(File::NULL, "w")
+          STDERR.reopen(File::NULL, "w")
+          File.binwrite(#{pid_path.dump}, Process.pid.to_s)
+          trap("TERM") {}
+          sleep 30
+        end
+        deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 2
+        until File.file?(#{pid_path.dump})
+          abort "detached child did not start" if
+            Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+          sleep 0.01
+        end
+        puts "parent complete"
+      RUBY
+      capture = Hive::Web::TaskCapture.new(
+        task_folder: task_folder,
+        environment: { "PATH" => fake_bin }
+      )
+      child_pid = nil
+
+      error = assert_raises(Hive::Web::TaskCapture::CaptureError) do
+        capture.send(:capture_git!, source, "status")
+      end
+      child_pid = Integer(File.binread(pid_path))
+
+      assert_match(/left child processes running/i, error.message)
+      refute Hive::ProcessKill.pid_alive?(child_pid),
+             "detached Git helper descendant #{child_pid} survived capture_git!"
+    ensure
+      child_pid ||= Integer(File.binread(pid_path)) if defined?(pid_path) && File.file?(pid_path)
+      if child_pid && Hive::ProcessKill.pid_alive?(child_pid)
+        Hive::ProcessKill.terminate_process(child_pid, grace_seconds: 0.1)
+      end
     end
   end
 
@@ -1209,6 +1550,48 @@ class WebTaskCaptureTest < Minitest::Test
 
   PNG_1X1_BASE64 =
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=".freeze
+
+  def write_executable(path, body)
+    File.binwrite(path, body)
+    FileUtils.chmod(0o755, path)
+  end
+
+  def start_unrelated_caller_child
+    pid = fork { sleep 60 }
+    start_time = Hive::ProcessKill.process_start_time(pid)
+    raise "unrelated caller child identity is unavailable" if start_time.to_s.empty?
+
+    { pid: pid, start_time: start_time }
+  rescue StandardError
+    stop_unrelated_caller_child(pid: pid, start_time: start_time) if pid
+    raise
+  end
+
+  def assert_unrelated_caller_child_alive(target)
+    pid = target.fetch(:pid)
+    assert_nil Process.waitpid(pid, Process::WNOHANG),
+               "unrelated caller child #{pid} exited during command custody"
+    assert Hive::ProcessKill.captured_process_alive?(target),
+           "unrelated caller child #{pid} lost its recorded identity during command custody"
+  rescue Errno::ECHILD
+    flunk "command custody reaped unrelated caller child #{pid}"
+  end
+
+  def stop_unrelated_caller_child(target)
+    return unless target
+
+    pid = target.fetch(:pid)
+    return if Process.waitpid(pid, Process::WNOHANG)
+
+    begin
+      Process.kill("TERM", pid)
+    rescue Errno::ESRCH
+      nil
+    end
+    Process.wait(pid)
+  rescue Errno::ECHILD
+    nil
+  end
 
   def prepare_conventional_provider_source(source, ignored: nil,
                                            provider_body: "#!/usr/bin/env ruby\n")

--- a/test/unit/web/task_capture_test.rb
+++ b/test/unit/web/task_capture_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "base64"
 require "hive/web/task_capture"
 
 class WebTaskCaptureTest < Minitest::Test
@@ -77,6 +78,9 @@ class WebTaskCaptureTest < Minitest::Test
       manifest = capture.call
 
       assert_equal "captured", manifest.fetch("status")
+      assert_equal 2, manifest.fetch("schema_version")
+      assert_equal "built_in", manifest.dig("recorder", "kind")
+      assert_equal "hivebox", manifest.dig("evidence", "type")
       assert_equal 2, manifest.fetch("artifacts").length
       assert_equal 2, source_bundle.calls,
                    "source must be validated before boot and again before publication"
@@ -184,6 +188,552 @@ class WebTaskCaptureTest < Minitest::Test
       capture.define_singleton_method(:owned_source_root) { source }
       error = assert_raises(Hive::Web::TaskCapture::CaptureError) { capture.call }
       assert_match(/does not match requirement/, error.message)
+    end
+  end
+
+  def test_conventional_project_without_provider_fails_before_hivebox_recorder_construction
+    with_capture_task do |root, task_folder, source|
+      FileUtils.mkdir_p(File.join(source, "app"))
+      File.write(File.join(source, "Gemfile.lock"), "GEM\n")
+      run!("git", "-C", source, "init", "-b", "main", "--quiet")
+      run!("git", "-C", source, "config", "user.email", "test@example.com")
+      run!("git", "-C", source, "config", "user.name", "Test")
+      run!("git", "-C", source, "config", "commit.gpgsign", "false")
+      run!("git", "-C", source, "add", ".")
+      run!("git", "-C", source, "commit", "-m", "fixture", "--quiet")
+      head = run!("git", "-C", source, "rev-parse", "HEAD").strip
+      capture = Hive::Web::TaskCapture.new(task_folder: task_folder)
+      capture.define_singleton_method(:capture_requirement) do
+        { "result" => "required", "implementation_head" => head }
+      end
+      capture.define_singleton_method(:owned_source_root) { source }
+      source_bundle_calls = 0
+      browser_calls = 0
+      server_calls = 0
+      source_bundle_constructor = lambda do |**|
+        source_bundle_calls += 1
+        raise "Hivebox recorder must not be constructed"
+      end
+      capture.define_singleton_method(:browser_bundle) do |_source_root|
+        browser_calls += 1
+        raise "browser bundle must not be constructed"
+      end
+      capture.define_singleton_method(:start_server) do |**|
+        server_calls += 1
+        raise "server must not start"
+      end
+
+      error = with_replaced_singleton_method(
+        Hive::Web::SourceBundle, :new, source_bundle_constructor
+      ) do
+        assert_raises(Hive::Web::TaskCapture::CaptureError) { capture.call }
+      end
+
+      assert_match(/no supported artifact capture provider/i, error.message)
+      assert_includes error.message, "artifacts.capture.provider"
+      refute_includes error.message, "web/Gemfile"
+      refute_includes error.message, "web/Gemfile.lock"
+      assert_equal 0, source_bundle_calls
+      assert_equal 0, browser_calls
+      assert_equal 0, server_calls
+      refute File.exist?(File.join(task_folder, "media"))
+      assert_equal root, File.dirname(File.dirname(File.dirname(File.dirname(task_folder))))
+    end
+  end
+
+  def test_complete_hive_tree_selects_the_built_in_recorder_capability
+    with_capture_task do |_root, task_folder, _source|
+      hive_root = File.expand_path("../../..", __dir__)
+      capture = Hive::Web::TaskCapture.new(task_folder: task_folder)
+
+      assert capture.send(:built_in_recorder_compatible?, hive_root)
+      assert_equal :built_in, capture.send(:select_recorder, hive_root).fetch(:kind)
+    end
+  end
+
+  def test_configured_conventional_provider_publishes_valid_v2_evidence_without_hivebox
+    with_capture_task do |_root, task_folder, source|
+      FileUtils.mkdir_p([ File.join(source, "app"), File.join(source, "bin") ])
+      File.write(File.join(source, "Gemfile.lock"), "GEM\n")
+      provider_path = File.join(source, "bin", "hive-capture")
+      File.write(provider_path, <<~'RUBY')
+        #!/usr/bin/env ruby
+        require "base64"
+        require "digest"
+        require "json"
+
+        request = JSON.parse($stdin.read)
+        path = File.join(request.fetch("staging_root"), "provider.png")
+        File.binwrite(
+          path,
+          Base64.decode64(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="
+          )
+        )
+        puts JSON.generate(
+          "schema" => "hive-project-capture-result",
+          "schema_version" => 1,
+          "status" => "captured",
+          "artifacts" => [
+            {
+              "file" => File.basename(path),
+              "bytes" => File.size(path),
+              "sha256" => Digest::SHA256.file(path).hexdigest
+            }
+          ],
+          "evidence" => {
+            "task" => request.fetch("task"),
+            "source_root" => request.fetch("source_root"),
+            "source_sha" => request.fetch("source_sha")
+          },
+          "cleanup" => {
+            "port" => "released", "processes" => "clean", "runtime" => "cleaned"
+          },
+          "diagnostic" => nil
+        )
+      RUBY
+      FileUtils.chmod(0o755, provider_path)
+      run!("git", "-C", source, "init", "-b", "main", "--quiet")
+      run!("git", "-C", source, "config", "user.email", "test@example.com")
+      run!("git", "-C", source, "config", "user.name", "Test")
+      run!("git", "-C", source, "config", "commit.gpgsign", "false")
+      run!("git", "-C", source, "add", ".")
+      run!("git", "-C", source, "commit", "-m", "fixture", "--quiet")
+      head = run!("git", "-C", source, "rev-parse", "HEAD").strip
+      File.write(
+        File.join(File.dirname(File.dirname(File.dirname(task_folder))), "config.yml"),
+        {
+          "artifacts" => {
+            "capture" => {
+              "provider" => {
+                "name" => "rails",
+                "command" => [ "bin/hive-capture" ],
+                "timeout_sec" => 10
+              }
+            }
+          }
+        }.to_yaml
+      )
+      capture = Hive::Web::TaskCapture.new(task_folder: task_folder)
+      capture.define_singleton_method(:capture_requirement) do
+        { "result" => "required", "implementation_head" => head }
+      end
+      capture.define_singleton_method(:owned_source_root) { source }
+      source_bundle_calls = 0
+
+      manifest = with_replaced_singleton_method(
+        Hive::Web::SourceBundle, :new,
+        lambda do |**|
+          source_bundle_calls += 1
+          raise "Hivebox recorder must not be constructed"
+        end
+      ) { capture.call }
+
+      assert_equal 0, source_bundle_calls
+      assert_equal 2, manifest.fetch("schema_version")
+      assert_equal "project_provider", manifest.dig("recorder", "kind")
+      assert_equal "rails", manifest.dig("recorder", "name")
+      assert_equal task_folder.split("/").last, manifest.dig("evidence", "details", "task")
+      assert_equal File.realpath(source), manifest.dig("evidence", "details", "source_root")
+      assert_equal head, manifest.dig("evidence", "details", "source_sha")
+      assert_equal 1, manifest.fetch("artifacts").length
+      assert_empty Dir.glob(File.join(task_folder, "media", ".capture-*"))
+
+      policy = Hive::Artifacts::CapturePolicy.new(
+        task: capture.task,
+        project: "demo",
+        changed_paths: [ "app/views/demo.html.erb" ],
+        task_generation: "provider-generation",
+        base_sha: "a" * 40,
+        head_sha: head
+      )
+      policy.ensure!
+      assert policy.capture_satisfied?
+    end
+  end
+
+  def test_provider_target_mutation_is_detected_before_any_media_is_published
+    with_capture_task do |_root, task_folder, source|
+      FileUtils.mkdir_p([ File.join(source, "app"), File.join(source, "bin") ])
+      lockfile = File.join(source, "Gemfile.lock")
+      File.write(lockfile, "GEM\n")
+      provider_path = File.join(source, "bin", "mutating-capture")
+      File.write(provider_path, <<~'RUBY')
+        #!/usr/bin/env ruby
+        require "digest"
+        require "json"
+
+        request = JSON.parse($stdin.read)
+        File.open(File.join(request.fetch("source_root"), "Gemfile.lock"), "a") { |file| file.puts("MUTATED") }
+        path = File.join(request.fetch("staging_root"), "provider.png")
+        File.binwrite(path, "provider")
+        puts JSON.generate(
+          "schema" => "hive-project-capture-result",
+          "schema_version" => 1,
+          "status" => "captured",
+          "artifacts" => [
+            {
+              "file" => File.basename(path),
+              "bytes" => File.size(path),
+              "sha256" => Digest::SHA256.file(path).hexdigest
+            }
+          ],
+          "evidence" => {},
+          "cleanup" => {
+            "port" => "released", "processes" => "clean", "runtime" => "cleaned"
+          },
+          "diagnostic" => nil
+        )
+      RUBY
+      FileUtils.chmod(0o755, provider_path)
+      run!("git", "-C", source, "init", "-b", "main", "--quiet")
+      run!("git", "-C", source, "config", "user.email", "test@example.com")
+      run!("git", "-C", source, "config", "user.name", "Test")
+      run!("git", "-C", source, "config", "commit.gpgsign", "false")
+      run!("git", "-C", source, "add", ".")
+      run!("git", "-C", source, "commit", "-m", "fixture", "--quiet")
+      head = run!("git", "-C", source, "rev-parse", "HEAD").strip
+      capture = Hive::Web::TaskCapture.new(
+        task_folder: task_folder,
+        project_config: {
+          "artifacts" => {
+            "capture" => {
+              "provider" => {
+                "name" => "mutator",
+                "command" => [ "bin/mutating-capture" ],
+                "timeout_sec" => 10
+              }
+            }
+          }
+        }
+      )
+      capture.define_singleton_method(:capture_requirement) do
+        { "result" => "required", "implementation_head" => head }
+      end
+      capture.define_singleton_method(:owned_source_root) { source }
+
+      error = assert_raises(Hive::Web::TaskCapture::CaptureError) { capture.call }
+
+      assert_match(/cleanliness changed/, error.message)
+      media = File.join(task_folder, "media")
+      assert File.directory?(media)
+      assert_empty Dir.children(media)
+      refute File.exist?(File.join(media, "capture-manifest.json"))
+    end
+  end
+
+  def test_real_provider_failures_revalidate_source_and_preserve_both_errors
+    failures = {
+      "nonzero" => /failed \(exit 7\)/,
+      "timeout" => /timed out after 1s/,
+      "malformed-output" => /returned malformed JSON/,
+      "overflow" => /stdout exceeded 262144 bytes/
+    }
+    provider_body = <<~'RUBY'
+      #!/usr/bin/env ruby
+
+      mode = ARGV.fetch(0)
+      File.open("Gemfile.lock", "a") { |file| file.puts("MUTATED") }
+      case mode
+      when "nonzero"
+        warn "fixture failure"
+        exit 7
+      when "timeout"
+        sleep 5
+      when "malformed-output"
+        puts "{"
+      when "overflow"
+        STDOUT.write("x" * (300 * 1024))
+      end
+    RUBY
+
+    failures.each do |failure, provider_pattern|
+      with_capture_task do |_root, task_folder, source|
+        head = prepare_conventional_provider_source(source, provider_body: provider_body)
+        capture = provider_capture(
+          task_folder: task_folder,
+          source: source,
+          head: head,
+          provider: nil,
+          command: [ "bin/provider", failure ]
+        )
+
+        error = assert_raises(Hive::Web::TaskCapture::CaptureError, failure) { capture.call }
+
+        assert_match provider_pattern, error.message, failure
+        assert_match(/source custody also failed.*source.*changed/i, error.message, failure)
+        assert_empty Dir.children(File.join(task_folder, "media")), failure
+      end
+    end
+  end
+
+  def test_provider_ignored_path_mutation_is_detected_before_publication
+    with_capture_task do |_root, task_folder, source|
+      head = prepare_conventional_provider_source(source, ignored: "tmp/\n")
+      provider = Object.new
+      provider.define_singleton_method(:call) do |staging_root:, source_root:, **|
+        FileUtils.mkdir_p(File.join(source_root, "tmp"))
+        File.write(File.join(source_root, "tmp", "ignored.txt"), "mutation")
+        path = File.join(staging_root, "proof.png")
+        File.binwrite(path, Base64.decode64(WebTaskCaptureTest::PNG_1X1_BASE64))
+        Hive::Web::ProjectCaptureProvider::Result.new(
+          name: "fixture",
+          command: [ "bin/provider" ],
+          environment_keys: [ "PATH" ],
+          artifacts: [
+            {
+              "file" => "proof.png",
+              "bytes" => File.size(path),
+              "sha256" => Digest::SHA256.file(path).hexdigest,
+              "source_path" => path
+            }
+          ],
+          evidence: {},
+          cleanup: Hive::Web::ProjectCaptureProvider::CLEANUP,
+          diagnostic: nil,
+          started_at: Time.now.utc,
+          finished_at: Time.now.utc
+        )
+      end
+      capture = provider_capture(
+        task_folder: task_folder,
+        source: source,
+        head: head,
+        provider: provider
+      )
+
+      error = assert_raises(Hive::Web::TaskCapture::CaptureError) { capture.call }
+
+      assert_match(/source.*changed/i, error.message)
+      assert File.file?(File.join(source, "tmp", "ignored.txt")),
+             "custody detection must not hide or restore the provider mutation"
+      assert_empty Dir.children(File.join(task_folder, "media"))
+    end
+  end
+
+  def test_sparse_ignored_source_mutation_hits_the_custody_byte_bound_promptly
+    with_capture_task do |_root, task_folder, source|
+      head = prepare_conventional_provider_source(source, ignored: "tmp/\n")
+      sparse_path = File.join(source, "tmp", "sparse.bin")
+      provider = Object.new
+      provider.define_singleton_method(:call) do |source_root:, **|
+        FileUtils.mkdir_p(File.dirname(sparse_path))
+        File.open(sparse_path, "wb") do |file|
+          file.truncate((1024 * 1024 * 1024) + 1)
+        end
+        nil
+      end
+      capture = provider_capture(
+        task_folder: task_folder,
+        source: source,
+        head: head,
+        provider: provider
+      )
+      started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+      error = assert_raises(Hive::Web::TaskCapture::CaptureError) { capture.call }
+      elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+
+      assert_match(/source.*custody.*1073741824-byte.*limit/i, error.message)
+      assert_operator elapsed, :<,
+                      Hive::Web::TaskCapture::PROVIDER_SOURCE_SNAPSHOT_TIMEOUT_SEC
+      assert_equal (1024 * 1024 * 1024) + 1, File.size(sparse_path)
+      assert_empty Dir.children(File.join(task_folder, "media"))
+    end
+  end
+
+  def test_provider_source_snapshot_deadline_fails_with_actionable_custody_error
+    with_capture_task do |_root, task_folder, source|
+      File.binwrite(File.join(source, "small.txt"), "small")
+      capture = Hive::Web::TaskCapture.new(task_folder: task_folder)
+      readings = [ 0, Hive::Web::TaskCapture::PROVIDER_SOURCE_SNAPSHOT_TIMEOUT_SEC ]
+      capture.define_singleton_method(:provider_custody_monotonic_now) do
+        readings.shift || readings.last
+      end
+
+      error = assert_raises(Hive::Web::TaskCapture::CaptureError) do
+        capture.send(:provider_source_snapshot!, source)
+      end
+
+      assert_match(/source custody exceeded the 30-second monotonic inventory deadline/i,
+                   error.message)
+      assert_match(/reduce the source tree/i, error.message)
+    end
+  end
+
+  def test_provider_manifest_over_the_producer_budget_is_rejected_before_publication
+    with_capture_task do |_root, task_folder, source|
+      head = prepare_conventional_provider_source(source)
+      provider = Object.new
+      provider.define_singleton_method(:call) do |staging_root:, **|
+        path = File.join(staging_root, "proof.png")
+        File.binwrite(path, Base64.decode64(WebTaskCaptureTest::PNG_1X1_BASE64))
+        Hive::Web::ProjectCaptureProvider::Result.new(
+          name: "fixture",
+          command: [ "bin/provider" ],
+          environment_keys: [ "PATH" ],
+          artifacts: [
+            {
+              "file" => "proof.png",
+              "bytes" => File.size(path),
+              "sha256" => Digest::SHA256.file(path).hexdigest,
+              "source_path" => path
+            }
+          ],
+          evidence: { "blob" => "x" * Hive::ARTIFACT_CAPTURE_MANIFEST_PRODUCER_MAX_BYTES },
+          cleanup: Hive::Web::ProjectCaptureProvider::CLEANUP,
+          diagnostic: nil,
+          started_at: Time.now.utc,
+          finished_at: Time.now.utc
+        )
+      end
+      capture = provider_capture(
+        task_folder: task_folder,
+        source: source,
+        head: head,
+        provider: provider
+      )
+
+      error = assert_raises(Hive::Web::TaskCapture::CaptureError) { capture.call }
+
+      assert_match(/manifest.*producer limit.*245760 bytes/i, error.message)
+      media = File.join(task_folder, "media")
+      refute File.exist?(File.join(media, "capture-manifest.json"))
+      assert_empty Dir.children(media)
+    end
+  end
+
+  def test_manifest_producer_budget_accepts_just_below_and_rejects_just_above
+    with_capture_task do |_root, task_folder, _source|
+      capture = Hive::Web::TaskCapture.new(task_folder: task_folder)
+      limit = Hive::ARTIFACT_CAPTURE_MANIFEST_PRODUCER_MAX_BYTES
+      manifest = { "blob" => "" }
+      manifest["blob"] = "x" * (limit - 1 - JSON.generate(manifest).bytesize - 1)
+
+      assert_equal limit - 1, JSON.generate(manifest).bytesize + 1
+      assert_equal limit - 1, capture.send(:validate_manifest_budget!, manifest)
+
+      manifest["blob"] << "xx"
+      error = assert_raises(Hive::Web::TaskCapture::CaptureError) do
+        capture.send(:validate_manifest_budget!, manifest)
+      end
+      assert_match(/producer limit of #{limit} bytes/, error.message)
+    end
+  end
+
+  def test_provider_recapture_rotates_changed_bytes_and_reuses_identical_bytes_at_the_same_head
+    with_capture_task do |_root, task_folder, source|
+      head = prepare_conventional_provider_source(source)
+      payloads = [
+        Base64.decode64(PNG_1X1_BASE64) + "first",
+        Base64.decode64(PNG_1X1_BASE64) + "second",
+        Base64.decode64(PNG_1X1_BASE64) + "second"
+      ]
+      provider = Object.new
+      provider.define_singleton_method(:call) do |staging_root:, **|
+        path = File.join(staging_root, "proof.png")
+        File.binwrite(path, payloads.shift)
+        Hive::Web::ProjectCaptureProvider::Result.new(
+          name: "fixture",
+          command: [ "bin/provider" ],
+          environment_keys: [ "PATH" ],
+          artifacts: [
+            {
+              "file" => "proof.png",
+              "bytes" => File.size(path),
+              "sha256" => Digest::SHA256.file(path).hexdigest,
+              "source_path" => path
+            }
+          ],
+          evidence: {},
+          cleanup: Hive::Web::ProjectCaptureProvider::CLEANUP,
+          diagnostic: nil,
+          started_at: Time.now.utc,
+          finished_at: Time.now.utc
+        )
+      end
+      capture = provider_capture(
+        task_folder: task_folder,
+        source: source,
+        head: head,
+        provider: provider
+      )
+
+      first = capture.call.fetch("artifacts").fetch(0).fetch("file")
+      assert File.file?(File.join(task_folder, "media", first))
+
+      second = capture.call.fetch("artifacts").fetch(0).fetch("file")
+      refute_equal first, second
+      refute File.exist?(File.join(task_folder, "media", first))
+      assert File.file?(File.join(task_folder, "media", second))
+
+      third = capture.call.fetch("artifacts").fetch(0).fetch("file")
+      assert_equal second, third
+      assert_equal(
+        [ "capture-manifest.json", second ].sort,
+        Dir.children(File.join(task_folder, "media")).sort
+      )
+      assert_empty payloads
+    end
+  end
+
+  def test_provider_recapture_replaces_non_object_retained_manifests
+    invalid_manifests = {
+      "array" => [],
+      "null" => nil,
+      "scalar recorder" => {
+        "schema" => "hive-artifact-capture",
+        "schema_version" => 2,
+        "recorder" => "not-an-object",
+        "artifacts" => []
+      }
+    }
+
+    invalid_manifests.each do |shape, retained_manifest|
+      with_capture_task do |_root, task_folder, source|
+        head = prepare_conventional_provider_source(source)
+        provider = Object.new
+        provider.define_singleton_method(:call) do |staging_root:, **|
+          path = File.join(staging_root, "proof.png")
+          File.binwrite(path, Base64.decode64(WebTaskCaptureTest::PNG_1X1_BASE64))
+          Hive::Web::ProjectCaptureProvider::Result.new(
+            name: "fixture",
+            command: [ "bin/provider" ],
+            environment_keys: [ "PATH" ],
+            artifacts: [
+              {
+                "file" => "proof.png",
+                "bytes" => File.size(path),
+                "sha256" => Digest::SHA256.file(path).hexdigest,
+                "source_path" => path
+              }
+            ],
+            evidence: {},
+            cleanup: Hive::Web::ProjectCaptureProvider::CLEANUP,
+            diagnostic: nil,
+            started_at: Time.now.utc,
+            finished_at: Time.now.utc
+          )
+        end
+        media = File.join(task_folder, "media")
+        FileUtils.mkdir_p(media)
+        File.binwrite(
+          File.join(media, "capture-manifest.json"),
+          JSON.generate(retained_manifest)
+        )
+        capture = provider_capture(
+          task_folder: task_folder,
+          source: source,
+          head: head,
+          provider: provider
+        )
+
+        manifest = capture.call
+
+        assert_equal 2, manifest.fetch("schema_version"), shape
+        assert_equal "project_provider", manifest.dig("recorder", "kind"), shape
+        assert_equal 1, manifest.fetch("artifacts").length, shape
+      end
     end
   end
 
@@ -656,6 +1206,50 @@ class WebTaskCaptureTest < Minitest::Test
   end
 
   private
+
+  PNG_1X1_BASE64 =
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=".freeze
+
+  def prepare_conventional_provider_source(source, ignored: nil,
+                                           provider_body: "#!/usr/bin/env ruby\n")
+    FileUtils.mkdir_p(File.join(source, "bin"))
+    File.write(File.join(source, "Gemfile.lock"), "GEM\n")
+    File.write(File.join(source, ".gitignore"), ignored) if ignored
+    provider_path = File.join(source, "bin", "provider")
+    File.write(provider_path, provider_body)
+    FileUtils.chmod(0o755, provider_path)
+    run!("git", "-C", source, "init", "-b", "main", "--quiet")
+    run!("git", "-C", source, "config", "user.email", "test@example.com")
+    run!("git", "-C", source, "config", "user.name", "Test")
+    run!("git", "-C", source, "config", "commit.gpgsign", "false")
+    run!("git", "-C", source, "add", ".")
+    run!("git", "-C", source, "commit", "-m", "fixture", "--quiet")
+    run!("git", "-C", source, "rev-parse", "HEAD").strip
+  end
+
+  def provider_capture(task_folder:, source:, head:, provider:, command: [ "bin/provider" ])
+    options = {
+      task_folder: task_folder,
+      project_config: {
+        "artifacts" => {
+          "capture" => {
+            "provider" => {
+              "name" => "fixture",
+              "command" => command,
+              "timeout_sec" => 1
+            }
+          }
+        }
+      }
+    }
+    options[:provider_factory] = ->(**) { provider } if provider
+    Hive::Web::TaskCapture.new(**options).tap do |capture|
+      capture.define_singleton_method(:capture_requirement) do
+        { "result" => "required", "implementation_head" => head }
+      end
+      capture.define_singleton_method(:owned_source_root) { source }
+    end
+  end
 
   def with_capture_task
     Dir.mktmpdir("hive-task-capture") do |root|

--- a/test/unit/web/task_capture_test.rb
+++ b/test/unit/web/task_capture_test.rb
@@ -364,20 +364,22 @@ class WebTaskCaptureTest < Minitest::Test
           }
         }.to_yaml
       )
-      capture = Hive::Web::TaskCapture.new(task_folder: task_folder)
-      capture.define_singleton_method(:capture_requirement) do
-        { "result" => "required", "implementation_head" => head }
-      end
-      capture.define_singleton_method(:owned_source_root) { source }
+      capture = nil
       source_bundle_calls = 0
-
-      manifest = with_replaced_singleton_method(
-        Hive::Web::SourceBundle, :new,
-        lambda do |**|
-          source_bundle_calls += 1
-          raise "Hivebox recorder must not be constructed"
+      manifest = with_fake_png_media_tools do
+        capture = Hive::Web::TaskCapture.new(task_folder: task_folder)
+        capture.define_singleton_method(:capture_requirement) do
+          { "result" => "required", "implementation_head" => head }
         end
-      ) { capture.call }
+        capture.define_singleton_method(:owned_source_root) { source }
+        with_replaced_singleton_method(
+          Hive::Web::SourceBundle, :new,
+          lambda do |**|
+            source_bundle_calls += 1
+            raise "Hivebox recorder must not be constructed"
+          end
+        ) { capture.call }
+      end
 
       assert_equal 0, source_bundle_calls
       assert_equal 2, manifest.fetch("schema_version")

--- a/web/app/models/task.rb
+++ b/web/app/models/task.rb
@@ -318,10 +318,14 @@ class Task
   end
 
   def capture_media_manifest(path)
-    manifest = JSON.parse(File.read(path, 256 * 1024))
+    stat = File.lstat(path)
+    return nil unless stat.file? && !stat.symlink?
+    return nil if stat.size > Hive::ARTIFACT_CAPTURE_MANIFEST_MAX_BYTES
+
+    manifest = JSON.parse(File.binread(path, Hive::ARTIFACT_CAPTURE_MANIFEST_MAX_BYTES))
     return nil unless manifest.is_a?(Hash)
     return nil unless manifest["schema"] == "hive-artifact-capture"
-    return nil unless manifest["schema_version"] == 1
+    return nil unless [ 1, 2 ].include?(manifest["schema_version"])
 
     status = manifest["status"].to_s
     return nil unless %w[captured failed].include?(status)

--- a/web/app/models/task.rb
+++ b/web/app/models/task.rb
@@ -1,4 +1,6 @@
 require "digest"
+require "json_schemer"
+require "pathname"
 require "hive/web/environment"
 
 class Task
@@ -6,6 +8,9 @@ class Task
 
   ARTIFACT_ORDER = %w[idea.md brainstorm.md plan.md task.md pr.md summary.md artifact.md].freeze
   MEDIA_FILENAME_RE = /\A[\w.-]+\.(?:png|jpe?g|gif|webp|webm|mp4)\z/i
+  CAPTURE_MANIFEST_V2_SCHEMER = JSONSchemer.schema(
+    Pathname.new(Hive::Schemas.schema_path("hive-artifact-capture", version: 2))
+  )
   DIFF_TIMEOUT_SEC = Integer(Hive::Web::Environment.value("HIVE_WEB_DIFF_TIMEOUT_SEC"))
   RECOVERY_ACTIONS = %w[recover_execute recover_review error].freeze
   RECOVERY_LABELS = {
@@ -326,6 +331,9 @@ class Task
     return nil unless manifest.is_a?(Hash)
     return nil unless manifest["schema"] == "hive-artifact-capture"
     return nil unless [ 1, 2 ].include?(manifest["schema_version"])
+    if manifest["schema_version"] == 2
+      return nil unless CAPTURE_MANIFEST_V2_SCHEMER.valid?(manifest)
+    end
 
     status = manifest["status"].to_s
     return nil unless %w[captured failed].include?(status)

--- a/web/test/models/task_test.rb
+++ b/web/test/models/task_test.rb
@@ -173,6 +173,100 @@ class TaskTest < ActiveSupport::TestCase
     FileUtils.remove_entry(root) if root&.exist?
   end
 
+  test "renders provider-neutral v2 capture-manifest artifacts" do
+    root = Pathname(Dir.mktmpdir("hive-web-capture-v2-model"))
+    folder = root.join("task")
+    media = folder.join("media")
+    media.mkpath
+    image = media.join("provider.png")
+    image.binwrite("png")
+    media.join("capture-manifest.json").write(JSON.generate(
+      "schema" => "hive-artifact-capture",
+      "schema_version" => 2,
+      "status" => "captured",
+      "diagnostic" => nil,
+      "artifacts" => [
+        {
+          "file" => image.basename.to_s,
+          "bytes" => image.size,
+          "sha256" => Digest::SHA256.file(image).hexdigest
+        }
+      ]
+    ))
+    task = Task.new(
+      project: Project.new("name" => "alpha"),
+      attributes: { "slug" => "ship-it-260720-abcd", "folder" => folder.to_s }
+    )
+
+    manifest = task.media_manifest
+
+    assert_equal "captured", manifest.fetch("status")
+    assert_equal [ "still" ], manifest.fetch("items").map { |item| item.fetch("type") }
+  ensure
+    FileUtils.remove_entry(root) if root&.exist?
+  end
+
+  test "hides capture-manifest versions it does not understand" do
+    root = Pathname(Dir.mktmpdir("hive-web-capture-future-model"))
+    folder = root.join("task")
+    media = folder.join("media")
+    media.mkpath
+    media.join("capture-manifest.json").write(JSON.generate(
+      "schema" => "hive-artifact-capture",
+      "schema_version" => 3,
+      "status" => "captured",
+      "diagnostic" => nil,
+      "artifacts" => []
+    ))
+    task = Task.new(
+      project: Project.new("name" => "alpha"),
+      attributes: { "slug" => "ship-it-260720-abcd", "folder" => folder.to_s }
+    )
+
+    assert_nil task.media_manifest
+  ensure
+    FileUtils.remove_entry(root) if root&.exist?
+  end
+
+  test "capture manifest reader enforces the shared byte ceiling" do
+    root = Pathname(Dir.mktmpdir("hive-web-capture-ceiling"))
+    folder = root.join("task")
+    media = folder.join("media")
+    media.mkpath
+    image = media.join("provider.png")
+    image.binwrite("png")
+    document = JSON.generate(
+      "schema" => "hive-artifact-capture",
+      "schema_version" => 2,
+      "status" => "captured",
+      "diagnostic" => nil,
+      "artifacts" => [
+        {
+          "file" => image.basename.to_s,
+          "bytes" => image.size,
+          "sha256" => Digest::SHA256.file(image).hexdigest
+        }
+      ]
+    )
+    limit = Hive::ARTIFACT_CAPTURE_MANIFEST_MAX_BYTES
+    task = Task.new(
+      project: Project.new("name" => "alpha"),
+      attributes: { "slug" => "ship-it-260720-abcd", "folder" => folder.to_s }
+    )
+
+    media.join("capture-manifest.json").binwrite(
+      document + (" " * (limit - 1 - document.bytesize))
+    )
+    assert_equal "captured", task.media_manifest.fetch("status")
+
+    media.join("capture-manifest.json").binwrite(
+      document + (" " * (limit + 1 - document.bytesize))
+    )
+    assert_nil task.media_manifest
+  ensure
+    FileUtils.remove_entry(root) if root&.exist?
+  end
+
   test "derives its display title from the original idea before the slug" do
     folder = Pathname(Dir.mktmpdir("hive-web-task-title"))
     folder.join("idea.md").write(<<~MARKDOWN)

--- a/web/test/models/task_test.rb
+++ b/web/test/models/task_test.rb
@@ -180,19 +180,9 @@ class TaskTest < ActiveSupport::TestCase
     media.mkpath
     image = media.join("provider.png")
     image.binwrite("png")
-    media.join("capture-manifest.json").write(JSON.generate(
-      "schema" => "hive-artifact-capture",
-      "schema_version" => 2,
-      "status" => "captured",
-      "diagnostic" => nil,
-      "artifacts" => [
-        {
-          "file" => image.basename.to_s,
-          "bytes" => image.size,
-          "sha256" => Digest::SHA256.file(image).hexdigest
-        }
-      ]
-    ))
+    media.join("capture-manifest.json").write(
+      JSON.generate(valid_v2_capture_manifest(image, task: "ship-it-260720-abcd"))
+    )
     task = Task.new(
       project: Project.new("name" => "alpha"),
       attributes: { "slug" => "ship-it-260720-abcd", "folder" => folder.to_s }
@@ -202,6 +192,58 @@ class TaskTest < ActiveSupport::TestCase
 
     assert_equal "captured", manifest.fetch("status")
     assert_equal [ "still" ], manifest.fetch("items").map { |item| item.fetch("type") }
+  ensure
+    FileUtils.remove_entry(root) if root&.exist?
+  end
+
+  test "v2 capture-manifest fails closed for every missing required field group" do
+    root = Pathname(Dir.mktmpdir("hive-web-capture-v2-required"))
+    folder = root.join("task")
+    media = folder.join("media")
+    media.mkpath
+    image = media.join("provider.png")
+    image.binwrite("png")
+    task = Task.new(
+      project: Project.new("name" => "alpha"),
+      attributes: { "slug" => "ship-it-260720-abcd", "folder" => folder.to_s }
+    )
+    manifest = valid_v2_capture_manifest(image, task: task.slug)
+    required = JSON.parse(
+      File.binread(Hive::Schemas.schema_path("hive-artifact-capture"))
+    ).fetch("required")
+
+    required.each do |field|
+      incomplete = JSON.parse(JSON.generate(manifest))
+      incomplete.delete(field)
+      media.join("capture-manifest.json").write(JSON.generate(incomplete))
+
+      assert_nil task.media_manifest, "v2 receipt missing #{field} must fail closed"
+    end
+  ensure
+    FileUtils.remove_entry(root) if root&.exist?
+  end
+
+  test "v2 capture-manifest applies nested shared schema constraints" do
+    root = Pathname(Dir.mktmpdir("hive-web-capture-v2-nested"))
+    folder = root.join("task")
+    media = folder.join("media")
+    media.mkpath
+    image = media.join("provider.png")
+    image.binwrite("png")
+    task = Task.new(
+      project: Project.new("name" => "alpha"),
+      attributes: { "slug" => "ship-it-260720-abcd", "folder" => folder.to_s }
+    )
+    manifest = valid_v2_capture_manifest(image, task: task.slug)
+    invalid_manifests = [
+      manifest.merge("environment_keys" => []),
+      manifest.merge("recorder" => manifest.fetch("recorder").merge("unexpected" => true))
+    ]
+
+    invalid_manifests.each do |invalid|
+      media.join("capture-manifest.json").write(JSON.generate(invalid))
+      assert_nil task.media_manifest
+    end
   ensure
     FileUtils.remove_entry(root) if root&.exist?
   end
@@ -236,17 +278,7 @@ class TaskTest < ActiveSupport::TestCase
     image = media.join("provider.png")
     image.binwrite("png")
     document = JSON.generate(
-      "schema" => "hive-artifact-capture",
-      "schema_version" => 2,
-      "status" => "captured",
-      "diagnostic" => nil,
-      "artifacts" => [
-        {
-          "file" => image.basename.to_s,
-          "bytes" => image.size,
-          "sha256" => Digest::SHA256.file(image).hexdigest
-        }
-      ]
+      valid_v2_capture_manifest(image, task: "ship-it-260720-abcd")
     )
     limit = Hive::ARTIFACT_CAPTURE_MANIFEST_MAX_BYTES
     task = Task.new(
@@ -391,5 +423,37 @@ class TaskTest < ActiveSupport::TestCase
     assert_same result, actual
     assert_same task, options.fetch(:task)
     assert_equal Task::DIFF_TIMEOUT_SEC, options.fetch(:timeout_sec)
+  end
+
+  private
+
+  def valid_v2_capture_manifest(image, task:)
+    {
+      "schema" => "hive-artifact-capture",
+      "schema_version" => 2,
+      "status" => "captured",
+      "task" => task,
+      "source_sha" => "a" * 40,
+      "recorder" => {
+        "kind" => "project_provider",
+        "name" => "fixture",
+        "command" => [ "bin/provider" ]
+      },
+      "environment_keys" => [ "PATH" ],
+      "started_at" => "2026-08-03T00:00:00Z",
+      "finished_at" => "2026-08-03T00:00:01Z",
+      "artifacts" => [
+        {
+          "file" => image.basename.to_s,
+          "bytes" => image.size,
+          "sha256" => Digest::SHA256.file(image).hexdigest
+        }
+      ],
+      "cleanup" => {
+        "port" => "released", "processes" => "clean", "runtime" => "cleaned"
+      },
+      "diagnostic" => nil,
+      "evidence" => { "type" => "project_provider", "details" => {} }
+    }
   end
 end

--- a/wiki/commands/web.md
+++ b/wiki/commands/web.md
@@ -861,16 +861,18 @@ provider returns one bounded `hive-project-capture-result` v1 JSON object:
 ```
 
 Provider stdout, stderr, execution time, evidence (64 KiB), and artifact totals
-are bounded. On Linux, a child-subreaper supervisor applies one wall-clock
-deadline to the provider, output drains, and every descendant, including a
-child that calls `setsid`; project-provider capture fails closed where that
-custody primitive is unavailable. The parent also temporarily owns subreaper
-custody, records the supervisor PID/start identity and exit status, and performs
-bounded TERM/KILL cleanup if the supervisor times out, is signalled, exits
-nonzero, closes its result pipe early, or returns an invalid/undecodable result.
-Ordinary and abnormal completion both verify that the full provider tree is
-gone before the call returns. The provider environment contains only a small
-ambient allowlist plus private HOME/XDG/tmp paths.
+are bounded. On Linux, Hive first forks a dedicated child-subreaper custody root
+and then runs the supervisor and provider beneath it. One wall-clock deadline
+covers the provider, output drains, and every descendant, including a child that
+calls `setsid`; project-provider capture fails closed where that custody
+primitive is unavailable. Hive never makes the invoking caller a subreaper, and
+its unrelated children are outside process discovery, signalling, and reaping.
+The dedicated custody root records the nested supervisor PID/start identity and
+exit status, and performs bounded TERM/KILL cleanup if the supervisor times out,
+is signalled, exits nonzero, closes its result pipe early, or returns an
+invalid/undecodable result. Ordinary and abnormal completion both verify that
+the full command tree is gone before the call returns. The provider environment
+contains only a small ambient allowlist plus private HOME/XDG/tmp paths.
 
 Hive accepts artifacts only from private staging and rejects nonzero exit,
 malformed or oversized output, secret-shaped content, incomplete cleanup,

--- a/wiki/commands/web.md
+++ b/wiki/commands/web.md
@@ -3,7 +3,7 @@ title: hive web
 type: command
 source: lib/hive/commands/web.rb, lib/hive/web/, web/, packaging/docker/, .github/workflows/release.yml
 created: 2026-06-04
-updated: 2026-07-26
+updated: 2026-08-02
 tags: [command, web, rails, turbo, hivebox-container, archive, retention]
 ---
 
@@ -826,13 +826,76 @@ ignores late responses after disconnect.
 supported task recorder. The task must be in `7-artifacts`, have a current
 `required` capture receipt, and own the exact clean source worktree. The
 optional source root is an assertion: it must resolve to that owned worktree.
-The command seeds deterministic private fixture data, records the board-to-task
-flow through pinned Playwright Chromium, verifies PNG and WebM output with
-ffmpeg/ffprobe, rechecks the clean source HEAD, and publishes task-local media
-plus `media/capture-manifest.json` only after teardown. `--json` emits that
-manifest; the text form reports the retained artifact count and destination.
-Capture applicability ignores generated HTML marker comments, so fields such
-as `browser=skipped` cannot manufacture a user request for visual proof.
+Recorder selection occurs before any Hivebox bundle, browser, server, runtime,
+or media-staging object is constructed. A positive capability check selects the
+built-in recorder only when the source has the complete locked Hive/Hivebox web
+layout. A conventional project instead uses its validated
+`artifacts.capture.provider` declaration. With neither capability nor a
+provider, capture stops with an actionable configuration diagnostic; it never
+asks the project to fabricate Hivebox dependency files.
+
+The built-in path seeds deterministic private fixture data, records the
+board-to-task flow through pinned Playwright Chromium, verifies PNG and WebM
+output with ffmpeg/ffprobe, rechecks the clean source HEAD, and publishes
+task-local media plus `media/capture-manifest.json` only after teardown.
+`--json` emits that manifest; the text form reports the retained artifact count
+and destination.
+
+A project provider is a tracked executable path relative to the owned source
+root and is launched as discrete argv, never through a shell. The complete argv
+is limited to 16 KiB. Hive sends one
+`hive-project-capture-request` v1 JSON document on stdin with the exact task
+slug, real source root, immutable source SHA, and private staging root. The
+provider returns one bounded `hive-project-capture-result` v1 JSON object:
+
+```json
+{
+  "schema": "hive-project-capture-result",
+  "schema_version": 1,
+  "status": "captured",
+  "artifacts": [{"file": "proof.png", "bytes": 123, "sha256": "<64 hex>"}],
+  "evidence": {},
+  "cleanup": {"port": "released", "processes": "clean", "runtime": "cleaned"},
+  "diagnostic": null
+}
+```
+
+Provider stdout, stderr, execution time, evidence (64 KiB), and artifact totals
+are bounded. On Linux, a child-subreaper supervisor applies one wall-clock
+deadline to the provider, output drains, and every descendant, including a
+child that calls `setsid`; project-provider capture fails closed where that
+custody primitive is unavailable. The parent also temporarily owns subreaper
+custody, records the supervisor PID/start identity and exit status, and performs
+bounded TERM/KILL cleanup if the supervisor times out, is signalled, exits
+nonzero, closes its result pipe early, or returns an invalid/undecodable result.
+Ordinary and abnormal completion both verify that the full provider tree is
+gone before the call returns. The provider environment contains only a small
+ambient allowlist plus private HOME/XDG/tmp paths.
+
+Hive accepts artifacts only from private staging and rejects nonzero exit,
+malformed or oversized output, secret-shaped content, incomplete cleanup,
+undeclared files, path traversal, symlinks/special files, missing or tampered
+media, and source mutation. Media must pass both an ffprobe type/container
+check and an ffmpeg decode. Source custody compares the exact HEAD, Git-visible
+cleanliness, and a complete working-tree entry/content snapshot (excluding Git
+administrative metadata) that includes ignored paths, after every attempted
+execution even when the provider fails; a combined diagnostic preserves both
+provider and custody failures. Each snapshot is limited to 250,000 entries and
+1 GiB of cumulative regular-file logical bytes, hashes files in 1 MiB streaming
+chunks, and checks one 30-second monotonic deadline throughout inventory and
+hashing. Oversized or over-deadline trees fail with a custody diagnostic before
+publication.
+
+The producer rejects a fully serialized manifest above 240 KiB before
+publication, below the shared 256 KiB policy/Web reader ceiling. Media names
+include source and artifact digests. A repeat capture at the same source SHA
+reuses identical bytes, gives changed bytes a new name, publishes the manifest
+last, and removes only superseded task-owned provider media after that publish.
+The tracked provider executable still runs as the local operator and is not an
+operating-system filesystem sandbox; projects should review it with the same
+trust as other project-owned tooling. Capture applicability ignores generated
+HTML marker comments, so fields such as `browser=skipped` cannot manufacture a
+user request for visual proof.
 
 `hive web capture-server` is an internal recorder interface. It requires an
 exact clean source root, private runtime root, lifecycle token, and inherited
@@ -857,7 +920,7 @@ capture runtime, so its externally compiled CSS and JavaScript are served in
 the recording without writing `public/assets` into the source worktree. Normal
 production web service asset handling is unchanged.
 
-The environment is deny-by-default: it gets private HOME/XDG/Hive/storage,
+The built-in environment is deny-by-default: it gets private HOME/XDG/Hive/storage,
 bundle, assets, and tmp roots plus an ephemeral Rails secret; provider,
 GitHub/Telegram/release, SSH-agent, proxy, Bundler/Gem override, and Ruby hook
 state is not inherited. `BrowserBundle` installs the exact Playwright 1.60.0

--- a/wiki/dependencies.md
+++ b/wiki/dependencies.md
@@ -3,7 +3,7 @@ title: Dependencies
 type: dependencies
 source: Gemfile, hive.gemspec, Gemfile.lock, web/Gemfile, web/Gemfile.lock, .github/workflows, components/agent-cli-runtime/mirror, .llm-wiki/post-commit-refresh.sh
 created: 2026-04-25
-updated: 2026-07-31
+updated: 2026-08-02
 tags: [dependencies, gems, runtime]
 ---
 
@@ -71,6 +71,7 @@ as of this refresh.
 | `telegram-bot-ruby` | `~> 2.7` (locked 2.8.0) | Telegram Bot API client for `hive bot`. The July 23, 2026 release adds Bot API 10.0 through 10.2 support, retains MFA on publish and Ruby >= 2.7 support, and keeps four direct runtime dependencies (`dry-struct`, `faraday`, `faraday-multipart`, `zeitwerk`). Root and packaged-web lockfiles pin the reviewed version while the gemspec preserves 2.x compatibility for downstream resolvers. |
 | `faraday` | `>= 2.14.2, < 3.0` (locked 2.14.2) | HTTP transport used directly by `Hive::Bot::Transcriber` and indirectly through `telegram-bot-ruby`. The lower bound is the bundler-audit floor for CVE-2026-33637 / GHSA-5rv5-xj5j-3484. |
 | `faraday-multipart` | `~> 1.0` (locked 1.2.0) | Multipart upload support for `Hive::Bot::Transcriber` voice-note POSTs and Telegram Bot API file transport. |
+| `fiddle` | `>= 1.1` (locked 1.1.8) | Calls Linux `prctl(PR_SET_CHILD_SUBREAPER)` for exact project-provider descendant custody. Declared because Fiddle leaves Ruby's default-gem set in Ruby 3.5. |
 | `bubbletea` | `~> 0.1.4` | MVU runtime for `hive tui`. FFI binding to the Charm Go library. Owns alt-screen lifecycle, raw-mode toggling, resize handling, and the keystroke event stream. `Hive::Tui::App.run_charm` boots a `Bubbletea::Runner` against the `Hive::Tui::BubbleModel` adapter. |
 | `erb` | `>= 4.0` (locked 6.0.6 in root and web) | Template rendering used by stages, task creation, workflows, and display names. Declared because Ruby is unbundling it and packaged installs cannot assume it is present. The 6.0.6 patch fixes ERB's standalone `-h` CLI path; Hive's rendering API is unchanged. |
 | `lipgloss` | `~> 0.2.2` | Lipgloss-ruby — declarative terminal styles consumed by every `Hive::Tui::Views::*` module (`Style#foreground/.bold/.reverse/.border/.padding/.render`). FFI binding to the Charm Go library. ANSI is stripped when stdout isn't a tty (the v0.2.2 limitation tracked in `docs/solutions/2026-04-27-charm-bubbletea-api-gaps.md`). |

--- a/wiki/gaps.md
+++ b/wiki/gaps.md
@@ -3,7 +3,7 @@ title: Gaps
 type: gaps
 source: wiki/* vs lib/, templates/, test/, bin/
 created: 2026-04-25
-updated: 2026-07-30
+updated: 2026-08-02
 tags: [gap, todo, release-proof, agent-skills]
 ---
 
@@ -30,6 +30,14 @@ tags: [gap, todo, release-proof, agent-skills]
   exact, status advances from `reset_required` to `current`, and no unrelated
   v2 owner changes. The abandoned v2 jobs backlog is an explicit product
   tradeoff, not a continuity promise or an unimplemented migration.
+
+- Project-owned artifact providers currently require Linux
+  `PR_SET_CHILD_SUBREAPER` plus `/proc` ancestry so detached descendants remain
+  in exact custody through output drain and teardown. Provider capture fails
+  closed on macOS/BSD rather than weakening that guarantee. A portable custody
+  primitive and a live conventional-project browser provider remain follow-up
+  work; the built-in Hivebox recorder is unaffected.
+
 - `agent-cli-runtime` 0.1.0 has a self-contained package, exact-artifact
   verifier, Linux/macOS install matrix, and component-scoped trusted-publishing
   workflow. Repository-hosted controls remain operator work: the

--- a/wiki/log.d/20260802T204202Z-project-capture-providers.md
+++ b/wiki/log.d/20260802T204202Z-project-capture-providers.md
@@ -1,0 +1,29 @@
+---
+date: 2026-08-02
+title: Artifact capture selects compatible or project-owned recorders
+tags: [web, capture, artifacts, config, security]
+---
+
+- Capture selects the built-in Hivebox recorder only for a complete compatible
+  source layout; conventional projects can declare a validated
+  `artifacts.capture.provider` executable.
+- Project providers receive an exact JSON request in a deny-default subprocess.
+  Linux child-subreaper custody covers detached descendants, output drains, and
+  abnormal supervisor death from a parent-owned PID/start-time and exit-status
+  boundary. Hive revalidates the complete working-tree snapshot, including
+  ignored paths, after every attempted execution and preserves combined
+  provider/custody failures. Snapshot hashing has explicit 1 GiB cumulative and
+  30-second monotonic bounds.
+- Fiddle is now an explicit runtime dependency for the Linux `prctl` custody
+  call instead of relying on its pre-Ruby-3.5 default-gem status.
+- Hive accepts artifacts only from private staging, then bounds evidence and
+  argv, decodes the declared image/video content, independently hashes it, and
+  publishes a sub-240-KiB manifest last. Content-addressed provider names make
+  changed- and identical-byte recapture deterministic and recoverable.
+- The tracked executable remains ordinary local project tooling, not an OS
+  filesystem sandbox.
+- Added provider-neutral `hive-artifact-capture` v2 manifests while retaining
+  explicit policy and Hive Web read compatibility for v1 evidence. Non-object
+  receipts and recorder envelopes fail closed and can be replaced on recapture.
+- Unsupported projects now receive an actionable provider declaration message
+  instead of a misleading missing Hivebox dependency error.

--- a/wiki/log.d/20260803134514-sparse-custody-coverage.md
+++ b/wiki/log.d/20260803134514-sparse-custody-coverage.md
@@ -1,0 +1,10 @@
+---
+title: Sparse custody subprocess coverage
+date: 2026-08-03
+tags: [testing, coverage, capture, process-custody]
+---
+
+Coverage-instrumented custody children now flush their observed line and branch
+hits before the production `exit!` boundary. Child result files omit untouched
+sources, while the parent result retains the complete source inventory for the
+100% line-coverage gate.

--- a/wiki/log.d/20260803T000000Z-project-capture-custody-contract.md
+++ b/wiki/log.d/20260803T000000Z-project-capture-custody-contract.md
@@ -1,0 +1,18 @@
+---
+date: 2026-08-03
+title: Tighten project capture custody and retained-receipt validation
+tags: [web, capture, artifacts, git, security]
+---
+
+- Configured capture commands now use direct executable argv semantics even for
+  one-item commands, keeping punctuation-bearing tracked filenames literal.
+- Source attestation rejects Git `assume-unchanged` and `skip-worktree` flags at
+  both custody boundaries. Git probes share one monotonic deadline, bounded
+  streams, and descendant cleanup with provider execution. A dedicated
+  subreaper process owns only each command subtree; unrelated caller children
+  are never included in discovery, signalling, or reaping.
+- Project providers fail early with a platform-accurate diagnostic away from
+  Linux, and blank provider diagnostics receive an actionable fallback.
+- New v2 manifests require at least one disclosed environment key. Hive Web now
+  validates retained v2 receipts against the complete shared strict schema while
+  retaining v1 display compatibility.

--- a/wiki/modules/config.md
+++ b/wiki/modules/config.md
@@ -3,11 +3,11 @@ title: Hive::Config
 type: module
 source: lib/hive/config.rb
 created: 2026-04-25
-updated: 2026-07-30
+updated: 2026-08-02
 tags: [config, yaml, validation]
 ---
 
-**TLDR**: Two YAML configs — global at `~/.config/hive/config.yml` (registered projects plus daemon, bot, update, web, and Screenote base-url settings, including voice-transcription defaults; `HIVE_HOME/config.yml` when overridden, legacy `~/Dev/hive/config.yml` when migrated) and per-project at `<project>/.hive-state/config.yml` (default branch, default workflow, worktree root, budgets, timeouts, **stage agents**, project-owned `models`, project/top-level and per-stage `permissions`, project-global `claude.mode`/`claude.permission_mode` plus `claude.model`/`claude.effort` pins, review-stage roles, daemon enrollment, experimental babysitter enrollment, ordinary patrol, and scheduled architecture patrol). Project config root keys are strict: `Config.load(project_root)` rejects unsupported keys before merging defaults, while registered workflow stage names remain the sanctioned dynamic extension for stage overrides. Architecture-patrol discovery, issue review output, and automatic mutation remain separate settings. Fresh init enables issue output with discovery as the default review surface; legacy or hand-written config that omits `issue_filing.enabled` remains effect-free. `Config.load(project_root)` captures frozen raw field provenance for implementation-owning `agent`/`model`/`effort` keys before it **recursively** deep-merges project values onto `Config::DEFAULTS`, then runs `validate!`. Arrays are replaced wholesale, never per-element merged. Screenote OAuth tokens live outside YAML in `screenote.json`, created by `hive connect screenote`.
+**TLDR**: Two YAML configs — global at `~/.config/hive/config.yml` (registered projects plus daemon, bot, update, web, and Screenote base-url settings, including voice-transcription defaults; `HIVE_HOME/config.yml` when overridden, legacy `~/Dev/hive/config.yml` when migrated) and per-project at `<project>/.hive-state/config.yml` (default branch, default workflow, worktree root, budgets, timeouts, **stage agents**, project-owned `models`, project/top-level and per-stage `permissions`, project-global `claude.mode`/`claude.permission_mode` plus `claude.model`/`claude.effort` pins, an optional project-owned artifact capture provider, review-stage roles, daemon enrollment, experimental babysitter enrollment, ordinary patrol, and scheduled architecture patrol). Project config root keys are strict: `Config.load(project_root)` rejects unsupported keys before merging defaults, while registered workflow stage names remain the sanctioned dynamic extension for stage overrides. Architecture-patrol discovery, issue review output, and automatic mutation remain separate settings. Fresh init enables issue output with discovery as the default review surface; legacy or hand-written config that omits `issue_filing.enabled` remains effect-free. `Config.load(project_root)` captures frozen raw field provenance for implementation-owning `agent`/`model`/`effort` keys before it **recursively** deep-merges project values onto `Config::DEFAULTS`, then runs `validate!`. Arrays are replaced wholesale, never per-element merged. Screenote OAuth tokens live outside YAML in `screenote.json`, created by `hive connect screenote`.
 
 The live project template includes a commented, copyable `models:` example.
 Exact and coarse entries inherit model and effort independently, never select an
@@ -86,6 +86,38 @@ overrides stay distinguishable. This structural pass runs before the legacy
 top-level-reviewers warning. Reachable-profile capability validation remains a
 separate, pure routing-domain step after exact/coarse shadowing is known.
 
+## Project artifact capture provider
+
+Hive checkouts need no declaration: the complete locked Hivebox web layout
+selects the built-in recorder. A conventional project can declare one
+project-owned executable:
+
+```yaml
+artifacts:
+  agent: claude
+  capture:
+    provider:
+      name: rails
+      command: [bin/hive-capture]
+      timeout_sec: 120
+```
+
+`provider` defaults to `nil`. When present it is a closed mapping: `name` must
+match `[a-z][a-z0-9_-]{0,63}`, `command` is 1–32 non-empty argv strings whose
+first item is a traversal-free project-relative executable path (the capture
+boundary also requires that executable to be tracked at the immutable HEAD),
+the complete argv is at most 16 KiB, and `timeout_sec` is an integer from 1
+through 600. Unknown fields, a shell command string, oversized argv,
+absolute/traversing executables, or malformed values fail during `Config.load`,
+before capture starts. The provider request/result ABI and publication checks
+are documented in [[commands/web]].
+
+This declaration is additive. Projects that omit it retain their prior config
+shape: compatible Hivebox trees continue on the built-in recorder, while
+incompatible conventional trees receive the precise unsupported-provider
+diagnostic until they opt in. Retained v1 capture manifests remain readable;
+new successful capture emits the provider-neutral v2 manifest.
+
 ## Condition authority
 
 ```yaml
@@ -146,7 +178,7 @@ The built-in downstream policy is `open_pr=medium`, `review.fix=high`, and `revi
   "plan"       => { "agent" => "claude" },
   "execute"    => { "agent" => "claude" },  # rendered template recommends `codex`
   "open_pr"    => {},
-  "artifacts"  => { "agent" => "claude" },
+  "artifacts"  => { "agent" => "claude", "capture" => { "provider" => nil } },
   "finalize"   => { "agent" => "claude" },
   "agents" => {
     "claude" => { "bin" => "claude", "env_override" => "HIVE_CLAUDE_BIN", "min_version" => "2.1.118" },

--- a/wiki/stages/artifacts.md
+++ b/wiki/stages/artifacts.md
@@ -10,7 +10,7 @@ tags: [stage, artifacts, release]
 **TLDR**: Artifact collection is the agent-backed handoff between autonomous
 review and PR finalization. Before spawn, Hive writes a deterministic,
 generation-bound `capture-requirement.json`. Visual work must retain a valid
-task-local `media/capture-manifest.json`; a bootstrap or recorder failure keeps
+task-local `media/capture-manifest.json`; a bootstrap, provider, or recorder failure keeps
 the stage in `ERROR reason=required_capture_missing`. Nonvisual work records
 `not_applicable`. Autonomous artifact collection never reads or injects
 Screenote credentials: external upload is a separate operator-confirmed action.
@@ -39,11 +39,31 @@ Screenote credentials: external upload is a separate operator-confirmed action.
 ## Media manifest
 
 Required capture writes `<task>/media/capture-manifest.json` using
-`hive-artifact-capture` v1. It binds the task slug and clean source SHA, both
-lockfile digests, immutable dependency-cache key, exact recorder command,
-fixture ids, viewport, accessibility assertions, artifact byte sizes and
-SHA-256 hashes, and teardown outcome. A `captured` receipt must contain at least
-one retained artifact and match the requirement's implementation head.
+`hive-artifact-capture` v2. Its provider-neutral envelope binds the task slug,
+clean source SHA, recorder identity and argv, disclosed environment-key names,
+artifact byte sizes and SHA-256 hashes, timestamps, diagnostic, and teardown
+outcome. Built-in Hivebox evidence keeps its lock digests, immutable cache key,
+fixture ids, viewport, and accessibility assertions inside the typed `evidence`
+block; project recorders use `evidence.type: project_provider` and bounded
+provider-specific `details`. A `captured` receipt must contain at least one
+retained artifact and match the requirement's implementation head.
+
+New producers reserve headroom by rejecting the complete serialized receipt
+above 240 KiB before publishing any provider media or manifest. Policy and Hive
+Web share a 256 KiB consumer ceiling and reject larger files before parsing.
+Project media must decode as its declared image/video type. Its published name
+contains both source and artifact digests, so an identical recapture is reused
+while changed bytes at the same source SHA publish under a new name; superseded
+task-owned provider media is removed only after the replacement manifest is
+durable.
+
+The policy continues to validate retained `hive-artifact-capture` v1 manifests
+against the v1 schema and built-in-recorder requirements. New captures emit v2;
+the Web reader renders v1 and v2 and hides unknown future versions. This is a
+read-compatible migration: existing task evidence does not need rewriting.
+Syntactically valid non-object receipts fail closed as unsatisfied, and provider
+recapture ignores a retained receipt unless both its root and `recorder` are
+objects with the expected provider identity.
 
 The older `<task>/media/manifest.json` remains a display compatibility format
 for existing tasks:

--- a/wiki/stages/artifacts.md
+++ b/wiki/stages/artifacts.md
@@ -3,7 +3,7 @@ title: 7-artifacts stage
 type: stage
 source: lib/hive/stages/artifacts.rb
 created: 2026-05-22
-updated: 2026-08-02
+updated: 2026-08-03
 tags: [stage, artifacts, release]
 ---
 
@@ -51,6 +51,18 @@ retained artifact and match the requirement's implementation head.
 New producers reserve headroom by rejecting the complete serialized receipt
 above 240 KiB before publishing any provider media or manifest. Policy and Hive
 Web share a 256 KiB consumer ceiling and reject larger files before parsing.
+The environment-key disclosure is always nonempty, and failed-provider blank
+diagnostics are normalized to an actionable fallback. Project-provider capture
+is Linux-only because its custody guarantee depends on child-subreaper support.
+Before and after invoking a provider, Hive rejects Git `assume-unchanged` and
+`skip-worktree` index entries and revalidates the complete source snapshot. Git
+attestation helpers and the provider share bounded output, one monotonic
+source-custody deadline, and complete descendant cleanup. Each command runs
+beneath a freshly forked subreaper custody root, so caller children outside that
+command subtree are never enumerated, signalled, or reaped. Configured commands
+always use Ruby's direct executable/argv form, including one-item commands, so
+shell punctuation in a tracked executable name remains literal.
+
 Project media must decode as its declared image/video type. Its published name
 contains both source and artifact digests, so an identical recapture is reused
 while changed bytes at the same source SHA publish under a new name; superseded
@@ -59,7 +71,8 @@ durable.
 
 The policy continues to validate retained `hive-artifact-capture` v1 manifests
 against the v1 schema and built-in-recorder requirements. New captures emit v2;
-the Web reader renders v1 and v2 and hides unknown future versions. This is a
+the Web reader validates v2 receipts against the complete shared strict schema,
+renders valid v1 and v2 receipts, and hides unknown future versions. This is a
 read-compatible migration: existing task evidence does not need rewriting.
 Syntactically valid non-object receipts fail closed as unsatisfied, and provider
 recapture ignores a retained receipt unless both its root and `recorder` are

--- a/wiki/state-model.md
+++ b/wiki/state-model.md
@@ -1125,11 +1125,22 @@ user-visible paths or an explicit visual-proof request as `required`; other
 work is `not_applicable`. Agents cannot demote the result. A demotion records a
 confirmed operator, rationale, timestamp, and the same task generation.
 
-When required, `media/capture-manifest.json` is
-`hive-artifact-capture` v1 and must identify the same task and implementation
-head with at least one retained artifact. A `COMPLETE` marker without matching
-capture evidence is not terminal truth: the artifacts runner rewrites it to
+When required, new `media/capture-manifest.json` receipts use the
+provider-neutral `hive-artifact-capture` v2 contract and must identify the same
+task and implementation head with at least one retained artifact. Retained v1
+receipts are still validated against their original schema and built-in
+evidence rules. A `COMPLETE` marker without matching v1 or v2 capture evidence
+is not terminal truth: the artifacts runner rewrites it to
 `ERROR reason=required_capture_missing`.
+JSON arrays, `null`, and receipts with non-object recorder envelopes are invalid
+evidence rather than exceptions. Provider recapture replaces those malformed
+receipts without treating any referenced media as task-owned cleanup input.
+
+The v2 producer ceiling is 240 KiB, leaving headroom below the 256 KiB ceiling
+shared by policy and Hive Web. Project-provider artifact names bind both source
+and content digests; replacement media becomes authoritative only when the new
+manifest is published, after which superseded task-owned provider files may be
+removed.
 
 See [[stages/index]] for one page per stage.
 

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -3,7 +3,7 @@ title: Testing
 type: reference
 source: test/, Rakefile, bin/hive-eval, .rubocop.yml, .github/workflows/{ci,live-agent-skills,release-candidate,release}.yml, packaging/{live_agent_skills,release_candidate}/, config/brakeman.ignore
 created: 2026-04-25
-updated: 2026-08-02
+updated: 2026-08-03
 tags: [test, minitest, fixtures, honeycomb, agent-skills, component-boundaries, terminal-outcomes, release-proof]
 ---
 
@@ -622,7 +622,9 @@ archive digest, but `release.yml` does not query or require that Check Run.
 `bundle exec rake smoke` also contains older live Claude workflows and may
 incur provider cost. Normal `rake test` remains local and network-free.
 `bundle exec rake coverage` uses the same network-free machinery but is
-normally owned by hosted CI.
+normally owned by hosted CI. Forked custody processes that terminate through
+`exit!` explicitly flush sparse, hit-only coverage results before exiting;
+the parent retains the complete source inventory used by the 100% line gate.
 
 ## Live Claude tmux dogfood
 


### PR DESCRIPTION
## Summary

- add project-owned artifact capture providers with direct executable argv semantics and bounded Linux process custody
- attest provider source state before and after capture, including Git index flags, literal pathspecs, shared deadlines, and bounded streamed Git output
- isolate helper cleanup to a Hive-created custody subtree so unrelated caller children neither block capture nor become cleanup targets
- align the v2 receipt contract across producer, schema, policy, and Hive Web while preserving v1 compatibility
- document the capture contract and add regression coverage for all reproduced boundaries

## Root-cause-repair proof

Fresh task `complete-and-certify-the-project-260803-59a0` completed the full workflow:

- reproduction: all seven baseline defects reproduced
- repair: unrelated Git refs were recorded and allowed to continue
- verification round 1: 0/1 ready; caught caller-wide child custody
- revision: dedicated custody-root process plus concurrent-parent regression
- verification round 2: 1/1 ready; no required edits or disagreements
- certificate: `Outcome: verified`

The exact unrelated-child command is green after rebase: 3 runs / 52 assertions.

## Validation on rebased head

- capture-focused matrix: 227 runs / 1,306 assertions, all green
- Hive Web model matrix: 18 runs / 81 assertions, all green
- adjacent config, artifacts, gemspec, bundle, command, and init matrix: 449 runs / 2,745 assertions, all green
- RuboCop: 8 files inspected, no offenses
- root and Web bundles: satisfied
- `git diff --check`: clean

The pinned workflow baseline also preserved the exact TopGreenDeals unsupported-provider diagnostic. On current `origin/main`, that live command now stops earlier because the external task journal references a JobStore-v2 attempt; the same failure was reproduced on an untouched main worktree, so it is not a branch regression.

## Notes

The broad local Rake harness was not used as a green claim: on this shared host it reached teardown with unrelated Bundler, tmux, DBus, and process-fixture contamination. Focused causal coverage and hosted CI are the merge gates.