### PR TITLE
fix(release): accept canonical Git PAX metadata

### DIFF
--- a/packaging/release_candidate/release_selector.rb
+++ b/packaging/release_candidate/release_selector.rb
@@ -546,7 +546,10 @@ module HiveReleaseCandidate
       raise Error, "candidate manifest filenames do not match the release identity" unless actual == expected
 
       source = File.join(candidate_dir, expected.fetch("source"))
-      selected = read_source_entries(source, [ SOURCE_VERSION_PATH, BASELINE_PATH ])
+      selected = read_source_entries(
+        source, [ SOURCE_VERSION_PATH, BASELINE_PATH ],
+        candidate_sha: candidate_sha
+      )
       source_version = selected.fetch(SOURCE_VERSION_PATH)
         .match(/\bVERSION\s*=\s*["']([^"']+)["']/)&.[](1)
       unless source_version == tag_version
@@ -569,13 +572,25 @@ module HiveReleaseCandidate
 
     private
 
-    def read_source_entries(path, wanted)
+    def read_source_entries(path, wanted, candidate_sha:)
       found = {}
+      global_header = false
       Zlib::GzipReader.open(path) do |gzip|
         Gem::Package::TarReader.new(gzip) do |tar|
           tar.each do |entry|
             name = entry.full_name.sub(%r{\A\./}, "")
             validate_tar_name!(name)
+            if entry.header.typeflag == "g"
+              expected = "52 comment=#{candidate_sha}\n"
+              valid = !global_header && name == "pax_global_header" &&
+                entry.size == expected.bytesize &&
+                entry.read(expected.bytesize + 1) == expected
+              unless valid
+                raise Error, "candidate source contains noncanonical global archive metadata"
+              end
+              global_header = true
+              next
+            end
             unless entry.file? || entry.directory?
               raise Error, "candidate source contains a link or special entry"
             end

--- a/test/unit/packaging/release_candidate_release_selector_test.rb
+++ b/test/unit/packaging/release_candidate_release_selector_test.rb
@@ -244,6 +244,22 @@ class ReleaseCandidateReleaseSelectorTest < Minitest::Test
     end
   end
 
+  def test_candidate_verifier_rejects_source_link_after_canonical_global_header
+    Dir.mktmpdir("release-candidate-link") do |dir|
+      candidate = build_candidate_fixture(
+        dir, VERSION, suffix: "-link", source_symlink: true
+      )
+
+      error = assert_raises(HiveReleaseCandidate::Error) do
+        HiveReleaseCandidate::ReleaseCandidateVerifier.new.call(
+          repo_root: ROOT, candidate_dir: candidate,
+          candidate_sha: CANDIDATE_SHA, tag_version: VERSION
+        )
+      end
+      assert_match(/unsupported archive entry|link or special entry/, error.message)
+    end
+  end
+
   def test_publication_verifier_rehashes_only_exact_manifest_bound_public_bytes
     Dir.mktmpdir("release-publication-verifier") do |dir|
       candidate = build_candidate_fixture(dir, VERSION)
@@ -394,7 +410,7 @@ class ReleaseCandidateReleaseSelectorTest < Minitest::Test
     }
   end
 
-  def build_candidate_fixture(root, version, suffix: "")
+  def build_candidate_fixture(root, version, suffix: "", source_symlink: false)
     directory = File.join(root, "candidate#{suffix}")
     FileUtils.mkdir_p(directory)
     source_name = "hive-source-#{CANDIDATE_SHA}.tar.gz"
@@ -404,7 +420,7 @@ class ReleaseCandidateReleaseSelectorTest < Minitest::Test
       "hive-web-#{version}.tar.gz" => [ "web", "web" ]
     }
     source_path = File.join(directory, source_name)
-    write_source_archive(source_path, version)
+    write_source_archive(source_path, version, source_symlink: source_symlink)
     files[source_name] = [ "source", File.binread(source_path) ]
     files.each do |name, (_kind, content)|
       path = File.join(directory, name)
