### PR TITLE
refactor(release): remove unused summary path helper

### DIFF
--- a/packaging/release_candidate/paths.rb
+++ b/packaging/release_candidate/paths.rb
@@ -78,10 +78,6 @@ module HiveReleaseCandidate
       File.join(attempt_dir(attempt_id), "evidence.json")
     end
 
-    def summary_path(attempt_id)
-      File.join(attempt_dir(attempt_id), "summary.md")
-    end
-
     def current_path
       File.join(candidate_root, "current.json")
     end

--- a/wiki/log.d/20260813T235400Z-unused-release-summary-path.md
+++ b/wiki/log.d/20260813T235400Z-unused-release-summary-path.md
@@ -1,0 +1,6 @@
+## Remove unused release summary path
+
+- Removed the cleanup target after tracked callsite, reflective-dispatch,
+  documentation, and available-history searches found no production consumer.
+- Retained focused coverage for the live behavior surrounding the orphaned
+  surface; untracked external Ruby callers remain the compatibility boundary.


### PR DESCRIPTION
## Summary

- remove the unused internal `HiveReleaseCandidate::Paths#summary_path` helper
- preserve release-candidate evidence output, which writes `summary.md` directly within the attempt directory

## Test plan

- baseline focused tests repeated 3x: 16 runs, 93 assertions, 0 failures/errors/skips per run
- post-change focused tests repeated 3x: 16 runs, 93 assertions, 0 failures/errors/skips per run
- seven adjacent release-candidate unit files: 46 runs, 310 assertions, 0 failures/errors/skips
- `ruby -c packaging/release_candidate/paths.rb`
- RuboCop on `packaging/release_candidate/paths.rb`: 1 file, 0 offenses
- `git diff --check`

## Evidence

- `summary_path` appears only at its definition in the exact tracked tree, with no literal reflective dispatch
- its introducing commit and later imports contain no caller; it remained definition-only for its full history
- `Evidence` has always written `File.join(directory, "summary.md")`, so removing this helper does not alter summary production
- the release-candidate wiki documents the stable facade and treats `Paths` as an internal collaborator; it does not document this helper
- focused correctness and standards review found no findings; artifact: `/tmp/compound-engineering-1000/ce-code-review/20260813-013030-480a549c`
- residual boundary: computed Ruby reflection or unsupported source-checkout consumers cannot be disproven from this repository

This is unused-code audit piece **5/100**.

## Post-Deploy Monitoring

No deployment-specific monitoring is required. Normal CI and any downstream `NoMethodError` reports cover the stated unsupported-consumer residual.

---

Built with [Compound Engineering](https://github.com/EveryInc/compound-engineering-plugin)
