### PR TITLE
fix(test): clean temporary directories reliably

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,7 @@ require "rake/testtask"
 require "fileutils"
 require "securerandom"
 require_relative "test/support/coverage"
+require_relative "test/support/tmp_cleanup"
 
 # These expensive outer proofs are intentionally separate from the normal local
 # suite. CI runs them as named merge gates.
@@ -161,29 +162,23 @@ namespace :test do
     t.description = "Run Telegram bot eval harness tests"
   end
 
-  desc "Remove leaked hive test tmp dirs (system tmpdir + legacy ~/Dev/hive-test*.worktrees)"
+  desc "Remove stale, inactive Hive test tmp dirs"
   task :clean_tmp do
-    require "tmpdir"
-    # Only sweep the unmistakably hive-owned prefixes the test helpers
-    # create (`Dir.mktmpdir("hive-test")` / `"hive-global"` /
-    # `"hive-test-wtbase"` and the `*.origin.git` siblings under them).
-    # A crashed test or a sibling bare repo can outlive its `ensure`, so
-    # this is the manual broom.
-    #
-    # The `~/Dev/hive-test*.worktrees` glob mops up the legacy real-home
-    # leak: before HIVE_WORKTREE_BASE existed, the default worktree root
-    # fell back to `~/Dev/<project>.worktrees`, and test projects named
-    # `hive-test<...>` seeded thousands of dirs in the developer's real
-    # ~/Dev. The `hive-test` prefix cannot match the production
-    # `~/Dev/hive.worktrees` root, so it stays untouched.
-    globs = [
-      File.join(Dir.tmpdir, "hive-test*"),
-      File.join(Dir.tmpdir, "hive-global*"),
-      File.expand_path("~/Dev/hive-test*.worktrees")
-    ]
-    stale = globs.flat_map { |glob| Dir.glob(glob) }.uniq
-    stale.each { |path| FileUtils.rm_rf(path) }
-    puts "Removed #{stale.size} stale hive test dir(s) (#{Dir.tmpdir} + ~/Dev legacy worktree leak)"
+    min_age_seconds = Integer(
+      ENV.fetch("HIVE_TEST_TMP_MIN_AGE_SECONDS", HiveTestTmpCleanup::DEFAULT_MIN_AGE_SECONDS.to_s),
+      10
+    )
+    result = HiveTestTmpCleanup.sweep(min_age_seconds: min_age_seconds)
+
+    puts "Removed #{result.removed.size} stale Hive test dir(s); " \
+         "skipped #{result.skipped_live.size} live, " \
+         "#{result.skipped_recent.size} recent, and " \
+         "#{result.skipped_unowned.size} unowned"
+
+    next if result.failed.empty?
+
+    result.failed.each { |failure| warn "Cleanup failed for #{failure.fetch(:path)}: #{failure.fetch(:error)}" }
+    raise "Failed to remove #{result.failed.size} stale Hive test dir(s)"
   end
 end
 

--- a/test/support/tmp_cleanup.rb
+++ b/test/support/tmp_cleanup.rb
@@ -1,0 +1,176 @@
+require "fileutils"
+require "tmpdir"
+
+module HiveTestTmpCleanup
+  DEFAULT_MIN_AGE_SECONDS = 24 * 60 * 60
+
+  # These are test-only names created by test/test_helper.rb or by the few
+  # tests that need a source tree to outlive the statement that creates it.
+  # Keep this narrower than `hive-*`: production code also uses Dir.tmpdir.
+  TMP_BASE_SOURCE = /(?:
+    hive-test[a-z0-9_-]* |
+    hive-global[a-z0-9_-]* |
+    hive-web-(?:bad|nested|no-gemfile|src) |
+    hive-noapp |
+    hive-pairing-command
+  )(?<date>\d{8})-(?<pid>\d+)-[a-z0-9]+/x.source.freeze
+  TMP_RELATED_SUFFIX_SOURCE = /(?:-worktrees|\.origin\.git|\.patrol-[0-9a-f]+\.lock)/.source.freeze
+  TMP_BASE_PATTERN = /\A#{TMP_BASE_SOURCE}\z/x.freeze
+  TMP_ENTRY_PATTERN = /\A#{TMP_BASE_SOURCE}(?:#{TMP_RELATED_SUFFIX_SOURCE})?\z/x.freeze
+  LEGACY_WORKTREE_PATTERN = /\Ahive-test[a-z0-9_-]*\d{8}-(?<pid>\d+)-[a-z0-9]+\.worktrees\z/.freeze
+
+  SweepResult = Data.define(:removed, :skipped_live, :skipped_recent, :skipped_unowned, :failed)
+
+  class UnsafePath < StandardError; end
+  class CleanupError < StandardError; end
+
+  module_function
+
+  def remove!(path, root: Dir.tmpdir, pattern: TMP_ENTRY_PATTERN)
+    target = File.expand_path(path)
+    root = File.expand_path(root)
+    basename = File.basename(target)
+
+    unless File.dirname(target) == root && pattern.match?(basename)
+      raise UnsafePath, "refusing to remove non-test tmp path: #{target}"
+    end
+
+    return false unless File.exist?(target) || File.symlink?(target)
+
+    stat = File.lstat(target)
+    unless stat.uid == Process.uid
+      raise UnsafePath, "refusing to remove test tmp path owned by uid #{stat.uid}: #{target}"
+    end
+
+    # remove_entry_secure repairs directory permissions while walking a sticky
+    # world-writable tmpdir. Ruby falls back to plain removal for a private
+    # TMPDIR (and for the legacy ~/Dev root), so make owned directories writable
+    # there first. Plain rm_rf silently leaves the 0555/0444 trees produced by
+    # managed-package tests.
+    parent_stat = File.stat(root)
+    if stat.directory? && !parent_stat.world_writable?
+      FileUtils.chmod_R(0o700, target, force: true)
+    end
+    FileUtils.rm_rf(target, secure: true)
+    if File.exist?(target) || File.symlink?(target)
+      raise CleanupError, "test tmp path still exists after removal: #{target}"
+    end
+
+    true
+  end
+
+  def remove_all!(paths)
+    failures = Array(paths).compact.reverse_each.filter_map do |path|
+      remove_with_related!(path)
+      nil
+    rescue StandardError => e
+      "#{path}: #{e.class}: #{e.message}"
+    end
+    return if failures.empty?
+
+    raise CleanupError, "failed to remove tracked test tmp paths:\n#{failures.join("\n")}"
+  end
+
+  def remove_with_related!(path, root: Dir.tmpdir)
+    target = File.expand_path(path)
+    root = File.expand_path(root)
+    basename = File.basename(target)
+    unless File.dirname(target) == root && TMP_BASE_PATTERN.match?(basename)
+      raise UnsafePath, "refusing to remove related paths for non-test tmp path: #{target}"
+    end
+
+    related = if Dir.exist?(root)
+      Dir.children(root).filter_map do |entry|
+        suffix = entry.delete_prefix(basename)
+        next if suffix == entry || !/\A#{TMP_RELATED_SUFFIX_SOURCE}\z/.match?(suffix)
+
+        File.join(root, entry)
+      end
+    else
+      []
+    end
+
+    failures = (related + [ target ]).filter_map do |entry|
+      remove!(entry, root: root)
+      nil
+    rescue StandardError => e
+      "#{entry}: #{e.class}: #{e.message}"
+    end
+    return if failures.empty?
+
+    raise CleanupError, "failed to remove test tmp path family:\n#{failures.join("\n")}"
+  end
+
+  def sweep(tmp_root: Dir.tmpdir, legacy_root: File.expand_path("~/Dev"),
+            min_age_seconds: DEFAULT_MIN_AGE_SECONDS, now: Time.now,
+            process_alive: method(:process_alive?))
+    min_age_seconds = Integer(min_age_seconds)
+    raise ArgumentError, "min_age_seconds must be non-negative" if min_age_seconds.negative?
+
+    candidates = candidates_under(tmp_root, TMP_ENTRY_PATTERN)
+    if legacy_root && Dir.exist?(legacy_root)
+      candidates.concat(candidates_under(legacy_root, LEGACY_WORKTREE_PATTERN))
+    end
+
+    removed = []
+    skipped_live = []
+    skipped_recent = []
+    skipped_unowned = []
+    failed = []
+
+    candidates.uniq.each do |candidate|
+      path = candidate.fetch(:path)
+      stat = File.lstat(path)
+      if stat.uid != Process.uid
+        skipped_unowned << path
+      elsif process_alive.call(candidate.fetch(:pid))
+        skipped_live << path
+      elsif stat.mtime > now - min_age_seconds
+        skipped_recent << path
+      else
+        remove!(path, root: candidate.fetch(:root), pattern: candidate.fetch(:pattern))
+        removed << path
+      end
+    rescue Errno::ENOENT
+      # A concurrently finishing test removed its own directory.
+      next
+    rescue StandardError => e
+      failed << { path: path, error: "#{e.class}: #{e.message}" }
+    end
+
+    SweepResult.new(
+      removed: removed.freeze,
+      skipped_live: skipped_live.freeze,
+      skipped_recent: skipped_recent.freeze,
+      skipped_unowned: skipped_unowned.freeze,
+      failed: failed.freeze
+    )
+  end
+
+  def process_alive?(pid)
+    Process.kill(0, Integer(pid))
+    true
+  rescue ArgumentError, TypeError, Errno::ESRCH
+    false
+  rescue Errno::EPERM
+    true
+  end
+
+  def candidates_under(root, pattern)
+    root = File.expand_path(root)
+    return [] unless Dir.exist?(root)
+
+    Dir.children(root).filter_map do |basename|
+      match = pattern.match(basename)
+      next unless match
+
+      {
+        path: File.join(root, basename),
+        root: root,
+        pattern: pattern,
+        pid: Integer(match[:pid])
+      }
+    end
+  end
+  private_class_method :candidates_under
+end

