### PR TITLE
refactor(attempts): remove unused generation query

### DIFF
--- a/lib/hive/attempts/store.rb
+++ b/lib/hive/attempts/store.rb
@@ -239,10 +239,6 @@ module Hive
         Scan.new(records: records.freeze, invalid_records: invalid.freeze)
       end
 
-      def for_generation(task_generation)
-        scan.records.select { |record| record.task_generation == task_generation }
-      end
-
       def claim(observed, owner:, claim_capability:, first_heartbeat_timeout_sec:, now:)
         raise CompareAndSwapFailed, "launch claim deadline expired" if observed.active_deadline && now > observed.active_deadline
         mutate(observed, allowed_states: [ "launching" ]) do |data|

--- a/test/unit/attempts/store_test.rb
+++ b/test/unit/attempts/store_test.rb
@@ -124,7 +124,7 @@ class AttemptsStoreTest < Minitest::Test
             store = Hive::Attempts::Store.new(root: root)
             created = nil
             store.with_generation_lock("generation-1") do
-              existing = store.for_generation("generation-1")
+              existing = store.scan.records.select { |record| record.task_generation == "generation-1" }
               created = existing.first || store.create_launching(
                 **identity.merge(attempt_id: "attempt-#{index}"), launch_timeout_sec: 30, now: NOW
               )
@@ -141,7 +141,8 @@ class AttemptsStoreTest < Minitest::Test
       pids.each { |pid| Process.wait(pid) }
 
       assert_equal 1, ids.uniq.size
-      assert_equal 1, Hive::Attempts::Store.new(root: root).for_generation("generation-1").size
+      records = Hive::Attempts::Store.new(root: root).scan.records
+      assert_equal 1, records.count { |record| record.task_generation == "generation-1" }
     end
   end
 

--- a/wiki/log.d/20260813T232600Z-unused-attempt-generation-query.md
+++ b/wiki/log.d/20260813T232600Z-unused-attempt-generation-query.md
@@ -1,0 +1,6 @@
+## Remove unused attempt generation query
+
+- Removed the cleanup target after tracked callsite, reflective-dispatch,
+  documentation, and available-history searches found no production consumer.
+- Retained focused coverage for the live behavior surrounding the orphaned
+  surface; untracked external Ruby callers remain the compatibility boundary.


### PR DESCRIPTION
## Summary

- refactor(attempts): remove unused generation query
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.