### PR TITLE
fix(release): align hosted upgrade qualification

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -43,11 +43,11 @@ jobs:
           run_root="$(mktemp -d "$RUNNER_TEMP/hive-release-candidate-sandbox.XXXXXX")"
           mkdir -p "$run_root/home" "$run_root/tmp"
           ruby_bin_dir="$(dirname "$(command -v ruby)")"
-          profile="(version 1) (deny default) (allow process*) (allow file-read*) (allow sysctl-read) (allow file-write* (subpath \"$run_root\")) (deny network*)"
+          profile="(version 1) (deny default) (allow process*) (allow file-read*) (allow sysctl-read) (allow file-write* (literal \"/dev/null\")) (allow file-write* (subpath \"$run_root\")) (deny network*)"
           sandbox-exec -p "$profile" env -i \
             "HOME=$run_root/home" "TMPDIR=$run_root/tmp" \
             "PATH=$ruby_bin_dir:/usr/local/bin:/usr/bin:/bin" \
-            ruby -e 'STDOUT.sync = true; puts "release-candidate-ruby-sandbox: passed"'
+            ruby -e 'File.open("/dev/null", "w") { |io| io.write("") }; STDOUT.sync = true; puts "release-candidate-ruby-sandbox: passed"'
 
   arch-dry-run:
     name: Arch dry run

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -646,7 +646,7 @@ jobs:
                 ruby /repo/packaging/release_candidate/hosted_upgrade_lane.rb "$1" "$2" "$3"
               ' sandbox "${{ matrix.row }}" "${{ matrix.platform }}" "$CANDIDATE_SHA"
           else
-            profile="(version 1) (deny default) (allow process*) (allow file-read*) (allow sysctl-read) (allow file-write* (subpath \"$HIVE_RC_RUN_ROOT\")) (deny network*)"
+            profile="(version 1) (deny default) (allow process*) (allow file-read*) (allow sysctl-read) (allow file-write* (literal \"/dev/null\")) (allow file-write* (subpath \"$HIVE_RC_RUN_ROOT\")) (deny network*)"
             sandbox_environment=(
               env -i
               "HOME=$HIVE_RC_RUN_ROOT/home"
@@ -677,7 +677,7 @@ jobs:
                 }
                 printf "hive-release-candidate: checkpoint=sandbox-shell status=entered\n"
                 run_phase ruby-smoke ruby -e \
-                  "STDOUT.sync = true; puts \"hive-release-candidate: checkpoint=ruby-smoke status=passed\""
+                  "File.open(\"/dev/null\", \"w\") { |io| io.write(\"\") }; STDOUT.sync = true; puts \"hive-release-candidate: checkpoint=ruby-smoke status=passed\""
                 run_phase hosted-stage-install \
                   ruby "$HIVE_RC_REPO_ROOT/packaging/release_candidate/hosted_stage.rb" install "$1" "$2" "$3"
                 run_phase sandbox-attestation test -f "$HIVE_RC_RUN_ROOT/sandbox-attestation.json"

--- a/packaging/release_candidate/invariant_snapshot.rb
+++ b/packaging/release_candidate/invariant_snapshot.rb
@@ -18,8 +18,8 @@ module HiveReleaseCandidate
     SEMANTIC_JSON_SECTIONS = %w[doctor_json status_json].freeze
     VOLATILE_JSON_KEYS = %w[
       age_seconds binary binary_path elapsed_ms executable finished_at generated_at
-      hive_version observed_at pid process_start_time schema_version started_at
-      timestamp updated_at version
+      hive_version observation_mtime observed_at pid process_start_time schema_version
+      started_at timestamp updated_at version
     ].freeze
 
     class << self

