### PR TITLE
refactor(migration): remove unused report validator alias

### DIFF
--- a/lib/hive/modules/migration/report.rb
+++ b/lib/hive/modules/migration/report.rb
@@ -47,8 +47,6 @@ module Hive
 
         def self.canonical(value) = Hive::WorkflowPackage::CanonicalJSON.generate(value)
 
-        def self.valid_payload?(payload) = valid_legacy_payload?(payload)
-
         def self.valid_legacy_payload?(payload)
           return false unless payload.is_a?(Hash) &&
                               payload["schema"] == "hive-module-migration-report" &&

--- a/test/unit/modules/migration/shadow_comparator_test.rb
+++ b/test/unit/modules/migration/shadow_comparator_test.rb
@@ -577,17 +577,6 @@ class ModulesMigrationShadowComparatorTest < Minitest::Test
     end
   end
 
-  def test_report_shape_guard_handles_hash_like_objects_that_break_mid_validation
-    liar = Object.new
-    liar.define_singleton_method(:is_a?) { |klass| klass == Hash || super(klass) }
-    payload = {
-      "schema" => "hive-module-migration-report", "schema_version" => 1,
-      "eligible" => false, "modules" => liar, "blockers" => []
-    }
-
-    refute Hive::Modules::Migration::Report.valid_payload?(payload)
-  end
-
   def test_report_bounds_external_streams_and_collapses_configuration_changes
     with_tmp_dir do |root|
       comparator = Hive::Modules::Migration::ShadowComparator.new(root: root)

--- a/wiki/log.d/20260813T234900Z-unused-migration-valid-payload.md
+++ b/wiki/log.d/20260813T234900Z-unused-migration-valid-payload.md
@@ -1,0 +1,6 @@
+## Remove unused migration payload alias
+
+- Removed the cleanup target after tracked callsite, reflective-dispatch,
+  documentation, and available-history searches found no production consumer.
+- Retained focused coverage for the live behavior surrounding the orphaned
+  surface; untracked external Ruby callers remain the compatibility boundary.


### PR DESCRIPTION
## Summary

- refactor(migration): remove unused report validator alias
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.