### PR TITLE
refactor(workflows): stage immutable creator values

### DIFF
--- a/config/component-boundaries.yml
+++ b/config/component-boundaries.yml
@@ -748,3 +748,40 @@ components:
       - test/unit/task_projection_test.rb
       - test/unit/workflow_test.rb
     migration_exceptions: []
+
+  - id: workflow-creator-values
+    name: Workflow Creator Values
+    state: candidate
+    entrypoint:
+      file: packaging/live_agent_skills/workflow_creator_values.rb
+      require: packaging/live_agent_skills/workflow_creator_values
+      constant: HiveLiveAgentProof::WorkflowCreator::Values
+    public_contract:
+      values:
+        - HiveLiveAgentProof::WorkflowCreator::Values.capture
+        - anonymous immutable workflow-creator value snapshot
+      errors:
+        - HiveLiveAgentProof::WorkflowCreator::Values::Error
+    owned_paths:
+      - packaging/live_agent_skills/workflow_creator_values.rb
+    state_contracts:
+      - "One capture owns fresh recursively frozen JSON-shaped values and their compact canonical UTF-8 bytes"
+    schema_contracts:
+      - "Canonical bytes preserve JSON scalar type, sort normalized UTF-8 object keys by owned bytes, and end with one newline"
+    lock_contracts:
+      - "No locks or durable state; concurrent caller mutation is outside the capture contract"
+    component_dependencies: []
+    allowed_hive_dependencies: []
+    internal_collaborators:
+      - HiveLiveAgentProof::WorkflowCreator::Values
+    forbidden_constructions: []
+    authorized_internal_constructions: []
+    hive_consumers: []
+    mutation_authority: "No external mutation authority; capture allocates only fresh in-memory values and bytes."
+    recovery_surface: "Capture fails closed with one fixed secret-free error and exposes no retry or recovery state."
+    wiki_page: wiki/component-boundaries.md
+    focused_tests:
+      - test/unit/packaging/workflow_creator_values_test.rb
+    migration_exceptions:
+      - reason: "U1a1vt must consume the staged values-only boundary before it can be promoted."
+        removal_unit: U1a1vt

