### PR TITLE
fix(release): preserve meaningful upgrade proof

### DIFF
--- a/packaging/release_candidate/invariant_snapshot.rb
+++ b/packaging/release_candidate/invariant_snapshot.rb
@@ -17,7 +17,7 @@ module HiveReleaseCandidate
     MAX_CAPTURE_BYTES = 1_048_576
     SEMANTIC_JSON_SECTIONS = %w[doctor_json status_json].freeze
     VOLATILE_JSON_KEYS = %w[
-      binary binary_path elapsed_ms executable finished_at generated_at
+      age_seconds binary binary_path elapsed_ms executable finished_at generated_at
       hive_version observed_at pid process_start_time schema_version started_at
       timestamp updated_at version
     ].freeze
@@ -32,7 +32,7 @@ module HiveReleaseCandidate
         raise Error, "invariant snapshot has unknown sections: #{extra.join(', ')}" unless extra.empty?
 
         SEMANTIC_JSON_SECTIONS.each do |name|
-          normalized[name] = semantic_json(normalized.fetch(name))
+          normalized[name] = semantic_json(normalized.fetch(name), path: [ name ])
         end
         canonical = deep_sort(normalized)
         {
@@ -163,19 +163,43 @@ module HiveReleaseCandidate
         end
       end
 
-      def semantic_json(value)
+      def semantic_json(value, path:)
         case value
         when Hash
           value.keys.sort.each_with_object({}) do |key, output|
-            next if VOLATILE_JSON_KEYS.include?(key)
-            output[key] = semantic_json(value.fetch(key))
+            child = value.fetch(key)
+            next if omit_semantic_json_key?(path: path, key: key, value: child)
+            output[key] = semantic_json(child, path: path + [ key ])
           end
         when Array
-          value.map { |child| semantic_json(child) }
+          value.each_with_index.map { |child, index| semantic_json(child, path: path + [ index ]) }
             .sort_by { |child| JSON.generate(deep_sort(child)) }
         else
           value
         end
+      end
+
+      def omit_semantic_json_key?(path:, key:, value:)
+        return true if VOLATILE_JSON_KEYS.include?(key)
+        return true if key == "expected" && doctor_managed_skill_path?(path)
+        return true if key == "hidden_archived_task_count" && value == 0 && status_project_path?(path)
+        return true if key == "closure" && value.nil? && status_task_path?(path)
+        return true if key == "outcomes" && value == [] && status_task_path?(path)
+
+        false
+      end
+
+      def doctor_managed_skill_path?(path)
+        path.length == 3 && path[0, 2] == %w[doctor_json managed_skills] && path[2].is_a?(Integer)
+      end
+
+      def status_project_path?(path)
+        path.length == 3 && path[0, 2] == %w[status_json projects] && path[2].is_a?(Integer)
+      end
+
+      def status_task_path?(path)
+        path.length == 5 && path[0, 2] == %w[status_json projects] &&
+          path[2].is_a?(Integer) && path[3] == "tasks" && path[4].is_a?(Integer)
       end
 
       def safe_root!(value)

--- a/packaging/release_candidate/upgrade_survivor/reviewed_channel_updater.rb
+++ b/packaging/release_candidate/upgrade_survivor/reviewed_channel_updater.rb
@@ -25,11 +25,14 @@ module HiveReleaseCandidate
           raise Error, "channel update path already exists: #{path}" if File.exist?(path) || File.symlink?(path)
         end
         prepare_channel_marker(prefix, channel)
+        channel_hive_home = File.join(run_root, "channel-state", "hive")
+        FileUtils.mkdir_p(channel_hive_home, mode: 0o700)
         shim = File.join(
           CONTROL_ROOT,
           channel == "linux-bash" ? "channel_shims/linux" : "channel_shims/macos"
         )
         environment = candidate_target.environment.merge(
+          "HIVE_HOME" => channel_hive_home,
           "PATH" => [ shim, candidate_target.environment.fetch("PATH") ].join(File::PATH_SEPARATOR),
           "HIVE_PREFIX" => prefix,
           "HOMEBREW_PREFIX" => prefix,

--- a/test/integration/release_candidate_latest_stable_upgrade_test.rb
+++ b/test/integration/release_candidate_latest_stable_upgrade_test.rb
@@ -210,6 +210,29 @@ class ReleaseCandidateLatestStableUpgradeTest < Minitest::Test
     end
   end
 
+  def test_default_channel_executor_ignores_the_phase_hive_home_channel_marker
+    with_tmp_dir do |dir|
+      baseline = target(dir, "baseline", "0.6.9", "a" * 64)
+      candidate = target(dir, "candidate", "0.7.0", "b" * 64)
+      phase_hive_home = candidate.environment.fetch("HIVE_HOME")
+      FileUtils.mkdir_p(phase_hive_home)
+      File.write(File.join(phase_hive_home, "install-channel"), "bash\n")
+      executor = HiveReleaseCandidate::UpgradeSurvivor::FixedChannelExecutor.new(
+        targets: { "baseline" => baseline, "candidate" => candidate }
+      )
+      run_root = File.join(dir, "run")
+      FileUtils.mkdir_p(run_root)
+
+      receipt = executor.call(
+        row: nil, platform: "linux-x86_64", candidate_target: candidate,
+        run_root: run_root
+      )
+
+      assert_equal "passed", receipt.fetch("status")
+      assert_equal "linux-bash", receipt.fetch("channel")
+    end
+  end
+
   def test_extracted_channel_updater_preserves_the_macos_shim_root
     with_tmp_dir do |dir|
       baseline = target(dir, "baseline", "0.6.9", "a" * 64)
@@ -270,6 +293,9 @@ class ReleaseCandidateLatestStableUpgradeTest < Minitest::Test
                #!/usr/bin/env bash
                set -euo pipefail
                if [[ "${1:-}" == "update" ]]; then
+                 if [[ -f "${HIVE_HOME:?}/install-channel" ]]; then
+                   exec "${HIVE_RC_CONTROL_ROOT:?}/channel_update_fixture.sh"
+                 fi
                  exec "${HIVE_RC_CONTROL_ROOT:?}/channel_update_fixture.sh" \
                    "--prefix=${HIVE_RC_CHANNEL_PREFIX:?}"
                fi

--- a/test/unit/packaging/release_candidate_invariant_snapshot_test.rb
+++ b/test/unit/packaging/release_candidate_invariant_snapshot_test.rb
@@ -87,6 +87,107 @@ class ReleaseCandidateInvariantSnapshotTest < Minitest::Test
     ).fetch("passed")
   end
 
+  def test_doctor_ignores_version_owned_managed_skill_expectations_but_not_observed_state
+    first = state("task body" => "keep")
+    first["doctor_json"] = {
+      "schema" => "hive-doctor",
+      "managed_skills" => [ {
+        "stage" => "hive.operations",
+        "expected" => { "version" => "0.6.9", "canonical_digest" => "a" * 64 },
+        "native" => { "available" => true, "tree_digest" => "c" * 64 }
+      } ]
+    }
+    second = Marshal.load(Marshal.dump(first))
+    second["doctor_json"]["managed_skills"][0]["expected"] = {
+      "version" => "0.7.0", "canonical_digest" => "b" * 64
+    }
+
+    before = HiveReleaseCandidate::InvariantSnapshot.build(
+      row_id: "latest-stable", sections: first
+    )
+    after = HiveReleaseCandidate::InvariantSnapshot.build(
+      row_id: "latest-stable", sections: second
+    )
+    assert HiveReleaseCandidate::InvariantSnapshot.compare(
+      before: before, after: after, allowed_migrations: []
+    ).fetch("passed")
+
+    second["doctor_json"]["managed_skills"][0]["native"]["tree_digest"] = "d" * 64
+    changed = HiveReleaseCandidate::InvariantSnapshot.build(
+      row_id: "latest-stable", sections: second
+    )
+    diff = HiveReleaseCandidate::InvariantSnapshot.compare(
+      before: before, after: changed, allowed_migrations: []
+    )
+
+    refute diff.fetch("passed")
+    assert_equal(
+      [ "/doctor_json/managed_skills/0/native/tree_digest" ],
+      diff.fetch("unexpected").map { |item| item.fetch("path") }
+    )
+  end
+
+  def test_status_ignores_elapsed_age_and_additive_empty_defaults
+    first = state("task body" => "keep")
+    first["status_json"] = {
+      "schema" => "hive-status",
+      "projects" => [ { "name" => "hive", "tasks" => [ { "id" => 7 } ] } ]
+    }
+    second = Marshal.load(Marshal.dump(first))
+    project = second["status_json"]["projects"][0]
+    project["hidden_archived_task_count"] = 0
+    project["tasks"][0].merge!(
+      "age_seconds" => 4,
+      "closure" => nil,
+      "outcomes" => []
+    )
+
+    before = HiveReleaseCandidate::InvariantSnapshot.build(
+      row_id: "latest-stable", sections: first
+    )
+    after = HiveReleaseCandidate::InvariantSnapshot.build(
+      row_id: "latest-stable", sections: second
+    )
+
+    assert HiveReleaseCandidate::InvariantSnapshot.compare(
+      before: before, after: after, allowed_migrations: []
+    ).fetch("passed")
+  end
+
+  def test_status_keeps_nonempty_archive_closure_and_outcome_state
+    first = state("task body" => "keep")
+    first["status_json"] = {
+      "schema" => "hive-status",
+      "projects" => [ { "name" => "hive", "tasks" => [ { "id" => 7 } ] } ]
+    }
+    second = Marshal.load(Marshal.dump(first))
+    project = second["status_json"]["projects"][0]
+    project["hidden_archived_task_count"] = 1
+    project["tasks"][0].merge!(
+      "closure" => { "status" => "operator_required" },
+      "outcomes" => [ { "name" => "approve" } ]
+    )
+
+    before = HiveReleaseCandidate::InvariantSnapshot.build(
+      row_id: "latest-stable", sections: first
+    )
+    after = HiveReleaseCandidate::InvariantSnapshot.build(
+      row_id: "latest-stable", sections: second
+    )
+    paths = HiveReleaseCandidate::InvariantSnapshot.compare(
+      before: before, after: after, allowed_migrations: []
+    ).fetch("unexpected").map { |item| item.fetch("path") }
+
+    assert_equal(
+      [
+        "/status_json/projects/0/hidden_archived_task_count",
+        "/status_json/projects/0/tasks/0/closure",
+        "/status_json/projects/0/tasks/0/outcomes"
+      ],
+      paths
+    )
+  end
+
   private
 
   def state(tasks)

--- a/wiki/log.d/20260805T215528Z-release-candidate-live-upgrade-proof.md
+++ b/wiki/log.d/20260805T215528Z-release-candidate-live-upgrade-proof.md
@@ -1,0 +1,19 @@
+---
+title: Repair first live 0.7.0 upgrade proof
+type: fix
+module: release-candidate
+created: 2026-08-05
+tags: [release-candidate, upgrade, invariants, channel]
+---
+
+The first full 0.7.0 candidate campaign exercised the real upgrade survivor
+and exposed two deterministic harness defects. Semantic snapshots now ignore
+elapsed task age, candidate-owned managed-skill expectations, and newly added
+empty status defaults while continuing to reject observed Doctor changes and
+non-empty user state. The reviewed channel updater now uses a dedicated empty
+`HIVE_HOME`, preventing the representative phase's channel marker from
+shadowing the simulated install prefix during `hive update`.
+
+Focused regressions cover both boundaries. This repair does not itself provide
+trusted candidate evidence or perform a release action; a fresh exact-main
+hosted campaign is still required.

--- a/wiki/release-candidate.md
+++ b/wiki/release-candidate.md
@@ -213,8 +213,12 @@ candidate migration runs.
 Snapshots name registry, config/default workflow, task identity/content/stage,
 dependencies, markers, durable attempts, dispatch receipts, channel sidecars,
 managed-web data, inert service definitions, status JSON, doctor JSON, and
-installed bytes. Status/doctor comparison removes only version, binary path,
-PID/timing, schema-version, and array-order noise. Every other state change
+installed bytes. Status/doctor comparison removes version, binary path,
+PID/timing, schema-version, and array-order noise. It also omits the candidate's
+version-owned managed-skill `expected` projection and treats newly emitted
+empty task defaults (`closure: null`, `outcomes: []`, and a zero hidden archive
+count) as equivalent to their absence. Observed managed-skill state and every
+non-empty task or archive value remain protected. Every other state change
 appears as a normalized JSON-pointer diff; the historical archive/runtime
 migration and candidate install identity are the only initial allowlisted
 migrations. A second candidate run accepts no changes.
@@ -224,7 +228,10 @@ any surviving daemon, TUI, web, producer, observer, candidate, or inert service
 stub. The channel phase first clones and records the authenticated baseline
 prefix, then invokes the installed candidate's real `hive update` command
 against an offline reviewed seam: a fixed curl/download shim on Linux and a
-fixed local-formula Homebrew shim on macOS. It verifies the candidate gem
+fixed local-formula Homebrew shim on macOS. The updater receives a dedicated
+empty `HIVE_HOME` beneath the lane run root, so representative phase state
+cannot shadow the reviewed prefix's channel marker or participate in the
+channel-only migration. It verifies the candidate gem
 digest, wrapper role, sidecars, dependency closure, exact active inventory, and
 absence of stale baseline files. AUR remains in its incumbent post-release
 gate.


### PR DESCRIPTION
## Summary

- Make upgrade qualification compare preserved user state, not elapsed task age, candidate-owned managed-skill expectations, or newly emitted empty defaults.
- Keep the gate fail-closed for observed Doctor changes and non-empty task/archive state.
- Run the reviewed channel update with an isolated `HIVE_HOME`, so the simulated install prefix selects the intended bash or Homebrew route instead of inheriting the representative phase marker.

## Test plan

- [x] focused release-candidate suite: 25 runs, 129 assertions, 0 failures/errors/skips
- [x] broad local checkpoint: 12,161 runs, 157,044 assertions, 0 failures/errors, 12 expected skips
- [x] RuboCop on the four changed Ruby/test files: no offenses
- [ ] fresh exact-main hosted release-candidate campaign after merge

## Notes for reviewer

The first full 0.7.0 candidate run, [31049181552](https://github.com/ivankuznetsov/hive/actions/runs/31049181552), correctly blocked publication and exposed these two deterministic harness defects. This PR does not claim release evidence; the authenticated multi-platform upgrade campaign must be rerun from the merged `main` SHA.