--- a/test/support/tmp_cleanup.rb
+++ b/test/support/tmp_cleanup.rb
@@ -14,7 +14,10 @@ module HiveTestTmpCleanup
     hive-noapp |
     hive-pairing-command
   )(?<date>\d{8})-(?<pid>\d+)-[a-z0-9]+/x.source.freeze
-  TMP_RELATED_SUFFIX_SOURCE = /(?:-worktrees|\.origin\.git|\.patrol-[0-9a-f]+\.lock)/.source.freeze
+  # Test helpers create a small set of sibling repositories/worktree roots
+  # beside their generated project root. Keep this list explicit: the cleanup
+  # boundary must grow only when a concrete test fixture shape needs it.
+  TMP_RELATED_SUFFIX_SOURCE = /(?:-worktrees|\.(?:managed-)?worktrees|\.(?:strict-|agent-worktree-)?origin\.git|\.patrol-[0-9a-f]+\.lock)/.source.freeze
   TMP_BASE_PATTERN = /\A#{TMP_BASE_SOURCE}\z/x.freeze
   TMP_ENTRY_PATTERN = /\A#{TMP_BASE_SOURCE}(?:#{TMP_RELATED_SUFFIX_SOURCE})?\z/x.freeze
   LEGACY_WORKTREE_PATTERN = /\Ahive-test[a-z0-9_-]*\d{8}-(?<pid>\d+)-[a-z0-9]+\.worktrees\z/.freeze
@@ -150,7 +153,7 @@ module HiveTestTmpCleanup
   def process_alive?(pid)
     Process.kill(0, Integer(pid))
     true
-  rescue ArgumentError, TypeError, Errno::ESRCH
+  rescue ArgumentError, TypeError, RangeError, Errno::ESRCH
     false
   rescue Errno::EPERM
     true

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,6 +20,7 @@ require "stringio"
 require "yaml"
 require "shellwords"
 require "English"
+require_relative "support/tmp_cleanup"
 
 # Never let a normal test subprocess inherit the operator's Hive state, home,
 # XDG roots, agent configuration, GitHub configuration, or global Git config.
@@ -46,7 +47,7 @@ unless ENV["HIVE_TEST_ALLOW_REAL_USER_ENV"] == "1"
     GIT_CONFIG_GLOBAL
   ].each { |key| ENV.delete(key) }
   Minitest.after_run do
-    FileUtils.rm_rf(HIVE_TEST_USER_ROOT)
+    HiveTestTmpCleanup.remove_with_related!(HIVE_TEST_USER_ROOT)
   end
 end
 
@@ -89,12 +90,16 @@ end
 
 # Route the default worktree base (`<base>/<project>.worktrees`) into a
 # tmp sandbox so tests that exercise worktree creation never seed the
-# developer's real ~/Dev. `||=` lets an explicit outer override win, and
-# the `hive-test-wtbase*` name lives under Dir.tmpdir so `rake test:clean_tmp`
-# also sweeps it. Cleaned on suite exit.
-ENV["HIVE_WORKTREE_BASE"] ||= Dir.mktmpdir("hive-test-wtbase")
+# developer's real ~/Dev. An explicit outer override wins and is never added
+# to the cleanup registry. The generated `hive-test-wtbase*` name lives under
+# Dir.tmpdir so `rake test:clean_tmp` also recognizes it after a crashed suite.
+HIVE_TEST_WORKTREE_BASE = if ENV["HIVE_WORKTREE_BASE"]
+  nil
+else
+  Dir.mktmpdir("hive-test-wtbase").tap { |path| ENV["HIVE_WORKTREE_BASE"] = path }
+end
 Minitest.after_run do
