### PR TITLE
Remove unused global agents reader

### DIFF
--- a/lib/hive/config.rb
+++ b/lib/hive/config.rb
@@ -1261,37 +1261,6 @@ module Hive
       changed
     end
 
-    # The operator's persisted backend selection from the global config,
-    # or `default_global_agents` when nothing is stored yet. Three "unset"
-    # shapes all fall through to the defaults: an absent `agents:` block, an
-    # absent `agents.selected` key, and a present-but-null `selected:` (a
-    # bare `selected:` with no value). A present-but-malformed block
-    # (non-Hash `agents:`, non-Array `selected`) is a hand-edit error and
-    # raises ConfigError. Note the deliberate asymmetry against an empty
-    # `selected: []`: a null `selected:` is treated as "unset" and yields
-    # the defaults, whereas an explicit empty list raises via
-    # `normalize_global_agents` — an empty array is a hand-edit mistake the
-    # prompt can never produce, a null value is just "nothing stored yet".
-    def load_global_agents
-      Hive::Paths.ensure_migrated!
-      validate_hive_home!
-      path = global_config_path
-      data = File.exist?(path) ? load_global_config(path) : {}
-      raise ConfigError, "global config at #{path} must be a hash" unless data.is_a?(Hash)
-
-      agents = data["agents"]
-      return default_global_agents if agents.nil?
-
-      unless agents.is_a?(Hash)
-        raise ConfigError, "agents in #{describe_source(path)} must be a Hash; got #{agents.class}"
-      end
-
-      selected = agents["selected"]
-      return default_global_agents if selected.nil?
-
-      normalize_global_agents(selected, source: describe_source(path))
-    end
-
     # Provider accounts are global because their external credential/config
     # contexts and concurrency are shared across projects. This reader is
     # intentionally called only after a project declares routing.pool; a
@@ -1331,15 +1300,14 @@ module Hive
       end
     end
 
-    # Validate and canonicalize a raw selection (from disk or a caller)
-    # into the persisted contract: a frozen array of frozen backend names
+    # Validate and canonicalize a caller-provided selection into the
+    # persisted contract: a frozen array of frozen backend names
     # in `GLOBAL_AGENT_BACKENDS` order, deduped, with at least one entry.
     # Enforcing "≥1 backend" here mirrors the prompt boundary
-    # (BackendPrompt) so neither a hand-edited `selected: []` nor a
-    # `write_global_agents!([])` can persist a zero-backend state the
-    # prompt can never produce. Each name must be a non-empty String that
-    # resolves to a registered backend; anything else is a hand-edit error
-    # and raises ConfigError.
+    # (BackendPrompt) so `write_global_agents!([])` cannot persist a
+    # zero-backend state the prompt can never produce. Each name must be a
+    # non-empty String that resolves to a registered backend; anything else
+    # raises ConfigError.
     def normalize_global_agents(agents, source:)
       unless agents.is_a?(Array)
         raise ConfigError,
@@ -1362,10 +1330,7 @@ module Hive
                 "agents.selected in #{source} must contain non-empty strings"
         end
 
-        # Downcase before the allowed-list check so a hand-edited
-        # `selected: [Claude]` — the exact capitalization the setup prompt
-        # displays — loads, matching the prompt's case-insensitive name
-        # resolution (BackendPrompt#resolve_token).
+        # Match BackendPrompt's case-insensitive name resolution.
         name = agent.strip.downcase
         unless allowed.include?(name)
           if GLOBAL_AGENT_BACKENDS.include?(name)

--- a/test/unit/config_global_agents_test.rb
+++ b/test/unit/config_global_agents_test.rb
@@ -4,19 +4,11 @@ require "hive/config"
 class ConfigGlobalAgentsTest < Minitest::Test
   include HiveTestHelper
 
-  def test_load_global_agents_defaults_when_key_absent
-    with_tmp_global_config do
-      assert_equal %w[claude codex], Hive::Config.load_global_agents
-    end
-  end
-
-  def test_write_and_load_global_agents_round_trips_in_backend_order
+  def test_write_global_agents_persists_backend_order
     with_tmp_global_config do |home|
       written = Hive::Config.write_global_agents!(%w[pi claude pi])
 
       assert_equal %w[claude pi], written
-      assert_equal %w[claude pi], Hive::Config.load_global_agents
-
       data = YAML.safe_load(File.read(File.join(home, "config.yml")))
       assert_equal %w[claude pi], data.dig("agents", "selected")
       assert_equal [], data.fetch("registered_projects")
