### PR TITLE
feat(patrol): expose bounded qualification CLI facade

### DIFF
--- a/bin/hive
+++ b/bin/hive
@@ -440,7 +440,8 @@ def json_usage_error_contract(argv)
         argv, argv.index("migration") || command_index,
         value_options: %w[--reviewer]
       )
-      migration_action == "report" ? "hive-module-migration-report" : "hive-module-migration"
+      %w[report deterministic-qualification].include?(migration_action) ?
+        "hive-module-migration-report" : "hive-module-migration"
     else "hive-module-lifecycle"
     end
     return { schema: schema, error_kind: "usage" }

--- a/lib/hive/commands/module.rb
+++ b/lib/hive/commands/module.rb
@@ -130,7 +130,8 @@ module Hive
         when "doctor" then "hive-module-doctor"
         when "dry-run" then "hive-module-dry-run"
         when "migration"
-          @subject == "report" ? "hive-module-migration-report" : "hive-module-migration"
+          %w[report deterministic-qualification].include?(@subject) ?
+            "hive-module-migration-report" : "hive-module-migration"
         else "hive-module-lifecycle"
         end
       end

--- a/lib/hive/commands/module/base.rb
+++ b/lib/hive/commands/module/base.rb
@@ -2,6 +2,7 @@ require "digest"
 require "json"
 require "time"
 require "hive"
+require "hive/commands/module/errors"
 require "hive/config"
 require "hive/git_ops"
 require "hive/lock"
@@ -15,14 +16,6 @@ require "hive/workflow_package/managed_store"
 module Hive
   module Commands
     class Module
-      class ConsentRequired < Hive::Error
-        def exit_code = Hive::ExitCodes::USAGE
-      end
-
-      class OwnershipError < Hive::Error
-        def exit_code = Hive::ExitCodes::USAGE
-      end
-
       class Base
         def initialize(project_root:, json:, stdout:, stdin: $stdin, yes: false, dry_run: false,
                        receipt: nil, store: nil, committer: nil, inspector: nil)

--- a/lib/hive/commands/module/errors.rb
+++ b/lib/hive/commands/module/errors.rb
@@ -1,0 +1,15 @@
+require "hive"
+
+module Hive
+  module Commands
+    class Module
+      class ConsentRequired < Hive::Error
+        def exit_code = Hive::ExitCodes::USAGE
+      end
+
+      class OwnershipError < Hive::Error
+        def exit_code = Hive::ExitCodes::USAGE
+      end
+    end
+  end
+end

--- a/lib/hive/commands/module/migration.rb
+++ b/lib/hive/commands/module/migration.rb
@@ -1,7 +1,7 @@
 require "json"
 require "time"
 require "hive/config"
-require "hive/commands/module/base"
+require "hive/commands/module/errors"
 require "hive/modules/migration/patrols"
 require "hive/modules/migration/report"
 require "hive/modules/migration/shadow_comparator"

--- a/lib/hive/commands/module/migration.rb
+++ b/lib/hive/commands/module/migration.rb
@@ -1,6 +1,7 @@
 require "json"
 require "time"
 require "hive/config"
+require "hive/commands/module/base"
 require "hive/modules/migration/patrols"
 require "hive/modules/migration/report"
 require "hive/modules/migration/shadow_comparator"
@@ -10,30 +11,83 @@ module Hive
   module Commands
     class Module
       class Migration
-        ACTIONS = %w[status report cutover rollback].freeze
+        ACTIONS = %w[
+          status report cutover rollback deterministic-receipt
+          deterministic-qualification
+        ].freeze
+        MAX_REQUEST_BYTES = 16 * 1024 * 1024
 
-        def initialize(action, project_root:, json:, stdout:, yes: false, reviewer: nil, **)
+        def initialize(action, project_root:, json:, stdout:, stdin: $stdin, yes: false,
+                       reviewer: nil, **)
           @action = action.to_s
           @project_root = File.expand_path(project_root)
           @json = json
           @stdout = stdout
