### PR TITLE
refactor(babysitter): remove unused CI rerun helper

### DIFF
--- a/lib/hive/babysitter/gh_ops.rb
+++ b/lib/hive/babysitter/gh_ops.rb
@@ -176,17 +176,6 @@ module Hive
         result(status.success?, out, err)
       end
 
-      def rerun_ci(worktree, run_id, cfg:, dry_run:)
-        return result(true, "[dry-run] gh run rerun skipped", "") if dry_run
-
-        out, err, status = Hive::Gh.capture3(
-          "gh", "run", "rerun", run_id.to_s,
-          chdir: worktree,
-          cfg: cfg
-        )
-        result(status.success?, out, err)
-      end
-
       def pr_has_label?(worktree, pr_number, label, cfg:)
         out, _err, status = Hive::Gh.capture3(
           "gh", "pr", "view", pr_number.to_s, "--json", "labels",

--- a/test/unit/babysitter/coverage_gaps_test.rb
+++ b/test/unit/babysitter/coverage_gaps_test.rb
@@ -434,11 +434,9 @@ class BabysitterCoverageGapsTest < Minitest::Test
     }) do
       assert Hive::Babysitter::GhOps.add_label("/tmp/wt", 42, "label", cfg: {}, dry_run: false).success?
       assert Hive::Babysitter::GhOps.post_pr_comment("/tmp/wt", 42, "body", cfg: {}, dry_run: false).success?
-      assert Hive::Babysitter::GhOps.rerun_ci("/tmp/wt", 99, cfg: {}, dry_run: false).success?
     end
     assert calls.any? { |cmd| cmd.include?("edit") }
     assert calls.any? { |cmd| cmd.include?("comment") }
-    assert calls.any? { |cmd| cmd.include?("rerun") }
 
     now = Time.utc(2026, 6, 3, 1, 0, 0)
     recent = Hive::Babysitter::GhOps.give_up_marker(now: now)

--- a/wiki/log.d/20260813T011955Z-unused-babysitter-rerun-ci.md
+++ b/wiki/log.d/20260813T011955Z-unused-babysitter-rerun-ci.md
@@ -1,0 +1,11 @@
+---
+date: 2026-08-13
+slug: unused-babysitter-rerun-ci
+pages: [modules/babysitter]
+---
+
+Removed the unused `Hive::Babysitter::GhOps.rerun_ci` helper and its
+coverage-only assertion. No production caller dispatched that GitHub action;
+the babysitter's live side-effect paths remain rebase, force-push, label
+management, and PR comments. Updated [[modules/babysitter]] to match the
+remaining API.

--- a/wiki/modules/babysitter.md
+++ b/wiki/modules/babysitter.md
@@ -3,7 +3,7 @@ title: Hive::Babysitter
 type: module
 source: lib/hive/babysitter/, bin/hive-babysitter-stub-git, bin/hive-babysitter-stub-gh.rb, bin/hive-babysitter-skip-log.rb
 created: 2026-05-26
-updated: 2026-08-07
+updated: 2026-08-13
 tags: [babysitter, module, daemon, github, agents]
 ---
 
@@ -20,7 +20,7 @@ tags: [babysitter, module, daemon, github, agents]
 | `Hive::Babysitter::PrFixer` | `lib/hive/babysitter/pr_fixer.rb` | Per-PR precheck, green-but-`BEHIND` auto-rebase, worktree setup, context gathering, prompt render, agent spawn, give-up handling. |
 | `Hive::Babysitter::ContextBuilder` | `lib/hive/babysitter/context_builder.rb` | Builds prompt-ready status rollup, failing-job logs, and diff stat. |
 | `Hive::Babysitter::Worktree` | `lib/hive/babysitter/worktree.rb` | Recreates `.hive-state/babysitter/worktrees/<pr>/` from a force-refreshed internal PR-head ref. Before add, it force-removes the old checkout, moves any undeletable residue to `.hive-state/babysitter/quarantine/worktrees/`, and immediately prunes stale Git metadata so rebased, force-pushed, interrupted, or container-contaminated worktrees do not wedge the babysitter cache. |
