### PR TITLE
refactor(workflow-creator): add semantic core boundary

### DIFF
--- a/config/component-boundaries.yml
+++ b/config/component-boundaries.yml
@@ -781,10 +781,10 @@ components:
 
   - id: workflow-creator-values
     name: Workflow Creator Values
-    state: candidate
+    state: boundary-ready
     entrypoint:
       file: packaging/live_agent_skills/workflow_creator_text_safety.rb
-      require: packaging/live_agent_skills/workflow_creator_text_safety
+      require: ./packaging/live_agent_skills/workflow_creator_text_safety
       constant: HiveLiveAgentProof::WorkflowCreator::TextSafety
     public_contract:
       values:
@@ -816,13 +816,60 @@ components:
       - HiveLiveAgentProof::WorkflowCreator::TextSafety
     forbidden_constructions: []
     authorized_internal_constructions: []
-    hive_consumers: []
+    hive_consumers:
+      - packaging/live_agent_skills/workflow_creator.rb
     mutation_authority: "No external mutation authority; capture and projection allocate only fresh in-memory values and text."
     recovery_surface: "Capture and projection fail closed with fixed secret-free errors and expose no retry or recovery state."
     wiki_page: wiki/component-boundaries.md
     focused_tests:
       - test/unit/packaging/workflow_creator_values_test.rb
       - test/unit/packaging/workflow_creator_text_safety_test.rb
+    migration_exceptions: []
+
+  - id: workflow-creator-core
+    name: Workflow Creator Core
+    state: candidate
+    entrypoint:
+      file: packaging/live_agent_skills/workflow_creator.rb
+      require: ./packaging/live_agent_skills/workflow_creator
+      constant: HiveLiveAgentProof::WorkflowCreator
+    public_contract:
+      values:
+        - HiveLiveAgentProof::WorkflowCreator::Vocabulary
+        - HiveLiveAgentProof::WorkflowCreator.failure
+        - HiveLiveAgentProof::WorkflowCreator.validate_nonpassing!
+        - HiveLiveAgentProof::WorkflowCreator.validate_primary!
+        - HiveLiveAgentProof::WorkflowCreator.validate_installation!
+        - HiveLiveAgentProof::WorkflowCreator.validate_execution!
+      errors:
+        - HiveLiveAgentProof::WorkflowCreator::Error
+    owned_paths:
+      - packaging/live_agent_skills/workflow_creator.rb
+      - packaging/live_agent_skills/workflow_creator_contract.rb
+      - packaging/live_agent_skills/workflow_creator_execution_contract.rb
+    state_contracts:
+      - "Each public input is captured once before semantic validation, and the admitted primary snapshot is returned"
+      - "Failure construction captures stable caller inputs and detail once, then captures only its constructed result"
+      - "The semantic core is declarative and owns no retention, publication, process, provider, or credential state"
+    schema_contracts:
+      - "Vocabulary and failed, primary, installation, and execution schema-v1 fields are exact and deeply immutable"
+      - "Installed closures, ordered commands, capture digests, classifications, and receipt summaries are cross-bound"
+    lock_contracts:
+      - "No locks or durable state; validation is pure over immutable Values snapshots"
+    component_dependencies:
+      - workflow-creator-values
+    allowed_hive_dependencies: []
+    internal_collaborators:
+      - HiveLiveAgentProof::WorkflowCreator::Contract
+      - HiveLiveAgentProof::WorkflowCreator::ExecutionContract
+    forbidden_constructions: []
+    authorized_internal_constructions: []
+    hive_consumers: []
+    mutation_authority: "No mutation authority; allocates only failure evidence and immutable semantic snapshots."
+    recovery_surface: "Validation fails closed with WorkflowCreator::Error and exposes no retry or recovery state."
+    wiki_page: wiki/component-boundaries.md
+    focused_tests:
+      - test/unit/packaging/workflow_creator_core_test.rb
     migration_exceptions:
-      - reason: "U1a1c must establish the staged boundary's first production consumer before promotion."
-        removal_unit: U1a1c
+      - reason: "U1a2 must establish retained bundle custody and the first incumbent proof consumer."
+        removal_unit: U1a2

--- a/packaging/live_agent_skills/workflow_creator.rb
+++ b/packaging/live_agent_skills/workflow_creator.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require "digest"
+require_relative "workflow_creator_text_safety"
+
+module HiveLiveAgentProof
+  module WorkflowCreator
+    class Error < StandardError; end
+
+    request = "Create a three-stage editorial workflow that researches, drafts, " \
+              "and requires approval before publishing."
+    prompt = <<~PROMPT
+      /hive
+      #{request}
+      Use the installed Hive workflow-creator capability in this initialized project.
+      This is creation-only: validate the result, report the defaults, and do not create or run a task.
+    PROMPT
+    task_request = "Research and draft the launch announcement for approval."
+    task_key = "workflow-creator-proof:editorial:live-proof"
+    task_slug = "editorial-live-proof"
+    task_prompt = <<~PROMPT
+      /hive
+      Use the validated editorial workflow to create and run one task for:
+      "#{task_request}"
+      Use idempotency key #{task_key}. In this exact order: create the task,
+      run its first stage once, repeat the same creation command once to prove the retry is a no-op,
+      then query operational status. Do not publish or perform any other external action.
+    PROMPT
+    task_argv = [
+      "new", "workflow-creator-proof", "--workflow", "editorial", "--idempotency-key", task_key,
+      "--json", task_request
+    ]
+    files = %w[
+      .hive-state/workflows/editorial.yml .hive-state/workflows/editorial/draft.md
+      .hive-state/workflows/editorial/research.md
+    ]
+    Vocabulary = Values.capture(
+      "schema_version" => 1,
+      "evidence_schema" => "hive-live-workflow-creator-evidence",
+      "installed_schema" => "hive-live-workflow-creator-installed-manifest",
+      "execution_schema" => "hive-live-workflow-creator-execution-receipt",
+      "execution_plan" => "hive-live-workflow-creator-execution-plan/v1",
+      "scanner" => "hive-live-agent-proof/v1",
+      "request" => request, "prompt" => prompt, "task_request" => task_request,
+      "task_key" => task_key, "task_slug" => task_slug, "task_prompt" => task_prompt,
+      "task_new_argv" => task_argv,
+      "commands" => [
+        [ "version" ], [ "workflow", "list", "--json" ], [ "workflow", "new", "editorial", "--json" ],
+        [ "workflow", "validate", "editorial", "--json" ], [ "workflow", "commit", "editorial" ], task_argv,
+        [ "run", task_slug ], task_argv, [ "status", "--operational", "--json" ]
+      ],
+      "files" => files, "executed_instruction" => files.fetch(2),
+      "native_activation" => { "kind" => "openclaw-skills-info", "invocation" => "/hive" },
+      "graph" => {
+        "valid" => true, "stages" => %w[research draft approval],
+        "automatic_edges" => [ %w[research draft], %w[draft approval] ],
+        "human_outcomes" => [
+          { "stage" => "approval", "name" => "approve", "complete" => true,
+            "artifact" => "draft.md", "to" => nil },
+          { "stage" => "approval", "name" => "reject", "complete" => false,
+            "artifact" => nil, "to" => "draft" }
+        ]
+      },
+      "task" => {
+        "slug" => task_slug, "workflow" => "editorial", "first_created" => true,
+        "retry_created" => false, "run_count" => 1, "current_stage" => "1-research"
+      },
+      "classification" => { "execution_kind" => "authenticated_openclaw", "model_loop" => "executed" },
+      "bundle_files" => %w[
+        openclaw-workflow-creator.json candidate-installed-manifest.json
+        openclaw-installed-manifest.json execution-receipt.json
+      ],
+      "member_roles" => {
+        "candidate" => %w[audit_gateway executable interpreter_or_launcher lock package],
+        "openclaw" => %w[executable interpreter_or_launcher lock package]
+      },
+      "outer_roles" => [
+        { "role" => "workflow-creation-model-loop", "prompt_sha256" => Digest::SHA256.hexdigest(prompt) },
+        { "role" => "authorized-work-model-loop", "prompt_sha256" => Digest::SHA256.hexdigest(task_prompt) }
+      ],
+      "archive_labels" => %w[candidate-package openclaw-package],
+      "archive_policy_sha256" => Digest::SHA256.hexdigest("hive-live-workflow-creator-archive-policy/v1"),
+      "cleanup_labels" => %w[proof-workspace]
+    ).value
+  end
+end
+
+require_relative "workflow_creator_contract"
+require_relative "workflow_creator_execution_contract"
+
+module HiveLiveAgentProof
+  module WorkflowCreator
+    private_constant :Contract, :ExecutionContract
+
+    def self.failure(...) = Contract.failure(...)
+    def self.validate_nonpassing!(row, exact_secrets: []) =
+      Contract.validate_nonpassing!(capture(row), capture(exact_secrets).value)
+    def self.validate_primary!(row:, manifest:, candidate_sha:, bundle_records:) =
+      Contract.validate_primary!(capture(row), capture(manifest), capture(candidate_sha), capture(bundle_records))
+    def self.validate_installation!(document:, kind:, manifest:, candidate_sha:) =
+      Contract.validate_installation!(capture(document), capture(kind), capture(manifest), capture(candidate_sha))
+    def self.validate_execution!(receipt:, row:, candidate_sha:, manifest:, installation_records:,
+                                 receipt_sha256:, candidate_installation:, openclaw_installation:) =
+      ExecutionContract.validate!(capture(receipt), capture(row), capture(candidate_sha), capture(manifest),
+                                  capture(installation_records), capture(receipt_sha256),
+                                  capture(candidate_installation), capture(openclaw_installation))
+    def self.capture(value)
+      Values.capture(value)
+    rescue Values::Error
+      raise Error, "workflow-creator input cannot be captured"
+    end
+    private_class_method :capture
+  end
+end