@@ -38,82 +30,58 @@ class ConfigGlobalAgentsTest < Minitest::Test
     end
   end
 
-  def test_load_global_agents_rejects_malformed_agents_block
-    with_tmp_global_config do |home|
-      File.write(File.join(home, "config.yml"), {
-        "registered_projects" => [],
-        "agents" => "claude"
-      }.to_yaml)
-
-      err = assert_raises(Hive::ConfigError) { Hive::Config.load_global_agents }
-      assert_match(/agents .* must be a Hash/, err.message)
-    end
-  end
-
-  def test_load_global_agents_rejects_malformed_selected_block
-    with_tmp_global_config do |home|
-      File.write(File.join(home, "config.yml"), {
-        "registered_projects" => [],
-        "agents" => { "selected" => "claude" }
-      }.to_yaml)
-
-      err = assert_raises(Hive::ConfigError) { Hive::Config.load_global_agents }
-      assert_match(/agents\.selected .* must be an Array/, err.message)
-    end
-  end
-
-  def test_load_global_agents_rejects_unknown_backend
-    with_tmp_global_config do |home|
-      File.write(File.join(home, "config.yml"), {
-        "registered_projects" => [],
-        "agents" => { "selected" => [ "claude", "unknown" ] }
-      }.to_yaml)
-
-      err = assert_raises(Hive::ConfigError) { Hive::Config.load_global_agents }
-      assert_match(/unknown backend "unknown"/, err.message)
-    end
-  end
-
-  def test_load_global_agents_rejects_blank_string_in_selected
-    with_tmp_global_config do |home|
-      File.write(File.join(home, "config.yml"), {
-        "registered_projects" => [],
-        "agents" => { "selected" => [ "claude", "" ] }
-      }.to_yaml)
-
-      err = assert_raises(Hive::ConfigError) { Hive::Config.load_global_agents }
-      assert_match(/must contain non-empty strings/, err.message)
-    end
-  end
-
-  def test_load_global_agents_rejects_non_string_in_selected
-    with_tmp_global_config do |home|
-      File.write(File.join(home, "config.yml"), {
-        "registered_projects" => [],
-        "agents" => { "selected" => [ 123 ] }
-      }.to_yaml)
-
-      err = assert_raises(Hive::ConfigError) { Hive::Config.load_global_agents }
-      assert_match(/must contain non-empty strings/, err.message)
-    end
-  end
-
-  def test_load_global_agents_rejects_empty_selected
-    with_tmp_global_config do |home|
-      File.write(File.join(home, "config.yml"), {
-        "registered_projects" => [],
-        "agents" => { "selected" => [] }
-      }.to_yaml)
-
-      err = assert_raises(Hive::ConfigError) { Hive::Config.load_global_agents }
-      assert_match(/must list at least one backend/, err.message)
-    end
-  end
-
   def test_write_global_agents_rejects_empty_selection
     with_tmp_global_config do
       err = assert_raises(Hive::ConfigError) { Hive::Config.write_global_agents!([]) }
       assert_match(/must list at least one backend/, err.message)
+    end
+  end
+
+  def test_write_global_agents_rejects_non_array_selection
+    with_tmp_global_config do
+      err = assert_raises(Hive::ConfigError) { Hive::Config.write_global_agents!("claude") }
+      assert_match(/must be an Array/, err.message)
+    end
+  end
+
+  def test_write_global_agents_rejects_blank_backend
+    with_tmp_global_config do
+      err = assert_raises(Hive::ConfigError) do
+        Hive::Config.write_global_agents!([ "claude", "" ])
+      end
+      assert_match(/must contain non-empty strings/, err.message)
+    end
+  end
+
+  def test_write_global_agents_rejects_unknown_backend
+    with_tmp_global_config do
+      err = assert_raises(Hive::ConfigError) do
+        Hive::Config.write_global_agents!(%w[claude unknown])
+      end
+      assert_match(/unknown backend "unknown"/, err.message)
+    end
+  end
+
+  def test_write_global_agents_distinguishes_unregistered_backend
+    with_tmp_global_config do
+      with_restricted_registry(%i[claude]) do
+        err = assert_raises(Hive::ConfigError) do
+          Hive::Config.write_global_agents!(%w[codex])
+        end
+        assert_match(/"codex", which is valid but/, err.message)
+        assert_match(/not installed or registered/, err.message)
+        refute_match(/unknown backend/, err.message)
+      end
+    end
+  end
+
+  def test_write_global_agents_normalizes_names_case_insensitively
+    with_tmp_global_config do |home|
+      written = Hive::Config.write_global_agents!(%w[Claude CODEX])
+
+      assert_equal %w[claude codex], written
+      data = YAML.safe_load(File.read(File.join(home, "config.yml")))
+      assert_equal %w[claude codex], data.dig("agents", "selected")
     end
   end
 
