### PR TITLE
Remove unused GitHub timeout wrapper

### DIFF
--- a/lib/hive/gh.rb
+++ b/lib/hive/gh.rb
@@ -1,5 +1,4 @@
 require "json"
-require "timeout"
 require "uri"
 require "yaml"
 require "hive/agent_git_gate"
@@ -961,12 +960,6 @@ module Hive
 
     def monotonic_now
       Process.clock_gettime(Process::CLOCK_MONOTONIC)
-    end
-
-    def with_network_timeout(timeout_sec: NETWORK_TIMEOUT_SEC, &block)
-      yield
-    rescue Timeout::Error
-      raise Hive::GhError, "network operation exceeded #{timeout_sec}s"
     end
   end
 end

--- a/test/unit/gh_test.rb
+++ b/test/unit/gh_test.rb
@@ -32,8 +32,6 @@ class GhUnitTest < Minitest::Test
       ].each { |k| ENV.delete(k) }
   end
 
-  # --- with_network_timeout --------------------------------------------
-
   def test_remote_branch_validation_matches_worktree_contract
     %w[feature//nested feature/.hidden feature/locked.lock feature@{upstream}].each do |branch|
       error = assert_raises(Hive::GhError) do
@@ -42,15 +40,6 @@ class GhUnitTest < Minitest::Test
       assert_match(/branch name is invalid/, error.message)
     end
     assert_equal "feature/nested", Hive::Gh.send(:validated_branch_name, " feature/nested ")
-  end
-
-  def test_with_network_timeout_raises_typed_error_on_timeout
-    err = assert_raises(Hive::GhError) do
-      Hive::Gh.with_network_timeout do
-        Timeout.timeout(0.01) { sleep 0.5 }
-      end
-    end
-    assert_match(/network operation exceeded/, err.message)
   end
 
   def test_capture3_enforces_stdout_limit_while_streaming

--- a/wiki/log.d/20260813T234200Z-unused-gh-timeout-wrapper.md
+++ b/wiki/log.d/20260813T234200Z-unused-gh-timeout-wrapper.md
@@ -1,0 +1,6 @@
+## Remove unused GitHub timeout wrapper
+
+- Removed the cleanup target after tracked callsite, reflective-dispatch,
+  documentation, and available-history searches found no production consumer.
+- Retained focused coverage for the live behavior surrounding the orphaned
+  surface; untracked external Ruby callers remain the compatibility boundary.


### PR DESCRIPTION
## Summary

- Remove unused GitHub timeout wrapper
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.