@@ -432,7 +448,7 @@ class ReleaseCandidateReleaseSelectorTest < Minitest::Test
     directory
   end
 
-  def write_source_archive(path, version)
+  def write_source_archive(path, version, source_symlink: false)
     entries = {
       "lib/hive/version.rb" => "module Hive\n  VERSION = \"#{version}\"\nend\n",
       "packaging/release_candidate/baselines.yml" =>
@@ -442,10 +458,19 @@ class ReleaseCandidateReleaseSelectorTest < Minitest::Test
       entries[name] = File.binread(File.join(ROOT, name))
     end
     Zlib::GzipWriter.open(path) do |gzip|
+      metadata = "52 comment=#{CANDIDATE_SHA}\n"
+      header = Gem::Package::TarHeader.new(
+        name: "pax_global_header", mode: 0o644, size: metadata.bytesize,
+        typeflag: "g", prefix: "", mtime: 0
+      )
+      gzip.write(header.to_s)
+      gzip.write(metadata)
+      gzip.write("\0" * ((512 - (metadata.bytesize % 512)) % 512))
       Gem::Package::TarWriter.new(gzip) do |tar|
         entries.each do |name, content|
           tar.add_file_simple(name, 0o600, content.bytesize) { |io| io.write(content) }
         end
+        tar.add_symlink("unsafe-link", "target", 0o777) if source_symlink
       end
     end
   end

--- a/wiki/log.d/20260806T023540Z-release-selector-pax-header.md
+++ b/wiki/log.d/20260806T023540Z-release-selector-pax-header.md
@@ -1,0 +1,18 @@
+---
+title: Admit canonical Git PAX metadata at tag handoff
+type: fix
+module: release-candidate
+created: 2026-08-06
+tags: [release, release-candidate, archive, pax]
+---
+
+The tag-time release selector now accepts the one canonical PAX global header
+that `git archive` emits for the candidate commit. The candidate builder had
+already authenticated and validated that header, but the later selector
+mistook it for a link or special entry and blocked publication before any
+assets were released.
+
+The selector independently binds the header payload to the exact candidate SHA
+and continues to reject duplicate or malformed global metadata, symlinks, and
+all other special archive entries. Focused fixtures now reproduce the
+production PAX header and retain a hostile source-link regression.

--- a/wiki/release-candidate.md
+++ b/wiki/release-candidate.md
@@ -410,6 +410,10 @@ agent-skill, and managed-web filenames for the tag version and target SHA. The
 source archive must declare that version through the canonical
 `lib/hive/version.rb` source, and it must remain newer than the catalog-pinned
 latest stable version already proven by the blocking candidate gate.
+Tag-time source inspection accepts the optional single canonical PAX global
+header emitted by `git archive` for the exact candidate SHA. It independently
+rejects duplicate or malformed global metadata and still rejects links and
+every other special archive entry.
 
 Only the manifest-bound gem, skill, and web bytes are restaged for native
 install and publication. The source archive stays an internal retained QA


### PR DESCRIPTION
## Summary

- admit the single canonical PAX global header emitted by `git archive` at tag-time source inspection
- bind that metadata to the exact candidate SHA and reject duplicates or malformed payloads
- retain fail-closed handling for source symlinks and every other special entry

## Release failure repaired

Release run 31065912946 selected and authenticated the trusted candidate/evidence, then failed before publication because `ReleaseCandidateVerifier` classified the canonical `pax_global_header` as a link or special entry. No release or downstream channel job ran.

## Proof

- exact failed candidate artifact replay now passes and reports 0.7.0 over baseline 0.6.9
- selector unit suite: 11 runs, 62 assertions, 0 failures
- release contract suite: 19 runs, 929 assertions, 0 failures
- production and test syntax checks pass
- hostile source-link regression remains rejected
