### PR TITLE
Remove unused architecture publisher facade

### DIFF
--- a/lib/hive/modules/event_publisher.rb
+++ b/lib/hive/modules/event_publisher.rb
@@ -110,13 +110,6 @@ module Hive
         )
       end
 
-      def architecture_patrol_finalized(entry, capture, schedule:, target_hook:)
-        event = prepare_architecture_patrol_finalized(
-          entry, capture, schedule: schedule, target_hook: target_hook
-        )
-        publish_prepared(entry, event)
-      end
-
       def publish_prepared(entry, event)
         ledger(entry).append(event)
       end

--- a/test/unit/modules/event_routing_test.rb
+++ b/test/unit/modules/event_routing_test.rb
@@ -147,12 +147,13 @@ class ModulesEventRoutingTest < Minitest::Test
     )
 
     publisher.patrol_reserved(entry, ordinary, schedule: "*/10 * * * *")
-    publisher.architecture_patrol_finalized(
+    architecture_event = publisher.prepare_architecture_patrol_finalized(
       entry,
       architecture,
       schedule: "*/10 * * * *",
       target_hook: "scheduled-discovery"
     )
+    publisher.publish_prepared(entry, architecture_event)
 
     patrol = ledger.records.fetch(0)
     assert_equal ordinary.to_h,

--- a/wiki/log.d/20260813T232300Z-unused-architecture-patrol-publisher-facade.md
+++ b/wiki/log.d/20260813T232300Z-unused-architecture-patrol-publisher-facade.md
@@ -1,0 +1,6 @@
+## Remove unused architecture-patrol publisher facade
+
+- Removed the cleanup target after tracked callsite, reflective-dispatch,
+  documentation, and available-history searches found no production consumer.
+- Retained focused coverage for the live behavior surrounding the orphaned
+  surface; untracked external Ruby callers remain the compatibility boundary.


### PR DESCRIPTION
## Summary

- Remove unused architecture publisher facade
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.