+          @stdin = stdin
           @yes = yes
           @reviewer = reviewer
         end
 
         def call
           unless ACTIONS.include?(@action)
-            raise UsageError, "module migration requires status, report, cutover, or rollback"
+            raise UsageError,
+                  "module migration requires status, report, cutover, rollback, " \
+                  "deterministic-receipt, or deterministic-qualification"
           end
           case @action
           when "status" then emit_state(read_state)
           when "report" then build_report
           when "cutover" then cutover
           when "rollback" then rollback
+          when "deterministic-receipt" then deterministic_receipt
+          when "deterministic-qualification" then deterministic_qualification
           end
         end
 
         private
+
+        def deterministic_receipt
+          request = read_request!(%w[metadata selector])
+          receipt = Hive::Modules::Migration::Patrols.deterministic_receipt_for!(
+            @project_root, selector: request.fetch("selector"),
+            metadata: request.fetch("metadata"), hive_state_path: hive_state_path
+          )
+          emit(receipt, "Patrol deterministic evidence receipt")
+        end
+
+        def deterministic_qualification
+          require_confirmation!("admit deterministic patrol qualification")
+          request = read_request!(
+            %w[expected_bindings expected_report_digest generated_at receipts]
+          )
+          projection = Hive::Modules::Migration::Patrols.admit_deterministic_qualification!(
+            @project_root, receipts: request.fetch("receipts"),
+            expected_bindings: request.fetch("expected_bindings"),
+            generated_at: request.fetch("generated_at"),
+            expected_report_digest: request.fetch("expected_report_digest"),
+            hive_state_path: hive_state_path
+          )
+          emit(projection.to_h, "Patrol deterministic qualification admitted")
+        end
+
+        def read_request!(expected_keys)
+          bytes = @stdin.read(MAX_REQUEST_BYTES + 1).to_s
+          if bytes.bytesize > MAX_REQUEST_BYTES
+            raise Hive::ConfigError,
+                  "module migration request exceeds #{MAX_REQUEST_BYTES} bytes"
+          end
+          text = bytes.dup.force_encoding(Encoding::UTF_8)
+          unless text.valid_encoding?
+            raise Hive::ConfigError, "module migration request must be valid UTF-8 JSON"
+          end
+          request = JSON.parse(text)
+          unless request.is_a?(Hash) && request.keys.sort == expected_keys
+            raise Hive::ConfigError, "module migration request has unexpected keys"
+          end
+          request
+        rescue JSON::ParserError, EncodingError
+          raise Hive::ConfigError, "module migration request must be one JSON object"
+        end
 
         def build_report
           require_confirmation!("review shadow evidence")

--- a/test/integration/module_cli_usage_test.rb
+++ b/test/integration/module_cli_usage_test.rb
@@ -8,6 +8,7 @@ class ModuleCliUsageTest < Minitest::Test
       [ %w[module list extra extra --json], "hive-module-list" ],
       [ %w[module migration status extra --json], "hive-module-migration" ],
       [ %w[module migration report extra --json], "hive-module-migration-report" ],
+      [ %w[module migration deterministic-qualification extra --json], "hive-module-migration-report" ],
       [ %w[module unknown --json], "hive-module-lifecycle" ]
     ].each do |argv, schema|
       out, _err, status = Open3.capture3(File.expand_path("../../bin/hive", __dir__), *argv)
@@ -17,5 +18,18 @@ class ModuleCliUsageTest < Minitest::Test
       refute documents.first.fetch("ok")
       assert_equal Hive::ExitCodes::USAGE, status.exitstatus
     end
+  end
+
+  def test_qualification_runtime_failure_uses_report_v2_error_contract
+    out, _err, status = Open3.capture3(
+      File.expand_path("../../bin/hive", __dir__), "module", "migration",
+      "deterministic-qualification", "--yes", "--json", stdin_data: "{"
+    )
+    document = JSON.parse(out)
+
+    assert_equal "hive-module-migration-report", document.fetch("schema")
+    assert_equal 2, document.fetch("schema_version")
+    refute document.fetch("ok")
+    refute status.success?
   end
 end

