### PR TITLE
Remove unused previous local day helper

### DIFF
--- a/lib/hive/local_date_window.rb
+++ b/lib/hive/local_date_window.rb
@@ -9,10 +9,6 @@ module Hive
       now.getlocal.to_date
     end
 
-    def previous_local_day(now: Time.now)
-      local_today(now: now) - 1
-    end
-
     def on_local_date?(instant, date)
       parse_time(instant).getlocal.to_date == parse_date(date)
     end

--- a/test/unit/local_date_window_test.rb
+++ b/test/unit/local_date_window_test.rb
@@ -29,12 +29,4 @@ class HiveLocalDateWindowTest < Minitest::Test
       assert_equal Date.new(2026, 6, 13), Hive::LocalDateWindow.local_today(now: now)
     end
   end
-
-  def test_previous_local_day_uses_host_timezone
-    with_env("TZ" => "America/Los_Angeles") do
-      now = Time.utc(2026, 6, 14, 6, 59, 59)
-
-      assert_equal Date.new(2026, 6, 12), Hive::LocalDateWindow.previous_local_day(now: now)
-    end
-  end
 end

--- a/wiki/log.d/20260813031700-remove-unused-previous-local-day.md
+++ b/wiki/log.d/20260813031700-remove-unused-previous-local-day.md
@@ -1,0 +1,8 @@
+---
+title: Remove unused previous-local-day helper
+date: 2026-08-13
+---
+
+- Removed the uncalled `Hive::LocalDateWindow.previous_local_day` convenience
+  helper. Runtime date-window checks continue through `local_today` and
+  `on_local_date?`.


### PR DESCRIPTION
## Summary

- remove the uncalled `Hive::LocalDateWindow.previous_local_day` convenience helper
- remove its send-only unit coverage
- record the cleanup in the managed wiki changelog

## Unused-code evidence

- On `origin/main`, exact tracked references were limited to the definition in `lib/hive/local_date_window.rb`, the dedicated test name, and its single assertion.
- Searches for symbol/string/reflection dispatch found no `send`, `public_send`, `method`, `respond_to?`, or symbol-based consumer.
- No wiki or documented-solution page exposes this method.
- Runtime date-window behavior continues through `local_today` and `on_local_date?`.

## Verification

- `test/unit/local_date_window_test.rb` passed three randomized runs: 3 runs, 7 assertions, zero failures/errors/skips each.
- RuboCop passed for both changed Ruby files.
- `git diff --check origin/main...HEAD` passed.
- Branch was rebased onto current `origin/main` before verification and push.

## Risk

`LocalDateWindow` uses `module_function`, so untracked external gem consumers could theoretically call this public singleton helper. The tracked repository, reflection, docs, and history searches found no consumer after the retired digest path.
