### PR TITLE
Remove unused directory metadata probe

### DIFF
--- a/lib/hive/managed_directory.rb
+++ b/lib/hive/managed_directory.rb
@@ -61,34 +61,6 @@ module Hive
       unsafe!
     end
 
-    # Descriptor-stable directory metadata probe. A missing directory is
-    # distinct from an unsafe symlink or non-directory binding.
-    def directory_metadata(relative = ".", missing: false)
-      components = relative_components(relative)
-      with_session(create_root: false) do |session|
-        session.with_directory(components, missing: missing) do |handle|
-          stat = IO.for_fd(
-            handle.directory.fileno, autoclose: false
-          ).stat
-          validate_directory!(stat)
-          {
-            mode: stat.mode & 0o777,
-            mtime: stat.mtime.utc
-          }.freeze
-        end
-      end
-    rescue MissingEntry
-      return nil if missing
-
-      unsafe!
-    rescue Errno::ENOENT
-      unsafe!
-    rescue Hive::ConfigError
-      raise
-    rescue SystemCallError, IOError, ArgumentError, TypeError
-      unsafe!
-    end
-
     # Returns :directory or :regular without following a symbolic link. This
     # is intentionally narrower than lstat: managed stores accept no other
     # entry kinds, and regular files must have exactly one link.

--- a/test/unit/managed_directory_test.rb
+++ b/test/unit/managed_directory_test.rb
@@ -75,63 +75,6 @@ class ManagedDirectoryTest < Minitest::Test
     end
   end
 
-  def test_directory_metadata_is_missing_aware_and_translates_failures
-    with_tmp_dir do |anchor|
-      root = File.join(anchor, "state")
-      nested = File.join(root, "nested")
-      directory = Hive::ManagedDirectory.new(
-        root: root, anchor: anchor, label: "test state"
-      )
-      directory.ensure_directory("nested")
-      File.chmod(0o750, nested)
-
-      metadata = directory.directory_metadata("nested")
-      assert_equal 0o750, metadata.fetch(:mode)
-      assert_equal File.stat(nested).mtime.utc, metadata.fetch(:mtime)
-      assert_nil directory.directory_metadata("missing", missing: true)
-      assert_raises(Hive::ConfigError) do
-        directory.directory_metadata("missing")
-      end
-      assert_raises(Hive::ConfigError) do
-        directory.directory_metadata("../outside")
-      end
-
-      native = directory.instance_variable_get(:@native)
-      original_open = native.method(:open_directory)
-      with_replaced_singleton_method(
-        native,
-        :open_directory,
-        lambda do |parent, name|
-          raise Errno::EIO, name if name == "broken"
-
-          original_open.call(parent, name)
-        end
-      ) do
-        assert_raises(Hive::ConfigError) do
-          directory.directory_metadata("broken")
-        end
-      end
-
-      nested_opens = 0
-      with_replaced_singleton_method(
-        native,
-        :open_directory,
-        lambda do |parent, name|
-          if name == "nested"
-            nested_opens += 1
-            raise Errno::ENOENT, name if nested_opens == 2
-          end
-
-          original_open.call(parent, name)
-        end
-      ) do
-        assert_raises(Hive::ConfigError) do
-          directory.directory_metadata("nested")
-        end
-      end
-    end
-  end
-
   def test_entry_type_translates_each_missing_and_unsafe_failure
     with_tmp_dir do |root|
       directory = Hive::ManagedDirectory.new(root: root, label: "test state")

--- a/wiki/log.d/2026-08-13-remove-unused-directory-metadata-probe.md
+++ b/wiki/log.d/2026-08-13-remove-unused-directory-metadata-probe.md
@@ -1,0 +1,6 @@
+# Remove unused directory metadata probe
+
+- Removed `ManagedDirectory#directory_metadata`, which had no production
+  caller.
+- Retained descriptor-stable directory custody, entry-type checks, and
+  file-metadata reads used by managed stores.


### PR DESCRIPTION
## Summary

- Remove unused directory metadata probe
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.