--- a/packaging/live_agent_skills/workflow_creator_contract.rb
+++ b/packaging/live_agent_skills/workflow_creator_contract.rb
@@ -1,0 +1,254 @@
+# frozen_string_literal: true
+
+module HiveLiveAgentProof::WorkflowCreator
+    module Contract
+      PRIMARY_KEYS = %w[schema schema_version platform candidate_sha result prompt_sha256 task_prompt_sha256 skill
+                        native_activation hive_commands created_files validation creation_only_task_count task_count
+                        task external_actions secret_scan execution_kind model_loop executed_instruction
+                        evidence_bundle containment teardown
+                        cleanup].freeze
+      FAILURE = %w[schema schema_version platform candidate_sha result phase reason detail execution_kind model_loop
+                    secret_scan].freeze
+      MANIFEST = %w[canonical_digest candidate_sha files hive_version schema schema_version skill_version].freeze
+      INSTALLATION_KEYS = %w[schema schema_version candidate_sha kind version closure_sha256 required_roles inventory
+                             total_size secret_scan].freeze
+      FILE_KEYS, ARTIFACT_KEYS = %w[path sha256 size].freeze, %w[sha256 size].freeze
+      BUNDLE_KEYS, SUMMARY_KEYS = %w[kind path sha256 size].freeze, %w[receipt_sha256 status].freeze
+      SHA = /\A[0-9a-f]{40}\z/.freeze
+      DIGEST = /\A[0-9a-f]{64}\z/.freeze
+      FAILURE_PART = /\A[a-z][a-z0-9_]{0,63}\z/.freeze
+      CLASSIFICATIONS = Values.capture([ %w[unavailable not_started], %w[deterministic_fixture not_exercised],
+                                         %w[authenticated_openclaw executed] ]).value
+      OMITTED_DETAIL = "[detail omitted: unsafe or oversized]".freeze
+      DETAIL_LIMIT, MAX_INVENTORY_ENTRIES = 1_000, 512
+      MAX_MEMBER_BYTES, MAX_TOTAL_BYTES = 268_435_456, 1_073_741_824
+      module_function
+      def failure(candidate_sha:, phase:, reason:, detail: nil, execution_kind: "unavailable",
+                  model_loop: "not_started", exact_secrets: [])
+        base = Values.capture(
+          "candidate_sha" => candidate_sha, "phase" => phase, "reason" => reason,
+          "execution_kind" => execution_kind, "model_loop" => model_loop,
+          "exact_secrets" => exact_secrets
+        ).value
+        candidate, failure_phase, failure_reason, kind, loop_state, secrets = base.values_at(
+          "candidate_sha", "phase", "reason", "execution_kind", "model_loop", "exact_secrets")
+        [ candidate, failure_phase, failure_reason, kind, loop_state ].each do |value|
+          assert!(value.instance_of?(String), "workflow-creator non-passing evidence is invalid")
+        end
+        detail_value = begin
+          captured = Values.capture(detail).value
+          if captured.nil?
+            nil
+          elsif captured.instance_of?(String)
+            TextSafety.redact(captured, exact_secrets: secrets, limit: DETAIL_LIMIT)
+          else
+            OMITTED_DETAIL
+          end
+        rescue Values::Error, TextSafety::Error
+          OMITTED_DETAIL
+        end
+        candidate = candidate.downcase
+        result = Values.capture(
+          "schema" => Vocabulary.fetch("evidence_schema"), "schema_version" => 1,
+          "platform" => "openclaw", "candidate_sha" => SHA.match?(candidate) ? candidate : "unresolved",
+          "result" => "failed", "phase" => failure_phase, "reason" => failure_reason,
+          "detail" => detail_value, "execution_kind" => kind, "model_loop" => loop_state,
+          "secret_scan" => { "status" => "passed", "scanner" => Vocabulary.fetch("scanner") }
+        )
+        validate_nonpassing!(result, secrets)
+      rescue Values::Error, KeyError
+        raise Error, "workflow-creator non-passing evidence is invalid"
+      end
+      def validate_nonpassing!(snapshot, exact_secrets)
+        row = snapshot.value
+        schema, scanner = Vocabulary.values_at("evidence_schema", "scanner")
+        expected = { "schema" => schema, "schema_version" => 1,
+                     "platform" => "openclaw", "result" => "failed",
+                     "secret_scan" => { "status" => "passed", "scanner" => scanner } }
+        exact!(row, FAILURE, "workflow-creator non-passing evidence is invalid", expected:)
+        version, candidate, phase, reason, detail, kind, model = row.values_at(
+          "schema_version", "candidate_sha", "phase", "reason", "detail", "execution_kind", "model_loop")
+        checks = {
+          "types" => [ version.class, candidate.class ] == [ Integer, String ],
+          "candidate" => candidate == "unresolved" || SHA.match?(candidate),
+          "phase" => FAILURE_PART.match?(phase), "reason" => FAILURE_PART.match?(reason),
+          "classification" => CLASSIFICATIONS.include?([ kind, model ])
+        }
+        assert!(checks.values.all?, "workflow-creator non-passing evidence is invalid")
+        if detail
+          assert!(detail.instance_of?(String), "workflow-creator non-passing evidence is invalid")
+          assert!(detail.bytesize <= DETAIL_LIMIT, "workflow-creator non-passing evidence is invalid")
+        end
+        secrets!(exact_secrets, texts: [ phase, reason, detail ].compact)
+        snapshot
+      rescue ArgumentError, IndexError, KeyError, NoMethodError, TypeError, TextSafety::Error
+        raise Error, "workflow-creator non-passing evidence is invalid"
+      end
+      def validate_primary!(row_snapshot, manifest_snapshot, candidate_snapshot, bundle_snapshot)
+        row, manifest = row_snapshot.value, manifest_snapshot.value
+        candidate_sha, bundle_records = candidate_snapshot.value, bundle_snapshot.value
+        exact!(row, PRIMARY_KEYS, "workflow-creator evidence fields are invalid")
+        manifest!(manifest, candidate_sha)
+        evidence_bundle = row.fetch("evidence_bundle")
+        bundles!(bundle_records)
+        bundles!(evidence_bundle)
+        assert!(Values.capture(evidence_bundle).canonical_bytes == bundle_snapshot.canonical_bytes,
+                "workflow-creator evidence bundle is invalid")
+        primary_claims!(row, manifest, candidate_sha)
+        primary_files!(row)
+        summary = { "status" => "passed", "receipt_sha256" => bundle_records.fetch(2).fetch("sha256") }
+        assert!(row.values_at("containment", "teardown", "cleanup").all? { |value| value == summary },
+                "workflow-creator execution claims are not passing")
+        row_snapshot
+      rescue ArgumentError, IndexError, KeyError, NoMethodError, TypeError, Values::Error, TextSafety::Error
+        raise Error, "workflow-creator contract is invalid"
+      end
+      def validate_installation!(document_snapshot, kind_snapshot, manifest_snapshot, candidate_snapshot)
+        document, kind = document_snapshot.value, kind_snapshot.value
+        manifest, candidate_sha = manifest_snapshot.value, candidate_snapshot.value
+        exact!(document, INSTALLATION_KEYS, "workflow-creator installed manifest fields are invalid")
+        assert!(%w[candidate openclaw].include?(kind), "workflow-creator installed manifest kind is invalid")
+        manifest!(manifest, candidate_sha)
+        roles = Vocabulary.fetch("member_roles").fetch(kind)
+        required, inventory = document.values_at("required_roles", "inventory")
+        inventory!(inventory, kind, required, roles)
+        required_roles!(required, roles, kind, manifest)
+        closure = Values.capture("required_roles" => required, "inventory" => inventory)
+        total = inventory.sum { |record| record.fetch("size") }
+        installation_identity!(document, kind, manifest, candidate_sha, closure, total)
+        document_snapshot
+      rescue ArgumentError, IndexError, KeyError, NoMethodError, TypeError, Values::Error, TextSafety::Error
+        raise Error, "workflow-creator installed manifest is invalid"
+      end
+      def secrets!(secrets, texts: [])
+        assert!(secrets.instance_of?(Array), "workflow-creator exact secrets are invalid")
+        assert!(secrets.length <= 64, "workflow-creator exact secrets are invalid")
+        secrets.each do |secret|
+          assert!(secret.instance_of?(String), "workflow-creator exact secrets are invalid")
+          assert!(secret.bytesize.between?(1, 4_096), "workflow-creator exact secrets are invalid")
+        end
+        texts.each do |text|
+          assert!(TextSafety.secret_findings(text, exact_secrets: secrets).empty?,
+                  "workflow-creator non-passing evidence contains secret-shaped material")
+        end
+      end
+      def bundles!(records)
+        paths = Vocabulary.fetch("bundle_files").drop(1)
+        kinds = %w[candidate_installation openclaw_installation execution_receipt]
+        assert!(records.instance_of?(Array), "workflow-creator evidence bundle is invalid")
+        assert!(records.length == 3, "workflow-creator evidence bundle is invalid")
+        records.each_with_index do |record, index|
+          record!(record, BUNDLE_KEYS, "workflow-creator evidence bundle is invalid",
+                  path: true, positive: true, binding: [ paths.fetch(index), kinds.fetch(index) ])
+        end
+      end
+      def primary_claims!(row, manifest, candidate_sha)
+        schema, activation, commands, graph, task, classification, scanner, prompt, task_prompt = Vocabulary.values_at(
+          "evidence_schema", "native_activation", "commands", "graph", "task", "classification", "scanner",
+          "prompt", "task_prompt")
+        expected = {
+          "schema" => schema, "schema_version" => 1, "platform" => "openclaw", "candidate_sha" => candidate_sha,
+          "result" => "passed", "skill" => manifest.slice("skill_version", "canonical_digest"),
+          "native_activation" => activation, "hive_commands" => commands, "validation" => graph,
+          "creation_only_task_count" => 0, "task_count" => 1, "task" => task, "external_actions" => [],
+          "secret_scan" => { "status" => "passed", "scanner" => scanner },
+          "execution_kind" => classification.fetch("execution_kind"),
+          "model_loop" => classification.fetch("model_loop"),
+          "prompt_sha256" => Digest::SHA256.hexdigest(prompt),
+          "task_prompt_sha256" => Digest::SHA256.hexdigest(task_prompt)
+        }
+        assert!(row.slice(*expected.keys) == expected, "workflow-creator primary claims are invalid")
+        numeric = row.values_at("schema_version", "creation_only_task_count", "task_count")
+        numeric << row.dig("task", "run_count")
+        assert!(numeric.all? { |value| value.instance_of?(Integer) }, "workflow-creator numeric claims are invalid")
+      end
+      def primary_files!(row)
+        created, instruction = row.values_at("created_files", "executed_instruction")
+        assert!(created.instance_of?(Array), "workflow-creator primary files are invalid")
+        created.each { |item| record!(item, FILE_KEYS, "workflow-creator file invalid", path: true, positive: true) }
+        record!(instruction, FILE_KEYS, "workflow-creator file invalid", path: true, positive: true)
+        paths = created.map { |item| item.fetch("path") }
+        authored = created.find { |item| item.fetch("path") == Vocabulary.fetch("executed_instruction") }
+        assert!(paths == Vocabulary.fetch("files"), "workflow-creator primary files are invalid")
+        assert!(instruction == authored, "workflow-creator primary instruction is invalid")
+      end
+      def inventory!(inventory, kind, required, roles)
+        message = "workflow-creator #{kind} installed inventory is invalid"
+        assert!(inventory.instance_of?(Array), message)
+        assert!(inventory.length.between?(1, MAX_INVENTORY_ENTRIES), message)
+        inventory.each { |item| record!(item, FILE_KEYS, message, path: true, positive: false) }
+        paths = inventory.map { |item| item.fetch("path") }
+        assert!(paths == paths.sort.uniq, message)
+        records = required.values
+        assert!(records.all? { |item| inventory.include?(item) }, message)
+        assert!(records.map { |item| item.fetch("path") }.uniq.length == roles.length, message)
+      end
+      def required_roles!(required, roles, kind, manifest)
+        message = "workflow-creator #{kind} installed required roles are invalid"
+        exact!(required, roles, message)
+        records = required.values
+        records.each { |item| record!(item, FILE_KEYS, message, path: true, positive: false) }
+        package = required.fetch("package")
+        assert!(package.fetch("size").positive?, message)
+        return unless kind == "candidate"
+        packages = manifest.fetch("files").select { |name, _item| name.match?(/\Ahive-cli-[0-9].*\.gem\z/) }.values
+        assert!(packages.length == 1, message)
+        assert!(package.values_at("sha256", "size") == packages.first.values_at("sha256", "size"), message)
+      end
+      def installation_identity!(document, kind, manifest, candidate_sha, closure, total)
+        version, revision, declared_total = document.values_at("version", "schema_version", "total_size")
+        schema, scanner = Vocabulary.values_at("installed_schema", "scanner")
+        expected_version = kind == "candidate" ? manifest.fetch("hive_version") : version
+        expected = {
+          "schema" => schema, "schema_version" => 1, "candidate_sha" => candidate_sha, "kind" => kind,
+          "version" => expected_version, "closure_sha256" => Digest::SHA256.hexdigest(closure.canonical_bytes),
+          "total_size" => total, "secret_scan" => { "status" => "passed", "scanner" => scanner }
+        }
+        assert!(document.slice(*expected.keys) == expected, "workflow-creator installation identity invalid")
+        assert!([ revision, declared_total ].all? { |value| value.instance_of?(Integer) },
+                "workflow-creator installed numeric claims are invalid")
+        assert!(version.instance_of?(String), "workflow-creator installed version is invalid")
+        assert!(!version.empty?, "workflow-creator installed version is invalid")
+        assert!(TextSafety.secret_findings(version, exact_secrets: Values.capture([]).value).empty?,
+                "workflow-creator installed version contains secret material")
+        assert!(total.between?(1, MAX_TOTAL_BYTES), "workflow-creator installed total is invalid")
+      end
+      def manifest!(manifest, candidate_sha)
+        exact!(manifest, MANIFEST, "artifact manifest fields are invalid")
+        digest, _candidate, files, version, _schema, revision, skill = manifest.values_at(*MANIFEST)
+        expected = { "schema" => "hive-live-agent-candidate-artifacts", "schema_version" => 1,
+                     "candidate_sha" => candidate_sha }
+        assert!(manifest.slice(*expected.keys) == expected, "workflow-creator evidence identity or result is invalid")
+        types = [ candidate_sha, revision, version, skill, digest, files ].map(&:class)
+        assert!(types == [ String, Integer, String, String, String, Hash ], "workflow-creator artifact types invalid")
+        assert!(SHA.match?(candidate_sha), "workflow-creator candidate identity is invalid")
+        assert!([ version, skill ].none?(&:empty?), "workflow-creator artifact versions are invalid")
+        assert!(DIGEST.match?(digest), "workflow-creator artifact digest is invalid")
+        names = [ "hive-agent-skills-#{candidate_sha}.tar.gz", "hive-cli-#{version}.gem",
+                  "hive-source-#{candidate_sha}.tar.gz" ].sort
+        assert!(files.keys.sort == names, "workflow-creator evidence identity or result is invalid")
+        files.each_value { |item| record!(item, ARTIFACT_KEYS, "artifact file invalid", path: false, positive: true) }
+      end
+      def record!(value, keys, message, path:, positive:, binding: nil)
+        exact!(value, keys, message)
+        size, digest = value.values_at("size", "sha256")
+        assert!([ digest.class, size.class ] == [ String, Integer ], message)
+        assert!(DIGEST.match?(digest), message)
+        assert!(TextSafety.safe_relative_path?(value.fetch("path")), message) if path
+        if positive
+          assert!(size.positive?, message)
+        else
+          assert!(size.between?(0, MAX_MEMBER_BYTES), message)
+        end
+        assert!(value.values_at("path", "kind") == binding, message) if binding
+      end
+      def exact!(value, keys, message, expected: nil)
+        assert!(value.instance_of?(Hash), message)
+        assert!(value.keys.sort == keys.sort, message)
+        assert!(value.slice(*expected.keys) == expected, message) if expected
+      end
+      def assert!(condition, message)
+        raise Error, message unless condition
+      end
+    end
+end

