### PR TITLE
refactor(brainstorm): remove unused question lookup

### DIFF
--- a/lib/hive/brainstorm_parser.rb
+++ b/lib/hive/brainstorm_parser.rb
@@ -122,10 +122,6 @@ module Hive
       parsed.select { |question| question.answer.nil? }
     end
 
-    def question_for(parsed, question_n)
-      parsed.find { |question| question.n == question_n }
-    end
-
     # Normalize layout-only differences before binding a presented question to
     # a durable fingerprint. NFC closes canonically-equivalent Unicode forms
     # without compatibility-folding distinct glyphs such as ①/1 or x²/x2;

--- a/test/unit/bot/brainstorm_parser_test.rb
+++ b/test/unit/bot/brainstorm_parser_test.rb
@@ -248,7 +248,7 @@ class HiveBotBrainstormParserTest < Minitest::Test
     assert_equal answer, parsed.answer
   end
 
-  def test_unanswered_questions_and_question_lookup_helpers
+  def test_unanswered_questions_helper
     questions = Hive::Bot::BrainstormParser.parse_text(<<~MARKDOWN)
       ## Round 1
 
@@ -267,8 +267,6 @@ class HiveBotBrainstormParserTest < Minitest::Test
     unanswered = Hive::Bot::BrainstormParser.unanswered_questions(questions)
 
     assert_equal [ 2, 3 ], unanswered.map(&:n)
-    assert_equal "Second?", Hive::Bot::BrainstormParser.question_for(questions, 2).text
-    assert_nil Hive::Bot::BrainstormParser.question_for(questions, 99)
   end
 
   def test_answered_predicate_reflects_presence_of_answer

--- a/wiki/log.d/20260813T233900Z-unused-brainstorm-question-lookup.md
+++ b/wiki/log.d/20260813T233900Z-unused-brainstorm-question-lookup.md
@@ -1,0 +1,6 @@
+## Remove unused brainstorm question lookup
+
+- Removed the cleanup target after tracked callsite, reflective-dispatch,
+  documentation, and available-history searches found no production consumer.
+- Retained focused coverage for the live behavior surrounding the orphaned
+  surface; untracked external Ruby callers remain the compatibility boundary.


### PR DESCRIPTION
## Summary

- refactor(brainstorm): remove unused question lookup
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.