### PR TITLE
Remove unused attempt transition predicate

### DIFF
--- a/lib/hive/attempts/record.rb
+++ b/lib/hive/attempts/record.rb
@@ -258,16 +258,6 @@ module Hive
         value && self.class.parse_time(value, label: "active deadline", error_class: InvalidRecord)
       end
 
-      def transition_allowed?(target)
-        return false if final?
-
-        case state
-        when "launching" then %w[launching running lost].include?(target)
-        when "running" then %w[running terminal lost].include?(target)
-        else false
-        end
-      end
-
       def [](key) = @data[key]
 
       def validate!

--- a/test/unit/attempts/record_test.rb
+++ b/test/unit/attempts/record_test.rb
@@ -329,8 +329,6 @@ class AttemptsRecordTest < Minitest::Test
       )
 
       assert record.final?
-      refute record.transition_allowed?("running")
-      refute record.transition_allowed?("launching")
     end
   end
 
@@ -353,23 +351,15 @@ class AttemptsRecordTest < Minitest::Test
     end
   end
 
-  def test_live_transition_matrix_and_record_field_validation
+  def test_live_record_field_validation
     launching = Hive::Attempts::Record.launching(**identity, now: NOW, launch_timeout_sec: 30)
-    assert launching.transition_allowed?("launching")
-    assert launching.transition_allowed?("running")
-    assert launching.transition_allowed?("lost")
-    refute launching.transition_allowed?("terminal")
 
     running_data = launching.to_h.merge(
       "state" => "running", "claim_deadline" => nil,
       "heartbeat_deadline" => (NOW + 30).iso8601(6),
       "wrapper" => { "pid" => 1 }
     )
-    running = Hive::Attempts::Record.new(running_data)
-    assert running.transition_allowed?("running")
-    assert running.transition_allowed?("terminal")
-    assert running.transition_allowed?("lost")
-    refute running.transition_allowed?("launching")
+    Hive::Attempts::Record.new(running_data)
 
     invalid_changes = [
       { "lease_version" => -1 },
@@ -391,12 +381,6 @@ class AttemptsRecordTest < Minitest::Test
     assert_raises(Hive::Attempts::InvalidRecord) do
       Hive::Attempts::Record.new(running_data.merge("heartbeat_deadline" => nil))
     end
-  end
-
-  def test_unknown_internal_state_has_no_legal_transition
-    record = Hive::Attempts::Record.allocate
-    record.instance_variable_set(:@data, { "state" => "unknown" })
-    refute record.transition_allowed?("running")
   end
 
   def test_launch_authority_requires_current_durable_fields_only

--- a/wiki/log.d/2026-08-13-remove-unused-attempt-transition-predicate.md
+++ b/wiki/log.d/2026-08-13-remove-unused-attempt-transition-predicate.md
@@ -1,0 +1,6 @@
+# Remove unused attempt transition predicate
+
+- Removed `Attempts::Record#transition_allowed?`, which had no production
+  caller.
+- Kept record state/schema validation and the store lifecycle/CAS tests that
+  enforce legal durable attempt transitions.


### PR DESCRIPTION
## Summary

- Remove unused attempt transition predicate
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.