-  FileUtils.rm_rf(ENV["HIVE_WORKTREE_BASE"]) if ENV["HIVE_WORKTREE_BASE"]&.include?("hive-test-wtbase")
+  HiveTestTmpCleanup.remove_with_related!(HIVE_TEST_WORKTREE_BASE) if HIVE_TEST_WORKTREE_BASE
 end
 
 if ENV["HIVE_COVERAGE"]
@@ -119,30 +124,43 @@ module HiveTestStdinIsolation
   end
 
   def after_teardown
-    super
-  ensure
-    if defined?(@hive_original_skip_llm_wiki_scheduler)
-      if @hive_original_skip_llm_wiki_scheduler.nil?
-        ENV.delete("HIVE_SKIP_LLM_WIKI_SCHEDULER")
-      else
-        ENV["HIVE_SKIP_LLM_WIKI_SCHEDULER"] = @hive_original_skip_llm_wiki_scheduler
+    teardown_error = nil
+    begin
+      super
+    rescue StandardError => e
+      teardown_error = e
+    ensure
+      begin
+        HiveTestTmpCleanup.remove_all!(@hive_tracked_tmp_dirs)
+      rescue StandardError => e
+        teardown_error ||= e
+      ensure
+        @hive_tracked_tmp_dirs = nil
+        if defined?(@hive_original_skip_llm_wiki_scheduler)
+          if @hive_original_skip_llm_wiki_scheduler.nil?
+            ENV.delete("HIVE_SKIP_LLM_WIKI_SCHEDULER")
+          else
+            ENV["HIVE_SKIP_LLM_WIKI_SCHEDULER"] = @hive_original_skip_llm_wiki_scheduler
+          end
+        end
+        if defined?(@hive_original_skip_llm_wiki_post_commit)
+          if @hive_original_skip_llm_wiki_post_commit.nil?
+            ENV.delete("HIVE_SKIP_LLM_WIKI_POST_COMMIT")
+          else
+            ENV["HIVE_SKIP_LLM_WIKI_POST_COMMIT"] = @hive_original_skip_llm_wiki_post_commit
+          end
+        end
+        if defined?(@hive_original_skip_llm_wiki_systemctl)
+          if @hive_original_skip_llm_wiki_systemctl.nil?
+            ENV.delete("HIVE_SKIP_LLM_WIKI_SYSTEMCTL")
+          else
+            ENV["HIVE_SKIP_LLM_WIKI_SYSTEMCTL"] = @hive_original_skip_llm_wiki_systemctl
+          end
+        end
+        $stdin = @hive_original_stdin if defined?(@hive_original_stdin)
       end
     end
-    if defined?(@hive_original_skip_llm_wiki_post_commit)
-      if @hive_original_skip_llm_wiki_post_commit.nil?
-        ENV.delete("HIVE_SKIP_LLM_WIKI_POST_COMMIT")
-      else
-        ENV["HIVE_SKIP_LLM_WIKI_POST_COMMIT"] = @hive_original_skip_llm_wiki_post_commit
-      end
-    end
-    if defined?(@hive_original_skip_llm_wiki_systemctl)
-      if @hive_original_skip_llm_wiki_systemctl.nil?
-        ENV.delete("HIVE_SKIP_LLM_WIKI_SYSTEMCTL")
-      else
-        ENV["HIVE_SKIP_LLM_WIKI_SYSTEMCTL"] = @hive_original_skip_llm_wiki_systemctl
-      end
-    end
-    $stdin = @hive_original_stdin if defined?(@hive_original_stdin)
+    raise teardown_error if teardown_error
   end
 end
 
@@ -157,6 +175,15 @@ FAKE_CLAUDE_FIXTURE = File.expand_path("fixtures/fake-claude", __dir__).freeze
 
 module HiveTestHelper
   UNSET_ENV = Object.new.freeze
+
+  # Register a tmpdir that must outlive its creating statement. The global
+  # teardown hook removes it securely after the current test, including trees
+  # whose subject changed nested directories/files to 0555/0444.
+  def tracked_tmp_dir(prefix = "hive-test")
+    Dir.mktmpdir(prefix).tap do |path|
+      (@hive_tracked_tmp_dirs ||= []) << path
+    end
+  end
 
   # Temporarily replace `receiver.name` with `replacement` for the duration
   # of the block; restore the original singleton method in `ensure`. Used
@@ -259,13 +286,13 @@ module HiveTestHelper
   # state like `bitmap-ref-tips_*` between scan and unlink, so `Dir.mktmpdir`'s
   # built-in cleanup (which uses `FileUtils.remove_entry`) intermittently
   # raises `Errno::ENOENT` under CI load. Replace the block form with an
-  # explicit ensure that uses `FileUtils.rm_rf`, which tolerates concurrent
-  # disappearance instead of raising.
+  # explicit ensure with verified, race-tolerant cleanup. This also handles
+  # subjects that make managed-package fixture trees read-only.
   def with_tmp_dir
     dir = Dir.mktmpdir("hive-test")
     yield dir
   ensure
-    FileUtils.rm_rf(dir) if dir
+    HiveTestTmpCleanup.remove_with_related!(dir) if dir
   end
 
   def with_tmp_git_repo
@@ -307,10 +334,8 @@ module HiveTestHelper
         yield(dir)
       end
     ensure
-      # Same race-tolerant cleanup as `with_tmp_dir`: tests inside this
-      # tmpdir invoke `hive`/git subprocesses that can leave the tree
-      # mid-rename.
-      FileUtils.rm_rf(dir) if dir
+      # Same verified cleanup as `with_tmp_dir`.
+      HiveTestTmpCleanup.remove_with_related!(dir) if dir
     end
   end
 
@@ -338,10 +363,8 @@ module HiveTestHelper
     ensure
       old_hive_home.nil? ? ENV.delete("HIVE_HOME") : ENV["HIVE_HOME"] = old_hive_home
       old_home.nil? ? ENV.delete("HOME") : ENV["HOME"] = old_home
-      # Same race-tolerant cleanup as `with_tmp_dir`: tests inside this
-      # tmpdir invoke `hive`/git subprocesses that can leave the tree
-      # mid-rename.
-      FileUtils.rm_rf(dir) if dir
+      # Same verified cleanup as `with_tmp_dir`.
+      HiveTestTmpCleanup.remove_with_related!(dir) if dir
     end
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,6 +22,8 @@ require "shellwords"
 require "English"
 require_relative "support/tmp_cleanup"
 
