### PR TITLE
test(patrol): add reduced installed-CLI qualification smoke

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -122,6 +122,16 @@ namespace :e2e do
   task :clean do
     ruby "bin/hive-e2e", "clean"
   end
+
+  Rake::TestTask.new(:patrol_qualification_reduced) do |t|
+    t.libs << "test"
+    t.libs << "lib"
+    t.test_files = FileList[
+      "test/e2e/qualification/patrol_qualification_test.rb"
+    ]
+    t.warning = false
+    t.description = "Run the opt-in reduced installed-CLI Patrol qualification smoke"
+  end
 end
 
 task "test:require_nonempty_ci_gate" do

--- a/test/e2e/fixtures/patrol_qualification/catalog.json
+++ b/test/e2e/fixtures/patrol_qualification/catalog.json
@@ -1,0 +1,46 @@
+{
+  "schema": "hive-patrol-reduced-qualification-catalog",
+  "schema_version": 1,
+  "expectations": {
+    "patrol": {
+      "decision_count": 10,
+      "decision_classes": ["disabled", "due", "not_due"],
+      "repository_sha_count": 2,
+      "change_window_count": 10
+    },
+    "architecture-patrol": {
+      "decision_count": 10,
+      "decision_classes": ["manual_complete", "manual_recovered"],
+      "repository_sha_count": 10,
+      "change_window_count": 10
+    }
+  },
+  "cases": [
+    {"id": "ordinary-01", "module": "patrol", "decision_class": "due", "fault": "none", "proof_kind": "e2e"},
+    {"id": "ordinary-02", "module": "patrol", "decision_class": "due", "fault": "provider_failure", "proof_kind": "e2e"},
+    {"id": "ordinary-03", "module": "patrol", "decision_class": "due", "fault": "post_reservation_capture_decision_restart", "proof_kind": "e2e"},
+    {"id": "ordinary-04", "module": "patrol", "decision_class": "disabled", "fault": "none", "proof_kind": "e2e"},
+    {"id": "ordinary-05", "module": "patrol", "decision_class": "not_due", "fault": "none", "proof_kind": "e2e"},
+    {"id": "ordinary-06", "module": "patrol", "decision_class": "due", "fault": "none", "proof_kind": "e2e"},
+    {"id": "ordinary-07", "module": "patrol", "decision_class": "disabled", "fault": "none", "proof_kind": "e2e"},
+    {"id": "ordinary-08", "module": "patrol", "decision_class": "not_due", "fault": "none", "proof_kind": "e2e"},
+    {"id": "ordinary-09", "module": "patrol", "decision_class": "due", "fault": "none", "proof_kind": "e2e"},
+    {"id": "ordinary-10", "module": "patrol", "decision_class": "not_due", "fault": "none", "proof_kind": "e2e"},
+    {"id": "architecture-01", "module": "architecture-patrol", "decision_class": "manual_complete", "fault": "none", "proof_kind": "e2e"},
+    {"id": "architecture-02", "module": "architecture-patrol", "decision_class": "manual_complete", "fault": "cli_failure", "proof_kind": "e2e"},
+    {"id": "architecture-03", "module": "architecture-patrol", "decision_class": "manual_recovered", "fault": "released_attempt_retry", "proof_kind": "e2e"},
+    {"id": "architecture-04", "module": "architecture-patrol", "decision_class": "manual_complete", "fault": "finalized_outbox_reconciliation_recovery", "proof_kind": "e2e"},
+    {"id": "architecture-05", "module": "architecture-patrol", "decision_class": "manual_complete", "fault": "none", "proof_kind": "e2e"},
+    {"id": "architecture-06", "module": "architecture-patrol", "decision_class": "manual_recovered", "fault": "released_attempt_retry", "proof_kind": "e2e"},
+    {"id": "architecture-07", "module": "architecture-patrol", "decision_class": "manual_complete", "fault": "none", "proof_kind": "e2e"},
+    {"id": "architecture-08", "module": "architecture-patrol", "decision_class": "manual_recovered", "fault": "released_attempt_retry", "proof_kind": "e2e"},
+    {"id": "architecture-09", "module": "architecture-patrol", "decision_class": "manual_complete", "fault": "none", "proof_kind": "e2e"},
+    {"id": "architecture-10", "module": "architecture-patrol", "decision_class": "manual_recovered", "fault": "released_attempt_retry", "proof_kind": "e2e"}
+  ],
+  "contracts": [
+    {"id": "capture-decision-persistence", "proof_kind": "focused_test", "test_file": "test/unit/modules/migration/occurrence_journal_test.rb", "test_method": "test_finalization_replay_uses_exact_capture_and_event_bytes"},
+    {"id": "module-projection-persistence", "proof_kind": "focused_test", "test_file": "test/unit/daemon/patrol_scheduler_test.rb", "test_method": "test_projection_recovery_drains_every_pending_occurrence_before_ownership_gate"},
+    {"id": "effect-intent-uncertain-dispatch", "proof_kind": "focused_test", "test_file": "test/unit/refactor_patrol/effect_gateway_test.rb", "test_method": "test_crashed_uncertainty_requires_exact_reconciliation"},
+    {"id": "github-shim-barrier", "proof_kind": "focused_test", "test_file": "test/e2e/lib/gh_stub_test.rb", "test_method": "test_absent_mismatched_and_exhausted_scripts_fail_closed_without_fallback"}
+  ]
+}