--- a/packaging/live_agent_skills/workflow_creator_execution_contract.rb
+++ b/packaging/live_agent_skills/workflow_creator_execution_contract.rb
@@ -1,0 +1,212 @@
+# frozen_string_literal: true
+
+module HiveLiveAgentProof::WorkflowCreator
+    module ExecutionContract
+      KEYS = %w[schema schema_version candidate_sha result execution_plan classification installed_manifests run gateway
+                archive_admissions commands outer_processes authored_instruction executed_instruction external_actions
+                containment teardown cleanup secret_scan].freeze
+      COMMAND_KEYS = %w[position attempt_label argv exit_code signal completed capture teardown].freeze
+      OUTER_KEYS = %w[label role argv_sha256 prompt_sha256 exit_code signal completed capture teardown].freeze
+      CAPTURE_KEYS = %w[limit_bytes stdout_bytes stderr_bytes stdout_sha256 stderr_sha256 stdout_truncated
+                        stderr_truncated secret_scan].freeze
+      PROCESS_TEARDOWN_KEYS = %w[status term_sent kill_sent reaped descendants owner_complete].freeze
+      ARCHIVE_KEYS = %w[label artifact_sha256 artifact_size policy_sha256 entry_count uncompressed_bytes status].freeze
+      RUN_KEYS, GATEWAY_KEYS = %w[correlation_id expected_labels].freeze, %w[identity command_labels status].freeze
+      CONTAINMENT_KEYS = %w[status mechanism established_before_launch owner_correlation_id root_loss_behavior].freeze
+      TEARDOWN_KEYS = %w[status expected_labels receipt_labels outer_root_reaped remaining_descendants].freeze
+      CLEANUP_KEYS, LABEL = %w[status targets].freeze, /\A[a-z][a-z0-9_-]{0,127}\z/.freeze
+      TARGET_KEYS = %w[label path_sha256 device inode created_by_run identity_matched removed].freeze
+      module_function
+      def validate!(receipt_snapshot, row_snapshot, candidate_snapshot, manifest_snapshot, records_snapshot,
+                    receipt_sha_snapshot, candidate_installation_snapshot, openclaw_installation_snapshot)
+        receipt, row = receipt_snapshot.value, row_snapshot.value
+        candidate_sha, records = candidate_snapshot.value, records_snapshot.value
+        Contract.exact!(receipt, KEYS, "workflow-creator execution receipt fields are invalid")
+        bundles = Values.capture(records + [ row.fetch("evidence_bundle").fetch(2) ])
+        Contract.validate_primary!(row_snapshot, manifest_snapshot, candidate_snapshot, bundles)
+        Contract.validate_installation!(candidate_installation_snapshot, Values.capture("candidate"),
+                                        manifest_snapshot, candidate_snapshot)
+        Contract.validate_installation!(openclaw_installation_snapshot, Values.capture("openclaw"),
+                                        manifest_snapshot, candidate_snapshot)
+        identity!(receipt, row, candidate_sha, records, candidate_installation_snapshot, openclaw_installation_snapshot)
+        labels, correlation = processes!(receipt)
+        aggregates!(receipt, row, labels, correlation, receipt_sha_snapshot.value, receipt_snapshot.canonical_bytes)
+        receipt_snapshot
+      rescue ArgumentError, IndexError, KeyError, NoMethodError, TypeError, Values::Error, TextSafety::Error
+        raise Error, "workflow-creator execution receipt is invalid"
+      end
+      def identity!(receipt, row, candidate_sha, records, candidate_snapshot, openclaw_snapshot)
+        message = "workflow-creator execution identity is inconsistent"
+        installed = receipt.fetch("installed_manifests")
+        installation_records!(records, installed, candidate_snapshot, openclaw_snapshot)
+        Contract.assert!(Values.capture(installed).canonical_bytes == Values.capture(records).canonical_bytes, message)
+        candidate, openclaw = candidate_snapshot.value, openclaw_snapshot.value
+        execution_identity!(receipt, row, candidate_sha, candidate)
+        instruction = row.fetch("executed_instruction")
+        instructions = receipt.values_at("authored_instruction", "executed_instruction")
+        Contract.assert!(instructions == [ instruction ] * 2, message)
+        Contract.assert!(receipt.fetch("external_actions") == [], "workflow-creator external actions are invalid")
+        archives = receipt.fetch("archive_admissions")
+        Contract.assert!([ archives.class, archives.length ] == [ Array, 2 ], message)
+        archives!(archives, candidate, openclaw)
+      end
+      def installation_records!(records, installed, candidate_snapshot, openclaw_snapshot)
+        message = "workflow-creator execution installation records are invalid"
+        Contract.assert!([ records.class, records.length ] == [ Array, 2 ], message)
+        Contract.assert!([ installed.class, installed.length ] == [ Array, 2 ], message)
+        paths = Vocabulary.fetch("bundle_files").slice(1, 2)
+        kinds = %w[candidate_installation openclaw_installation]
+        records.each_with_index do |record, index|
+          Contract.record!(record, Contract::BUNDLE_KEYS, message, path: true, positive: true,
+                           binding: [ paths.fetch(index), kinds.fetch(index) ])
+        end
+        [ candidate_snapshot, openclaw_snapshot ].each_with_index do |snapshot, index|
+          expected = [ Digest::SHA256.hexdigest(snapshot.canonical_bytes), snapshot.canonical_bytes.bytesize ]
+          Contract.assert!(records.fetch(index).values_at("sha256", "size") == expected, message)
+        end
+      end
+      def execution_identity!(receipt, row, candidate_sha, candidate)
+        schema, plan, classification, scanner = Vocabulary.values_at(
+          "execution_schema", "execution_plan", "classification", "scanner")
+        nested = { "execution_kind" => "deterministic_fixture", "model_loop" => "not_exercised" }
+        expected = {
+          "schema" => schema, "schema_version" => 1, "candidate_sha" => candidate_sha, "result" => "passed",
+          "execution_plan" => plan, "classification" => { "outer" => classification, "nested_stage" => nested },
+          "secret_scan" => { "status" => "passed", "scanner" => scanner }
+        }
+        Contract.assert!(receipt.slice(*expected.keys) == expected, "workflow-creator execution identity is invalid")
+        Contract.assert!(receipt.fetch("schema_version").instance_of?(Integer),
+                         "workflow-creator execution identity is invalid")
+        Contract.assert!(Contract::SHA.match?(candidate_sha), "workflow-creator execution identity is invalid")
+        Contract.assert!(row.values_at("execution_kind", "model_loop") == classification.values,
+                         "workflow-creator execution identity is invalid")
+        gateway = receipt.fetch("gateway")
+        Contract.exact!(gateway, GATEWAY_KEYS, "workflow-creator execution gateway fields are invalid")
+        Contract.assert!(gateway.fetch("identity") == candidate.fetch("required_roles").fetch("audit_gateway"),
+                         "workflow-creator execution gateway identity is invalid")
+        Contract.assert!(gateway.fetch("status") == "passed", "workflow-creator execution gateway is not passing")
+      end
+      def archives!(archives, candidate, openclaw)
+        message = "workflow-creator execution archive admission is invalid"
+        packages = [ candidate, openclaw ].map { |document| document.fetch("required_roles").fetch("package") }
+        archives.zip(packages, Vocabulary.fetch("archive_labels")).each do |archive, package, expected_label|
+          Contract.exact!(archive, ARCHIVE_KEYS, message)
+          label, digest, size, policy, entries, bytes, status = archive.values_at(*ARCHIVE_KEYS)
+          expected = [ expected_label, package.fetch("sha256"),
+                       package.fetch("size"), Vocabulary.fetch("archive_policy_sha256"), "passed" ]
+          Contract.assert!([ label, digest, size, policy, status ] == expected, message)
+          Contract.assert!([ size, entries, bytes ].all? { |value| value.instance_of?(Integer) }, message)
+          Contract.assert!(size.positive? && entries.between?(1, 16_384) && bytes.between?(1, 1_073_741_824), message)
+        end
+      end
+      def processes!(receipt)
+        commands = commands!(receipt.fetch("commands"))
+        outer = outer_processes!(receipt.fetch("outer_processes"))
+        labels = commands + outer
+        Contract.assert!(labels.uniq.length == labels.length, "workflow-creator execution process labels are invalid")
+        run = receipt.fetch("run")
+        Contract.exact!(run, RUN_KEYS, "workflow-creator execution run fields are invalid")
+        correlation = run.fetch("correlation_id")
+        Contract.assert!(LABEL.match?(correlation), "workflow-creator execution run identity is invalid")
+        Contract.assert!(run.fetch("expected_labels") == labels, "workflow-creator execution run labels are invalid")
+        Contract.assert!(receipt.fetch("gateway").fetch("command_labels") == commands,
+                         "workflow-creator execution gateway labels are invalid")
+        [ labels, correlation ]
+      end
+      def commands!(commands)
+        expected = Vocabulary.fetch("commands")
+        message = "workflow-creator command receipts are invalid"
+        Contract.assert!(commands.instance_of?(Array), message)
+        Contract.assert!(commands.length == expected.length, message)
+        commands.each_with_index.map do |command, index|
+          Contract.exact!(command, COMMAND_KEYS, message)
+          position, argv = command.values_at("position", "argv")
+          Contract.assert!([ position.class, position, argv ] == [ Integer, index + 1, expected.fetch(index) ], message)
+          process!(command, "attempt_label")
+          command.fetch("attempt_label")
+        end
+      end
+      def outer_processes!(outer)
+        expected = Vocabulary.fetch("outer_roles")
+        message = "workflow-creator outer processes are invalid"
+        Contract.assert!(outer.instance_of?(Array), message)
+        Contract.assert!(outer.length == expected.length, message)
+        outer.each_with_index.map do |process, index|
+          Contract.exact!(process, OUTER_KEYS, message)
+          Contract.assert!(process.values_at("role", "prompt_sha256") == expected.fetch(index).values, message)
+          Contract.assert!(Contract::DIGEST.match?(process.fetch("argv_sha256")), message)
+          process!(process, "label")
+          process.fetch("label")
+        end
+      end
+      def process!(process, label_key)
+        Contract.assert!(LABEL.match?(process.fetch(label_key)), "workflow-creator process label is invalid")
+        exit_code, signal, completed = process.values_at("exit_code", "signal", "completed")
+        Contract.assert!([ exit_code.class, exit_code, signal, completed ] == [ Integer, 0, nil, true ],
+                         "workflow-creator process result is invalid")
+        capture!(process.fetch("capture"))
+        teardown!(process.fetch("teardown"))
+      end
+      def capture!(capture)
+        message = "workflow-creator execution capture is invalid"
+        Contract.exact!(capture, CAPTURE_KEYS, message)
+        limit = capture.fetch("limit_bytes")
+        Contract.assert!(limit.instance_of?(Integer), message)
+        Contract.assert!(limit.between?(1, 1_048_576), message)
+        empty_digest = Digest::SHA256.hexdigest("")
+        %w[stdout stderr].each do |stream|
+          bytes, digest, truncated = capture.values_at("#{stream}_bytes", "#{stream}_sha256", "#{stream}_truncated")
+          checks = [ bytes.instance_of?(Integer), bytes.between?(0, limit), Contract::DIGEST.match?(digest),
+                     [ true, false ].include?(truncated), bytes.zero? == (digest == empty_digest),
+                     !truncated || bytes == limit ]
+          Contract.assert!(checks.all?, message)
+        end
+        scan = capture.fetch("secret_scan")
+        Contract.assert!(scan == { "status" => "passed", "scanner" => Vocabulary.fetch("scanner") }, message)
+      end
+      def teardown!(teardown)
+        message = "workflow-creator execution teardown is invalid"
+        Contract.exact!(teardown, PROCESS_TEARDOWN_KEYS, message)
+        status, term, kill, reaped, descendants, owner = teardown.values_at(*PROCESS_TEARDOWN_KEYS)
+        Contract.assert!([ status, reaped, descendants, owner ] == [ "passed", true, "none", true ], message)
+        Contract.assert!([ term, kill ].all? { |value| [ true, false ].include?(value) }, message)
+        Contract.assert!(!kill || term, message)
+      end
+      def aggregates!(receipt, row, labels, correlation, receipt_sha256, receipt_bytes)
+        containment, teardown, cleanup = receipt.values_at("containment", "teardown", "cleanup")
+        invalid = "workflow-creator execution aggregates are inconsistent"
+        cleanup_targets!(cleanup.fetch("targets"))
+        expected_containment = {
+          "status" => "passed", "mechanism" => "supervised-process-tree", "established_before_launch" => true,
+          "owner_correlation_id" => correlation, "root_loss_behavior" => "fail-closed"
+        }
+        expected_teardown = { "status" => "passed", "expected_labels" => labels, "receipt_labels" => labels,
+                              "outer_root_reaped" => true, "remaining_descendants" => 0 }
+        Contract.exact!(containment, CONTAINMENT_KEYS, invalid, expected: expected_containment)
+        Contract.exact!(teardown, TEARDOWN_KEYS, invalid, expected: expected_teardown)
+        Contract.exact!(cleanup, CLEANUP_KEYS, invalid, expected: { "status" => "passed" })
+        actual_identity = row.fetch("evidence_bundle").fetch(2).values_at("sha256", "size")
+        expected_identity = [ receipt_sha256, receipt_bytes.bytesize ]
+        summary = { "status" => "passed", "receipt_sha256" => receipt_sha256 }
+        Contract.assert!(teardown.fetch("remaining_descendants").instance_of?(Integer), invalid)
+        Contract.assert!(actual_identity == expected_identity, invalid)
+        Contract.assert!(receipt_sha256 == Digest::SHA256.hexdigest(receipt_bytes), invalid)
+        Contract.assert!(%w[containment teardown cleanup].all? { |field| row.fetch(field) == summary }, invalid)
+      end
+      def cleanup_targets!(targets)
+        labels = Vocabulary.fetch("cleanup_labels")
+        message = "workflow-creator execution cleanup targets are invalid"
+        Contract.assert!(targets.instance_of?(Array), message)
+        Contract.assert!(targets.length == labels.length, message)
+        targets.each_with_index do |target, index|
+          Contract.exact!(target, TARGET_KEYS, message)
+          label, path, device, inode, created, matched, removed = target.values_at(*TARGET_KEYS)
+          Contract.assert!([ label, created, matched, removed ] == [ labels.fetch(index), true, true, true ], message)
+          Contract.assert!(Contract::DIGEST.match?(path), message)
+          Contract.assert!([ device.class, inode.class ] == [ Integer, Integer ], message)
+          Contract.assert!(device >= 0, message)
+          Contract.assert!(inode.positive?, message)
+        end
+      end
+    end
+end

