### PR TITLE
Remove unused capture policy overrides

### DIFF
--- a/lib/hive/artifacts/capture_policy.rb
+++ b/lib/hive/artifacts/capture_policy.rb
@@ -16,8 +16,8 @@ require "hive/worktree"
 module Hive
   module Artifacts
     # Deterministic, generation-bound applicability decision written before the
-    # artifacts agent starts. Agents may consume this receipt but cannot demote
-    # it; required -> not_applicable is an explicit confirmed operator action.
+    # artifacts agent starts. Agents consume this receipt but cannot alter its
+    # applicability decision.
     class CapturePolicy
       SCHEMA = "hive-capture-requirement".freeze
       SCHEMA_VERSION = 1
@@ -35,7 +35,6 @@ module Hive
       }ix
       VISUAL_REQUEST = /\b(?:screenshot|screen[- ]?record|browser|visual proof|demo capture|video|gif)\b/i
 
-      class AuthorizationError < Hive::Error; end
       class ClassificationError < Hive::Error; end
 
       def self.for_task(task, project:, clock: -> { Time.now.utc })
@@ -132,35 +131,6 @@ module Hive
         end
 
         write!(desired)
-      end
-
-      def promote!(actor:, rationale:)
-        current = ensure!
-        return current if current["result"] == "required"
-
-        write!(current.merge(
-          "result" => "required",
-          "rationale" => rationale.to_s,
-          "override" => override("promotion", actor, rationale)
-        ))
-      end
-
-      def demote!(actor:, rationale:, confirmed:)
-        current = ensure!
-        actor = actor.to_s
-        unless confirmed == true && actor.match?(/\Aoperator(?::|$)/) && !rationale.to_s.strip.empty?
-          raise AuthorizationError,
-                "required capture can be demoted only by a confirmed operator with a rationale"
-        end
-        unless current["task_generation"] == @task_generation
-          raise AuthorizationError, "capture applicability changed generation; reclassify before confirming"
-        end
-
-        write!(current.merge(
-          "result" => "not_applicable",
-          "rationale" => rationale.to_s.strip,
-          "override" => override("confirmed_demotion", actor, rationale)
-        ))
       end
 
       def capture_satisfied?
@@ -334,16 +304,6 @@ module Hive
           "task", "project", "task_generation", "implementation_base",
           "implementation_head", "changed_paths_digest", "classifier_version"
         )
-      end
-
-      def override(kind, actor, rationale)
-        {
-          "kind" => kind,
-          "actor" => actor.to_s,
-          "rationale" => rationale.to_s.strip,
-          "confirmed_at" => iso_time(@clock.call),
-          "task_generation" => @task_generation
-        }
       end
 
       def write!(document)

--- a/test/unit/artifacts/capture_policy_test.rb
+++ b/test/unit/artifacts/capture_policy_test.rb
@@ -90,23 +90,6 @@ class ArtifactsCapturePolicyTest < Minitest::Test
     end
   end
 