--- a/test/e2e/lib/patrol_qualification.rb
+++ b/test/e2e/lib/patrol_qualification.rb
@@ -1,0 +1,720 @@
+require "digest"
+require "fileutils"
+require "json"
+require "open3"
+require "rbconfig"
+require "tmpdir"
+require "time"
+require "yaml"
+
+module Hive
+  module E2E
+    # Reduced, opt-in U3b successor. It qualifies real persisted shadow records
+    # through an exact archived/installed candidate's public CLI. It does not
+    # manufacture Patrol state or claim that same-head controls are independent.
+    module PatrolQualification
+      MODULES = %w[architecture-patrol patrol].freeze
+      EXTERNAL_FAULTS = %w[
+        cli_failure finalized_outbox_reconciliation_recovery none
+        post_reservation_capture_decision_restart provider_failure released_attempt_retry
+      ].freeze
+      MAX_STREAM_BYTES = 1 * 1024 * 1024
+      MAX_STDIN_BYTES = 8 * 1024 * 1024
+      MAX_EVIDENCE_BYTES = 512 * 1024
+      CHILD_TIMEOUT = 30.0
+
+      class Error < StandardError; end
+      class ChildTimeout < Error; end
+      class CampaignTimeout < Error; end
+
+      class ProcessFailure < Error
+        attr_reader :kind, :status
+
+        def initialize(kind, status, label)
+          @kind = kind
+          @status = status
+          super("#{label} failed (#{kind}=#{status})")
+        end
+      end
+
+      Result = Data.define(:stdout, :stderr, :status)
+      Case = Data.define(:id, :module_name, :decision_class, :fault)
+
+      module_function
+
+      def canonical(value)
+        JSON.generate(canonical_value(value)) + "\n"
+      end
+
+      def canonical_value(value)
+        case value
+        when Hash
+          value.keys.map(&:to_s).sort.to_h do |key|
+            original = value.key?(key) ? key : value.keys.find { |item| item.to_s == key }
+            [ key, canonical_value(value.fetch(original)) ]
+          end
+        when Array then value.map { |item| canonical_value(item) }
+        else value
+        end
+      end
+
+      class Catalog
+        attr_reader :cases, :contracts, :expectations, :bytes
+
+        def self.load(path)
+          stat = File.lstat(path)
+          raise Error, "qualification catalogue must be a bounded regular file" unless
+            stat.file? && !stat.symlink? && stat.size <= MAX_EVIDENCE_BYTES
+          new(File.binread(path))
+        rescue SystemCallError => e
+          raise Error, "qualification catalogue is unreadable: #{e.message}"
+        end
+
+        def initialize(bytes)
+          @bytes = bytes.freeze
+          data = JSON.parse(bytes)
+          exact_keys!(data, %w[cases contracts expectations schema schema_version])
+          unless data["schema"] == "hive-patrol-reduced-qualification-catalog" &&
+                 data["schema_version"] == 1
+            raise Error, "qualification catalogue schema is unsupported"
+          end
+          @cases = data.fetch("cases").map { |row| parse_case(row) }.freeze
+          @contracts = data.fetch("contracts").map { |row| parse_contract(row) }.freeze
+          @expectations = parse_expectations(data.fetch("expectations")).freeze
+          validate_inventory!
+        rescue JSON::ParserError, KeyError, TypeError => e
+          raise Error, "qualification catalogue is malformed: #{e.message}"
+        end
+
+        private
+
+        def parse_case(row)
+          exact_keys!(row, %w[decision_class fault id module proof_kind])
+          valid = row["proof_kind"] == "e2e" && safe_id?(row["id"]) &&
+            MODULES.include?(row["module"]) && EXTERNAL_FAULTS.include?(row["fault"]) &&
+            nonempty?(row["decision_class"])
+          raise Error, "qualification E2E case is malformed" unless valid
+
+          Case.new(row["id"], row["module"], row["decision_class"], row["fault"]).freeze
+        end
+
+        def parse_contract(row)
+          exact_keys!(row, %w[id proof_kind test_file test_method])
+          valid = safe_id?(row["id"]) && row["proof_kind"] == "focused_test" &&
+            row["test_file"].to_s.start_with?("test/") &&
+            row["test_method"].to_s.match?(/\Atest_[a-z0-9_]+\z/)
+          raise Error, "qualification focused-test contract is malformed" unless valid
+          row.freeze
+        end
+
+        def parse_expectations(value)
+          exact_keys!(value, MODULES)
+          value.to_h do |name, row|
+            exact_keys!(row, %w[change_window_count decision_classes decision_count repository_sha_count])
+            valid = row.values_at("decision_count", "repository_sha_count", "change_window_count")
+                       .all? { |number| number.is_a?(Integer) && number.positive? } &&
+              row["decision_classes"].is_a?(Array) &&
+              row["decision_classes"].all? { |item| nonempty?(item) }
+            raise Error, "qualification expectation is malformed" unless valid
+            [ name, row.freeze ]
+          end
+        end
+
+        def validate_inventory!
+          ids = cases.map(&:id) + contracts.map { |row| row.fetch("id") }
+          raise Error, "qualification IDs are not unique" unless ids.uniq == ids
+          MODULES.each do |name|
+            rows = cases.select { |row| row.module_name == name }
+            expected = expectations.fetch(name)
+            raise Error, "qualification case cardinality differs for #{name}" unless
+              rows.size == expected.fetch("decision_count")
+            raise Error, "qualification decision classes differ for #{name}" unless
+              rows.map(&:decision_class).uniq.sort == expected.fetch("decision_classes").sort
+          end
+        end
+
+        def exact_keys!(value, keys)
+          raise Error, "qualification catalogue keys are malformed" unless
+            value.is_a?(Hash) && value.keys.sort == keys.sort
+        end
+
+        def safe_id?(value) = value.is_a?(String) && value.match?(/\A[a-z0-9]+(?:-[a-z0-9]+)*\z/)
+        def nonempty?(value) = value.is_a?(String) && !value.empty?
+      end
+
+      class ChildProcess
+        def initialize(deadline:, env:)
+          @deadline = deadline
+          @env = env.freeze
+        end
+
+        def run(*command, label:, cwd:, stdin_data: "", timeout: CHILD_TIMEOUT)
+          raise Error, "#{label} stdin exceeds its bound" if stdin_data.bytesize > MAX_STDIN_BYTES
+          remaining = @deadline - monotonic
+          raise CampaignTimeout, "qualification campaign deadline expired" unless remaining.positive?
+          campaign_limited = remaining <= timeout
+          limit = [ remaining, timeout ].min
+          command_deadline = monotonic + limit
+          stdout = +""
+          stderr = +""
+          status = nil
+          pid = nil
+          cleaned_up = false
+          streams = []
+          workers = []
+          Open3.popen3(@env, *command, chdir: cwd, pgroup: true, unsetenv_others: true) do |input, out, err, wait|
+            pid = wait.pid
+            input.binmode
+            streams = [ input, out, err ]
+            workers = [ Thread.new { drain(out, stdout) }, Thread.new { drain(err, stderr) } ]
+            workers << Thread.new do
+              input.write(stdin_data)
+            rescue Errno::EPIPE, IOError
+              nil
+            ensure
+              close(input)
+            end
+            workers.each { |thread| thread.report_on_exception = false }
+            unless wait.join(limit)
+              terminate_group(pid)
+              streams.each { |io| close(io) }
+              join_until(workers, monotonic + 0.5)
+              cleaned_up = true
+              raise(campaign_limited ? CampaignTimeout : ChildTimeout,
+                    "#{label} exceeded #{limit.round(3)} seconds")
+            end
+            status = wait.value
+            unless join_until(workers, command_deadline)
+              terminate_group(pid)
+              streams.each { |io| close(io) }
+              join_until(workers, monotonic + 0.5)
+              raise(campaign_limited ? CampaignTimeout : ChildTimeout,
+                    "#{label} did not close its process streams before the deadline")
+            end
+          end
+          unless status.success?
+            kind, value = status.signaled? ? [ "signal", status.termsig ] : [ "exit", status.exitstatus ]
+            raise ProcessFailure.new(kind, value, label)
+          end
+          Result.new(stdout.freeze, stderr.freeze, status.exitstatus).freeze
+        rescue SystemCallError => e
+          raise ProcessFailure.new("spawn", e.class.name, label)
+        ensure
+          if pid && status.nil? && !cleaned_up
+            terminate_group(pid)
+            streams.each { |io| close(io) }
+            join_until(workers, monotonic + 0.5)
+          end
+        end
+
+        private
+
+        def drain(io, destination)
+          while (chunk = io.read(16 * 1024))
+            remaining = MAX_STREAM_BYTES - destination.bytesize
+            destination << chunk.byteslice(0, remaining) if remaining.positive?
+          end
+        rescue IOError
+          nil
+        end
+
+        def terminate_group(pid)
+          Process.kill("TERM", -pid)
+          deadline = monotonic + 0.5
+          sleep 0.02 while monotonic < deadline && process_group_alive?(pid)
+          Process.kill("KILL", -pid) if process_group_alive?(pid)
+          Process.waitpid(pid) rescue nil
+        rescue Errno::ESRCH, Errno::ECHILD
+          nil
+        end
+
+        def process_group_alive?(pid)
+          Process.kill(0, -pid)
+          true
+        rescue Errno::ESRCH
+          false
+        end
+
+        def join_until(threads, deadline)
+          threads.each do |thread|
+            remaining = deadline - monotonic
+            break unless remaining.positive?
+            thread.join(remaining)
+          end
+          threads.none?(&:alive?)
+        end
+
+        def close(io)
+          io.close unless io.closed?
+        rescue IOError, SystemCallError
+          nil
+        end
+
+        def monotonic = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      end
+
+      class ObservationReader
+        attr_reader :bytes
+
+        OBSERVATION_KEYS = %w[
+          change_window fault_observed id process_outcomes repository_sha trigger_id
+        ].freeze
+        OUTCOME_KEYS = %w[kind status].freeze
+        OUTCOME_KINDS = %w[child_timeout exit signal].freeze
+
+        def initialize(project_root:, observations_path:, catalog:)
+          @project_root = File.expand_path(project_root)
+          @catalog = catalog
+          @observations = read_observations(observations_path)
+        end
+
+        def each
+          records = comparable_records
+          selected = []
+          @catalog.cases.each do |case_row|
+            observation = @observations.fetch(case_row.id)
+            unless observation.fetch("fault_observed") == case_row.fault
+              raise Error, "#{case_row.id} fault observation differs from the catalogue"
+            end
+            matches = records.select do |record|
+              record.fetch("module") == case_row.module_name &&
+                record.dig("trigger", "id") == observation.fetch("trigger_id")
+            end
+            raise Error, "#{case_row.id} does not select exactly one shadow record" unless matches.one?
+            record = matches.first
+            unless record.dig("module_decision", "rationale") == case_row.decision_class
+              raise Error, "#{case_row.id} decision class differs from the catalogue"
+            end
+            selected << [ record.fetch("module"), record.dig("trigger", "id") ]
+            yield case_row, observation, record
+          end
+          unless selected.uniq.size == records.size
+            raise Error, "qualification selectors do not cover each shadow record exactly once"
+          end
+          validate_cardinality!(records)
+        end
+
+        private
+
+        def read_observations(path)
+          stat = File.lstat(path)
+          unless stat.file? && !stat.symlink? && stat.size <= MAX_EVIDENCE_BYTES
+            raise Error, "qualification observations must be a bounded regular file"
+          end
+          @bytes = File.binread(path).freeze
+          data = JSON.parse(@bytes)
+          unless data.is_a?(Hash) && data.keys.sort == %w[cases schema schema_version] &&
+                 data["schema"] == "hive-patrol-reduced-observations" && data["schema_version"] == 1
+            raise Error, "qualification observations are malformed"
+          end
+          rows = data.fetch("cases")
+          result = rows.to_h do |row|
+            raise Error, "qualification observation keys are malformed" unless
+              row.is_a?(Hash) && row.keys.sort == OBSERVATION_KEYS
+            valid = row["repository_sha"].to_s.match?(/\A[0-9a-f]{40}\z/) &&
+              EXTERNAL_FAULTS.include?(row["fault_observed"]) &&
+              [ row["id"], row["trigger_id"], row["change_window"] ].all? { |item| item.is_a?(String) && !item.empty? }
+            valid &&= valid_process_outcomes?(row)
+            raise Error, "qualification observation is malformed" unless valid
+            [ row.fetch("id"), row.freeze ]
+          end
+          raise Error, "qualification observation IDs differ from the catalogue" unless
+            result.keys.sort == @catalog.cases.map(&:id).sort
+          result.freeze
+        rescue JSON::ParserError, KeyError => e
+          raise Error, "qualification observations are malformed: #{e.message}"
+        end
+
+        def valid_process_outcomes?(row)
+          outcomes = row["process_outcomes"]
+          return false unless outcomes.is_a?(Array) && !outcomes.empty? && outcomes.size <= 4
+          return false unless outcomes.all? do |outcome|
+            outcome.is_a?(Hash) && outcome.keys.sort == OUTCOME_KEYS &&
+              OUTCOME_KINDS.include?(outcome["kind"]) &&
+              outcome["status"].is_a?(Integer) && outcome["status"].between?(0, 255)
+          end
+
+          failed = ->(outcome) { outcome["kind"] != "exit" || outcome["status"] != 0 }
+          successful = ->(outcome) { outcome == { "kind" => "exit", "status" => 0 } }
+          case row.fetch("fault_observed")
+          when "none" then outcomes.one? && successful.call(outcomes.first)
+          when "provider_failure", "cli_failure" then outcomes.any? { |item| failed.call(item) }
+          when "post_reservation_capture_decision_restart"
+            outcomes.first["kind"] == "signal" && outcomes.any? { |item| successful.call(item) }
+          when "released_attempt_retry"
+            outcomes.size >= 2 && failed.call(outcomes.first) && successful.call(outcomes.last)
+          when "finalized_outbox_reconciliation_recovery"
+            outcomes.size >= 2 && outcomes.first["kind"] == "signal" && successful.call(outcomes.last)
+          else false
+          end
+        end
+
+        def comparable_records
+          root = File.join(state_path, "module-runtime", "migration", "shadow")
+          records = []
+          extra = false
+          MODULES.each do |name|
+            Dir.glob(File.join(root, name, "*.json")) do |path|
+              stat = File.lstat(path)
+              raise Error, "shadow evidence is not a bounded regular file" unless
+                stat.file? && !stat.symlink? && stat.size <= MAX_EVIDENCE_BYTES
+              bytes = File.binread(path)
+              record = JSON.parse(bytes)
+              unless bytes == PatrolQualification.canonical(record)
+                raise Error, "shadow evidence is not canonical JSON"
+              end
+              next unless record["comparable"] == true && record["legacy_capture"]
+
+              if records.size < @catalog.cases.size
+                records << record
+              else
+                extra = true
+              end
+            end
+          end
+          raise Error, "shadow evidence contains extra or missing comparable records" unless
+            !extra && records.size == @catalog.cases.size
+          records
+        rescue JSON::ParserError, SystemCallError, TypeError => e
+          raise Error, "shadow evidence is unreadable: #{e.message}"
+        end
+
+        def validate_cardinality!(records)
+          MODULES.each do |name|
+            rows = records.select { |record| record.fetch("module") == name }
+            observations = @catalog.cases.select { |item| item.module_name == name }
+                                        .map { |item| @observations.fetch(item.id) }
+            expected = @catalog.expectations.fetch(name)
+            actual = {
+              "decision_count" => rows.size,
+              "repository_sha_count" => observations.map { |row| row.fetch("repository_sha") }.uniq.size,
+              "change_window_count" => observations.map { |row| row.fetch("change_window") }.uniq.size
+            }
+            actual.each do |key, value|
+              raise Error, "#{name} #{key} differs from the catalogue" unless value == expected.fetch(key)
+            end
+            classes = rows.map { |record| record.dig("module_decision", "rationale") }.uniq.sort
+            raise Error, "#{name} decision classes differ from the catalogue" unless
+              classes == expected.fetch("decision_classes").sort
+            configurations = rows.map { |record| record["configuration_digest"] }.uniq
+            raise Error, "#{name} configuration is missing or changed" unless
+              configurations.one? && configurations.first.to_s.match?(/\A[0-9a-f]{64}\z/)
+          end
+        end
+
+        def state_path
+          config = YAML.safe_load(File.binread(File.join(@project_root, ".hive-state", "config.yml"))) || {}
+          File.expand_path(config.fetch("hive_state_path", ".hive-state"), @project_root)
+        rescue Psych::Exception, SystemCallError
+          File.join(@project_root, ".hive-state")
+        end
+      end
+
+      class Controller
+        def initialize(repo_root:, project_root:, hive_home:, observations_path:, evidence_root:,
+                       campaign_timeout: 300.0, child_timeout: CHILD_TIMEOUT)
+          @repo_root = File.expand_path(repo_root)
+          @project_root = File.expand_path(project_root)
+          @hive_home = File.expand_path(hive_home)
+          @observations_path = File.expand_path(observations_path)
+          @evidence_root = File.expand_path(evidence_root)
+          @deadline = monotonic + campaign_timeout
+          @child_timeout = child_timeout
+        end
+
+        def run!
+          catalog_path = File.join(@repo_root, "test/e2e/fixtures/patrol_qualification/catalog.json")
+          catalog = Catalog.load(catalog_path)
+          Dir.mktmpdir("hive-patrol-u3br") do |run_root|
+            setup_process(run_root)
+            candidate = materialize_candidate(run_root)
+            install_candidate(candidate, run_root)
+            catalog_repo = build_module_catalog(candidate, run_root)
+            install_modules(catalog_repo)
+            prepared = collect_receipts(catalog, candidate)
+            report = admit_qualification(prepared)
+            proof = proof(candidate, catalog, report, prepared)
+            write_evidence(proof)
+            proof
+          rescue StandardError => e
+            write_evidence("status" => "failed", "error_class" => e.class.name,
+                           "error" => e.message.to_s.byteslice(0, 2048))
+            raise
+          end
+        end
+
+        private
+
+        def setup_process(run_root)
+          @env = {
+            "HOME" => @hive_home, "HIVE_HOME" => @hive_home,
+            "HIVE_SKIP_LLM_WIKI_SCHEDULER" => "1", "HIVE_SKIP_LLM_WIKI_SYSTEMCTL" => "1",
+            "HIVE_SKIP_LLM_WIKI_POST_COMMIT" => "1", "LANG" => "C.UTF-8", "LC_ALL" => "C.UTF-8",
+            "PATH" => [ File.dirname(RbConfig.ruby), "/usr/bin", "/bin" ].join(":"),
+            "TMPDIR" => run_root
+          }.freeze
+          @process = ChildProcess.new(deadline: @deadline, env: @env)
+        end
+
+        def materialize_candidate(run_root)
+          status = run("git", "-C", @repo_root, "status", "--porcelain", "--untracked-files=all",
+                       label: "inspect candidate").stdout
+          raise Error, "qualification requires a clean candidate checkout" unless status.empty?
+          sha = run("git", "-C", @repo_root, "rev-parse", "HEAD", label: "resolve candidate").stdout.strip
+          raise Error, "candidate HEAD is not a full SHA" unless sha.match?(/\A[0-9a-f]{40}\z/)
+          archive = File.join(run_root, "candidate.tar")
+          run("git", "-C", @repo_root, "archive", "--format=tar", "--output", archive, sha,
+              label: "archive candidate")
+          root = File.join(run_root, "candidate")
+          FileUtils.mkdir_p(root)
+          run("tar", "-xf", archive, "-C", root, label: "materialize candidate")
+          { "sha" => sha, "archive_sha256" => Digest::SHA256.file(archive).hexdigest, "root" => root }
+        end
+
+        def install_candidate(candidate, run_root)
+          gem_file = File.join(run_root, "candidate.gem")
+          run("gem", "build", "hive.gemspec", "--output", gem_file,
+              cwd: candidate.fetch("root"), label: "build candidate gem")
+          install_root = File.join(run_root, "installed")
+          installer = File.join(candidate.fetch("root"), "packaging/live_agent_skills/install_candidate_gem.sh")
+          run("/bin/bash", installer, gem_file, install_root, label: "install candidate gem")
+          @hive_bin = File.join(install_root, "bin", "hive")
+          stat = File.lstat(@hive_bin)
+          unless stat.file? && !stat.symlink? && File.executable?(@hive_bin)
+            raise Error, "candidate installer did not publish a regular bin/hive"
+          end
+          candidate["gem_sha256"] = Digest::SHA256.file(gem_file).hexdigest
+          candidate["installed_hive_sha256"] = Digest::SHA256.file(@hive_bin).hexdigest
+        end
+
+        def build_module_catalog(candidate, run_root)
+          root = File.join(run_root, "catalog")
+          entries = MODULES.map do |name|
+            source = File.join(candidate.fetch("root"), "modules", name)
+            manifest = YAML.safe_load(File.binread(File.join(source, "manifest.yml")))
+            version = manifest.fetch("version")
+            destination = File.join(root, "modules", name, version)
+            FileUtils.mkdir_p(File.dirname(destination))
+            FileUtils.cp_r(source, destination)
+            {
+              "name" => name, "version" => version, "latest_version" => version,
+              "type" => manifest.fetch("type"), "description" => manifest.fetch("description"),
+              "state" => "listed", "discoverable" => true,
+              "source_sha" => manifest.dig("source", "revision"),
+              "manifest_sha256" => manifest.fetch("release_sha256"),
+              "package_path" => "modules/#{name}/#{version}"
+            }
+          end
+          @catalog_manifests = entries.to_h { |entry| [ entry.fetch("name"), entry ] }
+          File.binwrite(File.join(root, "catalog.json"), PatrolQualification.canonical(
+            "schema" => "honeycomb-catalog/v3", "entries" => entries
+          ))
+          run("git", "init", "-b", "main", "--quiet", cwd: root, label: "initialize local catalog")
+          run("git", "add", "--", ".", cwd: root, label: "stage local catalog")
+          run("git", "-c", "user.email=qualification@example.invalid",
+              "-c", "user.name=Hive qualification", "-c", "commit.gpgsign=false",
+              "commit", "-m", "qualification catalog", "--quiet",
+              cwd: root, label: "commit local catalog")
+          @catalog_commit = run("git", "rev-parse", "HEAD", cwd: root, label: "resolve local catalog").stdout.strip
+          root
+        end
+
+        def install_modules(catalog_repo)
+          rewrite = {
+            "GIT_CONFIG_COUNT" => "1",
+            "GIT_CONFIG_KEY_0" => "url.file://#{catalog_repo}/.insteadOf",
+            "GIT_CONFIG_VALUE_0" => "https://github.com/ivankuznetsov/honeycomb.git"
+          }
+          MODULES.each do |name|
+            version = @catalog_manifests.fetch(name).fetch("version")
+            manifest = YAML.safe_load(File.binread(File.join(catalog_repo, "modules", name, version, "manifest.yml")))
+            choices = install_choices(manifest)
+            preview = hive([ "module", "install", "honeycomb/#{name}@#{manifest.fetch('version')}",
+                             "--dry-run", "--json", *choices ], env: rewrite)
+            receipt = JSON.parse(preview.stdout).fetch("preview_receipt")
+            hive([ "module", "install", "honeycomb/#{name}@#{manifest.fetch('version')}",
+                   "--yes", "--receipt", receipt, "--json", *choices ], env: rewrite)
+          end
+        end
+
+        def install_choices(manifest)
+          settings = manifest.fetch("settings").flat_map do |item|
+            [ "--setting", "#{item.fetch('name')}=#{item.fetch('default')}" ]
+          end
+          hooks = manifest.fetch("hooks").flat_map do |item|
+            enabled = item.fetch("id").start_with?("scheduled-") || item.fetch("default_enabled")
+            [ "--hook", "#{item.fetch('id')}=#{enabled ? 'enabled' : 'disabled'}" ]
+          end
+          grants = manifest.fetch("permissions").flat_map do |key, value|
+            values = value.is_a?(Array) ? value : [ value ]
+            values.map { |item| [ "--grant", "#{key}=#{item}" ] }
+          end
+          settings + hooks + grants.flatten
+        end
+
+        def collect_receipts(catalog, candidate)
+          reader = ObservationReader.new(project_root: @project_root,
+                                         observations_path: @observations_path,
+                                         catalog: catalog)
+          catalog_digest = Digest::SHA256.hexdigest(catalog.bytes)
+          common = {
+            "run_id" => "u3br-#{candidate.fetch('sha')[0, 12]}",
+            "candidate_sha" => candidate.fetch("sha"),
+            "catalog_digest" => catalog_digest,
+            "source_digest" => candidate.fetch("archive_sha256"),
+            "manifest_digest" => Digest::SHA256.hexdigest(MODULES.map { |name|
+              File.binread(File.join(candidate.fetch("root"), "modules", name, "manifest.yml"))
+            }.join("\0")),
+            "scenario_manifest_digest" => Digest::SHA256.hexdigest(catalog.bytes + "\0" + reader.bytes),
+            "artifacts" => [
+              { "kind" => "candidate_archive", "digest" => candidate.fetch("archive_sha256") },
+              { "kind" => "scenario_catalog", "digest" => catalog_digest }
+            ],
+            "reviewer" => "hive-e2e/u3br"
+          }
+          generated_at = Time.now.utc.iso8601(6)
+          prepared = []
+          case_results = []
+          reader.each do |case_row, observation, record|
+            expected = expected_receipt(common, case_row, observation, record, generated_at)
+            request = { "selector" => { "module" => case_row.module_name,
+                                        "trigger_id" => observation.fetch("trigger_id") },
+                        "metadata" => expected.reject { |key, _| %w[receipt_id capture module_projection effects].include?(key) } }
+            request.fetch("metadata").delete("schema")
+            request.fetch("metadata").delete("schema_version")
+            observed = JSON.parse(hive([ "module", "migration", "deterministic-receipt", "--json" ],
+                                       stdin_data: JSON.generate(request)).stdout)
+            raise Error, "#{case_row.id} public receipt differs from the read-only control" unless
+              PatrolQualification.canonical(observed) == PatrolQualification.canonical(expected)
+            prepared << [ expected, expected_bindings(expected) ]
+            case_results << {
+              "id" => case_row.id, "module" => case_row.module_name,
+              "fault" => case_row.fault,
+              "process_outcomes" => observation.fetch("process_outcomes")
+            }
+          end
+          { "receipts" => prepared.map(&:first), "bindings" => prepared.map(&:last),
+            "case_results" => case_results.sort_by { |row| row.fetch("id") },
+            "generated_at" => generated_at }
+        end
+
+        def expected_receipt(common, case_row, observation, record, generated_at)
+          capture = record.fetch("legacy_capture")
+          effects = (record.fetch("legacy_effects") + record.fetch("module_effects"))
+                    .sort_by { |effect| effect.fetch("receipt_id") }
+          repository = { "id" => capture.dig("project", "repository"),
+                         "sha" => observation.fetch("repository_sha"),
+                         "change_window" => observation.fetch("change_window") }
+          payload = common.merge(
+            "schema" => "hive-patrol-evidence-receipt", "schema_version" => 1,
+            "configuration_digest" => record.fetch("configuration_digest"),
+            "repository" => repository, "capture" => capture,
+            "module_projection" => record.fetch("module_decision"),
+            "decision_class" => case_row.decision_class, "effects" => effects,
+            "fault_steps" => case_row.fault == "none" ? [] : [ case_row.fault ],
+            "generated_at" => generated_at, "reviewed_at" => generated_at
+          )
+          payload.merge("receipt_id" => "evidence-#{Digest::SHA256.hexdigest(PatrolQualification.canonical(payload))}")
+        end
+
+        def expected_bindings(document)
+          capture = document.fetch("capture")
+          projection = document.fetch("module_projection")
+          document.slice(
+            "run_id", "candidate_sha", "catalog_digest", "source_digest", "manifest_digest",
+            "configuration_digest", "scenario_manifest_digest", "repository", "receipt_id",
+            "decision_class", "fault_steps", "artifacts", "reviewer", "generated_at", "reviewed_at"
+          ).merge(
+            "capture_id" => capture.fetch("capture_id"),
+            "trigger_id" => capture.dig("trigger", "id"),
+            "owner_epoch" => capture.fetch("owner_epoch"),
+            "module_projection_digest" => Digest::SHA256.hexdigest(PatrolQualification.canonical(projection)),
+            "effect_receipt_ids" => document.fetch("effects").map { |effect| effect.fetch("receipt_id") }
+          )
+        end
+
+        def admit_qualification(prepared)
+          report_path = File.join(state_path, "module-runtime", "migration", "report.json")
+          request = {
+            "expected_bindings" => prepared.fetch("bindings"),
+            "expected_report_digest" => Digest::SHA256.file(report_path).hexdigest,
+            "generated_at" => prepared.fetch("generated_at"),
+            "receipts" => prepared.fetch("receipts")
+          }
+          JSON.parse(hive([ "module", "migration", "deterministic-qualification", "--yes", "--json" ],
+                          stdin_data: JSON.generate(request)).stdout)
+        end
+
+        def proof(candidate, catalog, report, prepared)
+          lane = report.fetch("lanes").fetch("deterministic")
+          raise Error, "reduced deterministic evidence did not qualify" unless lane.fetch("status") == "qualified"
+          MODULES.each do |name|
+            expected = catalog.expectations.fetch(name).fetch("decision_count")
+            raise Error, "qualified #{name} decision count differs" unless
+              lane.dig("modules", name, "decision_count") == expected
+          end
+          case_results = prepared.fetch("case_results").sort_by { |row| row.fetch("id") }
+          unless case_results.map { |row| row.fetch("id") } == catalog.cases.map(&:id).sort
+            raise Error, "retained case results differ from the qualification catalogue"
+          end
+          {
+            "schema" => "hive-patrol-reduced-qualification-proof", "schema_version" => 1,
+            "status" => "qualified_smoke", "candidate_sha" => candidate.fetch("sha"),
+            "archive_sha256" => candidate.fetch("archive_sha256"), "gem_sha256" => candidate.fetch("gem_sha256"),
+            "installed_hive_sha256" => candidate.fetch("installed_hive_sha256"),
+            "catalog_commit" => @catalog_commit, "receipt_count" => prepared.fetch("receipts").size,
+            "e2e_case_count" => catalog.cases.size,
+            "focused_contract_count" => catalog.contracts.size,
+            "case_results" => case_results,
+            "qualification_id" => lane.fetch("qualification_id"),
+            "claim_fences" => [
+              "not_full_u3b", "not_u3c_installed_live", "same_candidate_controls_not_independent",
+              "prepared_records_not_fresh_scheduler_matrix"
+            ]
+          }
+        end
+
+        def write_evidence(value)
+          redacted = redact(value)
+          bytes = PatrolQualification.canonical(redacted)
+          raise Error, "qualification evidence exceeds its bound" if bytes.bytesize > MAX_EVIDENCE_BYTES
+          if bytes.match?(/(?:ghp_|github_pat_|sk-[A-Za-z0-9]|BEGIN (?:RSA |OPENSSH )?PRIVATE KEY)/)
+            raise Error, "qualification evidence contains a secret pattern"
+          end
+          FileUtils.mkdir_p(@evidence_root, mode: 0o700)
+          path = File.join(@evidence_root, "patrol-u3br-#{Time.now.utc.strftime('%Y%m%dT%H%M%SZ')}-#{Process.pid}.json")
+          File.open(path, File::WRONLY | File::CREAT | File::EXCL, 0o600) { |file| file.write(bytes) }
+          path
+        end
+
+        def redact(value)
+          case value
+          when Hash
+            value.to_h do |key, child|
+              [ key, key.to_s.match?(/token|secret|password|credential/i) ? "[REDACTED]" : redact(child) ]
+            end
+          when Array then value.map { |child| redact(child) }
+          else value
+          end
+        end
+
+        def state_path
+          config = YAML.safe_load(File.binread(File.join(@project_root, ".hive-state", "config.yml"))) || {}
+          File.expand_path(config.fetch("hive_state_path", ".hive-state"), @project_root)
+        end
+
+        def hive(args, stdin_data: "", env: {})
+          run(@hive_bin, *args, cwd: @project_root, stdin_data: stdin_data, env: env,
+              label: "installed hive #{args.first(3).join(' ')}")
+        end
+
+        def run(*command, label:, cwd: @repo_root, stdin_data: "", env: {})
+          process = env.empty? ? @process : ChildProcess.new(deadline: @deadline, env: @env.merge(env))
+          process.run(*command, label: label, cwd: cwd, stdin_data: stdin_data, timeout: @child_timeout)
+        end
+
+        def monotonic = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      end
+    end
+  end
+end

