### PR TITLE
refactor(patrol): expose deterministic receipt facade

### DIFF
--- a/lib/hive/daemon/patrol_scheduler.rb
+++ b/lib/hive/daemon/patrol_scheduler.rb
@@ -396,7 +396,7 @@ module Hive
           project: {
             "project_id" => entry.fetch("project_id"),
             "name" => entry.fetch("name"),
-            "repository" => entry["repository"]
+            "repository" => entry["repository_identity"]
           },
           trigger: trigger,
           reservation: {

--- a/lib/hive/modules/migration/patrols.rb
+++ b/lib/hive/modules/migration/patrols.rb
@@ -3,13 +3,16 @@ require "json"
 require "time"
 require "hive/atomic_file"
 require "hive/config"
+require "hive/gh/repository_identity"
 require "hive/module_package/managed_store"
 require "hive/modules/migration/patrol_effect_index"
+require "hive/modules/migration/patrol_evidence_receipt"
 require "hive/modules/migration/patrol_evidence_verifier"
 require "hive/modules/migration/patrol_qualification"
 require "hive/modules/migration/report"
 require "hive/modules/migration/report_migration"
 require "hive/modules/migration/report_projection"
+require "hive/modules/migration/shadow_comparator"
 require "hive/modules/migration/shadow_decision_migration"
 require "hive/workflow_package/canonical_json"
 
@@ -27,6 +30,14 @@ module Hive
         }.freeze
         STATUSES = %w[pending shadowing cutover_pending module rollback_pending rolled_back].freeze
         OWNERS = %w[legacy module].freeze
+        DETERMINISTIC_RECEIPT_SELECTOR_KEYS = %w[module trigger_id].freeze
+        DETERMINISTIC_RECEIPT_METADATA_KEYS = %w[
+          artifacts candidate_sha catalog_digest configuration_digest
+          decision_class fault_steps generated_at manifest_digest repository
+          reviewed_at reviewer run_id scenario_manifest_digest source_digest
+        ].freeze
+        private_constant :DETERMINISTIC_RECEIPT_SELECTOR_KEYS,
+                         :DETERMINISTIC_RECEIPT_METADATA_KEYS
         Outcome = Data.define(:status, :state, :blockers, :restored)
 
         class << self
@@ -153,6 +164,88 @@ module Hive
             File.join(File.dirname(state_file(project_root, hive_state_path: hive_state_path)), "report.json")
           end
 
+          # Build one receipt from the immutable comparison record selected by
+          # product identity. The harness supplies only candidate metadata; it
+          # cannot substitute captures, projections, or effect observations.
+          def deterministic_receipt_for!(project_root, selector:, metadata:,
+                                         hive_state_path: nil)
+            selector_label = "patrol deterministic receipt selector"
+            exact_string_keys!(
+              selector, DETERMINISTIC_RECEIPT_SELECTOR_KEYS,
+              label: selector_label
+            )
+            module_name = selector.fetch("module")
+            trigger_id = selector.fetch("trigger_id")
+            valid_selector = MODULES.include?(module_name) &&
+              trigger_id.is_a?(String) && trigger_id.valid_encoding? &&
+              !trigger_id.empty? &&
+              trigger_id.bytesize <= PatrolEvidenceReceipt::MAX_LABEL_BYTES
+            PatrolEvidence.malformed!(selector_label) unless valid_selector
+            exact_string_keys!(
+              metadata, DETERMINISTIC_RECEIPT_METADATA_KEYS,
+              label: "patrol deterministic receipt metadata"
+            )
+
+            with_migration_lock(
+              project_root, hive_state_path: hive_state_path, shared: false
+            ) do
+              comparator = ShadowComparator.new(
+                root: File.join(
+                  File.dirname(
+                    state_file(project_root, hive_state_path: hive_state_path)
+                  ),
+                  "shadow"
+                ),
+                admission_lock: ->(shared: true, &block) { block.call }
+              )
+              matches = []
+              comparator.each_record(module_name) do |record|
+                matches << record if record.dig("trigger", "id") == trigger_id
+                break if matches.size > 1
+              end
+              if matches.empty?
+                raise Hive::ConfigError,
+                      "patrol deterministic receipt evidence was not found"
+              end
+              unless matches.one?
+                raise Hive::ConfigError,
+                      "patrol deterministic receipt evidence is ambiguous"
+              end
+
+              record = matches.fetch(0)
+              unless record.fetch("comparable") &&
+                     record.fetch("unexplained_differences").empty? &&
+                     record.fetch("duplicate_effects").empty?
+                raise Hive::ConfigError,
+                      "patrol deterministic receipt evidence is inconsistent"
+              end
+              unless metadata.fetch("configuration_digest") ==
+                     record.fetch("configuration_digest")
+                raise Hive::ConfigError,
+                      "patrol deterministic receipt configuration changed"
+              end
+              capture_repository = record.dig(
+                "legacy_capture", "project", "repository"
+              )
+              metadata_repository = metadata.fetch("repository", nil)
+              repository_id = metadata_repository.fetch("id", nil) if
+                metadata_repository.is_a?(Hash)
+              unless canonical_repository_target?(capture_repository) &&
+                     capture_repository == repository_id
+                raise Hive::ConfigError,
+                      "patrol deterministic receipt repository changed"
+              end
+
+              PatrolEvidenceReceipt.build(
+                capture: record.fetch("legacy_capture"),
+                module_projection: record.fetch("module_decision"),
+                effects: record.fetch("legacy_effects") +
+                  record.fetch("module_effects"),
+                **metadata.transform_keys(&:to_sym)
+              ).to_h
+            end
+          end
+
           # Admit deterministic evidence without giving the E2E harness access
           # to verifier tokens or report construction. The caller supplies raw
           # receipt documents plus independently computed expected bindings;
