### PR TITLE
Remove unused legacy escalation text wrapper

### DIFF
--- a/lib/hive/stages/review.rb
+++ b/lib/hive/stages/review.rb
@@ -2021,10 +2021,6 @@ module Hive
         AcceptedFindings.new(text: out, count: answered.size)
       end
 
-      def collect_legacy_checked_escalations(path)
-        collect_legacy_checked_escalations_with_count(path).text
-      end
-
       def collect_legacy_checked_escalations_with_count(path)
         return AcceptedFindings.new(text: "", count: 0) unless File.exist?(path)
 

--- a/test/unit/stages/review/escalation_questions_test.rb
+++ b/test/unit/stages/review/escalation_questions_test.rb
@@ -149,9 +149,10 @@ class ReviewEscalationQuestionsTest < Minitest::Test
       assert_equal 1, payload.count
       assert_includes accepted, "Accepted legacy escalations from escalations-01.md"
       assert_includes accepted, "apply the requested legacy escalation fix"
-      assert_equal accepted, Hive::Stages::Review.collect_legacy_checked_escalations(
+      legacy = Hive::Stages::Review.collect_legacy_checked_escalations_with_count(
         Hive::Stages::Review::Triage.escalations_path(ctx)
       )
+      assert_equal accepted, legacy.text
       assert_equal 1, Hive::Stages::Review.count_escalations(ctx)
     end
   end
@@ -176,7 +177,10 @@ class ReviewEscalationQuestionsTest < Minitest::Test
       File.write(path, "- [x] accepted legacy finding\n")
 
       with_readlines_failure(path) do
-        assert_equal "", Hive::Stages::Review.collect_legacy_checked_escalations(path)
+        legacy = Hive::Stages::Review.collect_legacy_checked_escalations_with_count(path)
+
+        assert_equal "", legacy.text
+        assert_equal 0, legacy.count
       end
     end
   end

--- a/wiki/log.d/2026-08-13-remove-unused-legacy-escalation-text-wrapper.md
+++ b/wiki/log.d/2026-08-13-remove-unused-legacy-escalation-text-wrapper.md
@@ -1,0 +1,7 @@
+# Remove unused legacy escalation text wrapper
+
+- Removed the unused `Stages::Review.collect_legacy_checked_escalations`
+  text-only wrapper.
+- Kept legacy checked-escalation fallback and read-failure coverage on
+  `collect_legacy_checked_escalations_with_count`, the result API used by the
+  review pipeline.


### PR DESCRIPTION
## Summary

- Remove unused legacy escalation text wrapper
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.