### PR TITLE
fix(release): stabilize hosted upgrade runtime

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -33,7 +33,21 @@ jobs:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # pinned 2026-07-26
+        with:
+          ruby-version: "3.4"
       - run: bash install.sh --dry-run --version=v0.1.0
+      - name: Verify release-candidate Ruby sandbox
+        shell: bash
+        run: |
+          run_root="$(mktemp -d "$RUNNER_TEMP/hive-release-candidate-sandbox.XXXXXX")"
+          mkdir -p "$run_root/home" "$run_root/tmp"
+          ruby_bin_dir="$(dirname "$(command -v ruby)")"
+          profile="(version 1) (deny default) (allow process*) (allow file-read*) (allow sysctl-read) (allow file-write* (subpath \"$run_root\")) (deny network*)"
+          sandbox-exec -p "$profile" env -i \
+            "HOME=$run_root/home" "TMPDIR=$run_root/tmp" \
+            "PATH=$ruby_bin_dir:/usr/local/bin:/usr/bin:/bin" \
+            ruby -e 'STDOUT.sync = true; puts "release-candidate-ruby-sandbox: passed"'
 
   arch-dry-run:
     name: Arch dry run

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -646,7 +646,7 @@ jobs:
                 ruby /repo/packaging/release_candidate/hosted_upgrade_lane.rb "$1" "$2" "$3"
               ' sandbox "${{ matrix.row }}" "${{ matrix.platform }}" "$CANDIDATE_SHA"
           else
