### PR TITLE
fix(patrol): fence patrols to coding workflows

### DIFF
--- a/lib/hive/agent_skills/target_resolver.rb
+++ b/lib/hive/agent_skills/target_resolver.rb
@@ -1,5 +1,6 @@
 require "hive/agent_profiles"
 require "hive/agent_skills/manifest"
+require "hive/workflows"
 
 module Hive
   module AgentSkills
@@ -140,6 +141,8 @@ module Hive
       end
 
       def patrol_enabled?
+        return false unless Hive::Workflows.coding_id?(@config["default_workflow"])
+
         patrol = @config["patrol"]
         return false unless patrol.is_a?(Hash)
         return patrol["enabled"] unless patrol["enabled"].nil?

--- a/lib/hive/commands/patrol.rb
+++ b/lib/hive/commands/patrol.rb
@@ -20,6 +20,7 @@ require "hive/patrol/decision_projection"
 require "hive/patrol/state_store"
 require "hive/patrol/token_budget"
 require "hive/patrol/validator"
+require "hive/workflows"
 require "hive/worktree"
 
 module Hive
@@ -91,6 +92,11 @@ module Hive
 
         project_root = entry.fetch("path")
         cfg = @config_loader.call(project_root)
+        unless Hive::Workflows.coding_id?(cfg["default_workflow"])
+          raise Hive::ConfigError,
+                "hive patrol: project #{entry.fetch('name').inspect} uses non-coding " \
+                "default_workflow #{cfg['default_workflow'].inspect}"
+        end
         require_module_observation_capabilities!
         require_module_mutation_capabilities! unless @dry_run
         ensure_validation_configured!(cfg) unless @dry_run

--- a/lib/hive/commands/refactor_patrol.rb
+++ b/lib/hive/commands/refactor_patrol.rb
@@ -32,6 +32,7 @@ require "hive/refactor_patrol/reviewer"
 require "hive/refactor_patrol/discovery_transitions"
 require "hive/refactor_patrol/state_store"
 require "hive/refactor_patrol/thesis"
+require "hive/workflows"
 require "hive/worktree"
 
 module Hive
@@ -282,6 +283,11 @@ module Hive
 
         project_root = entry.fetch("path")
         cfg = @config_loader.call(project_root)
+        unless query_mode? || Hive::Workflows.coding_id?(cfg["default_workflow"])
+          raise Hive::ConfigError,
+                "hive refactor-patrol: project #{entry.fetch('name').inspect} uses non-coding " \
+                "default_workflow #{cfg['default_workflow'].inspect}"
+        end
         unless query_mode? || @actions || (cfg["refactor_patrol"] || {})["enabled"]
           raise Hive::ConfigError, "hive refactor-patrol: project #{entry.fetch('name').inspect} must opt in with refactor_patrol.enabled: true"
         end

--- a/lib/hive/daemon/patrol_scheduler.rb
+++ b/lib/hive/daemon/patrol_scheduler.rb
@@ -9,6 +9,7 @@ require "hive/modules/migration/evidence_store"
 require "hive/modules/migration/patrols"
 require "hive/patrol/decision_projection"
 require "hive/patrol/state_store"
+require "hive/workflows"
 
 module Hive
   module Daemon
@@ -118,6 +119,10 @@ module Hive
 
           cfg = @config_loader.call(entry.fetch("path"))
           patrol = cfg.fetch("patrol", {})
+          unless Hive::Workflows.coding_id?(cfg["default_workflow"])
+            @next_check_at[project] = now + patrol.fetch("poll_interval_sec", 600).to_i
+            next
+          end
           # Throttle every project we evaluate, including opted-out ones:
           # each branch below commits `@next_check_at` once the project's
           # config has been loaded. Otherwise a disabled project would
@@ -165,6 +170,12 @@ module Hive
         return nil unless @migration_ownership.call(entry, "patrol", @migration_authority)
         return nil if pending?(project)
 
