### PR TITLE
refactor(bench): remove unused suite predicate

### DIFF
--- a/templates/builtins/bench/runtime/harness/lib/test_result_parser.rb
+++ b/templates/builtins/bench/runtime/harness/lib/test_result_parser.rb
@@ -13,9 +13,7 @@ module HiveBench
   module TestResultParser
     module_function
 
-    Result = Data.define(:ran, :passed, :failed, :errored, :by_name) do
-      def suite_green? = ran && failed.zero? && errored.zero?
-    end
+    Result = Data.define(:ran, :passed, :failed, :errored, :by_name)
 
     # Minitest summary line, e.g. "12 runs, 34 assertions, 1 failures, 0 errors, 0 skips".
     SUMMARY = /(\d+)\s+runs?,\s+\d+\s+assertions?,\s+(\d+)\s+failures?,\s+(\d+)\s+errors?/

--- a/wiki/log.d/20260813T233600Z-unused-bench-suite-green.md
+++ b/wiki/log.d/20260813T233600Z-unused-bench-suite-green.md
@@ -1,0 +1,6 @@
+## Remove unused benchmark suite predicate
+
+- Removed the cleanup target after tracked callsite, reflective-dispatch,
+  documentation, and available-history searches found no production consumer.
+- Retained focused coverage for the live behavior surrounding the orphaned
+  surface; untracked external Ruby callers remain the compatibility boundary.


### PR DESCRIPTION
## Summary

- remove the unused `HiveBench::TestResultParser::Result#suite_green?` convenience predicate
- preserve parser result fields and the gate's per-test observation behavior

## Test plan

- parser smoke for green, failing, and unparseable output repeated 3x before and after: pass each run
- direct `HiveBench::Gate` integration smoke: gated pass
- packaged template/gemspec tests: 14 runs, 94 assertions, 0 failures/errors/skips
- `ruby -c templates/builtins/bench/runtime/harness/lib/test_result_parser.rb`
- RuboCop on the changed file: 1 file, 0 offenses
- `git diff --check`

## Evidence

- `suite_green?` appears only at its definition in the exact tracked tree, with no literal reflective dispatch
- every introducing/import history snapshot contains only the definition
- the gate consumes `ran`, `failed`, `errored`, `observed?`, and `test_outcome` directly; all remain unchanged
- focused correctness and standards review found no findings; artifact: `/tmp/compound-engineering-1000/ce-code-review/20260813-013930-a024be08`
- residual boundary: computed Ruby reflection or unsupported installed-runtime consumers cannot be disproven from this repository

This is unused-code audit piece **7/100**.

## Post-Deploy Monitoring

No deployment-specific monitoring is required. Normal CI and any downstream `NoMethodError` reports cover the stated unsupported-consumer residual.

---

Built with [Compound Engineering](https://github.com/EveryInc/compound-engineering-plugin)
