### PR TITLE
fix(recovery): normalize marker attribute encodings

### DIFF
--- a/lib/hive/daemon/recovery_coordinator.rb
+++ b/lib/hive/daemon/recovery_coordinator.rb
@@ -89,8 +89,7 @@ module Hive
         def observation_token(row)
           attrs = row_value(row, :marker_attrs)
           attrs = row_value(row, :attrs) unless attrs.is_a?(Hash)
-          attrs = attrs.is_a?(Hash) ? attrs.to_h.transform_keys(&:to_s) : {}
-          attrs = attrs.keys.sort.to_h { |key| [ key, attrs[key] ] }
+          attrs = attrs.is_a?(Hash) ? Hive::Recovery.canonical_marker_attrs(attrs) : {}
           observed_at = row_value(row, :state_file_mtime) ||
                         row_value(row, :observation_mtime) ||
                         row_value(row, :mtime)
@@ -313,7 +312,7 @@ module Hive
               row, locked_task, expected_generation, generation.task_generation
             )
           end
-          attrs = current.attrs.to_h.transform_keys(&:to_s)
+          attrs = Hive::Recovery.canonical_marker_attrs(current.attrs)
           marker_id = marker_identity(current)
           next_eligible_at = assessment[:retry_at].utc.iso8601(6)
           recovery = {
@@ -985,13 +984,12 @@ module Hive
       end
 
       def marker_generation(marker)
-        attrs = marker.attrs.to_h.transform_keys(&:to_s)
+        attrs = Hive::Recovery.canonical_marker_attrs(marker.attrs)
         return nil if attrs["marker_id"].to_s.empty?
 
-        canonical = attrs.keys.sort.to_h { |key| [ key, attrs[key] ] }
         ::Digest::SHA256.hexdigest(JSON.generate(
           "name" => marker.name.to_s,
-          "attrs" => canonical
+          "attrs" => attrs
         ))
       end
 
@@ -1146,9 +1144,7 @@ module Hive
       end
 
       def expected_attrs_match?(marker, expected)
-        expected.to_h.all? do |key, expected_value|
-          marker.attrs[key.to_s].to_s == expected_value.to_s
-        end
+        Hive::Recovery.marker_attrs_match?(marker.attrs, expected)
       end
 
       def retry_argv(row)

--- a/lib/hive/daemon/recovery_coordinator.rb
+++ b/lib/hive/daemon/recovery_coordinator.rb
@@ -20,7 +20,7 @@ module Hive
     # Sole producer and transition owner for ERROR / REVIEW_ERROR recovery.
     # Adapters submit an observed row; this coordinator re-resolves it under
     # the task lock, applies the shared cooldown and safety policy, then
-    # persists one restartable v4 request before any marker mutation.
+    # persists one restartable v5 request before any marker mutation.
     class RecoveryCoordinator
       LIFECYCLE_STATES = %w[
         queued cooldown running blocked terminal unavailable

--- a/lib/hive/markers.rb
+++ b/lib/hive/markers.rb
@@ -139,7 +139,7 @@ module Hive
         return false unless marker.name.to_s == expected_name.to_s.downcase
 
         expected = match_attrs.to_h.transform_keys(&:to_s)
-        return false unless expected.all? { |key, value| marker.attrs[key].to_s == value.to_s }
+        return false unless Hive::Recovery.marker_attrs_match?(marker.attrs, expected)
 
         if purge_history
           remove_all_markers(state_file_path)

--- a/lib/hive/operational_status.rb
+++ b/lib/hive/operational_status.rb
@@ -1,6 +1,7 @@
 require "time"
 require "hive/attempts/storage_health"
 require "hive/operational_action"
+require "hive/recovery"
 require "hive/workflows"
 require "hive/task_closure"
 require "hive/terminal_outcome"
@@ -506,17 +507,7 @@ module Hive
     end
 
     def canonical_scheduler_value(value)
-      case value
-      when Hash
-        value.keys.map(&:to_s).sort.to_h do |key|
-          original = value.key?(key) ? key : value.keys.find { |candidate| candidate.to_s == key }
-          [ key, canonical_scheduler_value(value.fetch(original)) ]
-        end
-      when Array
-        value.map { |entry| canonical_scheduler_value(entry) }
-      else
-        value
-      end
+      Hive::Recovery.canonical_wire_value(value)
     end
 
     def add_scheduler_join_issue(code:, project:, task:, message:)

--- a/lib/hive/recovery.rb
+++ b/lib/hive/recovery.rb
@@ -13,6 +13,45 @@ module Hive
       RECOVERABLE_MARKERS.include?(marker.to_s.downcase)
     end
 
+    # Marker reads intentionally use a binary view so invalid agent-authored
+    # artifacts cannot prevent Hive from finding a trailing ASCII marker.
+    # Durable requests and daemon snapshots pass through JSON, which restores
+    # valid text as UTF-8. Canonicalize valid UTF-8 bytes at that wire boundary
+    # so an encoding label alone cannot manufacture a generation conflict;
+    # preserve genuinely invalid bytes as binary so JSON still fails closed.
+    def canonical_wire_value(value)
+      case value
+      when Hash
+        originals = value.each_key.with_object({}) do |candidate, out|
+          key = candidate.to_s
+          out[key] = candidate if !out.key?(key) || candidate.is_a?(String)
+        end
+        originals.keys.sort.to_h do |key|
+          original = originals.fetch(key)
+          [ key, canonical_wire_value(value.fetch(original)) ]
+        end
+      when Array
+        value.map { |entry| canonical_wire_value(entry) }
+      when String
+        utf8 = value.dup.force_encoding(Encoding::UTF_8)
+        utf8.valid_encoding? ? utf8 : value.b
+      else
+        value
+      end
+    end
+
+    def canonical_marker_attrs(attrs)
+      canonical_wire_value(attrs.to_h.transform_keys(&:to_s))
+    end
+
+    def marker_attrs_match?(actual, expected)
+      actual = canonical_marker_attrs(actual)
+      canonical_marker_attrs(expected).all? do |key, expected_value|
+        canonical_wire_value(actual[key].to_s) ==
+          canonical_wire_value(expected_value.to_s)
+      end
+    end
+
     # A max-pass REVIEW_STALE with a concrete escalation artifact represents
     # unresolved reviewer input, not a failed agent launch. Ordinary retry
     # surfaces must not bypass that edit step. The TUI's explicit post-edit

--- a/test/unit/daemon/recovery_coordinator_test.rb
+++ b/test/unit/daemon/recovery_coordinator_test.rb
@@ -102,6 +102,53 @@ class HiveDaemonRecoveryCoordinatorTest < Minitest::Test
     end
   end
 
+  def test_resume_matches_unicode_marker_attrs_after_json_round_trip
+    attrs = {
+      "reason" => "implementer_failed",
+      "message" => "Claude stopped — retry the review",
+      "marker_id" => "marker-unicode"
+    }
+    with_fixture(marker_attrs: attrs) do |coordinator, row, state_home|
+      coordinator.request(
+        row: row, requestor: "healer", request_id: "recover-unicode", now: NOW
+      )
+      request = Q.fetch("recover-unicode", state_home: state_home)
+      current = Hive::Markers.current(row.state_file)
+
+      assert_equal Encoding::UTF_8,
+                   request.recovery.dig("expected_marker_attrs", "message").encoding
+      assert_equal Encoding::BINARY, current.attrs.fetch("message").encoding
+      assert_equal attrs.fetch("message").bytes,
+                   current.attrs.fetch("message").bytes
+
+      resumed = coordinator.resume(request: request, row: row)
+
+      assert_equal "queued", resumed.status
+      assert_equal "cleared", resumed.phase
+      assert Hive::Markers.current(row.state_file).none?
+    end
+  end
+
+  def test_request_rejects_invalid_utf8_marker_attrs_without_clearing_marker
+    message = "agent stopped \xFF".b
+    attrs = {
+      "reason" => "implementer_failed",
+      "message" => message,
+      "marker_id" => "marker-invalid-utf8"
+    }
+    with_fixture(marker_attrs: attrs) do |coordinator, row, state_home|
+      assert_raises JSON::GeneratorError do
+        coordinator.request(
+          row: row, requestor: "healer", request_id: "recover-invalid", now: NOW
+        )
+      end
+
+      assert_nil Q.fetch("recover-invalid", state_home: state_home)
+      assert_equal message.bytes,
+                   Hive::Markers.current(row.state_file).attrs.fetch("message").bytes
+    end
+  end
+
   def test_restart_after_marker_clear_recovers_from_expected_post_clear_fingerprint
     with_fixture do |coordinator, row, state_home|
       coordinator.request(

--- a/test/unit/operational_status_test.rb
+++ b/test/unit/operational_status_test.rb
@@ -474,6 +474,34 @@ class OperationalStatusTest < Minitest::Test
     assert_equal "current", result.dig("tasks", 0, "freshness", "scheduler_status")
   end
 
+  def test_scheduler_match_accepts_unicode_marker_attrs_from_binary_task_scan
+    message = "Claude stopped — retry the review"
+    source_task = task(
+      action: "error",
+      slug: "unicode-marker",
+      marker: "error",
+      attrs: { "message" => message.b }
+    )
+    snapshot = scheduler_snapshot_for(
+      source_task,
+      decision: "global_cap",
+      reason: "global dispatch capacity is exhausted"
+    )
+    snapshot.dig("tasks", 0)["marker_attrs"] = {
+      "message" => message,
+      "marker_id" => "marker-unicode-marker"
+    }
+
+    result = project(
+      status_payload(source_task),
+      project_context: { "demo" => { "daemon_enabled" => true } },
+      scheduler_snapshot: snapshot
+    )
+
+    assert_equal "complete", result.fetch("completeness")
+    assert_equal "current", result.dig("tasks", 0, "freshness", "scheduler_status")
+  end
+
   def test_scheduler_dispositions_map_to_closed_operational_states
     expectations = {
       "provider_hold" => [ "waiting_on_provider_or_scheduler", "provider" ],

--- a/wiki/commands/migrate.md
+++ b/wiki/commands/migrate.md
@@ -116,7 +116,7 @@ restore the workflow, then rerun migrate.
 ## Durable recovery schema cutover
 
 Runtime recovery supports only the current shapes: attempt v4, dispatch request
-v4, and dispatch result v2. `Hive::Recovery::Migration` performs a forward-only
+v5, and dispatch result v2. `Hive::Recovery::Migration` performs a forward-only
 physical cutover from `$HIVE_HOME/attempts/v3` to `attempts/v4` (and accepts a
 remaining supported v2 source). It takes the shared recovery lock and every
 source writer lock, rejects attempts whose owners may still be active, and

--- a/wiki/log.d/20260812T085119Z-recovery-marker-encoding-compatibility.md
+++ b/wiki/log.d/20260812T085119Z-recovery-marker-encoding-compatibility.md
@@ -1,0 +1,15 @@
+---
+title: Recovery accepts byte-identical Unicode marker attrs
+type: change
+date: 2026-08-12
+---
+
+Valid UTF-8 marker attrs now cross the shared `Hive::Recovery` compatibility
+boundary before durable request and scheduler-snapshot comparison. This keeps
+the marker scanner's binary safety while preventing an encoding-label-only
+`generation_conflict` after JSON restores the same bytes as UTF-8.
+
+`RecoveryCoordinator`, `Markers.clear_current`, recovery observation tokens,
+and operational scheduler joins share the canonicalization. Focused
+regressions cover an em-dash diagnostic round-tripping through the recovery
+queue and the same binary/UTF-8 split in operational status.

--- a/wiki/modules/daemon.md
+++ b/wiki/modules/daemon.md
@@ -666,6 +666,11 @@ owner/remediation, phase, retry count, terminal outcome/time, bounded routing
 admission observation, and immutable source terminal-receipt identity. Its
 closed recovery union distinguishes ordinary marker recovery from markerless
 initial route exhaustion keyed by task generation and frozen policy digest.
+Expected marker attrs are normalized through the policy-free `Hive::Recovery`
+compatibility boundary before JSON persistence. Live binary marker scans and
+JSON-restored UTF-8 attrs therefore compare by the same valid UTF-8 bytes, so
+non-ASCII provider diagnostics cannot create a false `generation_conflict` or
+make the operational scheduler snapshot appear stale.
 The one-off recovery migration upgrades pending v1-v4 deliveries before the runtime queue
 opens; queue readers accept v5 only and contain no inferred-generation
 compatibility path. Identity-bound recovery requests do not expire; the

--- a/wiki/modules/markers.md
+++ b/wiki/modules/markers.md
@@ -3,7 +3,7 @@ title: Hive::Markers
 type: module
 source: lib/hive/markers.rb
 created: 2026-04-25
-updated: 2026-08-02
+updated: 2026-08-12
 tags: [marker, protocol, flock, recovery, migration, binary, filesystem-safety]
 ---
 
@@ -58,6 +58,16 @@ operator repair primitive and performs the same history purge after its
 current-name and optional attribute guards pass. Both paths remove every
 recognized marker comment while preserving surrounding prose, so a successful
 retry cannot expose an older shadowed marker.
+
+Marker scans retain their binary encoding so malformed surrounding artifact
+bytes remain readable. `Hive::Recovery` is the shared compatibility boundary
+for marker attrs that subsequently cross JSON: byte-identical valid UTF-8 is
+retagged as UTF-8 before request/snapshot serialization and comparison.
+Consequently a non-ASCII diagnostic such as an em dash cannot make the
+persisted request look like a newer marker generation merely because the live
+scan is `ASCII-8BIT`. `Markers.clear_current`, `RecoveryCoordinator`, and the
+operational scheduler join all use that same comparison; genuinely invalid
+UTF-8 remains binary and fails closed at JSON boundaries.
 
 Regex: `MARKER_RE` enumerates every name in `KNOWN_NAMES`, requires a marker-name boundary, and captures attrs until the terminating `-->` without crossing another `<!--`. Quoted error details may contain `>` (for example Git stderr `branch -> branch`) and newlines. Adding a marker name requires updating BOTH the list AND the regex alternation (they are two sources of truth).
 


### PR DESCRIPTION
## Summary

Recovery no longer stalls when a provider error contains non-ASCII text. Hive now treats byte-identical valid UTF-8 marker attributes as the same value before and after durable JSON storage, while malformed bytes still fail closed.

The shared `Hive::Recovery` compatibility boundary now owns this normalization for recovery requests, observation tokens, marker clearing, and operational scheduler joins. This removes the encoding-only `generation_conflict` that blocked retries and prevents the same task from appearing stale in operational status.

## Validation

- Recovery coordinator: 42 runs, 247 assertions, 0 failures
- Operational status and marker focused suites: 89 runs, 350 assertions, 0 failures
- Broad suite on the same production diff: 12,649 runs, 160,060 assertions, 0 failures
- RuboCop: no offenses in changed Ruby and test files
- Invalid UTF-8 regression: request persistence fails closed and leaves the marker intact

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
