### PR TITLE
Remove unused manifest event name projection

### DIFF
--- a/lib/hive/module_package/manifest.rb
+++ b/lib/hive/module_package/manifest.rb
@@ -304,7 +304,6 @@ module Hive
       def hooks = data.fetch("hooks")
       def settings = data.fetch("settings")
       def permissions = data.fetch("permissions")
-      def event_names = hooks.flat_map { |hook| hook.fetch("events") }.uniq.sort.freeze
       def file_entries = data.fetch("files").map { |path, sha256| { "path" => path, "sha256" => sha256 } }
 
       private

--- a/test/unit/module_package/manifest_test.rb
+++ b/test/unit/module_package/manifest_test.rb
@@ -12,7 +12,6 @@ class ModulePackageManifestTest < Minitest::Test
 
       assert_equal "patrol", manifest.name
       assert_equal "1.0.0", manifest.version
-      assert_equal %w[project.registered task.completed], manifest.event_names
       assert_equal %w[scheduled-scan setup task-completed], manifest.hooks.map { |hook| hook.fetch("id") }
       assert_equal document.fetch("release_sha256"), manifest.digest
       assert_equal Hive::WorkflowPackage::CanonicalYAML.dump(document), manifest.bytes

--- a/wiki/log.d/20260813040200-remove-unused-manifest-event-names.md
+++ b/wiki/log.d/20260813040200-remove-unused-manifest-event-names.md
@@ -1,0 +1,8 @@
+---
+title: Remove unused manifest event-name projection
+date: 2026-08-13
+---
+
+- Removed the uncalled `Hive::ModulePackage::Manifest#event_names` convenience
+  projection. Runtime hook consumers continue to read the validated `hooks`
+  entries directly, including each hook's event list.


### PR DESCRIPTION
## Summary

- Remove unused manifest event name projection
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.