### PR TITLE
feat(packaging): add workflow creator execution custody

### DIFF
--- a/config/component-boundaries.yml
+++ b/config/component-boundaries.yml
@@ -888,7 +888,8 @@ components:
       - constant: HiveLiveAgentProof::WorkflowCreatorReceiptPublisher
         files:
           - packaging/live_agent_skills/workflow_creator_evidence.rb
-        reason: "The typed creator evidence facade is the sole publication composition root"
+          - packaging/live_agent_skills/workflow_creator_execution.rb
+        reason: "The typed evidence facade owns the primary receipt, while the execution facade may construct the same private publisher only for the three vocabulary-fixed support members"
     construction_scan_paths:
       - packaging
     hive_consumers:
@@ -900,5 +901,91 @@ components:
     focused_tests:
       - test/unit/packaging/workflow_creator_core_test.rb
       - test/unit/packaging/workflow_creator_evidence_test.rb
+      - test/unit/packaging/live_agent_proof_test.rb
+    migration_exceptions: []
+
+  - id: workflow-creator-execution
+    name: Workflow Creator Execution
+    state: boundary-ready
+    entrypoint:
+      file: packaging/live_agent_skills/workflow_creator_execution.rb
+      require: ./packaging/live_agent_skills/workflow_creator_execution
+      constant: HiveLiveAgentProof::WorkflowCreatorExecution
+    public_contract:
+      values:
+        - HiveLiveAgentProof::WorkflowCreatorExecution.start!
+        - HiveLiveAgentProof::WorkflowCreatorExecution#gateway_path
+        - HiveLiveAgentProof::WorkflowCreatorExecution#workspace_path
+        - HiveLiveAgentProof::WorkflowCreatorExecution#run_outer_workflow_creator
+        - HiveLiveAgentProof::WorkflowCreatorExecution#run_outer_authorized_work
+        - HiveLiveAgentProof::WorkflowCreatorExecution#draft!
+        - HiveLiveAgentProof::WorkflowCreatorExecution#finish!
+        - HiveLiveAgentProof::WorkflowCreatorExecution#result
+        - HiveLiveAgentProof::WorkflowCreatorExecution#close
+      errors:
+        - HiveLiveAgentProof::WorkflowCreatorExecution::Error
+        - HiveLiveAgentProof::WorkflowCreatorExecution::Conflict
+        - HiveLiveAgentProof::WorkflowCreatorExecution::Unavailable
+    owned_paths:
+      - packaging/live_agent_skills/workflow_creator_execution.rb
+      - packaging/live_agent_skills/workflow_creator_installation.rb
+      - packaging/live_agent_skills/workflow_creator_gateway.rb
+      - packaging/live_agent_skills/workflow_creator_archive.rb
+      - packaging/live_agent_skills/workflow_creator_process_supervisor.rb
+      - packaging/live_agent_skills/workflow_creator_capture.rb
+    state_contracts:
+      - "One typed session owns the proof workspace, fixed gateway, installed closures, archive admissions, bounded captures, supervisor receipts, draft support publication, and final result"
+      - "Linux child-subreaper custody covers the nine vocabulary-defined candidate commands and exactly two outer model-loop labels; zero launches remains not_started and each launch requires one complete teardown receipt"
+      - "The session exposes only its fixed gateway/workspace paths, two closed outer launches, draft, finish, result, and idempotent close lifecycle; it exposes no generic process, archive, installation, publisher, or cleanup primitive"
+      - "U14 is a deterministic stable substrate for U15 orchestration, not evidence that an authenticated provider run or live Workflow Creator proof occurred"
+    schema_contracts:
+      - "Command positions and labels come from the Workflow Creator Vocabulary and bind exact argv, created task slug, capture digest, teardown, archive, installation, and receipt identities"
+      - "Archive admission accepts only regular owner-controlled candidate-package and openclaw-package members under fixed entry, byte, ratio, path, and elapsed-time ceilings"
+      - "Installation closure binds exact caller-supplied roots, manifests, inventory bytes, required role paths, candidate identity, and OpenClaw version without selecting any of them"
+      - "Publication targets exactly candidate-installed-manifest.json, openclaw-installed-manifest.json, and execution-receipt.json from the vocabulary; the primary openclaw-workflow-creator.json remains owned by WorkflowCreatorEvidence"
+    lock_contracts:
+      - "The gateway serializes one sequence-bound local-socket transaction and poisons the session on changed command, candidate, wrapper, socket, workspace, or credential-environment evidence"
+      - "The supervisor retains Linux process-tree custody through containment, caller-loss handling, TERM/KILL escalation, drain, and reaping before a teardown receipt can pass"
+      - "Fixed support publication reuses the private descriptor-relative publisher and its cooperative directory lock; cleanup removes only a session-created path whose current device and inode match its ownership row"
+    component_dependencies:
+      - workflow-creator-core
+    allowed_hive_dependencies: []
+    internal_collaborators:
+      - HiveLiveAgentProof::WorkflowCreatorArchive
+      - HiveLiveAgentProof::WorkflowCreatorInstallation
+      - HiveLiveAgentProof::WorkflowCreatorGateway
+      - HiveLiveAgentProof::WorkflowCreator::ProcessSupervisor
+      - HiveLiveAgentProof::WorkflowCreator::Capture
+    forbidden_constructions:
+      - HiveLiveAgentProof::WorkflowCreatorGateway
+      - HiveLiveAgentProof::WorkflowCreator::ProcessSupervisor
+      - HiveLiveAgentProof::WorkflowCreator::Capture
+    authorized_internal_constructions:
+      - constant: HiveLiveAgentProof::WorkflowCreatorGateway
+        files:
+          - packaging/live_agent_skills/workflow_creator_execution.rb
+        reason: "WorkflowCreatorExecution is the sole fixed audit-gateway composition root"
+      - constant: HiveLiveAgentProof::WorkflowCreator::ProcessSupervisor
+        files:
+          - packaging/live_agent_skills/workflow_creator_execution.rb
+        reason: "WorkflowCreatorExecution is the sole Linux process-custody composition root"
+      - constant: HiveLiveAgentProof::WorkflowCreator::Capture
+        files:
+          - packaging/live_agent_skills/workflow_creator_process_supervisor.rb
+        reason: "ProcessSupervisor alone constructs bounded capture inside its private custody child"
+    construction_scan_paths:
+      - packaging
+    hive_consumers:
+      - packaging/live_agent_skills/proof.rb
+    mutation_authority: "The session may create and identity-bound-clean one proof workspace, execute only the eleven closed labels through its private Linux supervisor, inspect the two fixed archive kinds and caller-selected installed closures, and publish only the three vocabulary-fixed support members. It cannot publish the primary receipt or choose a provider, model, credential, installation version, workflow policy, or live-success classification."
+    recovery_surface: "Caller loss, timeouts, descendant teardown, partial capture, poisoned gateway state, changed filesystem/process identities, unsafe archives/installations, support-file conflicts, and close-before-finish fail closed with bounded receipts or fixed errors. Arbitrary coherent same-UID compromise and externally SIGKILLing the trusted custody root itself are outside the claim."
+    wiki_page: wiki/component-boundaries.md
+    focused_tests:
+      - test/unit/packaging/workflow_creator_execution_test.rb
+      - test/unit/packaging/workflow_creator_archive_test.rb
+      - test/unit/packaging/workflow_creator_installation_test.rb
+      - test/unit/packaging/workflow_creator_capture_test.rb
+      - test/unit/packaging/workflow_creator_process_supervisor_test.rb
+      - test/unit/packaging/workflow_creator_gateway_test.rb
       - test/unit/packaging/live_agent_proof_test.rb
     migration_exceptions: []

--- a/config/component-boundaries.yml
+++ b/config/component-boundaries.yml
@@ -836,6 +836,7 @@ components:
     public_contract:
       values:
         - HiveLiveAgentProof::WorkflowCreator::Vocabulary
+        - HiveLiveAgentProof::WorkflowCreator.commands_for
         - HiveLiveAgentProof::WorkflowCreator.failure
         - HiveLiveAgentProof::WorkflowCreator.validate_nonpassing!
         - HiveLiveAgentProof::WorkflowCreator.validate_primary!

--- a/config/component-boundaries.yml
+++ b/config/component-boundaries.yml
@@ -914,6 +914,8 @@ components:
     public_contract:
       values:
         - HiveLiveAgentProof::WorkflowCreatorExecution.start!
+        - HiveLiveAgentProof::WorkflowCreatorExecution::Draft
+        - HiveLiveAgentProof::WorkflowCreatorExecution::Result
         - HiveLiveAgentProof::WorkflowCreatorExecution#gateway_path
         - HiveLiveAgentProof::WorkflowCreatorExecution#workspace_path
         - HiveLiveAgentProof::WorkflowCreatorExecution#run_outer_workflow_creator
@@ -934,7 +936,7 @@ components:
       - packaging/live_agent_skills/workflow_creator_process_supervisor.rb
       - packaging/live_agent_skills/workflow_creator_capture.rb
     state_contracts:
-      - "One typed session owns the proof workspace, fixed gateway, installed closures, archive admissions, bounded captures, supervisor receipts, draft support publication, and final result"
+      - "One typed session owns the proof workspace, fixed gateway, installed closures, archive admissions, bounded captures, supervisor receipts, draft support bytes, fixed final support publication, and final result"
       - "Linux child-subreaper custody covers the nine vocabulary-defined candidate commands and exactly two outer model-loop labels; zero launches remains not_started and each launch requires one complete teardown receipt"
       - "The session exposes only its fixed gateway/workspace paths, two closed outer launches, draft, finish, result, and idempotent close lifecycle; it exposes no generic process, archive, installation, publisher, or cleanup primitive"
       - "U14 is a deterministic stable substrate for U15 orchestration, not evidence that an authenticated provider run or live Workflow Creator proof occurred"

--- a/docs/notes/2026-08-04-workflow-creator-execution-u14-admission.md
+++ b/docs/notes/2026-08-04-workflow-creator-execution-u14-admission.md
@@ -1,0 +1,82 @@
+# U14 workflow-creator execution admission
+
+Status: admitted for implementation from `origin/main`
+`7b71bfdabc0fa59ef47c5b62d9f3add4c600457c` after PR #943 merged.
+
+U14 owns only the deterministic execution trust substrate. U15 continues to
+own provider selection, credential exposure, model/workflow sequencing, and
+translation of an authenticated run into a passing claim.
+
+## Dependency direction
+
+```text
+U15 orchestration
+  -> WorkflowCreatorExecution
+       -> WorkflowCreatorInstallation
+       -> WorkflowCreatorGateway
+       -> WorkflowCreatorArchive
+       -> WorkflowCreatorProcessSupervisor
+            -> WorkflowCreatorCapture
+       -> merged WorkflowCreatorEvidence / Bundle / Core
+```
+
+Every edge points toward a U14 collaborator or the merged creator boundary.
+`proof.rb` remains a bundle attestor/consumer and is not a U14 runtime owner.
+
+## Production budget
+
+U14 is capped at eight production/config files and six runtime owners:
+
+| Path | Owner |
+| --- | --- |
+| `packaging/live_agent_skills/workflow_creator_execution.rb` | one typed session and result composition |
+| `packaging/live_agent_skills/workflow_creator_installation.rb` | exact candidate/OpenClaw installation closure |
+| `packaging/live_agent_skills/workflow_creator_gateway.rb` | serialized fixed command transaction |
+| `packaging/live_agent_skills/workflow_creator_archive.rb` | bounded regular-only archive admission |
+| `packaging/live_agent_skills/workflow_creator_capture.rb` | capped, redacted stdout/stderr evidence |
+| `packaging/live_agent_skills/workflow_creator_process_supervisor.rb` | containment, termination, reaping, and supervisor receipts |
+| `packaging/release_candidate/artifacts.rb` | exact source-builder closure only; no new owner |
+| `config/component-boundaries.yml` | one downward-only component row; no new owner |
+
+Tests and documentation do not count as production owners. Crossing either the
+18-production-file plan ceiling or this tighter eight-file projection requires
+re-scoping before further implementation. More than six runtime owners always
+requires re-scoping.
+
+## Settled boundaries
+
+- Process custody is Linux-only and fails closed elsewhere. Adding a separate
+  macOS descendant-custody design is not part of U14.
+- U14 computes and validates caller-supplied installed paths and lock/package
+  bytes; it never chooses an OpenClaw version or provider. U15 owns selection
+  and installation orchestration.
+- The supervisor admits only the closed creator labels: the nine semantic Hive
+  command positions plus the candidate and outer OpenClaw roots. Zero launches
+  is `not_started`; each launched label requires one complete teardown receipt.
+- U1b remains the only primary-receipt mutation owner. U14 writes only the three
+  fixed support members named by the merged vocabulary and exposes no generic
+  publisher, process runner, archive extractor, or cleanup API.
+- Receipt paths/descriptors remain supervisor-private. IPC is sequence-bound to
+  run, attempt, label, and command position. Coherent arbitrary same-UID host
+  compromise remains outside the guarantee.
+- Pre-existing cleanup destinations are refused. U14 removes only paths it
+  created whose current device/inode identity still matches its ownership row.
+
+## Forbidden scope
+
+No edits to the merged Values/TextSafety/Core/Bundle/Evidence/receipt-publisher
+semantics; no provider/model/workflow authority; no credential selection; no
+authenticated run; no live-success translation; no workflow YAML change; no
+compatibility reader; and no transplant from frozen PRs #906, #909, #920, or
+#921. Those PRs supply tests and historical findings only.
+
+## Implementation slices
+
+1. Archive and installation custody, including canonical retained manifests.
+2. Bounded capture and Linux process supervision, including hostile teardown.
+3. Fixed audit gateway and typed execution/session composition.
+4. Deterministic creator integration, source closure, component contract, wiki,
+   one broad local checkpoint, one three-lens final-head review, and hosted CI.
+
+The slices may be developed in path-disjoint worktrees, but the coordinator is
+the only writer to the U14 integration branch.

--- a/docs/notes/2026-08-04-workflow-creator-execution-u14-admission.md
+++ b/docs/notes/2026-08-04-workflow-creator-execution-u14-admission.md
@@ -44,11 +44,13 @@ re-scoping before further implementation. More than six runtime owners always
 requires re-scoping.
 
 The implementation slices retain separate readable aggregate ceilings:
-archive/installation at 390 lines, capture/supervision at 485 lines, and
-gateway/execution at 575 lines. The final pair budget was raised from the
-provisional 520-line projection when the real fixed IPC and two-phase receipt
+archive/installation at 410 lines, capture/supervision at 495 lines, and
+gateway/execution at 600 lines. The gateway/execution budget was raised from
+its provisional 520-line projection when the real fixed IPC and two-phase receipt
 composition plus disjoint custody roots proved that the smaller number required
-compressed lifecycle code or a weaker mutation boundary.
+compressed lifecycle code or a weaker mutation boundary. The final-head review
+added exact archive-tail, bounded-drain, stable-installation, and full-bundle
+completion checks without adding another owner.
 These are architecture budgets, not incentives
 to compress source formatting or weaken exception-path cleanup.
 

--- a/docs/notes/2026-08-04-workflow-creator-execution-u14-admission.md
+++ b/docs/notes/2026-08-04-workflow-creator-execution-u14-admission.md
@@ -43,6 +43,15 @@ Tests and documentation do not count as production owners. Crossing either the
 re-scoping before further implementation. More than six runtime owners always
 requires re-scoping.
 
+The implementation slices retain separate readable aggregate ceilings:
+archive/installation at 390 lines, capture/supervision at 485 lines, and
+gateway/execution at 575 lines. The final pair budget was raised from the
+provisional 520-line projection when the real fixed IPC and two-phase receipt
+composition plus disjoint custody roots proved that the smaller number required
+compressed lifecycle code or a weaker mutation boundary.
+These are architecture budgets, not incentives
+to compress source formatting or weaken exception-path cleanup.
+
 ## Settled boundaries
 
 - Process custody is Linux-only and fails closed elsewhere. Adding a separate
@@ -51,8 +60,13 @@ requires re-scoping.
   bytes; it never chooses an OpenClaw version or provider. U15 owns selection
   and installation orchestration.
 - The supervisor admits only the closed creator labels: the nine semantic Hive
-  command positions plus the candidate and outer OpenClaw roots. Zero launches
-  is `not_started`; each launched label requires one complete teardown receipt.
+  command positions plus `outer-workflow-creator` and
+  `outer-authorized-work`. Zero launches is `not_started`; each launched label
+  requires one complete teardown receipt.
+- `hive new` generates the task slug. Command position 7 therefore binds its
+  run target to the schema-valid `slug` returned by position 6; the receipt and
+  primary task row must carry the same value. A fixed proof-only slug is not an
+  executable contract.
 - U1b remains the only primary-receipt mutation owner. U14 writes only the three
   fixed support members named by the merged vocabulary and exposes no generic
   publisher, process runner, archive extractor, or cleanup API.
@@ -64,8 +78,8 @@ requires re-scoping.
 
 ## Forbidden scope
 
-No edits to the merged Values/TextSafety/Core/Bundle/Evidence/receipt-publisher
-semantics; no provider/model/workflow authority; no credential selection; no
+No further edits to the merged Values/TextSafety/Core/Bundle/Evidence semantics
+after the prerequisite generated-slug correction; no provider/model/workflow authority; no credential selection; no
 authenticated run; no live-success translation; no workflow YAML change; no
 compatibility reader; and no transplant from frozen PRs #906, #909, #920, or
 #921. Those PRs supply tests and historical findings only.

--- a/packaging/live_agent_skills/proof.rb
+++ b/packaging/live_agent_skills/proof.rb
@@ -51,7 +51,7 @@ module HiveLiveAgentProof
   WORKFLOW_CREATOR_TASK_SLUG = creator_vocabulary.fetch("task_slug")
   WORKFLOW_CREATOR_TASK_PROMPT = creator_vocabulary.fetch("task_prompt")
   WORKFLOW_CREATOR_TASK_NEW_ARGV = creator_vocabulary.fetch("task_new_argv")
-  WORKFLOW_CREATOR_COMMANDS = creator_vocabulary.fetch("commands")
+  WORKFLOW_CREATOR_COMMANDS = WorkflowCreator.commands_for(task_slug: WORKFLOW_CREATOR_TASK_SLUG).value
   WORKFLOW_CREATOR_FILES = creator_vocabulary.fetch("files")
 
   module_function

--- a/packaging/live_agent_skills/workflow_creator.rb
+++ b/packaging/live_agent_skills/workflow_creator.rb
@@ -18,6 +18,11 @@ module HiveLiveAgentProof
     task_request = "Research and draft the launch announcement for approval."
     task_key = "workflow-creator-proof:editorial:live-proof"
     task_slug = "editorial-live-proof"
+    command_labels = %w[
+      candidate-version candidate-workflow-list candidate-workflow-new candidate-workflow-validate
+      candidate-workflow-commit candidate-task-create candidate-task-run candidate-task-retry
+      candidate-operational-status
+    ]
     task_prompt = <<~PROMPT
       /hive
       Use the validated editorial workflow to create and run one task for:
@@ -44,11 +49,16 @@ module HiveLiveAgentProof
       "request" => request, "prompt" => prompt, "task_request" => task_request,
       "task_key" => task_key, "task_slug" => task_slug, "task_prompt" => task_prompt,
       "task_new_argv" => task_argv,
+      "command_labels" => command_labels,
       "commands" => [
         [ "version" ], [ "workflow", "list", "--json" ], [ "workflow", "new", "editorial", "--json" ],
         [ "workflow", "validate", "editorial", "--json" ], [ "workflow", "commit", "editorial" ], task_argv,
-        [ "run", task_slug ], task_argv, [ "status", "--operational", "--json" ]
+        [ "run", "{created_slug}" ], task_argv, [ "status", "--operational", "--json" ]
       ],
+      "task_slug_binding" => {
+        "source_position" => 6, "source_result_field" => "slug", "target_position" => 7,
+        "target_argument" => 1, "template" => "{created_slug}"
+      },
       "files" => files, "executed_instruction" => files.fetch(2),
       "native_activation" => { "kind" => "openclaw-skills-info", "invocation" => "/hive" },
       "graph" => {
@@ -62,7 +72,7 @@ module HiveLiveAgentProof
         ]
       },
       "task" => {
-        "slug" => task_slug, "workflow" => "editorial", "first_created" => true,
+        "workflow" => "editorial", "first_created" => true,
         "retry_created" => false, "run_count" => 1, "current_stage" => "1-research"
       },
       "classification" => { "execution_kind" => "authenticated_openclaw", "model_loop" => "executed" },
@@ -92,6 +102,19 @@ module HiveLiveAgentProof
   module WorkflowCreator
     private_constant :Contract, :ExecutionContract
 
+    def self.commands_for(task_slug:)
+      slug = capture(task_slug).value
+      Contract.assert!(Contract::TASK_SLUG.match?(slug), "workflow-creator task slug is invalid")
+      commands, binding = Vocabulary.values_at("commands", "task_slug_binding")
+      resolved = commands.map(&:dup)
+      target = resolved.fetch(binding.fetch("target_position") - 1)
+      Contract.assert!(target.fetch(binding.fetch("target_argument")) == binding.fetch("template"),
+                       "workflow-creator command template is invalid")
+      target[binding.fetch("target_argument")] = slug
+      Values.capture(resolved)
+    rescue ArgumentError, IndexError, KeyError, NoMethodError, TypeError, Values::Error
+      raise Error, "workflow-creator task slug is invalid"
+    end
     def self.failure(...) = Contract.failure(...)
     def self.validate_nonpassing!(row, exact_secrets: []) =
       Contract.validate_nonpassing!(capture(row), capture(exact_secrets).value)

--- a/packaging/live_agent_skills/workflow_creator_archive.rb
+++ b/packaging/live_agent_skills/workflow_creator_archive.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+
+require "digest"
+require "pathname"
+require "rubygems/package"
+require "zlib"
+require_relative "workflow_creator"
+
+module HiveLiveAgentProof
+  class WorkflowCreatorArchive
+    class Error < StandardError; end
+    MESSAGE = "workflow-creator archive is not safely admissible"
+    MAX_ARCHIVE_BYTES = 268_435_456
+    MAX_ENTRY_BYTES = 268_435_456
+    MAX_TOTAL_BYTES = 1_073_741_824
+    MAX_ENTRIES = 16_384
+    MAX_PATH_BYTES = 240
+    MAX_PATH_DEPTH = 32
+    MAX_COMPRESSION_RATIO = 100
+    MAX_SECONDS = 5.0
+    CHUNK_BYTES = 65_536
+    READ_FLAGS = if defined?(File::NOFOLLOW) && defined?(File::NONBLOCK)
+      File::RDONLY | File::NOFOLLOW | File::NONBLOCK
+    end
+
+    class << self
+      def admit!(archive:, label:, available_bytes:, available_entries:, clock: nil)
+        inputs = WorkflowCreator::Values.capture(
+          "archive" => archive, "label" => label,
+          "available_bytes" => available_bytes, "available_entries" => available_entries
+        ).value
+        validate_inputs!(inputs)
+        timer = clock || -> { Process.clock_gettime(Process::CLOCK_MONOTONIC) }
+        started = timestamp(timer)
+        result = inspect_archive(inputs.fetch("archive"), inputs.fetch("label"), timer, started)
+        filesystem_budget!(result, inputs.fetch("available_bytes"), inputs.fetch("available_entries"))
+        WorkflowCreator::Values.capture(result)
+      rescue StandardError
+        raise Error, MESSAGE, cause: nil
+      end
+      private
+
+      def validate_inputs!(inputs)
+        labels = WorkflowCreator::Vocabulary.fetch("archive_labels")
+        integers = inputs.values_at("available_bytes", "available_entries")
+        valid = labels.include?(inputs.fetch("label"))
+        valid &&= integers.all? { |value| value.instance_of?(Integer) && value >= 0 }
+        valid &&= READ_FLAGS
+        raise Error, MESSAGE unless valid
+      end
+
+      def inspect_archive(path, label, timer, started)
+        File.open(path, READ_FLAGS) do |file|
+          stat = file.stat
+          valid_file!(stat)
+          digest = digest_file(file, timer, started)
+          file.rewind
+          paths, total = read_entries(file, timer, started)
+          verify_identity!(file, stat)
+          validate_tree!(paths, total, stat.size)
+          archive_record(label, digest, stat.size, paths.length, total)
+        end
+      end
+
+      def valid_file!(stat)
+        valid = stat.file? && stat.nlink == 1 && stat.uid == Process.uid && (stat.mode & 0o022).zero?
+        valid &&= stat.size.between?(1, MAX_ARCHIVE_BYTES)
+        raise Error, MESSAGE unless valid
+      end
+
+      def digest_file(file, timer, started)
+        digest = Digest::SHA256.new
+        while (chunk = file.read(CHUNK_BYTES))
+          digest.update(chunk)
+          time_remaining!(timer, started)
+        end
+        digest.hexdigest
+      end
+
+      def read_entries(file, timer, started)
+        paths = {}
+        total = 0
+        gzip = Zlib::GzipReader.new(file)
+        Gem::Package::TarReader.new(gzip) do |tar|
+          tar.each do |entry|
+            raise Error, MESSAGE if paths.length >= MAX_ENTRIES
+            kind = entry_kind(entry)
+            path = normalized_path(entry.full_name, directory: kind == :directory)
+            raise Error, MESSAGE if paths.key?(path)
+            size = entry.header.size
+            raise Error, MESSAGE unless size.instance_of?(Integer) && size.between?(0, MAX_ENTRY_BYTES)
+            total += size
+            raise Error, MESSAGE if total > MAX_TOTAL_BYTES
+            paths[path] = kind
+            consume(entry, timer, started) if kind == :file
+            time_remaining!(timer, started)
+          end
+        end
+        [ paths, total ]
+      ensure
+        gzip&.finish
+      end
+
+      def entry_kind(entry)
+        case entry.header.typeflag
+        when "0", "\0" then :file
+        when "5" then :directory
+        else raise Error, MESSAGE
+        end
+      end
+
+      def normalized_path(raw, directory:)
+        path = raw.dup.force_encoding(Encoding::UTF_8)
+        path = path.delete_suffix("/") if directory
+        owned = WorkflowCreator::Values.capture(path).value
+        safe = owned.bytesize <= MAX_PATH_BYTES
+        safe &&= WorkflowCreator::TextSafety.safe_relative_path?(owned)
+        safe &&= Pathname.new(owned).cleanpath.to_s == owned
+        safe &&= owned.count("/") + 1 <= MAX_PATH_DEPTH
+        raise Error, MESSAGE unless safe
+        owned
+      end
+
+      def consume(entry, timer, started)
+        until entry.eof?
+          remaining = entry.size - entry.pos
+          chunk = entry.read([ CHUNK_BYTES, remaining ].min)
+          raise Error, MESSAGE if chunk.nil? || chunk.empty?
+          time_remaining!(timer, started)
+        end
+      end
+
+      def validate_tree!(paths, total, compressed)
+        ordered = paths.keys.sort
+        ordered.each_cons(2) do |left, right|
+          raise Error, MESSAGE if paths.fetch(left) == :file && right.start_with?("#{left}/")
+        end
+        valid = !ordered.empty? && total.positive?
+        valid &&= total <= compressed * MAX_COMPRESSION_RATIO
+        raise Error, MESSAGE unless valid
+      end
+
+      def filesystem_budget!(result, available_bytes, available_entries)
+        valid = result.fetch("uncompressed_bytes") <= available_bytes
+        valid &&= result.fetch("entry_count") <= available_entries
+        raise Error, MESSAGE unless valid
+      end
+
+      def verify_identity!(file, original)
+        current = file.stat
+        fields = %i[dev ino uid mode nlink size mtime ctime]
+        raise Error, MESSAGE unless fields.map { |field| current.public_send(field) } ==
+                                    fields.map { |field| original.public_send(field) }
+      end
+
+      def archive_record(label, digest, size, entries, total)
+        {
+          "label" => label, "artifact_sha256" => digest, "artifact_size" => size,
+          "policy_sha256" => WorkflowCreator::Vocabulary.fetch("archive_policy_sha256"),
+          "entry_count" => entries, "uncompressed_bytes" => total, "status" => "passed"
+        }
+      end
+
+      def timestamp(timer)
+        value = timer.call
+        raise Error, MESSAGE unless value.is_a?(Numeric) && value.finite?
+        value
+      end
+
+      def time_remaining!(timer, started)
+        elapsed = timestamp(timer) - started
+        raise Error, MESSAGE unless elapsed.between?(0, MAX_SECONDS)
+      end
+    end
+  end
+end

--- a/packaging/live_agent_skills/workflow_creator_archive.rb
+++ b/packaging/live_agent_skills/workflow_creator_archive.rb
@@ -17,6 +17,7 @@ module HiveLiveAgentProof
     MAX_PATH_BYTES = 240
     MAX_PATH_DEPTH = 32
     MAX_COMPRESSION_RATIO = 100
+    MAX_TAR_PADDING_BYTES = 1_048_576
     MAX_SECONDS = 5.0
     CHUNK_BYTES = 65_536
     READ_FLAGS = if defined?(File::NOFOLLOW) && defined?(File::NONBLOCK)
@@ -82,15 +83,18 @@ module HiveLiveAgentProof
           outer_bytes = scan_tar(file, state, timer, started) do |entry, path|
             next false unless path == "data.tar.gz"
             nested += 1
-            with_gzip(entry) do |gzip|
+            with_gzip(entry, timer, started) do |gzip|
               compression_budget!(scan_tar(gzip, state, timer, started), entry.size)
             end
             true
           end
           raise Error, MESSAGE unless nested == 1
+          validate_tar_tail!(file, timer, started)
           compression_budget!(outer_bytes, file.stat.size)
         else
-          with_gzip(file) { |gzip| compression_budget!(scan_tar(gzip, state, timer, started), file.stat.size) }
+          with_gzip(file, timer, started) do |gzip|
+            compression_budget!(scan_tar(gzip, state, timer, started), file.stat.size)
+          end
         end
         state
       end
@@ -120,9 +124,14 @@ module HiveLiveAgentProof
         local_total
       end
 
-      def with_gzip(io)
+      def with_gzip(io, timer, started)
         gzip = Zlib::GzipReader.new(io)
         yield gzip
+        validate_tar_tail!(gzip, timer, started)
+        unused = gzip.unused
+        gzip.finish
+        gzip = nil
+        raise Error, MESSAGE if (unused && !unused.empty?) || io.read(1)
       ensure
         gzip&.finish
       end
@@ -158,8 +167,21 @@ module HiveLiveAgentProof
 
       def validate_tree!(paths, total)
         ordered = paths.keys.sort
-        ordered.each_cons(2) { |left, right| raise Error, MESSAGE if paths.fetch(left) == :file && right.start_with?("#{left}/") }
+        ordered.each do |path|
+          parts = path.split("/")
+          1.upto(parts.length - 1) { |count| raise Error, MESSAGE if paths[parts.first(count).join("/")] == :file }
+        end
         raise Error, MESSAGE if ordered.empty? || !total.positive?
+      end
+
+      def validate_tar_tail!(io, timer, started)
+        padding = 0
+        while (chunk = io.read(CHUNK_BYTES))
+          padding += chunk.bytesize
+          raise Error, MESSAGE if padding > MAX_TAR_PADDING_BYTES || chunk.each_byte.any?(&:nonzero?)
+          time_remaining!(timer, started)
+        end
+        raise Error, MESSAGE unless padding.between?(512, MAX_TAR_PADDING_BYTES) && (padding % 512).zero?
       end
 
       def compression_budget!(total, compressed)

--- a/packaging/live_agent_skills/workflow_creator_archive.rb
+++ b/packaging/live_agent_skills/workflow_creator_archive.rb
@@ -31,19 +31,18 @@ module HiveLiveAgentProof
         ).value
         validate_inputs!(inputs)
         timer = clock || -> { Process.clock_gettime(Process::CLOCK_MONOTONIC) }
-        started = timestamp(timer)
-        result = inspect_archive(inputs.fetch("archive"), inputs.fetch("label"), timer, started)
+        result = inspect_archive(inputs.fetch("archive"), inputs.fetch("label"), timer, timestamp(timer))
         filesystem_budget!(result, inputs.fetch("available_bytes"), inputs.fetch("available_entries"))
         WorkflowCreator::Values.capture(result)
       rescue StandardError
         raise Error, MESSAGE, cause: nil
       end
+
       private
 
       def validate_inputs!(inputs)
-        labels = WorkflowCreator::Vocabulary.fetch("archive_labels")
         integers = inputs.values_at("available_bytes", "available_entries")
-        valid = labels.include?(inputs.fetch("label"))
+        valid = WorkflowCreator::Vocabulary.fetch("archive_labels").include?(inputs.fetch("label"))
         valid &&= integers.all? { |value| value.instance_of?(Integer) && value >= 0 }
         valid &&= READ_FLAGS
         raise Error, MESSAGE unless valid