--- a/test/e2e/lib/patrol_qualification.rb
+++ b/test/e2e/lib/patrol_qualification.rb
@@ -308,6 +308,14 @@ module Hive
             raise Error, "qualification observations are malformed"
           end
           rows = data.fetch("cases")
+          raise Error, "qualification observation cardinality is malformed" unless rows.is_a?(Array)
+          ids = rows.map { |row| row.is_a?(Hash) ? row["id"] : nil }
+          unless ids.none?(&:nil?) && ids.uniq.size == ids.size
+            raise Error, "qualification observation IDs are duplicated"
+          end
+          unless rows.size == @catalog.cases.size
+            raise Error, "qualification observation cardinality is malformed"
+          end
           result = rows.to_h do |row|
             raise Error, "qualification observation keys are malformed" unless
               row.is_a?(Hash) && row.keys.sort == OBSERVATION_KEYS
@@ -529,12 +537,65 @@ module Hive
             version = @catalog_manifests.fetch(name).fetch("version")
             manifest = YAML.safe_load(File.binread(File.join(catalog_repo, "modules", name, version, "manifest.yml")))
             choices = install_choices(manifest)
-            preview = hive([ "module", "install", "honeycomb/#{name}@#{manifest.fetch('version')}",
-                             "--dry-run", "--json", *choices ], env: rewrite)
-            receipt = JSON.parse(preview.stdout).fetch("preview_receipt")
-            hive([ "module", "install", "honeycomb/#{name}@#{manifest.fetch('version')}",
-                   "--yes", "--receipt", receipt, "--json", *choices ], env: rewrite)
+            source = "honeycomb/#{name}@#{manifest.fetch('version')}"
+            preview = JSON.parse(
+              hive([ "module", "install", source, "--dry-run", "--json", *choices ],
+                   env: rewrite).stdout
+            )
+            validate_lifecycle!(preview, name:, statuses: [ "preview" ])
+            unless preview["preview_receipt"].to_s.match?(/\A[0-9]+\.[0-9a-f]{64}\z/) &&
+                   preview["configuration_digest"].to_s.match?(/\A[0-9a-f]{64}\z/)
+              raise Error, "#{name} module preview identity is malformed"
+            end
+            expected = {
+              "version" => version, "catalog_commit" => @catalog_commit,
+              "source_commit" => @catalog_manifests.fetch(name).fetch("source_sha"),
+              "manifest_digest" => @catalog_manifests.fetch(name).fetch("manifest_sha256"),
+              "configuration_digest" => preview.fetch("configuration_digest")
+            }
+            apply = JSON.parse(
+              hive([ "module", "install", source, "--yes", "--receipt",
+                     preview.fetch("preview_receipt"), "--json", *choices ],
+                   env: rewrite).stdout
+            )
+            validate_lifecycle!(apply, name:, statuses: %w[installed already_current])
+            validate_generation!(apply.dig("selection", "active"), expected, name:)
+            inspected = JSON.parse(hive([ "module", "inspect", name, "--json" ]).stdout)
+            validate_inspection!(inspected, name:, expected:)
           end
+        end
+
+        def validate_lifecycle!(payload, name:, statuses:)
+          valid = payload.is_a?(Hash) &&
+            payload["schema"] == "hive-module-lifecycle" &&
+            payload["schema_version"] == 1 && payload["ok"] == true &&
+            payload["operation"] == "install" && payload["name"] == name &&
+            statuses.include?(payload["status"])
+          raise Error, "#{name} module lifecycle response is malformed" unless valid
+        end
+
+        def validate_generation!(generation, expected, name:)
+          unless generation.is_a?(Hash) && generation.keys.sort == expected.keys.sort &&
+                 generation == expected
+            raise Error, "#{name} installed generation differs from the exact catalogue"
+          end
+        end
+
+        def validate_inspection!(payload, name:, expected:)
+          valid = payload.is_a?(Hash) && payload.keys.sort == %w[modules ok schema schema_version] &&
+            payload["schema"] == "hive-module-status" && payload["schema_version"] == 1 &&
+            payload["ok"] == true && payload["modules"].is_a?(Array) && payload["modules"].one?
+          status = payload.dig("modules", 0)
+          valid &&= status.is_a?(Hash) && status["name"] == name &&
+            status["lifecycle_state"] == "active" && status["installed"] == true &&
+            status["enabled"] == true && status["failure_reason"].nil? &&
+            status["integrity"] == {
+              "configuration_valid" => true, "generation_present" => true,
+              "activation_fenced" => false, "journal_present" => false
+            }
+          raise Error, "#{name} installed selection is unavailable" unless valid
+
+          validate_generation!(status.fetch("active"), expected, name:)
         end
 
         def install_choices(manifest)
@@ -595,7 +656,7 @@ module Hive
           end
           { "receipts" => prepared.map(&:first), "bindings" => prepared.map(&:last),
             "case_results" => case_results.sort_by { |row| row.fetch("id") },
-            "generated_at" => generated_at }
+            "common" => common, "generated_at" => generated_at }
         end
 
         def expected_receipt(common, case_row, observation, record, generated_at)
@@ -641,11 +702,20 @@ module Hive
             "generated_at" => prepared.fetch("generated_at"),
             "receipts" => prepared.fetch("receipts")
           }
-          JSON.parse(hive([ "module", "migration", "deterministic-qualification", "--yes", "--json" ],
-                          stdin_data: JSON.generate(request)).stdout)
+          report = JSON.parse(
+            hive([ "module", "migration", "deterministic-qualification", "--yes", "--json" ],
+                 stdin_data: JSON.generate(request)).stdout
+          )
+          stat = File.lstat(report_path)
+          unless stat.file? && !stat.symlink? && stat.size <= MAX_EVIDENCE_BYTES &&
+                 File.binread(report_path) == PatrolQualification.canonical(report)
+            raise Error, "deterministic qualification response differs from the persisted report"
+          end
+          report
         end
 
         def proof(candidate, catalog, report, prepared)
+          validate_qualification_report!(report, candidate:, catalog:, prepared:)
           lane = report.fetch("lanes").fetch("deterministic")
           raise Error, "reduced deterministic evidence did not qualify" unless lane.fetch("status") == "qualified"
           MODULES.each do |name|
@@ -672,6 +742,81 @@ module Hive
               "prepared_records_not_fresh_scheduler_matrix"
             ]
           }