-| `Hive::Babysitter::GhOps` | `lib/hive/babysitter/gh_ops.rb` | Hive-driven GitHub/git side effects: `force_push_with_lease(worktree, branch, cfg:, dry_run:, expected_oid: nil)` (explicit `--force-with-lease=<branch>:<oid>` when `expected_oid` is given — robust without a local remote-tracking ref — else the bare `--force-with-lease`), `rebase_onto_base` (fetch base over the remote's **push URL** + rebase onto `FETCH_HEAD`, abort-on-conflict, returns a `RebaseResult` of `:success`/`:conflict`/`:failure`), idempotent provisioning and application of the Hive-owned `babysitter/needs-human` label, comment, rerun. Honors dry-run. |
+| `Hive::Babysitter::GhOps` | `lib/hive/babysitter/gh_ops.rb` | Hive-driven GitHub/git side effects: `force_push_with_lease(worktree, branch, cfg:, dry_run:, expected_oid: nil)` (explicit `--force-with-lease=<branch>:<oid>` when `expected_oid` is given — robust without a local remote-tracking ref — else the bare `--force-with-lease`), `rebase_onto_base` (fetch base over the remote's **push URL** + rebase onto `FETCH_HEAD`, abort-on-conflict, returns a `RebaseResult` of `:success`/`:conflict`/`:failure`), idempotent provisioning and application of the Hive-owned `babysitter/needs-human` label, and comments. Honors dry-run. |
 | `Hive::Babysitter::DryRunEnv` / `StubEnvironment` | `lib/hive/babysitter/{dry_run_env,stub_environment}.rb` + `bin/hive-babysitter-stub-git` / `bin/hive-babysitter-stub-gh.rb` | PATH overlay for agent-side dry-run `git` / `gh` wrapper launchers. One Ruby-owned startup/dynamic-loader environment definition is shared by the parent overlay and both stubs; the generated `gh` launcher invokes the Ruby stub directly, removing the separately packaged shell wrapper. Before writing launchers it `lstat`s and removes any pre-existing overlay path, creates a fresh owned `0700` directory, pins the parent-resolved real binary and worktree-root skip-log path, and confines read passthrough. |
 | `Hive::Babysitter::Events` | `lib/hive/babysitter/events.rb` | Append-only per-project JSONL events under `.hive-state/babysitter/events.jsonl`. |
 | `Hive::Babysitter::StatusWriter` | `lib/hive/babysitter/status_writer.rb` | Human-readable loop summary appended to `.hive-state/babysitter/status.md`. |


### PR DESCRIPTION
## Summary

- remove the uncalled `Hive::Babysitter::GhOps.rerun_ci` action wrapper
- remove its coverage-only assertion
- align the babysitter wiki with the remaining live GitHub mutation surface

This is unused-code audit piece **15/100**.

## Evidence

- `git grep` found no production caller; only the definition and its direct coverage assertion named `rerun_ci`
- the babysitter runtime uses rebase, force-push, labels, and comments, but never dispatches the removed `gh run rerun` action
- focused review artifact: `/tmp/compound-engineering-1000/ce-code-review/20260813-012047-a88df813/review.json`
- local review verdict: ready to merge, with no correctness or project-standards findings

## Test plan

- `test/unit/babysitter/coverage_gaps_test.rb` — 3 runs, 27 tests / 124 assertions each
- `test/unit/babysitter/gh_ops_test.rb` — 18 tests / 60 assertions
- RuboCop on the changed Ruby files

## Post-deploy monitoring

No runtime behavior should change. Watch babysitter logs for unexpected GitHub-operation failures; the live mutation paths are unchanged.

---

Built with [Compound Engineering](https://github.com/EveryInc/compound-engineering-plugin)