### PR TITLE
refactor(retention): remove obsolete reset hook

### DIFF
--- a/lib/hive/completed_at_backfiller.rb
+++ b/lib/hive/completed_at_backfiller.rb
@@ -95,8 +95,6 @@ module Hive
         cursor_store.write(state, selected.last.folder) if selected.any?
         selected
       end
-
-      def reset_progress! = nil
     end
 
     def initialize(history: nil, batch_size: BATCH_SIZE,

--- a/wiki/log.d/20260813T234000Z-unused-completed-at-reset-progress.md
+++ b/wiki/log.d/20260813T234000Z-unused-completed-at-reset-progress.md
@@ -1,0 +1,6 @@
+## Remove obsolete completion reset hook
+
+- Removed the cleanup target after tracked callsite, reflective-dispatch,
+  documentation, and available-history searches found no production consumer.
+- Retained focused coverage for the live behavior surrounding the orphaned
+  surface; untracked external Ruby callers remain the compatibility boundary.


### PR DESCRIPTION
## Summary

- remove the obsolete `Hive::CompletedAtBackfiller.reset_progress!` no-op
- keep the persistent `CursorStore` rotation behavior unchanged

## Test plan

- baseline `test/unit/completed_at_backfiller_test.rb`: 15 runs, 54 assertions, 0 failures/errors/skips
- repeated post-change focused runs: 15 runs, 54 assertions, 0 failures/errors/skips per run
- combined archive/backfill unit tests: 21 runs, 74 assertions, 0 failures/errors/skips
- `ruby -c lib/hive/completed_at_backfiller.rb`
- RuboCop on `lib/hive/completed_at_backfiller.rb`: 1 file, 0 offenses
- `git diff --check`

## Evidence

- the exact tracked tree contains no `reset_progress!` reference outside its definition, including no literal reflective dispatch
- history shows the method originally cleared process-local cursor hashes and had two test callers; the persistent `CursorStore` migration removed those callers and replaced the method with `nil`
- subsequent history never added a consumer, test, or documented API contract
- the focused correctness and standards review found no validated findings; artifact: `/tmp/compound-engineering-1000/ce-code-review/20260813-011905-d25cd25a`
- residual boundary: computed Ruby reflection, dynamic dispatch, or unsupported external consumers cannot be disproven from this repository

This is unused-code audit piece **3/100**.

## Post-Deploy Monitoring

No deployment-specific monitoring is required. Normal CI and any downstream `NoMethodError` reports cover the stated unsupported-consumer residual.

---

Built with [Compound Engineering](https://github.com/EveryInc/compound-engineering-plugin)