+        end
+
+        def validate_qualification_report!(report, candidate:, catalog:, prepared:)
+          keys = %w[
+            blockers candidate_sha generated_at lanes migration report_id
+            scenario_manifest_digest schema schema_version status supersedes
+          ]
+          common = prepared.fetch("common")
+          valid = report.is_a?(Hash) && report.keys.sort == keys.sort &&
+            report["schema"] == "hive-module-migration-report" &&
+            report["schema_version"] == 2 && report["candidate_sha"] == candidate.fetch("sha") &&
+            report["scenario_manifest_digest"] == common.fetch("scenario_manifest_digest") &&
+            %w[evidence_required qualified].include?(report["status"]) &&
+            report["blockers"].is_a?(Array) &&
+            report["lanes"].is_a?(Hash) && report["lanes"].keys.sort == %w[deterministic installed_live]
+          raise Error, "deterministic qualification report is malformed" unless valid
+
+          lane = report.dig("lanes", "deterministic")
+          lane_keys = %w[
+            blockers candidate_sha catalog_digest contradiction decision_replay_count
+            duplicate_effects effect_count effect_replay_count elapsed_seconds
+            evidence_started_at generated_at lane manifest_digest modules qualification_id
+            receipt_ids run_id scenario_manifest_digest source_digest status supersedes
+            unsettled_effects
+          ]
+          receipt_ids = prepared.fetch("receipts").map { |receipt| receipt.fetch("receipt_id") }.sort
+          valid = lane.is_a?(Hash) && lane.keys.sort == lane_keys.sort &&
+            lane["lane"] == "deterministic" && lane["status"] == "qualified" &&
+            lane["run_id"] == common.fetch("run_id") &&
+            lane["candidate_sha"] == candidate.fetch("sha") &&
+            lane["catalog_digest"] == common.fetch("catalog_digest") &&
+            lane["source_digest"] == common.fetch("source_digest") &&
+            lane["manifest_digest"] == common.fetch("manifest_digest") &&
+            lane["scenario_manifest_digest"] == common.fetch("scenario_manifest_digest") &&
+            receipt_ids.uniq.size == receipt_ids.size && lane["receipt_ids"] == receipt_ids &&
+            lane["modules"].is_a?(Hash) && lane["modules"].keys.sort == MODULES.sort &&
+            lane["blockers"] == [] &&
+            lane["duplicate_effects"] == [] && lane["unsettled_effects"] == []
+          raise Error, "deterministic qualification lane differs from this campaign" unless valid
+
+          MODULES.each do |name|
+            receipts = prepared.fetch("receipts").select do |receipt|
+              receipt.dig("module_projection", "module") == name
+            end
+            summary = lane.dig("modules", name)
+            expected = catalog.expectations.fetch(name)
+            summary_keys = %w[
+              blockers change_windows configuration_digest decision_classes
+              decision_count decision_identities elapsed_seconds repository_shas
+            ]
+            configurations = receipts.map { |row| row.fetch("configuration_digest") }.uniq
+            valid = summary.is_a?(Hash) && summary.keys.sort == summary_keys.sort &&
+              summary["decision_count"] == receipts.size &&
+              summary["decision_count"] == expected.fetch("decision_count") &&
+              summary["decision_identities"].is_a?(Array) &&
+              summary["decision_identities"].size == receipts.size &&
+              summary["decision_identities"].uniq.size == receipts.size &&
+              summary["decision_identities"].all? { |id| id.to_s.match?(/\Adecision-[0-9a-f]{64}\z/) } &&
+              summary["decision_classes"] == receipts.map { |row| row.fetch("decision_class") }.uniq.sort &&
+              summary["repository_shas"] == receipts.map { |row| row.dig("repository", "sha") }.uniq.sort &&
+              summary["change_windows"] == receipts.map { |row| row.dig("repository", "change_window") }.uniq.sort &&
+              configurations.one? && summary["configuration_digest"] == configurations.first &&
+              summary["blockers"] == []
+            raise Error, "qualified #{name} summary differs from this campaign" unless valid
+          end
+
+          qualification_id = "qualification-#{Digest::SHA256.hexdigest(
+            PatrolQualification.canonical(lane.reject { |key, _| key == "qualification_id" })
+          )}"
+          report_id = "report-#{Digest::SHA256.hexdigest(
+            PatrolQualification.canonical(report.reject { |key, _| key == "report_id" })
+          )}"
+          unless lane["qualification_id"] == qualification_id && report["report_id"] == report_id
+            raise Error, "deterministic qualification identity differs from its contents"
+          end
         end
 
         def write_evidence(value)

--- a/test/e2e/lib/patrol_qualification.rb
+++ b/test/e2e/lib/patrol_qualification.rb
@@ -6,6 +6,7 @@ require "rbconfig"
 require "tmpdir"
 require "time"
 require "yaml"
+require_relative "../../../lib/hive/secret_patterns"
 
 module Hive
   module E2E
@@ -21,7 +22,20 @@ module Hive
       MAX_STREAM_BYTES = 1 * 1024 * 1024
       MAX_STDIN_BYTES = 8 * 1024 * 1024
       MAX_EVIDENCE_BYTES = 512 * 1024
+      MAX_SHADOW_FILES = 64
+      MAX_SHADOW_BYTES = 8 * 1024 * 1024
       CHILD_TIMEOUT = 30.0
+      CHILD_TIMEOUT_STATUS = 124
+      TERMINAL_SIGNALS = %w[
+        HUP INT QUIT ILL TRAP ABRT IOT FPE KILL BUS SEGV SYS PIPE ALRM TERM
+        XCPU XFSZ VTALRM PROF USR1 USR2 PWR IO POLL
+      ].filter_map { |name| Signal.list[name] }.uniq.freeze
+      GIT_OVERRIDES = [
+        "-c", "core.hooksPath=/dev/null",
+        "-c", "commit.gpgsign=false",
+        "-c", "tag.gpgsign=false",
+        "-c", "credential.helper="
+      ].freeze
 
       class Error < StandardError; end
       class ChildTimeout < Error; end
@@ -58,16 +72,42 @@ module Hive
         end
       end
 
+      def monotonic
+        Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      end
+
+      def check_deadline!(deadline, label)
+        return unless deadline && monotonic >= deadline
+
+        raise CampaignTimeout, "qualification campaign deadline expired while reading #{label}"
+      end
+
+      def bounded_read(path, label:, limit: MAX_EVIDENCE_BYTES, deadline: nil)
+        check_deadline!(deadline, label)
+        raise Error, "#{label} cannot be opened without following links" unless
+          File.const_defined?(:NOFOLLOW) && File.const_defined?(:NONBLOCK)
+
+        flags = File::RDONLY | File::NOFOLLOW | File::NONBLOCK
+        File.open(path, flags) do |file|
+          stat = file.stat
+          raise Error, "#{label} must be a bounded regular file" unless
+            stat.file? && stat.size <= limit
+          bytes = file.read(limit + 1)
+          raise Error, "#{label} exceeds its byte bound" if bytes.bytesize > limit
+          check_deadline!(deadline, label)
+          bytes
+        end
+      rescue Errno::ELOOP, Errno::ENXIO, SystemCallError => e
+        raise Error, "#{label} is unreadable: #{e.message}"
+      end
+
       class Catalog
         attr_reader :cases, :contracts, :expectations, :bytes
 
-        def self.load(path)
-          stat = File.lstat(path)
-          raise Error, "qualification catalogue must be a bounded regular file" unless
-            stat.file? && !stat.symlink? && stat.size <= MAX_EVIDENCE_BYTES
-          new(File.binread(path))
-        rescue SystemCallError => e
-          raise Error, "qualification catalogue is unreadable: #{e.message}"
+        def self.load(path, deadline: nil)
+          new(PatrolQualification.bounded_read(
+            path, label: "qualification catalogue", deadline: deadline
+          ))
         end
 
         def initialize(bytes)
@@ -184,6 +224,8 @@ module Hive
                     "#{label} exceeded #{limit.round(3)} seconds")
             end
             status = wait.value
+            terminate_group(pid)
+            cleaned_up = true
             unless join_until(workers, command_deadline)
               terminate_group(pid)
               streams.each { |io| close(io) }
@@ -200,7 +242,7 @@ module Hive
         rescue SystemCallError => e
           raise ProcessFailure.new("spawn", e.class.name, label)
         ensure
-          if pid && status.nil? && !cleaned_up
+          if pid && !cleaned_up
             terminate_group(pid)
             streams.each { |io| close(io) }
             join_until(workers, monotonic + 0.5)
@@ -262,9 +304,10 @@ module Hive
         OUTCOME_KEYS = %w[kind status].freeze
         OUTCOME_KINDS = %w[child_timeout exit signal].freeze
 
-        def initialize(project_root:, observations_path:, catalog:)
+        def initialize(project_root:, observations_path:, catalog:, deadline: nil)
           @project_root = File.expand_path(project_root)
           @catalog = catalog
+          @deadline = deadline
           @observations = read_observations(observations_path)
         end
 
@@ -297,11 +340,9 @@ module Hive
         private
 
         def read_observations(path)
-          stat = File.lstat(path)
-          unless stat.file? && !stat.symlink? && stat.size <= MAX_EVIDENCE_BYTES
-            raise Error, "qualification observations must be a bounded regular file"
-          end
-          @bytes = File.binread(path).freeze
+          @bytes = PatrolQualification.bounded_read(
+            path, label: "qualification observations", deadline: @deadline
+          ).freeze
           data = JSON.parse(@bytes)
           unless data.is_a?(Hash) && data.keys.sort == %w[cases schema schema_version] &&
                  data["schema"] == "hive-patrol-reduced-observations" && data["schema_version"] == 1
@@ -337,9 +378,17 @@ module Hive
           outcomes = row["process_outcomes"]
           return false unless outcomes.is_a?(Array) && !outcomes.empty? && outcomes.size <= 4
           return false unless outcomes.all? do |outcome|
-            outcome.is_a?(Hash) && outcome.keys.sort == OUTCOME_KEYS &&
-              OUTCOME_KINDS.include?(outcome["kind"]) &&
+            next false unless outcome.is_a?(Hash) && outcome.keys.sort == OUTCOME_KEYS &&
+                              OUTCOME_KINDS.include?(outcome["kind"])
+
+            case outcome["kind"]
+            when "exit"
               outcome["status"].is_a?(Integer) && outcome["status"].between?(0, 255)
+            when "signal"
+              outcome["status"].is_a?(Integer) && TERMINAL_SIGNALS.include?(outcome["status"])
+            when "child_timeout"
+              outcome["status"] == CHILD_TIMEOUT_STATUS
+            end
           end
 
           failed = ->(outcome) { outcome["kind"] != "exit" || outcome["status"] != 0 }
@@ -361,12 +410,29 @@ module Hive
           root = File.join(state_path, "module-runtime", "migration", "shadow")
           records = []
           extra = false
+          file_count = 0
+          byte_count = 0
           MODULES.each do |name|
-            Dir.glob(File.join(root, name, "*.json")) do |path|
-              stat = File.lstat(path)
-              raise Error, "shadow evidence is not a bounded regular file" unless
-                stat.file? && !stat.symlink? && stat.size <= MAX_EVIDENCE_BYTES
-              bytes = File.binread(path)
+            directory = File.join(root, name)
+            directory_stat = File.lstat(directory)
+            raise Error, "shadow evidence directory must not be linked" unless
+              directory_stat.directory? && !directory_stat.symlink?
+            paths = []
+            Dir.foreach(directory) do |entry|
+              next if entry == "." || entry == ".."
+
+              PatrolQualification.check_deadline!(@deadline, "shadow inventory")
+              file_count += 1
+              raise Error, "shadow evidence exceeds its file-count bound" if file_count > MAX_SHADOW_FILES
+              raise Error, "shadow evidence contains an unexpected child" unless entry.match?(/\A[0-9a-f]{64}\.json\z/)
+              paths << File.join(directory, entry)
+            end
+            paths.sort.each do |path|
+              bytes = PatrolQualification.bounded_read(
+                path, label: "shadow evidence", deadline: @deadline
+              )
+              byte_count += bytes.bytesize
+              raise Error, "shadow evidence exceeds its aggregate byte bound" if byte_count > MAX_SHADOW_BYTES
               record = JSON.parse(bytes)
               unless bytes == PatrolQualification.canonical(record)
                 raise Error, "shadow evidence is not canonical JSON"
@@ -411,7 +477,10 @@ module Hive
         end
 
         def state_path
-          config = YAML.safe_load(File.binread(File.join(@project_root, ".hive-state", "config.yml"))) || {}
+          config = YAML.safe_load(PatrolQualification.bounded_read(
+            File.join(@project_root, ".hive-state", "config.yml"),
+            label: "qualification project config", deadline: @deadline
+          )) || {}
           File.expand_path(config.fetch("hive_state_path", ".hive-state"), @project_root)
         rescue Psych::Exception, SystemCallError
           File.join(@project_root, ".hive-state")
@@ -431,11 +500,13 @@ module Hive
         end
 
         def run!
-          catalog_path = File.join(@repo_root, "test/e2e/fixtures/patrol_qualification/catalog.json")
-          catalog = Catalog.load(catalog_path)
           Dir.mktmpdir("hive-patrol-u3br") do |run_root|
             setup_process(run_root)
             candidate = materialize_candidate(run_root)
+            catalog = Catalog.load(
+              File.join(candidate.fetch("root"), "test/e2e/fixtures/patrol_qualification/catalog.json"),
+              deadline: @deadline
+            )
             install_candidate(candidate, run_root)
             catalog_repo = build_module_catalog(candidate, run_root)
             install_modules(catalog_repo)