+HIVE_TEST_SUITE_TMP_DIRS = []
+
 # Never let a normal test subprocess inherit the operator's Hive state, home,
 # XDG roots, agent configuration, GitHub configuration, or global Git config.
 # Set only HOME and remove the optional overrides so production defaults keep
@@ -29,6 +31,7 @@ require_relative "support/tmp_cleanup"
 # opt out explicitly because they exercise the operator's real agent login.
 unless ENV["HIVE_TEST_ALLOW_REAL_USER_ENV"] == "1"
   HIVE_TEST_USER_ROOT = Dir.mktmpdir("hive-test-user").freeze
+  HIVE_TEST_SUITE_TMP_DIRS << HIVE_TEST_USER_ROOT
   test_home = File.join(HIVE_TEST_USER_ROOT, "home")
   FileUtils.mkdir_p(test_home)
   ENV["HOME"] = test_home
@@ -46,9 +49,6 @@ unless ENV["HIVE_TEST_ALLOW_REAL_USER_ENV"] == "1"
     GH_CONFIG_DIR
     GIT_CONFIG_GLOBAL
   ].each { |key| ENV.delete(key) }
-  Minitest.after_run do
-    HiveTestTmpCleanup.remove_with_related!(HIVE_TEST_USER_ROOT)
-  end
 end
 
 require "hive"
@@ -98,8 +98,9 @@ HIVE_TEST_WORKTREE_BASE = if ENV["HIVE_WORKTREE_BASE"]
 else
   Dir.mktmpdir("hive-test-wtbase").tap { |path| ENV["HIVE_WORKTREE_BASE"] = path }
 end
+HIVE_TEST_SUITE_TMP_DIRS << HIVE_TEST_WORKTREE_BASE if HIVE_TEST_WORKTREE_BASE
 Minitest.after_run do
-  HiveTestTmpCleanup.remove_with_related!(HIVE_TEST_WORKTREE_BASE) if HIVE_TEST_WORKTREE_BASE
+  HiveTestTmpCleanup.remove_all!(HIVE_TEST_SUITE_TMP_DIRS)
 end
 
 if ENV["HIVE_COVERAGE"]
@@ -180,9 +181,26 @@ module HiveTestHelper
   # teardown hook removes it securely after the current test, including trees
   # whose subject changed nested directories/files to 0555/0444.
   def tracked_tmp_dir(prefix = "hive-test")
-    Dir.mktmpdir(prefix).tap do |path|
-      (@hive_tracked_tmp_dirs ||= []) << path
+    path = Dir.mktmpdir(prefix)
+    unless HiveTestTmpCleanup::TMP_BASE_PATTERN.match?(File.basename(path))
+      FileUtils.remove_entry(path)
+      raise ArgumentError, "tracked_tmp_dir prefix is not a recognized Hive test tmp shape: #{prefix}"
     end
+
+    (@hive_tracked_tmp_dirs ||= []) << path
+    path
+  end
+
+  # A cleanup failure should fail an otherwise-green test, but it must not
+  # replace the assertion or exception that made the test fail in the first
+  # place. `$!` still carries that active exception when an ensure calls here.
+  def cleanup_tmp_dir!(path)
+    active_error = $!
+    HiveTestTmpCleanup.remove_with_related!(path)
+  rescue StandardError => cleanup_error
+    raise cleanup_error unless active_error
+
+    warn "Hive test tmp cleanup also failed: #{cleanup_error.class}: #{cleanup_error.message}"
   end
 
   # Temporarily replace `receiver.name` with `replacement` for the duration
@@ -292,7 +310,7 @@ module HiveTestHelper
     dir = Dir.mktmpdir("hive-test")
     yield dir
   ensure
-    HiveTestTmpCleanup.remove_with_related!(dir) if dir
+    cleanup_tmp_dir!(dir) if dir
   end
 
   def with_tmp_git_repo
@@ -335,7 +353,7 @@ module HiveTestHelper
       end
     ensure
       # Same verified cleanup as `with_tmp_dir`.
-      HiveTestTmpCleanup.remove_with_related!(dir) if dir
+      cleanup_tmp_dir!(dir) if dir
     end
   end
 
@@ -364,7 +382,7 @@ module HiveTestHelper
       old_hive_home.nil? ? ENV.delete("HIVE_HOME") : ENV["HIVE_HOME"] = old_hive_home
       old_home.nil? ? ENV.delete("HOME") : ENV["HOME"] = old_home
       # Same verified cleanup as `with_tmp_dir`.
-      HiveTestTmpCleanup.remove_with_related!(dir) if dir
+      cleanup_tmp_dir!(dir) if dir
     end
   end
 

--- a/test/unit/commands/pairing_test.rb
+++ b/test/unit/commands/pairing_test.rb
@@ -622,7 +622,7 @@ class HiveCommandsPairingTest < Minitest::Test
       args: args,
       json: json,
       output: output,
-      store: store || self.store(Dir.mktmpdir("hive-pairing-command")),
+      store: store || self.store(tracked_tmp_dir("hive-pairing-command")),
       process: process,
       now: now
     }

--- a/test/unit/tmp_cleanup_test.rb
+++ b/test/unit/tmp_cleanup_test.rb
@@ -20,6 +20,25 @@ class HiveTestTmpCleanupTest < Minitest::Test
     FileUtils.rm_rf(path) if path
   end
 
+  def test_remove_deletes_read_only_tree_under_private_tmp_root
+    Dir.mktmpdir("tmp-cleanup-private") do |root|
+      path = Dir.mktmpdir("hive-test-cleanup", root)
+      nested = File.join(path, "store", "version")
+      FileUtils.mkdir_p(nested)
+      File.write(File.join(nested, "manifest.json"), "{}\n")
+      FileUtils.chmod(0o444, File.join(nested, "manifest.json"))
+      FileUtils.chmod(0o555, nested)
+      FileUtils.chmod(0o555, File.dirname(nested))
+      FileUtils.chmod(0o555, path)
+
+      assert HiveTestTmpCleanup.remove!(path, root: root)
+      refute File.exist?(path)
+    ensure
+      FileUtils.chmod_R(0o700, path, force: true) if path && File.exist?(path)
+      FileUtils.rm_rf(path) if path
+    end
+  end
+
   def test_remove_refuses_paths_without_a_test_tmp_name
     Dir.mktmpdir("ordinary-directory") do |path|
       error = assert_raises(HiveTestTmpCleanup::UnsafePath) do
