### PR TITLE
refactor(attempts): remove unused reservation predicate

### DIFF
--- a/lib/hive/attempts/store.rb
+++ b/lib/hive/attempts/store.rb
@@ -16,9 +16,7 @@ module Hive
     # Invalid records are deliberately retained by scans and count as a
     # reservation. A downgraded or partially written store must never create
     # capacity for a duplicate owner by ignoring evidence it cannot parse.
-    InvalidStoredRecord = Data.define(:path, :error) do
-      def capacity_reservation? = true
-    end
+    InvalidStoredRecord = Data.define(:path, :error)
     Scan = Data.define(:records, :invalid_records)
 
     class Store

--- a/test/unit/attempts/store_test.rb
+++ b/test/unit/attempts/store_test.rb
@@ -156,7 +156,7 @@ class AttemptsStoreTest < Minitest::Test
       scan = store.scan
       assert_empty scan.records
       assert_equal 2, scan.invalid_records.size
-      assert scan.invalid_records.all?(&:capacity_reservation?)
+      assert_equal %w[broken.json newer.json], scan.invalid_records.map { |record| File.basename(record.path) }
     end
   end
 

--- a/wiki/log.d/20260813T234300Z-unused-invalid-capacity-predicate.md
+++ b/wiki/log.d/20260813T234300Z-unused-invalid-capacity-predicate.md
@@ -1,0 +1,6 @@
+## Remove unused capacity predicate
+
+- Removed the cleanup target after tracked callsite, reflective-dispatch,
+  documentation, and available-history searches found no production consumer.
+- Retained focused coverage for the live behavior surrounding the orphaned
+  surface; untracked external Ruby callers remain the compatibility boundary.


### PR DESCRIPTION
## Summary

- remove the unused `InvalidStoredRecord#capacity_reservation?` predicate
- preserve fail-closed attempt capacity by retaining every invalid record in the scan
- make the owning test assert the exact retained invalid-record filenames

## Test plan

- attempts store baseline/post-change repeated 3x: 16 runs, 165 assertions per post-change run, 0 failures/errors/skips
- attempt capacity tests: 10 runs, 30 assertions, 0 failures/errors/skips
- attempt reconciler tests: 17 runs, 64 assertions, 0 failures/errors/skips
- Ruby syntax, RuboCop, and `git diff --check`

## Evidence

- exact tracked-tree, history, reflection-pattern, documentation, and public GitHub searches found `capacity_reservation?` only in its definition and the replaced test assertion
- runtime capacity computes from `scan.invalid_records` directly; it never calls a predicate on each invalid record
- the revised test proves both malformed records remain retained, which is the fail-closed invariant that matters
- focused correctness and standards review found no findings; artifact: `/tmp/compound-engineering-1000/ce-code-review/20260813-011637-c84e1107`
- residual boundary: computed reflection or external consumers of this internal record value object cannot be disproven from this repository

This is unused-code audit piece **13/100**.

## Post-Deploy Monitoring

No deployment-specific monitoring is required. Normal CI and downstream `NoMethodError` reports cover the stated unsupported-consumer residual.

---

Built with [Compound Engineering](https://github.com/EveryInc/compound-engineering-plugin)
