### PR TITLE
refactor(bench): remove unused tie predicate

### DIFF
--- a/templates/builtins/bench/runtime/harness/judge.rb
+++ b/templates/builtins/bench/runtime/harness/judge.rb
@@ -19,12 +19,6 @@ module HiveBench
       # reasons defaults empty so pre-existing constructions (tests, merge paths)
       # stay valid — older records simply carry no rationale.
       def initialize(reasons: [], **rest) = super
-
-      # Two cells are a tie when their judge intervals overlap — the leaderboard
-      # must not order within noise.
-      def ties_with?(other)
-        interval.first <= other.interval.last && other.interval.first <= interval.last
-      end
     end
 
     PROMPT_PATH = File.expand_path("judge-prompt.md", __dir__)

--- a/wiki/log.d/20260813T233700Z-unused-bench-tie-predicate.md
+++ b/wiki/log.d/20260813T233700Z-unused-bench-tie-predicate.md
@@ -1,0 +1,6 @@
+## Remove unused benchmark tie predicate
+
+- Removed the cleanup target after tracked callsite, reflective-dispatch,
+  documentation, and available-history searches found no production consumer.
+- Retained focused coverage for the live behavior surrounding the orphaned
+  surface; untracked external Ruby callers remain the compatibility boundary.


### PR DESCRIPTION
## Summary

- remove the unused `HiveBench::Judge::Result#ties_with?` convenience predicate
- preserve score aggregation and the interval values consumed directly by benchmark ranking

## Test plan

- judge aggregation smoke repeated 3x before and after, covering mean, standard deviation, scores, interval, reasons, and equivalent overlap/non-overlap checks
- packaged template/gemspec tests: 14 runs, 94 assertions, 0 failures/errors/skips
- `ruby -c templates/builtins/bench/runtime/harness/judge.rb`
- `git diff --check`
- RuboCop comparison: identical 4 pre-existing offenses on `origin/main` and the changed file; 0 introduced

## Evidence

- `ties_with?` appears only at its definition in the exact tracked tree and historical snapshots, with no literal reflective dispatch or documentation reference
- the scoring path serializes and consumes `Result#interval` directly; no runtime path invokes the predicate
- focused correctness and standards review found no findings; artifact: `/tmp/compound-engineering-1000/ce-code-review/20260813-020140-9fbdb4f2`
- residual boundary: computed Ruby reflection or private installed-runtime consumers cannot be disproven from this repository

This is unused-code audit piece **10/100**.

## Post-Deploy Monitoring

No deployment-specific monitoring is required. Normal CI and any downstream `NoMethodError` reports cover the stated unsupported-consumer residual.

---

Built with [Compound Engineering](https://github.com/EveryInc/compound-engineering-plugin)
