### PR TITLE
Remove unused attempt logs path

### DIFF
--- a/lib/hive/paths.rb
+++ b/lib/hive/paths.rb
@@ -44,10 +44,6 @@ module Hive
       File.join(attempts_root, "records")
     end
 
-    def attempt_logs_root
-      File.join(attempts_root, "logs")
-    end
-
     def attempt_outputs_root
       File.join(attempts_root, "outputs")
     end

--- a/lib/hive/paths.rb
+++ b/lib/hive/paths.rb
@@ -52,10 +52,6 @@ module Hive
       File.join(attempts_root, "outputs")
     end
 
-    def attempt_generation_locks_root
-      File.join(attempts_root, "generation-locks")
-    end
-
     def attempt_proof_root
       File.join(attempts_root, "proof")
     end

--- a/lib/hive/paths.rb
+++ b/lib/hive/paths.rb
@@ -60,10 +60,6 @@ module Hive
       File.join(attempts_root, "proof")
     end
 
-    def attempt_decision_indexes_root
-      File.join(attempts_root, "decision-indexes")
-    end
-
     def attempt_pending_finalization_root
       File.join(attempts_root, "pending-finalization")
     end

--- a/test/unit/paths_test.rb
+++ b/test/unit/paths_test.rb
@@ -37,7 +37,6 @@ class PathsTest < Minitest::Test
         assert_equal File.join(attempts, "records"), Hive::Paths.attempt_records_root
         assert_equal File.join(attempts, "logs"), Hive::Paths.attempt_logs_root
         assert_equal File.join(attempts, "outputs"), Hive::Paths.attempt_outputs_root
-        assert_equal File.join(attempts, "generation-locks"), Hive::Paths.attempt_generation_locks_root
         assert_equal File.join(attempts, "proof"), Hive::Paths.attempt_proof_root
         assert_equal File.join(attempts, "decision-indexes"), Hive::Paths.attempt_decision_indexes_root
         assert_equal File.join(attempts, "pending-finalization"), Hive::Paths.attempt_pending_finalization_root

--- a/test/unit/paths_test.rb
+++ b/test/unit/paths_test.rb
@@ -35,7 +35,6 @@ class PathsTest < Minitest::Test
         attempts = File.join(dir, "state", "hive", "attempts", "v4")
         assert_equal attempts, Hive::Paths.attempts_root
         assert_equal File.join(attempts, "records"), Hive::Paths.attempt_records_root
-        assert_equal File.join(attempts, "logs"), Hive::Paths.attempt_logs_root
         assert_equal File.join(attempts, "outputs"), Hive::Paths.attempt_outputs_root
         assert_equal File.join(attempts, "generation-locks"), Hive::Paths.attempt_generation_locks_root
         assert_equal File.join(attempts, "proof"), Hive::Paths.attempt_proof_root

--- a/test/unit/paths_test.rb
+++ b/test/unit/paths_test.rb
@@ -39,7 +39,6 @@ class PathsTest < Minitest::Test
         assert_equal File.join(attempts, "outputs"), Hive::Paths.attempt_outputs_root
         assert_equal File.join(attempts, "generation-locks"), Hive::Paths.attempt_generation_locks_root
         assert_equal File.join(attempts, "proof"), Hive::Paths.attempt_proof_root
-        assert_equal File.join(attempts, "decision-indexes"), Hive::Paths.attempt_decision_indexes_root
         assert_equal File.join(attempts, "pending-finalization"), Hive::Paths.attempt_pending_finalization_root
         assert_equal File.join(dir, "state", "hive", "provider-health", "v1"),
                      Hive::Paths.provider_health_root

--- a/wiki/log.d/20260813T232400Z-unused-attempt-decision-indexes-path.md
+++ b/wiki/log.d/20260813T232400Z-unused-attempt-decision-indexes-path.md
@@ -1,0 +1,6 @@
+## Remove unused attempt decision-index path
+
+- Removed the cleanup target after tracked callsite, reflective-dispatch,
+  documentation, and available-history searches found no production consumer.
+- Retained focused coverage for the live behavior surrounding the orphaned
+  surface; untracked external Ruby callers remain the compatibility boundary.

--- a/wiki/log.d/20260813T232500Z-unused-attempt-generation-locks-path.md
+++ b/wiki/log.d/20260813T232500Z-unused-attempt-generation-locks-path.md
@@ -1,0 +1,6 @@
+## Remove unused attempt generation-lock path
+
+- Removed the cleanup target after tracked callsite, reflective-dispatch,
+  documentation, and available-history searches found no production consumer.
+- Retained focused coverage for the live behavior surrounding the orphaned
+  surface; untracked external Ruby callers remain the compatibility boundary.

--- a/wiki/log.d/20260813T232700Z-unused-attempt-logs-path.md
+++ b/wiki/log.d/20260813T232700Z-unused-attempt-logs-path.md
@@ -1,0 +1,6 @@
+## Remove unused attempt logs path
+
+- Removed the cleanup target after tracked callsite, reflective-dispatch,
+  documentation, and available-history searches found no production consumer.
+- Retained focused coverage for the live behavior surrounding the orphaned
+  surface; untracked external Ruby callers remain the compatibility boundary.


### PR DESCRIPTION
## Summary

- Remove unused attempt logs path
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.