@@ -456,6 +527,14 @@ module Hive
         def setup_process(run_root)
           @env = {
             "HOME" => @hive_home, "HIVE_HOME" => @hive_home,
+            "GIT_ATTR_NOSYSTEM" => "1", "GIT_CONFIG_GLOBAL" => "/dev/null",
+            "GIT_CONFIG_NOSYSTEM" => "1", "GIT_CONFIG_SYSTEM" => "/dev/null",
+            "GIT_CONFIG_COUNT" => "4",
+            "GIT_CONFIG_KEY_0" => "core.hooksPath", "GIT_CONFIG_VALUE_0" => "/dev/null",
+            "GIT_CONFIG_KEY_1" => "commit.gpgsign", "GIT_CONFIG_VALUE_1" => "false",
+            "GIT_CONFIG_KEY_2" => "tag.gpgsign", "GIT_CONFIG_VALUE_2" => "false",
+            "GIT_CONFIG_KEY_3" => "credential.helper", "GIT_CONFIG_VALUE_3" => "",
+            "GIT_TERMINAL_PROMPT" => "0",
             "HIVE_SKIP_LLM_WIKI_SCHEDULER" => "1", "HIVE_SKIP_LLM_WIKI_SYSTEMCTL" => "1",
             "HIVE_SKIP_LLM_WIKI_POST_COMMIT" => "1", "LANG" => "C.UTF-8", "LC_ALL" => "C.UTF-8",
             "PATH" => [ File.dirname(RbConfig.ruby), "/usr/bin", "/bin" ].join(":"),
@@ -465,17 +544,34 @@ module Hive
         end
 
         def materialize_candidate(run_root)
-          status = run("git", "-C", @repo_root, "status", "--porcelain", "--untracked-files=all",
+          sha = git("-C", @repo_root, "rev-parse", "HEAD", label: "resolve candidate").stdout.strip
+          raise Error, "candidate HEAD is not a full SHA" unless sha.match?(/\A[0-9a-f]{40}\z/)
+          status = git("-C", @repo_root, "status", "--porcelain", "--untracked-files=all",
                        label: "inspect candidate").stdout
           raise Error, "qualification requires a clean candidate checkout" unless status.empty?
-          sha = run("git", "-C", @repo_root, "rev-parse", "HEAD", label: "resolve candidate").stdout.strip
-          raise Error, "candidate HEAD is not a full SHA" unless sha.match?(/\A[0-9a-f]{40}\z/)
           archive = File.join(run_root, "candidate.tar")
-          run("git", "-C", @repo_root, "archive", "--format=tar", "--output", archive, sha,
+          git("-C", @repo_root, "archive", "--format=tar", "--output", archive, sha,
               label: "archive candidate")
           root = File.join(run_root, "candidate")
           FileUtils.mkdir_p(root)
           run("tar", "-xf", archive, "-C", root, label: "materialize candidate")
+          executing_controller = PatrolQualification.bounded_read(
+            File.expand_path(__FILE__), label: "executing qualification controller", deadline: @deadline
+          )
+          archived_controller = PatrolQualification.bounded_read(
+            File.join(root, "test/e2e/lib/patrol_qualification.rb"),
+            label: "archived qualification controller", deadline: @deadline
+          )
+          unless Digest::SHA256.digest(executing_controller) == Digest::SHA256.digest(archived_controller)
+            raise Error, "executing qualification controller differs from the archived candidate"
+          end
+          captured_head = git("-C", @repo_root, "rev-parse", "HEAD",
+                              label: "recheck candidate head").stdout.strip
+          captured_status = git("-C", @repo_root, "status", "--porcelain", "--untracked-files=all",
+                                label: "recheck candidate cleanliness").stdout
+          unless captured_head == sha && captured_status.empty?
+            raise Error, "candidate checkout changed while its archive was captured"
+          end
           { "sha" => sha, "archive_sha256" => Digest::SHA256.file(archive).hexdigest, "root" => root }
         end
 
@@ -517,21 +613,21 @@ module Hive
           File.binwrite(File.join(root, "catalog.json"), PatrolQualification.canonical(
             "schema" => "honeycomb-catalog/v3", "entries" => entries
           ))
-          run("git", "init", "-b", "main", "--quiet", cwd: root, label: "initialize local catalog")
-          run("git", "add", "--", ".", cwd: root, label: "stage local catalog")
-          run("git", "-c", "user.email=qualification@example.invalid",
+          git("init", "-b", "main", "--quiet", cwd: root, label: "initialize local catalog")
+          git("add", "--", ".", cwd: root, label: "stage local catalog")
+          git("-c", "user.email=qualification@example.invalid",
               "-c", "user.name=Hive qualification", "-c", "commit.gpgsign=false",
               "commit", "-m", "qualification catalog", "--quiet",
               cwd: root, label: "commit local catalog")
-          @catalog_commit = run("git", "rev-parse", "HEAD", cwd: root, label: "resolve local catalog").stdout.strip
+          @catalog_commit = git("rev-parse", "HEAD", cwd: root, label: "resolve local catalog").stdout.strip
           root
         end
 
         def install_modules(catalog_repo)
           rewrite = {
-            "GIT_CONFIG_COUNT" => "1",
-            "GIT_CONFIG_KEY_0" => "url.file://#{catalog_repo}/.insteadOf",
-            "GIT_CONFIG_VALUE_0" => "https://github.com/ivankuznetsov/honeycomb.git"
+            "GIT_CONFIG_COUNT" => "5",
+            "GIT_CONFIG_KEY_4" => "url.file://#{catalog_repo}/.insteadOf",
+            "GIT_CONFIG_VALUE_4" => "https://github.com/ivankuznetsov/honeycomb.git"
           }
           MODULES.each do |name|
             version = @catalog_manifests.fetch(name).fetch("version")
@@ -616,7 +712,7 @@ module Hive
         def collect_receipts(catalog, candidate)
           reader = ObservationReader.new(project_root: @project_root,
                                          observations_path: @observations_path,
-                                         catalog: catalog)
+                                         catalog: catalog, deadline: @deadline)
           catalog_digest = Digest::SHA256.hexdigest(catalog.bytes)
           common = {
             "run_id" => "u3br-#{candidate.fetch('sha')[0, 12]}",
@@ -696,9 +792,10 @@ module Hive
 
         def admit_qualification(prepared)
           report_path = File.join(state_path, "module-runtime", "migration", "report.json")
+          report_before = read_report(report_path)
           request = {
             "expected_bindings" => prepared.fetch("bindings"),
-            "expected_report_digest" => Digest::SHA256.file(report_path).hexdigest,
+            "expected_report_digest" => Digest::SHA256.hexdigest(report_before),
             "generated_at" => prepared.fetch("generated_at"),
             "receipts" => prepared.fetch("receipts")
           }
@@ -706,12 +803,17 @@ module Hive
             hive([ "module", "migration", "deterministic-qualification", "--yes", "--json" ],
                  stdin_data: JSON.generate(request)).stdout
           )
-          stat = File.lstat(report_path)
-          unless stat.file? && !stat.symlink? && stat.size <= MAX_EVIDENCE_BYTES &&
-                 File.binread(report_path) == PatrolQualification.canonical(report)
+          report_after = read_report(report_path)
+          unless report_after == PatrolQualification.canonical(report)
             raise Error, "deterministic qualification response differs from the persisted report"
           end
           report
+        end
+
+        def read_report(path)
+          PatrolQualification.bounded_read(
+            path, label: "qualification report", deadline: @deadline
+          )
         end
 
         def proof(candidate, catalog, report, prepared)
@@ -823,7 +925,7 @@ module Hive
           redacted = redact(value)
           bytes = PatrolQualification.canonical(redacted)
           raise Error, "qualification evidence exceeds its bound" if bytes.bytesize > MAX_EVIDENCE_BYTES
-          if bytes.match?(/(?:ghp_|github_pat_|sk-[A-Za-z0-9]|BEGIN (?:RSA |OPENSSH )?PRIVATE KEY)/)
+          if Hive::SecretPatterns.scan(bytes).any?
             raise Error, "qualification evidence contains a secret pattern"
           end
           FileUtils.mkdir_p(@evidence_root, mode: 0o700)
@@ -836,15 +938,25 @@ module Hive
           case value
           when Hash
             value.to_h do |key, child|
-              [ key, key.to_s.match?(/token|secret|password|credential/i) ? "[REDACTED]" : redact(child) ]
+              redacted_key = Hive::SecretPatterns.redact(key.to_s)
+              redacted_child = if key.to_s.match?(/token|secret|password|credential/i)
+                "[REDACTED]"
+              else
+                redact(child)
+              end
+              [ redacted_key, redacted_child ]
             end
           when Array then value.map { |child| redact(child) }
+          when String then Hive::SecretPatterns.redact(value)
           else value
           end
         end
 
         def state_path
-          config = YAML.safe_load(File.binread(File.join(@project_root, ".hive-state", "config.yml"))) || {}
+          config = YAML.safe_load(PatrolQualification.bounded_read(
+            File.join(@project_root, ".hive-state", "config.yml"),
+            label: "qualification project config", deadline: @deadline
+          )) || {}
           File.expand_path(config.fetch("hive_state_path", ".hive-state"), @project_root)
         end
 
@@ -856,6 +968,10 @@ module Hive
         def run(*command, label:, cwd: @repo_root, stdin_data: "", env: {})
           process = env.empty? ? @process : ChildProcess.new(deadline: @deadline, env: @env.merge(env))
           process.run(*command, label: label, cwd: cwd, stdin_data: stdin_data, timeout: @child_timeout)
+        end
+
+        def git(*arguments, **options)
+          run("git", *GIT_OVERRIDES, *arguments, **options)
         end
 
         def monotonic = Process.clock_gettime(Process::CLOCK_MONOTONIC)

--- a/test/e2e/lib/patrol_qualification_test.rb
+++ b/test/e2e/lib/patrol_qualification_test.rb
@@ -1,0 +1,266 @@
+require_relative "../../test_helper"
+require_relative "patrol_qualification"
+
+class E2EPatrolQualificationSupportTest < Minitest::Test
+  include Hive::E2E::PatrolQualification
+
+  CATALOG_PATH = File.expand_path(
+    "../fixtures/patrol_qualification/catalog.json", __dir__
+  )
+  REPO_ROOT = File.expand_path("../../..", __dir__)
+
+  def test_committed_catalogue_has_exact_e2e_inventory_and_real_focused_links
+    catalog = Catalog.load(CATALOG_PATH)
+
+    assert_equal 20, catalog.cases.size
+    assert_equal 4, catalog.contracts.size
+    assert_equal({ "architecture-patrol" => 10, "patrol" => 10 },
+                 catalog.cases.map(&:module_name).tally)
+    assert_equal %w[e2e], JSON.parse(File.read(CATALOG_PATH)).fetch("cases")
+                                     .map { |row| row.fetch("proof_kind") }.uniq
+    catalog.contracts.each do |contract|
+      path = File.join(REPO_ROOT, contract.fetch("test_file"))
+      assert File.file?(path), contract.fetch("test_file")
+      assert_match(/^\s*def #{Regexp.escape(contract.fetch('test_method'))}\b/,
+                   File.binread(path), contract.fetch("id"))
+    end
+  end
+
+  def test_real_reader_enforces_semantics_cardinality_and_does_not_mutate_records
+    Dir.mktmpdir("patrol-qualification-reader") do |root|
+      project = File.join(root, "project")
+      state = File.join(project, ".hive-state")
+      FileUtils.mkdir_p(state)
+      File.binwrite(File.join(state, "config.yml"), {}.to_yaml)
+      catalog = Catalog.load(CATALOG_PATH)
+      observations = write_records_and_observations(root, state, catalog)
+      before = tree_digest(state)
+      seen = []
+
+      ObservationReader.new(
+        project_root: project, observations_path: observations, catalog: catalog
+      ).each { |case_row, _, record| seen << [ case_row.id, record.fetch("module") ] }
+
+      assert_equal 20, seen.size
+      assert_equal before, tree_digest(state), "the evidence reader must be observation-only"
+    end
+  end
+
+  def test_reader_rejects_semantic_and_cardinality_drift
+    Dir.mktmpdir("patrol-qualification-drift") do |root|
+      project = File.join(root, "project")
+      state = File.join(project, ".hive-state")
+      FileUtils.mkdir_p(state)
+      File.binwrite(File.join(state, "config.yml"), {}.to_yaml)
+      catalog = Catalog.load(CATALOG_PATH)
+      observations = write_records_and_observations(root, state, catalog)
+      path = Dir.glob(File.join(state, "module-runtime/migration/shadow/patrol/*.json")).first
+      record = JSON.parse(File.binread(path))
+      record.fetch("module_decision")["rationale"] = "fabricated"
+      File.binwrite(path, Hive::E2E::PatrolQualification.canonical(record))
+
+      error = assert_raises(Hive::E2E::PatrolQualification::Error) do
+        ObservationReader.new(
+          project_root: project, observations_path: observations, catalog: catalog
+        ).each { }
+      end
+      assert_match(/decision class differs/, error.message)
+
+      record.fetch("module_decision")["rationale"] = "due"
+      File.binwrite(path, Hive::E2E::PatrolQualification.canonical(record))
+      document = JSON.parse(File.binread(observations))
+      document.fetch("cases")[1]["trigger_id"] = document.fetch("cases")[0].fetch("trigger_id")
+      File.binwrite(observations, JSON.generate(document))
+      duplicate = assert_raises(Hive::E2E::PatrolQualification::Error) do
+        ObservationReader.new(
+          project_root: project, observations_path: observations, catalog: catalog
+        ).each { }
+      end
+      assert_match(/selectors do not cover/, duplicate.message)
+    end
+  end
+
+  def test_child_process_has_allowlisted_environment_and_typed_failures
+    Dir.mktmpdir("patrol-qualification-child") do |root|
+      env = { "PATH" => "/usr/bin:/bin", "ONLY_ALLOWED" => "yes" }
+      process = ChildProcess.new(deadline: monotonic + 5, env: env)
+      result = process.run(
+        RbConfig.ruby, "-e", "puts ENV.keys.sort", label: "env", cwd: root
+      )
+      assert_equal %w[ONLY_ALLOWED PATH], result.stdout.lines.map(&:strip)
+
+      exit_error = assert_raises(ProcessFailure) do
+        process.run("/bin/sh", "-c", "exit 7", label: "exit", cwd: root)
+      end
+      assert_equal [ "exit", 7 ], [ exit_error.kind, exit_error.status ]
+
+      signal_error = assert_raises(ProcessFailure) do
+        process.run("/bin/sh", "-c", "kill -TERM $$", label: "signal", cwd: root)
+      end
+      assert_equal "signal", signal_error.kind
+
+      spawn_error = assert_raises(ProcessFailure) do
+        process.run(File.join(root, "missing"), label: "spawn", cwd: root)
+      end
+      assert_equal "spawn", spawn_error.kind
+    end
+  end
+
+  def test_controller_uses_only_the_archived_installed_public_boundary
+    source = File.binread(File.expand_path("patrol_qualification.rb", __dir__))
+
+    assert_includes source, '"archive", "--format=tar"'
+    assert_includes source, "packaging/live_agent_skills/install_candidate_gem.sh"
+    assert_includes source, "GIT_CONFIG_KEY_0"
+    assert_includes source, '"module", "migration", "deterministic-receipt", "--json"'
+    assert_includes source,
+                    '"module", "migration", "deterministic-qualification", "--yes", "--json"'
+    %w[ManagedStore ModuleScenarioSupport Scheduler Dispatcher].each do |forbidden|
+      refute_includes source, forbidden
+    end
+  end
+
+  def test_child_and_campaign_timeouts_are_distinct_and_kill_the_process_group
+    Dir.mktmpdir("patrol-qualification-timeout") do |root|
+      pid_path = File.join(root, "child.pid")
+      command = "sleep 30 & child=$!; echo $child > #{pid_path}; wait"
+      process = ChildProcess.new(deadline: monotonic + 5, env: { "PATH" => "/usr/bin:/bin" })
+      assert_raises(ChildTimeout) do
+        process.run("/bin/sh", "-c", command, label: "child", cwd: root, timeout: 0.1)
+      end
+      child_pid = Integer(File.read(pid_path))
+      refute process_alive?(child_pid), "timeout must kill descendants in the owned group"
+
+      campaign = ChildProcess.new(deadline: monotonic + 0.1, env: { "PATH" => "/usr/bin:/bin" })
+      assert_raises(CampaignTimeout) do
+        campaign.run("/bin/sh", "-c", "sleep 30", label: "campaign", cwd: root, timeout: 5)
+      end
+
+      noisy = ChildProcess.new(deadline: monotonic + 5, env: { "PATH" => "/usr/bin:/bin" })
+      started = monotonic
+      assert_raises(ChildTimeout) do
+        noisy.run(
+          RbConfig.ruby, "-e", 'STDOUT.sync = true; chunk = "x" * 16_384; loop { STDOUT.write(chunk) }',
+          label: "noisy", cwd: root, stdin_data: "i" * (2 * 1024 * 1024), timeout: 0.1
+        )
+      end
+      assert_operator monotonic - started, :<, 2.0,
+                      "blocked stdin and noisy stdout must remain under the child deadline"
+    end
+  end
+
+  def test_proof_retains_typed_case_results_and_exact_proof_counts
+    catalog = Catalog.load(CATALOG_PATH)
+    controller = Controller.allocate
+    controller.instance_variable_set(:@catalog_commit, "e" * 40)
+    case_results = catalog.cases.reverse.map do |case_row|
+      {
+        "id" => case_row.id, "module" => case_row.module_name,
+        "fault" => case_row.fault, "process_outcomes" => process_outcomes(case_row.fault)
+      }
+    end
+    report = {
+      "lanes" => {
+        "deterministic" => {
+          "status" => "qualified", "qualification_id" => "qualification-1",
+          "modules" => catalog.expectations.transform_values do |row|
+            { "decision_count" => row.fetch("decision_count") }
+          end
+        }
+      }
+    }
+    prepared = { "receipts" => Array.new(20) { {} }, "case_results" => case_results }
+    candidate = {
+      "sha" => "a" * 40, "archive_sha256" => "b" * 64,
+      "gem_sha256" => "c" * 64, "installed_hive_sha256" => "d" * 64
+    }
+
+    proof = controller.send(:proof, candidate, catalog, report, prepared)
+
+    assert_equal 20, proof.fetch("e2e_case_count")
+    assert_equal 4, proof.fetch("focused_contract_count")
+    assert_equal "d" * 64, proof.fetch("installed_hive_sha256")
+    assert_equal catalog.cases.map(&:id).sort,
+                 proof.fetch("case_results").map { |row| row.fetch("id") }
+    assert proof.fetch("case_results").all? { |row| row.fetch("process_outcomes").is_a?(Array) }
+  end
+
+  private
+
+  def write_records_and_observations(root, state, catalog)
+    observations = catalog.cases.map.with_index do |case_row, index|
+      module_index = catalog.cases.count do |candidate|
+        candidate.module_name == case_row.module_name && candidate.id <= case_row.id
+      end - 1
+      repository_sha = if case_row.module_name == "patrol"
+        (module_index < 5 ? "a" : "b") * 40
+      else
+        format("%040x", module_index + 1)
+      end
+      trigger_id = "trigger-#{case_row.id}"
+      record = {
+        "module" => case_row.module_name,
+        "trigger" => { "id" => trigger_id },
+        "comparable" => true,
+        "configuration_digest" => (case_row.module_name == "patrol" ? "c" : "d") * 64,
+        "legacy_capture" => {
+          "capture_id" => "capture-#{case_row.id}",
+          "project" => { "repository" => "github.com/acme/demo" }
+        },
+        "module_decision" => {
+          "module" => case_row.module_name, "rationale" => case_row.decision_class
+        },
+        "legacy_effects" => [],
+        "module_effects" => []
+      }
+      directory = File.join(state, "module-runtime", "migration", "shadow", case_row.module_name)
+      FileUtils.mkdir_p(directory)
+      File.binwrite(File.join(directory, "#{format('%064x', index + 1)}.json"),
+                    Hive::E2E::PatrolQualification.canonical(record))
+      {
+        "id" => case_row.id, "trigger_id" => trigger_id,
+        "repository_sha" => repository_sha,
+        "change_window" => "window-#{case_row.id}",
+        "fault_observed" => case_row.fault,
+        "process_outcomes" => process_outcomes(case_row.fault)
+      }
+    end
+    path = File.join(root, "observations.json")
+    File.binwrite(path, JSON.generate(
+      "schema" => "hive-patrol-reduced-observations", "schema_version" => 1,
+      "cases" => observations
+    ))
+    path
+  end
+
+  def tree_digest(root)
+    Digest::SHA256.hexdigest(
+      Dir.glob(File.join(root, "**", "*"), File::FNM_DOTMATCH).sort.filter_map do |path|
+        next unless File.file?(path)
+        "#{path.delete_prefix(root)}\0#{Digest::SHA256.file(path).hexdigest}"
+      end.join("\0")
+    )
+  end
+
+  def process_outcomes(fault)
+    success = { "kind" => "exit", "status" => 0 }
+    case fault
+    when "none" then [ success ]
+    when "provider_failure", "cli_failure" then [ { "kind" => "exit", "status" => 70 } ]
+    when "post_reservation_capture_decision_restart", "finalized_outbox_reconciliation_recovery"
+      [ { "kind" => "signal", "status" => 15 }, success ]
+    when "released_attempt_retry"
+      [ { "kind" => "exit", "status" => 70 }, success ]
+    else flunk("unknown fault #{fault}")
+    end
+  end
+
+  def monotonic = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+  def process_alive?(pid)
+    Process.kill(0, pid)
+    true
+  rescue Errno::ESRCH
+    false
+  end
+end

--- a/test/e2e/lib/patrol_qualification_test.rb
+++ b/test/e2e/lib/patrol_qualification_test.rb
@@ -69,6 +69,16 @@ class E2EPatrolQualificationSupportTest < Minitest::Test
       record.fetch("module_decision")["rationale"] = "due"
       File.binwrite(path, Hive::E2E::PatrolQualification.canonical(record))
       document = JSON.parse(File.binread(observations))
+      document.fetch("cases") << document.fetch("cases").first.dup
+      File.binwrite(observations, JSON.generate(document))
+      duplicate_id = assert_raises(Hive::E2E::PatrolQualification::Error) do
+        ObservationReader.new(
+          project_root: project, observations_path: observations, catalog: catalog
+        ).each { }
+      end
+      assert_match(/IDs are duplicated/, duplicate_id.message)
+
+      document.fetch("cases").pop
       document.fetch("cases")[1]["trigger_id"] = document.fetch("cases")[0].fetch("trigger_id")
       File.binwrite(observations, JSON.generate(document))
       duplicate = assert_raises(Hive::E2E::PatrolQualification::Error) do
@@ -120,6 +130,43 @@ class E2EPatrolQualificationSupportTest < Minitest::Test
     end
   end
 
+  def test_module_install_contract_rejects_noop_or_unbound_responses
+    controller = Controller.allocate
+    expected = {
+      "version" => "0.1.0", "catalog_commit" => "a" * 40,
+      "source_commit" => "b" * 40, "manifest_digest" => "c" * 64,
+      "configuration_digest" => "d" * 64
+    }
+    lifecycle = {
+      "schema" => "hive-module-lifecycle", "schema_version" => 1,
+      "ok" => true, "operation" => "install", "status" => "installed",
+      "name" => "patrol", "selection" => { "active" => expected }
+    }
+    inspection = {
+      "schema" => "hive-module-status", "schema_version" => 1, "ok" => true,
+      "modules" => [
+        {
+          "name" => "patrol", "lifecycle_state" => "active", "installed" => true,
+          "enabled" => true, "failure_reason" => nil, "active" => expected,
+          "integrity" => {
+            "configuration_valid" => true, "generation_present" => true,
+            "activation_fenced" => false, "journal_present" => false
+          }
+        }
+      ]
+    }
+
+    controller.send(:validate_lifecycle!, lifecycle, name: "patrol", statuses: [ "installed" ])
+    controller.send(:validate_generation!, expected, expected, name: "patrol")
+    controller.send(:validate_inspection!, inspection, name: "patrol", expected: expected)
+    assert_raises(Hive::E2E::PatrolQualification::Error) do
+      controller.send(:validate_lifecycle!, {}, name: "patrol", statuses: [ "installed" ])
+    end
+    assert_raises(Hive::E2E::PatrolQualification::Error) do
+      controller.send(:validate_generation!, {}, expected, name: "patrol")
+    end
+  end
+
   def test_child_and_campaign_timeouts_are_distinct_and_kill_the_process_group
     Dir.mktmpdir("patrol-qualification-timeout") do |root|
       pid_path = File.join(root, "child.pid")
@@ -159,21 +206,12 @@ class E2EPatrolQualificationSupportTest < Minitest::Test
         "fault" => case_row.fault, "process_outcomes" => process_outcomes(case_row.fault)
       }
     end
-    report = {
-      "lanes" => {
-        "deterministic" => {
-          "status" => "qualified", "qualification_id" => "qualification-1",
-          "modules" => catalog.expectations.transform_values do |row|
-            { "decision_count" => row.fetch("decision_count") }
-          end
-        }
-      }
-    }
-    prepared = { "receipts" => Array.new(20) { {} }, "case_results" => case_results }
     candidate = {
       "sha" => "a" * 40, "archive_sha256" => "b" * 64,
       "gem_sha256" => "c" * 64, "installed_hive_sha256" => "d" * 64
     }
+    prepared = qualification_prepared(catalog, candidate, case_results)
+    report = qualification_report(catalog, candidate, prepared)
 
     proof = controller.send(:proof, candidate, catalog, report, prepared)
 
@@ -183,6 +221,13 @@ class E2EPatrolQualificationSupportTest < Minitest::Test
     assert_equal catalog.cases.map(&:id).sort,
                  proof.fetch("case_results").map { |row| row.fetch("id") }
     assert proof.fetch("case_results").all? { |row| row.fetch("process_outcomes").is_a?(Array) }
+
+    stale = Marshal.load(Marshal.dump(report))
+    stale["candidate_sha"] = "f" * 40
+    stale["report_id"] = digest_id("report", stale, "report_id")
+    assert_raises(Hive::E2E::PatrolQualification::Error) do
+      controller.send(:proof, candidate, catalog, stale, prepared)
+    end
   end
 
   private
@@ -240,6 +285,80 @@ class E2EPatrolQualificationSupportTest < Minitest::Test
         "#{path.delete_prefix(root)}\0#{Digest::SHA256.file(path).hexdigest}"
       end.join("\0")
     )
+  end
+
+  def qualification_prepared(catalog, candidate, case_results)
+    common = {
+      "run_id" => "u3br-test", "candidate_sha" => candidate.fetch("sha"),
+      "catalog_digest" => "1" * 64, "source_digest" => "2" * 64,
+      "manifest_digest" => "3" * 64, "scenario_manifest_digest" => "4" * 64
+    }
+    receipts = catalog.cases.map.with_index do |case_row, index|
+      module_index = catalog.cases.count do |candidate_row|
+        candidate_row.module_name == case_row.module_name && candidate_row.id <= case_row.id
+      end - 1
+      repository_sha = if case_row.module_name == "patrol"
+        (module_index < 5 ? "a" : "b") * 40
+      else
+        format("%040x", module_index + 1)
+      end
+      common.merge(
+        "receipt_id" => "evidence-#{format('%064x', index + 1)}",
+        "configuration_digest" => (case_row.module_name == "patrol" ? "c" : "d") * 64,
+        "module_projection" => { "module" => case_row.module_name },
+        "decision_class" => case_row.decision_class,
+        "repository" => {
+          "id" => "github.com/acme/demo", "sha" => repository_sha,
+          "change_window" => "window-#{case_row.id}"
+        }
+      )
+    end
+    { "receipts" => receipts, "case_results" => case_results, "common" => common }
+  end
+
+  def qualification_report(catalog, candidate, prepared)
+    summaries = MODULES.to_h do |name|
+      receipts = prepared.fetch("receipts").select do |receipt|
+        receipt.dig("module_projection", "module") == name
+      end
+      [ name, {
+        "decision_count" => receipts.size,
+        "decision_identities" => receipts.each_index.map { |index| "decision-#{format('%064x', index + 1)}" },
+        "decision_classes" => receipts.map { |row| row.fetch("decision_class") }.uniq.sort,
+        "repository_shas" => receipts.map { |row| row.dig("repository", "sha") }.uniq.sort,
+        "change_windows" => receipts.map { |row| row.dig("repository", "change_window") }.uniq.sort,
+        "configuration_digest" => receipts.first.fetch("configuration_digest"),
+        "elapsed_seconds" => 1, "blockers" => []
+      } ]
+    end
+    common = prepared.fetch("common")
+    lane = common.merge(
+      "lane" => "deterministic", "status" => "qualified",
+      "receipt_ids" => prepared.fetch("receipts").map { |row| row.fetch("receipt_id") }.sort,
+      "decision_replay_count" => 0, "modules" => summaries,
+      "effect_count" => 0, "effect_replay_count" => 0,
+      "duplicate_effects" => [], "unsettled_effects" => [], "elapsed_seconds" => 1,
+      "evidence_started_at" => "2026-08-04T10:00:00.000000Z", "blockers" => [],
+      "supersedes" => nil, "contradiction" => nil,
+      "generated_at" => "2026-08-04T10:01:00.000000Z"
+    )
+    lane["qualification_id"] = digest_id("qualification", lane, "qualification_id")
+    report = {
+      "schema" => "hive-module-migration-report", "schema_version" => 2,
+      "generated_at" => "2026-08-04T10:01:00.000000Z",
+      "candidate_sha" => candidate.fetch("sha"),
+      "scenario_manifest_digest" => common.fetch("scenario_manifest_digest"),
+      "status" => "evidence_required",
+      "lanes" => { "deterministic" => lane, "installed_live" => nil },
+      "blockers" => [ "installed_live:evidence_required" ],
+      "supersedes" => nil, "migration" => nil
+    }
+    report.merge("report_id" => digest_id("report", report, "report_id"))
+  end
+
+  def digest_id(prefix, value, key)
+    payload = value.reject { |name, _| name == key }
+    "#{prefix}-#{Digest::SHA256.hexdigest(Hive::E2E::PatrolQualification.canonical(payload))}"
   end
 
   def process_outcomes(fault)

--- a/test/e2e/lib/patrol_qualification_test.rb
+++ b/test/e2e/lib/patrol_qualification_test.rb
@@ -90,6 +90,83 @@ class E2EPatrolQualificationSupportTest < Minitest::Test
     end
   end
 
+  def test_shadow_inventory_rejects_special_oversized_and_unbounded_evidence
+    Dir.mktmpdir("patrol-qualification-bounds") do |root|
+      project = File.join(root, "project")
+      state = File.join(project, ".hive-state")
+      FileUtils.mkdir_p(state)
+      File.binwrite(File.join(state, "config.yml"), {}.to_yaml)
+      catalog = Catalog.load(CATALOG_PATH)
+      observations = write_records_and_observations(root, state, catalog)
+      directory = File.join(state, "module-runtime/migration/shadow/architecture-patrol")
+      special_path = File.join(directory, "#{'f' * 64}.json")
+
+      File.mkfifo(special_path)
+      assert_raises(Error) { qualification_reader(project, observations, catalog).each { } }
+      FileUtils.rm_f(special_path)
+
+      target = Dir.glob(File.join(directory, "*.json")).first
+      File.symlink(target, special_path)
+      assert_raises(Error) { qualification_reader(project, observations, catalog).each { } }
+      FileUtils.rm_f(special_path)
+
+      File.binwrite(special_path, "x" * (MAX_EVIDENCE_BYTES + 1))
+      assert_raises(Error) { qualification_reader(project, observations, catalog).each { } }
+      FileUtils.rm_f(special_path)
+
+      excess_paths = 45.times.map do |index|
+        path = File.join(directory, "#{format('%064x', 1_000 + index)}.json")
+        File.binwrite(path, Hive::E2E::PatrolQualification.canonical({}))
+        path
+      end
+      count_error = assert_raises(Error) do
+        qualification_reader(project, observations, catalog).each { }
+      end
+      assert_match(/file-count bound/, count_error.message)
+      excess_paths.each { |path| FileUtils.rm_f(path) }
+
+      aggregate_paths = 16.times.map do |index|
+        path = File.join(directory, "#{format('%064x', 2_000 + index)}.json")
+        value = { "comparable" => false, "padding" => "x" * (MAX_EVIDENCE_BYTES - 100) }
+        File.binwrite(path, Hive::E2E::PatrolQualification.canonical(value))
+        path
+      end
+      byte_error = assert_raises(Error) do
+        qualification_reader(project, observations, catalog).each { }
+      end
+      assert_match(/aggregate byte bound/, byte_error.message)
+      aggregate_paths.each { |path| FileUtils.rm_f(path) }
+
+      reader = qualification_reader(project, observations, catalog)
+      reader.instance_variable_set(:@deadline, monotonic)
+      assert_raises(CampaignTimeout) { reader.each { } }
+    end
+  end
+
+  def test_report_reader_is_no_follow_bounded_and_deadline_limited
+    Dir.mktmpdir("patrol-qualification-report") do |root|
+      controller = Controller.allocate
+      controller.instance_variable_set(:@deadline, monotonic + 5)
+      report = File.join(root, "report.json")
+      target = File.join(root, "target.json")
+      File.binwrite(target, "{}\n")
+
+      File.mkfifo(report)
+      assert_raises(Error) { controller.send(:read_report, report) }
+      FileUtils.rm_f(report)
+
+      File.symlink(target, report)
+      assert_raises(Error) { controller.send(:read_report, report) }
+      FileUtils.rm_f(report)
+
+      File.binwrite(report, "x" * (MAX_EVIDENCE_BYTES + 1))
+      assert_raises(Error) { controller.send(:read_report, report) }
+
+      controller.instance_variable_set(:@deadline, monotonic)
+      assert_raises(CampaignTimeout) { controller.send(:read_report, target) }
+    end
+  end
+
   def test_child_process_has_allowlisted_environment_and_typed_failures
     Dir.mktmpdir("patrol-qualification-child") do |root|
       env = { "PATH" => "/usr/bin:/bin", "ONLY_ALLOWED" => "yes" }
@@ -116,17 +193,111 @@ class E2EPatrolQualificationSupportTest < Minitest::Test
     end
   end
 
+  def test_child_process_reaps_descendants_after_terminal_leader_results
+    Dir.mktmpdir("patrol-qualification-terminal-cleanup") do |root|
+      process = ChildProcess.new(deadline: monotonic + 5, env: { "PATH" => "/usr/bin:/bin" })
+
+      [ 0, 7 ].each do |exit_status|
+        pid_path = File.join(root, "descendant-#{exit_status}.pid")
+        command = "sleep 30 & child=$!; echo $child > #{pid_path}; exit #{exit_status}"
+        if exit_status.zero?
+          process.run("/bin/sh", "-c", command, label: "success", cwd: root)
+        else
+          error = assert_raises(ProcessFailure) do
+            process.run("/bin/sh", "-c", command, label: "failure", cwd: root)
+          end
+          assert_equal [ "exit", exit_status ], [ error.kind, error.status ]
+        end
+        descendant_pid = Integer(File.binread(pid_path))
+        refute process_alive?(descendant_pid), "terminal leader must not leave a descendant"
+      end
+    end
+  end
+
   def test_controller_uses_only_the_archived_installed_public_boundary
     source = File.binread(File.expand_path("patrol_qualification.rb", __dir__))
 
     assert_includes source, '"archive", "--format=tar"'
     assert_includes source, "packaging/live_agent_skills/install_candidate_gem.sh"
     assert_includes source, "GIT_CONFIG_KEY_0"
+    assert_includes source, '"GIT_CONFIG_NOSYSTEM" => "1"'
+    assert_includes source, '"GIT_CONFIG_GLOBAL" => "/dev/null"'
+    assert_includes source, '"GIT_CONFIG_SYSTEM" => "/dev/null"'
+    assert_includes source, '"GIT_ATTR_NOSYSTEM" => "1"'
+    assert_includes source, 'File.join(candidate.fetch("root"), "test/e2e/fixtures/patrol_qualification/catalog.json")'
+    assert_includes source, "executing qualification controller differs from the archived candidate"
+    assert_includes source, "candidate checkout changed while its archive was captured"
     assert_includes source, '"module", "migration", "deterministic-receipt", "--json"'
     assert_includes source,
                     '"module", "migration", "deterministic-qualification", "--yes", "--json"'
     %w[ManagedStore ModuleScenarioSupport Scheduler Dispatcher].each do |forbidden|
       refute_includes source, forbidden
+    end
+  end
+
+  def test_controller_closes_git_configuration_and_keeps_one_catalogue_rewrite
+    Dir.mktmpdir("patrol-qualification-git-env") do |root|
+      controller = Controller.allocate
+      controller.instance_variable_set(:@hive_home, File.join(root, "home"))
+      controller.instance_variable_set(:@deadline, monotonic + 5)
+      controller.send(:setup_process, root)
+      env = controller.instance_variable_get(:@env)
+
+      assert_equal "1", env.fetch("GIT_CONFIG_NOSYSTEM")
+      assert_equal "/dev/null", env.fetch("GIT_CONFIG_GLOBAL")
+      assert_equal "/dev/null", env.fetch("GIT_CONFIG_SYSTEM")
+      assert_equal "1", env.fetch("GIT_ATTR_NOSYSTEM")
+      assert_equal "4", env.fetch("GIT_CONFIG_COUNT")
+      assert_equal %w[core.hooksPath commit.gpgsign tag.gpgsign credential.helper],
+                   4.times.map { |index| env.fetch("GIT_CONFIG_KEY_#{index}") }
+
+      source = File.binread(File.expand_path("patrol_qualification.rb", __dir__))
+      assert_includes source, '"GIT_CONFIG_COUNT" => "5"'
+      assert_includes source, '"GIT_CONFIG_KEY_4" => "url.file://#{catalog_repo}/.insteadOf"'
+      refute_includes source, '"GIT_CONFIG_KEY_5"'
+    end
+  end
+
+  def test_candidate_capture_pins_archive_and_rechecks_the_checkout
+    Dir.mktmpdir("patrol-qualification-candidate") do |root|
+      fixture = File.join(root, "fixture")
+      archived_controller = File.join(fixture, "test/e2e/lib/patrol_qualification.rb")
+      FileUtils.mkdir_p(File.dirname(archived_controller))
+      FileUtils.cp(File.expand_path("patrol_qualification.rb", __dir__), archived_controller)
+      run_root = File.join(root, "run")
+      FileUtils.mkdir_p(run_root)
+      sha = "a" * 40
+      labels = []
+      controller = Controller.allocate
+      controller.instance_variable_set(:@repo_root, fixture)
+      controller.instance_variable_set(:@deadline, monotonic + 5)
+      controller.define_singleton_method(:git) do |*arguments, label:, **|
+        labels << label
+        case label
+        when "resolve candidate", "recheck candidate head"
+          Result.new("#{sha}\n", "", 0)
+        when "inspect candidate", "recheck candidate cleanliness"
+          Result.new("", "", 0)
+        when "archive candidate"
+          archive = arguments.fetch(arguments.index("--output") + 1)
+          system("tar", "-cf", archive, "-C", fixture, ".", exception: true)
+          Result.new("", "", 0)
+        else
+          flunk("unexpected Git label #{label}")
+        end
+      end
+      controller.define_singleton_method(:run) do |*command, **|
+        system(*command, exception: true)
+        Result.new("", "", 0)
+      end
+
+      candidate = controller.send(:materialize_candidate, run_root)
+
+      assert_equal sha, candidate.fetch("sha")
+      assert_equal [
+        "resolve candidate", "inspect candidate", "archive candidate",
+        "recheck candidate head", "recheck candidate cleanliness"
+      ], labels
     end
   end
 
@@ -183,16 +354,65 @@ class E2EPatrolQualificationSupportTest < Minitest::Test
         campaign.run("/bin/sh", "-c", "sleep 30", label: "campaign", cwd: root, timeout: 5)
       end
 
+      noisy_pid_path = File.join(root, "noisy.pids")
       noisy = ChildProcess.new(deadline: monotonic + 5, env: { "PATH" => "/usr/bin:/bin" })
+      timeout = 0.25
       started = monotonic
       assert_raises(ChildTimeout) do
+        program = <<~RUBY
+          STDOUT.sync = true
+          worker = spawn(#{RbConfig.ruby.inspect}, "-e", "sleep 30")
+          File.write(#{noisy_pid_path.inspect}, "\#{Process.pid} \#{worker}")
+          chunk = "x" * 16_384
+          loop { STDOUT.write(chunk) }
+        RUBY
         noisy.run(
-          RbConfig.ruby, "-e", 'STDOUT.sync = true; chunk = "x" * 16_384; loop { STDOUT.write(chunk) }',
-          label: "noisy", cwd: root, stdin_data: "i" * (2 * 1024 * 1024), timeout: 0.1
+          RbConfig.ruby, "-e", program, label: "noisy", cwd: root,
+          stdin_data: "i" * (2 * 1024 * 1024), timeout: timeout
         )
       end
-      assert_operator monotonic - started, :<, 2.0,
+      elapsed = monotonic - started
+      assert_operator elapsed, :>=, timeout * 0.6,
+                      "timeout should track the requested deadline instead of firing immediately"
+      assert_operator elapsed, :<, 1.5,
                       "blocked stdin and noisy stdout must remain under the child deadline"
+      leader_pid, worker_pid = File.binread(noisy_pid_path).split.map { |value| Integer(value) }
+      refute process_alive?(leader_pid), "timed-out leader must be gone"
+      refute process_group_alive?(leader_pid), "timed-out process group must be gone"
+      refute process_alive?(worker_pid), "timed-out worker must be gone"
+    end
+  end
+
+  def test_process_outcome_statuses_are_kind_specific
+    reader = ObservationReader.allocate
+    valid = ->(kind, status, fault = "provider_failure") do
+      reader.send(:valid_process_outcomes?,
+                  "fault_observed" => fault,
+                  "process_outcomes" => [ { "kind" => kind, "status" => status } ])
+    end
+
+    assert valid.call("exit", 0, "none")
+    assert valid.call("exit", 255)
+    assert valid.call("signal", Signal.list.fetch("TERM"))
+    assert valid.call("child_timeout", CHILD_TIMEOUT_STATUS)
+    [ -1, 256, "7" ].each { |status| refute valid.call("exit", status) }
+    [ 0, 999, "15" ].each { |status| refute valid.call("signal", status) }
+    [ 0, 123, "124" ].each { |status| refute valid.call("child_timeout", status) }
+  end
+
+  def test_evidence_redacts_secret_patterns_inside_error_strings
+    Dir.mktmpdir("patrol-qualification-redaction") do |root|
+      controller = Controller.allocate
+      controller.instance_variable_set(:@evidence_root, root)
+      token = "github_pat_#{'A' * 40}"
+
+      path = controller.send(:write_evidence,
+                             "status" => "failed", "error" => "request rejected: #{token}")
+      bytes = File.binread(path)
+
+      refute_includes bytes, token
+      assert_includes bytes, "[REDACTED:github_fine_grained_pat]"
+      assert_empty Hive::SecretPatterns.scan(bytes)
     end
   end
 
@@ -376,8 +596,22 @@ class E2EPatrolQualificationSupportTest < Minitest::Test
 
   def monotonic = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
+  def qualification_reader(project, observations, catalog)
+    ObservationReader.new(
+      project_root: project, observations_path: observations, catalog: catalog,
+      deadline: monotonic + 5
+    )
+  end
+
   def process_alive?(pid)
     Process.kill(0, pid)
+    true
+  rescue Errno::ESRCH
+    false
+  end
+
+  def process_group_alive?(pid)
+    Process.kill(0, -pid)
     true
   rescue Errno::ESRCH
     false

--- a/test/e2e/qualification/patrol_qualification_test.rb
+++ b/test/e2e/qualification/patrol_qualification_test.rb
@@ -1,0 +1,31 @@
+require_relative "../../test_helper"
+require_relative "../lib/patrol_qualification"
+
+class E2EPatrolQualificationTest < Minitest::Test
+  def test_prepared_real_patrol_records_qualify_through_the_installed_cli
+    required = %w[
+      HIVE_PATROL_QUALIFICATION_PROJECT
+      HIVE_PATROL_QUALIFICATION_HOME
+      HIVE_PATROL_QUALIFICATION_OBSERVATIONS
+      HIVE_PATROL_QUALIFICATION_EVIDENCE
+    ]
+    missing = required.reject { |key| ENV[key].to_s.start_with?("/") }
+    unless missing.empty?
+      flunk "opt-in qualification requires absolute paths in: #{missing.join(', ')}"
+    end
+
+    proof = Hive::E2E::PatrolQualification::Controller.new(
+      repo_root: File.expand_path("../../..", __dir__),
+      project_root: ENV.fetch("HIVE_PATROL_QUALIFICATION_PROJECT"),
+      hive_home: ENV.fetch("HIVE_PATROL_QUALIFICATION_HOME"),
+      observations_path: ENV.fetch("HIVE_PATROL_QUALIFICATION_OBSERVATIONS"),
+      evidence_root: ENV.fetch("HIVE_PATROL_QUALIFICATION_EVIDENCE")
+    ).run!
+
+    assert_equal "qualified_smoke", proof.fetch("status")
+    assert_equal 20, proof.fetch("receipt_count")
+    assert_includes proof.fetch("claim_fences"), "not_full_u3b"
+    assert_includes proof.fetch("claim_fences"),
+                    "same_candidate_controls_not_independent"
+  end
+end

--- a/wiki/e2e.md
+++ b/wiki/e2e.md
@@ -3,7 +3,7 @@ title: Agentic E2E Suite
 type: reference
 source: test/e2e/, bin/hive-e2e, schemas/hive-e2e-{coverage,selection}.v1.json, Rakefile
 created: 2026-04-29
-updated: 2026-07-27
+updated: 2026-08-04
 tags: [test, e2e, tui, incidents, modules, artifacts]
 ---
 
@@ -13,6 +13,7 @@ tags: [test, e2e, tui, incidents, modules, artifacts]
 
 ```bash
 bundle exec rake e2e:lib_test   # harness library tests
+bundle exec rake e2e:patrol_qualification_reduced # opt-in prepared-project smoke
 bin/hive-e2e list               # scenario inventory
 bin/hive-e2e run                # all scenarios
 bin/hive-e2e run --filter tui   # tag filter
@@ -25,6 +26,24 @@ bin/hive-e2e clean              # old run cleanup
 ```
 
 `rake e2e` delegates to `bin/hive-e2e run`. The default `rake test` suite does not run e2e scenarios.
+
+The reduced Patrol qualification smoke is also excluded from `rake e2e`, the
+default suite, coverage, and hosted CI. It requires four explicit absolute-path
+environment inputs for a disposable project, its isolated Hive home, a
+read-only observation document, and retained evidence. The controller archives
+the clean full candidate `HEAD`, builds and privately installs that gem, creates
+a local Git module catalogue from those archived bytes, and redirects only the
+catalogue URL through `GIT_CONFIG_*`. It then invokes only the installed
+`bin/hive` from the project directory for module installation and the internal
+deterministic receipt/qualification process facade.
+
+This is a prepared-record public-process smoke, not the full Patrol U3b matrix:
+it does not run the schedulers that produced the supplied records, and its
+catalogue and controls live at the same candidate head. Successful output
+therefore proves neither independent-control authority nor installed/live U3c
+coverage. Its retained proof includes exact E2E/focused counts and a compact
+ID-sorted record of every case's module, fault label, and typed process
+outcomes.
 
 ## Semantic coverage
 

--- a/wiki/gaps.md
+++ b/wiki/gaps.md
@@ -18,13 +18,21 @@ tags: [gap, todo, release-proof, agent-skills]
   trigger identity under the shared migration lock, constructs its canonical
   receipt from record-owned capture, projection, and effects, and admits raw
   receipt documents only after independently supplied bindings verify before
-  digest-CAS merging report v2. U3a still does not execute
-  the compressed campaign and is not installed/live or cutover evidence;
-  current report-v2 cutover is deliberately refused at the operator boundary.
-  U3b must still commit independent controls and a real-reader
-  deterministic catalogue that drives both modules through the complete fault
-  matrix, including intent/outcome restarts, shadow attempted-effect denial,
-  exact reconciliation, and run-level duplicate detection. Its temporal cases
+  digest-CAS merging report v2. A reduced, opt-in U3b successor now commits a
+  strict real-reader catalogue, archives and privately installs the exact
+  candidate gem, installs the first-party modules through the public CLI and a
+  local Git catalogue URL rewrite, and drives prepared real ordinary and
+  Architecture Patrol shadow records through the internal installed-CLI
+  receipt/admission process facade with bounded process custody and retained
+  secret-scanned evidence.
+  This is deliberately only a prepared-record installed-CLI smoke. Its
+  same-head controls are not independent, fixture/prepared-record ingestion is
+  not a fresh scheduler-driven fault matrix, and the private gem is not a live
+  package-channel install. Interior crash contracts are linked to focused tests
+  rather than mislabelled E2E. Current report-v2 cutover remains deliberately
+  refused at the operator boundary. Full U3b must still supply independent
+  controls and freshly drive both modules through the complete process-boundary
+  matrix; its temporal cases
   must explicitly simulate wall-clock/DST boundary changes, weekly cadence,
   quota/capacity reset, and restart plus log rotation; spreading one decision
   class over timestamps cannot qualify, and timestamp, fault-step, or artifact
@@ -36,7 +44,8 @@ tags: [gap, todo, release-proof, agent-skills]
   Long-lived external resource drift remains a declared U3c live limitation,
   not something elapsed time can prove equivalent. Elapsed telemetry remains
   useful, but neither it nor a seven-day window substitutes for diversity and
-  protocol completeness.
+  protocol completeness. The reduced smoke closes none of U3-ARCH-005, U3c,
+  catalogue promotion, or mutator cutover authority.
 
 - The explicit JobStore fresh-start reset is source- and focused-test-pinned,
   including no-write fresh status, exact registered-project binding,

--- a/wiki/log.d/20260804T102247Z-patrol-reduced-installed-cli-qualification.md
+++ b/wiki/log.d/20260804T102247Z-patrol-reduced-installed-cli-qualification.md
@@ -17,6 +17,9 @@ tags: [patrol, qualification, e2e, modules]
 - Bounded every child and campaign, killed whole owned process groups, isolated
   the environment, and retained bounded redacted secret-scanned evidence with
   exact proof counts and compact typed process outcomes for every case.
+- Reject duplicate observation rows, require exact module apply/inspect
+  generation readback, and bind the canonical persisted report to this exact
+  candidate, scenario, receipt set, module summaries, and content identities.
 - This does not prove independent same-head controls, fresh scheduler-driven
   matrix execution, installed/live package channels, full U3b/U3c, catalogue
   promotion, or mutator cutover.

--- a/wiki/log.d/20260804T102247Z-patrol-reduced-installed-cli-qualification.md
+++ b/wiki/log.d/20260804T102247Z-patrol-reduced-installed-cli-qualification.md
@@ -1,0 +1,22 @@
+---
+title: Reduced Patrol installed-CLI qualification smoke
+type: change
+date: 2026-08-04
+tags: [patrol, qualification, e2e, modules]
+---
+
+- Added an opt-in, test-only reduced Patrol qualification controller that
+  archives the exact clean candidate head, installs its gem privately, installs
+  both Patrol modules through the installed CLI and a local Git catalogue rewrite,
+  and invokes its internal deterministic receipt/admission process facade over prepared
+  real shadow records.
+- Added a committed twenty-case catalogue with exact ordinary/architecture
+  semantic and cardinality expectations. Only four externally observable
+  process-boundary fault families are E2E; four interior atomic contracts link
+  to exact existing focused tests.
+- Bounded every child and campaign, killed whole owned process groups, isolated
+  the environment, and retained bounded redacted secret-scanned evidence with
+  exact proof counts and compact typed process outcomes for every case.
+- This does not prove independent same-head controls, fresh scheduler-driven
+  matrix execution, installed/live package channels, full U3b/U3c, catalogue
+  promotion, or mutator cutover.

--- a/wiki/log.d/20260804T102247Z-patrol-reduced-installed-cli-qualification.md
+++ b/wiki/log.d/20260804T102247Z-patrol-reduced-installed-cli-qualification.md
@@ -15,8 +15,15 @@ tags: [patrol, qualification, e2e, modules]
   process-boundary fault families are E2E; four interior atomic contracts link
   to exact existing focused tests.
 - Bounded every child and campaign, killed whole owned process groups, isolated
-  the environment, and retained bounded redacted secret-scanned evidence with
-  exact proof counts and compact typed process outcomes for every case.
+  the environment and ambient Git configuration, and retained bounded evidence
+  whose every string is redacted and final bytes scanned through the shared
+  secret matcher. Terminal leaders cannot leave owned descendants, and compact
+  process outcomes now validate exit, signal, and timeout statuses by kind.
+- Pinned and materialized the candidate before loading the catalogue from its
+  archive, digest-matched the executing controller to that archived source, and
+  rechecked candidate HEAD and cleanliness after capture. Shadow inventory and
+  persisted report reads are descriptor-bound, no-follow, count/byte bounded,
+  and covered by the monotonic campaign deadline.
 - Reject duplicate observation rows, require exact module apply/inspect
   generation readback, and bind the canonical persisted report to this exact
   candidate, scenario, receipt set, module summaries, and content identities.

--- a/wiki/modules/patrol.md
+++ b/wiki/modules/patrol.md
@@ -313,7 +313,14 @@ under `test/e2e/` can take a prepared disposable project's real persisted
 ordinary and Architecture Patrol shadow records through an archived, privately
 installed candidate's internal receipt and qualification process facade. It neither creates
 those scheduler records nor supplies independent controls: catalogue and
-controller remain same-head test assets. Interior atomic crash contracts stay
+controller remain same-head test assets. The controller pins and archives the
+candidate before loading its catalogue, digest-binds its executing source to
+the archived copy, closes ambient Git configuration, and rechecks candidate
+HEAD and cleanliness after capture. Shadow/report input uses descriptor-bound
+no-follow reads, count and byte ceilings, and the campaign's monotonic deadline;
+owned process groups are reaped even after a terminal leader result. Retained
+evidence redacts and scans every string through `Hive::SecretPatterns`, and
+typed process outcomes validate status according to their exact kind. Interior atomic crash contracts stay
 owned by their exact focused tests. Full independent U3b qualification,
 installed/live U3c evidence, catalogue promotion, and mutator cutover therefore
 remain unproven.

--- a/wiki/modules/patrol.md
+++ b/wiki/modules/patrol.md
@@ -308,10 +308,15 @@ replay. Recovery failures persist one bounded UTF-8 diagnostic cell with
 60/300/900-second retry backoff; successful generation-matched recovery clears
 it after restart.
 
-This boundary remains an internal `candidate`. U3 must still bind the repaired
-production decision/effect stream into the compressed candidate evidence
-protocol and satisfy production qualification before the catalog can promote
-it or any mutator cutover can be claimed.
+This boundary remains an internal `candidate`. The opt-in reduced U3b successor
+under `test/e2e/` can take a prepared disposable project's real persisted
+ordinary and Architecture Patrol shadow records through an archived, privately
+installed candidate's internal receipt and qualification process facade. It neither creates
+those scheduler records nor supplies independent controls: catalogue and
+controller remain same-head test assets. Interior atomic crash contracts stay
+owned by their exact focused tests. Full independent U3b qualification,
+installed/live U3c evidence, catalogue promotion, and mutator cutover therefore
+remain unproven.
 
 ## Safety invariants
 

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -239,11 +239,16 @@ privately installs the exact candidate gem through
 `packaging/live_agent_skills/install_candidate_gem.sh`, and invokes only that
 installed `bin/hive` from the project cwd. Both first-party modules are
 installed through the public preview/receipt/consent CLI against a local Git
-catalogue selected with `GIT_CONFIG_*` URL rewriting. Each ordinary and
+catalogue selected with `GIT_CONFIG_*` URL rewriting. Apply responses and
+`module inspect` readback must bind the exact catalog commit, source revision,
+manifest digest, and configuration digest. Each ordinary and
 Architecture Patrol selector goes through the internal installed-CLI facade,
 `hive module migration deterministic-receipt --json`; the final raw receipts
 and independently reconstructed bindings go through
-`deterministic-qualification --yes --json` and real report-v2 digest CAS.
+`deterministic-qualification --yes --json` and real report-v2 digest CAS. The
+returned v2 projection must equal the canonical persisted report and bind this
+campaign's candidate, run, scenario, receipts, module summaries, and content
+identities.
 
 Every child has bounded stdin/stdout/stderr, an allowlisted environment, a
 monotonic child deadline nested under a campaign deadline, `pgroup: true`, and

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -214,6 +214,57 @@ paths and compares each owner's literal Hive require edges with the approved
 one-way graph. Existing U2 evidence tests remain the regression boundary for
 the receipt's embedded capture, intent, and terminal effect values.
 
+### Patrol reduced installed-CLI qualification smoke
+
+`bundle exec rake e2e:patrol_qualification_reduced` is opt-in and hostile to a
+casual checkout: it requires absolute `HIVE_PATROL_QUALIFICATION_PROJECT`,
+`HIVE_PATROL_QUALIFICATION_HOME`,
+`HIVE_PATROL_QUALIFICATION_OBSERVATIONS`, and
+`HIVE_PATROL_QUALIFICATION_EVIDENCE` paths. The disposable project must already
+contain exactly twenty real comparable shadow records described by the
+committed catalogue and observation document. The controller is read-only over
+those records.
+
+The observation document is a
+`hive-patrol-reduced-observations` v1 object with one exact case row per
+catalogue ID. Each row binds the persisted trigger ID, repository SHA, change
+window, catalogue fault label, and one-to-four typed external process outcomes
+(`exit`, `signal`, or `child_timeout`). Success is `{kind: "exit", status: 0}`;
+retry and restart cases must retain both the failed/signalled first outcome and
+the successful successor. These rows are process evidence supplied with the
+prepared project, not facts inferred from a receipt returned by the candidate.
+
+The controller uses `git archive <full HEAD>`, hashes the archive, builds and
+privately installs the exact candidate gem through
+`packaging/live_agent_skills/install_candidate_gem.sh`, and invokes only that
+installed `bin/hive` from the project cwd. Both first-party modules are
+installed through the public preview/receipt/consent CLI against a local Git
+catalogue selected with `GIT_CONFIG_*` URL rewriting. Each ordinary and
+Architecture Patrol selector goes through the internal installed-CLI facade,
+`hive module migration deterministic-receipt --json`; the final raw receipts
+and independently reconstructed bindings go through
+`deterministic-qualification --yes --json` and real report-v2 digest CAS.
+
+Every child has bounded stdin/stdout/stderr, an allowlisted environment, a
+monotonic child deadline nested under a campaign deadline, `pgroup: true`, and
+TERM/KILL whole-group teardown. Spawn, exit, signal, child-timeout, and
+campaign-timeout results remain distinct. Success and failure summaries are
+bounded, redacted, secret-scanned, mode-0600 evidence; successful evidence is
+not discarded. The successful proof records the exact E2E and focused-contract
+counts plus a compact, ID-sorted `case_results` inventory containing each
+case's module, fault label, and typed process outcomes.
+
+The catalogue labels only externally observable process-boundary cases as
+`e2e`: the combined post-reservation process restart, provider/CLI failure,
+released-attempt retry, and finalized outbox/reconciliation recovery. Capture versus
+decision persistence, module projection persistence, effect-intent uncertainty,
+and the GitHub shim barrier are `focused_test` links to exact existing test
+methods. External process kills do not claim those interior atomic contracts.
+The same-head catalogue is not an independent oracle, prepared records are not
+a fresh scheduler-driven matrix, and a private exact-gem install is not
+Homebrew/AUR/install.sh installed/live proof. This smoke therefore does not
+close full U3b, U3-ARCH-005, or U3c.
+
 ## Coverage
 
 ```bash


### PR DESCRIPTION
## Summary

- Adds the opt-in `rake e2e:patrol_qualification_reduced` harness outside default tests and hosted CI.
- Builds an exact clean-HEAD archive, privately installs the candidate gem, creates a local Git module catalogue, and verifies preview/apply/inspect through the installed CLI.
- Validates a strict 20-case Patrol and Architecture Patrol catalogue against prepared persisted records through deterministic receipt and qualification CLI facades.
- Retains bounded, shared-secret-redacted evidence with exact candidate, catalogue, module-generation, receipt, persisted-report, process-group, filesystem, and Git-configuration custody.

## Scope fence

This is the reduced U3b successor. It does not claim full independent U3b, U3-ARCH-005, U3c installed/live qualification, catalogue promotion/cutover, or a fresh scheduler-owned fault matrix. Same-head controls are not independent, and the full opt-in campaign still requires an externally prepared disposable project. There are no production `lib/**` or `.github/**` changes, and the hostile qualification suite is not part of main CI.

## Review and verification

- Architecture review: no findings.
- Correctness review: three bounded findings fixed.
- Reliability/security review: seven bounded findings fixed.
- Focused harness: 15 tests, 136 assertions, 0 failures/errors.
- Shared secret-pattern seam: 31 tests, 81 assertions, 0 failures/errors.
- Broad local suite on base `f1b89a3b55d6e984890c73e99c87855542d3cb07` and head `42d770696b7cb09c8efcbf03de96921df68f94d0`: 12,068 runs, 155,995 assertions, 0 failures, 0 errors, 10 intentional skips.
- Ruby syntax and `git diff --check`: clean.

The full prepared-project live campaign was not run in this worktree.