### PR TITLE
fix(attempts): route module hooks through public facade

### DIFF
--- a/lib/hive/attempts/api.rb
+++ b/lib/hive/attempts/api.rb
@@ -42,6 +42,19 @@ module Hive
         )
       end
 
+      def dispatch_module_hook(project_root:, generation:, subject:, argv:,
+                               request_id:, provider:, interactive: false,
+                               predecessor_attempt_id: nil, retry_charge: 0,
+                               now: Time.now.utc)
+        daemon.dispatch_module_hook(
+          project_root: project_root, generation: generation, subject: subject,
+          argv: argv, request_id: request_id, provider: provider,
+          interactive: interactive,
+          predecessor_attempt_id: predecessor_attempt_id,
+          retry_charge: retry_charge, now: now
+        )
+      end
+
       private
 
       def foreground

--- a/test/unit/attempts/api_test.rb
+++ b/test/unit/attempts/api_test.rb
@@ -92,6 +92,53 @@ class AttemptsAPITest < Minitest::Test
     assert_equal "codex", call.fetch(:provider)
   end
 
+  def test_dispatch_module_hook_delegates_daemon_admission
+    daemon = Object.new
+    call = nil
+    daemon.define_singleton_method(:dispatch_module_hook) do |**attributes|
+      call = attributes
+      :accepted
+    end
+    api = Hive::Attempts::API.new(foreground: Object.new, daemon: daemon)
+
+    result = api.dispatch_module_hook(
+      project_root: "/repo",
+      argv: %w[hive __module-hook attempt-1],
+      generation: :generation,
+      subject: :subject,
+      request_id: "request-3",
+      provider: "internal",
+      interactive: false,
+      predecessor_attempt_id: "attempt-2",
+      retry_charge: 2,
+      now: Time.at(2).utc
+    )
+
+    assert_equal :accepted, result
+    assert_equal "/repo", call.fetch(:project_root)
+    assert_equal %w[hive __module-hook attempt-1], call.fetch(:argv)
+    assert_equal :generation, call.fetch(:generation)
+    assert_equal :subject, call.fetch(:subject)
+    assert_equal "request-3", call.fetch(:request_id)
+    assert_equal "internal", call.fetch(:provider)
+    assert_equal false, call.fetch(:interactive)
+    assert_equal "attempt-2", call.fetch(:predecessor_attempt_id)
+    assert_equal 2, call.fetch(:retry_charge)
+    assert_equal Time.at(2).utc, call.fetch(:now)
+
+    assert_raises(ArgumentError) do
+      api.dispatch_module_hook(
+        project_root: "/repo",
+        generation: :generation,
+        subject: :subject,
+        argv: %w[hive __module-hook attempt-1],
+        request_id: "request-4",
+        provider: "internal",
+        providre: "typo"
+      )
+    end
+  end
+
   def test_default_adapters_share_the_injected_store
     store = Object.new
     foreground_store = nil

--- a/wiki/log.d/20260804T061241Z-attempts-module-hook-facade.md
+++ b/wiki/log.d/20260804T061241Z-attempts-module-hook-facade.md
@@ -1,0 +1,13 @@
+---
+title: Route module hooks through the Attempts facade
+type: change
+date: 2026-08-04
+tags: [attempts, modules, daemon, admission]
+---
+
+- Added `Attempts::API#dispatch_module_hook` so the module daemon reaches the
+  configured durable-attempt adapter through the same stable facade as task
+  admission and recovery.
+- Kept the public keyword contract explicit and closed while adding focused
+  delegation and unknown-key coverage for the complete supported module-hook
+  admission payload.

--- a/wiki/modules/attempts.md
+++ b/wiki/modules/attempts.md
@@ -3,7 +3,7 @@ title: Durable task attempts
 type: module
 source: lib/hive/attempts/
 created: 2026-07-16
-updated: 2026-07-27
+updated: 2026-08-04
 tags: [attempts, ownership, leases, daemon, recovery]
 ---
 
@@ -17,7 +17,7 @@ reconciles and applies policy; it does not own or reap task agents.
 
 | Module | Responsibility |
 |--------|----------------|
-| `API` | Provide Hive commands, bot delivery, and daemon recovery with the stable admission operations `dispatch`, `dispatch_request`, and `dispatch_successor`, while keeping one injected store shared by its foreground and daemon adapters. |
+| `API` | Provide Hive commands, bot delivery, daemon recovery, and module-hook delivery with the stable admission operations `dispatch`, `dispatch_request`, `dispatch_successor`, and `dispatch_module_hook`, while keeping one injected store shared by its foreground and daemon adapters. |
 | `Contracts` | Define the public `ClientResult`, `DispatchResult`, and `UnsupportedDetachment` values independently of the internal client, dispatcher, and launcher implementations. |
 | `Record`, `Store` | Read and write only v3 records, perform locked guarded transitions with atomic write/fsync/rename persistence, and copy nested record/checkpoint/receipt values through `Hive::StringifyKeys`. The default store fails closed while an old v1 root remains; daemon/bot startup or explicit `hive migrate` owns the one-off mutation. |
 | `Capability`, `Context` | Generate one-time launch authority, authenticate the exact worker process/task/stage, revalidate generation at the mutation boundary, and expose process-local compatibility projections after transport variables are scrubbed. |
@@ -36,7 +36,8 @@ reconciles and applies policy; it does not own or reap task agents.
 its first and primary consumer: durable CLI commands call `dispatch`, bot and
 other local producers call the same operation non-interactively, and daemon
 queue delivery or loss recovery call `dispatch_request` and
-`dispatch_successor`. An injected `Store` is shared by both adapter paths.
+`dispatch_successor`; the module daemon calls `dispatch_module_hook` through
+the same facade. An injected `Store` is shared by both adapter paths.
 
 `Entrypoint` and `ConfiguredDispatcher` are internal adapters behind that
 boundary. `Dispatcher`, `DetachedLauncher`, `Client`, and the persistence
@@ -61,7 +62,8 @@ candidate because this guarded reference does not turn the full durable-attempt
 lifecycle into a supported component API:
 reconciliation, supervision, capacity, loss processing, cancellation, export,
 and raw store operations remain internal. The supported facade still has only
-`dispatch`, `dispatch_request`, and `dispatch_successor`; its clean-process
+`dispatch`, `dispatch_request`, `dispatch_successor`, and the module-specific
+`dispatch_module_hook`; its clean-process
 load brings in the result contracts without commands, stages, web code, or
 other candidate entry points.
 


### PR DESCRIPTION
## Summary

Daemon-driven module hooks now reach durable Attempts admission through the supported API instead of failing at a missing facade operation. The public method exposes a closed set of module-hook and retry fields, so misspelled or future internal keywords are rejected before delegation and dispatcher internals remain private.

Related: #937

## Validation

- Attempts API and configured-dispatcher tests: 10 runs, 62 assertions, zero failures
- Component-boundary and nearest module consumer tests: 70 runs, 713 assertions, zero failures
- Three independent architecture, correctness, and reliability/security lenses: clean after one bounded resolution
- No CI workflow changes; the U3b campaign remains opt-in
