### PR TITLE
fix(storage): open managed directories on aarch64

### DIFF
--- a/lib/hive/managed_directory/native_at.rb
+++ b/lib/hive/managed_directory/native_at.rb
@@ -11,7 +11,12 @@ module Hive
 
       def self.platform_flags(platform)
         if platform.include?("linux")
-          { directory: 0o200000, cloexec: 0o2000000 }.freeze
+          directory = if platform.start_with?("aarch64-", "arm64-")
+            0o40000
+          else
+            0o200000
+          end
+          { directory: directory, cloexec: 0o2000000 }.freeze
         elsif platform.include?("darwin")
           { directory: 0x00100000, cloexec: 0x01000000 }.freeze
         end

--- a/test/unit/managed_directory_test.rb
+++ b/test/unit/managed_directory_test.rb
@@ -1204,6 +1204,10 @@ class ManagedDirectoryTest < Minitest::Test
         native.class.platform_flags("x86_64-linux")
       )
       assert_equal(
+        { directory: 0o40000, cloexec: 0o2000000 },
+        native.class.platform_flags("aarch64-linux")
+      )
+      assert_equal(
         { directory: 0x00100000, cloexec: 0x01000000 },
         native.class.platform_flags("arm64-darwin")
       )

--- a/wiki/log.d/20260812T164427Z-aarch64-managed-directory-flags.md
+++ b/wiki/log.d/20260812T164427Z-aarch64-managed-directory-flags.md
@@ -1,0 +1,9 @@
+## [2026-08-12T16:44:27Z] storage — open managed directories on Linux aarch64
+
+**Action:** Made the descriptor-backed managed-directory adapter select the
+architecture-specific Linux `O_DIRECTORY` flag and added an exact aarch64
+platform-contract regression.
+
+**Why:** The x86_64 flag value is invalid on Linux aarch64, so authenticated
+release upgrade and recovery migration failed closed while opening valid v4
+attempt decision-index directories.

--- a/wiki/modules/attempts.md
+++ b/wiki/modules/attempts.md
@@ -3,7 +3,7 @@ title: Durable task attempts
 type: module
 source: lib/hive/attempts/
 created: 2026-07-16
-updated: 2026-08-11
+updated: 2026-08-12
 tags: [attempts, ownership, leases, daemon, recovery, bounded-storage]
 ---
 
@@ -206,6 +206,9 @@ directory revalidates the winning entry before use.
 Lost-outcome and dirty-state directories receive the same containment check.
 Corrupt or replacement links therefore fail closed and never redirect attempt
 state or permission changes outside `$HIVE_HOME/attempts/v4`.
+The descriptor adapter selects Linux `O_DIRECTORY` by CPU architecture:
+x86_64 uses `0200000`, while aarch64 uses `040000`. This keeps the same
+fail-closed managed-directory custody on both supported Linux architectures.
 
 Record construction/readers and store transitions all use the same
 non-mutating `Hive::StringifyKeys` transform as the task journal and projection.


### PR DESCRIPTION
## Summary

- Restore Linux aarch64 recovery migration and upgrade by selecting that architecture's `O_DIRECTORY` value.
- Preserve descriptor-based fail-closed custody on x86_64 Linux and arm64 macOS.

## Test plan

- [x] `ruby -Itest test/unit/managed_directory_test.rb` — 29 runs, 134 assertions
- [x] RuboCop for the implementation and focused test — no offenses
- [x] Ruby 3.4.10 under `linux/arm64` prepared a real descriptor-backed managed directory
- [ ] Hosted CI coverage and release-adjacent gates

## Notes for reviewer

The 0.7.1 trusted release-candidate upgrade lane exposed this mismatch. The existing platform contract covered x86_64 Linux and arm64 macOS but omitted Linux aarch64.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