--- a/packaging/live_agent_skills/workflow_creator_values.rb
+++ b/packaging/live_agent_skills/workflow_creator_values.rb
@@ -1,0 +1,298 @@
+# frozen_string_literal: true
+
+module HiveLiveAgentProof
+  module WorkflowCreator
+    module Values
+      class Error < StandardError; end
+      CAPTURE_FAILURE = Error.new("workflow-creator value cannot be captured")
+      MARSHAL_FAILURE = TypeError.new("workflow-creator snapshots cannot be marshaled")
+      failure_protocol = %i[backtrace cause exception initialize_clone initialize_copy message set_backtrace to_s]
+      [ CAPTURE_FAILURE, MARSHAL_FAILURE ].each do |failure|
+        failure_protocol.each { |name| failure.singleton_class.alias_method(name, name) }
+        failure.freeze
+      end
+      INVOKE = :__workflow_creator_values_invoke__
+      MAX_DEPTH = 64
+      MAX_NODES = 8_192
+      MAX_SOURCE_BYTES = 262_144
+      MAX_CANONICAL_BYTES = 1_048_576
+      MAX_WORK_UNITS = 4_194_304
+      MAX_INTEGER_BITS = 4_096
+      NODES = 0
+      SOURCE_BYTES = 1
+      WORK_UNITS = 2
+      ACTIVE = 3
+      def self.seal(operation)
+        singleton = operation.singleton_class
+        singleton.alias_method(INVOKE, :bind_call)
+        singleton.__send__(:private, INVOKE)
+        singleton.alias_method(:send, :__send__)
+        operation.freeze
+      end
+      OBJECT_CLASS = seal(Object.instance_method(:class))
+      RAISE = seal(Kernel.instance_method(:raise))
+      OBJECT_CLONE = seal(Object.instance_method(:clone))
+      MODULE_CASE = seal(Module.instance_method(:===))
+      FAILURE_BASE = StandardError
+      OBJECT_FREEZE = seal(Object.instance_method(:freeze))
+      OBJECT_SET_IVAR = seal(Object.instance_method(:instance_variable_set))
+      OBJECT_EQUAL = seal(BasicObject.instance_method(:equal?))
+      CLASS_ALLOCATE = seal(Class.instance_method(:allocate))
+      HASH_EACH_PAIR = seal(Hash.instance_method(:each_pair))
+      HASH_LENGTH = seal(Hash.instance_method(:length))
+      HASH_SET = seal(Hash.instance_method(:[]=))
+      ARRAY_EACH = seal(Array.instance_method(:each))
+      ARRAY_INDEX = seal(Array.instance_method(:index))
+      ARRAY_LENGTH = seal(Array.instance_method(:length))
+      ARRAY_GET = seal(Array.instance_method(:[]))
+      ARRAY_SET = seal(Array.instance_method(:[]=))
+      ARRAY_PUSH = seal(Array.instance_method(:<<))
+      ARRAY_POP = seal(Array.instance_method(:pop))
+      ARRAY_SORT = seal(Array.instance_method(:sort!))
+      STRING_DUP = seal(String.instance_method(:dup))
+      STRING_ENCODING = seal(String.instance_method(:encoding))
+      STRING_BYTESIZE = seal(String.instance_method(:bytesize))
+      STRING_ENCODE = seal(String.instance_method(:encode))
+      STRING_EACH_BYTE = seal(String.instance_method(:each_byte))
+      STRING_BYTESLICE = seal(String.instance_method(:byteslice))
+      STRING_APPEND = seal(String.instance_method(:<<))
+      STRING_COMPARE = seal(String.instance_method(:<=>))
+      STRING_FORMAT = seal(String.instance_method(:%))
+      INTEGER_ADD = seal(Integer.instance_method(:+))
+      INTEGER_MULTIPLY = seal(Integer.instance_method(:*))
+      INTEGER_GREATER = seal(Integer.instance_method(:>))
+      INTEGER_EQUAL = seal(Integer.instance_method(:==))
+      INTEGER_BITS = seal(Integer.instance_method(:bit_length))
+      INTEGER_TO_S = seal(Integer.instance_method(:to_s))
+      FLOAT_FINITE = seal(Float.instance_method(:finite?))
+      FLOAT_TO_S = seal(Float.instance_method(:to_s))
+      ENCODING_DUMMY = seal(Encoding.instance_method(:dummy?))
+      UTF8 = Encoding::UTF_8
+      UTF16 = Encoding::UTF_16LE
+      BINARY = Encoding::BINARY
+      FAILURE_MATCHER = Module.new do
+        def self.===(error) = MODULE_CASE.send(INVOKE, FAILURE_BASE, error)
+      end.freeze
+      @snapshot_class = Class.new do
+        def value = @value
+        def canonical_bytes = @canonical_bytes
+        def inspect = "#<HiveLiveAgentProof::WorkflowCreator::Values snapshot>"
+        def marshal_dump
+          failure = OBJECT_CLONE.send(INVOKE, MARSHAL_FAILURE, freeze: false)
+          RAISE.send(INVOKE, self, failure, cause: nil)
+        end
+        def marshal_load(_payload)
+          failure = OBJECT_CLONE.send(INVOKE, MARSHAL_FAILURE, freeze: false)
+          RAISE.send(INVOKE, self, failure, cause: nil)
+        end
+        private :marshal_dump, :marshal_load
+        undef_method :dup, :clone, :instance_variable_set, :remove_instance_variable
+      end
+      @snapshot_class.singleton_class.class_eval do
+        private :new, :allocate
+        undef_method :dup, :clone
+      end
+      def self.capture(input)
+        state = [ 0, 0, 0, [] ]
+        charge!(state, 1)
+        owned, fragment = import_value(input, state, 0)
+        canonical = STRING_DUP.send(INVOKE, "")
+        append!(state, canonical, fragment)
+        append!(state, canonical, "\n")
+        OBJECT_FREEZE.send(INVOKE, canonical)
+        snapshot = CLASS_ALLOCATE.send(INVOKE, @snapshot_class)
+        OBJECT_SET_IVAR.send(INVOKE, snapshot, :@value, owned)
+        OBJECT_SET_IVAR.send(INVOKE, snapshot, :@canonical_bytes, canonical)
+        OBJECT_FREEZE.send(INVOKE, snapshot)
+      rescue FAILURE_MATCHER
+        fail_capture!
+      end
+      def self.fail_capture!
+        failure = OBJECT_CLONE.send(INVOKE, CAPTURE_FAILURE, freeze: false)
+        RAISE.send(INVOKE, self, failure, cause: nil)
+      end
+      def self.import_value(value, state, depth)
+        fail_capture! if INTEGER_GREATER.send(INVOKE, depth, MAX_DEPTH)
+        nodes = INTEGER_ADD.send(INVOKE, ARRAY_GET.send(INVOKE, state, NODES), 1)
+        fail_capture! if INTEGER_GREATER.send(INVOKE, nodes, MAX_NODES)
+        ARRAY_SET.send(INVOKE, state, NODES, nodes)
+        klass = OBJECT_CLASS.send(INVOKE, value)
+        if OBJECT_EQUAL.send(INVOKE, klass, Hash)
+          import_hash(value, state, depth)
+        elsif OBJECT_EQUAL.send(INVOKE, klass, Array)
+          import_array(value, state, depth)
+        elsif OBJECT_EQUAL.send(INVOKE, klass, String)
+          import_string(value, state)
+        elsif OBJECT_EQUAL.send(INVOKE, klass, Integer)
+          import_integer(value, state)
+        elsif OBJECT_EQUAL.send(INVOKE, klass, Float)
+          import_float(value, state)
+        elsif OBJECT_EQUAL.send(INVOKE, klass, TrueClass)
+          [ value, "true" ]
+        elsif OBJECT_EQUAL.send(INVOKE, klass, FalseClass)
+          [ value, "false" ]
+        elsif OBJECT_EQUAL.send(INVOKE, klass, NilClass)
+          [ value, "null" ]
+        else
+          fail_capture!
+        end
+      end
+      def self.import_hash(value, state, depth)
+        active = ARRAY_GET.send(INVOKE, state, ACTIVE)
+        duplicate = ARRAY_INDEX.send(INVOKE, active) { |item| OBJECT_EQUAL.send(INVOKE, item, value) }
+        fail_capture! if duplicate
+        length = HASH_LENGTH.send(INVOKE, value)
+        minimum = INTEGER_ADD.send(INVOKE, ARRAY_GET.send(INVOKE, state, NODES),
+                                      INTEGER_MULTIPLY.send(INVOKE, length, 2))
+        fail_capture! if INTEGER_GREATER.send(INVOKE, minimum, MAX_NODES)
+        ARRAY_PUSH.send(INVOKE, active, value)
+        begin
+          entries = []
+          owned = {}
+          HASH_EACH_PAIR.send(INVOKE, value) do |raw_key, raw_value|
+            import_hash_entry(raw_key, raw_value, state, depth, entries, owned)
+          end
+          charge!(state, INTEGER_MULTIPLY.send(INVOKE, length, INTEGER_BITS.send(INVOKE, length)))
+          ARRAY_SORT.send(INVOKE, entries) do |left, right|
+            STRING_COMPARE.send(INVOKE, ARRAY_GET.send(INVOKE, left, 0),
+                                    ARRAY_GET.send(INVOKE, right, 0))
+          end
+          build_collection(owned, entries, state, "{", "}")
+        ensure
+          ARRAY_POP.send(INVOKE, active)
+        end
+      end
+      def self.import_hash_entry(raw_key, raw_value, state, depth, entries, owned)
+        key_class = OBJECT_CLASS.send(INVOKE, raw_key)
+        fail_capture! unless OBJECT_EQUAL.send(INVOKE, key_class, String)
+        charge!(state, 3)
+        key, key_json = import_value(raw_key, state, INTEGER_ADD.send(INVOKE, depth, 1))
+        nested, nested_json = import_value(raw_value, state, INTEGER_ADD.send(INVOKE, depth, 1))
+        charge!(state, 1)
+        prior_length = HASH_LENGTH.send(INVOKE, owned)
+        HASH_SET.send(INVOKE, owned, key, nested)
+        if INTEGER_EQUAL.send(INVOKE, HASH_LENGTH.send(INVOKE, owned), prior_length)
+          fail_capture!
+        end
+        ARRAY_PUSH.send(INVOKE, entries, [ key, nested, [ key_json, ":", nested_json ] ])
+      end
+      def self.import_array(value, state, depth)
+        active = ARRAY_GET.send(INVOKE, state, ACTIVE)
+        duplicate = ARRAY_INDEX.send(INVOKE, active) { |item| OBJECT_EQUAL.send(INVOKE, item, value) }
+        fail_capture! if duplicate
+        length = ARRAY_LENGTH.send(INVOKE, value)
+        minimum = INTEGER_ADD.send(INVOKE, ARRAY_GET.send(INVOKE, state, NODES), length)
+        fail_capture! if INTEGER_GREATER.send(INVOKE, minimum, MAX_NODES)
+        ARRAY_PUSH.send(INVOKE, active, value)
+        begin
+          entries = []
+          owned = []
+          ARRAY_EACH.send(INVOKE, value) do |raw_value|
+            charge!(state, 2)
+            nested, nested_json = import_value(raw_value, state, INTEGER_ADD.send(INVOKE, depth, 1))
+            ARRAY_PUSH.send(INVOKE, entries, [ nil, nested, [ nested_json ] ])
+            ARRAY_PUSH.send(INVOKE, owned, nested)
+          end
+          build_collection(owned, entries, state, "[", "]")
+        ensure
+          ARRAY_POP.send(INVOKE, active)
+        end
+      end
+      def self.build_collection(owned, entries, state, opening, closing)
+        output = STRING_DUP.send(INVOKE, "")
+        append!(state, output, opening)
+        separator = ""
+        ARRAY_EACH.send(INVOKE, entries) do |entry|
+          append!(state, output, separator)
+          fragments = ARRAY_GET.send(INVOKE, entry, 2)
+          ARRAY_EACH.send(INVOKE, fragments) { |fragment| append!(state, output, fragment) }
+          separator = ","
+        end
+        append!(state, output, closing)
+        [ OBJECT_FREEZE.send(INVOKE, owned), output ]
+      end
+      def self.import_string(value, state)
+        encoding = STRING_ENCODING.send(INVOKE, value)
+        fail_capture! if ENCODING_DUMMY.send(INVOKE, encoding)
+        fail_capture! if OBJECT_EQUAL.send(INVOKE, encoding, BINARY)
+        bytes = STRING_BYTESIZE.send(INVOKE, value)
+        source = INTEGER_ADD.send(INVOKE, ARRAY_GET.send(INVOKE, state, SOURCE_BYTES), bytes)
+        fail_capture! if INTEGER_GREATER.send(INVOKE, source, MAX_SOURCE_BYTES)
+        ARRAY_SET.send(INVOKE, state, SOURCE_BYTES, source)
+        charge!(state, bytes)
+        validated = STRING_ENCODE.send(INVOKE, value, UTF16)
+        owned = STRING_ENCODE.send(INVOKE, validated, UTF8)
+        output = STRING_DUP.send(INVOKE, "")
+        append!(state, output, '"')
+        index = 0
+        STRING_EACH_BYTE.send(INVOKE, owned) do |byte|
+          append!(state, output, escape_byte(owned, byte, index))
+          index = INTEGER_ADD.send(INVOKE, index, 1)
+        end
+        append!(state, output, '"')
+        [ OBJECT_FREEZE.send(INVOKE, owned), output ]
+      end
+      def self.import_integer(value, state)
+        bits = INTEGER_BITS.send(INVOKE, value)
+        fail_capture! if INTEGER_GREATER.send(INVOKE, bits, MAX_INTEGER_BITS)
+        charge!(state, bits)
+        [ value, INTEGER_TO_S.send(INVOKE, value) ]
+      end
+      def self.import_float(value, state)
+        fail_capture! unless FLOAT_FINITE.send(INVOKE, value)
+        charge!(state, 64)
+        [ value, FLOAT_TO_S.send(INVOKE, value) ]
+      end
+      def self.escape_byte(value, byte, index)
+        if INTEGER_EQUAL.send(INVOKE, byte, 34)
+          '\\"'
+        elsif INTEGER_EQUAL.send(INVOKE, byte, 92)
+          "\\\\"
+        elsif INTEGER_EQUAL.send(INVOKE, byte, 8)
+          "\\b"
+        elsif INTEGER_EQUAL.send(INVOKE, byte, 12)
+          "\\f"
+        elsif INTEGER_EQUAL.send(INVOKE, byte, 10)
+          "\\n"
+        elsif INTEGER_EQUAL.send(INVOKE, byte, 13)
+          "\\r"
+        elsif INTEGER_EQUAL.send(INVOKE, byte, 9)
+          "\\t"
+        elsif INTEGER_GREATER.send(INVOKE, 32, byte)
+          STRING_FORMAT.send(INVOKE, "\\u00%02x", byte)
+        else
+          STRING_BYTESLICE.send(INVOKE, value, index, 1)
+        end
+      end
+      def self.append!(state, output, fragment)
+        bytes = STRING_BYTESIZE.send(INVOKE, fragment)
+        charge!(state, bytes)
+        size = INTEGER_ADD.send(INVOKE, STRING_BYTESIZE.send(INVOKE, output), bytes)
+        if INTEGER_GREATER.send(INVOKE, size, MAX_CANONICAL_BYTES)
+          fail_capture!
+        end
+        STRING_APPEND.send(INVOKE, output, fragment)
+      end
+      def self.charge!(state, amount)
+        units = INTEGER_ADD.send(INVOKE, ARRAY_GET.send(INVOKE, state, WORK_UNITS), amount)
+        fail_capture! if INTEGER_GREATER.send(INVOKE, units, MAX_WORK_UNITS)
+        ARRAY_SET.send(INVOKE, state, WORK_UNITS, units)
+      end
+      private_class_method :seal, :import_value, :import_hash_entry, :build_collection, :import_string, :import_integer,
+                           :import_float, :import_hash, :import_array, :escape_byte, :append!, :charge!, :fail_capture!
+      private_constant :CAPTURE_FAILURE, :MARSHAL_FAILURE, :INVOKE,
+                       :MAX_DEPTH, :MAX_NODES, :MAX_SOURCE_BYTES, :MAX_CANONICAL_BYTES, :MAX_WORK_UNITS,
+                       :MAX_INTEGER_BITS, :NODES, :SOURCE_BYTES, :WORK_UNITS, :ACTIVE, :OBJECT_CLASS, :OBJECT_FREEZE,
+                       :OBJECT_SET_IVAR, :OBJECT_EQUAL, :CLASS_ALLOCATE, :HASH_EACH_PAIR, :HASH_LENGTH, :HASH_SET,
+                       :ARRAY_EACH, :ARRAY_INDEX, :ARRAY_LENGTH, :ARRAY_GET, :ARRAY_SET, :ARRAY_PUSH, :ARRAY_POP,
+                       :ARRAY_SORT, :STRING_DUP, :STRING_ENCODING, :STRING_BYTESIZE, :STRING_ENCODE, :STRING_EACH_BYTE,
+                       :STRING_BYTESLICE, :STRING_APPEND, :STRING_COMPARE, :STRING_FORMAT, :INTEGER_ADD,
+                       :INTEGER_MULTIPLY, :INTEGER_GREATER, :INTEGER_EQUAL, :INTEGER_BITS, :INTEGER_TO_S, :FLOAT_FINITE,
+                       :RAISE, :OBJECT_CLONE, :MODULE_CASE, :FAILURE_BASE, :FAILURE_MATCHER, :FLOAT_TO_S,
+                       :ENCODING_DUMMY, :UTF8, :UTF16, :BINARY
+      OBJECT_FREEZE.send(INVOKE, @snapshot_class)
+      OBJECT_FREEZE.send(INVOKE, Error)
+      OBJECT_FREEZE.send(INVOKE, self)
+    end
+  end
+end

--- a/test/support/component_boundary_contract.rb
+++ b/test/support/component_boundary_contract.rb
@@ -164,7 +164,12 @@ class ComponentBoundaryContract
       next if field == "migration_exceptions"
 
       string_array!(value, "#{component_path}.#{field}",
-                    allow_empty: %w[component_dependencies allowed_hive_dependencies forbidden_constructions].include?(field))
+                    allow_empty: %w[
+                      component_dependencies
+                      allowed_hive_dependencies
+                      forbidden_constructions
+                      hive_consumers
+                    ].include?(field))
     end
     forbidden_allowed = row.fetch("allowed_hive_dependencies").select { |required| forbidden_require?(required) }
     unless forbidden_allowed.empty?
