### PR TITLE
refactor(daemon): remove unused running PID accessor

### DIFF
--- a/lib/hive/daemon/concurrency_controller.rb
+++ b/lib/hive/daemon/concurrency_controller.rb
@@ -329,10 +329,6 @@ module Hive
         @dropped_projects.add(project)
       end
 
-      def running_pids
-        @running.keys
-      end
-
       def running_task?(project:, slug:)
         @running.any? do |_pid, entry|
           entry[:project] == project && entry[:slug] == slug

--- a/test/unit/daemon/concurrency_controller_test.rb
+++ b/test/unit/daemon/concurrency_controller_test.rb
@@ -426,8 +426,8 @@ class HiveDaemonConcurrencyControllerTest < Minitest::Test
 
     c.record_completion(pid: 100, exit_code: Hive::ExitCodes::SUCCESS, completed_at: T0 + 1)
     assert_equal 1, c.in_flight_count
-    refute_includes c.running_pids, 100
-    assert_includes c.running_pids, 101
+    refute c.running_task?(project: "p1", slug: "s1")
+    assert c.running_task?(project: "p1", slug: "s2")
   end
 
   def test_running_task_detects_tracked_project_slug

--- a/wiki/log.d/20260813T231500Z-remove-unused-daemon-running-pids.md
+++ b/wiki/log.d/20260813T231500Z-remove-unused-daemon-running-pids.md
@@ -1,0 +1,7 @@
+## Remove unused daemon running-PID accessor
+
+- Removed `Daemon::ConcurrencyController#running_pids`, whose only callers
+  were two direct unit assertions and which exposed no documented operational
+  contract.
+- Retargeted the assertions to the live project/slug identity predicate while
+  retaining aggregate in-flight bookkeeping coverage.


### PR DESCRIPTION
## Summary

- refactor(daemon): remove unused running PID accessor
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.