### PR TITLE
feat(patrol): add bounded installed-live smoke

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,7 +20,9 @@ HIVE_DEFAULT_TEST_FILES = FileList[
   "test/{unit,integration,babysitter}/**/*_test.rb"
 ].exclude(*HIVE_CI_GATE_TESTS.values).to_a.freeze
 HIVE_HOSTILE_TEST_FILES = FileList[
-  "test/unit/packaging/workflow_creator_values_test.rb"
+  "test/unit/packaging/workflow_creator_values_test.rb",
+  "test/unit/packaging/patrol_evidence_candidate_test.rb",
+  "test/unit/packaging/patrol_evidence_sandbox_test.rb"
 ].to_a.freeze
 
 # Default local suite. Self-contained, uses fake-claude / fake-gh, and makes no
@@ -52,7 +54,7 @@ Rake::TestTask.new("test:hostile" => "test:enable_hostile") do |t|
   t.libs << "lib"
   t.test_files = HIVE_HOSTILE_TEST_FILES
   t.warning = false
-  t.description = "Run the opt-in Workflow Creator hostile/property campaign"
+  t.description = "Run opt-in hostile/property campaigns outside default CI"
 end
 
 desc "Run the default suite with merged stdlib Coverage reporting and a 100% line threshold"

--- a/bin/hive-patrol-installed-live-smoke
+++ b/bin/hive-patrol-installed-live-smoke
@@ -1,0 +1,85 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "optparse"
+require "securerandom"
+require "time"
+require_relative "../packaging/patrol_evidence/runner"
+
+repo_root = File.expand_path("..", __dir__)
+options = {
+  invocation_id: "manual-#{Time.now.utc.strftime('%Y%m%dT%H%M%SZ')}-#{SecureRandom.hex(4)}"
+}
+parser = OptionParser.new do |value|
+  value.banner = "Usage: bin/hive-patrol-installed-live-smoke [options]"
+  value.on("--controller-sha SHA", "Authorized protected-main controller SHA") { |item| options[:controller_sha] = item }
+  value.on("--candidate-sha SHA", "Distinct later candidate SHA") { |item| options[:candidate_sha] = item }
+  value.on("--authorization-file PATH", "Owner-private fresh authorization bytes") do |item|
+    options[:authorization_file] = item
+  end
+  value.on("--invocation-id ID", "Unique manual invocation identity") { |item| options[:invocation_id] = item }
+  value.on("--evidence-root PATH", "Pre-created owner-private local evidence store") do |item|
+    options[:evidence_root] = item
+  end
+  value.on("--cleanup-result PATH", "Remove one retained result after its minimum age") do |item|
+    options[:cleanup_result] = item
+  end
+  value.on("--project-root PATH", "Disposable prepared project root") { |item| options[:project_root] = item }
+  value.on("--observations PATH", "Prepared observation document") { |item| options[:observations_path] = item }
+  value.on("--image IMAGE@sha256:DIGEST", "Preinstalled immutable sandbox image") { |item| options[:image] = item }
+  value.on("-h", "--help", "Show this help") do
+    puts value
+    exit 0
+  end
+end
+begin
+parser.parse!
+
+if options[:cleanup_result]
+  abort "--evidence-root is required for cleanup" unless options[:evidence_root]
+  HivePatrolEvidence::Runner.cleanup!(
+    evidence_root: options.fetch(:evidence_root), result_path: options.fetch(:cleanup_result)
+  )
+  puts '{"status":"removed"}'
+  exit 0
+end
+
+required = %i[
+  controller_sha candidate_sha authorization_file evidence_root project_root observations_path image
+]
+missing = required.reject { |key| options.key?(key) }
+abort "missing required options: #{missing.join(', ')}" unless missing.empty?
+
+authorization_path = File.expand_path(options.fetch(:authorization_file))
+flags = File::RDONLY
+flags |= File::NOFOLLOW if File.const_defined?(:NOFOLLOW)
+authorization = File.open(authorization_path, flags) do |file|
+  stat = file.stat
+  unless stat.file? && stat.nlink == 1 && stat.uid == Process.uid &&
+         (stat.mode & 0o077).zero? && stat.size.between?(1, 4096)
+    abort "authorization file must be an owner-private bounded regular file"
+  end
+  file.read(4097)
+end
+
+outcome = HivePatrolEvidence::Runner.run!(
+  repo_root:,
+  evidence_root: options.fetch(:evidence_root),
+  controller_sha: options.fetch(:controller_sha),
+  candidate_sha: options.fetch(:candidate_sha),
+  authorization:,
+  invocation_id: options.fetch(:invocation_id),
+  project_root: options.fetch(:project_root),
+  observations_path: options.fetch(:observations_path),
+  image: options.fetch(:image)
+)
+$stdout.write(outcome.fetch("result").canonical_bytes)
+exit(outcome.fetch("status") == "installed_live_smoke_verified" ? 0 : 75)
+rescue OptionParser::ParseError => e
+  warn e.message
+  warn parser
+  exit 64
+rescue HivePatrolEvidence::Runner::Error => e
+  warn "patrol installed/live smoke refused: #{e.reason}"
+  exit 78
+end

--- a/bin/hive-patrol-installed-live-smoke
+++ b/bin/hive-patrol-installed-live-smoke
@@ -6,6 +6,8 @@ require "securerandom"
 require "time"
 require_relative "../packaging/patrol_evidence/runner"
 
+class PatrolSmokeUsageError < StandardError; end
+
 repo_root = File.expand_path("..", __dir__)
 options = {
   invocation_id: "manual-#{Time.now.utc.strftime('%Y%m%dT%H%M%SZ')}-#{SecureRandom.hex(4)}"
@@ -17,9 +19,15 @@ parser = OptionParser.new do |value|
   value.on("--authorization-file PATH", "Owner-private fresh authorization bytes") do |item|
     options[:authorization_file] = item
   end
+  value.on("--authorization-template", "Print one fresh exact-scope authorization document") do
+    options[:authorization_template] = true
+  end
   value.on("--invocation-id ID", "Unique manual invocation identity") { |item| options[:invocation_id] = item }
   value.on("--evidence-root PATH", "Pre-created owner-private local evidence store") do |item|
     options[:evidence_root] = item
+  end
+  value.on("--hive-home PATH", "Owner-private Hive registry root for the disposable project") do |item|
+    options[:hive_home] = item
   end
   value.on("--cleanup-result PATH", "Remove one retained result after its minimum age") do |item|
     options[:cleanup_result] = item
@@ -33,53 +41,87 @@ parser = OptionParser.new do |value|
   end
 end
 begin
-parser.parse!
+  parser.parse!
+  raise PatrolSmokeUsageError, "unexpected positional arguments: #{ARGV.join(' ')}" unless ARGV.empty?
 
-if options[:cleanup_result]
-  abort "--evidence-root is required for cleanup" unless options[:evidence_root]
-  HivePatrolEvidence::Runner.cleanup!(
-    evidence_root: options.fetch(:evidence_root), result_path: options.fetch(:cleanup_result)
-  )
-  puts '{"status":"removed"}'
-  exit 0
-end
-
-required = %i[
-  controller_sha candidate_sha authorization_file evidence_root project_root observations_path image
-]
-missing = required.reject { |key| options.key?(key) }
-abort "missing required options: #{missing.join(', ')}" unless missing.empty?
-
-authorization_path = File.expand_path(options.fetch(:authorization_file))
-flags = File::RDONLY
-flags |= File::NOFOLLOW if File.const_defined?(:NOFOLLOW)
-authorization = File.open(authorization_path, flags) do |file|
-  stat = file.stat
-  unless stat.file? && stat.nlink == 1 && stat.uid == Process.uid &&
-         (stat.mode & 0o077).zero? && stat.size.between?(1, 4096)
-    abort "authorization file must be an owner-private bounded regular file"
+  if options[:cleanup_result]
+    raise PatrolSmokeUsageError, "--evidence-root is required for cleanup" unless options[:evidence_root]
+    irrelevant = options.keys & %i[
+      authorization_file authorization_template candidate_sha controller_sha hive_home image
+      observations_path project_root
+    ]
+    unless irrelevant.empty?
+      raise PatrolSmokeUsageError, "cleanup does not accept: #{irrelevant.sort.join(', ')}"
+    end
+    HivePatrolEvidence::Runner.cleanup!(
+      evidence_root: options.fetch(:evidence_root), result_path: options.fetch(:cleanup_result)
+    )
+    puts '{"status":"removed"}'
+    exit 0
   end
-  file.read(4097)
-end
 
-outcome = HivePatrolEvidence::Runner.run!(
-  repo_root:,
-  evidence_root: options.fetch(:evidence_root),
-  controller_sha: options.fetch(:controller_sha),
-  candidate_sha: options.fetch(:candidate_sha),
-  authorization:,
-  invocation_id: options.fetch(:invocation_id),
-  project_root: options.fetch(:project_root),
-  observations_path: options.fetch(:observations_path),
-  image: options.fetch(:image)
-)
-$stdout.write(outcome.fetch("result").canonical_bytes)
-exit(outcome.fetch("status") == "installed_live_smoke_verified" ? 0 : 75)
-rescue OptionParser::ParseError => e
+  required = %i[
+    controller_sha candidate_sha evidence_root hive_home project_root observations_path image
+  ]
+  required << :authorization_file unless options[:authorization_template]
+  missing = required.reject { |key| options.key?(key) }
+  raise PatrolSmokeUsageError, "missing required options: #{missing.join(', ')}" unless missing.empty?
+
+  if options[:authorization_template]
+    raise PatrolSmokeUsageError, "--authorization-template and --authorization-file are mutually exclusive" if
+      options[:authorization_file]
+    $stdout.write(HivePatrolEvidence::Runner.authorization_template!(
+      repo_root:, evidence_root: options.fetch(:evidence_root), hive_home: options.fetch(:hive_home),
+      controller_sha: options.fetch(:controller_sha), candidate_sha: options.fetch(:candidate_sha),
+      invocation_id: options.fetch(:invocation_id), project_root: options.fetch(:project_root),
+      observations_path: options.fetch(:observations_path), image: options.fetch(:image)
+    ))
+    exit 0
+  end
+
+  authorization_path = File.expand_path(options.fetch(:authorization_file))
+  flags = File::RDONLY
+  flags |= File::NOFOLLOW if File.const_defined?(:NOFOLLOW)
+  authorization = File.open(authorization_path, flags) do |file|
+    stat = file.stat
+    unless stat.file? && stat.nlink == 1 && stat.uid == Process.uid &&
+           (stat.mode & 0o077).zero? && stat.size.between?(1, 8192)
+      raise HivePatrolEvidence::Runner::AuthorityError.new(
+        "manual_authority_missing", "authorization file is unsafe"
+      )
+    end
+    file.read(8193)
+  end
+
+  %w[INT TERM].each do |signal|
+    Signal.trap(signal) do
+      raise HivePatrolEvidence::Runner::CancellationError.new(
+        "process_custody", "patrol smoke was interrupted"
+      )
+    end
+  end
+  outcome = HivePatrolEvidence::Runner.run!(
+    repo_root:,
+    evidence_root: options.fetch(:evidence_root),
+    hive_home: options.fetch(:hive_home),
+    controller_sha: options.fetch(:controller_sha),
+    candidate_sha: options.fetch(:candidate_sha),
+    authorization:,
+    invocation_id: options.fetch(:invocation_id),
+    project_root: options.fetch(:project_root),
+    observations_path: options.fetch(:observations_path),
+    image: options.fetch(:image)
+  )
+  $stdout.write(outcome.fetch("result").canonical_bytes)
+  exit(outcome.fetch("status") == "installed_live_smoke_verified" ? 0 : 75)
+rescue OptionParser::ParseError, PatrolSmokeUsageError => e
   warn e.message
   warn parser
   exit 64
 rescue HivePatrolEvidence::Runner::Error => e
   warn "patrol installed/live smoke refused: #{e.reason}"
+  exit 78
+rescue Errno::ENOENT, Errno::ELOOP, Errno::EACCES, Errno::EISDIR
+  warn "patrol installed/live smoke refused: input_unavailable"
   exit 78
 end

--- a/docs/patrol-qualification-threat-model.md
+++ b/docs/patrol-qualification-threat-model.md
@@ -1,8 +1,8 @@
 # Patrol installed/live smoke threat model
 
-Status: proposed U3c admission; production mutation is forbidden until an
-independent reliability/security review accepts this document and the operator
-explicitly approves this exact scope.
+Status: reduced U3c infrastructure candidate. Credentialed execution remains
+forbidden until this exact infrastructure head is merged, hosted checks are
+terminal, and the operator separately authorizes one later candidate invocation.
 
 Design base: `3b8b6fc9b037359b3d0c3a6f7b8a8e3c0c33ef32`
 
@@ -66,7 +66,7 @@ record digests of the existing U3a report and reduced U3b proof, but it must not
 write the migration report, construct a `PatrolQualification`, or call the
 report-admission facade.
 
-Each run receives one new runner-owned mode-`0700` directory beneath an owned
+Each run receives one new runner-owned mode-`0700` result directory beneath an owned
 mode-`0700` local evidence store. The runner refuses a pre-existing run
 directory, persists mode-`0600` `not_started` until terminal replacement,
 retains the resulting file for at least 30 days, and never deletes evidence
@@ -76,6 +76,9 @@ aggregate; saturation returns
 cleanup after that minimum age may remove only a selected mode-`0600` regular
 file whose owner and recorded device/inode still match, followed by its
 unchanged empty run directory. Evidence otherwise remains until that cleanup.
+Candidate archives, admitted source, container IDs, and controller scratch data
+live in a separate runner-owned transient workspace that is identity-checked and
+removed before credential access. They never enter the retained result directory.
 
 ## Trust boundaries
 
@@ -171,21 +174,21 @@ provider, or publisher API.
 
 | Threat | Required control | Failure |
 | --- | --- | --- |
-| Candidate or dependency substitution | Resolve a full candidate commit distinct from the protected-main controller SHA, archive once, hash the archive/gem/installed executable/module manifests/dependency inventory, and verify those exact identities before and after execution. Hosted candidates must be reachable from protected `main`. Never select an executable by filename alone. | `failed:candidate_identity` |
+| Candidate or dependency substitution | Resolve a full candidate commit distinct from the protected-main controller SHA, archive once, safely materialize and hash a read-only source tree, build from a separate writable copy, treat installed gemspecs as opaque bounded bytes, and rehash the archive/gem/installed executable/module/source/dependency inventories before and after execution. Hosted candidates must be reachable from protected `main`. Never select an executable by filename alone. | `failed:candidate_identity` |
 | Mutable image or toolchain | Resolve the OCI image by immutable `sha256` digest before the run and prohibit later pulls. Record and reverify the engine identity, image/rootfs digest, Ruby, RubyGems, Bundler, controller script bytes, and the complete installed gem dependency closure before and after execution; the image/rootfs digest binds its native libraries. | `failed:runtime_identity` |
 | Archive traversal or special members | Admit only bounded regular files and directories beneath a new runner-owned root. Reject absolute paths, `..`, links, devices, sockets, fifos, duplicate members, and over-limit inventory before extraction. | `failed:candidate_archive` |
 | Pre-existing or replaced paths | Refuse every destination that exists before creation. Record device/inode after creation and remove only an unchanged owned identity. A replacement is preserved and cleanup fails closed. | `failed:path_custody` |
 | Candidate host access | Run the installed candidate in a dedicated, networkless, read-only-root container with no host procfs, no host home, no Docker socket, no credential, no ambient Git/SSH/provider variables, dropped capabilities, `no-new-privileges`, and only runner-created byte- and inode-limited tmpfs or quota-backed state/output mounts. Constrain every writable layer. Copy only bounded admitted outputs after verified teardown. No unsandboxed fallback. | `blocked:sandbox_unavailable` or `failed:sandbox_contract` |
-| Process or resource escape | Give the container an exact label/ID, private PID namespace, whole-container TERM/KILL teardown, bounded pids/memory/CPU/time/output/files, and verify terminal container/process-group state on success, error, timeout, interrupt, and runner exception. | `failed:process_custody` |
+| Process or resource escape | Give each invocation a unique label/name and owned CID, use one hashed engine executable under a closed environment, private PID namespace, whole-container TERM/KILL teardown by owned ID only, bounded pids/memory/CPU/time/output/files, and verify terminal container/process-group state on success, error, timeout, interrupt, and runner exception. | `failed:process_custody` |
 | Credential leakage | Select exactly one provider credential in the host probe. Candidate and sandbox environments contain none. Never place the credential in argv, paths, prompts, logs, exceptions, result fields, or uploaded artifacts. Scan retained bytes against exact-secret and generic secret patterns. | `failed:credential_custody` |
 | Transport override, exfiltration, or false success | Before reading the credential, bind one exact HTTPS origin/path, model, proxy policy, and CA policy and reject ambient endpoint, proxy, or CA overrides. Permit one fixed bounded request with redirects disabled. Success requires the expected JSON content type and schema, no error object, the selected model identity, non-empty output, and positive usage. Retain only admitted status/usage and the response digest, never response text. | `failed:provider_transport` |
 | Provider unavailability, expiry, or quota | Preserve the candidate custody evidence and return typed `blocked` or `failed`; never reuse an old live success for a new head and never convert provider failure into a skip. | `blocked:provider_unavailable` or typed provider failure |
 | External effect or target escape | Supply no GitHub/effect credential, deny candidate network, and run no mutating Patrol path. Prepared effect receipts are historical inputs only. Any future live effect requires a separately threat-modelled, repository-scoped readmission. | `failed:effect_forbidden` |
-| Self-attested live binding | Execute protected-main controller bytes outside the candidate mount. Resolve the disposable project registration, repository identity/HEAD, installed candidate, module generations/configuration, observation digest, and result path from host-owned inputs before and after execution. Candidate output cannot supply expected bindings. | `failed:authority_binding` |
+| Self-attested live binding | Execute commit-matched protected-main controller/support/catalog bytes outside the candidate mount. Resolve and digest the disposable project registration, path identity, repository identity/HEAD, state/configuration tree, observation file identity, installed candidate, and module generations from host-owned inputs before and after each phase. Candidate output cannot supply expected bindings. | `failed:authority_binding` |
 | Unbounded input or output | Stream inventories before sort/allocation; cap every admitted file, member count, child stream, provider body, result, process count, and campaign deadline. Do not hold two full admitted payloads simultaneously. | typed bound failure |
 | Partial or conflicting publication | Persist `not_started` before preflight. Hold one owner-checked, no-follow lock on a stable recorded inode from the expected-byte read through staged validation, file fsync, atomic replacement, and parent-directory fsync. Recheck path identity while locked. An existing different terminal result or competing writer is a conflict. | `failed:publication_conflict` |
 | Artifact accumulation or unsafe deletion | Use one owned evidence root and the retention/count/aggregate-byte limits in the result contract. Refuse new evidence when full. Never delete automatically; explicit cleanup verifies the selected regular file's owner and device/inode through an already-open no-follow descriptor. | `blocked:evidence_store_full` or `failed:evidence_custody` |
-| Execution authority confusion | Refuse unless the local controller checkout is clean, equals the explicitly authorized full controller SHA, and that SHA is reachable from protected `main`; the candidate SHA must be distinct. Resolve both from Git objects before reading the credential, run no host-side command from candidate bytes, and bind controller/candidate SHAs, runner digest, operator authorization input, and invocation identity into the terminal result. Hosted workflows remain credential-free and cannot emit success. | command fails before credential use |
+| Execution authority confusion | Scrub ambient Git state and require the remote protected-main ref; refuse unless the local controller checkout is clean, equals the explicitly authorized full controller SHA, and every loaded control file equals that commit. The candidate SHA must be distinct and reachable. Require one canonical authorization binding controller/candidate/image/invocation/provider/model/project/observations plus UTC issue/expiry and nonce; atomically reject a retained digest replay before credential access. Hosted workflows remain credential-free and cannot emit success. | command fails before credential use |
 
 Initial implementation bounds are deliberately conservative: at most 4,096
 candidate/dependency members and 256 MiB total admitted bytes; 8 MiB prepared

--- a/packaging/patrol_evidence/candidate.rb
+++ b/packaging/patrol_evidence/candidate.rb
@@ -32,9 +32,9 @@ module HivePatrolEvidence
     DIGEST = /\A[0-9a-f]{64}\z/
     IDENTITY_KEYS = %w[
       dependency_closure dependency_closure_sha256 gem_sha256 installed_hive_sha256
-      module_manifest_sha256 toolchain toolchain_sha256
+      module_manifest_sha256 source_tree_sha256 toolchain toolchain_sha256
     ].freeze
-    CLOSURE_KEYS = %w[full_name name platform spec_sha256 version].freeze
+    CLOSURE_KEYS = %w[basename bytesize spec_sha256].freeze
     TOOLCHAIN_KEYS = %w[bundler ruby rubygems].freeze
 
     def initialize(repo_root:, controller_sha:, candidate_sha:, command_runner: nil)
@@ -62,7 +62,10 @@ module HivePatrolEvidence
       end
       @archive_identity = stat
       inventory = self.class.send(:inspect_archive!, archive)
-      manifests = load_module_manifests
+      source = File.join(root, "candidate-source")
+      source_inventory = self.class.send(:materialize_archive!, archive, source)
+      @source_identity = File.lstat(source)
+      manifests = load_module_manifests(source)
       @prepared = {
         "controller_sha" => @controller_sha,
         "candidate_sha" => @candidate_sha,
@@ -70,6 +73,8 @@ module HivePatrolEvidence
         "archive_sha256" => inventory.fetch("archive_sha256"),
         "archive_member_count" => inventory.fetch("archive_member_count"),
         "archive_total_bytes" => inventory.fetch("archive_total_bytes"),
+        "source_path" => source,
+        "source_tree_sha256" => source_inventory.fetch("source_tree_sha256"),
         "module_manifests" => manifests,
         "module_manifest_sha256" => digest_json(manifests)
       }.freeze
@@ -82,6 +87,7 @@ module HivePatrolEvidence
     def verify!(receipt:)
       raise Error.new("candidate_identity", "candidate was not prepared") unless @prepared
       verify_archive!
+      verify_source!
       row = receipt.fetch("candidate")
       unless row.is_a?(Hash) && row.keys.sort == %w[archive_sha256 candidate_sha identity_after identity_before] &&
              row.values_at("candidate_sha", "archive_sha256") ==
@@ -94,6 +100,9 @@ module HivePatrolEvidence
       unless before.fetch("module_manifest_sha256") == @prepared.fetch("module_manifest_sha256")
         raise Error.new("candidate_identity", "installed module manifests differ")
       end
+      unless before.fetch("source_tree_sha256") == @prepared.fetch("source_tree_sha256")
+        raise Error.new("candidate_identity", "installed source tree differs")
+      end
 
       {
         "candidate_sha" => @candidate_sha,
@@ -101,6 +110,7 @@ module HivePatrolEvidence
         "archive_member_count" => @prepared.fetch("archive_member_count"),
         "archive_total_bytes" => @prepared.fetch("archive_total_bytes"),
         "module_manifest_sha256" => @prepared.fetch("module_manifest_sha256"),
+        "source_tree_sha256" => @prepared.fetch("source_tree_sha256"),
         "gem_sha256" => before.fetch("gem_sha256"),
         "installed_hive_sha256" => before.fetch("installed_hive_sha256"),
         "dependency_closure_sha256" => before.fetch("dependency_closure_sha256"),
@@ -167,6 +177,167 @@ module HivePatrolEvidence
         raise
       rescue SystemCallError, Gem::Package::TarInvalidError, ArgumentError
         raise Error.new("candidate_archive", "candidate archive is malformed"), cause: nil
+      end
+
+      def materialize_archive!(archive, root)
+        raise Error.new("path_custody", "candidate source destination already exists") if
+          File.exist?(root) || File.symlink?(root)
+        Dir.mkdir(root, 0o700)
+        File.open(archive, read_flags) do |file|
+          Gem::Package::TarReader.new(file) do |tar|
+            tar.each do |entry|
+              kind = entry_kind(entry)
+              if kind == :metadata
+                consume(entry)
+                next
+              end
+              name = safe_path(entry.full_name, directory: kind == :directory)
+              if kind == :directory
+                ensure_directory!(root, name)
+              else
+                write_file!(root, name, entry)
+              end
+            end
+          end
+        end
+        freeze_source_tree!(root)
+        inspect_source_tree!(root)
+      rescue Error
+        raise
+      rescue SystemCallError, Gem::Package::TarInvalidError, ArgumentError
+        raise Error.new("candidate_archive", "candidate source materialization failed"), cause: nil
+      end
+
+      def ensure_directory!(root, relative)
+        current = root
+        relative.split("/").each do |part|
+          current = File.join(current, part)
+          begin
+            Dir.mkdir(current, 0o700)
+          rescue Errno::EEXIST
+            nil
+          end
+          stat = File.lstat(current)
+          unless stat.directory? && !stat.symlink? && stat.uid == Process.uid
+            raise Error.new("path_custody", "candidate source directory is unsafe")
+          end
+        end
+      end
+
+      def write_file!(root, relative, entry)
+        parent = File.dirname(relative)
+        ensure_directory!(root, parent) unless parent == "."
+        path = File.join(root, relative)
+        flags = File::WRONLY | File::CREAT | File::EXCL
+        flags |= File::NOFOLLOW if File.const_defined?(:NOFOLLOW)
+        mode = (entry.header.mode.to_i & 0o111).zero? ? 0o444 : 0o555
+        File.open(path, flags, 0o600) do |output|
+          until entry.eof?
+            remaining = entry.size - entry.pos
+            chunk = entry.read([ CHUNK_BYTES, remaining ].min)
+            raise Error.new("candidate_archive", "candidate archive member ended early") if
+              chunk.nil? || chunk.empty?
+            output.write(chunk)
+          end
+          output.flush
+          output.fsync
+        end
+        File.chmod(mode, path)
+      rescue Errno::EEXIST, Errno::ELOOP
+        raise Error.new("path_custody", "candidate source file path is unsafe"), cause: nil
+      end
+
+      def freeze_source_tree!(root)
+        directories = [ root ]
+        walk = lambda do |directory|
+          Dir.each_child(directory) do |name|
+            path = File.join(directory, name)
+            stat = File.lstat(path)
+            if stat.directory? && !stat.symlink?
+              directories << path
+              walk.call(path)
+            elsif !stat.file? || stat.symlink?
+              raise Error.new("path_custody", "candidate source contains a special entry")
+            end
+          end
+        end
+        walk.call(root)
+        directories.sort_by { |path| -path.count(File::SEPARATOR) }.each do |directory|
+          File.chmod(0o555, directory)
+          File.open(directory, File::RDONLY) { |handle| handle.fsync }
+        end
+      end
+
+      def inspect_source_tree!(root)
+        root_stat = File.lstat(root)
+        unless root_stat.directory? && !root_stat.symlink? && root_stat.uid == Process.uid &&
+               (root_stat.mode & 0o777) == 0o555
+          raise Error.new("candidate_identity", "candidate source root is unsafe")
+        end
+        rows = []
+        total = 0
+        walk = lambda do |directory, prefix|
+          Dir.each_child(directory).sort_by(&:b).each do |name|
+            relative = prefix.empty? ? name : File.join(prefix, name)
+            path = File.join(directory, name)
+            stat = File.lstat(path)
+            kind = stat.directory? && !stat.symlink? ? :directory : :file
+            safe_path(relative, directory: kind == :directory)
+            raise Error.new("candidate_identity", "candidate source has too many members") if
+              rows.size >= MAX_MEMBERS
+            if kind == :directory
+              unless stat.uid == Process.uid && (stat.mode & 0o777) == 0o555
+                raise Error.new("candidate_identity", "candidate source directory is unsafe")
+              end
+              rows << { "kind" => "directory", "mode" => 0o555, "path" => relative }
+              walk.call(path, relative)
+            else
+              unless stat.file? && !stat.symlink? && stat.nlink == 1 && stat.uid == Process.uid &&
+                     [ 0o444, 0o555 ].include?(stat.mode & 0o777) &&
+                     stat.size.between?(0, MAX_MEMBER_BYTES)
+                raise Error.new("candidate_identity", "candidate source file is unsafe")
+              end
+              total += stat.size
+              raise Error.new("candidate_identity", "candidate source is oversized") if
+                total > MAX_TOTAL_BYTES
+              digest = Digest::SHA256.new
+              File.open(path, read_flags) do |file|
+                opened = file.stat
+                unless %i[dev ino uid mode nlink size].all? do |field|
+                  opened.public_send(field) == stat.public_send(field)
+                end
+                  raise Error.new("candidate_identity", "candidate source file identity changed")
+                end
+                while (chunk = file.read(CHUNK_BYTES))
+                  digest.update(chunk)
+                end
+              end
+              rows << {
+                "kind" => "file", "mode" => stat.mode & 0o777, "path" => relative,
+                "sha256" => digest.hexdigest, "size" => stat.size
+              }
+            end
+          end
+        end
+        walk.call(root, "")
+        raise Error.new("candidate_identity", "candidate source tree is empty") if rows.empty?
+        { "source_tree_sha256" => canonical_digest(rows.sort_by { |row| row.fetch("path") }) }
+      rescue Error
+        raise
+      rescue SystemCallError, ArgumentError
+        raise Error.new("candidate_identity", "candidate source tree is unavailable"), cause: nil
+      end
+
+      def canonical_digest(value)
+        Digest::SHA256.hexdigest(JSON.generate(canonical_value(value)))
+      end
+
+      def canonical_value(value)
+        case value
+        when Hash then value.keys.sort.to_h { |key| [ key, canonical_value(value.fetch(key)) ] }
+        when Array then value.map { |item| canonical_value(item) }
+        else value
+        end
       end
 
       def entry_kind(entry)
@@ -248,6 +419,22 @@ module HivePatrolEvidence
       raise Error.new("candidate_identity", "candidate archive is unavailable"), cause: nil
     end
 
+    def verify_source!
+      path = @prepared.fetch("source_path")
+      current = File.lstat(path)
+      unless %i[dev ino uid mode].all? do |field|
+        current.public_send(field) == @source_identity.public_send(field)
+      end
+        raise Error.new("candidate_identity", "candidate source root identity changed")
+      end
+      inventory = self.class.send(:inspect_source_tree!, path)
+      unless inventory.fetch("source_tree_sha256") == @prepared.fetch("source_tree_sha256")
+        raise Error.new("candidate_identity", "candidate source tree bytes changed")
+      end
+    rescue Errno::ENOENT, Errno::ELOOP, Errno::EACCES
+      raise Error.new("candidate_identity", "candidate source tree is unavailable"), cause: nil
+    end
+
     def validate_input!
       unless SHA.match?(@controller_sha) && SHA.match?(@candidate_sha) &&
              @controller_sha != @candidate_sha
@@ -258,10 +445,17 @@ module HivePatrolEvidence
       raise Error.new("candidate_identity", "candidate commit is unavailable") unless resolved == @candidate_sha
     end
 
-    def load_module_manifests
+    def load_module_manifests(source)
       MODULES.to_h do |name|
-        bytes = git_output("show", "#{@candidate_sha}:modules/#{name}/manifest.yml")
-        raise Error.new("candidate_identity", "module manifest is oversized") if bytes.bytesize > MAX_MANIFEST_BYTES
+        path = File.join(source, "modules", name, "manifest.yml")
+        bytes = File.open(path, self.class.send(:read_flags)) do |file|
+          stat = file.stat
+          unless stat.file? && stat.nlink == 1 && stat.uid == Process.uid &&
+                 stat.size.between?(1, MAX_MANIFEST_BYTES)
+            raise Error.new("candidate_identity", "module manifest is unsafe")
+          end
+          file.read(MAX_MANIFEST_BYTES + 1)
+        end
         manifest = YAML.safe_load(bytes, permitted_classes: [], permitted_symbols: [], aliases: false)
         valid = manifest.is_a?(Hash) && manifest["version"].is_a?(String) &&
           manifest["release_sha256"].to_s.match?(DIGEST) &&
@@ -288,15 +482,16 @@ module HivePatrolEvidence
       end
       closure = value.fetch("dependency_closure")
       unless closure.is_a?(Array) && closure.size.between?(1, MAX_CLOSURE_MEMBERS) &&
-             closure == closure.sort_by { |row| row.fetch("full_name") } &&
-             closure.map { |row| row.fetch("full_name") }.uniq.size == closure.size
+             closure == closure.sort_by { |row| row.fetch("basename") } &&
+             closure.map { |row| row.fetch("basename") }.uniq.size == closure.size
         raise Error.new("candidate_identity", "dependency closure is malformed")
       end
       closure.each do |row|
         valid = row.is_a?(Hash) && row.keys.sort == CLOSURE_KEYS &&
-          row.values_at("name", "version", "platform", "full_name").all? do |item|
-            item.is_a?(String) && item.bytesize.between?(1, 256)
-          end && row.fetch("spec_sha256").to_s.match?(DIGEST)
+          row.fetch("basename").is_a?(String) &&
+          row.fetch("basename").match?(/\A[A-Za-z0-9][A-Za-z0-9._-]{0,239}\.gemspec\z/) &&
+          row.fetch("bytesize").is_a?(Integer) && row.fetch("bytesize").between?(1, 1024 * 1024) &&
+          row.fetch("spec_sha256").to_s.match?(DIGEST)
         raise Error.new("candidate_identity", "dependency closure is malformed") unless valid
       end
       toolchain = value.fetch("toolchain")
@@ -313,14 +508,10 @@ module HivePatrolEvidence
       raise Error.new("candidate_identity", "installed identity is malformed"), cause: nil
     end
 
-    def digest_json(value) = Digest::SHA256.hexdigest(JSON.generate(canonical_value(value)))
+    def digest_json(value) = self.class.send(:canonical_digest, value)
 
     def canonical_value(value)
-      case value
-      when Hash then value.keys.sort.to_h { |key| [ key, canonical_value(value.fetch(key)) ] }
-      when Array then value.map { |item| canonical_value(item) }
-      else value
-      end
+      self.class.send(:canonical_value, value)
     end
 
     def git_output(*arguments)

--- a/packaging/patrol_evidence/candidate.rb
+++ b/packaging/patrol_evidence/candidate.rb
@@ -1,0 +1,351 @@
+# frozen_string_literal: true
+
+require "digest"
+require "json"
+require "open3"
+require "pathname"
+require "rubygems/package"
+require "yaml"
+
+module HivePatrolEvidence
+  # Admits one exact candidate archive and its post-install identity closure.
+  class Candidate
+    class Error < StandardError
+      attr_reader :reason
+
+      def initialize(reason, message = reason)
+        @reason = reason
+        super(message)
+      end
+    end
+
+    MODULES = %w[architecture-patrol patrol].freeze
+    MAX_MEMBERS = 4_096
+    MAX_TOTAL_BYTES = 256 * 1024 * 1024
+    MAX_MEMBER_BYTES = 256 * 1024 * 1024
+    MAX_PATH_BYTES = 240
+    MAX_PATH_DEPTH = 32
+    MAX_MANIFEST_BYTES = 1024 * 1024
+    MAX_CLOSURE_MEMBERS = 4_096
+    CHUNK_BYTES = 64 * 1024
+    SHA = /\A[0-9a-f]{40}\z/
+    DIGEST = /\A[0-9a-f]{64}\z/
+    IDENTITY_KEYS = %w[
+      dependency_closure dependency_closure_sha256 gem_sha256 installed_hive_sha256
+      module_manifest_sha256 toolchain toolchain_sha256
+    ].freeze
+    CLOSURE_KEYS = %w[full_name name platform spec_sha256 version].freeze
+    TOOLCHAIN_KEYS = %w[bundler ruby rubygems].freeze
+
+    def initialize(repo_root:, controller_sha:, candidate_sha:, command_runner: nil)
+      @repo_root = File.expand_path(repo_root)
+      @controller_sha = controller_sha.to_s.downcase
+      @candidate_sha = candidate_sha.to_s.downcase
+      @command_runner = command_runner || method(:run_command)
+      validate_input!
+    end
+
+    def prepare!(run_root:)
+      root = owned_directory!(run_root, "candidate run root")
+      archive = File.join(root, "candidate.tar")
+      raise Error.new("path_custody", "candidate archive destination already exists") if
+        File.exist?(archive) || File.symlink?(archive)
+
+      @command_runner.call(
+        [ "git", "-C", @repo_root, "archive", "--format=tar", "--output", archive, @candidate_sha ],
+        "archive candidate"
+      )
+      stat = File.lstat(archive)
+      unless stat.file? && !stat.symlink? && stat.nlink == 1 && stat.uid == Process.uid &&
+             (stat.mode & 0o022).zero? && stat.size.between?(1, MAX_TOTAL_BYTES)
+        raise Error.new("candidate_archive", "candidate archive file is unsafe")
+      end
+      @archive_identity = stat
+      inventory = self.class.send(:inspect_archive!, archive)
+      manifests = load_module_manifests
+      @prepared = {
+        "controller_sha" => @controller_sha,
+        "candidate_sha" => @candidate_sha,
+        "archive_path" => archive,
+        "archive_sha256" => inventory.fetch("archive_sha256"),
+        "archive_member_count" => inventory.fetch("archive_member_count"),
+        "archive_total_bytes" => inventory.fetch("archive_total_bytes"),
+        "module_manifests" => manifests,
+        "module_manifest_sha256" => digest_json(manifests)
+      }.freeze
+    rescue Error
+      raise
+    rescue SystemCallError, KeyError, TypeError
+      raise Error.new("candidate_archive", "candidate archive admission failed"), cause: nil
+    end
+
+    def verify!(receipt:)
+      raise Error.new("candidate_identity", "candidate was not prepared") unless @prepared
+      verify_archive!
+      row = receipt.fetch("candidate")
+      unless row.is_a?(Hash) && row.keys.sort == %w[archive_sha256 candidate_sha identity_after identity_before] &&
+             row.values_at("candidate_sha", "archive_sha256") ==
+               @prepared.values_at("candidate_sha", "archive_sha256")
+        raise Error.new("candidate_identity", "sandbox candidate binding differs")
+      end
+      before = admit_identity(row.fetch("identity_before"))
+      after = admit_identity(row.fetch("identity_after"))
+      raise Error.new("candidate_identity", "installed candidate identity drifted") unless before == after
+      unless before.fetch("module_manifest_sha256") == @prepared.fetch("module_manifest_sha256")
+        raise Error.new("candidate_identity", "installed module manifests differ")
+      end
+
+      {
+        "candidate_sha" => @candidate_sha,
+        "archive_sha256" => @prepared.fetch("archive_sha256"),
+        "archive_member_count" => @prepared.fetch("archive_member_count"),
+        "archive_total_bytes" => @prepared.fetch("archive_total_bytes"),
+        "module_manifest_sha256" => @prepared.fetch("module_manifest_sha256"),
+        "gem_sha256" => before.fetch("gem_sha256"),
+        "installed_hive_sha256" => before.fetch("installed_hive_sha256"),
+        "dependency_closure_sha256" => before.fetch("dependency_closure_sha256"),
+        "toolchain_sha256" => before.fetch("toolchain_sha256")
+      }.freeze
+    rescue Error
+      raise
+    rescue KeyError, TypeError
+      raise Error.new("candidate_identity", "sandbox candidate identity is malformed"), cause: nil
+    end
+
+    class << self
+      private
+
+      def inspect_archive!(path)
+        digest = Digest::SHA256.new
+        File.open(path, read_flags) do |file|
+          while (chunk = file.read(CHUNK_BYTES))
+            digest.update(chunk)
+          end
+        end
+
+        count = 0
+        total = 0
+        paths = {}
+        File.open(path, read_flags) do |file|
+          Gem::Package::TarReader.new(file) do |tar|
+            tar.each do |entry|
+              count += 1
+              raise Error.new("candidate_archive", "candidate archive has too many members") if
+                count > MAX_MEMBERS
+              kind = entry_kind(entry)
+              if kind == :metadata
+                size = entry.header.size
+                unless size.is_a?(Integer) && size.between?(0, MAX_MEMBER_BYTES)
+                  raise Error.new("candidate_archive", "candidate archive metadata is oversized")
+                end
+                total += size
+                raise Error.new("candidate_archive", "candidate archive is oversized") if total > MAX_TOTAL_BYTES
+                consume(entry)
+                next
+              end
+              name = safe_path(entry.full_name, directory: kind == :directory)
+              raise Error.new("candidate_archive", "candidate archive has duplicate members") if paths.key?(name)
+              size = entry.header.size
+              unless size.is_a?(Integer) && size.between?(0, MAX_MEMBER_BYTES)
+                raise Error.new("candidate_archive", "candidate archive member is oversized")
+              end
+              total += size
+              raise Error.new("candidate_archive", "candidate archive is oversized") if total > MAX_TOTAL_BYTES
+              reject_file_parent!(paths, name)
+              paths[name] = kind
+              consume(entry) if kind == :file
+            end
+          end
+        end
+        raise Error.new("candidate_archive", "candidate archive is empty") if paths.empty?
+        {
+          "archive_sha256" => digest.hexdigest,
+          "archive_member_count" => count,
+          "archive_total_bytes" => total
+        }
+      rescue Error
+        raise
+      rescue SystemCallError, Gem::Package::TarInvalidError, ArgumentError
+        raise Error.new("candidate_archive", "candidate archive is malformed"), cause: nil
+      end
+
+      def entry_kind(entry)
+        case entry.header.typeflag
+        when "0", "\0" then :file
+        when "5" then :directory
+        when "g" then :metadata
+        else raise Error.new("candidate_archive", "candidate archive contains a special member")
+        end
+      end
+
+      def safe_path(raw, directory:)
+        name = raw.to_s.dup.force_encoding(Encoding::UTF_8)
+        name = name.delete_suffix("/") if directory
+        clean = Pathname.new(name).cleanpath.to_s
+        safe = name.valid_encoding? && !name.empty? && name.bytesize <= MAX_PATH_BYTES &&
+          name == clean && !Pathname.new(name).absolute? && !name.start_with?("../") &&
+          name.split("/").none? { |part| part.empty? || part == "." || part == ".." } &&
+          name.count("/") + 1 <= MAX_PATH_DEPTH
+        raise Error.new("candidate_archive", "candidate archive path is unsafe") unless safe
+        name
+      rescue ArgumentError
+        raise Error.new("candidate_archive", "candidate archive path is unsafe"), cause: nil
+      end
+
+      def reject_file_parent!(paths, name)
+        parts = name.split("/")
+        1.upto(parts.length - 1) do |count|
+          parent = parts.first(count).join("/")
+          raise Error.new("candidate_archive", "candidate archive has a file-parent conflict") if
+            paths[parent] == :file
+        end
+        prefix = "#{name}/"
+        if paths.any? { |path, _kind| path.start_with?(prefix) }
+          raise Error.new("candidate_archive", "candidate archive has a descendant conflict")
+        end
+      end
+
+      def consume(entry)
+        until entry.eof?
+          remaining = entry.size - entry.pos
+          chunk = entry.read([ CHUNK_BYTES, remaining ].min)
+          raise Error.new("candidate_archive", "candidate archive member ended early") if
+            chunk.nil? || chunk.empty?
+        end
+      end
+
+      def read_flags
+        flags = File::RDONLY
+        flags |= File::NOFOLLOW if File.const_defined?(:NOFOLLOW)
+        flags |= File::NONBLOCK if File.const_defined?(:NONBLOCK)
+        flags
+      end
+    end
+
+    private
+
+    def verify_archive!
+      path = @prepared.fetch("archive_path")
+      flags = File::RDONLY
+      flags |= File::NOFOLLOW if File.const_defined?(:NOFOLLOW)
+      digest = Digest::SHA256.new
+      File.open(path, flags) do |file|
+        current = file.stat
+        fields = %i[dev ino uid mode nlink size]
+        unless current.file? && fields.all? do |field|
+          current.public_send(field) == @archive_identity.public_send(field)
+        end
+          raise Error.new("candidate_identity", "candidate archive identity changed")
+        end
+        while (chunk = file.read(CHUNK_BYTES))
+          digest.update(chunk)
+        end
+      end
+      unless digest.hexdigest == @prepared.fetch("archive_sha256")
+        raise Error.new("candidate_identity", "candidate archive bytes changed")
+      end
+    rescue Errno::ENOENT, Errno::ELOOP, Errno::EACCES
+      raise Error.new("candidate_identity", "candidate archive is unavailable"), cause: nil
+    end
+
+    def validate_input!
+      unless SHA.match?(@controller_sha) && SHA.match?(@candidate_sha) &&
+             @controller_sha != @candidate_sha
+        raise Error.new("candidate_identity", "candidate and controller identities are invalid")
+      end
+      owned_directory!(@repo_root, "candidate repository")
+      resolved = git_output("rev-parse", "--verify", "#{@candidate_sha}^{commit}").strip
+      raise Error.new("candidate_identity", "candidate commit is unavailable") unless resolved == @candidate_sha
+    end
+
+    def load_module_manifests
+      MODULES.to_h do |name|
+        bytes = git_output("show", "#{@candidate_sha}:modules/#{name}/manifest.yml")
+        raise Error.new("candidate_identity", "module manifest is oversized") if bytes.bytesize > MAX_MANIFEST_BYTES
+        manifest = YAML.safe_load(bytes, permitted_classes: [], permitted_symbols: [], aliases: false)
+        valid = manifest.is_a?(Hash) && manifest["version"].is_a?(String) &&
+          manifest["release_sha256"].to_s.match?(DIGEST) &&
+          manifest.dig("source", "revision").to_s.match?(SHA)
+        raise Error.new("candidate_identity", "module manifest is malformed") unless valid
+        [ name, {
+          "bytes_sha256" => Digest::SHA256.hexdigest(bytes),
+          "version" => manifest.fetch("version"),
+          "release_sha256" => manifest.fetch("release_sha256"),
+          "source_revision" => manifest.dig("source", "revision")
+        } ]
+      end
+    rescue Psych::Exception, KeyError, TypeError
+      raise Error.new("candidate_identity", "module manifest is malformed"), cause: nil
+    end
+
+    def admit_identity(value)
+      unless value.is_a?(Hash) && value.keys.sort == IDENTITY_KEYS &&
+             value.values_at("gem_sha256", "installed_hive_sha256", "module_manifest_sha256",
+                             "dependency_closure_sha256", "toolchain_sha256").all? do |digest|
+               digest.is_a?(String) && DIGEST.match?(digest)
+             end
+        raise Error.new("candidate_identity", "installed identity is malformed")
+      end
+      closure = value.fetch("dependency_closure")
+      unless closure.is_a?(Array) && closure.size.between?(1, MAX_CLOSURE_MEMBERS) &&
+             closure == closure.sort_by { |row| row.fetch("full_name") } &&
+             closure.map { |row| row.fetch("full_name") }.uniq.size == closure.size
+        raise Error.new("candidate_identity", "dependency closure is malformed")
+      end
+      closure.each do |row|
+        valid = row.is_a?(Hash) && row.keys.sort == CLOSURE_KEYS &&
+          row.values_at("name", "version", "platform", "full_name").all? do |item|
+            item.is_a?(String) && item.bytesize.between?(1, 256)
+          end && row.fetch("spec_sha256").to_s.match?(DIGEST)
+        raise Error.new("candidate_identity", "dependency closure is malformed") unless valid
+      end
+      toolchain = value.fetch("toolchain")
+      unless toolchain.is_a?(Hash) && toolchain.keys.sort == TOOLCHAIN_KEYS &&
+             toolchain.values.all? { |item| item.is_a?(String) && item.bytesize.between?(1, 256) }
+        raise Error.new("runtime_identity", "toolchain identity is malformed")
+      end
+      unless digest_json(closure) == value.fetch("dependency_closure_sha256") &&
+             digest_json(toolchain) == value.fetch("toolchain_sha256")
+        raise Error.new("candidate_identity", "installed identity digest differs")
+      end
+      canonical_value(value)
+    rescue KeyError, TypeError
+      raise Error.new("candidate_identity", "installed identity is malformed"), cause: nil
+    end
+
+    def digest_json(value) = Digest::SHA256.hexdigest(JSON.generate(canonical_value(value)))
+
+    def canonical_value(value)
+      case value
+      when Hash then value.keys.sort.to_h { |key| [ key, canonical_value(value.fetch(key)) ] }
+      when Array then value.map { |item| canonical_value(item) }
+      else value
+      end
+    end
+
+    def git_output(*arguments)
+      stdout, _stderr, status = Open3.capture3("git", "-C", @repo_root, *arguments)
+      raise Error.new("candidate_identity", "candidate Git object is unavailable") unless status.success?
+      stdout
+    rescue SystemCallError
+      raise Error.new("candidate_identity", "candidate Git object is unavailable")
+    end
+
+    def run_command(argv, _label)
+      _stdout, _stderr, status = Open3.capture3(*argv)
+      raise Error.new("candidate_archive", "candidate archive command failed") unless status.success?
+    rescue SystemCallError
+      raise Error.new("candidate_archive", "candidate archive command is unavailable")
+    end
+
+    def owned_directory!(path, label)
+      stat = File.lstat(path)
+      unless stat.directory? && !stat.symlink? && stat.uid == Process.uid
+        raise Error.new("path_custody", "#{label} is not an owned directory")
+      end
+      File.realpath(path)
+    rescue Errno::ENOENT, Errno::EACCES
+      raise Error.new("path_custody", "#{label} is unavailable")
+    end
+  end
+end

--- a/packaging/patrol_evidence/provider_probe.rb
+++ b/packaging/patrol_evidence/provider_probe.rb
@@ -1,0 +1,184 @@
+# frozen_string_literal: true
+
+require "digest"
+require "json"
+require "net/http"
+require "openssl"
+require "uri"
+require_relative "../../lib/hive/secret_patterns"
+
+module HivePatrolEvidence
+  # Owns one fixed OpenRouter authentication/transport probe and no Patrol decision.
+  class ProviderProbe
+    class Error < StandardError
+      attr_reader :reason, :status
+
+      def initialize(reason, message = reason, status: "failed")
+        @reason = reason
+        @status = status
+        super(message)
+      end
+    end
+
+    PROVIDER = "openrouter"
+    ENDPOINT = "https://openrouter.ai/api/v1/chat/completions"
+    MODEL = "openai/gpt-5.6-terra"
+    CREDENTIAL = "OPENROUTER_API_KEY"
+    EXPECTED_OUTPUT = "HIVE_PATROL_SMOKE_OK"
+    PROMPT = "Reply with exactly #{EXPECTED_OUTPUT}.".freeze
+    MAX_BODY_BYTES = 1024 * 1024
+    TIMEOUT = 180
+    OVERRIDE_ENV = %w[
+      OPENROUTER_BASE_URL HTTP_PROXY HTTPS_PROXY NO_PROXY http_proxy https_proxy no_proxy
+      SSL_CERT_FILE SSL_CERT_DIR NODE_EXTRA_CA_CERTS
+    ].freeze
+    OTHER_PROVIDER_CREDENTIALS = %w[OPENAI_API_KEY ANTHROPIC_API_KEY].freeze
+
+    def initialize(environment: ENV.to_h, transport: nil)
+      @environment = environment.to_h.transform_keys(&:to_s)
+      @transport = transport || method(:request_once)
+      @credential = nil
+    rescue NoMethodError, TypeError
+      raise Error.new("credential_custody", "provider environment is malformed"), cause: nil
+    end
+
+    def call
+      admit_environment!
+      @credential = @environment.fetch(CREDENTIAL, "").to_s
+      if @credential.empty?
+        raise Error.new("credential_unavailable", "selected provider credential is unavailable", status: "blocked")
+      end
+      raise Error.new("credential_custody", "selected provider credential is malformed") if
+        @credential.bytesize > 16 * 1024 || @credential.include?("\0")
+
+      request = fixed_request(@credential)
+      response = @transport.call(request)
+      admit_response(response)
+    rescue Error
+      raise
+    rescue Timeout::Error, Net::OpenTimeout, Net::ReadTimeout, SocketError,
+           Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::ETIMEDOUT
+      raise Error.new("provider_unavailable", "provider is unavailable", status: "blocked"), cause: nil
+    rescue SystemCallError, IOError
+      raise Error.new("provider_unavailable", "provider is unavailable", status: "blocked"), cause: nil
+    rescue StandardError
+      raise Error.new("provider_transport", "provider transport failed"), cause: nil
+    ensure
+      @environment = nil
+    end
+
+    def validate_retained!(bytes)
+      text = bytes.to_s
+      leaked = @credential && !@credential.empty? && text.include?(@credential)
+      leaked ||= Hive::SecretPatterns.match?(text)
+      raise Error.new("credential_custody", "retained evidence contains credential-shaped bytes") if leaked
+      true
+    end
+
+    private
+
+    def admit_environment!
+      override = OVERRIDE_ENV.any? { |key| !@environment.fetch(key, "").to_s.empty? }
+      multiple = OTHER_PROVIDER_CREDENTIALS.any? { |key| !@environment.fetch(key, "").to_s.empty? }
+      if override || multiple
+        raise Error.new("credential_custody", "provider transport or credential selection is overridden")
+      end
+    end
+
+    def fixed_request(secret)
+      body = JSON.generate(
+        "max_tokens" => 16,
+        "messages" => [ { "content" => PROMPT, "role" => "user" } ],
+        "model" => MODEL,
+        "temperature" => 0
+      )
+      {
+        uri: URI(ENDPOINT),
+        headers: {
+          "Accept" => "application/json",
+          "Authorization" => "Bearer #{secret}",
+          "Content-Type" => "application/json",
+          "User-Agent" => "hive-patrol-installed-live-smoke/1"
+        }.freeze,
+        body: body.freeze,
+        redirects: false,
+        timeout: TIMEOUT,
+        max_body_bytes: MAX_BODY_BYTES
+      }.freeze
+    end
+
+    def request_once(request)
+      uri = request.fetch(:uri)
+      unless uri.scheme == "https" && uri.host == "openrouter.ai" &&
+             uri.path == "/api/v1/chat/completions" && uri.query.nil?
+        raise Error.new("provider_transport", "provider endpoint differs")
+      end
+      http = Net::HTTP.new(uri.host, uri.port, nil)
+      http.use_ssl = true
+      http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+      http.open_timeout = TIMEOUT
+      http.read_timeout = TIMEOUT
+      http.write_timeout = TIMEOUT if http.respond_to?(:write_timeout=)
+      message = Net::HTTP::Post.new(uri.request_uri, request.fetch(:headers))
+      message.body = request.fetch(:body)
+      body = +""
+      response = http.request(message) do |incoming|
+        incoming.read_body do |chunk|
+          remaining = MAX_BODY_BYTES - body.bytesize
+          raise Error.new("output_bound", "provider response exceeds its bound") if chunk.bytesize > remaining
+          body << chunk
+        end
+      end
+      {
+        status: Integer(response.code, 10),
+        content_type: response["Content-Type"].to_s,
+        body: body
+      }
+    end
+
+    def admit_response(response)
+      unless response.is_a?(Hash) && response.keys.sort == %i[body content_type status]
+        raise Error.new("provider_transport", "provider response envelope is malformed")
+      end
+      status = Integer(response.fetch(:status))
+      if status == 429 || status >= 500
+        raise Error.new("provider_unavailable", "provider is unavailable", status: "blocked")
+      end
+      raise Error.new("provider_transport", "provider returned an unsuccessful status") unless status == 200
+      content_type = response.fetch(:content_type).to_s.downcase.split(";", 2).first.strip
+      raise Error.new("provider_transport", "provider content type is unexpected") unless
+        content_type == "application/json"
+      body = response.fetch(:body).to_s
+      raise Error.new("output_bound", "provider response exceeds its bound") if body.bytesize > MAX_BODY_BYTES
+      if body.include?(@credential) || Hive::SecretPatterns.match?(body)
+        raise Error.new("credential_custody", "provider response contains credential-shaped bytes")
+      end
+      document = JSON.parse(body)
+      raise Error.new("provider_transport", "provider returned an error object") if document.key?("error")
+      unless document.is_a?(Hash) && document.fetch("model") == MODEL &&
+             document.fetch("choices").is_a?(Array) && !document.fetch("choices").empty? &&
+             document.dig("choices", 0, "message", "content") == EXPECTED_OUTPUT
+        raise Error.new("provider_transport", "provider success predicate did not match")
+      end
+      usage = document.fetch("usage")
+      values = usage.values_at("prompt_tokens", "completion_tokens", "total_tokens")
+      unless values.all? { |value| value.is_a?(Integer) && value.positive? } &&
+             values.fetch(2) >= values.fetch(0) + values.fetch(1)
+        raise Error.new("provider_transport", "provider usage is malformed")
+      end
+      {
+        "status" => "passed",
+        "provider" => PROVIDER,
+        "model" => MODEL,
+        "response_sha256" => Digest::SHA256.hexdigest(body),
+        "usage" => {
+          "prompt_tokens" => values.fetch(0),
+          "completion_tokens" => values.fetch(1),
+          "total_tokens" => values.fetch(2)
+        }
+      }.freeze
+    rescue JSON::ParserError, KeyError, TypeError, ArgumentError
+      raise Error.new("provider_transport", "provider response is malformed"), cause: nil
+    end
+  end
+end

--- a/packaging/patrol_evidence/result.rb
+++ b/packaging/patrol_evidence/result.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+require "json"
+require "time"
+require_relative "../../lib/hive/secret_patterns"
+
+module HivePatrolEvidence
+  # The closed, secret-free result vocabulary for the reduced U3c smoke.
+  class Result
+    class Error < StandardError; end
+
+    SCHEMA = "hive-patrol-installed-live-smoke"
+    SCHEMA_VERSION = 1
+    MAX_RESULT_BYTES = 512 * 1024
+    CLAIM_FENCES = %w[
+      not_full_u3b
+      prepared_records_not_fresh_scheduler_matrix
+      controller_does_not_supply_full_independent_matrix
+      not_report_installed_live_qualification
+      provider_probe_not_patrol_decision
+      not_evidence_ready_for_operator
+      not_cutover_or_promotion_authority
+    ].freeze
+    SAME_USER_LIMITATION = "same_user_host_processes_are_outside_the_sandbox_claim".freeze
+    TERMINAL_STATUSES = %w[installed_live_smoke_verified blocked failed].freeze
+    REASONS = %w[
+      manual_authority_missing sandbox_unavailable installed_dependency_missing
+      credential_unavailable provider_unavailable evidence_store_full
+      candidate_identity candidate_archive runtime_identity path_custody sandbox_contract
+      process_custody credential_custody provider_transport effect_forbidden
+      authority_binding input_bound output_bound publication_conflict evidence_custody
+      smoke_validation unexpected_failure
+    ].freeze
+    AUTHORITY_KEYS = %w[
+      authorization_sha256 candidate_sha controller_script_sha256 controller_sha
+      invocation_id run_id runner_sha256
+    ].freeze
+
+    class << self
+      def not_started(authority:, started_at:)
+        build(
+          status: "not_started", reason: nil, authority:, candidate: nil, sandbox: nil,
+          smoke: nil, provider: nil, process_evidence: [], started_at:, finished_at: nil
+        )
+      end
+
+      def terminal(status:, reason:, authority:, candidate:, sandbox:, smoke:, provider:,
+                   process_evidence:, started_at:, finished_at:, exact_secrets: [])
+        build(
+          status:, reason:, authority:, candidate:, sandbox:, smoke:, provider:,
+          process_evidence:, started_at:, finished_at:, exact_secrets:
+        )
+      end
+
+      def canonical(value)
+        JSON.generate(canonical_value(value)) + "\n"
+      rescue JSON::GeneratorError, TypeError
+        raise Error, "patrol smoke result is not canonical JSON", cause: nil
+      end
+
+      private
+
+      def build(status:, reason:, authority:, candidate:, sandbox:, smoke:, provider:,
+                process_evidence:, started_at:, finished_at:, exact_secrets: [])
+        validate_status!(status, reason)
+        validate_authority!(authority)
+        validate_time!(started_at, "started_at")
+        validate_time!(finished_at, "finished_at") if finished_at
+        raise Error, "patrol smoke process evidence is malformed" unless process_evidence.is_a?(Array)
+
+        document = {
+          "schema" => SCHEMA,
+          "schema_version" => SCHEMA_VERSION,
+          "status" => status,
+          "reason" => reason,
+          "claim_fences" => CLAIM_FENCES,
+          "same_user_limitation" => SAME_USER_LIMITATION,
+          "authority" => authority,
+          "candidate" => candidate,
+          "sandbox" => sandbox,
+          "smoke" => smoke,
+          "provider" => provider,
+          "process_evidence" => process_evidence,
+          "started_at" => started_at,
+          "finished_at" => finished_at
+        }
+        bytes = canonical(document)
+        raise Error, "patrol smoke result exceeds its byte bound" if bytes.bytesize > MAX_RESULT_BYTES
+        reject_secrets!(bytes, exact_secrets)
+        new(deep_freeze(canonical_value(document)), bytes.freeze)
+      rescue KeyError, NoMethodError, TypeError
+        raise Error, "patrol smoke result is malformed", cause: nil
+      end
+
+      def validate_status!(status, reason)
+        valid = if status == "not_started"
+          reason.nil?
+        elsif status == "installed_live_smoke_verified"
+          reason.nil?
+        else
+          TERMINAL_STATUSES.include?(status) && REASONS.include?(reason)
+        end
+        raise Error, "patrol smoke status or reason is unsupported" unless valid
+      end
+
+      def validate_authority!(authority)
+        valid = authority.is_a?(Hash) && authority.keys.sort == AUTHORITY_KEYS &&
+          authority.values_at("controller_sha", "candidate_sha").all? do |sha|
+            sha.is_a?(String) && sha.match?(/\A[0-9a-f]{40}\z/)
+          end && authority.values_at("runner_sha256", "controller_script_sha256",
+                                     "authorization_sha256").all? do |digest|
+            digest.is_a?(String) && digest.match?(/\A[0-9a-f]{64}\z/)
+          end && authority.values_at("run_id", "invocation_id").all? do |value|
+            value.is_a?(String) && value.match?(/\A[A-Za-z0-9][A-Za-z0-9._-]{0,127}\z/)
+          end
+        raise Error, "patrol smoke authority binding is malformed" unless valid
+        raise Error, "controller and candidate SHAs must be distinct" if
+          authority.fetch("controller_sha") == authority.fetch("candidate_sha")
+      end
+
+      def validate_time!(value, label)
+        parsed = Time.iso8601(value.to_s)
+        raise Error, "#{label} must be UTC" unless parsed.utc_offset.zero?
+      rescue ArgumentError
+        raise Error, "#{label} is malformed", cause: nil
+      end
+
+      def reject_secrets!(bytes, exact_secrets)
+        secrets = Array(exact_secrets).compact.map(&:to_s).reject(&:empty?)
+        leaked = secrets.any? { |secret| bytes.include?(secret) }
+        leaked ||= Hive::SecretPatterns.match?(bytes)
+        raise Error, "patrol smoke result contains credential-shaped bytes" if leaked
+      end
+
+      def canonical_value(value)
+        case value
+        when Hash
+          raise Error, "patrol smoke result keys must be strings" unless value.keys.all?(String)
+          value.keys.sort.to_h { |key| [ key, canonical_value(value.fetch(key)) ] }
+        when Array then value.map { |item| canonical_value(item) }
+        when String, Integer, TrueClass, FalseClass, NilClass then value
+        else raise Error, "patrol smoke result contains an unsupported value"
+        end
+      end
+
+      def deep_freeze(value)
+        case value
+        when Hash
+          value.each { |key, item| key.freeze; deep_freeze(item) }
+        when Array then value.each { |item| deep_freeze(item) }
+        end
+        value.freeze
+      end
+    end
+
+    attr_reader :canonical_bytes
+
+    def initialize(document, canonical_bytes)
+      @document = document
+      @canonical_bytes = canonical_bytes
+      freeze
+    end
+    private_class_method :new
+
+    def to_h = @document
+  end
+end

--- a/packaging/patrol_evidence/result.rb
+++ b/packaging/patrol_evidence/result.rb
@@ -32,8 +32,29 @@ module HivePatrolEvidence
       smoke_validation unexpected_failure
     ].freeze
     AUTHORITY_KEYS = %w[
-      authorization_sha256 candidate_sha controller_script_sha256 controller_sha
-      invocation_id run_id runner_sha256
+      authorization_expires_at authorization_nonce_sha256 authorization_sha256 candidate_sha
+      control_tree_sha256 controller_script_sha256 controller_sha image invocation_id
+      observations_sha256 project_binding_sha256 run_id runner_sha256
+    ].freeze
+    CANDIDATE_PREPARED_KEYS = %w[
+      archive_member_count archive_sha256 archive_total_bytes candidate_sha
+      module_manifest_sha256 source_tree_sha256 status
+    ].freeze
+    CANDIDATE_VERIFIED_KEYS = %w[
+      archive_member_count archive_sha256 archive_total_bytes candidate_sha
+      dependency_closure_sha256 gem_sha256 installed_hive_sha256 module_manifest_sha256
+      source_tree_sha256 status toolchain_sha256
+    ].freeze
+    SANDBOX_KEYS = %w[
+      cpus engine engine_sha256 engine_version image image_id memory network process_limit
+      root_filesystem status writable_bytes writable_inodes
+    ].freeze
+    SMOKE_KEYS = %w[
+      catalog_digest modules receipt_count report_sha256 scenario_manifest_digest status
+    ].freeze
+    PROVIDER_KEYS = %w[model provider response_sha256 status usage].freeze
+    PROCESS_KEYS = %w[
+      container_id_sha256 exit_code outcome owner status stderr_sha256 stdout_sha256 teardown
     ].freeze
 
     class << self
@@ -66,7 +87,8 @@ module HivePatrolEvidence
         validate_authority!(authority)
         validate_time!(started_at, "started_at")
         validate_time!(finished_at, "finished_at") if finished_at
-        raise Error, "patrol smoke process evidence is malformed" unless process_evidence.is_a?(Array)
+        validate_records!(status, candidate:, sandbox:, smoke:, provider:, process_evidence:)
+        validate_cross_fields!(status, candidate:, sandbox:, smoke:, provider:, process_evidence:, finished_at:)
 
         document = {
           "schema" => SCHEMA,
@@ -107,15 +129,125 @@ module HivePatrolEvidence
         valid = authority.is_a?(Hash) && authority.keys.sort == AUTHORITY_KEYS &&
           authority.values_at("controller_sha", "candidate_sha").all? do |sha|
             sha.is_a?(String) && sha.match?(/\A[0-9a-f]{40}\z/)
-          end && authority.values_at("runner_sha256", "controller_script_sha256",
-                                     "authorization_sha256").all? do |digest|
+          end && authority.values_at(
+            "runner_sha256", "controller_script_sha256", "control_tree_sha256",
+            "authorization_sha256", "authorization_nonce_sha256", "observations_sha256",
+            "project_binding_sha256"
+          ).all? do |digest|
             digest.is_a?(String) && digest.match?(/\A[0-9a-f]{64}\z/)
           end && authority.values_at("run_id", "invocation_id").all? do |value|
             value.is_a?(String) && value.match?(/\A[A-Za-z0-9][A-Za-z0-9._-]{0,127}\z/)
-          end
+          end && authority.fetch("image").is_a?(String) &&
+          authority.fetch("image").match?(/\A[a-z0-9][a-z0-9._\/-]*@sha256:[0-9a-f]{64}\z/) &&
+          utc_time?(authority.fetch("authorization_expires_at"))
         raise Error, "patrol smoke authority binding is malformed" unless valid
         raise Error, "controller and candidate SHAs must be distinct" if
           authority.fetch("controller_sha") == authority.fetch("candidate_sha")
+      end
+
+      def validate_records!(status, candidate:, sandbox:, smoke:, provider:, process_evidence:)
+        raise Error, "patrol smoke process evidence is malformed" unless
+          process_evidence.is_a?(Array) && process_evidence.size <= 1
+        process_evidence.each { |row| validate_process!(row) }
+        validate_candidate!(candidate) if candidate
+        validate_sandbox!(sandbox) if sandbox
+        validate_smoke!(smoke) if smoke
+        validate_provider!(provider) if provider
+
+        return unless status == "installed_live_smoke_verified"
+
+        valid = candidate&.fetch("status", nil) == "verified" && sandbox&.fetch("status", nil) == "passed" &&
+          smoke&.fetch("status", nil) == "passed" && provider&.fetch("status", nil) == "passed" &&
+          process_evidence.one? && process_evidence.dig(0, "status") == "reaped" &&
+          process_evidence.dig(0, "outcome") == "success" &&
+          process_evidence.dig(0, "teardown") == "verified" &&
+          process_evidence.dig(0, "exit_code") == 0
+        raise Error, "verified patrol smoke is missing closed success evidence" unless valid
+      rescue KeyError, NoMethodError, TypeError
+        raise Error, "patrol smoke component evidence is malformed", cause: nil
+      end
+
+      def validate_cross_fields!(status, candidate:, sandbox:, smoke:, provider:, process_evidence:, finished_at:)
+        if status == "not_started"
+          valid = [ candidate, sandbox, smoke, provider, finished_at ].all?(&:nil?) && process_evidence.empty?
+        else
+          valid = !finished_at.nil?
+        end
+        raise Error, "patrol smoke status fields are inconsistent" unless valid
+      end
+
+      def validate_candidate!(value)
+        keys = value.fetch("status") == "prepared" ? CANDIDATE_PREPARED_KEYS : CANDIDATE_VERIFIED_KEYS
+        valid = value.is_a?(Hash) && %w[prepared verified].include?(value.fetch("status")) &&
+          value.keys.sort == keys &&
+          %w[candidate_sha].all? { |key| value.fetch(key).to_s.match?(/\A[0-9a-f]{40}\z/) } &&
+          %w[archive_sha256 module_manifest_sha256 source_tree_sha256].all? do |key|
+            value.fetch(key).to_s.match?(/\A[0-9a-f]{64}\z/)
+          end && value.fetch("archive_member_count").is_a?(Integer) &&
+          value.fetch("archive_member_count").positive? &&
+          value.fetch("archive_total_bytes").is_a?(Integer) && value.fetch("archive_total_bytes").positive?
+        if value.fetch("status") == "verified"
+          valid &&= %w[
+            dependency_closure_sha256 gem_sha256 installed_hive_sha256 toolchain_sha256
+          ].all? { |key| value.fetch(key).to_s.match?(/\A[0-9a-f]{64}\z/) }
+        end
+        raise Error, "patrol smoke candidate evidence is malformed" unless valid
+      end
+
+      def validate_sandbox!(value)
+        valid = value.is_a?(Hash) && value.keys.sort == SANDBOX_KEYS && value.fetch("status") == "passed" &&
+          %w[docker podman].include?(value.fetch("engine")) &&
+          value.fetch("engine_version").is_a?(String) && !value.fetch("engine_version").empty? &&
+          value.values_at("engine_sha256").all? { |item| item.to_s.match?(/\A[0-9a-f]{64}\z/) } &&
+          value.fetch("image").to_s.match?(/@sha256:[0-9a-f]{64}\z/) &&
+          value.fetch("image_id").to_s.match?(/\Asha256:[0-9a-f]{64}\z/) &&
+          value.values_at("network", "root_filesystem", "memory", "cpus") ==
+            %w[none read_only 2g 2] &&
+          value.fetch("process_limit").is_a?(Integer) && value.fetch("process_limit").positive? &&
+          value.fetch("writable_bytes").is_a?(Integer) && value.fetch("writable_bytes").positive? &&
+          value.fetch("writable_inodes").is_a?(Integer) && value.fetch("writable_inodes").positive?
+        raise Error, "patrol smoke sandbox evidence is malformed" unless valid
+      end
+
+      def validate_smoke!(value)
+        valid = value.is_a?(Hash) && value.keys.sort == SMOKE_KEYS && value.fetch("status") == "passed" &&
+          value.fetch("modules") == %w[architecture-patrol patrol] &&
+          value.fetch("receipt_count").is_a?(Integer) && value.fetch("receipt_count").positive? &&
+          %w[catalog_digest report_sha256 scenario_manifest_digest].all? do |key|
+            value.fetch(key).to_s.match?(/\A[0-9a-f]{64}\z/)
+          end
+        raise Error, "patrol smoke controller evidence is malformed" unless valid
+      end
+
+      def validate_provider!(value)
+        usage = value.fetch("usage")
+        valid = value.is_a?(Hash) && value.keys.sort == PROVIDER_KEYS && value.fetch("status") == "passed" &&
+          value.values_at("provider", "model") == [ "openrouter", "openai/gpt-5.6-terra" ] &&
+          value.fetch("response_sha256").to_s.match?(/\A[0-9a-f]{64}\z/) &&
+          usage.is_a?(Hash) && usage.keys.sort == %w[completion_tokens prompt_tokens total_tokens] &&
+          usage.values.all? { |item| item.is_a?(Integer) && item.positive? } &&
+          usage.fetch("total_tokens") >= usage.fetch("prompt_tokens") + usage.fetch("completion_tokens")
+        raise Error, "patrol smoke provider evidence is malformed" unless valid
+      end
+
+      def validate_process!(value)
+        valid = value.is_a?(Hash) && value.keys.sort == PROCESS_KEYS && value.fetch("owner") == "sandbox" &&
+          %w[reaped not_reaped].include?(value.fetch("status")) &&
+          %w[success failed timeout interrupted unavailable].include?(value.fetch("outcome")) &&
+          %w[verified unverified].include?(value.fetch("teardown")) &&
+          [ nil, Integer ].any? { |type| type.nil? ? value.fetch("exit_code").nil? : value.fetch("exit_code").is_a?(type) } &&
+          [ nil, value.fetch("container_id_sha256") ].compact.all? do |digest|
+            digest.to_s.match?(/\A[0-9a-f]{64}\z/)
+          end && %w[stdout_sha256 stderr_sha256].all? do |key|
+            value.fetch(key).to_s.match?(/\A[0-9a-f]{64}\z/)
+          end
+        raise Error, "patrol smoke process evidence is malformed" unless valid
+      end
+
+      def utc_time?(value)
+        Time.iso8601(value.to_s).utc_offset.zero?
+      rescue ArgumentError
+        false
       end
 
       def validate_time!(value, label)

--- a/packaging/patrol_evidence/runner.rb
+++ b/packaging/patrol_evidence/runner.rb
@@ -1,0 +1,482 @@
+# frozen_string_literal: true
+
+require "digest"
+require "fileutils"
+require "json"
+require "open3"
+require "securerandom"
+require "tempfile"
+require "time"
+require_relative "result"
+
+module HivePatrolEvidence
+  # Composes exactly one reduced installed smoke and publishes its single result.
+  class Runner
+    class Error < StandardError
+      attr_reader :reason
+
+      def initialize(reason, message = reason)
+        @reason = reason
+        super(message)
+      end
+    end
+    class AuthorityError < Error; end
+    class PublicationError < Error; end
+    class EvidenceError < Error; end
+
+    MAX_STORE_RESULTS = 128
+    MAX_STORE_BYTES = 64 * 1024 * 1024
+    MIN_RETENTION_DAYS = 30
+    SAFE_SHA = /\A[0-9a-f]{40}\z/
+    SAFE_ID = /\A[A-Za-z0-9][A-Za-z0-9._-]{0,127}\z/
+    READ_FLAGS = File::RDONLY | (File.const_defined?(:NOFOLLOW) ? File::NOFOLLOW : 0)
+
+    class << self
+      def run!(**options) = new(**options).send(:run)
+      def cleanup!(evidence_root:, result_path:, now: Time.now.utc)
+        allocate.send(:cleanup_result!, evidence_root:, result_path:, now:)
+      end
+
+      private :new
+    end
+
+    def initialize(repo_root:, evidence_root:, controller_sha:, candidate_sha:, authorization:,
+                   invocation_id:, project_root:, observations_path:, image:,
+                   candidate_factory: nil, sandbox_factory: nil, controller_factory: nil,
+                   provider_probe_factory: nil, clock: -> { Time.now.utc })
+      @repo_root = File.expand_path(repo_root)
+      @evidence_root = File.expand_path(evidence_root)
+      @controller_sha = controller_sha.to_s.downcase
+      @candidate_sha = candidate_sha.to_s.downcase
+      @authorization = authorization.to_s
+      @invocation_id = invocation_id.to_s
+      @project_root = File.expand_path(project_root)
+      @observations_path = File.expand_path(observations_path)
+      @image = image.to_s
+      @candidate_factory = candidate_factory
+      @sandbox_factory = sandbox_factory
+      @controller_factory = controller_factory
+      @provider_probe_factory = provider_probe_factory
+      @clock = clock
+    end
+
+    private
+
+    def cleanup_result!(evidence_root:, result_path:, now:)
+      root = File.realpath(File.expand_path(evidence_root))
+      root_stat = File.lstat(root)
+      unless root_stat.directory? && !root_stat.symlink? && root_stat.uid == Process.uid &&
+             (root_stat.mode & 0o777) == 0o700
+        raise EvidenceError.new("evidence_custody", "evidence store custody failed")
+      end
+      path = File.expand_path(result_path)
+      run_root = File.dirname(path)
+      unless File.basename(path) == "result.json" && File.dirname(run_root) == root &&
+             File.basename(run_root).match?(/\Au3c-[A-Za-z0-9._-]{1,123}\z/)
+        raise EvidenceError.new("evidence_custody", "cleanup result is outside the evidence store")
+      end
+      run_stat = File.lstat(run_root)
+      unless run_stat.directory? && !run_stat.symlink? && run_stat.uid == Process.uid &&
+             (run_stat.mode & 0o777) == 0o700
+        raise EvidenceError.new("evidence_custody", "cleanup run directory custody failed")
+      end
+      File.open(path, READ_FLAGS) do |file|
+        file.flock(File::LOCK_EX)
+        original = file.stat
+        unless original.file? && original.nlink == 1 && original.uid == Process.uid &&
+               (original.mode & 0o777) == 0o600 && original.size <= Result::MAX_RESULT_BYTES
+          raise EvidenceError.new("evidence_custody", "cleanup result custody failed")
+        end
+        bytes = file.read(Result::MAX_RESULT_BYTES + 1)
+        document = JSON.parse(bytes)
+        unless Result.canonical(document) == bytes &&
+               Result::TERMINAL_STATUSES.include?(document.fetch("status")) &&
+               document.fetch("finished_at")
+          raise EvidenceError.new("evidence_custody", "cleanup result is not terminal canonical evidence")
+        end
+        cutoff = now.utc - (MIN_RETENTION_DAYS * 86_400)
+        finished_at = Time.iso8601(document.fetch("finished_at"))
+        unless original.mtime.utc <= cutoff && finished_at.utc <= cutoff
+          raise EvidenceError.new("evidence_custody", "cleanup result is inside its retention window")
+        end
+        current = File.lstat(path)
+        unless %i[dev ino uid mode nlink].all? do |field|
+          current.public_send(field) == original.public_send(field)
+        end
+          raise EvidenceError.new("evidence_custody", "cleanup result identity changed")
+        end
+        File.unlink(path)
+        fsync_directory(run_root)
+      ensure
+        file.flock(File::LOCK_UN) rescue nil
+      end
+      unless Dir.empty?(run_root)
+        raise EvidenceError.new("evidence_custody", "cleanup run directory is not empty")
+      end
+      current_run = File.lstat(run_root)
+      unless %i[dev ino uid mode].all? do |field|
+        current_run.public_send(field) == run_stat.public_send(field)
+      end
+        raise EvidenceError.new("evidence_custody", "cleanup run directory identity changed")
+      end
+      Dir.rmdir(run_root)
+      fsync_directory(root)
+      true
+    rescue EvidenceError
+      raise
+    rescue JSON::ParserError, KeyError, ArgumentError, SystemCallError
+      raise EvidenceError.new("evidence_custody", "explicit evidence cleanup failed"), cause: nil
+    end
+
+    def run
+      verify_authority!
+      started_at = timestamp
+      run_id = run_id(started_at)
+      authority = authority_record(run_id)
+      begin
+        verify_evidence_store!
+      rescue EvidenceError => error
+        raise unless error.reason == "evidence_store_full"
+
+        terminal = Result.terminal(
+          status: "blocked", reason: error.reason, authority:, candidate: nil,
+          sandbox: nil, smoke: nil, provider: nil, process_evidence: [],
+          started_at: started_at.iso8601(6), finished_at: timestamp.iso8601(6)
+        )
+        return {
+          "status" => "blocked", "reason" => error.reason, "run_id" => run_id,
+          "result_path" => nil, "result" => terminal
+        }.freeze
+      end
+      run_root = create_run_root!(run_id)
+      result_path = File.join(run_root, "result.json")
+      initial = Result.not_started(authority:, started_at: started_at.iso8601(6))
+      create_initial_result!(result_path, initial.canonical_bytes)
+
+      candidate_owner = build_candidate
+      candidate = candidate_owner.prepare!(run_root:)
+      sandbox = build_sandbox
+      sandbox_receipt = sandbox.run!(
+        candidate:, project_root: @project_root, observations_path: @observations_path,
+        controller_root: @repo_root, run_root:, image: @image
+      )
+      admitted_candidate = candidate_owner.verify!(receipt: sandbox_receipt)
+      smoke = build_controller(run_root).external_smoke(
+        controller_sha: @controller_sha, candidate_sha: @candidate_sha,
+        candidate: admitted_candidate, sandbox_result: sandbox_receipt.fetch("payload")
+      )
+      reverify_control_bytes!(authority)
+      provider_owner = build_provider_probe
+      provider = provider_owner.call
+      reverify_control_bytes!(authority)
+      finished_at = timestamp
+      terminal = Result.terminal(
+        status: "installed_live_smoke_verified", reason: nil, authority:,
+        candidate: admitted_candidate, sandbox: sandbox_receipt.fetch("sandbox"),
+        smoke:, provider:, process_evidence: sandbox_receipt.fetch("process_evidence"),
+        started_at: started_at.iso8601(6), finished_at: finished_at.iso8601(6)
+      )
+      provider_owner.validate_retained!(terminal.canonical_bytes) if
+        provider_owner.respond_to?(:validate_retained!)
+      replace_expected!(result_path, initial.canonical_bytes, terminal.canonical_bytes)
+      {
+        "status" => terminal.to_h.fetch("status"), "run_id" => run_id,
+        "result_path" => result_path, "result" => terminal
+      }.freeze
+    rescue PublicationError
+      raise
+    rescue Error => error
+      publish_nonpassing(
+        error, result_path, initial, authority, started_at,
+        candidate: admitted_candidate, sandbox_receipt:, smoke:, provider:
+      )
+    rescue StandardError => error
+      reason = error.respond_to?(:reason) ? error.reason.to_s : "unexpected_failure"
+      reason = "unexpected_failure" unless Result::REASONS.include?(reason)
+      wrapped = Error.new(reason, error.class.name)
+      publish_nonpassing(
+        wrapped, result_path, initial, authority, started_at,
+        candidate: admitted_candidate, sandbox_receipt:, smoke:, provider:
+      )
+    end
+
+    def publish_nonpassing(error, result_path, initial, authority, started_at,
+                           candidate: nil, sandbox_receipt: nil, smoke: nil, provider: nil)
+      raise error unless result_path && initial && authority && started_at
+
+      status = blocked_reason?(error.reason) ? "blocked" : "failed"
+      reason = Result::REASONS.include?(error.reason) ? error.reason : "unexpected_failure"
+      terminal = Result.terminal(
+        status:, reason:, authority:, candidate:,
+        sandbox: sandbox_receipt&.fetch("sandbox"), smoke:, provider:,
+        process_evidence: sandbox_receipt&.fetch("process_evidence") || [],
+        started_at: started_at.iso8601(6),
+        finished_at: timestamp.iso8601(6)
+      )
+      replace_expected!(result_path, initial.canonical_bytes, terminal.canonical_bytes)
+      {
+        "status" => status, "reason" => reason, "run_id" => authority.fetch("run_id"),
+        "result_path" => result_path, "result" => terminal
+      }.freeze
+    end
+
+    def blocked_reason?(reason)
+      %w[
+        manual_authority_missing sandbox_unavailable installed_dependency_missing
+        credential_unavailable provider_unavailable evidence_store_full
+      ].include?(reason)
+    end
+
+    def verify_authority!
+      unless SAFE_SHA.match?(@controller_sha) && SAFE_SHA.match?(@candidate_sha) &&
+             @controller_sha != @candidate_sha
+        raise AuthorityError.new("authority_binding", "controller and candidate identities are invalid")
+      end
+      unless SAFE_ID.match?(@invocation_id) && @authorization.bytesize.between?(1, 4096)
+        raise AuthorityError.new("manual_authority_missing", "manual authorization is invalid")
+      end
+      repo = owned_directory!(@repo_root, "controller checkout")
+      head = git(repo, "rev-parse", "HEAD").strip
+      raise AuthorityError.new("authority_binding", "controller checkout is not the authorized SHA") unless
+        head == @controller_sha
+      status = git(repo, "status", "--porcelain", "--untracked-files=all")
+      raise AuthorityError.new("controller_checkout_dirty", "controller checkout is not clean") unless status.empty?
+      protected_main = protected_main_ref(repo)
+      ancestry!(repo, @controller_sha, protected_main, "controller is not reachable from protected main")
+      ancestry!(repo, @candidate_sha, protected_main, "candidate is not reachable from protected main")
+      ancestry!(repo, @controller_sha, @candidate_sha, "candidate does not descend from the controller")
+    end
+
+    def protected_main_ref(repo)
+      %w[refs/remotes/origin/main refs/heads/main].find do |ref|
+        _out, _err, status = Open3.capture3("git", "-C", repo, "rev-parse", "--verify", ref)
+        status.success?
+      end || raise(AuthorityError.new("authority_binding", "protected main is unavailable"))
+    end
+
+    def ancestry!(repo, ancestor, descendant, message)
+      _out, _err, status = Open3.capture3(
+        "git", "-C", repo, "merge-base", "--is-ancestor", ancestor, descendant
+      )
+      raise AuthorityError.new("authority_binding", message) unless status.success?
+    end
+
+    def verify_evidence_store!
+      root = owned_directory!(@evidence_root, "evidence store")
+      stat = File.lstat(root)
+      raise EvidenceError.new("evidence_custody", "evidence store must be mode 0700") unless
+        (stat.mode & 0o777) == 0o700
+      count = 0
+      bytes = 0
+      Dir.each_child(root) do |name|
+        path = File.join(root, name)
+        child = File.lstat(path)
+        unless child.directory? && !child.symlink? && child.uid == Process.uid &&
+               (child.mode & 0o777) == 0o700
+          raise EvidenceError.new("evidence_custody", "evidence store contains an unsafe run directory")
+        end
+        Dir.each_child(path) do |entry|
+          result = File.join(path, entry)
+          result_stat = File.lstat(result)
+          unless entry == "result.json" && result_stat.file? && !result_stat.symlink? &&
+                 result_stat.uid == Process.uid && (result_stat.mode & 0o777) == 0o600 &&
+                 result_stat.size <= Result::MAX_RESULT_BYTES
+            raise EvidenceError.new("evidence_custody", "evidence store contains an unsafe result")
+          end
+          count += 1
+          bytes += result_stat.size
+          if count >= MAX_STORE_RESULTS || bytes + Result::MAX_RESULT_BYTES > MAX_STORE_BYTES
+            raise EvidenceError.new("evidence_store_full", "evidence store is full")
+          end
+        end
+      end
+    rescue Errno::ENOENT, Errno::EACCES
+      raise EvidenceError.new("evidence_custody", "evidence store is unavailable")
+    end
+
+    def create_run_root!(run_id)
+      path = File.join(@evidence_root, run_id)
+      Dir.mkdir(path, 0o700)
+      stat = File.lstat(path)
+      unless stat.directory? && !stat.symlink? && stat.uid == Process.uid && (stat.mode & 0o777) == 0o700
+        raise EvidenceError.new("path_custody", "run directory custody failed")
+      end
+      path
+    rescue Errno::EEXIST
+      raise EvidenceError.new("path_custody", "run directory already exists")
+    end
+
+    def create_initial_result!(path, bytes)
+      flags = File::WRONLY | File::CREAT | File::EXCL
+      flags |= File::NOFOLLOW if File.const_defined?(:NOFOLLOW)
+      File.open(path, flags, 0o600) do |file|
+        file.binmode
+        file.write(bytes)
+        file.flush
+        file.fsync
+      end
+      File.chmod(0o600, path)
+      fsync_directory(File.dirname(path))
+    rescue SystemCallError
+      raise PublicationError.new("publication_conflict", "cannot create the initial result")
+    end
+
+    def replace_expected!(path, expected, replacement)
+      File.open(path, READ_FLAGS | File::RDWR) do |locked|
+        locked.flock(File::LOCK_EX)
+        original = locked.stat
+        validate_result_identity!(path, original)
+        actual = locked.read(Result::MAX_RESULT_BYTES + 1)
+        raise PublicationError.new("publication_conflict", "result expected bytes changed") unless
+          actual == expected
+
+        Tempfile.create([ ".patrol-result-", ".tmp" ], File.dirname(path), mode: File::RDWR, perm: 0o600) do |staged|
+          staged.binmode
+          staged.write(replacement)
+          staged.flush
+          staged.fsync
+          File.chmod(0o600, staged.path)
+          validate_result_identity!(path, original)
+          locked.rewind
+          raise PublicationError.new("publication_conflict", "result changed while locked") unless
+            locked.read(Result::MAX_RESULT_BYTES + 1) == expected
+          File.rename(staged.path, path)
+        end
+        fsync_directory(File.dirname(path))
+      ensure
+        locked.flock(File::LOCK_UN) rescue nil
+      end
+      File.open(path, READ_FLAGS) do |published|
+        stat = published.stat
+        valid = stat.file? && stat.uid == Process.uid && (stat.mode & 0o777) == 0o600 &&
+          published.read(Result::MAX_RESULT_BYTES + 1) == replacement
+        raise PublicationError.new("publication_conflict", "published result differs") unless valid
+      end
+    rescue PublicationError
+      raise
+    rescue SystemCallError
+      raise PublicationError.new("publication_conflict", "result publication failed")
+    end
+
+    def validate_result_identity!(path, expected)
+      current = File.lstat(path)
+      fields = %i[dev ino uid mode nlink]
+      valid = current.file? && !current.symlink? && current.nlink == 1 &&
+        fields.all? { |field| current.public_send(field) == expected.public_send(field) }
+      raise PublicationError.new("publication_conflict", "result path identity changed") unless valid
+    end
+
+    def build_candidate
+      return @candidate_factory.call(
+        repo_root: @repo_root, controller_sha: @controller_sha, candidate_sha: @candidate_sha
+      ) if @candidate_factory
+
+      require_relative "candidate"
+      Candidate.new(repo_root: @repo_root, controller_sha: @controller_sha, candidate_sha: @candidate_sha)
+    end
+
+    def build_sandbox
+      return @sandbox_factory.call(image: @image) if @sandbox_factory
+
+      require_relative "sandbox"
+      Sandbox.new(image: @image)
+    end
+
+    def build_controller(run_root)
+      return @controller_factory.call(
+        repo_root: @repo_root, project_root: @project_root,
+        observations_path: @observations_path, run_root:
+      ) if @controller_factory
+
+      require_relative "../../test/e2e/lib/patrol_qualification"
+      Hive::E2E::PatrolQualification::Controller.new(
+        repo_root: @repo_root, project_root: @project_root,
+        hive_home: File.join(run_root, "controller-home"),
+        observations_path: @observations_path, evidence_root: run_root
+      )
+    end
+
+    def build_provider_probe
+      @provider_probe ||= if @provider_probe_factory
+        @provider_probe_factory.call
+      else
+        require_relative "provider_probe"
+        ProviderProbe.new
+      end
+    end
+
+    def authority_record(run_id)
+      {
+        "run_id" => run_id,
+        "controller_sha" => @controller_sha,
+        "candidate_sha" => @candidate_sha,
+        "runner_sha256" => Digest::SHA256.file(__FILE__).hexdigest,
+        "controller_script_sha256" => controller_script_digest,
+        "authorization_sha256" => Digest::SHA256.hexdigest(@authorization),
+        "invocation_id" => @invocation_id
+      }
+    end
+
+    def run_id(time)
+      suffix = Digest::SHA256.hexdigest(
+        [ @controller_sha, @candidate_sha, @invocation_id, @authorization ].join("\0")
+      )[0, 12]
+      "u3c-#{time.utc.strftime('%Y%m%dT%H%M%S%6NZ')}-#{suffix}"
+    end
+
+    def reverify_control_bytes!(authority)
+      valid = Digest::SHA256.file(__FILE__).hexdigest == authority.fetch("runner_sha256") &&
+        controller_script_digest == authority.fetch("controller_script_sha256")
+      raise AuthorityError.new("authority_binding", "controller bytes changed during the run") unless valid
+    rescue SystemCallError
+      raise AuthorityError.new("authority_binding", "controller bytes are unavailable")
+    end
+
+    def controller_script_digest
+      path = File.join(@repo_root, "test/e2e/lib/patrol_qualification.rb")
+      flags = File::RDONLY
+      flags |= File::NOFOLLOW if File.const_defined?(:NOFOLLOW)
+      File.open(path, flags) do |file|
+        stat = file.stat
+        unless stat.file? && stat.nlink == 1 && stat.uid == Process.uid && stat.size <= 1024 * 1024
+          raise AuthorityError.new("authority_binding", "controller script is unsafe")
+        end
+        digest = Digest::SHA256.new
+        while (chunk = file.read(64 * 1024))
+          digest.update(chunk)
+        end
+        digest.hexdigest
+      end
+    rescue Errno::ENOENT, Errno::ELOOP, Errno::EACCES
+      raise AuthorityError.new("authority_binding", "controller script is unavailable")
+    end
+
+    def timestamp
+      value = @clock.call
+      raise AuthorityError.new("authority_binding", "clock is invalid") unless value.respond_to?(:utc)
+      value.utc
+    end
+
+    def owned_directory!(path, label)
+      stat = File.lstat(path)
+      unless stat.directory? && !stat.symlink? && stat.uid == Process.uid
+        raise AuthorityError.new("authority_binding", "#{label} is not an owned directory")
+      end
+      File.realpath(path)
+    rescue Errno::ENOENT, Errno::EACCES
+      raise AuthorityError.new("authority_binding", "#{label} is unavailable")
+    end
+
+    def git(repo, *arguments)
+      stdout, _stderr, status = Open3.capture3("git", "-C", repo, *arguments)
+      raise AuthorityError.new("authority_binding", "git authority check failed") unless status.success?
+      stdout
+    rescue SystemCallError
+      raise AuthorityError.new("authority_binding", "git authority check is unavailable")
+    end
+
+    def fsync_directory(path)
+      File.open(path, File::RDONLY) { |directory| directory.fsync }
+    end
+  end
+end

--- a/packaging/patrol_evidence/runner.rb
+++ b/packaging/patrol_evidence/runner.rb
@@ -7,6 +7,10 @@ require "open3"
 require "securerandom"
 require "tempfile"
 require "time"
+require "timeout"
+require "tmpdir"
+require "yaml"
+require_relative "../../lib/hive/repository_identity"
 require_relative "result"
 
 module HivePatrolEvidence
@@ -23,29 +27,75 @@ module HivePatrolEvidence
     class AuthorityError < Error; end
     class PublicationError < Error; end
     class EvidenceError < Error; end
+    class CancellationError < Error; end
 
     MAX_STORE_RESULTS = 128
     MAX_STORE_BYTES = 64 * 1024 * 1024
     MIN_RETENTION_DAYS = 30
     SAFE_SHA = /\A[0-9a-f]{40}\z/
+    SAFE_DIGEST = /\A[0-9a-f]{64}\z/
     SAFE_ID = /\A[A-Za-z0-9][A-Za-z0-9._-]{0,127}\z/
     READ_FLAGS = File::RDONLY | (File.const_defined?(:NOFOLLOW) ? File::NOFOLLOW : 0)
+    AUTHORIZATION_SCHEMA = "hive-patrol-installed-live-smoke-authorization"
+    AUTHORIZATION_KEYS = %w[
+      candidate_sha controller_sha expires_at image invocation_id issued_at model nonce
+      observations_sha256 project_binding_sha256 provider schema schema_version
+    ].freeze
+    CONTROL_PATHS = %w[
+      packaging/patrol_evidence/runner.rb
+      packaging/patrol_evidence/result.rb
+      packaging/patrol_evidence/candidate.rb
+      packaging/patrol_evidence/sandbox.rb
+      packaging/patrol_evidence/provider_probe.rb
+      test/e2e/lib/patrol_qualification.rb
+      test/e2e/fixtures/patrol_qualification/catalog.json
+      lib/hive/secret_patterns.rb
+    ].freeze
+    PROJECT_TREE_MAX_FILES = 4_096
+    PROJECT_TREE_MAX_BYTES = 64 * 1024 * 1024
+    INPUT_FILE_MAX_BYTES = 8 * 1024 * 1024
+    AUTHORIZATION_MAX_AGE = 3600
+    GIT_ENV = {
+      "HOME" => "/nonexistent", "PATH" => "/usr/bin:/bin",
+      "GIT_ATTR_NOSYSTEM" => "1", "GIT_CONFIG_GLOBAL" => "/dev/null",
+      "GIT_CONFIG_NOSYSTEM" => "1", "GIT_CONFIG_SYSTEM" => "/dev/null",
+      "GIT_NO_REPLACE_OBJECTS" => "1", "GIT_TERMINAL_PROMPT" => "0"
+    }.freeze
 
     class << self
-      def run!(**options) = new(**options).send(:run)
+      def run!(repo_root:, evidence_root:, hive_home:, controller_sha:, candidate_sha:,
+               authorization:, invocation_id:, project_root:, observations_path:, image:)
+        new(
+          repo_root:, evidence_root:, hive_home:, controller_sha:, candidate_sha:,
+          authorization:, invocation_id:, project_root:, observations_path:, image:
+        ).send(:run)
+      end
+
       def cleanup!(evidence_root:, result_path:, now: Time.now.utc)
         allocate.send(:cleanup_result!, evidence_root:, result_path:, now:)
+      end
+
+      def authorization_template!(repo_root:, evidence_root:, hive_home:, controller_sha:, candidate_sha:,
+                                  invocation_id:, project_root:, observations_path:, image:,
+                                  now: Time.now.utc, nonce: SecureRandom.hex(16))
+        runner = new(
+          repo_root:, evidence_root:, hive_home:, controller_sha:, candidate_sha:,
+          authorization: "", invocation_id:, project_root:, observations_path:, image:
+        )
+        runner.send(:verify_static_authority!)
+        runner.send(:authorization_template, now.utc, nonce)
       end
 
       private :new
     end
 
-    def initialize(repo_root:, evidence_root:, controller_sha:, candidate_sha:, authorization:,
+    def initialize(repo_root:, evidence_root:, hive_home:, controller_sha:, candidate_sha:, authorization:,
                    invocation_id:, project_root:, observations_path:, image:,
                    candidate_factory: nil, sandbox_factory: nil, controller_factory: nil,
                    provider_probe_factory: nil, clock: -> { Time.now.utc })
       @repo_root = File.expand_path(repo_root)
       @evidence_root = File.expand_path(evidence_root)
+      @hive_home = File.expand_path(hive_home)
       @controller_sha = controller_sha.to_s.downcase
       @candidate_sha = candidate_sha.to_s.downcase
       @authorization = authorization.to_s
@@ -99,6 +149,9 @@ module HivePatrolEvidence
         unless original.mtime.utc <= cutoff && finished_at.utc <= cutoff
           raise EvidenceError.new("evidence_custody", "cleanup result is inside its retention window")
         end
+        unless Dir.children(run_root) == [ "result.json" ]
+          raise EvidenceError.new("evidence_custody", "cleanup result is not the sole run artifact")
+        end
         current = File.lstat(path)
         unless %i[dev ino uid mode nlink].all? do |field|
           current.public_send(field) == original.public_send(field)
@@ -129,12 +182,21 @@ module HivePatrolEvidence
     end
 
     def run
-      verify_authority!
+      result_path = initial = transient_root = candidate_custody = admitted_candidate = nil
+      sandbox_receipt = smoke = provider = nil
       started_at = timestamp
+      verify_authority!(started_at)
       run_id = run_id(started_at)
       authority = authority_record(run_id)
       begin
-        verify_evidence_store!
+        with_store_lock do
+          verify_evidence_store!
+          reject_authorization_replay!(authority.fetch("authorization_sha256"))
+          run_root = create_run_root!(run_id)
+          result_path = File.join(run_root, "result.json")
+          initial = Result.not_started(authority:, started_at: started_at.iso8601(6))
+          create_initial_result!(result_path, initial.canonical_bytes)
+        end
       rescue EvidenceError => error
         raise unless error.reason == "evidence_store_full"
 
@@ -148,27 +210,28 @@ module HivePatrolEvidence
           "result_path" => nil, "result" => terminal
         }.freeze
       end
-      run_root = create_run_root!(run_id)
-      result_path = File.join(run_root, "result.json")
-      initial = Result.not_started(authority:, started_at: started_at.iso8601(6))
-      create_initial_result!(result_path, initial.canonical_bytes)
 
+      transient_root = create_transient_root!
       candidate_owner = build_candidate
-      candidate = candidate_owner.prepare!(run_root:)
+      candidate = candidate_owner.prepare!(run_root: transient_root)
+      candidate_custody = prepared_candidate_record(candidate)
+      reverify_phase_bindings!(authority)
       sandbox = build_sandbox
       sandbox_receipt = sandbox.run!(
         candidate:, project_root: @project_root, observations_path: @observations_path,
-        controller_root: @repo_root, run_root:, image: @image
+        controller_root: @repo_root, run_root: transient_root, image: @image
       )
-      admitted_candidate = candidate_owner.verify!(receipt: sandbox_receipt)
-      smoke = build_controller(run_root).external_smoke(
+      admitted_candidate = candidate_owner.verify!(receipt: sandbox_receipt).merge("status" => "verified").freeze
+      smoke = build_controller(transient_root).external_smoke(
         controller_sha: @controller_sha, candidate_sha: @candidate_sha,
         candidate: admitted_candidate, sandbox_result: sandbox_receipt.fetch("payload")
       )
-      reverify_control_bytes!(authority)
+      reverify_phase_bindings!(authority)
+      remove_transient_root!(transient_root)
+      transient_root = nil
       provider_owner = build_provider_probe
       provider = provider_owner.call
-      reverify_control_bytes!(authority)
+      reverify_phase_bindings!(authority)
       finished_at = timestamp
       terminal = Result.terminal(
         status: "installed_live_smoke_verified", reason: nil, authority:,
@@ -186,22 +249,40 @@ module HivePatrolEvidence
     rescue PublicationError
       raise
     rescue Error => error
+      process_evidence = error.respond_to?(:process_evidence) ? error.process_evidence : nil
+      error, transient_root = cleanup_after_error(error, transient_root)
       publish_nonpassing(
         error, result_path, initial, authority, started_at,
-        candidate: admitted_candidate, sandbox_receipt:, smoke:, provider:
+        candidate: admitted_candidate || candidate_custody, sandbox_receipt:, smoke:, provider:,
+        process_evidence:
       )
     rescue StandardError => error
+      process_evidence = error.respond_to?(:process_evidence) ? error.process_evidence : nil
       reason = error.respond_to?(:reason) ? error.reason.to_s : "unexpected_failure"
       reason = "unexpected_failure" unless Result::REASONS.include?(reason)
       wrapped = Error.new(reason, error.class.name)
+      wrapped, transient_root = cleanup_after_error(wrapped, transient_root)
       publish_nonpassing(
         wrapped, result_path, initial, authority, started_at,
-        candidate: admitted_candidate, sandbox_receipt:, smoke:, provider:
+        candidate: admitted_candidate || candidate_custody, sandbox_receipt:, smoke:, provider:,
+        process_evidence:
       )
+    ensure
+      remove_transient_root!(transient_root) if transient_root
+    end
+
+    def cleanup_after_error(error, transient_root)
+      return [ error, nil ] unless transient_root
+
+      remove_transient_root!(transient_root)
+      [ error, nil ]
+    rescue Error => cleanup_error
+      [ cleanup_error, nil ]
     end
 
     def publish_nonpassing(error, result_path, initial, authority, started_at,
-                           candidate: nil, sandbox_receipt: nil, smoke: nil, provider: nil)
+                           candidate: nil, sandbox_receipt: nil, smoke: nil, provider: nil,
+                           process_evidence: nil)
       raise error unless result_path && initial && authority && started_at
 
       status = blocked_reason?(error.reason) ? "blocked" : "failed"
@@ -209,7 +290,7 @@ module HivePatrolEvidence
       terminal = Result.terminal(
         status:, reason:, authority:, candidate:,
         sandbox: sandbox_receipt&.fetch("sandbox"), smoke:, provider:,
-        process_evidence: sandbox_receipt&.fetch("process_evidence") || [],
+        process_evidence: process_evidence || sandbox_receipt&.fetch("process_evidence") || [],
         started_at: started_at.iso8601(6),
         finished_at: timestamp.iso8601(6)
       )
@@ -227,38 +308,232 @@ module HivePatrolEvidence
       ].include?(reason)
     end
 
-    def verify_authority!
+    def verify_authority!(now)
+      verify_static_authority!
+      @authorization_record = admit_authorization(now)
+    end
+
+    def verify_static_authority!
       unless SAFE_SHA.match?(@controller_sha) && SAFE_SHA.match?(@candidate_sha) &&
              @controller_sha != @candidate_sha
         raise AuthorityError.new("authority_binding", "controller and candidate identities are invalid")
       end
-      unless SAFE_ID.match?(@invocation_id) && @authorization.bytesize.between?(1, 4096)
-        raise AuthorityError.new("manual_authority_missing", "manual authorization is invalid")
-      end
+      raise AuthorityError.new("manual_authority_missing", "manual invocation identity is invalid") unless
+        SAFE_ID.match?(@invocation_id)
       repo = owned_directory!(@repo_root, "controller checkout")
       head = git(repo, "rev-parse", "HEAD").strip
       raise AuthorityError.new("authority_binding", "controller checkout is not the authorized SHA") unless
         head == @controller_sha
       status = git(repo, "status", "--porcelain", "--untracked-files=all")
       raise AuthorityError.new("controller_checkout_dirty", "controller checkout is not clean") unless status.empty?
+      remote_identity = Hive::RepositoryIdentity.normalize(git(repo, "remote", "get-url", "origin"), base_path: repo)
+      unless remote_identity == "github.com/ivankuznetsov/hive"
+        raise AuthorityError.new("authority_binding", "controller repository identity differs")
+      end
       protected_main = protected_main_ref(repo)
       ancestry!(repo, @controller_sha, protected_main, "controller is not reachable from protected main")
       ancestry!(repo, @candidate_sha, protected_main, "candidate is not reachable from protected main")
       ancestry!(repo, @controller_sha, @candidate_sha, "candidate does not descend from the controller")
+      verify_control_tree!(repo)
+      @project_binding = build_project_binding
     end
 
     def protected_main_ref(repo)
-      %w[refs/remotes/origin/main refs/heads/main].find do |ref|
-        _out, _err, status = Open3.capture3("git", "-C", repo, "rev-parse", "--verify", ref)
-        status.success?
-      end || raise(AuthorityError.new("authority_binding", "protected main is unavailable"))
+      ref = "refs/remotes/origin/main"
+      resolved = git(repo, "rev-parse", "--verify", "#{ref}^{commit}").strip
+      raise AuthorityError.new("authority_binding", "protected main is unavailable") unless SAFE_SHA.match?(resolved)
+
+      resolved
     end
 
     def ancestry!(repo, ancestor, descendant, message)
-      _out, _err, status = Open3.capture3(
-        "git", "-C", repo, "merge-base", "--is-ancestor", ancestor, descendant
-      )
+      _out, _err, status = capture_git(repo, "merge-base", "--is-ancestor", ancestor, descendant)
       raise AuthorityError.new("authority_binding", message) unless status.success?
+    end
+
+    def verify_control_tree!(repo)
+      rows = CONTROL_PATHS.map do |relative|
+        path = File.join(repo, relative)
+        bytes = read_regular_file!(path, "controller file", 2 * 1024 * 1024)
+        committed = git(repo, "show", "#{@controller_sha}:#{relative}")
+        unless Digest::SHA256.digest(bytes) == Digest::SHA256.digest(committed)
+          raise AuthorityError.new("authority_binding", "controller file differs from its authorized commit")
+        end
+        [ relative, Digest::SHA256.hexdigest(bytes) ]
+      end
+      @control_tree_sha256 = digest_json(rows.to_h)
+    end
+
+    def admit_authorization(now)
+      unless @authorization.bytesize.between?(1, 8192)
+        raise AuthorityError.new("manual_authority_missing", "manual authorization is invalid")
+      end
+      document = JSON.parse(@authorization)
+      unless document.is_a?(Hash) && document.keys.sort == AUTHORIZATION_KEYS &&
+             Result.canonical(document) == @authorization &&
+             document.values_at("schema", "schema_version") == [ AUTHORIZATION_SCHEMA, 1 ]
+        raise AuthorityError.new("manual_authority_missing", "manual authorization is not canonical")
+      end
+      issued_at = Time.iso8601(document.fetch("issued_at"))
+      expires_at = Time.iso8601(document.fetch("expires_at"))
+      expected = {
+        "controller_sha" => @controller_sha, "candidate_sha" => @candidate_sha,
+        "invocation_id" => @invocation_id, "image" => @image,
+        "project_binding_sha256" => @project_binding.fetch("digest"),
+        "observations_sha256" => @project_binding.fetch("observations_sha256"),
+        "provider" => "openrouter", "model" => "openai/gpt-5.6-terra"
+      }
+      valid = expected.all? { |key, value| document.fetch(key) == value } &&
+        SAFE_ID.match?(document.fetch("nonce").to_s) && issued_at.utc_offset.zero? &&
+        expires_at.utc_offset.zero? && issued_at <= now && now < expires_at &&
+        expires_at > issued_at && expires_at - issued_at <= AUTHORIZATION_MAX_AGE
+      raise AuthorityError.new("manual_authority_missing", "manual authorization scope is invalid") unless valid
+
+      document.freeze
+    rescue JSON::ParserError, KeyError, ArgumentError, TypeError
+      raise AuthorityError.new("manual_authority_missing", "manual authorization is invalid"), cause: nil
+    end
+
+    def authorization_template(now, nonce)
+      unless SAFE_ID.match?(nonce.to_s)
+        raise AuthorityError.new("manual_authority_missing", "manual authorization nonce is invalid")
+      end
+      Result.canonical(
+        "schema" => AUTHORIZATION_SCHEMA,
+        "schema_version" => 1,
+        "controller_sha" => @controller_sha,
+        "candidate_sha" => @candidate_sha,
+        "invocation_id" => @invocation_id,
+        "image" => @image,
+        "project_binding_sha256" => @project_binding.fetch("digest"),
+        "observations_sha256" => @project_binding.fetch("observations_sha256"),
+        "provider" => "openrouter",
+        "model" => "openai/gpt-5.6-terra",
+        "issued_at" => now.iso8601(6),
+        "expires_at" => (now + 900).iso8601(6),
+        "nonce" => nonce.to_s
+      )
+    end
+
+    def build_project_binding
+      project = owned_directory!(@project_root, "disposable project")
+      hive_home = owned_directory!(@hive_home, "Hive registry root")
+      registry_path = File.join(hive_home, "config.yml")
+      registry_bytes = read_regular_file!(registry_path, "Hive project registry", 1024 * 1024)
+      registry = YAML.safe_load(registry_bytes, permitted_classes: [], permitted_symbols: [], aliases: false)
+      rows = registry.is_a?(Hash) ? Array(registry["registered_projects"]) : []
+      matches = rows.select do |row|
+        next false unless row.is_a?(Hash) && row["path"].is_a?(String)
+
+        File.realpath(File.expand_path(row.fetch("path"))) == project
+      rescue SystemCallError
+        false
+      end
+      unless matches.one?
+        raise AuthorityError.new("authority_binding", "disposable project registration is unavailable")
+      end
+      registration = admit_registration(matches.fetch(0), project)
+      repository_root = git(project, "rev-parse", "--show-toplevel").strip
+      unless File.realpath(repository_root) == project
+        raise AuthorityError.new("authority_binding", "disposable project is not a repository root")
+      end
+      repository_head = git(project, "rev-parse", "HEAD").strip
+      raise AuthorityError.new("authority_binding", "disposable project HEAD is invalid") unless
+        SAFE_SHA.match?(repository_head)
+      origin = git(project, "remote", "get-url", "origin").strip
+      repository_identity = Hive::RepositoryIdentity.normalize(origin, base_path: project)
+      unless repository_identity && repository_identity == registration.fetch("repository_identity")
+        raise AuthorityError.new("authority_binding", "disposable project repository identity differs")
+      end
+      state_root = File.join(project, ".hive-state")
+      state_stat = owned_directory_stat!(state_root, "disposable Hive state")
+      config_path = File.join(state_root, "config.yml")
+      config_bytes = read_regular_file!(config_path, "disposable project configuration", 1024 * 1024)
+      config = YAML.safe_load(config_bytes, permitted_classes: [], permitted_symbols: [], aliases: false)
+      unless config.is_a?(Hash) && File.expand_path(config.fetch("hive_state_path", ".hive-state"), project) == state_root
+        raise AuthorityError.new("authority_binding", "disposable project configuration escapes its state root")
+      end
+      observations = file_binding!(@observations_path, "prepared observations", INPUT_FILE_MAX_BYTES)
+      state_tree = tree_binding!(state_root)
+      project_stat = File.lstat(project)
+      payload = {
+        "project_path_sha256" => Digest::SHA256.hexdigest(project),
+        "project_identity" => stat_identity(project_stat),
+        "registration_sha256" => digest_json(registration),
+        "registry_sha256" => Digest::SHA256.hexdigest(registry_bytes),
+        "repository_identity_sha256" => Digest::SHA256.hexdigest(repository_identity),
+        "repository_head" => repository_head,
+        "state_identity" => stat_identity(state_stat),
+        "state_tree_sha256" => state_tree,
+        "config_sha256" => Digest::SHA256.hexdigest(config_bytes),
+        "observations_identity" => observations.fetch("identity"),
+        "observations_sha256" => observations.fetch("sha256")
+      }
+      payload.merge("digest" => digest_json(payload)).freeze
+    rescue Psych::Exception, KeyError, TypeError, SystemCallError
+      raise AuthorityError.new("authority_binding", "disposable project binding is invalid"), cause: nil
+    end
+
+    def admit_registration(row, project)
+      state = File.join(project, ".hive-state")
+      values = row.values_at(
+        "name", "path", "hive_state_path", "project_id", "registration_id",
+        "registered_at", "repository_identity"
+      )
+      valid = values.all? { |value| value.is_a?(String) && !value.empty? } &&
+        File.expand_path(row.fetch("path")) == project &&
+        File.expand_path(row.fetch("hive_state_path"), project) == state &&
+        (!row.key?("real_path") || File.expand_path(row.fetch("real_path")) == project)
+      raise AuthorityError.new("authority_binding", "disposable project registration is malformed") unless valid
+
+      row.slice(
+        "name", "path", "real_path", "hive_state_path", "project_id", "registration_id",
+        "registered_at", "repository_identity"
+      ).sort.to_h
+    end
+
+    def tree_binding!(root)
+      count = 0
+      bytes = 0
+      rows = []
+      walk = lambda do |directory, prefix|
+        Dir.children(directory).sort.each do |name|
+          raise AuthorityError.new("input_bound", "disposable state path is oversized") if
+            name.bytesize > 240 || name == "." || name == ".."
+          path = File.join(directory, name)
+          relative = prefix.empty? ? name : File.join(prefix, name)
+          stat = File.lstat(path)
+          count += 1
+          raise AuthorityError.new("input_bound", "disposable state tree has too many entries") if
+            count > PROJECT_TREE_MAX_FILES
+          if stat.directory? && !stat.symlink?
+            rows << [ relative, "directory", stat.mode & 0o777 ]
+            walk.call(path, relative)
+          elsif stat.file? && !stat.symlink? && stat.nlink == 1 && stat.uid == Process.uid
+            bytes += stat.size
+            raise AuthorityError.new("input_bound", "disposable state tree is oversized") if
+              bytes > PROJECT_TREE_MAX_BYTES
+            content = read_regular_file!(
+              path, "disposable state file", PROJECT_TREE_MAX_BYTES, allow_empty: true
+            )
+            rows << [ relative, "file", stat.mode & 0o777, stat.size, Digest::SHA256.hexdigest(content) ]
+          else
+            raise AuthorityError.new("authority_binding", "disposable state tree contains an unsafe entry")
+          end
+        end
+      end
+      walk.call(root, "")
+      digest_json(rows)
+    end
+
+    def file_binding!(path, label, limit)
+      bytes = read_regular_file!(path, label, limit)
+      stat = File.lstat(File.expand_path(path))
+      { "identity" => stat_identity(stat), "sha256" => Digest::SHA256.hexdigest(bytes) }
+    end
+
+    def stat_identity(stat)
+      %i[dev ino uid mode nlink size].to_h { |field| [ field.to_s, stat.public_send(field) ] }
     end
 
     def verify_evidence_store!
@@ -294,6 +569,36 @@ module HivePatrolEvidence
       raise EvidenceError.new("evidence_custody", "evidence store is unavailable")
     end
 
+    def with_store_lock
+      root = owned_directory!(@evidence_root, "evidence store")
+      File.open(root, File::RDONLY) do |directory|
+        directory.flock(File::LOCK_EX)
+        yield
+      ensure
+        directory.flock(File::LOCK_UN) rescue nil
+      end
+    rescue EvidenceError, AuthorityError
+      raise
+    rescue SystemCallError
+      raise EvidenceError.new("evidence_custody", "evidence store lock is unavailable"), cause: nil
+    end
+
+    def reject_authorization_replay!(digest)
+      Dir.each_child(@evidence_root) do |name|
+        path = File.join(@evidence_root, name, "result.json")
+        next unless File.file?(path)
+
+        bytes = read_regular_file!(path, "retained result", Result::MAX_RESULT_BYTES)
+        document = JSON.parse(bytes)
+        next unless Result.canonical(document) == bytes
+        next unless document.dig("authority", "authorization_sha256") == digest
+
+        raise AuthorityError.new("manual_authority_missing", "manual authorization was already used")
+      end
+    rescue JSON::ParserError, KeyError, TypeError
+      raise EvidenceError.new("evidence_custody", "retained evidence is malformed"), cause: nil
+    end
+
     def create_run_root!(run_id)
       path = File.join(@evidence_root, run_id)
       Dir.mkdir(path, 0o700)
@@ -304,6 +609,51 @@ module HivePatrolEvidence
       path
     rescue Errno::EEXIST
       raise EvidenceError.new("path_custody", "run directory already exists")
+    end
+
+    def create_transient_root!
+      path = Dir.mktmpdir("hive-patrol-u3c-")
+      File.chmod(0o700, path)
+      stat = File.lstat(path)
+      unless stat.directory? && !stat.symlink? && stat.uid == Process.uid && (stat.mode & 0o777) == 0o700
+        raise EvidenceError.new("path_custody", "transient workspace custody failed")
+      end
+      @transient_identity = stat_identity(stat)
+      path
+    rescue SystemCallError
+      raise EvidenceError.new("path_custody", "transient workspace is unavailable"), cause: nil
+    end
+
+    def remove_transient_root!(path)
+      absolute = File.expand_path(path)
+      stat = File.lstat(absolute)
+      unless @transient_identity && stat_identity(stat) == @transient_identity &&
+             stat.directory? && !stat.symlink? && stat.uid == Process.uid
+        raise EvidenceError.new("path_custody", "transient workspace identity changed")
+      end
+      FileUtils.remove_entry_secure(absolute)
+      @transient_identity = nil
+      true
+    rescue Errno::ENOENT
+      raise EvidenceError.new("path_custody", "transient workspace disappeared"), cause: nil
+    rescue EvidenceError
+      raise
+    rescue SystemCallError
+      raise EvidenceError.new("path_custody", "transient workspace cleanup failed"), cause: nil
+    end
+
+    def prepared_candidate_record(candidate)
+      keys = %w[
+        archive_member_count archive_sha256 archive_total_bytes candidate_sha
+        module_manifest_sha256 source_tree_sha256
+      ]
+      row = candidate.slice(*keys)
+      unless row.keys.sort == keys.sort
+        raise EvidenceError.new("candidate_identity", "prepared candidate custody is incomplete")
+      end
+      row.merge("status" => "prepared").freeze
+    rescue NoMethodError, TypeError
+      raise EvidenceError.new("candidate_identity", "prepared candidate custody is malformed"), cause: nil
     end
 
     def create_initial_result!(path, bytes)
@@ -412,22 +762,31 @@ module HivePatrolEvidence
         "candidate_sha" => @candidate_sha,
         "runner_sha256" => Digest::SHA256.file(__FILE__).hexdigest,
         "controller_script_sha256" => controller_script_digest,
+        "control_tree_sha256" => @control_tree_sha256,
         "authorization_sha256" => Digest::SHA256.hexdigest(@authorization),
-        "invocation_id" => @invocation_id
+        "authorization_nonce_sha256" => Digest::SHA256.hexdigest(@authorization_record.fetch("nonce")),
+        "authorization_expires_at" => @authorization_record.fetch("expires_at"),
+        "invocation_id" => @invocation_id,
+        "image" => @image,
+        "observations_sha256" => @project_binding.fetch("observations_sha256"),
+        "project_binding_sha256" => @project_binding.fetch("digest")
       }
     end
 
     def run_id(time)
       suffix = Digest::SHA256.hexdigest(
-        [ @controller_sha, @candidate_sha, @invocation_id, @authorization ].join("\0")
+        [ @controller_sha, @candidate_sha, @invocation_id, Digest::SHA256.hexdigest(@authorization) ].join("\0")
       )[0, 12]
       "u3c-#{time.utc.strftime('%Y%m%dT%H%M%S%6NZ')}-#{suffix}"
     end
 
-    def reverify_control_bytes!(authority)
+    def reverify_phase_bindings!(authority)
+      verify_control_tree!(@repo_root)
       valid = Digest::SHA256.file(__FILE__).hexdigest == authority.fetch("runner_sha256") &&
-        controller_script_digest == authority.fetch("controller_script_sha256")
-      raise AuthorityError.new("authority_binding", "controller bytes changed during the run") unless valid
+        controller_script_digest == authority.fetch("controller_script_sha256") &&
+        @control_tree_sha256 == authority.fetch("control_tree_sha256") &&
+        build_project_binding == @project_binding
+      raise AuthorityError.new("authority_binding", "controller or project authority changed during the run") unless valid
     rescue SystemCallError
       raise AuthorityError.new("authority_binding", "controller bytes are unavailable")
     end
@@ -467,12 +826,66 @@ module HivePatrolEvidence
       raise AuthorityError.new("authority_binding", "#{label} is unavailable")
     end
 
+    def owned_directory_stat!(path, label)
+      stat = File.lstat(path)
+      unless stat.directory? && !stat.symlink? && stat.uid == Process.uid
+        raise AuthorityError.new("authority_binding", "#{label} is not an owned directory")
+      end
+      stat
+    rescue Errno::ENOENT, Errno::EACCES
+      raise AuthorityError.new("authority_binding", "#{label} is unavailable")
+    end
+
+    def read_regular_file!(path, label, limit, allow_empty: false)
+      File.open(File.expand_path(path), READ_FLAGS) do |file|
+        stat = file.stat
+        minimum = allow_empty ? 0 : 1
+        unless stat.file? && stat.nlink == 1 && stat.uid == Process.uid &&
+               (stat.mode & 0o022).zero? && stat.size.between?(minimum, limit)
+          raise AuthorityError.new("authority_binding", "#{label} is unsafe")
+        end
+        bytes = file.read(limit + 1)
+        current = File.lstat(File.expand_path(path))
+        unless %i[dev ino uid mode nlink size].all? do |field|
+          current.public_send(field) == stat.public_send(field)
+        end
+          raise AuthorityError.new("authority_binding", "#{label} identity changed")
+        end
+        bytes
+      end
+    rescue Errno::ENOENT, Errno::ELOOP, Errno::EACCES
+      raise AuthorityError.new("authority_binding", "#{label} is unavailable"), cause: nil
+    end
+
     def git(repo, *arguments)
-      stdout, _stderr, status = Open3.capture3("git", "-C", repo, *arguments)
+      stdout, _stderr, status = capture_git(repo, *arguments)
       raise AuthorityError.new("authority_binding", "git authority check failed") unless status.success?
       stdout
     rescue SystemCallError
       raise AuthorityError.new("authority_binding", "git authority check is unavailable")
+    end
+
+    def capture_git(repo, *arguments)
+      Timeout.timeout(10) do
+        Open3.capture3(
+          GIT_ENV, "git", "-c", "core.hooksPath=/dev/null", "-C", repo, *arguments,
+          unsetenv_others: true
+        )
+      end
+    rescue Timeout::Error, SystemCallError
+      raise AuthorityError.new("authority_binding", "git authority check is unavailable"), cause: nil
+    end
+
+    def digest_json(value)
+      Digest::SHA256.hexdigest(JSON.generate(canonical_value(value)))
+    end
+
+    def canonical_value(value)
+      case value
+      when Hash then value.keys.sort.to_h { |key| [ key, canonical_value(value.fetch(key)) ] }
+      when Array then value.map { |item| canonical_value(item) }
+      else value
+      end
     end
 
     def fsync_directory(path)

--- a/packaging/patrol_evidence/sandbox.rb
+++ b/packaging/patrol_evidence/sandbox.rb
@@ -1,0 +1,368 @@
+# frozen_string_literal: true
+
+require "digest"
+require "json"
+require "open3"
+require "timeout"
+require_relative "result"
+
+module HivePatrolEvidence
+  # Owns the one fixed, networkless container used by the candidate smoke.
+  class Sandbox
+    class Error < StandardError
+      attr_reader :reason, :status
+
+      def initialize(reason, message = reason, status: "failed")
+        @reason = reason
+        @status = status
+        super(message)
+      end
+    end
+
+    IMAGE = /\A[a-z0-9][a-z0-9._\/-]*@sha256:[0-9a-f]{64}\z/
+    SHA = /\A[0-9a-f]{40}\z/
+    DIGEST = /\A[0-9a-f]{64}\z/
+    MAX_STDOUT_BYTES = 1024 * 1024
+    MAX_STDERR_BYTES = 1024 * 1024
+    CAMPAIGN_TIMEOUT = 600
+    PROCESS_LIMIT = 64
+    MEMORY = "2g"
+    CPUS = "2"
+    STATE_BYTES = 512 * 1024 * 1024
+    STATE_INODES = 16_384
+    WORKER = <<~'RUBY'.freeze
+      require "fileutils"
+      require "json"
+      root = "/state/candidate"
+      project = "/state/project"
+      FileUtils.mkdir_p(root)
+      FileUtils.mkdir_p(project)
+      FileUtils.mkdir_p("/state/home")
+      system("/bin/tar", "-xf", "/input/candidate.tar", "-C", root, exception: true)
+      FileUtils.cp_r("/input/project/.", project, preserve: true)
+      controller = Hive::E2E::PatrolQualification::Controller.new(
+        repo_root: root, project_root: project, hive_home: "/state/home",
+        observations_path: "/input/observations.json", evidence_root: "/state/evidence"
+      )
+      result = controller.external_smoke(
+        controller_sha: ENV.fetch("HIVE_PATROL_CONTROLLER_SHA"),
+        candidate_sha: ENV.fetch("HIVE_PATROL_CANDIDATE_SHA"),
+        candidate: {
+          "candidate_sha" => ENV.fetch("HIVE_PATROL_CANDIDATE_SHA"),
+          "archive_sha256" => ENV.fetch("HIVE_PATROL_ARCHIVE_SHA256"),
+          "module_manifest_sha256" => ENV.fetch("HIVE_PATROL_MODULE_MANIFEST_SHA256")
+        },
+        trusted_catalog_path: "/input/catalog.json", worker: true
+      )
+      STDOUT.write(Hive::E2E::PatrolQualification.canonical(result))
+    RUBY
+
+    def initialize(image:, engine_probe: nil, executor: nil, timeout: CAMPAIGN_TIMEOUT)
+      @image = image.to_s
+      @engine_probe = engine_probe || method(:probe_engine)
+      @executor = executor || method(:execute_container)
+      @timeout = Float(timeout)
+      raise Error.new("sandbox_contract", "sandbox image is not digest-pinned") unless IMAGE.match?(@image)
+      raise Error.new("sandbox_contract", "sandbox timeout is invalid") unless
+        @timeout.positive? && @timeout <= CAMPAIGN_TIMEOUT
+    rescue ArgumentError, TypeError
+      raise Error.new("sandbox_contract", "sandbox inputs are invalid"), cause: nil
+    end
+
+    def run!(candidate:, project_root:, observations_path:, controller_root:, run_root:, image:)
+      raise Error.new("sandbox_contract", "sandbox image binding changed") unless image.to_s == @image
+      inputs = admit_inputs(candidate, project_root, observations_path, controller_root, run_root)
+      before = admit_engine_identity(@engine_probe.call)
+      argv, name, cidfile = command(before, inputs)
+      raw = @executor.call(
+        argv:, timeout: @timeout, name:, engine: before.fetch("engine"), cidfile:
+      )
+      after = admit_engine_identity(@engine_probe.call)
+      raise Error.new("runtime_identity", "container runtime identity drifted") unless before == after
+      payload = admit_output(raw)
+      sandbox = before.merge(
+        "status" => "passed", "network" => "none", "root_filesystem" => "read_only",
+        "writable_bytes" => STATE_BYTES, "writable_inodes" => STATE_INODES,
+        "process_limit" => PROCESS_LIMIT, "memory" => MEMORY, "cpus" => CPUS
+      )
+      payload.merge("sandbox" => sandbox.freeze).freeze
+    rescue Error
+      raise
+    rescue StandardError
+      raise Error.new("sandbox_contract", "sandbox execution failed"), cause: nil
+    end
+
+    private
+
+    def admit_inputs(candidate, project_root, observations_path, controller_root, run_root)
+      unless candidate.is_a?(Hash) && candidate.fetch("controller_sha").to_s.match?(SHA) &&
+             candidate.fetch("candidate_sha").to_s.match?(SHA) &&
+             candidate.fetch("controller_sha") != candidate.fetch("candidate_sha") &&
+             candidate.fetch("archive_sha256").to_s.match?(DIGEST) &&
+             candidate.fetch("module_manifest_sha256").to_s.match?(DIGEST)
+        raise Error.new("sandbox_contract", "candidate sandbox binding is malformed")
+      end
+      archive = regular_file!(candidate.fetch("archive_path"), "candidate archive", 256 * 1024 * 1024)
+      unless Digest::SHA256.file(archive).hexdigest == candidate.fetch("archive_sha256")
+        raise Error.new("candidate_identity", "candidate archive changed before sandbox execution")
+      end
+      controller = owned_directory!(controller_root, "controller root")
+      catalog = regular_file!(
+        File.join(controller, "test/e2e/fixtures/patrol_qualification/catalog.json"),
+        "trusted qualification catalogue", 1024 * 1024
+      )
+      controller_script = regular_file!(
+        File.join(controller, "test/e2e/lib/patrol_qualification.rb"),
+        "trusted qualification controller", 1024 * 1024
+      )
+      controller_support = regular_file!(
+        File.join(controller, "lib/hive/secret_patterns.rb"),
+        "trusted controller support", 1024 * 1024
+      )
+      {
+        candidate:, archive:, project: owned_directory!(project_root, "disposable project"),
+        observations: regular_file!(observations_path, "prepared observations", 8 * 1024 * 1024),
+        catalog:, controller_script:, controller_support:,
+        run_root: owned_directory!(run_root, "sandbox run root")
+      }
+    rescue KeyError, TypeError
+      raise Error.new("sandbox_contract", "sandbox inputs are malformed"), cause: nil
+    end
+
+    def command(identity, inputs)
+      candidate = inputs.fetch(:candidate)
+      name = "hive-patrol-u3c-#{Digest::SHA256.hexdigest(candidate.fetch('candidate_sha'))[0, 16]}"
+      cidfile = File.join(inputs.fetch(:run_root), "container.cid")
+      begin
+        File.lstat(cidfile)
+        raise Error.new("path_custody", "sandbox container identifier path already exists")
+      rescue Errno::ENOENT
+        nil
+      end
+      state = [
+        "--tmpfs=/state:rw,nosuid,nodev,size=#{STATE_BYTES},nr_inodes=#{STATE_INODES}",
+        "uid=#{Process.uid},gid=#{Process.gid},mode=0700"
+      ].join(",")
+      mounts = {
+        inputs.fetch(:archive) => "/input/candidate.tar",
+        inputs.fetch(:project) => "/input/project",
+        inputs.fetch(:observations) => "/input/observations.json",
+        inputs.fetch(:catalog) => "/input/catalog.json",
+        inputs.fetch(:controller_script) => "/control/test/e2e/lib/patrol_qualification.rb",
+        inputs.fetch(:controller_support) => "/control/lib/hive/secret_patterns.rb"
+      }.flat_map do |source, target|
+        [ "--mount", "type=bind,source=#{source},target=#{target},readonly" ]
+      end
+      argv = [
+        identity.fetch("engine"), "run", "--name", name, "--rm", "--pull=never",
+        "--cidfile=#{cidfile}",
+        "--network=none", "--read-only", "--cap-drop=ALL",
+        "--security-opt", "no-new-privileges", "--pids-limit=#{PROCESS_LIMIT}",
+        "--memory=#{MEMORY}", "--cpus=#{CPUS}", "--stop-timeout=1",
+        "--user=#{Process.uid}:#{Process.gid}", state, *mounts,
+        "--env", "HOME=/state/home", "--env", "HIVE_HOME=/state/home",
+        "--env", "LANG=C.UTF-8", "--env", "LC_ALL=C.UTF-8",
+        "--env", "HIVE_SKIP_LLM_WIKI_SCHEDULER=1",
+        "--env", "HIVE_SKIP_LLM_WIKI_SYSTEMCTL=1",
+        "--env", "HIVE_SKIP_LLM_WIKI_POST_COMMIT=1",
+        "--env", "HIVE_PATROL_CONTROLLER_SHA=#{candidate.fetch('controller_sha')}",
+        "--env", "HIVE_PATROL_CANDIDATE_SHA=#{candidate.fetch('candidate_sha')}",
+        "--env", "HIVE_PATROL_ARCHIVE_SHA256=#{candidate.fetch('archive_sha256')}",
+        "--env", "HIVE_PATROL_MODULE_MANIFEST_SHA256=#{candidate.fetch('module_manifest_sha256')}",
+        @image, "/usr/local/bin/ruby",
+        "-r/control/test/e2e/lib/patrol_qualification", "-e", WORKER
+      ]
+      [ argv.freeze, name.freeze, cidfile.freeze ]
+    end
+
+    def admit_engine_identity(value)
+      valid = value.is_a?(Hash) && value.keys.sort == %w[engine engine_version image image_id] &&
+        %w[docker podman].include?(value["engine"]) &&
+        value["engine_version"].is_a?(String) && !value["engine_version"].empty? &&
+        value["image"] == @image && value["image_id"].to_s.match?(/\Asha256:[0-9a-f]{64}\z/)
+      raise Error.new("sandbox_unavailable", "compliant sandbox is unavailable", status: "blocked") unless valid
+      value.transform_values { |item| item.dup.freeze }.freeze
+    end
+
+    def admit_output(value)
+      unless value.is_a?(Hash) && value.keys.sort == %w[candidate payload process_evidence] &&
+             value["candidate"].is_a?(Hash) && value["payload"].is_a?(Hash) &&
+             value["process_evidence"].is_a?(Array) && value["process_evidence"].one? &&
+             value.dig("process_evidence", 0, "status") == "reaped"
+        raise Error.new("process_custody", "sandbox result or process custody is malformed")
+      end
+      bytes = Result.canonical(value)
+      raise Error.new("output_bound", "sandbox output exceeds its bound") if bytes.bytesize > MAX_STDOUT_BYTES
+      raise Error.new("credential_custody", "sandbox output contains credential-shaped bytes") if
+        Hive::SecretPatterns.match?(bytes)
+      value
+    end
+
+    def execute_container(argv:, timeout:, name:, engine:, cidfile:)
+      stdout = +""
+      stderr = +""
+      status = nil
+      pid = nil
+      readers = []
+      container_id = nil
+      Open3.popen3({}, *argv, unsetenv_others: true, pgroup: true) do |input, out, err, wait|
+        pid = wait.pid
+        input.close
+        readers = [ out, err ].zip([ stdout, stderr ], [ MAX_STDOUT_BYTES, MAX_STDERR_BYTES ]).map do |io, destination, limit|
+          Thread.new { read_bounded(io, destination, limit) }.tap { |thread| thread.report_on_exception = false }
+        end
+        unless wait.join(timeout)
+          Open3.capture3(engine, "kill", name)
+          terminate_group(pid)
+          raise Error.new("process_custody", "sandbox campaign timed out")
+        end
+        status = wait.value
+        readers.each { |thread| thread.join(1) }
+        raise Error.new("output_bound", "sandbox output did not close") if readers.any?(&:alive?)
+        readers.each(&:value)
+      end
+      container_id = read_container_id!(cidfile, required: true)
+      raise Error.new("sandbox_contract", "sandbox candidate command failed") unless status&.success?
+      payload = JSON.parse(stdout)
+      unless Result.canonical(payload) == stdout
+        raise Error.new("sandbox_contract", "sandbox result is not canonical")
+      end
+      payload.merge(
+        "process_evidence" => [ {
+          "owner" => "sandbox", "status" => "reaped",
+          "container_id_sha256" => Digest::SHA256.hexdigest(container_id),
+          "stdout_sha256" => Digest::SHA256.hexdigest(stdout),
+          "stderr_sha256" => Digest::SHA256.hexdigest(stderr)
+        } ]
+      )
+    rescue JSON::ParserError
+      raise Error.new("sandbox_contract", "sandbox result is malformed"), cause: nil
+    rescue SystemCallError
+      raise Error.new("sandbox_unavailable", "container runtime is unavailable", status: "blocked")
+    ensure
+      terminate_group(pid) if pid && !status
+      readers.each { |thread| thread.kill if thread.alive? }
+      teardown_container!(engine, name, cidfile, container_id)
+    end
+
+    def teardown_container!(engine, name, cidfile, container_id)
+      container_id ||= read_container_id!(cidfile, required: false)
+      identities = [ name, container_id ].compact.uniq
+      identities.each { |identity| Open3.capture3(engine, "rm", "-f", identity) }
+      identities.each do |identity|
+        _out, _err, status = Open3.capture3(engine, "container", "inspect", identity)
+        raise Error.new("process_custody", "sandbox container survived teardown") if status.success?
+      end
+      remove_container_id!(cidfile)
+    rescue Error
+      raise
+    rescue SystemCallError
+      raise Error.new("process_custody", "sandbox teardown could not be verified"), cause: nil
+    end
+
+    def read_container_id!(path, required:)
+      File.open(path, File::RDONLY | (File.const_defined?(:NOFOLLOW) ? File::NOFOLLOW : 0)) do |file|
+        stat = file.stat
+        value = file.read(66)
+        unless stat.file? && stat.nlink == 1 && stat.uid == Process.uid && stat.size <= 65 &&
+               value.match?(/\A[0-9a-f]{64}\n?\z/)
+          raise Error.new("process_custody", "sandbox container identifier is unsafe")
+        end
+        value.strip
+      end
+    rescue Errno::ENOENT
+      raise Error.new("process_custody", "sandbox container identifier is missing") if required
+      nil
+    rescue Errno::ELOOP, Errno::EACCES
+      raise Error.new("process_custody", "sandbox container identifier is unsafe"), cause: nil
+    end
+
+    def remove_container_id!(path)
+      return unless File.exist?(path)
+
+      stat = File.lstat(path)
+      read_container_id!(path, required: true)
+      current = File.lstat(path)
+      unless %i[dev ino uid mode nlink].all? { |field| current.public_send(field) == stat.public_send(field) }
+        raise Error.new("process_custody", "sandbox container identifier changed during teardown")
+      end
+      File.unlink(path)
+      File.open(File.dirname(path), File::RDONLY) { |directory| directory.fsync }
+    rescue Errno::ENOENT
+      nil
+    end
+
+    def probe_engine
+      %w[podman docker].each do |engine|
+        version, _version_err, version_status = Open3.capture3(engine, "--version")
+        next unless version_status.success?
+        _info, _info_err, info_status = Open3.capture3(engine, "info")
+        next unless info_status.success?
+        image_id, _image_err, image_status = Open3.capture3(
+          engine, "image", "inspect", "--format", "{{.Id}}", @image
+        )
+        next unless image_status.success?
+        return {
+          "engine" => engine, "engine_version" => version.lines.first.to_s.strip,
+          "image" => @image, "image_id" => image_id.strip
+        }
+      rescue SystemCallError
+        next
+      end
+      nil
+    end
+
+    def read_bounded(io, destination, limit)
+      while (chunk = io.read(16 * 1024))
+        remaining = limit - destination.bytesize
+        raise Error.new("output_bound", "sandbox child output exceeds its bound") if
+          chunk.bytesize > remaining
+        destination << chunk
+      end
+    ensure
+      io.close rescue nil
+    end
+
+    def terminate_group(pid)
+      Process.kill("TERM", -pid)
+      deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 0.5
+      while Process.clock_gettime(Process::CLOCK_MONOTONIC) < deadline
+        begin
+          Process.kill(0, -pid)
+        rescue Errno::ESRCH
+          return
+        end
+        sleep 0.02
+      end
+      Process.kill("KILL", -pid)
+    rescue Errno::ESRCH, Errno::ECHILD
+      nil
+    end
+
+    def owned_directory!(path, label)
+      absolute = File.expand_path(path)
+      stat = File.lstat(absolute)
+      unless stat.directory? && !stat.symlink? && stat.uid == Process.uid
+        raise Error.new("path_custody", "#{label} is not an owned directory")
+      end
+      absolute
+    rescue Errno::ENOENT, Errno::EACCES
+      raise Error.new("path_custody", "#{label} is unavailable")
+    end
+
+    def regular_file!(path, label, limit)
+      absolute = File.expand_path(path)
+      flags = File::RDONLY
+      flags |= File::NOFOLLOW if File.const_defined?(:NOFOLLOW)
+      File.open(absolute, flags) do |file|
+        stat = file.stat
+        unless stat.file? && stat.nlink == 1 && stat.uid == Process.uid && stat.size.between?(1, limit)
+          raise Error.new("path_custody", "#{label} is unsafe")
+        end
+      end
+      absolute
+    rescue Errno::ELOOP, Errno::ENOENT, Errno::EACCES
+      raise Error.new("path_custody", "#{label} is unavailable")
+    end
+  end
+end

--- a/packaging/patrol_evidence/sandbox.rb
+++ b/packaging/patrol_evidence/sandbox.rb
@@ -10,12 +10,17 @@ module HivePatrolEvidence
   # Owns the one fixed, networkless container used by the candidate smoke.
   class Sandbox
     class Error < StandardError
-      attr_reader :reason, :status
+      attr_reader :reason, :status, :process_evidence
 
-      def initialize(reason, message = reason, status: "failed")
+      def initialize(reason, message = reason, status: "failed", process_evidence: nil)
         @reason = reason
         @status = status
+        @process_evidence = process_evidence
         super(message)
+      end
+
+      def with_process_evidence(value)
+        self.class.new(reason, message, status:, process_evidence: value)
       end
     end
 
@@ -28,17 +33,36 @@ module HivePatrolEvidence
     PROCESS_LIMIT = 64
     MEMORY = "2g"
     CPUS = "2"
-    STATE_BYTES = 512 * 1024 * 1024
-    STATE_INODES = 16_384
+    WRITABLE_BYTES = 512 * 1024 * 1024
+    WRITABLE_INODES = 16_384
+    SHM_BYTES = 1024 * 1024
+    SHM_INODES = 128
+    STATE_BYTES = WRITABLE_BYTES - SHM_BYTES
+    STATE_INODES = WRITABLE_INODES - SHM_INODES
+    ENGINE_COMMAND_TIMEOUT = 10
+    ENGINE_PATHS = %w[/usr/bin/podman /usr/local/bin/podman /usr/bin/docker /usr/local/bin/docker].freeze
+    ENGINE_ENV = {
+      "HOME" => "/nonexistent", "PATH" => "/usr/bin:/bin", "LANG" => "C.UTF-8", "LC_ALL" => "C.UTF-8"
+    }.freeze
     WORKER = <<~'RUBY'.freeze
       require "fileutils"
+      require "find"
       require "json"
       root = "/state/candidate"
       project = "/state/project"
-      FileUtils.mkdir_p(root)
       FileUtils.mkdir_p(project)
       FileUtils.mkdir_p("/state/home")
-      system("/bin/tar", "-xf", "/input/candidate.tar", "-C", root, exception: true)
+      FileUtils.cp_r("/input/source", root, preserve: true)
+      Find.find(root) do |path|
+        stat = File.lstat(path)
+        if stat.directory? && !stat.symlink?
+          File.chmod(0o700, path)
+        elsif stat.file? && !stat.symlink?
+          File.chmod((stat.mode & 0o111).zero? ? 0o600 : 0o700, path)
+        else
+          raise "candidate build copy contains a special entry"
+        end
+      end
       FileUtils.cp_r("/input/project/.", project, preserve: true)
       controller = Hive::E2E::PatrolQualification::Controller.new(
         repo_root: root, project_root: project, hive_home: "/state/home",
@@ -50,7 +74,9 @@ module HivePatrolEvidence
         candidate: {
           "candidate_sha" => ENV.fetch("HIVE_PATROL_CANDIDATE_SHA"),
           "archive_sha256" => ENV.fetch("HIVE_PATROL_ARCHIVE_SHA256"),
-          "module_manifest_sha256" => ENV.fetch("HIVE_PATROL_MODULE_MANIFEST_SHA256")
+          "module_manifest_sha256" => ENV.fetch("HIVE_PATROL_MODULE_MANIFEST_SHA256"),
+          "source_root" => "/input/source",
+          "source_tree_sha256" => ENV.fetch("HIVE_PATROL_SOURCE_TREE_SHA256")
         },
         trusted_catalog_path: "/input/catalog.json", worker: true
       )
@@ -70,26 +96,33 @@ module HivePatrolEvidence
     end
 
     def run!(candidate:, project_root:, observations_path:, controller_root:, run_root:, image:)
+      raw = nil
       raise Error.new("sandbox_contract", "sandbox image binding changed") unless image.to_s == @image
       inputs = admit_inputs(candidate, project_root, observations_path, controller_root, run_root)
       before = admit_engine_identity(@engine_probe.call)
-      argv, name, cidfile = command(before, inputs)
+      argv, name, cidfile, owner_label = command(before, inputs)
       raw = @executor.call(
-        argv:, timeout: @timeout, name:, engine: before.fetch("engine"), cidfile:
+        argv:, timeout: @timeout, name:, engine: before.fetch("engine_path"), cidfile:, owner_label:
       )
       after = admit_engine_identity(@engine_probe.call)
       raise Error.new("runtime_identity", "container runtime identity drifted") unless before == after
       payload = admit_output(raw)
-      sandbox = before.merge(
+      sandbox = before.reject { |key, _| key == "engine_path" }.merge(
         "status" => "passed", "network" => "none", "root_filesystem" => "read_only",
-        "writable_bytes" => STATE_BYTES, "writable_inodes" => STATE_INODES,
+        "writable_bytes" => WRITABLE_BYTES, "writable_inodes" => WRITABLE_INODES,
         "process_limit" => PROCESS_LIMIT, "memory" => MEMORY, "cpus" => CPUS
       )
       payload.merge("sandbox" => sandbox.freeze).freeze
-    rescue Error
-      raise
+    rescue Error => error
+      evidence = raw.is_a?(Hash) && raw["process_evidence"].is_a?(Array) ? raw["process_evidence"] : nil
+      raise error if error.process_evidence || !evidence
+
+      raise error.with_process_evidence(evidence)
     rescue StandardError
-      raise Error.new("sandbox_contract", "sandbox execution failed"), cause: nil
+      evidence = raw.is_a?(Hash) && raw["process_evidence"].is_a?(Array) ? raw["process_evidence"] : nil
+      raise Error.new(
+        "sandbox_contract", "sandbox execution failed", process_evidence: evidence
+      ), cause: nil
     end
 
     private
@@ -99,13 +132,15 @@ module HivePatrolEvidence
              candidate.fetch("candidate_sha").to_s.match?(SHA) &&
              candidate.fetch("controller_sha") != candidate.fetch("candidate_sha") &&
              candidate.fetch("archive_sha256").to_s.match?(DIGEST) &&
-             candidate.fetch("module_manifest_sha256").to_s.match?(DIGEST)
+             candidate.fetch("module_manifest_sha256").to_s.match?(DIGEST) &&
+             candidate.fetch("source_tree_sha256").to_s.match?(DIGEST)
         raise Error.new("sandbox_contract", "candidate sandbox binding is malformed")
       end
       archive = regular_file!(candidate.fetch("archive_path"), "candidate archive", 256 * 1024 * 1024)
       unless Digest::SHA256.file(archive).hexdigest == candidate.fetch("archive_sha256")
         raise Error.new("candidate_identity", "candidate archive changed before sandbox execution")
       end
+      source = owned_directory!(candidate.fetch("source_path"), "admitted candidate source")
       controller = owned_directory!(controller_root, "controller root")
       catalog = regular_file!(
         File.join(controller, "test/e2e/fixtures/patrol_qualification/catalog.json"),
@@ -120,7 +155,7 @@ module HivePatrolEvidence
         "trusted controller support", 1024 * 1024
       )
       {
-        candidate:, archive:, project: owned_directory!(project_root, "disposable project"),
+        candidate:, archive:, source:, project: owned_directory!(project_root, "disposable project"),
         observations: regular_file!(observations_path, "prepared observations", 8 * 1024 * 1024),
         catalog:, controller_script:, controller_support:,
         run_root: owned_directory!(run_root, "sandbox run root")
@@ -131,7 +166,11 @@ module HivePatrolEvidence
 
     def command(identity, inputs)
       candidate = inputs.fetch(:candidate)
-      name = "hive-patrol-u3c-#{Digest::SHA256.hexdigest(candidate.fetch('candidate_sha'))[0, 16]}"
+      run_identity = File.basename(inputs.fetch(:run_root))
+      name_digest = Digest::SHA256.hexdigest(
+        [ candidate.fetch("candidate_sha"), run_identity ].join("\0")
+      )[0, 20]
+      name = "hive-patrol-u3c-#{name_digest}"
       cidfile = File.join(inputs.fetch(:run_root), "container.cid")
       begin
         File.lstat(cidfile)
@@ -143,8 +182,12 @@ module HivePatrolEvidence
         "--tmpfs=/state:rw,nosuid,nodev,size=#{STATE_BYTES},nr_inodes=#{STATE_INODES}",
         "uid=#{Process.uid},gid=#{Process.gid},mode=0700"
       ].join(",")
+      shared_memory = [
+        "--tmpfs=/dev/shm:rw,nosuid,nodev,noexec,size=#{SHM_BYTES},nr_inodes=#{SHM_INODES}",
+        "uid=#{Process.uid},gid=#{Process.gid},mode=0700"
+      ].join(",")
       mounts = {
-        inputs.fetch(:archive) => "/input/candidate.tar",
+        inputs.fetch(:source) => "/input/source",
         inputs.fetch(:project) => "/input/project",
         inputs.fetch(:observations) => "/input/observations.json",
         inputs.fetch(:catalog) => "/input/catalog.json",
@@ -154,12 +197,13 @@ module HivePatrolEvidence
         [ "--mount", "type=bind,source=#{source},target=#{target},readonly" ]
       end
       argv = [
-        identity.fetch("engine"), "run", "--name", name, "--rm", "--pull=never",
+        identity.fetch("engine_path"), "run", "--name", name, "--rm", "--pull=never",
         "--cidfile=#{cidfile}",
+        "--label=hive.patrol.owner=#{Digest::SHA256.hexdigest(run_identity)}",
         "--network=none", "--read-only", "--cap-drop=ALL",
         "--security-opt", "no-new-privileges", "--pids-limit=#{PROCESS_LIMIT}",
         "--memory=#{MEMORY}", "--cpus=#{CPUS}", "--stop-timeout=1",
-        "--user=#{Process.uid}:#{Process.gid}", state, *mounts,
+        "--user=#{Process.uid}:#{Process.gid}", state, shared_memory, *mounts,
         "--env", "HOME=/state/home", "--env", "HIVE_HOME=/state/home",
         "--env", "LANG=C.UTF-8", "--env", "LC_ALL=C.UTF-8",
         "--env", "HIVE_SKIP_LLM_WIKI_SCHEDULER=1",
@@ -169,26 +213,31 @@ module HivePatrolEvidence
         "--env", "HIVE_PATROL_CANDIDATE_SHA=#{candidate.fetch('candidate_sha')}",
         "--env", "HIVE_PATROL_ARCHIVE_SHA256=#{candidate.fetch('archive_sha256')}",
         "--env", "HIVE_PATROL_MODULE_MANIFEST_SHA256=#{candidate.fetch('module_manifest_sha256')}",
+        "--env", "HIVE_PATROL_SOURCE_TREE_SHA256=#{candidate.fetch('source_tree_sha256')}",
         @image, "/usr/local/bin/ruby",
         "-r/control/test/e2e/lib/patrol_qualification", "-e", WORKER
       ]
-      [ argv.freeze, name.freeze, cidfile.freeze ]
+      [ argv.freeze, name.freeze, cidfile.freeze, Digest::SHA256.hexdigest(run_identity).freeze ]
     end
 
     def admit_engine_identity(value)
-      valid = value.is_a?(Hash) && value.keys.sort == %w[engine engine_version image image_id] &&
+      valid = value.is_a?(Hash) && value.keys.sort == %w[
+        engine engine_path engine_sha256 engine_version image image_id
+      ] &&
         %w[docker podman].include?(value["engine"]) &&
+        File.basename(value.fetch("engine_path")) == value.fetch("engine") &&
+        value.fetch("engine_sha256").to_s.match?(DIGEST) &&
         value["engine_version"].is_a?(String) && !value["engine_version"].empty? &&
         value["image"] == @image && value["image_id"].to_s.match?(/\Asha256:[0-9a-f]{64}\z/)
       raise Error.new("sandbox_unavailable", "compliant sandbox is unavailable", status: "blocked") unless valid
-      value.transform_values { |item| item.dup.freeze }.freeze
+      value.transform_values { |item| item.is_a?(String) ? item.dup.freeze : item }.freeze
     end
 
     def admit_output(value)
       unless value.is_a?(Hash) && value.keys.sort == %w[candidate payload process_evidence] &&
              value["candidate"].is_a?(Hash) && value["payload"].is_a?(Hash) &&
              value["process_evidence"].is_a?(Array) && value["process_evidence"].one? &&
-             value.dig("process_evidence", 0, "status") == "reaped"
+             valid_success_process?(value.fetch("process_evidence").fetch(0))
         raise Error.new("process_custody", "sandbox result or process custody is malformed")
       end
       bytes = Result.canonical(value)
@@ -198,66 +247,119 @@ module HivePatrolEvidence
       value
     end
 
-    def execute_container(argv:, timeout:, name:, engine:, cidfile:)
+    def valid_success_process?(row)
+      row.is_a?(Hash) && row.keys.sort == Result::PROCESS_KEYS &&
+        row.values_at("owner", "status", "outcome", "teardown", "exit_code") ==
+          [ "sandbox", "reaped", "success", "verified", 0 ] &&
+        %w[container_id_sha256 stdout_sha256 stderr_sha256].all? do |key|
+          row.fetch(key).to_s.match?(DIGEST)
+        end
+    rescue KeyError, TypeError
+      false
+    end
+
+    def execute_container(argv:, timeout:, name:, engine:, cidfile:, owner_label:)
       stdout = +""
       stderr = +""
       status = nil
       pid = nil
       readers = []
       container_id = nil
-      Open3.popen3({}, *argv, unsetenv_others: true, pgroup: true) do |input, out, err, wait|
-        pid = wait.pid
-        input.close
-        readers = [ out, err ].zip([ stdout, stderr ], [ MAX_STDOUT_BYTES, MAX_STDERR_BYTES ]).map do |io, destination, limit|
-          Thread.new { read_bounded(io, destination, limit) }.tap { |thread| thread.report_on_exception = false }
+      payload = nil
+      outcome = "unavailable"
+      teardown = "unverified"
+      error = nil
+      begin
+        Open3.popen3(ENGINE_ENV, *argv, unsetenv_others: true, pgroup: true) do |input, out, err, wait|
+          pid = wait.pid
+          input.close
+          readers = [ out, err ].zip([ stdout, stderr ], [ MAX_STDOUT_BYTES, MAX_STDERR_BYTES ]).map do |io, destination, limit|
+            Thread.new { read_bounded(io, destination, limit) }.tap { |thread| thread.report_on_exception = false }
+          end
+          unless wait.join(timeout)
+            container_id = read_container_id!(cidfile, required: false)
+            capture_engine(engine, "kill", container_id) if container_id
+            terminate_group(pid)
+            outcome = "timeout"
+            raise Error.new("process_custody", "sandbox campaign timed out")
+          end
+          status = wait.value
+          readers.each { |thread| thread.join(1) }
+          raise Error.new("output_bound", "sandbox output did not close") if readers.any?(&:alive?)
+          readers.each(&:value)
         end
-        unless wait.join(timeout)
-          Open3.capture3(engine, "kill", name)
-          terminate_group(pid)
-          raise Error.new("process_custody", "sandbox campaign timed out")
+        container_id = read_container_id!(cidfile, required: true)
+        outcome = status&.success? ? "success" : "failed"
+        raise Error.new("sandbox_contract", "sandbox candidate command failed") unless status&.success?
+        payload = JSON.parse(stdout)
+        unless Result.canonical(payload) == stdout
+          raise Error.new("sandbox_contract", "sandbox result is not canonical")
         end
-        status = wait.value
-        readers.each { |thread| thread.join(1) }
-        raise Error.new("output_bound", "sandbox output did not close") if readers.any?(&:alive?)
-        readers.each(&:value)
+      rescue JSON::ParserError
+        error = Error.new("sandbox_contract", "sandbox result is malformed")
+      rescue Error => caught
+        error = caught
+      rescue SystemCallError
+        error = Error.new("sandbox_unavailable", "container runtime is unavailable", status: "blocked")
+      ensure
+        terminate_group(pid) if pid && !status
+        readers.each { |thread| thread.kill if thread.alive? }
+        begin
+          container_id ||= read_container_id!(cidfile, required: false)
+          teardown_container!(engine, cidfile, container_id, owner_label)
+          teardown = "verified"
+        rescue Error => teardown_error
+          error = teardown_error
+          teardown = "unverified"
+        end
       end
-      container_id = read_container_id!(cidfile, required: true)
-      raise Error.new("sandbox_contract", "sandbox candidate command failed") unless status&.success?
-      payload = JSON.parse(stdout)
-      unless Result.canonical(payload) == stdout
-        raise Error.new("sandbox_contract", "sandbox result is not canonical")
-      end
-      payload.merge(
-        "process_evidence" => [ {
-          "owner" => "sandbox", "status" => "reaped",
-          "container_id_sha256" => Digest::SHA256.hexdigest(container_id),
-          "stdout_sha256" => Digest::SHA256.hexdigest(stdout),
-          "stderr_sha256" => Digest::SHA256.hexdigest(stderr)
-        } ]
-      )
-    rescue JSON::ParserError
-      raise Error.new("sandbox_contract", "sandbox result is malformed"), cause: nil
-    rescue SystemCallError
-      raise Error.new("sandbox_unavailable", "container runtime is unavailable", status: "blocked")
-    ensure
-      terminate_group(pid) if pid && !status
-      readers.each { |thread| thread.kill if thread.alive? }
-      teardown_container!(engine, name, cidfile, container_id)
+      evidence = [ {
+        "owner" => "sandbox",
+        "status" => teardown == "verified" ? "reaped" : "not_reaped",
+        "outcome" => outcome,
+        "teardown" => teardown,
+        "exit_code" => status&.exitstatus,
+        "container_id_sha256" => container_id && Digest::SHA256.hexdigest(container_id),
+        "stdout_sha256" => Digest::SHA256.hexdigest(stdout),
+        "stderr_sha256" => Digest::SHA256.hexdigest(stderr)
+      }.freeze ].freeze
+      raise error.with_process_evidence(evidence) if error
+
+      payload.merge("process_evidence" => evidence)
     end
 
-    def teardown_container!(engine, name, cidfile, container_id)
-      container_id ||= read_container_id!(cidfile, required: false)
-      identities = [ name, container_id ].compact.uniq
-      identities.each { |identity| Open3.capture3(engine, "rm", "-f", identity) }
-      identities.each do |identity|
-        _out, _err, status = Open3.capture3(engine, "container", "inspect", identity)
-        raise Error.new("process_custody", "sandbox container survived teardown") if status.success?
+    def teardown_container!(engine, cidfile, container_id, owner_label)
+      unless container_id
+        remove_container_id!(cidfile)
+        return true
       end
+      label, _label_err, inspected = capture_engine(
+        engine, "container", "inspect", "--format", "{{ index .Config.Labels \"hive.patrol.owner\" }}",
+        container_id
+      )
+      if inspected.success?
+        unless label.strip == owner_label
+          raise Error.new("process_custody", "sandbox container ownership label differs")
+        end
+        _out, _err, removed = capture_engine(engine, "rm", "-f", container_id)
+        raise Error.new("process_custody", "sandbox container teardown failed") unless removed.success?
+      else
+        verify_engine_reachable!(engine)
+      end
+      _out, _err, survived = capture_engine(engine, "container", "inspect", container_id)
+      raise Error.new("process_custody", "sandbox container survived teardown") if survived.success?
+      verify_engine_reachable!(engine)
       remove_container_id!(cidfile)
+      true
     rescue Error
       raise
     rescue SystemCallError
       raise Error.new("process_custody", "sandbox teardown could not be verified"), cause: nil
+    end
+
+    def verify_engine_reachable!(engine)
+      _out, _err, status = capture_engine(engine, "info")
+      raise Error.new("process_custody", "container runtime teardown could not be verified") unless status.success?
     end
 
     def read_container_id!(path, required:)
@@ -293,23 +395,56 @@ module HivePatrolEvidence
     end
 
     def probe_engine
-      %w[podman docker].each do |engine|
-        version, _version_err, version_status = Open3.capture3(engine, "--version")
+      ENGINE_PATHS.each do |candidate|
+        next unless File.file?(candidate) && File.executable?(candidate)
+        engine = File.realpath(candidate)
+        stat = File.lstat(engine)
+        next unless stat.file? && !stat.symlink?
+        version, _version_err, version_status = capture_engine(engine, "--version")
         next unless version_status.success?
-        _info, _info_err, info_status = Open3.capture3(engine, "info")
+        _info, _info_err, info_status = capture_engine(engine, "info")
         next unless info_status.success?
-        image_id, _image_err, image_status = Open3.capture3(
+        image_id, _image_err, image_status = capture_engine(
           engine, "image", "inspect", "--format", "{{.Id}}", @image
         )
         next unless image_status.success?
         return {
-          "engine" => engine, "engine_version" => version.lines.first.to_s.strip,
+          "engine" => File.basename(engine), "engine_path" => engine,
+          "engine_sha256" => Digest::SHA256.file(engine).hexdigest,
+          "engine_version" => version.lines.first.to_s.strip,
           "image" => @image, "image_id" => image_id.strip
         }
-      rescue SystemCallError
+      rescue SystemCallError, Error
         next
       end
       nil
+    end
+
+    def capture_engine(engine, *arguments)
+      stdout = +""
+      stderr = +""
+      wait_status = nil
+      pid = nil
+      readers = []
+      Open3.popen3(ENGINE_ENV, engine, *arguments, unsetenv_others: true, pgroup: true) do |input, out, err, wait|
+        pid = wait.pid
+        input.close
+        readers = [ [ out, stdout ], [ err, stderr ] ].map do |io, destination|
+          Thread.new { read_bounded(io, destination, 64 * 1024) }.tap { |thread| thread.report_on_exception = false }
+        end
+        unless wait.join(ENGINE_COMMAND_TIMEOUT)
+          terminate_group(pid)
+          raise Error.new("process_custody", "container runtime command timed out")
+        end
+        wait_status = wait.value
+        readers.each { |thread| thread.join(1) }
+        raise Error.new("output_bound", "container runtime output did not close") if readers.any?(&:alive?)
+        readers.each(&:value)
+      end
+      [ stdout, stderr, wait_status ]
+    ensure
+      terminate_group(pid) if pid && !wait_status
+      readers.each { |thread| thread.kill if thread.alive? }
     end
 
     def read_bounded(io, destination, limit)

--- a/schemas/hive-patrol-installed-live-smoke.v1.json
+++ b/schemas/hive-patrol-installed-live-smoke.v1.json
@@ -1,0 +1,122 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://hive.local/schemas/hive-patrol-installed-live-smoke.v1.json",
+  "title": "Hive reduced Patrol installed/live smoke result",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema", "schema_version", "status", "reason", "claim_fences",
+    "same_user_limitation", "authority", "candidate", "sandbox", "smoke",
+    "provider", "process_evidence", "started_at", "finished_at"
+  ],
+  "properties": {
+    "schema": { "const": "hive-patrol-installed-live-smoke" },
+    "schema_version": { "const": 1 },
+    "status": {
+      "enum": ["not_started", "installed_live_smoke_verified", "blocked", "failed"]
+    },
+    "reason": {
+      "type": ["string", "null"],
+      "enum": [
+        null, "manual_authority_missing", "sandbox_unavailable",
+        "installed_dependency_missing", "credential_unavailable",
+        "provider_unavailable", "evidence_store_full", "candidate_identity",
+        "candidate_archive", "runtime_identity", "path_custody", "sandbox_contract",
+        "process_custody", "credential_custody", "provider_transport",
+        "effect_forbidden", "authority_binding", "input_bound", "output_bound",
+        "publication_conflict", "evidence_custody", "smoke_validation",
+        "unexpected_failure"
+      ]
+    },
+    "claim_fences": {
+      "const": [
+        "not_full_u3b",
+        "prepared_records_not_fresh_scheduler_matrix",
+        "controller_does_not_supply_full_independent_matrix",
+        "not_report_installed_live_qualification",
+        "provider_probe_not_patrol_decision",
+        "not_evidence_ready_for_operator",
+        "not_cutover_or_promotion_authority"
+      ]
+    },
+    "same_user_limitation": {
+      "const": "same_user_host_processes_are_outside_the_sandbox_claim"
+    },
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "run_id", "controller_sha", "candidate_sha", "runner_sha256",
+        "controller_script_sha256",
+        "authorization_sha256", "invocation_id"
+      ],
+      "properties": {
+        "run_id": { "$ref": "#/$defs/safeId" },
+        "controller_sha": { "$ref": "#/$defs/sha" },
+        "candidate_sha": { "$ref": "#/$defs/sha" },
+        "runner_sha256": { "$ref": "#/$defs/digest" },
+        "controller_script_sha256": { "$ref": "#/$defs/digest" },
+        "authorization_sha256": { "$ref": "#/$defs/digest" },
+        "invocation_id": { "$ref": "#/$defs/safeId" }
+      }
+    },
+    "candidate": { "$ref": "#/$defs/nullableRecord" },
+    "sandbox": { "$ref": "#/$defs/nullableRecord" },
+    "smoke": { "$ref": "#/$defs/nullableRecord" },
+    "provider": { "$ref": "#/$defs/nullableRecord" },
+    "process_evidence": {
+      "type": "array",
+      "maxItems": 64,
+      "items": { "type": "object" }
+    },
+    "started_at": { "type": "string", "format": "date-time", "maxLength": 64 },
+    "finished_at": {
+      "oneOf": [
+        { "type": "null" },
+        { "type": "string", "format": "date-time", "maxLength": 64 }
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "status": { "const": "not_started" } } },
+      "then": {
+        "properties": {
+          "reason": { "type": "null" },
+          "candidate": { "type": "null" },
+          "sandbox": { "type": "null" },
+          "smoke": { "type": "null" },
+          "provider": { "type": "null" },
+          "finished_at": { "type": "null" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "status": { "const": "installed_live_smoke_verified" } } },
+      "then": {
+        "properties": {
+          "reason": { "type": "null" },
+          "candidate": { "type": "object" },
+          "sandbox": { "type": "object" },
+          "smoke": { "type": "object" },
+          "provider": { "type": "object" },
+          "finished_at": { "type": "string" }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "safeId": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+    },
+    "sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+    "digest": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+    "nullableRecord": {
+      "oneOf": [
+        { "type": "null" },
+        { "type": "object" }
+      ]
+    }
+  }
+}

--- a/schemas/hive-patrol-installed-live-smoke.v1.json
+++ b/schemas/hive-patrol-installed-live-smoke.v1.json
@@ -47,8 +47,9 @@
       "additionalProperties": false,
       "required": [
         "run_id", "controller_sha", "candidate_sha", "runner_sha256",
-        "controller_script_sha256",
-        "authorization_sha256", "invocation_id"
+        "controller_script_sha256", "control_tree_sha256", "authorization_sha256",
+        "authorization_nonce_sha256", "authorization_expires_at", "invocation_id",
+        "image", "observations_sha256", "project_binding_sha256"
       ],
       "properties": {
         "run_id": { "$ref": "#/$defs/safeId" },
@@ -56,18 +57,30 @@
         "candidate_sha": { "$ref": "#/$defs/sha" },
         "runner_sha256": { "$ref": "#/$defs/digest" },
         "controller_script_sha256": { "$ref": "#/$defs/digest" },
+        "control_tree_sha256": { "$ref": "#/$defs/digest" },
         "authorization_sha256": { "$ref": "#/$defs/digest" },
-        "invocation_id": { "$ref": "#/$defs/safeId" }
+        "authorization_nonce_sha256": { "$ref": "#/$defs/digest" },
+        "authorization_expires_at": { "$ref": "#/$defs/time" },
+        "invocation_id": { "$ref": "#/$defs/safeId" },
+        "image": { "$ref": "#/$defs/image" },
+        "observations_sha256": { "$ref": "#/$defs/digest" },
+        "project_binding_sha256": { "$ref": "#/$defs/digest" }
       }
     },
-    "candidate": { "$ref": "#/$defs/nullableRecord" },
-    "sandbox": { "$ref": "#/$defs/nullableRecord" },
-    "smoke": { "$ref": "#/$defs/nullableRecord" },
-    "provider": { "$ref": "#/$defs/nullableRecord" },
+    "candidate": {
+      "oneOf": [
+        { "type": "null" },
+        { "$ref": "#/$defs/preparedCandidate" },
+        { "$ref": "#/$defs/verifiedCandidate" }
+      ]
+    },
+    "sandbox": { "oneOf": [{ "type": "null" }, { "$ref": "#/$defs/sandbox" }] },
+    "smoke": { "oneOf": [{ "type": "null" }, { "$ref": "#/$defs/smoke" }] },
+    "provider": { "oneOf": [{ "type": "null" }, { "$ref": "#/$defs/provider" }] },
     "process_evidence": {
       "type": "array",
       "maxItems": 64,
-      "items": { "type": "object" }
+      "items": { "$ref": "#/$defs/processEvidence" }
     },
     "started_at": { "type": "string", "format": "date-time", "maxLength": 64 },
     "finished_at": {
@@ -87,6 +100,7 @@
           "sandbox": { "type": "null" },
           "smoke": { "type": "null" },
           "provider": { "type": "null" },
+          "process_evidence": { "maxItems": 0 },
           "finished_at": { "type": "null" }
         }
       }
@@ -96,11 +110,36 @@
       "then": {
         "properties": {
           "reason": { "type": "null" },
-          "candidate": { "type": "object" },
-          "sandbox": { "type": "object" },
-          "smoke": { "type": "object" },
-          "provider": { "type": "object" },
+          "candidate": { "$ref": "#/$defs/verifiedCandidate" },
+          "sandbox": { "$ref": "#/$defs/sandbox" },
+          "smoke": { "$ref": "#/$defs/smoke" },
+          "provider": { "$ref": "#/$defs/provider" },
+          "process_evidence": {
+            "type": "array", "minItems": 1, "maxItems": 1,
+            "items": {
+              "allOf": [
+                { "$ref": "#/$defs/processEvidence" },
+                {
+                  "properties": {
+                    "status": { "const": "reaped" }, "outcome": { "const": "success" },
+                    "teardown": { "const": "verified" }, "exit_code": { "const": 0 },
+                    "container_id_sha256": { "$ref": "#/$defs/digest" }
+                  }
+                }
+              ]
+            }
+          },
           "finished_at": { "type": "string" }
+        },
+        "required": ["candidate", "sandbox", "smoke", "provider", "process_evidence"]
+      }
+    },
+    {
+      "if": { "properties": { "status": { "enum": ["blocked", "failed"] } } },
+      "then": {
+        "properties": {
+          "reason": { "type": "string" },
+          "finished_at": { "$ref": "#/$defs/time" }
         }
       }
     }
@@ -112,11 +151,111 @@
     },
     "sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
     "digest": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
-    "nullableRecord": {
-      "oneOf": [
-        { "type": "null" },
-        { "type": "object" }
+    "time": { "type": "string", "format": "date-time", "maxLength": 64 },
+    "image": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._/-]*@sha256:[0-9a-f]{64}$"
+    },
+    "candidateCore": {
+      "type": "object",
+      "properties": {
+        "candidate_sha": { "$ref": "#/$defs/sha" },
+        "archive_sha256": { "$ref": "#/$defs/digest" },
+        "archive_member_count": { "type": "integer", "minimum": 1, "maximum": 4096 },
+        "archive_total_bytes": { "type": "integer", "minimum": 1, "maximum": 268435456 },
+        "module_manifest_sha256": { "$ref": "#/$defs/digest" },
+        "source_tree_sha256": { "$ref": "#/$defs/digest" }
+      }
+    },
+    "preparedCandidate": {
+      "allOf": [
+        { "$ref": "#/$defs/candidateCore" },
+        {
+          "additionalProperties": false,
+          "required": ["status", "candidate_sha", "archive_sha256", "archive_member_count", "archive_total_bytes", "module_manifest_sha256", "source_tree_sha256"],
+          "properties": {
+            "status": { "const": "prepared" },
+            "candidate_sha": { "$ref": "#/$defs/sha" },
+            "archive_sha256": { "$ref": "#/$defs/digest" },
+            "archive_member_count": { "type": "integer", "minimum": 1, "maximum": 4096 },
+            "archive_total_bytes": { "type": "integer", "minimum": 1, "maximum": 268435456 },
+            "module_manifest_sha256": { "$ref": "#/$defs/digest" },
+            "source_tree_sha256": { "$ref": "#/$defs/digest" }
+          }
+        }
       ]
+    },
+    "verifiedCandidate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "candidate_sha", "archive_sha256", "archive_member_count", "archive_total_bytes", "module_manifest_sha256", "source_tree_sha256", "gem_sha256", "installed_hive_sha256", "dependency_closure_sha256", "toolchain_sha256"],
+      "properties": {
+        "status": { "const": "verified" },
+        "candidate_sha": { "$ref": "#/$defs/sha" },
+        "archive_sha256": { "$ref": "#/$defs/digest" },
+        "archive_member_count": { "type": "integer", "minimum": 1, "maximum": 4096 },
+        "archive_total_bytes": { "type": "integer", "minimum": 1, "maximum": 268435456 },
+        "module_manifest_sha256": { "$ref": "#/$defs/digest" },
+        "source_tree_sha256": { "$ref": "#/$defs/digest" },
+        "gem_sha256": { "$ref": "#/$defs/digest" },
+        "installed_hive_sha256": { "$ref": "#/$defs/digest" },
+        "dependency_closure_sha256": { "$ref": "#/$defs/digest" },
+        "toolchain_sha256": { "$ref": "#/$defs/digest" }
+      }
+    },
+    "sandbox": {
+      "type": "object", "additionalProperties": false,
+      "required": ["status", "engine", "engine_version", "engine_sha256", "image", "image_id", "network", "root_filesystem", "writable_bytes", "writable_inodes", "process_limit", "memory", "cpus"],
+      "properties": {
+        "status": { "const": "passed" }, "engine": { "enum": ["docker", "podman"] },
+        "engine_version": { "type": "string", "minLength": 1, "maxLength": 256 },
+        "engine_sha256": { "$ref": "#/$defs/digest" }, "image": { "$ref": "#/$defs/image" },
+        "image_id": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+        "network": { "const": "none" }, "root_filesystem": { "const": "read_only" },
+        "writable_bytes": { "const": 536870912 }, "writable_inodes": { "const": 16384 },
+        "process_limit": { "const": 64 }, "memory": { "const": "2g" }, "cpus": { "const": "2" }
+      }
+    },
+    "smoke": {
+      "type": "object", "additionalProperties": false,
+      "required": ["status", "modules", "receipt_count", "catalog_digest", "scenario_manifest_digest", "report_sha256"],
+      "properties": {
+        "status": { "const": "passed" },
+        "modules": { "const": ["architecture-patrol", "patrol"] },
+        "receipt_count": { "type": "integer", "minimum": 1 },
+        "catalog_digest": { "$ref": "#/$defs/digest" },
+        "scenario_manifest_digest": { "$ref": "#/$defs/digest" },
+        "report_sha256": { "$ref": "#/$defs/digest" }
+      }
+    },
+    "provider": {
+      "type": "object", "additionalProperties": false,
+      "required": ["status", "provider", "model", "response_sha256", "usage"],
+      "properties": {
+        "status": { "const": "passed" }, "provider": { "const": "openrouter" },
+        "model": { "const": "openai/gpt-5.6-terra" }, "response_sha256": { "$ref": "#/$defs/digest" },
+        "usage": {
+          "type": "object", "additionalProperties": false,
+          "required": ["prompt_tokens", "completion_tokens", "total_tokens"],
+          "properties": {
+            "prompt_tokens": { "type": "integer", "minimum": 1 },
+            "completion_tokens": { "type": "integer", "minimum": 1 },
+            "total_tokens": { "type": "integer", "minimum": 2 }
+          }
+        }
+      }
+    },
+    "processEvidence": {
+      "type": "object", "additionalProperties": false,
+      "required": ["owner", "status", "outcome", "teardown", "exit_code", "container_id_sha256", "stdout_sha256", "stderr_sha256"],
+      "properties": {
+        "owner": { "const": "sandbox" }, "status": { "enum": ["reaped", "not_reaped"] },
+        "outcome": { "enum": ["success", "failed", "timeout", "interrupted", "unavailable"] },
+        "teardown": { "enum": ["verified", "unverified"] },
+        "exit_code": { "type": ["integer", "null"] },
+        "container_id_sha256": { "oneOf": [{ "type": "null" }, { "$ref": "#/$defs/digest" }] },
+        "stdout_sha256": { "$ref": "#/$defs/digest" }, "stderr_sha256": { "$ref": "#/$defs/digest" }
+      }
     }
   }
 }

--- a/test/e2e/lib/patrol_qualification.rb
+++ b/test/e2e/lib/patrol_qualification.rb
@@ -3,7 +3,6 @@ require "fileutils"
 require "json"
 require "open3"
 require "rbconfig"
-require "rubygems"
 require "tmpdir"
 require "time"
 require "yaml"
@@ -25,6 +24,14 @@ module Hive
       MAX_EVIDENCE_BYTES = 512 * 1024
       MAX_SHADOW_FILES = 64
       MAX_SHADOW_BYTES = 8 * 1024 * 1024
+      MAX_EXTERNAL_SOURCE_MEMBERS = 4_096
+      MAX_EXTERNAL_SOURCE_BYTES = 256 * 1024 * 1024
+      MAX_EXTERNAL_SOURCE_PATH_BYTES = 240
+      MAX_EXTERNAL_SOURCE_PATH_DEPTH = 32
+      MAX_EXTERNAL_GEM_BYTES = 256 * 1024 * 1024
+      MAX_EXTERNAL_GEMSPEC_BYTES = 1024 * 1024
+      MAX_EXTERNAL_CLOSURE_BYTES = 64 * 1024 * 1024
+      MAX_EXTERNAL_HIVE_BYTES = 8 * 1024 * 1024
       CHILD_TIMEOUT = 30.0
       CHILD_TIMEOUT_STATUS = 124
       TERMINAL_SIGNALS = %w[
@@ -41,6 +48,15 @@ module Hive
       class Error < StandardError; end
       class ChildTimeout < Error; end
       class CampaignTimeout < Error; end
+
+      class StreamOverflow < Error
+        attr_reader :stream
+
+        def initialize(stream, label)
+          @stream = stream
+          super("#{label} #{stream} exceeds its byte bound")
+        end
+      end
 
       class ProcessFailure < Error
         attr_reader :kind, :status
@@ -207,7 +223,10 @@ module Hive
             pid = wait.pid
             input.binmode
             streams = [ input, out, err ]
-            workers = [ Thread.new { drain(out, stdout) }, Thread.new { drain(err, stderr) } ]
+            workers = [
+              Thread.new { drain(out, stdout, stream: "stdout", label:, pid:) },
+              Thread.new { drain(err, stderr, stream: "stderr", label:, pid:) }
+            ]
             workers << Thread.new do
               input.write(stdin_data)
             rescue Errno::EPIPE, IOError
@@ -220,6 +239,7 @@ module Hive
               terminate_group(pid)
               streams.each { |io| close(io) }
               join_until(workers, monotonic + 0.5)
+              raise_worker_errors!(workers)
               cleaned_up = true
               raise(campaign_limited ? CampaignTimeout : ChildTimeout,
                     "#{label} exceeded #{limit.round(3)} seconds")
@@ -234,6 +254,7 @@ module Hive
               raise(campaign_limited ? CampaignTimeout : ChildTimeout,
                     "#{label} did not close its process streams before the deadline")
             end
+            raise_worker_errors!(workers)
           end
           unless status.success?
             kind, value = status.signaled? ? [ "signal", status.termsig ] : [ "exit", status.exitstatus ]
@@ -252,13 +273,23 @@ module Hive
 
         private
 
-        def drain(io, destination)
+        def drain(io, destination, stream:, label:, pid:)
           while (chunk = io.read(16 * 1024))
             remaining = MAX_STREAM_BYTES - destination.bytesize
-            destination << chunk.byteslice(0, remaining) if remaining.positive?
+            if chunk.bytesize > remaining
+              begin
+                Process.kill("TERM", -pid)
+              rescue Errno::ESRCH
+                nil
+              end
+              raise StreamOverflow.new(stream, label)
+            end
+            destination << chunk
           end
         rescue IOError
           nil
+        ensure
+          close(io)
         end
 
         def terminate_group(pid)
@@ -285,6 +316,10 @@ module Hive
             thread.join(remaining)
           end
           threads.none?(&:alive?)
+        end
+
+        def raise_worker_errors!(threads)
+          threads.each { |thread| thread.value unless thread.alive? }
         end
 
         def close(io)
@@ -538,7 +573,8 @@ module Hive
                  controller_sha != candidate_sha && candidate.is_a?(Hash) &&
                  candidate.fetch("candidate_sha") == candidate_sha &&
                  candidate.fetch("archive_sha256").to_s.match?(/\A[0-9a-f]{64}\z/) &&
-                 candidate.fetch("module_manifest_sha256").to_s.match?(/\A[0-9a-f]{64}\z/)
+                 candidate.fetch("module_manifest_sha256").to_s.match?(/\A[0-9a-f]{64}\z/) &&
+                 candidate.fetch("source_tree_sha256").to_s.match?(/\A[0-9a-f]{64}\z/)
             raise Error, "external smoke authority binding is malformed"
           end
           unless sandbox_result.is_a?(Hash) && sandbox_result.keys.sort == %w[
@@ -622,7 +658,10 @@ module Hive
                  controller_sha != candidate_sha && candidate.is_a?(Hash) &&
                  candidate.fetch("candidate_sha") == candidate_sha &&
                  candidate.fetch("archive_sha256").to_s.match?(/\A[0-9a-f]{64}\z/) &&
-                 candidate.fetch("module_manifest_sha256").to_s.match?(/\A[0-9a-f]{64}\z/)
+                 candidate.fetch("module_manifest_sha256").to_s.match?(/\A[0-9a-f]{64}\z/) &&
+                 candidate.fetch("source_tree_sha256").to_s.match?(/\A[0-9a-f]{64}\z/) &&
+                 candidate.fetch("source_root").is_a?(String) &&
+                 File.absolute_path(candidate.fetch("source_root")) == candidate.fetch("source_root")
             raise Error, "external smoke worker authority binding is malformed"
           end
           run_root = File.join(File.dirname(@repo_root), "external-smoke")
@@ -636,12 +675,18 @@ module Hive
           installed = {
             "sha" => candidate_sha, "candidate_sha" => candidate_sha,
             "archive_sha256" => candidate.fetch("archive_sha256"), "root" => @repo_root,
+            "source_root" => candidate.fetch("source_root"),
+            "source_tree_sha256" => candidate.fetch("source_tree_sha256"),
             "module_manifest_sha256" => candidate.fetch("module_manifest_sha256")
           }
           install_candidate(installed, run_root)
           catalog_repo = build_module_catalog(installed, run_root)
           install_modules(catalog_repo)
           identity_before = external_installed_identity(installed)
+          unless identity_before.values_at("source_tree_sha256", "module_manifest_sha256") ==
+                 installed.values_at("source_tree_sha256", "module_manifest_sha256")
+            raise Error, "external smoke admitted source identity differs"
+          end
           prepared = collect_receipts(catalog, installed, claim: "u3c")
           inspections = revalidate_external_modules
           identity_after = external_installed_identity(installed)
@@ -687,29 +732,27 @@ module Hive
             raise Error, "installed dependency specifications are unavailable"
           end
           closure = []
+          closure_bytes = 0
           Dir.each_child(specifications) do |name|
             raise Error, "installed dependency closure exceeds its member bound" if closure.size >= 4_096
-            path = File.join(specifications, name)
-            bytes = PatrolQualification.bounded_read(
-              path, label: "installed dependency specification", limit: 1024 * 1024,
-              deadline: @deadline
-            )
-            specification = Gem::Specification.load(path)
-            unless specification && specification.name.to_s.bytesize.between?(1, 256) &&
-                   specification.version.to_s.bytesize.between?(1, 256) &&
-                   specification.platform.to_s.bytesize.between?(1, 256)
-              raise Error, "installed dependency specification is malformed"
+            unless name.match?(/\A[A-Za-z0-9][A-Za-z0-9._-]{0,239}\.gemspec\z/)
+              raise Error, "installed dependency specification name is unsafe"
             end
+            path = File.join(specifications, name)
+            identity = external_regular_file_identity(
+              path, label: "installed dependency specification",
+              limit: MAX_EXTERNAL_GEMSPEC_BYTES
+            )
+            closure_bytes += identity.fetch("bytesize")
+            raise Error, "installed dependency closure exceeds its aggregate byte bound" if
+              closure_bytes > MAX_EXTERNAL_CLOSURE_BYTES
             closure << {
-              "name" => specification.name.to_s,
-              "version" => specification.version.to_s,
-              "platform" => specification.platform.to_s,
-              "full_name" => specification.full_name.to_s,
-              "spec_sha256" => Digest::SHA256.hexdigest(bytes)
+              "basename" => name, "bytesize" => identity.fetch("bytesize"),
+              "spec_sha256" => identity.fetch("sha256")
             }
           end
-          closure.sort_by! { |row| row.fetch("full_name") }
-          names = closure.map { |row| row.fetch("full_name") }
+          closure.sort_by! { |row| row.fetch("basename") }
+          names = closure.map { |row| row.fetch("basename") }
           raise Error, "installed dependency closure is empty or duplicated" if
             closure.empty? || names.uniq.size != names.size
           toolchain = {
@@ -719,10 +762,17 @@ module Hive
           }
           canonical_closure = JSON.generate(PatrolQualification.canonical_value(closure))
           canonical_toolchain = JSON.generate(PatrolQualification.canonical_value(toolchain))
+          source_tree_sha256 = external_source_tree_sha256(candidate.fetch("source_root"))
+          module_manifest_sha256 = external_module_manifest_sha256(candidate.fetch("source_root"))
           {
-            "gem_sha256" => candidate.fetch("gem_sha256"),
-            "installed_hive_sha256" => candidate.fetch("installed_hive_sha256"),
-            "module_manifest_sha256" => candidate.fetch("module_manifest_sha256"),
+            "gem_sha256" => external_regular_file_identity(
+              @candidate_gem_path, label: "built candidate gem", limit: MAX_EXTERNAL_GEM_BYTES
+            ).fetch("sha256"),
+            "installed_hive_sha256" => external_regular_file_identity(
+              @hive_bin, label: "installed candidate hive", limit: MAX_EXTERNAL_HIVE_BYTES
+            ).fetch("sha256"),
+            "module_manifest_sha256" => module_manifest_sha256,
+            "source_tree_sha256" => source_tree_sha256,
             "dependency_closure" => closure,
             "dependency_closure_sha256" => Digest::SHA256.hexdigest(canonical_closure),
             "toolchain" => toolchain,
@@ -730,6 +780,116 @@ module Hive
           }
         rescue Errno::ENOENT, Errno::EACCES
           raise Error, "installed dependency closure is unavailable"
+        end
+
+        def external_regular_file_identity(path, label:, limit:)
+          flags = File::RDONLY
+          flags |= File::NOFOLLOW if File.const_defined?(:NOFOLLOW)
+          flags |= File::NONBLOCK if File.const_defined?(:NONBLOCK)
+          File.open(path, flags) do |file|
+            stat = file.stat
+            unless stat.file? && stat.nlink == 1 && stat.uid == Process.uid &&
+                   stat.size.between?(1, limit)
+              raise Error, "#{label} is not a bounded owner-controlled regular file"
+            end
+            digest = Digest::SHA256.new
+            bytesize = 0
+            while (chunk = file.read(64 * 1024))
+              bytesize += chunk.bytesize
+              raise Error, "#{label} exceeds its byte bound" if bytesize > limit
+              digest.update(chunk)
+              PatrolQualification.check_deadline!(@deadline, label)
+            end
+            { "bytesize" => bytesize, "sha256" => digest.hexdigest }
+          end
+        rescue Errno::ELOOP, Errno::ENXIO, SystemCallError => e
+          raise Error, "#{label} is unreadable: #{e.class.name}"
+        end
+
+        def external_regular_file_bytes(path, label:, limit:)
+          identity = external_regular_file_identity(path, label:, limit:)
+          bytes = PatrolQualification.bounded_read(path, label:, limit:, deadline: @deadline)
+          unless bytes.bytesize == identity.fetch("bytesize") &&
+                 Digest::SHA256.hexdigest(bytes) == identity.fetch("sha256")
+            raise Error, "#{label} changed while it was read"
+          end
+          bytes
+        end
+
+        def external_module_manifest_sha256(source_root)
+          manifests = MODULES.to_h do |name|
+            bytes = external_regular_file_bytes(
+              File.join(source_root, "modules", name, "manifest.yml"),
+              label: "admitted #{name} module manifest", limit: 1024 * 1024
+            )
+            manifest = YAML.safe_load(bytes, permitted_classes: [], permitted_symbols: [], aliases: false)
+            valid = manifest.is_a?(Hash) && manifest["version"].is_a?(String) &&
+              manifest["release_sha256"].to_s.match?(/\A[0-9a-f]{64}\z/) &&
+              manifest.dig("source", "revision").to_s.match?(/\A[0-9a-f]{40}\z/)
+            raise Error, "admitted #{name} module manifest is malformed" unless valid
+            [ name, {
+              "bytes_sha256" => Digest::SHA256.hexdigest(bytes),
+              "version" => manifest.fetch("version"),
+              "release_sha256" => manifest.fetch("release_sha256"),
+              "source_revision" => manifest.dig("source", "revision")
+            } ]
+          end
+          Digest::SHA256.hexdigest(JSON.generate(PatrolQualification.canonical_value(manifests)))
+        rescue Psych::Exception, KeyError, TypeError
+          raise Error, "admitted module manifest identity is malformed"
+        end
+
+        def external_source_tree_sha256(root)
+          root_stat = File.lstat(root)
+          unless root_stat.directory? && !root_stat.symlink? && root_stat.uid == Process.uid &&
+                 (root_stat.mode & 0o777) == 0o555
+            raise Error, "admitted source root is unsafe"
+          end
+          rows = []
+          total = 0
+          walk = lambda do |directory, prefix|
+            Dir.each_child(directory).sort_by(&:b).each do |name|
+              relative = prefix.empty? ? name : File.join(prefix, name)
+              path = File.join(directory, name)
+              stat = File.lstat(path)
+              valid_path = relative.valid_encoding? && !relative.empty? &&
+                relative.bytesize <= MAX_EXTERNAL_SOURCE_PATH_BYTES &&
+                relative.split("/").none? { |part| part.empty? || part == "." || part == ".." } &&
+                relative.count("/") + 1 <= MAX_EXTERNAL_SOURCE_PATH_DEPTH
+              raise Error, "admitted source path is unsafe" unless valid_path
+              raise Error, "admitted source exceeds its member bound" if
+                rows.size >= MAX_EXTERNAL_SOURCE_MEMBERS
+              if stat.directory? && !stat.symlink?
+                unless stat.uid == Process.uid && (stat.mode & 0o777) == 0o555
+                  raise Error, "admitted source directory is unsafe"
+                end
+                rows << { "kind" => "directory", "mode" => 0o555, "path" => relative }
+                walk.call(path, relative)
+              else
+                unless stat.file? && !stat.symlink? && stat.nlink == 1 && stat.uid == Process.uid &&
+                       [ 0o444, 0o555 ].include?(stat.mode & 0o777)
+                  raise Error, "admitted source file is unsafe"
+                end
+                identity = external_regular_file_identity(
+                  path, label: "admitted source file", limit: MAX_EXTERNAL_SOURCE_BYTES
+                )
+                total += identity.fetch("bytesize")
+                raise Error, "admitted source exceeds its aggregate byte bound" if
+                  total > MAX_EXTERNAL_SOURCE_BYTES
+                rows << {
+                  "kind" => "file", "mode" => stat.mode & 0o777, "path" => relative,
+                  "sha256" => identity.fetch("sha256"), "size" => identity.fetch("bytesize")
+                }
+              end
+            end
+          end
+          walk.call(root, "")
+          raise Error, "admitted source tree is empty" if rows.empty?
+          Digest::SHA256.hexdigest(JSON.generate(
+            PatrolQualification.canonical_value(rows.sort_by { |row| row.fetch("path") })
+          ))
+        rescue Errno::ELOOP, Errno::ENOENT, Errno::EACCES => e
+          raise Error, "admitted source tree is unavailable: #{e.class.name}"
         end
 
         def setup_process(run_root)
@@ -789,6 +949,7 @@ module Hive
               cwd: candidate.fetch("root"), label: "build candidate gem")
           install_root = File.join(run_root, "installed")
           @install_root = install_root
+          @candidate_gem_path = gem_file
           installer = File.join(candidate.fetch("root"), "packaging/live_agent_skills/install_candidate_gem.sh")
           run("/bin/bash", installer, gem_file, install_root, label: "install candidate gem")
           @hive_bin = File.join(install_root, "bin", "hive")
@@ -802,9 +963,13 @@ module Hive
 
         def build_module_catalog(candidate, run_root)
           root = File.join(run_root, "catalog")
+          admitted_root = candidate.fetch("source_root", candidate.fetch("root"))
           entries = MODULES.map do |name|
-            source = File.join(candidate.fetch("root"), "modules", name)
-            manifest = YAML.safe_load(File.binread(File.join(source, "manifest.yml")))
+            source = File.join(admitted_root, "modules", name)
+            manifest = YAML.safe_load(PatrolQualification.bounded_read(
+              File.join(source, "manifest.yml"), label: "catalogue #{name} manifest",
+              limit: 1024 * 1024, deadline: @deadline
+            ))
             version = manifest.fetch("version")
             destination = File.join(root, "modules", name, version)
             FileUtils.mkdir_p(File.dirname(destination))
@@ -925,18 +1090,19 @@ module Hive
                                          observations_path: @observations_path,
                                          catalog: catalog, deadline: @deadline)
           catalog_digest = Digest::SHA256.hexdigest(catalog.bytes)
+          manifest_digest = if claim == "u3c"
+            candidate.fetch("module_manifest_sha256")
+          else
+            Digest::SHA256.hexdigest(MODULES.map { |name|
+              File.binread(File.join(candidate.fetch("root"), "modules", name, "manifest.yml"))
+            }.join("\0"))
+          end
           common = {
             "run_id" => "#{claim}-#{candidate.fetch('sha')[0, 12]}",
             "candidate_sha" => candidate.fetch("sha"),
             "catalog_digest" => catalog_digest,
             "source_digest" => candidate.fetch("archive_sha256"),
-            "manifest_digest" => if claim == "u3c"
-              candidate.fetch("module_manifest_sha256")
-            else
-              Digest::SHA256.hexdigest(MODULES.map { |name|
-                File.binread(File.join(candidate.fetch("root"), "modules", name, "manifest.yml"))
-              }.join("\0"))
-            end,
+            "manifest_digest" => manifest_digest,
             "scenario_manifest_digest" => Digest::SHA256.hexdigest(catalog.bytes + "\0" + reader.bytes),
             "artifacts" => [
               { "kind" => "candidate_archive", "digest" => candidate.fetch("archive_sha256") },

--- a/test/e2e/lib/patrol_qualification.rb
+++ b/test/e2e/lib/patrol_qualification.rb
@@ -3,6 +3,7 @@ require "fileutils"
 require "json"
 require "open3"
 require "rbconfig"
+require "rubygems"
 require "tmpdir"
 require "time"
 require "yaml"
@@ -522,7 +523,214 @@ module Hive
           end
         end
 
+        # Read-only U3c seam. The worker branch runs only the archived candidate's
+        # build/install/receipt commands inside the admitted sandbox; this host
+        # branch independently replays the trusted catalogue controls and never
+        # reaches qualification/report publication.
+        def external_smoke(controller_sha:, candidate_sha:, candidate:, sandbox_result: nil,
+                           trusted_catalog_path: nil, worker: false)
+          return external_smoke_worker(
+            controller_sha:, candidate_sha:, candidate:, trusted_catalog_path:
+          ) if worker
+
+          unless controller_sha.to_s.match?(/\A[0-9a-f]{40}\z/) &&
+                 candidate_sha.to_s.match?(/\A[0-9a-f]{40}\z/) &&
+                 controller_sha != candidate_sha && candidate.is_a?(Hash) &&
+                 candidate.fetch("candidate_sha") == candidate_sha &&
+                 candidate.fetch("archive_sha256").to_s.match?(/\A[0-9a-f]{64}\z/) &&
+                 candidate.fetch("module_manifest_sha256").to_s.match?(/\A[0-9a-f]{64}\z/)
+            raise Error, "external smoke authority binding is malformed"
+          end
+          unless sandbox_result.is_a?(Hash) && sandbox_result.keys.sort == %w[
+            generated_at module_inspections receipts report_after_sha256 report_before_sha256
+          ]
+            raise Error, "external smoke sandbox result is malformed"
+          end
+          generated_at = Time.iso8601(sandbox_result.fetch("generated_at"))
+          raise Error, "external smoke generation time must be UTC" unless generated_at.utc_offset.zero?
+
+          catalog = Catalog.load(
+            File.join(@repo_root, "test/e2e/fixtures/patrol_qualification/catalog.json"),
+            deadline: @deadline
+          )
+          reader = ObservationReader.new(
+            project_root: @project_root, observations_path: @observations_path,
+            catalog:, deadline: @deadline
+          )
+          catalog_digest = Digest::SHA256.hexdigest(catalog.bytes)
+          common = {
+            "run_id" => "u3c-#{candidate_sha[0, 12]}",
+            "candidate_sha" => candidate_sha,
+            "catalog_digest" => catalog_digest,
+            "source_digest" => candidate.fetch("archive_sha256"),
+            "manifest_digest" => candidate.fetch("module_manifest_sha256"),
+            "scenario_manifest_digest" => Digest::SHA256.hexdigest(catalog.bytes + "\0" + reader.bytes),
+            "artifacts" => [
+              { "kind" => "candidate_archive", "digest" => candidate.fetch("archive_sha256") },
+              { "kind" => "scenario_catalog", "digest" => catalog_digest }
+            ],
+            "reviewer" => "hive-e2e/u3c-smoke"
+          }
+          expected_receipts = []
+          configurations = Hash.new { |hash, key| hash[key] = [] }
+          reader.each do |case_row, observation, record|
+            expected_receipts << expected_receipt(
+              common, case_row, observation, record, sandbox_result.fetch("generated_at")
+            )
+            configurations[case_row.module_name] << record.fetch("configuration_digest")
+          end
+          unless PatrolQualification.canonical(sandbox_result.fetch("receipts")) ==
+                 PatrolQualification.canonical(expected_receipts)
+            raise Error, "external smoke receipts differ from the trusted controls"
+          end
+          inspections = sandbox_result.fetch("module_inspections")
+          unless inspections.is_a?(Hash) && inspections.keys.sort == MODULES.sort
+            raise Error, "external smoke module inspection inventory differs"
+          end
+          MODULES.each do |name|
+            expected_configuration = configurations.fetch(name).uniq
+            row = inspections.fetch(name)
+            valid = expected_configuration.one? && row.is_a?(Hash) &&
+              row.keys.sort == %w[configuration_digest status] &&
+              row.values_at("status", "configuration_digest") ==
+                [ "active", expected_configuration.fetch(0) ]
+            raise Error, "external smoke #{name} revalidation differs" unless valid
+          end
+          report_digest = Digest::SHA256.hexdigest(read_report(
+            File.join(state_path, "module-runtime", "migration", "report.json")
+          ))
+          before, after = sandbox_result.values_at("report_before_sha256", "report_after_sha256")
+          unless before.to_s.match?(/\A[0-9a-f]{64}\z/) && before == after && before == report_digest
+            raise Error, "external smoke changed the migration report"
+          end
+          {
+            "status" => "passed", "modules" => MODULES,
+            "receipt_count" => expected_receipts.size,
+            "catalog_digest" => catalog_digest,
+            "scenario_manifest_digest" => common.fetch("scenario_manifest_digest"),
+            "report_sha256" => report_digest
+          }.freeze
+        rescue ArgumentError, KeyError, TypeError => e
+          raise Error, "external smoke result is malformed: #{e.class.name}"
+        end
+
         private
+
+        def external_smoke_worker(controller_sha:, candidate_sha:, candidate:, trusted_catalog_path:)
+          unless controller_sha.to_s.match?(/\A[0-9a-f]{40}\z/) &&
+                 candidate_sha.to_s.match?(/\A[0-9a-f]{40}\z/) &&
+                 controller_sha != candidate_sha && candidate.is_a?(Hash) &&
+                 candidate.fetch("candidate_sha") == candidate_sha &&
+                 candidate.fetch("archive_sha256").to_s.match?(/\A[0-9a-f]{64}\z/) &&
+                 candidate.fetch("module_manifest_sha256").to_s.match?(/\A[0-9a-f]{64}\z/)
+            raise Error, "external smoke worker authority binding is malformed"
+          end
+          run_root = File.join(File.dirname(@repo_root), "external-smoke")
+          raise Error, "external smoke worker root must not pre-exist" if File.exist?(run_root)
+          Dir.mkdir(run_root, 0o700)
+          FileUtils.mkdir_p(@evidence_root, mode: 0o700)
+          setup_process(run_root)
+          catalog = Catalog.load(trusted_catalog_path, deadline: @deadline)
+          report_path = File.join(state_path, "module-runtime", "migration", "report.json")
+          report_before = read_report(report_path)
+          installed = {
+            "sha" => candidate_sha, "candidate_sha" => candidate_sha,
+            "archive_sha256" => candidate.fetch("archive_sha256"), "root" => @repo_root,
+            "module_manifest_sha256" => candidate.fetch("module_manifest_sha256")
+          }
+          install_candidate(installed, run_root)
+          catalog_repo = build_module_catalog(installed, run_root)
+          install_modules(catalog_repo)
+          identity_before = external_installed_identity(installed)
+          prepared = collect_receipts(catalog, installed, claim: "u3c")
+          inspections = revalidate_external_modules
+          identity_after = external_installed_identity(installed)
+          report_after = read_report(report_path)
+          unless report_before == report_after
+            raise Error, "external smoke worker changed the migration report"
+          end
+          {
+            "candidate" => {
+              "candidate_sha" => candidate_sha,
+              "archive_sha256" => candidate.fetch("archive_sha256"),
+              "identity_before" => identity_before,
+              "identity_after" => identity_after
+            },
+            "payload" => {
+              "generated_at" => prepared.fetch("generated_at"),
+              "receipts" => prepared.fetch("receipts"),
+              "module_inspections" => inspections,
+              "report_before_sha256" => Digest::SHA256.hexdigest(report_before),
+              "report_after_sha256" => Digest::SHA256.hexdigest(report_after)
+            }
+          }
+        rescue SystemCallError, JSON::ParserError, Psych::Exception => e
+          raise Error, "external smoke worker failed: #{e.class.name}"
+        end
+
+        def revalidate_external_modules
+          MODULES.to_h do |name|
+            expected = @installed_generations.fetch(name)
+            inspected = JSON.parse(hive([ "module", "inspect", name, "--json" ]).stdout)
+            validate_inspection!(inspected, name:, expected:)
+            [ name, {
+              "status" => "active",
+              "configuration_digest" => expected.fetch("configuration_digest")
+            } ]
+          end
+        end
+
+        def external_installed_identity(candidate)
+          specifications = File.join(@install_root, "specifications")
+          stat = File.lstat(specifications)
+          unless stat.directory? && !stat.symlink? && stat.uid == Process.uid
+            raise Error, "installed dependency specifications are unavailable"
+          end
+          closure = []
+          Dir.each_child(specifications) do |name|
+            raise Error, "installed dependency closure exceeds its member bound" if closure.size >= 4_096
+            path = File.join(specifications, name)
+            bytes = PatrolQualification.bounded_read(
+              path, label: "installed dependency specification", limit: 1024 * 1024,
+              deadline: @deadline
+            )
+            specification = Gem::Specification.load(path)
+            unless specification && specification.name.to_s.bytesize.between?(1, 256) &&
+                   specification.version.to_s.bytesize.between?(1, 256) &&
+                   specification.platform.to_s.bytesize.between?(1, 256)
+              raise Error, "installed dependency specification is malformed"
+            end
+            closure << {
+              "name" => specification.name.to_s,
+              "version" => specification.version.to_s,
+              "platform" => specification.platform.to_s,
+              "full_name" => specification.full_name.to_s,
+              "spec_sha256" => Digest::SHA256.hexdigest(bytes)
+            }
+          end
+          closure.sort_by! { |row| row.fetch("full_name") }
+          names = closure.map { |row| row.fetch("full_name") }
+          raise Error, "installed dependency closure is empty or duplicated" if
+            closure.empty? || names.uniq.size != names.size
+          toolchain = {
+            "ruby" => run("ruby", "--version", label: "resolve installed Ruby").stdout.strip,
+            "rubygems" => run("gem", "--version", label: "resolve installed RubyGems").stdout.strip,
+            "bundler" => run("bundle", "--version", label: "resolve installed Bundler").stdout.strip
+          }
+          canonical_closure = JSON.generate(PatrolQualification.canonical_value(closure))
+          canonical_toolchain = JSON.generate(PatrolQualification.canonical_value(toolchain))
+          {
+            "gem_sha256" => candidate.fetch("gem_sha256"),
+            "installed_hive_sha256" => candidate.fetch("installed_hive_sha256"),
+            "module_manifest_sha256" => candidate.fetch("module_manifest_sha256"),
+            "dependency_closure" => closure,
+            "dependency_closure_sha256" => Digest::SHA256.hexdigest(canonical_closure),
+            "toolchain" => toolchain,
+            "toolchain_sha256" => Digest::SHA256.hexdigest(canonical_toolchain)
+          }
+        rescue Errno::ENOENT, Errno::EACCES
+          raise Error, "installed dependency closure is unavailable"
+        end
 
         def setup_process(run_root)
           @env = {
@@ -580,6 +788,7 @@ module Hive
           run("gem", "build", "hive.gemspec", "--output", gem_file,
               cwd: candidate.fetch("root"), label: "build candidate gem")
           install_root = File.join(run_root, "installed")
+          @install_root = install_root
           installer = File.join(candidate.fetch("root"), "packaging/live_agent_skills/install_candidate_gem.sh")
           run("/bin/bash", installer, gem_file, install_root, label: "install candidate gem")
           @hive_bin = File.join(install_root, "bin", "hive")
@@ -624,6 +833,7 @@ module Hive
         end
 
         def install_modules(catalog_repo)
+          @installed_generations = {}
           rewrite = {
             "GIT_CONFIG_COUNT" => "5",
             "GIT_CONFIG_KEY_4" => "url.file://#{catalog_repo}/.insteadOf",
@@ -658,6 +868,7 @@ module Hive
             validate_generation!(apply.dig("selection", "active"), expected, name:)
             inspected = JSON.parse(hive([ "module", "inspect", name, "--json" ]).stdout)
             validate_inspection!(inspected, name:, expected:)
+            @installed_generations[name] = expected.freeze
           end
         end
 
@@ -709,25 +920,29 @@ module Hive
           settings + hooks + grants.flatten
         end
 
-        def collect_receipts(catalog, candidate)
+        def collect_receipts(catalog, candidate, claim: "u3br")
           reader = ObservationReader.new(project_root: @project_root,
                                          observations_path: @observations_path,
                                          catalog: catalog, deadline: @deadline)
           catalog_digest = Digest::SHA256.hexdigest(catalog.bytes)
           common = {
-            "run_id" => "u3br-#{candidate.fetch('sha')[0, 12]}",
+            "run_id" => "#{claim}-#{candidate.fetch('sha')[0, 12]}",
             "candidate_sha" => candidate.fetch("sha"),
             "catalog_digest" => catalog_digest,
             "source_digest" => candidate.fetch("archive_sha256"),
-            "manifest_digest" => Digest::SHA256.hexdigest(MODULES.map { |name|
-              File.binread(File.join(candidate.fetch("root"), "modules", name, "manifest.yml"))
-            }.join("\0")),
+            "manifest_digest" => if claim == "u3c"
+              candidate.fetch("module_manifest_sha256")
+            else
+              Digest::SHA256.hexdigest(MODULES.map { |name|
+                File.binread(File.join(candidate.fetch("root"), "modules", name, "manifest.yml"))
+              }.join("\0"))
+            end,
             "scenario_manifest_digest" => Digest::SHA256.hexdigest(catalog.bytes + "\0" + reader.bytes),
             "artifacts" => [
               { "kind" => "candidate_archive", "digest" => candidate.fetch("archive_sha256") },
               { "kind" => "scenario_catalog", "digest" => catalog_digest }
             ],
-            "reviewer" => "hive-e2e/u3br"
+            "reviewer" => claim == "u3c" ? "hive-e2e/u3c-smoke" : "hive-e2e/u3br"
           }
           generated_at = Time.now.utc.iso8601(6)
           prepared = []

--- a/test/e2e/lib/patrol_qualification_test.rb
+++ b/test/e2e/lib/patrol_qualification_test.rb
@@ -450,6 +450,153 @@ class E2EPatrolQualificationSupportTest < Minitest::Test
     end
   end
 
+  def test_external_smoke_is_read_only_distinct_head_and_never_admits_qualification
+    Dir.mktmpdir("patrol-external-smoke") do |root|
+      project = File.join(root, "project")
+      state = File.join(project, ".hive-state")
+      FileUtils.mkdir_p(state)
+      File.binwrite(File.join(state, "config.yml"), "hive_state_path: .hive-state\n")
+      catalog = Catalog.load(CATALOG_PATH)
+      observations = write_records_and_observations(root, state, catalog)
+      report_path = File.join(state, "module-runtime", "migration", "report.json")
+      FileUtils.mkdir_p(File.dirname(report_path))
+      report_bytes = Hive::E2E::PatrolQualification.canonical(
+        "schema" => "hive-module-migration-report", "schema_version" => 2,
+        "status" => "evidence_required"
+      )
+      File.binwrite(report_path, report_bytes)
+      candidate = {
+        "candidate_sha" => "b" * 40, "archive_sha256" => "c" * 64,
+        "module_manifest_sha256" => "d" * 64
+      }
+      generated_at = "2026-08-05T10:00:00.000000Z"
+      reader = ObservationReader.new(
+        project_root: project, observations_path: observations, catalog: catalog,
+        deadline: monotonic + 5
+      )
+      common = {
+        "run_id" => "u3c-#{candidate.fetch('candidate_sha')[0, 12]}",
+        "candidate_sha" => candidate.fetch("candidate_sha"),
+        "catalog_digest" => Digest::SHA256.hexdigest(catalog.bytes),
+        "source_digest" => candidate.fetch("archive_sha256"),
+        "manifest_digest" => candidate.fetch("module_manifest_sha256"),
+        "scenario_manifest_digest" => Digest::SHA256.hexdigest(catalog.bytes + "\0" + reader.bytes),
+        "artifacts" => [
+          { "kind" => "candidate_archive", "digest" => candidate.fetch("archive_sha256") },
+          { "kind" => "scenario_catalog", "digest" => Digest::SHA256.hexdigest(catalog.bytes) }
+        ],
+        "reviewer" => "hive-e2e/u3c-smoke"
+      }
+      controller = Controller.allocate
+      controller.instance_variable_set(:@repo_root, File.expand_path("../../..", __dir__))
+      controller.instance_variable_set(:@project_root, project)
+      controller.instance_variable_set(:@observations_path, observations)
+      controller.instance_variable_set(:@deadline, monotonic + 5)
+      receipts = []
+      configurations = Hash.new { |hash, key| hash[key] = [] }
+      reader.each do |case_row, observation, record|
+        receipts << controller.send(:expected_receipt, common, case_row, observation, record, generated_at)
+        configurations[case_row.module_name] << record.fetch("configuration_digest")
+      end
+      sandbox_result = {
+        "generated_at" => generated_at,
+        "receipts" => receipts,
+        "module_inspections" => MODULES.to_h do |name|
+          [ name, { "status" => "active", "configuration_digest" => configurations.fetch(name).uniq.fetch(0) } ]
+        end,
+        "report_before_sha256" => Digest::SHA256.hexdigest(report_bytes),
+        "report_after_sha256" => Digest::SHA256.hexdigest(report_bytes)
+      }
+
+      result = controller.external_smoke(
+        controller_sha: "a" * 40, candidate_sha: candidate.fetch("candidate_sha"),
+        candidate:, sandbox_result:
+      )
+
+      assert_equal "passed", result.fetch("status")
+      assert_equal MODULES, result.fetch("modules")
+      assert_equal catalog.cases.size, result.fetch("receipt_count")
+      assert_equal report_bytes, File.binread(report_path)
+      source = File.binread(File.expand_path("patrol_qualification.rb", __dir__))
+      external_source = source[/def external_smoke\b.*?^        private/m]
+      refute_nil external_source
+      refute_includes external_source, "admit_qualification"
+      refute_includes external_source, "PatrolQualification.build"
+
+      sandbox_result["receipts"][0] = sandbox_result.fetch("receipts").fetch(1)
+      assert_raises(Hive::E2E::PatrolQualification::Error) do
+        controller.external_smoke(
+          controller_sha: "a" * 40, candidate_sha: candidate.fetch("candidate_sha"),
+          candidate:, sandbox_result:
+        )
+      end
+    end
+  end
+
+  def test_external_smoke_worker_runs_only_the_closed_sandbox_sequence
+    Dir.mktmpdir("patrol-external-worker") do |root|
+      candidate_root = File.join(root, "candidate")
+      FileUtils.mkdir_p(candidate_root)
+      calls = []
+      identity = {
+        "gem_sha256" => "1" * 64, "installed_hive_sha256" => "2" * 64,
+        "module_manifest_sha256" => "3" * 64, "dependency_closure" => [],
+        "dependency_closure_sha256" => "4" * 64, "toolchain" => {},
+        "toolchain_sha256" => "5" * 64
+      }
+      controller = Controller.allocate
+      controller.instance_variable_set(:@repo_root, candidate_root)
+      controller.instance_variable_set(:@project_root, File.join(root, "project"))
+      controller.instance_variable_set(:@observations_path, File.join(root, "observations.json"))
+      controller.instance_variable_set(:@evidence_root, File.join(root, "evidence"))
+      controller.instance_variable_set(:@deadline, monotonic + 5)
+      controller.define_singleton_method(:state_path) { File.join(root, "state") }
+      controller.define_singleton_method(:setup_process) { |_| calls << :setup }
+      controller.define_singleton_method(:read_report) { |_| "unchanged-report\n" }
+      controller.define_singleton_method(:install_candidate) do |candidate, _|
+        calls << :install_candidate
+        candidate["gem_sha256"] = "1" * 64
+        candidate["installed_hive_sha256"] = "2" * 64
+      end
+      controller.define_singleton_method(:build_module_catalog) do |_, _|
+        calls << :build_catalog
+        File.join(root, "catalog")
+      end
+      controller.define_singleton_method(:install_modules) { |_| calls << :install_modules }
+      controller.define_singleton_method(:external_installed_identity) do |_|
+        calls << :installed_identity
+        identity
+      end
+      controller.define_singleton_method(:collect_receipts) do |_, _, claim:|
+        calls << [ :collect_receipts, claim ]
+        { "generated_at" => "2026-08-05T10:00:00Z", "receipts" => [] }
+      end
+      controller.define_singleton_method(:revalidate_external_modules) do
+        calls << :revalidate_modules
+        MODULES.to_h { |name| [ name, { "status" => "active", "configuration_digest" => "6" * 64 } ] }
+      end
+
+      result = controller.external_smoke(
+        controller_sha: "a" * 40, candidate_sha: "b" * 40,
+        candidate: {
+          "candidate_sha" => "b" * 40, "archive_sha256" => "7" * 64,
+          "module_manifest_sha256" => "3" * 64
+        },
+        trusted_catalog_path: CATALOG_PATH, worker: true
+      )
+
+      assert_equal [
+        :setup, :install_candidate, :build_catalog, :install_modules,
+        :installed_identity, [ :collect_receipts, "u3c" ], :revalidate_modules,
+        :installed_identity
+      ], calls
+      assert_equal identity, result.dig("candidate", "identity_before")
+      assert_equal identity, result.dig("candidate", "identity_after")
+      assert_equal Digest::SHA256.hexdigest("unchanged-report\n"),
+                   result.dig("payload", "report_after_sha256")
+    end
+  end
+
   private
 
   def write_records_and_observations(root, state, catalog)

--- a/test/e2e/lib/patrol_qualification_test.rb
+++ b/test/e2e/lib/patrol_qualification_test.rb
@@ -214,6 +214,24 @@ class E2EPatrolQualificationSupportTest < Minitest::Test
     end
   end
 
+  def test_child_process_fails_closed_on_stream_overflow
+    Dir.mktmpdir("patrol-qualification-output-bound") do |root|
+      process = ChildProcess.new(deadline: monotonic + 5, env: { "PATH" => "/usr/bin:/bin" })
+
+      %w[stdout stderr].each do |stream|
+        descriptor = stream == "stdout" ? "STDOUT" : "STDERR"
+        error = assert_raises(StreamOverflow) do
+          process.run(
+            RbConfig.ruby, "-e", "#{descriptor}.write('x' * #{MAX_STREAM_BYTES + 1})",
+            label: "#{stream} overflow", cwd: root
+          )
+        end
+        assert_equal stream, error.stream
+        assert_match(/exceeds its byte bound/, error.message)
+      end
+    end
+  end
+
   def test_controller_uses_only_the_archived_installed_public_boundary
     source = File.binread(File.expand_path("patrol_qualification.rb", __dir__))
 
@@ -358,7 +376,7 @@ class E2EPatrolQualificationSupportTest < Minitest::Test
       noisy = ChildProcess.new(deadline: monotonic + 5, env: { "PATH" => "/usr/bin:/bin" })
       timeout = 0.25
       started = monotonic
-      assert_raises(ChildTimeout) do
+      overflow = assert_raises(StreamOverflow) do
         program = <<~RUBY
           STDOUT.sync = true
           worker = spawn(#{RbConfig.ruby.inspect}, "-e", "sleep 30")
@@ -372,10 +390,9 @@ class E2EPatrolQualificationSupportTest < Minitest::Test
         )
       end
       elapsed = monotonic - started
-      assert_operator elapsed, :>=, timeout * 0.6,
-                      "timeout should track the requested deadline instead of firing immediately"
+      assert_equal "stdout", overflow.stream
       assert_operator elapsed, :<, 1.5,
-                      "blocked stdin and noisy stdout must remain under the child deadline"
+                      "output overflow must fail before the outer child deadline"
       leader_pid, worker_pid = File.binread(noisy_pid_path).split.map { |value| Integer(value) }
       refute process_alive?(leader_pid), "timed-out leader must be gone"
       refute process_group_alive?(leader_pid), "timed-out process group must be gone"
@@ -467,7 +484,7 @@ class E2EPatrolQualificationSupportTest < Minitest::Test
       File.binwrite(report_path, report_bytes)
       candidate = {
         "candidate_sha" => "b" * 40, "archive_sha256" => "c" * 64,
-        "module_manifest_sha256" => "d" * 64
+        "module_manifest_sha256" => "d" * 64, "source_tree_sha256" => "e" * 64
       }
       generated_at = "2026-08-05T10:00:00.000000Z"
       reader = ObservationReader.new(
@@ -536,13 +553,15 @@ class E2EPatrolQualificationSupportTest < Minitest::Test
   def test_external_smoke_worker_runs_only_the_closed_sandbox_sequence
     Dir.mktmpdir("patrol-external-worker") do |root|
       candidate_root = File.join(root, "candidate")
+      source_root = File.join(root, "source")
       FileUtils.mkdir_p(candidate_root)
+      FileUtils.mkdir_p(source_root)
       calls = []
       identity = {
         "gem_sha256" => "1" * 64, "installed_hive_sha256" => "2" * 64,
         "module_manifest_sha256" => "3" * 64, "dependency_closure" => [],
         "dependency_closure_sha256" => "4" * 64, "toolchain" => {},
-        "toolchain_sha256" => "5" * 64
+        "toolchain_sha256" => "5" * 64, "source_tree_sha256" => "8" * 64
       }
       controller = Controller.allocate
       controller.instance_variable_set(:@repo_root, candidate_root)
@@ -558,8 +577,9 @@ class E2EPatrolQualificationSupportTest < Minitest::Test
         candidate["gem_sha256"] = "1" * 64
         candidate["installed_hive_sha256"] = "2" * 64
       end
-      controller.define_singleton_method(:build_module_catalog) do |_, _|
+      controller.define_singleton_method(:build_module_catalog) do |candidate, _|
         calls << :build_catalog
+        raise "source root was not preserved" unless candidate.fetch("source_root") == source_root
         File.join(root, "catalog")
       end
       controller.define_singleton_method(:install_modules) { |_| calls << :install_modules }
@@ -580,7 +600,8 @@ class E2EPatrolQualificationSupportTest < Minitest::Test
         controller_sha: "a" * 40, candidate_sha: "b" * 40,
         candidate: {
           "candidate_sha" => "b" * 40, "archive_sha256" => "7" * 64,
-          "module_manifest_sha256" => "3" * 64
+          "module_manifest_sha256" => "3" * 64, "source_root" => source_root,
+          "source_tree_sha256" => "8" * 64
         },
         trusted_catalog_path: CATALOG_PATH, worker: true
       )
@@ -596,8 +617,96 @@ class E2EPatrolQualificationSupportTest < Minitest::Test
                    result.dig("payload", "report_after_sha256")
     end
   end
+  def test_external_installed_identity_treats_gemspecs_as_opaque_and_rehashes_artifacts
+    Dir.mktmpdir("patrol-external-identity") do |root|
+      install_root = File.join(root, "installed")
+      specifications = File.join(install_root, "specifications")
+      source_root = File.join(root, "source")
+      FileUtils.mkdir_p(specifications)
+      write_external_source_manifests(source_root)
+      begin
+        candidate_gem = File.join(root, "candidate.gem")
+        hive_bin = File.join(install_root, "bin", "hive")
+        FileUtils.mkdir_p(File.dirname(hive_bin))
+        File.binwrite(candidate_gem, "candidate gem one\n")
+        File.binwrite(hive_bin, "installed hive one\n")
+        sentinel = File.join(root, "gemspec-executed")
+        gemspec = File.join(specifications, "hostile-1.0.0.gemspec")
+        gemspec_bytes = "File.binwrite(#{sentinel.dump}, 'executed')\n"
+        File.binwrite(gemspec, gemspec_bytes)
+
+        controller = Controller.allocate
+        controller.instance_variable_set(:@deadline, monotonic + 5)
+        controller.instance_variable_set(:@install_root, install_root)
+        controller.instance_variable_set(:@candidate_gem_path, candidate_gem)
+        controller.instance_variable_set(:@hive_bin, hive_bin)
+        controller.define_singleton_method(:run) do |command, *arguments, **|
+          value = [ command, *arguments ].join(" ")
+          Result.new("#{value} version\n", "", 0)
+        end
+        candidate = { "source_root" => source_root }
+
+        before = controller.send(:external_installed_identity, candidate)
+
+        refute File.exist?(sentinel), "opaque gemspec inventory must never evaluate Ruby"
+        assert_equal [ {
+          "basename" => "hostile-1.0.0.gemspec", "bytesize" => gemspec_bytes.bytesize,
+          "spec_sha256" => Digest::SHA256.hexdigest(gemspec_bytes)
+        } ], before.fetch("dependency_closure")
+        assert_equal Digest::SHA256.hexdigest("candidate gem one\n"), before.fetch("gem_sha256")
+        assert_equal Digest::SHA256.hexdigest("installed hive one\n"),
+                     before.fetch("installed_hive_sha256")
+
+        File.binwrite(candidate_gem, "candidate gem two\n")
+        File.binwrite(hive_bin, "installed hive two\n")
+        manifest_path = File.join(source_root, "modules", "patrol", "manifest.yml")
+        File.chmod(0o644, manifest_path)
+        File.binwrite(manifest_path, File.binread(manifest_path).sub("version: 1.0.0", "version: 1.0.1"))
+        File.chmod(0o444, manifest_path)
+        after = controller.send(:external_installed_identity, candidate)
+
+        refute_equal before.fetch("gem_sha256"), after.fetch("gem_sha256")
+        refute_equal before.fetch("installed_hive_sha256"), after.fetch("installed_hive_sha256")
+        refute_equal before.fetch("module_manifest_sha256"), after.fetch("module_manifest_sha256")
+        refute_equal before.fetch("source_tree_sha256"), after.fetch("source_tree_sha256")
+        refute File.exist?(sentinel)
+      ensure
+        thaw_external_source(source_root)
+      end
+    end
+  end
 
   private
+
+  def write_external_source_manifests(root)
+    MODULES.each do |name|
+      directory = File.join(root, "modules", name)
+      FileUtils.mkdir_p(directory)
+      File.binwrite(File.join(directory, "manifest.yml"), <<~YAML)
+        name: #{name}
+        version: 1.0.0
+        release_sha256: #{Digest::SHA256.hexdigest(name)}
+        source:
+          revision: #{"a" * 40}
+      YAML
+    end
+    Dir.glob(File.join(root, "**", "*"), File::FNM_DOTMATCH)
+       .select { |path| File.file?(path) }
+       .each { |path| File.chmod(0o444, path) }
+    Dir.glob(File.join(root, "**", "*"), File::FNM_DOTMATCH)
+       .select { |path| File.directory?(path) }
+       .sort_by { |path| -path.count(File::SEPARATOR) }
+       .each { |path| File.chmod(0o555, path) }
+    File.chmod(0o555, root)
+  end
+
+  def thaw_external_source(root)
+    return unless File.exist?(root)
+
+    [ root, *Dir.glob(File.join(root, "**", "*"), File::FNM_DOTMATCH) ]
+      .select { |path| File.directory?(path) }
+      .each { |path| File.chmod(0o755, path) }
+  end
 
   def write_records_and_observations(root, state, catalog)
     observations = catalog.cases.map.with_index do |case_row, index|

--- a/test/unit/ci_test_partition_test.rb
+++ b/test/unit/ci_test_partition_test.rb
@@ -104,7 +104,11 @@ class CiTestPartitionTest < Minitest::Test
       default_files = Object.const_get(:HIVE_DEFAULT_TEST_FILES)
       workflow = File.read(File.join(ROOT, ".github", "workflows", "ci.yml"))
 
-      assert_equal [ "test/unit/packaging/workflow_creator_values_test.rb" ], hostile_files
+      assert_equal %w[
+        test/unit/packaging/patrol_evidence_candidate_test.rb
+        test/unit/packaging/patrol_evidence_sandbox_test.rb
+        test/unit/packaging/workflow_creator_values_test.rb
+      ], hostile_files.sort
       assert hostile_files.all? { |file| default_files.include?(file) },
              "core Workflow Creator coverage must remain in the default suite"
       assert_equal [ "test:enable_hostile" ], Rake::Task["test:hostile"].prerequisites

--- a/test/unit/packaging/patrol_evidence_candidate_test.rb
+++ b/test/unit/packaging/patrol_evidence_candidate_test.rb
@@ -25,6 +25,11 @@ class PatrolEvidenceCandidateTest < Minitest::Test
         assert_operator record.fetch("archive_total_bytes"), :>, 0
         assert_equal %w[architecture-patrol patrol], record.fetch("module_manifests").keys
         assert record.fetch("module_manifest_sha256").match?(/\A[0-9a-f]{64}\z/)
+        assert record.fetch("source_tree_sha256").match?(/\A[0-9a-f]{64}\z/)
+        assert_equal 0o555, File.stat(record.fetch("source_path")).mode & 0o777
+        source_files = Dir.glob(File.join(record.fetch("source_path"), "**", "*"))
+                          .select { |path| File.file?(path) }
+        assert source_files.all? { |path| [ 0o444, 0o555 ].include?(File.stat(path).mode & 0o777) }
       end
     end
   end
@@ -62,6 +67,12 @@ class PatrolEvidenceCandidateTest < Minitest::Test
         receipt["candidate"]["identity_after"]["installed_hive_sha256"] = digest("changed")
         error = assert_raises(Candidate::Error) { owner.verify!(receipt:) }
         assert_equal "candidate_identity", error.reason
+
+        source_file = File.join(prepared.fetch("source_path"), "candidate.txt")
+        File.chmod(0o644, source_file)
+        File.binwrite(source_file, "changed source\n")
+        error = assert_raises(Candidate::Error) { owner.verify!(receipt:) }
+        assert_equal "candidate_identity", error.reason
       end
     end
   end
@@ -84,13 +95,14 @@ class PatrolEvidenceCandidateTest < Minitest::Test
 
   def installed_identity(prepared)
     closure = [
-      { "name" => "hive-cli", "version" => "0.7.0", "platform" => "ruby",
-        "full_name" => "hive-cli-0.7.0", "spec_sha256" => digest("spec") }
+      { "basename" => "hive-cli-0.7.0.gemspec", "bytesize" => 12,
+        "spec_sha256" => digest("spec") }
     ]
     {
       "gem_sha256" => digest("gem"),
       "installed_hive_sha256" => digest("hive"),
       "module_manifest_sha256" => prepared.fetch("module_manifest_sha256"),
+      "source_tree_sha256" => prepared.fetch("source_tree_sha256"),
       "dependency_closure" => closure,
       "dependency_closure_sha256" => digest(canonical_json(closure)),
       "toolchain" => {

--- a/test/unit/packaging/patrol_evidence_candidate_test.rb
+++ b/test/unit/packaging/patrol_evidence_candidate_test.rb
@@ -1,0 +1,146 @@
+require "test_helper"
+require "digest"
+require "json"
+require_relative "../../../packaging/patrol_evidence/candidate"
+
+class PatrolEvidenceCandidateTest < Minitest::Test
+  include HiveTestHelper
+
+  Candidate = HivePatrolEvidence::Candidate
+
+  def test_archives_one_distinct_commit_and_streams_a_bounded_regular_inventory
+    with_candidate_repository do |fixture|
+      with_tmp_dir do |run_root|
+        owner = Candidate.new(
+          repo_root: fixture.fetch(:repo), controller_sha: fixture.fetch(:controller_sha),
+          candidate_sha: fixture.fetch(:candidate_sha)
+        )
+
+        record = owner.prepare!(run_root:)
+
+        assert_equal fixture.fetch(:candidate_sha), record.fetch("candidate_sha")
+        assert_equal Digest::SHA256.file(record.fetch("archive_path")).hexdigest,
+                     record.fetch("archive_sha256")
+        assert_operator record.fetch("archive_member_count"), :>, 0
+        assert_operator record.fetch("archive_total_bytes"), :>, 0
+        assert_equal %w[architecture-patrol patrol], record.fetch("module_manifests").keys
+        assert record.fetch("module_manifest_sha256").match?(/\A[0-9a-f]{64}\z/)
+      end
+    end
+  end
+
+  def test_verification_binds_the_complete_before_and_after_installed_closure
+    with_candidate_repository do |fixture|
+      with_tmp_dir do |run_root|
+        owner = Candidate.new(
+          repo_root: fixture.fetch(:repo), controller_sha: fixture.fetch(:controller_sha),
+          candidate_sha: fixture.fetch(:candidate_sha)
+        )
+        prepared = owner.prepare!(run_root:)
+        identity = installed_identity(prepared)
+        receipt = {
+          "candidate" => {
+            "candidate_sha" => fixture.fetch(:candidate_sha),
+            "archive_sha256" => prepared.fetch("archive_sha256"),
+            "identity_before" => identity,
+            "identity_after" => Marshal.load(Marshal.dump(identity))
+          }
+        }
+
+        admitted = owner.verify!(receipt:)
+
+        assert_equal identity.fetch("dependency_closure_sha256"),
+                     admitted.fetch("dependency_closure_sha256")
+        assert_equal identity.fetch("installed_hive_sha256"), admitted.fetch("installed_hive_sha256")
+
+        archive_bytes = File.binread(prepared.fetch("archive_path"))
+        File.binwrite(prepared.fetch("archive_path"), "changed archive\n")
+        error = assert_raises(Candidate::Error) { owner.verify!(receipt:) }
+        assert_equal "candidate_identity", error.reason
+        File.binwrite(prepared.fetch("archive_path"), archive_bytes)
+
+        receipt["candidate"]["identity_after"]["installed_hive_sha256"] = digest("changed")
+        error = assert_raises(Candidate::Error) { owner.verify!(receipt:) }
+        assert_equal "candidate_identity", error.reason
+      end
+    end
+  end
+
+  def test_hostile_archive_campaign_is_opt_in
+    skip "set HIVE_HOSTILE_TESTS=1 for archive/path campaign" unless ENV["HIVE_HOSTILE_TESTS"] == "1"
+
+    with_tmp_dir do |root|
+      archive = File.join(root, "hostile.tar")
+      File.open(archive, "wb") do |file|
+        Gem::Package::TarWriter.new(file) { |tar| tar.add_symlink("escape", "../../outside", 0o777) }
+      end
+      assert_raises(Candidate::Error) do
+        Candidate.send(:inspect_archive!, archive)
+      end
+    end
+  end
+
+  private
+
+  def installed_identity(prepared)
+    closure = [
+      { "name" => "hive-cli", "version" => "0.7.0", "platform" => "ruby",
+        "full_name" => "hive-cli-0.7.0", "spec_sha256" => digest("spec") }
+    ]
+    {
+      "gem_sha256" => digest("gem"),
+      "installed_hive_sha256" => digest("hive"),
+      "module_manifest_sha256" => prepared.fetch("module_manifest_sha256"),
+      "dependency_closure" => closure,
+      "dependency_closure_sha256" => digest(canonical_json(closure)),
+      "toolchain" => {
+        "ruby" => "ruby 3.4", "rubygems" => "3.6", "bundler" => "2.6"
+      },
+      "toolchain_sha256" => digest(canonical_json(
+        "bundler" => "2.6", "ruby" => "ruby 3.4", "rubygems" => "3.6"
+      ))
+    }
+  end
+
+  def with_candidate_repository
+    with_tmp_dir do |root|
+      repo = File.join(root, "repo")
+      FileUtils.mkdir_p(File.join(repo, "modules", "patrol"))
+      FileUtils.mkdir_p(File.join(repo, "modules", "architecture-patrol"))
+      system("git", "init", "-b", "main", "--quiet", repo) or raise
+      File.write(File.join(repo, "README.md"), "controller\n")
+      %w[architecture-patrol patrol].each do |name|
+        File.write(File.join(repo, "modules", name, "manifest.yml"), <<~YAML)
+          name: #{name}
+          version: 1.0.0
+          release_sha256: #{digest(name)}
+          source:
+            revision: #{"a" * 40}
+        YAML
+      end
+      commit(repo, "controller")
+      controller_sha = git(repo, "rev-parse", "HEAD")
+      File.write(File.join(repo, "candidate.txt"), "candidate\n")
+      commit(repo, "candidate")
+      candidate_sha = git(repo, "rev-parse", "HEAD")
+      yield repo:, controller_sha:, candidate_sha:
+    end
+  end
+
+  def commit(repo, message)
+    system("git", "-C", repo, "add", ".") or raise
+    system("git", "-C", repo, "-c", "user.name=Hive", "-c", "user.email=hive@example.invalid",
+           "commit", "-m", message, "--quiet") or raise
+  end
+
+  def git(repo, *argv) = IO.popen([ "git", "-C", repo, *argv ], &:read).strip
+  def canonical_json(value)
+    normalized = case value
+    when Hash then value.keys.sort.to_h { |key| [ key, JSON.parse(canonical_json(value.fetch(key))) ] }
+    when Array then value.map { |item| JSON.parse(canonical_json(item)) }
+    else value
+    end
+    JSON.generate(normalized)
+  end
+  def digest(value) = Digest::SHA256.hexdigest(value)
+end

--- a/test/unit/packaging/patrol_evidence_command_test.rb
+++ b/test/unit/packaging/patrol_evidence_command_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+require "open3"
+
+class PatrolEvidenceCommandTest < Minitest::Test
+  COMMAND = File.expand_path("../../../bin/hive-patrol-installed-live-smoke", __dir__)
+
+  def test_manual_command_is_a_thin_local_only_runner_seam
+    stdout, stderr, status = Open3.capture3(COMMAND, "--help")
+
+    assert status.success?, stderr
+    assert_includes stdout, "--controller-sha"
+    assert_includes stdout, "--candidate-sha"
+    assert_includes stdout, "--authorization-file"
+    assert_includes stdout, "--evidence-root"
+    assert_includes stdout, "--cleanup-result"
+    assert_includes stdout, "--project-root"
+    assert_includes stdout, "--observations"
+    assert_includes stdout, "--image"
+    refute_includes stdout, "API_KEY"
+    refute_includes stdout, "credential"
+
+    source = File.binread(COMMAND)
+    assert_includes source, "HivePatrolEvidence::Runner.run!"
+    refute_match(/PatrolQualification|admit_qualification|report\.json|evidence_ready_for_operator/, source)
+    refute_match(/Net::HTTP|Open3|Process\.spawn|system\(/, source)
+  end
+end

--- a/test/unit/packaging/patrol_evidence_command_test.rb
+++ b/test/unit/packaging/patrol_evidence_command_test.rb
@@ -11,7 +11,9 @@ class PatrolEvidenceCommandTest < Minitest::Test
     assert_includes stdout, "--controller-sha"
     assert_includes stdout, "--candidate-sha"
     assert_includes stdout, "--authorization-file"
+    assert_includes stdout, "--authorization-template"
     assert_includes stdout, "--evidence-root"
+    assert_includes stdout, "--hive-home"
     assert_includes stdout, "--cleanup-result"
     assert_includes stdout, "--project-root"
     assert_includes stdout, "--observations"
@@ -23,5 +25,23 @@ class PatrolEvidenceCommandTest < Minitest::Test
     assert_includes source, "HivePatrolEvidence::Runner.run!"
     refute_match(/PatrolQualification|admit_qualification|report\.json|evidence_ready_for_operator/, source)
     refute_match(/Net::HTTP|Open3|Process\.spawn|system\(/, source)
+  end
+
+  def test_usage_and_input_failures_have_stable_codes_without_backtraces
+    _stdout, stderr, status = Open3.capture3(COMMAND, "unexpected")
+    assert_equal 64, status.exitstatus
+    assert_includes stderr, "unexpected positional arguments"
+    refute_includes stderr, "from "
+
+    _stdout, stderr, status = Open3.capture3(
+      COMMAND,
+      "--controller-sha", "a" * 40, "--candidate-sha", "b" * 40,
+      "--authorization-file", "/definitely/missing/hive-authorization.json",
+      "--evidence-root", "/tmp/evidence", "--hive-home", "/tmp/hive-home",
+      "--project-root", "/tmp/project", "--observations", "/tmp/observations.json",
+      "--image", "ruby@sha256:#{'c' * 64}"
+    )
+    assert_equal 78, status.exitstatus
+    assert_equal "patrol installed/live smoke refused: input_unavailable\n", stderr
   end
 end

--- a/test/unit/packaging/patrol_evidence_provider_probe_test.rb
+++ b/test/unit/packaging/patrol_evidence_provider_probe_test.rb
@@ -1,0 +1,73 @@
+require "test_helper"
+require "digest"
+require "json"
+require_relative "../../../packaging/patrol_evidence/provider_probe"
+
+class PatrolEvidenceProviderProbeTest < Minitest::Test
+  Probe = HivePatrolEvidence::ProviderProbe
+
+  def test_one_fixed_request_has_a_closed_success_predicate_and_retains_no_text
+    secret = "openrouter-secret-that-must-not-be-retained"
+    requests = []
+    response = {
+      status: 200, content_type: "application/json",
+      body: JSON.generate(
+        "model" => Probe::MODEL,
+        "choices" => [ { "message" => { "content" => Probe::EXPECTED_OUTPUT } } ],
+        "usage" => { "prompt_tokens" => 4, "completion_tokens" => 2, "total_tokens" => 6 }
+      )
+    }
+    probe = Probe.new(
+      environment: { "OPENROUTER_API_KEY" => secret },
+      transport: ->(request) { requests << request; response }
+    )
+
+    receipt = probe.call
+
+    assert_equal 1, requests.size
+    assert_equal URI(Probe::ENDPOINT), requests.first.fetch(:uri)
+    assert_equal "Bearer #{secret}", requests.first.dig(:headers, "Authorization")
+    assert_equal "passed", receipt.fetch("status")
+    assert_equal Digest::SHA256.hexdigest(response.fetch(:body)), receipt.fetch("response_sha256")
+    refute_includes JSON.generate(receipt), secret
+    refute_includes JSON.generate(receipt), Probe::EXPECTED_OUTPUT
+    assert probe.validate_retained!(JSON.generate(receipt))
+  end
+
+  def test_override_and_multiple_credential_checks_precede_transport
+    called = false
+    {
+      "HTTPS_PROXY" => "https://proxy.invalid",
+      "OPENROUTER_BASE_URL" => "https://evil.invalid",
+      "SSL_CERT_FILE" => "/tmp/ca",
+      "OPENAI_API_KEY" => "another-provider-secret"
+    }.each do |key, value|
+      probe = Probe.new(
+        environment: { "OPENROUTER_API_KEY" => "selected-secret", key => value },
+        transport: ->(*) { called = true }
+      )
+      error = assert_raises(Probe::Error, key) { probe.call }
+      assert_equal "credential_custody", error.reason
+    end
+    refute called
+  end
+
+  def test_provider_unavailability_and_false_success_never_become_a_skip
+    missing = Probe.new(environment: {}, transport: ->(*) { flunk("transport must not run") })
+    error = assert_raises(Probe::Error) { missing.call }
+    assert_equal "credential_unavailable", error.reason
+    assert_equal "blocked", error.status
+
+    malformed = Probe.new(
+      environment: { "OPENROUTER_API_KEY" => "selected-secret" },
+      transport: ->(*) do
+        { status: 200, content_type: "application/json",
+          body: JSON.generate("model" => Probe::MODEL, "choices" => [],
+                              "usage" => { "total_tokens" => 0 }) }
+      end
+    )
+    error = assert_raises(Probe::Error) { malformed.call }
+    assert_equal "provider_transport", error.reason
+    assert_equal "failed", error.status
+  end
+end

--- a/test/unit/packaging/patrol_evidence_result_test.rb
+++ b/test/unit/packaging/patrol_evidence_result_test.rb
@@ -1,0 +1,104 @@
+require "test_helper"
+require "json"
+require "json_schemer"
+require_relative "../../../packaging/patrol_evidence/result"
+
+class PatrolEvidenceResultTest < Minitest::Test
+  Result = HivePatrolEvidence::Result
+
+  def test_not_started_and_terminal_results_are_canonical_fenced_and_schema_valid
+    started = Result.not_started(authority: authority, started_at: "2026-08-05T10:00:00.000000Z")
+    terminal = Result.terminal(
+      status: "installed_live_smoke_verified", reason: nil, authority: authority,
+      candidate: { "archive_sha256" => digest("archive"), "closure_sha256" => digest("closure") },
+      sandbox: { "image" => "ruby@sha256:#{digest('image')}", "status" => "passed" },
+      smoke: { "status" => "passed", "modules" => %w[architecture-patrol patrol] },
+      provider: {
+        "status" => "passed", "provider" => "openrouter",
+        "model" => "openai/gpt-5.6-terra", "response_sha256" => digest("response"),
+        "usage" => { "prompt_tokens" => 1, "completion_tokens" => 1, "total_tokens" => 2 }
+      },
+      process_evidence: [ { "owner" => "sandbox", "status" => "reaped" } ],
+      started_at: "2026-08-05T10:00:00.000000Z",
+      finished_at: "2026-08-05T10:00:01.000000Z"
+    )
+
+    assert_equal "not_started", started.to_h.fetch("status")
+    assert_equal Result::CLAIM_FENCES, terminal.to_h.fetch("claim_fences")
+    assert_equal Result.canonical(terminal.to_h), terminal.canonical_bytes
+    assert terminal.frozen?
+    assert terminal.to_h.frozen?
+    assert terminal.to_h.fetch("claim_fences").frozen?
+    assert_operator terminal.canonical_bytes.bytesize, :<=, Result::MAX_RESULT_BYTES
+
+    schema = JSONSchemer.schema(JSON.parse(File.binread(
+      File.expand_path("../../../schemas/hive-patrol-installed-live-smoke.v1.json", __dir__)
+    )))
+    assert_empty schema.validate(JSON.parse(started.canonical_bytes)).to_a
+    assert_empty schema.validate(JSON.parse(terminal.canonical_bytes)).to_a
+  end
+
+  def test_result_vocabulary_and_claim_fences_are_closed
+    assert_raises(Result::Error) do
+      Result.terminal(
+        status: "installed_live", reason: nil, authority: authority,
+        candidate: {}, sandbox: {}, smoke: {}, provider: {}, process_evidence: [],
+        started_at: "2026-08-05T10:00:00Z", finished_at: "2026-08-05T10:00:01Z"
+      )
+    end
+
+    assert_raises(Result::Error) do
+      Result.terminal(
+        status: "failed", reason: "invented_failure", authority: authority,
+        candidate: nil, sandbox: nil, smoke: nil, provider: nil, process_evidence: [],
+        started_at: "2026-08-05T10:00:00Z", finished_at: "2026-08-05T10:00:01Z"
+      )
+    end
+
+    assert_equal %w[
+      not_full_u3b prepared_records_not_fresh_scheduler_matrix
+      controller_does_not_supply_full_independent_matrix
+      not_report_installed_live_qualification provider_probe_not_patrol_decision
+      not_evidence_ready_for_operator not_cutover_or_promotion_authority
+    ], Result::CLAIM_FENCES
+  end
+
+  def test_result_rejects_exact_and_generic_secrets_without_retaining_them
+    exact = "operator-secret-that-must-never-be-retained"
+    error = assert_raises(Result::Error) do
+      Result.terminal(
+        status: "failed", reason: "provider_transport", authority: authority,
+        candidate: nil, sandbox: nil, smoke: { "status" => exact }, provider: nil,
+        process_evidence: [], exact_secrets: [ exact ],
+        started_at: "2026-08-05T10:00:00Z", finished_at: "2026-08-05T10:00:01Z"
+      )
+    end
+    refute_includes error.message, exact
+
+    assert_raises(Result::Error) do
+      Result.terminal(
+        status: "failed", reason: "credential_custody", authority: authority,
+        candidate: nil, sandbox: nil,
+        smoke: { "diagnostic" => "api_key=abcdefghijklmnopqrstuvwxyz123456" },
+        provider: nil, process_evidence: [],
+        started_at: "2026-08-05T10:00:00Z", finished_at: "2026-08-05T10:00:01Z"
+      )
+    end
+  end
+
+  private
+
+  def authority
+    {
+      "run_id" => "u3c-20260805T100000Z-0123456789ab",
+      "controller_sha" => "a" * 40,
+      "candidate_sha" => "b" * 40,
+      "runner_sha256" => digest("runner"),
+      "controller_script_sha256" => digest("controller script"),
+      "authorization_sha256" => digest("authorization"),
+      "invocation_id" => "manual-20260805-1"
+    }
+  end
+
+  def digest(value) = Digest::SHA256.hexdigest(value)
+end

--- a/test/unit/packaging/patrol_evidence_result_test.rb
+++ b/test/unit/packaging/patrol_evidence_result_test.rb
@@ -10,16 +10,22 @@ class PatrolEvidenceResultTest < Minitest::Test
     started = Result.not_started(authority: authority, started_at: "2026-08-05T10:00:00.000000Z")
     terminal = Result.terminal(
       status: "installed_live_smoke_verified", reason: nil, authority: authority,
-      candidate: { "archive_sha256" => digest("archive"), "closure_sha256" => digest("closure") },
-      sandbox: { "image" => "ruby@sha256:#{digest('image')}", "status" => "passed" },
-      smoke: { "status" => "passed", "modules" => %w[architecture-patrol patrol] },
+      candidate: verified_candidate,
+      sandbox: sandbox,
+      smoke: smoke,
       provider: {
         "status" => "passed", "provider" => "openrouter",
         "model" => "openai/gpt-5.6-terra", "response_sha256" => digest("response"),
         "usage" => { "prompt_tokens" => 1, "completion_tokens" => 1, "total_tokens" => 2 }
       },
-      process_evidence: [ { "owner" => "sandbox", "status" => "reaped" } ],
+      process_evidence: [ process_evidence ],
       started_at: "2026-08-05T10:00:00.000000Z",
+      finished_at: "2026-08-05T10:00:01.000000Z"
+    )
+    failed = Result.terminal(
+      status: "failed", reason: "sandbox_contract", authority: authority,
+      candidate: prepared_candidate, sandbox: nil, smoke: nil, provider: nil,
+      process_evidence: [], started_at: "2026-08-05T10:00:00.000000Z",
       finished_at: "2026-08-05T10:00:01.000000Z"
     )
 
@@ -36,12 +42,32 @@ class PatrolEvidenceResultTest < Minitest::Test
     )))
     assert_empty schema.validate(JSON.parse(started.canonical_bytes)).to_a
     assert_empty schema.validate(JSON.parse(terminal.canonical_bytes)).to_a
+    assert_empty schema.validate(JSON.parse(failed.canonical_bytes)).to_a
+
+    impossible = JSON.parse(terminal.canonical_bytes).merge(
+      "candidate" => {}, "sandbox" => {}, "smoke" => {}, "provider" => {},
+      "process_evidence" => []
+    )
+    refute_empty schema.validate(impossible).to_a
+    blocked = JSON.parse(terminal.canonical_bytes).merge(
+      "status" => "blocked", "reason" => nil, "finished_at" => nil
+    )
+    refute_empty schema.validate(blocked).to_a
   end
 
   def test_result_vocabulary_and_claim_fences_are_closed
     assert_raises(Result::Error) do
       Result.terminal(
         status: "installed_live", reason: nil, authority: authority,
+        candidate: {}, sandbox: {}, smoke: {}, provider: {}, process_evidence: [],
+        started_at: "2026-08-05T10:00:00Z", finished_at: "2026-08-05T10:00:01Z"
+      )
+    end
+
+
+    assert_raises(Result::Error) do
+      Result.terminal(
+        status: "installed_live_smoke_verified", reason: nil, authority: authority,
         candidate: {}, sandbox: {}, smoke: {}, provider: {}, process_evidence: [],
         started_at: "2026-08-05T10:00:00Z", finished_at: "2026-08-05T10:00:01Z"
       )
@@ -68,7 +94,7 @@ class PatrolEvidenceResultTest < Minitest::Test
     error = assert_raises(Result::Error) do
       Result.terminal(
         status: "failed", reason: "provider_transport", authority: authority,
-        candidate: nil, sandbox: nil, smoke: { "status" => exact }, provider: nil,
+        candidate: nil, sandbox: sandbox.merge("engine_version" => exact), smoke: nil, provider: nil,
         process_evidence: [], exact_secrets: [ exact ],
         started_at: "2026-08-05T10:00:00Z", finished_at: "2026-08-05T10:00:01Z"
       )
@@ -78,9 +104,9 @@ class PatrolEvidenceResultTest < Minitest::Test
     assert_raises(Result::Error) do
       Result.terminal(
         status: "failed", reason: "credential_custody", authority: authority,
-        candidate: nil, sandbox: nil,
-        smoke: { "diagnostic" => "api_key=abcdefghijklmnopqrstuvwxyz123456" },
-        provider: nil, process_evidence: [],
+        candidate: nil,
+        sandbox: sandbox.merge("engine_version" => "api_key=abcdefghijklmnopqrstuvwxyz123456"),
+        smoke: nil, provider: nil, process_evidence: [],
         started_at: "2026-08-05T10:00:00Z", finished_at: "2026-08-05T10:00:01Z"
       )
     end
@@ -95,8 +121,59 @@ class PatrolEvidenceResultTest < Minitest::Test
       "candidate_sha" => "b" * 40,
       "runner_sha256" => digest("runner"),
       "controller_script_sha256" => digest("controller script"),
+      "control_tree_sha256" => digest("control tree"),
       "authorization_sha256" => digest("authorization"),
-      "invocation_id" => "manual-20260805-1"
+      "authorization_nonce_sha256" => digest("nonce"),
+      "authorization_expires_at" => "2026-08-05T10:15:00.000000Z",
+      "invocation_id" => "manual-20260805-1",
+      "image" => "ruby@sha256:#{digest('image')}",
+      "observations_sha256" => digest("observations"),
+      "project_binding_sha256" => digest("project binding")
+    }
+  end
+
+  def verified_candidate
+    {
+      "status" => "verified", "candidate_sha" => "b" * 40,
+      "archive_sha256" => digest("archive"), "archive_member_count" => 10,
+      "archive_total_bytes" => 100, "module_manifest_sha256" => digest("manifests"),
+      "source_tree_sha256" => digest("source"), "gem_sha256" => digest("gem"),
+      "installed_hive_sha256" => digest("hive"),
+      "dependency_closure_sha256" => digest("closure"), "toolchain_sha256" => digest("toolchain")
+    }
+  end
+
+  def prepared_candidate
+    verified_candidate.slice(
+      "candidate_sha", "archive_sha256", "archive_member_count", "archive_total_bytes",
+      "module_manifest_sha256", "source_tree_sha256"
+    ).merge("status" => "prepared")
+  end
+
+  def sandbox
+    {
+      "status" => "passed", "engine" => "docker", "engine_version" => "Docker 28.0",
+      "engine_sha256" => digest("engine"), "image" => "ruby@sha256:#{digest('image')}",
+      "image_id" => "sha256:#{digest('rootfs')}", "network" => "none",
+      "root_filesystem" => "read_only", "writable_bytes" => 536_870_912,
+      "writable_inodes" => 16_384, "process_limit" => 64, "memory" => "2g", "cpus" => "2"
+    }
+  end
+
+  def smoke
+    {
+      "status" => "passed", "modules" => %w[architecture-patrol patrol], "receipt_count" => 4,
+      "catalog_digest" => digest("catalog"), "scenario_manifest_digest" => digest("scenario"),
+      "report_sha256" => digest("report")
+    }
+  end
+
+  def process_evidence
+    {
+      "owner" => "sandbox", "status" => "reaped", "outcome" => "success",
+      "teardown" => "verified", "exit_code" => 0,
+      "container_id_sha256" => digest("container"), "stdout_sha256" => digest("stdout"),
+      "stderr_sha256" => digest("stderr")
     }
   end
 

--- a/test/unit/packaging/patrol_evidence_runner_test.rb
+++ b/test/unit/packaging/patrol_evidence_runner_test.rb
@@ -1,31 +1,27 @@
 require "test_helper"
 require "digest"
 require "json"
+require "shellwords"
+require "yaml"
 require_relative "../../../packaging/patrol_evidence/runner"
+require_relative "../../../packaging/patrol_evidence/sandbox"
 
 class PatrolEvidenceRunnerTest < Minitest::Test
   include HiveTestHelper
 
   Runner = HivePatrolEvidence::Runner
   Result = HivePatrolEvidence::Result
+  ROOT = File.expand_path("../../..", __dir__)
+  NOW = Time.utc(2026, 8, 5, 10, 0, 0)
 
-  def test_closed_composition_publishes_one_mode_safe_terminal_result
+  def test_closed_private_composition_publishes_one_mode_safe_terminal_result
     with_controller_repository do |fixture|
       calls = []
-      candidate = fake_candidate(calls)
-      sandbox = fake_sandbox(calls)
-      controller = fake_controller(calls)
-      provider = fake_provider(calls)
-
-      outcome = Runner.run!(
-        repo_root: fixture.fetch(:repo), evidence_root: fixture.fetch(:evidence),
-        controller_sha: fixture.fetch(:controller_sha), candidate_sha: fixture.fetch(:candidate_sha),
-        authorization: "one exact authorized invocation", invocation_id: "manual-1",
-        project_root: fixture.fetch(:project), observations_path: fixture.fetch(:observations),
-        image: "ruby@sha256:#{digest('image')}",
-        candidate_factory: ->(**) { candidate }, sandbox_factory: ->(**) { sandbox },
-        controller_factory: ->(**) { controller }, provider_probe_factory: ->(**) { provider },
-        clock: fixed_clock
+      outcome = run_test!(
+        fixture, invocation_id: "manual-1", candidate_factory: ->(**) { fake_candidate(calls) },
+        sandbox_factory: ->(**) { fake_sandbox(calls) },
+        controller_factory: ->(**) { fake_controller(calls) },
+        provider_probe_factory: ->(**) { fake_provider(calls) }
       )
 
       assert_equal %i[candidate sandbox external_smoke provider], calls
@@ -33,25 +29,31 @@ class PatrolEvidenceRunnerTest < Minitest::Test
       result_path = outcome.fetch("result_path")
       assert_equal 0o600, File.stat(result_path).mode & 0o777
       assert_equal 0o700, File.stat(File.dirname(result_path)).mode & 0o777
+      assert_equal [ "result.json" ], Dir.children(File.dirname(result_path))
       assert_equal outcome.fetch("result").canonical_bytes, File.binread(result_path)
       assert_equal Result::CLAIM_FENCES, JSON.parse(File.binread(result_path)).fetch("claim_fences")
     end
   end
 
+  def test_public_run_interface_rejects_dependency_factories
+    error = assert_raises(ArgumentError) do
+      Runner.run!(candidate_factory: -> { flunk "factory must not be reachable" })
+    end
+
+    assert_match(/missing keyword|unknown keyword/, error.message)
+  end
+
   def test_authority_and_store_checks_happen_before_candidate_or_credential_access
     with_controller_repository do |fixture|
+      authorization = authorization_for(fixture, "manual-2")
       File.write(File.join(fixture.fetch(:repo), "dirty"), "dirty")
       touched = false
 
       error = assert_raises(Runner::AuthorityError) do
-        Runner.run!(
-          repo_root: fixture.fetch(:repo), evidence_root: fixture.fetch(:evidence),
-          controller_sha: fixture.fetch(:controller_sha), candidate_sha: fixture.fetch(:candidate_sha),
-          authorization: "authorized", invocation_id: "manual-2",
-          project_root: fixture.fetch(:project), observations_path: fixture.fetch(:observations),
-          image: "ruby@sha256:#{digest('image')}",
+        run_test!(
+          fixture, invocation_id: "manual-2", authorization:,
           candidate_factory: ->(**) { touched = true },
-          provider_probe_factory: ->(**) { touched = true }, clock: fixed_clock
+          provider_probe_factory: ->(**) { touched = true }
         )
       end
 
@@ -64,22 +66,19 @@ class PatrolEvidenceRunnerTest < Minitest::Test
   def test_expected_byte_publication_detects_a_competing_writer
     with_controller_repository do |fixture|
       candidate = fake_candidate([])
-      candidate.define_singleton_method(:prepare!) do |run_root:, **|
-        File.binwrite(File.join(run_root, "result.json"), "competing bytes\n")
-        { "archive_sha256" => Digest::SHA256.hexdigest("archive"),
-          "closure_sha256" => Digest::SHA256.hexdigest("closure") }
+      prepared = prepared_candidate
+      candidate.define_singleton_method(:prepare!) do |**|
+        result_path = Dir.glob(File.join(fixture.fetch(:evidence), "*", "result.json")).fetch(0)
+        File.binwrite(result_path, "competing bytes\n")
+        prepared
       end
 
       error = assert_raises(Runner::PublicationError) do
-        Runner.run!(
-          repo_root: fixture.fetch(:repo), evidence_root: fixture.fetch(:evidence),
-          controller_sha: fixture.fetch(:controller_sha), candidate_sha: fixture.fetch(:candidate_sha),
-          authorization: "authorized", invocation_id: "manual-3",
-          project_root: fixture.fetch(:project), observations_path: fixture.fetch(:observations),
-          image: "ruby@sha256:#{digest('image')}", candidate_factory: ->(**) { candidate },
+        run_test!(
+          fixture, invocation_id: "manual-3", candidate_factory: ->(**) { candidate },
           sandbox_factory: ->(**) { fake_sandbox([]) },
           controller_factory: ->(**) { fake_controller([]) },
-          provider_probe_factory: ->(**) { fake_provider([]) }, clock: fixed_clock
+          provider_probe_factory: ->(**) { fake_provider([]) }
         )
       end
 
@@ -89,32 +88,85 @@ class PatrolEvidenceRunnerTest < Minitest::Test
     end
   end
 
-  def test_cleanup_is_explicit_owner_checked_and_retention_bounded
+  def test_authorization_is_exact_scope_expiring_and_one_time
     with_controller_repository do |fixture|
-      outcome = Runner.run!(
-        repo_root: fixture.fetch(:repo), evidence_root: fixture.fetch(:evidence),
-        controller_sha: fixture.fetch(:controller_sha), candidate_sha: fixture.fetch(:candidate_sha),
-        authorization: "authorized", invocation_id: "manual-cleanup",
-        project_root: fixture.fetch(:project), observations_path: fixture.fetch(:observations),
-        image: "ruby@sha256:#{digest('image')}",
+      invocation = "manual-replay"
+      authorization = authorization_for(fixture, invocation)
+      factories = {
         candidate_factory: ->(**) { fake_candidate([]) },
         sandbox_factory: ->(**) { fake_sandbox([]) },
         controller_factory: ->(**) { fake_controller([]) },
-        provider_probe_factory: ->(**) { fake_provider([]) }, clock: fixed_clock
+        provider_probe_factory: ->(**) { fake_provider([]) }
+      }
+
+      assert_equal "installed_live_smoke_verified",
+                   run_test!(fixture, invocation_id: invocation, authorization:, **factories).fetch("status")
+      replay = assert_raises(Runner::AuthorityError) do
+        run_test!(fixture, invocation_id: invocation, authorization:, **factories)
+      end
+      assert_equal "manual_authority_missing", replay.reason
+
+      expired = JSON.parse(authorization).merge(
+        "nonce" => "expired", "issued_at" => "2026-08-05T08:00:00.000000Z",
+        "expires_at" => "2026-08-05T08:15:00.000000Z"
+      )
+      error = assert_raises(Runner::AuthorityError) do
+        run_test!(
+          fixture, invocation_id: "manual-expired", authorization: Result.canonical(expired), **factories
+        )
+      end
+      assert_equal "manual_authority_missing", error.reason
+    end
+  end
+
+  def test_project_drift_blocks_before_provider_access
+    with_controller_repository do |fixture|
+      touched = false
+      controller = fake_controller([])
+      smoke = smoke_record
+      controller.define_singleton_method(:external_smoke) do |**|
+        File.open(File.join(fixture.fetch(:project), ".hive-state", "config.yml"), "ab") { |file| file.write("# drift\n") }
+        smoke
+      end
+
+      outcome = run_test!(
+        fixture, invocation_id: "manual-project-drift",
+        candidate_factory: ->(**) { fake_candidate([]) },
+        sandbox_factory: ->(**) { fake_sandbox([]) }, controller_factory: ->(**) { controller },
+        provider_probe_factory: ->(**) { touched = true }
+      )
+
+      assert_equal "failed", outcome.fetch("status")
+      assert_equal "authority_binding", outcome.fetch("reason")
+      refute touched
+    end
+  end
+
+  def test_cleanup_is_explicit_owner_checked_retention_bounded_and_non_destructive
+    with_controller_repository do |fixture|
+      outcome = run_test!(
+        fixture, invocation_id: "manual-cleanup",
+        candidate_factory: ->(**) { fake_candidate([]) },
+        sandbox_factory: ->(**) { fake_sandbox([]) },
+        controller_factory: ->(**) { fake_controller([]) },
+        provider_probe_factory: ->(**) { fake_provider([]) }
       )
       path = outcome.fetch("result_path")
 
       assert_raises(Runner::EvidenceError) do
-        Runner.cleanup!(
-          evidence_root: fixture.fetch(:evidence), result_path: path,
-          now: Time.utc(2026, 8, 6)
-        )
+        Runner.cleanup!(evidence_root: fixture.fetch(:evidence), result_path: path, now: Time.utc(2026, 8, 6))
       end
       old = Time.utc(2026, 8, 5)
       File.utime(old, old, path)
+      extra = File.join(File.dirname(path), "candidate.tar")
+      File.binwrite(extra, "must survive")
+      assert_raises(Runner::EvidenceError) do
+        Runner.cleanup!(evidence_root: fixture.fetch(:evidence), result_path: path, now: Time.utc(2026, 9, 6))
+      end
+      assert File.exist?(path), "cleanup must preserve evidence when the directory is contaminated"
+      File.unlink(extra)
       assert Runner.cleanup!(
-        evidence_root: fixture.fetch(:evidence), result_path: path,
-        now: Time.utc(2026, 9, 6)
+        evidence_root: fixture.fetch(:evidence), result_path: path, now: Time.utc(2026, 9, 6)
       )
       refute File.exist?(path)
       refute File.exist?(File.dirname(path))
@@ -131,14 +183,10 @@ class PatrolEvidenceRunnerTest < Minitest::Test
       end
       touched = false
 
-      outcome = Runner.run!(
-        repo_root: fixture.fetch(:repo), evidence_root: fixture.fetch(:evidence),
-        controller_sha: fixture.fetch(:controller_sha), candidate_sha: fixture.fetch(:candidate_sha),
-        authorization: "authorized", invocation_id: "manual-full-store",
-        project_root: fixture.fetch(:project), observations_path: fixture.fetch(:observations),
-        image: "ruby@sha256:#{digest('image')}",
+      outcome = run_test!(
+        fixture, invocation_id: "manual-full-store",
         candidate_factory: ->(**) { touched = true },
-        provider_probe_factory: ->(**) { touched = true }, clock: fixed_clock
+        provider_probe_factory: ->(**) { touched = true }
       )
 
       assert_equal "blocked", outcome.fetch("status")
@@ -149,7 +197,7 @@ class PatrolEvidenceRunnerTest < Minitest::Test
     end
   end
 
-  def test_provider_block_preserves_completed_candidate_and_sandbox_custody
+  def test_provider_block_preserves_completed_candidate_sandbox_and_process_custody
     with_controller_repository do |fixture|
       provider = Object.new
       provider.define_singleton_method(:call) do
@@ -158,73 +206,125 @@ class PatrolEvidenceRunnerTest < Minitest::Test
         raise error
       end
 
-      outcome = Runner.run!(
-        repo_root: fixture.fetch(:repo), evidence_root: fixture.fetch(:evidence),
-        controller_sha: fixture.fetch(:controller_sha), candidate_sha: fixture.fetch(:candidate_sha),
-        authorization: "authorized", invocation_id: "manual-provider-block",
-        project_root: fixture.fetch(:project), observations_path: fixture.fetch(:observations),
-        image: "ruby@sha256:#{digest('image')}",
+      outcome = run_test!(
+        fixture, invocation_id: "manual-provider-block",
         candidate_factory: ->(**) { fake_candidate([]) },
         sandbox_factory: ->(**) { fake_sandbox([]) },
         controller_factory: ->(**) { fake_controller([]) },
-        provider_probe_factory: ->(**) { provider }, clock: fixed_clock
+        provider_probe_factory: ->(**) { provider }
       )
 
       result = outcome.fetch("result").to_h
       assert_equal "blocked", outcome.fetch("status")
       assert_equal "provider_unavailable", outcome.fetch("reason")
-      refute_nil result.fetch("candidate")
-      refute_nil result.fetch("sandbox")
-      refute_nil result.fetch("smoke")
+      assert_equal "verified", result.dig("candidate", "status")
+      assert_equal "passed", result.dig("sandbox", "status")
+      assert_equal "passed", result.dig("smoke", "status")
       assert_nil result.fetch("provider")
       assert_equal "reaped", result.dig("process_evidence", 0, "status")
     end
   end
 
+  def test_sandbox_failure_retains_prepared_candidate_and_teardown_evidence
+    with_controller_repository do |fixture|
+      evidence = process_record.merge("outcome" => "failed", "exit_code" => 7)
+      sandbox = Object.new
+      sandbox.define_singleton_method(:run!) do |**|
+        raise HivePatrolEvidence::Sandbox::Error.new(
+          "sandbox_contract", "candidate failed", process_evidence: [ evidence ]
+        )
+      end
+
+      outcome = run_test!(
+        fixture, invocation_id: "manual-sandbox-failure",
+        candidate_factory: ->(**) { fake_candidate([]) },
+        sandbox_factory: ->(**) { sandbox },
+        controller_factory: ->(**) { flunk "controller must not run" },
+        provider_probe_factory: ->(**) { flunk "provider must not run" }
+      )
+
+      result = outcome.fetch("result").to_h
+      assert_equal "failed", outcome.fetch("status")
+      assert_equal "sandbox_contract", outcome.fetch("reason")
+      assert_equal "prepared", result.dig("candidate", "status")
+      assert_equal evidence, result.fetch("process_evidence").fetch(0)
+    end
+  end
+
   private
 
+  def run_test!(fixture, invocation_id:, authorization: nil, **factories)
+    authorization ||= authorization_for(fixture, invocation_id)
+    Runner.send(
+      :new, **runner_options(fixture, invocation_id:, authorization:), **factories,
+      clock: fixed_clock
+    ).send(:run)
+  end
+
+  def runner_options(fixture, invocation_id:, authorization:)
+    {
+      repo_root: fixture.fetch(:repo), evidence_root: fixture.fetch(:evidence),
+      hive_home: fixture.fetch(:hive_home), controller_sha: fixture.fetch(:controller_sha),
+      candidate_sha: fixture.fetch(:candidate_sha), authorization:, invocation_id:,
+      project_root: fixture.fetch(:project), observations_path: fixture.fetch(:observations),
+      image: fixture.fetch(:image)
+    }
+  end
+
+  def authorization_for(fixture, invocation_id)
+    Runner.authorization_template!(
+      **runner_options(fixture, invocation_id:, authorization: "").except(:authorization),
+      now: NOW, nonce: "nonce-#{invocation_id}"
+    )
+  end
+
   def fake_candidate(calls)
+    prepared = prepared_candidate
+    verified = verified_candidate
     Object.new.tap do |object|
       object.define_singleton_method(:prepare!) do |**|
         calls << :candidate
-        { "archive_sha256" => Digest::SHA256.hexdigest("archive"),
-          "closure_sha256" => Digest::SHA256.hexdigest("closure") }
+        prepared
       end
-      object.define_singleton_method(:verify!) { |receipt:| receipt.fetch("candidate") }
+      object.define_singleton_method(:verify!) { |receipt:| receipt.fetch("candidate") && verified }
     end
   end
 
   def fake_sandbox(calls)
+    candidate = verified_candidate
+    sandbox = sandbox_record
+    process = process_record
     Object.new.tap do |object|
       object.define_singleton_method(:run!) do |**|
         calls << :sandbox
-        { "candidate" => { "archive_sha256" => Digest::SHA256.hexdigest("archive"),
-                            "closure_sha256" => Digest::SHA256.hexdigest("closure") },
-          "sandbox" => { "status" => "passed", "image" => "ruby@sha256:#{Digest::SHA256.hexdigest('image')}" },
+        {
+          "candidate" => candidate,
+          "sandbox" => sandbox,
           "payload" => { "receipts" => [] },
-          "process_evidence" => [ { "owner" => "sandbox", "status" => "reaped" } ] }
+          "process_evidence" => [ process ]
+        }
       end
     end
   end
 
   def fake_controller(calls)
+    smoke = smoke_record
     Object.new.tap do |object|
       object.define_singleton_method(:external_smoke) do |**|
         calls << :external_smoke
-        { "status" => "passed", "modules" => %w[architecture-patrol patrol] }
+        smoke
       end
     end
   end
 
   def fake_provider(calls)
+    provider = provider_record
     Object.new.tap do |object|
       object.define_singleton_method(:call) do
         calls << :provider
-        { "status" => "passed", "provider" => "openrouter",
-          "model" => "openai/gpt-5.6-terra", "response_sha256" => Digest::SHA256.hexdigest("response"),
-          "usage" => { "prompt_tokens" => 1, "completion_tokens" => 1, "total_tokens" => 2 } }
+        provider
       end
-      object.define_singleton_method(:credential) { "operator-secret" }
+      object.define_singleton_method(:validate_retained!) { |_| true }
     end
   end
 
@@ -233,36 +333,138 @@ class PatrolEvidenceRunnerTest < Minitest::Test
       repo = File.join(root, "repo")
       FileUtils.mkdir_p(repo)
       system("git", "init", "-b", "main", "--quiet", repo) or raise
-      FileUtils.mkdir_p(File.join(repo, "test/e2e/lib"))
-      File.write(File.join(repo, "test/e2e/lib/patrol_qualification.rb"), "# controller\n")
+      Runner::CONTROL_PATHS.each do |relative|
+        target = File.join(repo, relative)
+        FileUtils.mkdir_p(File.dirname(target))
+        FileUtils.cp(File.join(ROOT, relative), target)
+      end
       File.write(File.join(repo, "tracked"), "controller\n")
-      system("git", "-C", repo, "-c", "user.name=Hive", "-c", "user.email=hive@example.invalid",
-             "add", ".") or raise
-      system("git", "-C", repo, "-c", "user.name=Hive", "-c", "user.email=hive@example.invalid",
-             "commit", "-m", "controller", "--quiet") or raise
-      controller_sha = `git -C #{Shellwords.escape(repo)} rev-parse HEAD`.strip
+      git_commit_all(repo, "controller")
+      controller_sha = git(repo, "rev-parse", "HEAD")
       File.write(File.join(repo, "tracked"), "candidate\n")
-      system("git", "-C", repo, "-c", "user.name=Hive", "-c", "user.email=hive@example.invalid",
-             "commit", "-am", "candidate", "--quiet") or raise
-      candidate_sha = `git -C #{Shellwords.escape(repo)} rev-parse HEAD`.strip
+      git_commit_all(repo, "candidate")
+      candidate_sha = git(repo, "rev-parse", "HEAD")
+      system("git", "-C", repo, "remote", "add", "origin", "https://github.com/ivankuznetsov/hive.git") or raise
+      system("git", "-C", repo, "update-ref", "refs/remotes/origin/main", candidate_sha) or raise
       system("git", "-C", repo, "checkout", "--detach", "--quiet", controller_sha) or raise
-      evidence = File.join(root, "evidence")
+
       project = File.join(root, "project")
+      project_remote = File.join(root, "project-origin.git")
+      system("git", "init", "--bare", "--quiet", project_remote) or raise
+      system("git", "init", "-b", "main", "--quiet", project) or raise
+      File.write(File.join(project, "README.md"), "disposable project\n")
+      git_commit_all(project, "project")
+      system("git", "-C", project, "remote", "add", "origin", project_remote) or raise
+      state = File.join(project, ".hive-state")
+      FileUtils.mkdir_p(File.join(state, "module-runtime", "migration"))
+      File.binwrite(File.join(state, "config.yml"), { "hive_state_path" => ".hive-state" }.to_yaml)
+      File.binwrite(File.join(state, "module-runtime", "migration", "report.json"), "{}\n")
+
+      hive_home = File.join(root, "hive-home")
+      evidence = File.join(root, "evidence")
+      FileUtils.mkdir_p(hive_home, mode: 0o700)
       FileUtils.mkdir_p(evidence, mode: 0o700)
-      FileUtils.mkdir_p(project, mode: 0o700)
+      registration = {
+        "name" => "disposable", "path" => project, "real_path" => File.realpath(project),
+        "hive_state_path" => state, "project_id" => "11111111-1111-4111-8111-111111111111",
+        "registration_id" => "22222222-2222-4222-8222-222222222222",
+        "registered_at" => "2026-08-05T09:00:00.000000Z",
+        "repository_identity" => "local:#{File.realpath(project_remote)}"
+      }
+      File.binwrite(File.join(hive_home, "config.yml"), { "registered_projects" => [ registration ] }.to_yaml)
       observations = File.join(root, "observations.json")
       File.binwrite(observations, "{}\n")
-      yield repo:, evidence:, project:, observations:, controller_sha:, candidate_sha:
+      image = "ruby@sha256:#{digest('image')}"
+      yield repo:, evidence:, hive_home:, project:, observations:, image:, controller_sha:, candidate_sha:
+    ensure
+      FileUtils.chmod_R(0o700, root) if root && File.exist?(root)
     end
   end
 
+  def git_commit_all(repo, message)
+    system("git", "-C", repo, "-c", "user.name=Hive", "-c", "user.email=hive@example.invalid",
+           "add", ".") or raise
+    system("git", "-C", repo, "-c", "user.name=Hive", "-c", "user.email=hive@example.invalid",
+           "commit", "-m", message, "--quiet") or raise
+  end
+
+  def git(repo, *arguments)
+    output = `git -C #{Shellwords.escape(repo)} #{arguments.map { |arg| Shellwords.escape(arg) }.join(" ")}`
+    raise unless $?.success?
+
+    output.strip
+  end
+
   def fixed_clock
-    times = [
-      Time.utc(2026, 8, 5, 10, 0, 0), Time.utc(2026, 8, 5, 10, 0, 1),
-      Time.utc(2026, 8, 5, 10, 0, 2), Time.utc(2026, 8, 5, 10, 0, 3)
-    ]
+    times = [ NOW, NOW + 1, NOW + 2, NOW + 3, NOW + 4 ]
     -> { times.shift || times.last }
   end
 
   def digest(value) = Digest::SHA256.hexdigest(value)
+
+  class << self
+    def prepared_candidate
+      {
+        "candidate_sha" => "b" * 40, "archive_sha256" => Digest::SHA256.hexdigest("archive"),
+        "archive_member_count" => 10, "archive_total_bytes" => 100,
+        "module_manifest_sha256" => Digest::SHA256.hexdigest("manifests"),
+        "source_tree_sha256" => Digest::SHA256.hexdigest("source"),
+        "archive_path" => "/transient/candidate.tar", "source_path" => "/transient/source"
+      }
+    end
+
+    def verified_candidate
+      prepared_candidate.except("archive_path", "source_path").merge(
+        "gem_sha256" => Digest::SHA256.hexdigest("gem"),
+        "installed_hive_sha256" => Digest::SHA256.hexdigest("hive"),
+        "dependency_closure_sha256" => Digest::SHA256.hexdigest("closure"),
+        "toolchain_sha256" => Digest::SHA256.hexdigest("toolchain")
+      )
+    end
+
+    def sandbox_record
+      {
+        "status" => "passed", "engine" => "docker", "engine_version" => "Docker 28.0",
+        "engine_sha256" => Digest::SHA256.hexdigest("engine"),
+        "image" => "ruby@sha256:#{Digest::SHA256.hexdigest('image')}",
+        "image_id" => "sha256:#{Digest::SHA256.hexdigest('rootfs')}", "network" => "none",
+        "root_filesystem" => "read_only", "writable_bytes" => 536_870_912,
+        "writable_inodes" => 16_384, "process_limit" => 64, "memory" => "2g", "cpus" => "2"
+      }
+    end
+
+    def smoke_record
+      {
+        "status" => "passed", "modules" => %w[architecture-patrol patrol], "receipt_count" => 4,
+        "catalog_digest" => Digest::SHA256.hexdigest("catalog"),
+        "scenario_manifest_digest" => Digest::SHA256.hexdigest("scenario"),
+        "report_sha256" => Digest::SHA256.hexdigest("report")
+      }
+    end
+
+    def provider_record
+      {
+        "status" => "passed", "provider" => "openrouter", "model" => "openai/gpt-5.6-terra",
+        "response_sha256" => Digest::SHA256.hexdigest("response"),
+        "usage" => { "prompt_tokens" => 1, "completion_tokens" => 1, "total_tokens" => 2 }
+      }
+    end
+
+    def process_record
+      {
+        "owner" => "sandbox", "status" => "reaped", "outcome" => "success",
+        "teardown" => "verified", "exit_code" => 0,
+        "container_id_sha256" => Digest::SHA256.hexdigest("container"),
+        "stdout_sha256" => Digest::SHA256.hexdigest("stdout"),
+        "stderr_sha256" => Digest::SHA256.hexdigest("stderr")
+      }
+    end
+  end
+
+  def prepared_candidate = self.class.prepared_candidate
+  def verified_candidate = self.class.verified_candidate
+  def sandbox_record = self.class.sandbox_record
+  def smoke_record = self.class.smoke_record
+  def provider_record = self.class.provider_record
+  def process_record = self.class.process_record
 end

--- a/test/unit/packaging/patrol_evidence_runner_test.rb
+++ b/test/unit/packaging/patrol_evidence_runner_test.rb
@@ -1,0 +1,268 @@
+require "test_helper"
+require "digest"
+require "json"
+require_relative "../../../packaging/patrol_evidence/runner"
+
+class PatrolEvidenceRunnerTest < Minitest::Test
+  include HiveTestHelper
+
+  Runner = HivePatrolEvidence::Runner
+  Result = HivePatrolEvidence::Result
+
+  def test_closed_composition_publishes_one_mode_safe_terminal_result
+    with_controller_repository do |fixture|
+      calls = []
+      candidate = fake_candidate(calls)
+      sandbox = fake_sandbox(calls)
+      controller = fake_controller(calls)
+      provider = fake_provider(calls)
+
+      outcome = Runner.run!(
+        repo_root: fixture.fetch(:repo), evidence_root: fixture.fetch(:evidence),
+        controller_sha: fixture.fetch(:controller_sha), candidate_sha: fixture.fetch(:candidate_sha),
+        authorization: "one exact authorized invocation", invocation_id: "manual-1",
+        project_root: fixture.fetch(:project), observations_path: fixture.fetch(:observations),
+        image: "ruby@sha256:#{digest('image')}",
+        candidate_factory: ->(**) { candidate }, sandbox_factory: ->(**) { sandbox },
+        controller_factory: ->(**) { controller }, provider_probe_factory: ->(**) { provider },
+        clock: fixed_clock
+      )
+
+      assert_equal %i[candidate sandbox external_smoke provider], calls
+      assert_equal "installed_live_smoke_verified", outcome.fetch("status")
+      result_path = outcome.fetch("result_path")
+      assert_equal 0o600, File.stat(result_path).mode & 0o777
+      assert_equal 0o700, File.stat(File.dirname(result_path)).mode & 0o777
+      assert_equal outcome.fetch("result").canonical_bytes, File.binread(result_path)
+      assert_equal Result::CLAIM_FENCES, JSON.parse(File.binread(result_path)).fetch("claim_fences")
+    end
+  end
+
+  def test_authority_and_store_checks_happen_before_candidate_or_credential_access
+    with_controller_repository do |fixture|
+      File.write(File.join(fixture.fetch(:repo), "dirty"), "dirty")
+      touched = false
+
+      error = assert_raises(Runner::AuthorityError) do
+        Runner.run!(
+          repo_root: fixture.fetch(:repo), evidence_root: fixture.fetch(:evidence),
+          controller_sha: fixture.fetch(:controller_sha), candidate_sha: fixture.fetch(:candidate_sha),
+          authorization: "authorized", invocation_id: "manual-2",
+          project_root: fixture.fetch(:project), observations_path: fixture.fetch(:observations),
+          image: "ruby@sha256:#{digest('image')}",
+          candidate_factory: ->(**) { touched = true },
+          provider_probe_factory: ->(**) { touched = true }, clock: fixed_clock
+        )
+      end
+
+      assert_equal "controller_checkout_dirty", error.reason
+      refute touched
+      assert_empty Dir.children(fixture.fetch(:evidence))
+    end
+  end
+
+  def test_expected_byte_publication_detects_a_competing_writer
+    with_controller_repository do |fixture|
+      candidate = fake_candidate([])
+      candidate.define_singleton_method(:prepare!) do |run_root:, **|
+        File.binwrite(File.join(run_root, "result.json"), "competing bytes\n")
+        { "archive_sha256" => Digest::SHA256.hexdigest("archive"),
+          "closure_sha256" => Digest::SHA256.hexdigest("closure") }
+      end
+
+      error = assert_raises(Runner::PublicationError) do
+        Runner.run!(
+          repo_root: fixture.fetch(:repo), evidence_root: fixture.fetch(:evidence),
+          controller_sha: fixture.fetch(:controller_sha), candidate_sha: fixture.fetch(:candidate_sha),
+          authorization: "authorized", invocation_id: "manual-3",
+          project_root: fixture.fetch(:project), observations_path: fixture.fetch(:observations),
+          image: "ruby@sha256:#{digest('image')}", candidate_factory: ->(**) { candidate },
+          sandbox_factory: ->(**) { fake_sandbox([]) },
+          controller_factory: ->(**) { fake_controller([]) },
+          provider_probe_factory: ->(**) { fake_provider([]) }, clock: fixed_clock
+        )
+      end
+
+      assert_equal "publication_conflict", error.reason
+      result = Dir.glob(File.join(fixture.fetch(:evidence), "*", "result.json")).fetch(0)
+      assert_equal "competing bytes\n", File.binread(result)
+    end
+  end
+
+  def test_cleanup_is_explicit_owner_checked_and_retention_bounded
+    with_controller_repository do |fixture|
+      outcome = Runner.run!(
+        repo_root: fixture.fetch(:repo), evidence_root: fixture.fetch(:evidence),
+        controller_sha: fixture.fetch(:controller_sha), candidate_sha: fixture.fetch(:candidate_sha),
+        authorization: "authorized", invocation_id: "manual-cleanup",
+        project_root: fixture.fetch(:project), observations_path: fixture.fetch(:observations),
+        image: "ruby@sha256:#{digest('image')}",
+        candidate_factory: ->(**) { fake_candidate([]) },
+        sandbox_factory: ->(**) { fake_sandbox([]) },
+        controller_factory: ->(**) { fake_controller([]) },
+        provider_probe_factory: ->(**) { fake_provider([]) }, clock: fixed_clock
+      )
+      path = outcome.fetch("result_path")
+
+      assert_raises(Runner::EvidenceError) do
+        Runner.cleanup!(
+          evidence_root: fixture.fetch(:evidence), result_path: path,
+          now: Time.utc(2026, 8, 6)
+        )
+      end
+      old = Time.utc(2026, 8, 5)
+      File.utime(old, old, path)
+      assert Runner.cleanup!(
+        evidence_root: fixture.fetch(:evidence), result_path: path,
+        now: Time.utc(2026, 9, 6)
+      )
+      refute File.exist?(path)
+      refute File.exist?(File.dirname(path))
+    end
+  end
+
+  def test_full_store_returns_typed_blocked_without_touching_candidate_or_provider
+    with_controller_repository do |fixture|
+      128.times do |index|
+        directory = File.join(fixture.fetch(:evidence), "u3c-existing-#{index}")
+        Dir.mkdir(directory, 0o700)
+        path = File.join(directory, "result.json")
+        File.open(path, File::WRONLY | File::CREAT | File::EXCL, 0o600) { |file| file.write("{}\n") }
+      end
+      touched = false
+
+      outcome = Runner.run!(
+        repo_root: fixture.fetch(:repo), evidence_root: fixture.fetch(:evidence),
+        controller_sha: fixture.fetch(:controller_sha), candidate_sha: fixture.fetch(:candidate_sha),
+        authorization: "authorized", invocation_id: "manual-full-store",
+        project_root: fixture.fetch(:project), observations_path: fixture.fetch(:observations),
+        image: "ruby@sha256:#{digest('image')}",
+        candidate_factory: ->(**) { touched = true },
+        provider_probe_factory: ->(**) { touched = true }, clock: fixed_clock
+      )
+
+      assert_equal "blocked", outcome.fetch("status")
+      assert_equal "evidence_store_full", outcome.fetch("reason")
+      assert_nil outcome.fetch("result_path")
+      refute touched
+      assert_equal 128, Dir.children(fixture.fetch(:evidence)).size
+    end
+  end
+
+  def test_provider_block_preserves_completed_candidate_and_sandbox_custody
+    with_controller_repository do |fixture|
+      provider = Object.new
+      provider.define_singleton_method(:call) do
+        error = StandardError.new("provider unavailable")
+        error.define_singleton_method(:reason) { "provider_unavailable" }
+        raise error
+      end
+
+      outcome = Runner.run!(
+        repo_root: fixture.fetch(:repo), evidence_root: fixture.fetch(:evidence),
+        controller_sha: fixture.fetch(:controller_sha), candidate_sha: fixture.fetch(:candidate_sha),
+        authorization: "authorized", invocation_id: "manual-provider-block",
+        project_root: fixture.fetch(:project), observations_path: fixture.fetch(:observations),
+        image: "ruby@sha256:#{digest('image')}",
+        candidate_factory: ->(**) { fake_candidate([]) },
+        sandbox_factory: ->(**) { fake_sandbox([]) },
+        controller_factory: ->(**) { fake_controller([]) },
+        provider_probe_factory: ->(**) { provider }, clock: fixed_clock
+      )
+
+      result = outcome.fetch("result").to_h
+      assert_equal "blocked", outcome.fetch("status")
+      assert_equal "provider_unavailable", outcome.fetch("reason")
+      refute_nil result.fetch("candidate")
+      refute_nil result.fetch("sandbox")
+      refute_nil result.fetch("smoke")
+      assert_nil result.fetch("provider")
+      assert_equal "reaped", result.dig("process_evidence", 0, "status")
+    end
+  end
+
+  private
+
+  def fake_candidate(calls)
+    Object.new.tap do |object|
+      object.define_singleton_method(:prepare!) do |**|
+        calls << :candidate
+        { "archive_sha256" => Digest::SHA256.hexdigest("archive"),
+          "closure_sha256" => Digest::SHA256.hexdigest("closure") }
+      end
+      object.define_singleton_method(:verify!) { |receipt:| receipt.fetch("candidate") }
+    end
+  end
+
+  def fake_sandbox(calls)
+    Object.new.tap do |object|
+      object.define_singleton_method(:run!) do |**|
+        calls << :sandbox
+        { "candidate" => { "archive_sha256" => Digest::SHA256.hexdigest("archive"),
+                            "closure_sha256" => Digest::SHA256.hexdigest("closure") },
+          "sandbox" => { "status" => "passed", "image" => "ruby@sha256:#{Digest::SHA256.hexdigest('image')}" },
+          "payload" => { "receipts" => [] },
+          "process_evidence" => [ { "owner" => "sandbox", "status" => "reaped" } ] }
+      end
+    end
+  end
+
+  def fake_controller(calls)
+    Object.new.tap do |object|
+      object.define_singleton_method(:external_smoke) do |**|
+        calls << :external_smoke
+        { "status" => "passed", "modules" => %w[architecture-patrol patrol] }
+      end
+    end
+  end
+
+  def fake_provider(calls)
+    Object.new.tap do |object|
+      object.define_singleton_method(:call) do
+        calls << :provider
+        { "status" => "passed", "provider" => "openrouter",
+          "model" => "openai/gpt-5.6-terra", "response_sha256" => Digest::SHA256.hexdigest("response"),
+          "usage" => { "prompt_tokens" => 1, "completion_tokens" => 1, "total_tokens" => 2 } }
+      end
+      object.define_singleton_method(:credential) { "operator-secret" }
+    end
+  end
+
+  def with_controller_repository
+    with_tmp_dir do |root|
+      repo = File.join(root, "repo")
+      FileUtils.mkdir_p(repo)
+      system("git", "init", "-b", "main", "--quiet", repo) or raise
+      FileUtils.mkdir_p(File.join(repo, "test/e2e/lib"))
+      File.write(File.join(repo, "test/e2e/lib/patrol_qualification.rb"), "# controller\n")
+      File.write(File.join(repo, "tracked"), "controller\n")
+      system("git", "-C", repo, "-c", "user.name=Hive", "-c", "user.email=hive@example.invalid",
+             "add", ".") or raise
+      system("git", "-C", repo, "-c", "user.name=Hive", "-c", "user.email=hive@example.invalid",
+             "commit", "-m", "controller", "--quiet") or raise
+      controller_sha = `git -C #{Shellwords.escape(repo)} rev-parse HEAD`.strip
+      File.write(File.join(repo, "tracked"), "candidate\n")
+      system("git", "-C", repo, "-c", "user.name=Hive", "-c", "user.email=hive@example.invalid",
+             "commit", "-am", "candidate", "--quiet") or raise
+      candidate_sha = `git -C #{Shellwords.escape(repo)} rev-parse HEAD`.strip
+      system("git", "-C", repo, "checkout", "--detach", "--quiet", controller_sha) or raise
+      evidence = File.join(root, "evidence")
+      project = File.join(root, "project")
+      FileUtils.mkdir_p(evidence, mode: 0o700)
+      FileUtils.mkdir_p(project, mode: 0o700)
+      observations = File.join(root, "observations.json")
+      File.binwrite(observations, "{}\n")
+      yield repo:, evidence:, project:, observations:, controller_sha:, candidate_sha:
+    end
+  end
+
+  def fixed_clock
+    times = [
+      Time.utc(2026, 8, 5, 10, 0, 0), Time.utc(2026, 8, 5, 10, 0, 1),
+      Time.utc(2026, 8, 5, 10, 0, 2), Time.utc(2026, 8, 5, 10, 0, 3)
+    ]
+    -> { times.shift || times.last }
+  end
+
+  def digest(value) = Digest::SHA256.hexdigest(value)
+end

--- a/test/unit/packaging/patrol_evidence_sandbox_test.rb
+++ b/test/unit/packaging/patrol_evidence_sandbox_test.rb
@@ -33,7 +33,10 @@ class PatrolEvidenceSandboxTest < Minitest::Test
       assert_includes argv, "no-new-privileges"
       assert_includes argv, "--memory=2g"
       assert_includes argv, "--cpus=2"
-      assert argv.grep(/\A--tmpfs=/).any? { |value| value.include?("size=536870912") && value.include?("nr_inodes=16384") }
+      tmpfs = argv.grep(/\A--tmpfs=/)
+      assert tmpfs.any? { |value| value.include?("/state") && value.include?("size=535822336") }
+      assert tmpfs.any? { |value| value.include?("/dev/shm") && value.include?("size=1048576") }
+      assert argv.any? { |value| value.include?("target=/input/source,readonly") }
       assert argv.any? { |value| value.include?("target=/control/test/e2e/lib/patrol_qualification.rb,readonly") }
       assert argv.any? { |value| value.include?("target=/control/lib/hive/secret_patterns.rb,readonly") }
       assert_includes argv, "-r/control/test/e2e/lib/patrol_qualification"
@@ -64,6 +67,82 @@ class PatrolEvidenceSandboxTest < Minitest::Test
     end
   end
 
+  def test_same_candidate_runs_receive_distinct_owned_container_names
+    with_tmp_dir do |root|
+      fixture = sandbox_fixture(root)
+      second_run = File.join(root, "run-2")
+      FileUtils.mkdir_p(second_run, mode: 0o700)
+      names = []
+      sandbox = Sandbox.new(
+        image: fixture.fetch(:image), engine_probe: -> { engine_identity(fixture.fetch(:image)) },
+        executor: ->(name:, **_options) do
+          names << name
+          sandbox_payload(fixture)
+        end
+      )
+
+      [ fixture.fetch(:run_root), second_run ].each do |run_root|
+        sandbox.run!(
+          candidate: fixture.fetch(:candidate), project_root: fixture.fetch(:project),
+          observations_path: fixture.fetch(:observations), controller_root: fixture.fetch(:controller),
+          run_root:, image: fixture.fetch(:image)
+        )
+      end
+
+      assert_equal 2, names.uniq.size
+      assert names.all? { |name| name.match?(/\Ahive-patrol-u3c-[0-9a-f]{20}\z/) }
+    end
+  end
+
+  def test_hostile_default_executor_reaps_detached_descendants_on_every_terminal_path
+    skip "run rake test:hostile for detached process custody" unless ENV["HIVE_HOSTILE_TESTS"] == "1"
+
+    %w[success failure timeout].each do |behavior|
+      with_tmp_dir do |root|
+        fixture = sandbox_fixture(root)
+        owner_label = digest(File.basename(fixture.fetch(:run_root)))
+        payload = HivePatrolEvidence::Result.canonical(
+          "candidate" => {}, "payload" => {}
+        )
+        engine, pid_path = hostile_engine(root, owner_label:, payload:, behavior:)
+        identity = engine_identity(fixture.fetch(:image)).merge(
+          "engine_path" => engine, "engine_sha256" => Digest::SHA256.file(engine).hexdigest
+        )
+        sandbox = Sandbox.new(
+          image: fixture.fetch(:image), engine_probe: -> { identity },
+          timeout: behavior == "timeout" ? 0.2 : 5
+        )
+
+        if behavior == "success"
+          receipt = sandbox.run!(
+            candidate: fixture.fetch(:candidate), project_root: fixture.fetch(:project),
+            observations_path: fixture.fetch(:observations), controller_root: fixture.fetch(:controller),
+            run_root: fixture.fetch(:run_root), image: fixture.fetch(:image)
+          )
+          assert_equal "reaped", receipt.dig("process_evidence", 0, "status")
+        else
+          error = assert_raises(Sandbox::Error) do
+            sandbox.run!(
+              candidate: fixture.fetch(:candidate), project_root: fixture.fetch(:project),
+              observations_path: fixture.fetch(:observations), controller_root: fixture.fetch(:controller),
+              run_root: fixture.fetch(:run_root), image: fixture.fetch(:image)
+            )
+          end
+          assert_equal "reaped", error.process_evidence.dig(0, "status")
+          assert_equal behavior == "timeout" ? "timeout" : "failed",
+                       error.process_evidence.dig(0, "outcome")
+        end
+
+        pid = Integer(File.binread(pid_path), 10)
+        deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 2
+        while process_alive?(pid) && Process.clock_gettime(Process::CLOCK_MONOTONIC) < deadline
+          sleep 0.02
+        end
+        refute process_alive?(pid), "#{behavior} detached process survived verified teardown"
+      end
+    end
+  end
+
   private
 
   def sandbox_fixture(root)
@@ -82,11 +161,17 @@ class PatrolEvidenceSandboxTest < Minitest::Test
     File.binwrite(observations, "{}\n")
     archive = File.join(root, "candidate.tar")
     File.binwrite(archive, "candidate")
+    source = File.join(root, "candidate-source")
+    FileUtils.mkdir_p(source)
+    File.binwrite(File.join(source, "tracked"), "candidate")
+    File.chmod(0o444, File.join(source, "tracked"))
+    File.chmod(0o555, source)
     image = "ruby@sha256:#{digest('image')}"
     {
       controller:, project:, run_root:, observations:, image:,
       candidate: {
         "controller_sha" => "a" * 40, "candidate_sha" => "b" * 40, "archive_path" => archive,
+        "source_path" => source, "source_tree_sha256" => digest("source"),
         "archive_sha256" => Digest::SHA256.file(archive).hexdigest,
         "module_manifest_sha256" => digest("manifests")
       }
@@ -94,8 +179,65 @@ class PatrolEvidenceSandboxTest < Minitest::Test
   end
 
   def engine_identity(image)
-    { "engine" => "docker", "engine_version" => "Docker 28.0",
+    { "engine" => "docker", "engine_path" => "/usr/bin/docker", "engine_sha256" => digest("engine"),
+      "engine_version" => "Docker 28.0",
       "image" => image, "image_id" => "sha256:#{digest('rootfs')}" }
+  end
+
+  def hostile_engine(root, owner_label:, payload:, behavior:)
+    path = File.join(root, "docker")
+    pid_path = File.join(root, "detached.pid")
+    state_path = File.join(root, "container.state")
+    script = <<~RUBY
+      #!/usr/bin/ruby
+      behavior = #{behavior.dump}
+      owner_label = #{owner_label.dump}
+      payload = #{payload.dump}
+      pid_path = #{pid_path.dump}
+      state_path = #{state_path.dump}
+      command = ARGV.fetch(0, "")
+      exit 0 if command == "info"
+      if command == "run"
+        cidfile = ARGV.find { |arg| arg.start_with?("--cidfile=") }.split("=", 2).last
+        File.binwrite(cidfile, "f" * 64 + "\n")
+        child = Process.spawn("/usr/bin/setsid", "/bin/sh", "-c", "trap '' HUP; sleep 60",
+                              in: :close, out: File::NULL, err: File::NULL)
+        File.binwrite(pid_path, child.to_s)
+        File.binwrite(state_path, child.to_s)
+        case behavior
+        when "success" then STDOUT.write(payload)
+        when "failure" then exit 7
+        when "timeout" then sleep 30
+        end
+        exit 0
+      end
+      if %w[kill rm].include?(command)
+        if File.exist?(state_path)
+          pid = Integer(File.binread(state_path), 10)
+          begin Process.kill("TERM", -pid); rescue Errno::ESRCH; end
+          sleep 0.05
+          begin Process.kill("KILL", -pid); rescue Errno::ESRCH; end
+          File.unlink(state_path) rescue nil
+        end
+        exit 0
+      end
+      if command == "container" && ARGV.fetch(1, "") == "inspect"
+        alive = File.exist?(state_path)
+        STDOUT.write("#{owner_label}\n") if alive && ARGV.include?("--format")
+        exit(alive ? 0 : 1)
+      end
+      exit 1
+    RUBY
+    File.binwrite(path, script)
+    File.chmod(0o700, path)
+    [ path, pid_path ]
+  end
+
+  def process_alive?(pid)
+    Process.kill(0, pid)
+    true
+  rescue Errno::ESRCH
+    false
   end
 
   def sandbox_payload(fixture)
@@ -104,8 +246,12 @@ class PatrolEvidenceSandboxTest < Minitest::Test
       "candidate" => { "candidate_sha" => "b" * 40,
         "archive_sha256" => fixture.dig(:candidate, "archive_sha256"),
         "identity_before" => {}, "identity_after" => {} },
-      "process_evidence" => [ { "owner" => "sandbox", "status" => "reaped",
-                                 "container_id_sha256" => digest("container") } ]
+      "process_evidence" => [ {
+        "owner" => "sandbox", "status" => "reaped", "outcome" => "success",
+        "teardown" => "verified", "exit_code" => 0,
+        "container_id_sha256" => digest("container"), "stdout_sha256" => digest("stdout"),
+        "stderr_sha256" => digest("stderr")
+      } ]
     }
   end
 

--- a/test/unit/packaging/patrol_evidence_sandbox_test.rb
+++ b/test/unit/packaging/patrol_evidence_sandbox_test.rb
@@ -1,0 +1,113 @@
+require "test_helper"
+require "digest"
+require_relative "../../../packaging/patrol_evidence/sandbox"
+
+class PatrolEvidenceSandboxTest < Minitest::Test
+  include HiveTestHelper
+
+  Sandbox = HivePatrolEvidence::Sandbox
+
+  def test_exact_container_contract_is_networkless_read_only_and_resource_bounded
+    with_tmp_dir do |root|
+      fixture = sandbox_fixture(root)
+      captured = nil
+      sandbox = Sandbox.new(
+        image: fixture.fetch(:image),
+        engine_probe: -> { engine_identity(fixture.fetch(:image)) },
+        executor: ->(argv:, **options) do
+          captured = { argv:, options: }
+          sandbox_payload(fixture)
+        end
+      )
+
+      receipt = sandbox.run!(
+        candidate: fixture.fetch(:candidate), project_root: fixture.fetch(:project),
+        observations_path: fixture.fetch(:observations), controller_root: fixture.fetch(:controller),
+        run_root: fixture.fetch(:run_root), image: fixture.fetch(:image)
+      )
+
+      argv = captured.fetch(:argv)
+      %w[--network=none --read-only --cap-drop=ALL --pids-limit=64 --pull=never].each do |flag|
+        assert_includes argv, flag
+      end
+      assert_includes argv, "no-new-privileges"
+      assert_includes argv, "--memory=2g"
+      assert_includes argv, "--cpus=2"
+      assert argv.grep(/\A--tmpfs=/).any? { |value| value.include?("size=536870912") && value.include?("nr_inodes=16384") }
+      assert argv.any? { |value| value.include?("target=/control/test/e2e/lib/patrol_qualification.rb,readonly") }
+      assert argv.any? { |value| value.include?("target=/control/lib/hive/secret_patterns.rb,readonly") }
+      assert_includes argv, "-r/control/test/e2e/lib/patrol_qualification"
+      refute_includes argv, "-r/state/candidate/test/e2e/lib/patrol_qualification"
+      refute argv.any? { |value| value.include?("docker.sock") || value.include?(ENV.fetch("HOME")) }
+      assert_equal "passed", receipt.dig("sandbox", "status")
+      assert_equal "reaped", receipt.dig("process_evidence", 0, "status")
+    end
+  end
+
+  def test_runtime_or_container_identity_drift_fails_closed
+    with_tmp_dir do |root|
+      fixture = sandbox_fixture(root)
+      probes = [ engine_identity(fixture.fetch(:image)), engine_identity(fixture.fetch(:image)).merge("image_id" => "sha256:#{digest('drift')}") ]
+      sandbox = Sandbox.new(
+        image: fixture.fetch(:image), engine_probe: -> { probes.shift },
+        executor: ->(**) { sandbox_payload(fixture) }
+      )
+
+      error = assert_raises(Sandbox::Error) do
+        sandbox.run!(
+          candidate: fixture.fetch(:candidate), project_root: fixture.fetch(:project),
+          observations_path: fixture.fetch(:observations), controller_root: fixture.fetch(:controller),
+          run_root: fixture.fetch(:run_root), image: fixture.fetch(:image)
+        )
+      end
+      assert_equal "runtime_identity", error.reason
+    end
+  end
+
+  private
+
+  def sandbox_fixture(root)
+    controller = File.join(root, "controller")
+    project = File.join(root, "project")
+    run_root = File.join(root, "run")
+    [ controller, project, run_root ].each { |path| FileUtils.mkdir_p(path, mode: 0o700) }
+    FileUtils.mkdir_p(File.join(controller, "test/e2e/fixtures/patrol_qualification"))
+    FileUtils.mkdir_p(File.join(controller, "test/e2e/lib"))
+    FileUtils.mkdir_p(File.join(controller, "lib/hive"))
+    catalog = File.join(controller, "test/e2e/fixtures/patrol_qualification/catalog.json")
+    File.binwrite(catalog, "{}\n")
+    File.binwrite(File.join(controller, "test/e2e/lib/patrol_qualification.rb"), "# trusted controller\n")
+    File.binwrite(File.join(controller, "lib/hive/secret_patterns.rb"), "# trusted support\n")
+    observations = File.join(root, "observations.json")
+    File.binwrite(observations, "{}\n")
+    archive = File.join(root, "candidate.tar")
+    File.binwrite(archive, "candidate")
+    image = "ruby@sha256:#{digest('image')}"
+    {
+      controller:, project:, run_root:, observations:, image:,
+      candidate: {
+        "controller_sha" => "a" * 40, "candidate_sha" => "b" * 40, "archive_path" => archive,
+        "archive_sha256" => Digest::SHA256.file(archive).hexdigest,
+        "module_manifest_sha256" => digest("manifests")
+      }
+    }
+  end
+
+  def engine_identity(image)
+    { "engine" => "docker", "engine_version" => "Docker 28.0",
+      "image" => image, "image_id" => "sha256:#{digest('rootfs')}" }
+  end
+
+  def sandbox_payload(fixture)
+    {
+      "payload" => { "receipts" => [] },
+      "candidate" => { "candidate_sha" => "b" * 40,
+        "archive_sha256" => fixture.dig(:candidate, "archive_sha256"),
+        "identity_before" => {}, "identity_after" => {} },
+      "process_evidence" => [ { "owner" => "sandbox", "status" => "reaped",
+                                 "container_id_sha256" => digest("container") } ]
+    }
+  end
+
+  def digest(value) = Digest::SHA256.hexdigest(value)
+end

--- a/wiki/component-boundaries.md
+++ b/wiki/component-boundaries.md
@@ -3,7 +3,7 @@ title: Component boundaries
 type: reference
 source: config/component-boundaries.yml, test/support/component_boundary_contract.rb
 created: 2026-07-25
-updated: 2026-08-04
+updated: 2026-08-05
 tags: [architecture, components, boundaries, monorepo]
 ---
 
@@ -17,7 +17,7 @@ the first and primary consumer.
 
 | Component | State | Current entry point | Narrative context |
 |-----------|-------|---------------------|-------------------|
-| Patrol Effect Evidence | `candidate` (U3a protocol complete; U3b/U3c proof pending) | `require "hive/modules/migration/patrol_evidence"` → `Hive::Modules::Migration::PatrolEvidence` | [[modules/patrol]] |
+| Patrol Effect Evidence | `candidate` (U3a protocol complete; reduced installed/live smoke source-pinned; full U3b/U3c proof pending) | `require "hive/modules/migration/patrol_evidence"` → `Hive::Modules::Migration::PatrolEvidence` | [[modules/patrol]] |
 | Attempts admission / future RunReceipt | `candidate` (guarded reference) | `require "hive/attempts/api"` → `Hive::Attempts::API` | [[modules/attempts]] |
 | Workflow Creator Values | `boundary-ready` | `require "./packaging/live_agent_skills/workflow_creator_text_safety"` → `HiveLiveAgentProof::WorkflowCreator::TextSafety` | [[component-boundaries]] |
 | Workflow Creator | `boundary-ready` | `require "./packaging/live_agent_skills/workflow_creator_evidence"` → `HiveLiveAgentProof::WorkflowCreatorEvidence` | [[component-boundaries]] |
@@ -160,7 +160,11 @@ contracts in focused tests, but does not produce qualification. U3b still owns
 the committed deterministic scenario catalogue, independent controls, pure
 collector, and complete both-module fault matrix; U3c still owns independently
 authorized installed/live candidate, project, artifact, credential, sandbox,
-process-custody, and publication proof. That exception is not permission for
+process-custody, and publication proof. The packaging-only reduced U3c harness
+now composes those custody checks through exactly five evidence owners and the
+existing E2E controller's read-only `external_smoke` entry, but it creates no
+catalog component, admission facade, report lane, recovery owner, or promotion
+authority. That exception is not permission for
 another recovery store, compatibility effect map, qualification runner, or
 cutover claim.
 

--- a/wiki/component-boundaries.md
+++ b/wiki/component-boundaries.md
@@ -164,7 +164,10 @@ process-custody, and publication proof. The packaging-only reduced U3c harness
 now composes those custody checks through exactly five evidence owners and the
 existing E2E controller's read-only `external_smoke` entry, but it creates no
 catalog component, admission facade, report lane, recovery owner, or promotion
-authority. That exception is not permission for
+authority. Candidate execution consumes an independently admitted read-only
+source mount while build mutations remain in sandbox state; host composition
+binds a canonical expiring authorization to the registered project's live
+repository/HEAD/state and retains only a closed terminal result. That exception is not permission for
 another recovery store, compatibility effect map, qualification runner, or
 cutover claim.
 

--- a/wiki/gaps.md
+++ b/wiki/gaps.md
@@ -43,11 +43,15 @@ tags: [gap, todo, release-proof, agent-skills]
   controls, freshly driven decisions for both modules, and explicit
   wall-clock/DST, weekly cadence, quota reset, credential expiry, restart, and
   log-rotation coverage.
-  The reduced admission now requires a read-only controller mode that proves
-  report bytes remain unchanged, an exact protected-main controller checkout,
-  digest-bound runtime closure, quota-backed writable storage, a closed
-  provider success predicate, locked publication, and bounded retained
-  evidence. None of those proposed U3c controls exists in production yet.
+  The reduced source boundary now implements the read-only controller mode,
+  exact protected-main control-tree check, live project/registry/repository/state
+  binding, one-hour canonical one-time authorization, immutable admitted source
+  plus opaque gemspec inventory, digest-bound runtime closure, aggregate-bounded
+  writable storage, closed provider predicate, locked publication, and
+  result-only retained evidence. Its credential-free contract tests include an
+  opt-in detached-process campaign outside default CI. No real container or
+  provider invocation has authenticated this infrastructure yet; that remains a
+  separate post-merge exact-head operator authorization, not a source claim.
   Long-lived external resource drift remains a declared U3c live limitation,
   not something elapsed time can prove equivalent. Elapsed telemetry remains
   useful, but neither it nor a seven-day window substitutes for diversity and

--- a/wiki/log.d/20260805T120000Z-patrol-installed-live-smoke.md
+++ b/wiki/log.d/20260805T120000Z-patrol-installed-live-smoke.md
@@ -1,0 +1,24 @@
+---
+title: Add the reduced Patrol installed/live smoke boundary
+date: 2026-08-05
+category: architecture
+module: patrol
+tags: [patrol, qualification, installed-live, sandbox, provider, u3c]
+---
+
+**Changed:** Added exactly five `packaging/patrol_evidence` runtime owners and
+one manual command. A clean exact protected-main controller evaluates a
+distinct later candidate, streams and binds its archive and installed closure,
+runs the installed candidate and both first-party modules inside one
+digest-pinned networkless/read-only-root resource-bounded container, verifies
+whole-process teardown, loads only separately mounted read-only trusted
+controller/support bytes rather than the candidate's controller copy, and
+performs one closed host-side authenticated
+provider transport probe. Canonical results use expected-byte atomic
+publication and explicit owner-checked retention cleanup.
+
+**Boundary:** The existing Patrol E2E controller gained only a bounded
+read-only `external_smoke` entry. The path cannot construct production
+qualification, write report v2's `installed_live` lane, call provider-backed
+Patrol decisions, emit operator-ready evidence, or authorize promotion or
+cutover. Full U3b/U3c and `U3-ARCH-006` remain open.

--- a/wiki/log.d/20260805T120000Z-patrol-installed-live-smoke.md
+++ b/wiki/log.d/20260805T120000Z-patrol-installed-live-smoke.md
@@ -9,13 +9,22 @@ tags: [patrol, qualification, installed-live, sandbox, provider, u3c]
 **Changed:** Added exactly five `packaging/patrol_evidence` runtime owners and
 one manual command. A clean exact protected-main controller evaluates a
 distinct later candidate, streams and binds its archive and installed closure,
+renders the archive into an independently hashed read-only source tree, treats
+installed gemspecs as opaque bytes, and builds only from a writable sandbox copy.
+Each run binds one canonical one-hour, one-time authorization to the exact
+controller/candidate/image/invocation and the live registered project,
+repository HEAD, state tree, and observation bytes. Transient inputs remain
+outside the result-only retained evidence store. It
 runs the installed candidate and both first-party modules inside one
 digest-pinned networkless/read-only-root resource-bounded container, verifies
-whole-process teardown, loads only separately mounted read-only trusted
+whole-process teardown through one hashed engine executable and closed runtime
+environment, loads only separately mounted read-only trusted
 controller/support bytes rather than the candidate's controller copy, and
 performs one closed host-side authenticated
 provider transport probe. Canonical results use expected-byte atomic
-publication and explicit owner-checked retention cleanup.
+publication, closed component schemas, and non-destructive owner-checked
+retention cleanup. The detached process campaign is opt-in and excluded from
+default/hosted CI.
 
 **Boundary:** The existing Patrol E2E controller gained only a bounded
 read-only `external_smoke` entry. The path cannot construct production

--- a/wiki/modules/patrol.md
+++ b/wiki/modules/patrol.md
@@ -1,9 +1,9 @@
 ---
 title: Hive::Patrol
 type: module
-source: lib/hive/patrol/
+source: lib/hive/patrol/, packaging/patrol_evidence/, test/e2e/lib/patrol_qualification.rb
 created: 2026-05-28
-updated: 2026-08-04
+updated: 2026-08-05
 tags: [module, patrol, review, worktree, pr, codex]
 ---
 
@@ -87,6 +87,20 @@ one exact-key, strict UTF-8 JSON object from bounded stdin; qualification also
 requires `--yes`. They accept no request path and add no runner, store, or
 cutover authority. Their command layer loads only shared lightweight errors,
 not the module lifecycle/store base.
+
+The separately invoked reduced installed/live smoke has exactly five
+packaging owners: `Result` owns the canonical bounded schema and claim fences;
+`Candidate` owns streamed archive and exact installed closure/module identity;
+`Sandbox` owns the fixed digest-pinned container and whole-process custody;
+`ProviderProbe` owns one closed host-side authenticated transport check; and
+`Runner` owns manual authority, composition, expected-byte publication, and
+explicit retention cleanup. The existing E2E controller supplies only the
+bounded read-only `external_smoke` operation. The sandbox mounts that exact
+trusted controller script and its secret-pattern support as separate read-only
+files; it never loads the candidate's controller copy or mounts the controller
+checkout. This path does not construct
+`PatrolQualification`, write report v2's `installed_live` lane, schedule or
+recover Patrol work, admit evidence for an operator, or authorize cutover.
 
 ## State
 

--- a/wiki/modules/patrol.md
+++ b/wiki/modules/patrol.md
@@ -97,8 +97,16 @@ packaging owners: `Result` owns the canonical bounded schema and claim fences;
 explicit retention cleanup. The existing E2E controller supplies only the
 bounded read-only `external_smoke` operation. The sandbox mounts that exact
 trusted controller script and its secret-pattern support as separate read-only
-files; it never loads the candidate's controller copy or mounts the controller
-checkout. This path does not construct
+files plus a separately admitted read-only candidate source tree; candidate
+builds run only from a writable copy. Installed gemspecs remain opaque hashed
+files and are never evaluated by the trusted controller. Runner binds one
+canonical one-hour authorization to the controller/candidate/image/invocation,
+the live registered project repository/HEAD/state tree, and the observation
+file, then rejects retained authorization replay. Transient archives, source,
+container custody, and controller scratch data stay outside the retained
+result-only evidence directory. The sandbox uses one hashed engine executable
+and a closed environment for probe, execution, and ID-owned teardown; it never
+loads the candidate's controller copy or mounts the controller checkout. This path does not construct
 `PatrolQualification`, write report v2's `installed_live` lane, schedule or
 recover Patrol work, admit evidence for an operator, or authorize cutover.
 

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -341,17 +341,30 @@ Focused tests under `test/unit/packaging/patrol_evidence_*_test.rb` pin canonica
 secret-free results, streamed archive/path limits, exact installed closure and
 module identity, a digest-pinned networkless/read-only-root container with
 whole-process teardown, the closed one-request provider predicate, manual
-authority before credential access, expected-byte publication, typed full-store
-refusal, explicit retention cleanup, and the command's non-ambient interface.
+authority before credential access, live registered-project/HEAD/state drift
+checks, one-time authorization replay refusal, expected-byte publication,
+result-only retention, typed full-store refusal, non-destructive explicit
+cleanup, closed success/failure record schemas, and the command's stable
+usage/refusal exits.
 The container contract loads separately mounted read-only protected-main
 controller/support files and explicitly forbids the candidate's controller
 copy from becoming execution authority.
 `test/e2e/lib/patrol_qualification_test.rb` separately proves that
 `external_smoke` cannot mutate report v2 or call normal qualification admission.
 
+The manual command is deliberately two-step: `--authorization-template` emits
+one canonical 15-minute document for the exact controller, later candidate,
+invocation ID, image, registered disposable project, and observations. The
+operator saves that document as an owner-private file and passes it once with
+`--authorization-file`; a changed scope, expiry, or retained replay fails before
+credential access. Generating a template is not itself permission to make the
+provider call.
+
 The hostile archive/path/process slice remains opt-in with
-`HIVE_HOSTILE_TESTS=1`; it is skipped by ordinary focused, default, coverage,
-and hosted-CI runs. Provider tests use an injected transport and never consume
+`bundle exec rake test:hostile` (or `HIVE_HOSTILE_TESTS=1`); it includes archive
+replacement/path cases and default-executor success/failure/timeout teardown of
+a detached session. Its hostile cases are skipped by ordinary focused, default,
+coverage, and hosted-CI runs. Provider tests use an injected transport and never consume
 a hosted credential. A real command invocation is therefore operator evidence,
 not a fact established by these tests.
 

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -1,9 +1,9 @@
 ---
 title: Testing
 type: reference
-source: test/, Rakefile, bin/hive-eval, .rubocop.yml, .github/workflows/{ci,live-agent-skills,release-candidate,release}.yml, packaging/{live_agent_skills,release_candidate}/, config/brakeman.ignore
+source: test/, Rakefile, bin/hive-eval, bin/hive-patrol-installed-live-smoke, .rubocop.yml, .github/workflows/{ci,live-agent-skills,release-candidate,release}.yml, packaging/{live_agent_skills,release_candidate,patrol_evidence}/, config/brakeman.ignore
 created: 2026-04-25
-updated: 2026-08-04
+updated: 2026-08-05
 tags: [test, minitest, fixtures, honeycomb, agent-skills, component-boundaries, terminal-outcomes, release-proof]
 ---
 
@@ -332,6 +332,28 @@ The same-head catalogue is not an independent oracle, prepared records are not
 a fresh scheduler-driven matrix, and a private exact-gem install is not
 Homebrew/AUR/install.sh installed/live proof. This smoke therefore does not
 close full U3b, U3-ARCH-005, or U3c.
+
+### Patrol reduced installed/live smoke contracts
+
+The production `packaging/patrol_evidence/` boundary has exactly five runtime
+owners: `Result`, `Candidate`, `Sandbox`, `ProviderProbe`, and `Runner`.
+Focused tests under `test/unit/packaging/patrol_evidence_*_test.rb` pin canonical
+secret-free results, streamed archive/path limits, exact installed closure and
+module identity, a digest-pinned networkless/read-only-root container with
+whole-process teardown, the closed one-request provider predicate, manual
+authority before credential access, expected-byte publication, typed full-store
+refusal, explicit retention cleanup, and the command's non-ambient interface.
+The container contract loads separately mounted read-only protected-main
+controller/support files and explicitly forbids the candidate's controller
+copy from becoming execution authority.
+`test/e2e/lib/patrol_qualification_test.rb` separately proves that
+`external_smoke` cannot mutate report v2 or call normal qualification admission.
+
+The hostile archive/path/process slice remains opt-in with
+`HIVE_HOSTILE_TESTS=1`; it is skipped by ordinary focused, default, coverage,
+and hosted-CI runs. Provider tests use an injected transport and never consume
+a hosted credential. A real command invocation is therefore operator evidence,
+not a fact established by these tests.
 
 ## Coverage
 


### PR DESCRIPTION
## Summary

This continues the Architecture Patrol refactor after #946 established the reduced U3c admission boundary. Hive can now qualify an exact candidate archive through the installed CLI, a resource-bounded sandbox, and a provider probe, then retain one closed-schema `result.json` artifact.

The boundary fails closed. It binds each authorization to the exact controller, candidate, runtime image, invocation, provider/model, project identity, and observation set; rejects replay; rechecks candidate and project custody at phase boundaries; and tears down only the container and process group owned by that run. Candidate scratch state is kept outside the evidence store and removed before provider access.

The production surface remains five focused owners: result validation, candidate custody, sandbox custody, provider probing, and orchestration. The heavier detached-process and hostile-input campaign remains opt-in through `test:hostile`, outside default and hosted CI.

## Validation

- Focused U3c checks: 57 runs, 448 assertions, 0 failures, 0 errors, 2 opt-in skips.
- Opt-in detached-process smoke: success, failure, and timeout paths; 1 run, 10 assertions, 0 failures.
- Changed-file RuboCop: 14 files inspected, no offenses.
- Broad local checkpoint: 12,210 runs, 157,222 assertions, 0 failures, 0 errors, 12 skips.
- No real provider or container qualification was invoked. That operation requires a fresh, separate operator authorization after this infrastructure is merged.

## Post-Deploy Monitoring & Validation

This PR does not deploy or release Hive. After merge, an operator may generate a fresh short-lived authorization template and explicitly approve one exact-head live qualification. That follow-up should verify the terminal result, absence of retained secrets, and absence of owned containers or descendant processes after success, failure, and timeout. A failed live proof does not trigger cutover and leaves only the bounded result artifact.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
