### PR TITLE
refactor(attempts): remove unused policy digest accessor

### DIFF
--- a/lib/hive/attempts/context.rb
+++ b/lib/hive/attempts/context.rb
@@ -199,7 +199,6 @@ module Hive
       end
 
       def explicit_routing? = routing["mode"] == "explicit"
-      def routing_policy_digest = explicit_routing? ? routing.fetch("policy_digest") : nil
       def routing_decision = explicit_routing? ? routing.fetch("decision") : nil
       def admitted_route = explicit_routing? ? routing.fetch("route") : nil
       def circuit_generations = explicit_routing? ? routing.fetch("circuit_generations") : EMPTY_ROUTING_VALUES

--- a/test/unit/attempts/context_test.rb
+++ b/test/unit/attempts/context_test.rb
@@ -52,7 +52,6 @@ class AttemptsContextTest < Minitest::Test
     routing.fetch("route")["model"] = "changed-after-admission"
 
     assert context.explicit_routing?
-    assert_equal "a" * 64, context.routing_policy_digest
     assert_equal "decision-1", context.routing_decision.fetch("decision_id")
     assert_equal "codex-account-a", context.provider_account_id
     assert_equal "codex", context.adapter

--- a/wiki/log.d/20260813T235500Z-unused-routing-policy-digest.md
+++ b/wiki/log.d/20260813T235500Z-unused-routing-policy-digest.md
@@ -1,0 +1,6 @@
+## Remove unused routing-policy accessor
+
+- Removed the cleanup target after tracked callsite, reflective-dispatch,
+  documentation, and available-history searches found no production consumer.
+- Retained focused coverage for the live behavior surrounding the orphaned
+  surface; untracked external Ruby callers remain the compatibility boundary.


### PR DESCRIPTION
## Summary

- remove the unused `Attempts::Context#routing_policy_digest` reader
- remove the assertion that existed solely to exercise that convenience accessor
- retain the stored routing payload and every live routing projection/accessor

This is unused-code audit piece **16/100**.

## Evidence

- the complete tracked Ruby search found only the definition and its direct unit assertion
- no production caller, reflective dispatch, CLI surface, documentation contract, or serialized field depends on the reader
- `routing`, `routing_decision`, `admitted_route`, circuit generations, probe bindings, and launch identity accessors remain unchanged
- focused review artifact: `/tmp/compound-engineering-1000/ce-code-review/20260813-012603-719c855e/review.json`
- local dual-review verdict: ready to merge with no findings

## Test plan

- `test/unit/attempts/context_test.rb` — 3 prior runs plus final run; final: 12 tests / 87 assertions
- `test/unit/provider_routing/configuration_test.rb` — 20 tests / 138 assertions
- `test/unit/provider_routing/operational_projection_test.rb` — 6 tests / 22 assertions
- RuboCop on the changed Ruby files

## Post-deploy monitoring

No runtime behavior should change. Monitor attempt launch/routing diagnostics for missing fields; the underlying routing payload and active readers are unchanged.

---

Built with [Compound Engineering](https://github.com/EveryInc/compound-engineering-plugin)