--- a/packaging/release_candidate/upgrade_survivor.rb
+++ b/packaging/release_candidate/upgrade_survivor.rb
@@ -33,9 +33,32 @@ module HiveReleaseCandidate
       ],
       "legacy-bench-v041" => %w[
         /builtin_runtime
+        /configuration/default_workflow
+        /default_workflow
+        /doctor_json
+        /global_registry
         /install_identity
         /legacy_descriptor
         /legacy_instructions
+        /project_registry
+        /status_json/projects/0/tasks/0/admission_error
+        /status_json/projects/0/tasks/0/attempt_id
+        /status_json/projects/0/tasks/0/commit_generation
+        /status_json/projects/0/tasks/0/condition_gate
+        /status_json/projects/0/tasks/0/condition_history
+        /status_json/projects/0/tasks/0/condition_migration
+        /status_json/projects/0/tasks/0/condition_overrides
+        /status_json/projects/0/tasks/0/condition_provenance
+        /status_json/projects/0/tasks/0/condition_task_generation
+        /status_json/projects/0/tasks/0/condition_warning
+        /status_json/projects/0/tasks/0/conditions
+        /status_json/projects/0/tasks/0/current_attempt
+        /status_json/projects/0/tasks/0/evidence
+        /status_json/projects/0/tasks/0/shadow_audit
+        /status_json/projects/0/tasks/0/task_generation
+        /status_json/projects/0/tasks/0/task_lock_id
+        /status_json/projects/0/tasks/0/task_lock_pid
+        /status_json/projects/0/tasks/0/task_lock_process_start_time
       ]
     }.freeze
     OUTPUT_LIMIT = 64 * 1024

--- a/test/integration/release_candidate_legacy_bench_v041_upgrade_test.rb
+++ b/test/integration/release_candidate_legacy_bench_v041_upgrade_test.rb
@@ -21,6 +21,7 @@ class ReleaseCandidateLegacyBenchV041UpgradeTest < ReleaseCandidateLatestStableU
       after["legacy_instructions"] = { "status" => "archived", "path" => "bench.legacy" }
       after["builtin_runtime"] = { "status" => "installed" }
       after["install_identity"]["gem_sha256"] = "6" * 64
+      apply_historical_schema_migrations!(after)
       executor = lambda do |target:, phase:, **|
         phases << [ target.role, phase ]
         snapshot = phase == "before" || phase == "observer" ? before : after
@@ -64,6 +65,8 @@ class ReleaseCandidateLegacyBenchV041UpgradeTest < ReleaseCandidateLatestStableU
       )
       assert_equal "legacy_workflow_collision", result.dig("phases", 1, "reason")
       assert result.dig("phases", 3, "task_continuation")
+      assert result.dig("invariants", "transition_diff", "passed")
+      assert_empty result.dig("invariants", "transition_diff", "unexpected")
     end
   end
 
@@ -88,11 +91,77 @@ class ReleaseCandidateLegacyBenchV041UpgradeTest < ReleaseCandidateLatestStableU
     end
   end
 
+  def test_historical_schema_allowlist_keeps_core_task_state_protected
+    before = legacy_state
+    after = Marshal.load(Marshal.dump(before))
+    apply_historical_schema_migrations!(after)
+    after.dig("status_json", "projects", 0, "tasks", 0)["stage"] = "9-done"
+
+    diff = HiveReleaseCandidate::InvariantSnapshot.compare(
+      before: HiveReleaseCandidate::InvariantSnapshot.build(
+        row_id: "legacy-bench-v041", sections: before
+      ),
+      after: HiveReleaseCandidate::InvariantSnapshot.build(
+        row_id: "legacy-bench-v041", sections: after
+      ),
+      allowed_migrations: HiveReleaseCandidate::UpgradeSurvivor::ALLOWED_MIGRATIONS.fetch(
+        "legacy-bench-v041"
+      )
+    )
+
+    refute diff.fetch("passed")
+    assert_equal(
+      [ "/status_json/projects/0/tasks/0/stage" ],
+      diff.fetch("unexpected").map { |change| change.fetch("path") }
+    )
+  end
+
   private
