### PR TITLE
refactor(workflow-creator): add crash-safe receipt publication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,8 +229,9 @@ jobs:
   # tests can only stub launchctl. This job exercises the real round-trip on a
   # hosted macOS runner (which runs the user in a GUI session, so user-agent
   # `launchctl load` works). Scope is the install mechanics — not that the
-  # service stays up (that needs the web bundle / a bound port). No untrusted
-  # workflow input is used in any run step.
+  # service stays up (that needs the web bundle / a bound port). One focused
+  # creator-evidence happy path also executes its native syscalls on Darwin.
+  # No untrusted workflow input is used in any run step.
   launchd-macos:
     name: launchd service install (macOS)
     runs-on: macos-15
@@ -240,6 +241,10 @@ jobs:
         with:
           ruby-version: "3.4"
           bundler-cache: true
+      - name: workflow creator native publication happy path
+        run: >-
+          bundle exec ruby -Itest test/unit/packaging/workflow_creator_evidence_test.rb
+          --name test_replacement_is_compare_and_swap_and_post_rename_retry_is_exact
       - name: daemon launchd install round-trip
         run: |
           set -euo pipefail

--- a/.github/workflows/live-agent-skills.yml
+++ b/.github/workflows/live-agent-skills.yml
@@ -244,7 +244,7 @@ jobs:
           HIVE_CREATOR_EVIDENCE_PATH: ${{ runner.temp }}/workflow-creator-evidence/openclaw-workflow-creator.json
         run: |
           set -euo pipefail
-          mkdir -p "$RUNNER_TEMP/workflow-creator-evidence"
+          install -d -m 0700 "$RUNNER_TEMP/workflow-creator-evidence"
           cd candidate-source
           bundle exec ruby -Itest test/smoke/live_hive_workflow_creator_smoke_test.rb
       - name: Upload redacted workflow-creator evidence

--- a/config/component-boundaries.yml
+++ b/config/component-boundaries.yml
@@ -873,7 +873,7 @@ components:
     lock_contracts:
       - "Semantic validation is pure; the publication state machine owns only the fixed primary receipt and bounded-prefix staging links"
       - "Held directory descriptors and native no-follow openat/linkat/renameat/unlinkat calls bind publication and cleanup"
-      - "A cooperative native lock on the held target-directory descriptor serializes complete replacement transitions"
+      - "A bounded cooperative native lock on the held target-directory descriptor serializes complete initialization and replacement transitions"
     component_dependencies:
       - workflow-creator-values
     allowed_hive_dependencies: []
@@ -890,12 +890,12 @@ components:
           - packaging/live_agent_skills/workflow_creator_evidence.rb
         reason: "The typed creator evidence facade is the sole publication composition root"
     construction_scan_paths:
-      - packaging/live_agent_skills
+      - packaging
     hive_consumers:
       - packaging/live_agent_skills/proof.rb
       - test/smoke/live_hive_workflow_creator_smoke_test.rb
-    mutation_authority: "Only the evidence facade publishes the vocabulary-fixed primary receipt; it cannot choose filenames, execute commands, select providers, handle credentials, or issue a live-success claim."
-    recovery_surface: "Exact retries and bounded same-inode transient recovery converge; ambiguous links, changed parents, unsafe entries, conflicts, and native failures fail through typed creator evidence errors."
+    mutation_authority: "Only the evidence facade publishes the vocabulary-fixed primary receipt; it cannot choose filenames, execute commands, acquire or select credentials, or issue a live-success claim."
+    recovery_surface: "Exact retries and bounded one-link or same-inode two-link recovery converge; ambiguous links, changed parents, unsafe entries, conflicts, and native failures fail through typed creator evidence errors."
     wiki_page: wiki/component-boundaries.md
     focused_tests:
       - test/unit/packaging/workflow_creator_core_test.rb

--- a/config/component-boundaries.yml
+++ b/config/component-boundaries.yml
@@ -827,12 +827,12 @@ components:
     migration_exceptions: []
 
   - id: workflow-creator-core
-    name: Workflow Creator Core
-    state: candidate
+    name: Workflow Creator
+    state: boundary-ready
     entrypoint:
-      file: packaging/live_agent_skills/workflow_creator.rb
-      require: ./packaging/live_agent_skills/workflow_creator
-      constant: HiveLiveAgentProof::WorkflowCreator
+      file: packaging/live_agent_skills/workflow_creator_evidence.rb
+      require: ./packaging/live_agent_skills/workflow_creator_evidence
+      constant: HiveLiveAgentProof::WorkflowCreatorEvidence
     public_contract:
       values:
         - HiveLiveAgentProof::WorkflowCreator::Vocabulary
@@ -841,26 +841,39 @@ components:
         - HiveLiveAgentProof::WorkflowCreator.validate_primary!
         - HiveLiveAgentProof::WorkflowCreator.validate_installation!
         - HiveLiveAgentProof::WorkflowCreator.validate_execution!
+        - HiveLiveAgentProof::WorkflowCreatorBundle.source
+        - HiveLiveAgentProof::WorkflowCreatorBundle.retained
+        - HiveLiveAgentProof::WorkflowCreatorEvidence.initialize!
+        - HiveLiveAgentProof::WorkflowCreatorEvidence.replace_nonpassing!
       errors:
         - HiveLiveAgentProof::Error
         - HiveLiveAgentProof::WorkflowCreator::Error
+        - HiveLiveAgentProof::WorkflowCreatorEvidence::Conflict
+        - HiveLiveAgentProof::WorkflowCreatorEvidence::UnsafeStorage
+        - HiveLiveAgentProof::WorkflowCreatorEvidence::Unavailable
     owned_paths:
       - packaging/live_agent_skills/workflow_creator.rb
       - packaging/live_agent_skills/workflow_creator_contract.rb
       - packaging/live_agent_skills/workflow_creator_execution_contract.rb
       - packaging/live_agent_skills/workflow_creator_bundle.rb
+      - packaging/live_agent_skills/workflow_creator_evidence.rb
+      - packaging/live_agent_skills/workflow_creator_receipt_publisher.rb
     state_contracts:
       - "Each public input is captured once before semantic validation, and the admitted primary snapshot is returned"
       - "Failure construction captures stable caller inputs and detail once, then captures only its constructed result"
       - "The semantic core is declarative and owns no retention, publication, process, provider, or credential state"
       - "The bundle owner reads one exact four-file source bundle and independently revalidates retained proof bytes"
+      - "The evidence facade alone initializes and compare-and-swap replaces the vocabulary-fixed primary receipt"
+      - "Publication converges exact retries and bounded transient recovery without clobbering conflicting bytes"
     schema_contracts:
       - "Vocabulary and failed, primary, installation, and execution schema-v1 fields are exact and deeply immutable"
       - "Installed closures, ordered commands, capture digests, classifications, and receipt summaries are cross-bound"
       - "Source and retained bundle members are canonical JSON whose exact bytes bind the primary, installations, and receipt"
+      - "Published non-passing receipts are exact canonical bytes admitted by the merged creator semantic contract"
     lock_contracts:
-      - "No locks or durable state; validation is pure over immutable Values snapshots"
-      - "Source custody uses owner-private no-follow reads; proof retention and output creation remain with the incumbent attestor"
+      - "Semantic validation is pure; the publication state machine owns only the fixed primary receipt and bounded-prefix staging links"
+      - "Held directory descriptors and native no-follow openat/linkat/renameat/unlinkat calls bind publication and cleanup"
+      - "A cooperative native lock on the held target-directory descriptor serializes complete replacement transitions"
     component_dependencies:
       - workflow-creator-values
     allowed_hive_dependencies: []
@@ -868,14 +881,24 @@ components:
       - HiveLiveAgentProof::WorkflowCreator::Contract
       - HiveLiveAgentProof::WorkflowCreator::ExecutionContract
       - HiveLiveAgentProof::WorkflowCreatorBundle
-    forbidden_constructions: []
-    authorized_internal_constructions: []
+      - HiveLiveAgentProof::WorkflowCreatorReceiptPublisher
+    forbidden_constructions:
+      - HiveLiveAgentProof::WorkflowCreatorReceiptPublisher
+    authorized_internal_constructions:
+      - constant: HiveLiveAgentProof::WorkflowCreatorReceiptPublisher
+        files:
+          - packaging/live_agent_skills/workflow_creator_evidence.rb
+        reason: "The typed creator evidence facade is the sole publication composition root"
+    construction_scan_paths:
+      - packaging/live_agent_skills
     hive_consumers:
       - packaging/live_agent_skills/proof.rb
-    mutation_authority: "No mutation authority; reads bounded exact bundle bytes and allocates only immutable validated results. Attestation retention remains above the seam."
-    recovery_surface: "Semantic or custody validation fails closed through HiveLiveAgentProof::Error and exposes no retry or recovery state."
+      - test/smoke/live_hive_workflow_creator_smoke_test.rb
+    mutation_authority: "Only the evidence facade publishes the vocabulary-fixed primary receipt; it cannot choose filenames, execute commands, select providers, handle credentials, or issue a live-success claim."
+    recovery_surface: "Exact retries and bounded same-inode transient recovery converge; ambiguous links, changed parents, unsafe entries, conflicts, and native failures fail through typed creator evidence errors."
     wiki_page: wiki/component-boundaries.md
     focused_tests:
       - test/unit/packaging/workflow_creator_core_test.rb
+      - test/unit/packaging/workflow_creator_evidence_test.rb
       - test/unit/packaging/live_agent_proof_test.rb
     migration_exceptions: []

--- a/packaging/live_agent_skills/proof.rb
+++ b/packaging/live_agent_skills/proof.rb
@@ -41,7 +41,7 @@ module HiveLiveAgentProof
 
   class Error < StandardError; end
 
-  require_relative "workflow_creator_bundle"
+  require_relative "workflow_creator_evidence"
 
   creator_vocabulary = WorkflowCreator::Vocabulary
   WORKFLOW_CREATOR_REQUEST = creator_vocabulary.fetch("request")

--- a/packaging/live_agent_skills/workflow_creator_evidence.rb
+++ b/packaging/live_agent_skills/workflow_creator_evidence.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require_relative "workflow_creator_bundle"
+require_relative "workflow_creator_receipt_publisher"
+
+module HiveLiveAgentProof
+  class WorkflowCreatorEvidence
+    class Error < StandardError; end
+    class Conflict < Error; end
+    class UnsafeStorage < Error; end
+    class Unavailable < Error; end
+
+    TARGET_NAME = WorkflowCreator::Vocabulary.fetch("bundle_files").first
+    private_constant :TARGET_NAME
+
+    class << self
+      def initialize!(bundle_directory:, candidate_sha:)
+        receipt = WorkflowCreator.failure(
+          candidate_sha:, phase: "preflight", reason: "not_started"
+        )
+        publisher(bundle_directory).initialize_receipt(receipt.canonical_bytes)
+        receipt
+      rescue WorkflowCreatorReceiptPublisher::Conflict
+        raise Conflict, "workflow-creator evidence initialization conflicts", cause: nil
+      rescue WorkflowCreatorReceiptPublisher::Unsafe
+        raise UnsafeStorage, "workflow-creator evidence storage is unsafe", cause: nil
+      rescue WorkflowCreatorReceiptPublisher::Unavailable
+        raise Unavailable, "workflow-creator evidence storage is unavailable", cause: nil
+      end
+
+      def replace_nonpassing!(bundle_directory:, expected:, receipt:, exact_secrets: [])
+        expected_receipt = WorkflowCreator.validate_nonpassing!(expected, exact_secrets:)
+        desired_receipt = WorkflowCreator.validate_nonpassing!(receipt, exact_secrets:)
+        publisher(bundle_directory).replace_receipt(
+          expected_receipt.canonical_bytes, desired_receipt.canonical_bytes
+        )
+        desired_receipt
+      rescue WorkflowCreatorReceiptPublisher::Conflict
+        raise Conflict, "workflow-creator evidence replacement conflicts", cause: nil
+      rescue WorkflowCreatorReceiptPublisher::Unsafe
+        raise UnsafeStorage, "workflow-creator evidence storage is unsafe", cause: nil
+      rescue WorkflowCreatorReceiptPublisher::Unavailable
+        raise Unavailable, "workflow-creator evidence storage is unavailable", cause: nil
+      end
+
+      private
+
+      def publisher(bundle_directory)
+        WorkflowCreatorReceiptPublisher.new(
+          bundle_directory:, target_name: TARGET_NAME
+        )
+      end
+    end
+  end
+
+  private_constant :WorkflowCreatorReceiptPublisher
+end

--- a/packaging/live_agent_skills/workflow_creator_receipt_publisher.rb
+++ b/packaging/live_agent_skills/workflow_creator_receipt_publisher.rb
@@ -29,27 +29,35 @@ module HiveLiveAgentProof
 
     def initialize_receipt(bytes)
       bytes = safe_bytes(bytes)
-      with_context do |context|
-        current = settle(context, accepted: [ bytes ], interrupted: bytes)
-        return durable_retry(context, current, bytes) if current
-
-        stage = write_stage(context, bytes)
+      with_locked_context do |context|
         begin
-          verify_bindings!(context)
-          @native.linkat(context.staging, stage.name, context.target, @target_name)
-        rescue Errno::EEXIST
-          remove_known_stage(context, stage)
-          winner = settle(context, accepted: [ bytes ], interrupted: bytes)
-          raise Conflict, "creator evidence initialization conflicts" unless winner&.bytes == bytes
+          current = settle(context)
+          if current
+            raise Conflict, "creator evidence initialization conflicts" unless current.bytes == bytes
 
-          return durable_retry(context, winner, bytes)
+            return durable_retry(context, current, bytes)
+          end
+
+          stage = write_stage(context, bytes)
+          begin
+            verify_bindings!(context)
+            @native.linkat(context.staging, stage.name, context.target, @target_name)
+          rescue Errno::EEXIST
+            remove_known_stage(context, stage)
+            stage = nil
+            winner = settle(context)
+            raise Conflict, "creator evidence initialization conflicts" unless winner&.bytes == bytes
+
+            return durable_retry(context, winner, bytes)
+          end
+          remove_linked_stage(context, stage)
+          stage = nil
+          verify_exact_target!(context, bytes)
+          sync_directories(context)
+          :initialized
+        ensure
+          remove_known_stage(context, stage) if stage
         end
-        remove_linked_stage(context, stage)
-        verify_exact_target!(context, bytes)
-        sync_directories(context)
-        :initialized
-      ensure
-        remove_known_stage(context, stage) if context && stage
       end
     rescue Conflict, Unsafe
       raise
@@ -62,11 +70,9 @@ module HiveLiveAgentProof
     def replace_receipt(expected_bytes, desired_bytes)
       expected = safe_bytes(expected_bytes)
       desired = safe_bytes(desired_bytes)
-      with_context do |context|
-        @native.lock(context.target)
-        locked = true
+      with_locked_context do |context|
         begin