-            profile="(version 1) (deny default) (allow process*) (allow file-read*) (allow file-write* (subpath \"$HIVE_RC_RUN_ROOT\")) (deny network*)"
+            profile="(version 1) (deny default) (allow process*) (allow file-read*) (allow sysctl-read) (allow file-write* (subpath \"$HIVE_RC_RUN_ROOT\")) (deny network*)"
             sandbox_environment=(
               env -i
               "HOME=$HIVE_RC_RUN_ROOT/home"

--- a/packaging/release_candidate/process_teardown.rb
+++ b/packaging/release_candidate/process_teardown.rb
@@ -128,7 +128,7 @@ module HiveReleaseCandidate
     end
 
     def read_bounded(io)
-      output = +""
+      output = String.new(encoding: Encoding::BINARY)
       truncated = false
       while (chunk = io.read(16 * 1024))
         remaining = @output_limit - output.bytesize
@@ -137,7 +137,8 @@ module HiveReleaseCandidate
         end
         truncated ||= chunk.bytesize > remaining
       end
-      [ output, truncated ]
+      output.force_encoding(Encoding::UTF_8)
+      [ output.scrub, truncated ]
     ensure
       io.close rescue nil
     end

--- a/packaging/release_candidate/upgrade_survivor.rb
+++ b/packaging/release_candidate/upgrade_survivor.rb
@@ -316,8 +316,8 @@ module HiveReleaseCandidate
     end
 
     def bounded(value)
-      string = value.to_s
-      string.bytesize > OUTPUT_LIMIT ? string.byteslice(0, OUTPUT_LIMIT) : string
+      string = value.to_s.b.byteslice(0, OUTPUT_LIMIT)
+      string.force_encoding(Encoding::UTF_8).scrub
     end
   end
 end

--- a/test/integration/release_candidate_latest_stable_upgrade_test.rb
+++ b/test/integration/release_candidate_latest_stable_upgrade_test.rb
@@ -62,6 +62,48 @@ class ReleaseCandidateLatestStableUpgradeTest < Minitest::Test
     end
   end
 
+  def test_normalizes_phase_diagnostics_before_serializing_evidence
+    with_tmp_dir do |dir|
+      targets = {
+        "baseline" => target(
+          dir, "baseline", "0.6.9",
+          "9e9d065f67ccf3381b263f9a5ca44afb79b3122309b1b87c2477ddb6b2fba7a1"
+        ),
+        "candidate" => target(dir, "candidate", "0.6.9", "b" * 64)
+      }
+      state = latest_state
+      executor = lambda do |target:, phase:, **|
+        snapshot = Marshal.load(Marshal.dump(state))
+        snapshot["install_identity"]["gem_sha256"] = "b" * 64 unless phase == "before"
+        {
+          "status" => "passed", "producer_kind" => "real-installed",
+          "target_gem_sha256" => target.manifest.fetch("gem_sha256"),
+          "snapshot" => snapshot, "stdout" => "diagnostic\xFF".b,
+          "stderr" => ("e" * 65_535 + "\xE2\x82\xAC").b,
+          "processes" => [], "services" => []
+        }
+      end
+      channel = lambda do |**|
+        {
+          "status" => "passed", "channel" => "linux-bash",
+          "candidate_gem_sha256" => "b" * 64, "stale_files" => [],
+          "wrapper_role" => "candidate", "sidecars_current" => true,
+          "dependencies_current" => true
+        }
+      end
+
+      result = runner(dir, targets, executor, channel).run(
+        row_id: "latest-stable", platform: "linux-x86_64"
+      )
+
+      result.fetch("phases").each do |phase|
+        assert_predicate phase.fetch("stdout"), :valid_encoding?
+        assert_predicate phase.fetch("stderr"), :valid_encoding?
+      end
+      assert JSON.generate(result)
+    end
+  end
+
   def test_rejects_task_change_non_idempotency_stale_channel_and_fixture_substitution
     with_tmp_dir do |dir|
       targets = {

--- a/test/unit/packaging/release_candidate_process_teardown_test.rb
+++ b/test/unit/packaging/release_candidate_process_teardown_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "json"
 require_relative "../../../packaging/release_candidate/process_teardown"
 
 class ReleaseCandidateProcessTeardownTest < Minitest::Test
@@ -68,6 +69,27 @@ class ReleaseCandidateProcessTeardownTest < Minitest::Test
       end
     ensure
       ENV.delete("HIVE_U4_HOST_SECRET")
+    end
+  end
+
+  def test_capture_normalizes_binary_and_truncated_output_for_json_receipts
+    Dir.mktmpdir("release-candidate-process") do |dir|
+      target = Struct.new(:role, :executable, :state_root).new(
+        "candidate", RbConfig.ruby, dir
+      )
+      runner = HiveReleaseCandidate::ProcessTeardown.new(output_limit: 5)
+
+      receipt = runner.capture(
+        target: target,
+        argv: [ "-e", "$stdout.binmode; $stdout.write(\"ok\\xFF\\xE2\\x82\\xAC\".b)" ],
+        environment: {}, cwd: dir, label: "binary-output"
+      )
+
+      assert receipt.fetch("stdout_truncated")
+      assert_equal Encoding::UTF_8, receipt.fetch("stdout").encoding
+      assert_predicate receipt.fetch("stdout"), :valid_encoding?
+      assert_equal "ok\uFFFD\uFFFD", receipt.fetch("stdout")
+      assert JSON.generate(receipt)
     end
   end
 end

--- a/test/unit/release_contract_test.rb
+++ b/test/unit/release_contract_test.rb
@@ -360,7 +360,7 @@ class ReleaseContractTest < Minitest::Test
     upgrade = jobs.fetch("upgrade").fetch("steps").find do |step|
       step["name"] == "Run installed historical producer and candidate without network"
     end.fetch("run")
-    profile = "(version 1) (deny default) (allow process*) (allow file-read*) " \
+    profile = "(version 1) (deny default) (allow process*) (allow file-read*) (allow sysctl-read) " \
       '(allow file-write* (subpath \"$HIVE_RC_RUN_ROOT\")) (deny network*)'
     assert_includes upgrade, %(profile="#{profile}")
     assert_equal 1, upgrade.scan('sandbox-exec -p "$profile"').size
@@ -374,8 +374,14 @@ class ReleaseContractTest < Minitest::Test
     ].each do |phase|
       assert_includes upgrade, "run_phase #{phase}"
     end
-    refute_includes upgrade, "allow sysctl-read"
     refute_includes upgrade, "allow mach-lookup"
+
+    install_smoke = read(".github/workflows/install-smoke.yml")
+    smoke_profile = "(version 1) (deny default) (allow process*) (allow file-read*) (allow sysctl-read) " \
+      '(allow file-write* (subpath \"$run_root\")) (deny network*)'
+    assert_includes install_smoke, %(profile="#{smoke_profile}")
+    assert_includes install_smoke, 'sandbox-exec -p "$profile" env -i'
+    refute_includes install_smoke, "allow mach-lookup"
   end
 
   def test_candidate_version_gate_reads_the_reviewed_catalog

--- a/wiki/log.d/20260805T220000Z-release-candidate-hosted-runtime.md
+++ b/wiki/log.d/20260805T220000Z-release-candidate-hosted-runtime.md
@@ -1,0 +1,18 @@
+---
+title: Repair hosted release-candidate runtime boundaries
+type: change
+module: release-candidate
+created: 2026-08-05
+tags: [release-candidate, workflow, macos, sandbox, encoding]
+---
+
+The macOS upgrade gate now permits read-only `sysctl` calls required to start
+the hosted Ruby runtime while retaining deny-default, deny-network, run-root-only
+writes, and no Mach service lookup. The ordinary macOS install-smoke job runs a
+minimal Ruby process under the same sandbox profile so this prerequisite fails
+on pull requests instead of during release qualification.
+
+Bounded subprocess stdout and stderr are normalized to valid UTF-8 after byte
+truncation. Legacy package warnings and split multibyte tails can therefore be
+retained in JSON receipts without making the hosted upgrade entrypoint fail
+during final serialization.

--- a/wiki/release-candidate.md
+++ b/wiki/release-candidate.md
@@ -278,11 +278,12 @@ construction, and publication remain at their existing review surfaces.
 Catalog integrity uses a full-history candidate checkout because its focused
 contracts read the reviewed historical tags. Managed-Web verification passes
 the helper's documented `--name=value` arguments. The macOS upgrade cell keeps
-its existing deny-default sandbox profile unchanged and runs bounded,
-same-profile shell and Ruby probes before installation. Constant-size
-checkpoint and exit-status lines then identify install, each required
-attestation, and upgrade-lane failures without adding sandbox permissions or
-provider credentials.
+a deny-default sandbox and permits read-only `sysctl` calls needed by the
+hosted Ruby runtime; network remains denied, writes remain confined to the run
+root, and Mach service lookup is not allowed. Install smoke exercises a minimal
+Ruby process under the same profile on every PR. Constant-size checkpoint and
+exit-status lines identify install, each required attestation, and upgrade-lane
+failures without provider credentials.
 
 Historical packages, dependency closures, and candidate bytes are downloaded
 and authenticated before installed package code runs. Installation and the U4
@@ -292,7 +293,9 @@ all capabilities are dropped, no-new-privileges and a PID ceiling are set,
 only the trusted control repository and authenticated cache are mounted
 read-only, and the run root is the sole writable mount. macOS uses a
 deny-network sandbox on its ephemeral runner with the same trusted-control,
-read-only-cache, and writable-run split.
+read-only-cache, and writable-run split. Captured subprocess diagnostics are
+bounded and normalized to valid UTF-8 before they enter JSON evidence, including
+when a byte limit cuts through a multibyte sequence.
 
 Every blocking cell compares its candidate-controlled harness paths
 byte-for-byte with the separately checked-out trusted workflow revision before


### PR DESCRIPTION
## Summary

- allow read-only sysctl calls needed for Ruby startup inside the macOS deny-default release-candidate sandbox while retaining deny-network, run-root-only writes, and no Mach lookup
- exercise the exact Ruby sandbox boundary in the ordinary macOS install-smoke job
- normalize bounded subprocess diagnostics to valid UTF-8 so legacy package output remains JSON-serializable

## Release evidence

This repairs the two required upgrade gates that failed in trusted candidate run 31055580468: macOS stopped at the pre-install Ruby smoke, and the legacy Linux lane completed its work but failed while serializing binary-encoded diagnostics. No tag or release was created from that blocked candidate.

## Verification

- process teardown: 4 runs, 20 assertions
- release workflow contract: 19 runs, 915 assertions
- upgrade survivor integration: 8 runs, 54 assertions
- broad suite: 12,164 runs, 157,088 assertions, 0 failures, 0 errors, 12 skips
- git diff --check

The macOS dry-run check on this PR is the live proof for the sandbox permission boundary.