### PR TITLE
fix(release): isolate candidate skill bootstrap

### DIFF
--- a/packaging/live_agent_skills/build.rb
+++ b/packaging/live_agent_skills/build.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 $LOAD_PATH.unshift(File.expand_path("../../lib", __dir__))
-require "hive"
 require "hive/agent_skills/canonical_skill"
 require_relative "proof"
 

--- a/test/unit/packaging/release_candidate_artifacts_test.rb
+++ b/test/unit/packaging/release_candidate_artifacts_test.rb
@@ -37,7 +37,10 @@ class ReleaseCandidateArtifactsTest < Minitest::Test
 
   def test_live_agent_builder_loads_without_hive_runtime_dependencies
     builder = File.expand_path("../../../packaging/live_agent_skills/build.rb", __dir__)
-    stdout, stderr, status = Open3.capture3(RbConfig.ruby, "--disable-gems", builder)
+    clean_ruby = { "BUNDLE_GEMFILE" => nil, "RUBYLIB" => nil, "RUBYOPT" => nil }
+    stdout, stderr, status = Open3.capture3(
+      clean_ruby, RbConfig.ruby, "--disable-gems", builder
+    )
 
     refute status.success?
     assert_empty stdout

--- a/test/unit/packaging/release_candidate_artifacts_test.rb
+++ b/test/unit/packaging/release_candidate_artifacts_test.rb
@@ -35,6 +35,15 @@ class ReleaseCandidateArtifactsTest < Minitest::Test
     with_tmp_dir { |dir| fixture_artifacts(dir).verify! }
   end
 
+  def test_live_agent_builder_loads_without_hive_runtime_dependencies
+    builder = File.expand_path("../../../packaging/live_agent_skills/build.rb", __dir__)
+    stdout, stderr, status = Open3.capture3(RbConfig.ruby, "--disable-gems", builder)
+
+    refute status.success?
+    assert_empty stdout
+    assert_equal "usage: build.rb CANDIDATE_SHA GEM SOURCE_ARCHIVE OUTPUT_DIR\n", stderr
+  end
+
   def test_rejects_a_non_full_candidate_sha_before_building
     error = assert_raises(HiveReleaseCandidate::Error) do
       HiveReleaseCandidate::Artifacts.new(

--- a/wiki/log.d/20260812T124500Z-release-candidate-leaf-load.md
+++ b/wiki/log.d/20260812T124500Z-release-candidate-leaf-load.md
@@ -1,0 +1,12 @@
+---
+title: Release candidate skill builder uses a leaf load
+module: release-candidate
+tags: [release, packaging, agent-skills, dependencies]
+problem_type: regression
+---
+
+The release-candidate artifact builder now loads the canonical Hive skill leaf
+instead of requiring the complete Hive runtime. This lets a committed source
+export build its skill artifact before `agent-cli-runtime` and the other
+candidate gem dependencies are installed. A `--disable-gems` regression pins
+that bootstrap boundary.

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -99,6 +99,11 @@ historical executor and reports `compliant_local_upgrade_executor_unavailable`;
 focused tests inject its fixed executor seam, while the real upgrade cells are
 hosted proof.
 
+The committed live-agent artifact builder loads only the canonical skill leaf,
+not the full Hive runtime. A `--disable-gems` regression keeps candidate source
+exports buildable before the candidate gem and its runtime dependencies are
+installed.
+
 The default suite excludes four expensive outer-proof files and skips the
 single large babysitter command-classification matrix. CI runs all five proofs
 as named gates and feeds their matrix result, together with exhaustive coverage,


### PR DESCRIPTION
Release candidates can again build their skill artifact from a clean source export before runtime gems are installed. The builder now loads only the canonical skill leaf, so the new `agent-cli-runtime` dependency no longer aborts candidate assembly.

Validation covers the dependency-free `--disable-gems` bootstrap contract, the focused artifact suite (10 tests, 48 assertions), RuboCop, and a real manifest-bound build that produced the gem, source, skills, and web artifacts for the committed head.
