### PR TITLE
chore(agent-runtime): prepare 0.1.1 release

### DIFF
--- a/components/agent-cli-runtime/CHANGELOG.md
+++ b/components/agent-cli-runtime/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.1.1 - 2026-08-11
 
 - Expose each profile's immutable credential-environment key inventory so
   orchestrators can isolate named subscription/session bindings without
@@ -10,6 +10,9 @@
   maintaining a second provider-specific table.
 - Include Claude's ambient auth-token override in the isolation inventory so a
   named subscription binding cannot be silently replaced by caller state.
+- Preserve an optional immutable provider signal in observable results so a
+  trusted orchestrator can carry structured transport evidence without moving
+  provider-health classification into the compatibility package.
 
 ## 0.1.0 - 2026-07-26
 

--- a/components/agent-cli-runtime/lib/agent_cli_runtime/version.rb
+++ b/components/agent-cli-runtime/lib/agent_cli_runtime/version.rb
@@ -1,3 +1,3 @@
 module AgentCliRuntime
-  VERSION = "0.1.0".freeze
+  VERSION = "0.1.1".freeze
 end

--- a/components/agent-cli-runtime/test/gemspec_test.rb
+++ b/components/agent-cli-runtime/test/gemspec_test.rb
@@ -7,7 +7,7 @@ class AgentCliRuntimeGemspecTest < Minitest::Test
     spec = Gem::Specification.load(GEMSPEC)
 
     assert_equal "agent-cli-runtime", spec.name
-    assert_equal Gem::Version.new("0.1.0"), spec.version
+    assert_equal Gem::Version.new("0.1.1"), spec.version
     assert_equal Gem::Requirement.new(">= 3.4.0"), spec.required_ruby_version
     assert_equal [ "agent-runtime" ], spec.executables
     assert_equal "MIT", spec.license

--- a/components/agent-cli-runtime/test/package_test.rb
+++ b/components/agent-cli-runtime/test/package_test.rb
@@ -19,7 +19,7 @@ class AgentCliRuntimePackageTest < Minitest::Test
       manifest = JSON.parse(out.lines.last)
       gem_path = manifest.fetch("gem_path")
       assert File.file?(gem_path)
-      assert_equal "agent-cli-runtime-0.1.0.gem", File.basename(gem_path)
+      assert_equal "agent-cli-runtime-0.1.1.gem", File.basename(gem_path)
       assert_equal Digest::SHA256.file(gem_path).hexdigest,
                    manifest.fetch("sha256")
       assert_equal !dirty.empty?, manifest.fetch("source_dirty")
@@ -45,7 +45,7 @@ class AgentCliRuntimePackageTest < Minitest::Test
     with_release_repository do |_repository, component, commit, _tag|
       {
         "v0.1.0" => /invalid component tag/,
-        "components/agent-cli-runtime/v0.1.1" => /tag\/source version mismatch/
+        "components/agent-cli-runtime/v0.1.2" => /tag\/source version mismatch/
       }.each do |tag, message|
         _out, err, status = run_preflight(component, tag, commit, "main")
         refute status.success?, tag
@@ -53,7 +53,7 @@ class AgentCliRuntimePackageTest < Minitest::Test
       end
 
       _out, err, status = run_preflight(
-        component, "components/agent-cli-runtime/v0.1.0",
+        component, "components/agent-cli-runtime/v0.1.1",
         commit[0, 12], "main"
       )
       refute status.success?
@@ -110,7 +110,7 @@ class AgentCliRuntimePackageTest < Minitest::Test
       git!(repository, "add", ".")
       commit_fixture!(repository, "fixture")
       commit = git!(repository, "rev-parse", "HEAD").strip
-      tag = "components/agent-cli-runtime/v0.1.0"
+      tag = "components/agent-cli-runtime/v0.1.1"
       git!(repository, "tag", tag)
 
       yield repository, component, commit, tag

--- a/test/unit/agent_cli_runtime_component_test.rb
+++ b/test/unit/agent_cli_runtime_component_test.rb
@@ -38,7 +38,7 @@ class AgentCliRuntimeComponentTest < Minitest::Test
     script = <<~'RUBY'
       require "agent_cli_runtime"
       abort "loaded Hive unexpectedly" if defined?(Hive)
-      abort "wrong version" unless AgentCliRuntime::VERSION == "0.1.0"
+      abort "wrong version" unless AgentCliRuntime::VERSION == "0.1.1"
       puts AgentCliRuntime::Profiles.names.join(",")
     RUBY
     out, err, status = Bundler.with_unbundled_env do


### PR DESCRIPTION
## Summary

- Prepares `agent-cli-runtime` 0.1.1 as the publishable package for the compatibility behavior already merged on `main`: credential-environment isolation, configuration-directory metadata, and optional provider signals.
- Keeps the publish-first boundary intact. Hive remains unchanged until this exact package is tagged, published, and verified from a fresh install.

## Test plan

- [x] Component suite: 48 runs, 448 assertions, 0 failures, 0 errors
- [x] Hive/package parity test: 9 runs, 80 assertions, 0 failures, 0 errors
- [x] Clean release candidate verified: `agent-cli-runtime-0.1.1.gem`
- [x] Candidate SHA-256: `f1b833320397e63268ebc9c739f790b42e2f767d6d0e69bed728f220913da5a2`
- [x] Independent code review: correctness, project standards, testing, and API contract; no findings
- [ ] Hosted CI and release-adjacent gates green

## Notes for reviewer

This PR changes package release metadata only. After merge, the protected `components/agent-cli-runtime/v0.1.1` tag will create the retained candidate, run Linux and macOS install checks, and publish through the `agent-cli-runtime-release` OIDC environment. Hive dependency replacement and duplicate-code removal are a separate follow-up after registry verification.

## Post-deploy monitoring and validation

- Confirm the tag resolves to the exact protected-`main` merge commit.
- Confirm the candidate, Linux install, macOS install, and publish jobs succeed.
- Download the retained workflow artifact and compare its checksum and metadata with the RubyGems download.
- Install 0.1.1 into a fresh gem home, require `agent_cli_runtime`, run `agent-runtime --version`, and exercise the JSON probe contract.
- Any tag, checksum, metadata, install, or publish mismatch blocks the Hive cutover. Do not reuse the version after RubyGems accepts it.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
