### PR TITLE
Remove unused job action index reader

### DIFF
--- a/lib/hive/refactor_patrol/job_store.rb
+++ b/lib/hive/refactor_patrol/job_store.rb
@@ -1433,14 +1433,6 @@ module Hive
         rebuild_indexes!.fetch("fingerprints")
       end
 
-      def action_index
-        read_derived_index(
-          action_index_path,
-          schema: JobIndexes::ACTION_SCHEMA,
-          collection: "actions"
-        ) { rebuild_indexes!.fetch("actions") }
-      end
-
       def fingerprint_index_path
         File.join(root, "indexes", "fingerprints.json")
       end
@@ -2232,19 +2224,6 @@ module Hive
 
       def timestamp!(value, label, path)
         @record_validator.timestamp!(value, label, path)
-      end
-
-      def read_derived_index(path, schema:, collection:)
-        relative = @job_files.relative_path(path)
-        data = @job_files.read_json(relative, missing: true)
-        return yield unless data
-        unless data.is_a?(Hash) && data["schema"] == schema && data["schema_version"] == SCHEMA_VERSION &&
-               data[collection].is_a?(Hash) && (data.keys - %w[schema schema_version] - [ collection ]).empty?
-          return yield
-        end
-        data
-      rescue JSON::ParserError, SystemCallError, IOError
-        yield
       end
 
       def atomic_write(path, data)

--- a/test/unit/refactor_patrol/job_store_test.rb
+++ b/test/unit/refactor_patrol/job_store_test.rb
@@ -259,7 +259,7 @@ class RefactorPatrolJobStoreTest < Minitest::Test
     end
   end
 
-  def test_rebuilds_derived_indexes_after_deletion_or_corruption
+  def test_rebuilds_fingerprint_index_after_corruption
     with_tmp_dir do |dir|
       store = Hive::RefactorPatrol::JobStore.new(dir)
       store.write_job!(job)
@@ -270,10 +270,8 @@ class RefactorPatrolJobStoreTest < Minitest::Test
                                          .fetch("occurrences").first.fetch("disposition")
       refute first.fetch("actions").fetch("actions").fetch("fix-fp-accepted").key?("receipts")
 
-      FileUtils.rm_f(store.action_index_path)
       File.write(store.fingerprint_index_path, "{")
 
-      assert_equal first.fetch("actions"), store.action_index
       assert_equal first.fetch("fingerprints"), store.fingerprint_index
     end
   end
@@ -2434,7 +2432,7 @@ class RefactorPatrolJobStoreTest < Minitest::Test
     end
   end
 
-  def test_low_level_validation_and_index_recovery_are_fail_closed
+  def test_low_level_validation_is_fail_closed
     with_tmp_dir do |dir|
       store = Hive::RefactorPatrol::JobStore.new(dir)
       assert_equal [ { "a" => 1 } ], store.send(:deep_sort, [ { "a" => 1 } ])
@@ -2447,14 +2445,6 @@ class RefactorPatrolJobStoreTest < Minitest::Test
       assert_raises(Hive::RefactorPatrol::JobStore::CorruptRecord) do
         store.send(:json_copy, Float::NAN)
       end
-
-      store.write_job!(job)
-      store.rebuild_indexes!
-      assert_equal "job-1", store.action_index.dig("actions", "fix-fp-accepted", "owner_job_id")
-      File.write(store.action_index_path, "[]")
-      assert_equal "job-1", store.action_index.dig("actions", "fix-fp-accepted", "owner_job_id")
-      File.write(store.action_index_path, "{")
-      assert_equal "job-1", store.action_index.dig("actions", "fix-fp-accepted", "owner_job_id")
     end
   end
 

--- a/wiki/log.d/2026-08-13-remove-unused-job-action-index-reader.md
+++ b/wiki/log.d/2026-08-13-remove-unused-job-action-index-reader.md
@@ -1,0 +1,6 @@
+# Remove unused job action-index reader
+
+- Removed `RefactorPatrol::JobStore#action_index`, which had no production
+  caller, together with its now-unreachable generic derived-index reader.
+- Kept action projection validation in `rebuild_indexes!` and retained live
+  fingerprint-index corruption recovery coverage.


### PR DESCRIPTION
## Summary

- Remove unused job action index reader
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.