-          current = settle(context, accepted: [ expected, desired ], interrupted: desired)
+          current = settle(context)
           raise Conflict, "creator evidence replacement has no expected target" unless current
           return durable_retry(context, current, desired) if current.bytes == desired
           raise Conflict, "creator evidence replacement conflicts" unless current.bytes == expected
@@ -80,10 +86,8 @@ module HiveLiveAgentProof
           sync_directories(context)
           :replaced
         ensure
-          @native.unlock(context.target) if locked
+          remove_known_stage(context, stage) if stage
         end
-      ensure
-        remove_known_stage(context, stage) if context && stage
       end
     rescue Conflict, Unsafe
       raise
@@ -99,8 +103,24 @@ module HiveLiveAgentProof
       context = open_context
       yield context
     ensure
-      context&.target&.close
-      context&.staging&.close
+      close_descriptors(context&.target, context&.staging, primary: $!)
+    end
+
+    def with_locked_context
+      with_context do |context|
+        @native.lock(context.target)
+        locked = true
+        begin
+          yield context
+        ensure
+          primary = $!
+          begin
+            @native.unlock(context.target) if locked
+          rescue StandardError => cleanup_error
+            raise cleanup_error unless primary
+          end
+        end
+      end
     end
 
     def open_context
@@ -124,13 +144,10 @@ module HiveLiveAgentProof
     rescue Errno::ELOOP, Errno::ENOTDIR
       raise Unsafe, "creator evidence directory binding is unsafe", cause: nil
     ensure
-      unless completed
-        target&.close
-        staging&.close
-      end
+      close_descriptors(target, staging, primary: $!) unless completed
     end
 
-    def settle(context, accepted:, interrupted:)
+    def settle(context)
       4.times do
         target = read_optional(context.target, @target_name)
         stages = staging_entries(context)
@@ -139,7 +156,6 @@ module HiveLiveAgentProof
           raise Unsafe, "creator evidence staging state is ambiguous" unless stages.length == 1
           stage = stages.first
           raise Unsafe, "creator evidence staging link state is unsafe" unless stage.links == 1
-          raise Conflict, "creator evidence initialization conflicts" unless stage.bytes == interrupted
 
           remove_entry(context.staging, stage.name)
           @native.fsync(context.staging)
@@ -152,8 +168,15 @@ module HiveLiveAgentProof
         end
         raise Unsafe, "creator evidence staging state is ambiguous" unless stages.length == 1
         stage = stages.first
+        if stage.links == 1
+          raise Unsafe, "creator evidence staging link state is unsafe" unless target.links == 1
+
+          remove_entry(context.staging, stage.name)
+          @native.fsync(context.staging)
+          next
+        end
         linked = target.links == 2 && stage.links == 2 && target.inode == stage.inode &&
-                 target.bytes == stage.bytes && accepted.include?(target.bytes)
+                 target.bytes == stage.bytes
         raise Unsafe, "creator evidence linked state is unsafe" unless linked
 
         remove_entry(context.staging, stage.name)
@@ -162,6 +185,20 @@ module HiveLiveAgentProof
         next
       end
       raise Unsafe, "creator evidence state did not stabilize"
+    end
+
+    def close_descriptors(*descriptors, primary:)
+      cleanup_error = nil
+      descriptors.compact.each do |descriptor|
+        next if descriptor.closed?
+
+        begin
+          @native.close(descriptor)
+        rescue StandardError => error
+          cleanup_error ||= error
+        end
+      end
+      raise cleanup_error if cleanup_error && !primary
     end
 
     def write_stage(context, bytes)
@@ -343,6 +380,8 @@ module HiveLiveAgentProof
     end
 
     class Native
+      LOCK_TIMEOUT_SECONDS = 2.0
+      LOCK_RETRY_SECONDS = 0.01
       FLAGS = {
         linux: { directory: 0o200000 | 0o400000 | 0o2000000 | 0o4000,
                  read: 0o400000 | 0o2000000 | 0o4000,
@@ -418,11 +457,26 @@ module HiveLiveAgentProof
       end
 
       def lock(directory)
-        call_zero(@flock, directory.fileno, File::LOCK_EX)
+        deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + LOCK_TIMEOUT_SECONDS
+        loop do
+          result = @flock.call(directory.fileno, File::LOCK_EX | File::LOCK_NB)
+          return if result.zero?
+
+          error = SystemCallError.new("native creator evidence lock", Fiddle.last_error)
+          raise error unless error.is_a?(Errno::EWOULDBLOCK) || error.is_a?(Errno::EAGAIN)
+          raise Errno::ETIMEDOUT, "creator evidence lock wait exceeded" if
+            Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+
+          sleep LOCK_RETRY_SECONDS
+        end
       end
 
       def unlock(directory)
         call_zero(@flock, directory.fileno, File::LOCK_UN)
+      end
+
+      def close(io)
+        io.close
       end
 
       private

--- a/packaging/live_agent_skills/workflow_creator_receipt_publisher.rb
+++ b/packaging/live_agent_skills/workflow_creator_receipt_publisher.rb
@@ -205,6 +205,7 @@ module HiveLiveAgentProof
       name = "#{context.prefix}#{SecureRandom.hex(16)}"
       file = @native.create_file_at(context.staging, name, FILE_MODE)
       begin
+        file.chmod(FILE_MODE)
         offset = 0
         offset += file.write(bytes.byteslice(offset..)) while offset < bytes.bytesize
         @native.fsync(file)
@@ -422,7 +423,11 @@ module HiveLiveAgentProof
       end
 
       def create_file_at(directory, name, mode)
-        io(call_fd(@openat, directory.fileno, name, @flags.fetch(:create), mode), "wb")
+        File.for_fd(
+          call_fd(@openat, directory.fileno, name, @flags.fetch(:create), mode),
+          "wb",
+          autoclose: true
+        )
       end
 
       def linkat(source_directory, source_name, target_directory, target_name)

--- a/packaging/live_agent_skills/workflow_creator_receipt_publisher.rb
+++ b/packaging/live_agent_skills/workflow_creator_receipt_publisher.rb
@@ -1,0 +1,454 @@
+# frozen_string_literal: true
+
+require "fiddle"
+require "securerandom"
+
+module HiveLiveAgentProof
+  class WorkflowCreatorReceiptPublisher
+    class Error < StandardError; end
+    class Conflict < Error; end
+    class Unsafe < Error; end
+    class Unavailable < Error; end
+    class Changed < Error; end
+    private_constant :Changed
+
+    MAX_RECEIPT_BYTES = 1_048_576
+    MAX_DIRECTORY_ENTRIES = 1_024
+    FILE_MODE = 0o600
+    DIRECTORY_MODE_MASK = 0o022
+    Entry = Data.define(:name, :identity, :inode, :bytes, :links)
+    Context = Data.define(:staging, :target, :staging_path, :target_path,
+                          :staging_identity, :target_identity, :prefix)
+    private_constant :Entry, :Context
+
+    def initialize(bundle_directory:, target_name:)
+      @bundle_directory = safe_path(bundle_directory)
+      @target_name = safe_component(target_name)
+      @native = Native.new
+    end
+
+    def initialize_receipt(bytes)
+      bytes = safe_bytes(bytes)
+      with_context do |context|
+        current = settle(context, accepted: [ bytes ], interrupted: bytes)
+        return durable_retry(context, current, bytes) if current
+
+        stage = write_stage(context, bytes)
+        begin
+          verify_bindings!(context)
+          @native.linkat(context.staging, stage.name, context.target, @target_name)
+        rescue Errno::EEXIST
+          remove_known_stage(context, stage)
+          winner = settle(context, accepted: [ bytes ], interrupted: bytes)
+          raise Conflict, "creator evidence initialization conflicts" unless winner&.bytes == bytes
+
+          return durable_retry(context, winner, bytes)
+        end
+        remove_linked_stage(context, stage)
+        verify_exact_target!(context, bytes)
+        sync_directories(context)
+        :initialized
+      ensure
+        remove_known_stage(context, stage) if context && stage
+      end
+    rescue Conflict, Unsafe
+      raise
+    rescue Changed
+      raise Unsafe, "creator evidence state changed during publication", cause: nil
+    rescue SystemCallError, IOError, Fiddle::DLError, NotImplementedError
+      raise Unavailable, "creator evidence storage operation failed", cause: nil
+    end
+
+    def replace_receipt(expected_bytes, desired_bytes)
+      expected = safe_bytes(expected_bytes)
+      desired = safe_bytes(desired_bytes)
+      with_context do |context|
+        @native.lock(context.target)
+        locked = true
+        begin
+          current = settle(context, accepted: [ expected, desired ], interrupted: desired)
+          raise Conflict, "creator evidence replacement has no expected target" unless current
+          return durable_retry(context, current, desired) if current.bytes == desired
+          raise Conflict, "creator evidence replacement conflicts" unless current.bytes == expected
+
+          stage = write_stage(context, desired)
+          verify_bindings!(context)
+          revalidate_expected!(context, current, expected)
+          @native.renameat(context.staging, stage.name, context.target, @target_name)
+          stage = nil
+          verify_exact_target!(context, desired)
+          sync_directories(context)
+          :replaced
+        ensure
+          @native.unlock(context.target) if locked
+        end
+      ensure
+        remove_known_stage(context, stage) if context && stage
+      end
+    rescue Conflict, Unsafe
+      raise
+    rescue Changed
+      raise Unsafe, "creator evidence state changed during publication", cause: nil
+    rescue SystemCallError, IOError, Fiddle::DLError, NotImplementedError
+      raise Unavailable, "creator evidence storage operation failed", cause: nil
+    end
+
+    private
+
+    def with_context
+      context = open_context
+      yield context
+    ensure
+      context&.target&.close
+      context&.staging&.close
+    end
+
+    def open_context
+      completed = false
+      staging_path = File.dirname(@bundle_directory)
+      target_leaf = safe_component(File.basename(@bundle_directory))
+      staging = @native.open_directory(staging_path)
+      target = @native.open_directory_at(staging, target_leaf)
+      staging_identity = directory_identity(staging.stat, private: false)
+      target_identity = directory_identity(target.stat, private: true)
+      raise Unsafe, "creator evidence directories cross filesystems" unless
+        staging_identity.fetch(:dev) == target_identity.fetch(:dev)
+
+      prefix = ".hive-creator-#{target_identity.fetch(:dev).to_s(16)}-" \
+               "#{target_identity.fetch(:ino).to_s(16)}-"
+      context = Context.new(staging:, target:, staging_path:, target_path: @bundle_directory,
+                            staging_identity:, target_identity:, prefix:)
+      verify_bindings!(context)
+      completed = true
+      context
+    rescue Errno::ELOOP, Errno::ENOTDIR
+      raise Unsafe, "creator evidence directory binding is unsafe", cause: nil
+    ensure
+      unless completed
+        target&.close
+        staging&.close
+      end
+    end
+
+    def settle(context, accepted:, interrupted:)
+      4.times do
+        target = read_optional(context.target, @target_name)
+        stages = staging_entries(context)
+        if target.nil?
+          return nil if stages.empty?
+          raise Unsafe, "creator evidence staging state is ambiguous" unless stages.length == 1
+          stage = stages.first
+          raise Unsafe, "creator evidence staging link state is unsafe" unless stage.links == 1
+          raise Conflict, "creator evidence initialization conflicts" unless stage.bytes == interrupted
+
+          remove_entry(context.staging, stage.name)
+          @native.fsync(context.staging)
+          next
+        end
+        if stages.empty?
+          return target if target.links == 1
+          next if target.links == 2
+          raise Unsafe, "creator evidence target link state is unsafe"
+        end
+        raise Unsafe, "creator evidence staging state is ambiguous" unless stages.length == 1
+        stage = stages.first
+        linked = target.links == 2 && stage.links == 2 && target.inode == stage.inode &&
+                 target.bytes == stage.bytes && accepted.include?(target.bytes)
+        raise Unsafe, "creator evidence linked state is unsafe" unless linked
+
+        remove_entry(context.staging, stage.name)
+        sync_directories(context)
+      rescue Changed, Errno::ENOENT
+        next
+      end
+      raise Unsafe, "creator evidence state did not stabilize"
+    end
+
+    def write_stage(context, bytes)
+      name = "#{context.prefix}#{SecureRandom.hex(16)}"
+      file = @native.create_file_at(context.staging, name, FILE_MODE)
+      begin
+        offset = 0
+        offset += file.write(bytes.byteslice(offset..)) while offset < bytes.bytesize
+        @native.fsync(file)
+        stat = file.stat
+        validate_file!(stat, links: 1)
+      ensure
+        file.close
+      end
+      entry = read_entry(context.staging, name)
+      raise Unsafe, "creator evidence staging bytes changed" unless entry.bytes == bytes
+
+      entry
+    rescue StandardError => error
+      begin
+        remove_entry(context.staging, name) if name
+      rescue SystemCallError, IOError
+        nil
+      end
+      raise error
+    end
+
+    def staging_entries(context)
+      names = @native.entries(context.staging, MAX_DIRECTORY_ENTRIES)
+      names.grep_v(/\A\.\.?\z/).select { |name| name.start_with?(context.prefix) }.filter_map do |name|
+        read_entry(context.staging, name)
+      rescue Errno::ENOENT
+        nil
+      rescue Errno::ELOOP, Errno::ENXIO
+        raise Unsafe, "creator evidence staging entry type is unsafe", cause: nil
+      end
+    end
+
+    def read_optional(directory, name)
+      read_entry(directory, name)
+    rescue Errno::ENOENT
+      nil
+    rescue Errno::ELOOP, Errno::ENXIO
+      raise Unsafe, "creator evidence entry type is unsafe", cause: nil
+    end
+
+    def read_entry(directory, name)
+      file = @native.open_file_at(directory, name)
+      before = file.stat
+      validate_file!(before)
+      content = file.read(MAX_RECEIPT_BYTES + 1)
+      raise Unsafe, "creator evidence receipt exceeds the size limit" if content.bytesize > MAX_RECEIPT_BYTES
+      after = file.stat
+      raise Changed, "creator evidence entry changed" unless file_identity(before) == file_identity(after)
+
+      Entry.new(name:, identity: file_identity(after), inode: inode_identity(after),
+                bytes: content.b.freeze, links: after.nlink)
+    ensure
+      file&.close
+    end
+
+    def revalidate_expected!(context, expected_entry, expected_bytes)
+      current = read_entry(context.target, @target_name)
+      valid = current.identity == expected_entry.identity && current.bytes == expected_bytes && current.links == 1
+      raise Conflict, "creator evidence replacement target changed" unless valid
+      verify_bindings!(context)
+    end
+
+    def verify_exact_target!(context, bytes)
+      current = read_entry(context.target, @target_name)
+      raise Unsafe, "creator evidence published target is not stable" unless current.links == 1 && current.bytes == bytes
+
+      current
+    end
+
+    def durable_retry(context, entry, bytes)
+      raise Conflict, "creator evidence target conflicts" unless entry.bytes == bytes && entry.links == 1
+      file = @native.open_file_at(context.target, @target_name)
+      validate_file!(file.stat, links: 1)
+      @native.fsync(file)
+      raise Changed, "creator evidence target changed" unless read_entry(context.target, @target_name).bytes == bytes
+      sync_directories(context)
+      :stable
+    ensure
+      file&.close
+    end
+
+    def remove_linked_stage(context, stage)
+      remove_entry(context.staging, stage.name)
+    rescue Errno::ENOENT
+      verify_exact_target!(context, stage.bytes)
+    end
+
+    def remove_known_stage(context, stage)
+      return unless stage
+      current = read_optional(context.staging, stage.name)
+      return unless current && current.inode == stage.inode
+
+      remove_entry(context.staging, stage.name)
+      @native.fsync(context.staging)
+    rescue Errno::ENOENT, Unsafe, Unavailable, SystemCallError, IOError
+      nil
+    end
+
+    def remove_entry(directory, name)
+      @native.unlinkat(directory, name)
+    end
+
+    def sync_directories(context)
+      verify_bindings!(context)
+      @native.fsync(context.target)
+      @native.fsync(context.staging)
+    end
+
+    def verify_bindings!(context)
+      staging = File.lstat(context.staging_path)
+      target = File.lstat(context.target_path)
+      valid = directory_identity(staging, private: false) == context.staging_identity &&
+              directory_identity(target, private: true) == context.target_identity
+      raise Unsafe, "creator evidence parent binding changed" unless valid
+    rescue Errno::ENOENT, Errno::ELOOP, Errno::ENOTDIR
+      raise Unsafe, "creator evidence parent binding changed", cause: nil
+    end
+
+    def directory_identity(stat, private:)
+      valid = stat.directory? && stat.uid == Process.uid
+      valid &&= (stat.mode & DIRECTORY_MODE_MASK).zero?
+      valid &&= (stat.mode & 0o077).zero? if private
+      raise Unsafe, "creator evidence directory is unsafe" unless valid
+
+      { dev: stat.dev, ino: stat.ino, uid: stat.uid, mode: stat.mode }
+    end
+
+    def validate_file!(stat, links: nil)
+      valid = stat.file? && stat.uid == Process.uid && (stat.mode & 0o777) == FILE_MODE
+      valid &&= stat.nlink == links if links
+      valid &&= stat.nlink.between?(1, 2)
+      raise Unsafe, "creator evidence entry is not an owned private regular file" unless valid
+    end
+
+    def file_identity(stat)
+      [ stat.dev, stat.ino, stat.uid, stat.mode, stat.nlink, stat.size,
+        stat.mtime.to_r, stat.ctime.to_r ]
+    end
+
+    def inode_identity(stat)
+      [ stat.dev, stat.ino ]
+    end
+
+    def safe_path(value)
+      path = value.to_str
+      raise Unsafe, "creator evidence directory path is unsafe" unless
+        path.valid_encoding? && !path.include?("\0") && path.bytesize.between?(1, 4_096)
+
+      File.expand_path(path)
+    rescue NoMethodError, TypeError, ArgumentError
+      raise Unsafe, "creator evidence directory path is unsafe", cause: nil
+    end
+
+    def safe_component(value)
+      component = value.to_str
+      valid = component.valid_encoding? && component.bytesize.between?(1, 255) &&
+              !component.include?("\0") && component != "." && component != ".." &&
+              !component.include?(File::SEPARATOR)
+      raise Unsafe, "creator evidence path component is unsafe" unless valid
+
+      component
+    rescue NoMethodError, TypeError
+      raise Unsafe, "creator evidence path component is unsafe", cause: nil
+    end
+
+    def safe_bytes(value)
+      bytes = value.to_str.b
+      raise Unsafe, "creator evidence receipt exceeds the size limit" if bytes.bytesize > MAX_RECEIPT_BYTES
+
+      bytes.freeze
+    rescue NoMethodError, TypeError
+      raise Unsafe, "creator evidence receipt bytes are invalid", cause: nil
+    end
+
+    class Native
+      FLAGS = {
+        linux: { directory: 0o200000 | 0o400000 | 0o2000000 | 0o4000,
+                 read: 0o400000 | 0o2000000 | 0o4000,
+                 create: 0o1 | 0o100 | 0o200 | 0o400000 | 0o2000000 | 0o4000 },
+        darwin: { directory: 0x100000 | 0x0100 | 0x1000000 | 0x0004,
+                  read: 0x0100 | 0x1000000 | 0x0004,
+                  create: 0x0001 | 0x0200 | 0x0800 | 0x0100 | 0x1000000 | 0x0004 }
+      }.freeze
+
+      def initialize
+        platform = RUBY_PLATFORM.include?("darwin") ? :darwin : :linux if
+          RUBY_PLATFORM.include?("darwin") || RUBY_PLATFORM.include?("linux")
+        raise NotImplementedError, "unsupported creator evidence platform" unless platform
+
+        @flags = FLAGS.fetch(platform)
+        handle = Fiddle::Handle::DEFAULT
+        @open = function(handle, "open", [ Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT, Fiddle::TYPE_INT ])
+        @openat = function(handle, "openat", [ Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP,
+                                               Fiddle::TYPE_INT, Fiddle::TYPE_INT ])
+        @linkat = function(handle, "linkat", [ Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP,
+                                               Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT ])
+        @renameat = function(handle, "renameat", [ Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP,
+                                                   Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP ])
+        @unlinkat = function(handle, "unlinkat", [ Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT ])
+        @flock = function(handle, "flock", [ Fiddle::TYPE_INT, Fiddle::TYPE_INT ])
+      end
+
+      def open_directory(path)
+        io(call_fd(@open, path, @flags.fetch(:directory), 0), "r")
+      end
+
+      def open_directory_at(directory, name)
+        io(call_fd(@openat, directory.fileno, name, @flags.fetch(:directory), 0), "r")
+      end
+
+      def open_file_at(directory, name)
+        io(call_fd(@openat, directory.fileno, name, @flags.fetch(:read), 0), "rb")
+      end
+
+      def create_file_at(directory, name, mode)
+        io(call_fd(@openat, directory.fileno, name, @flags.fetch(:create), mode), "wb")
+      end
+
+      def linkat(source_directory, source_name, target_directory, target_name)
+        call_zero(@linkat, source_directory.fileno, source_name,
+                  target_directory.fileno, target_name, 0)
+      end
+
+      def renameat(source_directory, source_name, target_directory, target_name)
+        call_zero(@renameat, source_directory.fileno, source_name,
+                  target_directory.fileno, target_name)
+      end
+
+      def unlinkat(directory, name)
+        call_zero(@unlinkat, directory.fileno, name, 0)
+      end
+
+      def entries(directory, limit)
+        duplicate = directory.dup
+        stream = Dir.for_fd(duplicate.fileno)
+        duplicate.autoclose = false
+        entries = stream.each_child.take(limit + 1)
+        raise Unsafe, "creator evidence staging enumeration exceeds the limit" if entries.length > limit
+
+        entries
+      ensure
+        stream&.close
+        duplicate&.close if duplicate&.autoclose?
+      end
+
+      def fsync(io)
+        io.fsync
+      end
+
+      def lock(directory)
+        call_zero(@flock, directory.fileno, File::LOCK_EX)
+      end
+
+      def unlock(directory)
+        call_zero(@flock, directory.fileno, File::LOCK_UN)
+      end
+
+      private
+
+      def function(handle, name, arguments)
+        Fiddle::Function.new(handle[name], arguments, Fiddle::TYPE_INT)
+      end
+
+      def call_fd(function, *arguments)
+        result = function.call(*arguments)
+        raise SystemCallError.new("native creator evidence open", Fiddle.last_error) if result.negative?
+
+        result
+      end
+
+      def call_zero(function, *arguments)
+        result = function.call(*arguments)
+        raise SystemCallError.new("native creator evidence operation", Fiddle.last_error) unless result.zero?
+
+        result
+      end
+
+      def io(descriptor, mode)
+        IO.for_fd(descriptor, mode, autoclose: true)
+      end
+    end
+    private_constant :Native
+  end
+end

--- a/packaging/release_candidate/artifacts.rb
+++ b/packaging/release_candidate/artifacts.rb
@@ -20,6 +20,8 @@ module HiveReleaseCandidate
       packaging/live_agent_skills/workflow_creator.rb
       packaging/live_agent_skills/workflow_creator_contract.rb
       packaging/live_agent_skills/workflow_creator_execution_contract.rb
+      packaging/live_agent_skills/workflow_creator_evidence.rb
+      packaging/live_agent_skills/workflow_creator_receipt_publisher.rb
       packaging/live_agent_skills/workflow_creator_text_safety.rb
       packaging/live_agent_skills/workflow_creator_values.rb
       packaging/live_agent_skills/build.rb

--- a/test/smoke/live_hive_workflow_creator_smoke_test.rb
+++ b/test/smoke/live_hive_workflow_creator_smoke_test.rb
@@ -7,6 +7,7 @@ require "rbconfig"
 require "timeout"
 require "yaml"
 require_relative "../../packaging/live_agent_skills/proof"
+require_relative "../../packaging/live_agent_skills/workflow_creator_evidence"
 
 # Authenticated, opt-in proof that OpenClaw discovers the exact candidate
 # /hive skill and follows its workflow-creator route. The success oracle is the
@@ -35,10 +36,14 @@ class LiveHiveWorkflowCreatorSmokeTest < Minitest::Test
     availability!(!evidence_path.empty?, "HIVE_CREATOR_EVIDENCE_PATH is missing")
     availability!(!credential.empty?, "OPENAI_API_KEY is unavailable")
     availability!(!binary.nil?, "openclaw binary is not on PATH")
+    initial_receipt = HiveLiveAgentProof::WorkflowCreatorEvidence.initialize!(
+      bundle_directory: File.dirname(evidence_path), candidate_sha:
+    )
 
     root = Dir.mktmpdir("hive-live-workflow-creator")
     FileUtils.chmod(0o700, root)
     evidence = base_evidence(candidate_sha)
+    model_loop_executed = false
     failure = nil
     begin
       manifest = validate_candidate_artifacts!(artifacts, candidate_sha)
@@ -62,6 +67,7 @@ class LiveHiveWorkflowCreatorSmokeTest < Minitest::Test
         ],
         chdir: workspace
       )
