### PR TITLE
Remove unused secret scan clean predicate

### DIFF
--- a/lib/hive/gh.rb
+++ b/lib/hive/gh.rb
@@ -43,11 +43,7 @@ module Hive
     # distinguishable from a clean scan. A blanket rescue that
     # returned `[]` on any error would reduce a security-critical
     # gate to a no-op on any transient gh hiccup.
-    ScanResult = Struct.new(:hits, :fetch_failed, :fetch_error, keyword_init: true) do
-      def clean?
-        hits.empty? && !fetch_failed
-      end
-    end
+    ScanResult = Struct.new(:hits, :fetch_failed, :fetch_error, keyword_init: true)
 
     module_function
 

--- a/test/unit/gh_test.rb
+++ b/test/unit/gh_test.rb
@@ -140,7 +140,7 @@ class GhUnitTest < Minitest::Test
       state = File.join(dir, "pr.md")
       File.write(state, "no secrets here\n")
       result = Hive::Gh.scan_pr_for_secrets(state_file: state, pr_url: "")
-      assert result.clean?
+      assert_empty result.hits
       refute result.fetch_failed
     end
   end
@@ -151,7 +151,7 @@ class GhUnitTest < Minitest::Test
         state_file: File.join(dir, "pr.md"), pr_url: ""
       )
 
-      assert result.clean?
+      assert_empty result.hits
       refute result.fetch_failed
     end
   end
@@ -161,7 +161,6 @@ class GhUnitTest < Minitest::Test
       state = File.join(dir, "pr.md")
       File.write(state, "key: sk-ant-#{'a' * 30}\n")
       result = Hive::Gh.scan_pr_for_secrets(state_file: state, pr_url: "")
-      refute result.clean?
       assert_includes result.hits.map { |h| h[:name].to_s }, "anthropic_api_key"
     end
   end
@@ -177,7 +176,6 @@ class GhUnitTest < Minitest::Test
       result = Hive::Gh.scan_pr_for_secrets(state_file: state, pr_url: "https://example.com/pr/42")
       assert result.fetch_failed, "gh pr view non-zero must set fetch_failed=true"
       refute_empty result.fetch_error.to_s, "fetch_error must preserve the gh failure detail"
-      refute result.clean?, "fetch_failed must NOT be reported as clean"
     end
   end
 

--- a/wiki/log.d/2026-08-13-remove-unused-scan-clean-predicate.md
+++ b/wiki/log.d/2026-08-13-remove-unused-scan-clean-predicate.md
@@ -1,0 +1,5 @@
+# Remove unused secret-scan clean predicate
+
+- Removed `Gh::ScanResult#clean?`, which had no production caller.
+- Kept clean, missing-file, secret-hit, and remote-fetch-failure coverage on
+  the `hits` and `fetch_failed` fields consumed by open-PR and finalize gates.


### PR DESCRIPTION
## Summary

- Remove unused secret scan clean predicate
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.