--- a/test/unit/component_boundaries_test.rb
+++ b/test/unit/component_boundaries_test.rb
@@ -22,6 +22,7 @@ class ComponentBoundariesTest < Minitest::Test
       skillpack
       user-service
       work-ledger
+      workflow-creator-core
       workflow-creator-values
     ], contract.components.map { |component| component.fetch("id") }.sort
 
@@ -261,11 +262,11 @@ class ComponentBoundariesTest < Minitest::Test
     assert_empty work_ledger.fetch("migration_exceptions")
 
     workflow_values = contract.component("workflow-creator-values")
-    assert_equal "candidate", workflow_values.fetch("state")
+    assert_equal "boundary-ready", workflow_values.fetch("state")
     assert_equal(
       {
         "file" => "packaging/live_agent_skills/workflow_creator_text_safety.rb",
-        "require" => "packaging/live_agent_skills/workflow_creator_text_safety",
+        "require" => "./packaging/live_agent_skills/workflow_creator_text_safety",
         "constant" => "HiveLiveAgentProof::WorkflowCreator::TextSafety"
       },
       workflow_values.fetch("entrypoint")
@@ -291,18 +292,31 @@ class ComponentBoundariesTest < Minitest::Test
     ], workflow_values.dig("public_contract", "errors").sort
     assert_empty workflow_values.fetch("component_dependencies")
     assert_empty workflow_values.fetch("allowed_hive_dependencies")
-    assert_empty workflow_values.fetch("hive_consumers")
-    assert_equal 1, workflow_values.fetch("migration_exceptions").length
-    assert_equal "U1a1c",
-                 workflow_values.dig("migration_exceptions", 0, "removal_unit")
+    assert_equal [ "packaging/live_agent_skills/workflow_creator.rb" ],
+                 workflow_values.fetch("hive_consumers")
+    assert_empty workflow_values.fetch("migration_exceptions")
+
+    workflow_core = contract.component("workflow-creator-core")
+    assert_equal "candidate", workflow_core.fetch("state")
+    assert_equal "./packaging/live_agent_skills/workflow_creator",
+                 workflow_core.dig("entrypoint", "require")
+    assert_equal [ "workflow-creator-values" ], workflow_core.fetch("component_dependencies")
+    assert_equal %w[
+      packaging/live_agent_skills/workflow_creator.rb
+      packaging/live_agent_skills/workflow_creator_contract.rb
+      packaging/live_agent_skills/workflow_creator_execution_contract.rb
+    ], workflow_core.fetch("owned_paths")
+    assert_empty workflow_core.fetch("hive_consumers")
+    assert_equal [ "U1a2" ],
+                 workflow_core.fetch("migration_exceptions").map { |entry| entry.fetch("removal_unit") }
 
     ready_components.push(
-      agent_abi, artifact_firewall, skillpack, git_gate, work_ledger
+      agent_abi, artifact_firewall, skillpack, git_gate, work_ledger, workflow_values
     )
     remaining_candidates = contract.components.reject do |component|
       ready_components.include?(component)
     end
-    assert_equal %w[attempts patrol-effects workflow-creator-values],
+    assert_equal %w[attempts patrol-effects workflow-creator-core],
                  remaining_candidates.map { |entry| entry.fetch("id") }.sort
     assert remaining_candidates.all? { |component| component.fetch("state") == "candidate" }
 
@@ -314,6 +328,7 @@ class ComponentBoundariesTest < Minitest::Test
       skillpack
       user-service
       work-ledger
+      workflow-creator-values
     ], ready_loads.keys.sort
     agent_abi_load = ready_loads.fetch("agent-abi")
     assert_equal "Hive::AgentRuntime", agent_abi_load.fetch("constant")
