### PR TITLE
fix(workflows): enforce bounded managed read roots

### DIFF
--- a/lib/hive/workflow_package/runtime_policy.rb
+++ b/lib/hive/workflow_package/runtime_policy.rb
@@ -197,15 +197,13 @@ module Hive
         # Yolo is already the explicit unbounded trust preset. Preserve the
         # caller's declared project/worktree roots as runner context so agents
         # such as Codex do not mistake an authorized target for an out-of-scope
-        # workspace. Portable non-yolo actors keep these roots read-only below.
+        # workspace. Bounded actors receive only roots declared by their own
+        # permission spec through scope.add_dirs_extra.
         if scope.yolo?
           directories = (directories + trusted_actor_read_roots(base_add_dirs)).uniq
         end
         child_environment = actor_environment(environment)
         if profile.name != :claude && !scope.yolo?
-          directories = (
-            directories + trusted_actor_read_roots(base_add_dirs)
-          ).uniq
           return compile_portable_actor(
             parsed, scope: scope, task_root: task_root,
             directories: directories, profile: profile, environment: child_environment,
@@ -279,6 +277,16 @@ module Hive
         unless %i[codex grok].include?(profile.name)
           raise Hive::ConfigError,
                 "runner #{profile.name.inspect} cannot enforce managed workflow policy"
+        end
+
+        path_read_rules = Array(parsed_spec["tools"]).filter_map do |rule|
+          match = Hive::PermissionScope::TOOL_RULE_PATTERN.match(rule.to_s.strip)
+          rule if match && match[:tool] == "Read" && match[:specifier]
+        end
+        unless path_read_rules.empty?
+          raise Hive::ConfigError,
+                "runner #{profile.name.inspect} cannot enforce path-qualified Read rules " \
+                "#{path_read_rules.inspect}"
         end
 
         tool_names = Array(scope.allowed_tools).flat_map do |rule|

--- a/test/unit/stages/agent_test.rb
+++ b/test/unit/stages/agent_test.rb
@@ -958,7 +958,7 @@ class StagesAgentTest < Minitest::Test
     end
   end
 
-  def test_managed_worktree_base_dirs_reach_portable_runtime_read_policy
+  def test_managed_worktree_base_dirs_do_not_widen_bounded_portable_runtime_policy
     with_tmp_git_repo do |project|
       package_root = File.join(
         project, ".hive-state", "workflows", "demo", "versions", "a" * 40
@@ -1005,9 +1005,9 @@ class StagesAgentTest < Minitest::Test
       end
 
       resolved_worktree = File.realpath(project)
-      assert_includes policy.directories, resolved_worktree
+      refute_includes policy.directories, resolved_worktree
       filesystem_flag = policy.cli_flags.find { |flag| flag.include?("filesystem=") }
-      assert_includes filesystem_flag, "#{JSON.generate(resolved_worktree)}=\"read\""
+      refute_includes filesystem_flag, JSON.generate(resolved_worktree)
     ensure
       policy&.cleanup!
     end

--- a/test/unit/workflow_package/runtime_policy_test.rb
+++ b/test/unit/workflow_package/runtime_policy_test.rb
@@ -664,7 +664,7 @@ class WorkflowPackageRuntimePolicyTest < Minitest::Test
     reset_codex_executable_cache
   end
 
-  def test_scoped_codex_actor_adds_trusted_caller_roots_as_read_only_without_expanding_outputs
+  def test_scoped_codex_actor_uses_only_descriptor_declared_read_roots
     with_tmp_dir do |dir|
       task = File.join(dir, "task")
       package = File.join(dir, "package")
@@ -687,10 +687,28 @@ class WorkflowPackageRuntimePolicyTest < Minitest::Test
       end
 
       resolved_worktree = File.realpath(worktree)
-      assert_includes policy.directories, resolved_worktree
+      refute_includes policy.directories, resolved_worktree
       filesystem_flag = policy.cli_flags.find { |flag| flag.include?("filesystem=") }
-      assert_includes filesystem_flag, "#{JSON.generate(resolved_worktree)}=\"read\""
+      refute_includes filesystem_flag, JSON.generate(resolved_worktree)
       assert_equal({ "article.md" => output }, policy.output_paths)
+
+      declared = with_env("HIVE_CODEX_BIN" => "/bin/true") do
+        Hive::WorkflowPackage::RuntimePolicy.compile_actor(
+          {
+            "preset" => "scoped",
+            "tools" => [ "Read", "Edit(./article.md)" ],
+            "dirs" => [ worktree ]
+          },
+          task_folder: task,
+          package_root: package,
+          profile: Hive::AgentProfiles.lookup(:codex),
+          base_add_dirs: [ worktree ],
+          managed_outputs: [ output ]
+        )
+      end
+      assert_includes declared.directories, resolved_worktree
+      declared_flag = declared.cli_flags.find { |flag| flag.include?("filesystem=") }
+      assert_includes declared_flag, "#{JSON.generate(resolved_worktree)}=\"read\""
 
       error = assert_raises(Hive::ConfigError) do
         with_env("HIVE_CODEX_BIN" => "/bin/true") do
@@ -710,6 +728,36 @@ class WorkflowPackageRuntimePolicyTest < Minitest::Test
       assert_includes error.message, "escapes the task folder"
     ensure
       policy&.cleanup!
+      declared&.cleanup!
+    end
+  end
+
+  def test_networked_bounded_portable_actors_do_not_inherit_project_root
+    with_tmp_dir do |dir|
+      task = File.join(dir, "task")
+      package = File.join(dir, "package")
+      project = File.join(dir, "project")
+      FileUtils.mkdir_p([ task, package, project ])
+      spec = {
+        "preset" => "scoped",
+        "tools" => [ "Read", "Edit(./web-research.md)", "WebSearch", "WebFetch" ]
+      }
+
+      %i[codex grok].each do |profile_name|
+        policy = Hive::WorkflowPackage::RuntimePolicy.compile_actor(
+          spec,
+          task_folder: task,
+          package_root: package,
+          profile: Hive::AgentProfiles.lookup(profile_name),
+          base_add_dirs: [ project ],
+          managed_outputs: [ File.join(task, "web-research.md") ],
+          prepare: false
+        )
+
+        assert_equal [ File.realpath(task), File.realpath(package) ], policy.directories,
+                     profile_name
+        refute_includes policy.directories, File.realpath(project), profile_name
+      end
     end
   end
 
@@ -736,7 +784,7 @@ class WorkflowPackageRuntimePolicyTest < Minitest::Test
     end
   end
 
-  def test_portable_actor_rejects_unavailable_or_non_directory_trusted_caller_roots
+  def test_yolo_actor_rejects_unavailable_or_non_directory_trusted_caller_roots
     with_tmp_dir do |dir|
       task = File.join(dir, "task")
       package = File.join(dir, "package")
@@ -748,7 +796,7 @@ class WorkflowPackageRuntimePolicyTest < Minitest::Test
         error = assert_raises(Hive::ConfigError) do
           with_env("HIVE_CODEX_BIN" => "/bin/true") do
             Hive::WorkflowPackage::RuntimePolicy.compile_actor(
-              "read-only",
+              "yolo",
               task_folder: task,
               package_root: package,
               profile: Hive::AgentProfiles.lookup(:codex),
@@ -945,7 +993,7 @@ class WorkflowPackageRuntimePolicyTest < Minitest::Test
     end
   end
 
-  def test_portable_admission_and_trusted_roots_fail_closed_without_preparing_a_runtime
+  def test_portable_admission_and_yolo_roots_fail_closed_without_preparing_a_runtime
     with_tmp_dir do |dir|
       task = File.join(dir, "task")
       package = File.join(dir, "package")
@@ -968,7 +1016,7 @@ class WorkflowPackageRuntimePolicyTest < Minitest::Test
       [ "not-an-array", [ "" ], [ "bad\0root" ] ].each do |roots|
         error = assert_raises(Hive::ConfigError) do
           Hive::WorkflowPackage::RuntimePolicy.compile_actor(
-            "read-only",
+            "yolo",
             task_folder: task,
             package_root: package,
             profile: Hive::AgentProfiles.lookup(:codex),
@@ -1019,6 +1067,22 @@ class WorkflowPackageRuntimePolicyTest < Minitest::Test
         )
       end
       assert_includes error.message, "path-qualified Edit"
+
+      %i[codex grok].each do |profile_name|
+        error = assert_raises(Hive::ConfigError) do
+          Hive::WorkflowPackage::RuntimePolicy.compile_actor(
+            {
+              "preset" => "scoped",
+              "tools" => [ "Read(./brief.md)", "WebSearch", "WebFetch", "Edit(./result.md)" ]
+            },
+            task_folder: task,
+            package_root: package,
+            profile: Hive::AgentProfiles.lookup(profile_name),
+            prepare: false
+          )
+        end
+        assert_includes error.message, "cannot enforce path-qualified Read", profile_name
+      end
     end
   end
 
@@ -1311,7 +1375,8 @@ class WorkflowPackageRuntimePolicyTest < Minitest::Test
           Hive::WorkflowPackage::RuntimePolicy.compile_actor(
             {
               "preset" => "scoped",
-              "tools" => [ "Read", "LS", "Grep", "Glob", "Edit(./reviews/**)" ]
+              "tools" => [ "Read", "LS", "Grep", "Glob", "Edit(./reviews/**)" ],
+              "dirs" => [ worktree ]
             },
             task_folder: task,
             package_root: package,

--- a/wiki/log.d/20260810T202500Z-bounded-managed-read-roots.md
+++ b/wiki/log.d/20260810T202500Z-bounded-managed-read-roots.md
@@ -1,0 +1,9 @@
+# Fence bounded managed actors to declared read roots
+
+- Stopped portable bounded Codex and Grok actors from inheriting the managed
+  task's project root through trusted caller context.
+- Kept task/package roots and descriptor `dirs` available, while explicit
+  `yolo` actors retain their intentional project/worktree context.
+- Rejected portable Codex/Grok mappings for file-qualified `Read(...)` scopes
+  their directory-level sandboxes cannot enforce.
+- Added Codex and Grok policy coverage for undeclared and declared roots.

--- a/wiki/modules/agent_profile.md
+++ b/wiki/modules/agent_profile.md
@@ -212,14 +212,19 @@ generation/selection policy and `Reconstructor` retains recovery policy.
   profile. Bounded Claude mappings keep the native tool policy. Bounded Codex
   mappings use a generated named filesystem permission profile with no shell
   network, MCP servers, apps, plugins, memory, hooks, or subagents. Bounded Grok
-  mappings run the static CLI inside bubblewrap with only declared task,
-  package, and extra read roots mounted. For both portable runners, Hive asks
+  mappings run the static CLI inside bubblewrap with only the task, package,
+  and descriptor-declared extra read roots mounted. Caller context does not
+  widen a bounded actor; only explicit `yolo` inherits the owning project root.
+  For both portable runners, Hive asks
   for schema-constrained file content under a read-only policy and atomically
   writes only descriptor-authorized output paths after validating the complete
   response. Managed launches isolate the environment and inject only values
   authorized for the executing stable slot. The strict Claude MCP isolation
   file carries an explicit empty `mcpServers` object so current Claude Code
-  releases accept the schema while exposing no servers.
+  releases accept the schema while exposing no servers. Portable Codex and
+  Grok mappings reject path-qualified `Read(...)` rules because their current
+  sandboxes cannot enforce file-granular reads without exposing the containing
+  task directory; Claude remains eligible for those slots.
 
 ## Managed skill inspection and provisioning
 


### PR DESCRIPTION
## Summary

- keep bounded Codex and Grok managed actors inside descriptor-declared read roots instead of inheriting the caller project
- reject file-qualified `Read(...)` policies on portable runners that cannot enforce file-granular access
- document and test the boundary through both runtime-policy and managed-worktree execution paths

## Test plan

- [x] `bundle exec ruby -Itest test/unit/stages/agent_test.rb` (69 runs, 307 assertions)
- [x] `bundle exec ruby -Itest test/unit/workflow_package/runtime_policy_test.rb` (41 runs, 284 assertions)
- [x] `ruby -Itest test/unit/permission_scope_test.rb` (30 runs, 323 assertions)
- [x] `ruby -Itest test/unit/workflow_package/permission_projection_test.rb` (6 runs, 24 assertions)
- [ ] hosted CI coverage and dedicated merge gates green

## Notes for reviewer

The broad local checkpoint ran 12,347 tests and exposed one outdated expectation owned by this change; that expectation is corrected and its full test file is green above. The remaining six failures/errors are an existing local Ruby 3.4 fixture issue: scrubbed provider subprocesses cannot load the `base64` default gem. The same narrow provider failures reproduce in the pre-existing checkout.

Explicit `yolo` actors still inherit the owning project root. Bounded actors that need repository access must declare it with descriptor `dirs`.
