### PR TITLE
refactor(review): remove unused escalation text facade

### DIFF
--- a/lib/hive/stages/review.rb
+++ b/lib/hive/stages/review.rb
@@ -1996,10 +1996,6 @@ module Hive
         true
       end
 
-      def collect_answered_escalation_findings(ctx)
-        collect_answered_escalation_findings_with_count(ctx).text
-      end
-
       def collect_answered_escalation_findings_with_count(ctx)
         path = Hive::Stages::Review::Triage.escalations_path(ctx)
         questions = parse_escalation_questions(path)

--- a/test/unit/stages/review/escalation_questions_test.rb
+++ b/test/unit/stages/review/escalation_questions_test.rb
@@ -73,7 +73,6 @@ class ReviewEscalationQuestionsTest < Minitest::Test
       ctx = make_ctx(dir, task_folder)
       payload = Hive::Stages::Review.collect_accepted_findings_with_count(ctx)
       accepted = payload.text
-      answered = Hive::Stages::Review.collect_answered_escalation_findings(ctx)
 
       assert_equal 4, payload.count
       assert_equal accepted, Hive::Stages::Review.collect_accepted_findings(ctx)
@@ -84,10 +83,6 @@ class ReviewEscalationQuestionsTest < Minitest::Test
       assert_includes accepted, "USER-ANSWERED ESCALATION Q2"
       assert_includes accepted, "Should we add a new abstraction?"
       assert_includes accepted, "keep the fix local"
-      assert_includes answered, "USER-ANSWERED ESCALATION Q1"
-      assert_includes answered, "USER-ANSWERED ESCALATION Q2"
-      assert_includes answered, "Use execute.agent"
-      assert_includes answered, "keep the fix local"
       refute_includes accepted, "RESOLVED/NO-FIX"
       refute_includes accepted, "Should this remain manual?"
     end

--- a/wiki/log.d/20260813T232200Z-unused-answered-escalation-facade.md
+++ b/wiki/log.d/20260813T232200Z-unused-answered-escalation-facade.md
@@ -1,0 +1,6 @@
+## Remove unused answered-escalation facade
+
+- Removed the cleanup target after tracked callsite, reflective-dispatch,
+  documentation, and available-history searches found no production consumer.
+- Retained focused coverage for the live behavior surrounding the orphaned
+  surface; untracked external Ruby callers remain the compatibility boundary.


### PR DESCRIPTION
## Summary

- refactor(review): remove unused escalation text facade
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.