+      model_loop_executed = true
       assert status.success?,
              "OpenClaw workflow creator failed: #{redact(stderr, credential).lines.first(12).join}\n" \
              "#{redact(stdout, credential).lines.first(12).join}"
@@ -138,9 +144,18 @@ class LiveHiveWorkflowCreatorSmokeTest < Minitest::Test
     ensure
       FileUtils.rm_rf(root)
       evidence["cleanup"] = { "status" => File.exist?(root) ? "failed" : "passed" }
-      write_evidence(evidence_path, evidence)
+      publication_failure = begin
+        publish_nonclaiming_receipt(
+          File.dirname(evidence_path), initial_receipt, candidate_sha, failure,
+          model_loop_executed
+        )
+        nil
+      rescue StandardError => e
+        e
+      end
     end
     raise failure if failure
+    raise publication_failure if publication_failure
   end
 
   def test_controlled_hive_enforces_the_editorial_graph_and_command_order
@@ -179,6 +194,33 @@ class LiveHiveWorkflowCreatorSmokeTest < Minitest::Test
       assert_equal false, retry_payload.fetch("created")
       assert_equal 1, task.fetch("run_count")
       assert_equal 1, task_count(workspace)
+    end
+  end
+
+
+  def test_nonclaiming_receipt_distinguishes_preloop_and_postloop_outcomes
+    with_tmp_dir do |root|
+      bundle = File.join(root, "preloop")
+      FileUtils.mkdir_p(bundle, mode: 0o700)
+      FileUtils.chmod(0o700, bundle)
+      initial = HiveLiveAgentProof::WorkflowCreatorEvidence.initialize!(
+        bundle_directory: bundle, candidate_sha: "a" * 40
+      )
+      publish_nonclaiming_receipt(bundle, initial, "a" * 40, RuntimeError.new("failed"), false)
+      preloop = JSON.parse(File.binread(File.join(bundle, "openclaw-workflow-creator.json")))
+      assert_equal [ "proof_failed", "unavailable", "not_started" ],
+                   preloop.values_at("reason", "execution_kind", "model_loop")
+
+      bundle = File.join(root, "postloop")
+      FileUtils.mkdir_p(bundle, mode: 0o700)
+      FileUtils.chmod(0o700, bundle)
+      initial = HiveLiveAgentProof::WorkflowCreatorEvidence.initialize!(
+        bundle_directory: bundle, candidate_sha: "a" * 40
+      )
+      publish_nonclaiming_receipt(bundle, initial, "a" * 40, nil, true)
+      postloop = JSON.parse(File.binread(File.join(bundle, "openclaw-workflow-creator.json")))
+      assert_equal [ "u14_execution_custody_unavailable", "authenticated_openclaw", "executed" ],
+                   postloop.values_at("reason", "execution_kind", "model_loop")
     end
   end
 
@@ -582,14 +624,19 @@ class LiveHiveWorkflowCreatorSmokeTest < Minitest::Test
     File.open(path, File::WRONLY | File::CREAT | File::TRUNC, 0o600) { |file| file.write(body) }
   end
 
-  def write_evidence(path, evidence)
-    return if path.to_s.empty?
-
-    findings = HiveLiveAgentProof.secret_findings(JSON.generate(evidence))
-    evidence["secret_scan"] = {
-      "status" => "failed", "scanner" => "hive-live-agent-proof/v1"
-    } unless findings.empty?
-    HiveLiveAgentProof.write_json(path, evidence)
+  def publish_nonclaiming_receipt(bundle, initial, candidate_sha, failure, model_loop_executed)
+    proven_but_uncomposed = failure.nil? && model_loop_executed
+    receipt = HiveLiveAgentProof::WorkflowCreator.failure(
+      candidate_sha:,
+      phase: proven_but_uncomposed ? "evidence" : "proof",
+      reason: proven_but_uncomposed ? "u14_execution_custody_unavailable" : "proof_failed",
+      detail: failure&.message,
+      execution_kind: model_loop_executed ? "authenticated_openclaw" : "unavailable",
+      model_loop: model_loop_executed ? "executed" : "not_started"
+    )
+    HiveLiveAgentProof::WorkflowCreatorEvidence.replace_nonpassing!(
+      bundle_directory: bundle, expected: initial.value, receipt: receipt.value
+    )
   end
 
   def find_executable(name)

