### PR TITLE
Remove unused reserved occurrence view

### DIFF
--- a/lib/hive/patrol/state_store.rb
+++ b/lib/hive/patrol/state_store.rb
@@ -115,12 +115,6 @@ module Hive
         )
       end
 
-      def each_reserved_occurrence(&block)
-        return @occurrence_store.each_reserved unless block
-
-        @occurrence_store.each_reserved(&block)
-      end
-
       def each_projection_pending_occurrence(&block)
         return @occurrence_store.each_projection_pending unless block
 

--- a/test/unit/daemon/patrol_scheduler_test.rb
+++ b/test/unit/daemon/patrol_scheduler_test.rb
@@ -89,11 +89,12 @@ class HiveDaemonPatrolSchedulerTest < Minitest::Test
       )
       assert scheduler.pending?("p1")
       state = Hive::Patrol::StateStore.new(dir)
-      occurrence = state.each_reserved_occurrence.first
+      occurrence_id = dispatches.first.fetch(:command).split.last
+      occurrence = state.occurrence(occurrence_id)
       capture = state.occurrence_capture(occurrence.fetch("occurrence_id"))
       assert_equal "reserved", occurrence.fetch("phase")
       assert_equal capture.occurrence_id,
-                   dispatches.first.fetch(:command).split.last
+                   occurrence_id
       assert_equal entry.fetch("repository_identity"),
                    capture.project.fetch("repository")
 
@@ -884,7 +885,7 @@ class HiveDaemonPatrolSchedulerTest < Minitest::Test
       refute sched.pending?("p1"),
              "an ended child must not retain process-local dispatch ownership"
       refute_empty Hive::Patrol::StateStore.new(dir)
-                                          .each_reserved_occurrence.to_a,
+                                          .each_recovery_active_occurrence.to_a,
                    "the reserved occurrence remains the recovery authority"
     end
   end

--- a/test/unit/patrol/state_store_effect_intents_test.rb
+++ b/test/unit/patrol/state_store_effect_intents_test.rb
@@ -514,20 +514,15 @@ class PatrolStateStoreEffectIntentsTest < Minitest::Test
         )
       end
 
-      reserved = []
       projection_pending = []
       all = []
-      store.each_reserved_occurrence { |record| reserved << record.fetch("occurrence_id") }
       store.each_projection_pending_occurrence do |record|
         projection_pending << record.fetch("occurrence_id")
       end
       store.each_occurrence { |record| all << record.fetch("occurrence_id") }
 
-      assert_empty reserved
       assert_equal [ capture.occurrence_id ], projection_pending
       assert_equal [ capture.occurrence_id ], all
-      assert_equal reserved,
-                   store.each_reserved_occurrence.map { |record| record.fetch("occurrence_id") }
       assert_equal projection_pending,
                    store.each_projection_pending_occurrence.map { |record| record.fetch("occurrence_id") }
       assert_equal all, store.each_occurrence.map { |record| record.fetch("occurrence_id") }

--- a/wiki/log.d/2026-08-13-remove-unused-reserved-occurrence-view.md
+++ b/wiki/log.d/2026-08-13-remove-unused-reserved-occurrence-view.md
@@ -1,0 +1,7 @@
+# Remove unused reserved occurrence view
+
+- Removed `Patrol::StateStore#each_reserved_occurrence`, a public wrapper with
+  no production caller.
+- Scheduler coverage now loads the exact occurrence emitted in its dispatch,
+  while restart authority remains covered through the production
+  `each_recovery_active_occurrence` view.


### PR DESCRIPTION
## Summary

- Remove unused reserved occurrence view
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.