### PR TITLE
refactor(routing): remove unused binding predicate

### DIFF
--- a/lib/hive/agent_profiles/launch_bindings.rb
+++ b/lib/hive/agent_profiles/launch_bindings.rb
@@ -20,8 +20,6 @@ module Hive
           )
           freeze
         end
-
-        def default? = id == "default"
       end
 
       module_function

--- a/test/unit/agent_profiles/launch_bindings_test.rb
+++ b/test/unit/agent_profiles/launch_bindings_test.rb
@@ -9,7 +9,7 @@ class AgentProfilesLaunchBindingsTest < Minitest::Test
       adapter: "codex", binding_id: "default", environment: {}
     )
 
-    assert binding.default?
+    assert_equal "default", binding.id
     assert_equal({ "OPENAI_API_KEY" => nil }, binding.environment)
     assert_nil binding.selector_name
   end

--- a/wiki/log.d/20260813T234500Z-unused-launch-binding-default-predicate.md
+++ b/wiki/log.d/20260813T234500Z-unused-launch-binding-default-predicate.md
@@ -1,0 +1,6 @@
+## Remove unused launch-binding predicate
+
+- Removed the cleanup target after tracked callsite, reflective-dispatch,
+  documentation, and available-history searches found no production consumer.
+- Retained focused coverage for the live behavior surrounding the orphaned
+  surface; untracked external Ruby callers remain the compatibility boundary.


### PR DESCRIPTION
## Summary

- remove the unused internal `LaunchBindings::Binding#default?` predicate
- retain the default-binding contract through the immutable binding `id`

## Test plan

- launch bindings test repeated 3x: 7 runs, 109 assertions per run, 0 failures/errors/skips
- provider routing/configuration suite: 20 runs, 138 assertions, 0 failures/errors/skips
- Ruby syntax, RuboCop, and `git diff --check`

## Evidence

- exact tracked-tree, history, reflection-pattern, documentation, and public GitHub searches found `default?` only in its definition and the replaced unit assertion
- production code consumes the binding `id`, adapter, selector, and environment fields directly; no runtime path calls this predicate
- the test still pins the default identity as `id == "default"`
- focused correctness and standards review found no findings; artifact: `/tmp/compound-engineering-1000/ce-code-review/20260813-011335-df91b8c2`
- residual boundary: computed reflection or external consumers of this internal value object cannot be disproven from this repository

This is unused-code audit piece **12/100**.

## Post-Deploy Monitoring

No deployment-specific monitoring is required. Normal CI and downstream `NoMethodError` reports cover the stated unsupported-consumer residual.

---

Built with [Compound Engineering](https://github.com/EveryInc/compound-engineering-plugin)
