### PR TITLE
refactor(bench): remove unused gated predicate

### DIFF
--- a/templates/builtins/bench/runtime/harness/gate.rb
+++ b/templates/builtins/bench/runtime/harness/gate.rb
@@ -16,9 +16,7 @@ module HiveBench
   # in the "judged" subset (scored by tiers 2–3 only). The gated:judged split is
   # what the leaderboard publishes so the "objective floor" isn't overstated.
   class Gate
-    Result = Data.define(:status, :subset, :reason, :details) do
-      def gated? = subset == "gated"
-    end
+    Result = Data.define(:status, :subset, :reason, :details)
 
     # exec: ->(cmd:, work_dir:) => { output: String, ok: Boolean }
     #   In production this runs the command inside the `--network none` runner

--- a/wiki/log.d/20260813T233300Z-unused-bench-gated-predicate.md
+++ b/wiki/log.d/20260813T233300Z-unused-bench-gated-predicate.md
@@ -1,0 +1,6 @@
+## Remove unused benchmark gated predicate
+
+- Removed the cleanup target after tracked callsite, reflective-dispatch,
+  documentation, and available-history searches found no production consumer.
+- Retained focused coverage for the live behavior surrounding the orphaned
+  surface; untracked external Ruby callers remain the compatibility boundary.


### PR DESCRIPTION
## Summary

- remove the unused `HiveBench::Gate::Result#gated?` convenience predicate
- preserve the serialized `subset` field consumed by scoring and leaderboard code

## Test plan

- direct judged/gated result smoke repeated 3x before and after: pass each run
- packaged template/gemspec tests: 14 runs, 94 assertions, 0 failures/errors/skips
- `ruby -c templates/builtins/bench/runtime/harness/gate.rb`
- RuboCop on the changed file: 1 file, 0 offenses
- `git diff --check`

## Evidence

- `gated?` appears only at its definition in the exact tracked tree, with no literal reflective dispatch
- every introducing/import history snapshot contains only the definition
- scoring reads `record["subset"] == "gated"`; result construction and serialization keep `subset` unchanged
- focused correctness and standards review found no findings; artifact: `/tmp/compound-engineering-1000/ce-code-review/20260813-013506-8b66b3d9`
- residual boundary: computed Ruby reflection or unsupported installed-runtime consumers cannot be disproven from this repository

This is unused-code audit piece **6/100**.

## Post-Deploy Monitoring

No deployment-specific monitoring is required. Normal CI and any downstream `NoMethodError` reports cover the stated unsupported-consumer residual.

---

Built with [Compound Engineering](https://github.com/EveryInc/compound-engineering-plugin)
