### PR TITLE
refactor(workflow-creator): establish exact bundle custody

### DIFF
--- a/config/component-boundaries.yml
+++ b/config/component-boundaries.yml
@@ -842,34 +842,40 @@ components:
         - HiveLiveAgentProof::WorkflowCreator.validate_installation!
         - HiveLiveAgentProof::WorkflowCreator.validate_execution!
       errors:
+        - HiveLiveAgentProof::Error
         - HiveLiveAgentProof::WorkflowCreator::Error
     owned_paths:
       - packaging/live_agent_skills/workflow_creator.rb
       - packaging/live_agent_skills/workflow_creator_contract.rb
       - packaging/live_agent_skills/workflow_creator_execution_contract.rb
+      - packaging/live_agent_skills/workflow_creator_bundle.rb
     state_contracts:
       - "Each public input is captured once before semantic validation, and the admitted primary snapshot is returned"
       - "Failure construction captures stable caller inputs and detail once, then captures only its constructed result"
       - "The semantic core is declarative and owns no retention, publication, process, provider, or credential state"
+      - "The bundle owner reads one exact four-file source bundle and independently revalidates retained proof bytes"
     schema_contracts:
       - "Vocabulary and failed, primary, installation, and execution schema-v1 fields are exact and deeply immutable"
       - "Installed closures, ordered commands, capture digests, classifications, and receipt summaries are cross-bound"
+      - "Source and retained bundle members are canonical JSON whose exact bytes bind the primary, installations, and receipt"
     lock_contracts:
       - "No locks or durable state; validation is pure over immutable Values snapshots"
+      - "Source custody uses owner-private no-follow reads; proof retention and output creation remain with the incumbent attestor"
     component_dependencies:
       - workflow-creator-values
     allowed_hive_dependencies: []
     internal_collaborators:
       - HiveLiveAgentProof::WorkflowCreator::Contract
       - HiveLiveAgentProof::WorkflowCreator::ExecutionContract
+      - HiveLiveAgentProof::WorkflowCreatorBundle
     forbidden_constructions: []
     authorized_internal_constructions: []
-    hive_consumers: []
-    mutation_authority: "No mutation authority; allocates only failure evidence and immutable semantic snapshots."
-    recovery_surface: "Validation fails closed with WorkflowCreator::Error and exposes no retry or recovery state."
+    hive_consumers:
+      - packaging/live_agent_skills/proof.rb
+    mutation_authority: "No mutation authority; reads bounded exact bundle bytes and allocates only immutable validated results. Attestation retention remains above the seam."
+    recovery_surface: "Semantic or custody validation fails closed through HiveLiveAgentProof::Error and exposes no retry or recovery state."
     wiki_page: wiki/component-boundaries.md
     focused_tests:
       - test/unit/packaging/workflow_creator_core_test.rb
-    migration_exceptions:
-      - reason: "U1a2 must establish retained bundle custody and the first incumbent proof consumer."
-        removal_unit: U1a2
+      - test/unit/packaging/live_agent_proof_test.rb
+    migration_exceptions: []

--- a/packaging/live_agent_skills/proof.rb
+++ b/packaging/live_agent_skills/proof.rb
@@ -465,9 +465,16 @@ module HiveLiveAgentProof
     end
 
     def validate_creator_evidence!(manifest)
-      WorkflowCreatorBundle.source(
+      bundle = WorkflowCreatorBundle.source(
         directory: @creator_evidence_dir, manifest:, candidate_sha: @candidate_sha
       )
+      bundle.bytes.each do |name, bytes|
+        findings = HiveLiveAgentProof.secret_findings(bytes)
+        unless findings.empty?
+          raise Error, "#{name} workflow-creator evidence secret scan failed: #{findings.join(', ')}"
+        end
+      end
+      bundle
     end
   end
 

--- a/packaging/live_agent_skills/proof.rb
+++ b/packaging/live_agent_skills/proof.rb
@@ -29,45 +29,6 @@ module HiveLiveAgentProof
     "--timeout", "20", "--max-events", "5", "--interval", "1", "--json-lines"
   ].freeze
   OBSERVATION_COMMANDS = [ STATUS_ARGV, WATCH_ARGV ].freeze
