### PR TITLE
Remove unused project dropped predicate

### DIFF
--- a/lib/hive/daemon/concurrency_controller.rb
+++ b/lib/hive/daemon/concurrency_controller.rb
@@ -347,10 +347,6 @@ module Hive
         @quarantine.include?([ project, slug ])
       end
 
-      def project_dropped?(project)
-        @dropped_projects.include?(project)
-      end
-
       def dropped_projects
         @dropped_projects.to_a
       end

--- a/test/unit/daemon/concurrency_controller_test.rb
+++ b/test/unit/daemon/concurrency_controller_test.rb
@@ -113,7 +113,7 @@ class HiveDaemonConcurrencyControllerTest < Minitest::Test
 
     c.record_completion(pid: 100, exit_code: Hive::ExitCodes::CONFIG, completed_at: T0)
 
-    refute c.project_dropped?("hive")
+    refute_includes c.dropped_projects, "hive"
     assert_equal 0, c.daily_count_for("hive", T0),
                  "a patrol scan must not consume an ordinary task's daily quota"
     assert_equal :ok, c.can_dispatch?(project: "hive", slug: "ordinary-task", now: T0)
@@ -328,7 +328,7 @@ class HiveDaemonConcurrencyControllerTest < Minitest::Test
     c = make
     dispatch(c, 100, "p1", "s1")
     c.record_completion(pid: 100, exit_code: Hive::ExitCodes::CONFIG, completed_at: T0 + 1)
-    assert c.project_dropped?("p1")
+    assert_includes c.dropped_projects, "p1"
     # Every task in the dropped project is now blocked, regardless of slug.
     assert_equal :project_dropped,
                  c.can_dispatch?(project: "p1", slug: "totally-different-slug", now: T0 + 100)
@@ -339,7 +339,7 @@ class HiveDaemonConcurrencyControllerTest < Minitest::Test
   def test_record_project_dropped_direct_api
     c = make
     c.record_project_dropped(project: "p1")
-    assert c.project_dropped?("p1")
+    assert_includes c.dropped_projects, "p1"
   end
 
   def test_dropped_projects_returns_recorded_projects
@@ -630,8 +630,8 @@ class HiveDaemonConcurrencyControllerTest < Minitest::Test
     dispatch(c, 100, "digest", "2026-06-13", kind: :digest)
     c.record_completion(pid: 100, exit_code: Hive::ExitCodes::CONFIG, completed_at: T0)
 
-    refute c.project_dropped?("digest"),
-           "a digest ConfigError must not drop a phantom 'digest' project"
+    refute_includes c.dropped_projects, "digest",
+                    "a digest ConfigError must not drop a phantom 'digest' project"
   end
 
   def test_digest_dispatch_does_not_leak_a_daily_count_entry

--- a/test/unit/daemon/dispatcher_test.rb
+++ b/test/unit/daemon/dispatcher_test.rb
@@ -943,7 +943,7 @@ class HiveDaemonDispatcherTest < Minitest::Test
 
     dispatcher.tick(now: T0)
 
-    refute controller.project_dropped?("p1")
+    refute_includes controller.dropped_projects, "p1"
     refute logger.events.any? { |name, attrs| name == :project_dropped && attrs[:project] == "p1" }
     assert_equal(
       [
@@ -2196,7 +2196,7 @@ class HiveDaemonDispatcherTest < Minitest::Test
 
     dispatcher.tick(now: T0)
 
-    refute ctrl.project_dropped?("answer_digest")
+    refute_includes ctrl.dropped_projects, "answer_digest"
     refute logger.events.any? { |name, attrs| name == :project_dropped && attrs[:project] == "answer_digest" }
     assert_equal [ { date: "2026-06-13", exit_code: Hive::ExitCodes::CONFIG, now: T0 } ],
                  answer_digest.completed
@@ -3319,7 +3319,7 @@ class HiveDaemonDispatcherTest < Minitest::Test
       status_consumer: status, logger: logger
     )
     dispatcher.tick(now: T0)
-    assert controller.project_dropped?("p1")
+    assert_includes controller.dropped_projects, "p1"
     assert events_include?(logger, :project_dropped)
   end
 
@@ -3339,7 +3339,7 @@ class HiveDaemonDispatcherTest < Minitest::Test
 
     dispatcher.tick(now: T0)
 
-    refute controller.project_dropped?("p1")
+    refute_includes controller.dropped_projects, "p1"
     refute logger.events.any? { |name, attrs| name == :project_dropped && attrs[:project] == "p1" }
   end
 

--- a/wiki/log.d/2026-08-13-remove-unused-project-dropped-predicate.md
+++ b/wiki/log.d/2026-08-13-remove-unused-project-dropped-predicate.md
@@ -1,0 +1,7 @@
+# Remove unused project-dropped predicate
+
+- Removed `Daemon::ConcurrencyController#project_dropped?`, which had no
+  production caller.
+- Retargeted controller and dispatcher tests to the retained
+  `dropped_projects` reporting collection while preserving admission and event
+  assertions.


### PR DESCRIPTION
## Summary

- Remove unused project dropped predicate
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.