### PR TITLE
Remove unused module secret accessor

### DIFF
--- a/lib/hive/modules/capability_context.rb
+++ b/lib/hive/modules/capability_context.rb
@@ -27,7 +27,6 @@ module Hive
 
       def require_github_mutation!(operation) = require_member!("github_mutations", operation)
       def require_external_command!(command) = require_member!("external_commands", executable(command))
-      def require_secret!(binding) = require_member!("secrets", binding)
       def require_network_host!(host) = require_member!("network_hosts", normalized_host(host))
       def require_filesystem_read!(path) = require_path!("filesystem_read", path)
       def require_filesystem_write!(path) = require_path!("filesystem_write", path)

--- a/test/unit/modules/capability_context_test.rb
+++ b/test/unit/modules/capability_context_test.rb
@@ -16,11 +16,9 @@ class ModulesCapabilityContextTest < Minitest::Test
     assert context.require_network_host!("https://api.github.com/repos")
     assert context.require_filesystem_read!("lib/hive.rb")
     assert context.require_filesystem_write!(".hive-state/patrol/**")
-    assert context.require_secret!("PATROL_TOKEN")
     assert_raises(Hive::Modules::CapabilityDenied) { context.require_github_mutation!("issues") }
     assert_raises(Hive::Modules::CapabilityDenied) { context.require_external_command!("bash") }
     assert_raises(Hive::Modules::CapabilityDenied) { context.require_network_host!("example.com") }
-    assert_raises(Hive::Modules::CapabilityDenied) { context.require_secret!("OTHER_TOKEN") }
     assert_raises(Hive::Modules::CapabilityDenied) do
       context.require_filesystem_read!("/etc/passwd")
     end

--- a/wiki/log.d/20260813035800-remove-unused-capability-secret-accessor.md
+++ b/wiki/log.d/20260813035800-remove-unused-capability-secret-accessor.md
@@ -1,0 +1,10 @@
+---
+title: Remove unused module secret accessor
+date: 2026-08-13
+---
+
+- Removed the uncalled
+  `Hive::Modules::CapabilityContext#require_secret!` accessor. Module execution
+  consumes validated secret grants through target configuration; no runtime
+  adapter requested individual bindings through this facade.
+- Capability snapshots still require and validate the `secrets` grant set.


### PR DESCRIPTION
## Summary

- Remove unused module secret accessor
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.