### PR TITLE
refactor(bot): remove unused message predicate

### DIFF
--- a/lib/hive/bot/telegram.rb
+++ b/lib/hive/bot/telegram.rb
@@ -24,10 +24,6 @@ module Hive
           super
         end
 
-        def message?
-          callback_data.nil? && !text.to_s.empty?
-        end
-
         def text?
           # Callback updates intentionally do not inherit source-message text.
           !text.to_s.empty?

--- a/test/unit/bot/telegram_test.rb
+++ b/test/unit/bot/telegram_test.rb
@@ -100,7 +100,6 @@ class HiveBotTelegramTest < Minitest::Test
 
     assert_equal [ 1001, 1002 ], updates.map(&:update_id)
     assert_equal [ 12345, 12345 ], updates.map(&:chat_id)
-    assert updates.first.message?
     assert updates.first.text?
     assert_equal "/status", updates.first.text
     assert updates.last.callback_query?

--- a/wiki/log.d/20260813T235700Z-unused-telegram-message-predicate.md
+++ b/wiki/log.d/20260813T235700Z-unused-telegram-message-predicate.md
@@ -1,0 +1,6 @@
+## Remove unused Telegram message predicate
+
+- Removed the cleanup target after tracked callsite, reflective-dispatch,
+  documentation, and available-history searches found no production consumer.
+- Retained focused coverage for the live behavior surrounding the orphaned
+  surface; untracked external Ruby callers remain the compatibility boundary.


### PR DESCRIPTION
## Summary

- remove the unused `Hive::Bot::Telegram::Update#message?` predicate
- preserve the text, callback, media, voice, and effective-text routing predicates used by the bot

## Test plan

- Telegram unit test repeated 3x: 34 runs, 137 assertions per post-change run, 0 failures/errors/skips
- bot router tests: 62 runs, 307 assertions, 0 failures/errors/skips
- bot supervisor tests: 174 runs, 782 assertions, 0 failures/errors/skips
- Ruby syntax, RuboCop, and `git diff --check`

## Evidence

- exact tracked-tree, history, reflection-pattern, documentation, and public GitHub searches found `message?` only in its definition and removed assertion
- runtime routing consumes `text?`, `callback_query?`, `media?`, `voice?`, and `effective_text` directly
- focused correctness and standards review found no findings; artifact: `/tmp/compound-engineering-1000/ce-code-review/20260813-011832-b72c06f4`
- residual boundary: computed reflection or private gem consumers of this internal update value object cannot be disproven from this repository

This is unused-code audit piece **14/100**.

## Post-Deploy Monitoring

No deployment-specific monitoring is required. Normal CI and downstream `NoMethodError` reports cover the stated unsupported-consumer residual.

---

Built with [Compound Engineering](https://github.com/EveryInc/compound-engineering-plugin)