@@ -240,6 +333,29 @@ module Hive
           rescue NoMethodError
             raise Hive::ConfigError, "patrol module migration state is malformed"
           end
+
+          def exact_string_keys!(value, keys, label:)
+            unless value.is_a?(Hash) &&
+                   value.keys.all? { |key| key.instance_of?(String) }
+              PatrolEvidence.malformed!(label)
+            end
+            PatrolEvidence.exact_keys!(value, keys, label: label)
+          end
+          private :exact_string_keys!
+
+          def canonical_repository_target?(value)
+            return false unless value.is_a?(String)
+
+            host, owner, name, *extra = value.split("/", -1)
+            return false unless extra.empty?
+
+            Hive::Gh::RepositoryIdentity.github_repository_target(
+              "#{owner}/#{name}", host
+            ) == value
+          rescue Hive::GhError
+            false
+          end
+          private :canonical_repository_target?
 
           def canonical(value) = Hive::WorkflowPackage::CanonicalJSON.generate(value)
         end

--- a/lib/hive/refactor_patrol/architecture_occurrence_lifecycle.rb
+++ b/lib/hive/refactor_patrol/architecture_occurrence_lifecycle.rb
@@ -50,7 +50,7 @@ module Hive
           project: {
             "project_id" => entry.fetch("project_id"),
             "name" => entry.fetch("name"),
-            "repository" => source.fetch("repository")
+            "repository" => entry["repository_identity"]
           },
           trigger: {
             "kind" => "pull_request.merged",

--- a/lib/hive/refactor_patrol/architecture_occurrence_store.rb
+++ b/lib/hive/refactor_patrol/architecture_occurrence_store.rb
@@ -30,10 +30,14 @@ module Hive
         Hive::RefactorPatrol::PrManifest.validate!(data)
         capture = capture_value(capture)
         source = data.fetch("source")
+        legacy_replay = legacy_repository_replay?(capture, source)
         valid = capture.reservation["job_id"] == data.fetch("job_id") &&
                 capture.reservation["id"] == data.fetch("job_id") &&
                 capture.project["name"] == source.fetch("registration") &&
-                capture.project["repository"] == source.fetch("repository") &&
+                repository_matches_source?(
+                  capture.project["repository"], source,
+                  allow_legacy: legacy_replay
+                ) &&
                 capture.trigger["manifest_digest"] ==
                   data.fetch("manifest_checksum") &&
                 capture.trigger["merge_sha"] == source.fetch("merge_sha")
@@ -50,17 +54,20 @@ module Hive
         id = validate_id!(job_id)
         capture = capture_value(capture)
         aggregate = @job_reader.call(id)
+        pointer_matches = aggregate.fetch("occurrence_id") ==
+                          capture.occurrence_id
         valid = capture.reservation["job_id"] == id &&
                 capture.reservation["id"] == id &&
                 capture.project["name"] ==
                   aggregate.dig("source", "registration") &&
-                capture.project["repository"] ==
-                  aggregate.dig("source", "repository")
+                repository_matches_source?(
+                  capture.project["repository"], aggregate.fetch("source"),
+                  allow_legacy: pointer_matches
+                )
         raise @inconsistent_record,
               "architecture patrol occurrence does not match its job" unless valid
 
-        unless aggregate.fetch("occurrence_id") ==
-               capture.occurrence_id
+        unless pointer_matches
           raise @inconsistent_record,
                 "architecture patrol job occurrence identity is immutable"
         end
@@ -245,6 +252,32 @@ module Hive
       end
 
       private
+
+      def repository_matches_source?(capture_repository, source,
+                                     allow_legacy: false)
+        repository = source.fetch("repository")
+        current = if source.key?("url")
+          capture_repository ==
+            Hive::RefactorPatrol::PrManifest.repository_target(source)
+        else
+          _host, separator, captured_slug =
+            capture_repository.to_s.partition("/")
+          !separator.empty? && captured_slug == repository
+        end
+        current || (allow_legacy && capture_repository == repository)
+      rescue Hive::ConfigError, KeyError, NoMethodError
+        false
+      end
+
+      def legacy_repository_replay?(capture, source)
+        return false unless
+          capture.project["repository"] == source.fetch("repository")
+
+        existing = @journal.fetch(capture.occurrence_id)
+        existing && existing.fetch("provisional_capture") == capture.to_h
+      rescue Hive::ConfigError, KeyError
+        false
+      end
 
       def architecture_intent!(value)
         intent =

--- a/lib/hive/refactor_patrol/pr_manifest.rb
+++ b/lib/hive/refactor_patrol/pr_manifest.rb
@@ -1,7 +1,9 @@
 require "digest"
 require "json"
 require "time"
+require "uri"
 require "hive"
+require "hive/gh/repository_identity"
 
 module Hive
   module RefactorPatrol
@@ -80,6 +82,31 @@ module Hive
         ::Digest::SHA256.hexdigest(canonical_json(payload))
       end
 
+      def repository_target(source)
+        repository = Hive::Gh::RepositoryIdentity.validated_repository_slug(
+          source.fetch("repository")
+        )
+        number = source.fetch("number")
+        uri = URI.parse(source.fetch("url"))
+        match = uri.path.match(
+          %r{\A/([^/]+/[^/]+)/pull/([1-9]\d*)\z}
+        ) if uri.path.is_a?(String)
+        valid = uri.is_a?(URI::HTTP) && uri.host && match &&
+                match[1].casecmp?(repository) &&
+                number.is_a?(Integer) && number.positive? &&
+                match[2].to_i == number && uri.userinfo.nil? &&
+                uri.query.nil? && uri.fragment.nil?
+        raise Invalid, "refactor patrol job manifest source repository is invalid" unless valid
+
+        Hive::Gh::RepositoryIdentity.github_repository_target(
+          repository, uri.host
+        )
+      rescue Hive::GhError, ArgumentError, KeyError, TypeError,
+             URI::InvalidURIError
+        raise Invalid,
+              "refactor patrol job manifest source repository is invalid"
+      end
+
       def valid_file?(file)
         return false unless file.is_a?(Hash)
         return false unless (file.keys - %w[path status previous_path]).empty?
@@ -126,6 +153,7 @@ module Hive
           raise Invalid, "refactor patrol job manifest source fields are invalid"
         end
         Time.iso8601(source.fetch("merged_at"))
+        repository_target(source)
       end
       private_class_method :canonical_json_value, :validate_source!
     end

--- a/lib/hive/refactor_patrol/transition_gateway.rb
+++ b/lib/hive/refactor_patrol/transition_gateway.rb
@@ -36,7 +36,8 @@ module Hive
             project: {
               "project_id" => project_id.to_s,
               "name" => source.fetch("registration"),
-              "repository" => source.fetch("repository")
+              "repository" =>
+                Hive::RefactorPatrol::PrManifest.repository_target(source)
             },
             trigger: {
               "kind" => "pull_request.merged",

--- a/test/unit/daemon/patrol_scheduler_test.rb
+++ b/test/unit/daemon/patrol_scheduler_test.rb
@@ -42,6 +42,7 @@ class HiveDaemonPatrolSchedulerTest < Minitest::Test
       "name" => name,
       "path" => dir,
       "project_id" => "#{name}-id",
+      "repository_identity" => "github.com/acme/#{name}",
       "hive_state_path" => File.join(dir, ".hive-state")
     }
   end
@@ -93,6 +94,8 @@ class HiveDaemonPatrolSchedulerTest < Minitest::Test
       assert_equal "reserved", occurrence.fetch("phase")
       assert_equal capture.occurrence_id,
                    dispatches.first.fetch(:command).split.last
+      assert_equal entry.fetch("repository_identity"),
+                   capture.project.fetch("repository")
 
       evidence = Hive::Modules::Migration::EvidenceStore.new(
         root: File.join(
@@ -870,7 +873,7 @@ class HiveDaemonPatrolSchedulerTest < Minitest::Test
       project: {
         "project_id" => entry.fetch("project_id"),
         "name" => entry.fetch("name"),
-        "repository" => entry["repository"]
+        "repository" => entry["repository_identity"]
       },
       trigger: {
         "kind" => "schedule",

--- a/test/unit/daemon/refactor_patrol_scheduler_test.rb
+++ b/test/unit/daemon/refactor_patrol_scheduler_test.rb
@@ -1,5 +1,6 @@
 require "test_helper"
 require "json"
+require "hive/daemon/patrol_scheduler"
 require "hive/daemon/refactor_patrol_scheduler"
 
 class HiveDaemonRefactorPatrolSchedulerTest < Minitest::Test
@@ -1221,7 +1222,8 @@ class HiveDaemonRefactorPatrolSchedulerTest < Minitest::Test
       store: store,
       entry: {
         "project_id" => "demo-id",
-        "name" => "demo"
+        "name" => "demo",
+        "repository_identity" => "github.com/acme/demo"
       },
       aggregate: {
         "job_id" => value.fetch("job_id"),
@@ -1242,6 +1244,26 @@ class HiveDaemonRefactorPatrolSchedulerTest < Minitest::Test
     assert_equal transition_capture.to_h,
                  lifecycle_capture.to_h
     assert_equal [ lifecycle_capture, T0 ], reserved
+
+    ordinary_capture = Hive::Daemon::PatrolScheduler
+      .new(registry: -> { [] })
+      .send(
+        :capture_reservation,
+        {
+          "project_id" => "demo-id", "name" => "demo",
+          "repository_identity" => "github.com/acme/demo"
+        },
+        { "owner" => "legacy", "admission" => true, "epoch" => 1 },
+        T0, poll_interval_sec: 600,
+        selection_input: {
+          "kind" => "operation", "operation" => "qualification-proof"
+        },
+        selection: Hive::Modules::Migration::PatrolDecisionProjection.build(
+          module_name: "patrol", rationale: "due"
+        )
+      )
+    assert_equal ordinary_capture.project.fetch("repository"),
+                 lifecycle_capture.project.fetch("repository")
   end
 
   def test_recovery_store_initialization_errors_keep_the_original_diagnostic

--- a/test/unit/modules/migration/patrols_test.rb
+++ b/test/unit/modules/migration/patrols_test.rb
@@ -172,6 +172,16 @@ class ModulesMigrationPatrolsTest < Minitest::Test
         )
         deterministic_receipt_metadata
       end,
+      "inconsistent" => lambda do |project|
+        capture = terminal_patrol_capture(patrol_capture)
+        projection = Hive::Modules::Migration::PatrolDecisionProjection.build(
+          module_name: "patrol", rationale: "not_due"
+        )
+        record_shadow_decision(
+          project, capture: capture, module_projection: projection
+        )
+        deterministic_receipt_metadata
+      end,
       "repository" => lambda do |project|
         record_shadow_decision(
           project, capture: terminal_patrol_capture(patrol_capture)
@@ -203,7 +213,7 @@ class ModulesMigrationPatrolsTest < Minitest::Test
     cases.each do |name, prepare|
       with_project do |project|
         metadata = prepare.call(project)
-        assert_raises(Hive::ConfigError, name) do
+        error = assert_raises(Hive::ConfigError, name) do
           Hive::Modules::Migration::Patrols.deterministic_receipt_for!(
             project.fetch("path"),
             selector: { "module" => "patrol", "trigger_id" => "manual-1" },
@@ -211,6 +221,7 @@ class ModulesMigrationPatrolsTest < Minitest::Test
             hive_state_path: project.fetch("hive_state_path")
           )
         end
+        assert_match(/inconsistent/, error.message) if name == "inconsistent"
       end
     end
   end
@@ -1824,6 +1835,7 @@ class ModulesMigrationPatrolsTest < Minitest::Test
   end
 
   def record_shadow_decision(project, capture:, effects: [],
+                             module_projection: capture.selection,
                              admission_lock: nil)
     root = File.join(
       project.fetch("hive_state_path"), "module-runtime", "migration", "shadow"
@@ -1834,7 +1846,7 @@ class ModulesMigrationPatrolsTest < Minitest::Test
       module_name: capture.module_name,
       trigger: capture.trigger,
       legacy_capture: capture,
-      module_projection: capture.selection,
+      module_projection: module_projection,
       configuration_digest: "c" * 64,
       occurred_at: capture.occurred_at,
       legacy_effects: effects

--- a/test/unit/modules/migration/patrols_test.rb
+++ b/test/unit/modules/migration/patrols_test.rb
@@ -3,10 +3,12 @@ require "hive/daemon/patrol_scheduler"
 require "hive/daemon/refactor_patrol_scheduler"
 require "hive/modules/migration/patrols"
 require "hive/modules/migration/coordinator"
+require "hive/modules/migration/shadow_comparator"
 require "hive/patrol/state_store"
 require "hive/refactor_patrol/job_store"
 require "hive/refactor_patrol/pr_manifest"
 require "hive/refactor_patrol/transition_gateway"
+require "timeout"
 
 class ModulesMigrationPatrolsTest < Minitest::Test
   include HiveTestHelper
@@ -92,6 +94,292 @@ class ModulesMigrationPatrolsTest < Minitest::Test
     def module_hook? = true
     def subject = { "module" => module_name }
     def [](key) = key == "project" ? project : nil
+  end
+
+  def test_deterministic_receipt_selects_one_terminal_shadow_capture
+    with_project do |project|
+      capture = patrol_capture
+      effect = legacy_effect_receipt(capture)
+      terminal = terminal_patrol_capture(
+        capture, effect_ids: [ effect.receipt_id ]
+      )
+      record_shadow_decision(project, capture: terminal, effects: [ effect ])
+
+      receipt = Hive::Modules::Migration::Patrols.deterministic_receipt_for!(
+        project.fetch("path"),
+        selector: { "module" => "patrol", "trigger_id" => "manual-1" },
+        metadata: deterministic_receipt_metadata,
+        hive_state_path: project.fetch("hive_state_path")
+      )
+
+      assert_equal terminal.capture_id, receipt.dig("capture", "capture_id")
+      assert_equal [ effect.receipt_id ],
+                   receipt.fetch("effects").map { |item| item.fetch("receipt_id") }
+      assert_equal "hive-patrol-evidence-receipt", receipt.fetch("schema")
+    end
+  end
+
+  def test_deterministic_receipt_requires_one_semantic_match
+    with_project do |project|
+      error = assert_raises(Hive::ConfigError) do
+        Hive::Modules::Migration::Patrols.deterministic_receipt_for!(
+          project.fetch("path"),
+          selector: { "module" => "patrol", "trigger_id" => "missing" },
+          metadata: deterministic_receipt_metadata,
+          hive_state_path: project.fetch("hive_state_path")
+        )
+      end
+      assert_match(/not found/, error.message)
+    end
+
+    with_project do |project|
+      [ "manual", "direct" ].each do |kind|
+        capture = terminal_patrol_capture(
+          patrol_capture(trigger: { "kind" => kind, "id" => "same" })
+        )
+        record_shadow_decision(project, capture: capture)
+      end
+
+      error = assert_raises(Hive::ConfigError) do
+        Hive::Modules::Migration::Patrols.deterministic_receipt_for!(
+          project.fetch("path"),
+          selector: { "module" => "patrol", "trigger_id" => "same" },
+          metadata: deterministic_receipt_metadata,
+          hive_state_path: project.fetch("hive_state_path")
+        )
+      end
+      assert_match(/ambiguous/, error.message)
+    end
+  end
+
+  def test_deterministic_receipt_rejects_mismatched_observational_evidence
+    cases = {
+      "nonterminal" => lambda do |project|
+        record_shadow_decision(project, capture: patrol_capture)
+        deterministic_receipt_metadata
+      end,
+      "configuration" => lambda do |project|
+        record_shadow_decision(
+          project, capture: terminal_patrol_capture(patrol_capture)
+        )
+        deterministic_receipt_metadata("configuration_digest" => "d" * 64)
+      end,
+      "effects" => lambda do |project|
+        capture = patrol_capture
+        record_shadow_decision(
+          project, capture: terminal_patrol_capture(capture),
+          effects: [ legacy_effect_receipt(capture) ]
+        )
+        deterministic_receipt_metadata
+      end,
+      "repository" => lambda do |project|
+        record_shadow_decision(
+          project, capture: terminal_patrol_capture(patrol_capture)
+        )
+        deterministic_receipt_metadata(
+          "repository" => deterministic_receipt_metadata.fetch("repository")
+            .merge("id" => "other/demo")
+        )
+      end,
+      "repository-unbound" => lambda do |project|
+        capture = patrol_capture(repository: nil)
+        record_shadow_decision(
+          project, capture: terminal_patrol_capture(capture)
+        )
+        deterministic_receipt_metadata
+      end,
+      "repository-hostless-replay" => lambda do |project|
+        capture = patrol_capture(repository: "acme/demo")
+        record_shadow_decision(
+          project, capture: terminal_patrol_capture(capture)
+        )
+        deterministic_receipt_metadata(
+          "repository" => deterministic_receipt_metadata
+            .fetch("repository").merge("id" => "acme/demo")
+        )
+      end
+    }
+
+    cases.each do |name, prepare|
+      with_project do |project|
+        metadata = prepare.call(project)
+        assert_raises(Hive::ConfigError, name) do
+          Hive::Modules::Migration::Patrols.deterministic_receipt_for!(
+            project.fetch("path"),
+            selector: { "module" => "patrol", "trigger_id" => "manual-1" },
+            metadata: metadata,
+            hive_state_path: project.fetch("hive_state_path")
+          )
+        end
+      end
+    end
+  end
+
+  def test_deterministic_receipt_rejects_mixed_selector_and_metadata_keys
+    selector = { "module" => "patrol", trigger_id: "manual-1" }
+    metadata = deterministic_receipt_metadata
+    metadata[:reviewer] = metadata.delete("reviewer")
+
+    with_project do |project|
+      [ [ selector, deterministic_receipt_metadata ],
+        [ { "module" => "patrol", "trigger_id" => "manual-1" }, metadata ] ]
+        .each do |candidate_selector, candidate_metadata|
+          error = assert_raises(Hive::ConfigError) do
+            Hive::Modules::Migration::Patrols.deterministic_receipt_for!(
+              project.fetch("path"),
+              selector: candidate_selector,
+              metadata: candidate_metadata,
+              hive_state_path: project.fetch("hive_state_path")
+            )
+          end
+          assert_match(/is malformed/, error.message)
+        end
+    end
+  end
+
+  def test_deterministic_receipt_supports_architecture_patrol_exact_evidence
+    with_project do |project|
+      capture = terminal_patrol_capture(
+        architecture_capture(architecture_manifest)
+      )
+      record_shadow_decision(project, capture: capture)
+
+      receipt = Hive::Modules::Migration::Patrols.deterministic_receipt_for!(
+        project.fetch("path"),
+        selector: {
+          "module" => "architecture-patrol",
+          "trigger_id" => capture.trigger.fetch("id")
+        },
+        metadata: deterministic_receipt_metadata,
+        hive_state_path: project.fetch("hive_state_path")
+      )
+
+      assert_equal "architecture-patrol", receipt.dig("capture", "module")
+      assert_empty receipt.fetch("effects")
+
+      assert_raises(Hive::ConfigError) do
+        Hive::Modules::Migration::Patrols.deterministic_receipt_for!(
+          project.fetch("path"),
+          selector: {
+            "module" => "architecture-patrol",
+            "trigger_id" => capture.trigger.fetch("id")
+          },
+          metadata: deterministic_receipt_metadata(
+            "configuration_digest" => "d" * 64
+          ),
+          hive_state_path: project.fetch("hive_state_path")
+        )
+      end
+    end
+
+    with_project do |project|
+      capture = terminal_patrol_capture(
+        architecture_capture(architecture_manifest)
+      )
+      record_shadow_decision(
+        project, capture: capture, effects: [ legacy_effect_receipt(capture) ]
+      )
+
+      assert_raises(Hive::ConfigError) do
+        Hive::Modules::Migration::Patrols.deterministic_receipt_for!(
+          project.fetch("path"),
+          selector: {
+            "module" => "architecture-patrol",
+            "trigger_id" => capture.trigger.fetch("id")
+          },
+          metadata: deterministic_receipt_metadata,
+          hive_state_path: project.fetch("hive_state_path")
+        )
+      end
+    end
+  end
+
+  def test_deterministic_receipt_excludes_a_concurrent_matching_write
+    with_project do |project|
+      capture = terminal_patrol_capture(patrol_capture)
+      record_shadow_decision(project, capture: capture)
+      entered_build = Queue.new
+      release_build = Queue.new
+      receipt_result = Queue.new
+      writer_entered_lock = Queue.new
+      writer_result = Queue.new
+      receipt_class = Hive::Modules::Migration::PatrolEvidenceReceipt
+      original_build = receipt_class.method(:build)
+      receipt_thread = nil
+      writer_thread = nil
+
+      build = lambda do |**attributes|
+        entered_build << true
+        release_build.pop
+        original_build.call(**attributes)
+      end
+
+      receipt_class.singleton_class.define_method(:build, &build)
+      begin
+        receipt_thread = Thread.new do
+          value = Hive::Modules::Migration::Patrols.deterministic_receipt_for!(
+            project.fetch("path"),
+            selector: { "module" => "patrol", "trigger_id" => "manual-1" },
+            metadata: deterministic_receipt_metadata,
+            hive_state_path: project.fetch("hive_state_path")
+          )
+          receipt_result << value
+        rescue StandardError => e
+          receipt_result << e
+        end
+        Timeout.timeout(5) { entered_build.pop }
+
+        writer_lock = lambda do |shared: true, &block|
+          writer_entered_lock << true
+          Hive::Modules::Migration::Patrols.with_migration_lock(
+            project.fetch("path"),
+            hive_state_path: project.fetch("hive_state_path"),
+            shared: shared,
+            &block
+          )
+        end
+        competing = terminal_patrol_capture(
+          patrol_capture(trigger: { "kind" => "direct", "id" => "manual-1" })
+        )
+        writer_thread = Thread.new do
+          record_shadow_decision(
+            project, capture: competing, admission_lock: writer_lock
+          )
+          writer_result << :written
+        rescue StandardError => e
+          writer_result << e
+        end
+        Timeout.timeout(5) { writer_entered_lock.pop }
+        Timeout.timeout(5) do
+          Thread.pass until writer_thread.status == "sleep" ||
+                            !writer_thread.alive?
+        end
+        assert writer_thread.alive?,
+               "the competing writer must remain fenced while the receipt builds"
+        assert_equal "sleep", writer_thread.status
+
+        release_build << true
+        assert receipt_thread.join(5), "receipt construction did not finish"
+        assert_kind_of Hash, receipt_result.pop
+        assert writer_thread.join(5), "competing writer did not finish"
+        assert_equal :written, writer_result.pop
+      ensure
+        receipt_class.singleton_class.define_method(:build, original_build)
+        release_build << true if receipt_thread&.alive?
+        receipt_thread&.join(1)
+        writer_thread&.join(1)
+      end
+
+      error = assert_raises(Hive::ConfigError) do
+        Hive::Modules::Migration::Patrols.deterministic_receipt_for!(
+          project.fetch("path"),
+          selector: { "module" => "patrol", "trigger_id" => "manual-1" },
+          metadata: deterministic_receipt_metadata,
+          hive_state_path: project.fetch("hive_state_path")
+        )
+      end
+      assert_match(/ambiguous/, error.message)
+    end
   end
 
   def test_fences_live_adoption_then_cuts_over_and_rolls_back_one_epoch
@@ -1488,15 +1776,16 @@ class ModulesMigrationPatrolsTest < Minitest::Test
     )
   end
 
-  def patrol_capture
+  def patrol_capture(trigger: { "kind" => "manual", "id" => "manual-1" },
+                     repository: "github.com/acme/demo")
     Hive::Modules::Migration::PatrolCapture.build(
       module_name: "patrol",
       project: {
         "project_id" => "project-1",
         "name" => "demo",
-        "repository" => "acme/demo"
+        "repository" => repository
       },
-      trigger: { "kind" => "manual", "id" => "manual-1" },
+      trigger: trigger,
       reservation: { "kind" => "ordinary", "id" => "reservation-1" },
       owner: "legacy",
       owner_epoch: 1,
@@ -1516,7 +1805,7 @@ class ModulesMigrationPatrolsTest < Minitest::Test
     )
   end
 
-  def terminal_patrol_capture(capture)
+  def terminal_patrol_capture(capture, effect_ids: capture.effect_ids)
     Hive::Modules::Migration::PatrolCapture.build(
       module_name: capture.module_name,
       project: capture.project,
@@ -1528,10 +1817,60 @@ class ModulesMigrationPatrolsTest < Minitest::Test
       selection: capture.selection,
       outcome_class: "completed",
       outcome: { "rationale" => "completed" },
-      effect_ids: capture.effect_ids,
+      effect_ids: effect_ids,
       occurred_at: capture.occurred_at,
       recorded_at: NOW
     )
+  end
+
+  def record_shadow_decision(project, capture:, effects: [],
+                             admission_lock: nil)
+    root = File.join(
+      project.fetch("hive_state_path"), "module-runtime", "migration", "shadow"
+    )
+    options = { root: root }
+    options[:admission_lock] = admission_lock if admission_lock
+    Hive::Modules::Migration::ShadowComparator.new(**options).record!(
+      module_name: capture.module_name,
+      trigger: capture.trigger,
+      legacy_capture: capture,
+      module_projection: capture.selection,
+      configuration_digest: "c" * 64,
+      occurred_at: capture.occurred_at,
+      legacy_effects: effects
+    )
+  end
+
+  def legacy_effect_receipt(capture)
+    intent = Hive::Modules::Migration::EffectIntent.build(
+      module_name: capture.module_name,
+      occurrence_id: capture.occurrence_id,
+      authority: "legacy", owner_epoch: capture.owner_epoch,
+      sink: "finding", target: "finding-1",
+      idempotency_key: "finding-1", capability: "finding_write",
+      created_at: NOW
+    )
+    Hive::Modules::Migration::EffectReceipt.build(
+      intent: intent, status: "committed",
+      outcome: { "finding_id" => "finding-1" }, recorded_at: NOW
+    )
+  end
+
+  def deterministic_receipt_metadata(overrides = {})
+    {
+      "run_id" => "run-1", "candidate_sha" => "1" * 40,
+      "catalog_digest" => "2" * 64, "source_digest" => "3" * 64,
+      "manifest_digest" => "4" * 64, "configuration_digest" => "c" * 64,
+      "scenario_manifest_digest" => "6" * 64,
+      "repository" => {
+        "id" => "github.com/acme/demo", "sha" => "7" * 40,
+        "change_window" => "window-1"
+      },
+      "decision_class" => "positive_finding", "fault_steps" => [ "restart" ],
+      "artifacts" => [ { "kind" => "comparison", "digest" => "8" * 64 } ],
+      "reviewer" => "reviewer-1", "generated_at" => NOW,
+      "reviewed_at" => NOW + 1
+    }.merge(overrides)
   end
 
   def architecture_manifest

--- a/test/unit/refactor_patrol/architecture_occurrence_store_test.rb
+++ b/test/unit/refactor_patrol/architecture_occurrence_store_test.rb
@@ -194,6 +194,7 @@ class RefactorPatrolArchitectureOccurrenceStoreTest < Minitest::Test
                  )
     urls = [
       "https://github.com/other/demo/pull/7",
+      "https://%",
       "mailto:user@example.com",
       "urn:foo"
     ]
@@ -234,6 +235,14 @@ class RefactorPatrolArchitectureOccurrenceStoreTest < Minitest::Test
                  replay.reserve!(
                    "job-7", capture: legacy, now: NOW
                  ).fetch("occurrence_id")
+
+    corrupt_journal = Journal.new
+    corrupt_journal.failure = :fetch
+    assert_raises(InconsistentRecord) do
+      occurrence_store(journal: corrupt_journal).reserve_manifest!(
+        manifest, capture: legacy, now: NOW
+      )
+    end
   end
 
   def test_rebuild_recovery_index_translates_journal_corruption
@@ -275,6 +284,19 @@ class RefactorPatrolArchitectureOccurrenceStoreTest < Minitest::Test
     end
     assert_raises(InconsistentRecord) do
       store.reserve_manifest!({}, capture: capture, now: NOW)
+    end
+
+    malformed_source = occurrence_store(
+      journal: journal,
+      job_reader: ->(_job_id) {
+        job.merge(
+          "occurrence_id" => capture.occurrence_id,
+          "source" => { "registration" => "demo" }
+        )
+      }
+    )
+    assert_raises(InconsistentRecord) do
+      malformed_source.reserve!("job-7", capture: capture, now: NOW)
     end
 
     assert_raises(InconsistentRecord) do

--- a/test/unit/refactor_patrol/architecture_occurrence_store_test.rb
+++ b/test/unit/refactor_patrol/architecture_occurrence_store_test.rb
@@ -187,6 +187,55 @@ class RefactorPatrolArchitectureOccurrenceStoreTest < Minitest::Test
                  )
   end
 
+  def test_manifest_repository_target_binds_the_pr_url_host_and_slug
+    assert_equal "github.com/owner/demo",
+                 Hive::RefactorPatrol::PrManifest.repository_target(
+                   manifest.fetch("source")
+                 )
+    urls = [
+      "https://github.com/other/demo/pull/7",
+      "mailto:user@example.com",
+      "urn:foo"
+    ]
+    urls.each do |url|
+      source = manifest.fetch("source").merge("url" => url)
+      assert_raises(Hive::RefactorPatrol::PrManifest::Invalid) do
+        Hive::RefactorPatrol::PrManifest.repository_target(source)
+      end
+    end
+  end
+
+  def test_pre_target_repository_capture_is_admitted_only_for_exact_replay
+    legacy = capture_for(
+      manifest,
+      project: capture.project.merge("repository" => "owner/demo")
+    )
+    fresh = occurrence_store(journal: Journal.new)
+    assert_raises(InconsistentRecord) do
+      fresh.reserve_manifest!(manifest, capture: legacy, now: NOW)
+    end
+
+    journal = Journal.new
+    journal.record = {
+      "occurrence_id" => legacy.occurrence_id,
+      "provisional_capture" => legacy.to_h
+    }
+    replay = occurrence_store(
+      journal: journal,
+      job_reader: ->(_job_id) {
+        job.merge("occurrence_id" => legacy.occurrence_id)
+      }
+    )
+    assert_equal legacy.occurrence_id,
+                 replay.reserve_manifest!(
+                   manifest, capture: legacy, now: NOW
+                 ).fetch("occurrence_id")
+    assert_equal legacy.occurrence_id,
+                 replay.reserve!(
+                   "job-7", capture: legacy, now: NOW
+                 ).fetch("occurrence_id")
+  end
+
   def test_rebuild_recovery_index_translates_journal_corruption
     journal = Journal.new
     journal.failure = :rebuild_recovery_index!
@@ -543,7 +592,8 @@ class RefactorPatrolArchitectureOccurrenceStoreTest < Minitest::Test
       project: project || {
         "project_id" => "project-1",
         "name" => source.fetch("registration"),
-        "repository" => source.fetch("repository")
+        "repository" =>
+          Hive::RefactorPatrol::PrManifest.repository_target(source)
       },
       trigger: {
         "kind" => "pull_request.merged",

--- a/wiki/gaps.md
+++ b/wiki/gaps.md
@@ -3,7 +3,7 @@ title: Gaps
 type: gaps
 source: wiki/* vs lib/, templates/, test/, bin/
 created: 2026-04-25
-updated: 2026-08-03
+updated: 2026-08-04
 tags: [gap, todo, release-proof, agent-skills]
 ---
 
@@ -14,8 +14,11 @@ tags: [gap, todo, release-proof, agent-skills]
 - Patrol capture/effect boundaries and the U3a receipt, independent verifier,
   duplicate index, qualification value, two-lane report, and one-off report
   conversion are source- and focused-test-pinned. A narrow `Patrols` facade
-  admits raw deterministic receipt documents only after independently supplied
-  bindings verify, then digest-CAS merges report v2. U3a still does not execute
+  now selects exactly one comparable terminal shadow decision by module and
+  trigger identity under the shared migration lock, constructs its canonical
+  receipt from record-owned capture, projection, and effects, and admits raw
+  receipt documents only after independently supplied bindings verify before
+  digest-CAS merging report v2. U3a still does not execute
   the compressed campaign and is not installed/live or cutover evidence;
   current report-v2 cutover is deliberately refused at the operator boundary.
   U3b must still commit independent controls and a real-reader

--- a/wiki/log.d/20260804T000000Z-patrol-deterministic-receipt-facade.md
+++ b/wiki/log.d/20260804T000000Z-patrol-deterministic-receipt-facade.md
@@ -1,0 +1,21 @@
+---
+title: Add bounded Patrol deterministic receipt facade
+type: added
+date: 2026-08-04
+---
+
+- Add one public `Patrols.deterministic_receipt_for!` seam that selects a
+  unique comparable terminal shadow decision by module and trigger identity
+  under the exclusive migration lock, excluding concurrent same-identity
+  writes until receipt construction finishes.
+- Construct the canonical qualification receipt only from descriptor-validated
+  capture, projection, and observational-effect evidence; caller authority is
+  limited to bounded candidate metadata, and its repository must exactly match
+  the nonempty host-qualified repository target captured by the scheduler.
+- Bind Architecture Patrol manifests to the exact host in their PR URL so both
+  Patrol products emit the same `host/owner/name` qualification identity.
+- Preserve only exact replay of already-durable owner/name captures; new
+  captures and qualification receipts require the host-qualified target, even
+  when caller metadata attempts to repeat a hostless replay identity.
+- Fail closed on missing or ambiguous selection and on nonterminal,
+  configuration, effect, projection, or repository identity mismatch.

--- a/wiki/modules/patrol.md
+++ b/wiki/modules/patrol.md
@@ -3,7 +3,7 @@ title: Hive::Patrol
 type: module
 source: lib/hive/patrol/
 created: 2026-05-28
-updated: 2026-08-03
+updated: 2026-08-04
 tags: [module, patrol, review, worktree, pr, codex]
 ---
 
@@ -54,8 +54,29 @@ tags: [module, patrol, review, worktree, pr, codex]
 | `Hive::Modules::Migration::ReportProjection` | `lib/hive/modules/migration/report_projection.rb` | Pure report-v2 projection over exactly `deterministic` and `installed_live` qualification lanes. Both lanes must bind the same candidate, catalogue, source, manifest, scenario, and configuration set. Persistence admits only monotonic successor reports: a missing lane may be added; an `evidence_required` lane may advance through a strict same-run receipt superset or a disjoint fresh run; a qualified lane may be exactly invalidated; and recovery from an invalidated report requires new run identities, disjoint receipt sets, and evidence beginning after the latest contradiction in both lanes. Successors preserve migration provenance and every transition remains digest-CAS guarded. The v2 JSON schema accepts both strict persisted projections and the command's shared current-version error envelope. An explicitly migrated empty report records `evidence_required` rather than qualification. |
 | `Hive::Modules::Migration::ReportMigration` | `lib/hive/modules/migration/report_migration.rb` | One-off project-local report converter over the existing `Report` storage facade. It accepts the complete released v1 success, null-configuration, and error-envelope shapes; preserves exact source bytes in a fixed archive; validates source/archive/receipt linkage on read-only probes; repairs a missing receipt only for the initial unsuperseded migration projection under the existing exclusive lock; rejects missing provenance after any successor; binds that immutable receipt to migration provenance rather than mutable later report bytes; uses digest CAS in both directions; and owns no cutover, rollback, retry, or effect recovery. |
 
-`Hive::Modules::Migration::Patrols.admit_deterministic_qualification!` is the
-single production admission path for U3b evidence. It accepts bounded raw
+`Hive::Modules::Migration::Patrols.deterministic_receipt_for!` is the bounded
+U3b receipt-construction seam. Its exact module/trigger-id selector must resolve
+one comparable terminal shadow record while the exclusive migration lock is held;
+the record supplies the capture, decision projection, and complete
+observational effect set, while caller metadata remains subject to the receipt
+protocol's configuration checks and must exactly match the nonempty repository
+target captured by the product scheduler. Both Patrol products use the same
+host-qualified `host/owner/name` target: ordinary Patrol derives it from the
+registration and Architecture Patrol binds the manifest repository to its PR
+URL host. Missing, ambiguous,
+nonterminal, divergent, duplicate-effect, configuration-mismatched, or
+identity-mismatched evidence fails closed.
+
+New Architecture Patrol captures require the host-qualified target. The
+occurrence store accepts an older owner/name-only project only when the exact
+same immutable capture is already durable (or its job pointer already binds
+that occurrence); replay compatibility cannot create new qualification
+evidence. The deterministic receipt facade requires an exact
+`host/owner/name` target and rejects owner/name-only replay even when caller
+metadata repeats that legacy value.
+
+`Hive::Modules::Migration::Patrols.admit_deterministic_qualification!` remains
+the single production admission path for U3b evidence. It accepts bounded raw
 receipt documents plus independently computed expected bindings, constructs no
 scenario or collector, and owns only verification, deterministic qualification,
 and digest-CAS report-v2 merge.


### PR DESCRIPTION
## Summary

Deliver the bounded U3b0 prerequisite after #923: one production-owned facade that turns an exact immutable shadow comparison into a deterministic qualification receipt.

- Selects one module and trigger identity under the exclusive migration lock, rejecting missing, ambiguous, divergent, duplicate-effect, malformed, or configuration-mismatched evidence.
- Binds caller metadata to the exact host-qualified repository target already captured by Patrol or Architecture Patrol.
- Makes both Patrol products emit the same host/owner/name identity; Architecture Patrol derives it from the manifest PR URL.
- Preserves pre-upgrade owner/name occurrences only for exact durable replay. Fresh hostless captures and all hostless qualification receipts fail closed.
- Corrects scheduled ordinary Patrol capture to use the registered repository identity.

## Boundary

This PR adds no scenario runner, fault matrix, provider broker, sandbox, process custody, retry/recovery authority, cutover, rollback, or U5-U7 construction. U3b scenarios remain a separate successor.

The Workflow Creator hostile/property campaign remains opt-in through rake test:hostile. Required CI does not invoke it or set HIVE_HOSTILE_TESTS.

## Verification

- Final head: cb9810c21a020b147bb5ab2a2bbd8feea97f4a54
- Base: 11b3454ff
- Focused final corpus: 187 runs / 1,454 assertions / 0 failures / 0 errors / 0 skips
- Full 20-receipt, two-module reproduction: qualified, no blockers
- Architecture, correctness, and reliability reviews: clean
- Focused RuboCop and git diff --check: clean
- Broad, coverage, hostile/property, and expensive CI lanes were intentionally not run locally

## Authority boundary

This PR does not perform migration cutover or rollback, live provider use, release, publication, deployment, or any external effect beyond this pull request.