-  WORKFLOW_CREATOR_REQUEST =
-    "Create a three-stage editorial workflow that researches, drafts, and requires approval before publishing.".freeze
-  WORKFLOW_CREATOR_PROMPT = <<~PROMPT.freeze
-    /hive
-    #{WORKFLOW_CREATOR_REQUEST}
-    Use the installed Hive workflow-creator capability in this initialized project.
-    This is creation-only: validate the result, report the defaults, and do not create or run a task.
-  PROMPT
-  WORKFLOW_CREATOR_TASK_REQUEST = "Research and draft the launch announcement for approval.".freeze
-  WORKFLOW_CREATOR_TASK_KEY = "workflow-creator-proof:editorial:live-proof".freeze
-  WORKFLOW_CREATOR_TASK_SLUG = "editorial-live-proof".freeze
-  WORKFLOW_CREATOR_TASK_PROMPT = <<~PROMPT.freeze
-    /hive
-    Use the validated editorial workflow to create and run one task for:
-    "#{WORKFLOW_CREATOR_TASK_REQUEST}"
-    Use idempotency key #{WORKFLOW_CREATOR_TASK_KEY}. In this exact order: create the task,
-    run its first stage once, repeat the same creation command once to prove the retry is a no-op,
-    then query operational status. Do not publish or perform any other external action.
-  PROMPT
-  WORKFLOW_CREATOR_TASK_NEW_ARGV = [
-    "new", "workflow-creator-proof", "--workflow", "editorial",
-    "--idempotency-key", WORKFLOW_CREATOR_TASK_KEY, "--json", WORKFLOW_CREATOR_TASK_REQUEST
-  ].freeze
-  WORKFLOW_CREATOR_COMMANDS = [
-    [ "version" ],
-    [ "workflow", "list", "--json" ],
-    [ "workflow", "new", "editorial", "--json" ],
-    [ "workflow", "validate", "editorial", "--json" ],
-    [ "workflow", "commit", "editorial" ],
-    WORKFLOW_CREATOR_TASK_NEW_ARGV,
-    [ "run", WORKFLOW_CREATOR_TASK_SLUG ],
-    WORKFLOW_CREATOR_TASK_NEW_ARGV,
-    [ "status", "--operational", "--json" ]
-  ].freeze
-  WORKFLOW_CREATOR_FILES = [
-    ".hive-state/workflows/editorial.yml",
-    ".hive-state/workflows/editorial/draft.md",
-    ".hive-state/workflows/editorial/research.md"
-  ].freeze
   SAFE_SHA = /\A[0-9a-f]{40}\z/.freeze
   SAFE_REPOSITORY = /\A[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\z/.freeze
   SECRET_PATTERNS = [
@@ -79,6 +40,19 @@ module HiveLiveAgentProof
   ].freeze
 
   class Error < StandardError; end
+
+  require_relative "workflow_creator_bundle"
+
+  creator_vocabulary = WorkflowCreator::Vocabulary
+  WORKFLOW_CREATOR_REQUEST = creator_vocabulary.fetch("request")
+  WORKFLOW_CREATOR_PROMPT = creator_vocabulary.fetch("prompt")
+  WORKFLOW_CREATOR_TASK_REQUEST = creator_vocabulary.fetch("task_request")
+  WORKFLOW_CREATOR_TASK_KEY = creator_vocabulary.fetch("task_key")
+  WORKFLOW_CREATOR_TASK_SLUG = creator_vocabulary.fetch("task_slug")
+  WORKFLOW_CREATOR_TASK_PROMPT = creator_vocabulary.fetch("task_prompt")
+  WORKFLOW_CREATOR_TASK_NEW_ARGV = creator_vocabulary.fetch("task_new_argv")
+  WORKFLOW_CREATOR_COMMANDS = creator_vocabulary.fetch("commands")
+  WORKFLOW_CREATOR_FILES = creator_vocabulary.fetch("files")
 
   module_function
 
@@ -369,25 +343,38 @@ module HiveLiveAgentProof
     def call
       manifest = validate_artifacts!
       evidence = validate_evidence!(manifest)
-      creator_evidence = validate_creator_evidence!(manifest)
+      creator_bundle = validate_creator_evidence!(manifest)
       raise Error, "proof output already exists: #{@output_dir}" if File.exist?(@output_dir)
       FileUtils.mkdir_p(File.join(@output_dir, "artifacts"), mode: 0o700)
       FileUtils.mkdir_p(File.join(@output_dir, "evidence"), mode: 0o700)
+      retain_artifacts!(manifest)
+      retain_evidence!(evidence, creator_bundle)
+      write_attestation!(attestation(manifest, evidence, creator_bundle))
+    end
 
+    private
+
+    def retain_artifacts!(manifest)
       manifest.fetch("files").each_key do |name|
         FileUtils.cp(File.join(@artifact_dir, name), File.join(@output_dir, "artifacts", name), preserve: false)
       end
       FileUtils.cp(File.join(@artifact_dir, "artifact-manifest.json"),
                    File.join(@output_dir, "artifacts", "artifact-manifest.json"), preserve: false)
+    end
+
+    def retain_evidence!(evidence, creator_bundle)
       evidence.each do |platform, row|
         HiveLiveAgentProof.write_json(File.join(@output_dir, "evidence", "#{platform}.json"), row)
       end
-      HiveLiveAgentProof.write_json(
-        File.join(@output_dir, "evidence", "openclaw-workflow-creator.json"),
-        creator_evidence
-      )
+      creator_bundle.bytes.each do |name, bytes|
+        File.open(File.join(@output_dir, "evidence", name), File::WRONLY | File::CREAT | File::EXCL, 0o600) do |file|
+          file.write(bytes)
+        end
+      end
+    end
 
-      attestation = {
+    def attestation(manifest, evidence, creator_bundle)
+      {
         "schema" => "hive-live-agent-skills-attestation",
         "schema_version" => SCHEMA_VERSION,
         "candidate_sha" => @candidate_sha,
@@ -401,13 +388,16 @@ module HiveLiveAgentProof
         },
         "artifacts" => manifest,
         "platforms" => PLATFORMS.to_h { |platform| [ platform, evidence.fetch(platform) ] },
-        "workflow_creator" => creator_evidence,
+        "workflow_creator" => creator_bundle.primary,
         "secret_scan" => {
           "status" => "passed",
           "scanner" => "hive-live-agent-proof/v1",
-          "files_scanned" => PLATFORMS.length + 2
+          "files_scanned" => PLATFORMS.length + creator_bundle.bytes.length + 1
         }
       }
+    end
+
+    def write_attestation!(attestation)
       attestation_path = File.join(@output_dir, "attestation.json")
       HiveLiveAgentProof.write_json(attestation_path, attestation)
       findings = HiveLiveAgentProof.secret_findings(File.read(attestation_path))
@@ -417,8 +407,6 @@ module HiveLiveAgentProof
       File.write(File.join(@output_dir, "attestation.sha256"), "#{digest}  attestation.json\n", mode: "w", perm: 0o600)
       { "attestation" => attestation, "sha256" => digest, "path" => attestation_path }
     end
-
-    private
 
     def validate_artifacts!
       path = File.join(@artifact_dir, "artifact-manifest.json")
@@ -477,79 +465,9 @@ module HiveLiveAgentProof
     end
 
     def validate_creator_evidence!(manifest)
-      actual_names = Dir.glob(File.join(@creator_evidence_dir, "*.json")).map { |path| File.basename(path) }
-      unless actual_names == [ "openclaw-workflow-creator.json" ]
-        raise Error, "workflow-creator evidence must contain exactly openclaw-workflow-creator.json"
-      end
-
-      path = File.join(@creator_evidence_dir, actual_names.fetch(0))
-      row = HiveLiveAgentProof.read_json(path)
-      unless row.is_a?(Hash) && row["schema"] == "hive-live-workflow-creator-evidence" &&
-             row["schema_version"] == SCHEMA_VERSION && row["platform"] == "openclaw" &&
-             row["candidate_sha"] == @candidate_sha && row["result"] == "passed"
-        raise Error, "workflow-creator evidence identity or result is invalid"
-      end
-      unless row.dig("skill", "canonical_digest") == manifest["canonical_digest"] &&
-             row.dig("skill", "skill_version") == manifest["skill_version"]
-        raise Error, "workflow-creator evidence canonical provenance mismatch"
-      end
-      unless HiveLiveAgentProof.valid_native_activation?("openclaw", row["native_activation"])
-        raise Error, "workflow-creator native activation evidence is invalid"
-      end
-      expected_prompt = Digest::SHA256.hexdigest(WORKFLOW_CREATOR_PROMPT)
-      expected_task_prompt = Digest::SHA256.hexdigest(WORKFLOW_CREATOR_TASK_PROMPT)
-      unless row["prompt_sha256"] == expected_prompt &&
-             row["task_prompt_sha256"] == expected_task_prompt &&
-             row["hive_commands"] == WORKFLOW_CREATOR_COMMANDS
-        raise Error, "workflow-creator prompt or command sequence is invalid"
-      end
-      validate_creator_result!(row)
-      unless row.dig("secret_scan", "status") == "passed" && row.dig("cleanup", "status") == "passed"
-        raise Error, "workflow-creator evidence lacks secret-scan or cleanup proof"
-      end
-      findings = HiveLiveAgentProof.secret_findings(File.read(path))
-      raise Error, "workflow-creator evidence secret scan failed: #{findings.join(', ')}" unless findings.empty?
-
-      row
-    end
-
-    def validate_creator_result!(row)
-      created = row["created_files"]
-      unless created.is_a?(Array) && created.map { |record| record["path"] }.sort == WORKFLOW_CREATOR_FILES
-        raise Error, "workflow-creator created files are incomplete"
-      end
-      unless created.all? { |record| record.keys.sort == %w[path sha256 size] &&
-        record["sha256"].to_s.match?(/\A[0-9a-f]{64}\z/) && record["size"].to_i.positive? }
-        raise Error, "workflow-creator created-file records are invalid"
-      end
-
-      validation = row["validation"]
-      stages = validation.is_a?(Hash) ? validation["stages"] : nil
-      outcomes = validation.is_a?(Hash) ? validation["human_outcomes"] : nil
-      unless validation&.fetch("valid", false) == true &&
-             stages == %w[research draft approval] &&
-             validation["automatic_edges"] == [ %w[research draft], %w[draft approval] ] &&
-             outcomes == [
-               { "stage" => "approval", "name" => "approve", "complete" => true,
-                 "artifact" => "draft.md", "to" => nil },
-               { "stage" => "approval", "name" => "reject", "complete" => false,
-                 "artifact" => nil, "to" => "draft" }
-             ]
-        raise Error, "workflow-creator normalized graph is invalid"
-      end
-      task = row["task"]
-      unless row["creation_only_task_count"] == 0 && row["task_count"] == 1 &&
-             task == {
-               "slug" => WORKFLOW_CREATOR_TASK_SLUG,
-               "workflow" => "editorial",
-               "first_created" => true,
-               "retry_created" => false,
-               "run_count" => 1,
-               "current_stage" => "1-research"
-             } &&
-             row["external_actions"] == []
-        raise Error, "workflow-creator proof contains an unauthorized side effect"
-      end
+      WorkflowCreatorBundle.source(
+        directory: @creator_evidence_dir, manifest:, candidate_sha: @candidate_sha
+      )
     end
   end
 
@@ -634,24 +552,11 @@ module HiveLiveAgentProof
     end
 
     def validate_workflow_creator!(manifest)
-      row = @attestation["workflow_creator"]
-      unless row.is_a?(Hash) && row["schema"] == "hive-live-workflow-creator-evidence" &&
-             row["platform"] == "openclaw" && row["candidate_sha"] == @candidate_sha &&
-             row["result"] == "passed" && row.dig("skill", "canonical_digest") == manifest["canonical_digest"] &&
-             row.dig("secret_scan", "status") == "passed" && row.dig("cleanup", "status") == "passed"
-        raise Error, "workflow-creator attested evidence is incomplete"
-      end
-      unless HiveLiveAgentProof.valid_native_activation?("openclaw", row["native_activation"])
-        raise Error, "workflow-creator attested native activation evidence is invalid"
-      end
-      unless row["prompt_sha256"] == Digest::SHA256.hexdigest(WORKFLOW_CREATOR_PROMPT) &&
-             row["task_prompt_sha256"] == Digest::SHA256.hexdigest(WORKFLOW_CREATOR_TASK_PROMPT) &&
-             row["hive_commands"] == WORKFLOW_CREATOR_COMMANDS &&
-             row["creation_only_task_count"] == 0 && row["task_count"] == 1 &&
-             row["task"].is_a?(Hash) && row["task"]["retry_created"] == false &&
-             row["task"]["run_count"] == 1 && row["external_actions"] == []
-        raise Error, "workflow-creator attested contract is invalid"
-      end
+      WorkflowCreatorBundle.retained(
+        directory: File.join(@proof_dir, "evidence"),
+        expected_primary: @attestation.fetch("workflow_creator", nil),
+        manifest:, candidate_sha: @candidate_sha
+      )
     end
   end
 end

--- a/packaging/live_agent_skills/workflow_creator_bundle.rb
+++ b/packaging/live_agent_skills/workflow_creator_bundle.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require "digest"
+require "json"
+require_relative "workflow_creator"
+
+module HiveLiveAgentProof
+  class Error < StandardError; end unless const_defined?(:Error, false)
+
+  class WorkflowCreatorBundle
+    Result = Data.define(:primary, :bytes)
+    private_constant :Result
+    FILES = WorkflowCreator::Vocabulary.fetch("bundle_files")
+    SUPPORT = %w[candidate_installation openclaw_installation execution_receipt].freeze
+    MAX_DIRECTORY_ENTRIES = 16
+    MAX_FILE_BYTES = 1_048_576
+    READ_FLAGS = if defined?(File::NOFOLLOW) && defined?(File::NONBLOCK)
+      File::RDONLY | File::NOFOLLOW | File::NONBLOCK
+    end
+
+    class << self
+      def source(directory:, manifest:, candidate_sha:)
+        validate(directory:, manifest:, candidate_sha:, expected_primary: nil, private_source: true)
+      end
+
+      def retained(directory:, expected_primary:, manifest:, candidate_sha:)
+        validate(directory:, manifest:, candidate_sha:, expected_primary:, private_source: false)
+      end
+
+      private
+
+      def validate(directory:, manifest:, candidate_sha:, expected_primary:, private_source:)
+        bytes, documents = read_bundle(directory, private_source)
+        primary, bundle_records = validate_documents(documents, bytes, manifest, candidate_sha)
+        unless private_source
+          attested = WorkflowCreator.validate_primary!(
+            row: expected_primary, manifest:, candidate_sha:, bundle_records:
+          )
+          unless primary.canonical_bytes == attested.canonical_bytes
+            raise Error, "workflow-creator retained primary does not match the attestation"
+          end
+        end
+
+        Result.new(primary: primary.value, bytes: bytes.transform_values { |content| content.b.freeze }.freeze).freeze
+      rescue JSON::ParserError
+        raise Error, "workflow-creator bundle JSON is invalid"
+      rescue WorkflowCreator::Error, WorkflowCreator::Values::Error
+        raise Error, "workflow-creator bundle contract is invalid"
+      rescue KeyError, TypeError, ArgumentError
+        raise Error, "workflow-creator bundle contract is invalid"
+      rescue Errno::ELOOP
+        raise Error, "workflow-creator bundle member is not a private regular file"
+      rescue SystemCallError, IOError
+        raise Error, "workflow-creator bundle cannot be read safely"
+      end
+
+      def read_bundle(directory, private_source)
+        root = File.expand_path(directory)
+        stat = File.lstat(root)
+        valid = stat.directory? && stat.uid == Process.uid
+        valid &&= (stat.mode & 0o077).zero? if private_source
+        raise Error, "workflow-creator bundle root is not an owner-private directory" unless valid
+
+        children = Dir.each_child(root).take(MAX_DIRECTORY_ENTRIES + 1)
+        raise Error, "workflow-creator bundle inventory exceeds the limit" if children.length > MAX_DIRECTORY_ENTRIES
+        admitted = private_source ? children.sort == FILES.sort : (FILES - children).empty?
+        raise Error, "workflow-creator bundle inventory is invalid" unless admitted
+
+        read_bundle_members(root, stat, private_source)
+      end
+
+      def read_bundle_members(root, stat, private_source)
+        bytes = FILES.to_h { |name| [ name, read_member(root, name, private_source) ] }
+        current = File.lstat(root)
+        identity = [ stat.dev, stat.ino, stat.uid, stat.mode ]
+        unless [ current.dev, current.ino, current.uid, current.mode ] == identity
+          raise Error, "workflow-creator bundle root identity changed during validation"
+        end
+        [ bytes, parse_documents(bytes) ]
+      end
+
+      def parse_documents(bytes)
+        bytes.to_h do |name, content|
+          document = JSON.parse(content)
+          canonical = WorkflowCreator::Values.capture(document).canonical_bytes
+          raise Error, "workflow-creator bundle member is not canonical JSON" unless content == canonical
+          [ name, document ]
+        end
+      end
+
+      def validate_documents(documents, bytes, manifest, candidate_sha)
+        installations = %w[candidate openclaw].map.with_index do |kind, index|
+          WorkflowCreator.validate_installation!(
+            document: documents.fetch(FILES.fetch(index + 1)), kind:, manifest:, candidate_sha:
+          )
+        end
+        records = SUPPORT.each_with_index.map do |kind, index|
+          content = bytes.fetch(FILES.fetch(index + 1))
+          { "kind" => kind, "path" => FILES.fetch(index + 1),
+            "sha256" => Digest::SHA256.hexdigest(content), "size" => content.bytesize }
+        end
+        primary = WorkflowCreator.validate_primary!(
+          row: documents.fetch(FILES.fetch(0)), manifest:, candidate_sha:, bundle_records: records
+        )
+        validate_execution(documents, installations, records, primary, manifest, candidate_sha)
+        [ primary, records ]
+      end
+
+      def validate_execution(documents, installations, records, primary, manifest, candidate_sha)
+        WorkflowCreator.validate_execution!(
+          receipt: documents.fetch(FILES.fetch(3)), row: primary.value, candidate_sha:, manifest:,
+          installation_records: records.first(2), receipt_sha256: records.fetch(2).fetch("sha256"),
+          candidate_installation: installations.fetch(0).value,
+          openclaw_installation: installations.fetch(1).value
+        )
+      end
+
+      def read_member(root, name, private_source)
+        raise Error, "workflow-creator safe bundle file-open flags are unavailable" unless READ_FLAGS
+        File.open(File.join(root, name), READ_FLAGS) do |file|
+          stat = file.stat
+          validate_member!(stat, private_source)
+          content = file.read(MAX_FILE_BYTES + 1)
+          if content.bytesize > MAX_FILE_BYTES
+            raise Error, "workflow-creator bundle member exceeds the size limit"
+          end
+          current = file.stat
+          identity = [ stat.dev, stat.ino, stat.size, stat.mtime, stat.ctime ]
+          unless [ current.dev, current.ino, current.size, current.mtime, current.ctime ] == identity
+            raise Error, "workflow-creator bundle member identity changed during validation"
+          end
+          content
+        end
+      end
+
+      def validate_member!(stat, private_source)
+        valid = stat.file? && stat.nlink == 1 && stat.uid == Process.uid
+        valid &&= (stat.mode & 0o077).zero? if private_source
+        raise Error, "workflow-creator bundle member is not a private regular file" unless valid
+        if stat.size > MAX_FILE_BYTES
+          raise Error, "workflow-creator bundle member exceeds the size limit"
+        end
+      end
+    end
+  end
+end

--- a/packaging/release_candidate/artifacts.rb
+++ b/packaging/release_candidate/artifacts.rb
@@ -39,6 +39,7 @@ module HiveReleaseCandidate
     MAX_BUILDER_INPUT_BYTES = 1_048_576
     MAX_SOURCE_TAR_PADDING_BYTES = 1_048_576
     SOURCE_ENTRY_TYPES = %w[0 5 g].freeze
+    MANAGED_WEB_ENV_KEYS = %w[PATH LANG LC_ALL LC_CTYPE TZ].freeze
 
     attr_reader :repo_root, :candidate_sha, :candidate_dir
 
@@ -264,9 +265,10 @@ module HiveReleaseCandidate
           version: ARGV.fetch(2), destination: ARGV.fetch(3)
         )
       RUBY
