### PR TITLE
fix(migrate): preserve daily admission parity

### DIFF
--- a/lib/hive/attempts/decision_index.rb
+++ b/lib/hive/attempts/decision_index.rb
@@ -183,14 +183,21 @@ module Hive
 
       def daily_counts(date:)
         utc_date = date_value(date)
-        value = read_value(DAILY_ACCOUNTING, accounting_key(utc_date))
-        return {}.freeze unless value
-
         counts = Hash.new(0)
-        value.fetch("attempts").each_value do |acceptance|
+        daily_acceptances(date: utc_date).each_value do |acceptance|
           counts[[ acceptance.fetch("project"), utc_date ]] += 1 unless acceptance["refunded"]
         end
         counts.to_h.freeze
+      end
+
+      def daily_acceptances(date:)
+        utc_date = date_value(date)
+        value = read_value(DAILY_ACCOUNTING, accounting_key(utc_date))
+        return {}.freeze unless value
+
+        value.fetch("attempts").to_h do |attempt_id, acceptance|
+          [ attempt_id.dup.freeze, acceptance.dup.freeze ]
+        end.freeze
       end
 
       # The host-wide admission lock is the transaction boundary for these

--- a/lib/hive/recovery/migration.rb
+++ b/lib/hive/recovery/migration.rb
@@ -520,7 +520,10 @@ module Hive
           )
         end
 
-        expected = Hive::Attempts::CapacitySnapshot.build(store: store, scan: scan, now: now)
+        expected = Hive::Attempts::CapacitySnapshot.build(
+          store: store, scan: scan, now: now,
+          daily_counts: durable_daily_counts(store, date: now.utc.to_date)
+        )
         actual = Hive::Attempts::CapacitySnapshot.build_from_live_reservations(
           scan: scan, reservations: index.live_reservations,
           daily_counts: index.daily_counts(date: now.utc.to_date)
@@ -544,6 +547,30 @@ module Hive
           "reserved" => snapshot.reserved_attempt_ids.sort,
           "invalid" => snapshot.invalid_count
         }
+      end
+
+      # Daily admission accounting outlives the bounded hot-record window.
+      # Validate each retained counter by point-fetching its hot record or
+      # immutable proof without enumerating uncharged historical proof.
+      def durable_daily_counts(store, date:)
+        counts = Hash.new(0)
+        store.decision_index.daily_acceptances(date: date).each do |attempt_id, acceptance|
+          record = store.fetch(attempt_id)
+          unless record && record["accepted_at"] == acceptance.fetch("accepted_at") &&
+                 record["project"] == acceptance.fetch("project")
+            raise Error, "daily accounting attempt #{attempt_id} has no matching durable record"
+          end
+
+          refunded = record.receipt &&
+            record.receipt["exit_status"] == Hive::ExitCodes::TEMPFAIL
+          unless acceptance.fetch("refunded") == !!refunded
+            raise Error, "daily accounting refund disagrees with durable attempt #{attempt_id}"
+          end
+          counts[[ record["project"], date ]] += 1 unless refunded
+        end
+        counts.to_h
+      rescue Hive::Attempts::StoreError, KeyError => error
+        raise Error, "daily accounting index is unreadable: #{error.message}"
       end
 
       def semantic_key(record)

--- a/test/unit/attempts/decision_index_test.rb
+++ b/test/unit/attempts/decision_index_test.rb
@@ -1,4 +1,5 @@
 require_relative "../../test_helper"
+require "hive/attempts/capability"
 require "hive/attempts/decision_index"
 require "hive/provider_routing"
 
@@ -42,6 +43,20 @@ class AttemptsDecisionIndexTest < Minitest::Test
     ], restarted.routing_decisions
     refute_includes all_bytes, "stdout"
     refute_includes all_bytes, "credential"
+  end
+
+  def test_daily_acceptances_expose_point_accounting_without_mutable_aliases
+    record = Hive::Attempts::Record.new(current_attempt)
+    @index.record_acceptance(record)
+
+    acceptances = @index.daily_acceptances(date: NOW.to_date)
+    assert_equal({
+      "accepted_at" => record["accepted_at"],
+      "project" => "demo",
+      "refunded" => false
+    }, acceptances.fetch("attempt-1"))
+    assert_predicate acceptances, :frozen?
+    assert_predicate acceptances.fetch("attempt-1"), :frozen?
   end
 
   def test_new_admission_observation_replaces_the_previous_projection