@@ -176,6 +181,11 @@ class ComponentBoundaryContract
     end
     repo_path!(row.fetch("wiki_page"), "#{component_path}.wiki_page")
     validate_migration_exceptions!(row, component_path)
+    if row.fetch("hive_consumers").empty? &&
+        (state != "candidate" || row.fetch("migration_exceptions").length != 1)
+      invalid!("#{component_path}.hive_consumers",
+               "may be empty only for a candidate with exactly one bounded migration exception")
+    end
     validate_authorized_internal_constructions!(row, component_path)
     string!(row.fetch("mutation_authority"), "#{component_path}.mutation_authority")
     string!(row.fetch("recovery_surface"), "#{component_path}.recovery_surface")
@@ -190,7 +200,9 @@ class ComponentBoundaryContract
       assert_keys!(exception, %w[reason removal_unit], path)
       string!(exception.fetch("reason"), "#{path}.reason")
       removal_unit = string!(exception.fetch("removal_unit"), "#{path}.removal_unit")
-      invalid!("#{path}.removal_unit", "must name a plan unit such as U3") unless removal_unit.match?(/\AU\d+\z/)
+      unless removal_unit.match?(/\AU\d+(?:[a-z]\d*)*\z/)
+        invalid!("#{path}.removal_unit", "must name a plan unit such as U3 or U1a1vt")
+      end
     end
     if row.fetch("state") == "boundary-ready" && !exceptions.empty?
       invalid!("#{component_path}.migration_exceptions", "boundary-ready components cannot retain exceptions")

--- a/test/unit/component_boundaries_test.rb
+++ b/test/unit/component_boundaries_test.rb
@@ -22,6 +22,7 @@ class ComponentBoundariesTest < Minitest::Test
       skillpack
       user-service
       work-ledger
+      workflow-creator-values
     ], contract.components.map { |component| component.fetch("id") }.sort
 
     attempts = contract.component("attempts")
@@ -242,13 +243,32 @@ class ComponentBoundariesTest < Minitest::Test
     )
     assert_empty work_ledger.fetch("migration_exceptions")
 
+    workflow_values = contract.component("workflow-creator-values")
+    assert_equal "candidate", workflow_values.fetch("state")
+    assert_equal(
+      {
+        "file" => "packaging/live_agent_skills/workflow_creator_values.rb",
+        "require" => "packaging/live_agent_skills/workflow_creator_values",
+        "constant" => "HiveLiveAgentProof::WorkflowCreator::Values"
+      },
+      workflow_values.fetch("entrypoint")
+    )
+    assert_equal [ "packaging/live_agent_skills/workflow_creator_values.rb" ],
+                 workflow_values.fetch("owned_paths")
+    assert_empty workflow_values.fetch("component_dependencies")
+    assert_empty workflow_values.fetch("allowed_hive_dependencies")
+    assert_empty workflow_values.fetch("hive_consumers")
+    assert_equal 1, workflow_values.fetch("migration_exceptions").length
+    assert_equal "U1a1vt",
+                 workflow_values.dig("migration_exceptions", 0, "removal_unit")
+
     ready_components.push(
       agent_abi, artifact_firewall, skillpack, git_gate, work_ledger
     )
     remaining_candidates = contract.components.reject do |component|
       ready_components.include?(component)
     end
-    assert_equal %w[attempts patrol-effects],
+    assert_equal %w[attempts patrol-effects workflow-creator-values],
                  remaining_candidates.map { |entry| entry.fetch("id") }.sort
     assert remaining_candidates.all? { |component| component.fetch("state") == "candidate" }
 
@@ -312,14 +332,13 @@ class ComponentBoundariesTest < Minitest::Test
       wiki_link = component.fetch("wiki_page").delete_prefix("wiki/").delete_suffix(".md")
       assert_includes row, "[[#{wiki_link}]]"
       assert_includes wiki_index, "[[#{wiki_link}]]"
-      exceptions = component.fetch("migration_exceptions")
-      if component.fetch("id") == "patrol-effects"
-        assert_equal [ "U3" ],
-                     exceptions.map { |entry| entry.fetch("removal_unit") }
-      else
-        assert_empty exceptions,
-                     "#{component.fetch('id')} retained an expired migration exception"
-      end
+      expected_removals = {
+        "patrol-effects" => [ "U3" ],
+        "workflow-creator-values" => [ "U1a1vt" ]
+      }.fetch(component.fetch("id"), [])
+      assert_equal expected_removals,
+                   component.fetch("migration_exceptions").map { |entry| entry.fetch("removal_unit") },
+                   "#{component.fetch('id')} has an unexpected migration fence"
 
       component_dependencies = component.fetch("component_dependencies")
       dependencies[component.fetch("id")] = component_dependencies unless component_dependencies.empty?
@@ -602,6 +621,48 @@ class ComponentBoundariesTest < Minitest::Test
     end
   end
 
+  def test_candidate_with_exactly_one_bounded_exception_accepts_empty_hive_consumers
+    with_contract_fixture(
+      entrypoint_source: example_api_source,
+      state: "candidate",
+      hive_consumers: [],
+      migration_exceptions: [
+        { "reason" => "temporary staged consumer", "removal_unit" => "U1a1vt" }
+      ]
+    ) do |contract|
+      assert contract.validate_catalog!
+    end
+  end
+
+  def test_empty_hive_consumers_require_candidate_state_and_exactly_one_exception
+    cases = {
+      "ready without exception" => [ "boundary-ready", [] ],
+      "candidate without exception" => [ "candidate", [] ],
+      "candidate with two exceptions" => [
+        "candidate",
+        [
+          { "reason" => "first staged consumer", "removal_unit" => "U1a1vt" },
+          { "reason" => "second staged consumer", "removal_unit" => "U2" }
+        ]
+      ]
+    }
+
+    cases.each do |label, (state, exceptions)|
+      with_contract_fixture(
+        entrypoint_source: example_api_source,
+        state: state,
+        hive_consumers: [],
+        migration_exceptions: exceptions
+      ) do |contract|
+        error = assert_raises(ComponentBoundaryContract::ValidationError, label) do
+          contract.validate_catalog!
+        end
+
+        assert_match(/example\.hive_consumers/, error.message, label)
+      end
+    end
+  end
+
   def test_boundary_ready_component_cannot_depend_on_a_candidate
     document = Marshal.load(Marshal.dump(@document))
     attempts = component(document, "attempts")
@@ -632,6 +693,20 @@ class ComponentBoundariesTest < Minitest::Test
 
       assert_match(/example\.migration_exceptions\[0\]\.removal_unit/, error.message)
       assert_match(/must name a plan unit such as U3/, error.message)
+    end
+  end
+
+  def test_migration_exception_accepts_hierarchical_removal_units
+    %w[U1a1vt U3c U1a2].each do |removal_unit|
+      with_contract_fixture(
+        entrypoint_source: example_api_source,
+        state: "candidate",
+        migration_exceptions: [
+          { "reason" => "temporary staged consumer", "removal_unit" => removal_unit }
+        ]
+      ) do |contract|
+        assert contract.validate_catalog!, removal_unit
+      end
     end
   end
 
@@ -1127,7 +1202,7 @@ class ComponentBoundariesTest < Minitest::Test
                             entrypoint_require: "example", owned_paths: nil,
                             component_dependencies: [], allowed_hive_dependencies: [],
                             migration_exceptions: [], authorized_internal_constructions: [],
-                            internal_collaborators: nil,
+                            internal_collaborators: nil, hive_consumers: [ "lib/consumer.rb" ],
                             extra_components: [], extra_files: {})
     Dir.mktmpdir do |root|
       write_fixture(root, entrypoint_file, entrypoint_source)
@@ -1150,7 +1225,8 @@ class ComponentBoundariesTest < Minitest::Test
             allowed_hive_dependencies: allowed_hive_dependencies,
             migration_exceptions: migration_exceptions,
             authorized_internal_constructions: authorized_internal_constructions,
-            internal_collaborators: internal_collaborators
+            internal_collaborators: internal_collaborators,
+            hive_consumers: hive_consumers
           ),
           *extra_components
         ]
