### PR TITLE
fix(migrate): avoid workflow lock re-entry

### DIFF
--- a/lib/hive/commands/migrate.rb
+++ b/lib/hive/commands/migrate.rb
@@ -90,10 +90,17 @@ module Hive
           plan = build_migration_plan(stages)
           preflight_collisions!(plan)
           store = @managed_store_factory.call(hive_state)
+          project_config = @config_loader.call(@project_path)
           migrator = Hive::WorkflowPackage::TaskMigrator.new(
-            hive_state, store: store, cfg: @config_loader.call(@project_path)
+            hive_state, store: store, cfg: project_config
           )
           prepared = migrator.prepare
+          Hive::Workflows::Project.load!(
+            @project_path, config: project_config, hive_state_path: hive_state
+          )
+          workflow_generation = Hive::Task.capture_workflow_generation(
+            @project_path, config: project_config
+          )
           workflow_migration = nil
           with_store_mutation_lock(store) do
             Hive::Lock.with_commit_lock(hive_state) do
@@ -110,7 +117,10 @@ module Hive
 
                 ensure_current_stage_dirs(stages)
                 backfilled_count = backfill_task_ids(stages)
-                recovery_marker_count = backfill_recovery_marker_ids(stages)
+                recovery_marker_count = backfill_recovery_marker_ids(
+                  stages, managed_store: store, cfg: project_config,
+                  workflow_generation: workflow_generation
+                )
 
                 if config_changed || moved.any? || backfilled_count.positive? ||
                    recovery_marker_count.positive? || workflow_task_count.positive?
@@ -295,9 +305,14 @@ module Hive
       # markers written before marker_id existed. Migrate them once, under the
       # project commit lock, so runtime recovery can reject id-less markers
       # instead of carrying a permanent compatibility identity algorithm.
-      def backfill_recovery_marker_ids(stages)
+      def backfill_recovery_marker_ids(
+        stages, managed_store: nil, cfg: {}, workflow_generation: nil
+      )
         task_folders(stages).count do |folder|
-          state_file = recovery_state_file(folder)
+          state_file = recovery_state_file(
+            folder, managed_store: managed_store, cfg: cfg,
+            workflow_generation: workflow_generation
+          )
           next false unless state_file
 
           marker = Hive::Markers.current(state_file)
@@ -308,8 +323,27 @@ module Hive
         end
       end
 
-      def recovery_state_file(folder)
-        Hive::Task.new(folder).state_file
+      def recovery_state_file(folder, managed_store: nil, cfg: {}, workflow_generation: nil)
+        read = Hive::TaskMeta.read_for_admission(folder)
+        if managed_store && read.status == :ok && read.data[:workflow_commit]
+          meta = read.data
+          workflow = managed_store.workflow(
+            meta.fetch(:workflow),
+            meta.fetch(:workflow_commit),
+            meta.fetch(:workflow_manifest_digest),
+            configuration_digest: meta[:workflow_configuration_digest],
+            cfg: cfg,
+            verify_profiles: false
+          )
+          stage = workflow.stage_for_dir(File.basename(File.dirname(folder)))
+          return File.join(folder, stage.state_file) if stage
+
+          return nil
+        end
+
+        # Runtime task loading without an immutable generation reads managed
+        # selections and would re-enter the mutation lock held by migrate.
+        Hive::Task.new(folder, workflow_generation: workflow_generation).state_file
       rescue Hive::InvalidTaskPath, Hive::ConfigError
         # An unknown or incomplete workflow cannot identify its authoritative
         # state file safely. Preserve it unchanged; recovery remains blocked

--- a/test/integration/migrate_test.rb
+++ b/test/integration/migrate_test.rb
@@ -176,9 +176,10 @@ class MigrateTest < Minitest::Test
           "configuration_digest" => current_pin.fetch(:workflow_configuration_digest)
         }
       end