@@ -55,10 +54,9 @@ module HiveLiveAgentProof
           valid_file!(stat)
           digest = digest_file(file, timer, started)
           file.rewind
-          paths, total = read_entries(file, timer, started)
+          count, total = read_entries(file, label, timer, started)
           verify_identity!(file, stat)
-          validate_tree!(paths, total, stat.size)
-          archive_record(label, digest, stat.size, paths.length, total)
+          archive_record(label, digest, stat.size, count, total)
         end
       end
 
@@ -77,26 +75,54 @@ module HiveLiveAgentProof
         digest.hexdigest
       end
 
-      def read_entries(file, timer, started)
+      def read_entries(file, label, timer, started)
+        state = [ 0, 0 ]
+        if label == "candidate-package"
+          nested = 0
+          outer_bytes = scan_tar(file, state, timer, started) do |entry, path|
+            next false unless path == "data.tar.gz"
+            nested += 1
+            with_gzip(entry) do |gzip|
+              compression_budget!(scan_tar(gzip, state, timer, started), entry.size)
+            end
+            true
+          end
+          raise Error, MESSAGE unless nested == 1
+          compression_budget!(outer_bytes, file.stat.size)
+        else
+          with_gzip(file) { |gzip| compression_budget!(scan_tar(gzip, state, timer, started), file.stat.size) }
+        end
+        state
+      end
+
+      def scan_tar(io, state, timer, started)
         paths = {}
-        total = 0
-        gzip = Zlib::GzipReader.new(file)
-        Gem::Package::TarReader.new(gzip) do |tar|
+        local_total = 0
+        Gem::Package::TarReader.new(io) do |tar|
           tar.each do |entry|
-            raise Error, MESSAGE if paths.length >= MAX_ENTRIES
+            state[0] += 1
+            raise Error, MESSAGE if state[0] > MAX_ENTRIES
             kind = entry_kind(entry)
             path = normalized_path(entry.full_name, directory: kind == :directory)
             raise Error, MESSAGE if paths.key?(path)
             size = entry.header.size
             raise Error, MESSAGE unless size.instance_of?(Integer) && size.between?(0, MAX_ENTRY_BYTES)
-            total += size
-            raise Error, MESSAGE if total > MAX_TOTAL_BYTES
+            local_total += size
+            state[1] += size
+            raise Error, MESSAGE if state[1] > MAX_TOTAL_BYTES
             paths[path] = kind
-            consume(entry, timer, started) if kind == :file
+            handled = kind == :file && block_given? && yield(entry, path)
+            consume(entry, timer, started) if kind == :file && !handled
             time_remaining!(timer, started)
           end
         end
-        [ paths, total ]
+        validate_tree!(paths, local_total)
+        local_total
+      end
+
+      def with_gzip(io)
+        gzip = Zlib::GzipReader.new(io)
+        yield gzip
       ensure
         gzip&.finish
       end
@@ -130,19 +156,18 @@ module HiveLiveAgentProof
         end
       end
 
-      def validate_tree!(paths, total, compressed)
+      def validate_tree!(paths, total)
         ordered = paths.keys.sort
-        ordered.each_cons(2) do |left, right|
-          raise Error, MESSAGE if paths.fetch(left) == :file && right.start_with?("#{left}/")
-        end
-        valid = !ordered.empty? && total.positive?
-        valid &&= total <= compressed * MAX_COMPRESSION_RATIO
-        raise Error, MESSAGE unless valid
+        ordered.each_cons(2) { |left, right| raise Error, MESSAGE if paths.fetch(left) == :file && right.start_with?("#{left}/") }
+        raise Error, MESSAGE if ordered.empty? || !total.positive?
+      end
+
+      def compression_budget!(total, compressed)
+        raise Error, MESSAGE unless compressed.positive? && total <= compressed * MAX_COMPRESSION_RATIO
       end
 
       def filesystem_budget!(result, available_bytes, available_entries)
-        valid = result.fetch("uncompressed_bytes") <= available_bytes
-        valid &&= result.fetch("entry_count") <= available_entries
+        valid = result.fetch("uncompressed_bytes") <= available_bytes && result.fetch("entry_count") <= available_entries
         raise Error, MESSAGE unless valid
       end
 
@@ -168,8 +193,7 @@ module HiveLiveAgentProof
       end
 
       def time_remaining!(timer, started)
-        elapsed = timestamp(timer) - started
-        raise Error, MESSAGE unless elapsed.between?(0, MAX_SECONDS)
+        raise Error, MESSAGE unless (timestamp(timer) - started).between?(0, MAX_SECONDS)
       end
     end
   end

--- a/packaging/live_agent_skills/workflow_creator_capture.rb
+++ b/packaging/live_agent_skills/workflow_creator_capture.rb
@@ -13,6 +13,7 @@ module HiveLiveAgentProof
       MAX_TAIL_BYTES = 4_096
       SCAN_SLICE_BYTES = 2_048
       REDACTED = "[REDACTED]".freeze
+      NO_SECRETS = [].freeze
 
       def initialize(limit_bytes:, tail_bytes: MAX_TAIL_BYTES, exact_secrets: [])
         @limit = integer_in!(limit_bytes, 1..MAX_LIMIT_BYTES, "capture limit")
@@ -86,10 +87,13 @@ module HiveLiveAgentProof
         while offset < bytes.bytesize
           slice = bytes.byteslice(offset, SCAN_SLICE_BYTES)
           state.fetch(:window) << slice
+          @exact_secrets.each_with_index do |secret, index|
+            state.fetch(:findings) << "exact-secret:#{index}" if state.fetch(:window).include?(secret.b)
+          end
           overflow = state.fetch(:window).bytesize - MAX_TAIL_BYTES
           state[:window] = state.fetch(:window).byteslice(overflow, MAX_TAIL_BYTES) if overflow.positive?
           owned = state.fetch(:window).dup.force_encoding(Encoding::UTF_8).scrub("").freeze
-          state.fetch(:findings).concat(TextSafety.secret_findings(owned, exact_secrets: @exact_secrets))
+          state.fetch(:findings).concat(TextSafety.secret_findings(owned, exact_secrets: NO_SECRETS))
           state.fetch(:findings).uniq!
           offset += slice.bytesize
         end

--- a/packaging/live_agent_skills/workflow_creator_capture.rb
+++ b/packaging/live_agent_skills/workflow_creator_capture.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require "digest"
+require_relative "workflow_creator"
+
+module HiveLiveAgentProof
+  module WorkflowCreator
+    class Capture
+      class Error < StandardError; end
+
+      STREAMS = %i[stdout stderr].freeze
+      MAX_LIMIT_BYTES = 1_048_576
+      MAX_TAIL_BYTES = 4_096
+      SCAN_SLICE_BYTES = 2_048
+      REDACTED = "[REDACTED]".freeze
+
+      def initialize(limit_bytes:, tail_bytes: MAX_TAIL_BYTES, exact_secrets: [])
+        @limit = integer_in!(limit_bytes, 1..MAX_LIMIT_BYTES, "capture limit")
+        @tail_limit = integer_in!(tail_bytes, 1..MAX_TAIL_BYTES, "capture tail limit")
+        @exact_secrets = Values.capture(exact_secrets).value
+        unless @exact_secrets.instance_of?(Array) && @exact_secrets.length <= 64 && @exact_secrets.all? do |secret|
+          secret.instance_of?(String) && !secret.empty? && secret.bytesize <= MAX_TAIL_BYTES
+        end
+          raise Error, "capture exact secrets are invalid"
+        end
+        @states = STREAMS.to_h do |stream|
+          [ stream, { bytes: 0, digest: Digest::SHA256.new, truncated: false,
+                      window: +"".b, findings: [] } ]
+        end
+        @finished = false
+      rescue Values::Error
+        raise Error, "capture exact secrets are invalid"
+      end
+
+      def write(stream, chunk)
+        raise Error, "capture is already finished" if @finished
+        state = @states[stream]
+        raise Error, "capture stream is invalid" unless state
+        raise Error, "capture chunk is invalid" unless chunk.instance_of?(String)
+
+        bytes = chunk.b
+        remaining = @limit - state.fetch(:bytes)
+        admitted = bytes.byteslice(0, remaining) || "".b
+        state.fetch(:digest).update(admitted)
+        state[:bytes] += admitted.bytesize
+        state[:truncated] ||= bytes.bytesize > remaining
+        scan(state, bytes)
+        self
+      end
+
+      def finish
+        return @result if @finished
+
+        @finished = true
+        findings = STREAMS.flat_map do |stream|
+          @states.fetch(stream).fetch(:findings).map { |finding| "#{stream}:#{finding}" }
+        end
+        result = { "limit_bytes" => @limit }
+        STREAMS.each do |stream|
+          state = @states.fetch(stream)
+          result["#{stream}_bytes"] = state.fetch(:bytes)
+          result["#{stream}_sha256"] = state.fetch(:digest).hexdigest
+          result["#{stream}_truncated"] = state.fetch(:truncated)
+        end
+        result["secret_scan"] = {
+          "status" => findings.empty? ? "passed" : "failed",
+          "scanner" => Vocabulary.fetch("scanner"), "findings" => findings.freeze
+        }.freeze
+        result["tails"] = STREAMS.to_h { |stream| [ stream.to_s, tail(@states.fetch(stream)) ] }.freeze
+        @result = result.freeze
+      end
+
+      private
+
+      def integer_in!(value, range, label)
+        integer = Integer(value)
+        raise Error, "#{label} is invalid" unless range.cover?(integer)
+
+        integer
+      rescue ArgumentError, TypeError
+        raise Error, "#{label} is invalid"
+      end
+
+      def scan(state, bytes)
+        offset = 0
+        while offset < bytes.bytesize
+          slice = bytes.byteslice(offset, SCAN_SLICE_BYTES)
+          state.fetch(:window) << slice
+          overflow = state.fetch(:window).bytesize - MAX_TAIL_BYTES
+          state[:window] = state.fetch(:window).byteslice(overflow, MAX_TAIL_BYTES) if overflow.positive?
+          owned = state.fetch(:window).dup.force_encoding(Encoding::UTF_8).scrub("").freeze
+          state.fetch(:findings).concat(TextSafety.secret_findings(owned, exact_secrets: @exact_secrets))
+          state.fetch(:findings).uniq!
+          offset += slice.bytesize
+        end
+      rescue TextSafety::Error
+        raise Error, "capture secret scan failed closed"
+      end
+
+      def tail(state)
+        return REDACTED if state.fetch(:findings).any?
+
+        window = state.fetch(:window)
+        offset = [ window.bytesize - @tail_limit, 0 ].max
+        raw = window.byteslice(offset, @tail_limit) || "".b
+        raw.force_encoding(Encoding::UTF_8).scrub("").freeze
+      end
+    end
+  end
+end

--- a/packaging/live_agent_skills/workflow_creator_contract.rb
+++ b/packaging/live_agent_skills/workflow_creator_contract.rb
@@ -16,6 +16,7 @@ module HiveLiveAgentProof::WorkflowCreator
       BUNDLE_KEYS, SUMMARY_KEYS = %w[kind path sha256 size].freeze, %w[receipt_sha256 status].freeze
       SHA = /\A[0-9a-f]{40}\z/.freeze
       DIGEST = /\A[0-9a-f]{64}\z/.freeze
+      TASK_SLUG = /\A[a-z][a-z0-9-]{0,62}[a-z0-9]\z/.freeze
       FAILURE_PART = /\A[a-z][a-z0-9_]{0,63}\z/.freeze
       CLASSIFICATIONS = Values.capture([ %w[unavailable not_started], %w[deterministic_fixture not_exercised],
                                          %w[authenticated_openclaw executed] ]).value
@@ -143,9 +144,12 @@ module HiveLiveAgentProof::WorkflowCreator
         end
       end
       def primary_claims!(row, manifest, candidate_sha)