+
+  def apply_historical_schema_migrations!(state)
+    state["configuration"]["default_workflow"] = "bench"
+    state["default_workflow"] = "bench"
+    state["global_registry"] = { "status" => "migrated", "project_id" => "project-1" }
+    state["project_registry"] = { "status" => "migrated", "project_id" => "project-1" }
+    state["doctor_json"] = {
+      "schema" => "hive-doctor.v2",
+      "summary" => { "legacy_failures" => 0, "warnings" => 0 },
+      "managed_skills" => []
+    }
+    state["status_json"] = {
+      "schema" => "hive-status",
+      "projects" => [ {
+        "name" => "project",
+        "tasks" => [ {
+          "id" => 7,
+          "stage" => "1-inbox",
+          "admission_error" => nil,
+          "attempt_id" => nil,
+          "commit_generation" => 0,
+          "condition_gate" => nil,
+          "condition_history" => [],
+          "condition_migration" => { "effective" => "markers" },
+          "condition_overrides" => [],
+          "condition_provenance" => { "projector" => "TaskProjection/v1" },
+          "condition_task_generation" => 0,
+          "condition_warning" => nil,
+          "conditions" => [ { "condition" => "Merged", "state" => "pending" } ],
+          "current_attempt" => nil,
+          "evidence" => [],
+          "observation_mtime" => "2026-08-06T00:48:15Z",
+          "shadow_audit" => { "ready" => false },
+          "task_generation" => nil,
+          "task_lock_id" => nil,
+          "task_lock_pid" => nil,
+          "task_lock_process_start_time" => nil
+        } ]
+      } ]
+    }
+  end
 
   def legacy_state
     latest_state.merge(
-      "default_workflow" => "bench",
+      "default_workflow" => "coding",
       "tasks" => {
         "task-7" => {
           "id" => 7, "slug" => "legacy-campaign-260714-abcd",
@@ -108,7 +177,19 @@ class ReleaseCandidateLegacyBenchV041UpgradeTest < ReleaseCandidateLatestStableU
         "sha256" => "8" * 64
       },
       "builtin_runtime" => { "status" => "absent" },
-      "install_identity" => { "gem_sha256" => "4" * 64 }
+      "install_identity" => { "gem_sha256" => "4" * 64 },
+      "status_json" => {
+        "schema" => "hive-status",
+        "projects" => [ {
+          "name" => "project",
+          "tasks" => [ { "id" => 7, "stage" => "1-inbox" } ]
+        } ]
+      },
+      "doctor_json" => {
+        "schema" => "hive-doctor.v1",
+        "checks" => [ { "kind" => "stage", "status" => "missing" } ],
+        "summary" => { "missing" => 1 }
+      }
     )
   end
 end

--- a/test/unit/packaging/release_candidate_invariant_snapshot_test.rb
+++ b/test/unit/packaging/release_candidate_invariant_snapshot_test.rb
@@ -138,6 +138,7 @@ class ReleaseCandidateInvariantSnapshotTest < Minitest::Test
     project["hidden_archived_task_count"] = 0
     project["tasks"][0].merge!(
       "age_seconds" => 4,
+      "observation_mtime" => "2026-08-06T00:48:15.176470Z",
       "closure" => nil,
       "outcomes" => []
     )

--- a/test/unit/release_contract_test.rb
+++ b/test/unit/release_contract_test.rb
@@ -361,11 +361,13 @@ class ReleaseContractTest < Minitest::Test
       step["name"] == "Run installed historical producer and candidate without network"
     end.fetch("run")
     profile = "(version 1) (deny default) (allow process*) (allow file-read*) (allow sysctl-read) " \
+      '(allow file-write* (literal \"/dev/null\")) ' \
       '(allow file-write* (subpath \"$HIVE_RC_RUN_ROOT\")) (deny network*)'
     assert_includes upgrade, %(profile="#{profile}")
     assert_equal 1, upgrade.scan('sandbox-exec -p "$profile"').size
     assert_includes upgrade, "checkpoint=sandbox-run"
     assert_includes upgrade, "checkpoint=ruby-smoke"
+    assert_includes upgrade, 'File.open(\"/dev/null\", \"w\")'
     assert_includes upgrade, "checkpoint=sandbox-shell"
     assert_includes upgrade, "failure phase=%s status=%s"
     %w[
@@ -378,9 +380,11 @@ class ReleaseContractTest < Minitest::Test
 
     install_smoke = read(".github/workflows/install-smoke.yml")
     smoke_profile = "(version 1) (deny default) (allow process*) (allow file-read*) (allow sysctl-read) " \
+      '(allow file-write* (literal \"/dev/null\")) ' \
       '(allow file-write* (subpath \"$run_root\")) (deny network*)'
     assert_includes install_smoke, %(profile="#{smoke_profile}")
     assert_includes install_smoke, 'sandbox-exec -p "$profile" env -i'
+    assert_includes install_smoke, 'File.open("/dev/null", "w")'
     refute_includes install_smoke, "allow mach-lookup"
   end
 

--- a/wiki/log.d/20260806T005441Z-release-candidate-upgrade-contract.md
+++ b/wiki/log.d/20260806T005441Z-release-candidate-upgrade-contract.md
@@ -1,0 +1,18 @@
+---
+title: Align the hosted upgrade contract with current migrations
+type: change
+module: release-candidate
+created: 2026-08-06
+tags: [release-candidate, upgrade, migration, macos, sandbox]
+---
+
+The historical v0.4.1 qualification row now recognizes the explicit migrations
+performed by current Hive: bench default binding, registry identity enrichment,
+doctor v2 replacement, and the named additive status-condition projection
+fields. User task identity, contents, stage, dependencies, and markers remain
+protected, and the second migration run still permits no changes.
+
+The macOS deny-default profile now permits writes only to the literal
+`/dev/null` device in addition to its existing run-root write boundary. The
+ordinary macOS install smoke opens that device under the exact profile, covering
+the RubyGems resolver behavior that the full hosted candidate exposed.

--- a/wiki/release-candidate.md
+++ b/wiki/release-candidate.md
@@ -3,7 +3,7 @@ title: Release Candidate Evidence
 type: reference
 source: bin/hive-release-candidate, packaging/release_candidate/, packaging/managed_web_archive.rb, .github/workflows/{release-candidate,release}.yml
 created: 2026-07-27
-updated: 2026-08-05
+updated: 2026-08-06
 tags: [release, candidate, evidence, packaging, safety]
 ---
 
@@ -217,11 +217,15 @@ installed bytes. Status/doctor comparison removes version, binary path,
 PID/timing, schema-version, and array-order noise. It also omits the candidate's
 version-owned managed-skill `expected` projection and treats newly emitted
 empty task defaults (`closure: null`, `outcomes: []`, and a zero hidden archive
-count) as equivalent to their absence. Observed managed-skill state and every
-non-empty task or archive value remain protected. Every other state change
-appears as a normalized JSON-pointer diff; the historical archive/runtime
-migration and candidate install identity are the only initial allowlisted
-migrations. A second candidate run accepts no changes.
+count) as equivalent to their absence. Observation mtimes are also volatile.
+Observed managed-skill state and persisted task or archive values remain
+protected. Every other state change appears as a normalized JSON-pointer diff.
+The v0.4.1 transition explicitly permits the legacy archive/runtime install,
+the candidate install identity, the bench default binding, the one-time project
+registry identity rewrite, the doctor v1-to-v2 envelope replacement, and only
+the named additive task-condition projection fields emitted by current status.
+Core task identity, contents, stage, dependencies, and markers remain outside
+the allowlist. A second candidate run accepts no changes.
 
 Each command has bounded stdout/stderr and a process group. Teardown fails for
 any surviving daemon, TUI, web, producer, observer, candidate, or inert service
@@ -279,11 +283,12 @@ Catalog integrity uses a full-history candidate checkout because its focused
 contracts read the reviewed historical tags. Managed-Web verification passes
 the helper's documented `--name=value` arguments. The macOS upgrade cell keeps
 a deny-default sandbox and permits read-only `sysctl` calls needed by the
-hosted Ruby runtime; network remains denied, writes remain confined to the run
-root, and Mach service lookup is not allowed. Install smoke exercises a minimal
-Ruby process under the same profile on every PR. Constant-size checkpoint and
-exit-status lines identify install, each required attestation, and upgrade-lane
-failures without provider credentials.
+hosted Ruby runtime plus writes to the literal `/dev/null` device used by
+RubyGems. Network remains denied, every other write remains confined to the run
+root, and Mach service lookup is not allowed. Install smoke starts Ruby and
+opens `/dev/null` for writing under the same profile on every PR. Constant-size
+checkpoint and exit-status lines identify install, each required attestation,
+and upgrade-lane failures without provider credentials.
 
 Historical packages, dependency closures, and candidate bytes are downloaded
 and authenticated before installed package code runs. Installation and the U4


### PR DESCRIPTION
## Summary

- permit only literal `/dev/null` writes in the deny-default macOS release-candidate sandbox and exercise that RubyGems prerequisite in ordinary install smoke
- recognize the explicit v0.4.1-to-current registry, workflow, doctor, and additive status-projection migrations while keeping core task state protected
- treat status observation mtimes as volatile evidence and document the hosted qualification contract

## Why

Trusted candidate run 31060374717 proved every blocking gate except two:

- macOS Ruby started under the sandbox, then RubyGems failed opening `/dev/null` for write during offline install
- the real v0.4.1 upgrade completed, remained idempotent, preserved task continuation, and updated the channel, but its 55 intentional schema/state migration diffs were outside the stale qualification allowlist

No release tag was created from that failed candidate.

## Verification

- `44 runs, 1054 assertions, 0 failures, 0 errors, 0 skips`
- replayed the real failed v0.4.1 before/after snapshots through this head: `passed=true`, `allowed_count=59`, `unexpected_count=0`
- regression test confirms `/status_json/projects/0/tasks/0/stage` remains unexpected
- `git diff --check`