-      store.define_singleton_method(:workflow) do |name, source, digest, configuration_digest:, cfg:|
+      store.define_singleton_method(:workflow) do |name, source, digest, configuration_digest:, cfg:,
+                                                     verify_profiles: true|
         pin = [ source, digest, configuration_digest ]
-        calls << [ :workflow, name, *pin, cfg ]
+        calls << [ :workflow, name, *pin, cfg, verify_profiles ]
         pin == old_pin.values ? old_workflow : current_workflow
       end
       store.define_singleton_method(:cleanup_unreferenced) do |name|
@@ -807,6 +808,8 @@ class MigrateTest < Minitest::Test
             "configuration_digest" => "e" * 64
           }
         end
+        research_workflow = migration_workflow("inbox", "brainstorm", "plan", "execute")
+        store.define_singleton_method(:workflow) { |*_args, **_kwargs| research_workflow }
         capture_io do
           migrate_command(
             dir,
@@ -1049,6 +1052,65 @@ class MigrateTest < Minitest::Test
     end
 
     assert_equal [ "workflows/architecture", "workflows/writing" ], calls.first.fetch(:pathspecs)
+  end
+
+  def test_managed_recovery_marker_path_does_not_reenter_the_workflow_mutation_lock
+    with_tmp_dir do |project|
+      stages = File.join(project, ".hive-state", "stages")
+      folder = write_task_folder(stages, "1-inbox", "managed-writing-260813-abcd")
+      pin = {
+        workflow_commit: "a" * 40,
+        workflow_manifest_digest: "b" * 64,
+        workflow_configuration_digest: "c" * 64
+      }
+      Hive::TaskMeta.write(
+        folder, id: 42, slug: File.basename(folder), display_name: "Managed writing",
+        workflow: "writing", **pin
+      )
+      workflow = migration_workflow("inbox", "review")
+      calls = []
+      store = Object.new
+      store.define_singleton_method(:workflow) do |name, commit, digest, configuration_digest:, cfg:,
+                                                     verify_profiles:|
+        calls << [ name, commit, digest, configuration_digest, cfg, verify_profiles ]
+        workflow
+      end
+      command = migrate_command(project)
+
+      with_replaced_singleton_method(Hive::Task, :new, lambda { |_folder|
+        raise "runtime task loading would re-enter the managed mutation lock"
+      }) do
+        assert_equal File.join(folder, "inbox.md"), command.send(
+          :recovery_state_file, folder,
+          managed_store: store,
+          cfg: { "project_name" => "writing" }
+        )
+      end
+
+      assert_equal false, calls.first.last
+      assert_equal pin.values, calls.first.values_at(1, 2, 3)
+    end
+  end
+
+  def test_unpinned_recovery_marker_path_uses_the_generation_captured_before_the_mutation_lock
+    with_tmp_dir do |project|
+      stages = File.join(project, ".hive-state", "stages")
+      folder = write_task_folder(stages, "1-inbox", "legacy-coding-260813-abcd")
+      generation = Object.new
+      task = Struct.new(:state_file).new(File.join(folder, "idea.md"))
+      calls = []
+
+      with_replaced_singleton_method(Hive::Task, :new, lambda { |candidate, workflow_generation:|
+        calls << [ candidate, workflow_generation ]
+        task
+      }) do
+        assert_equal task.state_file, migrate_command(project).send(
+          :recovery_state_file, folder, workflow_generation: generation
+        )
+      end
+
+      assert_equal [ [ folder, generation ] ], calls
+    end
   end
 
   def test_managed_workflow_cleanup_warns_when_its_state_commit_fails

--- a/test/integration/migrate_test.rb
+++ b/test/integration/migrate_test.rb
@@ -1113,6 +1113,40 @@ class MigrateTest < Minitest::Test
     end
   end
 
+  def test_managed_recovery_marker_path_skips_a_stage_missing_from_its_pinned_descriptor
+    with_tmp_dir do |project|
+      stages = File.join(project, ".hive-state", "stages")
+      folder = write_task_folder(stages, "1-inbox", "removed-stage-260813-abcd")
+      Hive::TaskMeta.write(
+        folder, id: 42, slug: File.basename(folder), display_name: "Removed stage",
+        workflow: "writing", workflow_commit: "a" * 40,
+        workflow_manifest_digest: "b" * 64, workflow_configuration_digest: "c" * 64
+      )
+      workflow = migration_workflow("review")
+      store = Object.new
+      store.define_singleton_method(:workflow) do |*_args, **_kwargs|
+        workflow
+      end
+
+      assert_nil migrate_command(project).send(
+        :recovery_state_file, folder, managed_store: store, cfg: {}
+      )
+    end
+  end
+
+  def test_recovery_marker_path_skips_an_invalid_unpinned_task
+    with_tmp_dir do |project|
+      folder = File.join(
+        project, ".hive-state", "stages", "1-inbox", "invalid-task-260813-abcd"
+      )
+      error = Hive::InvalidTaskPath.new("unknown workflow")
+
+      with_replaced_singleton_method(Hive::Task, :new, ->(*) { raise error }) do
+        assert_nil migrate_command(project).send(:recovery_state_file, folder)
+      end
+    end
+  end
+
   def test_managed_workflow_cleanup_warns_when_its_state_commit_fails
     ops = Object.new
     ops.define_singleton_method(:hive_commit) { |**| raise Hive::GitError, "commit blocked" }

--- a/wiki/commands/migrate.md
+++ b/wiki/commands/migrate.md
@@ -187,6 +187,12 @@ the selection-activation transaction, so the pointer and retained tasks land in
 one state commit; `hive workflow remove` refuses while any retained task still
 names the workflow.
 
+Recovery-marker backfill resolves a pinned managed task's state file directly
+from its descriptor while the workflow mutation lock is held. Unpinned tasks
+use an immutable workflow generation captured before that lock. Neither path
+performs live workflow loading inside the transaction, because that would
+reacquire the same non-reentrant lock and deadlock an update.
+
 The cutover is idempotent. Updating one or more pins restarts a running daemon
 so its managed-workflow cache observes the new selection immediately.
 

--- a/wiki/log.d/20260813T023200Z-managed-migration-lock-reentry.md
+++ b/wiki/log.d/20260813T023200Z-managed-migration-lock-reentry.md
@@ -1,0 +1,10 @@
+---
+title: Keep managed migration marker backfill inside one mutation lock
+---
+
+- Resolve pinned managed recovery state files from their descriptor and
+  unpinned tasks from a workflow generation captured before the transaction.
+- Prevent `hive migrate --all` from reacquiring its own non-reentrant managed
+  workflow mutation lock while backfilling marker identities.
+- Add regression coverage for both pinned and unpinned task resolution at this
+  locked migration boundary.


### PR DESCRIPTION
## Summary

- Prevent automatic update migration from deadlocking while recovery markers are backfilled under the managed-workflow mutation lock.
- Resolve pinned managed descriptors directly and reuse an immutable workflow generation for unpinned legacy tasks, so the locked transaction performs no live workflow reload.
- Document the lock invariant and cover both task shapes with regression tests.

## Test plan

- [x] `ruby -Itest -Ilib test/integration/migrate_test.rb` — 51 runs, 176 assertions
- [x] focused migrate-all, update, and installer tests — 50 runs, 296 assertions
- [x] changed-file RuboCop — no offenses
- [x] live `hive migrate /home/asterio/Dev/hive` completed, followed by an idempotent no-op rerun
- [ ] hosted CI and coverage

## Notes for reviewer

The live failure was a self-deadlock: migration held `workflows/.mutation.lock`, then recovery-marker discovery constructed `Hive::Task`, whose workflow loader attempted to acquire the same non-reentrant lock. The migration path now captures a stable workflow view before entering the transaction and bypasses runtime loading for pinned managed tasks.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