@@ -432,7 +447,7 @@ class ComponentBoundariesTest < Minitest::Test
       assert_includes wiki_index, "[[#{wiki_link}]]"
       expected_removals = {
         "patrol-effects" => [ "U3" ],
-        "workflow-creator-values" => [ "U1a1c" ]
+        "workflow-creator-core" => [ "U1a2" ]
       }.fetch(component.fetch("id"), [])
       assert_equal expected_removals,
                    component.fetch("migration_exceptions").map { |entry| entry.fetch("removal_unit") },
@@ -442,7 +457,10 @@ class ComponentBoundariesTest < Minitest::Test
       dependencies[component.fetch("id")] = component_dependencies unless component_dependencies.empty?
     end
 
-    assert_equal({ "skillpack" => [ "agent-abi" ] }, dependencies)
+    assert_equal(
+      { "skillpack" => [ "agent-abi" ], "workflow-creator-core" => [ "workflow-creator-values" ] },
+      dependencies
+    )
   end
 
   def test_production_consumers_do_not_bypass_artifact_firewall

--- a/test/unit/packaging/workflow_creator_core_test.rb
+++ b/test/unit/packaging/workflow_creator_core_test.rb
@@ -18,6 +18,8 @@ class WorkflowCreatorCoreTest < Minitest::Test
   SOURCES = %w[
     workflow_creator.rb workflow_creator_contract.rb workflow_creator_execution_contract.rb
   ].to_h { |name| [ name, File.join(ROOT, "packaging", "live_agent_skills", name) ] }.freeze
+  POISONED_CHILD_ENV = %w[HIVE_COVERAGE HIVE_COVERAGE_ROOT HIVE_COVERAGE_RUN_ID RUBYOPT]
+    .to_h { |name| [ name, nil ] }.freeze
   DECISIONS = %i[
     if unless elsif if_mod unless_mod ifop when in rescue rescue_mod while until for while_mod until_mod
   ].freeze
@@ -200,10 +202,12 @@ class WorkflowCreatorCoreTest < Minitest::Test
       "require './packaging/live_agent_skills/proof'; require './packaging/live_agent_skills/workflow_creator'"
     ]
     scripts.each do |script|
-      out, err, status = Open3.capture3(
-        RbConfig.ruby, "--disable-gems", "-I#{ROOT}", "-e",
-        "#{script}; puts HiveLiveAgentProof::WorkflowCreator::Vocabulary.fetch('schema_version')", chdir: ROOT
-      )
+      out, err, status = Bundler.with_unbundled_env do
+        Open3.capture3(
+          POISONED_CHILD_ENV, RbConfig.ruby, "--disable-gems", "-I#{ROOT}", "-e",
+          "#{script}; puts HiveLiveAgentProof::WorkflowCreator::Vocabulary.fetch('schema_version')", chdir: ROOT
+        )
+      end
       assert status.success?, err
       assert_equal "1\n", out
     end

