### PR TITLE
refactor(conditions): remove unused rule iterator

### DIFF
--- a/lib/hive/conditions/policy.rb
+++ b/lib/hive/conditions/policy.rb
@@ -83,8 +83,6 @@ module Hive
         end
       end
 
-      def each_rule(&block) = @rules.values.each(&block)
-
       def build_rule(transition:, required:, inhibitors:, options:, authoritative_capable:)
         transition = transition.to_s
         raise InvalidPolicy, "gate transition must be non-empty" if transition.empty?

--- a/wiki/log.d/20260813T234100Z-unused-conditions-each-rule.md
+++ b/wiki/log.d/20260813T234100Z-unused-conditions-each-rule.md
@@ -1,0 +1,6 @@
+## Remove unused conditions rule iterator
+
+- Removed the cleanup target after tracked callsite, reflective-dispatch,
+  documentation, and available-history searches found no production consumer.
+- Retained focused coverage for the live behavior surrounding the orphaned
+  surface; untracked external Ruby callers remain the compatibility boundary.


### PR DESCRIPTION
## Summary

- Continue the requested 100-piece dead-code audit after #997 with piece 2.
- Remove `Hive::Conditions::Policy#each_rule`, whose only tracked occurrence was its definition; supported rule lookup, construction, and validation stay unchanged.

## Test plan

- [x] Focused policy tests: 3 runs, 19 assertions, 0 failures, 0 errors, 0 skips.
- [x] Full conditions unit subsystem: 53 runs, 254 assertions, 0 failures, 0 errors, 0 skips.
- [x] `ruby -c lib/hive/conditions/policy.rb` reports `Syntax OK`.
- [x] RuboCop inspects the changed file with no offenses.
- [x] `git diff --check` passes.
- [ ] Hosted CI coverage and dedicated merge gates pass.

## Notes for reviewer

- Before deletion, exact tracked-tree and all-file searches found `each_rule` only at its definition. Symbol/string/reflection spellings (`send`, `public_send`, `respond_to?`, and `method`) had no matches.
- An AST walk of every tracked Ruby file also found no `each_rule` reference. History shows the helper arrived with the policy implementation and never gained a consumer.
- Independent correctness and project-standards review completed with no surviving finding. Review artifact: `/tmp/compound-engineering-1000/ce-code-review/20260813-004539-5dc45ebe`.
- Residual boundary: Ruby reflection, dynamic dispatch, and unsupported external gem consumers cannot be disproved from this repository. This PR removes only the unconsumed in-repository surface.
- This is piece 2 of the requested 100-piece unused-code audit. Each confirmed piece is isolated in its own evidence-backed PR.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. The removed iterator has no tracked caller or supported runtime path; exact-head hosted CI is the validation boundary.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