--- a/test/smoke/live_hive_workflow_creator_smoke_test.rb
+++ b/test/smoke/live_hive_workflow_creator_smoke_test.rb
@@ -147,7 +147,7 @@ class LiveHiveWorkflowCreatorSmokeTest < Minitest::Test
       publication_failure = begin
         publish_nonclaiming_receipt(
           File.dirname(evidence_path), initial_receipt, candidate_sha, failure,
-          model_loop_executed
+          model_loop_executed, exact_secrets: [ credential ]
         )
         nil
       rescue StandardError => e
@@ -221,6 +221,27 @@ class LiveHiveWorkflowCreatorSmokeTest < Minitest::Test
       postloop = JSON.parse(File.binread(File.join(bundle, "openclaw-workflow-creator.json")))
       assert_equal [ "u14_execution_custody_unavailable", "authenticated_openclaw", "executed" ],
                    postloop.values_at("reason", "execution_kind", "model_loop")
+    end
+  end
+
+  def test_nonclaiming_receipt_redacts_the_exact_provider_credential
+    with_tmp_dir do |root|
+      bundle = File.join(root, "credential")
+      FileUtils.mkdir_p(bundle, mode: 0o700)
+      FileUtils.chmod(0o700, bundle)
+      secret = "provider-credential-that-must-not-escape"
+      initial = HiveLiveAgentProof::WorkflowCreatorEvidence.initialize!(
+        bundle_directory: bundle, candidate_sha: "a" * 40
+      )
+
+      publish_nonclaiming_receipt(
+        bundle, initial, "a" * 40, RuntimeError.new("provider rejected #{secret}"), false,
+        exact_secrets: [ secret ]
+      )
+
+      bytes = File.binread(File.join(bundle, "openclaw-workflow-creator.json"))
+      refute_includes bytes, secret
+      assert_includes JSON.parse(bytes).fetch("detail"), "[REDACTED]"
     end
   end
 
@@ -624,7 +645,8 @@ class LiveHiveWorkflowCreatorSmokeTest < Minitest::Test
     File.open(path, File::WRONLY | File::CREAT | File::TRUNC, 0o600) { |file| file.write(body) }
   end
 
-  def publish_nonclaiming_receipt(bundle, initial, candidate_sha, failure, model_loop_executed)
+  def publish_nonclaiming_receipt(bundle, initial, candidate_sha, failure, model_loop_executed,
+                                  exact_secrets: [])
     proven_but_uncomposed = failure.nil? && model_loop_executed
     receipt = HiveLiveAgentProof::WorkflowCreator.failure(
       candidate_sha:,
@@ -632,10 +654,11 @@ class LiveHiveWorkflowCreatorSmokeTest < Minitest::Test
       reason: proven_but_uncomposed ? "u14_execution_custody_unavailable" : "proof_failed",
       detail: failure&.message,
       execution_kind: model_loop_executed ? "authenticated_openclaw" : "unavailable",
-      model_loop: model_loop_executed ? "executed" : "not_started"
+      model_loop: model_loop_executed ? "executed" : "not_started",
+      exact_secrets:
     )
     HiveLiveAgentProof::WorkflowCreatorEvidence.replace_nonpassing!(
-      bundle_directory: bundle, expected: initial.value, receipt: receipt.value
+      bundle_directory: bundle, expected: initial.value, receipt: receipt.value, exact_secrets:
     )
   end
 

--- a/test/support/component_boundary_contract.rb
+++ b/test/support/component_boundary_contract.rb
@@ -179,6 +179,11 @@ class ComponentBoundaryContract
     PATH_FIELDS.each do |field|
       row.fetch(field).each { |value| repo_path!(value, "#{component_path}.#{field}") }
     end
+    if row.key?("construction_scan_paths")
+      scans = string_array!(row.fetch("construction_scan_paths"),
+                            "#{component_path}.construction_scan_paths")
+      scans.each { |value| repo_path!(value, "#{component_path}.construction_scan_paths") }
+    end
     repo_path!(row.fetch("wiki_page"), "#{component_path}.wiki_page")
     validate_migration_exceptions!(row, component_path)
     if row.fetch("hive_consumers").empty? &&
@@ -217,7 +222,7 @@ class ComponentBoundaryContract
     return if sites.empty?
 
     seen_constants = Set.new
-    owned_files = ruby_files(row.fetch("owned_paths"))
+    scan_files = construction_scan_files(row)
 
     sites.each_with_index do |entry, index|
       path = "#{component_path}.authorized_internal_constructions[#{index}]"
@@ -239,9 +244,9 @@ class ComponentBoundaryContract
       invalid!("#{path}.files", "must not contain duplicates") unless files.uniq == files
       files.each_with_index do |relative, file_index|
         repo_path!(relative, "#{path}.files[#{file_index}]")
-        if owned_files.include?(relative)
+        unless scan_files.include?(relative)
           invalid!("#{path}.files[#{file_index}]",
-                   "component-owned files do not need construction authorization")
+                   "#{relative} is outside the construction scan surface")
         end
         unless ruby_syntax(relative).constructions.include?(constant)
           invalid!("#{path}.files[#{file_index}]",
@@ -339,8 +344,7 @@ class ComponentBoundaryContract
     authorized = entry.fetch("authorized_internal_constructions").each_with_object(Set.new) do |site, pairs|
       site.fetch("files").each { |relative| pairs << [ relative, site.fetch("constant") ] }
     end
-    owned_files = ruby_files(entry.fetch("owned_paths"))
-    (production_ruby_files - owned_files).each do |relative|
+    construction_scan_files(entry).each do |relative|
       constructions = ruby_syntax(relative).constructions
       invalid_constants = (constructions & forbidden).reject do |constant|
         authorized.include?([ relative, constant ])
@@ -423,6 +427,12 @@ class ComponentBoundaryContract
 
   def production_ruby_files
     @production_ruby_files ||= ruby_files([ "lib" ])
+  end
+
+  def construction_scan_files(entry)
+    return ruby_files(entry.fetch("construction_scan_paths")) if entry.key?("construction_scan_paths")
+
+    production_ruby_files - ruby_files(entry.fetch("owned_paths"))
   end
 
   def ruby_files(paths)
@@ -552,7 +562,7 @@ class ComponentBoundaryContract
     end
 
     def construction_constants(node, namespace)
-      return [] unless node[0] == :call &&
+      return [] unless %i[call command_call].include?(node[0]) &&
                        identifier(node[3]) == "new"
 
       receiver = constant_path(node[1])

--- a/test/support/component_boundary_contract.rb
+++ b/test/support/component_boundary_contract.rb
@@ -430,9 +430,10 @@ class ComponentBoundaryContract
   end
 
   def construction_scan_files(entry)
-    return ruby_files(entry.fetch("construction_scan_paths")) if entry.key?("construction_scan_paths")
+    external_production = production_ruby_files - ruby_files(entry.fetch("owned_paths"))
+    return external_production unless entry.key?("construction_scan_paths")
 
-    production_ruby_files - ruby_files(entry.fetch("owned_paths"))
+    (external_production + ruby_files(entry.fetch("construction_scan_paths"))).uniq
   end
 
   def ruby_files(paths)

--- a/test/unit/component_boundaries_test.rb
+++ b/test/unit/component_boundaries_test.rb
@@ -413,6 +413,37 @@ class ComponentBoundariesTest < Minitest::Test
     assert_match(/workflow_creator_evidence\.rb/, error.message)
   end
 
+  def test_custom_construction_roots_do_not_disable_the_production_scan
+    with_contract_fixture(
+      entrypoint_source: "module Example; class API; end; class Internal; end; end\n",
+      consumer_source: "Example::Internal.new\n",
+      construction_scan_paths: [ "packaging" ],
+      extra_files: { "packaging/release_candidate.rb" => "Example::API.new\n" }
+    ) do |contract|
+      error = assert_raises(ComponentBoundaryContract::ValidationError) do
+        contract.validate_static_boundaries!
+      end
+
+      assert_match(/lib\/consumer\.rb/, error.message)
+      assert_match(/Example::Internal/, error.message)
+    end
+  end
+
+  def test_custom_construction_roots_cover_packaging_release_code
+    with_contract_fixture(
+      entrypoint_source: "module Example; class API; end; class Internal; end; end\n",
+      construction_scan_paths: [ "packaging" ],
+      extra_files: { "packaging/release_candidate.rb" => "Example::Internal.new\n" }
+    ) do |contract|
+      error = assert_raises(ComponentBoundaryContract::ValidationError) do
+        contract.validate_static_boundaries!
+      end
+
+      assert_match(/packaging\/release_candidate\.rb/, error.message)
+      assert_match(/Example::Internal/, error.message)
+    end
+  end
+
 
   def test_workflow_creator_publication_stays_inside_the_u1b_owner_budget
     production = %w[
@@ -1416,7 +1447,7 @@ class ComponentBoundariesTest < Minitest::Test
                             component_dependencies: [], allowed_hive_dependencies: [],
                             migration_exceptions: [], authorized_internal_constructions: [],
                             internal_collaborators: nil, hive_consumers: [ "lib/consumer.rb" ],
-                            extra_components: [], extra_files: {})
+                            construction_scan_paths: nil, extra_components: [], extra_files: {})
     Dir.mktmpdir do |root|
       write_fixture(root, entrypoint_file, entrypoint_source)
       write_fixture(root, "lib/consumer.rb", consumer_source)
@@ -1440,7 +1471,9 @@ class ComponentBoundariesTest < Minitest::Test
             authorized_internal_constructions: authorized_internal_constructions,
             internal_collaborators: internal_collaborators,
             hive_consumers: hive_consumers
-          ),
+          ).tap do |component|
+            component["construction_scan_paths"] = construction_scan_paths if construction_scan_paths
+          end,
           *extra_components
         ]
       }

--- a/test/unit/component_boundaries_test.rb
+++ b/test/unit/component_boundaries_test.rb
@@ -298,8 +298,8 @@ class ComponentBoundariesTest < Minitest::Test
     assert_empty workflow_values.fetch("migration_exceptions")
 
     workflow_core = contract.component("workflow-creator-core")
-    assert_equal "candidate", workflow_core.fetch("state")
-    assert_equal "./packaging/live_agent_skills/workflow_creator",
+    assert_equal "boundary-ready", workflow_core.fetch("state")
+    assert_equal "./packaging/live_agent_skills/workflow_creator_evidence",
                  workflow_core.dig("entrypoint", "require")
     assert_equal [ "workflow-creator-values" ], workflow_core.fetch("component_dependencies")
     assert_equal %w[
@@ -307,15 +307,25 @@ class ComponentBoundariesTest < Minitest::Test
       packaging/live_agent_skills/workflow_creator_contract.rb
       packaging/live_agent_skills/workflow_creator_execution_contract.rb
       packaging/live_agent_skills/workflow_creator_bundle.rb
+      packaging/live_agent_skills/workflow_creator_evidence.rb
+      packaging/live_agent_skills/workflow_creator_receipt_publisher.rb
     ], workflow_core.fetch("owned_paths")
-    assert_equal [ "packaging/live_agent_skills/proof.rb" ], workflow_core.fetch("hive_consumers")
+    assert_equal [
+      "packaging/live_agent_skills/proof.rb",
+      "test/smoke/live_hive_workflow_creator_smoke_test.rb"
+    ], workflow_core.fetch("hive_consumers")
+    assert_equal [ "HiveLiveAgentProof::WorkflowCreatorReceiptPublisher" ],
+                 workflow_core.fetch("forbidden_constructions")
+    assert_equal [ "packaging/live_agent_skills/workflow_creator_evidence.rb" ],
+                 workflow_core.fetch("authorized_internal_constructions").first.fetch("files")
     assert_empty workflow_core.fetch("migration_exceptions")
 
-    ready_components.push(agent_abi, artifact_firewall, skillpack, git_gate, work_ledger, workflow_values)
+    ready_components.push(agent_abi, artifact_firewall, skillpack, git_gate, work_ledger,
+                          workflow_values, workflow_core)
     remaining_candidates = contract.components.reject do |component|
       ready_components.include?(component)
     end
-    assert_equal %w[attempts patrol-effects workflow-creator-core],
+    assert_equal %w[attempts patrol-effects],
                  remaining_candidates.map { |entry| entry.fetch("id") }.sort
     assert remaining_candidates.all? { |component| component.fetch("state") == "candidate" }
 
@@ -327,6 +337,7 @@ class ComponentBoundariesTest < Minitest::Test
       skillpack
       user-service
       work-ledger
+      workflow-creator-core
       workflow-creator-values
     ], ready_loads.keys.sort
     agent_abi_load = ready_loads.fetch("agent-abi")
@@ -354,7 +365,7 @@ class ComponentBoundariesTest < Minitest::Test
     assert_empty work_ledger_load.fetch("forbidden_loaded_features")
     assert_empty work_ledger_load.fetch("forbidden_constants")
     workflow_core_load = contract.validate_clean_load!("workflow-creator-core")
-    assert_equal "HiveLiveAgentProof::WorkflowCreator", workflow_core_load.fetch("constant")
+    assert_equal "HiveLiveAgentProof::WorkflowCreatorEvidence", workflow_core_load.fetch("constant")
     assert_empty workflow_core_load.fetch("forbidden_loaded_features")
     assert_empty workflow_core_load.fetch("forbidden_constants")
     patrol_effects_load = contract.validate_clean_load!("patrol-effects")
@@ -372,13 +383,57 @@ class ComponentBoundariesTest < Minitest::Test
       workflow_creator.rb workflow_creator_contract.rb workflow_creator_execution_contract.rb
     ].map { |name| File.read(File.join(ROOT, "packaging/live_agent_skills", name)) }.join("\n")
 
-    assert_includes proof, 'require_relative "workflow_creator_bundle"'
+    assert_includes proof, 'require_relative "workflow_creator_evidence"'
     assert_includes bundle, 'require_relative "workflow_creator"'
     refute_match(/workflow_creator_bundle|proof\.rb/, core)
     metrics = ruby_metrics(bundle)
     assert_operator File.readlines(bundle_path).length, :<=, 220
     assert_operator metrics.fetch(:callables), :<=, 10
     assert_operator metrics.fetch(:decisions), :<=, 28