--- a/test/unit/packaging/workflow_creator_core_test.rb
+++ b/test/unit/packaging/workflow_creator_core_test.rb
@@ -1,0 +1,485 @@
+require "test_helper"
+require "bundler"
+require "digest"
+require "open3"
+require "rbconfig"
+require "ripper"
+require "tmpdir"
+require "yaml"
+
+require_relative "../../../packaging/live_agent_skills/workflow_creator"
+
+class WorkflowCreatorCoreTest < Minitest::Test
+  ROOT = File.expand_path("../../..", __dir__)
+  SHA = "a" * 40
+  DIGEST = "b" * 64
+  Creator = HiveLiveAgentProof::WorkflowCreator
+  Values = Creator::Values
+  SOURCES = %w[
+    workflow_creator.rb workflow_creator_contract.rb workflow_creator_execution_contract.rb
+  ].to_h { |name| [ name, File.join(ROOT, "packaging", "live_agent_skills", name) ] }.freeze
+  DECISIONS = %i[
+    if unless elsif if_mod unless_mod ifop when in rescue rescue_mod while until for while_mod until_mod
+  ].freeze
+
+  def test_public_api_and_vocabulary_are_exact_and_deeply_frozen
+    assert_equal %i[
+      failure validate_execution! validate_installation! validate_nonpassing! validate_primary!
+    ], Creator.singleton_methods(false).sort
+    assert Creator::Error < StandardError
+    assert_equal %w[
+      schema_version evidence_schema installed_schema execution_schema execution_plan scanner
+      request prompt task_request task_key task_slug task_prompt task_new_argv commands files
+      executed_instruction native_activation graph task classification bundle_files member_roles
+      outer_roles archive_labels archive_policy_sha256 cleanup_labels
+    ], Creator::Vocabulary.keys
+    assert_equal 1, Creator::Vocabulary.fetch("schema_version")
+    assert_equal "hive-live-workflow-creator-evidence", Creator::Vocabulary.fetch("evidence_schema")
+    assert_equal "hive-live-workflow-creator-installed-manifest", Creator::Vocabulary.fetch("installed_schema")
+    assert_equal "hive-live-workflow-creator-execution-receipt", Creator::Vocabulary.fetch("execution_schema")
+    assert_deeply_frozen(Creator::Vocabulary)
+  end
+
+  def test_failure_is_total_at_detail_work_ceiling_and_returns_an_owned_snapshot
+    secret = "exact-boundary-secret"
+    detail = "x" * 980 + secret
+    detail << "y" * (4_096 - detail.bytesize)
+    at_limit = Creator.failure(
+      candidate_sha: SHA, phase: "preflight", reason: "provider_unavailable",
+      detail:, exact_secrets: [ secret ]
+    )
+    assert_snapshot(at_limit)
+    assert_includes at_limit.value.fetch("detail"), "[REDACTED]"
+    refute_includes at_limit.value.fetch("detail"), secret
+    assert_operator at_limit.value.fetch("detail").bytesize, :<=, 1_000
+
+    [ "x" * 4_097, "x" * 300_000 ].each do |detail|
+      omitted = Creator.failure(
+        candidate_sha: SHA, phase: "preflight", reason: "provider_unavailable", detail:
+      )
+      assert_snapshot(omitted)
+      assert_equal "[detail omitted: unsafe or oversized]", omitted.value.fetch("detail")
+    end
+
+    invalid = deep_dup(at_limit.value)
+    invalid["phase"] = 1
+    assert_raises(Creator::Error) { Creator.validate_nonpassing!(invalid) }
+  end
+
+  def test_public_validation_captures_each_caller_value_once_and_never_dispatches_to_it_later
+    fixture = valid_fixture
+    raw = [ fixture.fetch(:row), fixture.fetch(:manifest), SHA, fixture.fetch(:bundle_records) ]
+    captured_ids = []
+    trace = TracePoint.new(:call) do |event|
+      next unless event.defined_class == Values.singleton_class && event.method_id == :capture
+      captured_ids << event.binding.local_variable_get(:input).object_id
+    end
+    result = trace.enable do
+      Creator.validate_primary!(
+        row: raw.fetch(0), manifest: raw.fetch(1), candidate_sha: raw.fetch(2), bundle_records: raw.fetch(3)
+      )
+    end
+    raw.each { |value| assert_equal 1, captured_ids.count(value.object_id) }
+    assert_snapshot(result)
+    assert_equal fixture.fetch(:row), result.value
+    refute_same fixture.fetch(:row), result.value
+
+    fixture = valid_fixture
+    poison(fixture.fetch(:row), :keys, :fetch, :[], :dig)
+    poison(fixture.fetch(:manifest), :keys, :fetch, :[])
+    poison(fixture.fetch(:bundle_records), :each, :length, :fetch, :[])
+    assert_snapshot(validate_primary(fixture))
+  end
+
+  def test_failure_uses_caller_once_captures_then_one_internal_result_capture
+    detail = +"diagnostic"
+    capture_inputs = []
+    trace = TracePoint.new(:call) do |event|
+      next unless event.defined_class == Values.singleton_class && event.method_id == :capture
+      capture_inputs << event.binding.local_variable_get(:input)
+    end
+    result = trace.enable do
+      Creator.failure(candidate_sha: SHA, phase: "preflight", reason: "not_started", detail:)
+    end
+    assert_equal 3, capture_inputs.length
+    assert_same detail, capture_inputs.fetch(1)
+    assert capture_inputs.fetch(0).instance_of?(Hash), "first capture is the stable caller-input envelope"
+    assert capture_inputs.fetch(2).instance_of?(Hash), "last capture is the internally constructed result"
+    refute_same capture_inputs.fetch(0), capture_inputs.fetch(2)
+    admitted = Creator.validate_nonpassing!(result.value)
+    refute_same result, admitted
+    assert_equal result.canonical_bytes, admitted.canonical_bytes
+  end
+
+  def test_primary_contract_is_exact_typed_ordered_and_bound
+    fixture = valid_fixture
+    assert_snapshot(validate_primary(fixture))
+    mutations = {
+      extra_key: ->(item) { item[:row]["unexpected"] = true },
+      schema_float: ->(item) { item[:row]["schema_version"] = 1.0 },
+      command_order: ->(item) { item[:row]["hive_commands"].reverse! },
+      created_order: ->(item) { item[:row]["created_files"].reverse! },
+      task_count_float: ->(item) { item[:row]["task_count"] = 1.0 },
+      run_count_float: ->(item) { item[:row]["task"]["run_count"] = 1.0 },
+      bundle_order: ->(item) { item[:row]["evidence_bundle"].reverse! },
+      bundle_size_float: ->(item) { item[:bundle_records][0]["size"] = 12.0 },
+      external_effect: ->(item) { item[:row]["external_actions"] << "publish" }
+    }
+    mutations.each do |label, mutate|
+      invalid = valid_fixture
+      mutate.call(invalid)
+      assert_raises(Creator::Error, label.to_s) { validate_primary(invalid) }
+    end
+  end
+
+  def test_installation_contract_is_exact_typed_ordered_and_manifest_bound
+    fixture = valid_fixture
+    fixture.fetch(:installations).each do |kind, document|
+      result = Creator.validate_installation!(document:, kind:, manifest: fixture.fetch(:manifest), candidate_sha: SHA)
+      assert_snapshot(result)
+      assert_equal document, result.value
+    end
+    mutations = {
+      schema_float: ->(item) { item[:document]["schema_version"] = 1.0 },
+      inventory_order: ->(item) { item[:document]["inventory"].reverse! },
+      inventory_size_float: ->(item) { item[:document]["inventory"][0]["size"] = 1.0 },
+      required_roles_type: ->(item) { item[:document]["required_roles"] = [] },
+      missing_role: ->(item) { item[:document]["required_roles"].delete("executable") },
+      role_not_inventory: ->(item) { item[:document]["required_roles"]["executable"]["sha256"] = DIGEST },
+      closure: ->(item) { item[:document]["closure_sha256"] = DIGEST },
+      total_float: ->(item) { item[:document]["total_size"] = item[:document]["total_size"].to_f },
+      package: ->(item) { item[:document]["required_roles"]["package"]["sha256"] = DIGEST }
+    }
+    mutations.each do |label, mutate|
+      current = valid_fixture
+      item = { document: current.fetch(:installations).fetch("candidate"), manifest: current.fetch(:manifest) }
+      mutate.call(item)
+      assert_raises(Creator::Error, label.to_s) do
+        Creator.validate_installation!(document: item.fetch(:document), kind: "candidate",
+                                       manifest: item.fetch(:manifest), candidate_sha: SHA)
+      end
+    end
+  end
+
+  def test_execution_contract_binds_order_numeric_types_capture_digests_and_aggregates
+    fixture = valid_fixture
+    assert_snapshot(validate_execution(fixture))
+    mutations = {
+      schema_float: ->(item) { item[:receipt]["schema_version"] = 1.0 },
+      record_order: ->(item) { item[:receipt]["installed_manifests"].reverse! },
+      installation_records_type: ->(item) { item[:installation_records] = {} },
+      evidence_bundle_length: ->(item) { item[:row]["evidence_bundle"] = [] },
+      command_order: ->(item) { item[:receipt]["commands"].reverse! },
+      position_float: ->(item) { item[:receipt]["commands"][0]["position"] = 1.0 },
+      exit_float: ->(item) { item[:receipt]["commands"][0]["exit_code"] = 0.0 },
+      teardown_float: ->(item) { item[:receipt]["teardown"]["remaining_descendants"] = 0.0 },
+      capture_positive_empty_digest: lambda do |item|
+        item[:receipt]["commands"][0]["capture"]["stdout_bytes"] = 1
+      end,
+      capture_bytes_type: ->(item) { item[:receipt]["commands"][0]["capture"]["stdout_bytes"] = "1" },
+      capture_zero_nonempty_digest: lambda do |item|
+        item[:receipt]["commands"][0]["capture"]["stdout_sha256"] = Digest::SHA256.hexdigest("x")
+      end,
+      truncated_short: lambda do |item|
+        item[:receipt]["commands"][0]["capture"]["stdout_truncated"] = true
+      end,
+      instruction_binding: ->(item) { item[:receipt]["executed_instruction"]["sha256"] = DIGEST },
+      receipt_digest: ->(item) { item[:receipt_sha256] = DIGEST }
+    }
+    mutations.each do |label, mutate|
+      invalid = valid_fixture
+      mutate.call(invalid)
+      assert_raises(Creator::Error, label.to_s) { validate_execution(invalid) }
+    end
+  end
+
+  def test_core_clean_loads_alone_and_co_loads_with_untouched_proof_in_both_orders
+    scripts = [
+      "require './packaging/live_agent_skills/workflow_creator'",
+      "require './packaging/live_agent_skills/workflow_creator'; require './packaging/live_agent_skills/proof'",
+      "require './packaging/live_agent_skills/proof'; require './packaging/live_agent_skills/workflow_creator'"
+    ]
+    scripts.each do |script|
+      out, err, status = Open3.capture3(
+        RbConfig.ruby, "--disable-gems", "-I#{ROOT}", "-e",
+        "#{script}; puts HiveLiveAgentProof::WorkflowCreator::Vocabulary.fetch('schema_version')", chdir: ROOT
+      )
+      assert status.success?, err
+      assert_equal "1\n", out
+    end
+    SOURCES.each_value do |path|
+      source = File.read(path)
+      refute_match(/workflow_creator_bundle|release_candidate|proof\.rb/, source)
+    end
+  end
+
+  def test_r43_source_metrics_and_explicit_method_overlay_stay_within_budget
+    metrics = SOURCES.transform_values { |path| static_metrics(File.read(path)) }
+    expected_caps = {
+      "workflow_creator.rb" => [ 125, 7, 4 ],
+      "workflow_creator_contract.rb" => [ 260, 15, 24 ],
+      "workflow_creator_execution_contract.rb" => [ 215, 13, 20 ]
+    }
+    SOURCES.each do |name, path|
+      lines, callables, decisions = expected_caps.fetch(name)
+      assert_operator File.readlines(path).length, :<=, lines
+      assert_operator metrics.fetch(name).fetch(:callables), :<=, callables
+      assert_operator metrics.fetch(name).fetch(:decisions), :<=, decisions
+      assert_empty metrics.fetch(name).fetch(:closure_nodes)
+    end
+    assert_operator SOURCES.values.sum { |path| File.readlines(path).length }, :<=, 590
+    assert_operator metrics.values.sum { |item| item.fetch(:callables) }, :<=, 34
+    assert_operator metrics.values.sum { |item| item.fetch(:decisions) }, :<=, 48
+    values_path = File.join(ROOT, "packaging/live_agent_skills/workflow_creator_values.rb")
+    safety_path = File.join(ROOT, "packaging/live_agent_skills/workflow_creator_text_safety.rb")
+    values = static_metrics(File.read(values_path))
+    safety = static_metrics(File.read(safety_path))
+    composed_sources = SOURCES.values + [ values_path, safety_path ]
+    assert_operator composed_sources.sum { |path| File.readlines(path).length }, :<=, 1_090
+    assert_operator metrics.values.sum { |item| item.fetch(:callables) } + values.fetch(:callables) +
+                    safety.fetch(:callables), :<=, 68
+    assert_operator metrics.values.sum { |item| item.fetch(:decisions) } + values.fetch(:decisions) +
+                    safety.fetch(:decisions), :<=, 104
+    assert_r43_rubocop
+  end
+
+  private
+
+  def assert_snapshot(snapshot)
+    assert_equal "#<HiveLiveAgentProof::WorkflowCreator::Values snapshot>", snapshot.inspect
+    assert snapshot.frozen?
+    assert_deeply_frozen(snapshot.value)
+    assert snapshot.canonical_bytes.frozen?
+  end
+
+  def assert_deeply_frozen(value)
+    assert value.frozen?
+    case value
+    when Hash
+      value.each { |key, nested| assert_deeply_frozen(key); assert_deeply_frozen(nested) }
+    when Array
+      value.each { |nested| assert_deeply_frozen(nested) }
+    end
+  end
+
+  def validate_primary(fixture)
+    Creator.validate_primary!(row: fixture.fetch(:row), manifest: fixture.fetch(:manifest), candidate_sha: SHA,
+                              bundle_records: fixture.fetch(:bundle_records))
+  end
+
+  def validate_execution(fixture)
+    Creator.validate_execution!(
+      receipt: fixture.fetch(:receipt), row: fixture.fetch(:row), candidate_sha: SHA,
+      manifest: fixture.fetch(:manifest),
+      installation_records: fixture.fetch(:installation_records) { fixture.fetch(:bundle_records).first(2) },
+      receipt_sha256: fixture.fetch(:receipt_sha256),
+      candidate_installation: fixture.fetch(:installations).fetch("candidate"),
+      openclaw_installation: fixture.fetch(:installations).fetch("openclaw")
+    )
+  end
+
+  def valid_fixture
+    manifest = artifact_manifest
+    installations = %w[candidate openclaw].to_h { |kind| [ kind, installation(kind, manifest) ] }
+    records = installation_records(installations)
+    row = primary_row(manifest, records)
+    receipt = execution_receipt(row, records, installations)
+    bind_receipt!(row, records, receipt)
+    { manifest:, installations:, bundle_records: records, row:, receipt:,
+      receipt_sha256: records.fetch(2).fetch("sha256") }
+  end
+
+  def artifact_manifest
+    version = "1.2.3"
+    names = [ "hive-agent-skills-#{SHA}.tar.gz", "hive-cli-#{version}.gem", "hive-source-#{SHA}.tar.gz" ]
+    {
+      "schema" => "hive-live-agent-candidate-artifacts", "schema_version" => 1, "candidate_sha" => SHA,
+      "hive_version" => version, "skill_version" => "2026.8.4",
+      "canonical_digest" => Digest::SHA256.hexdigest("canonical"),
+      "files" => names.sort.to_h do |name|
+        [ name, { "sha256" => Digest::SHA256.hexdigest(name), "size" => name.bytesize } ]
+      end
+    }
+  end
+
+  def installation(kind, manifest)
+    roles = Creator::Vocabulary.fetch("member_roles").fetch(kind).to_h do |role|
+      path = role == "package" ? "packages/#{kind}.pkg" : "#{role}/fixture"
+      artifact = manifest.fetch("files").fetch("hive-cli-1.2.3.gem") if kind == "candidate" && role == "package"
+      [ role, { "path" => path, "sha256" => artifact&.fetch("sha256") || Digest::SHA256.hexdigest(path),
+                "size" => artifact&.fetch("size") || path.bytesize } ]
+    end
+    dependency = { "path" => "runtime/dependency.rb", "sha256" => Digest::SHA256.hexdigest("dependency"), "size" => 21 }
+    inventory = [ *roles.values.map { |record| deep_dup(record) }, dependency ].sort_by { |record| record.fetch("path") }
+    closure = { "required_roles" => roles, "inventory" => inventory }
+    {
+      "schema" => Creator::Vocabulary.fetch("installed_schema"), "schema_version" => 1,
+      "candidate_sha" => SHA, "kind" => kind,
+      "version" => kind == "candidate" ? manifest.fetch("hive_version") : "fixture-openclaw",
+      "closure_sha256" => Digest::SHA256.hexdigest(canonical(closure)), "required_roles" => roles,
+      "inventory" => inventory, "total_size" => inventory.sum { |record| record.fetch("size") },
+      "secret_scan" => passing_scan
+    }
+  end
+
+  def installation_records(installations)
+    %w[candidate openclaw].each_with_index.map do |kind, index|
+      bytes = canonical(installations.fetch(kind))
+      { "kind" => "#{kind}_installation", "path" => Creator::Vocabulary.fetch("bundle_files").fetch(index + 1),
+        "sha256" => Digest::SHA256.hexdigest(bytes), "size" => bytes.bytesize }
+    end << { "kind" => "execution_receipt", "path" => "execution-receipt.json",
+             "sha256" => Digest::SHA256.hexdigest("pending"), "size" => 1 }
+  end
+
+  def primary_row(manifest, records)
+    created = Creator::Vocabulary.fetch("files").map do |path|
+      { "path" => path, "sha256" => Digest::SHA256.hexdigest(path), "size" => path.bytesize }
+    end
+    summary = { "status" => "passed", "receipt_sha256" => records.fetch(2).fetch("sha256") }
+    {
+      "schema" => Creator::Vocabulary.fetch("evidence_schema"), "schema_version" => 1, "platform" => "openclaw",
+      "candidate_sha" => SHA, "result" => "passed",
+      "prompt_sha256" => Digest::SHA256.hexdigest(Creator::Vocabulary.fetch("prompt")),
+      "task_prompt_sha256" => Digest::SHA256.hexdigest(Creator::Vocabulary.fetch("task_prompt")),
+      "skill" => { "skill_version" => manifest.fetch("skill_version"),
+                   "canonical_digest" => manifest.fetch("canonical_digest") },
+      "native_activation" => deep_dup(Creator::Vocabulary.fetch("native_activation")),
+      "hive_commands" => deep_dup(Creator::Vocabulary.fetch("commands")), "created_files" => created,
+      "validation" => deep_dup(Creator::Vocabulary.fetch("graph")), "creation_only_task_count" => 0,
+      "task_count" => 1, "task" => deep_dup(Creator::Vocabulary.fetch("task")), "external_actions" => [],
+      "secret_scan" => passing_scan, "execution_kind" => "authenticated_openclaw", "model_loop" => "executed",
+      "executed_instruction" => deep_dup(created.fetch(2)), "evidence_bundle" => deep_dup(records),
+      "containment" => deep_dup(summary), "teardown" => deep_dup(summary), "cleanup" => deep_dup(summary)
+    }
+  end
+
+  def execution_receipt(row, records, installations)
+    command_labels = Creator::Vocabulary.fetch("commands").each_index.map { |index| format("command-%02d", index + 1) }
+    commands = Creator::Vocabulary.fetch("commands").each_with_index.map do |argv, index|
+      process_receipt("attempt_label" => command_labels.fetch(index)).merge(
+        "position" => index + 1, "argv" => deep_dup(argv)
+      )
+    end
+    outer = Creator::Vocabulary.fetch("outer_roles").each_with_index.map do |identity, index|
+      process_receipt("label" => %w[outer-workflow-creator outer-authorized-work].fetch(index)).merge(
+        deep_dup(identity), "argv_sha256" => Digest::SHA256.hexdigest("outer-#{index}")
+      )
+    end
+    labels = command_labels + outer.map { |process| process.fetch("label") }
+    correlation = "workflow-creator-proof-run"
+    packages = installations.values.map { |document| document.dig("required_roles", "package") }
+    archives = packages.each_with_index.map do |package, index|
+      { "label" => Creator::Vocabulary.fetch("archive_labels").fetch(index),
+        "artifact_sha256" => package.fetch("sha256"), "artifact_size" => package.fetch("size"),
+        "policy_sha256" => Creator::Vocabulary.fetch("archive_policy_sha256"),
+        "entry_count" => 5, "uncompressed_bytes" => 1_024, "status" => "passed" }
+    end
+    instruction = deep_dup(row.fetch("executed_instruction"))
+    {
+      "schema" => Creator::Vocabulary.fetch("execution_schema"), "schema_version" => 1,
+      "candidate_sha" => SHA, "result" => "passed", "execution_plan" => Creator::Vocabulary.fetch("execution_plan"),
+      "classification" => { "outer" => deep_dup(Creator::Vocabulary.fetch("classification")),
+                            "nested_stage" => { "execution_kind" => "deterministic_fixture",
+                                                "model_loop" => "not_exercised" } },
+      "installed_manifests" => deep_dup(records.first(2)),
+      "run" => { "correlation_id" => correlation, "expected_labels" => labels },
+      "gateway" => { "identity" => deep_dup(installations.fetch("candidate").dig("required_roles", "audit_gateway")),
+                     "command_labels" => command_labels, "status" => "passed" },
+      "archive_admissions" => archives, "commands" => commands, "outer_processes" => outer,
+      "authored_instruction" => deep_dup(instruction), "executed_instruction" => instruction,
+      "external_actions" => [],
+      "containment" => { "status" => "passed", "mechanism" => "supervised-process-tree",
+                         "established_before_launch" => true, "owner_correlation_id" => correlation,
+                         "root_loss_behavior" => "fail-closed" },
+      "teardown" => { "status" => "passed", "expected_labels" => labels, "receipt_labels" => deep_dup(labels),
+                      "outer_root_reaped" => true, "remaining_descendants" => 0 },
+      "cleanup" => { "status" => "passed", "targets" => [
+        { "label" => "proof-workspace", "path_sha256" => Digest::SHA256.hexdigest("workspace"),
+          "device" => 1, "inode" => 2, "created_by_run" => true, "identity_matched" => true, "removed" => true }
+      ] }, "secret_scan" => passing_scan
+    }
+  end
+
+  def process_receipt(label)
+    label.merge(
+      "exit_code" => 0, "signal" => nil, "completed" => true,
+      "capture" => { "limit_bytes" => 4_096, "stdout_bytes" => 0, "stderr_bytes" => 0,
+                     "stdout_sha256" => Digest::SHA256.hexdigest(""),
+                     "stderr_sha256" => Digest::SHA256.hexdigest(""),
+                     "stdout_truncated" => false, "stderr_truncated" => false, "secret_scan" => passing_scan },
+      "teardown" => { "status" => "passed", "term_sent" => false, "kill_sent" => false,
+                      "reaped" => true, "descendants" => "none", "owner_complete" => true }
+    )
+  end
+
+  def bind_receipt!(row, records, receipt)
+    bytes = canonical(receipt)
+    record = records.fetch(2)
+    record["sha256"], record["size"] = Digest::SHA256.hexdigest(bytes), bytes.bytesize
+    row.fetch("evidence_bundle")[2] = deep_dup(record)
+    summary = { "status" => "passed", "receipt_sha256" => record.fetch("sha256") }
+    %w[containment teardown cleanup].each { |field| row[field] = deep_dup(summary) }
+  end
+
+  def canonical(value) = Values.capture(value).canonical_bytes
+  def passing_scan = { "status" => "passed", "scanner" => Creator::Vocabulary.fetch("scanner") }
+  def deep_dup(value) = Marshal.load(Marshal.dump(value))
+
+  def poison(value, *names)
+    names.each { |name| value.define_singleton_method(name) { |*| raise "caller dispatch: #{name}" } }
+  end
+
+  def static_metrics(source)
+    syntax = Ripper.sexp(source) or raise "invalid Ruby source"
+    metrics = { callables: 0, decisions: 0, closure_nodes: [] }
+    walk = lambda do |node|
+      next unless node.instance_of?(Array)
+      type = node.first
+      metrics[:callables] += 1 if %i[def defs].include?(type)
+      if type == :lambda || proc_block_kind(node)
+        metrics[:callables] += 1
+        metrics[:closure_nodes] << type
+      end
+      metrics[:decisions] += 1 if DECISIONS.include?(type)
+      metrics[:decisions] += 1 if type == :binary && %i[&& ||].include?(node[2])
+      node.each { |child| walk.call(child) }
+    end
+    walk.call(syntax)
+    metrics
+  end
+
+  def proc_block_kind(node)
+    return unless node.first == :method_add_block
+    call = node[1]
+    identifiers = []
+    constants = []
+    collect = lambda do |child|
+      next unless child.instance_of?(Array)
+      identifiers << child[1] if child.first == :@ident
+      constants << child[1] if child.first == :@const
+      child.each { |nested| collect.call(nested) }
+    end
+    collect.call(call)
+    return :proc_new if constants.include?("Proc") && identifiers.include?("new")
+    :proc if identifiers.include?("lambda") || identifiers.include?("proc")
+  end
+
+  def assert_r43_rubocop
+    overlay = {
+      "AllCops" => { "TargetRubyVersion" => 3.4, "DisabledByDefault" => true, "NewCops" => "disable" },
+      "Metrics/CyclomaticComplexity" => { "Enabled" => true, "Max" => 15 },
+      "Metrics/PerceivedComplexity" => { "Enabled" => true, "Max" => 15 },
+      "Metrics/AbcSize" => { "Enabled" => true, "Max" => 25 },
+      "Metrics/MethodLength" => { "Enabled" => true, "Max" => 40 },
+      "Layout/LineLength" => { "Enabled" => true, "Max" => 120 }
+    }
+    Dir.mktmpdir do |directory|
+      config = File.join(directory, "u1a1c-rubocop.yml")
+      File.write(config, YAML.dump(overlay))
+      rubocop = File.join(Bundler.load.specs.find { |spec| spec.name == "rubocop" }.full_gem_path, "exe", "rubocop")
+      out, status = Open3.capture2e(RbConfig.ruby, rubocop, "--config", config, "--format", "simple", *SOURCES.values,
+                                    chdir: ROOT)
+      assert status.success?, out
+    end
+  end
+end

