### PR TITLE
feat(workflow-creator): complete live OpenClaw proof

### DIFF
--- a/.github/workflows/live-agent-skills.yml
+++ b/.github/workflows/live-agent-skills.yml
@@ -33,9 +33,14 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           INPUT_CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+          AUTHORIZED_DISPATCH_ACTOR: ${{ github.repository_owner }}
           EXPECTED_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/live-agent-skills.yml@refs/heads/main
         run: |
           set -euo pipefail
+          [[ "$GITHUB_ACTOR" == "$AUTHORIZED_DISPATCH_ACTOR" ]] || {
+            echo "live proof dispatch is restricted to the repository owner" >&2
+            exit 1
+          }
           [[ "$GITHUB_REF" == "refs/heads/main" ]] || {
             echo "proof must be dispatched from refs/heads/main" >&2
             exit 1
@@ -83,7 +88,7 @@ jobs:
         with:
           ref: ${{ needs.validate.outputs.candidate_sha }}
           fetch-depth: 0
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # pinned 2026-07-26
         with:
           ruby-version: "3.4"
           bundler-cache: true
@@ -145,7 +150,7 @@ jobs:
           set -euo pipefail
           mkdir -p candidate-source
           tar -xzf "candidate-artifacts/hive-source-${CANDIDATE_SHA}.tar.gz" -C candidate-source
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # pinned 2026-07-26
         with:
           ruby-version: "3.4"
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -204,38 +209,73 @@ jobs:
       actions: read
       contents: read
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.validate.outputs.candidate_sha }}
+          fetch-depth: 0
+          path: candidate-source
+          persist-credentials: false
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # pinned 2026-07-26
+        with:
+          ruby-version: "3.4"
+      - name: Initialize typed workflow-creator evidence
+        env:
+          HIVE_CANDIDATE_SHA: ${{ needs.validate.outputs.candidate_sha }}
+          HIVE_CREATOR_EVIDENCE_PATH: ${{ runner.temp }}/workflow-creator-evidence/openclaw-workflow-creator.json
+        run: |
+          set -euo pipefail
+          install -d -m 0700 "$RUNNER_TEMP/workflow-creator-evidence"
+          ruby candidate-source/packaging/live_agent_skills/workflow_creator_live_runner.rb initialize
+      - name: Download exact candidate artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: live-agent-candidate-artifacts-${{ github.run_attempt }}
           path: candidate-artifacts
-      - name: Extract the exact candidate source
-        env:
-          CANDIDATE_SHA: ${{ needs.validate.outputs.candidate_sha }}
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22.23.1"
+      - name: Install locked OpenClaw and exact candidate
         run: |
           set -euo pipefail
-          mkdir -p candidate-source
-          tar -xzf "candidate-artifacts/hive-source-${CANDIDATE_SHA}.tar.gz" -C candidate-source
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: "3.4"
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "22"
-      - name: Install OpenClaw in the ephemeral runner
-        run: npm install --global openclaw
-      - name: Install the exact candidate gem and test dependencies
-        run: |
-          set -euo pipefail
+          setup_root="$RUNNER_TEMP/workflow-creator-setup"
+          candidate_runtime="$setup_root/candidate-runtime"
+          openclaw_runtime="$setup_root/openclaw-runtime"
+          openclaw_package_root="$RUNNER_TEMP/workflow-creator-openclaw-package"
+          install -d -m 0700 "$setup_root" "$candidate_runtime" "$openclaw_runtime" "$openclaw_package_root"
+          install -m 0600 candidate-source/packaging/live_agent_skills/openclaw/package.json \
+            "$openclaw_runtime/package.json"
+          install -m 0600 candidate-source/packaging/live_agent_skills/openclaw/package-lock.json \
+            "$openclaw_runtime/package-lock.json"
+          npm ci --ignore-scripts --prefix "$openclaw_runtime"
+          npm audit --omit=dev --prefix "$openclaw_runtime"
+          openclaw_version="$(ruby -rjson -e \
+            'puts JSON.parse(File.binread(ARGV.fetch(0))).dig("dependencies", "openclaw")' \
+            "$openclaw_runtime/package.json")"
+          npm pack "openclaw@$openclaw_version" --ignore-scripts --silent \
+            --pack-destination "$openclaw_package_root"
+          mapfile -t openclaw_packages < <(find "$openclaw_package_root" -maxdepth 1 -type f -name '*.tgz' -print)
+          [[ "${#openclaw_packages[@]}" -eq 1 && -s "${openclaw_packages[0]}" ]]
           gem_file="$(find candidate-artifacts -maxdepth 1 -type f -name 'hive-cli-*.gem' -print -quit)"
           [[ -n "$gem_file" && -s "$gem_file" ]]
           bash candidate-source/packaging/live_agent_skills/install_candidate_gem.sh \
-            "$gem_file" "$RUNNER_TEMP/proven-gems"
-          "$RUNNER_TEMP/proven-gems/bin/hive" --version
+            "$gem_file" "$candidate_runtime"
+          "$candidate_runtime/bin/hive" --version
+          test -f "$candidate_runtime/rubygems-bin/hive"
+          test -f "$openclaw_runtime/node_modules/openclaw/openclaw.mjs"
+          {
+            echo "HIVE_CREATOR_SETUP_ROOT=$setup_root"
+            echo "HIVE_PROVEN_HIVE_BIN=$candidate_runtime/rubygems-bin/hive"
+            echo "HIVE_OPENCLAW_ENTRYPOINT=$openclaw_runtime/node_modules/openclaw/openclaw.mjs"
+            echo "HIVE_OPENCLAW_LOCK=$openclaw_runtime/package-lock.json"
+            echo "HIVE_OPENCLAW_PACKAGE=${openclaw_packages[0]}"
+            echo "HIVE_NODE_BIN=$(realpath "$(command -v node)")"
+          } >> "$GITHUB_ENV"
           cd candidate-source
           bundle install --jobs 4 --retry 2
       - name: Run authenticated workflow-creator proof
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           HIVE_LIVE_MODEL: ${{ vars.HIVE_LIVE_MODEL }}
           HIVE_LIVE_AGENT_SKILLS: "1"
           HIVE_RELEASE_GATE: "1"
@@ -249,10 +289,10 @@ jobs:
           bundle exec ruby -Itest test/smoke/live_hive_workflow_creator_smoke_test.rb
       - name: Upload redacted workflow-creator evidence
         if: ${{ always() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: workflow-creator-evidence-openclaw-${{ github.run_attempt }}
-          path: ${{ runner.temp }}/workflow-creator-evidence/openclaw-workflow-creator.json
+          path: ${{ runner.temp }}/workflow-creator-evidence
           if-no-files-found: error
           retention-days: 7
 
@@ -276,7 +316,7 @@ jobs:
           pattern: live-agent-evidence-*-${{ github.run_attempt }}
           path: evidence
           merge-multiple: true
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: workflow-creator-evidence-*-${{ github.run_attempt }}
           path: creator-evidence
@@ -288,7 +328,7 @@ jobs:
           set -euo pipefail
           mkdir -p candidate-source
           tar -xzf "candidate-artifacts/hive-source-${CANDIDATE_SHA}.tar.gz" -C candidate-source
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # pinned 2026-07-26
         with:
           ruby-version: "3.4"
       - name: Validate operating and workflow-creator proofs

--- a/.github/workflows/live-agent-skills.yml
+++ b/.github/workflows/live-agent-skills.yml
@@ -41,6 +41,14 @@ jobs:
             echo "live proof dispatch is restricted to the repository owner" >&2
             exit 1
           }
+          [[ "$GITHUB_TRIGGERING_ACTOR" == "$AUTHORIZED_DISPATCH_ACTOR" ]] || {
+            echo "live proof execution is restricted to the repository owner" >&2
+            exit 1
+          }
+          [[ "$GITHUB_RUN_ATTEMPT" == "1" ]] || {
+            echo "live proof requires a fresh owner dispatch; reruns are refused" >&2
+            exit 1
+          }
           [[ "$GITHUB_REF" == "refs/heads/main" ]] || {
             echo "proof must be dispatched from refs/heads/main" >&2
             exit 1
@@ -139,6 +147,14 @@ jobs:
             display: Pi
             npm_package: "@mariozechner/pi-coding-agent"
     steps:
+      - name: Revalidate live-proof authorization
+        env:
+          AUTHORIZED_DISPATCH_ACTOR: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+          [[ "$GITHUB_ACTOR" == "$AUTHORIZED_DISPATCH_ACTOR" ]]
+          [[ "$GITHUB_TRIGGERING_ACTOR" == "$AUTHORIZED_DISPATCH_ACTOR" ]]
+          [[ "$GITHUB_RUN_ATTEMPT" == "1" ]]
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: live-agent-candidate-artifacts-${{ github.run_attempt }}
@@ -209,6 +225,14 @@ jobs:
       actions: read
       contents: read
     steps:
+      - name: Revalidate live-proof authorization
+        env:
+          AUTHORIZED_DISPATCH_ACTOR: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+          [[ "$GITHUB_ACTOR" == "$AUTHORIZED_DISPATCH_ACTOR" ]]
+          [[ "$GITHUB_TRIGGERING_ACTOR" == "$AUTHORIZED_DISPATCH_ACTOR" ]]
+          [[ "$GITHUB_RUN_ATTEMPT" == "1" ]]
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.validate.outputs.candidate_sha }}
@@ -287,6 +311,13 @@ jobs:
           install -d -m 0700 "$RUNNER_TEMP/workflow-creator-evidence"
           cd candidate-source
           bundle exec ruby -Itest test/smoke/live_hive_workflow_creator_smoke_test.rb
+      - name: Finalize workflow-creator bootstrap failure evidence
+        if: ${{ failure() }}
+        env:
+          HIVE_CANDIDATE_SHA: ${{ needs.validate.outputs.candidate_sha }}
+          HIVE_CREATOR_EVIDENCE_PATH: ${{ runner.temp }}/workflow-creator-evidence/openclaw-workflow-creator.json
+        run: |
+          ruby candidate-source/packaging/live_agent_skills/workflow_creator_live_runner.rb finalize-bootstrap
       - name: Upload redacted workflow-creator evidence
         if: ${{ always() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/config/component-boundaries.yml
+++ b/config/component-boundaries.yml
@@ -846,6 +846,8 @@ components:
         - HiveLiveAgentProof::WorkflowCreatorBundle.retained
         - HiveLiveAgentProof::WorkflowCreatorEvidence.initialize!
         - HiveLiveAgentProof::WorkflowCreatorEvidence.replace_nonpassing!
+        - HiveLiveAgentProof::WorkflowCreatorEvidence.replace_primary!
+        - HiveLiveAgentProof::WorkflowCreatorEvidence.replace_primary_with_failure!
       errors:
         - HiveLiveAgentProof::Error
         - HiveLiveAgentProof::WorkflowCreator::Error
@@ -864,7 +866,7 @@ components:
       - "Failure construction captures stable caller inputs and detail once, then captures only its constructed result"
       - "The semantic core is declarative and owns no retention, publication, process, provider, or credential state"
       - "The bundle owner reads one exact four-file source bundle and independently revalidates retained proof bytes"
-      - "The evidence facade alone initializes and compare-and-swap replaces the vocabulary-fixed primary receipt"
+      - "The evidence facade alone initializes and compare-and-swap replaces the vocabulary-fixed primary receipt, including typed primary-to-failure finalization"
       - "Publication converges exact retries and bounded transient recovery without clobbering conflicting bytes"
     schema_contracts:
       - "Vocabulary and failed, primary, installation, and execution schema-v1 fields are exact and deeply immutable"
@@ -903,6 +905,80 @@ components:
       - test/unit/packaging/workflow_creator_core_test.rb
       - test/unit/packaging/workflow_creator_evidence_test.rb
       - test/unit/packaging/live_agent_proof_test.rb
+    migration_exceptions: []
+
+  - id: workflow-creator-live
+    name: Workflow Creator Live Orchestration
+    state: boundary-ready
+    entrypoint:
+      file: packaging/live_agent_skills/workflow_creator_live_setup.rb
+      require: ./packaging/live_agent_skills/workflow_creator_live_setup
+      constant: HiveLiveAgentProof::WorkflowCreatorLiveSetup
+    public_contract:
+      values:
+        - HiveLiveAgentProof::WorkflowCreatorLiveSetup.prepare!
+        - HiveLiveAgentProof::WorkflowCreatorLiveRunner.initialize_evidence!
+        - HiveLiveAgentProof::WorkflowCreatorLiveRunner.fail!
+        - HiveLiveAgentProof::WorkflowCreatorLiveRunner.run!
+        - HiveLiveAgentProof::WorkflowCreatorLiveRunner::Result
+        - HiveLiveAgentProof::WorkflowCreatorOpenClawRuntime.capture!
+        - HiveLiveAgentProof::WorkflowCreatorOpenClawRuntime.verify!
+      errors:
+        - HiveLiveAgentProof::WorkflowCreatorLiveSetup::Error
+        - HiveLiveAgentProof::WorkflowCreatorLiveRunner::Error
+        - HiveLiveAgentProof::WorkflowCreatorOpenClawRuntime::Error
+    owned_paths:
+      - packaging/live_agent_skills/workflow_creator_live_setup.rb
+      - packaging/live_agent_skills/workflow_creator_live_runner.rb
+      - packaging/live_agent_skills/workflow_creator_openclaw_runtime.rb
+      - packaging/live_agent_skills/openclaw/package.json
+      - packaging/live_agent_skills/openclaw/package-lock.json
+    state_contracts:
+      - "One setup result binds the exact candidate artifacts, installed candidate and OpenClaw runtimes, immutable dependency identities, projected skill, private workspace preparation, and independent external-action observation"
+      - "One runner derives the provider from the exact model prefix, exposes only its selected credential to the two outer OpenClaw launches, and strips provider and repository authority from every downstream tool process"
+      - "The initial typed non-passing receipt exists before setup or credential preflight; each ordinary exit compare-and-swap finalizes it through Workflow Creator Core as exactly one passing or typed non-passing primary"
+      - "The smoke test and workflow select fixtures and paths only; orchestration, policy, evidence translation, and cleanup remain inside this component"
+    schema_contracts:
+      - "The configuration record binds candidate SHA, model/provider/transport, exact OpenClaw lock and package identity, reviewed lifecycle scripts, runtime tree seal, shell sanitizer, and projected skill manifest"
+      - "OpenClaw configuration admits only workspace-scoped primitive file tools plus the exact U14 gateway path, and the SQLite-backed approvals policy must read back with exact security, ask, fallback, and allowlist fields before model execution"
+      - "Passing primary evidence comes only from the exact authored editorial graph, zero-task creation observation, one authorized task and deterministic first-stage fixture, exact nine candidate commands, two authenticated outer loops, and independently observed zero external actions"
+    lock_contracts:
+      - "Setup creates only absent owner-private closure, workspace, state, home, and evidence paths; identity seals are rechecked before credential injection and after both model loops"
+      - "The U14 execution session remains the sole candidate gateway and process-custody owner; live orchestration exposes no generic command runner or evidence filename"
+    component_dependencies:
+      - workflow-creator-core
+      - workflow-creator-execution
+    allowed_hive_dependencies: []
+    internal_collaborators:
+      - HiveLiveAgentProof::WorkflowCreatorLiveRunner
+      - HiveLiveAgentProof::WorkflowCreatorOpenClawRuntime
+      - HiveLiveAgentProof::WorkflowCreatorLiveSetup::WorkspacePreparer
+      - HiveLiveAgentProof::WorkflowCreatorLiveSetup::ExternalActionsObserver
+    forbidden_constructions:
+      - HiveLiveAgentProof::WorkflowCreatorLiveSetup::WorkspacePreparer
+      - HiveLiveAgentProof::WorkflowCreatorLiveSetup::ExternalActionsObserver
+    authorized_internal_constructions:
+      - constant: HiveLiveAgentProof::WorkflowCreatorLiveSetup::WorkspacePreparer
+        files:
+          - packaging/live_agent_skills/workflow_creator_live_setup.rb
+        reason: "The setup facade alone constructs the fixed workspace-preparation callable"
+      - constant: HiveLiveAgentProof::WorkflowCreatorLiveSetup::ExternalActionsObserver
+        files:
+          - packaging/live_agent_skills/workflow_creator_live_setup.rb
+        reason: "The setup facade alone constructs the fixed external-action observation callable"
+    construction_scan_paths:
+      - packaging
+    hive_consumers:
+      - test/smoke/live_hive_workflow_creator_smoke_test.rb
+    mutation_authority: "The setup may materialize only its exact immutable closures and one disposable proof workspace; the runner may invoke only the two vocabulary-fixed OpenClaw loops through U14, publish only through Workflow Creator Core, and delete only U14-owned disposable state. Neither may choose a dependency version, release, repository effect, or provider endpoint outside its committed records."
+    recovery_surface: "Missing credentials or prerequisites remain typed blocked evidence; invalid/tampered closures, policy drift, transport overrides, tool authority, model/process failures, incomplete observations, publication conflicts, and cleanup failures remain typed non-passing evidence. A head change invalidates authenticated evidence and requires fresh authorization."
+    wiki_page: wiki/component-boundaries.md
+    focused_tests:
+      - test/unit/packaging/workflow_creator_live_setup_test.rb
+      - test/unit/packaging/workflow_creator_live_runner_test.rb
+      - test/unit/packaging/workflow_creator_openclaw_runtime_test.rb
+      - test/smoke/live_hive_workflow_creator_smoke_test.rb
+      - test/unit/release_contract_test.rb
     migration_exceptions: []
 
   - id: workflow-creator-execution

--- a/config/component-boundaries.yml
+++ b/config/component-boundaries.yml
@@ -919,6 +919,7 @@ components:
         - HiveLiveAgentProof::WorkflowCreatorLiveSetup.prepare!
         - HiveLiveAgentProof::WorkflowCreatorLiveRunner.initialize_evidence!
         - HiveLiveAgentProof::WorkflowCreatorLiveRunner.fail!
+        - HiveLiveAgentProof::WorkflowCreatorLiveRunner.finalize_bootstrap_failure!
         - HiveLiveAgentProof::WorkflowCreatorLiveRunner.run!
         - HiveLiveAgentProof::WorkflowCreatorLiveRunner::Result
         - HiveLiveAgentProof::WorkflowCreatorOpenClawRuntime.capture!
@@ -936,14 +937,15 @@ components:
     state_contracts:
       - "One setup result binds the exact candidate artifacts, installed candidate and OpenClaw runtimes, immutable dependency identities, projected skill, private workspace preparation, and independent external-action observation"
       - "One runner derives the provider from the exact model prefix, exposes only its selected credential to the two outer OpenClaw launches, and strips provider and repository authority from every downstream tool process"
-      - "The initial typed non-passing receipt exists before setup or credential preflight; each ordinary exit compare-and-swap finalizes it through Workflow Creator Core as exactly one passing or typed non-passing primary"
+      - "Native OpenClaw skill discovery, the exact final operational task row, and the authored graph/task effects are all required retained inputs to a passing primary"
+      - "The initial typed non-passing receipt exists before setup or credential preflight; each ordinary exit compare-and-swap finalizes it through Workflow Creator Core as exactly one passing or typed non-passing primary, while the bootstrap finalizer preserves any more specific failure"
       - "The smoke test and workflow select fixtures and paths only; orchestration, policy, evidence translation, and cleanup remain inside this component"
     schema_contracts:
       - "The configuration record binds candidate SHA, model/provider/transport, exact OpenClaw lock and package identity, reviewed lifecycle scripts, runtime tree seal, shell sanitizer, and projected skill manifest"
       - "OpenClaw configuration admits only workspace-scoped primitive file tools plus the exact U14 gateway path, and the SQLite-backed approvals policy must read back with exact security, ask, fallback, and allowlist fields before model execution"
       - "Passing primary evidence comes only from the exact authored editorial graph, zero-task creation observation, one authorized task and deterministic first-stage fixture, exact nine candidate commands, two authenticated outer loops, and independently observed zero external actions"
     lock_contracts:
-      - "Setup creates only absent owner-private closure, workspace, state, home, and evidence paths; identity seals are rechecked before credential injection and after both model loops"
+      - "Setup keeps Git metadata, candidate homes, and OpenClaw state/config/approvals in an owner-private control root outside the model workspace; U14 keeps its socket in the owner-private workspace parent, and exact control and skill identities are checked at every candidate command and around both model loops"
       - "The U14 execution session remains the sole candidate gateway and process-custody owner; live orchestration exposes no generic command runner or evidence filename"
     component_dependencies:
       - workflow-creator-core
@@ -1013,7 +1015,7 @@ components:
       - packaging/live_agent_skills/workflow_creator_process_supervisor.rb
       - packaging/live_agent_skills/workflow_creator_capture.rb
     state_contracts:
-      - "One typed session owns the proof workspace, fixed gateway, installed closures, archive admissions, bounded captures, supervisor receipts, draft support bytes, fixed final support publication, and final result"
+      - "One typed session owns the proof workspace, fixed gateway and private sibling socket, installed closures, archive admissions, bounded captures, supervisor receipts, draft support bytes, fixed final support publication, and final result"
       - "Linux child-subreaper custody covers the nine vocabulary-defined candidate commands and exactly two outer model-loop labels; zero launches remains not_started and each launch requires one complete teardown receipt"
       - "The session exposes only its fixed gateway/workspace paths, two closed outer launches, draft, finish, result, and idempotent close lifecycle; it exposes no generic process, archive, installation, publisher, or cleanup primitive"
       - "U14 is a deterministic stable substrate for U15 orchestration, not evidence that an authenticated provider run or live Workflow Creator proof occurred"
@@ -1056,7 +1058,7 @@ components:
       - packaging
     hive_consumers:
       - packaging/live_agent_skills/proof.rb
-    mutation_authority: "The session may create and identity-bound-clean one proof workspace, execute only the eleven closed labels through its private Linux supervisor, inspect the two fixed archive kinds and caller-selected installed closures, and publish only the three vocabulary-fixed support members. It cannot publish the primary receipt or choose a provider, model, credential, installation version, workflow policy, or live-success classification."
+    mutation_authority: "The session may create and identity-bound-clean one proof workspace plus one temporary gateway socket in its owner-private parent, execute only the eleven closed labels through its private Linux supervisor, inspect the two fixed archive kinds and caller-selected installed closures, and publish only the three vocabulary-fixed support members. It cannot publish the primary receipt or choose a provider, model, credential, installation version, workflow policy, or live-success classification."
     recovery_surface: "Caller loss, timeouts, descendant teardown, partial capture, poisoned gateway state, changed filesystem/process identities, unsafe archives/installations, support-file conflicts, and close-before-finish fail closed with bounded receipts or fixed errors. Arbitrary coherent same-UID compromise and externally SIGKILLing the trusted custody root itself are outside the claim."
     wiki_page: wiki/component-boundaries.md
     focused_tests:

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -314,7 +314,10 @@ want an additional authenticated native-agent diagnostic may create four
 GitHub environments restricted to protected `main` workflow runs:
 
 - `live-agent-skills-openclaw`: `OPENAI_API_KEY` and environment variable
-  `HIVE_LIVE_MODEL` naming its OpenClaw model.
+  `HIVE_LIVE_MODEL` naming its OpenClaw model. The Workflow Creator lane also
+  accepts `OPENROUTER_API_KEY` when that model starts with `openrouter/`; the
+  exact model prefix selects one provider and the other credential is not
+  passed to OpenClaw.
 - `live-agent-skills-claude`: `ANTHROPIC_API_KEY` and a Claude-compatible
   `HIVE_LIVE_MODEL`.
 - `live-agent-skills-codex`: `CODEX_API_KEY` and a Codex-compatible
@@ -333,6 +336,15 @@ The optional workflow refuses a non-main dispatch, a workflow revision not
 loaded from `refs/heads/main`, a
 non-full SHA, a candidate not reachable from `origin/main`, or an unprotected
 main branch.
+
+The Workflow Creator diagnostic additionally installs the committed OpenClaw
+lock with lifecycle scripts disabled, audits production dependencies, seals the
+installed runtime before credentials are available, and admits the exact
+package archive and Node runtime recorded by that lock. It initializes a typed
+non-passing receipt before setup; setup, policy, provider, model, process, or
+evidence failure therefore remains uploadable rather than becoming a missing
+artifact. The authenticated run is authorization- and exact-head-bound and is
+not part of normal pull-request CI.
 
 ### 3. Homebrew tap
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -332,7 +332,9 @@ passes only the selected platform's credential into its disposable child
 environment, never copies host auth state, retains no model prose, scans raw
 process output before redaction, and removes the private home before success.
 
-The optional workflow refuses a non-main dispatch, a workflow revision not
+The optional workflow accepts only a fresh first-attempt dispatch whose
+dispatching and triggering actors are both the repository owner; reruns are
+refused before credential-bearing jobs. It also refuses a non-main dispatch, a workflow revision not
 loaded from `refs/heads/main`, a
 non-full SHA, a candidate not reachable from `origin/main`, or an unprotected
 main branch.
@@ -343,7 +345,10 @@ installed runtime before credentials are available, and admits the exact
 package archive and Node runtime recorded by that lock. It initializes a typed
 non-passing receipt before setup; setup, policy, provider, model, process, or
 evidence failure therefore remains uploadable rather than becoming a missing
-artifact. The authenticated run is authorization- and exact-head-bound and is
+artifact. Candidate homes, separate Git metadata, OpenClaw control state, and
+the sibling gateway socket remain outside the model workspace and are revalidated at
+command/launch boundaries. Success additionally requires retained native skill
+discovery and an operational row bound to the created task. The authenticated run is authorization- and exact-head-bound and is
 not part of normal pull-request CI.
 
 ### 3. Homebrew tap

--- a/docs/notes/2026-08-04-workflow-creator-execution-u14-admission.md
+++ b/docs/notes/2026-08-04-workflow-creator-execution-u14-admission.md
@@ -45,12 +45,15 @@ requires re-scoping.
 
 The implementation slices retain separate readable aggregate ceilings:
 archive/installation at 410 lines, capture/supervision at 495 lines, and
-gateway/execution at 600 lines. The gateway/execution budget was raised from
+gateway/execution at 615 lines. The gateway/execution budget was raised from
 its provisional 520-line projection when the real fixed IPC and two-phase receipt
 composition plus disjoint custody roots proved that the smaller number required
 compressed lifecycle code or a weaker mutation boundary. The final-head review
 added exact archive-tail, bounded-drain, stable-installation, and full-bundle
-completion checks without adding another owner.
+completion checks without adding another owner. U15's final security review
+then added an external model-inaccessible socket path, one injected command-
+boundary verifier, and final operational-result validation; the pair ceiling
+moved from 600 to 615 rather than compressing those checks or adding an owner.
 These are architecture budgets, not incentives
 to compress source formatting or weaken exception-path cleanup.
 

--- a/docs/notes/2026-08-04-workflow-creator-live-u15-admission.md
+++ b/docs/notes/2026-08-04-workflow-creator-live-u15-admission.md
@@ -1,0 +1,119 @@
+# U15 live workflow-creator orchestration admission
+
+Status: implemented and locally verified from `origin/main`
+`e822e12036a2d8e5b24b99b9895808a729ca5d88` after PR #944 merged;
+authenticated exact-head evidence remains authorization-gated.
+
+U15 owns only installed/live orchestration. The merged Workflow Creator Values,
+Core, Bundle/Evidence, and Execution components continue to own value import,
+schema semantics, primary publication, deterministic command custody, process
+containment, teardown, and support-bundle publication.
+
+## Dependency direction
+
+```text
+live workflow and smoke adapter
+  -> WorkflowCreatorRunner
+       -> WorkflowCreatorExecution (U14)
+       -> WorkflowCreatorEvidence (U1b)
+       -> WorkflowCreator Core / Bundle (U1a1c/U1a2)
+```
+
+No edge points back from a merged creator component into provider, credential,
+OpenClaw setup, or workflow policy.
+
+## Exact base characterization
+
+- The live creator smoke is 672 lines with 20 methods. Its credential-free
+  baseline at seed 944 is 4 runs, 22 assertions, zero failures/errors, and one
+  expected live skip. Direct stdlib Coverage reports 125/261 executable lines
+  and 13/24 branches on that file.
+- The live creator workflow job has eight steps, two read-only permissions, and
+  four external actions; none of those four uses is full-SHA pinned on this
+  base.
+- The smoke currently owns provider credential selection, OpenClaw discovery
+  and configuration, process launch/timeout, the controlled Hive fixture,
+  evidence projection, and cleanup. A successful model loop is deliberately
+  finalized as `u14_execution_custody_unavailable`, so current main cannot make
+  a passing composed live claim.
+
+## Implemented shape
+
+- The smoke is now a 127-line adapter with one authenticated test and one
+  expected default skip. Provider/setup/process/evidence policy moved into the
+  three packaging-owned U15 files; the workflow only installs the committed
+  closure and invokes that adapter.
+- The committed dependency is `openclaw@2026.7.2-beta.7` on Node `22.23.1`.
+  A clean exact-Node install reproduced 331 lock rows / 321 installed packages,
+  four reviewed lifecycle-script rows with scripts disabled, and zero
+  production audit findings.
+- A credential-free installed probe used the real beta7 runtime and candidate
+  gem, read back the SQLite approval policy, stopped before the model loop,
+  retained typed `workspace_preparation_failed` evidence with
+  `model_loop=not_started`, and removed the disposable workspace.
+
+## Owned and excluded paths
+
+U15 may add one packaging-owned runner and, only when separation remains
+narrow, one provider/environment policy collaborator. It may add the exact
+OpenClaw package lock/inventory, thin the creator smoke, edit only the live
+creator workflow job and its focused contract tests, add one component row,
+and update the required release/wiki documentation.
+
+U15 did not edit `workflow_creator_values.rb`, `workflow_creator_text_safety.rb`,
+`workflow_creator.rb`, either creator contract, or U14 archive, installation,
+capture, supervisor, or execution ownership. Two exact integration repairs were
+required: U1b gained fixed primary-replacement facade calls so U15 does not
+bypass publication custody, and U14's owner-private shebang gateway changed
+from mode `0600` to `0700` so OpenClaw can execute the already-public gateway
+path. Neither repair adds policy or state ownership. U15 does not transplant
+the frozen PR #906 subsystem or add a generic provider, process, archive,
+installation, configuration, evidence, or recovery framework.
+
+## Runtime owners and integration acceptance
+
+The production shape remains three responsibilities: exact candidate/OpenClaw
+setup and workspace policy, provider/transport orchestration, and bounded
+installed-runtime sealing. Tests and workflow adapters add no production owner.
+
+`U15-INT01` re-proves, without co-owning or reopening, the already closed
+`F01` evidence-identity and `F03` installation/teardown invariants. The final
+passing primary must be published through U1b, validated through the merged
+Core and Bundle contracts, and completed through U14 on the exact authored and
+executed instruction plus retained candidate/OpenClaw closures.
+
+## Required behavior
+
+- Persist the schema-valid `preflight/not_started` receipt before any model,
+  credential, binary, dependency, or artifact preflight; replace it with one
+  typed non-passing result on every ordinary failure.
+- Derive `openai` or `openrouter` solely from the configured model prefix and
+  expose exactly that provider's credential only to the outer OpenClaw child.
+- Remove provider, GitHub, Git helper/config, SSH, and generic agent authority
+  from model-invoked tool and candidate environments. Bind approved endpoint,
+  proxy, and CA inputs and reject unapproved overrides before credential use.
+- Admit and invoke the committed exact OpenClaw package/version/registry/
+  integrity closure and native executable path. The workflow installs that
+  lock; it does not select a floating package.
+- Compose the two exact outer prompts, authored instruction, U14 draft, U1b
+  primary publication, and U14 finish/cleanup without a compatibility reader
+  or synthetic success fields.
+- Keep the smoke responsible only for live availability and result assertions;
+  keep the workflow responsible only for immutable setup and artifact upload.
+
+## Verification and authority fence
+
+Run focused runner, smoke, workflow-contract, component-boundary, operating
+skill, and release-contract tests during implementation. Run one broad
+`bundle exec rake test` checkpoint on the final local head, then one parallel
+three-lens review and one hosted exact-head CI cycle.
+
+The final focused checkpoint before broad testing is 137 runs / 1,994
+assertions / zero failures / zero errors / one expected live skip. Hostile
+property campaigns remain optional and outside normal CI.
+
+An authenticated provider run is not authorized by implementation work. It
+requires fresh operator authorization bound to the unchanged exact head after
+credential-free proof, terminal CI, and the independent security review. A
+head change voids that authorization. Merge authority does not authorize a tag,
+release, package publication, or deployment.

--- a/docs/notes/2026-08-04-workflow-creator-live-u15-admission.md
+++ b/docs/notes/2026-08-04-workflow-creator-live-u15-admission.md
@@ -100,7 +100,9 @@ executed instruction plus retained candidate/OpenClaw closures.
   before and after both outer launches.
 - Admit and invoke the committed exact OpenClaw package/version/registry/
   integrity closure and native executable path. The workflow installs that
-  lock; it does not select a floating package.
+  lock; it does not select a floating package. External toolchain inputs must
+  be immutable regular files owned by either the runner or root, matching
+  hosted toolcache ownership without admitting foreign-user files.
 - Require retained native `openclaw skills info hive --json` evidence and bind
   the final operational payload to the one created editorial task at
   `1-research`; neither claim may be synthesized from model success alone.

--- a/docs/notes/2026-08-04-workflow-creator-live-u15-admission.md
+++ b/docs/notes/2026-08-04-workflow-creator-live-u15-admission.md
@@ -93,9 +93,11 @@ executed instruction plus retained candidate/OpenClaw closures.
   from model-invoked tool and candidate environments. Bind approved endpoint,
   proxy, and CA inputs and reject unapproved overrides before credential use.
 - Keep candidate homes, Git metadata, OpenClaw state/config/approvals, and the
-  sibling gateway socket outside the model-writable workspace. Revalidate the separate
-  Git control files and projected skill at every candidate command, and the
-  complete OpenClaw control plane before and after both outer launches.
+  sibling gateway socket outside the model-writable workspace. Initialize Hive
+  while `.git` is still the main-checkout directory, then relocate that directory
+  before any model loop. Revalidate the separate Git control files and projected
+  skill at every candidate command, and the complete OpenClaw control plane
+  before and after both outer launches.
 - Admit and invoke the committed exact OpenClaw package/version/registry/
   integrity closure and native executable path. The workflow installs that
   lock; it does not select a floating package.

--- a/docs/notes/2026-08-04-workflow-creator-live-u15-admission.md
+++ b/docs/notes/2026-08-04-workflow-creator-live-u15-admission.md
@@ -92,14 +92,24 @@ executed instruction plus retained candidate/OpenClaw closures.
 - Remove provider, GitHub, Git helper/config, SSH, and generic agent authority
   from model-invoked tool and candidate environments. Bind approved endpoint,
   proxy, and CA inputs and reject unapproved overrides before credential use.
+- Keep candidate homes, Git metadata, OpenClaw state/config/approvals, and the
+  sibling gateway socket outside the model-writable workspace. Revalidate the separate
+  Git control files and projected skill at every candidate command, and the
+  complete OpenClaw control plane before and after both outer launches.
 - Admit and invoke the committed exact OpenClaw package/version/registry/
   integrity closure and native executable path. The workflow installs that
   lock; it does not select a floating package.
+- Require retained native `openclaw skills info hive --json` evidence and bind
+  the final operational payload to the one created editorial task at
+  `1-research`; neither claim may be synthesized from model success alone.
 - Compose the two exact outer prompts, authored instruction, U14 draft, U1b
   primary publication, and U14 finish/cleanup without a compatibility reader
   or synthetic success fields.
 - Keep the smoke responsible only for live availability and result assertions;
   keep the workflow responsible only for immutable setup and artifact upload.
+- Refuse workflow reruns and revalidate both dispatch and triggering actor in
+  each credential-bearing job. Finalize only an outstanding `not_started`
+  receipt after bootstrap failure, preserving any more specific runner result.
 
 ## Verification and authority fence
 

--- a/packaging/live_agent_skills/openclaw/package-lock.json
+++ b/packaging/live_agent_skills/openclaw/package-lock.json
@@ -1,0 +1,3997 @@
+{
+  "name": "hive-openclaw-creator-proof",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "hive-openclaw-creator-proof",
+      "version": "1.0.0",
+      "dependencies": {
+        "openclaw": "2026.7.2-beta.7"
+      },
+      "engines": {
+        "node": "22.23.1"
+      }
+    },
+    "node_modules/@agentclientprotocol/sdk": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-1.3.0.tgz",
+      "integrity": "sha512-i3h/efaeuMUFAO1HSfo97QZQnnvMd7wWBYtBsdL6UMZg3a78sk3Ffya5Xu7C7tYsXomXoDXJBAzQF2PcFKAhIQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.115.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.115.0.tgz",
+      "integrity": "sha512-BJrFIVyjNuU8lfDyIJTvlRYzgQg+zEl78BxE7fq8esULsGz9IRQvGtW5spq3tydmtjQb/GFdooKGdGsetpx+lQ==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@clack/core": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.4.3.tgz",
+      "integrity": "sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-wrap-ansi": "^0.2.0",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@clack/prompts": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.7.0.tgz",
+      "integrity": "sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@clack/core": "1.4.3",
+        "fast-string-width": "^3.0.2",
+        "fast-wrap-ansi": "^0.2.0",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-tui": {
+      "version": "0.82.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.82.1.tgz",
+      "integrity": "sha512-9yN8hALfKaxZq7n54EMxqhFCWnMi6LHkraMJ/1YjHiATq75XrI6XDMVppn9EDtiK7Fks8hUe1SDXUTrIvwRWfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "1.6.0",
+        "marked": "18.0.5"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@google/genai": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.13.0.tgz",
+      "integrity": "sha512-GM7C8Kaomvjz05x5JEO6+l3d/pciL9LxAG9dUjJLD7nTPZ9X0Cfsf2Z7eET6UjgWyUmxXCHtYnQoQ77F9+ZIOQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@grammyjs/types": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@grammyjs/types/-/types-4.0.0.tgz",
+      "integrity": "sha512-Z8lDLTvOlo12e5Vnly/vQh3JC9ppaitS1dGZ3w068gNitOd/y8tTSiib+Xm38aBGbtYGmUZwOc6afYrLs2CSTg==",
+      "license": "MIT"
+    },
+    "node_modules/@homebridge/ciao": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.3.10.tgz",
+      "integrity": "sha512-ogAVdPZ9Fo3kSaULpq+acxbtbIvMtd2TDYEkqHIsqvQ9QHJnRNcjm8NQzegaBzJ3gUK1mVX07UWs2/B0NmabSw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "fast-deep-equal": "^3.1.3",
+        "source-map-support": "^0.5.21",
+        "tslib": "^2.8.1"
+      },
+      "bin": {
+        "ciao-bcs": "lib/bonjour-conformance-testing.js"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
+      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@lydell/node-pty": {
+      "version": "1.2.0-beta.14",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty/-/node-pty-1.2.0-beta.14.tgz",
+      "integrity": "sha512-RjQis46eBwL9xyDvfXqVsNS2JZ5zQQK/QAYsNE5j8sYPTf4/OpG5Ghm92WGn+w4Rsk3LTpj2adpaZM9Cb8rzDA==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "@lydell/node-pty-darwin-arm64": "1.2.0-beta.14",
+        "@lydell/node-pty-darwin-x64": "1.2.0-beta.14",
+        "@lydell/node-pty-linux-arm64": "1.2.0-beta.14",
+        "@lydell/node-pty-linux-x64": "1.2.0-beta.14",
+        "@lydell/node-pty-win32-arm64": "1.2.0-beta.14",
+        "@lydell/node-pty-win32-x64": "1.2.0-beta.14"
+      }
+    },
+    "node_modules/@lydell/node-pty-darwin-arm64": {
+      "version": "1.2.0-beta.14",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-darwin-arm64/-/node-pty-darwin-arm64-1.2.0-beta.14.tgz",
+      "integrity": "sha512-C0Zxnl8rTrW/ngu1CKb1NoIiBxoCDL+9SpFSkOaV5MytE7pFN/qTVDFtuIOruE1SL6v17A71jI9bpUIBHn6jJA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@lydell/node-pty-darwin-x64": {
+      "version": "1.2.0-beta.14",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-darwin-x64/-/node-pty-darwin-x64-1.2.0-beta.14.tgz",
+      "integrity": "sha512-P77aRx2TzjmlX6D3XUjTEi4rxvjkJA8VIBwUwe23pphg5DKdc9/g5Y+IsN3KX3lmNmKFVTBIbKcNkl+n8Cgwiw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@lydell/node-pty-linux-arm64": {
+      "version": "1.2.0-beta.14",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-linux-arm64/-/node-pty-linux-arm64-1.2.0-beta.14.tgz",
+      "integrity": "sha512-xZclf3acgWmHi7VMZeVBUJRyJQf78pjCkeBf3ofT/5Xvn5QkRICCZJXtcg1f2lJoCtdF1OWHkeddmJgVDOSv6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@lydell/node-pty-linux-x64": {
+      "version": "1.2.0-beta.14",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-linux-x64/-/node-pty-linux-x64-1.2.0-beta.14.tgz",
+      "integrity": "sha512-ijTyPgkECpLkrBqs/uuasaXgjv/lQf+5am19ywF6SQ6PsreHZgT36h2j5cdFTN551KHFEDMl6fCgMPDxEEyqxg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@lydell/node-pty-win32-arm64": {
+      "version": "1.2.0-beta.14",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-win32-arm64/-/node-pty-win32-arm64-1.2.0-beta.14.tgz",
+      "integrity": "sha512-yw1R4qPtspu0w2p4YhoYuznfQQsdHrVtQnKVDKYTjyuqzF720JZyIdfTRQ0Fl8ChcNesLIrq1kIBfkDPy7CXgg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@lydell/node-pty-win32-x64": {
+      "version": "1.2.0-beta.14",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-win32-x64/-/node-pty-win32-x64-1.2.0-beta.14.tgz",
+      "integrity": "sha512-aenTbinERVvWgCQkFwqj9SOR+t/1ZVJ8RqMAk6nB9Lh7oiuRCDzVfs0fNhHRw7JtURZ4jG4i51jou0uXg2yrIw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@mistralai/mistralai": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.5.0.tgz",
+      "integrity": "sha512-S/r6tkiUHblaDJGsb84WS0ePTF2YHVta2EoTi1NJqHNt5mfRRS2uE4v7hCYV134+an+fk6WgG3+aFfinJbQBjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.40.0",
+        "ws": "^8.18.0",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@openclaw/ai": {
+      "version": "2026.7.2-beta.7",
+      "resolved": "https://registry.npmjs.org/@openclaw/ai/-/ai-2026.7.2-beta.7.tgz",
+      "integrity": "sha512-TMVK6iipDrs/UgY9DudHvIF80sceXuZW5QZoNmgntFWMbFUcv6BCwHtHl3UoPY3oYpFiYOBrl++4pL3Hk0hHnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "0.115.0",
+        "@google/genai": "2.13.0",
+        "@mistralai/mistralai": "2.5.0",
+        "openai": "6.49.0",
+        "partial-json": "0.1.7",
+        "typebox": "1.3.6"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@openclaw/fs-safe": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@openclaw/fs-safe/-/fs-safe-0.5.0.tgz",
+      "integrity": "sha512-TPpFG8PkAKlM/eP7glzHhCeZnDX3sSqyjXgeoc0jeyii0y957/zePB62BIwc75gOFmxaeKLWkd4iF41/Ghlgjg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      },
+      "optionalDependencies": {
+        "jszip": "^3.10.1",
+        "tar": "7.5.21"
+      }
+    },
+    "node_modules/@openclaw/fs-safe/node_modules/tar": {
+      "version": "7.5.21",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.21.tgz",
+      "integrity": "sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==",
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@openclaw/proxyline": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@openclaw/proxyline/-/proxyline-0.3.4.tgz",
+      "integrity": "sha512-WuLE282PW7vLienDNFTjdSI/BCYDAepvr5siOTYABQhqFo8qbP9MgmJzZnwmskUqiYugGzle6gvaRbJTkwbZ8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      },
+      "peerDependencies": {
+        "undici": ">=8.5.0 <9"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/boolbase": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-2.0.0.tgz",
+      "integrity": "sha512-DkVaaQHymRhpYEYo9x1oo7Q7B0Y6KJUsjm3c9eTyFDby4MHLBTwZ6ZDWBel5zrYxj1WsZgC5oLpiz+93MluXeA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-6.0.0.tgz",
+      "integrity": "sha512-2uNTXIuTTxk7ciZgAU1BQcgnchcG0xXnrs6jzkQfj9SsRa9M2s5zE8WT96hS6KmG4MzWHSrvH43DF1m4XRkrFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-7.0.0.tgz",
+      "integrity": "sha512-snmjEVXy+1LnwXdxhYvTMj1d9tOh4HxkA1YmoayVBeeyR2C14Pum7fcxJIm4SswYspVy866eYNwlH6xC3/VH5g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^2.0.0",
+        "css-what": "^8.0.0",
+        "domhandler": "^6.0.1",
+        "domutils": "^4.0.2",
+        "nth-check": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-8.0.0.tgz",
+      "integrity": "sha512-DH0Bqq3DNp5tdOReuNyAA+Ev4Y2GS5FMbZpeTLP6C4CDi0h5nL0BmUPChXw3o/qbHLDWHl49sbNqQVY7bMSDdw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cssom": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+      "license": "MIT"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-3.1.1.tgz",
+      "integrity": "sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0",
+        "entities": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-3.0.0.tgz",
+      "integrity": "sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/domhandler": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-6.0.1.tgz",
+      "integrity": "sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-4.0.2.tgz",
+      "integrity": "sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^3.0.0",
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-10.0.0.tgz",
+      "integrity": "sha512-Cxl6MKxB1dr1H0FHmiizJ+lavKF7pV+fcDZFyqMB8d5m7qUPm/OtZYcD5vPWePKxSnTQ57KuBd9mtdZ3oNCvyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.1",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "path-key": "^4.0.0",
+        "pretty-ms": "^9.3.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "which-command": "^0.1.0",
+        "yoctocolors": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.0.tgz",
+      "integrity": "sha512-RB5vLV+vvQeoFPCX4QMK6/hjVkbIamPp1QSUD0CiZcnj12qbpiL+pLbYtgD+oZkWl0tl9z+o2Utp+MpM3QRhBA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
+      "integrity": "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/grammy": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/grammy/-/grammy-1.45.1.tgz",
+      "integrity": "sha512-Y4VL/hqJMZZxwlUr5ZgM68CFu2iIeEkNLR1cY3+Ww68CIvWARDsoXFix7+31rmyC0+7L85ZI+Pq3E5JSG5+nLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@grammyjs/types": "4.0.0",
+        "abort-controller": "^3.0.0",
+        "debug": "^4.4.3",
+        "node-fetch": "^2.7.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || >=14.13.1"
+      }
+    },
+    "node_modules/grammy/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
+      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+      "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+      "license": "MIT"
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/htmlparser2/node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
+      "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/kysely": {
+      "version": "0.29.4",
+      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.29.4.tgz",
+      "integrity": "sha512-y5mVgQNkMbs1eK9Xyc0pmNdabN2wHhRYY/5r4W5HrUT1rYCEPeVNSj1RUJeSDKT3U0p+mXCvLgkrFuIafYI6BA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/linkedom": {
+      "version": "0.18.13",
+      "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.18.13.tgz",
+      "integrity": "sha512-ES/o9qotMpzpN2MHs+Iq/JcVoOj8Fa5wiQYrTdFpvAnwXL0g66XHHUc9WUMk6nAlBtGsFQ24ne+SYnvnaQ2FSw==",
+      "license": "ISC",
+      "dependencies": {
+        "css-select": "^7.0.0",
+        "cssom": "^0.5.0",
+        "html-escaper": "^3.0.3",
+        "htmlparser2": "^10.1.0",
+        "uhyphen": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "canvas": ">= 2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/marked": {
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-3.0.1.tgz",
+      "integrity": "sha512-GX0gsdbGVCgnRgbeGaubfjpBXyYRWOOCVeYh08bSQvDZqxz5ndXs1OTfAt/h36G1xvI94YIspsI0sVFqAV9+RQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.49.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.49.0.tgz",
+      "integrity": "sha512-aYCc0C6L864eR6WSYIwQGyXriw/nIyZx0ObvhzOEVuk0zoBDpynjSbrionWI7q65B5H8jJX0DXR9snEzM6bfPg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
+        "@smithy/hash-node": ">=4.3.0 <5",
+        "@smithy/signature-v4": ">=5.4.0 <6",
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-node": {
+          "optional": true
+        },
+        "@smithy/hash-node": {
+          "optional": true
+        },
+        "@smithy/signature-v4": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/openclaw": {
+      "version": "2026.7.2-beta.7",
+      "resolved": "https://registry.npmjs.org/openclaw/-/openclaw-2026.7.2-beta.7.tgz",
+      "integrity": "sha512-raD4Z96RcZ5XY0cdtqsRRQVhPv8JOHgA4vK/0D2/BsF9czI3d5w9O1xhYGKGsNKXp+3A0HipL6oeV0zKRK/lAA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@agentclientprotocol/sdk": "1.3.0",
+        "@anthropic-ai/sdk": "0.115.0",
+        "@clack/core": "1.4.3",
+        "@clack/prompts": "1.7.0",
+        "@earendil-works/pi-tui": "0.82.1",
+        "@google/genai": "2.13.0",
+        "@grammyjs/runner": "2.0.3",
+        "@grammyjs/transformer-throttler": "1.2.1",
+        "@homebridge/ciao": "1.3.10",
+        "@lydell/node-pty": "1.2.0-beta.14",
+        "@mistralai/mistralai": "2.5.0",
+        "@modelcontextprotocol/sdk": "1.30.0",
+        "@mozilla/readability": "0.6.0",
+        "@openclaw/ai": "2026.7.2-beta.7",
+        "@openclaw/fs-safe": "0.5.0",
+        "@openclaw/proxyline": "0.3.4",
+        "@silvia-odwyer/photon-node": "0.3.4",
+        "acorn": "8.17.0",
+        "chalk": "6.0.0",
+        "chokidar": "5.0.0",
+        "clawpdf": "0.3.0",
+        "commander": "15.0.0",
+        "croner": "10.0.1",
+        "diff": "9.0.0",
+        "dotenv": "17.4.2",
+        "entities": "8.0.0",
+        "execa": "10.0.0",
+        "express": "5.2.1",
+        "file-type": "22.0.1",
+        "grammy": "1.45.1",
+        "highlight.js": "11.11.1",
+        "hosted-git-info": "10.1.1",
+        "iconv-lite": "0.7.3",
+        "ignore": "7.0.6",
+        "jiti": "2.7.0",
+        "json5": "2.2.3",
+        "jszip": "3.10.1",
+        "kysely": "0.29.4",
+        "linkedom": "0.18.13",
+        "minimatch": "10.2.5",
+        "ms": "2.1.3",
+        "node-edge-tts": "1.2.10",
+        "openai": "6.49.0",
+        "p-limit": "7.3.1",
+        "p-map": "7.0.6",
+        "partial-json": "0.1.7",
+        "playwright-core": "1.62.0",
+        "pretty-ms": "9.3.0",
+        "qrcode": "1.5.4",
+        "quickjs-wasi": "3.2.0",
+        "rastermill": "0.3.1",
+        "semver": "7.8.5",
+        "tar": "7.5.22",
+        "tree-sitter-bash": "0.25.1",
+        "tslog": "4.11.0",
+        "typebox": "1.3.6",
+        "typescript": "6.0.3",
+        "undici": "8.9.0",
+        "web-push": "3.6.7",
+        "web-tree-sitter": "0.26.11",
+        "ws": "8.21.1",
+        "yaml": "2.9.0",
+        "zod": "4.4.3"
+      },
+      "bin": {
+        "openclaw": "openclaw.mjs"
+      },
+      "engines": {
+        "node": ">=22.22.3 <23 || >=24.15.0 <25 || >=25.9.0"
+      },
+      "optionalDependencies": {
+        "sqlite-vec": "0.1.9"
+      }
+    },
+    "node_modules/openclaw/node_modules/@borewit/text-codec": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/openclaw/node_modules/@grammyjs/runner": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@grammyjs/runner/-/runner-2.0.3.tgz",
+      "integrity": "sha512-nckmTs1dPWfVQteK9cxqxzE+0m1VRvluLWB8UgFzsjg62w3qthPJt0TYtJBEdG7OedvfQq4vnFAyE6iaMkR42A==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=12.20.0 || >=14.13.1"
+      },
+      "peerDependencies": {
+        "grammy": "^1.13.1"
+      }
+    },
+    "node_modules/openclaw/node_modules/@grammyjs/transformer-throttler": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@grammyjs/transformer-throttler/-/transformer-throttler-1.2.1.tgz",
+      "integrity": "sha512-CpWB0F3rJdUiKsq7826QhQsxbZi4wqfz1ccKX+fr+AOC+o8K7ZvS+wqX0suSu1QCsyUq2MDpNiKhyL2ZOJUS4w==",
+      "license": "MIT",
+      "dependencies": {
+        "bottleneck": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || >=14.13.1"
+      },
+      "peerDependencies": {
+        "grammy": "^1.0.0"
+      }
+    },
+    "node_modules/openclaw/node_modules/@mozilla/readability": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@mozilla/readability/-/readability-0.6.0.tgz",
+      "integrity": "sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/openclaw/node_modules/@silvia-odwyer/photon-node": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
+      "integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/openclaw/node_modules/@tokenizer/inflate": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "token-types": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/openclaw/node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
+    },
+    "node_modules/openclaw/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/openclaw/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/openclaw/node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "node_modules/openclaw/node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "license": "MIT"
+    },
+    "node_modules/openclaw/node_modules/bottleneck": {
+      "version": "2.19.5",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
+      "license": "MIT"
+    },
+    "node_modules/openclaw/node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/openclaw/node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/openclaw/node_modules/clawpdf": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/clawpdf/-/clawpdf-0.3.0.tgz",
+      "integrity": "sha512-41+3AnKk9yek2sm+/9XvUlDTN8Wi+ag7fmxZuqw+ySn4lqaf/fCgLeamqPLiXY4gVbizKEHGoTG/JrIIFNE2rw==",
+      "license": "MIT",
+      "bin": {
+        "clawpdf": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/openclaw/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/openclaw/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/openclaw/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/openclaw/node_modules/croner": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/croner/-/croner-10.0.1.tgz",
+      "integrity": "sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g==",
+      "funding": [
+        {
+          "type": "other",
+          "url": "https://paypal.me/hexagonpp"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/hexagon"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0"
+      }
+    },
+    "node_modules/openclaw/node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/openclaw/node_modules/diff": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/openclaw/node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
+    },
+    "node_modules/openclaw/node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/openclaw/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/openclaw/node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/openclaw/node_modules/file-type": {
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-22.0.1.tgz",
+      "integrity": "sha512-ww5Mhre0EE+jmBvOXTmXAbEMuZE7uX4a3+oRCQFNj8w++g3ev913N6tXQz0XTXbueQ5TWQfm6BdaViEHHn8bhA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.5",
+        "token-types": "^6.1.2",
+        "uint8array-extras": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
+    "node_modules/openclaw/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/openclaw/node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/openclaw/node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/openclaw/node_modules/hosted-git-info": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-10.1.1.tgz",
+      "integrity": "sha512-DeOnSPAvOndYKfw075gt8yZzQ7S2hNztw34zBTfhIzLhmBTswIBg5/y+pqu/VD5cYWm5goAFTusDmUEmKZ0PEQ==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^11.1.0"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      }
+    },
+    "node_modules/openclaw/node_modules/http_ece": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
+      "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/openclaw/node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/openclaw/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/openclaw/node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/openclaw/node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/openclaw/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/openclaw/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/openclaw/node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
+    "node_modules/openclaw/node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/openclaw/node_modules/node-addon-api": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.8.0.tgz",
+      "integrity": "sha512-c5Ko1fZJIJmzhFIkhRN76WTq+fC6tWnGy9CXA0fA+XygsWZmEwG8vmbkNqxMyoaa0Tin4djul49NzdVcJJcjeA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/openclaw/node_modules/node-edge-tts": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/node-edge-tts/-/node-edge-tts-1.2.10.tgz",
+      "integrity": "sha512-bV2i4XU54D45+US0Zm1HcJRkifuB3W438dWyuJEHLQdKxnuqlI1kim2MOvR6Q3XUQZvfF9PoDyR1Rt7aeXhPdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "https-proxy-agent": "^7.0.1",
+        "ws": "^8.13.0",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "node-edge-tts": "bin.js"
+      }
+    },
+    "node_modules/openclaw/node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/openclaw/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openclaw/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/openclaw/node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/openclaw/node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/openclaw/node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/openclaw/node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/openclaw/node_modules/qrcode/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/openclaw/node_modules/qrcode/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/openclaw/node_modules/qrcode/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/openclaw/node_modules/qrcode/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/openclaw/node_modules/qrcode/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/openclaw/node_modules/rastermill": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/rastermill/-/rastermill-0.3.1.tgz",
+      "integrity": "sha512-CX4nij6+ZLHYIaojJNfLTr7W+AiH/IPJi6E9Aw1br2///1KZL2KBOHd68rkcLedc47MPvb4hhH+fzYeGFa4A/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@silvia-odwyer/photon-node": "0.3.4"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/openclaw/node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/openclaw/node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/openclaw/node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
+    },
+    "node_modules/openclaw/node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
+    },
+    "node_modules/openclaw/node_modules/sqlite-vec": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec/-/sqlite-vec-0.1.9.tgz",
+      "integrity": "sha512-L7XJWRIBNvR9O5+vh1FQ+IGkh/3D2AzVksW5gdtk28m78Hy8skFD0pqReKH1Yp0/BUKRGcffgKvyO/EON5JXpA==",
+      "license": "MIT OR Apache",
+      "optional": true,
+      "optionalDependencies": {
+        "sqlite-vec-darwin-arm64": "0.1.9",
+        "sqlite-vec-darwin-x64": "0.1.9",
+        "sqlite-vec-linux-arm64": "0.1.9",
+        "sqlite-vec-linux-x64": "0.1.9",
+        "sqlite-vec-windows-x64": "0.1.9"
+      }
+    },
+    "node_modules/openclaw/node_modules/sqlite-vec-darwin-arm64": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-darwin-arm64/-/sqlite-vec-darwin-arm64-0.1.9.tgz",
+      "integrity": "sha512-jSsZpE42OfBkGL/ItyJTVCUwl6o6Ka3U5rc4j+UBDIQzC1ulSSKMEhQLthsOnF/MdAf1MuAkYhkdKmmcjaIZQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/openclaw/node_modules/sqlite-vec-darwin-x64": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-darwin-x64/-/sqlite-vec-darwin-x64-0.1.9.tgz",
+      "integrity": "sha512-KDlVyqQT7pnOhU1ymB9gs7dMbSoVmKHitT+k1/xkjarcX8bBqPxWrGlK/R+C5WmWkfvWwyq5FfXfiBYCBs6PlA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/openclaw/node_modules/sqlite-vec-linux-arm64": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-linux-arm64/-/sqlite-vec-linux-arm64-0.1.9.tgz",
+      "integrity": "sha512-5wXVJ9c9kR4CHm/wVqXb/R+XUHTdpZ4nWbPHlS+gc9qQFVHs92Km4bPnCKX4rtcPMzvNis+SIzMJR1SCEwpuUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/openclaw/node_modules/sqlite-vec-linux-x64": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-linux-x64/-/sqlite-vec-linux-x64-0.1.9.tgz",
+      "integrity": "sha512-w3tCH8xK2finW8fQJ/m8uqKodXUZ9KAuAar2UIhz4BHILfpE0WM/MTGCRfa7RjYbrYim5Luk3guvMOGI7T7JQA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/openclaw/node_modules/sqlite-vec-windows-x64": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-windows-x64/-/sqlite-vec-windows-x64-0.1.9.tgz",
+      "integrity": "sha512-y3gEIyy/17bq2QFPQOWLE68TYWcRZkBQVA2XLrTPHNTOp55xJi/BBBmOm40tVMDMjtP+Elpk6UBUXdaq+46b0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/openclaw/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/openclaw/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/openclaw/node_modules/strtok3": {
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/openclaw/node_modules/token-types": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.1",
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/openclaw/node_modules/tree-sitter-bash": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter-bash/-/tree-sitter-bash-0.25.1.tgz",
+      "integrity": "sha512-7hMytuYIMoXOq24yRulgIxthE9YmggZIOHCyPTTuJcu6EU54tYD+4G39cUb28kxC6jMf/AbPfWGLQtgPTdh3xw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.1",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.25.0"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/openclaw/node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/openclaw/node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openclaw/node_modules/web-push": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
+      "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "asn1.js": "^5.3.0",
+        "http_ece": "1.2.0",
+        "https-proxy-agent": "^7.0.0",
+        "jws": "^4.0.0",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "web-push": "src/cli.js"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/openclaw/node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
+    "node_modules/openclaw/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/openclaw/node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/openclaw/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/openclaw/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/openclaw/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.6.tgz",
+      "integrity": "sha512-I4Prw6ivkd6p8PiYR1tXASOAOBzIJwu0TB7fqaX0c/8c3QAehNYmX57EijyGGGBt3c/BIowGwV03RVBtXvHEVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/partial-json": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+      "license": "MIT"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
+      "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/quickjs-wasi": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/quickjs-wasi/-/quickjs-wasi-3.2.0.tgz",
+      "integrity": "sha512-+7ArUWrc1qCtFLjpNVGI47eGih4TKWg3RSB+FfPFtnfZrKlgvCGUUWbClDalFL7lzNAYH82jrPPHsh3LBkuk7g==",
+      "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "license": "MIT"
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tslog": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/tslog/-/tslog-4.11.0.tgz",
+      "integrity": "sha512-gBe0FTKkRpOv3DenGipjQWQe073jNd1cOLj3nYfVM0/NP29sQzAIx6kfyfTTsQOiWMC+B+tSr289lNXtu7HCmQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/fullstack-build/tslog?sponsor=1"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typebox": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.6.tgz",
+      "integrity": "sha512-Sc8RA0NCMEFmApHNU9ZMzqcpQj46She44J8ffpLM/bdhLNUZKq7DJumcLcsFx1gRmDfQPgCgOmFFJ7rcnfWNyA==",
+      "license": "MIT"
+    },
+    "node_modules/uhyphen": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/uhyphen/-/uhyphen-0.2.0.tgz",
+      "integrity": "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==",
+      "license": "ISC"
+    },
+    "node_modules/undici": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.9.0.tgz",
+      "integrity": "sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/web-tree-sitter": {
+      "version": "0.26.11",
+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.26.11.tgz",
+      "integrity": "sha512-Q5Dm3YTIXSXuH6FxX6RuzX2Qwpc4DPGiYMU87Wg5Z8OIStiQFiUex4zMDc0vBTw78EphaYJacncJghCHzbZptg==",
+      "license": "MIT"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which-command": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/which-command/-/which-command-0.1.0.tgz",
+      "integrity": "sha512-XZyoF5/5hZtXitIwzrU4NKK+Wtbb9aB9CezUEw2Q0wlYK8NUYQxC1rRXgNueYLtBAJwXIb+/tFVk4dozciNJMA==",
+      "license": "MIT",
+      "bin": {
+        "which-command": "cli.js"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/which-command?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
+      "integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/packaging/live_agent_skills/openclaw/package.json
+++ b/packaging/live_agent_skills/openclaw/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "hive-openclaw-creator-proof",
+  "version": "1.0.0",
+  "private": true,
+  "engines": {
+    "node": "22.23.1"
+  },
+  "dependencies": {
+    "openclaw": "2026.7.2-beta.7"
+  }
+}

--- a/packaging/live_agent_skills/workflow_creator_contract.rb
+++ b/packaging/live_agent_skills/workflow_creator_contract.rb
@@ -3,10 +3,9 @@
 module HiveLiveAgentProof::WorkflowCreator
     module Contract
       PRIMARY_KEYS = %w[schema schema_version platform candidate_sha result prompt_sha256 task_prompt_sha256 skill
-                        native_activation hive_commands created_files validation creation_only_task_count task_count
-                        task external_actions secret_scan execution_kind model_loop executed_instruction
-                        evidence_bundle containment teardown
-                        cleanup].freeze
+                        native_activation native_activation_evidence hive_commands created_files validation
+                        creation_only_task_count task_count task external_actions secret_scan execution_kind
+                        model_loop executed_instruction evidence_bundle containment teardown cleanup].freeze
       FAILURE = %w[schema schema_version platform candidate_sha result phase reason detail execution_kind model_loop
                     secret_scan].freeze
       MANIFEST = %w[canonical_digest candidate_sha files hive_version schema schema_version skill_version].freeze
@@ -96,7 +95,7 @@ module HiveLiveAgentProof::WorkflowCreator
         assert!(Values.capture(evidence_bundle).canonical_bytes == bundle_snapshot.canonical_bytes,
                 "workflow-creator evidence bundle is invalid")
         primary_claims!(row, manifest, candidate_sha)
-        primary_files!(row)
+        primary_evidence!(row)
         summary = { "status" => "passed", "receipt_sha256" => bundle_records.fetch(2).fetch("sha256") }
         assert!(row.values_at("containment", "teardown", "cleanup").all? { |value| value == summary },
                 "workflow-creator execution claims are not passing")
@@ -166,7 +165,14 @@ module HiveLiveAgentProof::WorkflowCreator
         numeric << row.dig("task", "run_count")
         assert!(numeric.all? { |value| value.instance_of?(Integer) }, "workflow-creator numeric claims are invalid")
       end
-      def primary_files!(row)
+      def primary_evidence!(row)
+        activation = row.fetch("native_activation_evidence")
+        activation_expected = { "kind" => "openclaw-skills-info", "invocation" => "/hive", "name" => "hive",
+                                "eligible" => true, "user_invocable" => true,
+                                "path" => "skills/hive/SKILL.md" }
+        message = "workflow-creator native activation evidence is invalid"
+        exact!(activation, activation_expected.keys + %w[sha256 size], message, expected: activation_expected)
+        record!(activation.slice(*FILE_KEYS), FILE_KEYS, message, path: true, positive: true)
         created, instruction = row.values_at("created_files", "executed_instruction")
         assert!(created.instance_of?(Array), "workflow-creator primary files are invalid")
         created.each { |item| record!(item, FILE_KEYS, "workflow-creator file invalid", path: true, positive: true) }
@@ -239,11 +245,7 @@ module HiveLiveAgentProof::WorkflowCreator
         assert!([ digest.class, size.class ] == [ String, Integer ], message)
         assert!(DIGEST.match?(digest), message)
         assert!(TextSafety.safe_relative_path?(value.fetch("path")), message) if path
-        if positive
-          assert!(size.positive?, message)
-        else
-          assert!(size.between?(0, MAX_MEMBER_BYTES), message)
-        end
+        assert!(positive ? size.positive? : size.between?(0, MAX_MEMBER_BYTES), message)
         assert!(value.values_at("path", "kind") == binding, message) if binding
       end
       def exact!(value, keys, message, expected: nil)
@@ -251,8 +253,6 @@ module HiveLiveAgentProof::WorkflowCreator
         assert!(value.keys.sort == keys.sort, message)
         assert!(value.slice(*expected.keys) == expected, message) if expected
       end
-      def assert!(condition, message)
-        raise Error, message unless condition
-      end
+      def assert!(condition, message) = condition ? true : raise(Error, message)
     end
 end

--- a/packaging/live_agent_skills/workflow_creator_evidence.rb
+++ b/packaging/live_agent_skills/workflow_creator_evidence.rb
@@ -31,9 +31,30 @@ module HiveLiveAgentProof
       def replace_nonpassing!(bundle_directory:, expected:, receipt:, exact_secrets: [])
         expected_receipt = WorkflowCreator.validate_nonpassing!(expected, exact_secrets:)
         desired_receipt = WorkflowCreator.validate_nonpassing!(receipt, exact_secrets:)
-        publisher(bundle_directory).replace_receipt(
-          expected_receipt.canonical_bytes, desired_receipt.canonical_bytes
+        replace(bundle_directory, expected_receipt, desired_receipt)
+      end
+
+      def replace_primary!(bundle_directory:, expected:, receipt:, manifest:, candidate_sha:, bundle_records:)
+        expected_receipt = WorkflowCreator.validate_nonpassing!(expected)
+        desired_receipt = WorkflowCreator.validate_primary!(
+          row: receipt, manifest:, candidate_sha:, bundle_records:
         )
+        replace(bundle_directory, expected_receipt, desired_receipt)
+      end
+
+      def replace_primary_with_failure!(bundle_directory:, expected:, receipt:, manifest:, candidate_sha:,
+                                        bundle_records:, exact_secrets: [])
+        expected_receipt = WorkflowCreator.validate_primary!(
+          row: expected, manifest:, candidate_sha:, bundle_records:
+        )
+        desired_receipt = WorkflowCreator.validate_nonpassing!(receipt, exact_secrets:)
+        replace(bundle_directory, expected_receipt, desired_receipt)
+      end
+
+      private
+
+      def replace(bundle_directory, expected_receipt, desired_receipt)
+        publisher(bundle_directory).replace_receipt(expected_receipt.canonical_bytes, desired_receipt.canonical_bytes)
         desired_receipt
       rescue WorkflowCreatorReceiptPublisher::Conflict
         raise Conflict, "workflow-creator evidence replacement conflicts", cause: nil
@@ -42,8 +63,6 @@ module HiveLiveAgentProof
       rescue WorkflowCreatorReceiptPublisher::Unavailable
         raise Unavailable, "workflow-creator evidence storage is unavailable", cause: nil
       end
-
-      private
 
       def publisher(bundle_directory)
         WorkflowCreatorReceiptPublisher.new(

--- a/packaging/live_agent_skills/workflow_creator_execution.rb
+++ b/packaging/live_agent_skills/workflow_creator_execution.rb
@@ -29,7 +29,10 @@ module HiveLiveAgentProof
     attr_reader :gateway_path, :workspace_path
 
     def initialize(candidate_sha:, manifest:, candidate:, openclaw:, archives:, workspace_path:,
-                   bundle_directory:, correlation_id:, exact_secrets: [], supervisor_options: {})
+                   bundle_directory:, correlation_id:, exact_secrets: [], supervisor_options: {},
+                   command_boundary_verifier: nil)
+      @command_boundary_verifier = command_boundary_verifier
+      raise Error unless @command_boundary_verifier.nil? || @command_boundary_verifier.respond_to?(:call)
       input = WorkflowCreator::Values.capture(
         "candidate_sha" => candidate_sha, "manifest" => manifest, "candidate" => candidate,
         "openclaw" => openclaw, "archives" => archives, "workspace_path" => workspace_path,
@@ -46,6 +49,7 @@ module HiveLiveAgentProof
       @bundle_directory = File.realpath(input.fetch("bundle_directory")).freeze
       @candidate_root, @openclaw_root =
         [ @candidate.fetch("root"), @openclaw.fetch("root") ].map { |path| File.realpath(path) }
+      @socket_root = File.dirname(@workspace_path).freeze
       paths = [ @candidate_root, @openclaw_root, @workspace_path, @bundle_directory ]
       raise Error if paths.combination(2).any? do |left, right|
         left == right || left.start_with?("#{right}/") || right.start_with?("#{left}/")
@@ -72,7 +76,7 @@ module HiveLiveAgentProof
         root: File.dirname(gateway), candidate_executable: executable,
         candidate_identity: observed_file(executable, relative_role(@candidate, executable)),
         environment: @candidate.fetch("environment"), cwd: @workspace_path, supervisor: @supervisor,
-        socket_root: @workspace_path
+        socket_root: @socket_root, runtime_verifier: @command_boundary_verifier
       )
       @gateway_path = @gateway.start!
       @candidate_installation = scan_candidate

--- a/packaging/live_agent_skills/workflow_creator_gateway.rb
+++ b/packaging/live_agent_skills/workflow_creator_gateway.rb
@@ -112,12 +112,12 @@ module HiveLiveAgentProof
     end
 
     def install_wrapper!
-      File.open(@wrapper_path, File::WRONLY | File::CREAT | File::EXCL, 0o600) do |file|
+      File.open(@wrapper_path, File::WRONLY | File::CREAT | File::EXCL, 0o700) do |file|
         file.write(wrapper_source)
         file.flush
         file.fsync
       end
-      File.chmod(0o600, @wrapper_path)
+      File.chmod(0o700, @wrapper_path)
       @wrapper_identity = file_identity(File.lstat(@wrapper_path)).freeze
       @wrapper_digest = Digest::SHA256.file(@wrapper_path).hexdigest
     rescue SystemCallError
@@ -268,7 +268,7 @@ module HiveLiveAgentProof
       socket = File.lstat(@socket_path)
       wrapper = File.lstat(@wrapper_path)
       valid = socket.socket? && node_identity(socket) == @socket_identity
-      valid &&= wrapper.file? && (wrapper.mode & 0o777) == 0o600 && file_identity(wrapper) == @wrapper_identity
+      valid &&= wrapper.file? && (wrapper.mode & 0o777) == 0o700 && file_identity(wrapper) == @wrapper_identity
       valid &&= Digest::SHA256.file(@wrapper_path).hexdigest == @wrapper_digest
       raise Error unless valid
     rescue StandardError

--- a/packaging/live_agent_skills/workflow_creator_gateway.rb
+++ b/packaging/live_agent_skills/workflow_creator_gateway.rb
@@ -23,12 +23,13 @@ module HiveLiveAgentProof
     REFUSAL = "workflow-creator gateway refused request\n"
 
     def initialize(root:, candidate_executable:, candidate_identity:, environment:, cwd:, supervisor:,
-                   socket_root: root)
+                   socket_root: root, runtime_verifier: nil)
       @root, @socket_root, @candidate, @cwd =
         [ root, socket_root, candidate_executable, cwd ].map { |path| File.expand_path(path) }
       @identity = WorkflowCreator::Values.capture(candidate_identity).value
       @environment = WorkflowCreator::Values.capture(environment).value
       @supervisor = supervisor
+      @runtime_verifier = runtime_verifier
       @wrapper_path = File.join(@root, WRAPPER_NAME)
       @socket_path = File.join(@socket_root, SOCKET_NAME)
       @token = SecureRandom.hex(32).freeze
@@ -88,9 +89,10 @@ module HiveLiveAgentProof
           !CREDENTIAL.match?(key)
       end
       supervisor_valid = @supervisor.instance_of?(WorkflowCreator::ProcessSupervisor)
+      verifier_valid = @runtime_verifier.nil? || @runtime_verifier.respond_to?(:call)
       labels_valid = WorkflowCreator::Vocabulary.fetch("command_labels") ==
         WorkflowCreator::ProcessSupervisor::COMMAND_LABELS
-      raise Error unless environment_valid && supervisor_valid && labels_valid
+      raise Error unless environment_valid && supervisor_valid && verifier_valid && labels_valid
       admit_candidate!
     rescue KeyError, SystemCallError, Error
       raise Error, "workflow-creator gateway inputs are invalid"
@@ -217,9 +219,11 @@ module HiveLiveAgentProof
     end
 
     def semantic_result?(receipt, stdout)
-      return true unless [ 6, 8 ].include?(@position)
+      return true unless [ 6, 8, 9 ].include?(@position)
       return false unless receipt.dig("capture", "stdout_bytes") == stdout.b.bytesize
       payload = JSON.parse(stdout)
+      return operational_status?(payload) if @position == 9
+
       valid = payload.instance_of?(Hash) && payload.values_at("schema", "ok", "created") ==
         [ "hive-new", true, @position == 6 ]
       valid &&= @position == 6 ? TASK_SLUG.match?(payload["slug"]) : payload["slug"] == @task_slug
@@ -227,6 +231,14 @@ module HiveLiveAgentProof
       valid
     rescue JSON::ParserError, TypeError
       false
+    end
+
+    def operational_status?(payload)
+      valid = payload.instance_of?(Hash) && payload.values_at("schema", "schema_version", "ok") ==
+        [ "hive-operational-status", 3, true ] && payload["tasks"].instance_of?(Array) && payload["tasks"].one?
+      task = payload["tasks"].first if valid
+      valid && task.instance_of?(Hash) && task["workflow"] == "editorial" &&
+        task.dig("identity", "slug") == @task_slug && task.dig("position", "stage") == "1-research"
     end
 
     def passing?(receipt)
@@ -265,6 +277,7 @@ module HiveLiveAgentProof
 
     def verify_runtime!
       verify_base!
+      raise Error unless @runtime_verifier.nil? || @runtime_verifier.call == true
       socket = File.lstat(@socket_path)
       wrapper = File.lstat(@wrapper_path)
       valid = socket.socket? && node_identity(socket) == @socket_identity

--- a/packaging/live_agent_skills/workflow_creator_live_runner.rb
+++ b/packaging/live_agent_skills/workflow_creator_live_runner.rb
@@ -1,0 +1,676 @@
+# frozen_string_literal: true
+
+require "digest"
+require "fileutils"
+require "json"
+require "open3"
+require "uri"
+require "yaml"
+require_relative "workflow_creator_execution"
+
+module HiveLiveAgentProof
+  class WorkflowCreatorLiveRunner
+    class Error < StandardError; end
+    class Failure < Error
+      attr_reader :phase, :reason, :status
+
+      def initialize(phase, reason, status: "failed")
+        @phase, @reason, @status = phase, reason, status
+        super(reason)
+      end
+    end
+    private_constant :Failure
+
+    Result = Data.define(:status, :provider, :receipt)
+    CONFIGURATION_SCHEMA = "hive-live-openclaw-creator-configuration/v1"
+    NPM_REGISTRY = "https://registry.npmjs.org"
+    PROVIDERS = {
+      "openai" => {
+        "credential" => "OPENAI_API_KEY", "endpoint_env" => "OPENAI_BASE_URL",
+        "endpoint" => "https://api.openai.com/v1"
+      },
+      "openrouter" => {
+        "credential" => "OPENROUTER_API_KEY", "endpoint_env" => "OPENROUTER_BASE_URL",
+        "endpoint" => "https://openrouter.ai/api/v1"
+      }
+    }.freeze
+    CHILD_ENV = %w[PATH LANG LC_ALL TERM TMPDIR].freeze
+    ENDPOINT_ENV = PROVIDERS.values.map { |row| row.fetch("endpoint_env") }.freeze
+    PROXY_ENV = %w[HTTP_PROXY HTTPS_PROXY NO_PROXY http_proxy https_proxy no_proxy].freeze
+    CA_ENV = %w[SSL_CERT_FILE SSL_CERT_DIR NODE_EXTRA_CA_CERTS].freeze
+    AUTHORITY_ENV = /\A(?:GH_|GITHUB_|GIT_|SSH_|CI_JOB_TOKEN\z|CI_DEPLOY_PASSWORD\z)/i
+    CREDENTIAL_ENV = /(?:TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIAL|API_?KEY|PRIVATE_?KEY|AUTHORIZATION|COOKIE|SESSION)/i
+    SHA = /\A[0-9a-f]{40}\z/
+    SHELL_SANITIZER = <<~'SH'.freeze
+      #!/bin/bash
+      set -f
+      mapfile -t hive_environment_names < <(compgen -e)
+      for hive_environment_name in "${hive_environment_names[@]}"; do
+        hive_environment_key=${hive_environment_name^^}
+        case "$hive_environment_key" in
+          *TOKEN*|*SECRET*|*PASSWORD*|*PASSWD*|*CREDENTIAL*|*API_KEY*|*APIKEY*|*PRIVATE_KEY*|*PRIVATEKEY*|*AUTHORIZATION*|*COOKIE*|*SESSION*|GH_*|GITHUB_*|GIT_*|SSH_*|BASH_ENV|ENV|RUBYOPT|RUBYLIB|NODE_OPTIONS|PYTHONPATH|PERL5OPT|CDPATH|GLOBIGNORE|PROMPT_COMMAND)
+            unset "$hive_environment_name"
+            ;;
+        esac
+      done
+      unset -v hive_environment_names hive_environment_name hive_environment_key
+      exec /bin/bash --noprofile --norc "$@"
+    SH
+    private_constant :SHELL_SANITIZER
+
+    CONFIGURATION_KEYS = %w[schema schema_version candidate_sha provider model transport dependency
+                            tool_environment runtime_install skill].freeze
+    TRANSPORT_KEYS = %w[endpoint proxy ca redirects].freeze
+    DEPENDENCY_KEYS = %w[package version registry integrity lock_sha256 package_count node_engine node_version
+                         lifecycle_scripts].freeze
+    TOOL_ENVIRONMENT_KEYS = %w[authority pass_env shell].freeze
+    SHELL_KEYS = %w[path sha256 size].freeze
+    RUNTIME_INSTALL_KEYS = %w[schema schema_version root tree_sha256 file_count directory_count total_size
+                              launcher_sha256].freeze
+    SKILL_KEYS = %w[path projection_manifest_sha256].freeze
+    WORKSPACE_PREPARATION_KEYS = %w[schema schema_version status skill_manifest_sha256 init_stdout_sha256
+                                    git_head openclaw_config_validation_sha256
+                                    openclaw_effective_policy_sha256].freeze
+    CREATOR_ARGV = [ "agent", "--local", "--agent", "main", "--message",
+                     WorkflowCreator::Vocabulary.fetch("prompt"), "--timeout", "180", "--json" ].freeze
+    AUTHORIZED_ARGV = [ "agent", "--local", "--agent", "main", "--message",
+                        WorkflowCreator::Vocabulary.fetch("task_prompt"), "--timeout", "180", "--json" ].freeze
+
+    def self.run!(**options) = new(**options).send(:run)
+    def self.shell_sanitizer_bytes = SHELL_SANITIZER
+
+    def self.initialize_evidence!(bundle_directory:, candidate_sha:)
+      WorkflowCreatorEvidence.initialize!(bundle_directory:, candidate_sha:)
+    end
+
+    def self.fail!(bundle_directory:, candidate_sha:, phase:, reason:, detail: nil, exact_secrets: [])
+      path = File.join(bundle_directory, WorkflowCreator::Vocabulary.fetch("bundle_files").first)
+      expected = JSON.parse(File.binread(path))
+      receipt = WorkflowCreator.failure(candidate_sha:, phase:, reason:, detail:, exact_secrets:)
+      admitted = WorkflowCreatorEvidence.replace_nonpassing!(
+        bundle_directory:, expected:, receipt: receipt.value, exact_secrets:
+      )
+      Result.new(status: "failed", provider: nil, receipt: admitted)
+    rescue JSON::ParserError, SystemCallError
+      raise Error, "workflow-creator live failure evidence is unavailable", cause: nil
+    end
+
+    private_class_method :new
+
+    def initialize(candidate_sha:, model:, host_environment:, configuration_record:, execution_options:,
+                   external_actions_observer:, workspace_preparer:, runtime_install_verifier: nil,
+                   execution_factory: WorkflowCreatorExecution.method(:start!))
+      @candidate_sha = candidate_sha.to_s.downcase
+      @model = model.to_s
+      @host_environment = stringify(host_environment)
+      @configuration_record_path = configuration_record.to_s
+      @execution_options = execution_options.transform_keys(&:to_sym)
+      @external_actions_observer = external_actions_observer
+      @workspace_preparer = workspace_preparer
+      @runtime_install_verifier = runtime_install_verifier
+      @execution_factory = execution_factory
+      @bundle_directory = @execution_options.fetch(:bundle_directory)
+      @provider = @credential = @session = nil
+      @model_loop_started = false
+    rescue KeyError, NoMethodError, TypeError
+      raise Error, "workflow-creator live inputs are invalid", cause: nil
+    end
+
+    def run
+      @current = WorkflowCreatorEvidence.initialize!(
+        bundle_directory: @bundle_directory, candidate_sha: @candidate_sha
+      )
+      admit_preflight!
+      options = @execution_options.merge(exact_secrets: [ @credential ])
+      @session = @execution_factory.call(**options)
+      environment, gateway_link = configure_openclaw
+      prepare_workspace!(environment, gateway_link)
+      @model_loop_started = true
+      @session.run_outer_workflow_creator(
+        argv: CREATOR_ARGV, environment:, stdin_data: WorkflowCreator::Vocabulary.fetch("prompt")
+      )
+      observe_creation_only!
+      @session.run_outer_authorized_work(
+        argv: AUTHORIZED_ARGV, environment:, stdin_data: WorkflowCreator::Vocabulary.fetch("task_prompt")
+      )
+      observe_external_actions!
+      observe_task!
+      verify_runtime_install!
+      files = created_files
+      draft = @session.draft!(executed_instruction: files.fetch(2))
+      primary = primary_row(draft, files)
+      publish_primary(primary)
+      result = @session.finish!(primary_row: primary.value)
+      raise Failure.new("finalization", "execution_finalization_failed") unless result.status == "passed"
+
+      Result.new(status: "passed", provider: @provider, receipt: primary)
+    rescue Failure => failure
+      finalize_failure(failure)
+    rescue WorkflowCreatorExecution::Unavailable => error
+      finalize_failure(Failure.new("execution", "execution_unavailable", status: "blocked"), error.message)
+    rescue WorkflowCreatorExecution::Error, WorkflowCreator::Error, SystemCallError, JSON::ParserError => error
+      finalize_failure(Failure.new("execution", "execution_failed"), error.message)
+    rescue StandardError => error
+      finalize_failure(Failure.new("execution", "execution_failed"), error.message)
+    ensure
+      @session&.close
+    end
+
+    def admit_preflight!
+      raise Failure.new("preflight", "invalid_candidate_sha") unless SHA.match?(@candidate_sha)
+      @provider = provider_for(@model)
+      provider = PROVIDERS.fetch(@provider)
+      @credential = @host_environment.fetch(provider.fetch("credential"), "")
+      raise Failure.new("preflight", "missing_provider_credential", status: "blocked") if @credential.empty?
+
+      openclaw = @execution_options.fetch(:openclaw)
+      candidate = @execution_options.fetch(:candidate)
+      validate_downstream_environment!(candidate.fetch("environment"))
+      @configuration = admit_configuration!(openclaw)
+      admit_skill!(@configuration.fetch("skill"), candidate)
+      admit_tool_environment!(@configuration.fetch("tool_environment"), openclaw)
+      admit_transport!(@configuration.fetch("transport"), openclaw)
+      admit_dependency!(@configuration.fetch("dependency"), openclaw)
+      admit_node!(openclaw.fetch("interpreter_or_launcher"), @configuration.dig("dependency", "node_version"))
+      launcher_sha256 = admit_binary!(openclaw.fetch("executable"))
+      admit_runtime_install!(@configuration.fetch("runtime_install"), launcher_sha256)
+    rescue KeyError, TypeError
+      raise Failure.new("preflight", "invalid_openclaw_closure")
+    end
+
+    def provider_for(model)
+      parts = model.split("/")
+      raise Failure.new("preflight", "missing_model") if model.empty?
+      provider = parts.first
+      valid = (provider == "openai" && parts.length >= 2) || (provider == "openrouter" && parts.length >= 3)
+      raise Failure.new("preflight", "unsupported_provider") unless valid && parts.none?(&:empty?)
+      provider
+    end
+
+    def admit_configuration!(openclaw)
+      root = File.realpath(openclaw.fetch("root"))
+      path = File.expand_path(@configuration_record_path)
+      prefix = "#{root}/"
+      raise Failure.new("preflight", "invalid_openclaw_closure") unless path.start_with?(prefix)
+      relative = path.delete_prefix(prefix)
+      raise Failure.new("preflight", "invalid_openclaw_closure") unless openclaw.fetch("inventory").include?(relative)
+      raw = safe_file(path)
+      snapshot = WorkflowCreator::Values.capture(JSON.parse(raw))
+      raise Failure.new("preflight", "invalid_openclaw_closure") unless raw == snapshot.canonical_bytes
+      row = snapshot.value
+      exact!(row, CONFIGURATION_KEYS, "invalid_openclaw_closure")
+      identity = [ CONFIGURATION_SCHEMA, 1, @candidate_sha, @provider, @model ]
+      actual = row.values_at("schema", "schema_version", "candidate_sha", "provider", "model")
+      raise Failure.new("preflight", "invalid_openclaw_closure") unless actual == identity
+      row
+    rescue WorkflowCreator::Values::Error, JSON::ParserError, SystemCallError
+      raise Failure.new("preflight", "invalid_openclaw_closure")
+    end
+
+    def admit_tool_environment!(tool_environment, openclaw)
+      exact!(tool_environment, TOOL_ENVIRONMENT_KEYS, "invalid_tool_environment")
+      shell = tool_environment.fetch("shell")
+      exact!(shell, SHELL_KEYS, "invalid_tool_environment")
+      root = File.realpath(openclaw.fetch("root"))
+      relative = shell.fetch("path")
+      path = File.expand_path(relative, root)
+      prefix = "#{root}/"
+      valid = tool_environment.values_at("authority", "pass_env") == [ "shell_sanitized", [] ]
+      valid &&= path.start_with?(prefix) && openclaw.fetch("inventory").include?(relative)
+      bytes = safe_file(path)
+      stat = File.lstat(path)
+      valid &&= File.executable?(path) && (stat.mode & 0o022).zero?
+      valid &&= bytes == SHELL_SANITIZER
+      valid &&= shell.values_at("sha256", "size") == [ Digest::SHA256.hexdigest(bytes), bytes.bytesize ]
+      raise Failure.new("preflight", "invalid_tool_environment") unless valid
+
+      @shell_path = path
+    rescue KeyError, SystemCallError, TypeError
+      raise Failure.new("preflight", "invalid_tool_environment")
+    end
+
+    def admit_skill!(skill, candidate)
+      exact!(skill, SKILL_KEYS, "invalid_skill_projection")
+      root = File.realpath(candidate.fetch("root"))
+      relative = skill.fetch("path")
+      path = File.expand_path(relative, root)
+      prefix = "#{root}/"
+      valid = relative.instance_of?(String) && path.start_with?(prefix)
+      valid &&= path.delete_prefix(prefix) == relative
+      valid &&= File.realpath(path) == path && File.directory?(path) && !File.symlink?(path)
+      manifest = File.join(path, "projection-manifest.json")
+      manifest_relative = manifest.delete_prefix(prefix)
+      valid &&= candidate.fetch("inventory").include?(manifest_relative)
+      valid &&= /\A[0-9a-f]{64}\z/.match?(skill.fetch("projection_manifest_sha256"))
+      valid &&= Digest::SHA256.hexdigest(safe_file(manifest)) == skill.fetch("projection_manifest_sha256")
+      raise Failure.new("preflight", "invalid_skill_projection") unless valid
+    rescue KeyError, SystemCallError, TypeError
+      raise Failure.new("preflight", "invalid_skill_projection")
+    end
+
+    def admit_transport!(transport, openclaw)
+      exact!(transport, TRANSPORT_KEYS, "invalid_transport_identity")
+      expected = PROVIDERS.fetch(@provider).fetch("endpoint")
+      valid = transport.values_at("endpoint", "redirects") == [ expected, "deny" ]
+      valid &&= transport.fetch("proxy").nil? || safe_https?(transport.fetch("proxy"))
+      valid &&= admit_ca(transport.fetch("ca"), openclaw)
+      raise Failure.new("preflight", "invalid_transport_identity") unless valid
+      validate_transport_overrides!(transport)
+    end
+
+    def validate_transport_overrides!(transport)
+      selected_endpoint = PROVIDERS.fetch(@provider).fetch("endpoint_env")
+      ENDPOINT_ENV.each do |name|
+        next if @host_environment.fetch(name, "").empty?
+        expected = name == selected_endpoint ? transport.fetch("endpoint") : nil
+        raise Failure.new("preflight", "transport_override") unless @host_environment[name] == expected
+      end
+      PROXY_ENV.each do |name|
+        next if @host_environment.fetch(name, "").empty?
+        raise Failure.new("preflight", "transport_override") unless @host_environment[name] == transport.fetch("proxy")
+      end
+      expected_ca = transport.fetch("ca")&.fetch("path")
+      CA_ENV.each do |name|
+        next if @host_environment.fetch(name, "").empty?
+        raise Failure.new("preflight", "transport_override") unless name != "SSL_CERT_DIR" &&
+          @host_environment[name] == expected_ca
+      end
+    end
+
+    def admit_ca(ca, openclaw)
+      return true if ca.nil?
+      exact!(ca, %w[path sha256 size], "invalid_transport_identity")
+      root = File.realpath(openclaw.fetch("root"))
+      path = File.expand_path(ca.fetch("path"), root)
+      prefix = "#{root}/"
+      return false unless path.start_with?(prefix) && openclaw.fetch("inventory").include?(path.delete_prefix(prefix))
+      bytes = safe_file(path)
+      ca.values_at("path", "sha256", "size") ==
+        [ path, Digest::SHA256.hexdigest(bytes), bytes.bytesize ]
+    rescue KeyError, SystemCallError
+      false
+    end
+
+    def admit_dependency!(dependency, openclaw)
+      exact!(dependency, DEPENDENCY_KEYS, "invalid_openclaw_closure")
+      lock_path = File.expand_path(openclaw.fetch("lock"))
+      lock_bytes = safe_file(lock_path)
+      version, integrity, node_engine, node_version =
+        dependency.values_at("version", "integrity", "node_engine", "node_version")
+      valid = dependency.values_at("package", "registry", "lock_sha256") ==
+        [ "openclaw", NPM_REGISTRY, Digest::SHA256.hexdigest(lock_bytes) ]
+      valid &&= openclaw.fetch("version") == version
+      valid &&= version.instance_of?(String) && !version.empty?
+      valid &&= /\Asha512-[A-Za-z0-9+\/]+={0,2}\z/.match?(integrity)
+      valid &&= node_engine.instance_of?(String) && !node_engine.empty?
+      valid &&= /\A\d+\.\d+\.\d+\z/.match?(node_version)
+      lock = JSON.parse(lock_bytes)
+      packages = lock.fetch("packages")
+      valid &&= lock.fetch("lockfileVersion") == 3 && packages.instance_of?(Hash)
+      valid &&= packages.length == dependency.fetch("package_count")
+      valid &&= packages.dig("", "dependencies") == { "openclaw" => version }
+      valid &&= packages.dig("", "engines", "node") == node_version
+      valid &&= packages.all? { |path, row| path.empty? || admitted_package?(row) }
+      openclaw_row = packages.fetch("node_modules/openclaw")
+      valid &&= openclaw_row.values_at("version", "integrity") == [ version, integrity ]
+      valid &&= openclaw_row.dig("engines", "node") == node_engine
+      lifecycle = packages.filter_map { |path, row| path unless path.empty? || row["hasInstallScript"] != true }.sort
+      valid &&= lifecycle == dependency.fetch("lifecycle_scripts")
+      raise Failure.new("preflight", "invalid_openclaw_closure") unless valid
+    rescue JSON::ParserError, KeyError, SystemCallError, TypeError
+      raise Failure.new("preflight", "invalid_openclaw_closure")
+    end
+
+    def admit_node!(path, expected_version)
+      stat = File.lstat(path)
+      valid = stat.file? && !stat.symlink? && stat.uid == Process.uid && stat.nlink == 1
+      valid &&= (stat.mode & 0o022).zero? && File.executable?(path)
+      stdout, stderr, status = Open3.capture3({}, path, "--version", unsetenv_others: true)
+      valid &&= status.success? && stderr.empty? && stdout.strip == "v#{expected_version}"
+      raise Failure.new("preflight", "invalid_openclaw_node") unless valid
+    rescue SystemCallError
+      raise Failure.new("preflight", "invalid_openclaw_node")
+    end
+
+    def admitted_package?(row)
+      row.instance_of?(Hash) && row["link"] != true && row["version"].instance_of?(String) &&
+        row["resolved"].to_s.start_with?("#{NPM_REGISTRY}/") &&
+        /\Asha512-[A-Za-z0-9+\/]+={0,2}\z/.match?(row["integrity"])
+    end
+
+    def admit_binary!(path)
+      bytes = safe_file(path)
+      stat = File.lstat(path)
+      valid = File.executable?(path) && (stat.mode & 0o022).zero?
+      raise Failure.new("preflight", "invalid_openclaw_binary") unless valid
+      Digest::SHA256.hexdigest(bytes)
+    rescue SystemCallError
+      raise Failure.new("preflight", "invalid_openclaw_binary")
+    end
+
+    def admit_runtime_install!(runtime_install, launcher_sha256)
+      exact!(runtime_install, RUNTIME_INSTALL_KEYS, "runtime_install_unverified")
+      valid = runtime_install.values_at("schema", "schema_version", "launcher_sha256") ==
+        [ "hive-openclaw-runtime-install/v1", 1, launcher_sha256 ]
+      valid &&= /\A[0-9a-f]{64}\z/.match?(runtime_install.fetch("tree_sha256"))
+      valid &&= %w[file_count directory_count total_size].all? do |key|
+        runtime_install.fetch(key).instance_of?(Integer) && runtime_install.fetch(key).positive?
+      end
+      root = File.expand_path(runtime_install.fetch("root"))
+      valid &&= root == runtime_install.fetch("root") && File.realpath(root) == root
+      @runtime_install = WorkflowCreator::Values.capture(runtime_install)
+      @launcher_sha256 = launcher_sha256
+      observed = verify_runtime_install!
+      valid &&= observed
+      raise Failure.new("preflight", "runtime_install_unverified", status: "blocked") unless valid
+    rescue KeyError, SystemCallError, TypeError, WorkflowCreator::Values::Error
+      raise Failure.new("preflight", "runtime_install_unverified", status: "blocked")
+    end
+
+    def verify_runtime_install!
+      return false unless @runtime_install_verifier && @runtime_install
+
+      observed = @runtime_install_verifier.call(
+        runtime_install: @runtime_install.value, launcher_sha256: @launcher_sha256
+      )
+      valid = WorkflowCreator::Values.capture(observed).canonical_bytes == @runtime_install.canonical_bytes
+      raise Failure.new("execution", "runtime_install_changed") if @model_loop_started && !valid
+      valid
+    rescue StandardError
+      raise Failure.new("execution", "runtime_install_changed") if @model_loop_started
+      false
+    end
+
+    def validate_downstream_environment!(environment)
+      values = stringify(environment)
+      unsafe = values.any? { |key, value| authority?(key) || [ @credential ].include?(value) }
+      raise Failure.new("preflight", "unsafe_downstream_environment") if unsafe
+    end
+
+    def configure_openclaw
+      workspace = @session.workspace_path
+      state = File.join(workspace, ".hive-openclaw")
+      bin = File.join(state, "bin")
+      home = File.join(state, "home")
+      FileUtils.mkdir_p([ bin, home ], mode: 0o700)
+      link = File.join(bin, "hive")
+      File.symlink(@session.gateway_path, link)
+      raise Failure.new("configuration", "invalid_gateway_path") unless File.realpath(link) == File.realpath(@session.gateway_path)
+      config_path = File.join(state, "openclaw.json")
+      write_private(config_path, openclaw_configuration(workspace, bin))
+      [ openclaw_environment(home:, state:, config_path:), link ]
+    rescue SystemCallError
+      raise Failure.new("configuration", "openclaw_configuration_failed")
+    end
+
+    def openclaw_configuration(workspace, bin)
+      {
+        "agents" => { "defaults" => { "workspace" => workspace, "model" => { "primary" => @model } } },
+        "tools" => {
+          "allow" => %w[read write edit apply_patch exec], "fs" => { "workspaceOnly" => true },
+          "elevated" => { "enabled" => false },
+          "exec" => { "mode" => "allowlist", "host" => "gateway", "strictInlineEval" => true,
+                      "pathPrepend" => [ bin ] }
+        }
+      }
+    end
+
+    def openclaw_environment(home:, state:, config_path:)
+      environment = CHILD_ENV.to_h { |name| [ name, @host_environment[name] ] }.compact
+      provider = PROVIDERS.fetch(@provider)
+      transport = @configuration.fetch("transport")
+      environment[provider.fetch("credential")] = @credential
+      environment[provider.fetch("endpoint_env")] = transport.fetch("endpoint")
+      PROXY_ENV.each { |name| environment[name] = transport.fetch("proxy") if transport.fetch("proxy") }
+      ca = transport.fetch("ca")
+      environment["SSL_CERT_FILE"] = ca.fetch("path") if ca
+      environment.merge!("HOME" => home, "OPENCLAW_STATE_DIR" => state,
+                         "OPENCLAW_CONFIG_PATH" => config_path, "HIVE_LIVE_PROOF" => "1",
+                         "SHELL" => @shell_path)
+    end
+
+    def prepare_workspace!(openclaw_environment, gateway_path)
+      raise Failure.new("configuration", "workspace_preparation_failed") unless
+        @workspace_preparer.respond_to?(:call)
+      observation = @workspace_preparer.call(
+        workspace: @session.workspace_path,
+        candidate_environment: @execution_options.fetch(:candidate).fetch("environment"),
+        openclaw_environment:, gateway_path:
+      )
+      row = WorkflowCreator::Values.capture(observation).value
+      exact!(row, WORKSPACE_PREPARATION_KEYS, "workspace_preparation_failed")
+      valid = row.values_at("schema", "schema_version", "status", "skill_manifest_sha256") == [
+        "hive-workflow-creator-workspace-preparation", 1, "prepared",
+        @configuration.dig("skill", "projection_manifest_sha256")
+      ]
+      valid &&= /\A[0-9a-f]{40}\z/.match?(row.fetch("git_head"))
+      valid &&= %w[init_stdout_sha256 openclaw_config_validation_sha256
+                    openclaw_effective_policy_sha256].all? do |key|
+        /\A[0-9a-f]{64}\z/.match?(row.fetch(key))
+      end
+      raise Failure.new("configuration", "workspace_preparation_failed") unless valid
+    rescue Failure
+      raise
+    rescue StandardError
+      raise Failure.new("configuration", "workspace_preparation_failed")
+    end
+
+    def created_files
+      validate_authored_graph!
+      WorkflowCreator::Vocabulary.fetch("files").map do |relative|
+        path = File.join(@session.workspace_path, relative)
+        bytes = safe_file(path)
+        { "path" => relative, "sha256" => Digest::SHA256.hexdigest(bytes), "size" => bytes.bytesize }
+      end
+    rescue SystemCallError
+      raise Failure.new("evidence", "authored_files_missing")
+    end
+
+    def validate_authored_graph!
+      descriptor = File.join(@session.workspace_path, WorkflowCreator::Vocabulary.fetch("files").first)
+      actual = YAML.safe_load(safe_file(descriptor), permitted_classes: [], aliases: false)
+      expected = {
+        "id" => "editorial",
+        "stages" => [
+          { "name" => "research", "kind" => "agent", "state_file" => "research.md",
+            "instruction" => "editorial/research.md", "permissions" => "yolo" },
+          { "name" => "draft", "kind" => "agent", "state_file" => "draft.md",
+            "instruction" => "editorial/draft.md", "permissions" => "yolo" },
+          { "name" => "approval", "kind" => "human", "state_file" => "approval.md",
+            "input" => "draft.md", "outcomes" => {
+              "approve" => { "complete" => true, "artifact" => "draft.md" },
+              "reject" => { "to" => "draft" }
+            } }
+        ]
+      }
+      raise Failure.new("evidence", "authored_graph_invalid") unless actual == expected
+      WorkflowCreator::Vocabulary.fetch("files").drop(1).each do |relative|
+        raise Failure.new("evidence", "authored_graph_invalid") if
+          safe_file(File.join(@session.workspace_path, relative)).strip.empty?
+      end
+    rescue Psych::Exception, SystemCallError
+      raise Failure.new("evidence", "authored_graph_invalid")
+    end
+
+    def observe_creation_only!
+      @creation_only_task_count = task_directories.length
+      raise Failure.new("evidence", "creation_only_task_created") unless @creation_only_task_count.zero?
+    end
+
+    def observe_task!
+      tasks = task_directories
+      raise Failure.new("evidence", "task_observation_invalid") unless tasks.length == 1
+      path = tasks.fetch(0)
+      relative = path.delete_prefix("#{@session.workspace_path}/")
+      stage, slug = relative.split(File::SEPARATOR).last(2)
+      meta = YAML.safe_load(safe_file(File.join(path, "meta.yml")), permitted_classes: [], aliases: false)
+      valid = meta.instance_of?(Hash) && meta.values_at("workflow", "idempotency_key") ==
+        [ "editorial", WorkflowCreator::Vocabulary.fetch("task_key") ]
+      valid &&= meta.fetch("slug", slug) == slug && stage == "1-research"
+      raise Failure.new("evidence", "task_observation_invalid") unless valid
+      @task_observation = { "slug" => slug, "workflow" => "editorial", "current_stage" => stage }
+    rescue KeyError, Psych::Exception, SystemCallError, TypeError
+      raise Failure.new("evidence", "task_observation_invalid")
+    end
+
+    def task_directories
+      pattern = File.join(@session.workspace_path, ".hive-state", "stages", "*", "*")
+      Dir.glob(pattern).select { |path| File.directory?(path) && !File.symlink?(path) }.sort
+    end
+
+    def primary_row(draft, files)
+      receipt = JSON.parse(draft.receipt_bytes)
+      installed = receipt.fetch("installed_manifests")
+      slug = receipt.dig("task_slug_binding", "value")
+      raise Failure.new("evidence", "task_observation_invalid") unless
+        @task_observation && @task_observation.fetch("slug") == slug
+      receipt_record = { "kind" => "execution_receipt", "path" => "execution-receipt.json",
+                         "sha256" => draft.receipt_sha256, "size" => draft.receipt_size }
+      summary = { "status" => "passed", "receipt_sha256" => draft.receipt_sha256 }
+      manifest = @execution_options.fetch(:manifest)
+      row = {
+        "schema" => WorkflowCreator::Vocabulary.fetch("evidence_schema"), "schema_version" => 1,
+        "platform" => "openclaw", "candidate_sha" => @candidate_sha, "result" => "passed",
+        "prompt_sha256" => Digest::SHA256.hexdigest(WorkflowCreator::Vocabulary.fetch("prompt")),
+        "task_prompt_sha256" => Digest::SHA256.hexdigest(WorkflowCreator::Vocabulary.fetch("task_prompt")),
+        "skill" => manifest.slice("skill_version", "canonical_digest"),
+        "native_activation" => WorkflowCreator::Vocabulary.fetch("native_activation"),
+        "hive_commands" => WorkflowCreator.commands_for(task_slug: slug).value,
+        "created_files" => files, "validation" => WorkflowCreator::Vocabulary.fetch("graph"),
+        "creation_only_task_count" => @creation_only_task_count, "task_count" => 1,
+        "task" => WorkflowCreator::Vocabulary.fetch("task").merge(@task_observation),
+        "external_actions" => @external_actions.fetch("actions"),
+        "secret_scan" => { "status" => "passed", "scanner" => WorkflowCreator::Vocabulary.fetch("scanner") },
+        "execution_kind" => "authenticated_openclaw", "model_loop" => "executed",
+        "executed_instruction" => files.fetch(2), "evidence_bundle" => installed + [ receipt_record ],
+        "containment" => summary, "teardown" => summary, "cleanup" => summary
+      }
+      bundle = WorkflowCreator::Values.capture(installed + [ receipt_record ])
+      WorkflowCreator.validate_primary!(row:, manifest:, candidate_sha: @candidate_sha, bundle_records: bundle.value)
+    rescue KeyError, JSON::ParserError, WorkflowCreator::Error
+      raise Failure.new("evidence", "primary_evidence_invalid")
+    end
+
+    def observe_external_actions!
+      raise Failure.new("evidence", "external_actions_unverified") unless
+        @external_actions_observer.respond_to?(:call)
+
+      observation = @external_actions_observer.call(
+        workspace: @session.workspace_path,
+        candidate_environment: @execution_options.fetch(:candidate).fetch("environment")
+      )
+      @external_actions = WorkflowCreator::Values.capture(observation).value
+      valid = @external_actions.instance_of?(Hash) && @external_actions.keys.sort == %w[actions status]
+      valid &&= @external_actions.values_at("status", "actions") == [ "observed", [] ]
+      raise Failure.new("evidence", "external_actions_unverified") unless valid
+    rescue Failure
+      raise
+    rescue StandardError
+      raise Failure.new("evidence", "external_actions_unverified")
+    end
+
+    def publish_primary(primary)
+      @current = WorkflowCreatorEvidence.replace_primary!(
+        bundle_directory: @bundle_directory, expected: @current.value, receipt: primary.value,
+        manifest: @execution_options.fetch(:manifest), candidate_sha: @candidate_sha,
+        bundle_records: primary.value.fetch("evidence_bundle")
+      )
+    rescue StandardError
+      raise Failure.new("publication", "primary_publication_failed")
+    end
+
+    def finalize_failure(failure, detail = nil)
+      receipt = WorkflowCreator.failure(
+        candidate_sha: @candidate_sha, phase: failure.phase, reason: failure.reason, detail:,
+        execution_kind: @model_loop_started ? "authenticated_openclaw" : "unavailable",
+        model_loop: @model_loop_started ? "executed" : "not_started", exact_secrets: exact_secrets
+      )
+      if @current
+        if @current.value.fetch("result") == "failed"
+          @current = WorkflowCreatorEvidence.replace_nonpassing!(
+            bundle_directory: @bundle_directory, expected: @current.value,
+            receipt: receipt.value, exact_secrets: exact_secrets
+          )
+        else
+          @current = WorkflowCreatorEvidence.replace_primary_with_failure!(
+            bundle_directory: @bundle_directory, expected: @current.value, receipt: receipt.value,
+            manifest: @execution_options.fetch(:manifest), candidate_sha: @candidate_sha,
+            bundle_records: @current.value.fetch("evidence_bundle"), exact_secrets: exact_secrets
+          )
+        end
+      end
+      Result.new(status: failure.status, provider: @provider, receipt: @current || receipt)
+    rescue StandardError
+      raise Error, "workflow-creator live failure evidence is unavailable", cause: nil
+    end
+
+    def safe_file(path)
+      stat = File.lstat(path)
+      valid = stat.file? && !stat.symlink? && stat.uid == Process.uid && stat.nlink == 1
+      valid &&= (stat.mode & 0o022).zero? && stat.size.between?(1, 1_048_576)
+      raise Errno::EACCES unless valid
+      bytes = File.binread(path)
+      raise Errno::EACCES unless File.lstat(path).ino == stat.ino
+      bytes
+    end
+
+    def write_private(path, value)
+      File.open(path, File::WRONLY | File::CREAT | File::EXCL, 0o600) do |file|
+        file.write(JSON.pretty_generate(value))
+        file.write("\n")
+      end
+    end
+
+    def exact!(value, keys, reason)
+      raise Failure.new("preflight", reason) unless value.instance_of?(Hash) && value.keys.sort == keys.sort
+    end
+
+    def safe_https?(value)
+      uri = URI.parse(value)
+      uri.scheme == "https" && uri.host && !uri.host.empty? && uri.userinfo.nil? && uri.fragment.nil?
+    rescue URI::InvalidURIError
+      false
+    end
+
+    def authority?(key) = AUTHORITY_ENV.match?(key) || CREDENTIAL_ENV.match?(key)
+    def exact_secrets = PROVIDERS.values.filter_map { |row| @host_environment[row.fetch("credential")] }.reject(&:empty?)
+    def stringify(value) = value.to_h.to_h { |key, item| [ key.to_s, item.to_s ] }
+
+    class Command
+      def self.call(argv, environment: ENV)
+        command, *arguments = argv
+        bundle, candidate = inputs(environment)
+        case command
+        when "initialize"
+          WorkflowCreatorLiveRunner.initialize_evidence!(bundle_directory: bundle, candidate_sha: candidate)
+        when "fail"
+          raise Error unless arguments.length == 2
+          WorkflowCreatorLiveRunner.fail!(
+            bundle_directory: bundle, candidate_sha: candidate, phase: arguments.fetch(0),
+            reason: arguments.fetch(1), exact_secrets: provider_secrets(environment)
+          )
+        else
+          raise Error
+        end
+        0
+      rescue Error, KeyError, JSON::ParserError, SystemCallError
+        1
+      end
+
+      def self.inputs(environment)
+        path = environment.fetch("HIVE_CREATOR_EVIDENCE_PATH")
+        expected = WorkflowCreator::Vocabulary.fetch("bundle_files").first
+        raise Error unless File.basename(path) == expected
+        [ File.dirname(path), environment.fetch("HIVE_CANDIDATE_SHA") ]
+      end
+      private_class_method :inputs
+
+      def self.provider_secrets(environment)
+        PROVIDERS.values.filter_map { |row| environment[row.fetch("credential")] }.reject(&:empty?)
+      end
+      private_class_method :provider_secrets
+    end
+  end
+end
+
+exit HiveLiveAgentProof::WorkflowCreatorLiveRunner::Command.call(ARGV) if $PROGRAM_NAME == __FILE__

--- a/packaging/live_agent_skills/workflow_creator_live_runner.rb
+++ b/packaging/live_agent_skills/workflow_creator_live_runner.rb
@@ -70,7 +70,7 @@ module HiveLiveAgentProof
     SKILL_KEYS = %w[path projection_manifest_sha256].freeze
     WORKSPACE_PREPARATION_KEYS = %w[schema schema_version status skill_manifest_sha256 init_stdout_sha256
                                     git_head openclaw_config_validation_sha256
-                                    openclaw_effective_policy_sha256].freeze
+                                    openclaw_effective_policy_sha256 native_activation].freeze
     CREATOR_ARGV = [ "agent", "--local", "--agent", "main", "--message",
                      WorkflowCreator::Vocabulary.fetch("prompt"), "--timeout", "180", "--json" ].freeze
     AUTHORIZED_ARGV = [ "agent", "--local", "--agent", "main", "--message",
@@ -93,6 +93,25 @@ module HiveLiveAgentProof
       Result.new(status: "failed", provider: nil, receipt: admitted)
     rescue JSON::ParserError, SystemCallError
       raise Error, "workflow-creator live failure evidence is unavailable", cause: nil
+    end
+
+    def self.finalize_bootstrap_failure!(bundle_directory:, candidate_sha:)
+      path = File.join(bundle_directory, WorkflowCreator::Vocabulary.fetch("bundle_files").first)
+      expected = JSON.parse(File.binread(path))
+      admitted = WorkflowCreator.validate_nonpassing!(expected)
+      initial = admitted.value.values_at("candidate_sha", "phase", "reason", "result") ==
+        [ candidate_sha.to_s.downcase, "preflight", "not_started", "failed" ]
+      return Result.new(status: "failed", provider: nil, receipt: admitted) unless initial
+
+      receipt = WorkflowCreator.failure(
+        candidate_sha:, phase: "setup", reason: "bootstrap_failed"
+      )
+      replaced = WorkflowCreatorEvidence.replace_nonpassing!(
+        bundle_directory:, expected: admitted.value, receipt: receipt.value
+      )
+      Result.new(status: "failed", provider: nil, receipt: replaced)
+    rescue JSON::ParserError, SystemCallError, WorkflowCreator::Error
+      raise Error, "workflow-creator live bootstrap evidence is unavailable", cause: nil
     end
 
     private_class_method :new
@@ -121,16 +140,20 @@ module HiveLiveAgentProof
         bundle_directory: @bundle_directory, candidate_sha: @candidate_sha
       )
       admit_preflight!
-      options = @execution_options.merge(exact_secrets: [ @credential ])
+      admit_preparer!
+      options = @execution_options.except(:control_root).merge(
+        exact_secrets: [ @credential ],
+        command_boundary_verifier: @workspace_preparer.method(:verify_command_boundary!)
+      )
       @session = @execution_factory.call(**options)
       environment, gateway_link = configure_openclaw
       prepare_workspace!(environment, gateway_link)
       @model_loop_started = true
-      @session.run_outer_workflow_creator(
+      run_outer!(:run_outer_workflow_creator,
         argv: CREATOR_ARGV, environment:, stdin_data: WorkflowCreator::Vocabulary.fetch("prompt")
       )
       observe_creation_only!
-      @session.run_outer_authorized_work(
+      run_outer!(:run_outer_authorized_work,
         argv: AUTHORIZED_ARGV, environment:, stdin_data: WorkflowCreator::Vocabulary.fetch("task_prompt")
       )
       observe_external_actions!
@@ -176,6 +199,33 @@ module HiveLiveAgentProof
       admit_runtime_install!(@configuration.fetch("runtime_install"), launcher_sha256)
     rescue KeyError, TypeError
       raise Failure.new("preflight", "invalid_openclaw_closure")
+    end
+
+    def admit_preparer!
+      methods = %i[call verify_command_boundary! verify_control_plane!]
+      raise Failure.new("preflight", "invalid_workspace_preparer") unless
+        methods.all? { |method| @workspace_preparer.respond_to?(method) }
+    end
+
+    def run_outer!(method, **options)
+      verify_control_plane!
+      result = @session.public_send(method, **options)
+      verify_control_plane!
+      result
+    rescue Failure
+      raise
+    rescue StandardError
+      verify_control_plane!
+      raise
+    end
+
+    def verify_control_plane!
+      raise Failure.new("configuration", "control_plane_changed") unless
+        @workspace_preparer.verify_control_plane! == true
+    rescue Failure
+      raise
+    rescue StandardError
+      raise Failure.new("configuration", "control_plane_changed")
     end
 
     def provider_for(model)
@@ -242,9 +292,18 @@ module HiveLiveAgentProof
       manifest_relative = manifest.delete_prefix(prefix)
       valid &&= candidate.fetch("inventory").include?(manifest_relative)
       valid &&= /\A[0-9a-f]{64}\z/.match?(skill.fetch("projection_manifest_sha256"))
-      valid &&= Digest::SHA256.hexdigest(safe_file(manifest)) == skill.fetch("projection_manifest_sha256")
+      manifest_bytes = safe_file(manifest)
+      valid &&= Digest::SHA256.hexdigest(manifest_bytes) == skill.fetch("projection_manifest_sha256")
+      projection = JSON.parse(manifest_bytes)
+      files = projection.fetch("files")
+      skill_record = files.find { |record| record["path"] == "SKILL.md" }
+      valid &&= skill_record.instance_of?(Hash) && skill_record.keys.sort == %w[path sha256 size]
+      content = safe_file(File.join(path, "SKILL.md"))
+      valid &&= skill_record.values_at("sha256", "size") ==
+        [ Digest::SHA256.hexdigest(content), content.bytesize ]
       raise Failure.new("preflight", "invalid_skill_projection") unless valid
-    rescue KeyError, SystemCallError, TypeError
+      @skill_record = WorkflowCreator::Values.capture(skill_record).value
+    rescue JSON::ParserError, KeyError, NoMethodError, SystemCallError, TypeError, WorkflowCreator::Values::Error
       raise Failure.new("preflight", "invalid_skill_projection")
     end
 
@@ -389,7 +448,10 @@ module HiveLiveAgentProof
 
     def configure_openclaw
       workspace = @session.workspace_path
-      state = File.join(workspace, ".hive-openclaw")
+      control = File.expand_path(@execution_options.fetch(:control_root))
+      raise Failure.new("configuration", "openclaw_configuration_failed") unless
+        File.realpath(control) == control && (File.lstat(control).mode & 0o077).zero?
+      state = File.join(control, "openclaw")
       bin = File.join(state, "bin")
       home = File.join(state, "home")
       FileUtils.mkdir_p([ bin, home ], mode: 0o700)
@@ -448,11 +510,28 @@ module HiveLiveAgentProof
                     openclaw_effective_policy_sha256].all? do |key|
         /\A[0-9a-f]{64}\z/.match?(row.fetch(key))
       end
+      @native_activation = row.fetch("native_activation")
+      valid &&= valid_native_activation?(@native_activation)
       raise Failure.new("configuration", "workspace_preparation_failed") unless valid
     rescue Failure
       raise
     rescue StandardError
       raise Failure.new("configuration", "workspace_preparation_failed")
+    end
+
+    def valid_native_activation?(row)
+      expected_path = "skills/hive/SKILL.md"
+      expected = {
+        "kind" => "openclaw-skills-info", "invocation" => "/hive", "name" => "hive",
+        "eligible" => true, "user_invocable" => true, "path" => expected_path
+      }
+      row.instance_of?(Hash) && row.keys.sort ==
+        %w[eligible invocation kind name path sha256 size user_invocable] &&
+        row.slice(*expected.keys) == expected && /\A[0-9a-f]{64}\z/.match?(row["sha256"]) &&
+        row["size"].instance_of?(Integer) && row["size"].positive? &&
+        row.values_at("sha256", "size") == [ @skill_record.fetch("sha256"), @skill_record.fetch("size") ]
+    rescue KeyError, TypeError
+      false
     end
 
     def created_files
@@ -535,6 +614,7 @@ module HiveLiveAgentProof
         "task_prompt_sha256" => Digest::SHA256.hexdigest(WorkflowCreator::Vocabulary.fetch("task_prompt")),
         "skill" => manifest.slice("skill_version", "canonical_digest"),
         "native_activation" => WorkflowCreator::Vocabulary.fetch("native_activation"),
+        "native_activation_evidence" => @native_activation,
         "hive_commands" => WorkflowCreator.commands_for(task_slug: slug).value,
         "created_files" => files, "validation" => WorkflowCreator::Vocabulary.fetch("graph"),
         "creation_only_task_count" => @creation_only_task_count, "task_count" => 1,
@@ -648,6 +728,11 @@ module HiveLiveAgentProof
           WorkflowCreatorLiveRunner.fail!(
             bundle_directory: bundle, candidate_sha: candidate, phase: arguments.fetch(0),
             reason: arguments.fetch(1), exact_secrets: provider_secrets(environment)
+          )
+        when "finalize-bootstrap"
+          raise Error unless arguments.empty?
+          WorkflowCreatorLiveRunner.finalize_bootstrap_failure!(
+            bundle_directory: bundle, candidate_sha: candidate
           )
         else
           raise Error

--- a/packaging/live_agent_skills/workflow_creator_live_setup.rb
+++ b/packaging/live_agent_skills/workflow_creator_live_setup.rb
@@ -1,0 +1,788 @@
+# frozen_string_literal: true
+
+require "base64"
+require "digest"
+require "fileutils"
+require "find"
+require "json"
+require "open3"
+require "pathname"
+require "rubygems/package"
+require "timeout"
+require "zlib"
+require_relative "proof"
+require_relative "workflow_creator_live_runner"
+require_relative "workflow_creator_openclaw_runtime"
+
+module HiveLiveAgentProof
+  class WorkflowCreatorLiveSetup
+    class Error < StandardError; end
+
+    MAX_IDENTITY_FILES = 512
+    MAX_RUNTIME_FILES = 50_000
+    MAX_FILE_BYTES = 268_435_456
+    MAX_TOTAL_BYTES = 1_073_741_824
+    NPM_REGISTRY = "https://registry.npmjs.org"
+    CONFIGURATION_SCHEMA = "hive-live-openclaw-creator-configuration/v1"
+    CANDIDATE_RUNTIME_SCHEMA = "hive-workflow-creator-candidate-runtime/v1"
+    PROJECTION_SCHEMA = "hive-workflow-creator-openclaw-skill/v1"
+    FIXTURE_RECEIPT = {
+      "actions" => [], "run_count" => 1,
+      "schema" => "hive-workflow-creator-first-stage-fixture", "schema_version" => 1,
+      "stage" => "research", "status" => "passed"
+    }.freeze
+    PROVIDER_ENDPOINTS = {
+      "openai" => "https://api.openai.com/v1",
+      "openrouter" => "https://openrouter.ai/api/v1"
+    }.freeze
+    AUTHORITY = /\A(?:GH_|GITHUB_|GIT_|SSH_|CI_JOB_TOKEN\z|CI_DEPLOY_PASSWORD\z)/i
+    CREDENTIAL = /(?:TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIAL|API_?KEY|PRIVATE_?KEY|AUTHORIZATION|COOKIE|SESSION)/i
+    OPENCLAW_LOCAL_ENV = %w[HOME OPENCLAW_STATE_DIR OPENCLAW_CONFIG_PATH PATH LANG LC_ALL TERM TMPDIR
+                             SHELL HIVE_LIVE_PROOF].freeze
+
+    class << self
+      def prepare!(**options) = new(**options).send(:prepare)
+      private :new
+    end
+
+    def initialize(candidate_dir:, candidate_sha:, hive_version:, canonical:, candidate_runtime_root:,
+                   candidate_hive:, ruby:, openclaw_runtime_root:, openclaw_entrypoint:, node:,
+                   openclaw_lock:, openclaw_package:, output_root:, workspace_path:, bundle_directory:,
+                   model:, provider:, transport:, correlation_id:, supervisor_options: {})
+      @candidate_dir = absolute(candidate_dir)
+      @candidate_sha = HiveLiveAgentProof.validate_sha!(candidate_sha, "candidate_sha")
+      @hive_version = hive_version.to_s
+      @canonical = canonical
+      @output_root = absolute(output_root)
+      @candidate_runtime = absolute(candidate_runtime_root)
+      @candidate_hive = absolute(candidate_hive)
+      @ruby = absolute(ruby)
+      @openclaw_runtime = absolute(openclaw_runtime_root)
+      @openclaw_entrypoint = absolute(openclaw_entrypoint)
+      @node = absolute(node)
+      @openclaw_lock = absolute(openclaw_lock)
+      @openclaw_package = absolute(openclaw_package)
+      @workspace = absolute(workspace_path)
+      @bundle = absolute(bundle_directory)
+      @model, @provider = model.to_s, provider.to_s
+      @transport = WorkflowCreator::Values.capture(transport).value
+      @correlation_id = correlation_id.to_s
+      @supervisor_options = supervisor_options
+      validate_roots!
+    rescue StandardError => error
+      raise Error, "workflow-creator live setup inputs are invalid: #{error.message}", cause: nil
+    end
+
+    def prepare
+      verified = CandidateVerifier.new(
+        candidate_dir: @candidate_dir, candidate_sha: @candidate_sha,
+        expected_hive_version: @hive_version, canonical: @canonical
+      ).call
+      candidate, skill_source, fixture = build_candidate(verified)
+      openclaw, configuration = build_openclaw(candidate.fetch("root"), skill_source)
+      available_bytes, available_entries = filesystem_capacity(File.dirname(@workspace))
+      archives = {
+        "candidate-package" => archive_row(candidate.fetch("package"), available_bytes, available_entries),
+        "openclaw-package" => archive_row(openclaw.fetch("package"), available_bytes, available_entries)
+      }
+      candidate_environment = candidate.fetch("environment")
+      preparer = WorkspacePreparer.new(
+        workspace: @workspace, skill_source:, candidate_executable: candidate.fetch("executable"),
+        candidate_environment:, openclaw_executable: openclaw.fetch("executable"),
+        projection_manifest_sha256: configuration.dig("skill", "projection_manifest_sha256")
+      )
+      observer = ExternalActionsObserver.new(
+        workspace: @workspace, candidate_environment:, fixture_path: fixture,
+        receipt_bytes: WorkflowCreator::Values.capture(FIXTURE_RECEIPT).canonical_bytes
+      )
+      {
+        candidate_sha: @candidate_sha, model: @model, configuration_record: configuration.fetch("path"),
+        execution_options: {
+          candidate_sha: @candidate_sha, manifest: verified.fetch("manifest"), candidate:, openclaw:, archives:,
+          workspace_path: @workspace, bundle_directory: @bundle, correlation_id: @correlation_id,
+          supervisor_options: @supervisor_options
+        },
+        runtime_install_verifier: WorkflowCreatorOpenClawRuntime.method(:verify!),
+        external_actions_observer: observer, workspace_preparer: preparer,
+        skill_source:
+      }
+    rescue Error
+      raise
+    rescue StandardError => error
+      raise Error, "workflow-creator live setup failed: #{error.class}: #{error.message}", cause: nil
+    end
+
+    def build_candidate(verified)
+      root = create_identity_root("candidate-identity")
+      skill_source, projection_sha = extract_projection(verified.fetch("skills"), root)
+      package = copy_exact(verified.fetch("gem"), root, "packages/hive-cli-#{@hive_version}.gem", 0o600)
+      ruby = copy_exact(@ruby, root, "runtime/ruby", 0o700)
+      fixture = write_exact(root, "fixtures/first-stage-agent", first_stage_fixture_source, 0o700)
+      runtime_manifest = capture_candidate_runtime
+      manifest = write_exact(root, "runtime/candidate-runtime-manifest.json", runtime_manifest, 0o600)
+      manifest_sha = Digest::SHA256.file(manifest).hexdigest
+      guard = write_exact(root, "libexec/candidate-runtime-guard.rb", candidate_guard_source(manifest_sha), 0o600)
+      executable = write_exact(root, "bin/hive", candidate_launcher_source, 0o700)
+      lock = write_canonical(
+        root, "runtime/runtime-lock.json",
+        {
+          "schema" => "hive-workflow-creator-candidate-lock", "schema_version" => 1,
+          "candidate_sha" => @candidate_sha, "hive_version" => @hive_version,
+          "package_sha256" => Digest::SHA256.file(package).hexdigest,
+          "ruby_sha256" => Digest::SHA256.file(ruby).hexdigest,
+          "runtime_manifest_sha256" => manifest_sha,
+          "guard_sha256" => Digest::SHA256.file(guard).hexdigest,
+          "fixture_sha256" => Digest::SHA256.file(fixture).hexdigest,
+          "projection_manifest_sha256" => projection_sha
+        }
+      )
+      gateway_root = File.join(root, "gateway")
+      Dir.mkdir(gateway_root, 0o700)
+      gateway = File.join(gateway_root, WorkflowCreatorGateway::WRAPPER_NAME)
+      inventory = identity_inventory(root) + [ relative(root, gateway) ]
+      inventory = inventory.sort
+      raise Error if inventory.length > MAX_IDENTITY_FILES || inventory.uniq.length != inventory.length
+      environment = {
+        "PATH" => "/usr/bin:/bin", "HOME" => File.join(@workspace, ".hive-proof-home"),
+        "HIVE_HOME" => File.join(@workspace, ".hive-proof-hive-home"),
+        "GEM_HOME" => @candidate_runtime, "GEM_PATH" => @candidate_runtime,
+        "HIVE_CLAUDE_BIN" => fixture, "HIVE_DAEMON_NO_AUTO_REEXEC" => "1",
+        "HIVE_SKIP_LLM_WIKI_SCHEDULER" => "1", "HIVE_SKIP_LLM_WIKI_SYSTEMCTL" => "1",
+        "HIVE_SKIP_LLM_WIKI_POST_COMMIT" => "1"
+      }
+      [
+        {
+          "root" => root, "inventory" => inventory, "audit_gateway" => gateway,
+          "executable" => executable, "interpreter_or_launcher" => ruby,
+          "lock" => lock, "package" => package, "environment" => environment
+        },
+        skill_source, fixture
+      ]
+    end
+
+    def build_openclaw(candidate_root, skill_source)
+      dependency = dependency_identity
+      root = create_identity_root("openclaw-identity")
+      node = copy_exact(@node, root, "runtime/node", 0o700)
+      admit_node_version!(node, dependency.fetch("node_version"))
+      lock = copy_exact(@openclaw_lock, root, "package-lock.json", 0o600)
+      package = copy_exact(@openclaw_package, root, "packages/openclaw.tgz", 0o600)
+      shell = write_exact(root, "security/hive-creator-shell",
+                          WorkflowCreatorLiveRunner.shell_sanitizer_bytes, 0o700)
+      launcher = write_exact(root, "bin/openclaw", openclaw_launcher_source, 0o700)
+      launcher_sha = Digest::SHA256.file(launcher).hexdigest
+      runtime = WorkflowCreatorOpenClawRuntime.capture!(
+        root: @openclaw_runtime, launcher_sha256: launcher_sha
+      ).value
+      projection_manifest = File.join(skill_source, "projection-manifest.json")
+      configuration = {
+        "schema" => CONFIGURATION_SCHEMA, "schema_version" => 1,
+        "candidate_sha" => @candidate_sha, "provider" => @provider, "model" => @model,
+        "transport" => @transport, "dependency" => dependency,
+        "tool_environment" => {
+          "authority" => "shell_sanitized", "pass_env" => [],
+          "shell" => {
+            "path" => relative(root, shell), "sha256" => Digest::SHA256.file(shell).hexdigest,
+            "size" => File.size(shell)
+          }
+        },
+        "runtime_install" => runtime,
+        "skill" => {
+          "path" => relative(candidate_root, skill_source),
+          "projection_manifest_sha256" => Digest::SHA256.file(projection_manifest).hexdigest
+        }
+      }
+      configuration_path = write_canonical(root, "creator-configuration.json", configuration)
+      inventory = identity_inventory(root)
+      raise Error if inventory.length > MAX_IDENTITY_FILES
+      openclaw = {
+        "root" => root, "version" => dependency.fetch("version"), "inventory" => inventory,
+        "executable" => launcher, "interpreter_or_launcher" => node,
+        "lock" => lock, "package" => package
+      }
+      [ openclaw, configuration.merge("path" => configuration_path) ]
+    end
+
+    def dependency_identity
+      bytes = safe_file(@openclaw_lock, 16 * 1_048_576)
+      lock = JSON.parse(bytes)
+      packages = lock.fetch("packages")
+      root = packages.fetch("")
+      package = packages.fetch("node_modules/openclaw")
+      version = package.fetch("version")
+      node_version = observed_version(@node)
+      node_engine = package.dig("engines", "node")
+      expected_integrity = "sha512-#{Base64.strict_encode64(Digest::SHA512.file(@openclaw_package).digest)}"
+      resolved = "#{NPM_REGISTRY}/openclaw/-/openclaw-#{version}.tgz"
+      valid = lock.fetch("lockfileVersion") == 3 && root.dig("dependencies", "openclaw") == version
+      valid &&= root.dig("engines", "node") == node_version
+      valid &&= node_engine.instance_of?(String) && !node_engine.empty?
+      valid &&= package.values_at("resolved", "integrity") == [ resolved, expected_integrity ]
+      raise Error unless valid
+      lifecycle = packages.filter_map { |path, row| path unless path.empty? || row["hasInstallScript"] != true }.sort
+      {
+        "package" => "openclaw", "version" => version, "registry" => NPM_REGISTRY,
+        "integrity" => expected_integrity, "lock_sha256" => Digest::SHA256.hexdigest(bytes),
+        "package_count" => packages.length, "node_engine" => node_engine,
+        "node_version" => node_version, "lifecycle_scripts" => lifecycle
+      }
+    rescue JSON::ParserError, KeyError, TypeError
+      raise Error, "OpenClaw dependency identity is invalid", cause: nil
+    end
+
+    def extract_projection(archive, root)
+      expected = @canonical.render("openclaw")
+      prefix = "openclaw/hive/"
+      files = {}
+      Zlib::GzipReader.open(archive) do |gzip|
+        Gem::Package::TarReader.new(gzip) do |tar|
+          tar.each do |entry|
+            name = entry.full_name.delete_prefix("./")
+            next unless entry.file? && name.start_with?(prefix)
+            files[name.delete_prefix(prefix)] = entry.read
+          end
+        end
+      end
+      mismatch = (files.keys | expected.files.keys).select do |path|
+        files[path]&.b != expected.files[path]&.b
+      end
+      raise Error, "OpenClaw skill projection does not match canonical bytes" unless mismatch.empty?
+      skill = File.join(root, "skill", "hive")
+      files.sort.each { |path, bytes| write_exact(skill, path, bytes, 0o600) }
+      manifest = WorkflowCreator::Values.capture(
+        "schema" => PROJECTION_SCHEMA, "schema_version" => 1, "platform" => "openclaw",
+        "invocation" => expected.invocation, "skill_version" => expected.skill_version,
+        "canonical_digest" => expected.canonical_digest,
+        "files" => files.keys.sort.map do |path|
+          bytes = files.fetch(path)
+          { "path" => path, "sha256" => Digest::SHA256.hexdigest(bytes), "size" => bytes.bytesize }
+        end
+      )
+      path = write_exact(skill, "projection-manifest.json", manifest.canonical_bytes, 0o600)
+      [ skill, Digest::SHA256.file(path).hexdigest ]
+    rescue Zlib::GzipFile::Error, Gem::Package::TarInvalidError, EOFError
+      raise Error, "OpenClaw skill projection is invalid", cause: nil
+    end
+
+    def capture_candidate_runtime
+      records = scan_regular_tree(@candidate_runtime)
+      entrypoint = relative(@candidate_runtime, @candidate_hive)
+      raise Error unless records.any? { |row| row.fetch("path") == entrypoint }
+      canonical_records = records.map do |row|
+        { "mode" => row.fetch("mode"), "path" => row.fetch("path"),
+          "sha256" => row.fetch("sha256"), "size" => row.fetch("size") }
+      end
+      JSON.generate(
+        "entrypoint" => entrypoint, "files" => canonical_records,
+        "schema" => CANDIDATE_RUNTIME_SCHEMA, "schema_version" => 1
+      ) << "\n"
+    end
+
+    def scan_regular_tree(root)
+      records = []
+      total = 0
+      Find.find(root) do |path|
+        stat = File.lstat(path)
+        if stat.directory?
+          raise Error unless stat.uid == Process.uid && (stat.mode & 0o022).zero?
+          next
+        end
+        raise Error unless stat.file? && !stat.symlink? && stat.uid == Process.uid && stat.nlink == 1
+        raise Error unless (stat.mode & 0o022).zero? && stat.size.between?(0, MAX_FILE_BYTES)
+        total += stat.size
+        raise Error if total > MAX_TOTAL_BYTES
+        records << {
+          "path" => relative(root, path), "sha256" => Digest::SHA256.file(path).hexdigest,
+          "size" => stat.size, "mode" => stat.mode & 0o777
+        }
+        raise Error if records.length > MAX_RUNTIME_FILES
+      end
+      raise Error if records.empty?
+      records.sort_by { |row| row.fetch("path") }
+    end
+
+    def candidate_guard_source(manifest_sha)
+      <<~RUBY
+        # frozen_string_literal: true
+        require "digest"
+        require "find"
+        require "json"
+        root = File.realpath(File.expand_path("..", __dir__))
+        runtime = File.realpath(File.join(root, "..", "candidate-runtime"))
+        manifest_path = File.join(root, "runtime", "candidate-runtime-manifest.json")
+        abort "candidate runtime manifest changed" unless Digest::SHA256.file(manifest_path).hexdigest == #{manifest_sha.dump}
+        manifest = JSON.parse(File.binread(manifest_path))
+        abort "candidate runtime manifest invalid" unless manifest.keys.sort == %w[entrypoint files schema schema_version]
+        actual = []
+        Find.find(runtime) do |path|
+          stat = File.lstat(path)
+          if stat.directory?
+            abort "candidate runtime directory unsafe" unless stat.uid == Process.uid && (stat.mode & 0o022).zero?
+            next
+          end
+          abort "candidate runtime member unsafe" unless stat.file? && !stat.symlink? && stat.uid == Process.uid && stat.nlink == 1 && (stat.mode & 0o022).zero?
+          relative = path.delete_prefix("\#{runtime}/")
+          actual << { "path" => relative, "sha256" => Digest::SHA256.file(path).hexdigest,
+                      "size" => stat.size, "mode" => stat.mode & 0o777 }
+        end
+        actual.sort_by! { |row| row.fetch("path") }
+        abort "candidate runtime changed" unless actual == manifest.fetch("files")
+        hive = File.join(runtime, manifest.fetch("entrypoint"))
+        ruby = File.join(root, "runtime", "ruby")
+        exec ruby, hive, *ARGV
+      RUBY
+    end
+
+    def candidate_launcher_source
+      <<~'SH'
+        #!/bin/sh
+        set -eu
+        hive_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd -P)
+        exec "$hive_root/runtime/ruby" "$hive_root/libexec/candidate-runtime-guard.rb" "$@"
+      SH
+    end
+
+    def first_stage_fixture_source
+      receipt = WorkflowCreator::Values.capture(FIXTURE_RECEIPT).canonical_bytes
+      escaped_receipt = receipt.bytes.map { |byte| format("\\%03o", byte) }.join
+      <<~SH
+        #!/bin/bash
+        set -eu -o pipefail
+        if [[ "\${1:-}" == "--version" ]]; then
+          printf '%s (Claude Code)\\n' '2.1.118'
+          exit 0
+        fi
+        mapfile -t hive_research_files < <(find "$PWD/.hive-state/stages/1-research" -mindepth 2 -maxdepth 2 -type f -name research.md -print | sort)
+        [[ "\${#hive_research_files[@]}" -eq 1 ]] || { printf '%s\\n' 'fixture expected one research task' >&2; exit 64; }
+        receipt="$PWD/.hive-state/workflow-creator-fixture-receipt.json"
+        [[ ! -e "$receipt" ]] || { printf '%s\\n' 'fixture already executed' >&2; exit 64; }
+        printf '%s\\n\\n<!-- COMPLETE -->\\n' '# Deterministic first-stage research' > "\${hive_research_files[0]}"
+        printf '%b' #{escaped_receipt.dump} > "$receipt"
+        printf '%s\\n' '{"type":"result","result":"deterministic first-stage fixture"}'
+      SH
+    end
+
+    def openclaw_launcher_source
+      entrypoint = relative(@openclaw_runtime, @openclaw_entrypoint)
+      <<~SH
+        #!/bin/sh
+        set -eu
+        openclaw_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd -P)
+        runtime=$(CDPATH= cd -- "$openclaw_root/../openclaw-runtime" && pwd -P)
+        exec "$openclaw_root/runtime/node" "$runtime/#{entrypoint}" "$@"
+      SH
+    end
+
+    def validate_roots!
+      raise Error if @hive_version.empty? || @correlation_id.empty?
+      raise Error unless PROVIDER_ENDPOINTS.fetch(@provider) == @transport.fetch("endpoint")
+      raise Error unless @model.start_with?("#{@provider}/")
+      raise Error unless @transport.keys.sort == %w[ca endpoint proxy redirects]
+      raise Error unless @transport.fetch("redirects") == "deny"
+      raise Error unless File.directory?(@output_root) && private_directory?(@output_root)
+      expected = [ File.join(@output_root, "candidate-runtime"), File.join(@output_root, "openclaw-runtime") ]
+      raise Error unless [ @candidate_runtime, @openclaw_runtime ] == expected
+      raise Error unless [ @candidate_runtime, @openclaw_runtime, @bundle ].all? { |path| private_directory?(path) }
+      raise Error if File.exist?(@workspace) || File.symlink?(@workspace)
+      [ @candidate_hive, @ruby, @openclaw_entrypoint, @node, @openclaw_lock, @openclaw_package ].each do |path|
+        safe_file(path, 268_435_456)
+      end
+      relative(@candidate_runtime, @candidate_hive)
+      relative(@openclaw_runtime, @openclaw_entrypoint)
+    end
+
+    def create_identity_root(name)
+      root = File.join(@output_root, name)
+      Dir.mkdir(root, 0o700)
+      root
+    rescue SystemCallError
+      raise Error, "identity closure cannot be created", cause: nil
+    end
+
+    def copy_exact(source, root, relative_path, mode)
+      bytes = safe_file(source, 268_435_456)
+      write_exact(root, relative_path, bytes, mode)
+    end
+
+    def write_canonical(root, relative_path, value)
+      write_exact(root, relative_path, WorkflowCreator::Values.capture(value).canonical_bytes, 0o600)
+    end
+
+    def write_exact(root, relative_path, bytes, mode)
+      path = File.expand_path(relative_path, root)
+      raise Error unless path.start_with?("#{File.expand_path(root)}/")
+      FileUtils.mkdir_p(File.dirname(path), mode: 0o700)
+      File.open(path, File::WRONLY | File::CREAT | File::EXCL, mode) { |file| file.write(bytes) }
+      File.chmod(mode, path)
+      path
+    rescue SystemCallError
+      raise Error, "identity closure member cannot be written", cause: nil
+    end
+
+    def identity_inventory(root)
+      files = scan_regular_tree(root).map { |row| row.fetch("path") }
+      raise Error if files.length > MAX_IDENTITY_FILES
+      files
+    end
+
+    def safe_file(path, limit)
+      stat = File.lstat(path)
+      valid = stat.file? && !stat.symlink? && stat.uid == Process.uid && stat.nlink == 1
+      valid &&= (stat.mode & 0o022).zero? && stat.size.between?(1, limit)
+      raise Error unless valid
+      bytes = File.binread(path)
+      raise Error unless File.lstat(path).ino == stat.ino
+      bytes
+    rescue SystemCallError
+      raise Error, "setup input is not a safe regular file", cause: nil
+    end
+
+    def private_directory?(path)
+      stat = File.lstat(path)
+      File.realpath(path) == path && stat.directory? && !stat.symlink? && stat.uid == Process.uid &&
+        (stat.mode & 0o077).zero?
+    rescue SystemCallError
+      false
+    end
+
+    def observed_version(node)
+      stdout, stderr, status = Open3.capture3({}, node, "--version", unsetenv_others: true)
+      match = stdout.strip.match(/\Av(\d+\.\d+\.\d+)\z/)
+      raise Error unless status.success? && stderr.empty? && match
+      match[1]
+    end
+
+    def admit_node_version!(node, expected)
+      raise Error unless observed_version(node) == expected
+    end
+
+    def filesystem_capacity(path)
+      df = %w[/usr/bin/df /bin/df].find { |candidate| File.executable?(candidate) }
+      raise Error unless df
+      bytes = df_available(df, "-Pk", path) * 1024
+      entries = df_available(df, "-Pi", path)
+      raise Error unless bytes.positive? && entries.positive?
+      [ bytes, entries ]
+    end
+
+    def df_available(df, flag, path)
+      stdout, stderr, status = Open3.capture3({}, df, flag, path, unsetenv_others: true)
+      fields = stdout.lines.last.to_s.split
+      raise Error unless status.success? && stderr.empty? && fields.length >= 6
+      Integer(fields.fetch(3), 10)
+    end
+
+    def archive_row(path, available_bytes, available_entries)
+      { "path" => path, "available_bytes" => available_bytes, "available_entries" => available_entries }
+    end
+
+    def relative(root, path)
+      root = File.realpath(root)
+      path = File.expand_path(path)
+      raise Error unless path.start_with?("#{root}/")
+      value = WorkflowCreator::Values.capture(path.delete_prefix("#{root}/")).value
+      raise Error unless WorkflowCreator::TextSafety.safe_relative_path?(value)
+      value
+    rescue WorkflowCreator::TextSafety::Error, SystemCallError
+      raise Error, "setup path escapes its closure", cause: nil
+    end
+
+    def absolute(path)
+      expanded = File.expand_path(path.to_s)
+      raise Error if expanded.empty?
+      expanded
+    end
+
+    class WorkspacePreparer
+      def initialize(workspace:, skill_source:, candidate_executable:, candidate_environment:,
+                     openclaw_executable:, projection_manifest_sha256:)
+        @workspace, @skill_source, @candidate = workspace, skill_source, candidate_executable
+        @openclaw = openclaw_executable
+        @environment = WorkflowCreator::Values.capture(candidate_environment)
+        @projection_sha = projection_manifest_sha256
+        @git = %w[/usr/bin/git /bin/git].find { |path| File.executable?(path) }
+        raise Error unless @git
+      end
+
+      def call(workspace:, candidate_environment:, openclaw_environment:, gateway_path:)
+        raise Error unless workspace == @workspace
+        raise Error unless WorkflowCreator::Values.capture(candidate_environment).canonical_bytes ==
+                           @environment.canonical_bytes
+        stat = File.lstat(workspace)
+        raise Error unless stat.directory? && stat.uid == Process.uid && (stat.mode & 0o077).zero?
+        manifest = File.join(@skill_source, "projection-manifest.json")
+        raise Error unless Digest::SHA256.file(manifest).hexdigest == @projection_sha
+        projection = admit_skill_projection!(manifest)
+        destination = File.join(workspace, "skills", "hive")
+        raise Error if File.exist?(destination) || File.symlink?(destination)
+        materialize_skill!(destination, manifest, projection)
+        FileUtils.mkdir_p([ @environment.value.fetch("HOME"), @environment.value.fetch("HIVE_HOME") ], mode: 0o700)
+        write(File.join(workspace, ".gitignore"), proof_gitignore)
+        write(File.join(workspace, "README.md"), "# Workflow creator live proof\n")
+        git!(workspace, "init", "-b", "main")
+        git!(workspace, "config", "user.name", "Hive Live Proof")
+        git!(workspace, "config", "user.email", "hive-live-proof@example.invalid")
+        git!(workspace, "add", "--", ".gitignore", "README.md")
+        git!(workspace, "commit", "-m", "chore: initialize workflow creator proof")
+        stdout, stderr, status = Open3.capture3(
+          @environment.value, @candidate, "init", workspace, "--minimal", "--new-workflow", "proof-seed", "--json",
+          chdir: workspace, unsetenv_others: true
+        )
+        raise Error unless status.success? && stderr.empty?
+        init = JSON.parse(stdout)
+        answers = init.fetch("answers")
+        minimal = init.values_at("schema", "ok", "minimal") == [ "hive-init", true, true ]
+        disabled = answers.values_at(
+          "daemon_enabled", "babysitter_enabled", "daemon_autostart", "refactor_patrol_enabled",
+          "adhoc_auto_fix"
+        ) == [ false, false, false, false, false ]
+        disabled &&= answers.fetch("patrol_mode") == "off"
+        raise Error unless minimal && disabled
+        raise Error unless File.file?(File.join(workspace, ".hive-state", "config.yml"))
+        raise Error unless git_output(workspace, "remote").empty?
+        approval = configure_openclaw!(openclaw_environment, gateway_path)
+        WorkflowCreator::Values.capture(
+          "schema" => "hive-workflow-creator-workspace-preparation", "schema_version" => 1,
+          "status" => "prepared", "skill_manifest_sha256" => @projection_sha,
+          "init_stdout_sha256" => Digest::SHA256.hexdigest(stdout),
+          "git_head" => git_output(workspace, "rev-parse", "HEAD"),
+          "openclaw_config_validation_sha256" => approval.fetch("config_validation_sha256"),
+          "openclaw_effective_policy_sha256" => approval.fetch("effective_policy_sha256")
+        ).value
+      rescue StandardError => error
+        raise Error, "workflow-creator workspace preparation failed: #{error.class}: #{error.message}", cause: nil
+      end
+
+      private
+
+      def admit_skill_projection!(manifest_path)
+        bytes = safe_skill_file(manifest_path)
+        projection = WorkflowCreator::Values.capture(JSON.parse(bytes))
+        raise Error unless bytes == projection.canonical_bytes
+        row = projection.value
+        raise Error unless row.keys.sort == %w[canonical_digest files invocation platform schema schema_version skill_version]
+        raise Error unless row.values_at("schema", "schema_version", "platform") ==
+                           [ PROJECTION_SCHEMA, 1, "openclaw" ]
+        files = row.fetch("files")
+        raise Error unless files.instance_of?(Array) && !files.empty?
+        expected = files.map do |record|
+          raise Error unless record.keys.sort == %w[path sha256 size]
+          relative = record.fetch("path")
+          path = File.expand_path(relative, @skill_source)
+          raise Error unless path.delete_prefix("#{@skill_source}/") == relative
+          content = safe_skill_file(path)
+          raise Error unless record.values_at("sha256", "size") ==
+                             [ Digest::SHA256.hexdigest(content), content.bytesize ]
+          relative
+        end
+        actual = Dir.glob(File.join(@skill_source, "**", "*"), File::FNM_DOTMATCH).filter_map do |path|
+          stat = File.lstat(path)
+          raise Error if stat.symlink? || stat.uid != Process.uid || (stat.mode & 0o022).positive?
+          next if stat.directory?
+          path.delete_prefix("#{@skill_source}/")
+        end
+        raise Error unless actual.sort == (expected + [ "projection-manifest.json" ]).sort
+        projection.value
+      end
+
+      def materialize_skill!(destination, manifest, projection)
+        FileUtils.mkdir_p(destination, mode: 0o700)
+        projection.fetch("files").each do |row|
+          relative = row.fetch("path")
+          target = File.join(destination, relative)
+          FileUtils.mkdir_p(File.dirname(target), mode: 0o700)
+          write(target, safe_skill_file(File.join(@skill_source, relative)))
+        end
+        write(File.join(destination, "projection-manifest.json"), safe_skill_file(manifest))
+      end
+
+      def safe_skill_file(path)
+        stat = File.lstat(path)
+        valid = stat.file? && !stat.symlink? && stat.uid == Process.uid && stat.nlink == 1
+        valid &&= (stat.mode & 0o022).zero? && stat.size.between?(1, 1_048_576)
+        raise Error unless valid
+        bytes = File.binread(path)
+        raise Error unless File.lstat(path).ino == stat.ino
+        bytes
+      end
+
+      def configure_openclaw!(provided_environment, gateway_path)
+        environment = credential_free_openclaw_environment(provided_environment)
+        expected_gateway = File.join(@workspace, ".hive-openclaw", "bin", "hive")
+        raise Error unless gateway_path == expected_gateway && File.symlink?(gateway_path)
+        raise Error unless File.executable?(File.realpath(gateway_path))
+
+        config_stdout = run_openclaw!(environment, "config", "validate")
+        policy = approvals(gateway_path)
+        request_path = File.join(@workspace, ".hive-openclaw", "approvals-request.json")
+        write(request_path, WorkflowCreator::Values.capture(policy).canonical_bytes)
+        run_openclaw!(
+          environment, "approvals", "set", "--file", request_path, "--json",
+          allowed_stderr: "Writing local approvals.\n"
+        )
+        snapshot = JSON.parse(run_openclaw!(environment, "approvals", "get", "--json"))
+        effective = admit_effective_policy!(snapshot, policy)
+        {
+          "config_validation_sha256" => Digest::SHA256.hexdigest(config_stdout),
+          "effective_policy_sha256" => Digest::SHA256.hexdigest(
+            WorkflowCreator::Values.capture(effective).canonical_bytes
+          )
+        }
+      rescue JSON::ParserError, SystemCallError, WorkflowCreator::Values::Error
+        raise Error
+      end
+
+      def credential_free_openclaw_environment(environment)
+        raw = environment.to_h.to_h { |key, value| [ key.to_s, value.to_s ] }
+        raise Error if raw.empty?
+        required = %w[HOME OPENCLAW_STATE_DIR OPENCLAW_CONFIG_PATH SHELL HIVE_LIVE_PROOF]
+        raise Error unless required.all? { |key| raw.key?(key) }
+        expected = {
+          "HOME" => File.join(@workspace, ".hive-openclaw", "home"),
+          "OPENCLAW_STATE_DIR" => File.join(@workspace, ".hive-openclaw"),
+          "OPENCLAW_CONFIG_PATH" => File.join(@workspace, ".hive-openclaw", "openclaw.json"),
+          "HIVE_LIVE_PROOF" => "1"
+        }
+        raise Error unless expected.all? { |key, value| raw[key] == value }
+        local = OPENCLAW_LOCAL_ENV.to_h do |name|
+          [ name, name == "PATH" ? "/usr/bin:/bin" : raw[name] ]
+        end.compact
+        raise Error if local.any? { |key, _value| AUTHORITY.match?(key) || CREDENTIAL.match?(key) }
+        local
+      end
+
+      def approvals(gateway_path)
+        {
+          "version" => 1,
+          "defaults" => {
+            "security" => "deny", "ask" => "off", "askFallback" => "deny",
+            "autoAllowSkills" => false
+          },
+          "agents" => {
+            "main" => {
+              "security" => "allowlist", "ask" => "off", "askFallback" => "deny",
+              "autoAllowSkills" => false,
+              "allowlist" => [
+                { "id" => Digest::SHA256.hexdigest(gateway_path), "pattern" => gateway_path }
+              ]
+            }
+          }
+        }
+      end
+
+      def admit_effective_policy!(snapshot, expected)
+        raise Error unless snapshot.fetch("exists") == true
+        file = snapshot.fetch("file")
+        main = file.dig("agents", "main")
+        socket = file.fetch("socket")
+        exact_file = file.keys.sort == %w[agents defaults socket version]
+        exact_file &&= socket.instance_of?(Hash) && socket.keys.sort == %w[path token]
+        exact_file &&= socket.fetch("path") == File.join(@workspace, ".hive-openclaw", "exec-approvals.sock")
+        exact_file &&= /\A[A-Za-z0-9_-]{24,128}\z/.match?(socket.fetch("token"))
+        exact_file &&= file.fetch("version") == 1 && file.fetch("defaults") == expected.fetch("defaults")
+        exact_file &&= main == expected.dig("agents", "main")
+        raise Error unless exact_file
+        { "file" => expected }
+      end
+
+      def run_openclaw!(environment, *argv, allowed_stderr: "")
+        stdin, stdout_io, stderr_io, waiter = Open3.popen3(
+          environment, @openclaw, *argv, chdir: @workspace, unsetenv_others: true, pgroup: true
+        )
+        stdin.close
+        stdout_reader = Thread.new { stdout_io.read(1_048_577) }
+        stderr_reader = Thread.new { stderr_io.read(1_048_577) }
+        status = Timeout.timeout(20) { waiter.value }
+        stdout, stderr = [ stdout_reader, stderr_reader ].map { |reader| reader.value.to_s }
+        raise Error unless status.success? && stderr == allowed_stderr && stdout.bytesize <= 1_048_576
+        stdout
+      rescue Timeout::Error
+        terminate_process_group(waiter)
+        raise Error
+      ensure
+        [ stdin, stdout_io, stderr_io ].compact.each { |io| io.close unless io.closed? }
+      end
+
+      def terminate_process_group(waiter)
+        Process.kill("TERM", -waiter.pid)
+        return if waiter.join(1)
+        Process.kill("KILL", -waiter.pid)
+        waiter.join(1)
+      rescue Errno::ESRCH, Errno::ECHILD
+        nil
+      end
+
+      def git!(workspace, *argv)
+        _stdout, stderr, status = Open3.capture3(
+          { "HOME" => @environment.value.fetch("HOME") }, @git, "-C", workspace, *argv,
+          unsetenv_others: true
+        )
+        raise Error unless status.success? && stderr.empty?
+      end
+
+      def git_output(workspace, *argv)
+        stdout, stderr, status = Open3.capture3(
+          { "HOME" => @environment.value.fetch("HOME") }, @git, "-C", workspace, *argv,
+          unsetenv_others: true
+        )
+        raise Error unless status.success? && stderr.empty?
+        stdout.strip
+      end
+
+      def write(path, bytes)
+        File.open(path, File::WRONLY | File::CREAT | File::EXCL, 0o600) { |file| file.write(bytes) }
+      end
+
+      def proof_gitignore
+        ".workflow-creator-gateway.sock\n.hive-proof-home/\n.hive-proof-hive-home/\nskills/\n"
+      end
+    end
+
+    class ExternalActionsObserver
+      def initialize(workspace:, candidate_environment:, fixture_path:, receipt_bytes:)
+        @workspace, @fixture = workspace, fixture_path
+        @environment = WorkflowCreator::Values.capture(candidate_environment)
+        @receipt_bytes = receipt_bytes
+        @git = %w[/usr/bin/git /bin/git].find { |path| File.executable?(path) }
+        raise Error unless @git
+      end
+
+      def call(workspace:, candidate_environment:)
+        raise Error, "workspace changed" unless workspace == @workspace
+        observed = WorkflowCreator::Values.capture(candidate_environment)
+        raise Error, "candidate environment changed" unless observed.canonical_bytes == @environment.canonical_bytes
+        raise Error, "candidate environment has authority" if
+          observed.value.any? { |key, _value| AUTHORITY.match?(key) || CREDENTIAL.match?(key) }
+        raise Error, "fixture identity changed" unless observed.value.fetch("HIVE_CLAUDE_BIN") == @fixture
+        receipt = File.join(workspace, ".hive-state", "workflow-creator-fixture-receipt.json")
+        raise Error, "fixture receipt changed" unless File.binread(receipt) == @receipt_bytes
+        raise Error, "git remote exists" unless git_output(workspace, "remote").empty?
+        reject_git_authority!(git_output(workspace, "config", "--local", "--null", "--list"))
+        { "status" => "observed", "actions" => [] }
+      rescue StandardError => error
+        raise Error, "workflow-creator external actions are unverified: #{error.class}: #{error.message}", cause: nil
+      end
+
+      private
+
+      def reject_git_authority!(raw)
+        raw.split("\0").reject(&:empty?).each do |row|
+          key, value = row.split("\n", 2)
+          unsafe = key.match?(/\A(?:remote\.|url\.|credential\.|include\.|http\.|gpg\.)/i)
+          unsafe ||= key.match?(/\A(?:core\.hooksPath|core\.sshCommand|commit\.gpgSign|tag\.gpgSign)\z/i)
+          unsafe ||= key.match?(/\Abranch\..+\.remote\z/i) && value != "."
+          raise Error, "git authority exists: #{key}" if unsafe
+        end
+      end
+
+      def git_output(workspace, *argv)
+        stdout, _stderr, status = Open3.capture3(
+          { "HOME" => @environment.value.fetch("HOME") }, @git, "-C", workspace, *argv,
+          unsetenv_others: true
+        )
+        raise Error unless status.success?
+        stdout.strip
+      end
+    end
+  end
+end

--- a/packaging/live_agent_skills/workflow_creator_live_setup.rb
+++ b/packaging/live_agent_skills/workflow_creator_live_setup.rb
@@ -22,6 +22,7 @@ module HiveLiveAgentProof
     MAX_RUNTIME_FILES = 50_000
     MAX_FILE_BYTES = 268_435_456
     MAX_TOTAL_BYTES = 1_073_741_824
+    CONTROL_DIRECTORY = "workflow-creator-control"
     NPM_REGISTRY = "https://registry.npmjs.org"
     CONFIGURATION_SCHEMA = "hive-live-openclaw-creator-configuration/v1"
     CANDIDATE_RUNTIME_SCHEMA = "hive-workflow-creator-candidate-runtime/v1"
@@ -39,6 +40,7 @@ module HiveLiveAgentProof
     CREDENTIAL = /(?:TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIAL|API_?KEY|PRIVATE_?KEY|AUTHORIZATION|COOKIE|SESSION)/i
     OPENCLAW_LOCAL_ENV = %w[HOME OPENCLAW_STATE_DIR OPENCLAW_CONFIG_PATH PATH LANG LC_ALL TERM TMPDIR
                              SHELL HIVE_LIVE_PROOF].freeze
+    private_constant :CONTROL_DIRECTORY
 
     class << self
       def prepare!(**options) = new(**options).send(:prepare)
@@ -74,6 +76,8 @@ module HiveLiveAgentProof
     end
 
     def prepare
+      @control_root = File.join(@output_root, CONTROL_DIRECTORY)
+      Dir.mkdir(@control_root, 0o700)
       verified = CandidateVerifier.new(
         candidate_dir: @candidate_dir, candidate_sha: @candidate_sha,
         expected_hive_version: @hive_version, canonical: @canonical
@@ -89,7 +93,8 @@ module HiveLiveAgentProof
       preparer = WorkspacePreparer.new(
         workspace: @workspace, skill_source:, candidate_executable: candidate.fetch("executable"),
         candidate_environment:, openclaw_executable: openclaw.fetch("executable"),
-        projection_manifest_sha256: configuration.dig("skill", "projection_manifest_sha256")
+        projection_manifest_sha256: configuration.dig("skill", "projection_manifest_sha256"),
+        control_root: @control_root
       )
       observer = ExternalActionsObserver.new(
         workspace: @workspace, candidate_environment:, fixture_path: fixture,
@@ -99,7 +104,8 @@ module HiveLiveAgentProof
         candidate_sha: @candidate_sha, model: @model, configuration_record: configuration.fetch("path"),
         execution_options: {
           candidate_sha: @candidate_sha, manifest: verified.fetch("manifest"), candidate:, openclaw:, archives:,
-          workspace_path: @workspace, bundle_directory: @bundle, correlation_id: @correlation_id,
+          workspace_path: @workspace, bundle_directory: @bundle, control_root: @control_root,
+          correlation_id: @correlation_id,
           supervisor_options: @supervisor_options
         },
         runtime_install_verifier: WorkflowCreatorOpenClawRuntime.method(:verify!),
@@ -143,8 +149,8 @@ module HiveLiveAgentProof
       inventory = inventory.sort
       raise Error if inventory.length > MAX_IDENTITY_FILES || inventory.uniq.length != inventory.length
       environment = {
-        "PATH" => "/usr/bin:/bin", "HOME" => File.join(@workspace, ".hive-proof-home"),
-        "HIVE_HOME" => File.join(@workspace, ".hive-proof-hive-home"),
+        "PATH" => "/usr/bin:/bin", "HOME" => File.join(@control_root, "candidate-home"),
+        "HIVE_HOME" => File.join(@control_root, "candidate-hive-home"),
         "GEM_HOME" => @candidate_runtime, "GEM_PATH" => @candidate_runtime,
         "HIVE_CLAUDE_BIN" => fixture, "HIVE_DAEMON_NO_AUTO_REEXEC" => "1",
         "HIVE_SKIP_LLM_WIKI_SCHEDULER" => "1", "HIVE_SKIP_LLM_WIKI_SYSTEMCTL" => "1",
@@ -338,6 +344,8 @@ module HiveLiveAgentProof
         #!/bin/sh
         set -eu
         hive_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd -P)
+        export GIT_CONFIG_NOSYSTEM=1
+        export GIT_CONFIG_GLOBAL=/dev/null
         exec "$hive_root/runtime/ruby" "$hive_root/libexec/candidate-runtime-guard.rb" "$@"
       SH
     end
@@ -380,6 +388,8 @@ module HiveLiveAgentProof
       raise Error unless @transport.keys.sort == %w[ca endpoint proxy redirects]
       raise Error unless @transport.fetch("redirects") == "deny"
       raise Error unless File.directory?(@output_root) && private_directory?(@output_root)
+      control_root = File.join(@output_root, CONTROL_DIRECTORY)
+      raise Error if File.exist?(control_root) || File.symlink?(control_root)
       expected = [ File.join(@output_root, "candidate-runtime"), File.join(@output_root, "openclaw-runtime") ]
       raise Error unless [ @candidate_runtime, @openclaw_runtime ] == expected
       raise Error unless [ @candidate_runtime, @openclaw_runtime, @bundle ].all? { |path| private_directory?(path) }
@@ -495,11 +505,15 @@ module HiveLiveAgentProof
 
     class WorkspacePreparer
       def initialize(workspace:, skill_source:, candidate_executable:, candidate_environment:,
-                     openclaw_executable:, projection_manifest_sha256:)
+                     openclaw_executable:, projection_manifest_sha256:, control_root:)
         @workspace, @skill_source, @candidate = workspace, skill_source, candidate_executable
         @openclaw = openclaw_executable
         @environment = WorkflowCreator::Values.capture(candidate_environment)
         @projection_sha = projection_manifest_sha256
+        @control_root = File.realpath(control_root)
+        raise Error unless private_directory?(@control_root, exact: true)
+        raise Error if @control_root == @workspace || @control_root.start_with?("#{@workspace}/") ||
+          @workspace.start_with?("#{@control_root}/")
         @git = %w[/usr/bin/git /bin/git].find { |path| File.executable?(path) }
         raise Error unless @git
       end
@@ -519,7 +533,8 @@ module HiveLiveAgentProof
         FileUtils.mkdir_p([ @environment.value.fetch("HOME"), @environment.value.fetch("HIVE_HOME") ], mode: 0o700)
         write(File.join(workspace, ".gitignore"), proof_gitignore)
         write(File.join(workspace, "README.md"), "# Workflow creator live proof\n")
-        git!(workspace, "init", "-b", "main")
+        @git_directory = File.join(@control_root, "git")
+        git!(workspace, "init", "--separate-git-dir", @git_directory, "-b", "main")
         git!(workspace, "config", "user.name", "Hive Live Proof")
         git!(workspace, "config", "user.email", "hive-live-proof@example.invalid")
         git!(workspace, "add", "--", ".gitignore", "README.md")
@@ -540,17 +555,52 @@ module HiveLiveAgentProof
         raise Error unless minimal && disabled
         raise Error unless File.file?(File.join(workspace, ".hive-state", "config.yml"))
         raise Error unless git_output(workspace, "remote").empty?
+        @projection, @skill_destination = projection, destination
+        @git_pointer_bytes = safe_skill_file(File.join(workspace, ".git"))
+        @git_config_bytes = safe_skill_file(File.join(@git_directory, "config"))
         approval = configure_openclaw!(openclaw_environment, gateway_path)
+        @prepared = true
+        verify_control_plane!
         WorkflowCreator::Values.capture(
           "schema" => "hive-workflow-creator-workspace-preparation", "schema_version" => 1,
           "status" => "prepared", "skill_manifest_sha256" => @projection_sha,
           "init_stdout_sha256" => Digest::SHA256.hexdigest(stdout),
           "git_head" => git_output(workspace, "rev-parse", "HEAD"),
           "openclaw_config_validation_sha256" => approval.fetch("config_validation_sha256"),
-          "openclaw_effective_policy_sha256" => approval.fetch("effective_policy_sha256")
+          "openclaw_effective_policy_sha256" => approval.fetch("effective_policy_sha256"),
+          "native_activation" => approval.fetch("native_activation")
         ).value
       rescue StandardError => error
         raise Error, "workflow-creator workspace preparation failed: #{error.class}: #{error.message}", cause: nil
+      end
+
+      def verify_command_boundary!
+        raise Error unless @prepared && private_directory?(@control_root, exact: true)
+        raise Error unless private_directory?(@git_directory)
+        raise Error unless safe_skill_file(File.join(@workspace, ".git")) == @git_pointer_bytes
+        raise Error unless safe_skill_file(File.join(@git_directory, "config")) == @git_config_bytes
+        raise Error unless git_output(@workspace, "remote").empty?
+        raise Error unless active_git_hooks.empty?
+        raise Error if candidate_git_config_paths.any? { |path| File.exist?(path) || File.symlink?(path) }
+        verify_materialized_skill!
+        true
+      rescue StandardError
+        raise Error, "workflow-creator command boundary changed", cause: nil
+      end
+
+      def verify_control_plane!
+        verify_command_boundary!
+        raise Error unless safe_skill_file(@config_path) == @config_bytes
+        config_stdout = run_openclaw!(@openclaw_environment, "config", "validate")
+        raise Error unless Digest::SHA256.hexdigest(config_stdout) == @config_validation_sha256
+        snapshot = JSON.parse(run_openclaw!(@openclaw_environment, "approvals", "get", "--json"))
+        effective = admit_effective_policy!(snapshot, @policy)
+        digest = Digest::SHA256.hexdigest(WorkflowCreator::Values.capture(effective).canonical_bytes)
+        raise Error unless digest == @effective_policy_sha256
+        raise Error unless discover_openclaw_skill!(@openclaw_environment) == @native_activation
+        true
+      rescue StandardError
+        raise Error, "workflow-creator control plane changed", cause: nil
       end
 
       private
@@ -596,6 +646,16 @@ module HiveLiveAgentProof
         write(File.join(destination, "projection-manifest.json"), safe_skill_file(manifest))
       end
 
+      def verify_materialized_skill!
+        @projection.fetch("files").each do |record|
+          content = safe_skill_file(File.join(@skill_destination, record.fetch("path")))
+          raise Error unless record.values_at("sha256", "size") ==
+                             [ Digest::SHA256.hexdigest(content), content.bytesize ]
+        end
+        manifest = safe_skill_file(File.join(@skill_destination, "projection-manifest.json"))
+        raise Error unless Digest::SHA256.hexdigest(manifest) == @projection_sha
+      end
+
       def safe_skill_file(path)
         stat = File.lstat(path)
         valid = stat.file? && !stat.symlink? && stat.uid == Process.uid && stat.nlink == 1
@@ -608,13 +668,13 @@ module HiveLiveAgentProof
 
       def configure_openclaw!(provided_environment, gateway_path)
         environment = credential_free_openclaw_environment(provided_environment)
-        expected_gateway = File.join(@workspace, ".hive-openclaw", "bin", "hive")
+        expected_gateway = File.join(@control_root, "openclaw", "bin", "hive")
         raise Error unless gateway_path == expected_gateway && File.symlink?(gateway_path)
         raise Error unless File.executable?(File.realpath(gateway_path))
 
         config_stdout = run_openclaw!(environment, "config", "validate")
         policy = approvals(gateway_path)
-        request_path = File.join(@workspace, ".hive-openclaw", "approvals-request.json")
+        request_path = File.join(@control_root, "openclaw", "approvals-request.json")
         write(request_path, WorkflowCreator::Values.capture(policy).canonical_bytes)
         run_openclaw!(
           environment, "approvals", "set", "--file", request_path, "--json",
@@ -622,11 +682,19 @@ module HiveLiveAgentProof
         )
         snapshot = JSON.parse(run_openclaw!(environment, "approvals", "get", "--json"))
         effective = admit_effective_policy!(snapshot, policy)
+        @openclaw_environment = WorkflowCreator::Values.capture(environment).value
+        @config_path = environment.fetch("OPENCLAW_CONFIG_PATH")
+        @config_bytes = safe_skill_file(@config_path)
+        @policy = WorkflowCreator::Values.capture(policy).value
+        @config_validation_sha256 = Digest::SHA256.hexdigest(config_stdout)
+        @effective_policy_sha256 = Digest::SHA256.hexdigest(
+          WorkflowCreator::Values.capture(effective).canonical_bytes
+        )
+        @native_activation = discover_openclaw_skill!(environment)
         {
-          "config_validation_sha256" => Digest::SHA256.hexdigest(config_stdout),
-          "effective_policy_sha256" => Digest::SHA256.hexdigest(
-            WorkflowCreator::Values.capture(effective).canonical_bytes
-          )
+          "config_validation_sha256" => @config_validation_sha256,
+          "effective_policy_sha256" => @effective_policy_sha256,
+          "native_activation" => @native_activation
         }
       rescue JSON::ParserError, SystemCallError, WorkflowCreator::Values::Error
         raise Error
@@ -638,9 +706,9 @@ module HiveLiveAgentProof
         required = %w[HOME OPENCLAW_STATE_DIR OPENCLAW_CONFIG_PATH SHELL HIVE_LIVE_PROOF]
         raise Error unless required.all? { |key| raw.key?(key) }
         expected = {
-          "HOME" => File.join(@workspace, ".hive-openclaw", "home"),
-          "OPENCLAW_STATE_DIR" => File.join(@workspace, ".hive-openclaw"),
-          "OPENCLAW_CONFIG_PATH" => File.join(@workspace, ".hive-openclaw", "openclaw.json"),
+          "HOME" => File.join(@control_root, "openclaw", "home"),
+          "OPENCLAW_STATE_DIR" => File.join(@control_root, "openclaw"),
+          "OPENCLAW_CONFIG_PATH" => File.join(@control_root, "openclaw", "openclaw.json"),
           "HIVE_LIVE_PROOF" => "1"
         }
         raise Error unless expected.all? { |key, value| raw[key] == value }
@@ -677,12 +745,28 @@ module HiveLiveAgentProof
         socket = file.fetch("socket")
         exact_file = file.keys.sort == %w[agents defaults socket version]
         exact_file &&= socket.instance_of?(Hash) && socket.keys.sort == %w[path token]
-        exact_file &&= socket.fetch("path") == File.join(@workspace, ".hive-openclaw", "exec-approvals.sock")
+        exact_file &&= socket.fetch("path") == File.join(@control_root, "openclaw", "exec-approvals.sock")
         exact_file &&= /\A[A-Za-z0-9_-]{24,128}\z/.match?(socket.fetch("token"))
         exact_file &&= file.fetch("version") == 1 && file.fetch("defaults") == expected.fetch("defaults")
         exact_file &&= main == expected.dig("agents", "main")
         raise Error unless exact_file
         { "file" => expected }
+      end
+
+      def discover_openclaw_skill!(environment)
+        info = JSON.parse(run_openclaw!(environment, "skills", "info", "hive", "--json"))
+        expected_path = File.join(@skill_destination, "SKILL.md")
+        valid = info.values_at("name", "eligible", "userInvocable") == [ "hive", true, true ]
+        valid &&= File.realpath(info.fetch("filePath")) == File.realpath(expected_path)
+        raise Error unless valid
+        content = safe_skill_file(expected_path)
+        WorkflowCreator::Values.capture(
+          "kind" => "openclaw-skills-info", "invocation" => "/hive", "name" => "hive",
+          "eligible" => true, "user_invocable" => true, "path" => "skills/hive/SKILL.md",
+          "sha256" => Digest::SHA256.hexdigest(content), "size" => content.bytesize
+        ).value
+      rescue JSON::ParserError, KeyError, SystemCallError
+        raise Error
       end
 
       def run_openclaw!(environment, *argv, allowed_stderr: "")
@@ -712,9 +796,36 @@ module HiveLiveAgentProof
         nil
       end
 
+      def private_directory?(path, exact: false)
+        stat = File.lstat(path)
+        valid = File.realpath(path) == path && stat.directory? && !stat.symlink? && stat.uid == Process.uid
+        valid &&= exact ? (stat.mode & 0o077).zero? : (stat.mode & 0o022).zero?
+        valid
+      rescue SystemCallError
+        false
+      end
+
+      def active_git_hooks
+        hooks = File.join(@git_directory, "hooks")
+        return [] unless Dir.exist?(hooks)
+        Dir.children(hooks).reject { |name| name.end_with?(".sample") }
+      end
+
+      def candidate_git_config_paths
+        home = @environment.value.fetch("HOME")
+        [ File.join(home, ".gitconfig"), File.join(home, ".config", "git", "config") ]
+      end
+
+      def git_environment
+        {
+          "HOME" => @environment.value.fetch("HOME"),
+          "GIT_CONFIG_NOSYSTEM" => "1", "GIT_CONFIG_GLOBAL" => "/dev/null"
+        }
+      end
+
       def git!(workspace, *argv)
         _stdout, stderr, status = Open3.capture3(
-          { "HOME" => @environment.value.fetch("HOME") }, @git, "-C", workspace, *argv,
+          git_environment, @git, "-C", workspace, *argv,
           unsetenv_others: true
         )
         raise Error unless status.success? && stderr.empty?
@@ -722,7 +833,7 @@ module HiveLiveAgentProof
 
       def git_output(workspace, *argv)
         stdout, stderr, status = Open3.capture3(
-          { "HOME" => @environment.value.fetch("HOME") }, @git, "-C", workspace, *argv,
+          git_environment, @git, "-C", workspace, *argv,
           unsetenv_others: true
         )
         raise Error unless status.success? && stderr.empty?
@@ -734,7 +845,7 @@ module HiveLiveAgentProof
       end
 
       def proof_gitignore
-        ".workflow-creator-gateway.sock\n.hive-proof-home/\n.hive-proof-hive-home/\nskills/\n"
+        "skills/\n"
       end
     end
 
@@ -777,7 +888,11 @@ module HiveLiveAgentProof
 
       def git_output(workspace, *argv)
         stdout, _stderr, status = Open3.capture3(
-          { "HOME" => @environment.value.fetch("HOME") }, @git, "-C", workspace, *argv,
+          {
+            "HOME" => @environment.value.fetch("HOME"),
+            "GIT_CONFIG_NOSYSTEM" => "1", "GIT_CONFIG_GLOBAL" => "/dev/null"
+          },
+          @git, "-C", workspace, *argv,
           unsetenv_others: true
         )
         raise Error unless status.success?

--- a/packaging/live_agent_skills/workflow_creator_live_setup.rb
+++ b/packaging/live_agent_skills/workflow_creator_live_setup.rb
@@ -438,7 +438,8 @@ module HiveLiveAgentProof
 
     def safe_file(path, limit)
       stat = File.lstat(path)
-      valid = stat.file? && !stat.symlink? && stat.uid == Process.uid && stat.nlink == 1
+      trusted_owner = stat.uid == Process.uid || stat.uid.zero?
+      valid = stat.file? && !stat.symlink? && trusted_owner && stat.nlink == 1
       valid &&= (stat.mode & 0o022).zero? && stat.size.between?(1, limit)
       raise Error unless valid
       bytes = File.binread(path)

--- a/packaging/live_agent_skills/workflow_creator_live_setup.rb
+++ b/packaging/live_agent_skills/workflow_creator_live_setup.rb
@@ -382,7 +382,8 @@ module HiveLiveAgentProof
     end
 
     def validate_roots!
-      raise Error if @hive_version.empty? || @correlation_id.empty?
+      raise Error if @hive_version.empty? ||
+        !WorkflowCreator::ProcessSupervisor::LABEL.match?(@correlation_id)
       raise Error unless PROVIDER_ENDPOINTS.fetch(@provider) == @transport.fetch("endpoint")
       raise Error unless @model.start_with?("#{@provider}/")
       raise Error unless @transport.keys.sort == %w[ca endpoint proxy redirects]
@@ -504,6 +505,9 @@ module HiveLiveAgentProof
     end
 
     class WorkspacePreparer
+      LLM_WIKI_HOOK_BEGIN = "# BEGIN LLM WIKI POST-COMMIT\n"
+      LLM_WIKI_HOOK_END = "# END LLM WIKI POST-COMMIT\n"
+
       def initialize(workspace:, skill_source:, candidate_executable:, candidate_environment:,
                      openclaw_executable:, projection_manifest_sha256:, control_root:)
         @workspace, @skill_source, @candidate = workspace, skill_source, candidate_executable
@@ -534,7 +538,7 @@ module HiveLiveAgentProof
         write(File.join(workspace, ".gitignore"), proof_gitignore)
         write(File.join(workspace, "README.md"), "# Workflow creator live proof\n")
         @git_directory = File.join(@control_root, "git")
-        git!(workspace, "init", "--separate-git-dir", @git_directory, "-b", "main")
+        git!(workspace, "init", "-b", "main")
         git!(workspace, "config", "user.name", "Hive Live Proof")
         git!(workspace, "config", "user.email", "hive-live-proof@example.invalid")
         git!(workspace, "add", "--", ".gitignore", "README.md")
@@ -554,6 +558,8 @@ module HiveLiveAgentProof
         disabled &&= answers.fetch("patrol_mode") == "off"
         raise Error unless minimal && disabled
         raise Error unless File.file?(File.join(workspace, ".hive-state", "config.yml"))
+        remove_managed_post_commit_hook!
+        relocate_git_directory!
         raise Error unless git_output(workspace, "remote").empty?
         @projection, @skill_destination = projection, destination
         @git_pointer_bytes = safe_skill_file(File.join(workspace, ".git"))
@@ -821,6 +827,33 @@ module HiveLiveAgentProof
           "HOME" => @environment.value.fetch("HOME"),
           "GIT_CONFIG_NOSYSTEM" => "1", "GIT_CONFIG_GLOBAL" => "/dev/null"
         }
+      end
+
+      def relocate_git_directory!
+        source = File.join(@workspace, ".git")
+        raise Error unless private_directory?(source)
+        raise Error if File.exist?(@git_directory) || File.symlink?(@git_directory)
+
+        File.rename(source, @git_directory)
+        write(source, "gitdir: #{@git_directory}\n")
+      rescue SystemCallError
+        raise Error
+      end
+
+      def remove_managed_post_commit_hook!
+        path = File.join(@workspace, ".git", "hooks", "post-commit")
+        return unless File.exist?(path) || File.symlink?(path)
+
+        lines = safe_skill_file(path).lines
+        starts = lines.each_index.select { |index| lines.fetch(index) == LLM_WIKI_HOOK_BEGIN }
+        finishes = lines.each_index.select { |index| lines.fetch(index) == LLM_WIKI_HOOK_END }
+        raise Error unless starts.length == 1 && finishes.length == 1 && starts.first < finishes.first
+
+        retained = lines[...starts.first] + lines[(finishes.first + 1)..]
+        raise Error unless retained.join.strip == "#!/usr/bin/env bash"
+        File.unlink(path)
+      rescue SystemCallError
+        raise Error
       end
 
       def git!(workspace, *argv)

--- a/packaging/live_agent_skills/workflow_creator_openclaw_runtime.rb
+++ b/packaging/live_agent_skills/workflow_creator_openclaw_runtime.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+require "digest"
+require_relative "workflow_creator"
+
+module HiveLiveAgentProof
+  class WorkflowCreatorOpenClawRuntime
+    class Error < StandardError; end
+
+    SCHEMA = "hive-openclaw-runtime-install/v1"
+    MAX_FILES = 50_000
+    MAX_DIRECTORIES = 5_000
+    MAX_FILE_BYTES = 268_435_456
+    MAX_TOTAL_BYTES = 1_073_741_824
+    MAX_PATH_BYTES = 4_096
+    MAX_SECONDS = 30.0
+    CHUNK_BYTES = 65_536
+    SHA256 = /\A[0-9a-f]{64}\z/
+    IDENTITY_FIELDS = %i[dev ino uid mode nlink size mtime ctime].freeze
+    READ_FLAGS = if defined?(File::NOFOLLOW) && defined?(File::NONBLOCK)
+      File::RDONLY | File::NOFOLLOW | File::NONBLOCK
+    end
+
+    class << self
+      def capture!(root:, launcher_sha256:)
+        new(root:, launcher_sha256:).send(:capture)
+      end
+
+      def verify!(runtime_install:, launcher_sha256:)
+        expected = WorkflowCreator::Values.capture(runtime_install)
+        root = expected.value.fetch("root")
+        observed = capture!(root:, launcher_sha256:)
+        raise Error, "OpenClaw runtime installation changed" unless
+          observed.canonical_bytes == expected.canonical_bytes
+
+        observed.value
+      rescue KeyError, TypeError, WorkflowCreator::Values::Error
+        raise Error, "OpenClaw runtime installation evidence is invalid", cause: nil
+      end
+    end
+
+    private_class_method :new
+
+    def initialize(root:, launcher_sha256:)
+      @root = File.expand_path(root)
+      @launcher_sha256 = launcher_sha256.to_s
+      raise Error unless @root == root && SHA256.match?(@launcher_sha256) && READ_FLAGS
+
+      stat = File.lstat(@root)
+      raise Error unless File.realpath(@root) == @root && safe_directory?(stat)
+
+      @started = monotonic
+      @root_identity = identity(stat)
+    rescue SystemCallError, TypeError
+      raise Error, "OpenClaw runtime installation is invalid", cause: nil
+    end
+
+    def capture
+      digest = Digest::SHA256.new
+      digest << "hive-openclaw-runtime-tree/v1\0"
+      directories = []
+      queue = [ [ "", @root ] ]
+      file_count = directory_count = total_size = 0
+
+      until queue.empty?
+        relative, directory = queue.shift
+        stat = File.lstat(directory)
+        raise Error unless safe_directory?(stat)
+        raise Error if relative.empty? && identity(stat) != @root_identity
+
+        directory_count += 1
+        raise Error if directory_count > MAX_DIRECTORIES
+        directories << [ directory, identity(stat) ]
+        update(digest, "kind" => "directory", "path" => relative, "mode" => stat.mode & 0o777)
+
+        children = Dir.each_child(directory).take(MAX_FILES + MAX_DIRECTORIES + 1).sort
+        children.each do |name|
+          child_relative = relative.empty? ? name : File.join(relative, name)
+          validate_relative!(child_relative)
+          child = File.join(@root, child_relative)
+          child_stat = File.lstat(child)
+          if child_stat.directory?
+            queue << [ child_relative, child ]
+          else
+            file_count += 1
+            raise Error if file_count > MAX_FILES
+            size = add_node(digest, child, child_relative, child_stat)
+            total_size += size
+            raise Error if total_size > MAX_TOTAL_BYTES
+          end
+          time_remaining!
+        end
+      end
+
+      directories.each { |path, expected| raise Error unless identity(File.lstat(path)) == expected }
+      raise Error unless file_count.positive? && total_size.positive?
+
+      WorkflowCreator::Values.capture(
+        "schema" => SCHEMA, "schema_version" => 1, "root" => @root,
+        "tree_sha256" => digest.hexdigest, "file_count" => file_count,
+        "directory_count" => directory_count, "total_size" => total_size,
+        "launcher_sha256" => @launcher_sha256
+      )
+    rescue SystemCallError, WorkflowCreator::Values::Error
+      raise Error, "OpenClaw runtime installation is invalid", cause: nil
+    end
+
+    def add_node(digest, path, relative, stat)
+      if stat.file?
+        file_digest = digest_file(path, stat)
+        update(
+          digest, "kind" => "file", "path" => relative, "mode" => stat.mode & 0o777,
+          "size" => stat.size, "sha256" => file_digest
+        )
+        stat.size
+      elsif stat.symlink?
+        target = File.readlink(path)
+        resolved = File.realpath(path)
+        prefix = "#{@root}#{File::SEPARATOR}"
+        raise Error unless resolved.start_with?(prefix) && target.bytesize.between?(1, MAX_PATH_BYTES)
+        raise Error unless identity(File.lstat(path)) == identity(stat)
+
+        update(digest, "kind" => "symlink", "path" => relative, "target" => target)
+        target.bytesize
+      else
+        raise Error
+      end
+    end
+
+    def digest_file(path, stat)
+      valid = stat.nlink == 1 && stat.uid == Process.uid && (stat.mode & 0o022).zero?
+      valid &&= stat.size.between?(0, MAX_FILE_BYTES)
+      raise Error unless valid
+
+      digest = Digest::SHA256.new
+      File.open(path, READ_FLAGS) do |file|
+        opened = file.stat
+        raise Error unless identity(opened) == identity(stat)
+        while (chunk = file.read(CHUNK_BYTES))
+          digest.update(chunk)
+          time_remaining!
+        end
+        raise Error unless identity(file.stat) == identity(opened)
+      end
+      digest.hexdigest
+    end
+
+    def validate_relative!(relative)
+      valid = relative.bytesize.between?(1, MAX_PATH_BYTES)
+      valid &&= WorkflowCreator::TextSafety.safe_relative_path?(relative.dup.freeze)
+      valid &&= File.expand_path(relative, File::SEPARATOR) == File.join(File::SEPARATOR, relative)
+      raise Error unless valid
+    rescue WorkflowCreator::TextSafety::Error
+      raise Error
+    end
+
+    def update(digest, record)
+      digest << WorkflowCreator::Values.capture(record).canonical_bytes
+    end
+
+    def safe_directory?(stat)
+      stat.directory? && stat.uid == Process.uid && (stat.mode & 0o022).zero?
+    end
+
+    def identity(stat) = IDENTITY_FIELDS.map { |field| stat.public_send(field) }
+
+    def monotonic = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+    def time_remaining!
+      elapsed = monotonic - @started
+      raise Error unless elapsed.between?(0, MAX_SECONDS)
+    end
+  end
+end

--- a/packaging/release_candidate/artifacts.rb
+++ b/packaging/release_candidate/artifacts.rb
@@ -22,6 +22,9 @@ module HiveReleaseCandidate
       packaging/live_agent_skills/workflow_creator_execution.rb
       packaging/live_agent_skills/workflow_creator_gateway.rb
       packaging/live_agent_skills/workflow_creator_installation.rb
+      packaging/live_agent_skills/workflow_creator_live_runner.rb
+      packaging/live_agent_skills/workflow_creator_live_setup.rb
+      packaging/live_agent_skills/workflow_creator_openclaw_runtime.rb
       packaging/live_agent_skills/workflow_creator_process_supervisor.rb
       packaging/live_agent_skills/workflow_creator.rb
       packaging/live_agent_skills/workflow_creator_contract.rb

--- a/test/smoke/live_hive_workflow_creator_smoke_test.rb
+++ b/test/smoke/live_hive_workflow_creator_smoke_test.rb
@@ -1,672 +1,127 @@
 require "test_helper"
-require "digest"
-require "json"
-require "open3"
-require "pathname"
+require "fileutils"
 require "rbconfig"
-require "timeout"
-require "yaml"
-require_relative "../../packaging/live_agent_skills/proof"
-require_relative "../../packaging/live_agent_skills/workflow_creator_evidence"
+require "hive/agent_skills/canonical_skill"
+require_relative "../../packaging/live_agent_skills/workflow_creator_live_setup"
 
-# Authenticated, opt-in proof that OpenClaw discovers the exact candidate
-# /hive skill and follows its workflow-creator route. The success oracle is the
-# controlled Hive command stream plus the authored files and validation graph;
-# agent prose is never retained or trusted.
+# Thin, authenticated adapter over the packaging-owned U15 setup and runner.
+# Offline behavior belongs in their focused unit tests; this test proves only
+# the exact installed candidate/OpenClaw closure against a real provider.
 class LiveHiveWorkflowCreatorSmokeTest < Minitest::Test
   include HiveTestHelper
 
-  TIMEOUT_SEC = 240
-  PASSTHROUGH_ENV = %w[
-    PATH LANG LC_ALL TERM TMPDIR SSL_CERT_FILE SSL_CERT_DIR NODE_EXTRA_CA_CERTS
-    HTTP_PROXY HTTPS_PROXY NO_PROXY http_proxy https_proxy no_proxy
+  Setup = HiveLiveAgentProof::WorkflowCreatorLiveSetup
+  Runner = HiveLiveAgentProof::WorkflowCreatorLiveRunner
+  Bundle = HiveLiveAgentProof::WorkflowCreatorBundle
+  RUNNER_KEYS = %i[
+    candidate_sha model configuration_record execution_options
+    external_actions_observer workspace_preparer runtime_install_verifier
   ].freeze
+  ENDPOINTS = {
+    "openai" => "https://api.openai.com/v1",
+    "openrouter" => "https://openrouter.ai/api/v1"
+  }.freeze
 
-  def test_openclaw_creates_and_validates_editorial_workflow_without_a_task
-    availability!(ENV["HIVE_LIVE_AGENT_SKILLS"] == "1",
-                  "set HIVE_LIVE_AGENT_SKILLS=1 to run authenticated workflow-creator proof")
-    candidate_sha = ENV["HIVE_CANDIDATE_SHA"].to_s.downcase
-    artifacts = ENV["HIVE_PROOF_ARTIFACTS"].to_s
-    evidence_path = ENV["HIVE_CREATOR_EVIDENCE_PATH"].to_s
-    credential = ENV["OPENAI_API_KEY"].to_s
-    binary = find_executable("openclaw")
-    availability!(HiveLiveAgentProof::SAFE_SHA.match?(candidate_sha),
-                  "HIVE_CANDIDATE_SHA must be a full commit SHA")
-    availability!(File.directory?(artifacts), "HIVE_PROOF_ARTIFACTS is missing")
-    availability!(!evidence_path.empty?, "HIVE_CREATOR_EVIDENCE_PATH is missing")
-    availability!(!credential.empty?, "OPENAI_API_KEY is unavailable")
-    availability!(!binary.nil?, "openclaw binary is not on PATH")
-    initial_receipt = HiveLiveAgentProof::WorkflowCreatorEvidence.initialize!(
-      bundle_directory: File.dirname(evidence_path), candidate_sha:
+  def test_exact_openclaw_creator_closure_produces_a_retained_bundle
+    skip "set HIVE_LIVE_AGENT_SKILLS=1 to run the authenticated Workflow Creator proof" unless
+      ENV["HIVE_LIVE_AGENT_SKILLS"] == "1"
+
+    candidate_sha = HiveLiveAgentProof.validate_sha!(required_env("HIVE_CANDIDATE_SHA"), "candidate_sha")
+    evidence_path = File.expand_path(required_env("HIVE_CREATOR_EVIDENCE_PATH"))
+    expected_name = HiveLiveAgentProof::WorkflowCreator::Vocabulary.fetch("bundle_files").first
+    raise "unexpected Workflow Creator evidence path" unless File.basename(evidence_path) == expected_name
+
+    bundle = File.dirname(evidence_path)
+    FileUtils.mkdir_p(bundle, mode: 0o700)
+    File.chmod(0o700, bundle)
+    Runner.initialize_evidence!(bundle_directory: bundle, candidate_sha:)
+
+    model = required_env("HIVE_LIVE_MODEL")
+    provider = model.split("/", 2).first
+    raise "unsupported HIVE_LIVE_MODEL provider" unless ENDPOINTS.key?(provider)
+    output_root = required_directory("HIVE_CREATOR_SETUP_ROOT")
+    workspace = File.join(output_root, "workspace")
+    raise "Workflow Creator workspace must be absent before setup" if File.exist?(workspace) || File.symlink?(workspace)
+
+    setup = prepare_setup(
+      candidate_sha:, model:, provider:, bundle:, output_root:, workspace:
     )
+    result = Runner.run!(**setup.slice(*RUNNER_KEYS), host_environment: ENV)
 
-    root = Dir.mktmpdir("hive-live-workflow-creator")
-    FileUtils.chmod(0o700, root)
-    evidence = base_evidence(candidate_sha)
-    model_loop_executed = false
-    failure = nil
-    begin
-      manifest = validate_candidate_artifacts!(artifacts, candidate_sha)
-      skill_root = extract_openclaw_skill!(root, artifacts, manifest)
-      workspace, environment, destination = prepare_openclaw_home(
-        root, skill_root, credential
-      )
-      audit_path = File.join(root, "hive-argv.jsonl")
-      validation_path = File.join(root, "workflow-validation.json")
-      task_proof_path = File.join(root, "task-proof.json")
-      install_controlled_hive(workspace, root, audit_path, validation_path, task_proof_path)
-      environment["PATH"] = [ File.join(root, "bin"), environment.fetch("PATH") ].join(File::PATH_SEPARATOR)
-
-      discovery = discover_openclaw_skill(binary, environment, workspace, destination, credential)
-      stdout, stderr, status = run_bounded(
-        environment,
-        [
-          binary, "agent", "--local", "--agent", "main",
-          "--message", HiveLiveAgentProof::WORKFLOW_CREATOR_PROMPT,
-          "--timeout", "180", "--json"
-        ],
-        chdir: workspace
-      )
-      model_loop_executed = true
-      assert status.success?,
-             "OpenClaw workflow creator failed: #{redact(stderr, credential).lines.first(12).join}\n" \
-             "#{redact(stdout, credential).lines.first(12).join}"
-
-      assert_equal HiveLiveAgentProof::WORKFLOW_CREATOR_COMMANDS.first(5),
-                   read_audited_commands(audit_path)
-      validation = JSON.parse(File.read(validation_path))
-      assert_equal true, validation.fetch("valid")
-      created_files = created_file_records(workspace)
-      assert_equal HiveLiveAgentProof::WORKFLOW_CREATOR_FILES,
-                   created_files.map { |record| record.fetch("path") }.sort
-      assert_equal 0, task_count(workspace)
-      task_stdout, task_stderr, task_status = run_bounded(
-        environment,
-        [
-          binary, "agent", "--local", "--agent", "main",
-          "--message", HiveLiveAgentProof::WORKFLOW_CREATOR_TASK_PROMPT,
-          "--timeout", "180", "--json"
-        ],
-        chdir: workspace
-      )
-      assert task_status.success?,
-             "OpenClaw workflow task retry failed: #{redact(task_stderr, credential).lines.first(12).join}\n" \
-             "#{redact(task_stdout, credential).lines.first(12).join}"
-
-      commands = read_audited_commands(audit_path)
-      assert_equal HiveLiveAgentProof::WORKFLOW_CREATOR_COMMANDS, commands
-      task_proof = JSON.parse(File.read(task_proof_path))
-      assert_equal 1, task_count(workspace)
-      findings = HiveLiveAgentProof.secret_findings("#{stdout}\n#{stderr}", exact_secrets: [ credential ])
-      findings.concat(
-        HiveLiveAgentProof.secret_findings(
-          "#{task_stdout}\n#{task_stderr}", exact_secrets: [ credential ]
-        )
-      )
-      assert_empty findings, "OpenClaw retained output contains credential material"
-
-      projection = JSON.parse(File.read(File.join(skill_root, ".hive-skill.json")))
-      evidence.merge!(
-        "result" => "passed",
-        "prompt_sha256" => Digest::SHA256.hexdigest(HiveLiveAgentProof::WORKFLOW_CREATOR_PROMPT),
-        "task_prompt_sha256" =>
-          Digest::SHA256.hexdigest(HiveLiveAgentProof::WORKFLOW_CREATOR_TASK_PROMPT),
-        "agent" => {
-          "binary" => "openclaw",
-          "native_output_sha256" => Digest::SHA256.hexdigest("#{stdout}\n#{task_stdout}"),
-          "native_stderr_sha256" => Digest::SHA256.hexdigest("#{stderr}\n#{task_stderr}"),
-          "discovery_sha256" => Digest::SHA256.hexdigest(JSON.generate(discovery))
-        },
-        "skill" => {
-          "skill_version" => projection.fetch("skill_version"),
-          "canonical_digest" => projection.fetch("canonical_digest"),
-          "projection_manifest_sha256" =>
-            Digest::SHA256.file(File.join(skill_root, ".hive-skill.json")).hexdigest
-        },
-        "native_activation" => {
-          "kind" => HiveLiveAgentProof::NATIVE_ACTIVATION_KINDS.fetch("openclaw"),
-          "invocation" => HiveLiveAgentProof::INVOCATIONS.fetch("openclaw")
-        },
-        "hive_commands" => commands,
-        "created_files" => created_files,
-        "validation" => normalized_validation(validation),
-        "creation_only_task_count" => 0,
-        "task_count" => 1,
-        "task" => task_proof,
-        "external_actions" => [],
-        "secret_scan" => { "status" => "passed", "scanner" => "hive-live-agent-proof/v1" }
-      )
-    rescue Minitest::Assertion, StandardError => e
-      failure = e
-      evidence["result"] = "failed"
-      evidence["failure"] = redact(e.message.to_s, credential).byteslice(0, 1_000)
-      evidence["secret_scan"] ||= { "status" => "passed", "scanner" => "hive-live-agent-proof/v1" }
-    ensure
-      FileUtils.rm_rf(root)
-      evidence["cleanup"] = { "status" => File.exist?(root) ? "failed" : "passed" }
-      publication_failure = begin
-        publish_nonclaiming_receipt(
-          File.dirname(evidence_path), initial_receipt, candidate_sha, failure,
-          model_loop_executed, exact_secrets: [ credential ]
-        )
-        nil
-      rescue StandardError => e
-        e
-      end
-    end
-    raise failure if failure
-    raise publication_failure if publication_failure
-  end
-
-  def test_controlled_hive_enforces_the_editorial_graph_and_command_order
-    with_tmp_dir do |root|
-      workspace = File.join(root, "workspace")
-      FileUtils.mkdir_p(workspace)
-      audit_path = File.join(root, "audit.jsonl")
-      validation_path = File.join(root, "validation.json")
-      task_proof_path = File.join(root, "task-proof.json")
-      binary = install_controlled_hive(
-        workspace, root, audit_path, validation_path, task_proof_path
-      )
-
-      run_controlled!(binary, workspace, "version")
-      run_controlled!(binary, workspace, "workflow", "list", "--json")
-      scaffold = JSON.parse(run_controlled!(binary, workspace, "workflow", "new", "editorial", "--json"))
-      author_editorial(scaffold)
-      validation = JSON.parse(
-        run_controlled!(binary, workspace, "workflow", "validate", "editorial", "--json")
-      )
-      run_controlled!(binary, workspace, "workflow", "commit", "editorial")
-      first = JSON.parse(
-        run_controlled!(binary, workspace, *HiveLiveAgentProof::WORKFLOW_CREATOR_TASK_NEW_ARGV)
-      )
-      run_controlled!(binary, workspace, "run", HiveLiveAgentProof::WORKFLOW_CREATOR_TASK_SLUG)
-      retry_payload = JSON.parse(
-        run_controlled!(binary, workspace, *HiveLiveAgentProof::WORKFLOW_CREATOR_TASK_NEW_ARGV)
-      )
-      run_controlled!(binary, workspace, "status", "--operational", "--json")
-      task = JSON.parse(File.read(task_proof_path))
-
-      assert_equal HiveLiveAgentProof::WORKFLOW_CREATOR_COMMANDS, read_audited_commands(audit_path)
-      assert_equal %w[research draft approval], validation.fetch("stages").map { |stage| stage.fetch("name") }
-      assert_equal true, validation.fetch("valid")
-      assert_equal true, first.fetch("created")
-      assert_equal false, retry_payload.fetch("created")
-      assert_equal 1, task.fetch("run_count")
-      assert_equal 1, task_count(workspace)
-    end
-  end
-
-
-  def test_nonclaiming_receipt_distinguishes_preloop_and_postloop_outcomes
-    with_tmp_dir do |root|
-      bundle = File.join(root, "preloop")
-      FileUtils.mkdir_p(bundle, mode: 0o700)
-      FileUtils.chmod(0o700, bundle)
-      initial = HiveLiveAgentProof::WorkflowCreatorEvidence.initialize!(
-        bundle_directory: bundle, candidate_sha: "a" * 40
-      )
-      publish_nonclaiming_receipt(bundle, initial, "a" * 40, RuntimeError.new("failed"), false)
-      preloop = JSON.parse(File.binread(File.join(bundle, "openclaw-workflow-creator.json")))
-      assert_equal [ "proof_failed", "unavailable", "not_started" ],
-                   preloop.values_at("reason", "execution_kind", "model_loop")
-
-      bundle = File.join(root, "postloop")
-      FileUtils.mkdir_p(bundle, mode: 0o700)
-      FileUtils.chmod(0o700, bundle)
-      initial = HiveLiveAgentProof::WorkflowCreatorEvidence.initialize!(
-        bundle_directory: bundle, candidate_sha: "a" * 40
-      )
-      publish_nonclaiming_receipt(bundle, initial, "a" * 40, nil, true)
-      postloop = JSON.parse(File.binread(File.join(bundle, "openclaw-workflow-creator.json")))
-      assert_equal [ "u14_execution_custody_unavailable", "authenticated_openclaw", "executed" ],
-                   postloop.values_at("reason", "execution_kind", "model_loop")
-    end
-  end
-
-  def test_nonclaiming_receipt_redacts_the_exact_provider_credential
-    with_tmp_dir do |root|
-      bundle = File.join(root, "credential")
-      FileUtils.mkdir_p(bundle, mode: 0o700)
-      FileUtils.chmod(0o700, bundle)
-      secret = "provider-credential-that-must-not-escape"
-      initial = HiveLiveAgentProof::WorkflowCreatorEvidence.initialize!(
-        bundle_directory: bundle, candidate_sha: "a" * 40
-      )
-
-      publish_nonclaiming_receipt(
-        bundle, initial, "a" * 40, RuntimeError.new("provider rejected #{secret}"), false,
-        exact_secrets: [ secret ]
-      )
-
-      bytes = File.binread(File.join(bundle, "openclaw-workflow-creator.json"))
-      refute_includes bytes, secret
-      assert_includes JSON.parse(bytes).fetch("detail"), "[REDACTED]"
-    end
+    assert_equal "passed", result.status, failure_summary(result)
+    assert_equal provider, result.provider
+    retained = Bundle.retained(
+      directory: bundle, expected_primary: result.receipt.value,
+      manifest: setup.dig(:execution_options, :manifest), candidate_sha:
+    )
+    assert_equal "passed", retained.primary.fetch("result")
+    assert_equal HiveLiveAgentProof::WorkflowCreator::Vocabulary.fetch("bundle_files").sort,
+                 retained.bytes.keys.sort
+    refute File.exist?(workspace), "U14 must remove its proof workspace after finalization"
   end
 
   private
 
-  def availability!(condition, message)
-    return if condition
-    raise Minitest::Assertion, message if ENV["HIVE_RELEASE_GATE"] == "1"
-
-    skip message
-  end
-
-  def base_evidence(candidate_sha)
-    {
-      "schema" => "hive-live-workflow-creator-evidence",
-      "schema_version" => 1,
-      "platform" => "openclaw",
-      "candidate_sha" => candidate_sha,
-      "result" => "failed"
-    }
-  end
-
-  def validate_candidate_artifacts!(root, candidate_sha)
-    manifest = HiveLiveAgentProof.read_json(File.join(root, "artifact-manifest.json"))
-    assert_equal "hive-live-agent-candidate-artifacts", manifest.fetch("schema")
-    assert_equal candidate_sha, manifest.fetch("candidate_sha")
-    manifest.fetch("files").each do |name, record|
-      HiveLiveAgentProof.verify_file_record!(root, name, record)
-    end
-    manifest
-  end
-
-  def extract_openclaw_skill!(root, artifacts, manifest)
-    archive_name = "hive-agent-skills-#{manifest.fetch('candidate_sha')}.tar.gz"
-    archive = HiveLiveAgentProof.relative_file!(artifacts, archive_name)
-    listing, list_error, list_status = Open3.capture3("tar", "-tzf", archive)
-    assert list_status.success?, "cannot list skill archive: #{list_error}"
-    entries = listing.lines.map(&:strip).reject(&:empty?)
-    assert entries.all? { |entry| safe_archive_entry?(entry) },
-           "skill archive contains an unsafe path"
-
-    extract = File.join(root, "projections")
-    FileUtils.mkdir_p(extract, mode: 0o700)
-    _out, extract_error, extract_status = Open3.capture3("tar", "-xzf", archive, "-C", extract)
-    assert extract_status.success?, "cannot extract skill archive: #{extract_error}"
-    skill_root = File.join(extract, "openclaw", "hive")
-    projection = JSON.parse(File.read(File.join(skill_root, ".hive-skill.json")))
-    assert_equal "openclaw", projection.fetch("platform")
-    assert_equal manifest.fetch("skill_version"), projection.fetch("skill_version")
-    assert_equal manifest.fetch("canonical_digest"), projection.fetch("canonical_digest")
-    projection.fetch("files").each do |relative, digest|
-      path = HiveLiveAgentProof.relative_file!(skill_root, relative)
-      assert_equal digest, Digest::SHA256.file(path).hexdigest
-    end
-    skill_root
-  end
-
-  def safe_archive_entry?(entry)
-    normalized = entry.delete_prefix("./")
-    !normalized.empty? && !normalized.start_with?("/") &&
-      !Pathname.new(normalized).each_filename.include?("..")
-  end
-
-  def prepare_openclaw_home(root, skill_root, credential)
-    home = File.join(root, "home")
-    workspace = File.join(root, "workspace")
-    state = File.join(home, ".openclaw")
-    destination = File.join(workspace, "skills", "hive")
-    FileUtils.mkdir_p([ state, workspace, File.dirname(destination) ], mode: 0o700)
-    FileUtils.cp_r(skill_root, destination, preserve: false)
-    model = ENV["HIVE_LIVE_MODEL"].to_s
-    availability!(!model.empty?, "HIVE_LIVE_MODEL is required for OpenClaw proof")
-    config = {
-      "agents" => {
-        "defaults" => { "workspace" => workspace, "model" => { "primary" => model } }
+  def prepare_setup(candidate_sha:, model:, provider:, bundle:, output_root:, workspace:)
+    Setup.prepare!(
+      candidate_dir: required_directory("HIVE_PROOF_ARTIFACTS"), candidate_sha:,
+      hive_version: Hive::VERSION, canonical: Hive::AgentSkills::CanonicalSkill.new,
+      candidate_runtime_root: File.join(output_root, "candidate-runtime"),
+      candidate_hive: required_file("HIVE_PROVEN_HIVE_BIN"), ruby: RbConfig.ruby,
+      openclaw_runtime_root: File.join(output_root, "openclaw-runtime"),
+      openclaw_entrypoint: required_file("HIVE_OPENCLAW_ENTRYPOINT"),
+      node: required_file("HIVE_NODE_BIN"),
+      openclaw_lock: required_file("HIVE_OPENCLAW_LOCK"),
+      openclaw_package: required_file("HIVE_OPENCLAW_PACKAGE"),
+      output_root:, workspace_path: workspace, bundle_directory: bundle,
+      model:, provider:,
+      transport: {
+        "endpoint" => ENDPOINTS.fetch(provider), "proxy" => nil,
+        "ca" => nil, "redirects" => "deny"
       },
-      "tools" => { "profile" => "coding" }
-    }
-    config_path = File.join(state, "openclaw.json")
-    secure_write(config_path, JSON.pretty_generate(config) + "\n")
-    environment = PASSTHROUGH_ENV.to_h { |name| [ name, ENV[name] ] }.compact
-    environment.merge!(
-      "HOME" => home,
-      "OPENAI_API_KEY" => credential,
-      "OPENCLAW_STATE_DIR" => state,
-      "OPENCLAW_CONFIG_PATH" => config_path,
-      "HIVE_LIVE_PROOF" => "1"
+      correlation_id: correlation_id(candidate_sha), supervisor_options: {}
     )
-    [ workspace, environment, destination ]
+  rescue StandardError => error
+    Runner.fail!(
+      bundle_directory: bundle, candidate_sha:, phase: "setup", reason: "setup_failed",
+      detail: error.message, exact_secrets: provider_secrets
+    )
+    raise
   end
 
-  def discover_openclaw_skill(binary, environment, workspace, destination, credential)
-    stdout, stderr, status = run_bounded(
-      environment, [ binary, "skills", "info", "hive", "--json" ],
-      chdir: workspace, timeout: 60
-    )
-    assert status.success?, "OpenClaw skill discovery failed: #{redact(stderr, credential)}"
-    info = JSON.parse(stdout)
-    assert_equal "hive", info.fetch("name")
-    assert_equal true, info.fetch("eligible")
-    assert_equal true, info.fetch("userInvocable")
-    assert_equal File.realpath(File.join(destination, "SKILL.md")),
-                 File.realpath(info.fetch("filePath"))
-    {
-      "kind" => "openclaw-skills-info",
-      "name" => info.fetch("name"),
-      "file_path_sha256" => Digest::SHA256.hexdigest(info.fetch("filePath"))
-    }
+  def required_env(name)
+    value = ENV[name].to_s
+    raise "#{name} is required" if value.empty?
+    value
   end
 
-  def install_controlled_hive(workspace, root, audit_path, validation_path, task_proof_path)
-    state = File.join(workspace, ".hive-state")
-    workflows = File.join(state, "workflows")
-    FileUtils.mkdir_p(workflows, mode: 0o700)
-    secure_write(
-      File.join(state, "config.yml"),
-      YAML.dump(
-        "project_name" => "workflow-creator-proof",
-        "hive_state_path" => state,
-        "agents" => { "default" => "codex" },
-        "models" => { "default" => "project-default" }
-      )
-    )
-    bin_dir = File.join(root, "bin")
-    FileUtils.mkdir_p(bin_dir, mode: 0o700)
-    script = <<~RUBY
-      #!#{RbConfig.ruby}
-      require "json"
-      require "fileutils"
-      require "yaml"
-
-      allowed = #{HiveLiveAgentProof::WORKFLOW_CREATOR_COMMANDS.inspect}
-      audit = #{audit_path.dump}
-      ordinal = File.file?(audit) ? File.foreach(audit).count : 0
-      unless ARGV == allowed[ordinal]
-        warn "workflow-creator proof expected \#{allowed[ordinal].inspect}, got \#{ARGV.inspect}"
-        exit 64
-      end
-      File.open(audit, File::WRONLY | File::CREAT | File::APPEND, 0o600) do |file|
-        file.puts(JSON.generate("argv" => ARGV, "ordinal" => ordinal + 1))
-      end
-
-      workspace = #{workspace.dump}
-      workflows = File.join(workspace, ".hive-state", "workflows")
-      descriptor = File.join(workflows, "editorial.yml")
-      instruction_dir = File.join(workflows, "editorial")
-      task_dir = File.join(
-        workspace, ".hive-state", "stages", "1-research",
-        #{HiveLiveAgentProof::WORKFLOW_CREATOR_TASK_SLUG.dump}
-      )
-      case ARGV
-      when ["version"]
-        puts #{Hive::VERSION.dump}
-      when ["workflow", "list", "--json"]
-        puts JSON.generate(
-          "schema" => "hive-workflow-list", "schema_version" => 2,
-          "ok" => true, "workflows" => []
-        )
-      when ["workflow", "new", "editorial", "--json"]
-        abort "workflow already exists" if File.exist?(descriptor) || File.exist?(instruction_dir)
-        FileUtils.mkdir_p(instruction_dir)
-        File.write(File.join(instruction_dir, "work.md"), "Describe this stage.\\n")
-        File.write(descriptor, <<~YAML)
-          id: editorial
-          stages:
-            - name: work
-              kind: agent
-              state_file: work.md
-              instruction: editorial/work.md
-              permissions: yolo
-        YAML
-        puts JSON.generate(
-          "schema" => "hive-workflow-new", "schema_version" => 1, "ok" => true,
-          "id" => "editorial", "descriptor_path" => descriptor,
-          "instruction_path" => File.join(instruction_dir, "work.md"),
-          "next" => "hive new workflow-creator-proof --workflow editorial \\"<your idea>\\""
-        )
-      when ["workflow", "validate", "editorial", "--json"]
-        expected = {
-          "id" => "editorial",
-          "stages" => [
-            {
-              "name" => "research", "kind" => "agent", "state_file" => "research.md",
-              "instruction" => "editorial/research.md", "permissions" => "yolo"
-            },
-            {
-              "name" => "draft", "kind" => "agent", "state_file" => "draft.md",
-              "instruction" => "editorial/draft.md", "permissions" => "yolo"
-            },
-            {
-              "name" => "approval", "kind" => "human", "state_file" => "approval.md",
-              "input" => "draft.md",
-              "outcomes" => {
-                "approve" => { "complete" => true, "artifact" => "draft.md" },
-                "reject" => { "to" => "draft" }
-              }
-            }
-          ]
-        }
-        actual = YAML.safe_load(File.read(descriptor), aliases: false)
-        abort "editorial descriptor differs from the accepted graph" unless actual == expected
-        %w[research draft].each do |name|
-          path = File.join(instruction_dir, "\#{name}.md")
-          abort "missing or empty instruction \#{path}" unless File.file?(path) && !File.read(path).strip.empty?
-        end
-        expected_files = %w[draft.md research.md]
-        actual_files = Dir.children(instruction_dir).sort
-        abort "unexpected editorial instruction files: \#{actual_files.inspect}" unless actual_files == expected_files
-        payload = {
-          "schema" => "hive-workflow-validate", "schema_version" => 1,
-          "valid" => true, "id" => "editorial", "origin" => "authored",
-          "descriptor_path" => descriptor,
-          "instruction_paths" => expected_files.map { |name| File.join(instruction_dir, name) },
-          "stages" => [
-            { "name" => "research", "kind" => "agent" },
-            { "name" => "draft", "kind" => "agent" },
-            { "name" => "approval", "kind" => "human" }
-          ],
-          "automatic_edges" => [
-            { "from" => "research", "to" => "draft" },
-            { "from" => "draft", "to" => "approval" }
-          ],
-          "human_outcomes" => [
-            { "stage" => "approval", "name" => "approve", "complete" => true,
-              "artifact" => "draft.md", "to" => nil },
-            { "stage" => "approval", "name" => "reject", "complete" => false,
-              "artifact" => nil, "to" => "draft" }
-          ]
-        }
-        File.write(#{validation_path.dump}, JSON.pretty_generate(payload) + "\\n")
-        puts JSON.generate(payload)
-      when ["workflow", "commit", "editorial"]
-        abort "workflow was not validated before commit" unless File.file?(#{validation_path.dump})
-        puts "hive: committed populated workflow editorial"
-      when #{HiveLiveAgentProof::WORKFLOW_CREATOR_TASK_NEW_ARGV.inspect}
-        created = !File.directory?(task_dir)
-        if created
-          FileUtils.mkdir_p(task_dir)
-          File.write(File.join(task_dir, "research.md"), "<!-- WAITING -->\\n")
-          File.write(
-            File.join(task_dir, "meta.yml"),
-            YAML.dump(
-              "slug" => #{HiveLiveAgentProof::WORKFLOW_CREATOR_TASK_SLUG.dump},
-              "workflow" => "editorial",
-              "idempotency_key" => #{HiveLiveAgentProof::WORKFLOW_CREATOR_TASK_KEY.dump}
-            )
-          )
-          proof = {
-            "slug" => #{HiveLiveAgentProof::WORKFLOW_CREATOR_TASK_SLUG.dump},
-            "workflow" => "editorial", "first_created" => true,
-            "retry_created" => nil, "run_count" => 0, "current_stage" => "1-research"
-          }
-        else
-          proof = JSON.parse(File.read(#{task_proof_path.dump}))
-          proof["retry_created"] = false
-        end
-        File.write(#{task_proof_path.dump}, JSON.pretty_generate(proof) + "\\n")
-        puts JSON.generate(
-          "schema" => "hive-new", "schema_version" => 1, "ok" => true,
-          "created" => created, "slug" => proof.fetch("slug"), "workflow" => "editorial",
-          "current_stage" => "1-research", "task_folder" => task_dir,
-          "next_action" => {
-            "kind" => "run", "command" => "hive run \#{proof.fetch('slug')}"
-          }
-        )
-      when ["run", #{HiveLiveAgentProof::WORKFLOW_CREATOR_TASK_SLUG.dump}]
-        abort "task is missing" unless File.directory?(task_dir)
-        proof = JSON.parse(File.read(#{task_proof_path.dump}))
-        abort "first stage was dispatched more than once" unless proof.fetch("run_count") == 0
-        proof["run_count"] = 1
-        File.write(#{task_proof_path.dump}, JSON.pretty_generate(proof) + "\\n")
-        puts JSON.generate(
-          "schema" => "hive-run", "schema_version" => 1, "ok" => true,
-          "slug" => proof.fetch("slug"), "current_stage" => "1-research"
-        )
-      when ["status", "--operational", "--json"]
-        proof = JSON.parse(File.read(#{task_proof_path.dump}))
-        abort "idempotent retry did not occur" unless proof["retry_created"] == false
-        File.write(#{task_proof_path.dump}, JSON.pretty_generate(proof) + "\\n")
-        puts JSON.generate(
-          "schema" => "hive-operational-status", "schema_version" => 1,
-          "tasks" => [
-            {
-              "identity" => { "slug" => proof.fetch("slug") },
-              "position" => { "stage" => "1-research" },
-              "runtime" => { "daemon_disposition" => "manual" },
-              "transition" => { "next" => "draft" }
-            }
-          ]
-        )
-      end
-    RUBY
-    path = File.join(bin_dir, "hive")
-    secure_write(path, script)
-    FileUtils.chmod(0o700, path)
+  def required_directory(name)
+    path = File.expand_path(required_env(name))
+    raise "#{name} is not a directory" unless File.directory?(path) && !File.symlink?(path)
     path
   end
 
-  def author_editorial(scaffold)
-    descriptor = scaffold.fetch("descriptor_path")
-    instruction_dir = File.dirname(scaffold.fetch("instruction_path"))
-    FileUtils.rm_f(File.join(instruction_dir, "work.md"))
-    secure_write(File.join(instruction_dir, "research.md"), "Research and write research.md.\n")
-    secure_write(File.join(instruction_dir, "draft.md"), "Draft from research.md into draft.md.\n")
-    secure_write(descriptor, <<~YAML)
-      id: editorial
-      stages:
-        - name: research
-          kind: agent
-          state_file: research.md
-          instruction: editorial/research.md
-          permissions: yolo
-        - name: draft
-          kind: agent
-          state_file: draft.md
-          instruction: editorial/draft.md
-          permissions: yolo
-        - name: approval
-          kind: human
-          state_file: approval.md
-          input: draft.md
-          outcomes:
-            approve:
-              complete: true
-              artifact: draft.md
-            reject:
-              to: draft
-    YAML
+  def required_file(name)
+    path = File.expand_path(required_env(name))
+    raise "#{name} is not a regular file" unless File.file?(path) && !File.symlink?(path)
+    path
   end
 
-  def run_controlled!(binary, workspace, *argv)
-    stdout, stderr, status = Open3.capture3(binary, *argv, chdir: workspace)
-    assert status.success?, stderr
-    stdout
+  def correlation_id(candidate_sha)
+    run = ENV.fetch("GITHUB_RUN_ID", "local")
+    attempt = ENV.fetch("GITHUB_RUN_ATTEMPT", "1")
+    "workflow-creator:#{candidate_sha}:#{run}:#{attempt}"
   end
 
-  def read_audited_commands(path)
-    return [] unless File.file?(path)
-
-    File.readlines(path, chomp: true).map { |line| JSON.parse(line).fetch("argv") }
-  end
-
-  def normalized_validation(payload)
-    {
-      "valid" => payload.fetch("valid"),
-      "stages" => payload.fetch("stages").map { |stage| stage.fetch("name") },
-      "automatic_edges" =>
-        payload.fetch("automatic_edges").map { |edge| edge.values_at("from", "to") },
-      "human_outcomes" => payload.fetch("human_outcomes")
-    }
-  end
-
-  def created_file_records(workspace)
-    HiveLiveAgentProof::WORKFLOW_CREATOR_FILES.map do |relative|
-      path = File.join(workspace, relative)
-      assert File.file?(path), "missing created file #{relative}"
-      {
-        "path" => relative,
-        "sha256" => Digest::SHA256.file(path).hexdigest,
-        "size" => File.size(path)
-      }
+  def provider_secrets
+    %w[OPENAI_API_KEY OPENROUTER_API_KEY].filter_map do |name|
+      value = ENV[name].to_s
+      value unless value.empty?
     end
   end
 
-  def task_count(workspace)
-    Dir.glob(File.join(workspace, ".hive-state", "stages", "*", "*"))
-       .count { |path| File.directory?(path) }
-  end
-
-  def run_bounded(environment, argv, chdir:, timeout: TIMEOUT_SEC)
-    stdout = +""
-    stderr = +""
-    status = nil
-    Open3.popen3(environment, *argv, chdir: chdir, pgroup: true, unsetenv_others: true) do |stdin, out, err, wait|
-      stdin.close
-      out_reader = Thread.new { out.read }
-      err_reader = Thread.new { err.read }
-      begin
-        Timeout.timeout(timeout) { status = wait.value }
-      rescue Timeout::Error
-        Process.kill("TERM", -wait.pid)
-        status = wait.value
-        raise Minitest::Assertion, "#{File.basename(argv.first)} exceeded #{timeout}s proof timeout"
-      ensure
-        stdout = out_reader.value
-        stderr = err_reader.value
-      end
-    end
-    [ stdout, stderr, status ]
-  end
-
-  def redact(text, *secrets)
-    redacted = text.to_s.dup
-    secrets.flatten.compact.reject(&:empty?).each { |secret| redacted.gsub!(secret, "[REDACTED]") }
-    HiveLiveAgentProof::SECRET_PATTERNS.each { |pattern| redacted.gsub!(pattern, "[REDACTED]") }
-    redacted
-  end
-
-  def secure_write(path, body)
-    FileUtils.mkdir_p(File.dirname(path), mode: 0o700)
-    File.open(path, File::WRONLY | File::CREAT | File::TRUNC, 0o600) { |file| file.write(body) }
-  end
-
-  def publish_nonclaiming_receipt(bundle, initial, candidate_sha, failure, model_loop_executed,
-                                  exact_secrets: [])
-    proven_but_uncomposed = failure.nil? && model_loop_executed
-    receipt = HiveLiveAgentProof::WorkflowCreator.failure(
-      candidate_sha:,
-      phase: proven_but_uncomposed ? "evidence" : "proof",
-      reason: proven_but_uncomposed ? "u14_execution_custody_unavailable" : "proof_failed",
-      detail: failure&.message,
-      execution_kind: model_loop_executed ? "authenticated_openclaw" : "unavailable",
-      model_loop: model_loop_executed ? "executed" : "not_started",
-      exact_secrets:
-    )
-    HiveLiveAgentProof::WorkflowCreatorEvidence.replace_nonpassing!(
-      bundle_directory: bundle, expected: initial.value, receipt: receipt.value, exact_secrets:
-    )
-  end
-
-  def find_executable(name)
-    ENV.fetch("PATH", "").split(File::PATH_SEPARATOR).each do |directory|
-      path = File.join(directory, name)
-      return File.expand_path(path) if File.file?(path) && File.executable?(path)
-    end
-    nil
+  def failure_summary(result)
+    row = result.receipt.respond_to?(:value) ? result.receipt.value : result.receipt
+    "Workflow Creator live proof was #{result.status}: #{row['reason']}"
   end
 end

--- a/test/smoke/live_hive_workflow_creator_smoke_test.rb
+++ b/test/smoke/live_hive_workflow_creator_smoke_test.rb
@@ -110,7 +110,11 @@ class LiveHiveWorkflowCreatorSmokeTest < Minitest::Test
   def correlation_id(candidate_sha)
     run = ENV.fetch("GITHUB_RUN_ID", "local")
     attempt = ENV.fetch("GITHUB_RUN_ATTEMPT", "1")
-    "workflow-creator:#{candidate_sha}:#{run}:#{attempt}"
+    value = "workflow-creator-#{candidate_sha}-#{run}-#{attempt}"
+    raise "invalid Workflow Creator correlation identity" unless
+      HiveLiveAgentProof::WorkflowCreator::ProcessSupervisor::LABEL.match?(value)
+
+    value
   end
 
   def provider_secrets

--- a/test/unit/component_boundaries_test.rb
+++ b/test/unit/component_boundaries_test.rb
@@ -25,6 +25,7 @@ class ComponentBoundariesTest < Minitest::Test
       work-ledger
       workflow-creator-core
       workflow-creator-execution
+      workflow-creator-live
       workflow-creator-values
     ], contract.components.map { |component| component.fetch("id") }.sort
 
@@ -315,6 +316,8 @@ class ComponentBoundariesTest < Minitest::Test
       HiveLiveAgentProof::WorkflowCreatorBundle.retained
       HiveLiveAgentProof::WorkflowCreatorEvidence.initialize!
       HiveLiveAgentProof::WorkflowCreatorEvidence.replace_nonpassing!
+      HiveLiveAgentProof::WorkflowCreatorEvidence.replace_primary!
+      HiveLiveAgentProof::WorkflowCreatorEvidence.replace_primary_with_failure!
     ], workflow_core.dig("public_contract", "values")
     assert_equal %w[
       packaging/live_agent_skills/workflow_creator.rb
@@ -397,8 +400,32 @@ class ComponentBoundariesTest < Minitest::Test
     )
     assert_empty workflow_execution.fetch("migration_exceptions")
 
+    workflow_live = contract.component("workflow-creator-live")
+    assert_equal "boundary-ready", workflow_live.fetch("state")
+    assert_equal(
+      {
+        "file" => "packaging/live_agent_skills/workflow_creator_live_setup.rb",
+        "require" => "./packaging/live_agent_skills/workflow_creator_live_setup",
+        "constant" => "HiveLiveAgentProof::WorkflowCreatorLiveSetup"
+      },
+      workflow_live.fetch("entrypoint")
+    )
+    assert_equal %w[workflow-creator-core workflow-creator-execution],
+                 workflow_live.fetch("component_dependencies")
+    assert_empty workflow_live.fetch("allowed_hive_dependencies")
+    assert_equal %w[
+      packaging/live_agent_skills/workflow_creator_live_setup.rb
+      packaging/live_agent_skills/workflow_creator_live_runner.rb
+      packaging/live_agent_skills/workflow_creator_openclaw_runtime.rb
+      packaging/live_agent_skills/openclaw/package.json
+      packaging/live_agent_skills/openclaw/package-lock.json
+    ], workflow_live.fetch("owned_paths")
+    assert_equal [ "test/smoke/live_hive_workflow_creator_smoke_test.rb" ],
+                 workflow_live.fetch("hive_consumers")
+    assert_empty workflow_live.fetch("migration_exceptions")
+
     ready_components.push(agent_abi, artifact_firewall, skillpack, git_gate, work_ledger,
-                          workflow_values, workflow_core, workflow_execution)
+                          workflow_values, workflow_core, workflow_execution, workflow_live)
     remaining_candidates = contract.components.reject do |component|
       ready_components.include?(component)
     end
@@ -416,6 +443,7 @@ class ComponentBoundariesTest < Minitest::Test
       work-ledger
       workflow-creator-core
       workflow-creator-execution
+      workflow-creator-live
       workflow-creator-values
     ], ready_loads.keys.sort
     agent_abi_load = ready_loads.fetch("agent-abi")
@@ -709,6 +737,7 @@ class ComponentBoundariesTest < Minitest::Test
       {
         "skillpack" => [ "agent-abi" ],
         "workflow-creator-core" => [ "workflow-creator-values" ],
+        "workflow-creator-live" => [ "workflow-creator-core", "workflow-creator-execution" ],
         "workflow-creator-execution" => [ "workflow-creator-core" ]
       },
       dependencies

--- a/test/unit/component_boundaries_test.rb
+++ b/test/unit/component_boundaries_test.rb
@@ -538,7 +538,7 @@ class ComponentBoundariesTest < Minitest::Test
     assert_operator line_count.call("workflow_creator_capture.rb", "workflow_creator_process_supervisor.rb"),
                     :<=, 495
     assert_operator line_count.call("workflow_creator_gateway.rb", "workflow_creator_execution.rb"),
-                    :<=, 600
+                    :<=, 615
 
     assert contract.validate_static_boundaries!
   end

--- a/test/unit/packaging/live_agent_proof_test.rb
+++ b/test/unit/packaging/live_agent_proof_test.rb
@@ -439,6 +439,11 @@ class LiveAgentProofTest < Minitest::Test
       "task_prompt_sha256" => Digest::SHA256.hexdigest(Creator::Vocabulary.fetch("task_prompt")),
       "skill" => manifest.slice("skill_version", "canonical_digest"),
       "native_activation" => deep_dup(Creator::Vocabulary.fetch("native_activation")),
+      "native_activation_evidence" => {
+        "kind" => "openclaw-skills-info", "invocation" => "/hive", "name" => "hive",
+        "eligible" => true, "user_invocable" => true, "path" => "skills/hive/SKILL.md",
+        "sha256" => Digest::SHA256.hexdigest("fixture-skill"), "size" => 13
+      },
       "hive_commands" => deep_dup(Creator.commands_for(task_slug: CREATOR_TASK_SLUG).value),
       "created_files" => created,
       "validation" => deep_dup(Creator::Vocabulary.fetch("graph")), "creation_only_task_count" => 0,

--- a/test/unit/packaging/release_candidate_artifacts_test.rb
+++ b/test/unit/packaging/release_candidate_artifacts_test.rb
@@ -16,6 +16,9 @@ class ReleaseCandidateArtifactsTest < Minitest::Test
     packaging/live_agent_skills/workflow_creator_execution.rb
     packaging/live_agent_skills/workflow_creator_gateway.rb
     packaging/live_agent_skills/workflow_creator_installation.rb
+    packaging/live_agent_skills/workflow_creator_live_runner.rb
+    packaging/live_agent_skills/workflow_creator_live_setup.rb
+    packaging/live_agent_skills/workflow_creator_openclaw_runtime.rb
     packaging/live_agent_skills/workflow_creator_process_supervisor.rb
     packaging/live_agent_skills/workflow_creator.rb
     packaging/live_agent_skills/workflow_creator_contract.rb

--- a/test/unit/packaging/workflow_creator_core_test.rb
+++ b/test/unit/packaging/workflow_creator_core_test.rb
@@ -358,6 +358,11 @@ class WorkflowCreatorCoreTest < Minitest::Test
       "skill" => { "skill_version" => manifest.fetch("skill_version"),
                    "canonical_digest" => manifest.fetch("canonical_digest") },
       "native_activation" => deep_dup(Creator::Vocabulary.fetch("native_activation")),
+      "native_activation_evidence" => {
+        "kind" => "openclaw-skills-info", "invocation" => "/hive", "name" => "hive",
+        "eligible" => true, "user_invocable" => true, "path" => "skills/hive/SKILL.md",
+        "sha256" => Digest::SHA256.hexdigest("fixture-skill"), "size" => 13
+      },
       "hive_commands" => deep_dup(Creator.commands_for(task_slug: TASK_SLUG).value), "created_files" => created,
       "validation" => deep_dup(Creator::Vocabulary.fetch("graph")), "creation_only_task_count" => 0,
       "task_count" => 1, "task" => deep_dup(Creator::Vocabulary.fetch("task")).merge("slug" => TASK_SLUG),

--- a/test/unit/packaging/workflow_creator_evidence_test.rb
+++ b/test/unit/packaging/workflow_creator_evidence_test.rb
@@ -24,12 +24,19 @@ class WorkflowCreatorEvidenceTest < Minitest::Test
 
 
   def test_public_api_accepts_only_typed_bundle_operations_and_publisher_is_private
-    assert_equal %i[initialize! replace_nonpassing!], Evidence.singleton_methods(false).sort
+    assert_equal %i[
+      initialize! replace_nonpassing! replace_primary! replace_primary_with_failure!
+    ], Evidence.singleton_methods(false).sort
     assert_equal [ [ :keyreq, :bundle_directory ], [ :keyreq, :candidate_sha ] ],
                  Evidence.method(:initialize!).parameters
     replacement_parameters = Evidence.method(:replace_nonpassing!).parameters
     assert_equal %i[bundle_directory expected receipt exact_secrets],
                  replacement_parameters.map(&:last)
+    assert_equal %i[bundle_directory expected receipt manifest candidate_sha bundle_records],
+                 Evidence.method(:replace_primary!).parameters.map(&:last)
+    assert_equal %i[
+      bundle_directory expected receipt manifest candidate_sha bundle_records exact_secrets
+    ], Evidence.method(:replace_primary_with_failure!).parameters.map(&:last)
     assert_raises(NameError) { HiveLiveAgentProof::WorkflowCreatorReceiptPublisher }
   end
 

--- a/test/unit/packaging/workflow_creator_execution_test.rb
+++ b/test/unit/packaging/workflow_creator_execution_test.rb
@@ -42,7 +42,7 @@ class WorkflowCreatorExecutionTest < Minitest::Test
       refute File.exist?(primary_path)
       refute Dir.exist?(fixture.fetch(:workspace_path))
       assert fixture_pids.none? { |pid| process_alive?(pid) }
-      refute File.exist?(File.join(fixture.dig(:candidate, "root"), "audit", ".workflow-creator-gateway.sock"))
+      refute File.exist?(File.join(fixture.fetch(:root), ".workflow-creator-gateway.sock"))
 
       receipt = JSON.parse(draft.receipt_bytes)
       candidate_record, openclaw_record = receipt.fetch("installed_manifests")
@@ -349,7 +349,14 @@ class WorkflowCreatorExecutionTest < Minitest::Test
         puts JSON.generate("schema" => "hive-new", "ok" => true,
                            "created" => count.zero?, "slug" => #{SLUG.inspect})
       when ["run", #{SLUG.inspect}] then puts "ran"
-      when ["status", "--operational", "--json"] then puts JSON.generate("ok" => true)
+      when ["status", "--operational", "--json"]
+        puts JSON.generate(
+          "schema" => "hive-operational-status", "schema_version" => 3, "ok" => true,
+          "tasks" => [
+            { "identity" => { "slug" => #{SLUG.inspect} }, "workflow" => "editorial",
+              "position" => { "stage" => "1-research" } }
+          ]
+        )
       else exit 90
       end
     RUBY
@@ -461,6 +468,11 @@ class WorkflowCreatorExecutionTest < Minitest::Test
       "task_prompt_sha256" => Digest::SHA256.hexdigest(Creator::Vocabulary.fetch("task_prompt")),
       "skill" => fixture.fetch(:manifest).slice("skill_version", "canonical_digest"),
       "native_activation" => Creator::Vocabulary.fetch("native_activation"),
+      "native_activation_evidence" => {
+        "kind" => "openclaw-skills-info", "invocation" => "/hive", "name" => "hive",
+        "eligible" => true, "user_invocable" => true, "path" => "skills/hive/SKILL.md",
+        "sha256" => Digest::SHA256.hexdigest("fixture-skill"), "size" => 13
+      },
       "hive_commands" => Creator.commands_for(task_slug: SLUG).value,
       "created_files" => files, "validation" => Creator::Vocabulary.fetch("graph"),
       "creation_only_task_count" => 0, "task_count" => 1,

--- a/test/unit/packaging/workflow_creator_gateway_test.rb
+++ b/test/unit/packaging/workflow_creator_gateway_test.rb
@@ -179,7 +179,7 @@ class WorkflowCreatorGatewayTest < Minitest::Test
   def assert_private_gateway(root, wrapper)
     assert_equal 0o700, File.lstat(root).mode & 0o777
     assert_equal File.join(root, "workflow-creator-gateway"), wrapper
-    assert_equal 0o600, File.lstat(wrapper).mode & 0o777
+    assert_equal 0o700, File.lstat(wrapper).mode & 0o777
     socket = File.join(root, ".workflow-creator-gateway.sock")
     assert File.lstat(socket).socket?
     assert_equal 0o600, File.lstat(socket).mode & 0o777
@@ -193,7 +193,7 @@ class WorkflowCreatorGatewayTest < Minitest::Test
   end
 
   def invoke(wrapper, argv, inherited = {})
-    Open3.capture3(inherited, RUBY, wrapper, *argv, unsetenv_others: true)
+    Open3.capture3(inherited, wrapper, *argv, unsetenv_others: true)
   end
 
   def run_all(wrapper)

--- a/test/unit/packaging/workflow_creator_gateway_test.rb
+++ b/test/unit/packaging/workflow_creator_gateway_test.rb
@@ -84,6 +84,28 @@ class WorkflowCreatorGatewayTest < Minitest::Test
     end
   end
 
+  def test_operational_status_must_bind_the_exact_created_task_and_stage
+    %w[operational-malformed operational-wrong-slug operational-wrong-stage].each do |mode|
+      with_gateway(mode:) do |gateway, wrapper|
+        run_until_status(wrapper)
+        _out, _err, status = invoke(wrapper, Creator::Vocabulary.fetch("commands").fetch(8))
+
+        refute status.success?, mode
+        assert_raises(Gateway::Error, mode) { gateway.finish! }
+      end
+    end
+  end
+
+  def test_runtime_verifier_failure_poisons_before_candidate_launch
+    with_gateway(runtime_verifier: -> { false }) do |gateway, wrapper, log|
+      _out, _err, status = invoke(wrapper, Creator::Vocabulary.fetch("commands").first)
+
+      refute status.success?
+      refute File.exist?(log)
+      assert_raises(Gateway::Error) { gateway.finish! }
+    end
+  end
+
   def test_credential_like_inherited_environment_poison_is_reported_without_launch
     with_gateway do |gateway, wrapper, log|
       _out, _err, status = invoke(wrapper, [ "version" ], "API_TOKEN" => "must-not-cross")
@@ -146,13 +168,13 @@ class WorkflowCreatorGatewayTest < Minitest::Test
 
   private
 
-  def with_gateway(mode: "ok")
+  def with_gateway(mode: "ok", runtime_verifier: nil)
     Dir.mktmpdir("creator-gateway") do |dir|
       root, cwd = File.join(dir, "private"), File.join(dir, "cwd")
       [ root, cwd ].each { |path| Dir.mkdir(path, 0o700) }
       candidate = write_candidate(File.join(cwd, "candidate"))
       log = File.join(cwd, "launches.jsonl")
-      gateway = build_gateway(root:, cwd:, candidate:, log:, mode:)
+      gateway = build_gateway(root:, cwd:, candidate:, log:, mode:, runtime_verifier:)
       wrapper = gateway.start!
       yield gateway, wrapper, log, cwd, root, candidate
     ensure
@@ -160,7 +182,8 @@ class WorkflowCreatorGatewayTest < Minitest::Test
     end
   end
 
-  def build_gateway(root:, cwd:, candidate:, log:, mode: "ok", environment: nil)
+  def build_gateway(root:, cwd:, candidate:, log:, mode: "ok", environment: nil,
+                    runtime_verifier: nil)
     stat = File.lstat(candidate)
     identity = {
       "path" => File.basename(candidate), "sha256" => Digest::SHA256.file(candidate).hexdigest,
@@ -172,7 +195,8 @@ class WorkflowCreatorGatewayTest < Minitest::Test
     )
     Gateway.new(
       root:, candidate_executable: candidate, candidate_identity: identity,
-      environment: environment || { "FAKE_MODE" => mode, "FAKE_STATE" => log }, cwd:, supervisor:
+      environment: environment || { "FAKE_MODE" => mode, "FAKE_STATE" => log }, cwd:, supervisor:,
+      runtime_verifier:
     )
   end
 
@@ -197,11 +221,15 @@ class WorkflowCreatorGatewayTest < Minitest::Test
   end
 
   def run_all(wrapper)
+    run_until_status(wrapper)
+    assert_wrapper(wrapper, Creator::Vocabulary.fetch("commands").fetch(8))
+  end
+
+  def run_until_status(wrapper)
     commands = Creator::Vocabulary.fetch("commands")
     commands.first(6).each { |argv| assert_wrapper(wrapper, argv) }
     assert_wrapper(wrapper, [ "run", CREATED_SLUG ])
     assert_wrapper(wrapper, commands.fetch(7))
-    assert_wrapper(wrapper, commands.fetch(8))
   end
 
   def write_candidate(path)
@@ -234,7 +262,20 @@ class WorkflowCreatorGatewayTest < Minitest::Test
                              "created" => count.zero?, "slug" => #{CREATED_SLUG.inspect})
         end
       when ["run", #{CREATED_SLUG.inspect}] then puts "ran"
-      when ["status", "--operational", "--json"] then puts JSON.generate("ok" => true)
+      when ["status", "--operational", "--json"]
+        if mode == "operational-malformed"
+          puts "not-json"
+        else
+          slug = mode == "operational-wrong-slug" ? "another-created-task" : #{CREATED_SLUG.inspect}
+          stage = mode == "operational-wrong-stage" ? "2-draft" : "1-research"
+          puts JSON.generate(
+            "schema" => "hive-operational-status", "schema_version" => 3, "ok" => true,
+            "tasks" => [
+              { "identity" => { "slug" => slug }, "workflow" => "editorial",
+                "position" => { "stage" => stage } }
+            ]
+          )
+        end
       else
         warn "unexpected command"
         exit 90

--- a/test/unit/packaging/workflow_creator_live_runner_test.rb
+++ b/test/unit/packaging/workflow_creator_live_runner_test.rb
@@ -1,0 +1,610 @@
+require "test_helper"
+require "digest"
+require "json"
+require "open3"
+require_relative "../../../packaging/live_agent_skills/workflow_creator_live_runner"
+
+class WorkflowCreatorLiveRunnerTest < Minitest::Test
+  include HiveTestHelper
+
+  Creator = HiveLiveAgentProof::WorkflowCreator
+  Runner = HiveLiveAgentProof::WorkflowCreatorLiveRunner
+  SHA = "a" * 40
+  OPENAI_SECRET = "openai-selected-secret"
+  OPENROUTER_SECRET = "openrouter-selected-secret"
+  TEST_OPENCLAW_VERSION = "2026.8.4-test.1"
+  TEST_OPENCLAW_INTEGRITY = "sha512-#{[ "test-openclaw-integrity" ].pack("m0")}"
+  TEST_NODE_ENGINE = ">=22.19<23"
+  TEST_NODE_VERSION = "22.23.1"
+  NPM_REGISTRY = "https://registry.npmjs.org"
+
+  FakeResult = Data.define(:status)
+
+  class FakeSession
+    attr_reader :closed, :finished, :launches
+
+    def initialize(options)
+      @options = options
+      @workspace_path = options.fetch(:workspace_path)
+      FileUtils.mkdir_p(@workspace_path, mode: 0o700)
+      @gateway_path = File.join(File.dirname(@workspace_path), "workflow-creator-gateway")
+      File.binwrite(@gateway_path, "#!/bin/sh\nexit 0\n")
+      File.chmod(0o700, @gateway_path)
+      @launches = []
+    end
+
+    attr_reader :gateway_path, :workspace_path
+
+    def run_outer_workflow_creator(**launch)
+      @launches << launch
+      { "exit_code" => 0 }
+    end
+
+    def run_outer_authorized_work(**launch)
+      @launches << launch
+      Creator::Vocabulary.fetch("files").each do |relative|
+        path = File.join(@workspace_path, relative)
+        FileUtils.mkdir_p(File.dirname(path), mode: 0o700)
+        content = if relative.end_with?("editorial.yml")
+          <<~YAML
+            id: editorial
+            stages:
+              - name: research
+                kind: agent
+                state_file: research.md
+                instruction: editorial/research.md
+                permissions: yolo
+              - name: draft
+                kind: agent
+                state_file: draft.md
+                instruction: editorial/draft.md
+                permissions: yolo
+              - name: approval
+                kind: human
+                state_file: approval.md
+                input: draft.md
+                outcomes:
+                  approve:
+                    complete: true
+                    artifact: draft.md
+                  reject:
+                    to: draft
+          YAML
+        else
+          "authored:#{relative}\n"
+        end
+        File.binwrite(path, content)
+      end
+      task = File.join(@workspace_path, ".hive-state", "stages", "1-research", "created-editorial-42")
+      FileUtils.mkdir_p(task, mode: 0o700)
+      File.binwrite(
+        File.join(task, "meta.yml"),
+        YAML.dump(
+          "slug" => "created-editorial-42", "workflow" => "editorial",
+          "idempotency_key" => Creator::Vocabulary.fetch("task_key")
+        )
+      )
+      { "exit_code" => 0 }
+    end
+
+    def draft!(executed_instruction:)
+      @instruction = executed_instruction
+      receipt = {
+        "installed_manifests" => [
+          bundle_record("candidate_installation", "candidate-installed-manifest.json", "candidate"),
+          bundle_record("openclaw_installation", "openclaw-installed-manifest.json", "openclaw")
+        ],
+        "task_slug_binding" => { "value" => "created-editorial-42" }
+      }
+      bytes = Creator::Values.capture(receipt).canonical_bytes
+      HiveLiveAgentProof::WorkflowCreatorExecution::Draft.new(
+        receipt_bytes: bytes, receipt_sha256: Digest::SHA256.hexdigest(bytes), receipt_size: bytes.bytesize
+      )
+    end
+
+    def finish!(primary_row:)
+      @primary = primary_row
+      @finished = true
+      FakeResult.new(status: "passed")
+    end
+
+    def close
+      @closed = true
+    end
+
+    private
+
+    def bundle_record(kind, path, seed)
+      { "kind" => kind, "path" => path, "sha256" => Digest::SHA256.hexdigest(seed), "size" => seed.bytesize }
+    end
+  end
+
+  class EarlyTaskSession < FakeSession
+    def run_outer_workflow_creator(**launch)
+      super
+      FileUtils.mkdir_p(
+        File.join(@workspace_path, ".hive-state", "stages", "1-research", "too-early"),
+        mode: 0o700
+      )
+    end
+  end
+
+  class InvalidGraphSession < FakeSession
+    def run_outer_authorized_work(**launch)
+      super
+      descriptor = File.join(@workspace_path, Creator::Vocabulary.fetch("files").first)
+      File.binwrite(descriptor, "id: editorial\nstages: []\n")
+    end
+  end
+
+  def test_selects_each_provider_with_both_credentials_and_strips_authority
+    %w[openai openrouter].each do |provider|
+      with_fixture(provider:) do |fixture|
+        result = run_fixture(fixture)
+        session = fixture.fetch(:sessions).fetch(0)
+        child = session.launches.fetch(0).fetch(:environment)
+        selected = provider == "openai" ? "OPENAI_API_KEY" : "OPENROUTER_API_KEY"
+        opposite = provider == "openai" ? "OPENROUTER_API_KEY" : "OPENAI_API_KEY"
+
+        assert_equal "passed", result.status, result.receipt.value.inspect
+        assert_equal provider, result.provider
+        assert_equal fixture.dig(:environment, selected), child.fetch(selected)
+        refute child.key?(opposite)
+        %w[GH_TOKEN GITHUB_TOKEN GIT_CONFIG_GLOBAL GIT_ASKPASS SSH_AUTH_SOCK SSH_ASKPASS].each do |name|
+          refute child.key?(name), "#{name} escaped into the OpenClaw child"
+        end
+        config = JSON.parse(File.binread(child.fetch("OPENCLAW_CONFIG_PATH")))
+        assert_equal "allowlist", config.dig("tools", "exec", "mode")
+        assert_equal [ File.dirname(File.join(session.workspace_path, ".hive-openclaw", "bin", "hive")) ],
+                     config.dig("tools", "exec", "pathPrepend")
+        refute_includes JSON.generate(config), "passEnv"
+        assert_equal fixture.fetch(:shell_path), child.fetch("SHELL")
+        refute File.exist?(File.join(session.workspace_path, ".hive-openclaw", "exec-approvals.json"))
+      end
+    end
+  end
+
+  def test_workspace_preparer_runs_after_gateway_configuration_and_before_model_loops
+    with_fixture do |fixture|
+      prepared = false
+      preparer = lambda do |workspace:, candidate_environment:, openclaw_environment:, gateway_path:|
+        session = fixture.fetch(:sessions).fetch(0)
+        assert_empty session.launches
+        assert_equal session.workspace_path, workspace
+        assert_equal fixture.dig(:execution_options, :candidate, "environment"), candidate_environment
+        assert File.file?(openclaw_environment.fetch("OPENCLAW_CONFIG_PATH"))
+        assert File.symlink?(gateway_path)
+        assert_equal File.realpath(session.gateway_path), File.realpath(gateway_path)
+        prepared = true
+        workspace_preparation(fixture)
+      end
+
+      result = run_fixture(fixture, workspace_preparer: preparer)
+
+      assert_equal "passed", result.status, result.receipt.value.inspect
+      assert prepared
+    end
+  end
+
+  def test_trusted_shell_strips_provider_and_repository_authority_from_real_command_environment
+    with_fixture do |fixture|
+      hostile = fixture.fetch(:environment).merge(
+        "NODE_OPTIONS" => "--require=/tmp/ignored.js",
+        "OPENCLAW_GATEWAY_TOKEN" => "openclaw-token",
+        "custom_api_key" => "lowercase-secret"
+      )
+      stdout, stderr, status = Open3.capture3(
+        hostile, fixture.fetch(:shell_path), "-c", "/usr/bin/env", unsetenv_others: true
+      )
+
+      assert status.success?, stderr
+      %w[OPENAI_API_KEY OPENROUTER_API_KEY GH_TOKEN GITHUB_TOKEN GIT_CONFIG_GLOBAL GIT_ASKPASS
+         SSH_AUTH_SOCK SSH_ASKPASS NODE_OPTIONS OPENCLAW_GATEWAY_TOKEN custom_api_key].each do |name|
+        refute_match(/^#{Regexp.escape(name)}=/, stdout, "#{name} escaped into a model command")
+      end
+    end
+  end
+
+  def test_missing_or_unsupported_provider_and_missing_selected_credential_are_typed
+    cases = [
+      [ "", {}, "missing_model", "failed" ],
+      [ "anthropic/claude", {}, "unsupported_provider", "failed" ],
+      [ "openrouter/openai/gpt-5.6-terra", { "OPENROUTER_API_KEY" => "" },
+        "missing_provider_credential", "blocked" ]
+    ]
+    cases.each do |model, overrides, reason, status|
+      provider = model.start_with?("openai/") ? "openai" : "openrouter"
+      with_fixture(provider:, model:) do |fixture|
+        fixture.fetch(:environment).merge!(overrides)
+        result = run_fixture(fixture)
+        receipt = retained_receipt(fixture)
+
+        assert_equal status, result.status
+        assert_equal reason, receipt.fetch("reason")
+        assert_empty fixture.fetch(:sessions)
+      end
+    end
+  end
+
+  def test_hostile_transport_overrides_fail_before_credential_bearing_execution
+    with_fixture do |fixture|
+      fixture.fetch(:environment)["HTTPS_PROXY"] = "https://attacker.invalid:443"
+
+      result = run_fixture(fixture)
+
+      assert_equal "failed", result.status
+      assert_equal "transport_override", retained_receipt(fixture).fetch("reason")
+      assert_empty fixture.fetch(:sessions)
+    end
+
+    with_fixture do |fixture|
+      record = JSON.parse(File.binread(fixture.fetch(:configuration_record)))
+      record.fetch("transport")["endpoint"] = "https://attacker.invalid/v1"
+      write_canonical(fixture.fetch(:configuration_record), record)
+
+      result = run_fixture(fixture)
+
+      assert_equal "failed", result.status
+      assert_equal "invalid_transport_identity", retained_receipt(fixture).fetch("reason")
+    end
+  end
+
+  def test_invalid_dependency_closure_and_binary_fail_before_execution
+    with_fixture do |fixture|
+      File.open(fixture.fetch(:lock_path), "ab") { |file| file.write("\n") }
+
+      result = run_fixture(fixture)
+
+      assert_equal "failed", result.status
+      assert_equal "invalid_openclaw_closure", retained_receipt(fixture).fetch("reason")
+      assert_empty fixture.fetch(:sessions)
+    end
+
+    with_fixture do |fixture|
+      File.chmod(0o600, fixture.fetch(:openclaw_binary))
+
+      result = run_fixture(fixture)
+
+      assert_equal "failed", result.status
+      assert_equal "invalid_openclaw_binary", retained_receipt(fixture).fetch("reason")
+      assert_empty fixture.fetch(:sessions)
+    end
+
+
+    with_fixture do |fixture|
+      File.open(fixture.fetch(:shell_path), "ab") { |file| file.write("# drift\n") }
+
+      result = run_fixture(fixture)
+
+      assert_equal "failed", result.status
+      assert_equal "invalid_tool_environment", retained_receipt(fixture).fetch("reason")
+      assert_empty fixture.fetch(:sessions)
+    end
+
+    with_fixture do |fixture|
+      candidate = fixture.dig(:execution_options, :candidate)
+      skill_manifest = File.join(candidate.fetch("root"), candidate.fetch("inventory").fetch(0))
+      File.open(skill_manifest, "ab") { |file| file.write("drift\n") }
+
+      result = run_fixture(fixture)
+
+      assert_equal "failed", result.status
+      assert_equal "invalid_skill_projection", retained_receipt(fixture).fetch("reason")
+      assert_empty fixture.fetch(:sessions)
+    end
+  end
+
+
+  def test_runtime_install_requires_packaging_owned_verification
+    with_fixture do |fixture|
+      result = run_fixture(fixture, runtime_install_verifier: nil)
+
+      assert_equal "blocked", result.status
+      assert_equal "runtime_install_unverified", retained_receipt(fixture).fetch("reason")
+      assert_empty fixture.fetch(:sessions)
+    end
+  end
+
+  def test_runtime_install_drift_after_model_execution_fails_the_claim
+    with_fixture do |fixture|
+      scans = 0
+      verifier = lambda do |runtime_install:, launcher_sha256:|
+        scans += 1
+        assert_equal fixture.fetch(:runtime_install).fetch("launcher_sha256"), launcher_sha256
+        next runtime_install if scans == 1
+
+        runtime_install.merge("tree_sha256" => Digest::SHA256.hexdigest("changed-runtime"))
+      end
+
+      result = run_fixture(fixture, runtime_install_verifier: verifier)
+
+      assert_equal "failed", result.status
+      assert_equal "runtime_install_changed", retained_receipt(fixture).fetch("reason")
+      assert_equal 2, scans
+    end
+  end
+
+  def test_external_actions_are_observed_after_both_model_loops_and_fail_closed
+    with_fixture do |fixture|
+      observed = false
+      observer = lambda do |workspace:, candidate_environment:|
+        session = fixture.fetch(:sessions).fetch(0)
+        assert_equal 2, session.launches.length
+        assert_equal session.workspace_path, workspace
+        assert_equal fixture.dig(:execution_options, :candidate, "environment"), candidate_environment
+        observed = true
+        { "status" => "observed", "actions" => [] }
+      end
+
+      result = run_fixture(fixture, external_actions_observer: observer)
+
+      assert_equal "passed", result.status, result.receipt.value.inspect
+      assert observed
+    end
+
+    with_fixture do |fixture|
+      result = run_fixture(
+        fixture,
+        external_actions_observer: ->(**) { { "status" => "assumed", "actions" => [] } }
+      )
+
+      assert_equal "failed", result.status
+      assert_equal "external_actions_unverified", retained_receipt(fixture).fetch("reason")
+    end
+  end
+
+  def test_workspace_claims_require_creation_only_and_exact_authored_graph_evidence
+    with_fixture do |fixture|
+      factory = lambda do |**options|
+        EarlyTaskSession.new(options).tap { |session| fixture.fetch(:sessions) << session }
+      end
+
+      result = run_fixture(fixture, execution_factory: factory)
+
+      assert_equal "failed", result.status
+      assert_equal "creation_only_task_created", retained_receipt(fixture).fetch("reason")
+    end
+
+    with_fixture do |fixture|
+      factory = lambda do |**options|
+        InvalidGraphSession.new(options).tap { |session| fixture.fetch(:sessions) << session }
+      end
+
+      result = run_fixture(fixture, execution_factory: factory)
+
+      assert_equal "failed", result.status
+      assert_equal "authored_graph_invalid", retained_receipt(fixture).fetch("reason")
+    end
+  end
+
+  def test_initial_receipt_precedes_preflight_and_success_is_finalized_and_closed
+    with_fixture do |fixture|
+      factory = lambda do |**options|
+        initial = retained_receipt(fixture)
+        assert_equal [ "preflight", "not_started", "failed" ],
+                     initial.values_at("phase", "reason", "result")
+        session = FakeSession.new(options)
+        fixture.fetch(:sessions) << session
+        session
+      end
+
+      result = run_fixture(fixture, execution_factory: factory)
+      session = fixture.fetch(:sessions).fetch(0)
+      retained = retained_receipt(fixture)
+
+      assert_equal "passed", result.status, result.receipt.value.inspect
+      assert_equal "passed", retained.fetch("result")
+      assert session.finished
+      assert session.closed
+      refute_includes File.binread(fixture.fetch(:primary_path)), OPENAI_SECRET
+      refute_includes File.binread(fixture.fetch(:primary_path)), OPENROUTER_SECRET
+    end
+  end
+
+  def test_execution_failure_replaces_initial_receipt_with_secret_free_typed_failure
+    with_fixture do |fixture|
+      factory = lambda do |**_options|
+        raise HiveLiveAgentProof::WorkflowCreatorExecution::Error,
+              "provider rejected #{OPENROUTER_SECRET}"
+      end
+
+      result = run_fixture(fixture, execution_factory: factory)
+      receipt = retained_receipt(fixture)
+
+      assert_equal "failed", result.status
+      assert_equal "execution_failed", receipt.fetch("reason")
+      assert_includes receipt.fetch("detail"), "[REDACTED]"
+      refute_includes File.binread(fixture.fetch(:primary_path)), OPENROUTER_SECRET
+    end
+  end
+
+  def test_initialize_and_fail_entrypoints_preserve_typed_uploadable_evidence
+    with_tmp_dir do |root|
+      bundle = File.join(root, "bundle")
+      FileUtils.mkdir_p(bundle, mode: 0o700)
+      FileUtils.chmod(0o700, bundle)
+      environment = {
+        "HIVE_CANDIDATE_SHA" => SHA,
+        "HIVE_CREATOR_EVIDENCE_PATH" => File.join(bundle, "openclaw-workflow-creator.json")
+      }
+
+      assert_equal 0, Runner::Command.call([ "initialize" ], environment:)
+      assert_equal 0, Runner::Command.call([ "fail", "setup", "artifact_download_failed" ], environment:)
+      receipt = JSON.parse(File.binread(environment.fetch("HIVE_CREATOR_EVIDENCE_PATH")))
+
+      assert_equal [ "setup", "artifact_download_failed", "failed" ],
+                   receipt.values_at("phase", "reason", "result")
+    end
+  end
+
+  private
+
+  def run_fixture(fixture, execution_factory: nil, runtime_install_verifier: :fixture,
+                  external_actions_observer: nil, workspace_preparer: nil)
+    execution_factory ||= lambda do |**options|
+      FakeSession.new(options).tap { |session| fixture.fetch(:sessions) << session }
+    end
+    runtime_install_verifier = lambda do |runtime_install:, launcher_sha256:|
+      assert_equal fixture.fetch(:runtime_install), runtime_install
+      assert_equal fixture.fetch(:runtime_install).fetch("launcher_sha256"), launcher_sha256
+      runtime_install
+    end if runtime_install_verifier == :fixture
+    external_actions_observer ||= ->(**) { { "status" => "observed", "actions" => [] } }
+    workspace_preparer ||= ->(**) { workspace_preparation(fixture) }
+    Runner.run!(
+      candidate_sha: SHA, model: fixture.fetch(:model), host_environment: fixture.fetch(:environment),
+      configuration_record: fixture.fetch(:configuration_record),
+      execution_options: fixture.fetch(:execution_options), external_actions_observer:,
+      workspace_preparer:, execution_factory:, runtime_install_verifier:
+    )
+  end
+
+  def with_fixture(provider: "openrouter", model: nil)
+    with_tmp_dir do |root|
+      bundle = File.join(root, "bundle")
+      openclaw_root = File.join(root, "openclaw")
+      candidate_root = File.join(root, "candidate")
+      skill_root = File.join(candidate_root, "skill", "hive")
+      workspace = File.join(root, "workspace")
+      runtime_install_root = File.join(root, "openclaw-runtime-install")
+      FileUtils.mkdir_p(
+        [ bundle, runtime_install_root, skill_root, File.join(openclaw_root, "bin"), File.join(openclaw_root, "runtime"),
+          File.join(openclaw_root, "security") ], mode: 0o700
+      )
+      FileUtils.chmod(0o700, bundle)
+      skill_manifest = File.join(skill_root, "projection-manifest.json")
+      File.binwrite(skill_manifest, "{\"schema\":\"test-openclaw-skill\"}\n")
+      skill_sha = Digest::SHA256.file(skill_manifest).hexdigest
+      binary = File.join(openclaw_root, "bin", "openclaw")
+      File.binwrite(binary, "#!/bin/sh\nexit 0\n")
+      File.chmod(0o700, binary)
+      shell_path = File.join(openclaw_root, "security", "hive-creator-shell")
+      File.binwrite(shell_path, Runner.shell_sanitizer_bytes)
+      File.chmod(0o700, shell_path)
+      node = File.join(openclaw_root, "runtime", "node")
+      File.binwrite(node, "#!/bin/sh\nprintf 'v#{TEST_NODE_VERSION}\\n'\n")
+      File.chmod(0o700, node)
+      lock_path = File.join(openclaw_root, "package-lock.json")
+      lock = package_lock
+      File.binwrite(lock_path, JSON.generate(lock))
+      package = File.join(openclaw_root, "openclaw.tgz")
+      File.binwrite(package, "openclaw-package\n")
+      model ||= provider == "openai" ? "openai/gpt-5.6-terra" : "openrouter/openai/gpt-5.6-terra"
+      runtime_install = {
+        "schema" => "hive-openclaw-runtime-install/v1", "schema_version" => 1,
+        "root" => runtime_install_root, "tree_sha256" => Digest::SHA256.hexdigest("runtime-tree"),
+        "file_count" => 34_911, "directory_count" => 2_040, "total_size" => 123_456_789,
+        "launcher_sha256" => Digest::SHA256.file(binary).hexdigest
+      }
+      config_path = File.join(openclaw_root, "creator-configuration.json")
+      record = configuration_record(
+        provider:, model:, lock_path:, shell_path:, openclaw_root:, runtime_install:,
+        candidate_root:, skill_sha:
+      )
+      write_canonical(config_path, record)
+      inventory = [ binary, node, lock_path, package, shell_path, config_path ].map do |path|
+        path.delete_prefix("#{openclaw_root}/")
+      end.sort
+      environment = {
+        "PATH" => "/usr/bin:/bin", "LANG" => "C.UTF-8", "OPENAI_API_KEY" => OPENAI_SECRET,
+        "OPENROUTER_API_KEY" => OPENROUTER_SECRET, "GH_TOKEN" => "github-secret",
+        "GITHUB_TOKEN" => "github-secret-2", "GIT_CONFIG_GLOBAL" => "/tmp/host.gitconfig",
+        "GIT_ASKPASS" => "/tmp/askpass", "SSH_AUTH_SOCK" => "/tmp/ssh-agent",
+        "SSH_ASKPASS" => "/tmp/ssh-askpass"
+      }
+      hive_version = "1.0.0"
+      manifest_files = [ "hive-agent-skills-#{SHA}.tar.gz", "hive-cli-#{hive_version}.gem",
+                         "hive-source-#{SHA}.tar.gz" ].to_h do |name|
+        [ name, { "sha256" => Digest::SHA256.hexdigest(name), "size" => name.bytesize } ]
+      end
+      manifest = {
+        "schema" => "hive-live-agent-candidate-artifacts", "schema_version" => 1,
+        "candidate_sha" => SHA, "hive_version" => hive_version, "skill_version" => "2026.8.4",
+        "canonical_digest" => Digest::SHA256.hexdigest("canonical"), "files" => manifest_files
+      }
+      execution_options = {
+        candidate_sha: SHA, manifest:,
+        candidate: {
+          "root" => candidate_root, "environment" => {},
+          "inventory" => [ skill_manifest.delete_prefix("#{candidate_root}/") ]
+        },
+        openclaw: {
+          "root" => openclaw_root, "version" => TEST_OPENCLAW_VERSION, "inventory" => inventory,
+          "executable" => binary, "interpreter_or_launcher" => node, "lock" => lock_path, "package" => package
+        },
+        archives: {}, workspace_path: workspace, bundle_directory: bundle,
+        correlation_id: "live-creator", supervisor_options: {}
+      }
+      yield root:, bundle:, model:, environment:, configuration_record: config_path, lock_path:,
+            openclaw_binary: binary, shell_path:, runtime_install:, sessions: [], execution_options:,
+            primary_path: File.join(bundle, "openclaw-workflow-creator.json")
+    end
+  end
+
+  def package_lock
+    {
+      "name" => "hive-openclaw-creator-proof", "lockfileVersion" => 3,
+      "packages" => {
+        "" => { "dependencies" => { "openclaw" => TEST_OPENCLAW_VERSION },
+                "engines" => { "node" => TEST_NODE_VERSION } },
+        "node_modules/openclaw" => {
+          "version" => TEST_OPENCLAW_VERSION,
+          "resolved" => "https://registry.npmjs.org/openclaw/-/openclaw-#{TEST_OPENCLAW_VERSION}.tgz",
+          "integrity" => TEST_OPENCLAW_INTEGRITY, "hasInstallScript" => true,
+          "engines" => { "node" => TEST_NODE_ENGINE }
+        }
+      }
+    }
+  end
+
+  def configuration_record(provider:, model:, lock_path:, shell_path:, openclaw_root:, runtime_install:,
+                           candidate_root:, skill_sha:)
+    {
+      "schema" => Runner::CONFIGURATION_SCHEMA, "schema_version" => 1,
+      "candidate_sha" => SHA, "provider" => provider, "model" => model,
+      "transport" => {
+        "endpoint" => Runner::PROVIDERS.fetch(provider).fetch("endpoint"),
+        "proxy" => nil, "ca" => nil, "redirects" => "deny"
+      },
+      "dependency" => {
+        "package" => "openclaw", "version" => TEST_OPENCLAW_VERSION,
+        "registry" => NPM_REGISTRY, "integrity" => TEST_OPENCLAW_INTEGRITY,
+        "lock_sha256" => Digest::SHA256.file(lock_path).hexdigest,
+        "package_count" => 2, "node_engine" => TEST_NODE_ENGINE, "node_version" => TEST_NODE_VERSION,
+        "lifecycle_scripts" => [ "node_modules/openclaw" ]
+      },
+      "tool_environment" => {
+        "pass_env" => [], "authority" => "shell_sanitized",
+        "shell" => {
+          "path" => shell_path.delete_prefix("#{openclaw_root}/"),
+          "sha256" => Digest::SHA256.file(shell_path).hexdigest, "size" => File.size(shell_path)
+        }
+      },
+      "runtime_install" => runtime_install,
+      "skill" => {
+        "path" => "skill/hive", "projection_manifest_sha256" => skill_sha
+      }
+    }
+  end
+
+  def workspace_preparation(fixture)
+    digest = fixture.fetch(:configuration_record).then { |path| Digest::SHA256.file(path).hexdigest }
+    {
+      "schema" => "hive-workflow-creator-workspace-preparation", "schema_version" => 1,
+      "status" => "prepared", "skill_manifest_sha256" =>
+        JSON.parse(File.binread(fixture.fetch(:configuration_record))).dig("skill", "projection_manifest_sha256"),
+      "init_stdout_sha256" => digest, "git_head" => "b" * 40,
+      "openclaw_config_validation_sha256" => digest,
+      "openclaw_effective_policy_sha256" => digest
+    }
+  end
+
+  def write_canonical(path, value)
+    File.binwrite(path, Creator::Values.capture(value).canonical_bytes)
+    File.chmod(0o600, path)
+  end
+
+  def retained_receipt(fixture)
+    JSON.parse(File.binread(fixture.fetch(:primary_path)))
+  end
+end

--- a/test/unit/packaging/workflow_creator_live_runner_test.rb
+++ b/test/unit/packaging/workflow_creator_live_runner_test.rb
@@ -137,6 +137,23 @@ class WorkflowCreatorLiveRunnerTest < Minitest::Test
     end
   end
 
+  class VerifiedPreparer
+    attr_reader :control_checks
+
+    def initialize(callable, fail_control_at: nil)
+      @callable, @fail_control_at, @control_checks = callable, fail_control_at, 0
+    end
+
+    def call(**options) = @callable.call(**options)
+    def verify_command_boundary! = true
+
+    def verify_control_plane!
+      @control_checks += 1
+      raise "control plane changed" if @control_checks == @fail_control_at
+      true
+    end
+  end
+
   def test_selects_each_provider_with_both_credentials_and_strips_authority
     %w[openai openrouter].each do |provider|
       with_fixture(provider:) do |fixture|
@@ -155,11 +172,12 @@ class WorkflowCreatorLiveRunnerTest < Minitest::Test
         end
         config = JSON.parse(File.binread(child.fetch("OPENCLAW_CONFIG_PATH")))
         assert_equal "allowlist", config.dig("tools", "exec", "mode")
-        assert_equal [ File.dirname(File.join(session.workspace_path, ".hive-openclaw", "bin", "hive")) ],
+        assert_equal [ File.join(fixture.dig(:execution_options, :control_root), "openclaw", "bin") ],
                      config.dig("tools", "exec", "pathPrepend")
         refute_includes JSON.generate(config), "passEnv"
         assert_equal fixture.fetch(:shell_path), child.fetch("SHELL")
-        refute File.exist?(File.join(session.workspace_path, ".hive-openclaw", "exec-approvals.json"))
+        refute File.exist?(File.join(fixture.dig(:execution_options, :control_root),
+                                     "openclaw", "exec-approvals.json"))
       end
     end
   end
@@ -183,6 +201,36 @@ class WorkflowCreatorLiveRunnerTest < Minitest::Test
 
       assert_equal "passed", result.status, result.receipt.value.inspect
       assert prepared
+      assert_equal 4, fixture.fetch(:preparer).control_checks
+    end
+  end
+
+  def test_control_plane_change_between_outer_loops_fails_the_claim
+    with_fixture do |fixture|
+      preparer = VerifiedPreparer.new(->(**) { workspace_preparation(fixture) }, fail_control_at: 3)
+      result = run_fixture(fixture, workspace_preparer: preparer)
+
+      assert_equal "failed", result.status
+      assert_equal "control_plane_changed", retained_receipt(fixture).fetch("reason")
+      assert_equal 1, fixture.fetch(:sessions).fetch(0).launches.length
+    end
+  end
+
+  def test_missing_or_invalid_native_skill_discovery_cannot_publish
+    [
+      ->(row) { row.delete("native_activation") },
+      ->(row) { row.fetch("native_activation")["eligible"] = false }
+    ].each do |mutate|
+      with_fixture do |fixture|
+        preparer = lambda do |**|
+          workspace_preparation(fixture).tap { |row| mutate.call(row) }
+        end
+        result = run_fixture(fixture, workspace_preparer: preparer)
+
+        assert_equal "failed", result.status
+        assert_equal "workspace_preparation_failed", retained_receipt(fixture).fetch("reason")
+        assert_empty fixture.fetch(:sessions).fetch(0).launches
+      end
     end
   end
 
@@ -434,6 +482,19 @@ class WorkflowCreatorLiveRunnerTest < Minitest::Test
 
       assert_equal [ "setup", "artifact_download_failed", "failed" ],
                    receipt.values_at("phase", "reason", "result")
+
+      assert_equal 0, Runner::Command.call([ "finalize-bootstrap" ], environment:)
+      preserved = JSON.parse(File.binread(environment.fetch("HIVE_CREATOR_EVIDENCE_PATH")))
+      assert_equal "artifact_download_failed", preserved.fetch("reason")
+
+      fresh = File.join(root, "fresh")
+      FileUtils.mkdir_p(fresh, mode: 0o700)
+      environment["HIVE_CREATOR_EVIDENCE_PATH"] = File.join(fresh, "openclaw-workflow-creator.json")
+      assert_equal 0, Runner::Command.call([ "initialize" ], environment:)
+      assert_equal 0, Runner::Command.call([ "finalize-bootstrap" ], environment:)
+      finalized = JSON.parse(File.binread(environment.fetch("HIVE_CREATOR_EVIDENCE_PATH")))
+      assert_equal [ "setup", "bootstrap_failed", "failed" ],
+                   finalized.values_at("phase", "reason", "result")
     end
   end
 
@@ -451,6 +512,9 @@ class WorkflowCreatorLiveRunnerTest < Minitest::Test
     end if runtime_install_verifier == :fixture
     external_actions_observer ||= ->(**) { { "status" => "observed", "actions" => [] } }
     workspace_preparer ||= ->(**) { workspace_preparation(fixture) }
+    workspace_preparer = VerifiedPreparer.new(workspace_preparer) unless
+      workspace_preparer.respond_to?(:verify_control_plane!)
+    fixture[:preparer] = workspace_preparer
     Runner.run!(
       candidate_sha: SHA, model: fixture.fetch(:model), host_environment: fixture.fetch(:environment),
       configuration_record: fixture.fetch(:configuration_record),
@@ -467,13 +531,29 @@ class WorkflowCreatorLiveRunnerTest < Minitest::Test
       skill_root = File.join(candidate_root, "skill", "hive")
       workspace = File.join(root, "workspace")
       runtime_install_root = File.join(root, "openclaw-runtime-install")
+      control_root = File.join(root, "workflow-creator-control")
       FileUtils.mkdir_p(
         [ bundle, runtime_install_root, skill_root, File.join(openclaw_root, "bin"), File.join(openclaw_root, "runtime"),
-          File.join(openclaw_root, "security") ], mode: 0o700
+          File.join(openclaw_root, "security"), control_root ], mode: 0o700
       )
       FileUtils.chmod(0o700, bundle)
+      FileUtils.chmod(0o700, control_root)
       skill_manifest = File.join(skill_root, "projection-manifest.json")
-      File.binwrite(skill_manifest, "{\"schema\":\"test-openclaw-skill\"}\n")
+      skill_path = File.join(skill_root, "SKILL.md")
+      skill_bytes = "# Hive fixture skill\n"
+      File.binwrite(skill_path, skill_bytes)
+      write_canonical(
+        skill_manifest,
+        {
+          "schema" => "hive-workflow-creator-openclaw-skill/v1", "schema_version" => 1,
+          "platform" => "openclaw", "invocation" => "/hive", "skill_version" => "2026.8.4",
+          "canonical_digest" => Digest::SHA256.hexdigest("canonical"),
+          "files" => [
+            { "path" => "SKILL.md", "sha256" => Digest::SHA256.hexdigest(skill_bytes),
+              "size" => skill_bytes.bytesize }
+          ]
+        }
+      )
       skill_sha = Digest::SHA256.file(skill_manifest).hexdigest
       binary = File.join(openclaw_root, "bin", "openclaw")
       File.binwrite(binary, "#!/bin/sh\nexit 0\n")
@@ -532,7 +612,7 @@ class WorkflowCreatorLiveRunnerTest < Minitest::Test
           "root" => openclaw_root, "version" => TEST_OPENCLAW_VERSION, "inventory" => inventory,
           "executable" => binary, "interpreter_or_launcher" => node, "lock" => lock_path, "package" => package
         },
-        archives: {}, workspace_path: workspace, bundle_directory: bundle,
+        archives: {}, workspace_path: workspace, bundle_directory: bundle, control_root:,
         correlation_id: "live-creator", supervisor_options: {}
       }
       yield root:, bundle:, model:, environment:, configuration_record: config_path, lock_path:,
@@ -589,13 +669,22 @@ class WorkflowCreatorLiveRunnerTest < Minitest::Test
 
   def workspace_preparation(fixture)
     digest = fixture.fetch(:configuration_record).then { |path| Digest::SHA256.file(path).hexdigest }
+    configuration = JSON.parse(File.binread(fixture.fetch(:configuration_record)))
+    skill = File.join(
+      fixture.dig(:execution_options, :candidate, "root"), configuration.dig("skill", "path"), "SKILL.md"
+    )
     {
       "schema" => "hive-workflow-creator-workspace-preparation", "schema_version" => 1,
       "status" => "prepared", "skill_manifest_sha256" =>
-        JSON.parse(File.binread(fixture.fetch(:configuration_record))).dig("skill", "projection_manifest_sha256"),
+        configuration.dig("skill", "projection_manifest_sha256"),
       "init_stdout_sha256" => digest, "git_head" => "b" * 40,
       "openclaw_config_validation_sha256" => digest,
-      "openclaw_effective_policy_sha256" => digest
+      "openclaw_effective_policy_sha256" => digest,
+      "native_activation" => {
+        "kind" => "openclaw-skills-info", "invocation" => "/hive", "name" => "hive",
+        "eligible" => true, "user_invocable" => true, "path" => "skills/hive/SKILL.md",
+        "sha256" => Digest::SHA256.file(skill).hexdigest, "size" => File.size(skill)
+      }
     }
   end
 

--- a/test/unit/packaging/workflow_creator_live_setup_test.rb
+++ b/test/unit/packaging/workflow_creator_live_setup_test.rb
@@ -1,0 +1,332 @@
+require "test_helper"
+require "base64"
+require "digest"
+require "json"
+require "open3"
+require "rbconfig"
+require "rubygems/package"
+require "zlib"
+require "hive/agent_skills/canonical_skill"
+require_relative "../../../packaging/live_agent_skills/proof"
+require_relative "../../../packaging/live_agent_skills/workflow_creator_live_setup"
+
+class WorkflowCreatorLiveSetupTest < Minitest::Test
+  include HiveTestHelper
+
+  Setup = HiveLiveAgentProof::WorkflowCreatorLiveSetup
+  Runtime = HiveLiveAgentProof::WorkflowCreatorOpenClawRuntime
+  SHA = "a" * 40
+  NODE_VERSION = "22.23.1"
+  OPENCLAW_VERSION = "2026.8.4-test.1"
+
+  def test_builds_bounded_exact_closures_and_prepares_an_isolated_workspace
+    with_setup_fixture do |fixture|
+      result = prepare(fixture)
+      options = result.fetch(:execution_options)
+      candidate = options.fetch(:candidate)
+      openclaw = options.fetch(:openclaw)
+      configuration = JSON.parse(File.binread(result.fetch(:configuration_record)))
+
+      assert_operator candidate.fetch("inventory").length, :<=, 512
+      assert_operator openclaw.fetch("inventory").length, :<=, 512
+      gateway_relative = candidate.fetch("audit_gateway").delete_prefix("#{candidate.fetch("root")}/")
+      assert_includes candidate.fetch("inventory"), gateway_relative
+      assert File.directory?(File.dirname(candidate.fetch("audit_gateway")))
+      refute File.exist?(candidate.fetch("audit_gateway"))
+      assert_equal result.fetch(:skill_source),
+                   File.join(candidate.fetch("root"), configuration.dig("skill", "path"))
+      assert_equal Digest::SHA256.file(
+        File.join(result.fetch(:skill_source), "projection-manifest.json")
+      ).hexdigest, configuration.dig("skill", "projection_manifest_sha256")
+      assert options.fetch(:archives).values.all? { |row| row.fetch("available_bytes").positive? }
+      assert options.fetch(:archives).values.all? { |row| row.fetch("available_entries").positive? }
+
+      observation = prepare_workspace(result, fixture)
+      assert_equal "prepared", observation.fetch("status")
+      assert_match(/\A[0-9a-f]{64}\z/, observation.fetch("openclaw_effective_policy_sha256"))
+      assert File.file?(File.join(fixture.fetch(:workspace), ".hive-openclaw/state/openclaw.sqlite"))
+      assert File.file?(File.join(fixture.fetch(:workspace), "skills/hive/SKILL.md"))
+      assert File.file?(File.join(fixture.fetch(:workspace), ".hive-state/config.yml"))
+      remotes, status = Open3.capture2(fixture.fetch(:git), "-C", fixture.fetch(:workspace), "remote")
+      assert status.success?
+      assert_empty remotes
+    end
+  end
+
+  def test_runtime_and_candidate_artifact_tamper_fail_closed
+    with_setup_fixture do |fixture|
+      result = prepare(fixture)
+      executable = result.dig(:execution_options, :candidate, "executable")
+      environment = result.dig(:execution_options, :candidate, "environment")
+      assert_equal fixture.fetch(:candidate_runtime), environment.fetch("GEM_HOME")
+      assert_equal fixture.fetch(:candidate_runtime), environment.fetch("GEM_PATH")
+      assert_equal %w[1 1 1], environment.values_at(
+        "HIVE_SKIP_LLM_WIKI_SCHEDULER", "HIVE_SKIP_LLM_WIKI_SYSTEMCTL",
+        "HIVE_SKIP_LLM_WIKI_POST_COMMIT"
+      )
+      _stdout, stderr, status = Open3.capture3(environment, executable, "version", unsetenv_others: true)
+      assert status.success?, stderr
+
+      File.open(fixture.fetch(:candidate_hive), "ab") { |file| file.write("# drift\n") }
+      _stdout, _stderr, status = Open3.capture3(environment, executable, "version", unsetenv_others: true)
+      refute status.success?
+
+      File.open(fixture.fetch(:openclaw_entrypoint), "ab") { |file| file.write("// drift\n") }
+      assert_raises(Runtime::Error) do
+        result.fetch(:runtime_install_verifier).call(
+          runtime_install: JSON.parse(File.binread(result.fetch(:configuration_record))).fetch("runtime_install"),
+          launcher_sha256: Digest::SHA256.file(result.dig(:execution_options, :openclaw, "executable")).hexdigest
+        )
+      end
+    end
+
+    with_setup_fixture do |fixture|
+      File.open(fixture.fetch(:candidate_gem), "ab") { |file| file.write("drift") }
+      assert_raises(Setup::Error) { prepare(fixture) }
+    end
+  end
+
+  def test_first_stage_fixture_is_deterministic_and_observer_is_fail_closed
+    first = second = nil
+    with_setup_fixture do |fixture|
+      result = prepare(fixture)
+      fixture_path = result.dig(:execution_options, :candidate, "environment", "HIVE_CLAUDE_BIN")
+      first = File.binread(fixture_path)
+      prepare_workspace(result, fixture)
+
+      assert_raises(Setup::Error) do
+        result.fetch(:external_actions_observer).call(
+          workspace: fixture.fetch(:workspace),
+          candidate_environment: result.dig(:execution_options, :candidate, "environment")
+        )
+      end
+
+      research = File.join(
+        fixture.fetch(:workspace), ".hive-state/stages/1-research/editorial-live-proof/research.md"
+      )
+      FileUtils.mkdir_p(File.dirname(research), mode: 0o700)
+      File.binwrite(research, "<!-- WAITING -->\n")
+      _stdout, stderr, status = Open3.capture3(
+        result.dig(:execution_options, :candidate, "environment"), fixture_path,
+        chdir: fixture.fetch(:workspace), unsetenv_others: true
+      )
+      assert status.success?, stderr
+      assert_equal({ "status" => "observed", "actions" => [] },
+                   result.fetch(:external_actions_observer).call(
+                     workspace: fixture.fetch(:workspace),
+                     candidate_environment: result.dig(:execution_options, :candidate, "environment")
+                   ))
+
+      system(fixture.fetch(:git), "-C", fixture.fetch(:workspace), "remote", "add", "origin",
+             "https://example.invalid/hive.git", exception: true)
+      assert_raises(Setup::Error) do
+        result.fetch(:external_actions_observer).call(
+          workspace: fixture.fetch(:workspace),
+          candidate_environment: result.dig(:execution_options, :candidate, "environment")
+        )
+      end
+    end
+
+    with_setup_fixture do |fixture|
+      result = prepare(fixture)
+      second = File.binread(result.dig(:execution_options, :candidate, "environment", "HIVE_CLAUDE_BIN"))
+    end
+    assert_equal first, second
+  end
+
+  def test_candidate_runtime_manifest_is_bounded_but_not_limited_to_small_value_snapshots
+    with_setup_fixture do |fixture|
+      library = File.join(fixture.fetch(:candidate_runtime), "large-fixture")
+      FileUtils.mkdir_p(library, mode: 0o700)
+      1_700.times { |index| File.binwrite(File.join(library, format("%04d.rb", index)), "# fixture\n") }
+
+      result = prepare(fixture)
+      root = result.dig(:execution_options, :candidate, "root")
+      manifest = JSON.parse(File.binread(File.join(root, "runtime/candidate-runtime-manifest.json")))
+      assert_equal 1_701, manifest.fetch("files").length
+      assert_equal "bin/hive", manifest.fetch("entrypoint")
+    end
+  end
+
+  private
+
+  def prepare(fixture)
+    Setup.prepare!(
+      candidate_dir: fixture.fetch(:candidate_dir), candidate_sha: SHA,
+      hive_version: Hive::VERSION, canonical: fixture.fetch(:canonical),
+      candidate_runtime_root: fixture.fetch(:candidate_runtime),
+      candidate_hive: fixture.fetch(:candidate_hive), ruby: RbConfig.ruby,
+      openclaw_runtime_root: fixture.fetch(:openclaw_runtime),
+      openclaw_entrypoint: fixture.fetch(:openclaw_entrypoint), node: fixture.fetch(:node),
+      openclaw_lock: fixture.fetch(:openclaw_lock), openclaw_package: fixture.fetch(:openclaw_package),
+      output_root: fixture.fetch(:output), workspace_path: fixture.fetch(:workspace),
+      bundle_directory: fixture.fetch(:bundle), model: "openrouter/openai/gpt-5.6-terra",
+      provider: "openrouter",
+      transport: {
+        "endpoint" => "https://openrouter.ai/api/v1", "proxy" => nil,
+        "ca" => nil, "redirects" => "deny"
+      },
+      correlation_id: "workflow-creator-live-setup", supervisor_options: {}
+    )
+  end
+
+  def prepare_workspace(result, fixture)
+    workspace = fixture.fetch(:workspace)
+    state = File.join(workspace, ".hive-openclaw")
+    home = File.join(state, "home")
+    bin = File.join(state, "bin")
+    FileUtils.mkdir_p([ workspace, state, home, bin ], mode: 0o700)
+    gateway = File.join(bin, "hive")
+    File.symlink(result.dig(:execution_options, :candidate, "executable"), gateway)
+    config = File.join(state, "openclaw.json")
+    File.binwrite(config, JSON.generate(
+      "agents" => { "defaults" => { "workspace" => workspace } },
+      "tools" => {
+        "allow" => %w[read write edit apply_patch exec],
+        "fs" => { "workspaceOnly" => true },
+        "exec" => { "mode" => "allowlist", "host" => "gateway" }
+      }
+    ))
+    openclaw_environment = {
+      "HOME" => home, "OPENCLAW_STATE_DIR" => state, "OPENCLAW_CONFIG_PATH" => config,
+      "PATH" => "/usr/bin:/bin", "SHELL" => "/bin/bash", "HIVE_LIVE_PROOF" => "1",
+      "OPENROUTER_API_KEY" => "must-not-reach-local-cli"
+    }
+    result.fetch(:workspace_preparer).call(
+      workspace:, candidate_environment: result.dig(:execution_options, :candidate, "environment"),
+      openclaw_environment:, gateway_path: gateway
+    )
+  end
+
+  def with_setup_fixture
+    with_tmp_dir do |root|
+      canonical = Hive::AgentSkills::CanonicalSkill.new
+      artifacts_root = File.join(root, "artifact-input")
+      candidate_dir = File.join(root, "candidate-artifacts")
+      output = File.join(root, "setup")
+      candidate_runtime = File.join(output, "candidate-runtime")
+      openclaw_runtime = File.join(output, "openclaw-runtime")
+      bundle = File.join(root, "bundle")
+      workspace = File.join(root, "workspace")
+      FileUtils.mkdir_p([ artifacts_root, candidate_runtime, openclaw_runtime, bundle ], mode: 0o700)
+      FileUtils.chmod(0o700, bundle)
+
+      candidate_gem = File.join(artifacts_root, "hive-cli-#{Hive::VERSION}.gem")
+      source = File.join(artifacts_root, "source.tar.gz")
+      File.binwrite(candidate_gem, "candidate-gem\n")
+      File.binwrite(source, "candidate-source\n")
+      HiveLiveAgentProof::Builder.new(
+        candidate_sha: SHA, gem_path: candidate_gem, source_archive: source,
+        output_dir: candidate_dir, canonical:
+      ).call
+      candidate_gem = File.join(candidate_dir, File.basename(candidate_gem))
+
+      candidate_hive = File.join(candidate_runtime, "bin/hive")
+      FileUtils.mkdir_p(File.dirname(candidate_hive), mode: 0o700)
+      File.binwrite(candidate_hive, fake_hive_source)
+      File.chmod(0o700, candidate_hive)
+
+      openclaw_entrypoint = File.join(openclaw_runtime, "node_modules/openclaw/openclaw.mjs")
+      FileUtils.mkdir_p(File.dirname(openclaw_entrypoint), mode: 0o700)
+      File.binwrite(openclaw_entrypoint, "console.log('openclaw fixture')\n")
+      node = File.join(root, "node")
+      File.binwrite(node, fake_node_source)
+      File.chmod(0o700, node)
+      openclaw_package = File.join(root, "openclaw.tgz")
+      write_tgz(openclaw_package)
+      openclaw_lock = File.join(root, "package-lock.json")
+      File.binwrite(openclaw_lock, JSON.generate(package_lock(openclaw_package)))
+      git = %w[/usr/bin/git /bin/git].find { |path| File.executable?(path) }
+
+      yield root:, canonical:, candidate_dir:, candidate_gem:, output:, candidate_runtime:,
+            candidate_hive:, openclaw_runtime:, openclaw_entrypoint:, node:, openclaw_package:,
+            openclaw_lock:, bundle:, workspace:, git:
+    end
+  end
+
+  def fake_hive_source
+    <<~'RUBY'
+      require "fileutils"
+      require "json"
+      if ARGV.first == "init"
+        workspace = File.expand_path(ARGV.fetch(1))
+        state = File.join(workspace, ".hive-state")
+        FileUtils.mkdir_p(state)
+        File.write(File.join(state, "config.yml"), "---\ndaemon:\n  enabled: false\n")
+        puts JSON.generate(
+          "schema" => "hive-init", "ok" => true, "minimal" => true,
+          "answers" => {
+            "daemon_enabled" => false, "babysitter_enabled" => false,
+            "daemon_autostart" => false, "refactor_patrol_enabled" => false,
+            "adhoc_auto_fix" => false, "patrol_mode" => "off"
+          }
+        )
+      elsif ARGV == ["version"]
+        puts "fixture-hive"
+      else
+        abort "unexpected fixture argv: #{ARGV.inspect}"
+      end
+    RUBY
+  end
+
+  def fake_node_source
+    <<~SH
+      #!/bin/sh
+      set -eu
+      if [ "\${1:-}" = "--version" ]; then
+        printf 'v#{NODE_VERSION}\\n'
+        exit 0
+      fi
+      [ -z "\${OPENROUTER_API_KEY:-}" ] || exit 80
+      shift
+      if [ "\${1:-} \${2:-}" = "config validate" ]; then
+        [ -f "$OPENCLAW_CONFIG_PATH" ]
+        printf 'Configuration valid\\n'
+      elif [ "\${1:-} \${2:-}" = "approvals set" ]; then
+        [ "\${3:-}" = "--file" ]
+        mkdir -p "$OPENCLAW_STATE_DIR/state"
+        hive_approvals=$(cat "$4")
+        printf '%s' "\${hive_approvals%?}" > "$OPENCLAW_STATE_DIR/effective-approvals.json"
+        printf ',"socket":{"path":"%s/exec-approvals.sock","token":"fixture_socket_token_1234"}}' \
+          "$OPENCLAW_STATE_DIR" >> "$OPENCLAW_STATE_DIR/effective-approvals.json"
+        : > "$OPENCLAW_STATE_DIR/state/openclaw.sqlite"
+        printf 'Writing local approvals.\\n' >&2
+        printf '{}\\n'
+      elif [ "\${1:-} \${2:-} \${3:-}" = "approvals get --json" ]; then
+        printf '{"exists":true,"file":'
+        cat "$OPENCLAW_STATE_DIR/effective-approvals.json"
+        printf '}\\n'
+      else
+        exit 81
+      fi
+    SH
+  end
+
+  def write_tgz(path)
+    Zlib::GzipWriter.open(path) do |gzip|
+      Gem::Package::TarWriter.new(gzip) do |tar|
+        bytes = "openclaw package\n"
+        tar.add_file_simple("package/openclaw.mjs", 0o644, bytes.bytesize) { |io| io.write(bytes) }
+      end
+    end
+  end
+
+  def package_lock(package)
+    integrity = "sha512-#{Base64.strict_encode64(Digest::SHA512.file(package).digest)}"
+    {
+      "name" => "hive-openclaw-proof", "lockfileVersion" => 3,
+      "packages" => {
+        "" => {
+          "dependencies" => { "openclaw" => OPENCLAW_VERSION },
+          "engines" => { "node" => NODE_VERSION }
+        },
+        "node_modules/openclaw" => {
+          "version" => OPENCLAW_VERSION,
+          "resolved" => "https://registry.npmjs.org/openclaw/-/openclaw-#{OPENCLAW_VERSION}.tgz",
+          "integrity" => integrity, "hasInstallScript" => true,
+          "engines" => { "node" => ">=22.22.3 <23" }
+        }
+      }
+    }
+  end
+end

--- a/test/unit/packaging/workflow_creator_live_setup_test.rb
+++ b/test/unit/packaging/workflow_creator_live_setup_test.rb
@@ -182,17 +182,30 @@ class WorkflowCreatorLiveSetupTest < Minitest::Test
     end
   end
 
-  def test_admits_an_immutable_root_owned_toolchain_binary
-    path = %w[/usr/bin/ruby /bin/sh].find do |candidate|
+  def test_admits_an_immutable_runner_or_root_owned_toolchain_binary
+    path = [ File.realpath(RbConfig.ruby), "/usr/bin/ruby", "/bin/sh" ].find do |candidate|
       stat = File.lstat(candidate)
-      stat.file? && !stat.symlink? && stat.uid.zero? && (stat.mode & 0o022).zero?
+      trusted_owner = stat.uid == Process.uid || stat.uid.zero?
+      stat.file? && !stat.symlink? && trusted_owner && stat.nlink == 1 &&
+        (stat.mode & 0o022).zero?
     rescue SystemCallError
       false
     end
-    skip "no immutable root-owned toolchain binary is available" unless path
+    skip "no immutable runner- or root-owned toolchain binary is available" unless path
 
     bytes = Setup.allocate.send(:safe_file, path, 268_435_456)
     assert_equal File.binread(path), bytes
+  end
+
+  def test_fixture_seals_inputs_under_a_group_writable_ambient_umask
+    previous_umask = File.umask(0o002)
+    with_setup_fixture do |fixture|
+      result = prepare(fixture)
+
+      assert_equal SHA, result.fetch(:candidate_sha)
+    end
+  ensure
+    File.umask(previous_umask) if previous_umask
   end
 
   private
@@ -246,6 +259,7 @@ class WorkflowCreatorLiveSetupTest < Minitest::Test
   end
 
   def with_setup_fixture
+    previous_umask = File.umask(0o077)
     with_tmp_dir do |root|
       canonical = Hive::AgentSkills::CanonicalSkill.new
       artifacts_root = File.join(root, "artifact-input")
@@ -289,6 +303,8 @@ class WorkflowCreatorLiveSetupTest < Minitest::Test
             candidate_hive:, openclaw_runtime:, openclaw_entrypoint:, node:, openclaw_package:,
             openclaw_lock:, bundle:, workspace:, git:
     end
+  ensure
+    File.umask(previous_umask) if previous_umask
   end
 
   def fake_hive_source

--- a/test/unit/packaging/workflow_creator_live_setup_test.rb
+++ b/test/unit/packaging/workflow_creator_live_setup_test.rb
@@ -51,6 +51,7 @@ class WorkflowCreatorLiveSetupTest < Minitest::Test
       assert File.file?(File.join(fixture.fetch(:workspace), ".hive-state/config.yml"))
       assert File.file?(File.join(fixture.fetch(:workspace), ".git"))
       assert File.directory?(File.join(control, "git"))
+      refute File.exist?(File.join(control, "git/hooks/post-commit"))
       candidate_environment = options.dig(:candidate, "environment")
       refute candidate_environment.fetch("HOME").start_with?("#{fixture.fetch(:workspace)}/")
       refute candidate_environment.fetch("HIVE_HOME").start_with?("#{fixture.fetch(:workspace)}/")
@@ -175,9 +176,15 @@ class WorkflowCreatorLiveSetupTest < Minitest::Test
     end
   end
 
+  def test_rejects_a_correlation_identity_the_process_supervisor_cannot_admit
+    with_setup_fixture do |fixture|
+      assert_raises(Setup::Error) { prepare(fixture, correlation_id: "workflow-creator:invalid") }
+    end
+  end
+
   private
 
-  def prepare(fixture)
+  def prepare(fixture, correlation_id: "workflow-creator-live-setup")
     Setup.prepare!(
       candidate_dir: fixture.fetch(:candidate_dir), candidate_sha: SHA,
       hive_version: Hive::VERSION, canonical: fixture.fetch(:canonical),
@@ -193,7 +200,7 @@ class WorkflowCreatorLiveSetupTest < Minitest::Test
         "endpoint" => "https://openrouter.ai/api/v1", "proxy" => nil,
         "ca" => nil, "redirects" => "deny"
       },
-      correlation_id: "workflow-creator-live-setup", supervisor_options: {}
+      correlation_id:, supervisor_options: {}
     )
   end
 
@@ -277,6 +284,16 @@ class WorkflowCreatorLiveSetupTest < Minitest::Test
       require "json"
       if ARGV.first == "init"
         workspace = File.expand_path(ARGV.fetch(1))
+        abort "init requires the main checkout" unless File.directory?(File.join(workspace, ".git"))
+        hook = File.join(workspace, ".git", "hooks", "post-commit")
+        File.write(hook, <<~HOOK)
+          #!/usr/bin/env bash
+
+          # BEGIN LLM WIKI POST-COMMIT
+          exit 0
+          # END LLM WIKI POST-COMMIT
+        HOOK
+        File.chmod(0o755, hook)
         state = File.join(workspace, ".hive-state")
         FileUtils.mkdir_p(state)
         File.write(File.join(state, "config.yml"), "---\ndaemon:\n  enabled: false\n")

--- a/test/unit/packaging/workflow_creator_live_setup_test.rb
+++ b/test/unit/packaging/workflow_creator_live_setup_test.rb
@@ -182,6 +182,19 @@ class WorkflowCreatorLiveSetupTest < Minitest::Test
     end
   end
 
+  def test_admits_an_immutable_root_owned_toolchain_binary
+    path = %w[/usr/bin/ruby /bin/sh].find do |candidate|
+      stat = File.lstat(candidate)
+      stat.file? && !stat.symlink? && stat.uid.zero? && (stat.mode & 0o022).zero?
+    rescue SystemCallError
+      false
+    end
+    skip "no immutable root-owned toolchain binary is available" unless path
+
+    bytes = Setup.allocate.send(:safe_file, path, 268_435_456)
+    assert_equal File.binread(path), bytes
+  end
+
   private
 
   def prepare(fixture, correlation_id: "workflow-creator-live-setup")

--- a/test/unit/packaging/workflow_creator_live_setup_test.rb
+++ b/test/unit/packaging/workflow_creator_live_setup_test.rb
@@ -197,11 +197,15 @@ class WorkflowCreatorLiveSetupTest < Minitest::Test
     assert_equal File.binread(path), bytes
   end
 
-  def test_fixture_seals_inputs_under_a_group_writable_ambient_umask
+  def test_fixture_normalizes_host_toolchain_ownership_and_ambient_umask
     previous_umask = File.umask(0o002)
     with_setup_fixture do |fixture|
+      ruby = File.lstat(fixture.fetch(:ruby))
       result = prepare(fixture)
 
+      assert_equal Process.uid, ruby.uid
+      assert_equal 1, ruby.nlink
+      assert_equal 0, ruby.mode & 0o022
       assert_equal SHA, result.fetch(:candidate_sha)
     end
   ensure
@@ -215,7 +219,7 @@ class WorkflowCreatorLiveSetupTest < Minitest::Test
       candidate_dir: fixture.fetch(:candidate_dir), candidate_sha: SHA,
       hive_version: Hive::VERSION, canonical: fixture.fetch(:canonical),
       candidate_runtime_root: fixture.fetch(:candidate_runtime),
-      candidate_hive: fixture.fetch(:candidate_hive), ruby: RbConfig.ruby,
+      candidate_hive: fixture.fetch(:candidate_hive), ruby: fixture.fetch(:ruby),
       openclaw_runtime_root: fixture.fetch(:openclaw_runtime),
       openclaw_entrypoint: fixture.fetch(:openclaw_entrypoint), node: fixture.fetch(:node),
       openclaw_lock: fixture.fetch(:openclaw_lock), openclaw_package: fixture.fetch(:openclaw_package),
@@ -272,6 +276,10 @@ class WorkflowCreatorLiveSetupTest < Minitest::Test
       FileUtils.mkdir_p([ artifacts_root, candidate_runtime, openclaw_runtime, bundle ], mode: 0o700)
       FileUtils.chmod(0o700, bundle)
 
+      ruby = File.join(artifacts_root, "ruby")
+      FileUtils.copy_file(File.realpath(RbConfig.ruby), ruby)
+      File.chmod(0o700, ruby)
+
       candidate_gem = File.join(artifacts_root, "hive-cli-#{Hive::VERSION}.gem")
       source = File.join(artifacts_root, "source.tar.gz")
       File.binwrite(candidate_gem, "candidate-gem\n")
@@ -299,7 +307,7 @@ class WorkflowCreatorLiveSetupTest < Minitest::Test
       File.binwrite(openclaw_lock, JSON.generate(package_lock(openclaw_package)))
       git = %w[/usr/bin/git /bin/git].find { |path| File.executable?(path) }
 
-      yield root:, canonical:, candidate_dir:, candidate_gem:, output:, candidate_runtime:,
+      yield root:, canonical:, candidate_dir:, candidate_gem:, output:, candidate_runtime:, ruby:,
             candidate_hive:, openclaw_runtime:, openclaw_entrypoint:, node:, openclaw_package:,
             openclaw_lock:, bundle:, workspace:, git:
     end

--- a/test/unit/packaging/workflow_creator_live_setup_test.rb
+++ b/test/unit/packaging/workflow_creator_live_setup_test.rb
@@ -44,12 +44,39 @@ class WorkflowCreatorLiveSetupTest < Minitest::Test
       observation = prepare_workspace(result, fixture)
       assert_equal "prepared", observation.fetch("status")
       assert_match(/\A[0-9a-f]{64}\z/, observation.fetch("openclaw_effective_policy_sha256"))
-      assert File.file?(File.join(fixture.fetch(:workspace), ".hive-openclaw/state/openclaw.sqlite"))
+      assert_equal "openclaw-skills-info", observation.dig("native_activation", "kind")
+      control = options.fetch(:control_root)
+      assert File.file?(File.join(control, "openclaw/state/openclaw.sqlite"))
       assert File.file?(File.join(fixture.fetch(:workspace), "skills/hive/SKILL.md"))
       assert File.file?(File.join(fixture.fetch(:workspace), ".hive-state/config.yml"))
+      assert File.file?(File.join(fixture.fetch(:workspace), ".git"))
+      assert File.directory?(File.join(control, "git"))
+      candidate_environment = options.dig(:candidate, "environment")
+      refute candidate_environment.fetch("HOME").start_with?("#{fixture.fetch(:workspace)}/")
+      refute candidate_environment.fetch("HIVE_HOME").start_with?("#{fixture.fetch(:workspace)}/")
+      assert result.fetch(:workspace_preparer).verify_control_plane!
       remotes, status = Open3.capture2(fixture.fetch(:git), "-C", fixture.fetch(:workspace), "remote")
       assert status.success?
       assert_empty remotes
+    end
+  end
+
+  def test_model_writable_git_skill_and_openclaw_control_tamper_fail_closed
+    with_setup_fixture do |fixture|
+      result = prepare(fixture)
+      prepare_workspace(result, fixture)
+      File.binwrite(File.join(fixture.fetch(:workspace), ".git"), "gitdir: /tmp/attacker\n")
+
+      assert_raises(Setup::Error) { result.fetch(:workspace_preparer).verify_command_boundary! }
+    end
+
+    with_setup_fixture do |fixture|
+      result = prepare(fixture)
+      prepare_workspace(result, fixture)
+      config = File.join(result.dig(:execution_options, :control_root), "openclaw/openclaw.json")
+      File.open(config, "ab") { |file| file.write("drift") }
+
+      assert_raises(Setup::Error) { result.fetch(:workspace_preparer).verify_control_plane! }
     end
   end
 
@@ -172,7 +199,7 @@ class WorkflowCreatorLiveSetupTest < Minitest::Test
 
   def prepare_workspace(result, fixture)
     workspace = fixture.fetch(:workspace)
-    state = File.join(workspace, ".hive-openclaw")
+    state = File.join(result.dig(:execution_options, :control_root), "openclaw")
     home = File.join(state, "home")
     bin = File.join(state, "bin")
     FileUtils.mkdir_p([ workspace, state, home, bin ], mode: 0o700)
@@ -296,6 +323,8 @@ class WorkflowCreatorLiveSetupTest < Minitest::Test
         printf '{"exists":true,"file":'
         cat "$OPENCLAW_STATE_DIR/effective-approvals.json"
         printf '}\\n'
+      elif [ "\${1:-} \${2:-} \${3:-} \${4:-}" = "skills info hive --json" ]; then
+        printf '{"name":"hive","eligible":true,"userInvocable":true,"filePath":"%s/skills/hive/SKILL.md"}\\n' "$PWD"
       else
         exit 81
       fi

--- a/test/unit/packaging/workflow_creator_openclaw_runtime_test.rb
+++ b/test/unit/packaging/workflow_creator_openclaw_runtime_test.rb
@@ -1,0 +1,73 @@
+require "test_helper"
+require "digest"
+require_relative "../../../packaging/live_agent_skills/workflow_creator_openclaw_runtime"
+
+class WorkflowCreatorOpenClawRuntimeTest < Minitest::Test
+  include HiveTestHelper
+
+  Runtime = HiveLiveAgentProof::WorkflowCreatorOpenClawRuntime
+  LAUNCHER_SHA256 = Digest::SHA256.hexdigest("launcher")
+
+  def test_captures_and_reverifies_a_regular_owned_runtime_tree
+    with_runtime do |root|
+      seal = Runtime.capture!(root:, launcher_sha256: LAUNCHER_SHA256)
+
+      assert_equal Runtime::SCHEMA, seal.value.fetch("schema")
+      assert_equal 3, seal.value.fetch("file_count")
+      assert_equal 4, seal.value.fetch("directory_count")
+      assert_equal seal.value,
+                   Runtime.verify!(runtime_install: seal.value, launcher_sha256: LAUNCHER_SHA256)
+    end
+  end
+
+  def test_file_or_symlink_drift_fails_closed
+    with_runtime do |root|
+      seal = Runtime.capture!(root:, launcher_sha256: LAUNCHER_SHA256)
+      File.binwrite(File.join(root, "node_modules", "openclaw", "entry.js"), "changed\n")
+
+      assert_raises(Runtime::Error) do
+        Runtime.verify!(runtime_install: seal.value, launcher_sha256: LAUNCHER_SHA256)
+      end
+    end
+
+    with_runtime do |root|
+      seal = Runtime.capture!(root:, launcher_sha256: LAUNCHER_SHA256)
+      link = File.join(root, "node_modules", ".bin", "openclaw")
+      File.unlink(link)
+      File.symlink("../openclaw/other.js", link)
+
+      assert_raises(Runtime::Error) do
+        Runtime.verify!(runtime_install: seal.value, launcher_sha256: LAUNCHER_SHA256)
+      end
+    end
+  end
+
+  def test_escaping_symlink_and_writable_tree_are_rejected
+    with_tmp_dir do |root|
+      File.symlink("/tmp", File.join(root, "escape"))
+      assert_raises(Runtime::Error) { Runtime.capture!(root:, launcher_sha256: LAUNCHER_SHA256) }
+    end
+
+    with_runtime do |root|
+      directory = File.join(root, "node_modules")
+      File.chmod(0o777, directory)
+      assert_raises(Runtime::Error) { Runtime.capture!(root:, launcher_sha256: LAUNCHER_SHA256) }
+    ensure
+      File.chmod(0o700, directory) if directory && File.exist?(directory)
+    end
+  end
+
+  private
+
+  def with_runtime
+    with_tmp_dir do |root|
+      package = File.join(root, "node_modules", "openclaw")
+      bin = File.join(root, "node_modules", ".bin")
+      FileUtils.mkdir_p([ package, bin ], mode: 0o700)
+      File.binwrite(File.join(package, "entry.js"), "entry\n")
+      File.binwrite(File.join(package, "other.js"), "other\n")
+      File.symlink("../openclaw/entry.js", File.join(bin, "openclaw"))
+      yield root
+    end
+  end
+end

--- a/test/unit/release_contract_test.rb
+++ b/test/unit/release_contract_test.rb
@@ -103,6 +103,7 @@ class ReleaseContractTest < Minitest::Test
     assert_includes body, "workflow_dispatch:"
     assert_includes body, "candidate_sha:"
     assert_includes body, '[[ "$GITHUB_REF" == "refs/heads/main" ]]'
+    assert_includes body, '[[ "$GITHUB_ACTOR" == "$AUTHORIZED_DISPATCH_ACTOR" ]]'
     assert_includes body, "git merge-base --is-ancestor"
     assert_equal({ "node-version" => "22" }, setup_node.fetch("with"))
     assert_includes body, "branches/main"
@@ -157,6 +158,55 @@ class ReleaseContractTest < Minitest::Test
     assert_includes creator_step.fetch("run"), 'install -d -m 0700 "$RUNNER_TEMP/workflow-creator-evidence"'
     assert_includes body, "workflow-creator-evidence-openclaw"
     assert_includes body, "creator-evidence"
+  end
+
+  def test_live_workflow_creator_has_one_pinned_credential_and_evidence_boundary
+    workflow = YAML.safe_load_file(LIVE_AGENT_WORKFLOW, aliases: true)
+    jobs = workflow.fetch("jobs")
+    creator = jobs.fetch("live-workflow-creator")
+    steps = creator.fetch("steps")
+
+    assert_equal({ "actions" => "read", "contents" => "read" }, creator.fetch("permissions"))
+    steps.filter_map { |step| step["uses"] }.each do |action|
+      assert_match(/@[0-9a-f]{40}\z/, action, "#{action} must be full-SHA pinned")
+    end
+
+    checkout = steps.find { |step| step.fetch("uses", "").start_with?("actions/checkout@") }
+    refute_nil checkout
+    assert_equal false, checkout.dig("with", "persist-credentials")
+    initialize_step = steps.find { |step| step["name"] == "Initialize typed workflow-creator evidence" }
+    download_step = steps.find { |step| step["name"] == "Download exact candidate artifacts" }
+    install_step = steps.find { |step| step["name"] == "Install locked OpenClaw and exact candidate" }
+    run_step = steps.find { |step| step["name"] == "Run authenticated workflow-creator proof" }
+    upload_step = steps.find { |step| step["name"] == "Upload redacted workflow-creator evidence" }
+    [ initialize_step, download_step, install_step, run_step, upload_step ].each { |step| refute_nil step }
+    assert_operator steps.index(initialize_step), :<, steps.index(download_step)
+    creator_node = steps.find { |step| step.fetch("uses", "") == SETUP_NODE_ACTION }
+    assert_equal({ "node-version" => "22.23.1" }, creator_node.fetch("with"))
+    assert_includes install_step.fetch("run"), "npm ci --ignore-scripts"
+    assert_includes install_step.fetch("run"), "npm audit --omit=dev"
+    assert_includes install_step.fetch("run"), 'npm pack "openclaw@$openclaw_version" --ignore-scripts'
+    assert_includes install_step.fetch("run"), "HIVE_PROVEN_HIVE_BIN=\$candidate_runtime/rubygems-bin/hive"
+    assert_includes install_step.fetch("run"), 'HIVE_NODE_BIN=$(realpath "$(command -v node)")'
+    assert_equal "${{ always() }}", upload_step.fetch("if")
+    assert_match(%r{workflow-creator-evidence/?\z}, upload_step.dig("with", "path"))
+
+    provider_keys = %w[OPENAI_API_KEY OPENROUTER_API_KEY]
+    credential_steps = steps.select do |step|
+      (step.fetch("env", {}).keys & provider_keys).any?
+    end
+    assert_equal [ run_step ], credential_steps
+    assert_equal provider_keys, run_step.fetch("env").keys.grep(/API_KEY\z/).sort
+    %w[GH_TOKEN GITHUB_TOKEN GIT_ASKPASS SSH_AUTH_SOCK].each do |name|
+      refute run_step.fetch("env").key?(name)
+    end
+
+    steps.filter_map { |step| step["run"] }.each do |script|
+      refute_match(/\$\{\{\s*(?:inputs|github\.event)\./, script)
+    end
+    assert_equal "${{ github.repository_owner }}",
+                 jobs.fetch("validate").fetch("steps").find { |step| step["id"] == "candidate" }
+                     .dig("env", "AUTHORIZED_DISPATCH_ACTOR")
   end
 
   def test_tag_release_selects_and_reverifies_exact_pre_tag_candidate

--- a/test/unit/release_contract_test.rb
+++ b/test/unit/release_contract_test.rb
@@ -104,6 +104,8 @@ class ReleaseContractTest < Minitest::Test
     assert_includes body, "candidate_sha:"
     assert_includes body, '[[ "$GITHUB_REF" == "refs/heads/main" ]]'
     assert_includes body, '[[ "$GITHUB_ACTOR" == "$AUTHORIZED_DISPATCH_ACTOR" ]]'
+    assert_includes body, '[[ "$GITHUB_TRIGGERING_ACTOR" == "$AUTHORIZED_DISPATCH_ACTOR" ]]'
+    assert_includes body, '[[ "$GITHUB_RUN_ATTEMPT" == "1" ]]'
     assert_includes body, "git merge-base --is-ancestor"
     assert_equal({ "node-version" => "22" }, setup_node.fetch("with"))
     assert_includes body, "branches/main"
@@ -178,8 +180,13 @@ class ReleaseContractTest < Minitest::Test
     download_step = steps.find { |step| step["name"] == "Download exact candidate artifacts" }
     install_step = steps.find { |step| step["name"] == "Install locked OpenClaw and exact candidate" }
     run_step = steps.find { |step| step["name"] == "Run authenticated workflow-creator proof" }
+    finalizer_step = steps.find do |step|
+      step["name"] == "Finalize workflow-creator bootstrap failure evidence"
+    end
     upload_step = steps.find { |step| step["name"] == "Upload redacted workflow-creator evidence" }
-    [ initialize_step, download_step, install_step, run_step, upload_step ].each { |step| refute_nil step }
+    [ initialize_step, download_step, install_step, run_step, finalizer_step, upload_step ].each do |step|
+      refute_nil step
+    end
     assert_operator steps.index(initialize_step), :<, steps.index(download_step)
     creator_node = steps.find { |step| step.fetch("uses", "") == SETUP_NODE_ACTION }
     assert_equal({ "node-version" => "22.23.1" }, creator_node.fetch("with"))
@@ -189,6 +196,10 @@ class ReleaseContractTest < Minitest::Test
     assert_includes install_step.fetch("run"), "HIVE_PROVEN_HIVE_BIN=\$candidate_runtime/rubygems-bin/hive"
     assert_includes install_step.fetch("run"), 'HIVE_NODE_BIN=$(realpath "$(command -v node)")'
     assert_equal "${{ always() }}", upload_step.fetch("if")
+    assert_equal "${{ failure() }}", finalizer_step.fetch("if")
+    assert_includes finalizer_step.fetch("run"), "workflow_creator_live_runner.rb finalize-bootstrap"
+    assert_operator steps.index(run_step), :<, steps.index(finalizer_step)
+    assert_operator steps.index(finalizer_step), :<, steps.index(upload_step)
     assert_match(%r{workflow-creator-evidence/?\z}, upload_step.dig("with", "path"))
 
     provider_keys = %w[OPENAI_API_KEY OPENROUTER_API_KEY]
@@ -207,6 +218,14 @@ class ReleaseContractTest < Minitest::Test
     assert_equal "${{ github.repository_owner }}",
                  jobs.fetch("validate").fetch("steps").find { |step| step["id"] == "candidate" }
                      .dig("env", "AUTHORIZED_DISPATCH_ACTOR")
+    %w[live-agent live-workflow-creator].each do |job_name|
+      authorization = jobs.fetch(job_name).fetch("steps").find do |step|
+        step["name"] == "Revalidate live-proof authorization"
+      end
+      refute_nil authorization
+      assert_includes authorization.fetch("run"), "GITHUB_TRIGGERING_ACTOR"
+      assert_includes authorization.fetch("run"), "GITHUB_RUN_ATTEMPT"
+    end
   end
 
   def test_tag_release_selects_and_reverifies_exact_pre_tag_candidate

--- a/wiki/component-boundaries.md
+++ b/wiki/component-boundaries.md
@@ -21,7 +21,8 @@ the first and primary consumer.
 | Attempts admission / future RunReceipt | `candidate` (guarded reference) | `require "hive/attempts/api"` → `Hive::Attempts::API` | [[modules/attempts]] |
 | Workflow Creator Values | `boundary-ready` | `require "./packaging/live_agent_skills/workflow_creator_text_safety"` → `HiveLiveAgentProof::WorkflowCreator::TextSafety` | [[component-boundaries]] |
 | Workflow Creator | `boundary-ready` | `require "./packaging/live_agent_skills/workflow_creator_evidence"` → `HiveLiveAgentProof::WorkflowCreatorEvidence` | [[component-boundaries]] |
-| Workflow Creator Execution | `boundary-ready` (deterministic U14 substrate; U15 live orchestration pending) | `require "./packaging/live_agent_skills/workflow_creator_execution"` → `HiveLiveAgentProof::WorkflowCreatorExecution` | [[component-boundaries]] |
+| Workflow Creator Execution | `boundary-ready` (deterministic U14 substrate) | `require "./packaging/live_agent_skills/workflow_creator_execution"` → `HiveLiveAgentProof::WorkflowCreatorExecution` | [[component-boundaries]] |
+| Workflow Creator Live Orchestration | `boundary-ready` (U15 runner; authenticated exact-head proof remains optional and authorization-gated) | `require "./packaging/live_agent_skills/workflow_creator_live_setup"` → `HiveLiveAgentProof::WorkflowCreatorLiveSetup` | [[component-boundaries]] |
 | UserService | `boundary-ready` | `require "hive/user_service"` → `Hive::UserService` | [[modules/user_service]] |
 | Agent ABI | `boundary-ready`; standalone package candidate | `require "hive/agent_runtime"` → `Hive::AgentRuntime` | [[modules/agent_cli_runtime]], [[modules/agent_profile]] |
 | Agent Artifact Firewall | `boundary-ready` | `require "hive/artifact_firewall"` → `Hive::ArtifactFirewall` | [[modules/protected_files]] |
@@ -37,23 +38,25 @@ has earned a gem, version, repository, or release.
 
 ## Final graph audit
 
-The catalog on 2026-08-04 retains eleven components: nine are
+The catalog on 2026-08-04 retains twelve components: ten are
 `boundary-ready`; Attempts and Patrol Effect Evidence remain `candidate`.
 Patrol retains one bounded U3 exception for deterministic public-path and
 independently authorized installed/live proof. Workflow Creator is composed
-through its U1b typed publication facade, and Workflow Creator Execution adds
-the stable deterministic U14 custody seam below still-pending U15 authenticated
-orchestration.
+through its U1b typed publication facade, Workflow Creator Execution supplies
+the stable deterministic U14 custody seam, and Workflow Creator Live
+Orchestration owns the U15 provider/setup/evidence sequence above it.
 Every retained entry point has focused clean-process load proof, every
 catalog-owned path and focused test resolves inside this repository, and the
 direct-construction guards pass against all production Ruby sources.
 
-The component dependency graph has three edges:
+The component dependency graph has five edges:
 
 ```mermaid
 flowchart LR
   skillpack[Skillpack] --> agent_abi[Agent ABI]
   workflow_execution[Workflow Creator Execution] --> workflow_core[Workflow Creator]
+  workflow_live[Workflow Creator Live Orchestration] --> workflow_execution
+  workflow_live --> workflow_core
   workflow_core[Workflow Creator] --> workflow_values[Workflow Creator Values]
   patrol_effects[Patrol Effect Evidence - candidate]
   attempts[Attempts admission - candidate]
@@ -296,9 +299,10 @@ the nine Vocabulary command positions through its fixed local gateway, launch
 the two fixed outer labels only with their vocabulary-bound prompts, capture
 bounded redacted output, supervise teardown, publish the three support members,
 and remove only the workspace whose current device/inode still matches its
-creation row. The wrapper stays inside the stable candidate closure while its
-private socket lives in the proof workspace; permanent gateway poison admits no
-later command. Final rescans must match the pre-launch installation snapshots.
+creation row. The owner-executable wrapper stays inside the stable private
+candidate closure while its private socket lives in the proof workspace;
+permanent gateway poison admits no later command. Final rescans must match the
+pre-launch installation snapshots.
 It cannot choose or expose a
 provider, model, credential, installed version, workflow policy, primary-receipt
 writer, or passing/live classification.
@@ -310,9 +314,20 @@ TERM/KILL escalation, output drain, descendant reaping, and one teardown receipt
 per launch. It does not claim survival after an external actor SIGKILLs that
 trusted custody root itself, and coherent arbitrary same-UID compromise remains
 outside the contract. Boundary readiness therefore means the deterministic U14
-substrate is stable; U15 still must supply authenticated provider/credential
-routing, live orchestration, and translation of a completed run into a passing
-proof claim.
+substrate is stable; it does not itself claim an authenticated provider run.
+
+`WorkflowCreatorLiveSetup` is the U15 composition entry point. It admits the
+exact candidate artifacts and installed candidate/OpenClaw runtimes, creates
+small immutable identity closures, projects the exact candidate `/hive` skill,
+prepares one private initialized project, installs and reads back the exact
+SQLite-backed OpenClaw execution policy, and returns only closed runner
+callables. `WorkflowCreatorLiveRunner` selects the provider from the committed
+model prefix, exposes exactly the selected credential to the two U14-supervised
+OpenClaw launches, strips provider and repository authority from tool children,
+observes the exact authored graph/task/fixture effects, and finalizes the U1b
+primary receipt. The workflow and smoke remain adapters. An authenticated
+passing artifact is still exact-head and explicit-authorization evidence; the
+catalog row does not make that optional network proof a normal CI gate.
 
 The `Agent ABI` is boundary-ready below orchestration. `AgentRuntime` exposes
 immutable request, compiled invocation, capability/probe evidence, and

--- a/wiki/component-boundaries.md
+++ b/wiki/component-boundaries.md
@@ -332,6 +332,9 @@ socket stays in the owner-private workspace parent; the model sees only the
 disposable worktree.
 Exact Git, skill, config, and approval identities are
 rechecked at every candidate command and around both model loops.
+Setup accepts immutable external toolchain files owned only by the current
+runner or root; copied identity members are always recreated under the runner's
+private closure.
 `WorkflowCreatorLiveRunner` selects the provider from the committed model
 prefix, exposes exactly the selected credential to the two U14-supervised
 OpenClaw launches, strips provider and repository authority from tool children,

--- a/wiki/component-boundaries.md
+++ b/wiki/component-boundaries.md
@@ -300,7 +300,8 @@ the two fixed outer labels only with their vocabulary-bound prompts, capture
 bounded redacted output, supervise teardown, publish the three support members,
 and remove only the workspace whose current device/inode still matches its
 creation row. The owner-executable wrapper stays inside the stable private
-candidate closure while its private socket lives in the proof workspace;
+candidate closure while its private socket lives in the owner-private parent
+outside the model workspace;
 permanent gateway poison admits no later command. Final rescans must match the
 pre-launch installation snapshots.
 It cannot choose or expose a
@@ -321,11 +322,17 @@ exact candidate artifacts and installed candidate/OpenClaw runtimes, creates
 small immutable identity closures, projects the exact candidate `/hive` skill,
 prepares one private initialized project, installs and reads back the exact
 SQLite-backed OpenClaw execution policy, and returns only closed runner
-callables. `WorkflowCreatorLiveRunner` selects the provider from the committed
-model prefix, exposes exactly the selected credential to the two U14-supervised
+callables. Candidate homes, the separate Git directory, OpenClaw state/config,
+and approvals stay in that control root, while U14's socket stays in the
+owner-private workspace parent; the model sees only the disposable worktree.
+Exact Git, skill, config, and approval identities are
+rechecked at every candidate command and around both model loops.
+`WorkflowCreatorLiveRunner` selects the provider from the committed model
+prefix, exposes exactly the selected credential to the two U14-supervised
 OpenClaw launches, strips provider and repository authority from tool children,
-observes the exact authored graph/task/fixture effects, and finalizes the U1b
-primary receipt. The workflow and smoke remain adapters. An authenticated
+requires real `openclaw skills info hive --json` discovery and the exact final
+operational task row, observes the authored graph/task/fixture effects, and
+finalizes the U1b primary receipt. The workflow and smoke remain adapters. An authenticated
 passing artifact is still exact-head and explicit-authorization evidence; the
 catalog row does not make that optional network proof a normal CI gate.
 

--- a/wiki/component-boundaries.md
+++ b/wiki/component-boundaries.md
@@ -322,9 +322,14 @@ exact candidate artifacts and installed candidate/OpenClaw runtimes, creates
 small immutable identity closures, projects the exact candidate `/hive` skill,
 prepares one private initialized project, installs and reads back the exact
 SQLite-backed OpenClaw execution policy, and returns only closed runner
-callables. Candidate homes, the separate Git directory, OpenClaw state/config,
-and approvals stay in that control root, while U14's socket stays in the
-owner-private workspace parent; the model sees only the disposable worktree.
+callables. Hive initialization runs against an ordinary main checkout, then
+setup atomically relocates its Git directory into the control root and leaves
+only Git's pointer file behind. It removes the otherwise active managed LLM-wiki
+post-commit hook before relocation because the bounded proof does not run wiki
+refreshes. Candidate homes, that separate Git directory,
+OpenClaw state/config, and approvals stay in the control root, while U14's
+socket stays in the owner-private workspace parent; the model sees only the
+disposable worktree.
 Exact Git, skill, config, and approval identities are
 rechecked at every candidate command and around both model loops.
 `WorkflowCreatorLiveRunner` selects the provider from the committed model

--- a/wiki/gaps.md
+++ b/wiki/gaps.md
@@ -863,13 +863,14 @@ not produce a trusted live attestation. Keep this gap open until the dedicated
 `live-workflow-creator` job succeeds for an exact protected-main candidate and
 the resulting Check Run binds the prompt, candidate skill digest, ordered Hive
 commands, exact editorial graph, zero task count, secret scan, and cleanup.
-U1b now owns crash-safe publication of the fixed primary receipt, but its
-temporary protected-smoke adapter intentionally records
-`u14_execution_custody_unavailable` rather than turning successful model output
-into a live-success claim. U14 now supplies the deterministic installed,
-archive, gateway, capture, process-custody, and fixed-support-publication
-substrate, but U15 must still route credentials/providers, orchestrate the
-authenticated run, and own the final passing translation.
+U1b owns crash-safe publication of the fixed primary receipt and U14 supplies
+the deterministic installed, archive, gateway, capture, process-custody, and
+fixed-support-publication substrate. U15 now owns exact dependency/setup
+admission, selected-provider credential routing, OpenClaw policy readback, the
+two authenticated outer loops, independent task/effect observation, and final
+passing translation. This gap remains open only until that runner produces a
+successful explicitly authorized artifact on the unchanged exact head; offline
+and hosted non-network tests do not substitute for that evidence.
 The same proof must also attest one explicitly authorized task, one first-stage
 run, a no-op retry with the same idempotency key, and matching operational
 status.
@@ -1021,14 +1022,15 @@ on every channel, run one disposable installed upgrade for brew, AUR, and bash
 and retain the updater plus migration output. This gap does not weaken the
 local command contract or its deterministic tests.
 
-## Live Workflow Creator still needs complete bundle production (2026-08-04)
+## Live Workflow Creator still needs authorized exact-head evidence (2026-08-04)
 
 U1a2 makes the incumbent attestor and verifier require, retain, and
 independently revalidate the exact four-file Workflow Creator bundle. U1b owns
 the primary receipt, and U14 adds a boundary-ready deterministic substrate that
-can publish only the two installation manifests and execution receipt. The
-protected live workflow still lacks U15 authenticated orchestration, so no
-provider-backed result may be upgraded to a passing claim. The old one-file
-shape remains rejected; U14 introduces no compatibility reader. No
-provider-backed run, publication, or release qualification was performed here;
-hostile/property campaigns remain optional and outside the normal merge gate.
+can publish only the two installation manifests and execution receipt. U15 now
+composes the authenticated OpenClaw run, exact task/effect observations, U1b
+primary publication, and U14 finalization into that four-file bundle. The old
+one-file shape remains rejected and no compatibility reader exists. No
+provider-backed exact-head run, publication, or release qualification was
+performed here; hostile/property campaigns remain optional and outside the
+normal merge gate.

--- a/wiki/gaps.md
+++ b/wiki/gaps.md
@@ -1029,7 +1029,9 @@ independently revalidate the exact four-file Workflow Creator bundle. U1b owns
 the primary receipt, and U14 adds a boundary-ready deterministic substrate that
 can publish only the two installation manifests and execution receipt. U15 now
 composes the authenticated OpenClaw run, exact task/effect observations, U1b
-primary publication, and U14 finalization into that four-file bundle. The old
+primary publication, retained native skill discovery, exact operational task
+binding, external control-root revalidation, and U14 finalization into that
+four-file bundle. The old
 one-file shape remains rejected and no compatibility reader exists. No
 provider-backed exact-head run, publication, or release qualification was
 performed here; hostile/property campaigns remain optional and outside the

--- a/wiki/log.d/20260804T220000Z-workflow-creator-live-orchestration.md
+++ b/wiki/log.d/20260804T220000Z-workflow-creator-live-orchestration.md
@@ -1,0 +1,32 @@
+## 2026-08-04 — Workflow Creator live orchestration boundary
+
+**Change:** Added the U15 `WorkflowCreatorLiveSetup` and
+`WorkflowCreatorLiveRunner` boundary above U14. Setup admits exact candidate and
+OpenClaw artifacts, immutable installed runtimes, the candidate `/hive`
+projection, one private initialized workspace, and the effective SQLite-backed
+OpenClaw execution policy. The runner owns selected-provider credential routing,
+the two vocabulary-fixed OpenClaw model loops, observed graph/task/effect truth,
+and U1b primary finalization.
+
+**Security:** Only the credential selected by the exact model prefix reaches the
+outer OpenClaw processes. The configured shell strips both provider credentials
+and GitHub/Git/SSH authority before model-invoked tools, and U14 remains the sole
+gateway and process-custody owner. Dependency, transport, runtime, policy, and
+workspace drift fail with typed non-passing evidence.
+
+**Workflow:** The smoke and GitHub workflow are thin adapters. The committed
+`openclaw@2026.7.2-beta.7` / Node `22.23.1` lock is installed with lifecycle
+scripts disabled, production dependencies are audited, and evidence is
+initialized before setup so failures remain uploadable. The U14 private
+shebang gateway is now owner-executable so OpenClaw can invoke its allowlisted
+path without widening ownership. Hostile suites and authenticated provider
+calls remain optional rather than part of normal pull-request CI.
+
+**Proof:** The focused checkpoint passed 137 runs / 1,994 assertions with only
+the expected credential-gated skip. A credential-free installed probe used the
+real beta7 runtime, authenticated the SQLite policy, stopped before model
+execution, retained typed non-passing evidence, and removed its workspace.
+
+**Limit:** A passing live claim still requires an explicitly authorized run on
+the unchanged exact head. Local deterministic proof and ordinary hosted CI do
+not replace that artifact.

--- a/wiki/log.d/20260805T005200Z-workflow-creator-live-review-hardening.md
+++ b/wiki/log.d/20260805T005200Z-workflow-creator-live-review-hardening.md
@@ -14,6 +14,9 @@ The bounded proof also removes Hive init's managed LLM-wiki post-commit hook
 before relocation, leaving no active Git hook in the candidate control plane.
 The smoke now emits the supervisor's admitted hyphenated correlation identity;
 setup rejects incompatible identities before building either closure.
+Hosted coverage exposed root-owned Ruby/Node toolcache inputs. Setup now admits
+only immutable regular inputs owned by UID 0 or the current runner, then copies
+them into the runner-owned identity closure; foreign-user inputs remain denied.
 The existing U14 gateway/execution pair budget moved narrowly from 600 to 615
 lines to retain the external socket, injected boundary verifier, and semantic
 status check without compressed lifecycle code or a seventh runtime owner.

--- a/wiki/log.d/20260805T005200Z-workflow-creator-live-review-hardening.md
+++ b/wiki/log.d/20260805T005200Z-workflow-creator-live-review-hardening.md
@@ -6,6 +6,14 @@ writable workspace; U14's socket now lives in the owner-private workspace
 parent. The gateway checks Git/skill
 identity before every candidate command, and the runner checks the complete
 OpenClaw control plane around both model loops.
+Setup performs deterministic Hive initialization while the repository is still
+a main checkout, then atomically moves `.git` into the control root before any
+model process starts; this preserves both Hive's init precondition and the
+model-write isolation boundary.
+The bounded proof also removes Hive init's managed LLM-wiki post-commit hook
+before relocation, leaving no active Git hook in the candidate control plane.
+The smoke now emits the supervisor's admitted hyphenated correlation identity;
+setup rejects incompatible identities before building either closure.
 The existing U14 gateway/execution pair budget moved narrowly from 600 to 615
 lines to retain the external socket, injected boundary verifier, and semantic
 status check without compressed lifecycle code or a seventh runtime owner.

--- a/wiki/log.d/20260805T005200Z-workflow-creator-live-review-hardening.md
+++ b/wiki/log.d/20260805T005200Z-workflow-creator-live-review-hardening.md
@@ -1,0 +1,26 @@
+## 2026-08-05 — Workflow Creator live proof review hardening
+
+**Change:** Final review moved candidate homes, the Git directory, and OpenClaw
+state/config/approvals into an owner-private control root outside the model-
+writable workspace; U14's socket now lives in the owner-private workspace
+parent. The gateway checks Git/skill
+identity before every candidate command, and the runner checks the complete
+OpenClaw control plane around both model loops.
+The existing U14 gateway/execution pair budget moved narrowly from 600 to 615
+lines to retain the external socket, injected boundary verifier, and semantic
+status check without compressed lifecycle code or a seventh runtime owner.
+
+**Evidence:** A passing primary now retains validated native
+`openclaw skills info hive --json` evidence and accepts the final operational
+status only when it names exactly the created editorial task at `1-research`.
+Bootstrap failures replace only the initial `preflight/not_started` receipt;
+more specific typed failures remain unchanged.
+
+**Authorization:** The live workflow requires the repository owner as both the
+dispatching and triggering actor, refuses rerun attempts, and repeats that gate
+inside every credential-bearing job before provider secrets are exposed.
+
+**Proof:** The post-review focused checkpoint passed 117 runs and 4,176
+assertions with zero failures, errors, or skips. Thirteen changed Ruby files
+passed RuboCop, both changed YAML contracts parsed, and the diff whitespace and
+literal-secret scans passed. The optional hostile suite was not run.

--- a/wiki/log.d/20260805T005200Z-workflow-creator-live-review-hardening.md
+++ b/wiki/log.d/20260805T005200Z-workflow-creator-live-review-hardening.md
@@ -14,7 +14,7 @@ The bounded proof also removes Hive init's managed LLM-wiki post-commit hook
 before relocation, leaving no active Git hook in the candidate control plane.
 The smoke now emits the supervisor's admitted hyphenated correlation identity;
 setup rejects incompatible identities before building either closure.
-Hosted coverage exposed root-owned Ruby/Node toolcache inputs. Setup now admits
+The installed-runtime probe exercises root-owned toolchain inputs. Setup admits
 only immutable regular inputs owned by UID 0 or the current runner, then copies
 them into the runner-owned identity closure; foreign-user inputs remain denied.
 The existing U14 gateway/execution pair budget moved narrowly from 600 to 615

--- a/wiki/log.d/20260805T020130Z-workflow-creator-live-fixture-umask.md
+++ b/wiki/log.d/20260805T020130Z-workflow-creator-live-fixture-umask.md
@@ -1,0 +1,12 @@
+## 2026-08-05 — Seal Workflow Creator live fixtures independently of ambient umask
+
+**Fix:** Hosted coverage ran with a group-writable ambient umask, so the live
+setup fixture created an OpenClaw entrypoint that production correctly rejected
+as mutable. The fixture now holds umask `0077` across all generated inputs and
+restores the caller's umask afterward. A focused regression starts from `0002`
+and proves setup still receives owner-private inputs; production admission was
+not relaxed.
+
+**Evidence:** The exact hosted seed passes all eight setup tests under ambient
+umask `0002` with 47 assertions and no failures, errors, or skips. The optional
+hostile campaign remains outside normal CI and was not run.

--- a/wiki/log.d/20260805T020130Z-workflow-creator-live-fixture-umask.md
+++ b/wiki/log.d/20260805T020130Z-workflow-creator-live-fixture-umask.md
@@ -1,12 +1,14 @@
 ## 2026-08-05 — Seal Workflow Creator live fixtures independently of ambient umask
 
-**Fix:** Hosted coverage ran with a group-writable ambient umask, so the live
-setup fixture created an OpenClaw entrypoint that production correctly rejected
-as mutable. The fixture now holds umask `0077` across all generated inputs and
-restores the caller's umask afterward. A focused regression starts from `0002`
-and proves setup still receives owner-private inputs; production admission was
-not relaxed.
+**Fix:** Hosted coverage runs Ruby from a toolcache artifact owned by its build
+UID rather than the test process or root, so production correctly rejects that
+foreign-owned executable. The live setup fixture now copies the exact host Ruby
+into its current-user-owned input closure before admission. It also holds umask
+`0077` across all generated inputs and restores the caller's umask afterward.
+A focused regression starts from `0002` and proves the copied interpreter has
+the current UID, one link, and no group/world write bits; production admission
+was not relaxed.
 
 **Evidence:** The exact hosted seed passes all eight setup tests under ambient
-umask `0002` with 47 assertions and no failures, errors, or skips. The optional
+umask `0002` with 50 assertions and no failures, errors, or skips. The optional
 hostile campaign remains outside normal CI and was not run.

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -48,10 +48,10 @@ secret scanning, and cleanup. Missing
 provider credentials make this live gate explicitly unavailable; they never
 turn a skipped test into release evidence.
 
-The U1b adapter publishes through `WorkflowCreatorEvidence` but deliberately
-retains a typed non-passing receipt after a successful model loop. U14 now
-supplies deterministic execution custody; U15 still owns authenticated
-provider orchestration and the final passing claim.
+U1b remains the only primary publisher, U14 owns deterministic execution
+custody, and the U15 live runner now composes them into the final passing claim.
+The default local test remains credential-free and skipped; only an explicitly
+authorized run on the unchanged exact head can produce authenticated evidence.
 
 ## Local feedback loop
 
@@ -813,6 +813,17 @@ The protected `live-agent-skills.yml` workflow can additionally:
    seven-day structural evidence;
 7. validate all four evidence rows, assemble the candidate/provenance-bound
    private proof, and create a `live-agent-skills` Check Run on the exact SHA.
+
+The separate Workflow Creator cell is a thin adapter over
+`WorkflowCreatorLiveSetup` and `WorkflowCreatorLiveRunner`. Offline focused
+tests cover exact OpenAI/OpenRouter selection, opposite-provider and tool-child
+credential stripping, transport refusal, immutable candidate/OpenClaw closure
+admission, SQLite-backed OpenClaw approval-policy readback, authored editorial
+graph and task observation, deterministic first-stage execution, typed failure
+publication, and runtime tamper detection. The smoke test contributes only live
+availability gates and final bundle assertions. Its authenticated model calls
+run only through explicit workflow dispatch and exact-head authorization; the
+hostile suites and live lane are not normal pull-request CI.
 
 The repository-owned selector and attestation verifier remain covered by
 executable fixtures for optional diagnostic runs. They validate workflow/run

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -170,7 +170,7 @@ Vocabulary-fixed support members. It also checks that command labels are
 sourced from `WorkflowCreator::Vocabulary`, that the six-source relative
 require closure cannot widen to Hive runtime code, and that the readable
 pairwise source budgets remain exact: archive + installation at most 410 lines,
-capture + supervisor at most 495, and gateway + execution at most 600. These
+capture + supervisor at most 495, and gateway + execution at most 615. These
 are pair budgets, not per-file compression targets.
 
 The archive, installation, capture, supervisor, and gateway files exercise
@@ -818,11 +818,14 @@ The separate Workflow Creator cell is a thin adapter over
 `WorkflowCreatorLiveSetup` and `WorkflowCreatorLiveRunner`. Offline focused
 tests cover exact OpenAI/OpenRouter selection, opposite-provider and tool-child
 credential stripping, transport refusal, immutable candidate/OpenClaw closure
-admission, SQLite-backed OpenClaw approval-policy readback, authored editorial
-graph and task observation, deterministic first-stage execution, typed failure
+admission, native `skills info` path/content proof, SQLite-backed OpenClaw
+approval-policy readback, external control-root and separate-Git-dir tamper
+refusal, exact operational task binding, authored editorial graph and task
+observation, deterministic first-stage execution, typed bootstrap/failure
 publication, and runtime tamper detection. The smoke test contributes only live
 availability gates and final bundle assertions. Its authenticated model calls
-run only through explicit workflow dispatch and exact-head authorization; the
+run only through a fresh, first-attempt owner dispatch and exact-head
+authorization; workflow reruns are refused before any credential-bearing job. The
 hostile suites and live lane are not normal pull-request CI.
 
 The repository-owned selector and attestation verifier remain covered by

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -822,9 +822,10 @@ admission, native `skills info` path/content proof, SQLite-backed OpenClaw
 approval-policy readback, external control-root and separate-Git-dir tamper
 refusal, exact operational task binding, authored editorial graph and task
 observation, deterministic first-stage execution, typed bootstrap/failure
-publication, and runtime tamper detection. The setup fixture seals its generated
-external inputs under umask `0077`, so strict writable-input rejection is
-independent of a runner's ambient umask.
+publication, and runtime tamper detection. The setup fixture copies the host
+Ruby into its current-user-owned input closure and seals all generated inputs
+under umask `0077`, so strict ownership and writable-input rejection are
+independent of toolcache ownership and a runner's ambient umask.
 The smoke test contributes only live availability gates and final bundle
 assertions. Its authenticated model calls run only through a fresh,
 first-attempt owner dispatch and exact-head

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -822,11 +822,14 @@ admission, native `skills info` path/content proof, SQLite-backed OpenClaw
 approval-policy readback, external control-root and separate-Git-dir tamper
 refusal, exact operational task binding, authored editorial graph and task
 observation, deterministic first-stage execution, typed bootstrap/failure
-publication, and runtime tamper detection. The smoke test contributes only live
-availability gates and final bundle assertions. Its authenticated model calls
-run only through a fresh, first-attempt owner dispatch and exact-head
-authorization; workflow reruns are refused before any credential-bearing job. The
-hostile suites and live lane are not normal pull-request CI.
+publication, and runtime tamper detection. The setup fixture seals its generated
+external inputs under umask `0077`, so strict writable-input rejection is
+independent of a runner's ambient umask.
+The smoke test contributes only live availability gates and final bundle
+assertions. Its authenticated model calls run only through a fresh,
+first-attempt owner dispatch and exact-head
+authorization; workflow reruns are refused before any credential-bearing job.
+The hostile suites and live lane are not normal pull-request CI.
 
 The repository-owned selector and attestation verifier remain covered by
 executable fixtures for optional diagnostic runs. They validate workflow/run


### PR DESCRIPTION
## Summary

- Workflow Creator can now turn an explicitly authorized, exact-head OpenClaw run into the same four-member retained bundle its attestor already requires; successful model output no longer stops at U14 custody.
- The lane installs an exact audited OpenClaw/Node closure, exposes only the credential selected by the model prefix, and forces model-invoked Hive commands through the private nine-command U14 gateway.
- Candidate Git/home and OpenClaw control state remain outside the model workspace; native skill discovery, final operational binding, owner-triggered first-attempt authorization, and bootstrap failure evidence now fail closed.
- The old 672-line smoke is a 127-line adapter; hostile campaigns and authenticated provider calls remain outside normal PR CI.

## Test plan

- [x] focused final checkpoint: 120 runs / 4,183 assertions / 0 failures/errors/skips
- [x] broad pre-review checkpoint: 12,177 runs / 156,883 assertions / 0 failures/errors / 10 expected skips
- [x] RuboCop: 20 changed Ruby files, no offenses
- [x] exact Node 22.23.1/OpenClaw 2026.7.2-beta.7 clean install and npm audit
- [x] credential-free beta7 probes: native `/hive` retained and workspace removed with both runner-owned and root-owned toolchain inputs
- [x] hosted exact-head CI: 14 CI jobs + 8 install-smoke jobs, all green (run 30969559342)
- [ ] authenticated exact-head provider run (requires fresh operator authorization)
- [ ] hostile suite (optional; deliberately not run)

## Notes for reviewer

- U1b gained fixed typed transitions only; U14 keeps the executable wrapper and an external private socket, with the gateway/execution pair budget narrowly 600 to 615 for the security boundary.
- OpenClaw state/config/approvals, candidate homes, and separate Git metadata are outside the model workspace and revalidated at command/launch boundaries. Setup initializes Hive as a main checkout, removes its unused managed post-commit hook, then relocates Git metadata before any model loop.
- External toolchain inputs must be immutable regular files owned by UID 0 or the current runner, matching hosted toolcache ownership without admitting foreign-user files.
- The dependency closure is exact OpenClaw 2026.7.2-beta.7 plus Node 22.23.1.
- The one final architecture/correctness/security review pass is resolved; no release, tag, publication, or deployment is included.

