### PR TITLE
refactor(release): remove unused artifact collector

### DIFF
--- a/packaging/release_candidate/baseline_catalog.rb
+++ b/packaging/release_candidate/baseline_catalog.rb
@@ -89,12 +89,6 @@ module HiveReleaseCandidate
         raise(UsageError, "unknown release baseline #{id.inspect}")
     end
 
-    def all_artifacts
-      entries.flat_map do |entry|
-        entry.packages.values.map { |package| package.fetch("artifact") }
-      end
-    end
-
     def package_requirements
       entries.flat_map do |entry|
         entry.packages.map do |role, package|

--- a/wiki/log.d/20260813T233200Z-unused-baseline-all-artifacts.md
+++ b/wiki/log.d/20260813T233200Z-unused-baseline-all-artifacts.md
@@ -1,0 +1,6 @@
+## Remove unused baseline artifact collector
+
+- Removed the cleanup target after tracked callsite, reflective-dispatch,
+  documentation, and available-history searches found no production consumer.
+- Retained focused coverage for the live behavior surrounding the orphaned
+  surface; untracked external Ruby callers remain the compatibility boundary.


### PR DESCRIPTION
## Summary

- remove the unused internal `HiveReleaseCandidate::BaselineCatalog#all_artifacts` helper
- preserve catalog parsing, package requirements, cache materialization, and hosted release evidence behavior

## Test plan

- baseline focused test repeated 3x: 9 runs, 89 assertions, 0 failures/errors/skips per run
- post-change focused test repeated 3x: 9 runs, 89 assertions, 0 failures/errors/skips per run
- seven adjacent release-candidate unit files: 46 runs, 310 assertions, 0 failures/errors/skips
- `ruby -c packaging/release_candidate/baseline_catalog.rb`
- RuboCop on `packaging/release_candidate/baseline_catalog.rb`: 1 file, 0 offenses
- `git diff --check`

## Evidence

- `all_artifacts` appears only at its definition in the exact tracked tree, with no literal reflective dispatch
- its introducing commit and both later imports contain no caller; the helper remained definition-only for its full history
- the release-candidate wiki documents supported catalog behavior and the stable facade, but not this internal helper
- focused correctness and standards review found no validated findings; artifact: `/tmp/compound-engineering-1000/ce-code-review/20260813-012538-cc3cb192`
- residual boundary: computed Ruby reflection or unsupported source-checkout consumers cannot be disproven from this repository

This is unused-code audit piece **4/100**.

## Post-Deploy Monitoring

No deployment-specific monitoring is required. Normal CI and any downstream `NoMethodError` reports cover the stated unsupported-consumer residual.

---

Built with [Compound Engineering](https://github.com/EveryInc/compound-engineering-plugin)