--- a/wiki/component-boundaries.md
+++ b/wiki/component-boundaries.md
@@ -3,7 +3,7 @@ title: Component boundaries
 type: reference
 source: config/component-boundaries.yml, test/support/component_boundary_contract.rb
 created: 2026-07-25
-updated: 2026-08-03
+updated: 2026-08-04
 tags: [architecture, components, boundaries, monorepo]
 ---
 
@@ -19,7 +19,8 @@ the first and primary consumer.
 |-----------|-------|---------------------|-------------------|
 | Patrol Effect Evidence | `candidate` (U3a protocol complete; U3b/U3c proof pending) | `require "hive/modules/migration/patrol_evidence"` → `Hive::Modules::Migration::PatrolEvidence` | [[modules/patrol]] |
 | Attempts admission / future RunReceipt | `candidate` (guarded reference) | `require "hive/attempts/api"` → `Hive::Attempts::API` | [[modules/attempts]] |
-| Workflow Creator Values | `candidate` (U1a1c consumer pending) | `require "packaging/live_agent_skills/workflow_creator_text_safety"` → `HiveLiveAgentProof::WorkflowCreator::TextSafety` | [[component-boundaries]] |
+| Workflow Creator Values | `boundary-ready` | `require "./packaging/live_agent_skills/workflow_creator_text_safety"` → `HiveLiveAgentProof::WorkflowCreator::TextSafety` | [[component-boundaries]] |
+| Workflow Creator Core | `candidate` (U1a2 consumer pending) | `require "./packaging/live_agent_skills/workflow_creator"` → `HiveLiveAgentProof::WorkflowCreator` | [[component-boundaries]] |
 | UserService | `boundary-ready` | `require "hive/user_service"` → `Hive::UserService` | [[modules/user_service]] |
 | Agent ABI | `boundary-ready`; standalone package candidate | `require "hive/agent_runtime"` → `Hive::AgentRuntime` | [[modules/agent_cli_runtime]], [[modules/agent_profile]] |
 | Agent Artifact Firewall | `boundary-ready` | `require "hive/artifact_firewall"` → `Hive::ArtifactFirewall` | [[modules/protected_files]] |
@@ -35,24 +36,23 @@ has earned a gem, version, repository, or release.
 
 ## Final graph audit
 
-The catalog on 2026-08-03 retains nine components: six are
-`boundary-ready`; Attempts, Patrol Effect Evidence, and Workflow Creator
-Values remain `candidate`. Patrol retains one bounded U3 exception for
-deterministic public-path and independently authorized installed/live proof.
-Workflow Creator Values
-retains one bounded U1a1c exception until its first production consumer lands.
+The catalog on 2026-08-04 retains ten components: seven are
+`boundary-ready`; Attempts, Patrol Effect Evidence, and Workflow Creator Core
+remain `candidate`. Patrol retains one bounded U3 exception for deterministic
+public-path and independently authorized installed/live proof. Workflow Creator
+Core retains one bounded U1a2 exception for custody and incumbent-consumer proof.
 Every retained entry point has focused clean-process load proof, every
 catalog-owned path and focused test resolves inside this repository, and the
 direct-construction guards pass against all production Ruby sources.
 