--- a/test/unit/commands/module_command_test.rb
+++ b/test/unit/commands/module_command_test.rb
@@ -117,7 +117,8 @@ class ModuleCommandTest < Minitest::Test
       [ "doctor", "demo" ] => "hive-module-doctor",
       [ "dry-run", "demo" ] => "hive-module-dry-run",
       [ "migration", "status" ] => "hive-module-migration",
-      [ "migration", "report" ] => "hive-module-migration-report"
+      [ "migration", "report" ] => "hive-module-migration-report",
+      [ "migration", "deterministic-qualification" ] => "hive-module-migration-report"
     }
     mappings.each do |(verb, subject), schema|
       command = Hive::Commands::Module.new(verb, subject, project_root: "/project")

--- a/test/unit/commands/module_migration_test.rb
+++ b/test/unit/commands/module_migration_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "open3"
 require "hive/commands/module/migration"
 
 class ModuleMigrationCommandTest < Minitest::Test
@@ -184,6 +185,17 @@ class ModuleMigrationCommandTest < Minitest::Test
     end
     assert_equal Hive::ExitCodes::USAGE, error.exit_code
     assert_match(/deterministic-receipt, or deterministic-qualification/, error.message)
+  end
+
+  def test_migration_load_does_not_load_the_module_lifecycle_base
+    script = <<~RUBY
+      $LOAD_PATH.unshift(#{File.expand_path("../../../lib", __dir__).inspect})
+      require "hive/commands/module/migration"
+      abort "module lifecycle base loaded" if $LOADED_FEATURES.any? { |path| path.end_with?("/hive/commands/module/base.rb") }
+    RUBY
+    _out, err, status = Open3.capture3(RbConfig.ruby, "-e", script)
+
+    assert status.success?, err
   end
 
   private

--- a/test/unit/commands/module_migration_test.rb
+++ b/test/unit/commands/module_migration_test.rb
@@ -70,11 +70,128 @@ class ModuleMigrationCommandTest < Minitest::Test
     end
   end
 
+  def test_deterministic_receipt_delegates_and_emits_the_receipt
+    with_tmp_dir do |project|
+      selector = { "module" => "patrol", "trigger_id" => "trigger-1" }
+      metadata = { "configuration_digest" => "config", "repository" => { "id" => "repo" } }
+      receipt = { "schema" => "hive-patrol-evidence-receipt", "schema_version" => 1 }
+      arguments = nil
+      migration = command(
+        "deterministic-receipt", project, yes: false,
+        stdin: StringIO.new(JSON.generate("selector" => selector, "metadata" => metadata))
+      )
+      migration.define_singleton_method(:hive_state_path) { "/state" }
+
+      replacement = lambda do |root, selector:, metadata:, hive_state_path:|
+        arguments = [ root, selector, metadata, hive_state_path ]
+        receipt
+      end
+      with_singleton_method(Hive::Modules::Migration::Patrols, :deterministic_receipt_for!, replacement) do
+        assert_equal receipt, migration.call
+      end
+
+      assert_equal [ File.expand_path(project), selector, metadata, "/state" ], arguments
+      assert_equal receipt, JSON.parse(migration.instance_variable_get(:@stdout).string)
+    end
+  end
+
+  def test_deterministic_qualification_requires_confirmation_then_delegates
+    with_tmp_dir do |project|
+      request = {
+        "receipts" => [ { "receipt" => 1 } ],
+        "expected_bindings" => [ { "binding" => 1 } ],
+        "generated_at" => "2026-08-04T00:00:00Z",
+        "expected_report_digest" => "a" * 64
+      }
+      denied = command(
+        "deterministic-qualification", project, yes: false,
+        stdin: StringIO.new(JSON.generate(request))
+      )
+      assert_raises(Hive::Commands::Module::ConsentRequired) { denied.call }
+
+      report = { "schema" => "hive-module-migration-report", "schema_version" => 2 }
+      projection = Struct.new(:to_h).new(report)
+      arguments = nil
+      migration = command(
+        "deterministic-qualification", project, yes: true,
+        stdin: StringIO.new(JSON.generate(request))
+      )
+      migration.define_singleton_method(:hive_state_path) { "/state" }
+      replacement = lambda do |root, receipts:, expected_bindings:, generated_at:,
+                              expected_report_digest:, hive_state_path:|
+        arguments = [
+          root, receipts, expected_bindings, generated_at,
+          expected_report_digest, hive_state_path
+        ]
+        projection
+      end
+      with_singleton_method(Hive::Modules::Migration::Patrols, :admit_deterministic_qualification!, replacement) do
+        assert_equal report, migration.call
+      end
+
+      assert_equal [
+        File.expand_path(project), request.fetch("receipts"),
+        request.fetch("expected_bindings"), request.fetch("generated_at"),
+        request.fetch("expected_report_digest"), "/state"
+      ], arguments
+      assert_equal report, JSON.parse(migration.instance_variable_get(:@stdout).string)
+    end
+  end
+
+  def test_deterministic_input_is_bounded_strict_utf8_json_object
+    with_tmp_dir do |project|
+      invalid_inputs = [
+        " " * (Hive::Commands::Module::Migration::MAX_REQUEST_BYTES + 1),
+        "{",
+        "[]",
+        "\xFF".b
+      ]
+      invalid_inputs.each do |input|
+        migration = command(
+          "deterministic-receipt", project, yes: false, stdin: StringIO.new(input)
+        )
+        assert_raises(Hive::ConfigError) { migration.call }
+      end
+    end
+  end
+
+  def test_deterministic_input_rejects_extra_top_level_keys
+    with_tmp_dir do |project|
+      receipt_request = { "selector" => {}, "metadata" => {}, "extra" => true }
+      qualification_request = {
+        "receipts" => [], "expected_bindings" => [], "generated_at" => "now",
+        "expected_report_digest" => "a" * 64, "extra" => true
+      }
+
+      assert_raises(Hive::ConfigError) do
+        command(
+          "deterministic-receipt", project, yes: false,
+          stdin: StringIO.new(JSON.generate(receipt_request))
+        ).call
+      end
+      assert_raises(Hive::ConfigError) do
+        command(
+          "deterministic-qualification", project, yes: true,
+          stdin: StringIO.new(JSON.generate(qualification_request))
+        ).call
+      end
+    end
+  end
+
+  def test_unknown_action_error_lists_all_actions
+    error = assert_raises(Hive::Error) do
+      command("unknown", Dir.pwd, yes: false).call
+    end
+    assert_equal Hive::ExitCodes::USAGE, error.exit_code
+    assert_match(/deterministic-receipt, or deterministic-qualification/, error.message)
+  end
+
   private
 
-  def command(action, project, yes:, json: true)
+  def command(action, project, yes:, json: true, stdin: StringIO.new)
     Hive::Commands::Module::Migration.new(
-      action, project_root: project, json: json, stdout: StringIO.new, yes: yes
+      action, project_root: project, json: json, stdout: StringIO.new, stdin: stdin,
+      yes: yes
     )
   end
 

--- a/wiki/log.d/20260804T091833Z-patrol-qualification-cli-facade.md
+++ b/wiki/log.d/20260804T091833Z-patrol-qualification-cli-facade.md
@@ -1,0 +1,12 @@
+---
+title: Add bounded Patrol qualification CLI facade
+type: added
+date: 2026-08-04
+---
+
+- Add internal deterministic receipt and qualification migration actions that
+  accept one bounded, strict UTF-8, exact-key JSON object from stdin.
+- Delegate receipt construction and confirmed qualification admission to the
+  existing Patrols facades and emit their existing receipt/report documents.
+- Reject oversized, malformed, non-object, and extra-key requests without
+  adding request files, schemas, stores, runners, or lifecycle authority.

--- a/wiki/log.d/20260804T091833Z-patrol-qualification-cli-facade.md
+++ b/wiki/log.d/20260804T091833Z-patrol-qualification-cli-facade.md
@@ -8,5 +8,7 @@ date: 2026-08-04
   accept one bounded, strict UTF-8, exact-key JSON object from stdin.
 - Delegate receipt construction and confirmed qualification admission to the
   existing Patrols facades and emit their existing receipt/report documents.
+- Keep the facade independent of the lifecycle/store base and route
+  qualification failures through the same report-v2 schema as successes.
 - Reject oversized, malformed, non-object, and extra-key requests without
   adding request files, schemas, stores, runners, or lifecycle authority.

--- a/wiki/modules/patrol.md
+++ b/wiki/modules/patrol.md
@@ -85,7 +85,8 @@ The internal `hive module migration deterministic-receipt` and
 `deterministic-qualification` actions expose only those two facades. They read
 one exact-key, strict UTF-8 JSON object from bounded stdin; qualification also
 requires `--yes`. They accept no request path and add no runner, store, or
-cutover authority.
+cutover authority. Their command layer loads only shared lightweight errors,
+not the module lifecycle/store base.
 
 ## State
 

--- a/wiki/modules/patrol.md
+++ b/wiki/modules/patrol.md
@@ -81,6 +81,12 @@ receipt documents plus independently computed expected bindings, constructs no
 scenario or collector, and owns only verification, deterministic qualification,
 and digest-CAS report-v2 merge.
 
+The internal `hive module migration deterministic-receipt` and
+`deterministic-qualification` actions expose only those two facades. They read
+one exact-key, strict UTF-8 JSON object from bounded stdin; qualification also
+requires `--yes`. They accept no request path and add no runner, store, or
+cutover authority.
+
 ## State
 
 Patrol state is deliberately inspectable and removable:

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -188,7 +188,9 @@ strict JSON-schema composition with the U2 values, complete released-v1 migratio
 source/archive/receipt linkage, interrupted receipt repair, reverse digest CAS,
 descriptor-safe shared locking, stable-admission restoration after interrupted
 upgrade, typed report-v2 cutover refusal, and report migration from every stable
-Patrol adoption state. They do not execute a
+Patrol adoption state. The focused module-migration command test also pins the
+bounded strict-UTF-8 stdin facade, exact top-level request keys, delegation,
+result projection, and deterministic-qualification consent gate. They do not execute a
 scenario, launch a provider, produce installed/live qualification, or exercise
 authorized cutover and rollback:
 


### PR DESCRIPTION
## Summary

Patrol's deterministic evidence and admission paths can now be exercised through the installed Hive CLI. This lets the reduced U3b qualification campaign test the public boundary without constructing migration stores or other production internals.

The two internal actions accept one bounded, strict UTF-8, exact-key JSON document from stdin and delegate to the existing Patrol facades; qualification additionally requires explicit `--yes` consent. Qualification successes and failures share the report-v2 machine contract, while the command adapter loads only lightweight shared errors rather than the module lifecycle/store base.

## Validation

- Focused command, router, base, and integration coverage: 20 runs, 143 assertions, 0 failures or errors.
- Broad local checkpoint: 12,068 runs, 155,995 assertions, 0 failures or errors, 10 intentional skips.
- RuboCop could not run locally because its executable is not installed in this worktree's locked bundle; hosted CI remains the lint authority.

## Post-Deploy Monitoring & Validation

- Search CLI reports for `deterministic-receipt`, `deterministic-qualification`, `module migration request`, and `hive-module-migration-report` during the next U3b campaign and release-candidate run.
- Healthy: receipts use the existing receipt-v1 schema; qualification success and error documents use report-v2; malformed input fails closed; existing status/report/cutover/rollback behavior remains green.
- Failure trigger: a generic migration-v1 qualification error, lifecycle/store loading from the facade, or any existing migration-action regression. Mitigation is to revert this PR before running the U3b campaign.
- Validation window and owner: the next U3b qualification run through the first release candidate, owned by the Hive maintainers.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