+      environment = MANAGED_WEB_ENV_KEYS.to_h { |key| [ key, ENV[key] ] }.compact
       _stdout, stderr, status = Open3.capture3(
-        RbConfig.ruby, "--disable-gems", "-r", helper, "-e", script,
-        repo_root, candidate_sha, version, destination, chdir: export
+        environment, RbConfig.ruby, "--disable-gems", "-r", helper, "-e", script,
+        repo_root, candidate_sha, version, destination, chdir: export, unsetenv_others: true
       )
       unless status.success? && File.file?(destination) && !File.symlink?(destination)
         FileUtils.rm_f(destination)

--- a/packaging/release_candidate/artifacts.rb
+++ b/packaging/release_candidate/artifacts.rb
@@ -9,7 +9,6 @@ require "rubygems/package"
 require "tmpdir"
 require "zlib"
 require_relative "paths"
-require_relative "../managed_web_archive"
 
 module HiveReleaseCandidate
   class Artifacts
@@ -110,10 +109,7 @@ module HiveReleaseCandidate
       FileUtils.rm_f(incumbent_manifest_path)
 
       web_name = "hive-web-#{version}.tar.gz"
-      HiveManagedWebArchive.build(
-        repo_root: repo_root, candidate_sha: candidate_sha, version: version,
-        destination: File.join(output, web_name)
-      )
+      build_managed_web(export, version, File.join(output, web_name))
 
       expected = {
         "gem" => gem_name,
@@ -146,8 +142,6 @@ module HiveReleaseCandidate
       write_private_json(File.join(output, "manifest.json"), manifest)
     rescue JSON::ParserError, KeyError => e
       raise Error, "invalid incumbent candidate manifest: #{e.message}"
-    rescue HiveManagedWebArchive::Error => e
-      raise Error, e.message
     end
 
     def verify_directory!(directory)
@@ -257,6 +251,27 @@ module HiveReleaseCandidate
         "gem", "build", "hive.gemspec", "--output", destination, chdir: export
       )
       raise Error, "cannot build committed candidate gem: #{stderr.strip}" unless status.success?
+    end
+
+    def build_managed_web(export, version, destination)
+      helper = File.join(export, "packaging", "managed_web_archive.rb")
+      unless File.file?(helper) && !File.symlink?(helper)
+        raise Error, "committed candidate has no managed web artifact builder"
+      end
+      script = <<~'RUBY'
+        HiveManagedWebArchive.build(
+          repo_root: ARGV.fetch(0), candidate_sha: ARGV.fetch(1),
+          version: ARGV.fetch(2), destination: ARGV.fetch(3)
+        )
+      RUBY
+      _stdout, stderr, status = Open3.capture3(
+        RbConfig.ruby, "--disable-gems", "-r", helper, "-e", script,
+        repo_root, candidate_sha, version, destination, chdir: export
+      )
+      unless status.success? && File.file?(destination) && !File.symlink?(destination)
+        FileUtils.rm_f(destination)
+        raise Error, "committed managed web builder failed: #{stderr.strip}"
+      end
     end
 
     def builder_revision(export)

--- a/packaging/release_candidate/artifacts.rb
+++ b/packaging/release_candidate/artifacts.rb
@@ -15,6 +15,31 @@ module HiveReleaseCandidate
   class Artifacts
     MANIFEST_SCHEMA = "hive-release-candidate-artifacts"
     KINDS = %w[gem source skills web].freeze
+    LIVE_AGENT_BUILDER_INPUTS = %w[
+      packaging/live_agent_skills/proof.rb
+      packaging/live_agent_skills/workflow_creator_bundle.rb
+      packaging/live_agent_skills/workflow_creator.rb
+      packaging/live_agent_skills/workflow_creator_contract.rb
+      packaging/live_agent_skills/workflow_creator_execution_contract.rb
+      packaging/live_agent_skills/workflow_creator_text_safety.rb
+      packaging/live_agent_skills/workflow_creator_values.rb
+      packaging/live_agent_skills/build.rb
+    ].freeze
+    BUILDER_INPUTS = (LIVE_AGENT_BUILDER_INPUTS + [ "packaging/managed_web_archive.rb" ]).freeze
+    BUILDER_ARCHIVE_PATHS = BUILDER_INPUTS.each_with_object({}) do |path, result|
+      parts = path.split("/")
+      (1...parts.length).each do |length|
+        ancestor = parts.first(length).join("/")
+        result[ancestor.downcase] = [ ancestor, :directory ].freeze
+      end
+      result[path.downcase] = [ path, :file ].freeze
+    end.freeze
+    MAX_SOURCE_ARCHIVE_BYTES = 268_435_456
+    MAX_SOURCE_ARCHIVE_ENTRIES = 16_384
+    MAX_SOURCE_EXPANDED_BYTES = 1_073_741_824
+    MAX_BUILDER_INPUT_BYTES = 1_048_576
+    MAX_SOURCE_TAR_PADDING_BYTES = 1_048_576
+    SOURCE_ENTRY_TYPES = %w[0 5 g].freeze
 
     attr_reader :repo_root, :candidate_sha, :candidate_dir
 
@@ -235,15 +260,14 @@ module HiveReleaseCandidate
     end
 
     def builder_revision(export)
-      paths = [
-        File.join(export, "packaging", "live_agent_skills", "proof.rb"),
-        File.join(export, "packaging", "live_agent_skills", "build.rb"),
-        File.expand_path("../managed_web_archive.rb", __dir__)
-      ]
       digest = Digest::SHA256.new
-      paths.each do |path|
+      BUILDER_INPUTS.each do |label|
+        path = File.join(export, label)
         raise Error, "candidate builder input is missing: #{path}" unless File.file?(path) && !File.symlink?(path)
-        digest << File.basename(path) << "\0" << File.binread(path) << "\0"
+        if File.size(path) > MAX_BUILDER_INPUT_BYTES
+          raise Error, "candidate builder input exceeds the size limit: #{label}"
+        end
+        digest << label << "\0" << File.binread(path) << "\0"
       end
       digest.hexdigest
     end
@@ -252,36 +276,109 @@ module HiveReleaseCandidate
       source_name, = files.find { |_name, record| record["kind"] == "source" }
       raise Error, "candidate source artifact is missing" unless source_name
 
-      wanted = %w[
-        packaging/live_agent_skills/proof.rb
-        packaging/live_agent_skills/build.rb
-      ]
-      contents = {}
-      Zlib::GzipReader.open(File.join(directory, source_name)) do |gzip|
-        Gem::Package::TarReader.new(gzip) do |tar|
-          tar.each do |entry|
-            name = entry.full_name.sub(%r{\A\./}, "")
-            contents[name] = entry.read if entry.file? && wanted.include?(name)
-          end
-        end
-      end
-      missing = wanted - contents.keys
+      source_path = File.join(directory, source_name)
+      contents = source_builder_contents(source_path)
+      missing = BUILDER_INPUTS - contents.keys
       unless missing.empty?
         raise Error, "candidate source omits builder input #{missing.first}"
       end
 
       digest = Digest::SHA256.new
-      wanted.each do |name|
-        digest << File.basename(name) << "\0" << contents.fetch(name) << "\0"
+      BUILDER_INPUTS.each do |name|
+        digest << name << "\0" << contents.fetch(name) << "\0"
       end
-      managed = File.expand_path("../managed_web_archive.rb", __dir__)
-      unless File.file?(managed) && !File.symlink?(managed)
-        raise Error, "managed web builder input is missing"
-      end
-      digest << File.basename(managed) << "\0" << File.binread(managed) << "\0"
       digest.hexdigest
     rescue Zlib::GzipFile::Error, Gem::Package::TarInvalidError, EOFError => e
       raise Error, "cannot verify candidate source builder inputs: #{e.message}"
+    end
+
+    def source_builder_contents(source_path)
+      unless File.size(source_path).between?(1, MAX_SOURCE_ARCHIVE_BYTES)
+        raise Error, "candidate source archive exceeds the compressed-size limit"
+      end
+      state = { contents: {}, destinations: {}, entries: 0, expanded: 0, global_header: false }
+      compressed = File.open(source_path, "rb")
+      gzip = Zlib::GzipReader.new(compressed)
+      Gem::Package::TarReader.new(gzip) do |tar|
+        tar.each { |entry| collect_source_entry!(entry, state) }
+      end
+      validate_source_tail!(gzip, compressed, state)
+      gzip = nil
+      state.fetch(:contents)
+    ensure
+      gzip&.close
+      compressed&.close unless compressed&.closed?
+    end
+
+    def collect_source_entry!(entry, state)
+      state[:entries] += 1
+      state[:expanded] += entry.size
+      unless state[:entries] <= MAX_SOURCE_ARCHIVE_ENTRIES && state[:expanded] <= MAX_SOURCE_EXPANDED_BYTES
+        raise Error, "candidate source archive exceeds the entry or expanded-size limit"
+      end
+      type = entry.header.typeflag
+      raise Error, "candidate source contains an unsupported archive entry" unless SOURCE_ENTRY_TYPES.include?(type)
+      return collect_global_header!(entry, state) if type == "g"
+
+      name = source_entry_name!(entry)
+      return unless name
+      key = name.downcase
+      raise Error, "candidate source duplicates an archive destination" if state[:destinations].key?(key)
+      state[:destinations][key] = true
+      collect_builder_entry!(entry, state, name, key)
+    end
+
+    def source_entry_name!(entry)
+      raw = entry.full_name.sub(%r{\A\./}, "")
+      name = entry.directory? ? raw.delete_suffix("/") : raw
+      return if name == "." && entry.directory?
+      parts = name.split("/", -1)
+      unsafe = name.start_with?("/") || parts.any? { |part| part.empty? || part == "." || part == ".." }
+      raise Error, "candidate source contains an unsafe archive entry" if unsafe
+      name
+    end
+
+    def collect_builder_entry!(entry, state, name, key)
+      expected, expected_type = BUILDER_ARCHIVE_PATHS[key]
+      return unless expected
+      valid_type = expected_type == :directory ? entry.directory? : entry.file?
+      unless name == expected && valid_type
+        raise Error, "candidate source builder path has a noncanonical name or wrong type"
+      end
+      return unless expected_type == :file
+      raise Error, "candidate source builder input exceeds the size limit" if entry.size > MAX_BUILDER_INPUT_BYTES
+      state[:contents][expected] = entry.read(MAX_BUILDER_INPUT_BYTES + 1)
+    end
+
+    def collect_global_header!(entry, state)
+      expected = "52 comment=#{candidate_sha}\n"
+      valid = !state[:global_header] && entry.full_name == "pax_global_header" &&
+        entry.size == expected.bytesize && entry.read(expected.bytesize + 1) == expected
+      raise Error, "candidate source contains noncanonical global archive metadata" unless valid
+      state[:global_header] = true
+    end
+
+    def validate_source_tail!(gzip, compressed, state)
+      padding = 0
+      begin
+        loop do
+          chunk = gzip.readpartial(16_384)
+          padding += chunk.bytesize
+          state[:expanded] += chunk.bytesize
+          valid = padding <= MAX_SOURCE_TAR_PADDING_BYTES && state[:expanded] <= MAX_SOURCE_EXPANDED_BYTES &&
+            chunk.each_byte.all?(&:zero?)
+          raise Error, "candidate source contains noncanonical tar padding" unless valid
+        end
+      rescue EOFError
+        nil
+      end
+      unused = gzip.unused
+      gzip.finish
+      trailing_member = (unused && !unused.empty?) || compressed.read(1)
+      raise Error, "candidate source must contain exactly one gzip member" if trailing_member
+      unless padding.between?(512, MAX_SOURCE_TAR_PADDING_BYTES) && (padding % 512).zero?
+        raise Error, "candidate source contains noncanonical tar padding"
+      end
     end
 
     def write_private_json(path, value)