@@ -1163,7 +1239,7 @@ class ComponentBoundariesTest < Minitest::Test
   def fixture_component(id:, state:, entrypoint_file:, entrypoint_require:, entrypoint_constant:,
                         owned_paths:, component_dependencies: [], allowed_hive_dependencies: [],
                         migration_exceptions: [], authorized_internal_constructions: [],
-                        internal_collaborators: nil)
+                        internal_collaborators: nil, hive_consumers: [ "lib/consumer.rb" ])
     namespace = entrypoint_constant.split("::").first
     internal_collaborators ||= [ "#{namespace}::Internal" ]
     {
@@ -1188,7 +1264,7 @@ class ComponentBoundariesTest < Minitest::Test
       "internal_collaborators" => internal_collaborators,
       "forbidden_constructions" => [ "#{namespace}::Internal" ],
       "authorized_internal_constructions" => authorized_internal_constructions,
-      "hive_consumers" => [ "lib/consumer.rb" ],
+      "hive_consumers" => hive_consumers,
       "mutation_authority" => "none",
       "recovery_surface" => "none",
       "wiki_page" => "wiki/example.md",

--- a/test/unit/packaging/workflow_creator_values_test.rb
+++ b/test/unit/packaging/workflow_creator_values_test.rb
@@ -1,0 +1,800 @@
+require "test_helper"
+require "bundler"
+require "json"
+require "open3"
+require "rbconfig"
+require "ripper"
+require "tmpdir"
+require "yaml"
+require_relative "../../../packaging/live_agent_skills/workflow_creator_values"
+
+class WorkflowCreatorValuesTest < Minitest::Test
+  ROOT = File.expand_path("../../..", __dir__)
+  VALUES_PATH = File.join(ROOT, "packaging", "live_agent_skills", "workflow_creator_values.rb")
+  VALUES_REQUIRE = "packaging/live_agent_skills/workflow_creator_values"
+  Values = HiveLiveAgentProof::WorkflowCreator::Values
+  MAX_DEPTH = 64
+  MAX_NODES = 8_192
+  MAX_SOURCE_BYTES = 262_144
+  MAX_CANONICAL_BYTES = 1_048_576
+  MAX_WORK_UNITS = 4_194_304
+  MAX_INTEGER_BITS = 4_096
+  POISONED_CHILD_ENV = %w[HIVE_COVERAGE HIVE_COVERAGE_ROOT HIVE_COVERAGE_RUN_ID RUBYOPT]
+    .to_h { |name| [ name, nil ] }.freeze
+  DECISION_NODES = %i[
+    if unless elsif if_mod unless_mod ifop when in rescue rescue_mod
+    while until for while_mod until_mod
+  ].freeze
+  POST_LOAD_FAILURE_POISONS = {
+    "Kernel#raise" => "Kernel.module_eval { define_method(:raise) { |*| Process.exit!(71) } }",
+    "Exception#initialize" => "Exception.class_eval { define_method(:initialize) { |*| Process.exit!(72) } }",
+    "Exception#exception" => "Exception.class_eval { define_method(:exception) { |*| attacker } }",
+    "Exception#backtrace" => "Exception.class_eval { define_method(:backtrace) { Process.exit!(73) } }",
+    "Exception#set_backtrace" =>
+      "Exception.class_eval { define_method(:set_backtrace) { |*| Process.exit!(74) } }",
+    "Exception#cause" => "Exception.class_eval { define_method(:cause) { Process.exit!(80) } }",
+    "Exception#message" => "Exception.class_eval { define_method(:message) { Process.exit!(81) } }",
+    "Exception#to_s" => "Exception.class_eval { define_method(:to_s) { Process.exit!(82) } }",
+    "Module#===" => "Module.class_eval { define_method(:===) { |*| Process.exit!(75) } }",
+    "Class#===" => "Class.class_eval { define_method(:===) { |*| Process.exit!(76) } }",
+    "clone protocol" => <<~'RUBY',
+      Object.class_eval { define_method(:clone) { |*| Process.exit!(77) } }
+      Exception.class_eval do
+        define_method(:initialize_clone) { |*| Process.exit!(78) }
+        define_method(:initialize_copy) { |*| Process.exit!(79) }
+      end
+    RUBY
+    "complete failure surface" => <<~'RUBY'
+      Kernel.module_eval { define_method(:raise) { |*| Process.exit!(71) } }
+      Object.class_eval { define_method(:clone) { |*| Process.exit!(77) } }
+      Exception.class_eval do
+        define_method(:initialize) { |*| Process.exit!(72) }
+        define_method(:exception) { |*| attacker }
+        define_method(:backtrace) { Process.exit!(73) }
+        define_method(:set_backtrace) { |*| Process.exit!(74) }
+        define_method(:cause) { Process.exit!(80) }
+        define_method(:message) { Process.exit!(81) }
+        define_method(:to_s) { Process.exit!(82) }
+        define_method(:initialize_clone) { |*| Process.exit!(78) }
+        define_method(:initialize_copy) { |*| Process.exit!(79) }
+      end
+      Module.class_eval { define_method(:===) { |*| Process.exit!(75) } }
+      Class.class_eval { define_method(:===) { |*| Process.exit!(76) } }
+    RUBY
+  }.freeze
+
+  def test_capture_copies_every_exact_json_type_into_compact_canonical_bytes
+    input = {
+      "z" => [ true, false, nil, 0, -7, 1.0, -0.0 ],
+      "a" => { "empty_object" => {}, "empty_array" => [], "empty_string" => "" }
+    }
+    captured = Values.capture(input)
+
+    expected_value = {
+      "a" => { "empty_array" => [], "empty_object" => {}, "empty_string" => "" },
+      "z" => [ true, false, nil, 0, -7, 1.0, -0.0 ]
+    }
+    assert_equal expected_value, captured.value
+    assert_equal "{\"a\":{\"empty_array\":[],\"empty_object\":{},\"empty_string\":\"\"}," \
+                 "\"z\":[true,false,null,0,-7,1.0,-0.0]}\n", captured.canonical_bytes
+    refute_same input, captured.value
+    assert_deeply_frozen captured.value
+    assert captured.canonical_bytes.frozen?
+    assert_equal Encoding::UTF_8, captured.canonical_bytes.encoding
+  end
+
+  def test_capture_rejects_subclasses_non_string_keys_and_lookalikes
+    hash_subclass = Class.new(Hash).new
+    hash_subclass["key"] = "value"
+    array_subclass = Class.new(Array).new([ "value" ])
+    string_subclass = Class.new(String).new("value")
+    unsupported = [ hash_subclass, array_subclass, string_subclass, { 1 => "value" }, Object.new, :symbol ]
+
+    unsupported.each do |value|
+      assert_capture_error(value)
+    end
+  end
+
+  def test_exact_base_objects_bypass_direct_public_protected_and_private_hooks
+    key = +"key"
+    value = +"value"
+    list = [ value ]
+
+    install_direct_poison(key, :public, %i[class encoding bytesize encode each_byte byteslice to_json hash eql? ==])
+    install_direct_poison(value, :protected, %i[encoding bytesize encode each_byte byteslice to_json])
+    install_direct_poison(list, :private, %i[class each length to_json])
+    key.freeze
+    input = {}.compare_by_identity
+    input[key] = list
+    install_direct_poison(input, :public, %i[class each each_pair length to_json])
+    assert_same key, input.keys.first
+
+    captured = Values.capture(input)
+
+    assert_equal({ "key" => [ "value" ] }, captured.value)
+    assert_equal "{\"key\":[\"value\"]}\n", captured.canonical_bytes
+  end
+
+  def test_exact_base_objects_bypass_extend_include_prepend_and_missing_hooks
+    poison = Module.new do
+      def class = raise("class dispatched")
+      def each = raise("each dispatched")
+      def each_pair = raise("each_pair dispatched")
+      def length = raise("length dispatched")
+      def encoding = raise("encoding dispatched")
+      def bytesize = raise("bytesize dispatched")
+      def encode(*) = raise("encode dispatched")
+      def each_byte = raise("each_byte dispatched")
+      def byteslice(*) = raise("byteslice dispatched")
+      def to_json(*) = raise("to_json dispatched")
+      def respond_to_missing?(*) = raise("respond_to_missing? dispatched")
+      def method_missing(*) = raise("method_missing dispatched")
+
+      protected :each, :bytesize, :respond_to_missing?
+      private :each_pair, :encode, :method_missing
+    end
+    key = +"key"
+    key.extend(poison)
+    key.freeze
+    value = +"value"
+    value.singleton_class.include(poison)
+    list = [ value ]
+    list.singleton_class.prepend(poison)
+    input = {}.compare_by_identity
+    input[key] = list
+    input.singleton_class.prepend(poison)
+    assert_same key, input.keys.first
+
+    captured = Values.capture(input)
+
+    assert_equal({ "key" => [ "value" ] }, captured.value)
+    assert_equal "{\"key\":[\"value\"]}\n", captured.canonical_bytes
+  end
+
+  def test_exact_base_objects_bypass_undefined_hooks
+    key = +"key"
+    key.singleton_class.undef_method(:encode)
+    key.freeze
+    value = +"value"
+    value.singleton_class.undef_method(:bytesize)
+    list = [ value ]
+    list.singleton_class.undef_method(:each)
+    input = {}.compare_by_identity
+    input[key] = list
+    input.singleton_class.undef_method(:each_pair)
+    assert_same key, input.keys.first
+
+    captured = Values.capture(input)
+
+    assert_equal({ "key" => [ "value" ] }, captured.value)
+    assert_equal "{\"key\":[\"value\"]}\n", captured.canonical_bytes
+  end
+
+  def test_snapshot_is_anonymous_frozen_secret_free_and_has_no_public_reconstruction_api
+    secret = "u1a1vir-secret-value"
+    snapshot = Values.capture({ "secret" => secret })
+    snapshot_class = snapshot.class
+
+    refute Values.const_defined?(:Snapshot, false)
+    refute_respond_to Values, :snapshot?
+    assert Values.frozen?
+    assert Values::Error.frozen?
+    assert snapshot_class.frozen?
+    assert snapshot.frozen?
+    assert_equal "#<HiveLiveAgentProof::WorkflowCreator::Values snapshot>", snapshot.inspect
+    refute_includes snapshot.inspect, secret
+    refute_respond_to snapshot_class, :new
+    refute_respond_to snapshot_class, :allocate
+    refute_respond_to snapshot, :dup
+    refute_respond_to snapshot, :clone
+    refute_respond_to snapshot, :with
+    refute_respond_to snapshot, :update
+    refute_respond_to snapshot, :instance_variable_set
+    assert_raises(NoMethodError) { snapshot_class.new(nil, +"mutable") }
+    assert_raises(NoMethodError) { snapshot_class.allocate }
+    assert_raises(NoMethodError) { snapshot.dup }
+    assert_raises(NoMethodError) { snapshot.clone }
+    assert_raises(TypeError) { Marshal.dump(snapshot) }
+    assert_raises(TypeError) { snapshot.__send__(:marshal_dump) }
+    assert_raises(TypeError) { snapshot.__send__(:marshal_load, {}) }
+  end
+
+  def test_capture_owns_fresh_aliases_and_survives_caller_and_module_mutation
+    extension = Module.new do
+      def to_json(*) = "\"forged\""
+    end
+    child = { "message" => +"original" }
+    child.extend(extension)
+    input = [ child, child ]
+    captured = Values.capture(input)
+
+    child.fetch("message").replace("changed")
+    child["new"] = true
+    extension.module_eval do
+      define_method(:each_pair) { raise("late module dispatch") }
+    end
+
+    assert_equal [ { "message" => "original" }, { "message" => "original" } ], captured.value
+    refute_same captured.value.fetch(0), captured.value.fetch(1)
+    refute_same captured.value.fetch(0).keys.first, captured.value.fetch(1).keys.first
+    assert_equal "[{\"message\":\"original\"},{\"message\":\"original\"}]\n", captured.canonical_bytes
+  end
+
+  def test_load_captured_core_and_invocation_paths_resist_post_load_replacement
+    script = <<~'RUBY'
+      require ARGV.fetch(0)
+      UnboundMethod.class_eval do
+        define_method(:bind_call) { |*| raise("intercepted UnboundMethod#bind_call") }
+        define_method(:bind) { |*| raise("intercepted UnboundMethod#bind") }
+      end
+      Method.class_eval { define_method(:call) { |*| raise("intercepted Method#call") } }
+      BasicObject.class_eval { define_method(:__send__) { |*| raise("intercepted BasicObject#__send__") } }
+      {
+        Hash => %i[each_pair length key? [] []= delete],
+        String => %i[initialize encoding valid_encoding? bytesize encode each_byte byteslice << <=> % hash eql? == dup],
+        Integer => %i[+ - * / % > >= < <= == bit_length to_s zero?],
+        Float => %i[finite? to_s],
+        Encoding => %i[dummy?],
+        Object => %i[class freeze instance_variable_get instance_variable_set],
+        BasicObject => %i[equal? __id__],
+        Class => %i[allocate],
+        Array => %i[each index length << pop sort! [] []=]
+      }.each do |owner, names|
+        names.each { |name| owner.class_eval { define_method(name) { |*| raise("intercepted #{owner}##{name}") } } }
+      end
+      captured = HiveLiveAgentProof::WorkflowCreator::Values.capture(
+        { "z" => [1.5, "value"], "a" => -7 }
+      )
+      STDOUT.write(captured.canonical_bytes)
+    RUBY
+
+    out, err, status = poisoned_capture3(script, VALUES_PATH)
+
+    assert status.success?, err
+    assert_equal "{\"a\":-7,\"z\":[1.5,\"value\"]}\n", out
+  end
+
+  def test_capture_error_resists_post_load_raise_and_exception_construction_replacement
+    assert_failure_poison_resistance(
+      expression: "values.capture(Object.new)",
+      rescue_class: "values::Error",
+      expected: "HiveLiveAgentProof::WorkflowCreator::Values::Error|" \
+                "workflow-creator value cannot be captured|true|false"
+    )
+  end
+
+  def test_snapshot_marshal_error_resists_post_load_raise_and_exception_construction_replacement
+    assert_failure_poison_resistance(
+      expression: "snapshot.__send__(:marshal_dump)",
+      rescue_class: "TypeError",
+      expected: "TypeError|workflow-creator snapshots cannot be marshaled|true|false",
+      setup: "snapshot = values.capture(nil)"
+    )
+  end
+
+  def test_encoding_normalization_controls_and_unicode_are_exact
+    latin = "é".encode(Encoding::ISO_8859_1)
+    normalized = Values.capture(latin)
+    assert_equal "é", normalized.value
+    assert_equal Encoding::UTF_8, normalized.value.encoding
+
+    controls = "\0\b\f\n\r\t\x1f\"\\é😀"
+    expected = "\"\\u0000\\b\\f\\n\\r\\t\\u001f\\\"\\\\é😀\"\n"
+    assert_equal expected, Values.capture(controls).canonical_bytes
+
+    collision = { "é" => 1, latin => 2 }
+    invalid_utf8 = "\xFF".dup.force_encoding(Encoding::UTF_8)
+    dummy = "\x00a".dup.force_encoding(Encoding::UTF_16)
+    binary = "ascii".b
+    [ collision, invalid_utf8, dummy, binary ].each { |value| assert_capture_error(value) }
+  end
+
+  def test_integer_float_and_signed_zero_boundaries_are_exact
+    largest_positive = 1 << (MAX_INTEGER_BITS - 1)
+    largest_negative = -(1 << MAX_INTEGER_BITS)
+    assert_equal largest_positive, Values.capture(largest_positive).value
+    assert_equal largest_negative, Values.capture(largest_negative).value
+    assert_capture_error(1 << MAX_INTEGER_BITS)
+    assert_capture_error(-(1 << MAX_INTEGER_BITS) - 1)
+
+    assert_equal "[1,1.0,-0.0]\n", Values.capture([ 1, 1.0, -0.0 ]).canonical_bytes
+    assert_equal(-Float::INFINITY, 1.0 / Values.capture(-0.0).value)
+    [ Float::NAN, Float::INFINITY, -Float::INFINITY ].each { |value| assert_capture_error(value) }
+  end
+
+  def test_deterministic_finite_ieee_754_tokens_roundtrip_byte_exactly
+    patterns = [ 0, 1 << 63 ]
+    seen = patterns.to_h { |bits| [ bits, true ] }
+    random = Random.new(0x1EE7_F10A7)
+    while patterns.length < 20_000
+      bits = random.rand(0..0xffff_ffff_ffff_ffff)
+      next if seen.key?(bits)
+
+      value = [ bits ].pack("Q>").unpack1("G")
+      next unless value.finite?
+
+      seen[bits] = true
+      patterns << bits
+    end
+
+    patterns.each_with_index do |bits, index|
+      value = [ bits ].pack("Q>").unpack1("G")
+      canonical = Values.capture(value).canonical_bytes
+      token = canonical.delete_suffix("\n")
+      roundtrip_bits = [ Float(token) ].pack("G").unpack1("Q>")
+      assert_equal bits, roundtrip_bits, "IEEE-754 case #{index}: #{token}"
+      assert_equal "#{value}\n", canonical, "IEEE-754 token #{index}"
+    end
+    assert_equal "0.0\n", Values.capture(0.0).canonical_bytes
+    assert_equal "-0.0\n", Values.capture(-0.0).canonical_bytes
+  end
+
+  def test_large_finite_float_roundtrip_and_canonical_property_corpus
+    floats = [ Float::MAX, -Float::MAX, Float::MIN, Float::EPSILON, 1.0e300, 1.0e-300, 3.141592653589793 ]
+    floats.each do |value|
+      bytes = Values.capture(value).canonical_bytes
+      token = bytes.delete_suffix("\n")
+      assert_equal value, Float(token), token
+      assert_equal "#{value}\n", bytes
+    end
+
+    random = Random.new(0xA11A1)
+    250.times do |index|
+      value = property_value(random)
+      captured = Values.capture(value)
+      assert_equal reference_canonical(value), captured.canonical_bytes, "property case #{index}"
+      assert captured.value == JSON.parse(captured.canonical_bytes), "semantic case #{index}"
+    end
+  end
+
+  def test_shared_graphs_copy_per_occurrence_and_cycles_fail_closed
+    shared = { "value" => [ 1, 2, 3 ] }
+    captured = Values.capture([ shared, shared ])
+    refute_same captured.value.fetch(0), captured.value.fetch(1)
+    refute_same captured.value.fetch(0).fetch("value"), captured.value.fetch(1).fetch("value")
+
+    array_cycle = []
+    array_cycle << array_cycle
+    hash_cycle = {}
+    hash_cycle["self"] = hash_cycle
+    assert_capture_error(array_cycle)
+    assert_capture_error(hash_cycle)
+  end
+
+  def test_depth_cap_accepts_n_and_rejects_n_plus_one
+    at_limit = nil
+    MAX_DEPTH.times { at_limit = [ at_limit ] }
+    over_limit = [ at_limit ]
+
+    assert_equal at_limit, Values.capture(at_limit).value
+    assert_capture_error(over_limit)
+  end
+
+  def test_node_cap_accepts_n_and_rejects_n_plus_one_before_child_import
+    at_limit = Array.new(MAX_NODES - 1, nil)
+    over_limit = Array.new(MAX_NODES, nil)
+    assert_equal MAX_NODES - 1, Values.capture(at_limit).value.length
+    assert_capture_error(over_limit)
+    assert_capture_error([ Array.new(MAX_NODES - 2, nil), nil ])
+
+    impossible_hash = (0...(MAX_NODES / 2)).to_h { |index| [ "key-#{index}", nil ] }
+    encode_calls = 0
+    trace = TracePoint.new(:c_call) do |event|
+      encode_calls += 1 if event.defined_class == String && event.method_id == :encode
+    end
+    trace.enable { assert_capture_error(impossible_hash) }
+    assert_equal 0, encode_calls, "impossible cardinality must fail before key transcoding"
+  end
+
+  def test_maximum_hash_collision_admission_has_no_quadratic_key_comparison_scan
+    maximum_entries = (MAX_NODES - 1) / 2
+    input = maximum_entries.times.to_h do |index|
+      [ format("key-%04d", maximum_entries - index), nil ]
+    end
+    captured = nil
+    comparisons = string_comparison_counts { captured = Values.capture(input) }
+
+    comparison_budget = maximum_entries * maximum_entries.bit_length * 2
+    assert_equal maximum_entries, captured.value.length
+    assert_operator comparisons.values.sum, :<=, comparison_budget,
+                    "collision admission must not scan every previously imported key"
+
+    diagnostic_size = 128
+    diagnostic_keys = Array.new(diagnostic_size) { |index| format("probe-%03d", index) }
+    quadratic = string_comparison_counts do
+      diagnostic_keys.each_with_index do |key, index|
+        diagnostic_keys.first(index).each { |prior| key == prior || key.eql?(prior) }
+      end
+    end
+    equality_comparisons = quadratic.fetch(:==, 0) + quadratic.fetch(:eql?, 0)
+    diagnostic_budget = diagnostic_size * diagnostic_size.bit_length * 2
+    assert_operator equality_comparisons, :>, diagnostic_budget,
+                    "diagnostic fixture must expose equality-based quadratic scans"
+  end
+
+  def test_source_string_byte_cap_accepts_n_and_rejects_n_plus_one_before_transcode
+    at_limit = "x" * MAX_SOURCE_BYTES
+    assert_equal at_limit, Values.capture(at_limit).value
+
+    encode_calls = 0
+    trace = TracePoint.new(:c_call) do |event|
+      encode_calls += 1 if event.defined_class == String && event.method_id == :encode
+    end
+    trace.enable { assert_capture_error("x" * (MAX_SOURCE_BYTES + 1)) }
+    assert_equal 0, encode_calls, "source limit must be charged before transcoding"
+  end
+
+  def test_canonical_byte_cap_including_newline_accepts_n_and_rejects_n_plus_one
+    at_limit = ("\0" * 174_762) + "a"
+    over_limit = at_limit + "a"
+
+    captured = Values.capture(at_limit)
+    assert_equal MAX_CANONICAL_BYTES, captured.canonical_bytes.bytesize
+    assert_capture_error(over_limit)
+  end
+
+  def test_logical_work_cap_accepts_n_and_rejects_n_plus_one
+    at_limit = logical_work_value(source_bytes: 62_510, escaped_bytes: 24)
+    over_limit = logical_work_value(source_bytes: 62_511, escaped_bytes: 23)
+
+    assert Values.capture(at_limit).frozen?
+    assert_capture_error(over_limit)
+  end
+
+  def test_errors_are_fixed_secret_free_and_have_no_cause
+    secret = "u1a1vir-rejected-secret"
+    invalid = "#{secret}\xFF".dup.force_encoding(Encoding::UTF_8)
+
+    error = assert_capture_error(invalid)
+
+    assert_equal "workflow-creator value cannot be captured", error.message
+    assert_nil error.cause
+    refute_includes error.full_message, secret
+    refute_includes error.inspect, secret
+  end
+
+  def test_clean_disable_gems_load_has_no_json_dependency_or_named_snapshot
+    script = <<~'RUBY'
+      require ARGV.fetch(0)
+      values = HiveLiveAgentProof::WorkflowCreator::Values
+      abort("JSON loaded") if defined?(JSON)
+      abort("named Snapshot") if values.const_defined?(:Snapshot, false)
+      captured = values.capture({ "b" => true, "a" => nil })
+      abort("wrong bytes") unless captured.canonical_bytes == "{\"a\":null,\"b\":true}\n"
+    RUBY
+    out, err, status = Open3.capture3(
+      POISONED_CHILD_ENV,
+      RbConfig.ruby,
+      "--disable-gems",
+      "-I#{ROOT}",
+      "-e",
+      script,
+      VALUES_REQUIRE
+    )
+
+    assert status.success?, "stdout=#{out.inspect} stderr=#{err.inspect}"
+  end
+
+  def test_source_tokens_reject_bare_and_qualified_require_identifiers_but_ignore_non_code
+    executable_examples = {
+      "bare require" => [ "require \"json\"\n", "require" ],
+      "bare require_relative" => [ "require_relative(\"support\")\n", "require_relative" ],
+      "qualified require" => [ "Kernel.require(\"json\")\n", "require" ],
+      "qualified require_relative" => [ "::Kernel.require_relative(\"support\")\n", "require_relative" ]
+    }
+    executable_examples.each do |label, (source, expected)|
+      assert_equal [ expected ], require_identifiers(source).map(&:last), label
+    end
+
+    non_code = <<~'RUBY'
+      # require "commented"
+      EXAMPLE = "Kernel.require_relative('string content')"
+    RUBY
+    assert_empty require_identifiers(non_code)
+    assert_empty require_identifiers(File.read(VALUES_PATH))
+  end
+
+  def test_capture_is_pure_and_source_has_no_io_or_json_dependency
+    source = File.read(VALUES_PATH)
+    refute_match(/\bJSON\b/, source)
+    refute_match(/\b(?:File|IO|Dir|Process|Open3)\b/, source)
+
+    script = <<~'RUBY'
+      require ARGV.fetch(0)
+      [File, Dir, Process].each do |owner|
+        %i[open read write binread binwrite spawn exec].each do |name|
+          owner.define_singleton_method(name) { |*| raise("I/O dispatched: #{owner}.#{name}") }
+        end
+      end
+      HiveLiveAgentProof::WorkflowCreator::Values.capture({ "safe" => [1, true, nil] })
+    RUBY
+    out, err, status = poisoned_capture3(script, VALUES_PATH)
+    assert status.success?, "stdout=#{out.inspect} stderr=#{err.inspect}"
+  end
+
+  def test_static_metric_harness_counts_every_decision_form
+    fixtures = {
+      if: [ "if flag\n  work\nend\n", 1 ],
+      unless: [ "unless flag\n  work\nend\n", 1 ],
+      elsif: [ "if first\n  work\nelsif second\n  work\nend\n", 2 ],
+      if_modifier: [ "work if flag\n", 1 ],
+      unless_modifier: [ "work unless flag\n", 1 ],
+      ternary: [ "flag ? left : right\n", 1 ],
+      when: [ "case value\nwhen 1\n  work\nend\n", 1 ],
+      in: [ "case value\nin Integer\n  work\nend\n", 1 ],
+      rescue: [ "begin\n  work\nrescue Error\n  recover\nend\n", 1 ],
+      rescue_modifier: [ "work rescue recover\n", 1 ],
+      while: [ "while flag\n  work\nend\n", 1 ],
+      until: [ "until flag\n  work\nend\n", 1 ],
+      for: [ "for value in values\n  work\nend\n", 1 ],
+      while_modifier: [ "work while flag\n", 1 ],
+      until_modifier: [ "work until flag\n", 1 ],
+      boolean_and: [ "left && right\n", 1 ],
+      boolean_or: [ "left || right\n", 1 ]
+    }
+
+    fixtures.each do |name, (source, expected)|
+      assert_equal expected, static_metrics(source).fetch(:decisions), name
+    end
+  end
+
+  def test_static_metric_harness_rejects_donor_shaped_false_green_fixture
+    definitions = 8.times.map { |index| "def method_#{index}; true; end" }.join("\n")
+    closures = 7.times.map { |index| "LAMBDA_#{index} = -> { true }" } +
+               5.times.map { |index| "PROC_#{index} = proc { true }" } +
+               [ "PROC_NEW = Proc.new { true }" ]
+    source = "#{definitions}\n#{closures.join("\n")}\n"
+    naive_method_only_count = source.lines.count { |line| line.match?(/^def /) }
+    observed = static_metrics(source)
+
+    assert_equal 8, naive_method_only_count
+    assert_equal 21, observed.fetch(:callables)
+    assert_operator observed.fetch(:callables), :>, 20
+    assert_includes observed.fetch(:closure_nodes), :proc_new
+    assert_equal 0, naive_decision_count("def guarded; left && right || fallback; end\n")
+    assert_equal 2, static_metrics("def guarded; left && right || fallback; end\n").fetch(:decisions)
+  end
+
+  def test_production_file_stays_within_u1a1vir_exact_caps
+    source = File.read(VALUES_PATH)
+    metrics = static_metrics(source)
+    required_callables = %i[
+      value canonical_bytes inspect marshal_dump marshal_load capture import_value
+      import_hash import_array import_string import_integer import_float escape_byte append! charge! seal
+      fail_capture! ===
+    ]
+
+    assert_operator source.lines.length, :<=, 300
+    assert_operator metrics.fetch(:callables), :<=, 20
+    assert_operator metrics.fetch(:decisions), :<=, 32
+    assert_empty metrics.fetch(:closure_nodes)
+    required_callables.each { |name| assert_includes metrics.fetch(:method_names), name }
+    refute_match(/rubocop\s*:(?:disable|todo)/i, source)
+    refute_match(/\b(?:Struct|Data)\b/, source)
+    refute_match(/\b(?:define_method|define_singleton_method|attr_reader|attr_writer|attr_accessor)\b/, source)
+    refute_match(/\b(?:lambda|proc)\b|\bProc\.new\b/, source)
+  end
+
+  def test_every_production_method_passes_the_explicit_r43_rubocop_overlay
+    overlay = {
+      "AllCops" => {
+        "TargetRubyVersion" => 3.4,
+        "DisabledByDefault" => true,
+        "NewCops" => "disable"
+      },
+      "Metrics/CyclomaticComplexity" => { "Enabled" => true, "Max" => 15 },
+      "Metrics/PerceivedComplexity" => { "Enabled" => true, "Max" => 15 },
+      "Metrics/AbcSize" => { "Enabled" => true, "Max" => 25 },
+      "Metrics/MethodLength" => { "Enabled" => true, "Max" => 40 },
+      "Layout/LineLength" => { "Enabled" => true, "Max" => 120 }
+    }
+
+    Dir.mktmpdir do |directory|
+      config = File.join(directory, "u1a1vir-rubocop.yml")
+      File.write(config, YAML.dump(overlay))
+      rubocop_spec = Bundler.load.specs.find { |spec| spec.name == "rubocop" }
+      refute_nil rubocop_spec, "the selected bundle must include RuboCop"
+      rubocop_executable = File.join(rubocop_spec.full_gem_path, "exe", "rubocop")
+      assert File.file?(rubocop_executable), "missing #{rubocop_executable}"
+      out, status = Open3.capture2e(
+        POISONED_CHILD_ENV,
+        RbConfig.ruby,
+        rubocop_executable,
+        "--config",
+        config,
+        "--format",
+        "simple",
+        VALUES_PATH,
+        chdir: ROOT
+      )
+
+      assert status.success?, out
+    end
+  end
+
+  private
+
+  def assert_failure_poison_resistance(expression:, rescue_class:, expected:, setup: "")
+    observed = POST_LOAD_FAILURE_POISONS.map do |label, poison|
+      script = <<~RUBY
+        require ARGV.fetch(0)
+        values = HiveLiveAgentProof::WorkflowCreator::Values
+        attacker = RuntimeError.new("attacker failure")
+        module_case = Module.instance_method(:===)
+        class_case = Class.instance_method(:===)
+        #{setup}
+        errors = 2.times.map do
+          begin
+            #{poison}
+            begin
+              #{expression}
+            ensure
+              Module.class_eval { define_method(:===, module_case) }
+              Class.class_eval { define_method(:===, class_case) }
+            end
+          rescue #{rescue_class} => error
+            error
+          end
+        end
+        error = errors.fetch(0)
+        STDOUT.write(
+          [ error.class.name, error.message, error.cause.nil?, error.equal?(errors.fetch(1)) ].join("|")
+        )
+      RUBY
+
+      out, err, status = poisoned_capture3(script, VALUES_PATH)
+      [ label, status.exitstatus, out, err ]
+    end
+
+    expected_results = POST_LOAD_FAILURE_POISONS.keys.map { |label| [ label, 0, expected, "" ] }
+    assert_equal expected_results, observed
+  end
+
+  def assert_capture_error(value)
+    error = assert_raises(Values::Error) { Values.capture(value) }
+    assert_equal "workflow-creator value cannot be captured", error.message
+    assert_nil error.cause
+    error
+  end
+
+  def assert_deeply_frozen(value)
+    assert value.frozen?
+    value.each { |key, nested| assert_deeply_frozen(key); assert_deeply_frozen(nested) } if value.instance_of?(Hash)
+    value.each { |nested| assert_deeply_frozen(nested) } if value.instance_of?(Array)
+  end
+
+  def install_direct_poison(value, visibility, names)
+    singleton = value.singleton_class
+    names.each do |name|
+      singleton.define_method(name) { |*| raise("direct #{visibility} #{name} dispatched") }
+      singleton.send(visibility, name)
+    end
+  end
+
+  def logical_work_value(source_bytes:, escaped_bytes:)
+    # For D nested one-item arrays around L source bytes with Q quotes, capture charges
+    # (D + 3) * L + (D + 2) * Q + D**2 + 7 * D + 6 deterministic work units.
+    leaf = ('"' * escaped_bytes) + ("a" * (source_bytes - escaped_bytes))
+    MAX_DEPTH.times { leaf = [ leaf ] }
+    leaf
+  end
+
+  def property_value(random, depth = 0)
+    strings = [ "", "plain", "quote=\" slash=\\ control=\0\n", "é😀" ]
+    floats = [ 0.0, -0.0, 1.0e20, 1.0e-6, 1.0e-7, 3.141592653589793 ]
+    scalars = [ nil, true, false, random.rand(-1_000_000..1_000_000),
+               floats.fetch(random.rand(floats.length)), strings.fetch(random.rand(strings.length)) ]
+    return scalars.fetch(random.rand(scalars.length)) if depth >= 3 || random.rand(3).zero?
+
+    return Array.new(random.rand(5)) { property_value(random, depth + 1) } if random.rand(2).zero?
+
+    Array.new(random.rand(5)) do |index|
+      [ "k#{depth}-#{index}-#{random.rand(1_000_000)}", property_value(random, depth + 1) ]
+    end.to_h
+  end
+
+  def reference_canonical(value)
+    "#{reference_token(value)}\n"
+  end
+
+  def reference_token(value)
+    if value.instance_of?(Hash)
+      entries = value.map do |key, nested|
+        normalized = key.encode(Encoding::UTF_8)
+        [ normalized, "#{JSON.generate(normalized)}:#{reference_token(nested)}" ]
+      end
+      "{#{entries.sort_by { |key, _token| key.b }.map(&:last).join(',')}}"
+    elsif value.instance_of?(Array)
+      "[#{value.map { |nested| reference_token(nested) }.join(',')}]"
+    elsif value.instance_of?(String)
+      JSON.generate(value.encode(Encoding::UTF_8))
+    elsif value.instance_of?(Integer) || value.instance_of?(Float)
+      value.to_s
+    elsif value.equal?(true)
+      "true"
+    elsif value.equal?(false)
+      "false"
+    else
+      "null"
+    end
+  end
+
+  def poisoned_capture3(script, *arguments)
+    Bundler.with_unbundled_env do
+      Open3.capture3(POISONED_CHILD_ENV, RbConfig.ruby, "-e", script, *arguments)
+    end
+  end
+
+  def string_comparison_counts
+    counts = Hash.new(0)
+    methods = %i[<=> == eql?]
+    trace = TracePoint.new(:c_call) do |event|
+      counts[event.method_id] += 1 if event.defined_class == String && methods.include?(event.method_id)
+    end
+    trace.enable { yield }
+    counts
+  end
+
+  def naive_decision_count(source)
+    syntax = Ripper.sexp(source) or raise "invalid Ruby fixture"
+    count = 0
+    walk = lambda do |node|
+      next unless node.instance_of?(Array)
+
+      count += 1 if DECISION_NODES.include?(node.first)
+      node.each { |child| walk.call(child) }
+    end
+    walk.call(syntax)
+    count
+  end
+
+  def require_identifiers(source)
+    Ripper.lex(source).filter_map do |position, event, token, _state|
+      [ position, token ] if event == :on_ident && %w[require require_relative].include?(token)
+    end
+  end
+
+  def static_metrics(source)
+    syntax = Ripper.sexp(source) or raise "invalid Ruby source"
+    metrics = { callables: 0, decisions: 0, method_names: [], closure_nodes: [] }
+    walk = lambda do |node|
+      next unless node.instance_of?(Array)
+
+      type = node.first
+      if %i[def defs].include?(type)
+        metrics[:callables] += 1
+        name_node = type == :def ? node[1] : node[3]
+        metrics[:method_names] << name_node[1].to_sym
+      elsif type == :lambda
+        metrics[:callables] += 1
+        metrics[:closure_nodes] << type
+      elsif (closure_kind = proc_block_kind(node))
+        metrics[:callables] += 1
+        metrics[:closure_nodes] << closure_kind
+      end
+      metrics[:decisions] += 1 if DECISION_NODES.include?(type)
+      metrics[:decisions] += 1 if type == :binary && %i[&& ||].include?(node[2])
+      node.each { |child| walk.call(child) }
+    end
+    walk.call(syntax)
+    metrics
+  end
+
+  def proc_block_kind(node)
+    return unless node.first == :method_add_block
+
+    call = node[1]
+    identifiers = []
+    constants = []
+    collect_identifiers = lambda do |child|
+      next unless child.instance_of?(Array)
+
+      identifiers << child[1] if child.first == :@ident
+      constants << child[1] if child.first == :@const
+      child.each { |nested| collect_identifiers.call(nested) }
+    end
+    collect_identifiers.call(call)
+    return :proc_new if constants.include?("Proc") && identifiers.include?("new")
+    :proc if identifiers.include?("lambda") || identifiers.include?("proc")
+  end
+end

--- a/wiki/component-boundaries.md
+++ b/wiki/component-boundaries.md
@@ -3,7 +3,7 @@ title: Component boundaries
 type: reference
 source: config/component-boundaries.yml, test/support/component_boundary_contract.rb
 created: 2026-07-25
-updated: 2026-07-30
+updated: 2026-08-03
 tags: [architecture, components, boundaries, monorepo]
 ---
 
@@ -19,6 +19,7 @@ the first and primary consumer.
 |-----------|-------|---------------------|-------------------|
 | Patrol Effect Evidence | `candidate` (U3 qualification pending) | `require "hive/modules/migration/patrol_evidence"` → `Hive::Modules::Migration::PatrolEvidence` | [[modules/patrol]] |
 | Attempts admission / future RunReceipt | `candidate` (guarded reference) | `require "hive/attempts/api"` → `Hive::Attempts::API` | [[modules/attempts]] |
+| Workflow Creator Values | `candidate` (U1a1vt consumer pending) | `require "packaging/live_agent_skills/workflow_creator_values"` → `HiveLiveAgentProof::WorkflowCreator::Values` | [[component-boundaries]] |
 | UserService | `boundary-ready` | `require "hive/user_service"` → `Hive::UserService` | [[modules/user_service]] |
 | Agent ABI | `boundary-ready`; standalone package candidate | `require "hive/agent_runtime"` → `Hive::AgentRuntime` | [[modules/agent_cli_runtime]], [[modules/agent_profile]] |
 | Agent Artifact Firewall | `boundary-ready` | `require "hive/artifact_firewall"` → `Hive::ArtifactFirewall` | [[modules/protected_files]] |
@@ -34,13 +35,14 @@ has earned a gem, version, repository, or release.
 
 ## Final graph audit
 
-The final U2 resolution on 2026-07-29 retains eight components: six are
-`boundary-ready`; Attempts and Patrol Effect Evidence remain `candidate`.
-Patrol retains one bounded U3 exception for compressed evidence qualification
-and cutover proof. Every retained entry point has a focused clean-process load
-proof, every catalog-owned path and focused test resolves inside this
-repository, and the direct-construction guards pass against all production
-Ruby sources.
+The catalog on 2026-08-03 retains nine components: six are
+`boundary-ready`; Attempts, Patrol Effect Evidence, and Workflow Creator
+Values remain `candidate`. Patrol retains one bounded U3 exception for
+compressed evidence qualification and cutover proof. Workflow Creator Values
+retains one bounded U1a1vt exception until its first production consumer lands.
+Every retained entry point has focused clean-process load proof, every
+catalog-owned path and focused test resolves inside this repository, and the
+direct-construction guards pass against all production Ruby sources.
 
 The component dependency graph has one edge:
 
@@ -49,6 +51,7 @@ flowchart LR
   skillpack[Skillpack] --> agent_abi[Agent ABI]
   patrol_effects[Patrol Effect Evidence - candidate]
   attempts[Attempts admission - candidate]
+  workflow_values[Workflow Creator Values - candidate]
   user_service[UserService]
   artifact_firewall[Agent Artifact Firewall]
   git_gate[Safe Agent Git Gate]
@@ -58,9 +61,9 @@ flowchart LR
 All other cataloged components depend only on explicitly allowed lower-level
 Hive primitives. The source audit found no retained experimental facade outside
 the catalog: each promoted facade is owned by a catalog row and used by Hive,
-while Attempts and Patrol Effect Evidence are deliberately retained as guarded
-candidates rather than being promoted ahead of their remaining lifecycle or
-qualification proof.
+while Attempts, Patrol Effect Evidence, and Workflow Creator Values are
+deliberately retained as guarded candidates rather than being promoted ahead
+of their remaining lifecycle, qualification, or consumer proof.
 
 This is an internal architecture verdict, not a packaging verdict. None of the
 six ready components currently has the named non-Hive adopter and independent
@@ -141,6 +144,25 @@ Attempts intentionally remains the guarded reference instead of claiming that
 its full lifecycle is a supported component boundary: the slice does not
 publish raw storage, reconciliation, supervision, capacity, loss-policy,
 cancellation, export, or generic lifecycle operations.
+
+`Workflow Creator Values` is a staged values-only candidate.
+`HiveLiveAgentProof::WorkflowCreator::Values.capture` accepts exact core
+JSON-shaped Ruby values and returns an anonymous frozen snapshot exposing only
+fresh recursively frozen owned values and compact canonical UTF-8 bytes.
+Unsupported subclasses, non-finite floats, ambiguous or invalid encodings,
+normalized-key collisions, cycles, and declared depth, node, source-byte,
+canonical-byte, logical-work, and integer-bit ceilings fail through one fixed
+secret-free error. The leaf loads without JSON, I/O, workflow, process,
+credential, or provider dependencies.
+
+The candidate has no production consumer yet. Its sole migration exception is
+`removal_unit: U1a1vt`; that unit must consume and expand the same staged row
+before promotion. U1a1vir owns no text, path, or secret projection, creator
+schema, custody, publication, or live behavior. Its source proof is deliberately
+leaf-local: the focused test uses `Ripper.lex` to reject bare and qualified
+`require` and `require_relative` identifiers while ignoring comments and
+strings, and a direct `ruby --disable-gems -I<repository-root>` subprocess
+proves clean loading. This is not generic Ruby grammar or require-path analysis.
 
 The `Agent ABI` is boundary-ready below orchestration. `AgentRuntime` exposes
 immutable request, compiled invocation, capability/probe evidence, and
@@ -267,7 +289,9 @@ Owned paths cannot overlap between components, component dependencies must form
 an acyclic graph, and every path in the catalog must resolve inside the
 repository. A temporary exception must include both a reason and the
 implementation unit that removes it. A `boundary-ready` component cannot keep
-an exception or depend on a `candidate` component.
+an exception or depend on a `candidate` component. A consumer list may be
+empty only for a `candidate` with exactly one bounded migration exception;
+hierarchical plan identifiers such as `U1a1vt` are valid removal units.
 
 ## Enforcement
 
@@ -294,6 +318,11 @@ Run the focused contract with:
 ```bash
 bundle exec ruby -Itest -Ilib test/unit/component_boundaries_test.rb
 ```
+
+The Workflow Creator Values candidate does not widen this shared syntax guard
+or the generic component clean-loader. Its no-require and direct clean-load
+proofs live only in
+`test/unit/packaging/workflow_creator_values_test.rb`.
 
 The syntax scan is an architecture regression guard, not a Ruby sandbox. Its
 construction rule covers literal `Constant.new`, not aliases or factory

--- a/wiki/gaps.md
+++ b/wiki/gaps.md
@@ -3,7 +3,7 @@ title: Gaps
 type: gaps
 source: wiki/* vs lib/, templates/, test/, bin/
 created: 2026-04-25
-updated: 2026-08-02
+updated: 2026-08-03
 tags: [gap, todo, release-proof, agent-skills]
 ---
 
@@ -130,14 +130,24 @@ tags: [gap, todo, release-proof, agent-skills]
 
 ## Internal component boundary gap
 
-- The final internal graph audit retains eight catalog rows: UserService, Agent
+- The internal graph now retains nine catalog rows: UserService, Agent
   ABI, Agent Artifact Firewall, Skillpack, Safe Agent Git Gate, and WorkLedger
-  are `boundary-ready`; Attempts admission and Patrol Effect Evidence remain
-  `candidate`. Skillpack to Agent ABI is the only component dependency. Patrol
-  retains one bounded U3 exception for compressed candidate evidence and
-  production qualification; Attempts remains unready because Hive has no
+  are `boundary-ready`; Attempts admission, Patrol Effect Evidence, and
+  Workflow Creator Values remain `candidate`. Skillpack to Agent ABI is the
+  only component dependency. Patrol retains one bounded U3 exception for
+  compressed candidate evidence and production qualification. Workflow Creator
+  Values retains exactly one U1a1vt exception because it has no production
+  consumer yet; Attempts remains unready because Hive has no
   demonstrated need for a supported reconciliation, supervision, capacity,
   loss-processing, cancellation, export, or raw-store lifecycle API.
+- U1a1vir proves the import-side R43 file, callable, decision, per-method, and
+  line-length budgets. The inherited `U1A1V-R02-ARCH-002` remains program-open
+  and transfers to U1a1vt as the sole owner of the combined values/projection
+  metric proof; the values candidate must not be described as boundary-ready
+  before that consumer and moving-fence step lands.
+  Downstream code must not accept caller-supplied snapshot instances or
+  authenticate solely by class identity because same-process Ruby reflection
+  is outside this leaf guarantee.
 - No ready component has yet earned standalone packaging. There is no named
   non-Hive adopter, independently installed component artifact, separate
   compatibility promise, or explicit release decision. Those proofs belong to

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -3,7 +3,7 @@ title: hive Wiki
 type: index
 source: wiki/**/*.md
 created: 2026-05-14
-updated: 2026-07-30
+updated: 2026-08-03
 tags: [index, wiki]
 ---
 
@@ -14,17 +14,19 @@ proof, while built-in content/bench, installable Honeycomb, and owner-authored
 workflows use the same folder-backed execution model.
 
 Page count: 98
-Updated: 2026-07-30
+Updated: 2026-08-03
 
 Folder-as-agent workflow engine: a Ruby 3.4 / Thor CLI control plane where descriptor-backed workflows move task folders through filesystem stages, stage agents compile provider-neutral invocations through `Hive::AgentRuntime` and configurable AgentProfile adapters (`claude` default, `codex`, `pi`, `grok`), and `mv` between directories remains the approval primitive. The built-in `coding` workflow drives the nine-stage PR pipeline (`1-inbox` → `2-brainstorm` → `3-plan` → `4-execute` → `5-open-pr` → `6-review` → `7-artifacts` → `8-finalize` → `9-done`), while the built-in `content` and `bench` workflows and project-authored workflows share the same generic runner/status/action machinery. Agent operation is centered on the additive operational status contract, coherent daemon scheduler snapshots, bounded semantic `hive watch`, tokenized routine `hive act`, and stable-ID semantic E2E profiles; the legacy full JSON graph remains compatible. Hive packages one canonical operating skill projected to OpenClaw `/hive`, Claude `/hive`, Codex `$hive`, and Pi `/skill:hive`, with read-only `hive doctor`, consent-safe setup, deterministic trusted pre-release proof, and optional four-agent live diagnostics.
 
 Reusable mechanisms remain in this monorepo behind the canonical
-[[component-boundaries]] catalog. The final internal graph has six
+[[component-boundaries]] catalog. The nine-row internal graph has six
 `boundary-ready` facades—UserService, Agent ABI, Agent Artifact Firewall,
-Skillpack, Safe Agent Git Gate, and WorkLedger—and one guarded `candidate`,
-Attempts admission. Skillpack's downward dependency on the Agent ABI is the
-only component-to-component edge; no migration exceptions remain. Hive is the
-first and primary consumer, and internal readiness does not imply a gem,
+Skillpack, Safe Agent Git Gate, and WorkLedger—and three guarded candidates:
+Attempts admission, Patrol Effect Evidence, and Workflow Creator Values.
+Skillpack's downward dependency on the Agent ABI is the only
+component-to-component edge. Patrol's U3 qualification fence and Workflow
+Creator Values' U1a1vt consumer fence are the only migration exceptions. Hive
+is the first and primary consumer, and internal readiness does not imply a gem,
 version, repository, or release.
 
 Agent spawns that own controller artifacts use the boundary-ready

--- a/wiki/log.d/20260803T113221Z-workflow-creator-values.md
+++ b/wiki/log.d/20260803T113221Z-workflow-creator-values.md
@@ -1,0 +1,29 @@
+---
+title: Stage the Workflow Creator Values candidate
+type: change
+created: 2026-08-03
+tags: [architecture, component-boundaries, workflow-creator, values]
+---
+
+- Added the dependency-free
+  `HiveLiveAgentProof::WorkflowCreator::Values` leaf. Capture imports exact
+  JSON-shaped Ruby values through load-captured core operations into an
+  anonymous, non-copyable, non-marshalable, recursively frozen snapshot and
+  emits owned canonical UTF-8 bytes.
+- Added focused hostile-value proof for caller hooks, post-load core
+  replacement, mutation, cycles, encodings, key collisions, numeric forms,
+  resource ceilings, canonical-byte properties, and the exact R43
+  line/callable/decision and per-method budgets.
+- Kept dependency proof local to the leaf: `Ripper.lex` rejects bare and
+  qualified `require` and `require_relative` identifiers while ignoring
+  comments and strings, and a direct
+  `ruby --disable-gems -I<repository-root>` subprocess proves clean loading.
+  No generic Ruby/path analyzer or component-loader behavior was added.
+- Added one values-only `candidate` catalog row with no consumers,
+  dependencies, or production activation and exactly one
+  `removal_unit: U1a1vt` fence. The shared validator changed only to admit
+  that exact empty-consumer shape and hierarchical removal-unit identifiers.
+- `U1A1VI-ARCH-003` is disposed by removing the misplaced generic analyzer
+  responsibility. The aggregate `U1A1V-R02-ARCH-002` finding remains
+  program-open for U1a1vt; this change does not claim generic require-path
+  canonicalization, boundary readiness, publication, or live behavior.

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -119,16 +119,33 @@ Claude, Codex, Pi, and Grok.
 repository-local paths, unique ownership, an acyclic component graph, bounded
 migration exceptions, selected source-level dependency/construction rules,
 exact authorized internal-construction sites, and fresh-process loading for
-every `boundary-ready` component:
+every `boundary-ready` component. One staged candidate may have an empty
+consumer list only when it carries exactly one bounded migration exception;
+removal units accept hierarchical plan IDs such as `U1a1vt`:
 
 ```bash
 bundle exec ruby -Itest -Ilib test/unit/component_boundaries_test.rb
+bundle exec ruby -Itest test/unit/packaging/workflow_creator_values_test.rb
 ```
 
 Ready components cannot depend on candidates. Forbidden-construction rules
 also apply to guarded candidates, and the helper can run a named focused
 clean-load proof for a candidate such as Attempts without representing the
 whole component graph as ready.
+
+Workflow Creator Values keeps its clean-load and dependency proof outside the
+generic component loader. Its focused suite directly runs the leaf under
+`ruby --disable-gems -I<repository-root>`, verifies JSON remains unloaded and
+that capture performs no `File`, `Dir`, or `Process` calls, and uses a
+leaf-local `Ripper.lex` token check that catches bare and qualified `require`
+and `require_relative` identifiers without treating comments or strings as
+code. The same suite covers exact core type admission,
+recursive ownership/freezing, canonical bytes, hostile direct and
+module-contributed dispatch, post-load core replacement, copy/Marshal denial,
+encoding and numeric boundaries, cycles/shared graphs, declared resource
+ceilings, property comparisons, and the exact R43 line/callable/decision and
+per-method RuboCop budgets. It does not assert generic require-path
+canonicalization.
 
 The helper uses Ruby syntax rather than comments or string examples for literal
 `require`, `require_relative`, and `Constant.new` checks. It remains an


### PR DESCRIPTION
## Summary

Workflow-creator inputs can now be captured once as owned, recursively frozen values with deterministic canonical bytes. This establishes the minimum values boundary needed by the creator chain without expanding shared component analysis into another generic Ruby subsystem.

The component is deliberately staged as a candidate with no production consumer. U1a1vt must consume this same entrypoint and move or remove the sole zero-consumer fence before promotion.

Session-settled decisions carried from planning: the OpenClaw proof chain remains split by owner (user-authorized re-scope), trusted creator semantics operate on one owned immutable snapshot (user-authorized re-scope), and this replacement keeps only exact values-leaf proof with one three-lens candidate gate (user-approved).

## Design decisions

- The values leaf captures trusted core operations at clean load, recaptures hostile JSON-shaped input into fresh owned values, and exposes only an anonymous non-copyable snapshot plus canonical bytes.
- Require detection and metric proof stay leaf-local. The shared component validator receives only the two bounded catalog accommodations needed by this candidate.
- Same-process reflection and pre-load core mutation remain outside this leaf guarantee. Downstream code must recapture caller input and must not authenticate caller-supplied snapshots by class identity; U14 owns stronger executable and dependency custody.

## Validation

- Focused values and component tests: 65 runs, 41,283 assertions, 0 failures, 0 errors.
- Broad checkpoint: 11,781 runs, 192,497 assertions, 0 failures, 0 errors, 8 skips.
- Focused RuboCop: 4 changed Ruby files, 0 offenses; `git diff --check` clean.
- Leaf budget: 298 lines, 20 executable callables, 32 static decisions, 0 closures.
- Exact-head parallel review: architecture/dependency, correctness/compatibility, and reliability/security/agent-native all returned zero findings.

## Related

Related: #925