@@ -183,6 +198,20 @@ class AttemptsDecisionIndexTest < Minitest::Test
       decision_id: id,
       decided_at: NOW
     )
+  end
+
+  def current_attempt
+    Hive::Attempts::Record.launching(
+      attempt_id: "attempt-1", request_id: "request-1",
+      predecessor_attempt_id: nil,
+      task_id: "42", project: "demo", task_slug: "task",
+      intended_stage: "4-execute", task_generation: "generation-1",
+      progress_token: "progress-1", provider: "codex",
+      worker_argv: [ "hive", "run", "task" ],
+      claim_capability_digest: Hive::Attempts::Capability.digest("c" * 64),
+      starting_revision: nil, retry_charge: 0, inherited_outputs: [],
+      launch_timeout_sec: 30, now: NOW
+    ).to_h
   end
 
   def request

--- a/test/unit/recovery/migration_test.rb
+++ b/test/unit/recovery/migration_test.rb
@@ -656,6 +656,48 @@ class RecoveryMigrationTest < Minitest::Test
     end
   end
 
+  def test_daily_parity_rejects_accounting_without_a_durable_record
+    acceptance = {
+      "accepted_at" => NOW.iso8601(6), "project" => "demo", "refunded" => false
+    }
+    store = daily_parity_store(acceptances: { "missing" => acceptance })
+
+    error = assert_raises(Hive::Recovery::Migration::Error) do
+      migration.send(:durable_daily_counts, store, date: NOW.to_date)
+    end
+
+    assert_includes error.message, "daily accounting attempt missing has no matching durable record"
+  end
+
+  def test_daily_parity_rejects_a_refund_that_disagrees_with_the_record
+    record = Hive::Attempts::Record.new(current_attempt(attempt_id: "refund-mismatch"))
+    acceptance = {
+      "accepted_at" => record["accepted_at"], "project" => record["project"],
+      "refunded" => true
+    }
+    store = daily_parity_store(
+      acceptances: { record.attempt_id => acceptance }, records: { record.attempt_id => record }
+    )
+
+    error = assert_raises(Hive::Recovery::Migration::Error) do
+      migration.send(:durable_daily_counts, store, date: NOW.to_date)
+    end
+
+    assert_includes error.message, "daily accounting refund disagrees with durable attempt"
+  end
+
+  def test_daily_parity_rejects_an_unreadable_index
+    store = daily_parity_store(
+      error: Hive::Attempts::StoreError.new("injected daily index failure")
+    )
+
+    error = assert_raises(Hive::Recovery::Migration::Error) do
+      migration.send(:durable_daily_counts, store, date: NOW.to_date)
+    end
+
+    assert_equal "daily accounting index is unreadable: injected daily index failure", error.message
+  end
+
   def test_blocks_hot_removal_when_generated_indexes_do_not_match_the_scan
     with_tmp_dir do |state_home|
       write_v3_record(state_home, terminal_attempt(current_attempt(attempt_id: "terminal")))
@@ -877,6 +919,23 @@ class RecoveryMigrationTest < Minitest::Test
   end
 
   private
+
+  def migration
+    Hive::Recovery::Migration.new(state_home: "/unused")
+  end
+
+  def daily_parity_store(acceptances: {}, records: {}, error: nil)
+    index = Object.new
+    index.define_singleton_method(:daily_acceptances) do |**|
+      raise error if error
+
+      acceptances
+    end
+    Object.new.tap do |store|
+      store.define_singleton_method(:decision_index) { index }
+      store.define_singleton_method(:fetch) { |attempt_id| records[attempt_id] }
+    end
+  end
 
   def migrate(state_home)
     observer = Object.new

--- a/test/unit/recovery/migration_test.rb
+++ b/test/unit/recovery/migration_test.rb
@@ -1,6 +1,7 @@
 require "test_helper"
 require "digest"
 require "json"
+require "hive/attempts/decision_index"
 require "hive/attempts/store"
 require "hive/daemon/dispatch_request_queue"
 require "hive/daemon/dispatch_result_queue"
@@ -628,6 +629,30 @@ class RecoveryMigrationTest < Minitest::Test
       assert_match(/\A[0-9a-f]{64}\z/, result.dig("attempts", "decision_digest"))
       assert_equal result.dig("attempts", "decision_digest"), checkpoint.fetch("decision_digest")
       assert_equal 12, result.dig("attempts", "hot")
