### PR TITLE
Remove unused eligible jobs query

### DIFF
--- a/lib/hive/refactor_patrol/job_store.rb
+++ b/lib/hive/refactor_patrol/job_store.rb
@@ -353,14 +353,6 @@ module Hive
         raise CorruptRecord, "refactor patrol manifest is missing #{e.key.inspect}"
       end
 
-      # Expose independently due intake jobs so one old backoff-bound
-      # occurrence cannot hide later work.
-      def eligible_jobs(now: Time.now)
-        eligible_from(jobs, now: now).sort_by { |aggregate| scheduling_key(aggregate) }
-      rescue ArgumentError => e
-        raise InconsistentRecord, "refactor patrol job has invalid scheduling timestamp (#{e.message})"
-      end
-
       def eligible_from(records, now:)
         records.select do |aggregate|
           next false if aggregate.fetch("complete")

--- a/test/unit/refactor_patrol/job_store_test.rb
+++ b/test/unit/refactor_patrol/job_store_test.rb
@@ -406,7 +406,7 @@ class RefactorPatrolJobStoreTest < Minitest::Test
     end
   end
 
-  def test_eligible_jobs_filters_backoff_per_job_without_starving_later_work
+  def test_claimable_jobs_filters_backoff_per_job_without_starving_later_work
     with_tmp_dir do |dir|
       store = Hive::RefactorPatrol::JobStore.new(dir)
       first_manifest = manifest(
@@ -433,9 +433,9 @@ class RefactorPatrolJobStoreTest < Minitest::Test
       )
 
       assert_equal [ second.fetch("job_id") ],
-                   store.eligible_jobs(now: T0 + 180).map { |entry| entry.fetch("job_id") }
+                   store.claimable_jobs(now: T0 + 180).map { |entry| entry.fetch("job_id") }
       assert_equal %w[pr-7-stable pr-8-stable],
-                   store.eligible_jobs(now: T0 + 7200).map { |entry| entry.fetch("job_id") }
+                   store.claimable_jobs(now: T0 + 7200).map { |entry| entry.fetch("job_id") }
     end
   end
 
@@ -732,8 +732,8 @@ class RefactorPatrolJobStoreTest < Minitest::Test
       assert_equal "blocked", released.fetch("state")
       assert_equal (T0 + 61).iso8601, released.fetch("attempts").last.fetch("next_eligible_at")
       assert_empty released.dig("dispositions", "accepted")
-      assert_empty store.eligible_jobs(now: T0 + 60)
-      assert_equal [ "pr-7-stable" ], store.eligible_jobs(now: T0 + 61).map { |item| item.fetch("job_id") }
+      assert_empty store.claimable_jobs(now: T0 + 60)
+      assert_equal [ "pr-7-stable" ], store.claimable_jobs(now: T0 + 61).map { |item| item.fetch("job_id") }
     end
   end
 
@@ -1725,7 +1725,7 @@ class RefactorPatrolJobStoreTest < Minitest::Test
       )
       store.define_singleton_method(:jobs) { [ queued ] }
       assert_raises(Hive::RefactorPatrol::JobStore::InconsistentRecord) do
-        store.eligible_jobs(now: T0)
+        store.claimable_jobs(now: T0)
       end
 
       active = initialized_store(File.join(dir, "actions"))

--- a/wiki/log.d/2026-08-13-remove-unused-eligible-jobs-query.md
+++ b/wiki/log.d/2026-08-13-remove-unused-eligible-jobs-query.md
@@ -1,0 +1,6 @@
+# Remove unused eligible-jobs query
+
+- Removed `RefactorPatrol::JobStore#eligible_jobs`, which had no production
+  caller.
+- Retargeted backoff, starvation, and malformed-timestamp coverage to
+  `claimable_jobs`, the query used by the architecture patrol scheduler.


### PR DESCRIPTION
## Summary

- Remove unused eligible jobs query
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.