@@ -29,6 +48,41 @@ class HiveTestTmpCleanupTest < Minitest::Test
       assert_match(/refusing to remove non-test tmp path/, error.message)
       assert Dir.exist?(path)
     end
+  end
+
+  def test_remove_refuses_test_shaped_path_below_a_nested_directory
+    Dir.mktmpdir("tmp-cleanup-nested") do |root|
+      nested_root = File.join(root, "nested")
+      FileUtils.mkdir_p(nested_root)
+      path = create_candidate(nested_root, "hive-test-nested", pid: 99, mtime: Time.now)
+
+      assert_raises(HiveTestTmpCleanup::UnsafePath) do
+        HiveTestTmpCleanup.remove!(path, root: root)
+      end
+      assert Dir.exist?(path)
+    end
+  end
+
+  def test_remove_unlinks_test_shaped_symlink_without_following_it
+    Dir.mktmpdir("tmp-cleanup-symlink") do |root|
+      Dir.mktmpdir("tmp-cleanup-external") do |external|
+        marker = File.join(external, "keep.txt")
+        File.write(marker, "keep\n")
+        path = File.join(root, "hive-test-link20260810-98-abc123")
+        File.symlink(external, path)
+
+        assert HiveTestTmpCleanup.remove!(path, root: root)
+        refute File.symlink?(path)
+        assert_equal "keep\n", File.read(marker)
+      end
+    end
+  end
+
+  def test_remove_returns_false_when_path_already_disappeared
+    path = File.join(Dir.tmpdir, "hive-test-gone20260810-97-abc123")
+    FileUtils.rm_rf(path)
+
+    refute HiveTestTmpCleanup.remove!(path)
   end
 
   def test_remove_raises_when_fileutils_silently_leaves_the_path
@@ -47,24 +101,52 @@ class HiveTestTmpCleanupTest < Minitest::Test
 
   def test_remove_with_related_deletes_known_worktree_and_lock_siblings
     path = Dir.mktmpdir("hive-test-cleanup")
-    worktrees = "#{path}-worktrees"
+    related = [
+      "#{path}-worktrees",
+      "#{path}.worktrees",
+      "#{path}.managed-worktrees",
+      "#{path}.origin.git",
+      "#{path}.strict-origin.git",
+      "#{path}.agent-worktree-origin.git"
+    ]
     lock = "#{path}.patrol-0123456789abcdef.lock"
     unrelated = "#{path}-notes"
-    FileUtils.mkdir_p(worktrees)
+    related.each { |entry| FileUtils.mkdir_p(entry) }
     File.write(lock, "")
     File.write(unrelated, "keep\n")
 
     HiveTestTmpCleanup.remove_with_related!(path)
 
     refute File.exist?(path)
-    refute File.exist?(worktrees)
+    related.each { |entry| refute File.exist?(entry), "expected cleanup of #{entry}" }
     refute File.exist?(lock)
     assert File.exist?(unrelated)
   ensure
     FileUtils.rm_rf(path) if path
-    FileUtils.rm_rf(worktrees) if worktrees
+    related&.each { |entry| FileUtils.rm_rf(entry) }
     FileUtils.rm_f(lock) if lock
     FileUtils.rm_f(unrelated) if unrelated
+  end
+
+  def test_remove_all_attempts_every_root_before_raising
+    paths = %w[
+      hive-test-first20260810-95-abc123
+      hive-test-second20260810-96-abc123
+    ].map { |name| File.join(Dir.tmpdir, name) }
+    attempted = []
+    replacement = lambda do |path|
+      attempted << path
+      raise HiveTestTmpCleanup::CleanupError, "first failed" if path == paths.last
+    end
+
+    with_replaced_singleton_method(HiveTestTmpCleanup, :remove_with_related!, replacement) do
+      error = assert_raises(HiveTestTmpCleanup::CleanupError) do
+        HiveTestTmpCleanup.remove_all!(paths)
+      end
+
+      assert_equal paths.reverse, attempted
+      assert_match(/first failed/, error.message)
+    end
   end
 
   def test_sweep_removes_only_old_inactive_test_paths
@@ -77,8 +159,14 @@ class HiveTestTmpCleanupTest < Minitest::Test
       recent = create_candidate(root, "hive-global", pid: 102, mtime: now - 60)
       live = create_candidate(root, "hive-web-src", pid: 103, mtime: now - 86_401)
       unrelated = File.join(root, "hive-production-data")
-      FileUtils.mkdir_p(unrelated)
-      File.utime(now - 86_401, now - 86_401, unrelated)
+      production = [
+        File.join(root, "hive-web-capture-20260810-4242-abc123"),
+        File.join(root, "hive-terminal-state-20260810-4242-abc123")
+      ]
+      [ unrelated, *production ].each do |entry|
+        FileUtils.mkdir_p(entry)
+        File.utime(now - 86_401, now - 86_401, entry)
+      end
 
       result = HiveTestTmpCleanup.sweep(
         tmp_root: root,
@@ -97,6 +185,7 @@ class HiveTestTmpCleanupTest < Minitest::Test
       assert Dir.exist?(recent)
       assert Dir.exist?(live)
       assert Dir.exist?(unrelated)
+      production.each { |entry| assert Dir.exist?(entry), "production tmp path must survive: #{entry}" }
     end
   end
 
@@ -111,6 +200,11 @@ class HiveTestTmpCleanupTest < Minitest::Test
           mtime: now - 86_401,
           suffix: ".worktrees"
         )
