### PR TITLE
fix(release): pin macOS candidate locale to UTF-8

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -46,8 +46,9 @@ jobs:
           profile="(version 1) (deny default) (allow process*) (allow file-read*) (allow sysctl-read) (allow file-write* (literal \"/dev/null\")) (allow file-write* (subpath \"$run_root\")) (deny network*)"
           sandbox-exec -p "$profile" env -i \
             "HOME=$run_root/home" "TMPDIR=$run_root/tmp" \
+            "LANG=en_US.UTF-8" "LC_ALL=en_US.UTF-8" \
             "PATH=$ruby_bin_dir:/usr/local/bin:/usr/bin:/bin" \
-            ruby -e 'File.open("/dev/null", "w") { |io| io.write("") }; STDOUT.sync = true; puts "release-candidate-ruby-sandbox: passed"'
+            ruby -e 'abort "expected UTF-8 external encoding" unless Encoding.default_external == Encoding::UTF_8; File.open("/dev/null", "w") { |io| io.write("") }; STDOUT.sync = true; puts "release-candidate-ruby-sandbox: passed"'
 
   arch-dry-run:
     name: Arch dry run

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -652,6 +652,8 @@ jobs:
               "HOME=$HIVE_RC_RUN_ROOT/home"
               "HIVE_HOME=$HIVE_RC_RUN_ROOT/hive"
               "TMPDIR=$HIVE_RC_RUN_ROOT/tmp"
+              "LANG=en_US.UTF-8"
+              "LC_ALL=en_US.UTF-8"
               "XDG_CONFIG_HOME=$HIVE_RC_RUN_ROOT/xdg/config"
               "XDG_CACHE_HOME=$HIVE_RC_RUN_ROOT/xdg/cache"
               "XDG_DATA_HOME=$HIVE_RC_RUN_ROOT/xdg/data"
@@ -677,7 +679,7 @@ jobs:
                 }
                 printf "hive-release-candidate: checkpoint=sandbox-shell status=entered\n"
                 run_phase ruby-smoke ruby -e \
-                  "File.open(\"/dev/null\", \"w\") { |io| io.write(\"\") }; STDOUT.sync = true; puts \"hive-release-candidate: checkpoint=ruby-smoke status=passed\""
+                  "abort \"expected UTF-8 external encoding\" unless Encoding.default_external == Encoding::UTF_8; File.open(\"/dev/null\", \"w\") { |io| io.write(\"\") }; STDOUT.sync = true; puts \"hive-release-candidate: checkpoint=ruby-smoke status=passed\""
                 run_phase hosted-stage-install \
                   ruby "$HIVE_RC_REPO_ROOT/packaging/release_candidate/hosted_stage.rb" install "$1" "$2" "$3"
                 run_phase sandbox-attestation test -f "$HIVE_RC_RUN_ROOT/sandbox-attestation.json"

--- a/test/unit/release_contract_test.rb
+++ b/test/unit/release_contract_test.rb
@@ -367,6 +367,9 @@ class ReleaseContractTest < Minitest::Test
     assert_equal 1, upgrade.scan('sandbox-exec -p "$profile"').size
     assert_includes upgrade, "checkpoint=sandbox-run"
     assert_includes upgrade, "checkpoint=ruby-smoke"
+    assert_includes upgrade, '"LANG=en_US.UTF-8"'
+    assert_includes upgrade, '"LC_ALL=en_US.UTF-8"'
+    assert_includes upgrade, "Encoding.default_external == Encoding::UTF_8"
     assert_includes upgrade, 'File.open(\"/dev/null\", \"w\")'
     assert_includes upgrade, "checkpoint=sandbox-shell"
     assert_includes upgrade, "failure phase=%s status=%s"
@@ -384,6 +387,8 @@ class ReleaseContractTest < Minitest::Test
       '(allow file-write* (subpath \"$run_root\")) (deny network*)'
     assert_includes install_smoke, %(profile="#{smoke_profile}")
     assert_includes install_smoke, 'sandbox-exec -p "$profile" env -i'
+    assert_includes install_smoke, '"LANG=en_US.UTF-8" "LC_ALL=en_US.UTF-8"'
+    assert_includes install_smoke, "Encoding.default_external == Encoding::UTF_8"
     assert_includes install_smoke, 'File.open("/dev/null", "w")'
     refute_includes install_smoke, "allow mach-lookup"
   end

--- a/wiki/log.d/20260806T013259Z-release-candidate-macos-utf8-locale.md
+++ b/wiki/log.d/20260806T013259Z-release-candidate-macos-utf8-locale.md
@@ -1,0 +1,16 @@
+---
+title: Pin UTF-8 in the macOS release-candidate sandbox
+type: change
+module: release-candidate
+created: 2026-08-06
+tags: [release-candidate, workflow, macos, sandbox, encoding]
+---
+
+The macOS release-candidate sandbox now fixes `LANG` and `LC_ALL` to
+`en_US.UTF-8`. Installed baseline and candidate commands therefore retain a
+deterministic UTF-8 external encoding after the host environment is scrubbed,
+instead of falling back to US-ASCII while reading project configuration.
+
+The ordinary install-smoke workflow exercises the same environment and fails
+unless Ruby reports UTF-8 as its default external encoding, keeping this hosted
+runtime prerequisite visible on pull requests.

--- a/wiki/release-candidate.md
+++ b/wiki/release-candidate.md
@@ -284,11 +284,15 @@ contracts read the reviewed historical tags. Managed-Web verification passes
 the helper's documented `--name=value` arguments. The macOS upgrade cell keeps
 a deny-default sandbox and permits read-only `sysctl` calls needed by the
 hosted Ruby runtime plus writes to the literal `/dev/null` device used by
-RubyGems. Network remains denied, every other write remains confined to the run
-root, and Mach service lookup is not allowed. Install smoke starts Ruby and
-opens `/dev/null` for writing under the same profile on every PR. Constant-size
-checkpoint and exit-status lines identify install, each required attestation,
-and upgrade-lane failures without provider credentials.
+RubyGems. Its scrubbed process environment fixes `LANG` and `LC_ALL` to
+`en_US.UTF-8`, so installed historical and candidate processes receive a
+deterministic UTF-8 external encoding instead of macOS's US-ASCII fallback.
+Network remains denied, every other write remains confined to the run root,
+and Mach service lookup is not allowed. Install smoke starts Ruby, verifies
+that exact external encoding, and opens `/dev/null` for writing under the same
+profile on every PR. Constant-size checkpoint and exit-status lines identify
+install, each required attestation, and upgrade-lane failures without provider
+credentials.
 
 Historical packages, dependency closures, and candidate bytes are downloaded
 and authenticated before installed package code runs. Installation and the U4


### PR DESCRIPTION
## Summary

- pin `LANG` and `LC_ALL` to `en_US.UTF-8` inside the scrubbed macOS release-candidate sandbox
- make the ordinary macOS install smoke assert Ruby uses UTF-8 under the exact profile
- document the hosted runtime boundary

## Failure repaired

Release candidate run 31062431991 reached the real v0.6.9-to-0.7.0 macOS upgrade, but both candidate migration phases failed at `ROOT_REVIEWERS_LINE.match?` with `invalid byte sequence in US-ASCII`. The sandbox intentionally used `env -i`; without an explicit locale, `InstalledTarget` had no safe locale to preserve for installed commands.

## Local proof

- `mise exec ruby@3.4.7 -- bundle exec ruby -Itest test/unit/release_contract_test.rb` — 19 runs, 929 assertions, 0 failures
- both workflow YAML files parse with aliases enabled
- `git diff --check`