-  def test_required_capture_cannot_be_demoted_without_confirmed_operator
-    with_task do |task|
-      policy = Hive::Artifacts::CapturePolicy.new(
-        task: task, project: "demo", changed_paths: [ "web/app.css" ],
-        task_generation: "g", base_sha: "a" * 40, head_sha: "b" * 40
-      )
-      policy.ensure!
-
-      assert_raises(Hive::Artifacts::CapturePolicy::AuthorizationError) do
-        policy.demote!(actor: "agent", rationale: "tool missing", confirmed: false)
-      end
-      receipt = policy.demote!(actor: "operator:local", rationale: "verified no visual delta", confirmed: true)
-      assert_equal "not_applicable", receipt.fetch("result")
-      assert_equal "confirmed_demotion", receipt.dig("override", "kind")
-    end
-  end
-
   def test_required_capture_verifies_schema_files_hashes_cleanup_and_accessibility
     with_task do |task|
       policy = Hive::Artifacts::CapturePolicy.new(
@@ -417,43 +400,6 @@ class ArtifactsCapturePolicyTest < Minitest::Test
     end
 
     assert_match(/not a repository/, error.message)
-  end
-
-  def test_promote_records_operator_rationale_and_is_idempotent
-    with_task do |task|
-      policy = Hive::Artifacts::CapturePolicy.new(
-        task: task, project: "demo", changed_paths: [ "lib/hive/config.rb" ],
-        task_generation: "g", base_sha: "a" * 40, head_sha: "b" * 40,
-        clock: -> { Time.utc(2026, 7, 26, 3) }
-      )
-
-      promoted = policy.promote!(actor: "operator:local", rationale: "Needs a visual walkthrough")
-      repeated = policy.promote!(actor: "operator:other", rationale: "ignored")
-
-      assert_equal "required", promoted.fetch("result")
-      assert_equal "promotion", promoted.dig("override", "kind")
-      assert_equal "operator:local", promoted.dig("override", "actor")
-      assert_equal promoted, repeated
-    end
-  end
-
-  def test_demotion_rejects_a_stale_generation_receipt
-    with_task do |task|
-      policy = Hive::Artifacts::CapturePolicy.new(
-        task: task, project: "demo", changed_paths: [ "web/app.css" ],
-        task_generation: "current", base_sha: "a" * 40, head_sha: "b" * 40
-      )
-      stale = policy.build.merge("task_generation" => "stale")
-      policy.define_singleton_method(:ensure!) { stale }
-
-      error = assert_raises(Hive::Artifacts::CapturePolicy::AuthorizationError) do
-        policy.demote!(
-          actor: "operator:local", rationale: "Confirmed nonvisual", confirmed: true
-        )
-      end
-
-      assert_match(/changed generation/, error.message)
-    end
   end
 
   def test_invalid_capture_times_and_missing_media_fail_validation

--- a/wiki/log.d/2026-08-13-remove-unused-capture-policy-overrides.md
+++ b/wiki/log.d/2026-08-13-remove-unused-capture-policy-overrides.md
@@ -1,0 +1,7 @@
+# Remove unused capture-policy overrides
+
+- Removed the uncalled `CapturePolicy#promote!` and `#demote!` APIs and their
+  private override-record builder.
+- Capture applicability remains deterministic and generation-bound; receipts
+  retain `override: nil` for schema compatibility, and live capture validation
+  is unchanged.

--- a/wiki/stages/artifacts.md
+++ b/wiki/stages/artifacts.md
@@ -100,9 +100,8 @@ for existing tasks:
 ```
 
 For new work, applicability is not agent-authored: `not_applicable` is the
-classifier result, while required capture failure is a stage error. Promotion
-is unrestricted; demotion requires a confirmed generation-bound operator and
-rationale. See [[commands/web]].
+classifier result, while required capture failure is a stage error. See
+[[commands/web]].
 
 ## Marker -> next action
 

--- a/wiki/state-model.md
+++ b/wiki/state-model.md
@@ -1147,8 +1147,9 @@ Since 2026-05-22, `Hive::Stages::DIRS` has all nine slots filled in order; `Stag
 Its stable identity is the task/project, task generation, implementation
 base/head, changed-path digest, and classifier version. Hive classifies
 user-visible paths or an explicit visual-proof request as `required`; other
-work is `not_applicable`. Agents cannot demote the result. A demotion records a
-confirmed operator, rationale, timestamp, and the same task generation.
+work is `not_applicable`. The result is deterministic and has no runtime
+promotion or demotion API; the nullable `override` field remains empty for v1
+receipt compatibility.
 
 When required, new `media/capture-manifest.json` receipts use the
 provider-neutral `hive-artifact-capture` v2 contract and must identify the same


### PR DESCRIPTION
## Summary

- Remove unused capture policy overrides
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.