--- a/test/unit/component_boundaries_test.rb
+++ b/test/unit/component_boundaries_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "ripper"
 require_relative "../support/component_boundary_contract"
 
 class ComponentBoundariesTest < Minitest::Test
@@ -305,14 +306,12 @@ class ComponentBoundariesTest < Minitest::Test
       packaging/live_agent_skills/workflow_creator.rb
       packaging/live_agent_skills/workflow_creator_contract.rb
       packaging/live_agent_skills/workflow_creator_execution_contract.rb
+      packaging/live_agent_skills/workflow_creator_bundle.rb
     ], workflow_core.fetch("owned_paths")
-    assert_empty workflow_core.fetch("hive_consumers")
-    assert_equal [ "U1a2" ],
-                 workflow_core.fetch("migration_exceptions").map { |entry| entry.fetch("removal_unit") }
+    assert_equal [ "packaging/live_agent_skills/proof.rb" ], workflow_core.fetch("hive_consumers")
+    assert_empty workflow_core.fetch("migration_exceptions")
 
-    ready_components.push(
-      agent_abi, artifact_firewall, skillpack, git_gate, work_ledger, workflow_values
-    )
+    ready_components.push(agent_abi, artifact_firewall, skillpack, git_gate, work_ledger, workflow_values)
     remaining_candidates = contract.components.reject do |component|
       ready_components.include?(component)
     end
@@ -354,11 +353,32 @@ class ComponentBoundariesTest < Minitest::Test
     assert_equal "Hive::WorkLedger", work_ledger_load.fetch("constant")
     assert_empty work_ledger_load.fetch("forbidden_loaded_features")
     assert_empty work_ledger_load.fetch("forbidden_constants")
+    workflow_core_load = contract.validate_clean_load!("workflow-creator-core")
+    assert_equal "HiveLiveAgentProof::WorkflowCreator", workflow_core_load.fetch("constant")
+    assert_empty workflow_core_load.fetch("forbidden_loaded_features")
+    assert_empty workflow_core_load.fetch("forbidden_constants")
     patrol_effects_load = contract.validate_clean_load!("patrol-effects")
     assert_equal "Hive::Modules::Migration::PatrolEvidence",
                  patrol_effects_load.fetch("constant")
     assert_empty patrol_effects_load.fetch("forbidden_loaded_features")
     assert_empty patrol_effects_load.fetch("forbidden_constants")
+  end
+
+  def test_workflow_creator_bundle_dependency_direction_and_budget
+    proof = File.read(File.join(ROOT, "packaging/live_agent_skills/proof.rb"))
+    bundle_path = File.join(ROOT, "packaging/live_agent_skills/workflow_creator_bundle.rb")
+    bundle = File.read(bundle_path)
+    core = %w[
+      workflow_creator.rb workflow_creator_contract.rb workflow_creator_execution_contract.rb
+    ].map { |name| File.read(File.join(ROOT, "packaging/live_agent_skills", name)) }.join("\n")
+
+    assert_includes proof, 'require_relative "workflow_creator_bundle"'
+    assert_includes bundle, 'require_relative "workflow_creator"'
+    refute_match(/workflow_creator_bundle|proof\.rb/, core)
+    metrics = ruby_metrics(bundle)
+    assert_operator File.readlines(bundle_path).length, :<=, 220
+    assert_operator metrics.fetch(:callables), :<=, 10
+    assert_operator metrics.fetch(:decisions), :<=, 28
   end
 
   def test_patrol_u3a_require_graph_is_closed_and_one_way
@@ -446,8 +466,7 @@ class ComponentBoundariesTest < Minitest::Test
       assert_includes row, "[[#{wiki_link}]]"
       assert_includes wiki_index, "[[#{wiki_link}]]"
       expected_removals = {
-        "patrol-effects" => [ "U3" ],
-        "workflow-creator-core" => [ "U1a2" ]
+        "patrol-effects" => [ "U3" ]
       }.fetch(component.fetch("id"), [])
       assert_equal expected_removals,
                    component.fetch("migration_exceptions").map { |entry| entry.fetch("removal_unit") },
@@ -1271,6 +1290,25 @@ class ComponentBoundariesTest < Minitest::Test
   end
 
   private
+
+  def ruby_metrics(source)
+    stack = [ Ripper.sexp(source) ]
+    callables = 0
+    decisions = 0
+    decision_nodes = %i[
+      if unless elsif if_mod unless_mod ifop when in rescue rescue_mod while until for while_mod until_mod
+    ]
+    until stack.empty?
+      node = stack.pop
+      next unless node.instance_of?(Array)
+      type = node.first
+      callables += 1 if %i[def defs lambda].include?(type)
+      decisions += 1 if decision_nodes.include?(type)
+      decisions += 1 if type == :binary && %i[&& ||].include?(node[2])
+      stack.concat(node.select { |child| child.instance_of?(Array) })
+    end
+    { callables:, decisions: }
+  end
 
   def contract_component_owned_files(id)
     component(@document, id).fetch("owned_paths").flat_map do |relative|

--- a/test/unit/packaging/live_agent_proof_test.rb
+++ b/test/unit/packaging/live_agent_proof_test.rb
@@ -8,6 +8,7 @@ class LiveAgentProofTest < Minitest::Test
   SHA = "a" * 40
   WORKFLOW_SHA = "b" * 40
   REPOSITORY = "ivankuznetsov/hive"
+  Creator = HiveLiveAgentProof::WorkflowCreator
 
   def test_builder_produces_deterministic_four_platform_artifacts
     with_tmp_dir do |dir|
@@ -93,13 +94,14 @@ class LiveAgentProofTest < Minitest::Test
       creator_evidence = prepare_creator_evidence(dir, artifacts)
       proof = File.join(dir, "proof")
       result = attest(artifacts, evidence, creator_evidence, proof)
+      FileUtils.rm_rf(creator_evidence)
 
       verified = HiveLiveAgentProof::Verifier.new(
         proof_dir: proof, candidate_sha: SHA, workflow_revision: WORKFLOW_SHA,
         repository: REPOSITORY, run_id: "42", run_attempt: "1", attestation_sha256: result.fetch("sha256")
       ).call
 