-        schema, activation, commands, graph, task, classification, scanner, prompt, task_prompt = Vocabulary.values_at(
-          "evidence_schema", "native_activation", "commands", "graph", "task", "classification", "scanner",
+        schema, activation, graph, task, classification, scanner, prompt, task_prompt = Vocabulary.values_at(
+          "evidence_schema", "native_activation", "graph", "task", "classification", "scanner",
           "prompt", "task_prompt")
+        task_slug = row.dig("task", "slug")
+        commands = HiveLiveAgentProof::WorkflowCreator.commands_for(task_slug:).value
+        task = task.merge("slug" => task_slug)
         expected = {
           "schema" => schema, "schema_version" => 1, "platform" => "openclaw", "candidate_sha" => candidate_sha,
           "result" => "passed", "skill" => manifest.slice("skill_version", "canonical_digest"),

--- a/packaging/live_agent_skills/workflow_creator_execution.rb
+++ b/packaging/live_agent_skills/workflow_creator_execution.rb
@@ -1,0 +1,259 @@
+# frozen_string_literal: true
+
+require "digest"
+require_relative "workflow_creator_archive"
+require_relative "workflow_creator_evidence"
+require_relative "workflow_creator_gateway"
+require_relative "workflow_creator_installation"
+
+module HiveLiveAgentProof
+  class WorkflowCreatorExecution
+    class Error < StandardError; end
+    class Conflict < Error; end
+    class Unavailable < Error; end
+    Draft = Data.define(:receipt_bytes, :receipt_sha256, :receipt_size) do
+      def initialize(receipt_bytes:, receipt_sha256:, receipt_size:)
+        super(receipt_bytes: receipt_bytes.dup.freeze,
+              receipt_sha256: receipt_sha256.dup.freeze, receipt_size:)
+      end
+    end
+    Result = Data.define(:status)
+    LABELS = WorkflowCreator::ProcessSupervisor::LABELS
+    OUTER_LABELS = LABELS.last(2)
+    ARCHIVE_LABELS = WorkflowCreator::Vocabulary.fetch("archive_labels")
+    SUPERVISOR_KEYS = %w[output_limit tail_limit timeout term_grace kill_grace].freeze
+
+    def self.start!(**options) = new(**options).tap(&:start!)
+    private_class_method :new
+
+    attr_reader :gateway_path, :workspace_path
+
+    def initialize(candidate_sha:, manifest:, candidate:, openclaw:, archives:, workspace_path:,
+                   bundle_directory:, correlation_id:, exact_secrets: [], supervisor_options: {})
+      input = WorkflowCreator::Values.capture(
+        "candidate_sha" => candidate_sha, "manifest" => manifest, "candidate" => candidate,
+        "openclaw" => openclaw, "archives" => archives, "workspace_path" => workspace_path,
+        "bundle_directory" => bundle_directory, "correlation_id" => correlation_id,
+        "exact_secrets" => exact_secrets, "supervisor_options" => supervisor_options
+      ).value
+      @candidate_sha, @manifest, @candidate, @openclaw, @archives = input.values_at(
+        "candidate_sha", "manifest", "candidate", "openclaw", "archives")
+      raise Error unless @archives.keys == ARCHIVE_LABELS
+      options = input.fetch("supervisor_options")
+      raise Error unless options.instance_of?(Hash) && (options.keys - SUPERVISOR_KEYS).empty?
+      @workspace_path = File.expand_path(input.fetch("workspace_path")).freeze
+      @bundle_directory = File.expand_path(input.fetch("bundle_directory")).freeze
+      @correlation_id = input.fetch("correlation_id")
+      @exact_secrets = input.fetch("exact_secrets")
+      @supervisor_options = options.transform_keys(&:to_sym)
+      @result = Result.new(status: "not_started")
+      @outer_launches = {}
+    rescue WorkflowCreator::Values::Error, KeyError, TypeError
+      raise Error, "workflow-creator execution inputs are invalid", cause: nil
+    end
+
+    def start!
+      @supervisor = WorkflowCreator::ProcessSupervisor.new(
+        correlation_id: @correlation_id, exact_secrets: @exact_secrets, **@supervisor_options
+      )
+      @supervisor.create_proof_workspace(@workspace_path)
+      @openclaw_installation = scan_openclaw
+      executable = role_path(@candidate, "executable")
+      gateway = role_path(@candidate, "audit_gateway")
+      @gateway = WorkflowCreatorGateway.new(
+        root: File.dirname(gateway), candidate_executable: executable,
+        candidate_identity: observed_file(executable, relative_role(@candidate, executable)),
+        environment: @candidate.fetch("environment"), cwd: @workspace_path, supervisor: @supervisor
+      )
+      @gateway_path = @gateway.start!
+      self
+    rescue StandardError => error
+      abort_session
+      raise error
+    end
+
+    def run_outer_workflow_creator(**launch) = run_outer(OUTER_LABELS.first, launch)
+    def run_outer_authorized_work(**launch) = run_outer(OUTER_LABELS.last, launch)
+
+    def draft!(executed_instruction:)
+      raise Conflict, "workflow-creator execution draft already exists" if @draft
+      observation = WorkflowCreator::Values.capture(executed_instruction).value
+      expected = WorkflowCreator::Vocabulary.fetch("executed_instruction")
+      raise Error unless observation == observed_file(File.join(@workspace_path, expected), expected)
+      commands = @gateway.finish!
+      @candidate_installation = scan_candidate
+      @openclaw_installation = scan_openclaw
+      archives = ARCHIVE_LABELS.map do |label|
+        row = @archives.fetch(label)
+        WorkflowCreatorArchive.admit!(archive: row.fetch("path"), label:,
+                                      available_bytes: row.fetch("available_bytes"),
+                                      available_entries: row.fetch("available_entries")).value
+      end
+      teardown = @supervisor.teardown
+      raise Error, "workflow-creator execution teardown is incomplete" unless teardown.fetch("status") == "passed"
+      outer = project_outer(@supervisor.receipts)
+      cleanup = @supervisor.cleanup_proof_workspace
+      @cleaned = cleanup.values_at("identity_matched", "removed").all?
+      raise Error, "workflow-creator execution cleanup failed" unless @cleaned
+
+      names = WorkflowCreator::Vocabulary.fetch("bundle_files").slice(1, 2)
+      @installation_records = [ @candidate_installation, @openclaw_installation ].each_with_index.map do |snapshot, index|
+        bytes = snapshot.canonical_bytes
+        { "kind" => %w[candidate_installation openclaw_installation].fetch(index),
+          "path" => names.fetch(index), "sha256" => Digest::SHA256.hexdigest(bytes), "size" => bytes.bytesize }
+      end
+      @receipt = receipt(commands, outer, archives, observation, teardown, cleanup)
+      bytes = WorkflowCreator::Values.capture(@receipt).canonical_bytes
+      @draft = Draft.new(receipt_bytes: bytes, receipt_sha256: Digest::SHA256.hexdigest(bytes),
+                         receipt_size: bytes.bytesize)
+    rescue StandardError => error
+      abort_session
+      raise error
+    end
+
+    def finish!(primary_row:)
+      raise Error, "workflow-creator execution has no draft" unless @draft
+      primary = WorkflowCreator::Values.capture(primary_row)
+      WorkflowCreator.validate_execution!(
+        receipt: @receipt, row: primary.value, candidate_sha: @candidate_sha, manifest: @manifest,
+        installation_records: @installation_records, receipt_sha256: @draft.receipt_sha256,
+        candidate_installation: @candidate_installation.value,
+        openclaw_installation: @openclaw_installation.value
+      )
+      raise Conflict, "workflow-creator execution primary identity conflicts" if
+        @primary_bytes && @primary_bytes != primary.canonical_bytes
+      @primary_bytes ||= primary.canonical_bytes
+      names = WorkflowCreator::Vocabulary.fetch("bundle_files").drop(1)
+      members = [ @candidate_installation.canonical_bytes, @openclaw_installation.canonical_bytes,
+                  @draft.receipt_bytes ]
+      names.zip(members).each do |name, bytes|
+        WorkflowCreatorReceiptPublisher.new(bundle_directory: @bundle_directory, target_name: name)
+                                       .initialize_receipt(bytes)
+      end
+      @result = Result.new(status: "passed")
+    rescue WorkflowCreatorReceiptPublisher::Conflict
+      fail_result
+      raise Conflict, "workflow-creator execution publication conflicts", cause: nil
+    rescue WorkflowCreatorReceiptPublisher::Unavailable
+      fail_result
+      raise Unavailable, "workflow-creator execution publication is unavailable", cause: nil
+    rescue WorkflowCreatorReceiptPublisher::Error
+      fail_result
+      raise Error, "workflow-creator execution publication failed", cause: nil
+    rescue StandardError => error
+      fail_result
+      raise error
+    end
+
+    def result = @result
+
+    def close
+      @gateway&.close
+      cleanup_workspace unless @cleaned
+      fail_result unless @result.status == "passed"
+      nil
+    end
+
+    private
+
+    def run_outer(label, launch)
+      raise Error unless ([ :argv, :environment ]..[ :argv, :environment, :stdin_data ]).cover?(launch.keys.sort)
+      current = scan_openclaw
+      raise Error unless current.canonical_bytes == @openclaw_installation.canonical_bytes
+      raw = { "argv" => launch.fetch(:argv), "environment" => launch.fetch(:environment),
+              "stdin_data" => launch[:stdin_data] }
+      options = WorkflowCreator::Values.capture(raw).value
+      @outer_launches[label] = options.fetch("argv")
+      args = { executable: role_path(@openclaw, "executable"), argv: options.fetch("argv"),
+               environment: options.fetch("environment"), cwd: @workspace_path,
+               stdin_data: options.fetch("stdin_data") }
+      label == OUTER_LABELS.first ? @supervisor.run_outer_workflow_creator(**args) :
+        @supervisor.run_outer_authorized_work(**args)
+    rescue StandardError => error
+      fail_result
+      raise error
+    end
+
+    def scan_candidate
+      args = @candidate.except("environment").transform_keys(&:to_sym)
+      WorkflowCreatorInstallation.candidate!(**args, candidate_sha: @candidate_sha, manifest: @manifest)
+    end
+
+    def scan_openclaw
+      WorkflowCreatorInstallation.openclaw!(**@openclaw.transform_keys(&:to_sym),
+                                            candidate_sha: @candidate_sha, manifest: @manifest)
+    end
+
+    def project_outer(receipts)
+      roles = WorkflowCreator::Vocabulary.fetch("outer_roles")
+      OUTER_LABELS.each_with_index.map do |label, index|
+        process = receipts.find { |row| row.fetch("label") == label }
+        raise Error unless passing_process?(process)
+        capture = process.fetch("capture").except("tails")
+        capture["secret_scan"] = capture.fetch("secret_scan").except("findings")
+        role = roles.fetch(index)
+        { "label" => label, "role" => role.fetch("role"),
+          "argv_sha256" => Digest::SHA256.hexdigest(WorkflowCreator::Values.capture(@outer_launches.fetch(label)).canonical_bytes),
+          "prompt_sha256" => role.fetch("prompt_sha256"), "exit_code" => process.fetch("exit_code"),
+          "signal" => process.fetch("signal"), "completed" => process.fetch("completed"),
+          "capture" => capture, "teardown" => process.fetch("teardown") }
+      end
+    end
+
+    def passing_process?(process)
+      process && process.values_at("exit_code", "signal", "completed", "timed_out") == [ 0, nil, true, false ] &&
+        process.dig("teardown", "status") == "passed" &&
+        process.dig("capture", "secret_scan", "status") == "passed" &&
+        %w[stdout stderr].none? { |stream| process.dig("capture", "#{stream}_truncated") }
+    end
+
+    def receipt(commands, outer, archives, observation, teardown, cleanup)
+      slug = commands.fetch(6).fetch("argv").fetch(1)
+      vocabulary = WorkflowCreator::Vocabulary
+      { "schema" => vocabulary.fetch("execution_schema"), "schema_version" => 1,
+        "candidate_sha" => @candidate_sha, "result" => "passed",
+        "execution_plan" => vocabulary.fetch("execution_plan"),
+        "classification" => { "outer" => vocabulary.fetch("classification"), "nested_stage" => {
+          "execution_kind" => "deterministic_fixture", "model_loop" => "not_exercised" } },
+        "installed_manifests" => @installation_records,
+        "run" => { "correlation_id" => @correlation_id, "expected_labels" => LABELS },
+        "gateway" => { "identity" => @candidate_installation.value.dig("required_roles", "audit_gateway"),
+                       "command_labels" => vocabulary.fetch("command_labels"), "status" => "passed" },
+        "task_slug_binding" => vocabulary.fetch("task_slug_binding").merge("value" => slug),
+        "archive_admissions" => archives, "commands" => commands, "outer_processes" => outer,
+        "authored_instruction" => observation, "executed_instruction" => observation, "external_actions" => [],
+        "containment" => { "status" => "passed", "mechanism" => "supervised-process-tree",
+                           "established_before_launch" => true, "owner_correlation_id" => @correlation_id,
+                           "root_loss_behavior" => "fail-closed" },
+        "teardown" => teardown, "cleanup" => { "status" => "passed", "targets" => [ cleanup ] },
+        "secret_scan" => { "status" => "passed", "scanner" => vocabulary.fetch("scanner") } }
+    end
+
+    def role_path(source, role)
+      value = source.fetch(role)
+      value.start_with?(File::SEPARATOR) ? value : File.join(source.fetch("root"), value)
+    end
+
+    def relative_role(source, path)
+      prefix = "#{source.fetch("root")}/"
+      raise Error unless path.start_with?(prefix)
+      path.delete_prefix(prefix)
+    end
+
+    def observed_file(path, relative)
+      stat = File.lstat(path)
+      raise Error unless stat.file? && !stat.symlink? && stat.nlink == 1 && stat.uid == Process.uid
+      { "path" => relative, "sha256" => Digest::SHA256.file(path).hexdigest, "size" => stat.size }
+    end
+
+    def cleanup_workspace
+      cleanup = @supervisor&.cleanup_proof_workspace
+      @cleaned = cleanup && cleanup.values_at("identity_matched", "removed").all?
+    rescue StandardError
+      @cleaned = false
+    end
+
+    def abort_session = close
+    def fail_result = @result = Result.new(status: "failed")
+  end
+end

--- a/packaging/live_agent_skills/workflow_creator_execution.rb
+++ b/packaging/live_agent_skills/workflow_creator_execution.rb
@@ -44,8 +44,9 @@ module HiveLiveAgentProof
       workspace = input.fetch("workspace_path")
       @workspace_path = File.join(File.realpath(File.dirname(workspace)), File.basename(workspace)).freeze
       @bundle_directory = File.realpath(input.fetch("bundle_directory")).freeze
-      paths = [ @candidate.fetch("root"), @openclaw.fetch("root") ].map { |path| File.realpath(path) }
-      paths.concat([ @workspace_path, @bundle_directory ])
+      @candidate_root, @openclaw_root =
+        [ @candidate.fetch("root"), @openclaw.fetch("root") ].map { |path| File.realpath(path) }
+      paths = [ @candidate_root, @openclaw_root, @workspace_path, @bundle_directory ]
       raise Error if paths.combination(2).any? do |left, right|
         left == right || left.start_with?("#{right}/") || right.start_with?("#{left}/")
       end
@@ -66,12 +67,15 @@ module HiveLiveAgentProof
       @openclaw_installation = scan_openclaw
       executable = role_path(@candidate, "executable")
       gateway = role_path(@candidate, "audit_gateway")
+      raise Error unless File.basename(gateway) == WorkflowCreatorGateway::WRAPPER_NAME
       @gateway = WorkflowCreatorGateway.new(
         root: File.dirname(gateway), candidate_executable: executable,
         candidate_identity: observed_file(executable, relative_role(@candidate, executable)),
-        environment: @candidate.fetch("environment"), cwd: @workspace_path, supervisor: @supervisor
+        environment: @candidate.fetch("environment"), cwd: @workspace_path, supervisor: @supervisor,
+        socket_root: @workspace_path
       )
       @gateway_path = @gateway.start!
+      @candidate_installation = scan_candidate
       self
     rescue StandardError => error
       abort_session
@@ -84,12 +88,13 @@ module HiveLiveAgentProof
 
     def draft!(executed_instruction:)
       raise Conflict, "workflow-creator execution draft already exists" if @draft
+      raise Error, "workflow-creator execution has failed" unless @result.status == "not_started"
       observation = WorkflowCreator::Values.capture(executed_instruction).value
       expected = WorkflowCreator::Vocabulary.fetch("executed_instruction")
       raise Error unless observation == observed_file(File.join(@workspace_path, expected), expected)
       commands = @gateway.finish!
-      @candidate_installation = scan_candidate
-      @openclaw_installation = scan_openclaw
+      raise Error unless scan_candidate.canonical_bytes == @candidate_installation.canonical_bytes
+      raise Error unless scan_openclaw.canonical_bytes == @openclaw_installation.canonical_bytes
       archives = ARCHIVE_LABELS.map do |label|
         row = @archives.fetch(label)
         WorkflowCreatorArchive.admit!(archive: row.fetch("path"), label:,
@@ -137,6 +142,10 @@ module HiveLiveAgentProof
         WorkflowCreatorReceiptPublisher.new(bundle_directory: @bundle_directory, target_name: name)
                                        .initialize_receipt(bytes)
       end
+      WorkflowCreatorBundle.retained(
+        directory: @bundle_directory, expected_primary: primary.value,
+        manifest: @manifest, candidate_sha: @candidate_sha
+      )
       @result = Result.new(status: "passed")
     rescue WorkflowCreatorReceiptPublisher::Conflict
       fail_result
@@ -171,12 +180,15 @@ module HiveLiveAgentProof
       raw = { "argv" => launch.fetch(:argv), "environment" => launch.fetch(:environment),
               "stdin_data" => launch[:stdin_data] }
       options = WorkflowCreator::Values.capture(raw).value
-      @outer_launches[label] = options.fetch("argv")
+      prompt = WorkflowCreator::Vocabulary.values_at("prompt", "task_prompt").fetch(OUTER_LABELS.index(label))
+      raise Error unless options.fetch("stdin_data") == prompt
       args = { executable: role_path(@openclaw, "executable"), argv: options.fetch("argv"),
                environment: options.fetch("environment"), cwd: @workspace_path,
                stdin_data: options.fetch("stdin_data") }
-      label == OUTER_LABELS.first ? @supervisor.run_outer_workflow_creator(**args) :
+      receipt = label == OUTER_LABELS.first ? @supervisor.run_outer_workflow_creator(**args) :
         @supervisor.run_outer_authorized_work(**args)
+      @outer_launches[label] = options
+      receipt
     rescue StandardError => error
       fail_result
       raise_execution(error)
@@ -200,9 +212,11 @@ module HiveLiveAgentProof
         capture = process.fetch("capture").except("tails")
         capture["secret_scan"] = capture.fetch("secret_scan").except("findings")
         role = roles.fetch(index)
+        launch = @outer_launches.fetch(label)
         { "label" => label, "role" => role.fetch("role"),
-          "argv_sha256" => Digest::SHA256.hexdigest(WorkflowCreator::Values.capture(@outer_launches.fetch(label)).canonical_bytes),
-          "prompt_sha256" => role.fetch("prompt_sha256"), "exit_code" => process.fetch("exit_code"),
+          "argv_sha256" => Digest::SHA256.hexdigest(WorkflowCreator::Values.capture(launch.fetch("argv")).canonical_bytes),
+          "prompt_sha256" => Digest::SHA256.hexdigest(launch.fetch("stdin_data")),
+          "exit_code" => process.fetch("exit_code"),
           "signal" => process.fetch("signal"), "completed" => process.fetch("completed"),
           "capture" => capture, "teardown" => process.fetch("teardown") }
       end
@@ -238,12 +252,15 @@ module HiveLiveAgentProof
     end
 
     def role_path(source, role)
+      root = File.realpath(source.fetch("root"))
       value = source.fetch(role)
-      value.start_with?(File::SEPARATOR) ? value : File.join(source.fetch("root"), value)
+      path = File.expand_path(value, root)
+      raise Error unless path.start_with?("#{root}/")
+      path
     end
 
     def relative_role(source, path)
-      prefix = "#{source.fetch("root")}/"
+      prefix = "#{File.realpath(source.fetch("root"))}/"
       raise Error unless path.start_with?(prefix)
       path.delete_prefix(prefix)
     end

--- a/packaging/live_agent_skills/workflow_creator_execution.rb
+++ b/packaging/live_agent_skills/workflow_creator_execution.rb
@@ -23,7 +23,7 @@ module HiveLiveAgentProof
     ARCHIVE_LABELS = WorkflowCreator::Vocabulary.fetch("archive_labels")
     SUPERVISOR_KEYS = %w[output_limit tail_limit timeout term_grace kill_grace].freeze
 
-    def self.start!(**options) = new(**options).tap(&:start!)
+    def self.start!(**options) = new(**options).send(:activate)
     private_class_method :new
 
     attr_reader :gateway_path, :workspace_path
@@ -41,18 +41,24 @@ module HiveLiveAgentProof
       raise Error unless @archives.keys == ARCHIVE_LABELS
       options = input.fetch("supervisor_options")
       raise Error unless options.instance_of?(Hash) && (options.keys - SUPERVISOR_KEYS).empty?
-      @workspace_path = File.expand_path(input.fetch("workspace_path")).freeze
-      @bundle_directory = File.expand_path(input.fetch("bundle_directory")).freeze
+      workspace = input.fetch("workspace_path")
+      @workspace_path = File.join(File.realpath(File.dirname(workspace)), File.basename(workspace)).freeze
+      @bundle_directory = File.realpath(input.fetch("bundle_directory")).freeze
+      paths = [ @candidate.fetch("root"), @openclaw.fetch("root") ].map { |path| File.realpath(path) }
+      paths.concat([ @workspace_path, @bundle_directory ])
+      raise Error if paths.combination(2).any? do |left, right|
+        left == right || left.start_with?("#{right}/") || right.start_with?("#{left}/")
+      end
       @correlation_id = input.fetch("correlation_id")
       @exact_secrets = input.fetch("exact_secrets")
       @supervisor_options = options.transform_keys(&:to_sym)
       @result = Result.new(status: "not_started")
       @outer_launches = {}
-    rescue WorkflowCreator::Values::Error, KeyError, TypeError
+    rescue WorkflowCreator::Values::Error, KeyError, TypeError, SystemCallError
       raise Error, "workflow-creator execution inputs are invalid", cause: nil
     end
 
-    def start!
+    def activate
       @supervisor = WorkflowCreator::ProcessSupervisor.new(
         correlation_id: @correlation_id, exact_secrets: @exact_secrets, **@supervisor_options
       )
@@ -69,8 +75,9 @@ module HiveLiveAgentProof
       self
     rescue StandardError => error
       abort_session
-      raise error
+      raise_execution(error)
     end
+    private :activate
 
     def run_outer_workflow_creator(**launch) = run_outer(OUTER_LABELS.first, launch)
     def run_outer_authorized_work(**launch) = run_outer(OUTER_LABELS.last, launch)
@@ -108,7 +115,7 @@ module HiveLiveAgentProof
                          receipt_size: bytes.bytesize)
     rescue StandardError => error
       abort_session
-      raise error
+      raise_execution(error)
     end
 
     def finish!(primary_row:)
@@ -142,7 +149,7 @@ module HiveLiveAgentProof
       raise Error, "workflow-creator execution publication failed", cause: nil
     rescue StandardError => error
       fail_result
-      raise error
+      raise_execution(error)
     end
 
     def result = @result
@@ -157,7 +164,8 @@ module HiveLiveAgentProof
     private
 
     def run_outer(label, launch)
-      raise Error unless ([ :argv, :environment ]..[ :argv, :environment, :stdin_data ]).cover?(launch.keys.sort)
+      keys = launch.keys.sort
+      raise Error unless keys == %i[argv environment] || keys == %i[argv environment stdin_data]
       current = scan_openclaw
       raise Error unless current.canonical_bytes == @openclaw_installation.canonical_bytes
       raw = { "argv" => launch.fetch(:argv), "environment" => launch.fetch(:environment),
@@ -171,7 +179,7 @@ module HiveLiveAgentProof
         @supervisor.run_outer_authorized_work(**args)
     rescue StandardError => error
       fail_result
-      raise error
+      raise_execution(error)
     end
 
     def scan_candidate
@@ -255,5 +263,10 @@ module HiveLiveAgentProof
 
     def abort_session = close
     def fail_result = @result = Result.new(status: "failed")
+
+    def raise_execution(error)
+      raise error if error.is_a?(Error)
+      raise Error, "workflow-creator execution failed", cause: nil
+    end
   end
 end

--- a/packaging/live_agent_skills/workflow_creator_execution_contract.rb
+++ b/packaging/live_agent_skills/workflow_creator_execution_contract.rb
@@ -3,7 +3,8 @@
 module HiveLiveAgentProof::WorkflowCreator
     module ExecutionContract
       KEYS = %w[schema schema_version candidate_sha result execution_plan classification installed_manifests run gateway
-                archive_admissions commands outer_processes authored_instruction executed_instruction external_actions
+                task_slug_binding archive_admissions commands outer_processes authored_instruction executed_instruction
+                external_actions
                 containment teardown cleanup secret_scan].freeze
       COMMAND_KEYS = %w[position attempt_label argv exit_code signal completed capture teardown].freeze
       OUTER_KEYS = %w[label role argv_sha256 prompt_sha256 exit_code signal completed capture teardown].freeze
@@ -12,6 +13,7 @@ module HiveLiveAgentProof::WorkflowCreator
       PROCESS_TEARDOWN_KEYS = %w[status term_sent kill_sent reaped descendants owner_complete].freeze
       ARCHIVE_KEYS = %w[label artifact_sha256 artifact_size policy_sha256 entry_count uncompressed_bytes status].freeze
       RUN_KEYS, GATEWAY_KEYS = %w[correlation_id expected_labels].freeze, %w[identity command_labels status].freeze
+      BINDING_KEYS = %w[source_position source_result_field target_position target_argument template value].freeze
       CONTAINMENT_KEYS = %w[status mechanism established_before_launch owner_correlation_id root_loss_behavior].freeze
       TEARDOWN_KEYS = %w[status expected_labels receipt_labels outer_root_reaped remaining_descendants].freeze
       CLEANUP_KEYS, LABEL = %w[status targets].freeze, /\A[a-z][a-z0-9_-]{0,127}\z/.freeze
@@ -29,7 +31,7 @@ module HiveLiveAgentProof::WorkflowCreator
         Contract.validate_installation!(openclaw_installation_snapshot, Values.capture("openclaw"),
                                         manifest_snapshot, candidate_snapshot)
         identity!(receipt, row, candidate_sha, records, candidate_installation_snapshot, openclaw_installation_snapshot)
-        labels, correlation = processes!(receipt)
+        labels, correlation = processes!(receipt, row)
         aggregates!(receipt, row, labels, correlation, receipt_sha_snapshot.value, receipt_snapshot.canonical_bytes)
         receipt_snapshot
       rescue ArgumentError, IndexError, KeyError, NoMethodError, TypeError, Values::Error, TextSafety::Error
@@ -99,8 +101,11 @@ module HiveLiveAgentProof::WorkflowCreator
           Contract.assert!(size.positive? && entries.between?(1, 16_384) && bytes.between?(1, 1_073_741_824), message)
         end
       end
-      def processes!(receipt)
-        commands = commands!(receipt.fetch("commands"))
+      def processes!(receipt, row)
+        binding = receipt.fetch("task_slug_binding")
+        commands = commands!(receipt.fetch("commands"), binding)
+        Contract.assert!(row.dig("task", "slug") == binding.fetch("value"),
+                         "workflow-creator task slug binding is invalid")
         outer = outer_processes!(receipt.fetch("outer_processes"))
         labels = commands + outer
         Contract.assert!(labels.uniq.length == labels.length, "workflow-creator execution process labels are invalid")
@@ -113,18 +118,25 @@ module HiveLiveAgentProof::WorkflowCreator
                          "workflow-creator execution gateway labels are invalid")
         [ labels, correlation ]
       end
-      def commands!(commands)
-        expected = Vocabulary.fetch("commands")
+      def commands!(commands, binding)
         message = "workflow-creator command receipts are invalid"
+        Contract.exact!(binding, BINDING_KEYS, message)
+        Contract.assert!(binding.except("value") == Vocabulary.fetch("task_slug_binding"), message)
+        expected = HiveLiveAgentProof::WorkflowCreator.commands_for(task_slug: binding.fetch("value")).value
+        labels = Vocabulary.fetch("command_labels")
         Contract.assert!(commands.instance_of?(Array), message)
         Contract.assert!(commands.length == expected.length, message)
         commands.each_with_index.map do |command, index|
-          Contract.exact!(command, COMMAND_KEYS, message)
-          position, argv = command.values_at("position", "argv")
-          Contract.assert!([ position.class, position, argv ] == [ Integer, index + 1, expected.fetch(index) ], message)
-          process!(command, "attempt_label")
-          command.fetch("attempt_label")
+          command!(command, index, expected.fetch(index), labels.fetch(index), message)
         end
+      end
+      def command!(command, index, expected, label, message)
+        Contract.exact!(command, COMMAND_KEYS, message)
+        position, argv = command.values_at("position", "argv")
+        Contract.assert!([ position.class, position, argv, command.fetch("attempt_label") ] ==
+                         [ Integer, index + 1, expected, label ], message)
+        process!(command, "attempt_label")
+        command.fetch("attempt_label")
       end
       def outer_processes!(outer)
         expected = Vocabulary.fetch("outer_roles")

--- a/packaging/live_agent_skills/workflow_creator_gateway.rb
+++ b/packaging/live_agent_skills/workflow_creator_gateway.rb
@@ -22,13 +22,15 @@ module HiveLiveAgentProof
     /ix
     REFUSAL = "workflow-creator gateway refused request\n"
 
-    def initialize(root:, candidate_executable:, candidate_identity:, environment:, cwd:, supervisor:)
-      @root, @candidate, @cwd = [ root, candidate_executable, cwd ].map { |path| File.expand_path(path) }
+    def initialize(root:, candidate_executable:, candidate_identity:, environment:, cwd:, supervisor:,
+                   socket_root: root)
+      @root, @socket_root, @candidate, @cwd =
+        [ root, socket_root, candidate_executable, cwd ].map { |path| File.expand_path(path) }
       @identity = WorkflowCreator::Values.capture(candidate_identity).value
       @environment = WorkflowCreator::Values.capture(environment).value
       @supervisor = supervisor
       @wrapper_path = File.join(@root, WRAPPER_NAME)
-      @socket_path = File.join(@root, SOCKET_NAME)
+      @socket_path = File.join(@socket_root, SOCKET_NAME)
       @token = SecureRandom.hex(32).freeze
       @receipts, @position, @mutex = [], 1, Mutex.new
       @poisoned = @started = @stopping = false
@@ -59,6 +61,7 @@ module HiveLiveAgentProof
     def finish!
       complete = @mutex.synchronize do
         valid = @started && !@poisoned && @receipts.length == 9 && @position == 10
+        @stopping = true
         @poisoned = true unless valid
         valid
       end
@@ -78,6 +81,7 @@ module HiveLiveAgentProof
 
     def validate_inputs!
       @root_identity = directory_identity(@root, private: true)
+      @socket_root_identity = directory_identity(@socket_root, private: true)
       @cwd_identity = directory_identity(@cwd, private: false)
       environment_valid = @environment.instance_of?(Hash) && @environment.all? do |key, value|
         [ key, value ].all? { |item| item.instance_of?(String) && !item.empty? && !item.include?("\0") } &&
@@ -178,7 +182,8 @@ module HiveLiveAgentProof
     end
 
     def dispatch(request)
-      valid = request.instance_of?(Hash) && request.keys.sort == %w[argv credential_env token]
+      valid = @started && !@stopping && !@poisoned && request.instance_of?(Hash) &&
+        request.keys.sort == %w[argv credential_env token]
       valid &&= request.values_at("token", "credential_env") == [ @token, false ]
       expected = expected_command
       unless valid && request["argv"].instance_of?(Array) && request["argv"] == expected
@@ -251,6 +256,7 @@ module HiveLiveAgentProof
 
     def verify_base!
       raise Error unless directory_identity(@root, private: true) == @root_identity
+      raise Error unless directory_identity(@socket_root, private: true) == @socket_root_identity
       raise Error unless directory_identity(@cwd, private: false) == @cwd_identity
       stat = File.lstat(@candidate)
       valid = file_identity(stat) == @candidate_identity && Digest::SHA256.file(@candidate).hexdigest == @candidate_digest
@@ -289,7 +295,7 @@ module HiveLiveAgentProof
       nil
     end
     def stop_server
-      @stopping = true
+      @mutex.synchronize { @stopping = true }
       @server&.close rescue nil
       @thread&.join(2)
       stat = File.lstat(@socket_path)

--- a/packaging/live_agent_skills/workflow_creator_gateway.rb
+++ b/packaging/live_agent_skills/workflow_creator_gateway.rb
@@ -1,0 +1,295 @@
+# frozen_string_literal: true
+
+require "digest"
+require "json"
+require "rbconfig"
+require "securerandom"
+require "socket"
+require_relative "workflow_creator_process_supervisor"
+
+module HiveLiveAgentProof
+  class WorkflowCreatorGateway
+    class Error < StandardError; end
+
+    MAX_IPC_BYTES = 32 * 1024
+    WRAPPER_NAME = "workflow-creator-gateway"
+    SOCKET_NAME = ".workflow-creator-gateway.sock"
+    TASK_SLUG = /\A[a-z][a-z0-9-]{0,62}[a-z0-9]\z/
+    REFUSAL = "workflow-creator gateway refused request\n"
+
+    def initialize(root:, candidate_executable:, candidate_identity:, environment:, cwd:, supervisor:)
+      @root, @candidate, @cwd = [ root, candidate_executable, cwd ].map { |path| File.expand_path(path) }
+      @identity = WorkflowCreator::Values.capture(candidate_identity).value
+      @environment = WorkflowCreator::Values.capture(environment).value
+      @supervisor = supervisor
+      @wrapper_path = File.join(@root, WRAPPER_NAME)
+      @socket_path = File.join(@root, SOCKET_NAME)
+      @token = SecureRandom.hex(32).freeze
+      @receipts, @position, @mutex = [], 1, Mutex.new
+      @poisoned = @started = @stopping = false
+      validate_inputs!
+    rescue WorkflowCreator::Values::Error
+      raise Error, "workflow-creator gateway inputs are invalid"
+    end
+
+    def start!
+      @mutex.synchronize do
+        raise Error, "workflow-creator gateway cannot be started" if @started || @poisoned
+        verify_base!
+        [ @socket_path, @wrapper_path ].each { |path| refuse_existing!(path) }
+        @server = UNIXServer.new(@socket_path)
+        File.chmod(0o600, @socket_path)
+        @socket_identity = node_identity(File.lstat(@socket_path))
+        install_wrapper!
+        @started = true
+        @thread = Thread.new { serve }
+      end
+      @wrapper_path.dup.freeze
+    rescue StandardError => error
+      stop_server
+      raise error if error.instance_of?(Error)
+      raise Error, "workflow-creator gateway cannot be started", cause: nil
+    end
+
+    def finish!
+      complete = @mutex.synchronize do
+        valid = @started && !@poisoned && @receipts.length == 9 && @position == 10
+        @poisoned = true unless valid
+        valid
+      end
+      stop_server
+      raise Error, "workflow-creator gateway is incomplete" unless complete
+      WorkflowCreator::Values.capture(@receipts).value
+    rescue WorkflowCreator::Values::Error
+      raise Error, "workflow-creator gateway is incomplete"
+    end
+
+    def close
+      stop_server
+      nil
+    end
+
+    private
+
+    def validate_inputs!
+      @root_identity = directory_identity(@root, private: true)
+      @cwd_identity = directory_identity(@cwd, private: false)
+      environment_valid = @environment.instance_of?(Hash) && @environment.all? do |key, value|
+        [ key, value ].all? { |item| item.instance_of?(String) && !item.empty? && !item.include?("\0") }
+      end
+      supervisor_valid = @supervisor.instance_of?(WorkflowCreator::ProcessSupervisor)
+      labels_valid = WorkflowCreator::Vocabulary.fetch("command_labels") ==
+        WorkflowCreator::ProcessSupervisor::COMMAND_LABELS
+      raise Error unless environment_valid && supervisor_valid && labels_valid
+      admit_candidate!
+    rescue KeyError, SystemCallError, Error
+      raise Error, "workflow-creator gateway inputs are invalid"
+    end
+
+    def admit_candidate!
+      stat = File.lstat(@candidate)
+      path, digest, size = @identity.values_at("path", "sha256", "size") if @identity.instance_of?(Hash)
+      relative = path.instance_of?(String) && WorkflowCreator::TextSafety.safe_relative_path?(path)
+      valid = @identity.instance_of?(Hash) && @identity.keys.sort == %w[path sha256 size]
+      valid &&= path == @candidate || (relative && @candidate.end_with?("/#{path}"))
+      valid &&= /\A[0-9a-f]{64}\z/.match?(digest) && size.instance_of?(Integer) && size.positive?
+      valid &&= stat.file? && !stat.symlink? && stat.uid == Process.uid && File.executable?(@candidate)
+      valid &&= (stat.mode & 0o022).zero? && stat.size == size && Digest::SHA256.file(@candidate).hexdigest == digest
+      raise Error unless valid
+      @candidate_identity, @candidate_digest = file_identity(stat).freeze, digest
+    rescue WorkflowCreator::TextSafety::Error, SystemCallError
+      raise Error, "workflow-creator candidate identity is invalid"
+    end
+
+    def install_wrapper!
+      File.open(@wrapper_path, File::WRONLY | File::CREAT | File::EXCL, 0o600) do |file|
+        file.write(wrapper_source)
+        file.flush
+        file.fsync
+      end
+      File.chmod(0o600, @wrapper_path)
+      @wrapper_identity = file_identity(File.lstat(@wrapper_path)).freeze
+      @wrapper_digest = Digest::SHA256.file(@wrapper_path).hexdigest
+    rescue SystemCallError
+      raise Error, "workflow-creator gateway wrapper could not be installed"
+    end
+
+    def wrapper_source
+      <<~RUBY
+        #!#{RbConfig.ruby}
+        require "json"
+        require "socket"
+        TOKEN = #{@token.dump}
+        SOCKET_PATH = #{@socket_path.dump}
+        LIMIT = #{MAX_IPC_BYTES}
+        CREDENTIAL = /(?:^|_)(?:TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIALS?|API_?KEY|PRIVATE_?KEY|AUTH(?:ORIZATION)?|COOKIE|SESSION)(?:_|$)/i
+        begin
+          unsafe = ENV.keys.any? { |key| CREDENTIAL.match?(key) }
+          request = JSON.generate("token" => TOKEN, "argv" => ARGV, "credential_env" => unsafe)
+          raise if request.bytesize > LIMIT
+          socket = UNIXSocket.new(SOCKET_PATH)
+          socket.write(request)
+          socket.close_write
+          raw = socket.read(LIMIT + 1)
+          raise if raw.bytesize > LIMIT
+          response = JSON.parse(raw)
+          raise unless response.instance_of?(Hash) && response.keys.sort == %w[exit_code signal stderr stdout]
+          stdout, stderr = response.values_at("stdout", "stderr")
+          raise unless stdout.instance_of?(String) && stderr.instance_of?(String)
+          STDOUT.binmode.write(stdout)
+          STDERR.binmode.write(stderr)
+          if (signal = response.fetch("signal"))
+            Signal.trap(signal, "DEFAULT")
+            Process.kill(signal, Process.pid)
+          end
+          exit Integer(response.fetch("exit_code"))
+        rescue StandardError
+          STDERR.write(#{REFUSAL.dump})
+          exit 125
+        end
+      RUBY
+    end
+
+    def serve
+      loop do
+        client = @server.accept
+        raw = client.read(MAX_IPC_BYTES + 1)
+        raise Error if raw.bytesize > MAX_IPC_BYTES
+        response = @mutex.synchronize { dispatch(JSON.parse(raw)) }
+        payload = JSON.generate(response)
+        raise Error if payload.bytesize > MAX_IPC_BYTES
+        client.write(payload)
+      rescue IOError, Errno::EBADF
+        break if @stopping
+        poison_server!
+        break
+      rescue StandardError
+        poison_server!
+        client&.write(JSON.generate(refusal)) rescue nil
+      ensure
+        client&.close rescue nil
+      end
+    end
+
+    def dispatch(request)
+      valid = request.instance_of?(Hash) && request.keys.sort == %w[argv credential_env token]
+      valid &&= request.values_at("token", "credential_env") == [ @token, false ]
+      expected = expected_command
+      unless valid && request["argv"].instance_of?(Array) && request["argv"] == expected
+        poison!
+        return refusal
+      end
+      verify_runtime!
+      receipt = @supervisor.run_command(
+        position: @position, executable: @candidate, argv: expected,
+        environment: @environment, cwd: @cwd
+      )
+      streams = receipt.fetch("capture").fetch("tails").slice("stdout", "stderr")
+      unless passing?(receipt) && semantic_result?(receipt, streams.fetch("stdout"))
+        poison!
+        return process_response(receipt, streams, passing: false)
+      end
+      @receipts << command_receipt(receipt, expected)
+      @position += 1
+      process_response(receipt, streams, passing: true)
+    rescue StandardError
+      poison!
+      refusal
+    end
+
+    def expected_command
+      commands = @task_slug ? WorkflowCreator.commands_for(task_slug: @task_slug).value :
+        WorkflowCreator::Vocabulary.fetch("commands")
+      commands.fetch(@position - 1)
+    rescue IndexError
+      nil
+    end
+
+    def semantic_result?(receipt, stdout)
+      return true unless [ 6, 8 ].include?(@position)
+      return false unless receipt.dig("capture", "stdout_bytes") == stdout.b.bytesize
+      payload = JSON.parse(stdout)
+      valid = payload.instance_of?(Hash) && payload.values_at("schema", "ok", "created") ==
+        [ "hive-new", true, @position == 6 ]
+      valid &&= @position == 6 ? TASK_SLUG.match?(payload["slug"]) : payload["slug"] == @task_slug
+      @task_slug = payload["slug"].dup.freeze if valid && @position == 6
+      valid
+    rescue JSON::ParserError, TypeError
+      false
+    end
+
+    def passing?(receipt)
+      capture, teardown = receipt.values_at("capture", "teardown")
+      scan = capture.fetch("secret_scan")
+      receipt.values_at("exit_code", "signal", "completed", "timed_out") == [ 0, nil, true, false ] &&
+        %w[stdout stderr].none? { |stream| capture.fetch("#{stream}_truncated") } &&
+        scan.values_at("status", "findings") == [ "passed", [] ] && teardown.fetch("status") == "passed"
+    end
+
+    def process_response(receipt, streams, passing:)
+      code = receipt.fetch("exit_code")
+      { "stdout" => streams.fetch("stdout"), "stderr" => streams.fetch("stderr"),
+        "exit_code" => passing || (code && !code.zero?) ? code : 125, "signal" => receipt.fetch("signal") }
+    end
+
+    def command_receipt(receipt, argv)
+      capture = receipt.fetch("capture").except("tails")
+      capture["secret_scan"] = capture.fetch("secret_scan").except("findings")
+      WorkflowCreator::Values.capture(
+        "position" => @position,
+        "attempt_label" => WorkflowCreator::Vocabulary.fetch("command_labels").fetch(@position - 1),
+        "argv" => argv, "exit_code" => receipt.fetch("exit_code"), "signal" => receipt.fetch("signal"),
+        "completed" => receipt.fetch("completed"), "capture" => capture, "teardown" => receipt.fetch("teardown")
+      ).value
+    end
+
+    def verify_base!
+      raise Error unless directory_identity(@root, private: true) == @root_identity
+      raise Error unless directory_identity(@cwd, private: false) == @cwd_identity
+      stat = File.lstat(@candidate)
+      valid = file_identity(stat) == @candidate_identity && Digest::SHA256.file(@candidate).hexdigest == @candidate_digest
+      raise Error unless valid
+    end
+
+    def verify_runtime!
+      verify_base!
+      socket = File.lstat(@socket_path)
+      wrapper = File.lstat(@wrapper_path)
+      valid = socket.socket? && node_identity(socket) == @socket_identity
+      valid &&= wrapper.file? && (wrapper.mode & 0o777) == 0o600 && file_identity(wrapper) == @wrapper_identity
+      valid &&= Digest::SHA256.file(@wrapper_path).hexdigest == @wrapper_digest
+      raise Error unless valid
+    rescue StandardError
+      raise Error, "workflow-creator gateway runtime identity changed"
+    end
+
+    def directory_identity(path, private:)
+      stat = File.lstat(path)
+      valid = File.realpath(path) == path && stat.directory? && !stat.symlink? && stat.uid == Process.uid
+      valid &&= (stat.mode & 0o077).zero? if private
+      raise Error unless valid
+      node_identity(stat)
+    end
+
+    def poison! = @poisoned = true
+    def poison_server! = @mutex.synchronize { poison! }
+    def refusal = { "stdout" => "", "stderr" => REFUSAL, "exit_code" => 125, "signal" => nil }
+    def node_identity(stat) = [ stat.dev, stat.ino, stat.uid, stat.mode ]
+    def file_identity(stat) = [ *node_identity(stat), stat.size, stat.mtime, stat.ctime ]
+    def refuse_existing!(path)
+      File.lstat(path)
+      raise Error, "workflow-creator gateway member already exists"
+    rescue Errno::ENOENT
+      nil
+    end
+    def stop_server
+      @stopping = true
+      @server&.close rescue nil
+      @thread&.join(2)
+      stat = File.lstat(@socket_path)
+      File.unlink(@socket_path) if @socket_identity && node_identity(stat) == @socket_identity
+    rescue Errno::ENOENT
+      nil
+    end
+  end
+end

--- a/packaging/live_agent_skills/workflow_creator_gateway.rb
+++ b/packaging/live_agent_skills/workflow_creator_gateway.rb
@@ -15,6 +15,11 @@ module HiveLiveAgentProof
     WRAPPER_NAME = "workflow-creator-gateway"
     SOCKET_NAME = ".workflow-creator-gateway.sock"
     TASK_SLUG = /\A[a-z][a-z0-9-]{0,62}[a-z0-9]\z/
+    CREDENTIAL = /
+      (?:^|_)
+      (?:TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIALS?|API_?KEY|PRIVATE_?KEY|AUTH(?:ORIZATION)?|COOKIE|SESSION)
+      (?:_|$)
+    /ix
     REFUSAL = "workflow-creator gateway refused request\n"
 
     def initialize(root:, candidate_executable:, candidate_identity:, environment:, cwd:, supervisor:)
@@ -75,7 +80,8 @@ module HiveLiveAgentProof
       @root_identity = directory_identity(@root, private: true)
       @cwd_identity = directory_identity(@cwd, private: false)
       environment_valid = @environment.instance_of?(Hash) && @environment.all? do |key, value|
-        [ key, value ].all? { |item| item.instance_of?(String) && !item.empty? && !item.include?("\0") }
+        [ key, value ].all? { |item| item.instance_of?(String) && !item.empty? && !item.include?("\0") } &&
+          !CREDENTIAL.match?(key)
       end
       supervisor_valid = @supervisor.instance_of?(WorkflowCreator::ProcessSupervisor)
       labels_valid = WorkflowCreator::Vocabulary.fetch("command_labels") ==
@@ -122,7 +128,7 @@ module HiveLiveAgentProof
         TOKEN = #{@token.dump}
         SOCKET_PATH = #{@socket_path.dump}
         LIMIT = #{MAX_IPC_BYTES}
-        CREDENTIAL = /(?:^|_)(?:TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIALS?|API_?KEY|PRIVATE_?KEY|AUTH(?:ORIZATION)?|COOKIE|SESSION)(?:_|$)/i
+        CREDENTIAL = #{CREDENTIAL.inspect}
         begin
           unsafe = ENV.keys.any? { |key| CREDENTIAL.match?(key) }
           request = JSON.generate("token" => TOKEN, "argv" => ARGV, "credential_env" => unsafe)

--- a/packaging/live_agent_skills/workflow_creator_installation.rb
+++ b/packaging/live_agent_skills/workflow_creator_installation.rb
@@ -1,0 +1,184 @@
+# frozen_string_literal: true
+
+require "digest"
+require_relative "workflow_creator"
+
+module HiveLiveAgentProof
+  class WorkflowCreatorInstallation
+    class Error < StandardError; end
+    MESSAGE = "workflow-creator installation closure is invalid"
+    MAX_FILES = 512
+    MAX_NODES = 1_024
+    MAX_FILE_BYTES = 268_435_456
+    MAX_TOTAL_BYTES = 1_073_741_824
+    MAX_PATH_BYTES = 1_024
+    CHUNK_BYTES = 65_536
+    READ_FLAGS = if defined?(File::NOFOLLOW) && defined?(File::NONBLOCK)
+      File::RDONLY | File::NOFOLLOW | File::NONBLOCK
+    end
+
+    class << self
+      def candidate!(root:, candidate_sha:, manifest:, inventory:, audit_gateway:, executable:,
+                     interpreter_or_launcher:, lock:, package:)
+        build(
+          kind: "candidate", root:, candidate_sha:, manifest:, inventory:, version: nil,
+          role_paths: { "audit_gateway" => audit_gateway, "executable" => executable,
+                        "interpreter_or_launcher" => interpreter_or_launcher, "lock" => lock, "package" => package }
+        )
+      end
+
+      def openclaw!(root:, version:, candidate_sha:, manifest:, inventory:, executable:,
+                    interpreter_or_launcher:, lock:, package:)
+        build(
+          kind: "openclaw", root:, candidate_sha:, manifest:, inventory:, version:,
+          role_paths: { "executable" => executable, "interpreter_or_launcher" => interpreter_or_launcher,
+                        "lock" => lock, "package" => package }
+        )
+      end
+      private
+
+      def build(kind:, root:, candidate_sha:, manifest:, inventory:, version:, role_paths:)
+        input = WorkflowCreator::Values.capture(
+          "root" => root, "candidate_sha" => candidate_sha, "manifest" => manifest,
+          "inventory" => inventory, "version" => version, "role_paths" => role_paths
+        ).value
+        root_path, admitted_root = admit_root(input.fetch("root"))
+        records, directories = scan_root(root_path, admitted_root)
+        expected = normalize_inventory(root_path, input.fetch("inventory"))
+        raise Error, MESSAGE unless records.map { |record| record.fetch("path") } == expected
+        required = required_roles(kind, root_path, input.fetch("role_paths"), records)
+        verify_directories!(directories)
+        document = manifest_document(kind, input, required, records)
+        WorkflowCreator.validate_installation!(
+          document:, kind:, manifest: input.fetch("manifest"), candidate_sha: input.fetch("candidate_sha")
+        )
+      rescue StandardError
+        raise Error, MESSAGE, cause: nil
+      end
+
+      def admit_root(raw)
+        root = File.expand_path(raw)
+        stat = File.lstat(root)
+        valid = File.realpath(root) == root && safe_directory?(stat)
+        raise Error, MESSAGE unless valid && READ_FLAGS
+        [ root, identity(stat) ]
+      end
+
+      def scan_root(root, admitted_root)
+        records = []
+        directories = []
+        queue = [ [ "", root ] ]
+        nodes = 0
+        total = 0
+        until queue.empty?
+          relative, directory = queue.shift
+          stat = File.lstat(directory)
+          raise Error, MESSAGE unless safe_directory?(stat)
+          raise Error, MESSAGE if relative.empty? && identity(stat) != admitted_root
+          directories << [ directory, identity(stat) ]
+          children = Dir.each_child(directory).take(MAX_NODES + 1).sort
+          nodes += children.length
+          raise Error, MESSAGE if nodes > MAX_NODES
+          children.each do |name|
+            path = relative.empty? ? name : File.join(relative, name)
+            normalized = normalize_relative(path)
+            absolute = File.join(root, normalized)
+            child = File.lstat(absolute)
+            if child.directory?
+              queue << [ normalized, absolute ]
+            elsif child.file?
+              total += child.size
+              raise Error, MESSAGE if total > MAX_TOTAL_BYTES
+              records << file_record(absolute, normalized, child)
+              raise Error, MESSAGE if records.length > MAX_FILES
+            else
+              raise Error, MESSAGE
+            end
+          end
+        end
+        [ records.sort_by { |record| record.fetch("path") }, directories ]
+      end
+      def safe_directory?(stat)
+        stat.directory? && stat.uid == Process.uid && (stat.mode & 0o022).zero?
+      end
+      def file_record(path, relative, lstat)
+        valid = lstat.file? && lstat.nlink == 1 && lstat.uid == Process.uid
+        valid &&= (lstat.mode & 0o022).zero? && lstat.size.between?(0, MAX_FILE_BYTES)
+        raise Error, MESSAGE unless valid
+        digest = Digest::SHA256.new
+        File.open(path, READ_FLAGS) do |file|
+          opened = file.stat
+          raise Error, MESSAGE unless identity(opened) == identity(lstat)
+          while (chunk = file.read(CHUNK_BYTES))
+            digest.update(chunk)
+          end
+          raise Error, MESSAGE unless identity(file.stat) == identity(opened)
+        end
+        { "path" => relative, "sha256" => digest.hexdigest, "size" => lstat.size }
+      end
+
+      def normalize_inventory(root, paths)
+        normalized = paths.map { |path| role_relative(root, path) }
+        raise Error, MESSAGE unless normalized.length.between?(1, MAX_FILES)
+        raise Error, MESSAGE unless normalized.uniq.length == normalized.length
+        normalized.sort
+      end
+
+      def required_roles(kind, root, role_paths, records)
+        by_path = records.to_h { |record| [ record.fetch("path"), record ] }
+        roles = WorkflowCreator::Vocabulary.fetch("member_roles").fetch(kind)
+        raise Error, MESSAGE unless role_paths.keys == roles
+        required = roles.to_h do |role|
+          relative = role_relative(root, role_paths.fetch(role))
+          [ role, by_path.fetch(relative) ]
+        end
+        raise Error, MESSAGE unless required.values.uniq.length == roles.length
+        required
+      end
+
+      def role_relative(root, path)
+        if path.start_with?(File::SEPARATOR)
+          expanded = File.expand_path(path)
+          prefix = "#{root}#{File::SEPARATOR}"
+          raise Error, MESSAGE unless expanded == path && expanded.start_with?(prefix)
+          normalize_relative(expanded.delete_prefix(prefix))
+        else
+          normalize_relative(path)
+        end
+      end
+
+      def normalize_relative(path)
+        owned = WorkflowCreator::Values.capture(path).value
+        safe = owned.bytesize <= MAX_PATH_BYTES
+        safe &&= WorkflowCreator::TextSafety.safe_relative_path?(owned)
+        safe &&= File.expand_path(owned, File::SEPARATOR) == File.join(File::SEPARATOR, owned)
+        raise Error, MESSAGE unless safe
+        owned
+      end
+
+      def verify_directories!(directories)
+        directories.each do |path, expected|
+          raise Error, MESSAGE unless identity(File.lstat(path)) == expected
+        end
+      end
+
+      def manifest_document(kind, input, required, inventory)
+        closure = WorkflowCreator::Values.capture("required_roles" => required, "inventory" => inventory)
+        total = inventory.sum { |record| record.fetch("size") }
+        raise Error, MESSAGE unless total.between?(1, MAX_TOTAL_BYTES)
+        version = kind == "candidate" ? input.fetch("manifest").fetch("hive_version") : input.fetch("version")
+        {
+          "schema" => WorkflowCreator::Vocabulary.fetch("installed_schema"), "schema_version" => 1,
+          "candidate_sha" => input.fetch("candidate_sha"), "kind" => kind, "version" => version,
+          "closure_sha256" => Digest::SHA256.hexdigest(closure.canonical_bytes),
+          "required_roles" => required, "inventory" => inventory, "total_size" => total,
+          "secret_scan" => { "status" => "passed", "scanner" => WorkflowCreator::Vocabulary.fetch("scanner") }
+        }
+      end
+
+      def identity(stat)
+        %i[dev ino uid mode nlink size mtime ctime].map { |field| stat.public_send(field) }
+      end
+    end
+  end
+end

--- a/packaging/live_agent_skills/workflow_creator_process_supervisor.rb
+++ b/packaging/live_agent_skills/workflow_creator_process_supervisor.rb
@@ -30,8 +30,8 @@ module HiveLiveAgentProof
         @timeout = positive_float(timeout, "timeout")
         @term_grace = positive_float(term_grace, "TERM grace")
         @kill_grace = positive_float(kill_grace, "KILL grace")
-        @launched = {}
-        @receipts = []
+        @launched, @receipts = {}, []
+        @state_mutex = Mutex.new
         @workspace = @cleanup = nil
       rescue Values::Error
         raise Error, "workflow-creator exact secrets are invalid"
@@ -45,16 +45,19 @@ module HiveLiveAgentProof
       end
       def run_outer_workflow_creator(**options) = launch("outer-workflow-creator", **options)
       def run_outer_authorized_work(**options) = launch("outer-authorized-work", **options)
-      def receipts = copy(@receipts)
+      def receipts = @state_mutex.synchronize { copy(@receipts) }
       def teardown
-        labels = @receipts.map { |row| row.fetch("label") }
-        started = @launched.any?
-        all_received = started && @receipts.length == @launched.length
-        complete = labels == LABELS && @receipts.all? { |row| row.dig("teardown", "status") == "passed" }
+        launched, receipts = @state_mutex.synchronize { [ @launched.dup, copy(@receipts) ] }
+        labels = receipts.map { |row| row.fetch("label") }
+        started = launched.any?
+        all_received = started && receipts.length == launched.length
+        complete = all_received && launched.keys.sort == LABELS.sort && labels.sort == LABELS.sort &&
+                   labels.uniq.length == LABELS.length &&
+                   receipts.all? { |row| row.dig("teardown", "status") == "passed" }
         copy("status" => started ? (complete ? "passed" : "failed") : "not_started",
-             "expected_labels" => LABELS, "receipt_labels" => labels,
+             "expected_labels" => LABELS, "receipt_labels" => complete ? LABELS : labels,
              "outer_root_reaped" => all_received,
-                          "remaining_descendants" => started ? remaining_receipts : nil)
+             "remaining_descendants" => started ? remaining_receipts(receipts) : nil)
       end
       def create_proof_workspace(path)
         raise Error, "proof workspace is already owned" if @workspace
@@ -82,9 +85,11 @@ module HiveLiveAgentProof
       private
       def launch(label, executable:, argv:, environment:, cwd:, stdin_data: nil)
         validate_launch!(executable, argv, environment, cwd, stdin_data)
-        raise Error, "workflow-creator process label was already launched" if @launched.key?(label)
-        @launched[label] = true
-        sequence = @launched.length
+        sequence = @state_mutex.synchronize do
+          raise Error, "workflow-creator process label was already launched" if @launched.key?(label)
+          @launched[label] = true
+          @launched.length
+        end
         reader, writer = IO.pipe
         cancel_reader, cancel_writer = IO.pipe
         writer.close_on_exec = true
@@ -110,7 +115,7 @@ module HiveLiveAgentProof
         raise Error, "workflow-creator supervisor receipt is invalid" unless envelope_valid
         receipt = envelope.fetch("receipt")
         validate_receipt!(receipt, label)
-        @receipts << receipt
+        @state_mutex.synchronize { @receipts << receipt }
         copy(receipt)
       rescue JSON::ParserError, SystemCallError, Timeout::Error
         raise Error, "workflow-creator supervisor receipt is invalid"
@@ -338,7 +343,7 @@ module HiveLiveAgentProof
         copy(@cleanup)
       end
 
-      def remaining_receipts = @receipts.count { |row| row.dig("teardown", "descendants") != "none" }
+      def remaining_receipts(receipts) = receipts.count { |row| row.dig("teardown", "descendants") != "none" }
       def safe_string?(value) = value.instance_of?(String) && !value.empty? && !value.include?("\0")
       def path_exists?(path)
         File.lstat(path)

--- a/packaging/live_agent_skills/workflow_creator_process_supervisor.rb
+++ b/packaging/live_agent_skills/workflow_creator_process_supervisor.rb
@@ -17,6 +17,7 @@ module HiveLiveAgentProof
       LABEL = /\A[a-z][a-z0-9_-]{0,127}\z/
       MAX_IPC_BYTES = 64 * 1024
       MAX_STDIN_BYTES = 16 * 1024
+      MAX_DRAIN_READS = 8
       POLL_SECONDS = 0.01
       PR_SET_CHILD_SUBREAPER = 36
       def initialize(correlation_id:, output_limit: 64 * 1024, tail_limit: 4_096, exact_secrets: [],
@@ -196,8 +197,8 @@ module HiveLiveAgentProof
           drain(streams, capture)
         end
       end
-      def descendants
-        pending = child_pids(Process.pid, true)
+      def descendants(root_pid = Process.pid, required: true)
+        pending = child_pids(root_pid, required)
         seen = {}
         pending.each_with_object([]) do |pid, targets|
           next if seen[pid]
@@ -248,7 +249,7 @@ module HiveLiveAgentProof
       def drain(streams, capture)
         ready = IO.select(streams.keys, nil, nil, POLL_SECONDS)&.first || []
         ready.each do |io|
-          loop do
+          MAX_DRAIN_READS.times do
             chunk = io.read_nonblock(8_192, exception: false)
             break if chunk == :wait_readable
             if chunk.nil?
@@ -306,11 +307,12 @@ module HiveLiveAgentProof
       end
 
       def terminate_custody(pid, identity)
-        Process.kill("KILL", -pid) if process_start_time(pid) == identity
-      rescue Errno::ESRCH
+        return unless process_start_time(pid) == identity
+        signal_targets("KILL", descendants(pid, required: false))
+        Process.kill("KILL", pid)
+        Process.waitpid(pid)
+      rescue Errno::ESRCH, Errno::ECHILD
         nil
-      ensure
-        Process.waitpid(pid, Process::WNOHANG) rescue nil
       end
 
       def settle_custody(pid, identity)

--- a/packaging/live_agent_skills/workflow_creator_process_supervisor.rb
+++ b/packaging/live_agent_skills/workflow_creator_process_supervisor.rb
@@ -1,0 +1,372 @@
+# frozen_string_literal: true
+
+require "digest"
+require "fiddle"
+require "fileutils"
+require "json"
+require "timeout"
+require_relative "workflow_creator_capture"
+
+module HiveLiveAgentProof
+  module WorkflowCreator
+    class ProcessSupervisor
+      class Error < StandardError; end
+
+      COMMAND_LABELS = %w[candidate-version candidate-workflow-list candidate-workflow-new
+                          candidate-workflow-validate candidate-workflow-commit candidate-task-create
+                          candidate-task-run candidate-task-retry candidate-operational-status].freeze
+      LABELS = (COMMAND_LABELS + %w[outer-workflow-creator outer-authorized-work]).freeze
+      LABEL = /\A[a-z][a-z0-9_-]{0,127}\z/
+      MAX_IPC_BYTES = 64 * 1024
+      MAX_STDIN_BYTES = 16 * 1024
+      POLL_SECONDS = 0.01
+      PR_SET_CHILD_SUBREAPER = 36
+      def initialize(correlation_id:, output_limit: 64 * 1024, tail_limit: 4_096, exact_secrets: [],
+                     timeout: 120, term_grace: 0.2, kill_grace: 0.2, platform: RUBY_PLATFORM)
+        raise Error, "workflow-creator process custody requires Linux" unless platform.include?("linux")
+        raise Error, "workflow-creator correlation identity is invalid" unless LABEL.match?(correlation_id.to_s)
+        @correlation_id = correlation_id.to_s
+        @capture_options = { limit_bytes: positive_integer(output_limit, "output limit"),
+                             tail_bytes: positive_integer(tail_limit, "tail limit"),
+                             exact_secrets: Values.capture(exact_secrets).value }
+        @timeout = positive_float(timeout, "timeout")
+        @term_grace = positive_float(term_grace, "TERM grace")
+        @kill_grace = positive_float(kill_grace, "KILL grace")
+        @launched = {}
+        @receipts = []
+        @workspace = @cleanup = nil
+      rescue Values::Error
+        raise Error, "workflow-creator exact secrets are invalid"
+      end
+      def run_command(position:, **options)
+        index = Integer(position) - 1
+        raise IndexError unless index.between?(0, COMMAND_LABELS.length - 1)
+        launch(COMMAND_LABELS.fetch(index), **options)
+      rescue ArgumentError, IndexError, TypeError
+        raise Error, "workflow-creator command position is invalid"
+      end
+      def run_outer_workflow_creator(**options) = launch("outer-workflow-creator", **options)
+      def run_outer_authorized_work(**options) = launch("outer-authorized-work", **options)
+      def receipts = copy(@receipts)
+      def teardown
+        labels = @receipts.map { |row| row.fetch("label") }
+        started = @launched.any?
+        all_received = started && @receipts.length == @launched.length
+        complete = labels == LABELS && @receipts.all? { |row| row.dig("teardown", "status") == "passed" }
+        copy("status" => started ? (complete ? "passed" : "failed") : "not_started",
+             "expected_labels" => LABELS, "receipt_labels" => labels,
+             "outer_root_reaped" => all_received,
+                          "remaining_descendants" => started ? remaining_receipts : nil)
+      end
+      def create_proof_workspace(path)
+        raise Error, "proof workspace is already owned" if @workspace
+        absolute = File.expand_path(path)
+        raise Error, "proof workspace must not pre-exist" if path_exists?(absolute)
+        Dir.mkdir(absolute, 0o700)
+        stat = File.lstat(absolute)
+        raise Error, "proof workspace could not be owned" unless stat.directory? && stat.uid == Process.uid
+        @workspace = { "label" => "proof-workspace", "path" => absolute,
+                       "path_sha256" => Digest::SHA256.hexdigest(absolute), "device" => stat.dev,
+                       "inode" => stat.ino, "created_by_run" => true }
+        copy(@workspace)
+      rescue SystemCallError
+        raise Error, "proof workspace could not be created"
+      end
+      def cleanup_proof_workspace
+        raise Error, "proof workspace was not created" unless @workspace
+        stat = File.lstat(@workspace.fetch("path"))
+        matched = stat.dev == @workspace.fetch("device") && stat.ino == @workspace.fetch("inode")
+        FileUtils.remove_entry_secure(@workspace.fetch("path")) if matched
+        finish_cleanup(matched, matched && !path_exists?(@workspace.fetch("path")))
+      rescue SystemCallError
+        finish_cleanup(false, false)
+      end
+      private
+      def launch(label, executable:, argv:, environment:, cwd:, stdin_data: nil)
+        validate_launch!(executable, argv, environment, cwd, stdin_data)
+        raise Error, "workflow-creator process label was already launched" if @launched.key?(label)
+        @launched[label] = true
+        sequence = @launched.length
+        reader, writer = IO.pipe
+        cancel_reader, cancel_writer = IO.pipe
+        writer.close_on_exec = true
+        custody_pid = Process.fork do
+          reader.close
+          cancel_writer.close
+          custody_child(writer, cancel_reader, label, sequence) do
+            supervise(label, executable, argv, environment, cwd, stdin_data, cancel_reader)
+          end
+        end
+        custody_identity = process_start_time(custody_pid)
+        cancel_reader.close
+        writer.close
+        raw = Timeout.timeout(@timeout + @term_grace + @kill_grace + 1) { reader.read(MAX_IPC_BYTES + 1) }
+        raise Error, "workflow-creator supervisor receipt exceeded its limit" if raw.bytesize > MAX_IPC_BYTES
+        _pid, status = Timeout.timeout(@term_grace + @kill_grace + 1) { Process.wait2(custody_pid) }
+        custody_pid = nil
+        raise Error, "workflow-creator supervisor custody failed" unless status.success?
+        envelope = JSON.parse(raw)
+        envelope_valid = envelope.instance_of?(Hash) && envelope.keys.sort ==
+          %w[correlation_id label receipt sequence].sort &&
+          envelope.values_at("correlation_id", "sequence", "label") == [ @correlation_id, sequence, label ]
+        raise Error, "workflow-creator supervisor receipt is invalid" unless envelope_valid
+        receipt = envelope.fetch("receipt")
+        validate_receipt!(receipt, label)
+        @receipts << receipt
+        copy(receipt)
+      rescue JSON::ParserError, SystemCallError, Timeout::Error
+        raise Error, "workflow-creator supervisor receipt is invalid"
+      ensure
+        cancel_writer&.close
+        settle_custody(custody_pid, custody_identity) if custody_pid
+        close_ios(reader, writer, cancel_reader, cancel_writer)
+      end
+      def custody_child(writer, cancel_reader, label, sequence)
+        Process.setsid
+        write_payload(writer, "correlation_id" => @correlation_id, "sequence" => sequence,
+                              "label" => label, "receipt" => yield)
+      rescue Exception # rubocop:disable Lint/RescueException -- the custody child must fail by private IPC
+        write_payload(writer, "error" => "supervision_failed")
+      ensure
+        close_ios(writer, cancel_reader)
+        exit! 0
+      end
+      def supervise(label, executable, argv, environment, cwd, stdin_data, cancel_reader)
+        pid = status = nil
+        streams = {}
+        capture = Capture.new(**@capture_options)
+        enable_subreaper!
+        raise Error, "supervisor has pre-existing descendants" unless child_pids(Process.pid, true).empty?
+        input, input_writer = IO.pipe
+        output, output_writer = IO.pipe
+        error, error_writer = IO.pipe
+        pid = Process.spawn(environment, [ executable, executable ], *argv, chdir: cwd, in: input,
+                            out: output_writer, err: error_writer, pgroup: true,
+                            unsetenv_others: true, close_others: true)
+        raise Error, "process identity custody is unavailable" unless process_start_time(pid)
+        close_ios(input, output_writer, error_writer)
+        input_writer.write(stdin_data) if stdin_data
+        input_writer.close
+        streams = { output => :stdout, error => :stderr }
+        status = wait_for_root(pid, streams, capture, cancel_reader, monotonic + @timeout)
+        timed_out = status.nil?
+        status, teardown = teardown_tree(pid, status, streams, capture)
+        10.times { break if streams.empty?; drain(streams, capture) }
+        { "label" => label, "exit_code" => status&.exitstatus, "signal" => status&.termsig,
+          "completed" => !status.nil?, "timed_out" => timed_out, "containment_established" => true,
+          "capture" => capture.finish, "teardown" => teardown }
+      rescue StandardError
+        emergency_teardown(pid, status, streams, capture) if pid
+        raise
+      ensure
+        close_ios(input, input_writer, output, output_writer, error, error_writer)
+      end
+      def wait_for_root(pid, streams, capture, cancel_reader, deadline)
+        status = nil
+        until status || monotonic >= deadline
+          raise Error, "workflow-creator caller custody was lost" if caller_lost?(cancel_reader)
+          status = reap_all(pid, status)
+          drain(streams, capture)
+        end
+        status
+      end
+      def teardown_tree(root_pid, status, streams, capture)
+        targets = descendants
+        term_sent = targets.any?
+        signal_targets("TERM", targets)
+        status, targets = wait_tree(root_pid, status, streams, capture, @term_grace, "TERM")
+        kill_sent = targets.any?
+        signal_targets("KILL", targets)
+        status, targets = wait_tree(root_pid, status, streams, capture, @kill_grace, "KILL")
+        reaped = targets.empty? && !status.nil?
+        [ status, { "status" => reaped ? "passed" : "failed", "term_sent" => term_sent,
+                    "kill_sent" => kill_sent, "reaped" => reaped,
+                    "descendants" => targets.empty? ? "none" : "unknown", "owner_complete" => reaped } ]
+      end
+      def wait_tree(root_pid, status, streams, capture, grace, signal)
+        deadline = monotonic + grace
+        loop do
+          status = reap_all(root_pid, status)
+          targets = descendants
+          return [ status, targets ] if targets.empty? || monotonic >= deadline
+          signal_targets(signal, targets)
+          drain(streams, capture)
+        end
+      end
+      def descendants
+        pending = child_pids(Process.pid, true)
+        seen = {}
+        pending.each_with_object([]) do |pid, targets|
+          next if seen[pid]
+          seen[pid] = true
+          identity = process_start_time(pid)
+          next unless identity
+          targets << { pid: pid, start_time: identity }
+          pending.concat(child_pids(pid, false))
+        end
+      end
+      def child_pids(pid, required)
+        Dir.children("/proc/#{pid}/task").flat_map do |task|
+          File.read("/proc/#{pid}/task/#{task}/children").split.map { |value| Integer(value, 10) }
+        rescue Errno::ENOENT
+          []
+        end.uniq
+      rescue Errno::ENOENT
+        raise Error, "process-tree custody is unavailable" if required
+        []
+      rescue SystemCallError, ArgumentError
+        raise Error, "process-tree custody is unavailable"
+      end
+
+      def process_start_time(pid)
+        File.read("/proc/#{pid}/stat").split(") ", 2).fetch(1).split.fetch(19)
+      rescue Errno::ENOENT, IndexError
+        nil
+      end
+
+      def signal_targets(signal, targets)
+        targets.each do |target|
+          next unless process_start_time(target.fetch(:pid)) == target.fetch(:start_time)
+          Process.kill(signal, target.fetch(:pid))
+        rescue Errno::ESRCH
+          nil
+        end
+      end
+
+      def reap_all(root_pid, status)
+        while (pair = Process.waitpid2(-1, Process::WNOHANG))
+          status = pair.fetch(1) if pair.fetch(0) == root_pid
+        end
+        status
+      rescue Errno::ECHILD
+        status
+      end
+
+      def drain(streams, capture)
+        ready = IO.select(streams.keys, nil, nil, POLL_SECONDS)&.first || []
+        ready.each do |io|
+          loop do
+            chunk = io.read_nonblock(8_192, exception: false)
+            break if chunk == :wait_readable
+            if chunk.nil?
+              streams.delete(io)
+              io.close
+              break
+            end
+            capture.write(streams.fetch(io), chunk)
+          end
+        rescue IOError, Errno::EBADF
+          streams.delete(io)
+        end
+      end
+
+      def enable_subreaper!
+        function = Fiddle::Function.new(Fiddle::Handle::DEFAULT["prctl"],
+                                        [ Fiddle::TYPE_INT, Fiddle::TYPE_LONG, Fiddle::TYPE_LONG,
+                                          Fiddle::TYPE_LONG, Fiddle::TYPE_LONG ], Fiddle::TYPE_INT)
+        raise Error, "child-subreaper custody is unavailable" unless function.call(PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0).zero?
+      rescue Fiddle::DLError
+        raise Error, "child-subreaper custody is unavailable"
+      end
+
+      def validate_launch!(executable, argv, environment, cwd, stdin_data)
+        plain = executable.instance_of?(String) && cwd.instance_of?(String) &&
+                argv.instance_of?(Array) && argv.all? { |value| safe_string?(value) } &&
+                environment.instance_of?(Hash) && environment.all? { |key, value| safe_string?(key) && safe_string?(value) } &&
+                (stdin_data.nil? || (stdin_data.instance_of?(String) && stdin_data.bytesize <= MAX_STDIN_BYTES))
+        raise Error, "workflow-creator launch inputs are invalid" unless plain
+        stat = File.lstat(executable)
+        cwd_stat = File.lstat(cwd)
+        valid = File.absolute_path(executable) == executable && stat.file? && !stat.symlink? &&
+                File.executable?(executable) && File.absolute_path(cwd) == cwd && cwd_stat.directory? &&
+                !cwd_stat.symlink? && cwd_stat.uid == Process.uid
+        raise Error, "workflow-creator launch inputs are invalid" unless valid
+      rescue SystemCallError, ArgumentError
+        raise Error, "workflow-creator launch inputs are invalid"
+      end
+
+      def validate_receipt!(receipt, label)
+        keys = %w[label exit_code signal completed timed_out containment_established capture teardown]
+        teardown = receipt["teardown"]
+        valid = receipt.instance_of?(Hash) && receipt.keys.sort == keys.sort && receipt["label"] == label &&
+                [ true, false ].include?(receipt["completed"]) && receipt["containment_established"] == true &&
+                teardown.instance_of?(Hash) && teardown.keys.sort ==
+                  %w[status term_sent kill_sent reaped descendants owner_complete].sort
+        raise Error, "workflow-creator supervisor receipt is invalid" unless valid
+      end
+
+      def write_payload(writer, payload)
+        bytes = JSON.generate(payload)
+        writer.write(bytes) if bytes.bytesize <= MAX_IPC_BYTES
+      rescue SystemCallError, IOError
+        nil
+      end
+
+      def terminate_custody(pid, identity)
+        Process.kill("KILL", -pid) if process_start_time(pid) == identity
+      rescue Errno::ESRCH
+        nil
+      ensure
+        Process.waitpid(pid, Process::WNOHANG) rescue nil
+      end
+
+      def settle_custody(pid, identity)
+        Timeout.timeout(@term_grace + @kill_grace + 0.5) { Process.waitpid(pid) }
+      rescue Errno::ECHILD
+        nil
+      rescue Timeout::Error
+        terminate_custody(pid, identity)
+      end
+
+      def caller_lost?(reader)
+        return false unless IO.select([ reader ], nil, nil, 0)
+        reader.read_nonblock(1, exception: false).nil?
+      rescue IOError, Errno::EBADF
+        true
+      end
+
+      def emergency_teardown(pid, status, streams, capture)
+        teardown_tree(pid, status, streams, capture)
+      rescue StandardError
+        %w[TERM KILL].each do |signal|
+          Process.kill(signal, -pid) rescue nil
+          sleep(signal == "TERM" ? @term_grace : @kill_grace)
+        end
+        reap_all(pid, status)
+      end
+
+      def finish_cleanup(matched, removed)
+        @cleanup = @workspace.except("path").merge("identity_matched" => matched, "removed" => removed)
+        copy(@cleanup)
+      end
+
+      def remaining_receipts = @receipts.count { |row| row.dig("teardown", "descendants") != "none" }
+      def safe_string?(value) = value.instance_of?(String) && !value.empty? && !value.include?("\0")
+      def path_exists?(path)
+        File.lstat(path)
+        true
+      rescue Errno::ENOENT
+        false
+      end
+      def monotonic = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      def copy(value) = JSON.parse(JSON.generate(value))
+      def close_ios(*ios) = ios.compact.each { |io| io.close unless io.closed? }
+
+      def positive_integer(value, label)
+        integer = Integer(value)
+        raise Error, "#{label} is invalid" unless integer.positive?
+        integer
+      rescue ArgumentError, TypeError
+        raise Error, "#{label} is invalid"
+      end
+
+      def positive_float(value, label)
+        number = Float(value)
+        raise Error, "#{label} is invalid" unless number.positive? && number.finite?
+        number
+      rescue ArgumentError, TypeError
+        raise Error, "#{label} is invalid"
+      end
+    end
+  end
+end

--- a/packaging/live_agent_skills/workflow_creator_process_supervisor.rb
+++ b/packaging/live_agent_skills/workflow_creator_process_supervisor.rb
@@ -12,9 +12,7 @@ module HiveLiveAgentProof
     class ProcessSupervisor
       class Error < StandardError; end
 
-      COMMAND_LABELS = %w[candidate-version candidate-workflow-list candidate-workflow-new
-                          candidate-workflow-validate candidate-workflow-commit candidate-task-create
-                          candidate-task-run candidate-task-retry candidate-operational-status].freeze
+      COMMAND_LABELS = Vocabulary.fetch("command_labels")
       LABELS = (COMMAND_LABELS + %w[outer-workflow-creator outer-authorized-work]).freeze
       LABEL = /\A[a-z][a-z0-9_-]{0,127}\z/
       MAX_IPC_BYTES = 64 * 1024

--- a/packaging/release_candidate/artifacts.rb
+++ b/packaging/release_candidate/artifacts.rb
@@ -16,7 +16,13 @@ module HiveReleaseCandidate
     KINDS = %w[gem source skills web].freeze
     LIVE_AGENT_BUILDER_INPUTS = %w[
       packaging/live_agent_skills/proof.rb
+      packaging/live_agent_skills/workflow_creator_archive.rb
       packaging/live_agent_skills/workflow_creator_bundle.rb
+      packaging/live_agent_skills/workflow_creator_capture.rb
+      packaging/live_agent_skills/workflow_creator_execution.rb
+      packaging/live_agent_skills/workflow_creator_gateway.rb
+      packaging/live_agent_skills/workflow_creator_installation.rb
+      packaging/live_agent_skills/workflow_creator_process_supervisor.rb
       packaging/live_agent_skills/workflow_creator.rb
       packaging/live_agent_skills/workflow_creator_contract.rb
       packaging/live_agent_skills/workflow_creator_execution_contract.rb

--- a/test/unit/component_boundaries_test.rb
+++ b/test/unit/component_boundaries_test.rb
@@ -304,6 +304,19 @@ class ComponentBoundariesTest < Minitest::Test
                  workflow_core.dig("entrypoint", "require")
     assert_equal [ "workflow-creator-values" ], workflow_core.fetch("component_dependencies")
     assert_equal %w[
+      HiveLiveAgentProof::WorkflowCreator::Vocabulary
+      HiveLiveAgentProof::WorkflowCreator.commands_for
+      HiveLiveAgentProof::WorkflowCreator.failure
+      HiveLiveAgentProof::WorkflowCreator.validate_nonpassing!
+      HiveLiveAgentProof::WorkflowCreator.validate_primary!
+      HiveLiveAgentProof::WorkflowCreator.validate_installation!
+      HiveLiveAgentProof::WorkflowCreator.validate_execution!
+      HiveLiveAgentProof::WorkflowCreatorBundle.source
+      HiveLiveAgentProof::WorkflowCreatorBundle.retained
+      HiveLiveAgentProof::WorkflowCreatorEvidence.initialize!
+      HiveLiveAgentProof::WorkflowCreatorEvidence.replace_nonpassing!
+    ], workflow_core.dig("public_contract", "values")
+    assert_equal %w[
       packaging/live_agent_skills/workflow_creator.rb
       packaging/live_agent_skills/workflow_creator_contract.rb
       packaging/live_agent_skills/workflow_creator_execution_contract.rb
@@ -493,11 +506,11 @@ class ComponentBoundariesTest < Minitest::Test
 
     line_count = ->(*names) { names.sum { |name| File.readlines(File.join(directory, name)).length } }
     assert_operator line_count.call("workflow_creator_archive.rb", "workflow_creator_installation.rb"),
-                    :<=, 390
+                    :<=, 410
     assert_operator line_count.call("workflow_creator_capture.rb", "workflow_creator_process_supervisor.rb"),
-                    :<=, 485
+                    :<=, 495
     assert_operator line_count.call("workflow_creator_gateway.rb", "workflow_creator_execution.rb"),
-                    :<=, 575
+                    :<=, 600
 
     assert contract.validate_static_boundaries!
   end

--- a/test/unit/component_boundaries_test.rb
+++ b/test/unit/component_boundaries_test.rb
@@ -350,6 +350,8 @@ class ComponentBoundariesTest < Minitest::Test
     assert_equal(
       %w[
         HiveLiveAgentProof::WorkflowCreatorExecution.start!
+        HiveLiveAgentProof::WorkflowCreatorExecution::Draft
+        HiveLiveAgentProof::WorkflowCreatorExecution::Result
         HiveLiveAgentProof::WorkflowCreatorExecution#gateway_path
         HiveLiveAgentProof::WorkflowCreatorExecution#workspace_path
         HiveLiveAgentProof::WorkflowCreatorExecution#run_outer_workflow_creator
@@ -495,7 +497,7 @@ class ComponentBoundariesTest < Minitest::Test
     assert_operator line_count.call("workflow_creator_capture.rb", "workflow_creator_process_supervisor.rb"),
                     :<=, 485
     assert_operator line_count.call("workflow_creator_gateway.rb", "workflow_creator_execution.rb"),
-                    :<=, 520
+                    :<=, 575
 
     assert contract.validate_static_boundaries!
   end

--- a/test/unit/component_boundaries_test.rb
+++ b/test/unit/component_boundaries_test.rb
@@ -24,6 +24,7 @@ class ComponentBoundariesTest < Minitest::Test
       user-service
       work-ledger
       workflow-creator-core
+      workflow-creator-execution
       workflow-creator-values
     ], contract.components.map { |component| component.fetch("id") }.sort
 
@@ -316,12 +317,73 @@ class ComponentBoundariesTest < Minitest::Test
     ], workflow_core.fetch("hive_consumers")
     assert_equal [ "HiveLiveAgentProof::WorkflowCreatorReceiptPublisher" ],
                  workflow_core.fetch("forbidden_constructions")
-    assert_equal [ "packaging/live_agent_skills/workflow_creator_evidence.rb" ],
+    assert_equal %w[
+      packaging/live_agent_skills/workflow_creator_evidence.rb
+      packaging/live_agent_skills/workflow_creator_execution.rb
+    ],
                  workflow_core.fetch("authorized_internal_constructions").first.fetch("files")
     assert_empty workflow_core.fetch("migration_exceptions")
 
+    workflow_execution = contract.component("workflow-creator-execution")
+    assert_equal "boundary-ready", workflow_execution.fetch("state")
+    assert_equal(
+      {
+        "file" => "packaging/live_agent_skills/workflow_creator_execution.rb",
+        "require" => "./packaging/live_agent_skills/workflow_creator_execution",
+        "constant" => "HiveLiveAgentProof::WorkflowCreatorExecution"
+      },
+      workflow_execution.fetch("entrypoint")
+    )
+    assert_equal %w[
+      packaging/live_agent_skills/workflow_creator_execution.rb
+      packaging/live_agent_skills/workflow_creator_installation.rb
+      packaging/live_agent_skills/workflow_creator_gateway.rb
+      packaging/live_agent_skills/workflow_creator_archive.rb
+      packaging/live_agent_skills/workflow_creator_process_supervisor.rb
+      packaging/live_agent_skills/workflow_creator_capture.rb
+    ], workflow_execution.fetch("owned_paths")
+    assert_equal [ "workflow-creator-core" ],
+                 workflow_execution.fetch("component_dependencies")
+    assert_empty workflow_execution.fetch("allowed_hive_dependencies")
+    assert_equal [ "packaging/live_agent_skills/proof.rb" ],
+                 workflow_execution.fetch("hive_consumers")
+    assert_equal(
+      %w[
+        HiveLiveAgentProof::WorkflowCreatorExecution.start!
+        HiveLiveAgentProof::WorkflowCreatorExecution#gateway_path
+        HiveLiveAgentProof::WorkflowCreatorExecution#workspace_path
+        HiveLiveAgentProof::WorkflowCreatorExecution#run_outer_workflow_creator
+        HiveLiveAgentProof::WorkflowCreatorExecution#run_outer_authorized_work
+        HiveLiveAgentProof::WorkflowCreatorExecution#draft!
+        HiveLiveAgentProof::WorkflowCreatorExecution#finish!
+        HiveLiveAgentProof::WorkflowCreatorExecution#result
+        HiveLiveAgentProof::WorkflowCreatorExecution#close
+      ],
+      workflow_execution.dig("public_contract", "values")
+    )
+    assert_equal %w[
+      HiveLiveAgentProof::WorkflowCreatorExecution::Error
+      HiveLiveAgentProof::WorkflowCreatorExecution::Conflict
+      HiveLiveAgentProof::WorkflowCreatorExecution::Unavailable
+    ],
+                 workflow_execution.dig("public_contract", "errors")
+    assert_equal(
+      {
+        "HiveLiveAgentProof::WorkflowCreatorGateway" =>
+          [ "packaging/live_agent_skills/workflow_creator_execution.rb" ],
+        "HiveLiveAgentProof::WorkflowCreator::ProcessSupervisor" =>
+          [ "packaging/live_agent_skills/workflow_creator_execution.rb" ],
+        "HiveLiveAgentProof::WorkflowCreator::Capture" =>
+          [ "packaging/live_agent_skills/workflow_creator_process_supervisor.rb" ]
+      },
+      workflow_execution.fetch("authorized_internal_constructions").to_h do |entry|
+        [ entry.fetch("constant"), entry.fetch("files") ]
+      end
+    )
+    assert_empty workflow_execution.fetch("migration_exceptions")
+
     ready_components.push(agent_abi, artifact_firewall, skillpack, git_gate, work_ledger,
-                          workflow_values, workflow_core)
+                          workflow_values, workflow_core, workflow_execution)
     remaining_candidates = contract.components.reject do |component|
       ready_components.include?(component)
     end
@@ -338,6 +400,7 @@ class ComponentBoundariesTest < Minitest::Test
       user-service
       work-ledger
       workflow-creator-core
+      workflow-creator-execution
       workflow-creator-values
     ], ready_loads.keys.sort
     agent_abi_load = ready_loads.fetch("agent-abi")
@@ -368,11 +431,73 @@ class ComponentBoundariesTest < Minitest::Test
     assert_equal "HiveLiveAgentProof::WorkflowCreatorEvidence", workflow_core_load.fetch("constant")
     assert_empty workflow_core_load.fetch("forbidden_loaded_features")
     assert_empty workflow_core_load.fetch("forbidden_constants")
+    workflow_execution_load = ready_loads.fetch("workflow-creator-execution")
+    assert_equal "HiveLiveAgentProof::WorkflowCreatorExecution",
+                 workflow_execution_load.fetch("constant")
+    assert_empty workflow_execution_load.fetch("forbidden_loaded_features")
+    assert_empty workflow_execution_load.fetch("forbidden_constants")
     patrol_effects_load = contract.validate_clean_load!("patrol-effects")
     assert_equal "Hive::Modules::Migration::PatrolEvidence",
                  patrol_effects_load.fetch("constant")
     assert_empty patrol_effects_load.fetch("forbidden_loaded_features")
     assert_empty patrol_effects_load.fetch("forbidden_constants")
+  end
+
+  def test_workflow_creator_execution_closure_construction_roots_and_line_budgets
+    contract = ComponentBoundaryContract.new(@document, root: ROOT)
+    component = contract.component("workflow-creator-execution")
+    directory = File.join(ROOT, "packaging", "live_agent_skills")
+    paths = component.fetch("owned_paths")
+    sources = paths.to_h { |relative| [ relative, File.read(File.join(ROOT, relative)) ] }
+
+    assert_equal 6, paths.length
+    assert_equal [ "workflow-creator-core" ], component.fetch("component_dependencies")
+    assert_empty component.fetch("allowed_hive_dependencies")
+    assert sources.values.none? { |source| source.match?(/^require ["']hive\//) }
+
+    allowed_relatives = %w[
+      workflow_creator
+      workflow_creator_archive
+      workflow_creator_capture
+      workflow_creator_gateway
+      workflow_creator_installation
+      workflow_creator_process_supervisor
+      workflow_creator_evidence
+      workflow_creator_receipt_publisher
+    ]
+    require_graph = sources.transform_values do |source|
+      source.scan(/^require_relative ["']([^"']+)["']/).flatten
+    end
+    assert_empty require_graph.values.flatten - allowed_relatives,
+                 "U14 source closure must stay inside its six owners and workflow-creator-core"
+    assert_equal [ "workflow_creator" ],
+                 require_graph.fetch("packaging/live_agent_skills/workflow_creator_archive.rb")
+    assert_equal [ "workflow_creator" ],
+                 require_graph.fetch("packaging/live_agent_skills/workflow_creator_installation.rb")
+    assert_equal [ "workflow_creator" ],
+                 require_graph.fetch("packaging/live_agent_skills/workflow_creator_capture.rb")
+    assert_equal [ "workflow_creator_capture" ],
+                 require_graph.fetch("packaging/live_agent_skills/workflow_creator_process_supervisor.rb")
+    assert_equal [ "workflow_creator_process_supervisor" ],
+                 require_graph.fetch("packaging/live_agent_skills/workflow_creator_gateway.rb")
+
+    supervisor = sources.fetch(
+      "packaging/live_agent_skills/workflow_creator_process_supervisor.rb"
+    )
+    assert_includes supervisor,
+                    'COMMAND_LABELS = Vocabulary.fetch("command_labels")'
+    assert_includes sources.fetch("packaging/live_agent_skills/workflow_creator_gateway.rb"),
+                    'WorkflowCreator::Vocabulary.fetch("command_labels")'
+
+    line_count = ->(*names) { names.sum { |name| File.readlines(File.join(directory, name)).length } }
+    assert_operator line_count.call("workflow_creator_archive.rb", "workflow_creator_installation.rb"),
+                    :<=, 390
+    assert_operator line_count.call("workflow_creator_capture.rb", "workflow_creator_process_supervisor.rb"),
+                    :<=, 485
+    assert_operator line_count.call("workflow_creator_gateway.rb", "workflow_creator_execution.rb"),
+                    :<=, 520
+
+    assert contract.validate_static_boundaries!
   end
 
   def test_workflow_creator_bundle_dependency_direction_and_budget
@@ -393,14 +518,17 @@ class ComponentBoundariesTest < Minitest::Test
   end
 
 
-  def test_workflow_creator_publisher_is_constructed_only_by_the_typed_facade
+  def test_workflow_creator_publisher_is_constructed_only_by_fixed_typed_facades
     contract = ComponentBoundaryContract.new(@document, root: ROOT)
     component = contract.component("workflow-creator-core")
     publisher = "HiveLiveAgentProof::WorkflowCreatorReceiptPublisher"
     authorized = component.fetch("authorized_internal_constructions").first
 
     assert_equal publisher, authorized.fetch("constant")
-    assert_equal [ "packaging/live_agent_skills/workflow_creator_evidence.rb" ],
+    assert_equal %w[
+      packaging/live_agent_skills/workflow_creator_evidence.rb
+      packaging/live_agent_skills/workflow_creator_execution.rb
+    ],
                  authorized.fetch("files")
     assert contract.validate_static_boundaries!
 
@@ -563,7 +691,11 @@ class ComponentBoundariesTest < Minitest::Test
     end
 
     assert_equal(
-      { "skillpack" => [ "agent-abi" ], "workflow-creator-core" => [ "workflow-creator-values" ] },
+      {
+        "skillpack" => [ "agent-abi" ],
+        "workflow-creator-core" => [ "workflow-creator-values" ],
+        "workflow-creator-execution" => [ "workflow-creator-core" ]
+      },
       dependencies
     )
   end

--- a/test/unit/packaging/live_agent_proof_test.rb
+++ b/test/unit/packaging/live_agent_proof_test.rb
@@ -9,6 +9,7 @@ class LiveAgentProofTest < Minitest::Test
   WORKFLOW_SHA = "b" * 40
   REPOSITORY = "ivankuznetsov/hive"
   Creator = HiveLiveAgentProof::WorkflowCreator
+  CREATOR_TASK_SLUG = "research-and-draft-the-launch-260804-ab12"
 
   def test_builder_produces_deterministic_four_platform_artifacts
     with_tmp_dir do |dir|
@@ -438,9 +439,12 @@ class LiveAgentProofTest < Minitest::Test
       "task_prompt_sha256" => Digest::SHA256.hexdigest(Creator::Vocabulary.fetch("task_prompt")),
       "skill" => manifest.slice("skill_version", "canonical_digest"),
       "native_activation" => deep_dup(Creator::Vocabulary.fetch("native_activation")),
-      "hive_commands" => deep_dup(Creator::Vocabulary.fetch("commands")), "created_files" => created,
+      "hive_commands" => deep_dup(Creator.commands_for(task_slug: CREATOR_TASK_SLUG).value),
+      "created_files" => created,
       "validation" => deep_dup(Creator::Vocabulary.fetch("graph")), "creation_only_task_count" => 0,
-      "task_count" => 1, "task" => deep_dup(Creator::Vocabulary.fetch("task")), "external_actions" => [],
+      "task_count" => 1,
+      "task" => deep_dup(Creator::Vocabulary.fetch("task")).merge("slug" => CREATOR_TASK_SLUG),
+      "external_actions" => [],
       "secret_scan" => creator_passing_scan, "execution_kind" => "authenticated_openclaw",
       "model_loop" => "executed", "executed_instruction" => deep_dup(created.fetch(2)),
       "evidence_bundle" => deep_dup(records), "containment" => deep_dup(summary),
@@ -449,10 +453,8 @@ class LiveAgentProofTest < Minitest::Test
   end
 
   def creator_execution_receipt(row, records, installations)
-    command_labels = Creator::Vocabulary.fetch("commands").each_index.map do |index|
-      format("command-%02d", index + 1)
-    end
-    commands = Creator::Vocabulary.fetch("commands").each_with_index.map do |argv, index|
+    command_labels = Creator::Vocabulary.fetch("command_labels")
+    commands = Creator.commands_for(task_slug: CREATOR_TASK_SLUG).value.each_with_index.map do |argv, index|
       creator_process_receipt("attempt_label" => command_labels.fetch(index)).merge(
         "position" => index + 1, "argv" => deep_dup(argv)
       )
@@ -483,6 +485,9 @@ class LiveAgentProofTest < Minitest::Test
         "nested_stage" => { "execution_kind" => "deterministic_fixture", "model_loop" => "not_exercised" }
       },
       "installed_manifests" => deep_dup(records.first(2)),
+      "task_slug_binding" => deep_dup(Creator::Vocabulary.fetch("task_slug_binding")).merge(
+        "value" => CREATOR_TASK_SLUG
+      ),
       "run" => { "correlation_id" => correlation, "expected_labels" => labels },
       "gateway" => {
         "identity" => deep_dup(installations.fetch("candidate").dig("required_roles", "audit_gateway")),

--- a/test/unit/packaging/release_candidate_artifacts_test.rb
+++ b/test/unit/packaging/release_candidate_artifacts_test.rb
@@ -10,7 +10,13 @@ class ReleaseCandidateArtifactsTest < Minitest::Test
 
   BUILDER_INPUTS = %w[
     packaging/live_agent_skills/proof.rb
+    packaging/live_agent_skills/workflow_creator_archive.rb
     packaging/live_agent_skills/workflow_creator_bundle.rb
+    packaging/live_agent_skills/workflow_creator_capture.rb
+    packaging/live_agent_skills/workflow_creator_execution.rb
+    packaging/live_agent_skills/workflow_creator_gateway.rb
+    packaging/live_agent_skills/workflow_creator_installation.rb
+    packaging/live_agent_skills/workflow_creator_process_supervisor.rb
     packaging/live_agent_skills/workflow_creator.rb
     packaging/live_agent_skills/workflow_creator_contract.rb
     packaging/live_agent_skills/workflow_creator_execution_contract.rb

--- a/test/unit/packaging/workflow_creator_archive_test.rb
+++ b/test/unit/packaging/workflow_creator_archive_test.rb
@@ -63,7 +63,8 @@ class WorkflowCreatorArchiveTest < Minitest::Test
       "traversal" => [ [ :file, "../escape", "x" ] ],
       "absolute" => [ [ :file, "/escape", "x" ] ],
       "duplicate" => [ [ :file, "same", "x" ], [ :file, "same", "y" ] ],
-      "file-parent" => [ [ :file, "node", "x" ], [ :file, "node/child", "y" ] ]
+      "file-parent" => [ [ :file, "node", "x" ], [ :file, "node/child", "y" ] ],
+      "separated-file-parent" => [ [ :file, "a", "x" ], [ :file, "a.", "x" ], [ :file, "a/child", "y" ] ]
     }
 
     cases.each do |name, entries|
@@ -74,6 +75,21 @@ class WorkflowCreatorArchiveTest < Minitest::Test
         error = assert_raises(Archive::Error, name) { admit(path) }
         assert_equal "workflow-creator archive is not safely admissible", error.message
       end
+    end
+  end
+
+  def test_refuses_trailing_gzip_members_and_raw_gem_bytes
+    with_tmp_dir do |root|
+      path = File.join(root, "concatenated.tar.gz")
+      first = gzip_tar_bytes { |tar| tar.add_file_simple("first", 0o644, 1) { |io| io.write("a") } }
+      second = gzip_tar_bytes { |tar| tar.add_file_simple("second", 0o644, 1) { |io| io.write("b") } }
+      File.binwrite(path, first + second)
+
+      assert_raises(Archive::Error) { admit(path) }
+
+      gem = build_fixture_gem(root)
+      File.open(gem, "ab") { |file| file.write("trailing") }
+      assert_raises(Archive::Error) { admit(gem, label: "candidate-package") }
     end
   end
 

--- a/test/unit/packaging/workflow_creator_archive_test.rb
+++ b/test/unit/packaging/workflow_creator_archive_test.rb
@@ -1,0 +1,127 @@
+require "test_helper"
+require "digest"
+require "rubygems/package"
+require "zlib"
+require_relative "../../../packaging/live_agent_skills/workflow_creator_archive"
+
+class WorkflowCreatorArchiveTest < Minitest::Test
+  include HiveTestHelper
+
+  Archive = HiveLiveAgentProof::WorkflowCreatorArchive
+  Creator = HiveLiveAgentProof::WorkflowCreator
+
+  def test_public_api_admits_a_regular_archive_into_the_exact_execution_record
+    with_tmp_dir do |root|
+      path = File.join(root, "candidate.tar.gz")
+      write_archive(path, [ [ :directory, "bin", nil ], [ :file, "bin/hive", "hive\n" ] ])
+
+      result = Archive.admit!(
+        archive: path, label: "candidate-package", available_bytes: 1_000_000,
+        available_entries: 100
+      )
+
+      assert_equal %i[admit!], Archive.singleton_methods(false)
+      assert_equal %i[archive label available_bytes available_entries clock],
+                   Archive.method(:admit!).parameters.map(&:last)
+      assert_equal({
+        "label" => "candidate-package", "artifact_sha256" => Digest::SHA256.file(path).hexdigest,
+        "artifact_size" => File.size(path),
+        "policy_sha256" => Creator::Vocabulary.fetch("archive_policy_sha256"),
+        "entry_count" => 2, "uncompressed_bytes" => 5, "status" => "passed"
+      }, result.value)
+      assert_equal result.canonical_bytes, Creator::Values.capture(result.value).canonical_bytes
+      assert result.frozen?
+    end
+  end
+
+  def test_refuses_traversal_absolute_duplicate_and_conflicting_destinations
+    cases = {
+      "traversal" => [ [ :file, "../escape", "x" ] ],
+      "absolute" => [ [ :file, "/escape", "x" ] ],
+      "duplicate" => [ [ :file, "same", "x" ], [ :file, "same", "y" ] ],
+      "file-parent" => [ [ :file, "node", "x" ], [ :file, "node/child", "y" ] ]
+    }
+
+    cases.each do |name, entries|
+      with_tmp_dir do |root|
+        path = File.join(root, "#{name}.tar.gz")
+        write_archive(path, entries)
+
+        error = assert_raises(Archive::Error, name) { admit(path) }
+        assert_equal "workflow-creator archive is not safely admissible", error.message
+      end
+    end
+  end
+
+  def test_refuses_links_devices_and_other_special_members
+    %w[1 2 3 4 6 x].each do |type|
+      with_tmp_dir do |root|
+        path = File.join(root, "special.tar.gz")
+        write_raw_archive(path, name: "unsafe", typeflag: type)
+
+        assert_raises(Archive::Error, "type #{type}") { admit(path) }
+      end
+    end
+  end
+
+  def test_refuses_depth_path_compression_time_and_filesystem_budget_exhaustion
+    with_tmp_dir do |root|
+      path = File.join(root, "limits.tar.gz")
+      write_archive(path, [ [ :file, ([ "deep" ] * 33).join("/"), "x" ] ])
+      assert_raises(Archive::Error) { admit(path) }
+
+      long_path = "#{"p" * 140}/#{"q" * 100}"
+      write_archive(path, [ [ :file, long_path, "x" ] ])
+      assert_raises(Archive::Error) { admit(path) }
+
+      write_archive(path, [ [ :file, "bomb", "\0" * 200_000 ] ])
+      assert_raises(Archive::Error) { admit(path) }
+
+      write_archive(path, [ [ :file, "safe", "content" ] ])
+      assert_raises(Archive::Error) { admit(path, available_bytes: 6) }
+      assert_raises(Archive::Error) { admit(path, available_entries: 0) }
+
+      ticks = [ 0.0, 0.0, 6.0 ]
+      assert_raises(Archive::Error) { admit(path, clock: -> { ticks.shift || 6.0 }) }
+    end
+  end
+
+  def test_refuses_a_linked_or_replaced_archive_file
+    with_tmp_dir do |root|
+      path = File.join(root, "archive.tar.gz")
+      write_archive(path, [ [ :file, "safe", "content" ] ])
+      File.link(path, File.join(root, "alias.tar.gz"))
+
+      assert_raises(Archive::Error) { admit(path) }
+    end
+  end
+
+  private
+
+  def admit(path, available_bytes: 1_000_000, available_entries: 100, clock: nil)
+    Archive.admit!(
+      archive: path, label: "candidate-package", available_bytes:, available_entries:, clock:
+    )
+  end
+
+  def write_archive(path, entries)
+    Zlib::GzipWriter.open(path) do |gzip|
+      Gem::Package::TarWriter.new(gzip) do |tar|
+        entries.each do |kind, name, content|
+          if kind == :directory
+            tar.mkdir(name, 0o755)
+          else
+            tar.add_file_simple(name, 0o644, content.bytesize) { |io| io.write(content) }
+          end
+        end
+      end
+    end
+  end
+
+  def write_raw_archive(path, name:, typeflag:)
+    header = Gem::Package::TarHeader.new(
+      name:, prefix: "", mode: 0o644, size: 0, typeflag:, linkname: "target"
+    )
+    Zlib::GzipWriter.open(path) { |gzip| gzip.write(header.to_s + ("\0" * 1_024)) }
+  end
+end

--- a/test/unit/packaging/workflow_creator_archive_test.rb
+++ b/test/unit/packaging/workflow_creator_archive_test.rb
@@ -1,6 +1,7 @@
 require "test_helper"
 require "digest"
 require "rubygems/package"
+require "stringio"
 require "zlib"
 require_relative "../../../packaging/live_agent_skills/workflow_creator_archive"
 
@@ -12,11 +13,11 @@ class WorkflowCreatorArchiveTest < Minitest::Test
 
   def test_public_api_admits_a_regular_archive_into_the_exact_execution_record
     with_tmp_dir do |root|
-      path = File.join(root, "candidate.tar.gz")
+      path = File.join(root, "openclaw.tar.gz")
       write_archive(path, [ [ :directory, "bin", nil ], [ :file, "bin/hive", "hive\n" ] ])
 
       result = Archive.admit!(
-        archive: path, label: "candidate-package", available_bytes: 1_000_000,
+        archive: path, label: "openclaw-package", available_bytes: 1_000_000,
         available_entries: 100
       )
 
@@ -24,13 +25,36 @@ class WorkflowCreatorArchiveTest < Minitest::Test
       assert_equal %i[archive label available_bytes available_entries clock],
                    Archive.method(:admit!).parameters.map(&:last)
       assert_equal({
-        "label" => "candidate-package", "artifact_sha256" => Digest::SHA256.file(path).hexdigest,
+        "label" => "openclaw-package", "artifact_sha256" => Digest::SHA256.file(path).hexdigest,
         "artifact_size" => File.size(path),
         "policy_sha256" => Creator::Vocabulary.fetch("archive_policy_sha256"),
         "entry_count" => 2, "uncompressed_bytes" => 5, "status" => "passed"
       }, result.value)
       assert_equal result.canonical_bytes, Creator::Values.capture(result.value).canonical_bytes
       assert result.frozen?
+    end
+  end
+
+  def test_candidate_admits_a_real_gem_envelope_and_its_nested_data_archive
+    with_tmp_dir do |root|
+      path = build_fixture_gem(root)
+
+      result = admit(path, label: "candidate-package")
+
+      assert_equal "candidate-package", result.value.fetch("label")
+      assert_equal Digest::SHA256.file(path).hexdigest, result.value.fetch("artifact_sha256")
+      assert_equal 4, result.value.fetch("entry_count")
+      assert_operator result.value.fetch("uncompressed_bytes"), :>, "FIXTURE = true\n".bytesize
+    end
+  end
+
+  def test_candidate_refuses_an_unsafe_member_inside_nested_data_archive
+    with_tmp_dir do |root|
+      path = File.join(root, "unsafe.gem")
+      nested = gzip_tar_bytes { |tar| tar.add_symlink("lib/escape", "../../outside", 0o777) }
+      write_gem_envelope(path, nested)
+
+      assert_raises(Archive::Error) { admit(path, label: "candidate-package") }
     end
   end
 
@@ -98,9 +122,9 @@ class WorkflowCreatorArchiveTest < Minitest::Test
 
   private
 
-  def admit(path, available_bytes: 1_000_000, available_entries: 100, clock: nil)
+  def admit(path, label: "openclaw-package", available_bytes: 1_000_000, available_entries: 100, clock: nil)
     Archive.admit!(
-      archive: path, label: "candidate-package", available_bytes:, available_entries:, clock:
+      archive: path, label:, available_bytes:, available_entries:, clock:
     )
   end
 
@@ -123,5 +147,47 @@ class WorkflowCreatorArchiveTest < Minitest::Test
       name:, prefix: "", mode: 0o644, size: 0, typeflag:, linkname: "target"
     )
     Zlib::GzipWriter.open(path) { |gzip| gzip.write(header.to_s + ("\0" * 1_024)) }
+  end
+
+  def build_fixture_gem(root)
+    FileUtils.mkdir_p(File.join(root, "lib"))
+    File.write(File.join(root, "lib", "workflow_creator_fixture.rb"), "FIXTURE = true\n")
+    spec = Gem::Specification.new do |value|
+      value.name = "workflow-creator-fixture"
+      value.version = "1.0.0"
+      value.summary = "Workflow creator archive fixture"
+      value.authors = [ "Hive" ]
+      value.files = [ "lib/workflow_creator_fixture.rb" ]
+    end
+    filename = nil
+    capture_io { Dir.chdir(root) { filename = Gem::Package.build(spec, true) } }
+    File.join(root, filename)
+  end
+
+  def write_gem_envelope(path, nested)
+    File.open(path, "wb") do |file|
+      Gem::Package::TarWriter.new(file) do |tar|
+        { "metadata.gz" => gzip_bytes("metadata"), "data.tar.gz" => nested,
+          "checksums.yaml.gz" => gzip_bytes("checksums") }.each do |name, bytes|
+          tar.add_file_simple(name, 0o644, bytes.bytesize) { |entry| entry.write(bytes) }
+        end
+      end
+    end
+  end
+
+  def gzip_tar_bytes
+    io = StringIO.new("".b)
+    gzip = Zlib::GzipWriter.new(io)
+    Gem::Package::TarWriter.new(gzip) { |tar| yield tar }
+    gzip.finish
+    io.string
+  end
+
+  def gzip_bytes(bytes)
+    io = StringIO.new("".b)
+    gzip = Zlib::GzipWriter.new(io)
+    gzip.write(bytes)
+    gzip.finish
+    io.string
   end
 end

--- a/test/unit/packaging/workflow_creator_capture_test.rb
+++ b/test/unit/packaging/workflow_creator_capture_test.rb
@@ -1,0 +1,77 @@
+require "test_helper"
+require "digest"
+require_relative "../../../packaging/live_agent_skills/workflow_creator_capture"
+
+class WorkflowCreatorCaptureTest < Minitest::Test
+  Capture = HiveLiveAgentProof::WorkflowCreator::Capture
+
+  def test_caps_each_stream_and_digests_only_admitted_bytes
+    capture = Capture.new(limit_bytes: 8, tail_bytes: 16)
+    capture.write(:stdout, "abc")
+    capture.write(:stdout, "defghijkl")
+    capture.write(:stderr, "err")
+
+    result = capture.finish
+
+    assert_equal 8, result.fetch("stdout_bytes")
+    assert_equal Digest::SHA256.hexdigest("abcdefgh"), result.fetch("stdout_sha256")
+    assert result.fetch("stdout_truncated")
+    assert_equal 3, result.fetch("stderr_bytes")
+    assert_equal Digest::SHA256.hexdigest("err"), result.fetch("stderr_sha256")
+    refute result.fetch("stderr_truncated")
+    assert_equal "abcdefghijkl", result.dig("tails", "stdout")
+    assert_equal "passed", result.dig("secret_scan", "status")
+  end
+
+  def test_detects_an_exact_secret_split_across_chunks_and_redacts_the_tail
+    secret = "creator-secret-value"
+    capture = Capture.new(limit_bytes: 64, tail_bytes: 64, exact_secrets: [ secret ])
+
+    capture.write(:stdout, "safe creator-se")
+    capture.write(:stdout, "cret-value suffix")
+    result = capture.finish
+
+    assert_equal "failed", result.dig("secret_scan", "status")
+    assert_equal [ "stdout:exact-secret:0" ], result.dig("secret_scan", "findings")
+    assert_equal "[REDACTED]", result.dig("tails", "stdout")
+    refute_includes result.to_s, secret
+  end
+
+  def test_detects_a_secret_pattern_split_across_chunks_after_the_byte_cap
+    token = "sk-proj-#{'a' * 24}"
+    capture = Capture.new(limit_bytes: 4, tail_bytes: 32)
+
+    capture.write(:stderr, "noise" * 2_000 + token.byteslice(0, 10))
+    capture.write(:stderr, token.byteslice(10, token.bytesize))
+    result = capture.finish
+
+    assert_equal 4, result.fetch("stderr_bytes")
+    assert result.fetch("stderr_truncated")
+    assert_includes result.dig("secret_scan", "findings"), "stderr:pattern:openai"
+    assert_equal "[REDACTED]", result.dig("tails", "stderr")
+  end
+
+  def test_empty_streams_have_the_empty_digest_and_bounded_utf8_tails
+    capture = Capture.new(limit_bytes: 32, tail_bytes: 5)
+    capture.write(:stdout, "x\xFFé".b)
+    result = capture.finish
+
+    assert_equal Digest::SHA256.hexdigest(""), result.fetch("stderr_sha256")
+    assert_equal "xé", result.dig("tails", "stdout")
+    assert_operator result.dig("tails", "stdout").bytesize, :<=, 5
+  end
+
+  def test_rejects_invalid_limits_streams_chunks_and_exact_secrets
+    assert_raises(Capture::Error) { Capture.new(limit_bytes: 0) }
+    assert_raises(Capture::Error) { Capture.new(limit_bytes: 1_048_577) }
+    assert_raises(Capture::Error) { Capture.new(limit_bytes: 8, tail_bytes: 4_097) }
+    assert_raises(Capture::Error) { Capture.new(limit_bytes: 8, exact_secrets: [ "" ]) }
+    assert_raises(Capture::Error) { Capture.new(limit_bytes: 8, exact_secrets: [ "x" ] * 65) }
+
+    capture = Capture.new(limit_bytes: 8)
+    assert_raises(Capture::Error) { capture.write(:other, "value") }
+    assert_raises(Capture::Error) { capture.write(:stdout, Object.new) }
+    capture.finish
+    assert_raises(Capture::Error) { capture.write(:stdout, "late") }
+  end
+end

--- a/test/unit/packaging/workflow_creator_capture_test.rb
+++ b/test/unit/packaging/workflow_creator_capture_test.rb
@@ -37,6 +37,18 @@ class WorkflowCreatorCaptureTest < Minitest::Test
     refute_includes result.to_s, secret
   end
 
+  def test_detects_a_maximum_window_secret_before_trimming_scan_overlap
+    secret = "s" * 3_000
+    capture = Capture.new(limit_bytes: 8_192, exact_secrets: [ secret ])
+
+    capture.write(:stdout, ("x" * 1_097) + secret + ("y" * 2_047))
+    result = capture.finish
+
+    assert_equal "failed", result.dig("secret_scan", "status")
+    assert_equal [ "stdout:exact-secret:0" ], result.dig("secret_scan", "findings")
+    assert_equal "[REDACTED]", result.dig("tails", "stdout")
+  end
+
   def test_detects_a_secret_pattern_split_across_chunks_after_the_byte_cap
     token = "sk-proj-#{'a' * 24}"
     capture = Capture.new(limit_bytes: 4, tail_bytes: 32)

--- a/test/unit/packaging/workflow_creator_core_test.rb
+++ b/test/unit/packaging/workflow_creator_core_test.rb
@@ -13,6 +13,7 @@ class WorkflowCreatorCoreTest < Minitest::Test
   ROOT = File.expand_path("../../..", __dir__)
   SHA = "a" * 40
   DIGEST = "b" * 64
+  TASK_SLUG = "research-and-draft-the-launch-260804-ab12"
   Creator = HiveLiveAgentProof::WorkflowCreator
   Values = Creator::Values
   SOURCES = %w[
@@ -26,12 +27,13 @@ class WorkflowCreatorCoreTest < Minitest::Test
 
   def test_public_api_and_vocabulary_are_exact_and_deeply_frozen
     assert_equal %i[
-      failure validate_execution! validate_installation! validate_nonpassing! validate_primary!
+      commands_for failure validate_execution! validate_installation! validate_nonpassing! validate_primary!
     ], Creator.singleton_methods(false).sort
     assert Creator::Error < StandardError
     assert_equal %w[
       schema_version evidence_schema installed_schema execution_schema execution_plan scanner
-      request prompt task_request task_key task_slug task_prompt task_new_argv commands files
+      request prompt task_request task_key task_slug task_prompt task_new_argv command_labels commands
+      task_slug_binding files
       executed_instruction native_activation graph task classification bundle_files member_roles
       outer_roles archive_labels archive_policy_sha256 cleanup_labels
     ], Creator::Vocabulary.keys
@@ -39,6 +41,11 @@ class WorkflowCreatorCoreTest < Minitest::Test
     assert_equal "hive-live-workflow-creator-evidence", Creator::Vocabulary.fetch("evidence_schema")
     assert_equal "hive-live-workflow-creator-installed-manifest", Creator::Vocabulary.fetch("installed_schema")
     assert_equal "hive-live-workflow-creator-execution-receipt", Creator::Vocabulary.fetch("execution_schema")
+    assert_equal [ "run", "{created_slug}" ], Creator::Vocabulary.fetch("commands").fetch(6)
+    assert_equal TASK_SLUG, Creator.commands_for(task_slug: TASK_SLUG).value.fetch(6).fetch(1)
+    assert_equal({ "source_position" => 6, "source_result_field" => "slug",
+                   "target_position" => 7, "target_argument" => 1, "template" => "{created_slug}" },
+                 Creator::Vocabulary.fetch("task_slug_binding"))
     assert_deeply_frozen(Creator::Vocabulary)
   end
 
@@ -172,6 +179,9 @@ class WorkflowCreatorCoreTest < Minitest::Test
       installation_records_type: ->(item) { item[:installation_records] = {} },
       evidence_bundle_length: ->(item) { item[:row]["evidence_bundle"] = [] },
       command_order: ->(item) { item[:receipt]["commands"].reverse! },
+      command_label: ->(item) { item[:receipt]["commands"][0]["attempt_label"] = "command-01" },
+      task_slug_binding: ->(item) { item[:receipt]["task_slug_binding"]["value"] = "other-task-260804-ab12" },
+      task_slug_source: ->(item) { item[:receipt]["task_slug_binding"]["source_position"] = 5 },
       position_float: ->(item) { item[:receipt]["commands"][0]["position"] = 1.0 },
       exit_float: ->(item) { item[:receipt]["commands"][0]["exit_code"] = 0.0 },
       teardown_float: ->(item) { item[:receipt]["teardown"]["remaining_descendants"] = 0.0 },
@@ -220,9 +230,9 @@ class WorkflowCreatorCoreTest < Minitest::Test
   def test_r43_source_metrics_and_explicit_method_overlay_stay_within_budget
     metrics = SOURCES.transform_values { |path| static_metrics(File.read(path)) }
     expected_caps = {
-      "workflow_creator.rb" => [ 125, 7, 4 ],
+      "workflow_creator.rb" => [ 140, 7, 4 ],
       "workflow_creator_contract.rb" => [ 260, 15, 24 ],
-      "workflow_creator_execution_contract.rb" => [ 215, 13, 20 ]
+      "workflow_creator_execution_contract.rb" => [ 235, 14, 20 ]
     }
     SOURCES.each do |name, path|
       lines, callables, decisions = expected_caps.fetch(name)
@@ -231,17 +241,17 @@ class WorkflowCreatorCoreTest < Minitest::Test
       assert_operator metrics.fetch(name).fetch(:decisions), :<=, decisions
       assert_empty metrics.fetch(name).fetch(:closure_nodes)
     end
-    assert_operator SOURCES.values.sum { |path| File.readlines(path).length }, :<=, 590
-    assert_operator metrics.values.sum { |item| item.fetch(:callables) }, :<=, 34
+    assert_operator SOURCES.values.sum { |path| File.readlines(path).length }, :<=, 635
+    assert_operator metrics.values.sum { |item| item.fetch(:callables) }, :<=, 36
     assert_operator metrics.values.sum { |item| item.fetch(:decisions) }, :<=, 48
     values_path = File.join(ROOT, "packaging/live_agent_skills/workflow_creator_values.rb")
     safety_path = File.join(ROOT, "packaging/live_agent_skills/workflow_creator_text_safety.rb")
     values = static_metrics(File.read(values_path))
     safety = static_metrics(File.read(safety_path))
     composed_sources = SOURCES.values + [ values_path, safety_path ]
-    assert_operator composed_sources.sum { |path| File.readlines(path).length }, :<=, 1_090
+    assert_operator composed_sources.sum { |path| File.readlines(path).length }, :<=, 1_135
     assert_operator metrics.values.sum { |item| item.fetch(:callables) } + values.fetch(:callables) +
-                    safety.fetch(:callables), :<=, 68
+                    safety.fetch(:callables), :<=, 70
     assert_operator metrics.values.sum { |item| item.fetch(:decisions) } + values.fetch(:decisions) +
                     safety.fetch(:decisions), :<=, 104
     assert_r43_rubocop
@@ -348,9 +358,10 @@ class WorkflowCreatorCoreTest < Minitest::Test
       "skill" => { "skill_version" => manifest.fetch("skill_version"),
                    "canonical_digest" => manifest.fetch("canonical_digest") },
       "native_activation" => deep_dup(Creator::Vocabulary.fetch("native_activation")),
-      "hive_commands" => deep_dup(Creator::Vocabulary.fetch("commands")), "created_files" => created,
+      "hive_commands" => deep_dup(Creator.commands_for(task_slug: TASK_SLUG).value), "created_files" => created,
       "validation" => deep_dup(Creator::Vocabulary.fetch("graph")), "creation_only_task_count" => 0,
-      "task_count" => 1, "task" => deep_dup(Creator::Vocabulary.fetch("task")), "external_actions" => [],
+      "task_count" => 1, "task" => deep_dup(Creator::Vocabulary.fetch("task")).merge("slug" => TASK_SLUG),
+      "external_actions" => [],
       "secret_scan" => passing_scan, "execution_kind" => "authenticated_openclaw", "model_loop" => "executed",
       "executed_instruction" => deep_dup(created.fetch(2)), "evidence_bundle" => deep_dup(records),
       "containment" => deep_dup(summary), "teardown" => deep_dup(summary), "cleanup" => deep_dup(summary)
@@ -358,8 +369,8 @@ class WorkflowCreatorCoreTest < Minitest::Test
   end
 
   def execution_receipt(row, records, installations)
-    command_labels = Creator::Vocabulary.fetch("commands").each_index.map { |index| format("command-%02d", index + 1) }
-    commands = Creator::Vocabulary.fetch("commands").each_with_index.map do |argv, index|
+    command_labels = Creator::Vocabulary.fetch("command_labels")
+    commands = Creator.commands_for(task_slug: TASK_SLUG).value.each_with_index.map do |argv, index|
       process_receipt("attempt_label" => command_labels.fetch(index)).merge(
         "position" => index + 1, "argv" => deep_dup(argv)
       )
@@ -386,6 +397,7 @@ class WorkflowCreatorCoreTest < Minitest::Test
                             "nested_stage" => { "execution_kind" => "deterministic_fixture",
                                                 "model_loop" => "not_exercised" } },
       "installed_manifests" => deep_dup(records.first(2)),
+      "task_slug_binding" => deep_dup(Creator::Vocabulary.fetch("task_slug_binding")).merge("value" => TASK_SLUG),
       "run" => { "correlation_id" => correlation, "expected_labels" => labels },
       "gateway" => { "identity" => deep_dup(installations.fetch("candidate").dig("required_roles", "audit_gateway")),
                      "command_labels" => command_labels, "status" => "passed" },

--- a/test/unit/packaging/workflow_creator_execution_test.rb
+++ b/test/unit/packaging/workflow_creator_execution_test.rb
@@ -21,14 +21,15 @@ class WorkflowCreatorExecutionTest < Minitest::Test
   def test_real_outer_processes_interleave_gateway_commands_and_publish_support_last
     with_fixture do |fixture|
       primary_path = File.join(fixture.fetch(:bundle_directory), "openclaw-workflow-creator.json")
-      File.binwrite(primary_path, "preexisting-primary\n")
       session = start_session(fixture)
 
       session.run_outer_workflow_creator(
-        argv: [ "creator" ], environment: outer_environment(session, fixture)
+        argv: [ "creator" ], environment: outer_environment(session, fixture),
+        stdin_data: Creator::Vocabulary.fetch("prompt")
       )
       session.run_outer_authorized_work(
-        argv: [ "work" ], environment: outer_environment(session, fixture)
+        argv: [ "work" ], environment: outer_environment(session, fixture),
+        stdin_data: Creator::Vocabulary.fetch("task_prompt")
       )
       fixture_pids = File.readlines(fixture.fetch(:outer_pids), chomp: true).map { |value| Integer(value) }
       observation = file_record(fixture.fetch(:workspace_path), Creator::Vocabulary.fetch("executed_instruction"))
@@ -37,7 +38,7 @@ class WorkflowCreatorExecutionTest < Minitest::Test
       assert_equal %i[receipt_bytes receipt_sha256 receipt_size], draft.members
       assert_equal Digest::SHA256.hexdigest(draft.receipt_bytes), draft.receipt_sha256
       assert_equal draft.receipt_bytes.bytesize, draft.receipt_size
-      assert_equal "preexisting-primary\n", File.binread(primary_path)
+      refute File.exist?(primary_path)
       refute Dir.exist?(fixture.fetch(:workspace_path))
       assert fixture_pids.none? { |pid| process_alive?(pid) }
       refute File.exist?(File.join(fixture.dig(:candidate, "root"), "audit", ".workflow-creator-gateway.sock"))
@@ -45,10 +46,11 @@ class WorkflowCreatorExecutionTest < Minitest::Test
       receipt = JSON.parse(draft.receipt_bytes)
       candidate_record, openclaw_record = receipt.fetch("installed_manifests")
       primary = primary_row(fixture, draft, observation, candidate_record, openclaw_record)
+      primary_bytes = publish_primary(fixture, primary)
       result = session.finish!(primary_row: primary)
 
       assert_equal "passed", result.status
-      assert_equal "preexisting-primary\n", File.binread(primary_path)
+      assert_equal primary_bytes, File.binread(primary_path)
       members = Dir.children(fixture.fetch(:bundle_directory)).sort_by do |name|
         Creator::Vocabulary.fetch("bundle_files").index(name)
       end
@@ -96,6 +98,10 @@ class WorkflowCreatorExecutionTest < Minitest::Test
       assert_raises(Execution::Error) { session.finish!(primary_row: invalid) }
       assert_empty Dir.children(fixture.fetch(:bundle_directory))
       assert_equal "failed", session.result.status
+      assert_raises(Execution::Error) { session.finish!(primary_row: primary) }
+      assert_equal Creator::Vocabulary.fetch("bundle_files").drop(1).sort,
+                   Dir.children(fixture.fetch(:bundle_directory)).sort
+      publish_primary(fixture, primary)
       assert_equal "passed", session.finish!(primary_row: primary).status
       assert_equal "passed", session.finish!(primary_row: primary).status
     ensure
@@ -112,12 +118,68 @@ class WorkflowCreatorExecutionTest < Minitest::Test
     end
   end
 
+  def test_gateway_destination_must_stay_inside_the_candidate_closure
+    with_fixture do |fixture|
+      escaped = fixture.merge(
+        candidate: fixture.fetch(:candidate).merge(
+          "audit_gateway" => File.join(fixture.fetch(:bundle_directory), "workflow-creator-gateway")
+        )
+      )
+
+      assert_raises(Execution::Error) { start_session(escaped) }
+      assert_empty Dir.children(fixture.fetch(:bundle_directory))
+      refute Dir.exist?(fixture.fetch(:workspace_path))
+    end
+  end
+
+  def test_outer_prompts_and_installed_closures_are_launch_bound
+    with_fixture do |fixture|
+      session = start_session(fixture)
+      assert_raises(Execution::Error) do
+        session.run_outer_workflow_creator(
+          argv: [ "creator" ], environment: outer_environment(session, fixture)
+        )
+      end
+      refute File.exist?(fixture.fetch(:outer_pids))
+    ensure
+      session&.close
+    end
+
+    with_fixture do |fixture|
+      session, observation = execute_outer(fixture)
+      File.binwrite(fixture.dig(:openclaw, "lock"), "drifted-lock\n")
+
+      assert_raises(Execution::Error) { session.draft!(executed_instruction: observation) }
+      assert_empty Dir.children(fixture.fetch(:bundle_directory))
+    ensure
+      session&.close
+    end
+  end
+
+  def test_rejected_duplicate_outer_launch_cannot_rewrite_evidence
+    with_fixture do |fixture|
+      session, observation = execute_outer(fixture)
+
+      assert_raises(Execution::Error) do
+        session.run_outer_workflow_creator(
+          argv: [ "different" ], environment: outer_environment(session, fixture),
+          stdin_data: Creator::Vocabulary.fetch("prompt")
+        )
+      end
+      assert_raises(Execution::Error) { session.draft!(executed_instruction: observation) }
+      assert_empty Dir.children(fixture.fetch(:bundle_directory))
+    ensure
+      session&.close
+    end
+  end
+
   def test_partial_publication_converges_and_partial_or_failed_outer_runs_cannot_draft
     with_fixture do |fixture|
       session, observation = execute_outer(fixture)
       draft = session.draft!(executed_instruction: observation)
       receipt = JSON.parse(draft.receipt_bytes)
       primary = primary_row(fixture, draft, observation, *receipt.fetch("installed_manifests"))
+      publish_primary(fixture, primary)
       blocker = File.join(fixture.fetch(:bundle_directory), "openclaw-installed-manifest.json")
       Dir.mkdir(blocker, 0o700)
 
@@ -133,7 +195,6 @@ class WorkflowCreatorExecutionTest < Minitest::Test
 
     with_fixture do |fixture|
       primary_path = File.join(fixture.fetch(:bundle_directory), "openclaw-workflow-creator.json")
-      File.binwrite(primary_path, "keep-primary\n")
       support = File.join(fixture.fetch(:bundle_directory), "candidate-installed-manifest.json")
       File.binwrite(support, "divergent")
       File.chmod(0o600, support)
@@ -141,9 +202,10 @@ class WorkflowCreatorExecutionTest < Minitest::Test
       draft = session.draft!(executed_instruction: observation)
       receipt = JSON.parse(draft.receipt_bytes)
       primary = primary_row(fixture, draft, observation, *receipt.fetch("installed_manifests"))
+      primary_bytes = publish_primary(fixture, primary)
 
       assert_raises(Execution::Error) { session.finish!(primary_row: primary) }
-      assert_equal "keep-primary\n", File.binread(primary_path)
+      assert_equal primary_bytes, File.binread(primary_path)
       refute File.exist?(File.join(fixture.fetch(:bundle_directory), "execution-receipt.json"))
       assert_equal "divergent", File.binread(support)
     ensure
@@ -152,7 +214,10 @@ class WorkflowCreatorExecutionTest < Minitest::Test
 
     with_fixture do |fixture|
       session = start_session(fixture)
-      session.run_outer_workflow_creator(argv: [ "creator" ], environment: outer_environment(session, fixture))
+      session.run_outer_workflow_creator(
+        argv: [ "creator" ], environment: outer_environment(session, fixture),
+        stdin_data: Creator::Vocabulary.fetch("prompt")
+      )
       assert_raises(Execution::Error) { session.draft!(executed_instruction: {}) }
       assert_empty Dir.children(fixture.fetch(:bundle_directory))
       assert_equal "failed", session.result.status
@@ -187,10 +252,12 @@ class WorkflowCreatorExecutionTest < Minitest::Test
   def execute_outer(fixture, outcome: "passed")
     session = start_session(fixture)
     session.run_outer_workflow_creator(
-      argv: [ "creator" ], environment: outer_environment(session, fixture)
+      argv: [ "creator" ], environment: outer_environment(session, fixture),
+      stdin_data: Creator::Vocabulary.fetch("prompt")
     )
     session.run_outer_authorized_work(
-      argv: [ "work" ], environment: outer_environment(session, fixture, outcome:)
+      argv: [ "work" ], environment: outer_environment(session, fixture, outcome:),
+      stdin_data: Creator::Vocabulary.fetch("task_prompt")
     )
     observation = file_record(fixture.fetch(:workspace_path), Creator::Vocabulary.fetch("executed_instruction"))
     [ session, observation ]
@@ -368,6 +435,14 @@ class WorkflowCreatorExecutionTest < Minitest::Test
   def file_record(root, relative)
     path = File.join(root, relative)
     { "path" => relative, "sha256" => Digest::SHA256.file(path).hexdigest, "size" => File.size(path) }
+  end
+
+  def publish_primary(fixture, primary)
+    bytes = Creator::Values.capture(primary).canonical_bytes
+    path = File.join(fixture.fetch(:bundle_directory), "openclaw-workflow-creator.json")
+    File.binwrite(path, bytes)
+    File.chmod(0o600, path)
+    bytes
   end
 
   def primary_row(fixture, draft, observation, candidate_record, openclaw_record)

--- a/test/unit/packaging/workflow_creator_execution_test.rb
+++ b/test/unit/packaging/workflow_creator_execution_test.rb
@@ -93,13 +93,22 @@ class WorkflowCreatorExecutionTest < Minitest::Test
       invalid = JSON.parse(JSON.generate(primary))
       invalid.fetch("evidence_bundle").fetch(2)["sha256"] = "0" * 64
 
-      assert_raises(Creator::Error) { session.finish!(primary_row: invalid) }
+      assert_raises(Execution::Error) { session.finish!(primary_row: invalid) }
       assert_empty Dir.children(fixture.fetch(:bundle_directory))
       assert_equal "failed", session.result.status
       assert_equal "passed", session.finish!(primary_row: primary).status
       assert_equal "passed", session.finish!(primary_row: primary).status
     ensure
       session&.close
+    end
+  end
+
+  def test_owned_paths_must_not_overlap
+    with_fixture do |fixture|
+      overlapping = fixture.merge(bundle_directory: fixture.dig(:candidate, "root"))
+
+      assert_raises(Execution::Error) { start_session(overlapping) }
+      refute Dir.exist?(fixture.fetch(:workspace_path))
     end
   end
 

--- a/test/unit/packaging/workflow_creator_execution_test.rb
+++ b/test/unit/packaging/workflow_creator_execution_test.rb
@@ -1,0 +1,402 @@
+require "test_helper"
+require "digest"
+require "json"
+require "rubygems/package"
+require "stringio"
+require "zlib"
+require_relative "../../../packaging/live_agent_skills/workflow_creator_execution"
+
+class WorkflowCreatorExecutionTest < Minitest::Test
+  include HiveTestHelper
+
+  Creator = HiveLiveAgentProof::WorkflowCreator
+  Execution = HiveLiveAgentProof::WorkflowCreatorExecution
+  SHA = "a" * 40
+  SLUG = "created-editorial-42"
+
+  def setup
+    skip "Linux process custody is required" unless RUBY_PLATFORM.include?("linux")
+  end
+
+  def test_real_outer_processes_interleave_gateway_commands_and_publish_support_last
+    with_fixture do |fixture|
+      primary_path = File.join(fixture.fetch(:bundle_directory), "openclaw-workflow-creator.json")
+      File.binwrite(primary_path, "preexisting-primary\n")
+      session = start_session(fixture)
+
+      session.run_outer_workflow_creator(
+        argv: [ "creator" ], environment: outer_environment(session, fixture)
+      )
+      session.run_outer_authorized_work(
+        argv: [ "work" ], environment: outer_environment(session, fixture)
+      )
+      fixture_pids = File.readlines(fixture.fetch(:outer_pids), chomp: true).map { |value| Integer(value) }
+      observation = file_record(fixture.fetch(:workspace_path), Creator::Vocabulary.fetch("executed_instruction"))
+      draft = session.draft!(executed_instruction: observation)
+
+      assert_equal %i[receipt_bytes receipt_sha256 receipt_size], draft.members
+      assert_equal Digest::SHA256.hexdigest(draft.receipt_bytes), draft.receipt_sha256
+      assert_equal draft.receipt_bytes.bytesize, draft.receipt_size
+      assert_equal "preexisting-primary\n", File.binread(primary_path)
+      refute Dir.exist?(fixture.fetch(:workspace_path))
+      assert fixture_pids.none? { |pid| process_alive?(pid) }
+      refute File.exist?(File.join(fixture.dig(:candidate, "root"), "audit", ".workflow-creator-gateway.sock"))
+
+      receipt = JSON.parse(draft.receipt_bytes)
+      candidate_record, openclaw_record = receipt.fetch("installed_manifests")
+      primary = primary_row(fixture, draft, observation, candidate_record, openclaw_record)
+      result = session.finish!(primary_row: primary)
+
+      assert_equal "passed", result.status
+      assert_equal "preexisting-primary\n", File.binread(primary_path)
+      members = Dir.children(fixture.fetch(:bundle_directory)).sort_by do |name|
+        Creator::Vocabulary.fetch("bundle_files").index(name)
+      end
+      assert_equal Creator::Vocabulary.fetch("bundle_files"), members
+      assert_equal draft.receipt_bytes,
+                   File.binread(File.join(fixture.fetch(:bundle_directory), "execution-receipt.json"))
+      assert_equal Creator::ProcessSupervisor::LABELS, receipt.dig("teardown", "receipt_labels")
+      assert_equal Creator::ProcessSupervisor::LABELS, receipt.dig("run", "expected_labels")
+      assert_equal SLUG, receipt.dig("task_slug_binding", "value")
+      assert_equal receipt.dig("gateway", "identity"),
+                   JSON.parse(File.binread(File.join(fixture.fetch(:bundle_directory),
+                                                     "candidate-installed-manifest.json")))
+                     .dig("required_roles", "audit_gateway")
+      assert_equal "passed", session.finish!(primary_row: primary).status
+
+      File.binwrite(File.join(fixture.fetch(:bundle_directory), "candidate-installed-manifest.json"), "divergent")
+      assert_raises(Execution::Error) { session.finish!(primary_row: primary) }
+      assert_equal "failed", session.result.status
+    ensure
+      session&.close
+    end
+  end
+
+  def test_invalid_instruction_and_primary_digest_fail_before_publication
+    with_fixture do |fixture|
+      session, observation = execute_outer(fixture)
+      invalid = observation.merge("sha256" => "0" * 64)
+
+      assert_raises(Execution::Error) { session.draft!(executed_instruction: invalid) }
+      assert_empty Dir.children(fixture.fetch(:bundle_directory))
+      assert_equal "failed", session.result.status
+      refute Dir.exist?(fixture.fetch(:workspace_path))
+    ensure
+      session&.close
+    end
+
+    with_fixture do |fixture|
+      session, observation = execute_outer(fixture)
+      draft = session.draft!(executed_instruction: observation)
+      receipt = JSON.parse(draft.receipt_bytes)
+      primary = primary_row(fixture, draft, observation, *receipt.fetch("installed_manifests"))
+      invalid = JSON.parse(JSON.generate(primary))
+      invalid.fetch("evidence_bundle").fetch(2)["sha256"] = "0" * 64
+
+      assert_raises(Creator::Error) { session.finish!(primary_row: invalid) }
+      assert_empty Dir.children(fixture.fetch(:bundle_directory))
+      assert_equal "failed", session.result.status
+      assert_equal "passed", session.finish!(primary_row: primary).status
+      assert_equal "passed", session.finish!(primary_row: primary).status
+    ensure
+      session&.close
+    end
+  end
+
+  def test_partial_publication_converges_and_partial_or_failed_outer_runs_cannot_draft
+    with_fixture do |fixture|
+      session, observation = execute_outer(fixture)
+      draft = session.draft!(executed_instruction: observation)
+      receipt = JSON.parse(draft.receipt_bytes)
+      primary = primary_row(fixture, draft, observation, *receipt.fetch("installed_manifests"))
+      blocker = File.join(fixture.fetch(:bundle_directory), "openclaw-installed-manifest.json")
+      Dir.mkdir(blocker, 0o700)
+
+      assert_raises(Execution::Error) { session.finish!(primary_row: primary) }
+      assert File.file?(File.join(fixture.fetch(:bundle_directory), "candidate-installed-manifest.json"))
+      refute File.exist?(File.join(fixture.fetch(:bundle_directory), "execution-receipt.json"))
+      Dir.rmdir(blocker)
+      assert_equal "passed", session.finish!(primary_row: primary).status
+    ensure
+      session&.close
+    end
+
+
+    with_fixture do |fixture|
+      primary_path = File.join(fixture.fetch(:bundle_directory), "openclaw-workflow-creator.json")
+      File.binwrite(primary_path, "keep-primary\n")
+      support = File.join(fixture.fetch(:bundle_directory), "candidate-installed-manifest.json")
+      File.binwrite(support, "divergent")
+      File.chmod(0o600, support)
+      session, observation = execute_outer(fixture)
+      draft = session.draft!(executed_instruction: observation)
+      receipt = JSON.parse(draft.receipt_bytes)
+      primary = primary_row(fixture, draft, observation, *receipt.fetch("installed_manifests"))
+
+      assert_raises(Execution::Error) { session.finish!(primary_row: primary) }
+      assert_equal "keep-primary\n", File.binread(primary_path)
+      refute File.exist?(File.join(fixture.fetch(:bundle_directory), "execution-receipt.json"))
+      assert_equal "divergent", File.binread(support)
+    ensure
+      session&.close
+    end
+
+    with_fixture do |fixture|
+      session = start_session(fixture)
+      session.run_outer_workflow_creator(argv: [ "creator" ], environment: outer_environment(session, fixture))
+      assert_raises(Execution::Error) { session.draft!(executed_instruction: {}) }
+      assert_empty Dir.children(fixture.fetch(:bundle_directory))
+      assert_equal "failed", session.result.status
+    ensure
+      session&.close
+    end
+
+    %w[failed signaled].each do |outcome|
+      with_fixture do |fixture|
+        session, observation = execute_outer(fixture, outcome:)
+        assert_raises(Execution::Error, outcome) { session.draft!(executed_instruction: observation) }
+        assert_empty Dir.children(fixture.fetch(:bundle_directory)), outcome
+        assert_equal "failed", session.result.status
+      ensure
+        session&.close
+      end
+    end
+  end
+
+  private
+
+  def start_session(fixture)
+    Execution.start!(
+      candidate_sha: SHA, manifest: fixture.fetch(:manifest), candidate: fixture.fetch(:candidate),
+      openclaw: fixture.fetch(:openclaw), archives: fixture.fetch(:archives),
+      workspace_path: fixture.fetch(:workspace_path), bundle_directory: fixture.fetch(:bundle_directory),
+      correlation_id: "creator-execution", exact_secrets: [],
+      supervisor_options: { "timeout" => 2, "term_grace" => 0.05, "kill_grace" => 0.2 }
+    )
+  end
+
+  def execute_outer(fixture, outcome: "passed")
+    session = start_session(fixture)
+    session.run_outer_workflow_creator(
+      argv: [ "creator" ], environment: outer_environment(session, fixture)
+    )
+    session.run_outer_authorized_work(
+      argv: [ "work" ], environment: outer_environment(session, fixture, outcome:)
+    )
+    observation = file_record(fixture.fetch(:workspace_path), Creator::Vocabulary.fetch("executed_instruction"))
+    [ session, observation ]
+  end
+
+  def outer_environment(session, fixture, outcome: "passed")
+    { "GATEWAY" => session.gateway_path, "FIXTURE_RUBY" => fixture.fetch(:ruby),
+      "OUTER_PIDS" => fixture.fetch(:outer_pids), "OUTER_RESULT" => outcome }
+  end
+
+  def with_fixture
+    with_tmp_dir do |root|
+      candidate_root = File.join(root, "candidate")
+      openclaw_root = File.join(root, "openclaw")
+      bundle_directory = File.join(root, "bundle")
+      [ candidate_root, openclaw_root, bundle_directory ].each { |path| Dir.mkdir(path, 0o700) }
+      ruby = File.realpath(RbConfig.ruby).encode(Encoding::UTF_8)
+      candidate_package = File.join(candidate_root, "packages", "hive-cli.gem")
+      openclaw_package = File.join(openclaw_root, "packages", "openclaw.tar.gz")
+      candidate_executable = File.join(candidate_root, "bin", "hive")
+      openclaw_executable = File.join(openclaw_root, "bin", "openclaw")
+      workspace_path = File.join(root, "proof-workspace")
+      outer_pids = File.join(workspace_path, "outer-pids")
+      write_candidate(candidate_executable, ruby)
+      write_outer(openclaw_executable, ruby)
+      write_candidate_archive(candidate_package)
+      write_archive(openclaw_package)
+      candidate = installation_fixture(
+        candidate_root, candidate_executable, candidate_package, candidate: true,
+        state_path: File.join(workspace_path, "command-count")
+      )
+      openclaw = installation_fixture(openclaw_root, openclaw_executable, openclaw_package, candidate: false)
+      manifest = artifact_manifest(File.binread(candidate_package))
+      archives = {
+        "candidate-package" => archive_fixture(candidate_package),
+        "openclaw-package" => archive_fixture(openclaw_package)
+      }
+      yield root:, ruby:, candidate:, openclaw:, manifest:, archives:,
+            workspace_path:, bundle_directory:, outer_pids:
+    end
+  end
+
+  def installation_fixture(root, executable, package, candidate:, state_path: nil)
+    paths = {
+      "executable" => executable, "interpreter_or_launcher" => write_member(root, "runtime/ruby"),
+      "lock" => write_member(root, "lock/package.lock"), "package" => package
+    }
+    paths["audit_gateway"] = File.join(root, "audit", "workflow-creator-gateway") if candidate
+    Dir.mkdir(File.join(root, "audit"), 0o700) if candidate
+    inventory = paths.values.map { |path| path.delete_prefix("#{root}/") }
+    paths.merge(
+      "root" => root, "inventory" => inventory.sort,
+      "environment" => { "FAKE_STATE" => state_path },
+      "version" => "openclaw-2026.8.4"
+    ).tap do |fixture|
+      fixture.delete("environment") unless candidate
+      fixture.delete("version") if candidate
+    end
+  end
+
+  def write_member(root, relative)
+    path = File.join(root, relative)
+    FileUtils.mkdir_p(File.dirname(path), mode: 0o700)
+    File.binwrite(path, "fixture:#{relative}\n")
+    path
+  end
+
+  def write_candidate(path, ruby)
+    FileUtils.mkdir_p(File.dirname(path), mode: 0o700)
+    File.binwrite(path, <<~RUBY)
+      #!#{ruby}
+      require "fileutils"
+      require "json"
+      count_path = ENV.fetch("FAKE_STATE")
+      case ARGV
+      when ["version"] then puts "hive 1.0"
+      when ["workflow", "list", "--json"] then puts JSON.generate("schema" => "hive-workflow-list")
+      when ["workflow", "new", "editorial", "--json"] then puts JSON.generate("ok" => true)
+      when ["workflow", "validate", "editorial", "--json"] then puts JSON.generate("ok" => true)
+      when ["workflow", "commit", "editorial"]
+        #{Creator::Vocabulary.fetch("files").inspect}.each do |relative|
+          FileUtils.mkdir_p(File.dirname(relative), mode: 0o700)
+          File.binwrite(relative, "authored:\#{relative}\n")
+        end
+      when #{Creator::Vocabulary.fetch("task_new_argv").inspect}
+        count = File.exist?(count_path) ? Integer(File.binread(count_path)) : 0
+        File.binwrite(count_path, (count + 1).to_s)
+        puts JSON.generate("schema" => "hive-new", "ok" => true,
+                           "created" => count.zero?, "slug" => #{SLUG.inspect})
+      when ["run", #{SLUG.inspect}] then puts "ran"
+      when ["status", "--operational", "--json"] then puts JSON.generate("ok" => true)
+      else exit 90
+      end
+    RUBY
+    File.chmod(0o700, path)
+  end
+
+  def write_outer(path, ruby)
+    FileUtils.mkdir_p(File.dirname(path), mode: 0o700)
+    commands = Creator::Vocabulary.fetch("commands")
+    File.binwrite(path, <<~RUBY)
+      #!#{ruby}
+      wrapper, ruby = ENV.values_at("GATEWAY", "FIXTURE_RUBY")
+      File.open(ENV.fetch("OUTER_PIDS"), "a", 0o600) { |file| file.puts(Process.pid) }
+      commands = #{commands.inspect}
+      commands[6] = ["run", #{SLUG.inspect}]
+      selected = ARGV == ["creator"] ? commands.first(5) : commands.drop(5)
+      selected.each { |argv| exit 91 unless system(ruby, wrapper, *argv) }
+      exit 7 if ARGV == ["work"] && ENV["OUTER_RESULT"] == "failed"
+      Process.kill("TERM", Process.pid) if ARGV == ["work"] && ENV["OUTER_RESULT"] == "signaled"
+    RUBY
+    File.chmod(0o700, path)
+  end
+
+  def write_candidate_archive(path)
+    FileUtils.mkdir_p(File.dirname(path), mode: 0o700)
+    nested = gzip_tar_bytes do |tar|
+      bytes = "candidate\n"
+      tar.add_file_simple("lib/candidate.rb", 0o644, bytes.bytesize) { |io| io.write(bytes) }
+    end
+    File.open(path, "wb") do |file|
+      Gem::Package::TarWriter.new(file) do |tar|
+        { "metadata.gz" => gzip_bytes("metadata"), "data.tar.gz" => nested,
+          "checksums.yaml.gz" => gzip_bytes("checksums") }.each do |name, bytes|
+          tar.add_file_simple(name, 0o644, bytes.bytesize) { |entry| entry.write(bytes) }
+        end
+      end
+    end
+  end
+
+  def write_archive(path)
+    FileUtils.mkdir_p(File.dirname(path), mode: 0o700)
+    Zlib::GzipWriter.open(path) do |gzip|
+      Gem::Package::TarWriter.new(gzip) do |tar|
+        bytes = "openclaw\n"
+        tar.add_file_simple("bin/openclaw", 0o755, bytes.bytesize) { |io| io.write(bytes) }
+      end
+    end
+  end
+
+  def gzip_tar_bytes
+    io = StringIO.new("".b)
+    gzip = Zlib::GzipWriter.new(io)
+    Gem::Package::TarWriter.new(gzip) { |tar| yield tar }
+    gzip.finish
+    io.string
+  end
+
+  def gzip_bytes(bytes)
+    io = StringIO.new("".b)
+    gzip = Zlib::GzipWriter.new(io)
+    gzip.write(bytes)
+    gzip.finish
+    io.string
+  end
+
+  def archive_fixture(path)
+    { "path" => path, "available_bytes" => 1_000_000, "available_entries" => 100 }
+  end
+
+  def artifact_manifest(candidate_package)
+    version = "1.2.3"
+    names = [ "hive-agent-skills-#{SHA}.tar.gz", "hive-cli-#{version}.gem", "hive-source-#{SHA}.tar.gz" ]
+    files = names.to_h do |name|
+      bytes = name.start_with?("hive-cli-") ? candidate_package : "artifact:#{name}"
+      [ name, { "sha256" => Digest::SHA256.hexdigest(bytes), "size" => bytes.bytesize } ]
+    end
+    {
+      "schema" => "hive-live-agent-candidate-artifacts", "schema_version" => 1,
+      "candidate_sha" => SHA, "hive_version" => version, "skill_version" => "2026.8.4",
+      "canonical_digest" => Digest::SHA256.hexdigest("canonical"), "files" => files
+    }
+  end
+
+  def file_record(root, relative)
+    path = File.join(root, relative)
+    { "path" => relative, "sha256" => Digest::SHA256.file(path).hexdigest, "size" => File.size(path) }
+  end
+
+  def primary_row(fixture, draft, observation, candidate_record, openclaw_record)
+    files = Creator::Vocabulary.fetch("files").map { |path| file_record_from_content(path) }
+    files[2] = observation
+    receipt_record = {
+      "kind" => "execution_receipt", "path" => "execution-receipt.json",
+      "sha256" => draft.receipt_sha256, "size" => draft.receipt_size
+    }
+    summary = { "status" => "passed", "receipt_sha256" => draft.receipt_sha256 }
+    {
+      "schema" => Creator::Vocabulary.fetch("evidence_schema"), "schema_version" => 1,
+      "platform" => "openclaw", "candidate_sha" => SHA, "result" => "passed",
+      "prompt_sha256" => Digest::SHA256.hexdigest(Creator::Vocabulary.fetch("prompt")),
+      "task_prompt_sha256" => Digest::SHA256.hexdigest(Creator::Vocabulary.fetch("task_prompt")),
+      "skill" => fixture.fetch(:manifest).slice("skill_version", "canonical_digest"),
+      "native_activation" => Creator::Vocabulary.fetch("native_activation"),
+      "hive_commands" => Creator.commands_for(task_slug: SLUG).value,
+      "created_files" => files, "validation" => Creator::Vocabulary.fetch("graph"),
+      "creation_only_task_count" => 0, "task_count" => 1,
+      "task" => Creator::Vocabulary.fetch("task").merge("slug" => SLUG), "external_actions" => [],
+      "secret_scan" => { "status" => "passed", "scanner" => Creator::Vocabulary.fetch("scanner") },
+      "execution_kind" => "authenticated_openclaw", "model_loop" => "executed",
+      "executed_instruction" => observation,
+      "evidence_bundle" => [ candidate_record, openclaw_record, receipt_record ],
+      "containment" => summary, "teardown" => summary, "cleanup" => summary
+    }
+  end
+
+  def file_record_from_content(path)
+    bytes = "authored:#{path}\n"
+    { "path" => path, "sha256" => Digest::SHA256.hexdigest(bytes), "size" => bytes.bytesize }
+  end
+
+  def process_alive?(pid)
+    Process.kill(0, pid)
+    true
+  rescue Errno::ESRCH
+    false
+  end
+end

--- a/test/unit/packaging/workflow_creator_execution_test.rb
+++ b/test/unit/packaging/workflow_creator_execution_test.rb
@@ -13,6 +13,7 @@ class WorkflowCreatorExecutionTest < Minitest::Test
   Execution = HiveLiveAgentProof::WorkflowCreatorExecution
   SHA = "a" * 40
   SLUG = "created-editorial-42"
+  SUPERVISOR_TIMEOUT = 10
 
   def setup
     skip "Linux process custody is required" unless RUBY_PLATFORM.include?("linux")
@@ -245,7 +246,7 @@ class WorkflowCreatorExecutionTest < Minitest::Test
       openclaw: fixture.fetch(:openclaw), archives: fixture.fetch(:archives),
       workspace_path: fixture.fetch(:workspace_path), bundle_directory: fixture.fetch(:bundle_directory),
       correlation_id: "creator-execution", exact_secrets: [],
-      supervisor_options: { "timeout" => 2, "term_grace" => 0.05, "kill_grace" => 0.2 }
+      supervisor_options: { "timeout" => SUPERVISOR_TIMEOUT, "term_grace" => 0.05, "kill_grace" => 0.2 }
     )
   end
 

--- a/test/unit/packaging/workflow_creator_gateway_test.rb
+++ b/test/unit/packaging/workflow_creator_gateway_test.rb
@@ -47,16 +47,22 @@ class WorkflowCreatorGatewayTest < Minitest::Test
   end
 
   def test_wrong_order_and_duplicate_each_permanently_poison_the_gateway
-    with_gateway do |gateway, wrapper|
+    with_gateway do |gateway, wrapper, log|
       _out, _err, status = invoke(wrapper, Creator::Vocabulary.fetch("commands").fetch(1))
       refute status.success?
+      _out, _err, status = invoke(wrapper, Creator::Vocabulary.fetch("commands").first)
+      refute status.success?
+      refute File.exist?(log)
       assert_raises(Gateway::Error) { gateway.finish! }
     end
 
-    with_gateway do |gateway, wrapper|
+    with_gateway do |gateway, wrapper, log|
       assert_wrapper(wrapper, [ "version" ])
       _out, _err, status = invoke(wrapper, [ "version" ])
       refute status.success?
+      _out, _err, status = invoke(wrapper, Creator::Vocabulary.fetch("commands").fetch(1))
+      refute status.success?
+      assert_equal 1, File.readlines(log).length
       assert_raises(Gateway::Error) { gateway.finish! }
     end
   end

--- a/test/unit/packaging/workflow_creator_gateway_test.rb
+++ b/test/unit/packaging/workflow_creator_gateway_test.rb
@@ -1,0 +1,225 @@
+require "test_helper"
+require "digest"
+require "fileutils"
+require "json"
+require "open3"
+require "rbconfig"
+require_relative "../../../packaging/live_agent_skills/workflow_creator_gateway"
+
+class WorkflowCreatorGatewayTest < Minitest::Test
+  Creator = HiveLiveAgentProof::WorkflowCreator
+  Gateway = HiveLiveAgentProof::WorkflowCreatorGateway
+  Supervisor = Creator::ProcessSupervisor
+  RUBY = File.realpath(RbConfig.ruby)
+  CREATED_SLUG = "server-created-42"
+
+  def setup
+    skip "Linux process custody is required" unless RUBY_PLATFORM.include?("linux")
+  end
+
+  def test_real_wrapper_binds_the_dynamic_slug_and_retry_to_nine_frozen_receipts
+    with_gateway do |gateway, wrapper, log, cwd, root|
+      assert_private_gateway(root, wrapper)
+
+      commands = Creator::Vocabulary.fetch("commands")
+      commands.first(6).each { |argv| assert_wrapper(wrapper, argv) }
+      assert_wrapper(wrapper, [ "run", CREATED_SLUG ])
+      assert_wrapper(wrapper, commands.fetch(7))
+      assert_wrapper(wrapper, commands.fetch(8))
+
+      receipts = gateway.finish!
+      assert_equal 9, receipts.length
+      assert receipts.frozen?
+      assert receipts.all?(&:frozen?)
+      assert_equal [ "run", CREATED_SLUG ], receipts.fetch(6).fetch("argv")
+      assert_equal commands.fetch(5), receipts.fetch(7).fetch("argv")
+      assert_equal Creator::Vocabulary.fetch("command_labels"), receipts.map { |row| row.fetch("attempt_label") }
+      assert receipts.all? { |row| row.fetch("capture").frozen? && !row.fetch("capture").key?("tails") }
+      assert receipts.all? { |row| !row.dig("capture", "secret_scan").key?("findings") }
+
+      launches = File.readlines(log, chomp: true).map { |line| JSON.parse(line) }
+      assert_equal receipts.map { |row| row.fetch("argv") }, launches.map { |row| row.fetch("argv") }
+      assert launches.all? { |row| row.fetch("cwd") == cwd }
+      assert launches.all? { |row| row.fetch("environment") == { "FAKE_MODE" => "ok", "FAKE_STATE" => log } }
+      refute File.exist?(File.join(root, ".workflow-creator-gateway.sock"))
+      assert File.file?(wrapper)
+    end
+  end
+
+  def test_wrong_order_and_duplicate_each_permanently_poison_the_gateway
+    with_gateway do |gateway, wrapper|
+      _out, _err, status = invoke(wrapper, Creator::Vocabulary.fetch("commands").fetch(1))
+      refute status.success?
+      assert_raises(Gateway::Error) { gateway.finish! }
+    end
+
+    with_gateway do |gateway, wrapper|
+      assert_wrapper(wrapper, [ "version" ])
+      _out, _err, status = invoke(wrapper, [ "version" ])
+      refute status.success?
+      assert_raises(Gateway::Error) { gateway.finish! }
+    end
+  end
+
+  def test_candidate_failure_and_malformed_creation_each_permanently_poison
+    with_gateway(mode: "failure") do |gateway, wrapper|
+      Creator::Vocabulary.fetch("commands").first(3).each { |argv| assert_wrapper(wrapper, argv) }
+      _out, err, status = invoke(wrapper, Creator::Vocabulary.fetch("commands").fetch(3))
+      assert_equal 9, status.exitstatus
+      assert_equal "candidate failure\n", err
+      assert_raises(Gateway::Error) { gateway.finish! }
+    end
+
+    with_gateway(mode: "malformed") do |gateway, wrapper|
+      Creator::Vocabulary.fetch("commands").first(5).each { |argv| assert_wrapper(wrapper, argv) }
+      _out, _err, status = invoke(wrapper, Creator::Vocabulary.fetch("commands").fetch(5))
+      refute status.success?
+      assert_raises(Gateway::Error) { gateway.finish! }
+    end
+  end
+
+  def test_credential_like_inherited_environment_poison_is_reported_without_launch
+    with_gateway do |gateway, wrapper, log|
+      _out, _err, status = invoke(wrapper, [ "version" ], "API_TOKEN" => "must-not-cross")
+
+      refute status.success?
+      refute File.exist?(log)
+      assert_raises(Gateway::Error) { gateway.finish! }
+    end
+  end
+
+  def test_an_extra_command_after_position_nine_poisons_the_completed_sequence
+    with_gateway do |gateway, wrapper|
+      run_all(wrapper)
+      _out, _err, status = invoke(wrapper, [ "version" ])
+
+      refute status.success?
+      assert_raises(Gateway::Error) { gateway.finish! }
+    end
+  end
+
+  def test_candidate_identity_is_fixed_and_preexisting_gateway_members_are_refused
+    with_gateway do |gateway, wrapper, _log, _cwd, _root, candidate|
+      moved = "#{candidate}.original"
+      File.rename(candidate, moved)
+      write_candidate(candidate)
+      _out, _err, status = invoke(wrapper, [ "version" ])
+
+      refute status.success?
+      assert_raises(Gateway::Error) { gateway.finish! }
+    end
+
+    Dir.mktmpdir("creator-gateway-exclusive") do |dir|
+      root, cwd = File.join(dir, "private"), File.join(dir, "cwd")
+      [ root, cwd ].each { |path| Dir.mkdir(path, 0o700) }
+      candidate = write_candidate(File.join(cwd, "candidate"))
+      File.write(File.join(root, "workflow-creator-gateway"), "keep")
+      gateway = build_gateway(root:, cwd:, candidate:, log: File.join(cwd, "log"))
+
+      assert_raises(Gateway::Error) { gateway.start! }
+      assert_equal "keep", File.read(File.join(root, "workflow-creator-gateway"))
+    ensure
+      gateway&.close
+    end
+  end
+
+  private
+
+  def with_gateway(mode: "ok")
+    Dir.mktmpdir("creator-gateway") do |dir|
+      root, cwd = File.join(dir, "private"), File.join(dir, "cwd")
+      [ root, cwd ].each { |path| Dir.mkdir(path, 0o700) }
+      candidate = write_candidate(File.join(cwd, "candidate"))
+      log = File.join(cwd, "launches.jsonl")
+      gateway = build_gateway(root:, cwd:, candidate:, log:, mode:)
+      wrapper = gateway.start!
+      yield gateway, wrapper, log, cwd, root, candidate
+    ensure
+      gateway&.close
+    end
+  end
+
+  def build_gateway(root:, cwd:, candidate:, log:, mode: "ok")
+    stat = File.lstat(candidate)
+    identity = {
+      "path" => File.basename(candidate), "sha256" => Digest::SHA256.file(candidate).hexdigest,
+      "size" => stat.size
+    }
+    supervisor = Supervisor.new(
+      correlation_id: "creator-gateway", output_limit: 8_192, tail_limit: 4_096,
+      timeout: 1, term_grace: 0.05, kill_grace: 0.2
+    )
+    Gateway.new(
+      root:, candidate_executable: candidate, candidate_identity: identity,
+      environment: { "FAKE_MODE" => mode, "FAKE_STATE" => log }, cwd:, supervisor:
+    )
+  end
+
+  def assert_private_gateway(root, wrapper)
+    assert_equal 0o700, File.lstat(root).mode & 0o777
+    assert_equal File.join(root, "workflow-creator-gateway"), wrapper
+    assert_equal 0o600, File.lstat(wrapper).mode & 0o777
+    socket = File.join(root, ".workflow-creator-gateway.sock")
+    assert File.lstat(socket).socket?
+    assert_equal 0o600, File.lstat(socket).mode & 0o777
+    assert_equal [ ".workflow-creator-gateway.sock", "workflow-creator-gateway" ], Dir.children(root).sort
+    assert_match(/\b[0-9a-f]{64}\b/, File.read(wrapper))
+  end
+
+  def assert_wrapper(wrapper, argv)
+    _out, err, status = invoke(wrapper, argv)
+    assert status.success?, "wrapper failed for #{argv.inspect}: #{err}"
+  end
+
+  def invoke(wrapper, argv, inherited = {})
+    Open3.capture3(inherited, RUBY, wrapper, *argv, unsetenv_others: true)
+  end
+
+  def run_all(wrapper)
+    commands = Creator::Vocabulary.fetch("commands")
+    commands.first(6).each { |argv| assert_wrapper(wrapper, argv) }
+    assert_wrapper(wrapper, [ "run", CREATED_SLUG ])
+    assert_wrapper(wrapper, commands.fetch(7))
+    assert_wrapper(wrapper, commands.fetch(8))
+  end
+
+  def write_candidate(path)
+    File.write(path, <<~RUBY)
+      #!#{RUBY}
+      require "json"
+      state = ENV.fetch("FAKE_STATE")
+      mode = ENV.fetch("FAKE_MODE")
+      record = { "argv" => ARGV, "cwd" => Dir.pwd, "environment" => ENV.to_h }
+      File.open(state, "a", 0o600) { |file| file.puts(JSON.generate(record)) }
+      case ARGV
+      when ["version"] then puts "hive 1.0"
+      when ["workflow", "list", "--json"] then puts JSON.generate("schema" => "hive-workflow-list")
+      when ["workflow", "new", "editorial", "--json"] then puts JSON.generate("ok" => true)
+      when ["workflow", "validate", "editorial", "--json"]
+        if mode == "failure"
+          warn "candidate failure"
+          exit 9
+        end
+        puts JSON.generate("ok" => true)
+      when ["workflow", "commit", "editorial"] then nil
+      when #{Creator::Vocabulary.fetch("task_new_argv").inspect}
+        if mode == "malformed"
+          puts "not-json"
+        else
+          count_path = "\#{state}.count"
+          count = File.exist?(count_path) ? Integer(File.read(count_path)) : 0
+          File.write(count_path, (count + 1).to_s)
+          puts JSON.generate("schema" => "hive-new", "ok" => true,
+                             "created" => count.zero?, "slug" => #{CREATED_SLUG.inspect})
+        end
+      when ["run", #{CREATED_SLUG.inspect}] then puts "ran"
+      when ["status", "--operational", "--json"] then puts JSON.generate("ok" => true)
+      else
+        warn "unexpected command"
+        exit 90
+      end
+    RUBY
+    File.chmod(0o700, path)
+    path
+  end
+end

--- a/test/unit/packaging/workflow_creator_gateway_test.rb
+++ b/test/unit/packaging/workflow_creator_gateway_test.rb
@@ -88,6 +88,21 @@ class WorkflowCreatorGatewayTest < Minitest::Test
     end
   end
 
+  def test_credential_like_candidate_environment_is_rejected_before_start
+    Dir.mktmpdir("creator-gateway-environment") do |dir|
+      root, cwd = File.join(dir, "private"), File.join(dir, "cwd")
+      [ root, cwd ].each { |path| Dir.mkdir(path, 0o700) }
+      candidate = write_candidate(File.join(cwd, "candidate"))
+
+      assert_raises(Gateway::Error) do
+        build_gateway(
+          root:, cwd:, candidate:, log: File.join(cwd, "log"),
+          environment: { "API_TOKEN" => "must-not-cross" }
+        )
+      end
+    end
+  end
+
   def test_an_extra_command_after_position_nine_poisons_the_completed_sequence
     with_gateway do |gateway, wrapper|
       run_all(wrapper)
@@ -139,7 +154,7 @@ class WorkflowCreatorGatewayTest < Minitest::Test
     end
   end
 
-  def build_gateway(root:, cwd:, candidate:, log:, mode: "ok")
+  def build_gateway(root:, cwd:, candidate:, log:, mode: "ok", environment: nil)
     stat = File.lstat(candidate)
     identity = {
       "path" => File.basename(candidate), "sha256" => Digest::SHA256.file(candidate).hexdigest,
@@ -151,7 +166,7 @@ class WorkflowCreatorGatewayTest < Minitest::Test
     )
     Gateway.new(
       root:, candidate_executable: candidate, candidate_identity: identity,
-      environment: { "FAKE_MODE" => mode, "FAKE_STATE" => log }, cwd:, supervisor:
+      environment: environment || { "FAKE_MODE" => mode, "FAKE_STATE" => log }, cwd:, supervisor:
     )
   end
 

--- a/test/unit/packaging/workflow_creator_installation_test.rb
+++ b/test/unit/packaging/workflow_creator_installation_test.rb
@@ -1,0 +1,136 @@
+require "test_helper"
+require "digest"
+require_relative "../../../packaging/live_agent_skills/workflow_creator_installation"
+
+class WorkflowCreatorInstallationTest < Minitest::Test
+  include HiveTestHelper
+
+  Installation = HiveLiveAgentProof::WorkflowCreatorInstallation
+  Creator = HiveLiveAgentProof::WorkflowCreator
+  SHA = "a" * 40
+
+  def test_candidate_computes_and_validates_the_exact_caller_supplied_closure
+    with_installation("candidate") do |fixture|
+      result = Installation.candidate!(**fixture.fetch(:arguments))
+
+      assert_equal %i[candidate! openclaw!], Installation.singleton_methods(false).sort
+      assert_equal Creator::Vocabulary.fetch("member_roles").fetch("candidate"),
+                   result.value.fetch("required_roles").keys
+      assert_equal fixture.fetch(:inventory).sort,
+                   result.value.fetch("inventory").map { |record| record.fetch("path") }
+      assert_equal fixture.fetch(:manifest).fetch("hive_version"), result.value.fetch("version")
+      assert_equal result.canonical_bytes, Creator::Values.capture(result.value).canonical_bytes
+      validated = Creator.validate_installation!(
+        document: result.value, kind: "candidate", manifest: fixture.fetch(:manifest), candidate_sha: SHA
+      )
+      assert_equal result.canonical_bytes, validated.canonical_bytes
+    end
+  end
+
+  def test_openclaw_uses_the_exact_caller_supplied_version_without_selecting_or_installing
+    with_installation("openclaw") do |fixture|
+      arguments = fixture.fetch(:arguments).merge(version: "openclaw-2026.8.4")
+
+      result = Installation.openclaw!(**arguments)
+
+      assert_equal "openclaw", result.value.fetch("kind")
+      assert_equal "openclaw-2026.8.4", result.value.fetch("version")
+      assert_equal Creator::Vocabulary.fetch("member_roles").fetch("openclaw"),
+                   result.value.fetch("required_roles").keys
+      assert_equal [], Dir.children(fixture.fetch(:root)).grep(/manifest/)
+    end
+  end
+
+  def test_refuses_missing_duplicate_outside_and_unmanifested_inputs
+    with_installation("candidate") do |fixture|
+      arguments = fixture.fetch(:arguments)
+      assert_invalid(arguments.merge(inventory: arguments.fetch(:inventory) - [ "runtime/dependency.rb" ]))
+      assert_invalid(arguments.merge(inventory: arguments.fetch(:inventory) + [ "lock/lockfile" ]))
+      assert_invalid(arguments.merge(executable: "../outside"))
+
+      File.write(File.join(fixture.fetch(:root), "unmanifested"), "foreign")
+      assert_invalid(arguments)
+    end
+  end
+
+  def test_refuses_symlinks_hardlinks_special_files_and_mutable_directories
+    with_installation("candidate") do |fixture|
+      arguments = fixture.fetch(:arguments)
+      executable = File.join(fixture.fetch(:root), arguments.fetch(:executable))
+      FileUtils.rm_f(executable)
+      File.symlink("../lock/lockfile", executable)
+      assert_invalid(arguments)
+    end
+
+    with_installation("candidate") do |fixture|
+      arguments = fixture.fetch(:arguments)
+      source = File.join(fixture.fetch(:root), arguments.fetch(:executable))
+      File.link(source, File.join(fixture.fetch(:root), "executable-alias"))
+      assert_invalid(arguments.merge(inventory: arguments.fetch(:inventory) + [ "executable-alias" ]))
+    end
+
+    with_installation("candidate") do |fixture|
+      FileUtils.chmod(0o777, fixture.fetch(:root))
+      assert_invalid(fixture.fetch(:arguments))
+    end
+  end
+
+  def test_refuses_stale_candidate_package_identity_and_invalid_openclaw_version
+    with_installation("candidate") do |fixture|
+      package = File.join(fixture.fetch(:root), fixture.dig(:arguments, :package))
+      File.binwrite(package, "changed")
+      assert_invalid(fixture.fetch(:arguments))
+    end
+
+    with_installation("openclaw") do |fixture|
+      assert_raises(Installation::Error) do
+        Installation.openclaw!(**fixture.fetch(:arguments), version: "")
+      end
+    end
+  end
+
+  private
+
+  def assert_invalid(arguments)
+    error = assert_raises(Installation::Error) { Installation.candidate!(**arguments) }
+    assert_equal "workflow-creator installation closure is invalid", error.message
+  end
+
+  def with_installation(kind)
+    with_tmp_dir do |root|
+      roles = Creator::Vocabulary.fetch("member_roles").fetch(kind)
+      role_paths = roles.to_h { |role| [ role.to_sym, role_path(role) ] }
+      inventory = [ *role_paths.values, "runtime/dependency.rb" ].sort
+      inventory.each do |path|
+        target = File.join(root, path)
+        FileUtils.mkdir_p(File.dirname(target), mode: 0o700)
+        File.binwrite(target, "bytes:#{path}")
+      end
+      manifest = artifact_manifest(File.binread(File.join(root, role_paths.fetch(:package))))
+      arguments = {
+        root:, candidate_sha: SHA, manifest:, inventory:,
+        **role_paths
+      }
+      arguments.delete(:audit_gateway) if kind == "openclaw"
+      yield root:, manifest:, inventory:, arguments:
+    end
+  end
+
+  def role_path(role)
+    role == "package" ? "packages/package.tgz" : "#{role}/fixture"
+  end
+
+  def artifact_manifest(candidate_package)
+    version = "1.2.3"
+    names = [ "hive-agent-skills-#{SHA}.tar.gz", "hive-cli-#{version}.gem", "hive-source-#{SHA}.tar.gz" ]
+    files = names.to_h do |name|
+      bytes = name.start_with?("hive-cli-") ? candidate_package : "artifact:#{name}"
+      [ name, { "sha256" => Digest::SHA256.hexdigest(bytes), "size" => bytes.bytesize } ]
+    end
+    {
+      "schema" => "hive-live-agent-candidate-artifacts", "schema_version" => 1,
+      "candidate_sha" => SHA, "hive_version" => version, "skill_version" => "2026.8.4",
+      "canonical_digest" => Digest::SHA256.hexdigest("canonical"), "files" => files
+    }
+  end
+end

--- a/test/unit/packaging/workflow_creator_process_supervisor_test.rb
+++ b/test/unit/packaging/workflow_creator_process_supervisor_test.rb
@@ -91,6 +91,35 @@ class WorkflowCreatorProcessSupervisorTest < Minitest::Test
     end
   end
 
+  def test_continuous_output_cannot_starve_timeout_or_reaping
+    pid = nil
+    Dir.mktmpdir("creator-supervisor-output") do |dir|
+      pid_file = File.join(dir, "writer.pid")
+      code = <<~RUBY
+        File.write(#{pid_file.dump}, Process.pid)
+        trap("TERM") {}
+        chunk = "x" * 8_192
+        loop { STDOUT.write(chunk); STDOUT.flush }
+      RUBY
+      supervisor = build_supervisor(timeout: 0.1, term_grace: 0.03, kill_grace: 0.2,
+                                    output_limit: 4_096)
+      started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      receipt = supervisor.run_command(
+        position: 1, executable: RUBY, argv: [ "-e", code ], environment: {}, cwd: dir
+      )
+      elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+      pid = Integer(File.read(pid_file))
+
+      assert receipt.fetch("timed_out")
+      assert receipt.dig("capture", "stdout_truncated")
+      assert_equal "passed", receipt.dig("teardown", "status")
+      assert_operator elapsed, :<, 2
+      refute process_alive?(pid)
+    end
+  ensure
+    Process.kill("KILL", pid) if pid && process_alive?(pid)
+  end
+
   def test_detached_descendant_is_discovered_killed_and_reaped_after_root_exit
     detached_pid = nil
     Dir.mktmpdir("creator-supervisor") do |dir|

--- a/test/unit/packaging/workflow_creator_process_supervisor_test.rb
+++ b/test/unit/packaging/workflow_creator_process_supervisor_test.rb
@@ -1,0 +1,269 @@
+require "test_helper"
+require "fileutils"
+require "rbconfig"
+require_relative "../../../packaging/live_agent_skills/workflow_creator_process_supervisor"
+
+class WorkflowCreatorProcessSupervisorTest < Minitest::Test
+  Supervisor = HiveLiveAgentProof::WorkflowCreator::ProcessSupervisor
+  RUBY = File.realpath(RbConfig.ruby)
+
+  def setup
+    skip "Linux process custody is required" unless RUBY_PLATFORM.include?("linux")
+  end
+
+  def test_has_one_closed_creator_label_for_each_command_and_root
+    assert_equal %w[
+      candidate-version candidate-workflow-list candidate-workflow-new candidate-workflow-validate
+      candidate-workflow-commit candidate-task-create candidate-task-run candidate-task-retry
+      candidate-operational-status outer-workflow-creator outer-authorized-work
+    ], Supervisor::LABELS
+    assert Supervisor::LABELS.frozen?
+  end
+
+  def test_zero_launches_is_not_started_and_partial_launches_cannot_pass
+    Dir.mktmpdir("creator-supervisor") do |dir|
+      supervisor = build_supervisor
+      assert_equal "not_started", supervisor.teardown.fetch("status")
+
+      receipt = run_command(supervisor, dir, position: 1)
+
+      assert_equal "passed", receipt.dig("teardown", "status")
+      assert_equal "failed", supervisor.teardown.fetch("status")
+      assert_raises(Supervisor::Error) { run_command(supervisor, dir, position: 1) }
+      assert_raises(Supervisor::Error) { run_command(supervisor, dir, position: 0) }
+    end
+  end
+
+  def test_all_closed_labels_produce_one_complete_teardown_row
+    Dir.mktmpdir("creator-supervisor") do |dir|
+      supervisor = build_supervisor
+      1.upto(9) { |position| run_command(supervisor, dir, position: position) }
+      supervisor.run_outer_workflow_creator(**launch_options(dir))
+      supervisor.run_outer_authorized_work(**launch_options(dir))
+
+      teardown = supervisor.teardown
+      assert_equal "passed", teardown.fetch("status")
+      assert_equal Supervisor::LABELS, teardown.fetch("receipt_labels")
+      assert_equal 11, supervisor.receipts.length
+      assert supervisor.receipts.all? { |row| row.dig("teardown", "owner_complete") }
+    end
+  end
+
+  def test_containment_precedes_sensitive_input_and_receipts_are_not_inherited
+    secret = "supervisor-private-secret"
+    Dir.mktmpdir("creator-supervisor") do |dir|
+      supervisor = build_supervisor(exact_secrets: [ secret ])
+      code = <<~'RUBY'
+        inherited = (3..64).count do |fd|
+          IO.for_fd(fd, autoclose: false).write("forged")
+          true
+        rescue StandardError
+          false
+        end
+        STDOUT.write(STDIN.read)
+        STDERR.write("fds=#{inherited}")
+      RUBY
+      receipt = supervisor.run_command(
+        position: 1, executable: RUBY, argv: [ "-e", code ], environment: {}, cwd: dir,
+        stdin_data: secret
+      )
+
+      assert receipt.fetch("containment_established")
+      assert_equal "failed", receipt.dig("capture", "secret_scan", "status")
+      assert_equal "[REDACTED]", receipt.dig("capture", "tails", "stdout")
+      assert_equal "fds=0", receipt.dig("capture", "tails", "stderr")
+    end
+  end
+
+  def test_timeout_escalates_term_to_kill_and_reaps_the_root
+    Dir.mktmpdir("creator-supervisor") do |dir|
+      supervisor = build_supervisor(timeout: 0.2, term_grace: 0.03, kill_grace: 0.2)
+      receipt = supervisor.run_command(
+        position: 1, executable: RUBY,
+        argv: [ "-e", "trap('TERM') {}; sleep 30" ], environment: {}, cwd: dir
+      )
+
+      assert receipt.fetch("timed_out")
+      assert receipt.dig("teardown", "term_sent")
+      assert receipt.dig("teardown", "kill_sent")
+      assert receipt.dig("teardown", "reaped")
+      assert_equal "none", receipt.dig("teardown", "descendants")
+    end
+  end
+
+  def test_detached_descendant_is_discovered_killed_and_reaped_after_root_exit
+    detached_pid = nil
+    Dir.mktmpdir("creator-supervisor") do |dir|
+      pid_file = File.join(dir, "detached.pid")
+      child = "Process.setsid; trap('TERM') {}; File.write(ARGV.fetch(0), Process.pid); sleep 30"
+      root = <<~RUBY
+        Process.spawn(#{RUBY.dump}, "-e", #{child.dump}, #{pid_file.dump}, out: File::NULL, err: File::NULL)
+        sleep 0.01 until File.exist?(#{pid_file.dump})
+      RUBY
+      supervisor = build_supervisor
+      receipt = supervisor.run_command(
+        position: 1, executable: RUBY, argv: [ "-e", root ], environment: {}, cwd: dir
+      )
+      detached_pid = Integer(File.read(pid_file))
+
+      assert receipt.dig("teardown", "kill_sent")
+      refute process_alive?(detached_pid)
+      assert_equal "passed", receipt.dig("teardown", "status")
+    end
+  ensure
+    Process.kill("KILL", detached_pid) if detached_pid && process_alive?(detached_pid)
+  end
+
+  def test_capture_failure_still_reaps_a_detached_term_ignoring_descendant
+    detached_pid = nil
+    Dir.mktmpdir("creator-supervisor") do |dir|
+      pid_file = File.join(dir, "failure-detached.pid")
+      child = "Process.setsid; trap('TERM') {}; File.write(ARGV.fetch(0), Process.pid); sleep 30"
+      root = <<~RUBY
+        Process.spawn(#{RUBY.dump}, "-e", #{child.dump}, #{pid_file.dump}, out: File::NULL, err: File::NULL)
+        sleep 30
+      RUBY
+      failing_supervisor = Class.new(Supervisor) do
+        define_method(:initialize) do |fault_file:, **options|
+          @fault_file = fault_file
+          super(**options)
+        end
+
+        private
+
+        def drain(...)
+          unless @faulted
+            sleep 0.01 until File.exist?(@fault_file)
+            @faulted = true
+            raise IOError, "forced capture failure"
+          end
+          super
+        end
+      end.new(
+        fault_file: pid_file, correlation_id: "creator-run", timeout: 1,
+        term_grace: 0.05, kill_grace: 0.2
+      )
+
+      assert_raises(Supervisor::Error) do
+        failing_supervisor.run_command(
+          position: 1, executable: RUBY, argv: [ "-e", root ], environment: {}, cwd: dir
+        )
+      end
+      detached_pid = Integer(File.read(pid_file))
+      refute process_alive?(detached_pid)
+      assert_equal "failed", failing_supervisor.teardown.fetch("status")
+    end
+  ensure
+    Process.kill("KILL", detached_pid) if detached_pid && process_alive?(detached_pid)
+  end
+
+  def test_caller_loss_reaps_a_detached_term_ignoring_descendant
+    caller_pid = detached_pid = nil
+    Dir.mktmpdir("creator-caller-loss") do |dir|
+      pid_file = File.join(dir, "caller-loss-detached.pid")
+      child = "Process.setsid; trap('TERM') {}; File.write(ARGV.fetch(0), Process.pid); sleep 30"
+      root = <<~RUBY
+        Process.spawn(#{RUBY.dump}, "-e", #{child.dump}, #{pid_file.dump}, out: File::NULL, err: File::NULL)
+        sleep 30
+      RUBY
+      caller_pid = Process.fork do
+        build_supervisor(timeout: 30).run_command(
+          position: 1, executable: RUBY, argv: [ "-e", root ], environment: {}, cwd: dir
+        )
+      end
+      wait_until { File.exist?(pid_file) }
+      detached_pid = Integer(File.read(pid_file))
+
+      Process.kill("KILL", caller_pid)
+      Process.waitpid(caller_pid)
+      caller_pid = nil
+
+      wait_until { !process_alive?(detached_pid) }
+      refute process_alive?(detached_pid)
+    end
+  ensure
+    Process.kill("KILL", caller_pid) if caller_pid && process_alive?(caller_pid)
+    Process.waitpid(caller_pid) if caller_pid
+    Process.kill("KILL", detached_pid) if detached_pid && process_alive?(detached_pid)
+  end
+
+  def test_proof_workspace_refuses_preexisting_paths_and_removes_only_its_identity
+    Dir.mktmpdir("creator-cleanup") do |dir|
+      supervisor = build_supervisor
+      %w[file directory symlink].each do |kind|
+        path = File.join(dir, kind)
+        kind == "file" ? File.write(path, "keep") : Dir.mkdir(path)
+        if kind == "symlink"
+          Dir.rmdir(path)
+          File.symlink("file", path)
+        end
+        assert_raises(Supervisor::Error) { supervisor.create_proof_workspace(path) }
+        assert File.exist?(path) || File.symlink?(path)
+      end
+
+      owned = File.join(dir, "owned")
+      row = supervisor.create_proof_workspace(owned)
+      assert_equal true, row.fetch("created_by_run")
+      cleanup = supervisor.cleanup_proof_workspace
+      assert cleanup.values_at("identity_matched", "removed").all?
+      refute File.exist?(owned)
+    end
+  end
+
+  def test_replacement_after_workspace_creation_fails_closed_without_deleting_it
+    Dir.mktmpdir("creator-cleanup") do |dir|
+      supervisor = build_supervisor
+      owned = File.join(dir, "owned")
+      original = File.join(dir, "original")
+      supervisor.create_proof_workspace(owned)
+      File.rename(owned, original)
+      Dir.mkdir(owned)
+
+      row = supervisor.cleanup_proof_workspace
+
+      assert_equal false, row.fetch("identity_matched")
+      assert_equal false, row.fetch("removed")
+      assert Dir.exist?(owned)
+      refute row.values_at("identity_matched", "removed").all?
+    end
+  end
+
+  def test_non_linux_platform_fails_closed
+    error = assert_raises(Supervisor::Error) do
+      Supervisor.new(correlation_id: "creator-run", platform: "darwin")
+    end
+    assert_equal "workflow-creator process custody requires Linux", error.message
+  end
+
+  private
+
+  def build_supervisor(**options)
+    Supervisor.new(
+      correlation_id: "creator-run", timeout: 1, term_grace: 0.05, kill_grace: 0.2,
+      **options
+    )
+  end
+
+  def launch_options(dir)
+    { executable: RUBY, argv: [ "-e", "exit 0" ], environment: {}, cwd: dir }
+  end
+
+  def run_command(supervisor, dir, position:)
+    supervisor.run_command(position: position, **launch_options(dir))
+  end
+
+  def process_alive?(pid)
+    Process.kill(0, pid)
+    true
+  rescue Errno::ESRCH
+    false
+  end
+
+  def wait_until(timeout: 3)
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+    until yield
+      raise "condition did not become true" if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+      sleep 0.01
+    end
+  end
+end

--- a/wiki/component-boundaries.md
+++ b/wiki/component-boundaries.md
@@ -283,16 +283,23 @@ for the three vocabulary-fixed support filenames
 `candidate-installed-manifest.json`, `openclaw-installed-manifest.json`, and
 `execution-receipt.json`. The downstream `proof.rb` consumer observes those
 members only through `WorkflowCreatorBundle`'s exact retained-bundle
-revalidation. U14 cannot publish `openclaw-workflow-creator.json`.
+revalidation. `finish!` now performs that same full retained-bundle check before
+returning `passed`; a missing or divergent independently written primary leaves
+the support publication retryable but non-passing. U14 cannot publish
+`openclaw-workflow-creator.json`.
 
 The mutation boundary is exact. Callers supply candidate/OpenClaw roots,
 versions, manifests, inventories, executable/launcher/lock/package paths,
 environment, and secrets. U14 may validate those bytes, admit only the two
 fixed archive labels, create one absent owner-private proof workspace, serialize
 the nine Vocabulary command positions through its fixed local gateway, launch
-the two fixed outer labels, capture bounded redacted output, supervise teardown,
-publish the three support members, and remove only the workspace whose current
-device/inode still matches its creation row. It cannot choose or expose a
+the two fixed outer labels only with their vocabulary-bound prompts, capture
+bounded redacted output, supervise teardown, publish the three support members,
+and remove only the workspace whose current device/inode still matches its
+creation row. The wrapper stays inside the stable candidate closure while its
+private socket lives in the proof workspace; permanent gateway poison admits no
+later command. Final rescans must match the pre-launch installation snapshots.
+It cannot choose or expose a
 provider, model, credential, installed version, workflow policy, primary-receipt
 writer, or passing/live classification.
 

--- a/wiki/component-boundaries.md
+++ b/wiki/component-boundaries.md
@@ -183,7 +183,11 @@ one fixed secret-free error.
 component edge. The core owns an immutable schema-v1 vocabulary and validates
 failed, primary, installed-closure, and declarative execution receipts only
 after caller values have been imported into owned snapshots. Successful
-validation returns the primary snapshot. Failure construction separately
+validation returns the primary snapshot. Its nine-command plan assigns one
+semantic label to each position. Because `hive new` owns slug generation,
+position 7 is an explicit `{created_slug}` template: the execution receipt binds
+argument 1 to the `slug` field returned by position 6, and the primary task row
+must carry that same value. Failure construction separately
 captures stable inputs and diagnostic detail, substitutes a fixed omitted-detail
 marker when projection exceeds its bounded work ceiling, and snapshots only the
 internally constructed result afterward. It owns no retention, publication,
@@ -227,8 +231,8 @@ even after its model loop succeeds; U14/U15 retain execution and live-claim
 authority.
 
 The approved U1a1c budget re-scope permits only named private semantic-helper
-decomposition. Its ceilings are 125/7/4 for the facade, 260/15/24 for the
-contract, 215/13/20 for execution, 590/34/48 for U1a1c, and 1090/68/104 for the
+decomposition. Its ceilings are 140/7/4 for the facade, 260/15/24 for the
+contract, 235/14/20 for execution, 635/36/48 for U1a1c, and 1135/70/104 for the
 Values/TextSafety/Core composition (lines/callables/decisions). The U1a2 bundle
 owner is independently capped at 220/10/28 and currently measures 146/10/26. Public APIs,
 owned files, responsibilities, dependency direction, and decision ceilings did

--- a/wiki/component-boundaries.md
+++ b/wiki/component-boundaries.md
@@ -21,6 +21,7 @@ the first and primary consumer.
 | Attempts admission / future RunReceipt | `candidate` (guarded reference) | `require "hive/attempts/api"` → `Hive::Attempts::API` | [[modules/attempts]] |
 | Workflow Creator Values | `boundary-ready` | `require "./packaging/live_agent_skills/workflow_creator_text_safety"` → `HiveLiveAgentProof::WorkflowCreator::TextSafety` | [[component-boundaries]] |
 | Workflow Creator | `boundary-ready` | `require "./packaging/live_agent_skills/workflow_creator_evidence"` → `HiveLiveAgentProof::WorkflowCreatorEvidence` | [[component-boundaries]] |
+| Workflow Creator Execution | `boundary-ready` (deterministic U14 substrate; U15 live orchestration pending) | `require "./packaging/live_agent_skills/workflow_creator_execution"` → `HiveLiveAgentProof::WorkflowCreatorExecution` | [[component-boundaries]] |
 | UserService | `boundary-ready` | `require "hive/user_service"` → `Hive::UserService` | [[modules/user_service]] |
 | Agent ABI | `boundary-ready`; standalone package candidate | `require "hive/agent_runtime"` → `Hive::AgentRuntime` | [[modules/agent_cli_runtime]], [[modules/agent_profile]] |
 | Agent Artifact Firewall | `boundary-ready` | `require "hive/artifact_firewall"` → `Hive::ArtifactFirewall` | [[modules/protected_files]] |
@@ -36,21 +37,23 @@ has earned a gem, version, repository, or release.
 
 ## Final graph audit
 
-The catalog on 2026-08-04 retains ten components: eight are
+The catalog on 2026-08-04 retains eleven components: nine are
 `boundary-ready`; Attempts and Patrol Effect Evidence remain `candidate`.
 Patrol retains one bounded U3 exception for deterministic public-path and
-independently authorized installed/live proof. Workflow Creator is now composed
-through its U1b typed publication facade after the incumbent proof consumer
-adopted exact bundle custody.
+independently authorized installed/live proof. Workflow Creator is composed
+through its U1b typed publication facade, and Workflow Creator Execution adds
+the stable deterministic U14 custody seam below still-pending U15 authenticated
+orchestration.
 Every retained entry point has focused clean-process load proof, every
 catalog-owned path and focused test resolves inside this repository, and the
 direct-construction guards pass against all production Ruby sources.
 
-The component dependency graph has two edges:
+The component dependency graph has three edges:
 
 ```mermaid
 flowchart LR
   skillpack[Skillpack] --> agent_abi[Agent ABI]
+  workflow_execution[Workflow Creator Execution] --> workflow_core[Workflow Creator]
   workflow_core[Workflow Creator] --> workflow_values[Workflow Creator Values]
   patrol_effects[Patrol Effect Evidence - candidate]
   attempts[Attempts admission - candidate]
@@ -68,7 +71,7 @@ candidates rather than being promoted ahead of their remaining lifecycle or
 qualification proof.
 
 This is an internal architecture verdict, not a packaging verdict. None of the
-eight ready components currently has the named non-Hive adopter and independent
+nine ready components currently has the named non-Hive adopter and independent
 package proof required by the standalone-gem plan.
 
 `Patrol Effect Evidence` owns the immutable cross-product capture, selection,
@@ -261,6 +264,48 @@ lines / 14 callables / 23 decisions for `TextSafety`, and 498 / 34 / 55 when
 composed. The Values source retains its leaf-local `Ripper.lex` no-require proof;
 the TextSafety entry point has exactly one downward `require_relative` to Values.
 This is not generic Ruby grammar, require-path analysis, or provenance security.
+
+`WorkflowCreatorExecution` is the boundary-ready U14 entry point above exactly
+six runtime owners: execution/session composition, installed closure, audit
+gateway, archive admission, Linux process supervision, and bounded capture. Its
+only component dependency is Workflow Creator Core; it imports no Hive runtime
+dependency. `start!` returns one typed session exposing `gateway_path`,
+`workspace_path`, the two closed outer model-loop launch methods, `draft!`,
+`finish!`, `result`, and `close`. It exposes no generic archive reader,
+installation scanner, receipt publisher, process runner, or cleanup machinery.
+
+Construction is correspondingly narrow. `WorkflowCreatorExecution` alone may
+construct `WorkflowCreatorGateway` and `WorkflowCreator::ProcessSupervisor`;
+the supervisor alone may construct `WorkflowCreator::Capture`. The Core's
+private `WorkflowCreatorReceiptPublisher` remains private: the evidence facade
+constructs it for the primary receipt, while execution may construct it only
+for the three vocabulary-fixed support filenames
+`candidate-installed-manifest.json`, `openclaw-installed-manifest.json`, and
+`execution-receipt.json`. The downstream `proof.rb` consumer observes those
+members only through `WorkflowCreatorBundle`'s exact retained-bundle
+revalidation. U14 cannot publish `openclaw-workflow-creator.json`.
+
+The mutation boundary is exact. Callers supply candidate/OpenClaw roots,
+versions, manifests, inventories, executable/launcher/lock/package paths,
+environment, and secrets. U14 may validate those bytes, admit only the two
+fixed archive labels, create one absent owner-private proof workspace, serialize
+the nine Vocabulary command positions through its fixed local gateway, launch
+the two fixed outer labels, capture bounded redacted output, supervise teardown,
+publish the three support members, and remove only the workspace whose current
+device/inode still matches its creation row. It cannot choose or expose a
+provider, model, credential, installed version, workflow policy, primary-receipt
+writer, or passing/live classification.
+
+Process custody is deliberately Linux-only: the supervisor depends on child
+subreaping and `/proc` ancestry and fails closed elsewhere. Focused proof covers
+caller loss while the trusted custody root remains alive, including containment,
+TERM/KILL escalation, output drain, descendant reaping, and one teardown receipt
+per launch. It does not claim survival after an external actor SIGKILLs that
+trusted custody root itself, and coherent arbitrary same-UID compromise remains
+outside the contract. Boundary readiness therefore means the deterministic U14
+substrate is stable; U15 still must supply authenticated provider/credential
+routing, live orchestration, and translation of a completed run into a passing
+proof claim.
 
 The `Agent ABI` is boundary-ready below orchestration. `AgentRuntime` exposes
 immutable request, compiled invocation, capability/probe evidence, and

--- a/wiki/gaps.md
+++ b/wiki/gaps.md
@@ -866,11 +866,22 @@ commands, exact editorial graph, zero task count, secret scan, and cleanup.
 U1b now owns crash-safe publication of the fixed primary receipt, but its
 temporary protected-smoke adapter intentionally records
 `u14_execution_custody_unavailable` rather than turning successful model output
-into a live-success claim. U14 must first prove installed execution custody and
-U15 must then own credential routing and the authenticated final translation.
+into a live-success claim. U14 now supplies the deterministic installed,
+archive, gateway, capture, process-custody, and fixed-support-publication
+substrate, but U15 must still route credentials/providers, orchestrate the
+authenticated run, and own the final passing translation.
 The same proof must also attest one explicitly authorized task, one first-stage
 run, a no-op retry with the same idempotency key, and matching operational
 status.
+
+U14 process custody is Linux-only and deliberately fails closed on other
+platforms. It tests caller loss while the trusted custody root remains alive;
+it does not claim recovery after an external actor SIGKILLs that custody root
+itself. Coherent arbitrary same-UID compromise is also excluded because such
+an actor can rewrite process, filesystem, and private IPC evidence together.
+Closing those stronger guarantees would require a separate OS identity or
+equivalent protected broker, not a compatibility reader or another in-process
+Ruby fence.
 
 ## WorkLedger is an internal boundary, not a published format (2026-07-26)
 
@@ -1013,13 +1024,11 @@ local command contract or its deterministic tests.
 ## Live Workflow Creator still needs complete bundle production (2026-08-04)
 
 U1a2 makes the incumbent attestor and verifier require, retain, and
-independently revalidate the exact four-file Workflow Creator bundle. The
-Core therefore has a real consumer and no migration exception, but remains a
-custody-complete candidate until U1b supplies the publication boundary. The
-current live workflow still uploads only `openclaw-workflow-creator.json`, so
-that live result is now explicitly unavailable rather than accepted through a
-legacy one-file fallback. U1b/U14/U15 must produce the two installation
-manifests and execution receipt alongside the primary before a live passing
-claim is possible. No provider-backed run, publication, or release
-qualification was performed here; hostile/property campaigns remain optional
-and outside the normal merge gate.
+independently revalidate the exact four-file Workflow Creator bundle. U1b owns
+the primary receipt, and U14 adds a boundary-ready deterministic substrate that
+can publish only the two installation manifests and execution receipt. The
+protected live workflow still lacks U15 authenticated orchestration, so no
+provider-backed result may be upgraded to a passing claim. The old one-file
+shape remains rejected; U14 introduces no compatibility reader. No
+provider-backed run, publication, or release qualification was performed here;
+hostile/property campaigns remain optional and outside the normal merge gate.

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -19,12 +19,13 @@ Updated: 2026-08-04
 Folder-as-agent workflow engine: a Ruby 3.4 / Thor CLI control plane where descriptor-backed workflows move task folders through filesystem stages, stage agents compile provider-neutral invocations through `Hive::AgentRuntime` and configurable AgentProfile adapters (`claude` default, `codex`, `pi`, `grok`), and `mv` between directories remains the approval primitive. The built-in `coding` workflow drives the nine-stage PR pipeline (`1-inbox` → `2-brainstorm` → `3-plan` → `4-execute` → `5-open-pr` → `6-review` → `7-artifacts` → `8-finalize` → `9-done`), while the built-in `content` and `bench` workflows and project-authored workflows share the same generic runner/status/action machinery. Agent operation is centered on the additive operational status contract, coherent daemon scheduler snapshots, bounded semantic `hive watch`, tokenized routine `hive act`, and stable-ID semantic E2E profiles; the legacy full JSON graph remains compatible. Hive packages one canonical operating skill projected to OpenClaw `/hive`, Claude `/hive`, Codex `$hive`, and Pi `/skill:hive`, with read-only `hive doctor`, consent-safe setup, deterministic trusted pre-release proof, and optional four-agent live diagnostics.
 
 Reusable mechanisms remain in this monorepo behind the canonical
-[[component-boundaries]] catalog. The ten-row internal graph has eight
+[[component-boundaries]] catalog. The eleven-row internal graph has nine
 `boundary-ready` facades—UserService, Agent ABI, Agent Artifact Firewall,
 Skillpack, Safe Agent Git Gate, WorkLedger, and Workflow Creator Values/Text
-Safety plus the composed Workflow Creator—and two guarded candidates: Attempts
-admission and Patrol Effect Evidence. Skillpack's dependency on Agent ABI and
-the Core's dependency on Values are the two component edges. Patrol's U3
+Safety plus the composed Workflow Creator and deterministic Workflow Creator
+Execution custody—and two guarded candidates: Attempts admission and Patrol
+Effect Evidence. Skillpack's dependency on Agent ABI, Execution's dependency
+on Core, and Core's dependency on Values are the three component edges. Patrol's U3
 qualification fence is the only migration exception. Hive
 is the first and primary consumer, and internal readiness does not imply a gem,
 version, repository, or release.

--- a/wiki/log.d/20260804T181819Z-workflow-creator-task-slug-binding.md
+++ b/wiki/log.d/20260804T181819Z-workflow-creator-task-slug-binding.md
@@ -1,0 +1,16 @@
+---
+title: Bind Workflow Creator execution to the created task slug
+type: change
+created: 2026-08-04
+tags: [workflow-creator, execution, evidence]
+---
+
+The Workflow Creator semantic contract no longer assumes a fixed task slug.
+Its nine-command vocabulary gives every position an exact semantic label and
+represents the run target as `{created_slug}`. Execution receipts must prove
+that argument 1 of command position 7 was bound from the `slug` result field of
+task-creation position 6, and the primary task row must carry the same slug.
+
+Focused core, proof-bundle, and deterministic smoke coverage resolve a realistic
+generated slug before validating exact argv and reject command-label or binding
+substitution.

--- a/wiki/log.d/20260804T190325Z-workflow-creator-execution.md
+++ b/wiki/log.d/20260804T190325Z-workflow-creator-execution.md
@@ -18,7 +18,11 @@ orchestration remains pending.
 ProcessSupervisor alone constructs Capture. The private receipt publisher
 remains hidden and is authorized from execution only for fixed support-file
 publication. Source closure, command-label vocabulary ownership, clean loading,
-and the 390/485/520 pairwise readable-line budgets are component-tested.
+and the 390/485/575 pairwise readable-line budgets are component-tested. The
+gateway/execution projection was corrected from 520 after implementation showed
+that the smaller number encouraged compression across fixed IPC and two-phase
+receipt lifecycle code or omission of disjoint custody-root validation without
+removing a responsibility owner.
 
 **Limits:** Process custody is Linux-only. Caller-loss teardown is tested, but
 externally SIGKILLing the trusted custody root itself is not claimed, and

--- a/wiki/log.d/20260804T190325Z-workflow-creator-execution.md
+++ b/wiki/log.d/20260804T190325Z-workflow-creator-execution.md
@@ -1,0 +1,25 @@
+## 2026-08-04 — Workflow creator deterministic execution boundary
+
+**Change:** Added the `boundary-ready` Workflow Creator Execution catalog row
+for exactly six U14 runtime owners. Its only component edge points to Workflow
+Creator Core, its clean entry point is `WorkflowCreatorExecution`, and its typed
+session surface is limited to the gateway/workspace paths, two closed outer
+launches, draft/finish/result, and close lifecycle.
+
+**Authority:** U14 may admit the two fixed archives and caller-selected
+installed closures, serialize the nine vocabulary commands, own Linux process
+teardown and bounded capture, create and identity-bound-clean one workspace,
+and publish only the three vocabulary-fixed support members. It has no
+provider, model, credential, installed-version, workflow-policy,
+primary-receipt, or passing/live-proof authority. U15 authenticated
+orchestration remains pending.
+
+**Fences:** Execution alone constructs Gateway and ProcessSupervisor;
+ProcessSupervisor alone constructs Capture. The private receipt publisher
+remains hidden and is authorized from execution only for fixed support-file
+publication. Source closure, command-label vocabulary ownership, clean loading,
+and the 390/485/520 pairwise readable-line budgets are component-tested.
+
+**Limits:** Process custody is Linux-only. Caller-loss teardown is tested, but
+externally SIGKILLing the trusted custody root itself is not claimed, and
+coherent arbitrary same-UID compromise remains outside the guarantee.

--- a/wiki/log.d/20260804T190325Z-workflow-creator-execution.md
+++ b/wiki/log.d/20260804T190325Z-workflow-creator-execution.md
@@ -18,11 +18,18 @@ orchestration remains pending.
 ProcessSupervisor alone constructs Capture. The private receipt publisher
 remains hidden and is authorized from execution only for fixed support-file
 publication. Source closure, command-label vocabulary ownership, clean loading,
-and the 390/485/575 pairwise readable-line budgets are component-tested. The
+and the 410/495/600 pairwise readable-line budgets are component-tested. The
 gateway/execution projection was corrected from 520 after implementation showed
 that the smaller number encouraged compression across fixed IPC and two-phase
 receipt lifecycle code or omission of disjoint custody-root validation without
 removing a responsibility owner.
+
+**Final review:** The one three-lens exact-head pass closed permanent-poison,
+continuous-output timeout, archive-tail/tree, long exact-secret, external
+gateway-destination, prompt/argv binding, installation-drift, full-bundle
+completion, and catalog-truth gaps. Support publication can remain partially
+complete for retry, but the typed result cannot pass until the independently
+written primary and all three support members revalidate as one retained bundle.
 
 **Limits:** Process custody is Linux-only. Caller-loss teardown is tested, but
 externally SIGKILLing the trusted custody root itself is not claimed, and

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -39,9 +39,12 @@ editorial prompt in a disposable initialized project. Its controlled Hive
 surface permits only version, workflow inventory, scaffold, validation, and
 the populated-graph commit before task creation.
 Attestation verifies the prompt digest, native `/hive` discovery, ordered argv,
-created-file digests, exact normalized graph, zero tasks after creation-only,
-then one created-and-run slug plus a no-op retry with the same idempotency key,
-operational status, no external actions, secret scanning, and cleanup. Missing
+the exact nine semantic command labels, and the receipt binding that takes the
+`slug` returned by task-creation position 6 and places it into argument 1 of
+run position 7. It also verifies created-file digests, the exact normalized
+graph, zero tasks after creation-only, then one created-and-run slug plus a no-op
+retry with the same idempotency key, operational status, no external actions,
+secret scanning, and cleanup. Missing
 provider credentials make this live gate explicitly unavailable; they never
 turn a skipped test into release evidence.
 

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -169,8 +169,8 @@ allows the private receipt publisher in execution only for the three
 Vocabulary-fixed support members. It also checks that command labels are
 sourced from `WorkflowCreator::Vocabulary`, that the six-source relative
 require closure cannot widen to Hive runtime code, and that the readable
-pairwise source budgets remain exact: archive + installation at most 390 lines,
-capture + supervisor at most 485, and gateway + execution at most 575. These
+pairwise source budgets remain exact: archive + installation at most 410 lines,
+capture + supervisor at most 495, and gateway + execution at most 600. These
 are pair budgets, not per-file compression targets.
 
 The archive, installation, capture, supervisor, and gateway files exercise
@@ -180,6 +180,16 @@ sequence-bound nine-command gateway. They establish a deterministic U14
 substrate only. No focused test selects a provider/model/credential, performs
 an authenticated model loop, lets U14 publish the primary receipt, or upgrades
 the result into a live passing claim; those remain U15 responsibilities.
+
+The final-head regressions also cover concatenated gzip members and raw gem
+tail bytes, non-adjacent file/descendant archive conflicts, 3,000-byte exact
+secrets across scan slices, a continuously writable child that must still time
+out and be reaped, commands after permanent gateway poison, gateway paths that
+escape the candidate closure, missing outer prompt bytes, duplicate outer
+launches, final installed-closure drift, and full-bundle validation before a
+session can return `passed`. A missing primary can leave the fixed support
+members as a safe partial publication; adding the independently authored
+canonical primary and retrying converges without U14 writing that primary.
 
 The live-agent proof suite exercises the strict U1a2 cutover: source admission
 requires the exact four canonical vocabulary-named JSON files in an

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -49,8 +49,9 @@ provider credentials make this live gate explicitly unavailable; they never
 turn a skipped test into release evidence.
 
 The U1b adapter publishes through `WorkflowCreatorEvidence` but deliberately
-retains a typed non-passing receipt after a successful model loop until U14
-supplies execution custody and U15 owns the final authenticated claim.
+retains a typed non-passing receipt after a successful model loop. U14 now
+supplies deterministic execution custody; U15 still owns authenticated
+provider orchestration and the final passing claim.
 
 ## Local feedback loop
 
@@ -143,6 +144,12 @@ bundle exec ruby -Itest test/unit/packaging/workflow_creator_values_test.rb
 bundle exec ruby -Itest test/unit/packaging/workflow_creator_text_safety_test.rb
 bundle exec ruby -Itest test/unit/packaging/workflow_creator_core_test.rb
 bundle exec ruby -Itest test/unit/packaging/workflow_creator_evidence_test.rb
+bundle exec ruby -Itest test/unit/packaging/workflow_creator_execution_test.rb
+bundle exec ruby -Itest test/unit/packaging/workflow_creator_archive_test.rb
+bundle exec ruby -Itest test/unit/packaging/workflow_creator_installation_test.rb
+bundle exec ruby -Itest test/unit/packaging/workflow_creator_capture_test.rb
+bundle exec ruby -Itest test/unit/packaging/workflow_creator_process_supervisor_test.rb
+bundle exec ruby -Itest test/unit/packaging/workflow_creator_gateway_test.rb
 bundle exec ruby -Itest test/unit/packaging/live_agent_proof_test.rb
 ```
 
@@ -154,6 +161,26 @@ catalog-authorized composition file. The helper can run a named focused
 clean-load proof for a candidate such as Attempts without representing the
 whole component graph as ready.
 
+The Workflow Creator Execution row fixes the U14 inventory at exactly six
+runtime sources and one downward component edge to Workflow Creator Core. Its
+contract test makes execution the only constructor of Gateway and
+ProcessSupervisor, ProcessSupervisor the only constructor of Capture, and
+allows the private receipt publisher in execution only for the three
+Vocabulary-fixed support members. It also checks that command labels are
+sourced from `WorkflowCreator::Vocabulary`, that the six-source relative
+require closure cannot widen to Hive runtime code, and that the readable
+pairwise source budgets remain exact: archive + installation at most 390 lines,
+capture + supervisor at most 485, and gateway + execution at most 520. These
+are pair budgets, not per-file compression targets.
+
+The archive, installation, capture, supervisor, and gateway files exercise
+regular-only bounded archives, exact installed closures, capped redacted
+streams, Linux-only process custody with caller-loss teardown, and the
+sequence-bound nine-command gateway. They establish a deterministic U14
+substrate only. No focused test selects a provider/model/credential, performs
+an authenticated model loop, lets U14 publish the primary receipt, or upgrades
+the result into a live passing claim; those remain U15 responsibilities.
+
 The live-agent proof suite exercises the strict U1a2 cutover: source admission
 requires the exact four canonical vocabulary-named JSON files in an
 owner-private directory, attestation retains those exact bytes, and verification
@@ -164,10 +191,9 @@ Semantically valid support members containing credential-shaped bytes also
 fail before any proof directory is created. Release-candidate coverage proves
 the managed-Web archive executes the exported candidate helper even when it
 differs from the checkout-loaded implementation.
-The live workflow still produces only the former primary file, so provider-backed
-Workflow Creator proof remains unavailable until the complete bundle-producing
-units land; this focused suite is deterministic custody/semantic proof, not a
-live pass.
+The protected live workflow is not yet wired through U14 by authenticated U15
+orchestration, so provider-backed Workflow Creator proof remains unavailable;
+this focused suite is deterministic custody/semantic proof, not a live pass.
 
 Workflow Creator Values keeps its clean-load and dependency proof outside the
 generic component loader. The Values suite directly runs its leaf under

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -170,7 +170,7 @@ Vocabulary-fixed support members. It also checks that command labels are
 sourced from `WorkflowCreator::Vocabulary`, that the six-source relative
 require closure cannot widen to Hive runtime code, and that the readable
 pairwise source budgets remain exact: archive + installation at most 390 lines,
-capture + supervisor at most 485, and gateway + execution at most 520. These
+capture + supervisor at most 485, and gateway + execution at most 575. These
 are pair budgets, not per-file compression targets.
 
 The archive, installation, capture, supervisor, and gateway files exercise


### PR DESCRIPTION
## Summary

- Workflow Creator qualification can now exercise candidate gems and the prescribed Hive/agent commands through one fail-closed execution boundary, without giving the candidate direct provider, credential, or network authority.
- Archive admission, isolated installation, bounded secret-aware capture, process-group custody, candidate/install drift checks, and independently retained proof artifacts make the result reproducible and reject incomplete or tampered runs.
- This deliberately stops at U14: authenticated live provider/OpenClaw orchestration remains U15, rather than expanding this unit into another qualification subsystem.

## Test plan

- [x] Focused execution, gateway, and supervisor tests passed under seeds 1, 77, and 999: 26 runs / 185 assertions per seed.
- [x] Focused archive, capture, installation, core, component-boundary, live-proof, release-artifact, and wiki-log tests passed.
- [x] RuboCop passed for all 11 changed Ruby files; `git diff --check` is clean.
- [x] Broad local checkpoint: 12,156 runs, 156,602 assertions, 0 failures, 0 errors, 10 skips.
- [ ] Hosted CI and dedicated merge gates pass on this exact head.

## Notes for reviewer

Three independent final-head reviews covered architecture/dependencies, correctness/compatibility, and reliability/security. Their 11 actionable findings were resolved in one correction batch, including bounded output draining, strict gzip/tar admission, long-secret scanning, canonical retained-artifact verification, launch-input binding, fail-closed gateway poisoning, and post-execution drift detection.

The intended residual boundaries are explicit: Linux process semantics are required; uninterruptible kernel tasks cannot be killed promptly; coherent arbitrary same-UID compromise is outside this unit; and provider-authenticated live qualification belongs to U15.

### Post-deploy monitoring and validation

- No deployment is performed by this PR. The next U15 integration/dogfood run owns runtime validation.
- Healthy signals are complete retained bundles, authenticated receipts, no residual process/socket/workspace state, and green packaged qualification checks.
- Investigate `workflow-creator gateway refused`, execution/supervisor receipt failures, unsafe-archive rejections, timeouts, or leaked custody state. Roll back if packaged proof regresses or any candidate escapes its declared closure.
