### PR TITLE
Remove unused dispatch queued predicate

### DIFF
--- a/lib/hive/bot/dispatch_request_writer.rb
+++ b/lib/hive/bot/dispatch_request_writer.rb
@@ -15,9 +15,7 @@ module Hive
     module DispatchRequestWriter
       module_function
 
-      DispatchReference = Data.define(:request_id, :attempt_id, :state, :status, :argv) do
-        def queued? = status == :queued
-      end
+      DispatchReference = Data.define(:request_id, :attempt_id, :state, :status, :argv)
 
       def generate_request_id
         Hive::Daemon::DispatchRequestQueue.generate_request_id

--- a/test/unit/bot/dispatch_request_writer_durable_test.rb
+++ b/test/unit/bot/dispatch_request_writer_durable_test.rb
@@ -65,7 +65,7 @@ class BotDispatchRequestWriterDurableTest < Minitest::Test
           request_id: "request-1", state_home: state_home, entrypoint: entrypoint
         )
 
-        assert reference.queued?
+        assert_equal :queued, reference.status
         assert_equal 1, Hive::Daemon::DispatchRequestQueue.pending(state_home: state_home).size
       end
     end
@@ -93,7 +93,7 @@ class BotDispatchRequestWriterDurableTest < Minitest::Test
           request_id: "request-no-route", state_home: state_home, entrypoint: entrypoint
         )
 
-        assert reference.queued?
+        assert_equal :queued, reference.status
         assert_nil reference.attempt_id
         assert_equal 1,
                      Hive::Daemon::DispatchRequestQueue.pending(state_home: state_home).size
@@ -194,7 +194,7 @@ class BotDispatchRequestWriterDurableTest < Minitest::Test
           entrypoint: entrypoint
         )
 
-        assert reference.queued?
+        assert_equal :queued, reference.status
       end
 
       request = Hive::Daemon::DispatchRequestQueue.pending(state_home: state_home).fetch(0)

--- a/wiki/log.d/2026-08-13-remove-unused-dispatch-queued-predicate.md
+++ b/wiki/log.d/2026-08-13-remove-unused-dispatch-queued-predicate.md
@@ -1,0 +1,6 @@
+# Remove unused dispatch queued predicate
+
+- Removed `Bot::DispatchRequestWriter::DispatchReference#queued?`, which had no
+  production caller.
+- Kept durable deferral and resolution-race coverage on the reference's
+  canonical `status == :queued` value.


### PR DESCRIPTION
## Summary

- Remove unused dispatch queued predicate
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.