### PR TITLE
fix(release): make gem gate portable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,9 +197,12 @@ jobs:
         # emulated cell must never block a release (real Arch install is
         # covered post-release by install-verify.yml).
         run: |
-          gem_file="$(find selected/dist -maxdepth 1 -type f -name 'hive-cli-*.gem' -print)"
-          test "$(printf '%s\n' "$gem_file" | sed '/^$/d' | wc -l)" = 1
-          [[ -s "$gem_file" ]] || { echo "no hive-cli-*.gem artifact" >&2; exit 1; }
+          gem_files=(selected/dist/hive-cli-*.gem)
+          [[ "${#gem_files[@]}" -eq 1 && -f "${gem_files[0]}" && -s "${gem_files[0]}" ]] || {
+            echo "expected exactly one non-empty hive-cli-*.gem artifact" >&2
+            exit 1
+          }
+          gem_file="${gem_files[0]}"
           sandbox="$(mktemp -d)/gem-sandbox"
           mkdir -p "$sandbox"
           GEM_HOME="$sandbox" GEM_PATH="$sandbox" gem install "$gem_file" \

--- a/test/unit/release_contract_test.rb
+++ b/test/unit/release_contract_test.rb
@@ -519,6 +519,12 @@ class ReleaseContractTest < Minitest::Test
     assert_equal "select-candidate", install.fetch("needs")
     assert_equal [ "select-candidate", "install-gate" ], finalize.fetch("needs")
 
+    install_body = install.fetch("steps").filter_map { |step| step["run"] }.join("\n")
+    assert_includes install_body, "gem_files=(selected/dist/hive-cli-*.gem)"
+    assert_includes install_body,
+                    '[[ "${#gem_files[@]}" -eq 1 && -f "${gem_files[0]}" && -s "${gem_files[0]}" ]]'
+    refute_includes install_body, "wc -l"
+
     finalize_body = finalize.fetch("steps").filter_map { |step| step["run"] }.join("\n")
     assert_includes finalize_body, "select_release_candidate.rb publication"
     assert_includes finalize_body, "selected/dist/SHA256SUMS"

--- a/wiki/log.d/20260806T035224Z-release-install-gate-portability.md
+++ b/wiki/log.d/20260806T035224Z-release-install-gate-portability.md
@@ -1,0 +1,16 @@
+---
+title: Make the release install gate portable on macOS
+type: fix
+module: release
+created: 2026-08-06
+tags: [release, workflow, macos, portability]
+---
+
+The tag-time native gem-install gate now selects its sole candidate gem with a
+Bash glob array and verifies that entry is non-empty. This replaces a string
+comparison against `wc -l`, whose BSD implementation pads the count with
+leading spaces and stopped the macOS gate before `gem install` despite an exact,
+authenticated artifact.
+
+The Linux ARM behavior and the fail-closed zero/multiple/empty-file checks are
+preserved.

--- a/wiki/release-candidate.md
+++ b/wiki/release-candidate.md
@@ -416,8 +416,11 @@ rejects duplicate or malformed global metadata and still rejects links and
 every other special archive entry.
 
 Only the manifest-bound gem, skill, and web bytes are restaged for native
-install and publication. The source archive stays an internal retained QA
-input. The tag workflow has no gem, source, skill, or web build and no fallback
+install and publication. The macOS and Linux ARM install gates count the
+selected gem with a shell glob array and require its sole entry to be non-empty;
+they do not parse platform-specific, padded `wc` output. The source archive
+stays an internal retained QA input. The tag workflow has no gem, source,
+skill, or web build and no fallback
 dispatch or rebuild: missing, expired, mixed, stale, or substituted proof fails
 before the existing GitHub Release, Homebrew, AUR, Docker, and post-release
 graph can begin.


### PR DESCRIPTION
## Summary

- replace the tag-time gem count parsed from `wc -l` with a Bash glob-array cardinality check
- retain exact-one, regular-file, and non-empty fail-closed validation
- pin the portable contract and document the tag handoff

## Why

The 0.7.0 macOS release gate stopped before `gem install` because BSD `wc -l` renders a padded count (`       1`), which did not equal the literal `1`. The authenticated release artifact itself was correct, and the parallel Linux ARM gate passed.

## Verification

- `mise exec ruby@3.4.7 -- bundle exec ruby -Itest test/unit/release_contract_test.rb`
  - 19 runs, 935 assertions, 0 failures
- `git diff --check`