### PR TITLE
refactor(bench): remove unused retry helper

### DIFF
--- a/templates/builtins/bench/runtime/harness/lib/agent_limit.rb
+++ b/templates/builtins/bench/runtime/harness/lib/agent_limit.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "time"
-
 module HiveBench
   # Detects when a candidate run hit a provider usage/credit/rate limit rather
   # than genuinely failing. A limit is not a clean exit code — it surfaces as a
@@ -57,8 +55,6 @@ module HiveBench
       /resource[_\s-]*exhausted/i
     ].freeze
 
-    UTC_RESET_HINT = /resets\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)\s+\(UTC\)/i
-
     # True if any non-benign line matches a limit pattern.
     def limit_hit?(text)
       normalize(text).each_line.any? do |line|
@@ -72,28 +68,6 @@ module HiveBench
 
     def normalize(text)
       text.to_s.scrub.gsub(%r{\e\[[0-9;?]*[ -/]*[@-~]}, "")
-    end
-
-    # Prefer a provider's explicit UTC reset boundary over the generic cooldown.
-    # Claude currently emits messages such as "resets 12am (UTC)". A small
-    # grace period keeps the retry off the exact boundary; absent/malformed or
-    # non-UTC hints retain the conservative one-hour fallback.
-    def retry_after(text, now: Time.now.utc, fallback_seconds: 3600, grace_seconds: 60)
-      now = now.utc
-      fallback = (now + fallback_seconds).iso8601
-      match = normalize(text).scan(UTC_RESET_HINT).last
-      return fallback unless match
-
-      hour, minute, meridiem = match
-      hour = Integer(hour)
-      minute = Integer(minute || 0)
-      return fallback unless (1..12).cover?(hour) && (0..59).cover?(minute)
-
-      hour %= 12
-      hour += 12 if meridiem.downcase == "pm"
-      reset = Time.utc(now.year, now.month, now.day, hour, minute) + grace_seconds
-      reset += 86_400 if reset <= now
-      reset.iso8601
     end
   end
 end

--- a/wiki/log.d/20260813T233500Z-unused-bench-retry-after.md
+++ b/wiki/log.d/20260813T233500Z-unused-bench-retry-after.md
@@ -1,0 +1,6 @@
+## Remove unused benchmark retry helper
+
+- Removed the cleanup target after tracked callsite, reflective-dispatch,
+  documentation, and available-history searches found no production consumer.
+- Retained focused coverage for the live behavior surrounding the orphaned
+  surface; untracked external Ruby callers remain the compatibility boundary.


### PR DESCRIPTION
## Summary

- remove the unused `HiveBench::AgentLimit.retry_after` helper
- remove its private reset-pattern constant and now-unneeded `time` require
- preserve the live provider-limit classification used by benchmark runs

## Test plan

- focused AgentLimit baseline and post-change smoke repeated 3x
- bench unit suite: 23 runs, 170 assertions, 0 failures/errors/skips
- packaged install integration: 17 runs, 202 assertions, 0 failures/errors/skips
- packaged gemspec tests: 14 runs, 94 assertions, 0 failures/errors/skips
- Ruby syntax, RuboCop, and `git diff --check`

## Evidence

- exact tracked-tree, AST, history, import-snapshot, reflection-pattern, and public GitHub searches found no `retry_after` consumer
- all live harness callers use `HiveBench::AgentLimit.limit_hit?`; none schedules retries through this helper
- supported Ruby 3.4 exposes `Time#iso8601` without the removed transitive `time` load
- focused correctness and standards review found no findings; artifact: `/tmp/compound-engineering-1000/ce-code-review/20260813-011039-3fa120a1`
- residual boundary: computed reflection or private installed-runtime consumers cannot be disproven from this repository

This is unused-code audit piece **11/100**.

## Post-Deploy Monitoring

No deployment-specific monitoring is required. Normal CI and any downstream `NoMethodError` reports cover the stated unsupported-consumer residual.

---

Built with [Compound Engineering](https://github.com/EveryInc/compound-engineering-plugin)
