### PR TITLE
Remove unused invariant tree capture

### DIFF
--- a/packaging/release_candidate/invariant_snapshot.rb
+++ b/packaging/release_candidate/invariant_snapshot.rb
@@ -2,7 +2,6 @@
 
 require "digest"
 require "json"
-require "pathname"
 require_relative "paths"
 
 module HiveReleaseCandidate
@@ -14,7 +13,6 @@ module HiveReleaseCandidate
       doctor_json tasks
     ].freeze
     HISTORICAL_SECTIONS = %w[builtin_runtime legacy_descriptor legacy_instructions].freeze
-    MAX_CAPTURE_BYTES = 1_048_576
     SEMANTIC_JSON_SECTIONS = %w[doctor_json status_json].freeze
     VOLATILE_JSON_KEYS = %w[
       age_seconds binary binary_path elapsed_ms executable finished_at generated_at
@@ -63,19 +61,6 @@ module HiveReleaseCandidate
           "allowed" => permitted,
           "unexpected" => unexpected
         }
-      end
-
-      def capture_tree(root:, sections:)
-        root = safe_root!(root)
-        unless sections.is_a?(Hash) && !sections.empty?
-          raise UsageError, "capture sections must be a non-empty hash"
-        end
-        captured = sections.to_h do |name, relative|
-          name = name.to_s
-          path = confined_path!(root, relative)
-          [ name, capture_path(path, root) ]
-        end
-        captured
       end
 
       private
@@ -200,48 +185,6 @@ module HiveReleaseCandidate
       def status_task_path?(path)
         path.length == 5 && path[0, 2] == %w[status_json projects] &&
           path[2].is_a?(Integer) && path[3] == "tasks" && path[4].is_a?(Integer)
-      end
-
-      def safe_root!(value)
-        root = File.expand_path(value)
-        stat = File.lstat(root)
-        unless stat.directory? && !stat.symlink? && stat.uid == Process.uid
-          raise Error, "invariant capture root must be an owned directory"
-        end
-        root
-      rescue Errno::ENOENT, Errno::EACCES
-        raise Error, "invariant capture root must be an owned directory"
-      end
-
-      def confined_path!(root, value)
-        relative = Pathname.new(value.to_s)
-        clean = relative.cleanpath.to_s
-        if relative.absolute? || clean == ".." || clean.start_with?("../") || value.to_s.include?("\\")
-          raise Error, "invariant capture path escapes its root"
-        end
-        File.join(root, clean)
-      end
-
-      def capture_path(path, root)
-        stat = File.lstat(path)
-        raise Error, "invariant capture refuses symlink: #{path}" if stat.symlink?
-        if stat.file?
-          raise Error, "invariant capture file exceeds #{MAX_CAPTURE_BYTES} bytes" if stat.size > MAX_CAPTURE_BYTES
-          return {
-            "kind" => "file", "size" => stat.size,
-            "sha256" => Digest::SHA256.file(path).hexdigest
-          }
-        end
-        raise Error, "invariant capture path is not a regular file or directory" unless stat.directory?
-
-        entries = Dir.children(path).sort.to_h do |name|
-          child = File.join(path, name)
-          relative = Pathname.new(child).relative_path_from(Pathname.new(root)).to_s
-          [ name, capture_path(confined_path!(root, relative), root) ]
-        end
-        { "kind" => "directory", "entries" => entries }
-      rescue Errno::ENOENT, Errno::EACCES => e
-        raise Error, "cannot capture invariant path #{path}: #{e.message}"
       end
     end
   end

--- a/test/unit/packaging/release_candidate_invariant_snapshot_test.rb
+++ b/test/unit/packaging/release_candidate_invariant_snapshot_test.rb
@@ -33,28 +33,13 @@ class ReleaseCandidateInvariantSnapshotTest < Minitest::Test
     assert_equal [ "/tasks/task body" ], diff.fetch("unexpected").map { |item| item.fetch("path") }
   end
 
-  def test_missing_required_named_invariant_and_symlinked_capture_root_fail_closed
+  def test_missing_required_named_invariant_fails_closed
     missing = state("task body" => "keep")
     missing.delete("durable_attempts")
     error = assert_raises(HiveReleaseCandidate::Error) do
       HiveReleaseCandidate::InvariantSnapshot.build(row_id: "latest-stable", sections: missing)
     end
     assert_includes error.message, "durable_attempts"
-
-    with_tmp_dir do |dir|
-      outside = File.join(dir, "outside")
-      root = File.join(dir, "root")
-      FileUtils.mkdir_p([ outside, root ])
-      File.write(File.join(outside, "secret"), "do not read")
-      File.symlink(outside, File.join(root, "linked"))
-
-      error = assert_raises(HiveReleaseCandidate::Error) do
-        HiveReleaseCandidate::InvariantSnapshot.capture_tree(
-          root: root, sections: { "tasks" => "linked" }
-        )
-      end
-      assert_includes error.message, "symlink"
-    end
   end
 
   def test_status_and_doctor_ignore_timestamp_order_version_and_binary_noise

--- a/wiki/log.d/20260813T234400Z-unused-invariant-tree-capture.md
+++ b/wiki/log.d/20260813T234400Z-unused-invariant-tree-capture.md
@@ -1,0 +1,6 @@
+## Remove unused invariant-tree capture
+
+- Removed the cleanup target after tracked callsite, reflective-dispatch,
+  documentation, and available-history searches found no production consumer.
+- Retained focused coverage for the live behavior surrounding the orphaned
+  surface; untracked external Ruby callers remain the compatibility boundary.


### PR DESCRIPTION
## Summary

- Remove unused invariant tree capture
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.