-      assert_match(/hive-cli-1\.2\.3\.gem\z/, verified.fetch("gem"))
+      assert_match(/hive-cli-#{Regexp.escape(Hive::VERSION)}\.gem\z/, verified.fetch("gem"))
       assert_match(/hive-agent-skills-#{SHA}\.tar\.gz\z/, verified.fetch("skills"))
     end
   end
@@ -147,30 +149,50 @@ class LiveAgentProofTest < Minitest::Test
     end
   end
 
-  def test_attestor_rejects_workflow_creator_mutation_or_graph_drift
+  def test_attestor_rejects_workflow_creator_cross_binding_drift
     with_tmp_dir do |dir|
       artifacts = prepare_artifacts(dir)
       evidence = prepare_evidence(dir, artifacts)
       creator_evidence = prepare_creator_evidence(dir, artifacts)
-      row_path = File.join(creator_evidence, "openclaw-workflow-creator.json")
-      row = JSON.parse(File.read(row_path))
-      row["task_count"] = 2
-      HiveLiveAgentProof.write_json(row_path, row)
+      path = File.join(creator_evidence, "candidate-installed-manifest.json")
+      document = JSON.parse(File.read(path))
+      document["candidate_sha"] = "c" * 40
+      write_canonical_json(path, document)
 
       error = assert_raises(HiveLiveAgentProof::Error) do
-        attest(artifacts, evidence, creator_evidence, File.join(dir, "proof-task"))
+        attest(artifacts, evidence, creator_evidence, File.join(dir, "proof-installation"))
       end
-      assert_includes error.message, "unauthorized side effect"
+      assert_includes error.message, "workflow-creator"
 
       creator_evidence = prepare_creator_evidence(dir, artifacts)
-      row_path = File.join(creator_evidence, "openclaw-workflow-creator.json")
-      row = JSON.parse(File.read(row_path))
-      row["validation"]["stages"] << "publish"
-      HiveLiveAgentProof.write_json(row_path, row)
+      path = File.join(creator_evidence, "execution-receipt.json")
+      receipt = JSON.parse(File.read(path))
+      receipt["installed_manifests"].reverse!
+      write_canonical_json(path, receipt)
       error = assert_raises(HiveLiveAgentProof::Error) do
-        attest(artifacts, evidence, creator_evidence, File.join(dir, "proof-publish"))
+        attest(artifacts, evidence, creator_evidence, File.join(dir, "proof-receipt"))
       end
-      assert_includes error.message, "normalized graph"
+      assert_includes error.message, "workflow-creator"
+    end
+  end
+
+  def test_attestor_rejects_unsafe_workflow_creator_sources
+    with_tmp_dir do |dir|
+      artifacts = prepare_artifacts(dir)
+      evidence = prepare_evidence(dir, artifacts)
+      expected = {
+        missing: "inventory", extra: "inventory", symlink: "regular file", hardlink: "regular file",
+        public_root: "owner-private", public_member: "private regular file",
+        oversize: "size limit", noncanonical: "canonical JSON"
+      }
+      expected.each do |kind, message|
+        bundle = prepare_creator_evidence(File.join(dir, kind.to_s), artifacts)
+        mutate_creator_bundle(bundle, kind, dir)
+        error = assert_raises(HiveLiveAgentProof::Error, kind.to_s) do
+          attest(artifacts, evidence, bundle, File.join(dir, "proof-#{kind}"))
+        end
+        assert_includes error.message, message, kind.to_s
+      end
     end
   end
 
@@ -196,6 +218,24 @@ class LiveAgentProofTest < Minitest::Test
       File.open(gem, "ab") { |file| file.write("substitution") }
       error = assert_raises(HiveLiveAgentProof::Error) { verifier(proof, result.fetch("sha256")).call }
       assert_includes error.message, "digest mismatch"
+
+      artifacts = prepare_artifacts(File.join(dir, "retained"))
+      evidence = prepare_evidence(File.join(dir, "retained"), artifacts)
+      creator_evidence = prepare_creator_evidence(File.join(dir, "retained"), artifacts)
+      proof = File.join(dir, "proof-retained")
+      result = attest(artifacts, evidence, creator_evidence, proof)
+      numeric_substitution = deep_dup(result.dig("attestation", "workflow_creator"))
+      numeric_substitution["task_count"] = 1.0
+      assert_raises(HiveLiveAgentProof::Error) do
+        HiveLiveAgentProof::WorkflowCreatorBundle.retained(
+          directory: File.join(proof, "evidence"), expected_primary: numeric_substitution,
+          manifest: result.dig("attestation", "artifacts"), candidate_sha: SHA
+        )
+      end
+      retained = File.join(proof, "evidence", "openclaw-installed-manifest.json")
+      File.open(retained, "ab") { |file| file.write(" ") }
+      error = assert_raises(HiveLiveAgentProof::Error) { verifier(proof, result.fetch("sha256")).call }
+      assert_includes error.message, "canonical JSON"
     end
   end
 
@@ -216,8 +256,9 @@ class LiveAgentProofTest < Minitest::Test
   end
 
   def prepare_artifacts(dir)
+    FileUtils.mkdir_p(dir)
     artifacts = File.join(dir, "candidate")
-    gem = write_file(File.join(dir, "hive-cli-1.2.3.gem"), "gem-bytes")
+    gem = write_file(File.join(dir, "hive-cli-#{Hive::VERSION}.gem"), "gem-bytes")
     source = write_file(File.join(dir, "source.tar.gz"), "source-bytes")
     build(gem, source, artifacts, Hive::AgentSkills::CanonicalSkill.new)
     artifacts
@@ -276,57 +317,204 @@ class LiveAgentProofTest < Minitest::Test
   def prepare_creator_evidence(dir, artifacts)
     evidence = File.join(dir, "creator-evidence")
     FileUtils.rm_rf(evidence)
-    FileUtils.mkdir_p(evidence)
+    FileUtils.mkdir_p(evidence, mode: 0o700)
+    File.chmod(0o700, evidence)
     manifest = JSON.parse(File.read(File.join(artifacts, "artifact-manifest.json")))
-    row = {
-      "schema" => "hive-live-workflow-creator-evidence",
-      "schema_version" => 1,
-      "platform" => "openclaw",
-      "candidate_sha" => SHA,
-      "result" => "passed",
-      "prompt_sha256" => Digest::SHA256.hexdigest(HiveLiveAgentProof::WORKFLOW_CREATOR_PROMPT),
-      "task_prompt_sha256" =>
-        Digest::SHA256.hexdigest(HiveLiveAgentProof::WORKFLOW_CREATOR_TASK_PROMPT),
-      "skill" => {
-        "skill_version" => manifest.fetch("skill_version"),
-        "canonical_digest" => manifest.fetch("canonical_digest")
-      },
-      "native_activation" => {
-        "kind" => HiveLiveAgentProof::NATIVE_ACTIVATION_KINDS.fetch("openclaw"),
-        "invocation" => HiveLiveAgentProof::INVOCATIONS.fetch("openclaw")
-      },
-      "hive_commands" => HiveLiveAgentProof::WORKFLOW_CREATOR_COMMANDS,
-      "created_files" => HiveLiveAgentProof::WORKFLOW_CREATOR_FILES.map do |path|
-        { "path" => path, "sha256" => "c" * 64, "size" => 10 }
-      end,
-      "validation" => {
-        "valid" => true,
-        "stages" => %w[research draft approval],
-        "automatic_edges" => [ %w[research draft], %w[draft approval] ],
-        "human_outcomes" => [
-          { "stage" => "approval", "name" => "approve", "complete" => true,
-            "artifact" => "draft.md", "to" => nil },
-          { "stage" => "approval", "name" => "reject", "complete" => false,
-            "artifact" => nil, "to" => "draft" }
-        ]
-      },
-      "creation_only_task_count" => 0,
-      "task_count" => 1,
-      "task" => {
-        "slug" => HiveLiveAgentProof::WORKFLOW_CREATOR_TASK_SLUG,
-        "workflow" => "editorial",
-        "first_created" => true,
-        "retry_created" => false,
-        "run_count" => 1,
-        "current_stage" => "1-research"
-      },
-      "external_actions" => [],
-      "secret_scan" => { "status" => "passed" },
-      "cleanup" => { "status" => "passed" }
+    installations = %w[candidate openclaw].to_h do |kind|
+      [ kind, creator_installation(kind, manifest) ]
+    end
+    records = creator_installation_records(installations)
+    row = creator_primary_row(manifest, records)
+    receipt = creator_execution_receipt(row, records, installations)
+    bind_creator_receipt!(row, records, receipt)
+    documents = {
+      "openclaw-workflow-creator.json" => row,
+      "candidate-installed-manifest.json" => installations.fetch("candidate"),
+      "openclaw-installed-manifest.json" => installations.fetch("openclaw"),
+      "execution-receipt.json" => receipt
     }
-    HiveLiveAgentProof.write_json(File.join(evidence, "openclaw-workflow-creator.json"), row)
+    documents.each { |name, document| write_canonical_json(File.join(evidence, name), document) }
     evidence
   end
+
+  def mutate_creator_bundle(bundle, kind, root)
+    receipt = File.join(bundle, "execution-receipt.json")
+    case kind
+    when :missing
+      FileUtils.rm_f(receipt)
+    when :extra
+      File.write(File.join(bundle, "legacy.json"), "{}\n")
+    when :symlink
+      outside = File.join(root, "outside-receipt.json")
+      FileUtils.mv(receipt, outside)
+      File.symlink(outside, receipt)
+    when :hardlink
+      File.link(receipt, File.join(root, "receipt-hardlink.json"))
+    when :public_root
+      File.chmod(0o755, bundle)
+    when :public_member
+      File.chmod(0o644, receipt)
+    when :oversize
+      File.binwrite(receipt, " " * (1_048_576 + 1))
+    when :noncanonical
+      member = File.join(bundle, "candidate-installed-manifest.json")
+      File.binwrite(member, JSON.pretty_generate(JSON.parse(File.read(member))) + "\n")
+    end
+  end
+
+  def creator_installation(kind, manifest)
+    roles = Creator::Vocabulary.fetch("member_roles").fetch(kind).to_h do |role|
+      path = role == "package" ? "packages/#{kind}.pkg" : "#{role}/fixture"
+      artifact = manifest.fetch("files").values_at("hive-cli-#{Hive::VERSION}.gem").first if
+        kind == "candidate" && role == "package"
+      [ role, { "path" => path, "sha256" => artifact&.fetch("sha256") || Digest::SHA256.hexdigest(path),
+                "size" => artifact&.fetch("size") || path.bytesize } ]
+    end
+    dependency = {
+      "path" => "runtime/dependency.rb", "sha256" => Digest::SHA256.hexdigest("dependency"), "size" => 21
+    }
+    inventory = [ *roles.values.map { |record| deep_dup(record) }, dependency ]
+      .sort_by { |record| record.fetch("path") }
+    closure = { "required_roles" => roles, "inventory" => inventory }
+    {
+      "schema" => Creator::Vocabulary.fetch("installed_schema"), "schema_version" => 1,
+      "candidate_sha" => SHA, "kind" => kind,
+      "version" => kind == "candidate" ? manifest.fetch("hive_version") : "fixture-openclaw",
+      "closure_sha256" => Digest::SHA256.hexdigest(canonical(closure)), "required_roles" => roles,
+      "inventory" => inventory, "total_size" => inventory.sum { |record| record.fetch("size") },
+      "secret_scan" => creator_passing_scan
+    }
+  end
+
+  def creator_installation_records(installations)
+    records = %w[candidate openclaw].each_with_index.map do |kind, index|
+      bytes = canonical(installations.fetch(kind))
+      {
+        "kind" => "#{kind}_installation",
+        "path" => Creator::Vocabulary.fetch("bundle_files").fetch(index + 1),
+        "sha256" => Digest::SHA256.hexdigest(bytes), "size" => bytes.bytesize
+      }
+    end
+    records << {
+      "kind" => "execution_receipt", "path" => "execution-receipt.json",
+      "sha256" => Digest::SHA256.hexdigest("pending"), "size" => 1
+    }
+  end
+
+  def creator_primary_row(manifest, records)
+    created = Creator::Vocabulary.fetch("files").map do |path|
+      { "path" => path, "sha256" => Digest::SHA256.hexdigest(path), "size" => path.bytesize }
+    end
+    summary = { "status" => "passed", "receipt_sha256" => records.fetch(2).fetch("sha256") }
+    {
+      "schema" => Creator::Vocabulary.fetch("evidence_schema"), "schema_version" => 1,
+      "platform" => "openclaw", "candidate_sha" => SHA, "result" => "passed",
+      "prompt_sha256" => Digest::SHA256.hexdigest(Creator::Vocabulary.fetch("prompt")),
+      "task_prompt_sha256" => Digest::SHA256.hexdigest(Creator::Vocabulary.fetch("task_prompt")),
+      "skill" => manifest.slice("skill_version", "canonical_digest"),
+      "native_activation" => deep_dup(Creator::Vocabulary.fetch("native_activation")),
+      "hive_commands" => deep_dup(Creator::Vocabulary.fetch("commands")), "created_files" => created,
+      "validation" => deep_dup(Creator::Vocabulary.fetch("graph")), "creation_only_task_count" => 0,
+      "task_count" => 1, "task" => deep_dup(Creator::Vocabulary.fetch("task")), "external_actions" => [],
+      "secret_scan" => creator_passing_scan, "execution_kind" => "authenticated_openclaw",
+      "model_loop" => "executed", "executed_instruction" => deep_dup(created.fetch(2)),
+      "evidence_bundle" => deep_dup(records), "containment" => deep_dup(summary),
+      "teardown" => deep_dup(summary), "cleanup" => deep_dup(summary)
+    }
+  end
+
+  def creator_execution_receipt(row, records, installations)
+    command_labels = Creator::Vocabulary.fetch("commands").each_index.map do |index|
+      format("command-%02d", index + 1)
+    end
+    commands = Creator::Vocabulary.fetch("commands").each_with_index.map do |argv, index|
+      creator_process_receipt("attempt_label" => command_labels.fetch(index)).merge(
+        "position" => index + 1, "argv" => deep_dup(argv)
+      )
+    end
+    outer = Creator::Vocabulary.fetch("outer_roles").each_with_index.map do |identity, index|
+      creator_process_receipt("label" => %w[outer-workflow-creator outer-authorized-work].fetch(index)).merge(
+        deep_dup(identity), "argv_sha256" => Digest::SHA256.hexdigest("outer-#{index}")
+      )
+    end
+    labels = command_labels + outer.map { |process| process.fetch("label") }
+    correlation = "workflow-creator-proof-run"
+    archives = installations.values.map { |document| document.dig("required_roles", "package") }
+      .each_with_index.map do |package, index|
+      {
+        "label" => Creator::Vocabulary.fetch("archive_labels").fetch(index),
+        "artifact_sha256" => package.fetch("sha256"), "artifact_size" => package.fetch("size"),
+        "policy_sha256" => Creator::Vocabulary.fetch("archive_policy_sha256"),
+        "entry_count" => 5, "uncompressed_bytes" => 1_024, "status" => "passed"
+      }
+    end
+    instruction = deep_dup(row.fetch("executed_instruction"))
+    {
+      "schema" => Creator::Vocabulary.fetch("execution_schema"), "schema_version" => 1,
+      "candidate_sha" => SHA, "result" => "passed",
+      "execution_plan" => Creator::Vocabulary.fetch("execution_plan"),
+      "classification" => {
+        "outer" => deep_dup(Creator::Vocabulary.fetch("classification")),
+        "nested_stage" => { "execution_kind" => "deterministic_fixture", "model_loop" => "not_exercised" }
+      },
+      "installed_manifests" => deep_dup(records.first(2)),
+      "run" => { "correlation_id" => correlation, "expected_labels" => labels },
+      "gateway" => {
+        "identity" => deep_dup(installations.fetch("candidate").dig("required_roles", "audit_gateway")),
+        "command_labels" => command_labels, "status" => "passed"
+      },
+      "archive_admissions" => archives, "commands" => commands, "outer_processes" => outer,
+      "authored_instruction" => deep_dup(instruction), "executed_instruction" => instruction,
+      "external_actions" => [],
+      "containment" => {
+        "status" => "passed", "mechanism" => "supervised-process-tree", "established_before_launch" => true,
+        "owner_correlation_id" => correlation, "root_loss_behavior" => "fail-closed"
+      },
+      "teardown" => {
+        "status" => "passed", "expected_labels" => labels, "receipt_labels" => deep_dup(labels),
+        "outer_root_reaped" => true, "remaining_descendants" => 0
+      },
+      "cleanup" => { "status" => "passed", "targets" => [
+        { "label" => "proof-workspace", "path_sha256" => Digest::SHA256.hexdigest("workspace"),
+          "device" => 1, "inode" => 2, "created_by_run" => true,
+          "identity_matched" => true, "removed" => true }
+      ] },
+      "secret_scan" => creator_passing_scan
+    }
+  end
+
+  def creator_process_receipt(label)
+    label.merge(
+      "exit_code" => 0, "signal" => nil, "completed" => true,
+      "capture" => {
+        "limit_bytes" => 4_096, "stdout_bytes" => 0, "stderr_bytes" => 0,
+        "stdout_sha256" => Digest::SHA256.hexdigest(""), "stderr_sha256" => Digest::SHA256.hexdigest(""),
+        "stdout_truncated" => false, "stderr_truncated" => false, "secret_scan" => creator_passing_scan
+      },
+      "teardown" => {
+        "status" => "passed", "term_sent" => false, "kill_sent" => false,
+        "reaped" => true, "descendants" => "none", "owner_complete" => true
+      }
+    )
+  end
+
+  def bind_creator_receipt!(row, records, receipt)
+    bytes = canonical(receipt)
+    record = records.fetch(2)
+    record["sha256"], record["size"] = Digest::SHA256.hexdigest(bytes), bytes.bytesize
+    row.fetch("evidence_bundle")[2] = deep_dup(record)
+    summary = { "status" => "passed", "receipt_sha256" => record.fetch("sha256") }
+    %w[containment teardown cleanup].each { |field| row[field] = deep_dup(summary) }
+  end
+
+  def write_canonical_json(path, value)
+    File.binwrite(path, canonical(value))
+    File.chmod(0o600, path)
+  end
+
+  def canonical(value) = Creator::Values.capture(value).canonical_bytes
+  def creator_passing_scan = { "status" => "passed", "scanner" => Creator::Vocabulary.fetch("scanner") }
+  def deep_dup(value) = Marshal.load(Marshal.dump(value))
 
   def attest(artifacts, evidence, creator_evidence, proof)
     HiveLiveAgentProof::Attestor.new(

--- a/test/unit/packaging/live_agent_proof_test.rb
+++ b/test/unit/packaging/live_agent_proof_test.rb
@@ -176,6 +176,31 @@ class LiveAgentProofTest < Minitest::Test
     end
   end
 
+  def test_attestor_rejects_secrets_in_workflow_creator_support_members
+    with_tmp_dir do |dir|
+      artifacts = prepare_artifacts(dir)
+      evidence = prepare_evidence(dir, artifacts)
+      creator_evidence = prepare_creator_evidence(dir, artifacts)
+      row_path = File.join(creator_evidence, "openclaw-workflow-creator.json")
+      receipt_path = File.join(creator_evidence, "execution-receipt.json")
+      row = JSON.parse(File.read(row_path))
+      receipt = JSON.parse(File.read(receipt_path))
+      secret = "sk-ant-abcdefghijklmnop"
+      receipt.fetch("run")["correlation_id"] = secret
+      receipt.fetch("containment")["owner_correlation_id"] = secret
+      bind_creator_receipt!(row, row.fetch("evidence_bundle"), receipt)
+      write_canonical_json(receipt_path, receipt)
+      write_canonical_json(row_path, row)
+
+      proof = File.join(dir, "proof-secret")
+      error = assert_raises(HiveLiveAgentProof::Error) do
+        attest(artifacts, evidence, creator_evidence, proof)
+      end
+      assert_includes error.message, "secret scan failed"
+      refute_path_exists proof
+    end
+  end
+
   def test_attestor_rejects_unsafe_workflow_creator_sources
     with_tmp_dir do |dir|
       artifacts = prepare_artifacts(dir)

--- a/test/unit/packaging/release_candidate_artifacts_test.rb
+++ b/test/unit/packaging/release_candidate_artifacts_test.rb
@@ -92,6 +92,29 @@ class ReleaseCandidateArtifactsTest < Minitest::Test
     end
   end
 
+  def test_managed_web_build_executes_the_exported_candidate_helper
+    with_tmp_dir do |dir|
+      export = File.join(dir, "export")
+      helper = File.join(export, "packaging", "managed_web_archive.rb")
+      FileUtils.mkdir_p(File.dirname(helper))
+      File.write(helper, <<~'RUBY')
+        module HiveManagedWebArchive
+          def self.build(repo_root:, candidate_sha:, version:, destination:)
+            File.binwrite(destination, [repo_root, candidate_sha, version, "candidate-helper"].join("\n"))
+          end
+        end
+      RUBY
+      destination = File.join(dir, "hive-web.tar.gz")
+      artifacts = HiveReleaseCandidate::Artifacts.new(
+        repo_root: dir, candidate_sha: "a" * 40, candidate_dir: File.join(dir, "candidate")
+      )
+
+      artifacts.send(:build_managed_web, export, "0.6.9", destination)
+
+      assert_equal [ dir, "a" * 40, "0.6.9", "candidate-helper" ].join("\n"), File.binread(destination)
+    end
+  end
+
   def test_artifact_path_collision_fails_before_any_build
     with_tmp_dir do |dir|
       candidate = File.join(dir, "candidate")

--- a/test/unit/packaging/release_candidate_artifacts_test.rb
+++ b/test/unit/packaging/release_candidate_artifacts_test.rb
@@ -100,7 +100,10 @@ class ReleaseCandidateArtifactsTest < Minitest::Test
       File.write(helper, <<~'RUBY')
         module HiveManagedWebArchive
           def self.build(repo_root:, candidate_sha:, version:, destination:)
-            File.binwrite(destination, [repo_root, candidate_sha, version, "candidate-helper"].join("\n"))
+            File.binwrite(
+              destination,
+              [repo_root, candidate_sha, version, "candidate-helper", ENV.fetch("RUBYOPT", "scrubbed")].join("\n")
+            )
           end
         end
       RUBY
@@ -109,9 +112,12 @@ class ReleaseCandidateArtifactsTest < Minitest::Test
         repo_root: dir, candidate_sha: "a" * 40, candidate_dir: File.join(dir, "candidate")
       )
 
-      artifacts.send(:build_managed_web, export, "0.6.9", destination)
+      poisoned_rubyopt = [ "-rjson", ENV.fetch("RUBYOPT") ].join(" ")
+      with_env("RUBYOPT" => poisoned_rubyopt) do
+        artifacts.send(:build_managed_web, export, "0.6.9", destination)
+      end
 
-      assert_equal [ dir, "a" * 40, "0.6.9", "candidate-helper" ].join("\n"), File.binread(destination)
+      assert_equal [ dir, "a" * 40, "0.6.9", "candidate-helper", "scrubbed" ].join("\n"), File.binread(destination)
     end
   end
 

--- a/test/unit/packaging/release_candidate_artifacts_test.rb
+++ b/test/unit/packaging/release_candidate_artifacts_test.rb
@@ -8,6 +8,22 @@ require_relative "../../../packaging/release_candidate/runner"
 class ReleaseCandidateArtifactsTest < Minitest::Test
   include HiveTestHelper
 
+  BUILDER_INPUTS = %w[
+    packaging/live_agent_skills/proof.rb
+    packaging/live_agent_skills/workflow_creator_bundle.rb
+    packaging/live_agent_skills/workflow_creator.rb
+    packaging/live_agent_skills/workflow_creator_contract.rb
+    packaging/live_agent_skills/workflow_creator_execution_contract.rb
+    packaging/live_agent_skills/workflow_creator_text_safety.rb
+    packaging/live_agent_skills/workflow_creator_values.rb
+    packaging/live_agent_skills/build.rb
+  ].freeze
+
+  def test_builder_identity_covers_the_exact_live_agent_source_closure
+    assert_equal BUILDER_INPUTS, HiveReleaseCandidate::Artifacts::LIVE_AGENT_BUILDER_INPUTS
+    with_tmp_dir { |dir| fixture_artifacts(dir).verify! }
+  end
+
   def test_rejects_a_non_full_candidate_sha_before_building
     error = assert_raises(HiveReleaseCandidate::Error) do
       HiveReleaseCandidate::Artifacts.new(
@@ -55,6 +71,24 @@ class ReleaseCandidateArtifactsTest < Minitest::Test
       File.write(manifest_path, JSON.generate(manifest))
       error = assert_raises(HiveReleaseCandidate::Error) { artifacts.verify! }
       assert_includes error.message, "builder revision"
+    end
+  end
+
+  def test_source_closure_rejects_missing_duplicate_wrong_type_and_oversize_inputs
+    cases = {
+      drift: { drift: "packaging/live_agent_skills/proof.rb" },
+      missing: { missing: "packaging/live_agent_skills/workflow_creator_bundle.rb" },
+      duplicate: { duplicate: "packaging/live_agent_skills/proof.rb" },
+      wrong_type: { wrong_type: "packaging/live_agent_skills/workflow_creator_contract.rb" },
+      oversize: { oversize: "packaging/live_agent_skills/workflow_creator_values.rb" },
+      second_gzip_member: { second_gzip_member: true },
+      nonzero_padding: { nonzero_padding: true }
+    }
+    with_tmp_dir do |dir|
+      cases.each do |label, mutation|
+        artifacts = fixture_artifacts(File.join(dir, label.to_s), source_mutation: mutation)
+        assert_raises(HiveReleaseCandidate::Error, label.to_s) { artifacts.verify! }
+      end
     end
   end
 
@@ -134,7 +168,7 @@ class ReleaseCandidateArtifactsTest < Minitest::Test
 
   private
 
-  def fixture_artifacts(dir)
+  def fixture_artifacts(dir, source_mutation: {})
     candidate = File.join(dir, "candidate")
     FileUtils.mkdir_p(candidate)
     files = {
@@ -147,13 +181,10 @@ class ReleaseCandidateArtifactsTest < Minitest::Test
       File.binwrite(path, bytes)
     end
     source_name = "hive-source-#{'a' * 40}.tar.gz"
-    proof_bytes = "proof builder\n"
-    build_bytes = "build wrapper\n"
+    builder_bytes = BUILDER_INPUTS.to_h { |path| [ path, "#{path} source\n" ] }
     build_source_fixture(
       File.join(candidate, source_name),
-      proof_bytes: proof_bytes,
-      build_bytes: build_bytes,
-      root: dir
+      builder_bytes:, root: dir, mutation: source_mutation
     )
     files[source_name] = [ "source", nil ]
     records = files.to_h do |name, (kind, _bytes)|
@@ -168,10 +199,11 @@ class ReleaseCandidateArtifactsTest < Minitest::Test
       ]
     end
     builder_digest = Digest::SHA256.new
-    builder_digest << "proof.rb\0" << proof_bytes << "\0"
-    builder_digest << "build.rb\0" << build_bytes << "\0"
+    BUILDER_INPUTS.each do |path|
+      builder_digest << path << "\0" << builder_bytes.fetch(path) << "\0"
+    end
     managed = File.expand_path("../../../packaging/managed_web_archive.rb", __dir__)
-    builder_digest << "managed_web_archive.rb\0" << File.binread(managed) << "\0"
+    builder_digest << "packaging/managed_web_archive.rb\0" << File.binread(managed) << "\0"
     manifest = {
       "schema" => HiveReleaseCandidate::Artifacts::MANIFEST_SCHEMA,
       "schema_version" => 1,
@@ -188,14 +220,44 @@ class ReleaseCandidateArtifactsTest < Minitest::Test
     )
   end
 
-  def build_source_fixture(destination, proof_bytes:, build_bytes:, root:)
+  def build_source_fixture(destination, builder_bytes:, root:, mutation:)
     stage = File.join(root, "source-stage")
-    builders = File.join(stage, "packaging/live_agent_skills")
-    FileUtils.mkdir_p(builders)
-    File.binwrite(File.join(builders, "proof.rb"), proof_bytes)
-    File.binwrite(File.join(builders, "build.rb"), build_bytes)
-    _stdout, stderr, status = Open3.capture3("tar", "-czf", destination, "-C", stage, ".")
+    FileUtils.rm_rf(stage)
+    managed = File.expand_path("../../../packaging/managed_web_archive.rb", __dir__)
+    source_bytes = builder_bytes.merge("packaging/managed_web_archive.rb" => File.binread(managed))
+    source_bytes.each do |relative, bytes|
+      next if mutation[:missing] == relative
+      path = File.join(stage, relative)
+      if mutation[:wrong_type] == relative
+        FileUtils.mkdir_p(path)
+      else
+        FileUtils.mkdir_p(File.dirname(path))
+        content = if mutation[:oversize] == relative
+          "x" * 1_048_577
+        elsif mutation[:drift] == relative
+          "drifted source\n"
+        else
+          bytes
+        end
+        File.binwrite(path, content)
+      end
+    end
+    argv = [ "tar", "-czf", destination, "-C", stage, "." ]
+    argv += [ "-C", stage, mutation.fetch(:duplicate) ] if mutation[:duplicate]
+    _stdout, stderr, status = Open3.capture3(*argv)
     raise stderr unless status.success?
+
+    if mutation[:second_gzip_member]
+      File.open(destination, "ab") do |file|
+        gzip = Zlib::GzipWriter.new(file)
+        gzip.write("\0" * 1_024)
+        gzip.finish
+      end
+    elsif mutation[:nonzero_padding]
+      bytes = Zlib::GzipReader.open(destination, &:read)
+      bytes.setbyte(bytes.bytesize - 1, "x".ord)
+      Zlib::GzipWriter.open(destination) { |gzip| gzip.write(bytes) }
+    end
   end
 
   def run_git(repo, *argv)

--- a/test/unit/packaging/release_candidate_release_selector_test.rb
+++ b/test/unit/packaging/release_candidate_release_selector_test.rb
@@ -426,12 +426,11 @@ class ReleaseCandidateReleaseSelectorTest < Minitest::Test
     entries = {
       "lib/hive/version.rb" => "module Hive\n  VERSION = \"#{version}\"\nend\n",
       "packaging/release_candidate/baselines.yml" =>
-        File.binread(File.join(ROOT, "packaging/release_candidate/baselines.yml")),
-      "packaging/live_agent_skills/proof.rb" =>
-        File.binread(File.join(ROOT, "packaging/live_agent_skills/proof.rb")),
-      "packaging/live_agent_skills/build.rb" =>
-        File.binread(File.join(ROOT, "packaging/live_agent_skills/build.rb"))
+        File.binread(File.join(ROOT, "packaging/release_candidate/baselines.yml"))
     }
+    HiveReleaseCandidate::Artifacts::BUILDER_INPUTS.each do |name|
+      entries[name] = File.binread(File.join(ROOT, name))
+    end
     Zlib::GzipWriter.open(path) do |gzip|
       Gem::Package::TarWriter.new(gzip) do |tar|
         entries.each do |name, content|
@@ -443,13 +442,8 @@ class ReleaseCandidateReleaseSelectorTest < Minitest::Test
 
   def builder_revision
     digest = Digest::SHA256.new
-    %w[
-      packaging/live_agent_skills/proof.rb
-      packaging/live_agent_skills/build.rb
-      packaging/managed_web_archive.rb
-    ].each do |path|
-      digest << File.basename(path) << "\0" <<
-        File.binread(File.join(ROOT, path)) << "\0"
+    HiveReleaseCandidate::Artifacts::BUILDER_INPUTS.each do |path|
+      digest << path << "\0" << File.binread(File.join(ROOT, path)) << "\0"
     end
     digest.hexdigest
   end

--- a/wiki/component-boundaries.md
+++ b/wiki/component-boundaries.md
@@ -20,7 +20,7 @@ the first and primary consumer.
 | Patrol Effect Evidence | `candidate` (U3a protocol complete; U3b/U3c proof pending) | `require "hive/modules/migration/patrol_evidence"` → `Hive::Modules::Migration::PatrolEvidence` | [[modules/patrol]] |
 | Attempts admission / future RunReceipt | `candidate` (guarded reference) | `require "hive/attempts/api"` → `Hive::Attempts::API` | [[modules/attempts]] |
 | Workflow Creator Values | `boundary-ready` | `require "./packaging/live_agent_skills/workflow_creator_text_safety"` → `HiveLiveAgentProof::WorkflowCreator::TextSafety` | [[component-boundaries]] |
-| Workflow Creator Core | `candidate` (U1a2 consumer pending) | `require "./packaging/live_agent_skills/workflow_creator"` → `HiveLiveAgentProof::WorkflowCreator` | [[component-boundaries]] |
+| Workflow Creator Core | `candidate` (U1a2 custody complete; U1b publication pending) | `require "./packaging/live_agent_skills/workflow_creator"` → `HiveLiveAgentProof::WorkflowCreator` | [[component-boundaries]] |
 | UserService | `boundary-ready` | `require "hive/user_service"` → `Hive::UserService` | [[modules/user_service]] |
 | Agent ABI | `boundary-ready`; standalone package candidate | `require "hive/agent_runtime"` → `Hive::AgentRuntime` | [[modules/agent_cli_runtime]], [[modules/agent_profile]] |
 | Agent Artifact Firewall | `boundary-ready` | `require "hive/artifact_firewall"` → `Hive::ArtifactFirewall` | [[modules/protected_files]] |
@@ -38,9 +38,11 @@ has earned a gem, version, repository, or release.
 
 The catalog on 2026-08-04 retains ten components: seven are
 `boundary-ready`; Attempts, Patrol Effect Evidence, and Workflow Creator Core
-remain `candidate`. Patrol retains one bounded U3 exception for deterministic
-public-path and independently authorized installed/live proof. Workflow Creator
-Core retains one bounded U1a2 exception for custody and incumbent-consumer proof.
+remain `candidate`.
+Patrol retains one bounded U3 exception for deterministic public-path and
+independently authorized installed/live proof. Workflow Creator Core removed
+its U1a2 exception after the incumbent proof consumer adopted exact bundle
+custody, but stays candidate until U1b supplies the publication boundary.
 Every retained entry point has focused clean-process load proof, every
 catalog-owned path and focused test resolves inside this repository, and the
 direct-construction guards pass against all production Ruby sources.
@@ -64,7 +66,7 @@ Hive primitives. The source audit found no retained experimental facade outside
 the catalog: each promoted facade is owned by a catalog row and used by Hive,
 while Attempts, Patrol Effect Evidence, and Workflow Creator Core are
 deliberately retained as guarded candidates rather than being promoted ahead
-of their remaining lifecycle, qualification, or consumer proof.
+of their remaining lifecycle, qualification, or publication proof.
 
 This is an internal architecture verdict, not a packaging verdict. None of the
 seven ready components currently has the named non-Hive adopter and independent
@@ -188,10 +190,23 @@ marker when projection exceeds its bounded work ceiling, and snapshots only the
 internally constructed result afterward. It owns no retention, publication,
 process, provider, credential, archive I/O, or recovery authority.
 
+`WorkflowCreatorBundle` is the component's bounded custody owner above that
+semantic facade. `proof.rb` requires only this owner, which requires the Core;
+the Core never requires upward into custody or proof. Source admission accepts
+exactly the four vocabulary-named canonical JSON files from an owner-private
+directory through no-follow, single-link, current-owner, size-bounded,
+identity-stable descriptors. It validates both installation manifests, the
+primary and exact bundle records, then the execution receipt through the Core's
+public facade. Attestation retains those exact four bytes. Verification repeats
+the same validation from the retained evidence directory, where platform JSON
+may coexist, and compares the independently captured attested primary by
+canonical bytes. No one-file compatibility path remains.
+
 The approved U1a1c budget re-scope permits only named private semantic-helper
 decomposition. Its ceilings are 125/7/4 for the facade, 260/15/24 for the
 contract, 215/13/20 for execution, 590/34/48 for U1a1c, and 1090/68/104 for the
-Values/TextSafety/Core composition (lines/callables/decisions). Public APIs,
+Values/TextSafety/Core composition (lines/callables/decisions). The U1a2 bundle
+owner is independently capped at 220/10/28 and currently measures 146/10/26. Public APIs,
 owned files, responsibilities, dependency direction, and decision ceilings did
 not widen.
 
@@ -208,10 +223,11 @@ handles, and focused subprocess proof covers both load orders and post-load core
 replacement. The sources load without JSON, I/O, workflow, process, credential,
 or provider dependencies.
 
-The Values seam now has its first production consumer and no migration
-exception. Workflow Creator Core retains `removal_unit: U1a2` until retained
-bundle custody and the first incumbent proof consumer land. U1a1vt adds no
-creator schema, custody, publication, or live behavior.
+The Values seam and Workflow Creator Core both have production consumers and no
+migration exception. Core remains a custody-complete candidate: U1a2 adds proof
+custody and independent retained verification, but no provider, process,
+publisher, workflow mutation, or claim that the live workflow already emits the
+complete bundle.
 The exact R43 proof is 298 lines / 20 callables / 32 decisions for `Values`, 200
 lines / 14 callables / 23 decisions for `TextSafety`, and 498 / 34 / 55 when
 composed. The Values source retains its leaf-local `Ripper.lex` no-require proof;
@@ -378,7 +394,9 @@ entry point without widening the generic loader. Its Values no-require proof, co
 R43 proof, direct entry-point load-order proof, and projection behavior live in
 `test/unit/packaging/workflow_creator_values_test.rb` and
 `test/unit/packaging/workflow_creator_text_safety_test.rb`; semantic-core proof
-lives in `test/unit/packaging/workflow_creator_core_test.rb`.
+lives in `test/unit/packaging/workflow_creator_core_test.rb`, while exact source
+and retained bundle custody is covered by
+`test/unit/packaging/live_agent_proof_test.rb`.
 
 The syntax scan is an architecture regression guard, not a Ruby sandbox. Its
 construction rule covers literal `Constant.new`, not aliases or factory

--- a/wiki/component-boundaries.md
+++ b/wiki/component-boundaries.md
@@ -200,7 +200,10 @@ primary and exact bundle records, then the execution receipt through the Core's
 public facade. Attestation retains those exact four bytes. Verification repeats
 the same validation from the retained evidence directory, where platform JSON
 may coexist, and compares the independently captured attested primary by
-canonical bytes. No one-file compatibility path remains.
+canonical bytes. Before retention, the incumbent attestor applies its raw
+credential-pattern scan to every admitted member, so the aggregate scan count
+describes bytes that were actually scanned. No one-file compatibility path
+remains.
 
 The approved U1a1c budget re-scope permits only named private semantic-helper
 decomposition. Its ceilings are 125/7/4 for the facade, 260/15/24 for the

--- a/wiki/gaps.md
+++ b/wiki/gaps.md
@@ -1005,10 +1005,16 @@ on every channel, run one disposable installed upgrade for brew, AUR, and bash
 and retain the updater plus migration output. This gap does not weaken the
 local command contract or its deterministic tests.
 
-## Workflow Creator semantic core awaits custody (2026-08-04)
+## Live Workflow Creator still needs complete bundle production (2026-08-04)
 
-Workflow Creator Core is intentionally a semantic-only candidate until U1a2
-supplies retained-bundle custody and the first incumbent proof consumer. The
-current boundary proves immutable, caller-isolated schema validation but does
-not claim that `proof.rb` delegates to it or that validated receipt bytes are
-retained, published, or release-qualified.
+U1a2 makes the incumbent attestor and verifier require, retain, and
+independently revalidate the exact four-file Workflow Creator bundle. The
+Core therefore has a real consumer and no migration exception, but remains a
+custody-complete candidate until U1b supplies the publication boundary. The
+current live workflow still uploads only `openclaw-workflow-creator.json`, so
+that live result is now explicitly unavailable rather than accepted through a
+legacy one-file fallback. U1b/U14/U15 must produce the two installation
+manifests and execution receipt alongside the primary before a live passing
+claim is possible. No provider-backed run, publication, or release
+qualification was performed here; hostile/property campaigns remain optional
+and outside the normal merge gate.

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -25,8 +25,7 @@ Skillpack, Safe Agent Git Gate, WorkLedger, and Workflow Creator Values/Text
 Safety—and three guarded candidates: Attempts admission, Patrol Effect
 Evidence, and Workflow Creator Core. Skillpack's dependency on Agent ABI and
 the Core's dependency on Values are the two component edges. Patrol's U3
-qualification fence and Workflow Creator Core's U1a2 consumer fence are the
-only migration exceptions. Hive
+qualification fence is the only migration exception. Hive
 is the first and primary consumer, and internal readiness does not imply a gem,
 version, repository, or release.
 

--- a/wiki/log.d/20260804T132349Z-workflow-creator-bundle-custody.md
+++ b/wiki/log.d/20260804T132349Z-workflow-creator-bundle-custody.md
@@ -1,0 +1,19 @@
+---
+title: Workflow Creator bundle custody
+type: change
+date: 2026-08-04
+---
+
+- Cut the incumbent live-agent attestor and verifier over to one exact
+  four-file Workflow Creator bundle with no legacy primary-only fallback.
+- Added bounded no-follow source custody, exact-byte retention, independent
+  retained validation, and canonical attestation-primary binding through the
+  existing semantic facade.
+- Recorded the first Workflow Creator Core proof consumer and removed the U1a2
+  migration exception while retaining `candidate` state until U1b publication.
+- Bound release-candidate builder identity to the exact committed live-agent
+  builder source closure using stable repository-relative labels and bounded
+  source-archive admission.
+- Kept live Workflow Creator proof explicitly unavailable until U1b/U14/U15
+  produce the complete bundle; no provider, publication, or release claim was
+  added.

--- a/wiki/log.d/20260804T132349Z-workflow-creator-bundle-custody.md
+++ b/wiki/log.d/20260804T132349Z-workflow-creator-bundle-custody.md
@@ -7,13 +7,14 @@ date: 2026-08-04
 - Cut the incumbent live-agent attestor and verifier over to one exact
   four-file Workflow Creator bundle with no legacy primary-only fallback.
 - Added bounded no-follow source custody, exact-byte retention, independent
-  retained validation, and canonical attestation-primary binding through the
-  existing semantic facade.
+  retained validation, raw secret scanning for every retained member, and
+  canonical attestation-primary binding through the existing semantic facade.
 - Recorded the first Workflow Creator Core proof consumer and removed the U1a2
   migration exception while retaining `candidate` state until U1b publication.
 - Bound release-candidate builder identity to the exact committed live-agent
-  builder source closure using stable repository-relative labels and bounded
-  source-archive admission.
+  builder source closure using stable repository-relative labels, bounded
+  source-archive admission, and isolated execution of the exported managed-Web
+  helper.
 - Kept live Workflow Creator proof explicitly unavailable until U1b/U14/U15
   produce the complete bundle; no provider, publication, or release claim was
   added.

--- a/wiki/log.d/20260804T152657Z-release-candidate-builder-environment.md
+++ b/wiki/log.d/20260804T152657Z-release-candidate-builder-environment.md
@@ -1,0 +1,11 @@
+---
+title: Isolate the committed managed-Web builder environment
+type: change
+date: 2026-08-04
+---
+
+- Launched the committed managed-Web helper with a minimal allowlisted
+  path/locale environment instead of inherited Ruby, Bundler, and coverage
+  startup hooks.
+- Added a focused regression for the default-json/locked-json activation
+  conflict that failed the hosted release-candidate artifact test.

--- a/wiki/release-candidate.md
+++ b/wiki/release-candidate.md
@@ -26,7 +26,10 @@ the retained source archive with bounded compressed size, entry count,
 expanded bytes, and per-input bytes. Missing, duplicate, case/noncanonical,
 wrong-type, linked/unsupported, oversized, or drifted closure entries fail
 closed; this is narrow exact-input admission for the builder closure, not a
-generic archive extraction subsystem.
+generic archive extraction subsystem. The managed-Web helper runs in an
+isolated Ruby process from that exported candidate source, so the executed
+implementation and the recorded builder identity cannot diverge when a local
+checkout differs from the requested candidate SHA.
 
 `plan` is the default and is read-only. `list` and `inspect` are observational.
 `run`, `resume`, and `rerun` are explicit local mutations; local attempts use

--- a/wiki/release-candidate.md
+++ b/wiki/release-candidate.md
@@ -18,6 +18,16 @@ timestamp. Archiving `<sha>:web` without that explicit timestamp would use the
 wall clock for the tree object and make repeated exact-SHA builds produce
 different bytes.
 
+Candidate `builder_revision` hashes stable repository-relative labels plus the
+exact committed bytes for `proof.rb`, the Workflow Creator bundle/Core/
+contract/execution/Values/TextSafety sources, `build.rb`, and
+`packaging/managed_web_archive.rb`. Verification re-derives that identity from
+the retained source archive with bounded compressed size, entry count,
+expanded bytes, and per-input bytes. Missing, duplicate, case/noncanonical,
+wrong-type, linked/unsupported, oversized, or drifted closure entries fail
+closed; this is narrow exact-input admission for the builder closure, not a
+generic archive extraction subsystem.
+
 `plan` is the default and is read-only. `list` and `inspect` are observational.
 `run`, `resume`, and `rerun` are explicit local mutations; local attempts use
 the candidate SHA plus attempt ID, refuse identity drift, and take a nonblocking

--- a/wiki/release-candidate.md
+++ b/wiki/release-candidate.md
@@ -3,7 +3,7 @@ title: Release Candidate Evidence
 type: reference
 source: bin/hive-release-candidate, packaging/release_candidate/, packaging/managed_web_archive.rb, .github/workflows/{release-candidate,release}.yml
 created: 2026-07-27
-updated: 2026-07-27
+updated: 2026-08-04
 tags: [release, candidate, evidence, packaging, safety]
 ---
 
@@ -27,9 +27,11 @@ expanded bytes, and per-input bytes. Missing, duplicate, case/noncanonical,
 wrong-type, linked/unsupported, oversized, or drifted closure entries fail
 closed; this is narrow exact-input admission for the builder closure, not a
 generic archive extraction subsystem. The managed-Web helper runs in an
-isolated Ruby process from that exported candidate source, so the executed
-implementation and the recorded builder identity cannot diverge when a local
-checkout differs from the requested candidate SHA.
+isolated Ruby process from that exported candidate source with only an
+allowlisted path/locale environment. Parent Ruby, Bundler, and coverage startup
+hooks cannot alter helper loading, so the executed implementation and the
+recorded builder identity cannot diverge when a local checkout or process
+environment differs from the requested candidate SHA.
 
 `plan` is the default and is read-only. `list` and `inspect` are observational.
 `run`, `resume`, and `rerun` are explicit local mutations; local attempts use

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -135,12 +135,24 @@ bundle exec ruby -Itest -Ilib test/unit/component_boundaries_test.rb
 bundle exec ruby -Itest test/unit/packaging/workflow_creator_values_test.rb
 bundle exec ruby -Itest test/unit/packaging/workflow_creator_text_safety_test.rb
 bundle exec ruby -Itest test/unit/packaging/workflow_creator_core_test.rb
+bundle exec ruby -Itest test/unit/packaging/live_agent_proof_test.rb
 ```
 
 Ready components cannot depend on candidates. Forbidden-construction rules
 also apply to guarded candidates, and the helper can run a named focused
 clean-load proof for a candidate such as Attempts without representing the
 whole component graph as ready.
+
+The live-agent proof suite exercises the strict U1a2 cutover: source admission
+requires the exact four canonical vocabulary-named JSON files in an
+owner-private directory, attestation retains those exact bytes, and verification
+revalidates them after the source directory disappears. Missing, extra,
+symlinked, hardlinked, non-private, oversized, noncanonical, cross-bound, or
+retained-substituted members fail through the existing proof error boundary.
+The live workflow still produces only the former primary file, so provider-backed
+Workflow Creator proof remains unavailable until the complete bundle-producing
+units land; this focused suite is deterministic custody/semantic proof, not a
+live pass.
 
 Workflow Creator Values keeps its clean-load and dependency proof outside the
 generic component loader. The Values suite directly runs its leaf under

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -149,6 +149,10 @@ owner-private directory, attestation retains those exact bytes, and verification
 revalidates them after the source directory disappears. Missing, extra,
 symlinked, hardlinked, non-private, oversized, noncanonical, cross-bound, or
 retained-substituted members fail through the existing proof error boundary.
+Semantically valid support members containing credential-shaped bytes also
+fail before any proof directory is created. Release-candidate coverage proves
+the managed-Web archive executes the exported candidate helper even when it
+differs from the checkout-loaded implementation.
 The live workflow still produces only the former primary file, so provider-backed
 Workflow Creator proof remains unavailable until the complete bundle-producing
 units land; this focused suite is deterministic custody/semantic proof, not a


### PR DESCRIPTION
## Summary

- Workflow Creator proof now accepts one exact four-file semantic bundle and independently revalidates the retained bytes. The former primary-only proof path is gone, so incomplete or cross-bound evidence cannot qualify through compatibility behavior.
- Release-candidate identity now covers the full committed live-agent builder closure. The managed-Web helper executes from the same exported candidate source whose bytes are recorded, so a dirty or historical checkout cannot attest code that did not run.
- Workflow Creator Core now has its first incumbent consumer and no U1a2 migration exception. It remains a candidate until U1b supplies the publication boundary; this PR does not claim a live provider pass.

## Test plan

- [x] Focused U1a2 checkpoint: 67 runs, 2,787 assertions, 0 failures, 0 errors.
- [x] Release-selector fixture checkpoint: 9 runs, 58 assertions, 0 failures, 0 errors.
- [x] Syntax checks for the changed production Ruby and `git diff --check`.
- [x] Three parallel architecture, correctness, and reliability reviews; both material findings were fixed before push.
- [ ] Hosted CI coverage and dedicated merge gates are green.

The single broad local checkpoint completed 12,074 runs and 155,892 assertions. It reported 9 failures and 34 errors: one U1a2 fixture drift was fixed and passed in isolation afterward; the remaining output was dominated by sandbox-denied TCP/Unix sockets, tmux, and user-bus access, plus unrelated state-order failures. Hosted CI is the authoritative broad gate for this PR.

## Notes for reviewer

- The bundle owner is intentionally narrow: exact vocabulary-named JSON members, bounded no-follow reads, canonical bytes, semantic cross-binding, exact retention, and no legacy fallback.
- Credential-pattern scanning remains with the incumbent attestor and now covers all four admitted bundle members before output creation.
- Generic archive/path analysis, provider execution, publication, cutover, and rollback remain outside U1a2.
- The live workflow still emits only the former primary file. U1b/U14/U15 must produce the two installation manifests and execution receipt before a live passing claim is available.

## Post-Deploy Monitoring & Validation

- Owner/window: the release operator during the first release-candidate build and live-agent qualification attempt after merge.
- Search logs for `workflow-creator bundle`, `workflow-creator evidence secret scan failed`, `committed managed web builder failed`, and `candidate builder revision does not match`.
- Healthy signals: the source and retained proof each admit exactly four canonical members; the attestation reports nine actually scanned files; repeated candidate builds produce the same builder revision.
- Failure signals: any primary-only proof is accepted, a support member bypasses scanning, or the executed managed-Web helper differs from the recorded candidate closure.
- Mitigation: stop candidate promotion and revert this PR before retrying. There is no data migration or durable-schema rollback.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