@@ -152,79 +120,6 @@ class ConfigGlobalAgentsTest < Minitest::Test
 
     assert_equal %w[claude codex grok pi], names.sort
     assert(names.all?(String), "registered_agent_names must be strings, not symbols")
-  end
-
-  def test_load_global_agents_distinguishes_valid_but_unregistered_backend
-    # A backend that IS in GLOBAL_AGENT_BACKENDS but isn't registered on
-    # this machine (the synced-dotfiles case) gets the "valid but not
-    # installed here" message, NOT the typo-flavored "unknown backend" one.
-    with_tmp_global_config do |home|
-      File.write(File.join(home, "config.yml"), {
-        "registered_projects" => [],
-        "agents" => { "selected" => [ "codex" ] }
-      }.to_yaml)
-
-      with_restricted_registry(%i[claude]) do
-        err = assert_raises(Hive::ConfigError) { Hive::Config.load_global_agents }
-        assert_match(/"codex", which is valid but/, err.message)
-        assert_match(/not installed or registered/, err.message)
-        refute_match(/unknown backend/, err.message)
-      end
-    end
-  end
-
-  def test_load_global_agents_rejects_typo_with_unknown_backend_message
-    # A name not in GLOBAL_AGENT_BACKENDS at all keeps the typo-flavored
-    # "unknown backend" message — the other half of the message split.
-    with_tmp_global_config do |home|
-      File.write(File.join(home, "config.yml"), {
-        "registered_projects" => [],
-        "agents" => { "selected" => [ "claud" ] }
-      }.to_yaml)
-
-      err = assert_raises(Hive::ConfigError) { Hive::Config.load_global_agents }
-      assert_match(/unknown backend "claud"/, err.message)
-      refute_match(/valid but/, err.message)
-    end
-  end
-
-  def test_load_global_agents_accepts_capitalized_names_case_insensitively
-    # The capitalization the setup prompt itself displays ([claude]) must
-    # load: normalize downcases before the allowed-list check.
-    with_tmp_global_config do |home|
-      File.write(File.join(home, "config.yml"), {
-        "registered_projects" => [],
-        "agents" => { "selected" => %w[Claude CODEX] }
-      }.to_yaml)
-
-      assert_equal %w[claude codex], Hive::Config.load_global_agents
-    end
-  end
-
-  def test_load_global_agents_defaults_on_cold_start_without_config_file
-    # The genuine first-run path: no config.yml exists yet.
-    # with_tmp_global_config pre-writes one, so delete it to exercise the
-    # `File.exist?(path) ? load_global_config(path) : {}` branch that
-    # resolves to the built-in defaults.
-    with_tmp_global_config do |home|
-      File.delete(File.join(home, "config.yml"))
-
-      assert_equal %w[claude codex], Hive::Config.load_global_agents
-    end
-  end
-
-  def test_load_global_agents_defaults_when_selected_is_null
-    # A bare `selected:` (YAML key present, value null) is treated as "unset"
-    # and resolves to the defaults — deliberately asymmetric with the empty
-    # `selected: []` array, which raises (see test below).
-    with_tmp_global_config do |home|
-      File.write(File.join(home, "config.yml"), {
-        "registered_projects" => [],
-        "agents" => { "selected" => nil }
-      }.to_yaml)
-
-      assert_equal %w[claude codex], Hive::Config.load_global_agents
-    end
   end
 
   def test_write_global_agents_overwrites_existing_selection_keeping_siblings

--- a/wiki/log.d/2026-08-13-remove-unused-global-agents-reader.md
+++ b/wiki/log.d/2026-08-13-remove-unused-global-agents-reader.md
@@ -1,0 +1,7 @@
+# Remove unused global agents reader
+
+- Removed `Config.load_global_agents`, a tested but unconnected reader with no
+  executable, setup, init, or routing caller.
+- Retained direct coverage for the separately tested selection writer,
+  normalizer, and setup prompt. Those surfaces are not connected to the
+  current setup executable and remain separate cleanup candidates.


### PR DESCRIPTION
## Summary

- Remove unused global agents reader
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.