### PR TITLE
refactor(bench): remove unused pipeline lookup

### DIFF
--- a/templates/builtins/bench/runtime/harness/profiles/slate.rb
+++ b/templates/builtins/bench/runtime/harness/profiles/slate.rb
@@ -56,10 +56,6 @@ module HiveBench
       ]
     end
 
-    def pipeline_by_id(id)
-      pipelines.find { |p| p.id == id }
-    end
-
     # The recorded incumbent: scored from claude-opus-4.7's RAW execute output
     # (reused — see lib/reuse.rb), never run fresh (we don't ship the 4.7 CLI).
     # headless_argv is unused for a reused cell but kept for shape/preflight.

--- a/wiki/log.d/20260813T233400Z-unused-bench-pipeline-lookup.md
+++ b/wiki/log.d/20260813T233400Z-unused-bench-pipeline-lookup.md
@@ -1,0 +1,6 @@
+## Remove unused benchmark pipeline lookup
+
+- Removed the cleanup target after tracked callsite, reflective-dispatch,
+  documentation, and available-history searches found no production consumer.
+- Retained focused coverage for the live behavior surrounding the orphaned
+  surface; untracked external Ruby callers remain the compatibility boundary.


### PR DESCRIPTION
## Summary

- remove the unused `HiveBench::Slate.pipeline_by_id` lookup helper
- preserve the fixed seven-profile slate and six self/cross pipelines consumed as complete collections

## Test plan

- slate construction smoke repeated 3x before and after: 7 unique profiles, 6 unique pipelines, all endpoints present
- packaged template/gemspec tests: 14 runs, 94 assertions, 0 failures/errors/skips
- `ruby -c templates/builtins/bench/runtime/harness/profiles/slate.rb`
- `git diff --check`
- RuboCop comparison: identical 12 pre-existing array-spacing offenses on `origin/main` and the changed file; 0 introduced

## Evidence

- `pipeline_by_id` appears only at its definition in the exact tracked tree, with no literal reflective dispatch
- every introducing/import history snapshot contains only the definition
- runtime consumers use `Slate.pipelines` and `Slate.profiles` directly; both collections and their identities remain unchanged
- focused correctness and standards review found no findings; artifact: `/tmp/compound-engineering-1000/ce-code-review/20260813-014336-7760306b`
- residual boundary: computed Ruby reflection or unsupported installed-runtime consumers cannot be disproven from this repository

This is unused-code audit piece **8/100**.

## Post-Deploy Monitoring

No deployment-specific monitoring is required. Normal CI and any downstream `NoMethodError` reports cover the stated unsupported-consumer residual.

---

Built with [Compound Engineering](https://github.com/EveryInc/compound-engineering-plugin)