+  end
+
+
+  def test_workflow_creator_publisher_is_constructed_only_by_the_typed_facade
+    contract = ComponentBoundaryContract.new(@document, root: ROOT)
+    component = contract.component("workflow-creator-core")
+    publisher = "HiveLiveAgentProof::WorkflowCreatorReceiptPublisher"
+    authorized = component.fetch("authorized_internal_constructions").first
+
+    assert_equal publisher, authorized.fetch("constant")
+    assert_equal [ "packaging/live_agent_skills/workflow_creator_evidence.rb" ],
+                 authorized.fetch("files")
+    assert contract.validate_static_boundaries!
+
+    document = Marshal.load(Marshal.dump(@document))
+    component(document, "workflow-creator-core")["authorized_internal_constructions"] = []
+    error = assert_raises(ComponentBoundaryContract::ValidationError) do
+      ComponentBoundaryContract.new(document, root: ROOT).validate_static_boundaries!
+    end
+    assert_match(/workflow-creator-core\.forbidden_constructions/, error.message)
+    assert_match(/workflow_creator_evidence\.rb/, error.message)
+  end
+
+
+  def test_workflow_creator_publication_stays_inside_the_u1b_owner_budget
+    production = %w[
+      packaging/live_agent_skills/workflow_creator_evidence.rb
+      packaging/live_agent_skills/workflow_creator_receipt_publisher.rb
+    ]
+    facade, publisher = production.map { |relative| File.read(File.join(ROOT, relative)) }
+
+    assert_equal 2, production.length
+    assert_includes facade, 'require_relative "workflow_creator_bundle"'
+    assert_includes facade, 'require_relative "workflow_creator_receipt_publisher"'
+    assert_equal 1, facade.scan(/WorkflowCreatorReceiptPublisher\.new/).length
+    assert_includes publisher, "class WorkflowCreatorReceiptPublisher"
+    assert_includes publisher, "class Native"
+    assert_match(/openat/, publisher)
+    assert_match(/linkat/, publisher)
+    assert_match(/renameat/, publisher)
+    assert_match(/unlinkat/, publisher)
+    refute_match(/Hive::AtomicFile|WorkflowCreatorAtomicFile/, "#{facade}\n#{publisher}")
+    refute_match(/OpenClaw|credential|provider|Process\.(?:spawn|kill|wait)|Open3/,
+                 "#{facade}\n#{publisher}")
   end
 
   def test_patrol_u3a_require_graph_is_closed_and_one_way
@@ -1065,6 +1120,15 @@ class ComponentBoundariesTest < Minitest::Test
     end
   end
 
