### PR TITLE
fix(release): isolate version bootstrap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
             echo "repository main branch is not protected" >&2
             exit 1
           fi
-          source_version="$(ruby -Ilib -e 'require "hive"; print Hive::VERSION')"
+          source_version="$(ruby --disable-gems -Ilib -e 'require "hive/version"; print Hive::VERSION')"
           if test "$source_version" != "$version"; then
             echo "tag version $version does not match source version $source_version" >&2
             exit 1

--- a/test/unit/release_contract_test.rb
+++ b/test/unit/release_contract_test.rb
@@ -257,6 +257,10 @@ class ReleaseContractTest < Minitest::Test
     assert_equal [ "select-candidate", "install-gate" ],
                  jobs.fetch("release-finalize").fetch("needs")
     assert_includes selector_body, 'candidate_sha="$(git rev-parse "${GITHUB_REF}^{commit}")"'
+    assert_includes selector_body,
+                    %(ruby --disable-gems -Ilib -e 'require "hive/version"; print Hive::VERSION')
+    refute_includes selector_body,
+                    %(ruby -Ilib -e 'require "hive"; print Hive::VERSION')
     assert_includes selector_body, "commits/${candidate_sha}/check-runs?per_page=100"
     assert_includes selector_body, "select_release_candidate.rb select"
     assert_includes selector_body, "select_release_candidate.rb verify"

--- a/wiki/log.d/20260812T194355Z-release-version-bootstrap.md
+++ b/wiki/log.d/20260812T194355Z-release-version-bootstrap.md
@@ -1,0 +1,9 @@
+## [2026-08-12T19:43:55Z] release — isolate tag version bootstrap
+
+**Action:** Made the tag-time release selector read `Hive::VERSION` from its
+dependency-free leaf with RubyGems disabled, and pinned that bootstrap in the
+release contract.
+
+**Why:** Loading the top-level Hive runtime before candidate dependencies were
+installed made a proven release fail selection when `agent_cli_runtime` became
+a published runtime dependency.

--- a/wiki/release-candidate.md
+++ b/wiki/release-candidate.md
@@ -410,6 +410,9 @@ agent-skill, and managed-web filenames for the tag version and target SHA. The
 source archive must declare that version through the canonical
 `lib/hive/version.rb` source, and it must remain newer than the catalog-pinned
 latest stable version already proven by the blocking candidate gate.
+The tag selector also reads that dependency-free version leaf with RubyGems
+disabled before candidate selection; it does not load the top-level Hive
+runtime or require installed runtime dependencies merely to compare the tag.
 Tag-time source inspection accepts the optional single canonical PAX global
 header emitted by `git archive` for the exact candidate SHA. It independently
 rejects duplicate or malformed global metadata and still rejects links and


### PR DESCRIPTION
## Summary

- Let the tag-time selector validate Hive’s version before runtime dependencies are installed.
- Keep the check fail-closed by loading only the canonical version leaf with RubyGems disabled.

## Test plan

- [x] `ruby -Itest test/unit/release_contract_test.rb` — 19 runs, 943 assertions
- [x] Dependency-free `ruby --disable-gems` version probe
- [x] RuboCop and workflow YAML parse
- [ ] Hosted CI and release-adjacent gates

## Notes for reviewer

The trusted 0.7.1 candidate passed every gate. Publication stopped before assets were created because the release selector loaded top-level Hive before the published `agent_cli_runtime` dependency had been installed.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
