### PR TITLE
refactor(agent): remove unused final-message wrapper

### DIFF
--- a/lib/hive/agent.rb
+++ b/lib/hive/agent.rb
@@ -938,13 +938,6 @@ module Hive
       end
     end
 
-    def extract_final_message(data)
-      Hive::Agent::MessageExtractor.extract(
-        data,
-        structured_output_protocol: @profile.structured_output_protocol
-      )
-    end
-
     def parse_json_line(line)
       Hive::Agent::MessageExtractor.parse_json_line(line)
     end

--- a/test/unit/agent_message_extractor_test.rb
+++ b/test/unit/agent_message_extractor_test.rb
@@ -23,6 +23,18 @@ class AgentMessageExtractorTest < Minitest::Test
     assert_equal "Line title", Hive::Agent::MessageExtractor.extract(line)
   end
 
+  def test_extracts_claude_assistant_content_and_rejects_malformed_messages
+    assert_nil Hive::Agent::MessageExtractor.extract({
+      "type" => "assistant", "message" => "not-a-hash"
+    })
+    assert_equal "assistant content", Hive::Agent::MessageExtractor.extract({
+      "type" => "assistant",
+      "message" => {
+        "content" => [ { "type" => "text", "text" => "assistant content" } ]
+      }
+    })
+  end
+
   def test_extracts_grok_text_chunk_without_stripping_significant_space
     event = { "type" => "text", "data" => " a summary" }
 

--- a/test/unit/agent_test.rb
+++ b/test/unit/agent_test.rb
@@ -2086,25 +2086,6 @@ class AgentTest < Minitest::Test
     end
   end
 
-  def test_extract_final_message_handles_agent_and_assistant_shapes
-    with_tmp_dir do |dir|
-      agent = Hive::Agent.new(task: make_task(dir), prompt: "x", max_budget_usd: 1, timeout_sec: 5)
-
-      assert_equal "agent says hi", agent.send(:extract_final_message, JSON.generate(
-        "type" => "agent_message",
-        "text" => " agent says hi "
-      ))
-      assert_nil agent.send(:extract_final_message, JSON.generate(
-        "type" => "assistant",
-        "message" => "not-a-hash"
-      ))
-      assert_equal "assistant content", agent.send(:extract_final_message, JSON.generate(
-        "type" => "assistant",
-        "message" => { "content" => [ { "type" => "text", "text" => "assistant content" } ] }
-      ))
-    end
-  end
-
   def test_claude_write_tool_event_recognizes_completed_assistant_tool_use
     with_tmp_dir do |dir|
       agent = Hive::Agent.new(task: make_task(dir), prompt: "x", max_budget_usd: 1, timeout_sec: 5)

--- a/wiki/log.d/20260813T232000Z-unused-agent-final-message-wrapper.md
+++ b/wiki/log.d/20260813T232000Z-unused-agent-final-message-wrapper.md
@@ -1,0 +1,6 @@
+## Remove unused final-message wrapper
+
+- Removed the cleanup target after tracked callsite, reflective-dispatch,
+  documentation, and available-history searches found no production consumer.
+- Retained focused coverage for the live behavior surrounding the orphaned
+  surface; untracked external Ruby callers remain the compatibility boundary.


### PR DESCRIPTION
## Summary

- refactor(agent): remove unused final-message wrapper
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.