+
+  def test_parenthesized_and_parenthesis_free_new_forms_are_both_detected
+    forms = [ "Example::Internal.new(:value)\n", "Example::Internal.new :value\n" ]
+    forms.each do |source|
+      syntax = ComponentBoundaryContract::RubySyntax.new(source, "construction-form.rb")
+      assert_includes syntax.constructions, "Example::Internal", source
+    end
+  end
+
   def test_lexically_resolved_internal_construction_cannot_evade_boundary
     with_contract_fixture(
       entrypoint_source: <<~RUBY,
@@ -1241,11 +1305,6 @@ class ComponentBoundariesTest < Minitest::Test
         mutate: ->(site, _sites) { site["files"] << site.fetch("files").first },
         field: /authorized_internal_constructions\[0\]\.files/,
         message: /must not contain duplicates/
-      },
-      "component-owned file" => {
-        mutate: ->(site, _sites) { site["files"] = [ "lib/owned_builder.rb" ] },
-        field: /authorized_internal_constructions\[0\]\.files\[0\]/,
-        message: /component-owned files do not need construction authorization/
       },
       "blank reason" => {
         mutate: ->(site, _sites) { site["reason"] = " " },

--- a/test/unit/packaging/release_candidate_artifacts_test.rb
+++ b/test/unit/packaging/release_candidate_artifacts_test.rb
@@ -14,6 +14,8 @@ class ReleaseCandidateArtifactsTest < Minitest::Test
     packaging/live_agent_skills/workflow_creator.rb
     packaging/live_agent_skills/workflow_creator_contract.rb
     packaging/live_agent_skills/workflow_creator_execution_contract.rb
+    packaging/live_agent_skills/workflow_creator_evidence.rb
+    packaging/live_agent_skills/workflow_creator_receipt_publisher.rb
     packaging/live_agent_skills/workflow_creator_text_safety.rb
     packaging/live_agent_skills/workflow_creator_values.rb
     packaging/live_agent_skills/build.rb

--- a/test/unit/packaging/workflow_creator_evidence_test.rb
+++ b/test/unit/packaging/workflow_creator_evidence_test.rb
@@ -251,6 +251,7 @@ class WorkflowCreatorEvidenceTest < Minitest::Test
 
   def test_replacement_is_compare_and_swap_and_post_rename_retry_is_exact
     with_private_bundle do |bundle|
+      native_publisher(bundle).initialize_receipt(initial_receipt.canonical_bytes)
       initial = Evidence.initialize!(bundle_directory: bundle, candidate_sha: SHA)
       desired = failure_receipt("proof_failed")
 
@@ -721,8 +722,18 @@ class WorkflowCreatorEvidenceTest < Minitest::Test
   end
 
   def native_class
-    publisher = HiveLiveAgentProof.const_get(:WorkflowCreatorReceiptPublisher, false)
-    publisher.const_get(:Native, false)
+    publisher_class.const_get(:Native, false)
+  end
+
+  def native_publisher(bundle)
+    publisher_class.new(
+      bundle_directory: bundle,
+      target_name: Creator::Vocabulary.fetch("bundle_files").first
+    )
+  end
+
+  def publisher_class
+    HiveLiveAgentProof.const_get(:WorkflowCreatorReceiptPublisher, false)
   end
 
   def with_native_method(native, name, replacement)

--- a/test/unit/packaging/workflow_creator_evidence_test.rb
+++ b/test/unit/packaging/workflow_creator_evidence_test.rb
@@ -1,0 +1,547 @@
+require "test_helper"
+require "json"
+require "timeout"
+require_relative "../../../packaging/live_agent_skills/workflow_creator_evidence"
+
+class WorkflowCreatorEvidenceTest < Minitest::Test
+  include HiveTestHelper
+
+  SHA = "a" * 40
+  Creator = HiveLiveAgentProof::WorkflowCreator
+  Evidence = HiveLiveAgentProof::WorkflowCreatorEvidence
+
+  def test_initialize_publishes_the_fixed_private_canonical_receipt
+    with_private_bundle do |bundle|
+      receipt = Evidence.initialize!(bundle_directory: bundle, candidate_sha: SHA)
+      target = File.join(bundle, Creator::Vocabulary.fetch("bundle_files").first)
+
+      assert_equal receipt.value, JSON.parse(File.binread(target))
+      assert_equal receipt.canonical_bytes, File.binread(target)
+      assert_equal 0o600, File.stat(target).mode & 0o777
+      assert_equal [ File.basename(target) ], Dir.children(bundle)
+    end
+  end
+
+
+  def test_public_api_accepts_only_typed_bundle_operations_and_publisher_is_private
+    assert_equal %i[initialize! replace_nonpassing!], Evidence.singleton_methods(false).sort
+    assert_equal [ [ :keyreq, :bundle_directory ], [ :keyreq, :candidate_sha ] ],
+                 Evidence.method(:initialize!).parameters
+    replacement_parameters = Evidence.method(:replace_nonpassing!).parameters
+    assert_equal %i[bundle_directory expected receipt exact_secrets],
+                 replacement_parameters.map(&:last)
+    assert_raises(NameError) { HiveLiveAgentProof::WorkflowCreatorReceiptPublisher }
+  end
+
+
+  def test_exact_retry_converges_without_replacing_the_target
+    with_private_bundle do |bundle|
+      first = Evidence.initialize!(bundle_directory: bundle, candidate_sha: SHA)
+      path = target(bundle)
+      identity = File.stat(path).ino
+
+      second = Evidence.initialize!(bundle_directory: bundle, candidate_sha: SHA)
+
+      assert_equal first.canonical_bytes, second.canonical_bytes
+      assert_equal identity, File.stat(path).ino
+      assert_equal 1, File.stat(path).nlink
+    end
+  end
+
+  def test_different_initialization_conflicts_without_clobbering
+    with_private_bundle do |bundle|
+      first = Evidence.initialize!(bundle_directory: bundle, candidate_sha: SHA)
+
+      error = assert_raises(Evidence::Conflict) do
+        Evidence.initialize!(bundle_directory: bundle, candidate_sha: "b" * 40)
+      end
+
+      assert_equal first.canonical_bytes, File.binread(target(bundle))
+      assert_equal "workflow-creator evidence initialization conflicts", error.message
+    end
+  end
+
+  def test_transient_link_is_recovered_and_both_cleanup_orders_converge
+    with_private_bundle do |bundle|
+      receipt = initial_receipt
+      stage = staging_path(bundle, "linked")
+      write_private(stage, receipt.canonical_bytes)
+      File.link(stage, target(bundle))
+
+      recovered = Evidence.initialize!(bundle_directory: bundle, candidate_sha: SHA)
+
+      assert_equal receipt.canonical_bytes, recovered.canonical_bytes
+      refute_path_exists stage
+      assert_equal 1, File.stat(target(bundle)).nlink
+
+      retried = Evidence.initialize!(bundle_directory: bundle, candidate_sha: SHA)
+      assert_equal recovered.canonical_bytes, retried.canonical_bytes
+    end
+  end
+
+  def test_two_recovery_callers_converge_on_one_stable_target
+    with_private_bundle do |bundle|
+      receipt = initial_receipt
+      stage = staging_path(bundle, "linked")
+      write_private(stage, receipt.canonical_bytes)
+      File.link(stage, target(bundle))
+      ready = Queue.new
+      start = Queue.new
+      results = 2.times.map do
+        Thread.new do
+          ready << true
+          start.pop
+          Evidence.initialize!(bundle_directory: bundle, candidate_sha: SHA)
+        rescue StandardError => e
+          e
+        end
+      end
+      2.times { ready.pop }
+      2.times { start << true }
+      values = results.map(&:value)
+
+      assert values.all? { |value| value.respond_to?(:canonical_bytes) }, values.map(&:inspect).join("\n")
+      assert_equal 1, File.stat(target(bundle)).nlink
+      assert_empty staging_entries(bundle)
+    end
+  end
+
+  def test_interrupted_one_link_stage_is_cleaned_before_initialization
+    with_private_bundle do |bundle|
+      orphan = staging_path(bundle, "orphan")
+      write_private(orphan, initial_receipt.canonical_bytes)
+
+      Evidence.initialize!(bundle_directory: bundle, candidate_sha: SHA)
+
+      refute_path_exists orphan
+      assert_equal [ File.basename(target(bundle)) ], Dir.children(bundle)
+      assert_empty staging_entries(bundle)
+    end
+  end
+
+  def test_link_ambiguities_fail_closed
+    cases = {
+      outside_prefix: lambda do |bundle, receipt|
+        write_private(target(bundle), receipt.canonical_bytes)
+        File.link(target(bundle), File.join(File.dirname(bundle), "outside-link"))
+      end,
+      greater_than_two: lambda do |bundle, receipt|
+        write_private(target(bundle), receipt.canonical_bytes)
+        File.link(target(bundle), staging_path(bundle, "one"))
+        File.link(target(bundle), staging_path(bundle, "two"))
+      end,
+      multiple_prefix: lambda do |bundle, receipt|
+        write_private(staging_path(bundle, "one"), receipt.canonical_bytes)
+        write_private(staging_path(bundle, "two"), receipt.canonical_bytes)
+      end
+    }
+    cases.each do |label, prepare|
+      with_private_bundle do |bundle|
+        prepare.call(bundle, initial_receipt)
+        assert_raises(Evidence::UnsafeStorage, label.to_s) do
+          Evidence.initialize!(bundle_directory: bundle, candidate_sha: SHA)
+        end
+      end
+    end
+  end
+
+  def test_replacement_is_compare_and_swap_and_post_rename_retry_is_exact
+    with_private_bundle do |bundle|
+      initial = Evidence.initialize!(bundle_directory: bundle, candidate_sha: SHA)
+      desired = failure_receipt("proof_failed")
+
+      replaced = Evidence.replace_nonpassing!(
+        bundle_directory: bundle, expected: initial.value, receipt: desired.value
+      )
+      inode = File.stat(target(bundle)).ino
+      retried = Evidence.replace_nonpassing!(
+        bundle_directory: bundle, expected: initial.value, receipt: desired.value
+      )
+
+      assert_equal desired.canonical_bytes, replaced.canonical_bytes
+      assert_equal desired.canonical_bytes, retried.canonical_bytes
+      assert_equal inode, File.stat(target(bundle)).ino
+      assert_empty staging_entries(bundle)
+    end
+  end
+
+  def test_replacement_preserves_canonical_non_ascii_bytes
+    with_private_bundle do |bundle|
+      initial = Evidence.initialize!(bundle_directory: bundle, candidate_sha: SHA)
+      desired = Creator.failure(
+        candidate_sha: SHA, phase: "proof", reason: "proof_failed", detail: "café — 東京"
+      )
+
+      Evidence.replace_nonpassing!(
+        bundle_directory: bundle, expected: initial.value, receipt: desired.value
+      )
+
+      assert_equal desired.canonical_bytes.b, File.binread(target(bundle))
+      assert_equal desired.value, JSON.parse(File.binread(target(bundle)))
+    end
+  end
+
+  def test_replacement_rejects_a_target_changed_away_from_expected_and_desired
+    with_private_bundle do |bundle|
+      initial = Evidence.initialize!(bundle_directory: bundle, candidate_sha: SHA)
+      foreign = failure_receipt("provider_unavailable")
+      write_private(target(bundle), foreign.canonical_bytes, truncate: true)
+
+      assert_raises(Evidence::Conflict) do
+        Evidence.replace_nonpassing!(
+          bundle_directory: bundle, expected: initial.value,
+          receipt: failure_receipt("proof_failed").value
+        )
+      end
+      assert_equal foreign.canonical_bytes, File.binread(target(bundle))
+    end
+  end
+
+
+  def test_two_replacers_serialize_before_revalidation_and_cannot_clobber_the_winner
+    with_private_bundle do |bundle|
+      initial = Evidence.initialize!(bundle_directory: bundle, candidate_sha: SHA)
+      first_desired = failure_receipt("proof_failed")
+      second_desired = failure_receipt("provider_unavailable")
+      entered_rename = Queue.new
+      release_rename = Queue.new
+      attempted_lock = Queue.new
+      with_native_method(native_class, :lock, lambda do |original, instance, *args|
+        attempted_lock << true if Thread.current[:u1b_replacer] == :second
+        original.bind_call(instance, *args)
+      end) do
+        with_native_method(native_class, :renameat, lambda do |original, instance, *args|
+          if Thread.current[:u1b_replacer] == :first
+            entered_rename << true
+            release_rename.pop
+          end
+          original.bind_call(instance, *args)
+        end) do
+          first = Thread.new do
+            Thread.current[:u1b_replacer] = :first
+            Evidence.replace_nonpassing!(
+              bundle_directory: bundle, expected: initial.value, receipt: first_desired.value
+            )
+          rescue StandardError => e
+            e
+          end
+          Timeout.timeout(2) { entered_rename.pop }
+          second = Thread.new do
+            Thread.current[:u1b_replacer] = :second
+            Evidence.replace_nonpassing!(
+              bundle_directory: bundle, expected: initial.value, receipt: second_desired.value
+            )
+          rescue StandardError => e
+            e
+          end
+          Timeout.timeout(2) { attempted_lock.pop }
+          assert second.alive?, "second replacer passed the held descriptor lock"
+          release_rename << true
+          first_result = first.value
+          second_result = second.value
+
+          assert_equal first_desired.canonical_bytes, first_result.canonical_bytes
+          assert_instance_of Evidence::Conflict, second_result
+          assert_equal first_desired.canonical_bytes, File.binread(target(bundle))
+          assert_empty staging_entries(bundle)
+        ensure
+          release_rename << true if first&.alive?
+          first&.join(1)
+          second&.join(1)
+        end
+      end
+    end
+  end
+
+  def test_descriptor_lock_failure_is_typed_and_leaves_no_stage
+    with_private_bundle do |bundle|
+      initial = Evidence.initialize!(bundle_directory: bundle, candidate_sha: SHA)
+      with_native_method(native_class, :lock, lambda do |_original, _instance, *|
+        raise Errno::EACCES, "injected lock failure"
+      end) do
+        error = assert_raises(Evidence::Unavailable) do
+          Evidence.replace_nonpassing!(
+            bundle_directory: bundle, expected: initial.value,
+            receipt: failure_receipt("proof_failed").value
+          )
+        end
+        assert_nil error.cause
+      end
+      assert_equal initial.canonical_bytes, File.binread(target(bundle))
+      assert_empty staging_entries(bundle)
+    end
+  end
+
+  def test_file_fsync_precedes_link_and_cleanup_precedes_directory_fsync
+    with_private_bundle do |bundle|
+      events = []
+      native = native_class
+      with_native_method(native, :fsync, lambda do |original, instance, io|
+        events << (io.stat.file? ? :file_fsync : :directory_fsync)
+        original.bind_call(instance, io)
+      end) do
+        with_native_method(native, :linkat, lambda do |original, instance, *args|
+          events << :link
+          original.bind_call(instance, *args)
+        end) do
+          with_native_method(native, :unlinkat, lambda do |original, instance, *args|
+            events << :unlink
+            original.bind_call(instance, *args)
+          end) do
+            Evidence.initialize!(bundle_directory: bundle, candidate_sha: SHA)
+          end
+        end
+      end
+
+      assert_operator events.index(:file_fsync), :<, events.index(:link)
+      assert_operator events.index(:link), :<, events.index(:unlink)
+      assert_operator events.index(:unlink), :<, events.index(:directory_fsync)
+    end
+  end
+
+  def test_fsync_failures_are_typed_and_retryable
+    with_private_bundle do |bundle|
+      native = native_class
+      with_native_method(native, :fsync, lambda do |_original, _instance, io|
+        raise IOError, "injected file fsync" if io.stat.file?
+        0
+      end) do
+        assert_raises(Evidence::Unavailable) do
+          Evidence.initialize!(bundle_directory: bundle, candidate_sha: SHA)
+        end
+      end
+      refute_path_exists target(bundle)
+      assert_empty staging_entries(bundle)
+
+      Evidence.initialize!(bundle_directory: bundle, candidate_sha: SHA)
+      assert_equal initial_receipt.canonical_bytes, File.binread(target(bundle))
+    end
+  end
+
+
+  def test_post_publication_directory_fsync_failure_leaves_an_exact_retryable_target
+    with_private_bundle do |bundle|
+      failed = false
+      with_native_method(native_class, :fsync, lambda do |original, instance, io|
+        if io.stat.directory? && !failed
+          failed = true
+          raise IOError, "injected directory fsync"
+        end
+        original.bind_call(instance, io)
+      end) do
+        assert_raises(Evidence::Unavailable) do
+          Evidence.initialize!(bundle_directory: bundle, candidate_sha: SHA)
+        end
+      end
+
+      assert_equal initial_receipt.canonical_bytes, File.binread(target(bundle))
+      recovered = Evidence.initialize!(bundle_directory: bundle, candidate_sha: SHA)
+      assert_equal initial_receipt.canonical_bytes, recovered.canonical_bytes
+      assert_equal 1, File.stat(target(bundle)).nlink
+    end
+  end
+
+  def test_rename_failure_preserves_expected_target_and_cleans_staging
+    with_private_bundle do |bundle|
+      initial = Evidence.initialize!(bundle_directory: bundle, candidate_sha: SHA)
+      with_native_method(native_class, :renameat, lambda do |_original, _instance, *|
+        raise Errno::EACCES, "injected rename failure"
+      end) do
+        assert_raises(Evidence::Unavailable) do
+          Evidence.replace_nonpassing!(
+            bundle_directory: bundle, expected: initial.value,
+            receipt: failure_receipt("proof_failed").value
+          )
+        end
+      end
+      assert_equal initial.canonical_bytes, File.binread(target(bundle))
+      assert_empty staging_entries(bundle)
+    end
+  end
+
+  def test_cross_filesystem_target_descriptor_is_rejected
+    skip "/dev/shm is unavailable" unless File.directory?("/dev/shm")
+    with_private_bundle do |bundle|
+      foreign = Dir.mktmpdir("hive-u1b", "/dev/shm")
+      FileUtils.chmod(0o700, foreign)
+      staging_device = File.stat(File.dirname(bundle)).dev
+      skip "test filesystems share a device" if File.stat(foreign).dev == staging_device
+
+      with_native_method(native_class, :open_directory_at, lambda do |_original, _instance, *|
+        File.open(foreign, File::RDONLY)
+      end) do
+        assert_raises(Evidence::UnsafeStorage) do
+          Evidence.initialize!(bundle_directory: bundle, candidate_sha: SHA)
+        end
+      end
+    ensure
+      FileUtils.remove_entry_secure(foreign) if foreign && File.directory?(foreign)
+    end
+  end
+
+  def test_context_open_failure_closes_the_held_parent_descriptor
+    with_private_bundle do |bundle|
+      parent = nil
+      with_native_method(native_class, :open_directory, lambda do |original, instance, *args|
+        parent = original.bind_call(instance, *args)
+      end) do
+        with_native_method(native_class, :open_directory_at, lambda do |_original, _instance, *|
+          raise Errno::EACCES, "injected child open failure"
+        end) do
+          assert_raises(Evidence::Unavailable) do
+            Evidence.initialize!(bundle_directory: bundle, candidate_sha: SHA)
+          end
+        end
+      end
+
+      assert_predicate parent, :closed?
+    end
+  end
+
+  def test_symlink_fifo_special_and_permission_fail_without_blocking
+    skip "mkfifo is unavailable" unless File.respond_to?(:mkfifo)
+    with_private_bundle do |bundle|
+      outside = File.join(File.dirname(bundle), "outside")
+      write_private(outside, "sentinel")
+      File.symlink(outside, target(bundle))
+      assert_raises(Evidence::UnsafeStorage) do
+        Evidence.initialize!(bundle_directory: bundle, candidate_sha: SHA)
+      end
+    end
+    with_private_bundle do |bundle|
+      fifo = staging_path(bundle, "fifo")
+      File.mkfifo(fifo, 0o600)
+      Timeout.timeout(2) do
+        assert_raises(Evidence::UnsafeStorage) do
+          Evidence.initialize!(bundle_directory: bundle, candidate_sha: SHA)
+        end
+      end
+    end
+    with_private_bundle do |bundle|
+      FileUtils.chmod(0o755, bundle)
+      assert_raises(Evidence::UnsafeStorage) do
+        Evidence.initialize!(bundle_directory: bundle, candidate_sha: SHA)
+      end
+    end
+  end
+
+  def test_native_permission_failure_is_normalized_and_cleans_staging
+    with_private_bundle do |bundle|
+      with_native_method(native_class, :linkat, lambda do |_original, _instance, *|
+        raise Errno::EACCES, "injected"
+      end) do
+        error = assert_raises(Evidence::Unavailable) do
+          Evidence.initialize!(bundle_directory: bundle, candidate_sha: SHA)
+        end
+        assert_nil error.cause
+      end
+      refute_path_exists target(bundle)
+      assert_empty staging_entries(bundle)
+    end
+  end
+
+  def test_parent_rebinding_fails_without_clobbering_the_replacement_directory
+    with_private_bundle do |bundle|
+      initial = Evidence.initialize!(bundle_directory: bundle, candidate_sha: SHA)
+      parked = "#{bundle}.parked"
+      sentinel = "attacker sentinel"
+      rebound = false
+      with_native_method(native_class, :renameat, lambda do |original, instance, *args|
+        unless rebound
+          File.rename(bundle, parked)
+          FileUtils.mkdir_p(bundle, mode: 0o700)
+          FileUtils.chmod(0o700, bundle)
+          write_private(target(bundle), sentinel)
+          rebound = true
+        end
+        original.bind_call(instance, *args)
+      end) do
+        assert_raises(Evidence::UnsafeStorage) do
+          Evidence.replace_nonpassing!(
+            bundle_directory: bundle, expected: initial.value,
+            receipt: failure_receipt("proof_failed").value
+          )
+        end
+      end
+      assert_equal sentinel, File.binread(target(bundle))
+    ensure
+      FileUtils.rm_rf(bundle) if bundle && File.exist?(bundle)
+      File.rename(parked, bundle) if parked && File.directory?(parked)
+    end
+  end
+
+  def test_staging_enumeration_is_bounded
+    with_private_bundle do |bundle|
+      parent = File.dirname(bundle)
+      1_025.times { |index| write_private(File.join(parent, "unrelated-#{index}"), "x") }
+
+      assert_raises(Evidence::UnsafeStorage) do
+        Evidence.initialize!(bundle_directory: bundle, candidate_sha: SHA)
+      end
+    end
+  end
+
+  def test_native_flag_tables_cover_linux_and_macos_nofollow_nonblock_modes
+    flags = native_class.const_get(:FLAGS, false)
+    assert_equal %i[darwin linux], flags.keys.sort
+    assert_operator flags.dig(:linux, :read) & 0o400000, :>, 0
+    assert_operator flags.dig(:linux, :read) & 0o4000, :>, 0
+    assert_operator flags.dig(:darwin, :read) & 0x0100, :>, 0
+    assert_operator flags.dig(:darwin, :read) & 0x0004, :>, 0
+  end
+
+  private
+
+  def target(bundle)
+    File.join(bundle, Creator::Vocabulary.fetch("bundle_files").first)
+  end
+
+  def initial_receipt
+    Creator.failure(candidate_sha: SHA, phase: "preflight", reason: "not_started")
+  end
+
+  def failure_receipt(reason)
+    Creator.failure(candidate_sha: SHA, phase: "proof", reason:,
+                    execution_kind: "authenticated_openclaw", model_loop: "executed")
+  end
+
+  def staging_path(bundle, suffix)
+    stat = File.stat(bundle)
+    File.join(File.dirname(bundle), ".hive-creator-#{stat.dev.to_s(16)}-#{stat.ino.to_s(16)}-#{suffix}")
+  end
+
+  def staging_entries(bundle)
+    prefix = File.basename(staging_path(bundle, ""))
+    Dir.children(File.dirname(bundle)).select { |name| name.start_with?(prefix) }
+  end
+
+  def write_private(path, bytes, truncate: false)
+    flags = File::WRONLY | File::CREAT | (truncate ? File::TRUNC : File::EXCL)
+    File.open(path, flags, 0o600) { |file| file.write(bytes) }
+    FileUtils.chmod(0o600, path)
+  end
+
+  def native_class
+    publisher = HiveLiveAgentProof.const_get(:WorkflowCreatorReceiptPublisher, false)
+    publisher.const_get(:Native, false)
+  end
+
+  def with_native_method(native, name, replacement)
+    original = native.instance_method(name)
+    native.define_method(name) do |*args|
+      replacement.call(original, self, *args)
+    end
+    yield
+  ensure
+    native.define_method(name, original) if original
+  end
+
+  def with_private_bundle
+    with_tmp_dir do |root|
+      bundle = File.join(root, "bundle")
+      FileUtils.mkdir_p(bundle, mode: 0o700)
+      FileUtils.chmod(0o700, bundle)
+      yield bundle
+    end
+  end
+end

--- a/test/unit/packaging/workflow_creator_evidence_test.rb
+++ b/test/unit/packaging/workflow_creator_evidence_test.rb
@@ -61,6 +61,52 @@ class WorkflowCreatorEvidenceTest < Minitest::Test
     end
   end
 
+  def test_two_initializers_serialize_the_complete_transition
+    with_private_bundle do |bundle|
+      entered_link = Queue.new
+      release_link = Queue.new
+      attempted_lock = Queue.new
+      with_native_method(native_class, :lock, lambda do |original, instance, *args|
+        attempted_lock << true if Thread.current[:u1b_initializer] == :second
+        original.bind_call(instance, *args)
+      end) do
+        with_native_method(native_class, :linkat, lambda do |original, instance, *args|
+          if Thread.current[:u1b_initializer] == :first
+            entered_link << true
+            release_link.pop
+          end
+          original.bind_call(instance, *args)
+        end) do
+          first = Thread.new do
+            Thread.current[:u1b_initializer] = :first
+            Evidence.initialize!(bundle_directory: bundle, candidate_sha: SHA)
+          rescue StandardError => e
+            e
+          end
+          Timeout.timeout(2) { entered_link.pop }
+          second = Thread.new do
+            Thread.current[:u1b_initializer] = :second
+            Evidence.initialize!(bundle_directory: bundle, candidate_sha: SHA)
+          rescue StandardError => e
+            e
+          end
+          Timeout.timeout(2) { attempted_lock.pop }
+          assert second.alive?, "second initializer passed the held descriptor lock"
+          release_link << true
+          values = [ first.value, second.value ]
+
+          assert values.all? { |value| value.respond_to?(:canonical_bytes) }, values.map(&:inspect).join("\n")
+          assert_equal 1, File.stat(target(bundle)).nlink
+          assert_empty staging_entries(bundle)
+        ensure
+          release_link << true if first&.alive?
+          first&.join(1)
+          second&.join(1)
+        end
+      end
+    end
+  end
+
   def test_transient_link_is_recovered_and_both_cleanup_orders_converge
     with_private_bundle do |bundle|
       receipt = initial_receipt
@@ -85,24 +131,47 @@ class WorkflowCreatorEvidenceTest < Minitest::Test
       stage = staging_path(bundle, "linked")
       write_private(stage, receipt.canonical_bytes)
       File.link(stage, target(bundle))
-      ready = Queue.new
-      start = Queue.new
-      results = 2.times.map do
-        Thread.new do
-          ready << true
-          start.pop
-          Evidence.initialize!(bundle_directory: bundle, candidate_sha: SHA)
-        rescue StandardError => e
-          e
+      entered_cleanup = Queue.new
+      release_cleanup = Queue.new
+      attempted_lock = Queue.new
+      with_native_method(native_class, :lock, lambda do |original, instance, *args|
+        attempted_lock << true if Thread.current[:u1b_recovery] == :second
+        original.bind_call(instance, *args)
+      end) do
+        with_native_method(native_class, :unlinkat, lambda do |original, instance, *args|
+          if Thread.current[:u1b_recovery] == :first
+            entered_cleanup << true
+            release_cleanup.pop
+          end
+          original.bind_call(instance, *args)
+        end) do
+          first = Thread.new do
+            Thread.current[:u1b_recovery] = :first
+            Evidence.initialize!(bundle_directory: bundle, candidate_sha: SHA)
+          rescue StandardError => e
+            e
+          end
+          Timeout.timeout(2) { entered_cleanup.pop }
+          second = Thread.new do
+            Thread.current[:u1b_recovery] = :second
+            Evidence.initialize!(bundle_directory: bundle, candidate_sha: SHA)
+          rescue StandardError => e
+            e
+          end
+          Timeout.timeout(2) { attempted_lock.pop }
+          assert second.alive?, "second recovery caller passed the held descriptor lock"
+          release_cleanup << true
+          values = [ first.value, second.value ]
+
+          assert values.all? { |value| value.respond_to?(:canonical_bytes) }, values.map(&:inspect).join("\n")
+          assert_equal 1, File.stat(target(bundle)).nlink
+          assert_empty staging_entries(bundle)
+        ensure
+          release_cleanup << true if first&.alive?
+          first&.join(1)
+          second&.join(1)
         end
       end
-      2.times { ready.pop }
-      2.times { start << true }
-      values = results.map(&:value)
-
-      assert values.all? { |value| value.respond_to?(:canonical_bytes) }, values.map(&:inspect).join("\n")
-      assert_equal 1, File.stat(target(bundle)).nlink
-      assert_empty staging_entries(bundle)
     end
   end
 
@@ -115,6 +184,41 @@ class WorkflowCreatorEvidenceTest < Minitest::Test
 
       refute_path_exists orphan
       assert_equal [ File.basename(target(bundle)) ], Dir.children(bundle)
+      assert_empty staging_entries(bundle)
+    end
+  end
+
+  def test_interrupted_pre_rename_stage_is_cleaned_before_replacement
+    with_private_bundle do |bundle|
+      initial = Evidence.initialize!(bundle_directory: bundle, candidate_sha: SHA)
+      desired = failure_receipt("proof_failed")
+      orphan = staging_path(bundle, "pre-rename")
+      write_private(orphan, desired.canonical_bytes)
+
+      replaced = Evidence.replace_nonpassing!(
+        bundle_directory: bundle, expected: initial.value, receipt: desired.value
+      )
+
+      assert_equal desired.canonical_bytes, replaced.canonical_bytes
+      assert_equal desired.canonical_bytes, File.binread(target(bundle))
+      refute_path_exists orphan
+      assert_empty staging_entries(bundle)
+    end
+  end
+
+  def test_linked_different_initialization_settles_to_a_conflict
+    with_private_bundle do |bundle|
+      receipt = initial_receipt
+      stage = staging_path(bundle, "linked-different")
+      write_private(stage, receipt.canonical_bytes)
+      File.link(stage, target(bundle))
+
+      assert_raises(Evidence::Conflict) do
+        Evidence.initialize!(bundle_directory: bundle, candidate_sha: "b" * 40)
+      end
+
+      assert_equal receipt.canonical_bytes, File.binread(target(bundle))
+      assert_equal 1, File.stat(target(bundle)).nlink
       assert_empty staging_entries(bundle)
     end
   end
@@ -272,6 +376,89 @@ class WorkflowCreatorEvidenceTest < Minitest::Test
     end
   end
 
+  def test_descriptor_lock_wait_is_bounded
+    skip "fork is unavailable" unless Process.respond_to?(:fork)
+    with_private_bundle do |bundle|
+      ready_read, ready_write = IO.pipe
+      release_read, release_write = IO.pipe
+      child = Process.fork do
+        ready_read.close
+        release_write.close
+        File.open(bundle, File::RDONLY) do |directory|
+          directory.flock(File::LOCK_EX)
+          ready_write.write("1")
+          ready_write.close
+          release_read.read(1)
+        end
+        exit! 0
+      end
+      ready_write.close
+      release_read.close
+      assert_equal "1", Timeout.timeout(2) { ready_read.read(1) }
+      started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+      assert_raises(Evidence::Unavailable) do
+        Evidence.initialize!(bundle_directory: bundle, candidate_sha: SHA)
+      end
+      elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+
+      assert_operator elapsed, :>=, 1.5
+      assert_operator elapsed, :<, 3.0
+      refute_path_exists target(bundle)
+      assert_empty staging_entries(bundle)
+    ensure
+      begin
+        release_write&.write("1")
+      rescue IOError
+        nil
+      end
+      release_write&.close
+      ready_read&.close
+      Process.wait(child) if child
+    end
+  end
+
+  def test_unlock_failure_preserves_a_primary_conflict_and_exact_retry_converges
+    with_private_bundle do |bundle|
+      initial = Evidence.initialize!(bundle_directory: bundle, candidate_sha: SHA)
+      with_native_method(native_class, :unlock, lambda do |_original, _instance, *|
+        raise IOError, "injected unlock failure"
+      end) do
+        assert_raises(Evidence::Conflict) do
+          Evidence.initialize!(bundle_directory: bundle, candidate_sha: "b" * 40)
+        end
+        assert_raises(Evidence::Unavailable) do
+          Evidence.initialize!(bundle_directory: bundle, candidate_sha: SHA)
+        end
+      end
+
+      recovered = Evidence.initialize!(bundle_directory: bundle, candidate_sha: SHA)
+      assert_equal initial.canonical_bytes, recovered.canonical_bytes
+      assert_empty staging_entries(bundle)
+    end
+  end
+
+  def test_context_cleanup_attempts_both_descriptor_closes
+    with_private_bundle do |bundle|
+      descriptors = []
+      with_native_method(native_class, :close, lambda do |original, instance, io|
+        descriptors << io
+        raise IOError, "injected first close failure" if descriptors.length == 1
+
+        original.bind_call(instance, io)
+      end) do
+        assert_raises(Evidence::Unavailable) do
+          Evidence.initialize!(bundle_directory: bundle, candidate_sha: SHA)
+        end
+      end
+
+      assert_equal 2, descriptors.length
+      assert_predicate descriptors.last, :closed?
+      descriptors.first.close unless descriptors.first.closed?
+      assert_equal initial_receipt.canonical_bytes, File.binread(target(bundle))
+    end
+  end
+
   def test_file_fsync_precedes_link_and_cleanup_precedes_directory_fsync
     with_private_bundle do |bundle|
       events = []
@@ -344,18 +531,30 @@ class WorkflowCreatorEvidenceTest < Minitest::Test
   def test_rename_failure_preserves_expected_target_and_cleans_staging
     with_private_bundle do |bundle|
       initial = Evidence.initialize!(bundle_directory: bundle, candidate_sha: SHA)
-      with_native_method(native_class, :renameat, lambda do |_original, _instance, *|
-        raise Errno::EACCES, "injected rename failure"
+      events = []
+      with_native_method(native_class, :unlinkat, lambda do |original, instance, *args|
+        events << :cleanup
+        original.bind_call(instance, *args)
       end) do
-        assert_raises(Evidence::Unavailable) do
-          Evidence.replace_nonpassing!(
-            bundle_directory: bundle, expected: initial.value,
-            receipt: failure_receipt("proof_failed").value
-          )
+        with_native_method(native_class, :unlock, lambda do |original, instance, *args|
+          events << :unlock
+          original.bind_call(instance, *args)
+        end) do
+          with_native_method(native_class, :renameat, lambda do |_original, _instance, *|
+            raise Errno::EACCES, "injected rename failure"
+          end) do
+            assert_raises(Evidence::Unavailable) do
+              Evidence.replace_nonpassing!(
+                bundle_directory: bundle, expected: initial.value,
+                receipt: failure_receipt("proof_failed").value
+              )
+            end
+          end
         end
       end
       assert_equal initial.canonical_bytes, File.binread(target(bundle))
       assert_empty staging_entries(bundle)
+      assert_operator events.index(:cleanup), :<, events.index(:unlock)
     end
   end
 

--- a/test/unit/packaging/workflow_creator_evidence_test.rb
+++ b/test/unit/packaging/workflow_creator_evidence_test.rb
@@ -286,6 +286,21 @@ class WorkflowCreatorEvidenceTest < Minitest::Test
     end
   end
 
+  def test_initialization_corrects_a_too_open_created_descriptor
+    with_private_bundle do |bundle|
+      with_native_method(native_class, :create_file_at, lambda do |original, instance, *args|
+        file = original.bind_call(instance, *args)
+        file.chmod(0o644)
+        file
+      end) do
+        receipt = Evidence.initialize!(bundle_directory: bundle, candidate_sha: SHA)
+
+        assert_equal receipt.canonical_bytes, File.binread(target(bundle))
+        assert_equal 0o600, File.stat(target(bundle)).mode & 0o777
+      end
+    end
+  end
+
   def test_replacement_rejects_a_target_changed_away_from_expected_and_desired
     with_private_bundle do |bundle|
       initial = Evidence.initialize!(bundle_directory: bundle, candidate_sha: SHA)

--- a/test/unit/release_contract_test.rb
+++ b/test/unit/release_contract_test.rb
@@ -154,6 +154,7 @@ class ReleaseContractTest < Minitest::Test
     refute_nil creator_step
     assert_equal "${{ secrets.OPENAI_API_KEY }}", creator_step.dig("env", "OPENAI_API_KEY")
     assert_includes creator_step.fetch("run"), "live_hive_workflow_creator_smoke_test.rb"
+    assert_includes creator_step.fetch("run"), 'install -d -m 0700 "$RUNNER_TEMP/workflow-creator-evidence"'
     assert_includes body, "workflow-creator-evidence-openclaw"
     assert_includes body, "creator-evidence"
   end

--- a/wiki/component-boundaries.md
+++ b/wiki/component-boundaries.md
@@ -209,15 +209,19 @@ constructor of the private `WorkflowCreatorReceiptPublisher`. Its public API
 accepts a bundle directory, derives the primary target exclusively from the
 frozen creator vocabulary, and publishes only canonical non-passing receipts
 admitted by the semantic core. Initialization uses an fsynced 0600 regular
-staging inode and descriptor-relative no-clobber linking. Exact retries and the
-bounded two-link recovery state converge without replacement; different bytes,
+staging inode and descriptor-relative no-clobber linking. A bounded cooperative
+directory lock serializes complete initialization and replacement transitions.
+Exact retries and one-link or two-link interrupted states converge; different bytes,
 unsafe types or permissions, excess or outside-prefix links, parent rebinding,
 and native failures fail through typed evidence errors. Replacement revalidates
 the expected identity and bytes under a cooperative lock on the held target
 directory descriptor immediately before descriptor-relative rename,
 and a retry after rename re-fsyncs the exact desired target. Directory scanning
-is bounded and FIFO/special entries use no-follow, nonblocking opens. The
-protected smoke adapter currently emits an explicit non-passing U14-custody gap
+is bounded and FIFO/special entries use no-follow, nonblocking opens. The boundary
+assumes all supported writers use the facade; arbitrary same-user raw filesystem
+mutation is outside its cooperative contract and does not justify a second
+cross-platform exchange subsystem in U1b. The protected smoke adapter currently
+emits an explicit non-passing U14-custody gap
 even after its model loop succeeds; U14/U15 retain execution and live-claim
 authority.
 
@@ -242,11 +246,11 @@ handles, and focused subprocess proof covers both load orders and post-load core
 replacement. The sources load without JSON, I/O, workflow, process, credential,
 or provider dependencies.
 
-The Values seam and Workflow Creator Core both have production consumers and no
-migration exception. Core remains a custody-complete candidate: U1a2 adds proof
-custody and independent retained verification, but no provider, process,
-publisher, workflow mutation, or claim that the live workflow already emits the
-complete bundle.
+The Values seam and composed Workflow Creator are boundary-ready, have production
+consumers, and retain no migration exception. U1a2 adds proof custody and
+independent retained verification; U1b adds the fixed non-passing receipt
+publication boundary, but neither claims provider/process custody or that the live
+workflow already emits the complete bundle.
 The exact R43 proof is 298 lines / 20 callables / 32 decisions for `Values`, 200
 lines / 14 callables / 23 decisions for `TextSafety`, and 498 / 34 / 55 when
 composed. The Values source retains its leaf-local `Ripper.lex` no-require proof;

--- a/wiki/component-boundaries.md
+++ b/wiki/component-boundaries.md
@@ -20,7 +20,7 @@ the first and primary consumer.
 | Patrol Effect Evidence | `candidate` (U3a protocol complete; U3b/U3c proof pending) | `require "hive/modules/migration/patrol_evidence"` → `Hive::Modules::Migration::PatrolEvidence` | [[modules/patrol]] |
 | Attempts admission / future RunReceipt | `candidate` (guarded reference) | `require "hive/attempts/api"` → `Hive::Attempts::API` | [[modules/attempts]] |
 | Workflow Creator Values | `boundary-ready` | `require "./packaging/live_agent_skills/workflow_creator_text_safety"` → `HiveLiveAgentProof::WorkflowCreator::TextSafety` | [[component-boundaries]] |
-| Workflow Creator Core | `candidate` (U1a2 custody complete; U1b publication pending) | `require "./packaging/live_agent_skills/workflow_creator"` → `HiveLiveAgentProof::WorkflowCreator` | [[component-boundaries]] |
+| Workflow Creator | `boundary-ready` | `require "./packaging/live_agent_skills/workflow_creator_evidence"` → `HiveLiveAgentProof::WorkflowCreatorEvidence` | [[component-boundaries]] |
 | UserService | `boundary-ready` | `require "hive/user_service"` → `Hive::UserService` | [[modules/user_service]] |
 | Agent ABI | `boundary-ready`; standalone package candidate | `require "hive/agent_runtime"` → `Hive::AgentRuntime` | [[modules/agent_cli_runtime]], [[modules/agent_profile]] |
 | Agent Artifact Firewall | `boundary-ready` | `require "hive/artifact_firewall"` → `Hive::ArtifactFirewall` | [[modules/protected_files]] |
@@ -36,13 +36,12 @@ has earned a gem, version, repository, or release.
 
 ## Final graph audit
 
-The catalog on 2026-08-04 retains ten components: seven are
-`boundary-ready`; Attempts, Patrol Effect Evidence, and Workflow Creator Core
-remain `candidate`.
+The catalog on 2026-08-04 retains ten components: eight are
+`boundary-ready`; Attempts and Patrol Effect Evidence remain `candidate`.
 Patrol retains one bounded U3 exception for deterministic public-path and
-independently authorized installed/live proof. Workflow Creator Core removed
-its U1a2 exception after the incumbent proof consumer adopted exact bundle
-custody, but stays candidate until U1b supplies the publication boundary.
+independently authorized installed/live proof. Workflow Creator is now composed
+through its U1b typed publication facade after the incumbent proof consumer
+adopted exact bundle custody.
 Every retained entry point has focused clean-process load proof, every
 catalog-owned path and focused test resolves inside this repository, and the
 direct-construction guards pass against all production Ruby sources.
@@ -52,7 +51,7 @@ The component dependency graph has two edges:
 ```mermaid
 flowchart LR
   skillpack[Skillpack] --> agent_abi[Agent ABI]
-  workflow_core[Workflow Creator Core - candidate] --> workflow_values[Workflow Creator Values]
+  workflow_core[Workflow Creator] --> workflow_values[Workflow Creator Values]
   patrol_effects[Patrol Effect Evidence - candidate]
   attempts[Attempts admission - candidate]
   user_service[UserService]
@@ -64,12 +63,12 @@ flowchart LR
 All other cataloged components depend only on explicitly allowed lower-level
 Hive primitives. The source audit found no retained experimental facade outside
 the catalog: each promoted facade is owned by a catalog row and used by Hive,
-while Attempts, Patrol Effect Evidence, and Workflow Creator Core are
-deliberately retained as guarded candidates rather than being promoted ahead
-of their remaining lifecycle, qualification, or publication proof.
+while Attempts and Patrol Effect Evidence are deliberately retained as guarded
+candidates rather than being promoted ahead of their remaining lifecycle or
+qualification proof.
 
 This is an internal architecture verdict, not a packaging verdict. None of the
-seven ready components currently has the named non-Hive adopter and independent
+eight ready components currently has the named non-Hive adopter and independent
 package proof required by the standalone-gem plan.
 
 `Patrol Effect Evidence` owns the immutable cross-product capture, selection,
@@ -204,6 +203,23 @@ canonical bytes. Before retention, the incumbent attestor applies its raw
 credential-pattern scan to every admitted member, so the aggregate scan count
 describes bytes that were actually scanned. No one-file compatibility path
 remains.
+
+`WorkflowCreatorEvidence` is the composed component entry point and the only
+constructor of the private `WorkflowCreatorReceiptPublisher`. Its public API
+accepts a bundle directory, derives the primary target exclusively from the
+frozen creator vocabulary, and publishes only canonical non-passing receipts
+admitted by the semantic core. Initialization uses an fsynced 0600 regular
+staging inode and descriptor-relative no-clobber linking. Exact retries and the
+bounded two-link recovery state converge without replacement; different bytes,
+unsafe types or permissions, excess or outside-prefix links, parent rebinding,
+and native failures fail through typed evidence errors. Replacement revalidates
+the expected identity and bytes under a cooperative lock on the held target
+directory descriptor immediately before descriptor-relative rename,
+and a retry after rename re-fsyncs the exact desired target. Directory scanning
+is bounded and FIFO/special entries use no-follow, nonblocking opens. The
+protected smoke adapter currently emits an explicit non-passing U14-custody gap
+even after its model loop succeeds; U14/U15 retain execution and live-claim
+authority.
 
 The approved U1a1c budget re-scope permits only named private semantic-helper
 decomposition. Its ceilings are 125/7/4 for the facade, 260/15/24 for the
@@ -399,10 +415,13 @@ R43 proof, direct entry-point load-order proof, and projection behavior live in
 `test/unit/packaging/workflow_creator_text_safety_test.rb`; semantic-core proof
 lives in `test/unit/packaging/workflow_creator_core_test.rb`, while exact source
 and retained bundle custody is covered by
-`test/unit/packaging/live_agent_proof_test.rb`.
+`test/unit/packaging/live_agent_proof_test.rb`. Publication state, crash,
+concurrency, path, special-file, native-platform, and cleanup proof lives in
+`test/unit/packaging/workflow_creator_evidence_test.rb`.
 
 The syntax scan is an architecture regression guard, not a Ruby sandbox. Its
-construction rule covers literal `Constant.new`, not aliases or factory
+construction rule covers literal parenthesized and parenthesis-free
+`Constant.new` calls, not aliases or factory
 methods. Construction authorization is file-granular: it rejects a named
 internal from a newly listed file, but it does not distinguish multiple call
 sites for that internal inside an already authorized composition root. It does

--- a/wiki/component-boundaries.md
+++ b/wiki/component-boundaries.md
@@ -208,8 +208,9 @@ remains.
 constructor of the private `WorkflowCreatorReceiptPublisher`. Its public API
 accepts a bundle directory, derives the primary target exclusively from the
 frozen creator vocabulary, and publishes only canonical non-passing receipts
-admitted by the semantic core. Initialization uses an fsynced 0600 regular
-staging inode and descriptor-relative no-clobber linking. A bounded cooperative
+admitted by the semantic core. Initialization descriptor-tightens a newly
+created regular staging inode to 0600 before writing any bytes, fsyncs it, and
+uses descriptor-relative no-clobber linking. A bounded cooperative
 directory lock serializes complete initialization and replacement transitions.
 Exact retries and one-link or two-link interrupted states converge; different bytes,
 unsafe types or permissions, excess or outside-prefix links, parent rebinding,

--- a/wiki/gaps.md
+++ b/wiki/gaps.md
@@ -863,6 +863,11 @@ not produce a trusted live attestation. Keep this gap open until the dedicated
 `live-workflow-creator` job succeeds for an exact protected-main candidate and
 the resulting Check Run binds the prompt, candidate skill digest, ordered Hive
 commands, exact editorial graph, zero task count, secret scan, and cleanup.
+U1b now owns crash-safe publication of the fixed primary receipt, but its
+temporary protected-smoke adapter intentionally records
+`u14_execution_custody_unavailable` rather than turning successful model output
+into a live-success claim. U14 must first prove installed execution custody and
+U15 must then own credential routing and the authenticated final translation.
 The same proof must also attest one explicitly authorized task, one first-stage
 run, a no-op retry with the same idempotency key, and matching operational
 status.

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -19,11 +19,11 @@ Updated: 2026-08-04
 Folder-as-agent workflow engine: a Ruby 3.4 / Thor CLI control plane where descriptor-backed workflows move task folders through filesystem stages, stage agents compile provider-neutral invocations through `Hive::AgentRuntime` and configurable AgentProfile adapters (`claude` default, `codex`, `pi`, `grok`), and `mv` between directories remains the approval primitive. The built-in `coding` workflow drives the nine-stage PR pipeline (`1-inbox` → `2-brainstorm` → `3-plan` → `4-execute` → `5-open-pr` → `6-review` → `7-artifacts` → `8-finalize` → `9-done`), while the built-in `content` and `bench` workflows and project-authored workflows share the same generic runner/status/action machinery. Agent operation is centered on the additive operational status contract, coherent daemon scheduler snapshots, bounded semantic `hive watch`, tokenized routine `hive act`, and stable-ID semantic E2E profiles; the legacy full JSON graph remains compatible. Hive packages one canonical operating skill projected to OpenClaw `/hive`, Claude `/hive`, Codex `$hive`, and Pi `/skill:hive`, with read-only `hive doctor`, consent-safe setup, deterministic trusted pre-release proof, and optional four-agent live diagnostics.
 
 Reusable mechanisms remain in this monorepo behind the canonical
-[[component-boundaries]] catalog. The ten-row internal graph has seven
+[[component-boundaries]] catalog. The ten-row internal graph has eight
 `boundary-ready` facades—UserService, Agent ABI, Agent Artifact Firewall,
 Skillpack, Safe Agent Git Gate, WorkLedger, and Workflow Creator Values/Text
-Safety—and three guarded candidates: Attempts admission, Patrol Effect
-Evidence, and Workflow Creator Core. Skillpack's dependency on Agent ABI and
+Safety plus the composed Workflow Creator—and two guarded candidates: Attempts
+admission and Patrol Effect Evidence. Skillpack's dependency on Agent ABI and
 the Core's dependency on Values are the two component edges. Patrol's U3
 qualification fence is the only migration exception. Hive
 is the first and primary consumer, and internal readiness does not imply a gem,

--- a/wiki/log.d/20260804T162015Z-workflow-creator-publication.md
+++ b/wiki/log.d/20260804T162015Z-workflow-creator-publication.md
@@ -1,0 +1,26 @@
+## 2026-08-04 — Workflow creator receipt publication boundary
+
+**Change:** Added the typed `WorkflowCreatorEvidence` facade and its private,
+creator-specific receipt publisher. The facade accepts only a bundle directory,
+derives the primary filename from the frozen vocabulary, validates canonical
+non-passing receipts through the merged creator core, and owns descriptor-bound
+initialization, compare-and-swap replacement, bounded recovery, cleanup, and
+durability.
+
+**Safety:** Publication uses held directory descriptors plus native
+`openat`/`linkat`/`renameat`/`unlinkat`, owner-only regular files, no-follow and
+nonblocking opens, file-before-publication fsync, directory-after-cleanup fsync,
+one held-directory-descriptor replacement lock, and fail-closed
+link/path/type/permission checks. The Ripper construction fence
+now recognizes parenthesized and parenthesis-free `.new` calls and permits the
+private publisher only from its public facade.
+
+**Proof:** Focused tests cover exact and conflicting retries, both transient
+cleanup orders, concurrent recovery, interrupted and replacement crash gaps,
+link ambiguity, fsync order and failure, parent rebinding, bounded FIFO/special
+enumeration, typed native errors, cleanup, and Linux/macOS flag tables. Release
+candidate source identity now includes both publication files.
+
+**Authority:** The temporary protected smoke adapter emits only a typed
+non-passing U14 custody gap. It does not select credentials, execute the future
+U14 transaction, or claim U15 live success.

--- a/wiki/log.d/20260804T173314Z-workflow-creator-darwin-permissions.md
+++ b/wiki/log.d/20260804T173314Z-workflow-creator-darwin-permissions.md
@@ -1,0 +1,11 @@
+## 2026-08-04 — Workflow creator Darwin staging permissions
+
+**Change:** Workflow Creator receipt publication now wraps newly created staging
+descriptors as `File` objects and applies descriptor-bound mode `0600` before
+writing receipt bytes. This matches Hive's established managed-directory
+creation pattern and removes dependence on the platform's initial create mode.
+
+**Proof:** The focused publication suite injects a too-open `0644` created
+descriptor and verifies that initialization publishes the exact canonical bytes
+as a single-link `0600` file. The protected macOS CI path executes the same
+native initialization and replacement flow on Darwin.

--- a/wiki/log.d/20260804T181500Z-workflow-creator-publication-review-hardening.md
+++ b/wiki/log.d/20260804T181500Z-workflow-creator-publication-review-hardening.md
@@ -1,0 +1,19 @@
+---
+title: Workflow Creator publication review hardening
+type: change
+created: 2026-08-04
+tags: [workflow-creator, evidence, publication, recovery]
+---
+
+Workflow Creator evidence publication now holds one bounded cooperative directory
+lock across complete initialization and replacement transitions. Exact retries
+recover private one-link pre-publication stages and linked post-publication stages;
+stable different bytes remain typed conflicts. Unlock and descriptor-close cleanup
+preserve the primary outcome, lock waits are bounded, and both held descriptors are
+offered for cleanup.
+
+The protected live adapter creates its evidence directory as owner-only and passes
+the exact provider credential through failure-receipt redaction and validation.
+Construction fencing now keeps the production-wide Ruby scan when a component adds
+packaging scan roots. The existing macOS CI lane executes one native publication
+happy path; the hostile publication matrix remains outside ordinary CI.

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -45,6 +45,10 @@ operational status, no external actions, secret scanning, and cleanup. Missing
 provider credentials make this live gate explicitly unavailable; they never
 turn a skipped test into release evidence.
 
+The U1b adapter publishes through `WorkflowCreatorEvidence` but deliberately
+retains a typed non-passing receipt after a successful model loop until U14
+supplies execution custody and U15 owns the final authenticated claim.
+
 ## Local feedback loop
 
 During implementation, run the smallest relevant test files directly:
@@ -135,11 +139,15 @@ bundle exec ruby -Itest -Ilib test/unit/component_boundaries_test.rb
 bundle exec ruby -Itest test/unit/packaging/workflow_creator_values_test.rb
 bundle exec ruby -Itest test/unit/packaging/workflow_creator_text_safety_test.rb
 bundle exec ruby -Itest test/unit/packaging/workflow_creator_core_test.rb
+bundle exec ruby -Itest test/unit/packaging/workflow_creator_evidence_test.rb
 bundle exec ruby -Itest test/unit/packaging/live_agent_proof_test.rb
 ```
 
 Ready components cannot depend on candidates. Forbidden-construction rules
-also apply to guarded candidates, and the helper can run a named focused
+also apply to guarded candidates. Components can name a bounded construction
+scan surface; its Ripper fence recognizes both parenthesized and
+parenthesis-free `.new` calls and permits a private collaborator only at the
+catalog-authorized composition file. The helper can run a named focused
 clean-load proof for a candidate such as Attempts without representing the
 whole component graph as ready.
 


### PR DESCRIPTION
## Summary

- Gives Workflow Creator one typed boundary for initializing and compare-and-swap replacing its fixed primary receipt, with canonical bytes and explicit conflict, unsafe-storage, and unavailable outcomes.
- Makes cooperative callers converge after interrupted one-link or transient two-link publication states while bounding lock waits, directory scans, cleanup, and durability work.
- Promotes the composed creator component to boundary-ready without absorbing execution custody, provider selection, credentials, or live-success authority from U14/U15.

## Test plan

- [x] Publication matrix: 31 runs, 131 assertions, 0 failures/errors/skips
- [x] Component boundaries: 44 runs, 602 assertions, 0 failures/errors/skips
- [x] Workflow-creator smoke: 4 runs, 22 assertions, 0 failures/errors; 1 expected credential-gated live skip
- [x] Release contracts: 16 runs, 746 assertions, 0 failures/errors/skips
- [x] Focused RuboCop: 6 files, no offenses; workflow YAML and `git diff --check` clean
- [x] Pre-review broad checkpoint: 12,144 runs, 156,587 assertions, 0 failures/errors, 10 skips
- [x] Hosted CI, including the single focused native Darwin publication path

## Notes for reviewer

The state machine holds one bounded descriptor lock across complete initialization or replacement, removes only its own unambiguous interrupted stages, and performs cleanup before unlock. Stable different bytes remain a typed conflict; ambiguous links, types, permissions, or path bindings fail closed.

The construction fence now scans all production Ruby plus the declared packaging root. The live adapter creates the evidence directory owner-only and redacts the exact selected credential before publishing a failure receipt. The full hostile/property campaign remains opt-in; ordinary CI adds only one native happy-path assertion to the existing macOS job.

Session-settled decisions carried from planning: U1b is a creator-specific publication boundary (user-approved), arbitrary same-user writes outside the facade are outside its cooperative contract, and a generic cross-platform exchange/CAS subsystem remains explicitly out of scope.