-The component dependency graph has one edge:
+The component dependency graph has two edges:
 
 ```mermaid
 flowchart LR
   skillpack[Skillpack] --> agent_abi[Agent ABI]
+  workflow_core[Workflow Creator Core - candidate] --> workflow_values[Workflow Creator Values]
   patrol_effects[Patrol Effect Evidence - candidate]
   attempts[Attempts admission - candidate]
-  workflow_values[Workflow Creator Values - candidate]
   user_service[UserService]
   artifact_firewall[Agent Artifact Firewall]
   git_gate[Safe Agent Git Gate]
@@ -62,12 +62,12 @@ flowchart LR
 All other cataloged components depend only on explicitly allowed lower-level
 Hive primitives. The source audit found no retained experimental facade outside
 the catalog: each promoted facade is owned by a catalog row and used by Hive,
-while Attempts, Patrol Effect Evidence, and Workflow Creator Values are
+while Attempts, Patrol Effect Evidence, and Workflow Creator Core are
 deliberately retained as guarded candidates rather than being promoted ahead
 of their remaining lifecycle, qualification, or consumer proof.
 
 This is an internal architecture verdict, not a packaging verdict. None of the
-six ready components currently has the named non-Hive adopter and independent
+seven ready components currently has the named non-Hive adopter and independent
 package proof required by the standalone-gem plan.
 
 `Patrol Effect Evidence` owns the immutable cross-product capture, selection,
@@ -167,7 +167,7 @@ its full lifecycle is a supported component boundary: the slice does not
 publish raw storage, reconciliation, supervision, capacity, loss-policy,
 cancellation, export, or generic lifecycle operations.
 
-`Workflow Creator Values` is a staged values-and-projection candidate. Its
+`Workflow Creator Values` is the boundary-ready values-and-projection seam. Its
 singular entry point is
 `HiveLiveAgentProof::WorkflowCreator::TextSafety`; loading it real-requires the
 sibling `Values` leaf so both public modules become available. `Values.capture`
@@ -177,6 +177,23 @@ canonical UTF-8 bytes. Unsupported subclasses, non-finite floats, ambiguous or
 invalid encodings, normalized-key collisions, cycles, and declared depth, node,
 source-byte, canonical-byte, logical-work, and integer-bit ceilings fail through
 one fixed secret-free error.
+
+`Workflow Creator Core` is its first production consumer and the only upward
+component edge. The core owns an immutable schema-v1 vocabulary and validates
+failed, primary, installed-closure, and declarative execution receipts only
+after caller values have been imported into owned snapshots. Successful
+validation returns the primary snapshot. Failure construction separately
+captures stable inputs and diagnostic detail, substitutes a fixed omitted-detail
+marker when projection exceeds its bounded work ceiling, and snapshots only the
+internally constructed result afterward. It owns no retention, publication,
+process, provider, credential, archive I/O, or recovery authority.
+
+The approved U1a1c budget re-scope permits only named private semantic-helper
+decomposition. Its ceilings are 125/7/4 for the facade, 260/15/24 for the
+contract, 215/13/20 for execution, 590/34/48 for U1a1c, and 1090/68/104 for the
+Values/TextSafety/Core composition (lines/callables/decisions). Public APIs,
+owned files, responsibilities, dependency direction, and decision ceilings did
+not widen.
 
 `TextSafety` projects exact frozen plain strings and arrays produced through a
 snapshot's `value`. That plain-shape check is a documented internal ownership
@@ -191,9 +208,10 @@ handles, and focused subprocess proof covers both load orders and post-load core
 replacement. The sources load without JSON, I/O, workflow, process, credential,
 or provider dependencies.
 
-The candidate still has no production consumer. Its sole migration exception is
-`removal_unit: U1a1c`; that unit must establish the first consumer before
-promotion. U1a1vt adds no creator schema, custody, publication, or live behavior.
+The Values seam now has its first production consumer and no migration
+exception. Workflow Creator Core retains `removal_unit: U1a2` until retained
+bundle custody and the first incumbent proof consumer land. U1a1vt adds no
+creator schema, custody, publication, or live behavior.
 The exact R43 proof is 298 lines / 20 callables / 32 decisions for `Values`, 200
 lines / 14 callables / 23 decisions for `TextSafety`, and 498 / 34 / 55 when
 composed. The Values source retains its leaf-local `Ripper.lex` no-require proof;
@@ -355,11 +373,12 @@ Run the focused contract with:
 bundle exec ruby -Itest -Ilib test/unit/component_boundaries_test.rb
 ```
 
-The Workflow Creator Values candidate does not widen this shared syntax guard
-or the generic component clean-loader. Its Values no-require proof, composed
+Workflow Creator Values now clean-loads through its repository-relative catalog
+entry point without widening the generic loader. Its Values no-require proof, composed
 R43 proof, direct entry-point load-order proof, and projection behavior live in
 `test/unit/packaging/workflow_creator_values_test.rb` and
-`test/unit/packaging/workflow_creator_text_safety_test.rb`.
+`test/unit/packaging/workflow_creator_text_safety_test.rb`; semantic-core proof
+lives in `test/unit/packaging/workflow_creator_core_test.rb`.
 
 The syntax scan is an architecture regression guard, not a Ruby sandbox. Its
 construction rule covers literal `Constant.new`, not aliases or factory

--- a/wiki/gaps.md
+++ b/wiki/gaps.md
@@ -995,3 +995,11 @@ mutated during this implementation. Before calling the operational path proven
 on every channel, run one disposable installed upgrade for brew, AUR, and bash
 and retain the updater plus migration output. This gap does not weaken the
 local command contract or its deterministic tests.
+
+## Workflow Creator semantic core awaits custody (2026-08-04)
+
+Workflow Creator Core is intentionally a semantic-only candidate until U1a2
+supplies retained-bundle custody and the first incumbent proof consumer. The
+current boundary proves immutable, caller-isolated schema validation but does
+not claim that `proof.rb` delegates to it or that validated receipt bytes are
+retained, published, or release-qualified.

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -3,7 +3,7 @@ title: hive Wiki
 type: index
 source: wiki/**/*.md
 created: 2026-05-14
-updated: 2026-08-03
+updated: 2026-08-04
 tags: [index, wiki]
 ---
 
@@ -14,20 +14,19 @@ proof, while built-in content/bench, installable Honeycomb, and owner-authored
 workflows use the same folder-backed execution model.
 
 Page count: 98
-Updated: 2026-08-03
+Updated: 2026-08-04
 
 Folder-as-agent workflow engine: a Ruby 3.4 / Thor CLI control plane where descriptor-backed workflows move task folders through filesystem stages, stage agents compile provider-neutral invocations through `Hive::AgentRuntime` and configurable AgentProfile adapters (`claude` default, `codex`, `pi`, `grok`), and `mv` between directories remains the approval primitive. The built-in `coding` workflow drives the nine-stage PR pipeline (`1-inbox` → `2-brainstorm` → `3-plan` → `4-execute` → `5-open-pr` → `6-review` → `7-artifacts` → `8-finalize` → `9-done`), while the built-in `content` and `bench` workflows and project-authored workflows share the same generic runner/status/action machinery. Agent operation is centered on the additive operational status contract, coherent daemon scheduler snapshots, bounded semantic `hive watch`, tokenized routine `hive act`, and stable-ID semantic E2E profiles; the legacy full JSON graph remains compatible. Hive packages one canonical operating skill projected to OpenClaw `/hive`, Claude `/hive`, Codex `$hive`, and Pi `/skill:hive`, with read-only `hive doctor`, consent-safe setup, deterministic trusted pre-release proof, and optional four-agent live diagnostics.
 
 Reusable mechanisms remain in this monorepo behind the canonical
-[[component-boundaries]] catalog. The nine-row internal graph has six
+[[component-boundaries]] catalog. The ten-row internal graph has seven
 `boundary-ready` facades—UserService, Agent ABI, Agent Artifact Firewall,
-Skillpack, Safe Agent Git Gate, and WorkLedger—and three guarded candidates:
-Attempts admission, Patrol Effect Evidence, and Workflow Creator Values/Text
-Safety.
-Skillpack's downward dependency on the Agent ABI is the only
-component-to-component edge. Patrol's U3 qualification fence and Workflow
-Creator Values/Text Safety's U1a1c consumer fence are the only migration
-exceptions. Hive
+Skillpack, Safe Agent Git Gate, WorkLedger, and Workflow Creator Values/Text
+Safety—and three guarded candidates: Attempts admission, Patrol Effect
+Evidence, and Workflow Creator Core. Skillpack's dependency on Agent ABI and
+the Core's dependency on Values are the two component edges. Patrol's U3
+qualification fence and Workflow Creator Core's U1a2 consumer fence are the
+only migration exceptions. Hive
 is the first and primary consumer, and internal readiness does not imply a gem,
 version, repository, or release.
 

--- a/wiki/log.d/20260804T120000Z-workflow-creator-semantic-core.md
+++ b/wiki/log.d/20260804T120000Z-workflow-creator-semantic-core.md
@@ -1,0 +1,15 @@
+---
+title: Workflow Creator semantic core
+type: change
+date: 2026-08-04
+---
+
+- Promoted Workflow Creator Values/Text Safety to `boundary-ready` after adding
+  its first one-way production consumer.
+- Added the `workflow-creator-core` candidate with an immutable vocabulary and
+  failed, primary, installed-closure, and declarative execution validation over
+  Values-owned snapshots.
+- Kept hostile/property campaigns opt-in; the normal focused contract is a
+  compact deterministic suite, and U1a2 retains the sole consumer fence.
+- Applied the approved helper-only budget re-scope without changing public,
+  file, responsibility, dependency, or decision fences.

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -3,7 +3,7 @@ title: Testing
 type: reference
 source: test/, Rakefile, bin/hive-eval, .rubocop.yml, .github/workflows/{ci,live-agent-skills,release-candidate,release}.yml, packaging/{live_agent_skills,release_candidate}/, config/brakeman.ignore
 created: 2026-04-25
-updated: 2026-08-03
+updated: 2026-08-04
 tags: [test, minitest, fixtures, honeycomb, agent-skills, component-boundaries, terminal-outcomes, release-proof]
 ---
 
@@ -134,6 +134,7 @@ removal units accept hierarchical plan IDs such as `U1a1c`:
 bundle exec ruby -Itest -Ilib test/unit/component_boundaries_test.rb
 bundle exec ruby -Itest test/unit/packaging/workflow_creator_values_test.rb
 bundle exec ruby -Itest test/unit/packaging/workflow_creator_text_safety_test.rb
+bundle exec ruby -Itest test/unit/packaging/workflow_creator_core_test.rb
 ```
 
 Ready components cannot depend on candidates. Forbidden-construction rules


### PR DESCRIPTION
## Summary

- add the reduced U1a1c Workflow Creator semantic core across three production files
- validate failed, primary, installation, and execution evidence as exact immutable snapshots
- register the core as a candidate component with only the Workflow Creator Values dependency
- normalize malformed JSON shapes to the declared `WorkflowCreator::Error` boundary

## Scope guard

- no filesystem, process, provider, credential, retention, publication, recovery, or bundle-custody authority
- no generic candidate require/path analyzer
- production source is 114 / 254 / 212 lines, 580 total under the approved 590-line cap
- U1a2 remains the explicit removal unit for the temporary candidate exception and first incumbent consumer

## Verification

- semantic core: 9 runs, 2,077 assertions, 0 failures/errors/skips
- component boundaries: 38 runs, 544 assertions, 0 failures/errors/skips
- exact R43 source and RuboCop overlays are enforced by the focused semantic-core test
- correctness, reliability/security, and architecture/cap reviews are clean at head `9f1447793`
- `git diff --check` and Ruby syntax checks pass

The hostile/property campaign remains opt-in through `rake test:hostile` and is not part of required CI. No broad, coverage, or hostile suite was run locally.