+        production = [
+          File.join(legacy_root, "hive.worktrees"),
+          File.join(legacy_root, "hive-test.worktrees")
+        ]
+        production.each { |entry| FileUtils.mkdir_p(entry) }
 
         result = HiveTestTmpCleanup.sweep(
           tmp_root: tmp_root,
@@ -122,8 +216,48 @@ class HiveTestTmpCleanupTest < Minitest::Test
         assert_equal [ legacy ], result.removed
         assert_empty result.failed
         refute File.exist?(legacy)
+        production.each { |entry| assert Dir.exist?(entry), "non-test worktree root must survive: #{entry}" }
       end
     end
+  end
+
+  def test_process_alive_treats_out_of_range_pid_as_inactive
+    refute HiveTestTmpCleanup.process_alive?(10**100)
+  end
+
+  def test_tracked_tmp_dir_rejects_unrecognized_prefix_without_leaking
+    path = File.join(Dir.tmpdir, "fixture-store20260810-94-abc123")
+    replacement = lambda do |_prefix|
+      FileUtils.mkdir_p(path)
+      path
+    end
+
+    with_replaced_singleton_method(Dir, :mktmpdir, replacement) do
+      error = assert_raises(ArgumentError) { tracked_tmp_dir("fixture-store") }
+      assert_match(/not a recognized Hive test tmp shape/, error.message)
+    end
+    refute File.exist?(path)
+  ensure
+    FileUtils.rm_rf(path) if path
+  end
+
+  def test_cleanup_tmp_dir_preserves_the_active_test_error
+    path = File.join(Dir.tmpdir, "hive-test-body-error20260810-93-abc123")
+    replacement = ->(_path) { raise HiveTestTmpCleanup::CleanupError, "cleanup failed" }
+
+    _out, err = capture_io do
+      with_replaced_singleton_method(HiveTestTmpCleanup, :remove_with_related!, replacement) do
+        error = assert_raises(RuntimeError) do
+          begin
+            raise "test body failed"
+          ensure
+            cleanup_tmp_dir!(path)
+          end
+        end
+        assert_equal "test body failed", error.message
+      end
+    end
+    assert_match(/cleanup also failed/, err)
   end
 
   def test_sweep_reports_a_path_that_removal_leaves_behind

--- a/test/unit/tmp_cleanup_test.rb
+++ b/test/unit/tmp_cleanup_test.rb
@@ -1,0 +1,157 @@
+require "test_helper"
+
+class HiveTestTmpCleanupTest < Minitest::Test
+  include HiveTestHelper
+
+  def test_remove_deletes_read_only_managed_tree_and_verifies_absence
+    path = Dir.mktmpdir("hive-test-cleanup")
+    nested = File.join(path, "store", "version")
+    FileUtils.mkdir_p(nested)
+    File.write(File.join(nested, "manifest.json"), "{}\n")
+    FileUtils.chmod(0o444, File.join(nested, "manifest.json"))
+    FileUtils.chmod(0o555, nested)
+    FileUtils.chmod(0o555, File.dirname(nested))
+    FileUtils.chmod(0o555, path)
+
+    assert HiveTestTmpCleanup.remove!(path)
+    refute File.exist?(path)
+  ensure
+    FileUtils.chmod_R(0o700, path, force: true) if path && File.exist?(path)
+    FileUtils.rm_rf(path) if path
+  end
+
+  def test_remove_refuses_paths_without_a_test_tmp_name
+    Dir.mktmpdir("ordinary-directory") do |path|
+      error = assert_raises(HiveTestTmpCleanup::UnsafePath) do
+        HiveTestTmpCleanup.remove!(path)
+      end
+
+      assert_match(/refusing to remove non-test tmp path/, error.message)
+      assert Dir.exist?(path)
+    end
+  end
+
+  def test_remove_raises_when_fileutils_silently_leaves_the_path
+    path = Dir.mktmpdir("hive-test-cleanup")
+    replacement = ->(*) { nil }
+
+    with_replaced_singleton_method(FileUtils, :rm_rf, replacement) do
+      error = assert_raises(HiveTestTmpCleanup::CleanupError) do
+        HiveTestTmpCleanup.remove!(path)
+      end
+      assert_match(/still exists after removal/, error.message)
+    end
+  ensure
+    FileUtils.rm_rf(path) if path
+  end
+
+  def test_remove_with_related_deletes_known_worktree_and_lock_siblings
+    path = Dir.mktmpdir("hive-test-cleanup")
+    worktrees = "#{path}-worktrees"
+    lock = "#{path}.patrol-0123456789abcdef.lock"
+    unrelated = "#{path}-notes"
+    FileUtils.mkdir_p(worktrees)
+    File.write(lock, "")
+    File.write(unrelated, "keep\n")
+
+    HiveTestTmpCleanup.remove_with_related!(path)
+
+    refute File.exist?(path)
+    refute File.exist?(worktrees)
+    refute File.exist?(lock)
+    assert File.exist?(unrelated)
+  ensure
+    FileUtils.rm_rf(path) if path
+    FileUtils.rm_rf(worktrees) if worktrees
+    FileUtils.rm_f(lock) if lock
+    FileUtils.rm_f(unrelated) if unrelated
+  end
+
+  def test_sweep_removes_only_old_inactive_test_paths
+    now = Time.utc(2026, 8, 10, 12, 0, 0)
+    Dir.mktmpdir("tmp-cleanup-sweep") do |root|
+      old = create_candidate(root, "hive-test-old", pid: 101, mtime: now - 86_401)
+      old_worktrees = "#{old}-worktrees"
+      FileUtils.mkdir_p(old_worktrees)
+      File.utime(now - 86_401, now - 86_401, old_worktrees)
+      recent = create_candidate(root, "hive-global", pid: 102, mtime: now - 60)
+      live = create_candidate(root, "hive-web-src", pid: 103, mtime: now - 86_401)
+      unrelated = File.join(root, "hive-production-data")
+      FileUtils.mkdir_p(unrelated)
+      File.utime(now - 86_401, now - 86_401, unrelated)
+
+      result = HiveTestTmpCleanup.sweep(
+        tmp_root: root,
+        legacy_root: nil,
+        now: now,
+        process_alive: ->(pid) { pid == 103 }
+      )
+
+      assert_equal [ old, old_worktrees ].sort, result.removed.sort
+      assert_equal [ live ], result.skipped_live
+      assert_equal [ recent ], result.skipped_recent
+      assert_empty result.skipped_unowned
+      assert_empty result.failed
+      refute File.exist?(old)
+      refute File.exist?(old_worktrees)
+      assert Dir.exist?(recent)
+      assert Dir.exist?(live)
+      assert Dir.exist?(unrelated)
+    end
+  end
+
+  def test_sweep_removes_the_legacy_test_worktree_shape
+    now = Time.utc(2026, 8, 10, 12, 0, 0)
+    Dir.mktmpdir("tmp-cleanup-root") do |tmp_root|
+      Dir.mktmpdir("tmp-cleanup-legacy") do |legacy_root|
+        legacy = create_candidate(
+          legacy_root,
+          "hive-test-project",
+          pid: 104,
+          mtime: now - 86_401,
+          suffix: ".worktrees"
+        )
+
+        result = HiveTestTmpCleanup.sweep(
+          tmp_root: tmp_root,
+          legacy_root: legacy_root,
+          now: now,
+          process_alive: ->(_pid) { false }
+        )
+
+        assert_equal [ legacy ], result.removed
+        assert_empty result.failed
+        refute File.exist?(legacy)
+      end
+    end
+  end
+
+  def test_sweep_reports_a_path_that_removal_leaves_behind
+    now = Time.utc(2026, 8, 10, 12, 0, 0)
+    Dir.mktmpdir("tmp-cleanup-failure") do |root|
+      path = create_candidate(root, "hive-test-failure", pid: 105, mtime: now - 86_401)
+
+      with_replaced_singleton_method(FileUtils, :rm_rf, ->(*) { nil }) do
+        result = HiveTestTmpCleanup.sweep(
+          tmp_root: root,
+          legacy_root: nil,
+          now: now,
+          process_alive: ->(_pid) { false }
+        )
+
+        assert_empty result.removed
+        assert_equal [ path ], result.failed.map { |failure| failure.fetch(:path) }
+        assert_match(/still exists after removal/, result.failed.first.fetch(:error))
+      end
+    end
+  end
+
+  private
+
+  def create_candidate(root, prefix, pid:, mtime:, suffix: "")
+    path = File.join(root, "#{prefix}20260810-#{pid}-abc123#{suffix}")
+    FileUtils.mkdir_p(path)
+    File.utime(mtime, mtime, path)
+    path
+  end
+end

--- a/test/unit/web/app_bundle_test.rb
+++ b/test/unit/web/app_bundle_test.rb
@@ -408,7 +408,7 @@ class WebAppBundleTest < Minitest::Test
     with_hive_home do
       # A source dir with content but no config/application.rb (and no nested
       # wrapper that contains one) must be rejected rather than installed.
-      src = Dir.mktmpdir("hive-web-bad")
+      src = tracked_tmp_dir("hive-web-bad")
       FileUtils.mkdir_p(File.join(src, "lib"))
       File.write(File.join(src, "lib", "thing.rb"), "# not the app\n")
 
@@ -422,7 +422,7 @@ class WebAppBundleTest < Minitest::Test
 
   def test_ensure_raises_when_bundle_lacks_gemfile
     with_hive_home do
-      src = Dir.mktmpdir("hive-web-no-gemfile")
+      src = tracked_tmp_dir("hive-web-no-gemfile")
       FileUtils.mkdir_p(File.join(src, "config"))
       File.write(File.join(src, "config", "application.rb"), "# app\n")
 
@@ -938,7 +938,7 @@ class WebAppBundleTest < Minitest::Test
   # top-level versioned directory — the shape `tar -czf` produces for a
   # GitHub release. Exercises ensure!'s nested-unwrap branch.
   def seed_nested_source_app
-    src = Dir.mktmpdir("hive-web-nested")
+    src = tracked_tmp_dir("hive-web-nested")
     wrapped = File.join(src, "hive-web-#{Hive::VERSION}")
     FileUtils.mkdir_p(File.join(wrapped, "config"))
     File.write(File.join(wrapped, "config", "application.rb"), "# app\n")
@@ -950,7 +950,7 @@ class WebAppBundleTest < Minitest::Test
   # fetch_and_extract copies verbatim, including a Gemfile so prepare!
   # invokes the injected runner.
   def seed_source_app
-    src = Dir.mktmpdir("hive-web-src")
+    src = tracked_tmp_dir("hive-web-src")
     FileUtils.mkdir_p(File.join(src, "config"))
     File.write(File.join(src, "config", "application.rb"), "# app\n")
     File.write(File.join(src, "Gemfile"), "source 'https://rubygems.org'\n")

--- a/test/unit/web/web_command_test.rb
+++ b/test/unit/web/web_command_test.rb
@@ -9,16 +9,18 @@ class WebCommandTest < Minitest::Test
   # a source checkout (no web/ dir, no HIVE_WEB_APP_DIR) it must fail
   # loudly with guidance instead of exec-ing into a missing app.
   def test_missing_rails_app_exits_with_guidance
-    with_tmp_global_config do
-      with_env("HIVE_WEB_APP_DIR" => File.join(Dir.mktmpdir("hive-noapp"), "nope")) do
-        command = Hive::Commands::Web.new
-        # Singleton override instead of minitest/mock (not bundled): the
-        # checkout itself contains web/, so the fallback path would resolve.
-        command.define_singleton_method(:rails_app_dir) { |**| nil }
-        err = assert_raises(SystemExit) do
-          capture_io { command.call }
+    Dir.mktmpdir("hive-noapp") do |root|
+      with_tmp_global_config do
+        with_env("HIVE_WEB_APP_DIR" => File.join(root, "nope")) do
+          command = Hive::Commands::Web.new
+          # Singleton override instead of minitest/mock (not bundled): the
+          # checkout itself contains web/, so the fallback path would resolve.
+          command.define_singleton_method(:rails_app_dir) { |**| nil }
+          err = assert_raises(SystemExit) do
+            capture_io { command.call }
+          end
+          assert_equal 1, err.status, "a missing web app must exit 1"
         end
-        assert_equal 1, err.status, "a missing web app must exit 1"
       end
     end
   end

--- a/wiki/log.d/20260810T221342Z-test-tmp-cleanup.md
+++ b/wiki/log.d/20260810T221342Z-test-tmp-cleanup.md
@@ -11,6 +11,15 @@ The cleanup family also removes only the root's exact `-worktrees`,
 siblings from refactor-Patrol tests, and focused fixer/token-budget reruns now
 leave none.
 
+Review then found additional real sibling shapes used by worktree tests. The
+allowlist now includes exact `.worktrees`, `.managed-worktrees`,
+`.strict-origin.git`, and `.agent-worktree-origin.git` forms, with regression
+coverage for every accepted suffix. Suite roots share one aggregate shutdown
+hook so one removal failure cannot skip the other root. Helper cleanup keeps an
+already-active assertion as the primary failure, and private-TMPDIR, symlink,
+direct-child, production-name refusal, and invalid-prefix boundaries are
+covered explicitly.
+
 **Recovery broom:** Hardened `rake test:clean_tmp` around exact test-shaped
 names, current-uid ownership, a 24-hour age floor, and creator-PID liveness.
 The task still recognizes the legacy `~/Dev/hive-test*.worktrees` shape, but

--- a/wiki/log.d/20260810T221342Z-test-tmp-cleanup.md
+++ b/wiki/log.d/20260810T221342Z-test-tmp-cleanup.md
@@ -1,0 +1,33 @@
+## [2026-08-10T22:13:42Z] testing — verify and bound Hive test tmp cleanup
+
+**Action:** Replaced the test helpers' permissive `FileUtils.rm_rf` cleanup
+with a shared, scope-checked remover that handles read-only managed-package
+trees and verifies absence. Added per-test tracking for source/store fixtures,
+then migrated the Web app bundle and pairing allocations that previously
+outlived their tests. The suite-owned `HIVE_WORKTREE_BASE` is now recorded
+separately so an explicit caller override can never be removed at shutdown.
+The cleanup family also removes only the root's exact `-worktrees`,
+`.origin.git`, and Patrol-lock siblings; a broad-suite proof exposed 56 such
+siblings from refactor-Patrol tests, and focused fixer/token-budget reruns now
+leave none.
+
+**Recovery broom:** Hardened `rake test:clean_tmp` around exact test-shaped
+names, current-uid ownership, a 24-hour age floor, and creator-PID liveness.
+The task still recognizes the legacy `~/Dev/hive-test*.worktrees` shape, but
+does not sweep generic production `hive-*` temp families. It reports live,
+recent, and unowned skips separately, verifies every deletion, and fails on
+retained candidates. `HIVE_TEST_TMP_MIN_AGE_SECONDS=0` provides an explicit
+inactive-only immediate sweep.
+
+**Coverage:** Added cleanup regressions for 0555/0444 trees, unsafe-name
+refusal, silent deletion failure, stale/recent/live classification, and the
+legacy worktree shape. Focused Web app bundle, Web command, pairing, managed
+store, cleanup-helper, refactor-Patrol fixer, and Patrol token-budget tests
+pass. An immediate inactive-only broom removed 3,894 recognized leftovers with
+no deletion failures; the final recognized-family count was zero. The broad
+checkpoint's standalone runtime package passed (43 runs, 411 assertions). Its
+main suite completed 12,353 runs and 157,951 assertions with two failures and
+four errors, all from project-capture fixture subprocesses losing Ruby 3.4's
+non-default `base64` gem after isolated `HOME`; the untouched checkout
+reproduced the same project-capture failures, so they are not caused by this
+cleanup change.

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -456,10 +456,30 @@ task default: :test
   `rake smoke` task explicitly opts out because it exists to exercise real
   operator logins; direct smoke-file runs must set
   `HIVE_TEST_ALLOW_REAL_USER_ENV=1` deliberately.
-- `with_tmp_dir` — `Dir.mktmpdir("hive-test", &block)`.
+- `with_tmp_dir` — creates a `hive-test*` directory and removes it through
+  `HiveTestTmpCleanup` in `ensure`. The cleanup is restricted to direct
+  children with test-shaped names owned by the current uid, handles read-only
+  managed-package trees, removes the exact root's known `-worktrees`,
+  `.origin.git`, and Patrol-lock siblings, and verifies that every path is
+  actually gone.
+- `tracked_tmp_dir(prefix)` — registers a statement-spanning fixture for the
+  current test's teardown hook. Use this instead of assigning `Dir.mktmpdir`
+  directly when a helper must return the path.
 - `with_tmp_git_repo` — `git init -b master`, configures user/email and disables GPG signing, makes one initial commit, yields the path.
 - `with_tmp_global_config(home: nil)` — overrides `ENV["HIVE_HOME"]` to a tmp dir, writes an empty `registered_projects: []` YAML, and defaults `HOME` to the same tmp dir so subprocesses and service-installer tests do not touch the operator's real home. Pass `home:` when a test intentionally installs fake user-level skills or plugins under a separate fake HOME.
 - `run!(*cmd)` — shells out and raises on non-zero exit (used in setup helpers; not for testing the CLI itself).
+
+`rake test:clean_tmp` is the crash-recovery broom, not a generic `/tmp`
+cleaner. It recognizes only the test-helper families plus the historically
+leaked `~/Dev/hive-test*.worktrees` shape and known test-root sibling shapes.
+By default it removes entries older than 24 hours whose encoded creator PID is
+no longer alive; recent, live, and other-uid entries are reported and left
+alone. Set
+`HIVE_TEST_TMP_MIN_AGE_SECONDS=0` for an immediate inactive-only sweep. A
+removal counts only after the path is absent, and any retained candidate makes
+the task fail instead of printing a false success. Production `hive-*` temp
+families remain the responsibility of their owning lifecycle and the system
+tmp reaper.
 
 ## Fixtures
 

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -460,8 +460,8 @@ task default: :test
   `HiveTestTmpCleanup` in `ensure`. The cleanup is restricted to direct
   children with test-shaped names owned by the current uid, handles read-only
   managed-package trees, removes the exact root's known `-worktrees`,
-  `.origin.git`, and Patrol-lock siblings, and verifies that every path is
-  actually gone.
+  `.worktrees`, managed-worktree, strict/agent origin-repository, and
+  Patrol-lock siblings, and verifies that every path is actually gone.
 - `tracked_tmp_dir(prefix)` — registers a statement-spanning fixture for the
   current test's teardown hook. Use this instead of assigning `Dir.mktmpdir`
   directly when a helper must return the path.
@@ -480,6 +480,11 @@ removal counts only after the path is absent, and any retained candidate makes
 the task fail instead of printing a false success. Production `hive-*` temp
 families remain the responsibility of their owning lifecycle and the system
 tmp reaper.
+
+Suite-level fake-HOME and generated worktree-base cleanup uses one aggregate
+shutdown hook. It attempts every registered root before reporting cleanup
+failures. Block helpers also preserve an active assertion or test exception if
+cleanup fails, while a cleanup failure still fails an otherwise-green test.
 
 ## Fixtures
 


### PR DESCRIPTION
## Summary

- Prevent Hive's test suite from silently retaining read-only temporary trees and their exact worktree, origin-repository, and Patrol-lock siblings.
- Track statement-spanning fixtures for per-test teardown and make `test:clean_tmp` remove only old, inactive, current-user test-shaped paths.
- Keep production `hive-*` temporary families out of the broom; their lifecycle and the system temporary-file reaper remain responsible for them.

## Test plan

- [x] Final focused cleanup, helper, worktree, agent, Web, pairing, managed-store, Patrol, and wiki tests: 402 unique runs, 1,630 assertions
- [x] RuboCop: 7 changed Ruby files, no offenses
- [x] Immediate cleanup with `HIVE_TEST_TMP_MIN_AGE_SECONDS=0`: removed 3,894 inactive test paths with no failures; final recognized count zero
- [x] Compound Engineering review: all 3 validated findings fixed and independently rechecked
- [ ] Broad local checkpoint: agent runtime passed (43 runs, 411 assertions); the main suite completed 12,353 runs and 157,951 assertions with 2 failures and 4 errors because Ruby 3.4 fixture subprocesses lost the non-default `base64` gem. The unchanged checkout reproduces the same project-capture failures.

## Notes for reviewer

The remover is deliberately test-only: direct children must match a generated test shape and be owned by the current uid. It verifies absence after deletion and fails instead of reporting a false success. The manual broom defaults to a 24-hour age floor and skips live encoded PIDs.

The final review pass added exact coverage for all sibling forms created by current producer tests, aggregate suite-root shutdown cleanup, private-TMPDIR permission repair, symlink/direct-child boundaries, and production-name refusal.