+    end
+  end
+
+  def test_daily_parity_includes_attempts_already_moved_to_permanent_proof
+    with_tmp_dir do |state_home|
+      terminal = terminal_attempt(current_attempt(
+        attempt_id: "proof-only-daily", accepted_at: NOW
+      ))
+      write_v3_proof(state_home, terminal)
+      current = Hive::Attempts::Record.new(
+        Hive::Attempts::RecordMigration.convert_v3(legacy_v3(terminal))
+      )
+      Hive::Attempts::DecisionIndex.new(
+        root: File.join(state_home, "attempts", "v3", "decision-indexes")
+      ).record_acceptance(current)
+
+      result = migrate(state_home)
+      store = Hive::Attempts::Store.new(
+        root: File.join(state_home, "attempts", "v4"), create_directories: false
+      )
+
+      assert_equal 0, result.dig("attempts", "source_count")
+      assert_equal current.to_h, store.permanent_proofs.fetch("proof-only-daily").to_h
+      assert_equal 1, store.decision_index.daily_count(project: "demo", date: NOW.to_date)
     end
   end
 

--- a/wiki/commands/migrate.md
+++ b/wiki/commands/migrate.md
@@ -34,9 +34,14 @@ cleanup commands while keeping the fleet result visibly incomplete.
 Before project-local changes, the command runs the owner-private recovery-state
 cutover for the current Hive state home. Daemon and bot startup run the same
 cutover before opening their stores or queues. A foreground default attempt
-store opens only the physical v3 layout after the cutover. An obsolete v1 root
-or competing material v2/v3 roots fail closed, so an upgrade cannot silently
-choose or create a second authority.
+store opens only the physical v4 layout after the cutover. Obsolete v1 roots
+or competing material v2/v3/v4 roots fail closed, so an upgrade cannot
+silently choose or create a second authority.
+
+The v4 cutover verifies daily admission accounting against both bounded hot
+records and immutable permanent proofs. Terminal attempts may already have
+moved out of the hot window before a migration resumes; their same-day counts
+remain authoritative and must not be discarded as stale index entries.
 
 ## Task-folder renames
 

--- a/wiki/log.d/20260812T142000Z-v4-migration-daily-parity.md
+++ b/wiki/log.d/20260812T142000Z-v4-migration-daily-parity.md
@@ -1,0 +1,9 @@
+## [2026-08-12T14:20:00Z] recovery — preserve daily accounting across v4 cutover resume
+
+**Action:** Made recovery migration verify same-day admission accounting from
+both bounded hot attempts and immutable permanent proofs, with a regression for
+a terminal attempt already promoted before the v4 cutover resumes.
+
+**Why:** Live migration retained the correct daily decision index but stopped
+because its parity oracle considered only the hot scan and therefore treated
+promoted same-day attempts as stale counters.

--- a/wiki/modules/attempts.md
+++ b/wiki/modules/attempts.md
@@ -93,7 +93,10 @@ model/effort, enclosing circuit generation vector, and probe bindings. Runtime
 readers accept v4 only. The one-off recovery migration converts valid schema-v3
 records and permanent proofs to v4 legacy mode while moving the physical v3
 tree to v4; malformed hot bytes remain exact capacity reservations, while an
-unreadable immutable proof aborts the cutover.
+unreadable immutable proof aborts the cutover. Its exact-parity gate rebuilds
+same-day admission accounting from both the bounded hot set and permanent
+proofs, because finalization may promote a terminal attempt before an
+interrupted cutover resumes.
 
 Both subjects share the same CAS record store, leases, capabilities,
 heartbeats, detached ownership, bounded retry accounting, receipts, output


### PR DESCRIPTION
## Summary
- expose immutable point accounting for retained daily admission entries
- validate migration parity against both bounded hot attempts and permanent proofs
- keep same-day counts authoritative when terminal attempts were promoted before a resumed cutover

## Why
A resumed v3-to-v4 cutover could retain a correct daily decision index but compare it only with the bounded hot scan. Terminal attempts already moved into immutable proofs then looked like stale counters and blocked migration. This is release-critical for the 0.7.1 live upgrade.

## Validation
- `bundle exec ruby -Itest test/unit/attempts/decision_index_test.rb` — 7 runs, 34 assertions
- `bundle exec ruby -Itest test/unit/recovery/migration_test.rb` — 36 runs, 247 assertions
- `rubocop` on the four changed Ruby files — clean
- `git diff --check` — clean
