### PR TITLE
Remove unused evidence receipt lookup

### DIFF
--- a/lib/hive/modules/migration/evidence_store.rb
+++ b/lib/hive/modules/migration/evidence_store.rb
@@ -62,15 +62,6 @@ module Hive
           )
         end
 
-        def fetch_receipt(receipt_id)
-          receipt_id = validated_id(receipt_id, :receipt)
-          read_record(
-            File.join(receipts_root, "#{receipt_id}.json"),
-            expected_id: receipt_id,
-            type: EffectReceipt
-          )
-        end
-
         def captures
           records(captures_root, type: PatrolCapture)
         end

--- a/test/unit/modules/migration/evidence_store_test.rb
+++ b/test/unit/modules/migration/evidence_store_test.rb
@@ -25,7 +25,6 @@ class ModulesMigrationEvidenceStoreTest < Minitest::Test
 
       restarted = Hive::Modules::Migration::EvidenceStore.new(root: root)
       assert_equal capture, restarted.fetch_capture(capture.capture_id)
-      assert_equal receipt, restarted.fetch_receipt(receipt.receipt_id)
       assert_equal [ capture ], restarted.captures
       assert_equal [ receipt ], restarted.receipts
     end
@@ -61,11 +60,10 @@ class ModulesMigrationEvidenceStoreTest < Minitest::Test
     end
   end
 
-  def test_fetch_rejects_untrusted_paths_and_no_follow_reads
+  def test_capture_fetch_rejects_untrusted_paths_and_no_follow_reads
     with_tmp_dir do |root|
       store = Hive::Modules::Migration::EvidenceStore.new(root: root)
       assert_raises(Hive::ConfigError) { store.fetch_capture("../../config") }
-      assert_raises(Hive::ConfigError) { store.fetch_receipt("/tmp/receipt") }
 
       capture = capture_for(recorded_at: NOW)
       outside = File.join(root, "outside.json")

--- a/wiki/log.d/20260813032800-remove-unused-evidence-receipt-fetch.md
+++ b/wiki/log.d/20260813032800-remove-unused-evidence-receipt-fetch.md
@@ -1,0 +1,10 @@
+---
+title: Remove unused evidence receipt lookup
+date: 2026-08-13
+---
+
+- Removed the uncalled
+  `Hive::Modules::Migration::EvidenceStore#fetch_receipt` single-record lookup.
+  Patrol migration adapters continue to read durable receipt evidence through
+  the indexed `receipts_for_occurrence` API, while collection and index tests
+  retain restart, validation, and no-follow coverage.


### PR DESCRIPTION
## Summary

- Remove unused evidence receipt lookup
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.