+        cfg = nil
+        unless candidate[:recovery_occurrence_id]
+          cfg = @config_loader.call(entry.fetch("path"))
+          return nil unless Hive::Workflows.coding_id?(cfg["default_workflow"])
+        end
+
         snapshot = @migration_snapshot.call(entry, "patrol")
         return nil unless reservation_owner?(snapshot)
 
@@ -172,8 +183,7 @@ module Hive
         capture = if candidate[:recovery_occurrence_id]
           state.occurrence_capture(candidate.fetch(:recovery_occurrence_id))
         else
-          interval = @config_loader.call(entry.fetch("path"))
-                                   .dig("patrol", "poll_interval_sec") || 600
+          interval = cfg.dig("patrol", "poll_interval_sec") || 600
           base_id = schedule_reservation_id(entry, now, interval)
           state.reserve_attempt_occurrence!(
             base_id,
@@ -266,7 +276,8 @@ module Hive
 
       def schedule_selection_input(entry, cfg, patrol, now)
         trigger = patrol.fetch("trigger", "continuous").to_s
-        unless patrol["enabled"] == true
+        unless patrol["enabled"] == true &&
+               Hive::Workflows.coding_id?(cfg["default_workflow"])
           return Hive::Patrol::DecisionProjection.schedule_input(
             enabled: false,
             trigger: trigger,

--- a/lib/hive/daemon/refactor_patrol_merge_reconciler.rb
+++ b/lib/hive/daemon/refactor_patrol_merge_reconciler.rb
@@ -14,6 +14,7 @@ require "hive/refactor_patrol/job_store"
 require "hive/refactor_patrol/github_gateway"
 require "hive/refactor_patrol/policy"
 require "hive/refactor_patrol/pr_manifest_resolver"
+require "hive/workflows"
 
 module Hive
   module Daemon
@@ -635,7 +636,9 @@ module Hive
       end
 
       def intake_enabled?(cfg)
-        cfg.dig("daemon", "enabled") == true && cfg.dig("refactor_patrol", "enabled") == true
+        cfg.dig("daemon", "enabled") == true &&
+          Hive::Workflows.coding_id?(cfg["default_workflow"]) &&
+          cfg.dig("refactor_patrol", "enabled") == true
       end
 
       def default_branch(cfg)

--- a/lib/hive/daemon/refactor_patrol_scheduler.rb
+++ b/lib/hive/daemon/refactor_patrol_scheduler.rb
@@ -24,6 +24,7 @@ require "hive/modules/migration/evidence_store"
 require "hive/modules/migration/patrols"
 require "hive/patrol/token_budget"
 require "hive/workflow_package/canonical_json"
+require "hive/workflows"
 
 module Hive
   module Daemon
@@ -248,6 +249,7 @@ module Hive
           raise ReservationBlocked.new("project_config_unavailable", evidence)
         end
         enabled = cfg.dig("daemon", "enabled") == true &&
+                  Hive::Workflows.coding_id?(cfg["default_workflow"]) &&
                   (phase == :action || cfg.dig("refactor_patrol", "enabled") == true)
         unless enabled
           raise ReservationBlocked.new("architecture_patrol_disabled")
@@ -515,6 +517,7 @@ module Hive
 
           cfg = @config_loader.call(entry.fetch("path"))
           next unless cfg.dig("daemon", "enabled") == true
+          next unless Hive::Workflows.coding_id?(cfg["default_workflow"])
 
           entry.merge("_refactor_patrol_cfg" => cfg)
         rescue StandardError => e

--- a/lib/hive/refactor_patrol/repository_ownership.rb
+++ b/lib/hive/refactor_patrol/repository_ownership.rb
@@ -2,6 +2,7 @@ require "hive/config"
 require "hive/gh"
 require "hive/refactor_patrol/job_store"
 require "hive/refactor_patrol/publication_attempt"
+require "hive/workflows"
 require "uri"
 
 module Hive
@@ -150,7 +151,9 @@ module Hive
           )
         end
 
-        if cfg.dig("refactor_patrol", "enabled") == true
+        if !Hive::Workflows.coding_id?(cfg.dig("default_workflow"))
+          decision(:blocked, "architecture_patrol_disabled")
+        elsif cfg.dig("refactor_patrol", "enabled") == true
           decision(:full)
         elsif continuation
           decision(:continuation_only, "architecture_patrol_disabled")
@@ -210,7 +213,10 @@ module Hive
           unresolved << registration_evidence(entry).merge("error" => "#{e.class}: #{e.message}")
           nil
         end
-        enabled = configured.select { |_entry, cfg| cfg.dig("refactor_patrol", "enabled") == true }
+        enabled = configured.select do |_entry, cfg|
+          Hive::Workflows.coding_id?(cfg.dig("default_workflow")) &&
+            cfg.dig("refactor_patrol", "enabled") == true
+        end
         [ enabled, unresolved, registered, configured ]
       rescue StandardError => e
         unresolved << registration_evidence(target).merge("error" => "#{e.class}: #{e.message}")

--- a/test/integration/patrol_command_test.rb
+++ b/test/integration/patrol_command_test.rb
@@ -1207,6 +1207,25 @@ class PatrolCommandTest < Minitest::Test
     end
   end
 
+  def test_non_coding_default_workflow_rejects_manual_patrol
+    with_patrol_project do |repo|
+      config_path = File.join(repo, ".hive-state", "config.yml")
+      cfg = YAML.safe_load(File.read(config_path))
+      cfg["default_workflow"] = "content"
+      File.write(config_path, cfg.to_yaml)
+
+      out, err, status = with_captured_exit do
+        command_for(dry_run: true).call
+      end
+      payload = JSON.parse(out)
+
+      assert_equal Hive::ExitCodes::CONFIG, status
+      assert_match(/non-coding default_workflow "content"/, err)
+      assert_equal "config", payload.fetch("error_kind")
+      refute Dir.exist?(File.join(repo, ".hive-state", "patrol", "runs"))
+    end
+  end
+
   def test_non_json_success_and_internal_error_payload
     with_patrol_project do
       out, _err, status = with_captured_exit do

--- a/test/integration/refactor_patrol_command_test.rb
+++ b/test/integration/refactor_patrol_command_test.rb
@@ -1257,6 +1257,24 @@ class RefactorPatrolCommandTest < Minitest::Test
     end
   end
 
+  def test_non_coding_default_workflow_rejects_architecture_patrol_execution
+    with_refactor_patrol_project do |repo|
+      config_path = File.join(repo, ".hive-state", "config.yml")
+      cfg = YAML.safe_load(File.read(config_path))
+      cfg["default_workflow"] = "content"
+      File.write(config_path, cfg.to_yaml)
+
+      out, err, status = with_captured_exit do
+        command_for(features: []).call
+      end
+      payload = JSON.parse(out)
+
+      assert_equal Hive::ExitCodes::CONFIG, status
+      assert_match(/non-coding default_workflow "content"/, err)
+      assert_equal "config", payload.fetch("error_kind")
+    end
+  end
+
   def test_review_errors_do_not_advance_last_scanned_sha
     with_refactor_patrol_project do |repo|
       state_dir = File.join(repo, ".hive-state", "refactor_patrol")
@@ -1715,6 +1733,7 @@ class RefactorPatrolCommandTest < Minitest::Test
       config_path = File.join(repo, ".hive-state", "config.yml")
       raw = YAML.safe_load(File.read(config_path))
       raw.fetch("refactor_patrol")["enabled"] = false
+      raw["default_workflow"] = "content"
       File.write(config_path, raw.to_yaml)
       v2_root = File.join(repo, ".hive-state", "refactor_patrol", "v2")
       v2_jobs = File.join(v2_root, "jobs")

--- a/test/unit/agent_skills/inspector_test.rb
+++ b/test/unit/agent_skills/inspector_test.rb
@@ -548,6 +548,25 @@ class AgentSkillsInspectorTest < Minitest::Test
     assert_raises(Hive::ConfigError) { resolver.resolve(skills: [ "ghost-skill" ]) }
   end
 
+  def test_target_resolver_omits_patrol_reviewers_for_non_coding_workflows
+    cfg = config
+    cfg["default_workflow"] = "content"
+    cfg["patrol"] = {
+      "enabled" => true,
+      "review" => {
+        "reviewers" => [
+          { "name" => "native", "kind" => "codex_review", "agent" => "codex", "skill" => "" }
+        ]
+      }
+    }
+
+    targets = Hive::AgentSkills::TargetResolver.new(
+      config: cfg, project_root: "/tmp/project"
+    ).resolve
+
+    refute targets.any? { |target| target.surfaces.any? { |surface| surface.start_with?("patrol.") } }
+  end
+
   def test_target_resolver_rejects_a_prerequisite_without_an_agent_capability
     package = Struct.new(:prerequisites).new([ "missing-package" ])
     manifest = Object.new

--- a/test/unit/daemon/patrol_scheduler_test.rb
+++ b/test/unit/daemon/patrol_scheduler_test.rb
@@ -226,6 +226,34 @@ class HiveDaemonPatrolSchedulerTest < Minitest::Test
     end
   end
 
+  def test_non_coding_default_workflow_is_ineligible_even_when_patrol_is_enabled
+    with_tmp_dir do |dir|
+      cfg = enabled_cfg("default_workflow" => "content")
+      git = CountingGit.new
+
+      assert_empty scheduler(project_entry(dir), cfg, git: git).candidates(now: T0)
+      assert_equal 0, git.rev_parse_calls,
+                   "an ineligible workflow must stop before repository inspection"
+    end
+  end
+
+  def test_reservation_rechecks_non_coding_workflow_eligibility
+    with_tmp_dir do |dir|
+      entry = project_entry(dir)
+      cfg = enabled_cfg
+      sched = Hive::Daemon::PatrolScheduler.new(
+        registry: -> { [ entry ] },
+        config_loader: ->(_path) { cfg },
+        git: FakeGit.new
+      )
+      candidate = sched.candidates(now: T0).fetch(0)
+      cfg = enabled_cfg("default_workflow" => "content")
+
+      assert_nil sched.reserve(candidate, now: T0)
+      refute sched.pending?(entry.fetch("name"))
+    end
+  end
+
   def test_timer_mode_honors_interval
     with_tmp_dir do |dir|
       cfg = enabled_cfg("patrol" => {

--- a/test/unit/daemon/refactor_patrol_merge_reconciler_test.rb
+++ b/test/unit/daemon/refactor_patrol_merge_reconciler_test.rb
@@ -162,6 +162,18 @@ class HiveDaemonRefactorPatrolMergeReconcilerTest < Minitest::Test
     end
   end
 
+  def test_non_coding_default_workflow_never_starts_merge_intake
+    with_tmp_dir do |dir|
+      gh = FakeGh.new
+      cfg = enabled_cfg.merge("default_workflow" => "content")
+
+      assert_empty reconciler(dir, gh, cfg: cfg).tick(now: T0)
+      assert_empty gh.identity_calls
+      assert_empty gh.page_calls
+      refute File.exist?(state_path(dir))
+    end
+  end
+
   def test_first_enable_blocks_when_active_overlap_itself_exceeds_search_cap
     with_tmp_dir do |dir|
       gh = FakeGh.new

--- a/test/unit/daemon/refactor_patrol_scheduler_test.rb
+++ b/test/unit/daemon/refactor_patrol_scheduler_test.rb
@@ -963,6 +963,27 @@ class HiveDaemonRefactorPatrolSchedulerTest < Minitest::Test
     end
   end
 
+  def test_non_coding_default_workflow_blocks_discovery_and_reservation
+    with_project do |_dir, entry, store|
+      enqueue(store)
+      cfg = enabled_cfg.merge("default_workflow" => "content")
+      scheduler = Hive::Daemon::RefactorPatrolScheduler.new(
+        registry: -> { [ entry ] }, config_loader: ->(_path) { cfg },
+        job_store_factory: ->(_path) { store },
+        repository_resolver: ->(_entry, _cfg) { repository_identity },
+        checkout_guard_factory: ->(*) { Guard.new }, owner: "daemon-a"
+      )
+
+      assert_empty scheduler.candidates(now: T0)
+      aggregate = store.read_job("job-7")
+      candidate = scheduler.send(:candidate_for, entry, aggregate, phase: :discovery)
+      error = assert_raises(Hive::Daemon::RefactorPatrolScheduler::ReservationBlocked) do
+        scheduler.reserve(candidate, now: T0)
+      end
+      assert_equal "architecture_patrol_disabled", error.reason
+    end
+  end
+
   def test_candidate_store_failure_is_reported_as_scheduler_error
     with_tmp_dir do |dir|
       entry = entry(dir, "demo")

--- a/test/unit/refactor_patrol/repository_ownership_test.rb
+++ b/test/unit/refactor_patrol/repository_ownership_test.rb
@@ -357,6 +357,22 @@ class RefactorPatrolRepositoryOwnershipTest < Minitest::Test
     end
   end
 
+  def test_non_coding_registration_cannot_continue_architecture_patrol
+    with_tmp_dir do |dir|
+      guard = guard_for(
+        [ entry("demo", dir) ], identities: { dir => identity("acme/demo", "github.com") }
+      )
+      cfg = config(enabled: true).merge("default_workflow" => "content")
+
+      decision = guard.call(
+        entry: entry("demo", dir), cfg: cfg, continuation: true
+      )
+
+      assert decision.blocked?
+      assert_equal "architecture_patrol_disabled", decision.reason
+    end
+  end
+
   def test_unexpected_authority_evaluation_failure_is_reported
     with_tmp_dir do |dir|
       target = entry("demo", dir)

--- a/wiki/commands/patrol.md
+++ b/wiki/commands/patrol.md
@@ -19,6 +19,11 @@ hive patrol my-project --json
 
 `PROJECT` is a registered project name from the global config. The project must opt in through `<project>/.hive-state/config.yml`:
 
+The project's resolved `default_workflow` must also be `coding`. Patrol opens
+code-fix PRs and synthetic coding review tasks, so Hive rejects manual runs and
+daemon scheduling for non-coding defaults even if their stale configuration
+still says Patrol is enabled.
+
 ```yaml
 patrol:
   enabled: true

--- a/wiki/commands/refactor-patrol.md
+++ b/wiki/commands/refactor-patrol.md
@@ -50,6 +50,11 @@ init can resolve the whole architecture-patrol choice before any project-state w
 with `hive init --refactor-patrol` or `hive init --no-refactor-patrol`;
 omitting both keeps the enabled default.
 
+Execution and merged-PR intake additionally require the project's resolved
+`default_workflow` to be `coding`. Non-coding defaults cannot discover or act
+even when stale configuration leaves `refactor_patrol.enabled: true`; read-only
+`--list` and `--show` history queries remain available.
+
 ```yaml
 refactor_patrol:
   enabled: true

--- a/wiki/log.d/20260810T110753Z-non-coding-patrol-eligibility.md
+++ b/wiki/log.d/20260810T110753Z-non-coding-patrol-eligibility.md
@@ -1,0 +1,15 @@
+---
+title: Fence repository patrol to coding workflows
+date: 2026-08-10
+---
+
+- Ordinary Patrol and Architecture Patrol now require the registered project's
+  resolved default workflow to be `coding`, regardless of stale enable flags.
+- The daemon stops before repository inspection or merged-PR intake for
+  non-coding defaults, and reservation-time checks prevent a workflow change
+  from racing a queued dispatch.
+- Manual execution is rejected for non-coding projects, while Architecture
+  Patrol's read-only job queries and ordinary receipt-only recovery remain
+  available.
+- Agent skill provisioning no longer includes Patrol reviewers for a
+  non-coding project.

--- a/wiki/modules/patrol.md
+++ b/wiki/modules/patrol.md
@@ -204,6 +204,15 @@ state as proof of completion.
 
 Patrol is **opt-in**. A project with **no patrol section at all** (or a patrol section that omits `mode:`) resolves to `enabled: false` — [[modules/config]] only derives mode knobs when `mode:` is **explicitly present** in the raw config. `medium` is the default offered by the `hive init` *prompt* (which writes an explicit `mode: "medium"` into the rendered template), never a config-resolution default, so legacy projects without a patrol block are never silently enabled.
 
+Repository patrol is also coding-workflow-only. Ordinary scheduling, merged-PR
+architecture intake, architecture discovery/action reservation, and direct
+execution all require the project's resolved `default_workflow` to be
+`coding`; a stale or hand-edited enable flag cannot launch either patrol for
+Writing, Architecture, Bench, or another non-coding default. Architecture
+Patrol's read-only `--list` and `--show` queries remain available so prior
+evidence is not hidden, and ordinary recovery can finish projecting an already
+reserved receipt without starting a new repository scan.
+
 Operators normally configure scheduling through `patrol.mode`, which [[modules/config]] resolves into cadence plus token, launch, native budget-equivalent, and per-launch token ceilings before the daemon sees the project config. `ultrapatrol`, `high`, `medium`, and `low` deliberately receive progressively smaller envelopes as cadence falls; `off` resolves to `enabled: false`. Measured input and output from both ordinary and architecture stages share the same project/day total; cached counts remain visible but uncharged. Ordinary fix stages apply `fix_budget_multiplier` (default `2`) only to their streamed per-agent cap so editing and proof do not consume review capacity; ordinary cycle/day token and launch limits remain unchanged. Architecture stages apply `architecture_budget_multiplier` (default `2`) to cycle token/launch limits and the streamed per-agent token cap, not the native budget-equivalent guard. Architecture stages ignore `max_agent_spawns_per_day`; reviews instead stop at `max_architecture_review_spawns_per_day` (default `8`) while architecture fixes remain eligible. Their multiplied per-cycle launch bound, shared daily token pool, per-agent cap, advisory lock, and native guard remain active. The two multipliers do not compound for architecture fixes. Unmetered architecture children also consume the separate `max_architecture_unmetered_spawns_per_day` safety ceiling (default `96`), preventing an accounting failure from bypassing durable limits across scheduler cycles. Explicit granular knobs always win over a set mode and survive the deep-merge even when no `mode:` is set.
 
 Each patrol launch also needs enough remaining allowance for its profile's


### PR DESCRIPTION
## Summary

- Prevent ordinary Patrol and Architecture Patrol from launching for projects whose resolved `default_workflow` is not `coding`, even when stale configuration still enables them.
- Enforce the boundary for manual commands, daemon scheduling and reservation, merged-PR intake, repository ownership, and Patrol reviewer skill provisioning.
- Keep Architecture Patrol history queries and ordinary receipt-only recovery available so the policy does not hide evidence or discard an already-reserved result.

## Test plan

- [x] Focused Patrol command, scheduler, ownership, reconciliation, and skill-resolution tests: 279 runs, 1,670 assertions, 0 failures, 0 errors
- [x] Managed wiki log validation: 7 runs, 27 assertions, 0 failures
- [ ] `bundle exec rake test` broad local checkpoint (the locked local bundle does not provide the `rake` executable; hosted CI owns this gate)
- [ ] Hosted CI coverage and dedicated merge gates green

## Notes for reviewer

Read-only `hive refactor-patrol --list` and `--show` remain valid for non-coding projects. Ordinary Patrol may only finish projecting a durable receipt that was reserved before the workflow changed; it cannot start a new repository scan.
