### PR TITLE
Remove unused module launch predicate

### DIFF
--- a/lib/hive/modules/dispatcher.rb
+++ b/lib/hive/modules/dispatcher.rb
@@ -14,9 +14,7 @@ require "hive/workflow_package/canonical_json"
 
 module Hive
   module Modules
-    ModuleDispatchResult = Data.define(:decision, :attempt_result, :event) do
-      def launched? = decision && decision["outcome"] == "launch"
-    end
+    ModuleDispatchResult = Data.define(:decision, :attempt_result, :event)
 
     # Project-local hook admission coordinator. One hook lock covers enabled
     # state, binding cursor, dedupe/concurrency evidence, attempt admission,

--- a/test/e2e/lib/module_scenario_support.rb
+++ b/test/e2e/lib/module_scenario_support.rb
@@ -89,7 +89,9 @@ module Hive
         attempts = runtime.fetch(:attempt_store).scan.records
         decisions = runtime.fetch(:journal).all
 
-        raise "first occurrence was not admitted" unless first.launched?
+        unless first.decision.fetch("outcome") == "launch"
+          raise "first occurrence was not admitted"
+        end
         raise "replay was not an explainable duplicate" unless replay.decision.fetch("reason") == "duplicate"
         raise "replay created duplicate attempts" unless attempts.one? && attempts.first.module_hook?
         raise "expected launch and skip receipts" unless decisions.map { |row| row.fetch("reason") } ==

--- a/test/integration/architecture_patrol_module_test.rb
+++ b/test/integration/architecture_patrol_module_test.rb
@@ -78,7 +78,7 @@ class ArchitecturePatrolModuleIntegrationTest < Minitest::Test
         result = dispatcher.dispatch(
           module_name: "architecture-patrol", hook_id: "merged-pr-discovery", event: event
         )
-        assert result.launched?
+        assert_equal "launch", result.decision.fetch("outcome")
         assert attempts.scan.records.fetch(0).module_hook?
         command = Hive::Commands::ModuleHook.from_argv(launcher.record["worker_argv"].drop(2))
         assert_equal 0, command.call

--- a/test/integration/patrol_module_test.rb
+++ b/test/integration/patrol_module_test.rb
@@ -73,7 +73,7 @@ class PatrolModuleIntegrationTest < Minitest::Test
         )
 
         result = dispatcher.dispatch(module_name: "patrol", hook_id: "task-completed", event: event)
-        assert result.launched?
+        assert_equal "launch", result.decision.fetch("outcome")
         assert attempts.scan.records.fetch(0).module_hook?
         command = Hive::Commands::ModuleHook.from_argv(launcher.record["worker_argv"].drop(2))
         assert_equal 0, command.call

--- a/test/unit/modules/dispatcher_test.rb
+++ b/test/unit/modules/dispatcher_test.rb
@@ -58,8 +58,8 @@ class ModulesDispatcherTest < Minitest::Test
         module_name: "demo", hook_id: "task", event: runtime.fetch(:event)
       )
 
-      assert first.launched?
-      refute second.launched?
+      assert_equal "launch", first.decision.fetch("outcome")
+      refute_equal "launch", second.decision.fetch("outcome")
       assert_equal "duplicate", second.decision.fetch("reason")
       assert_equal 1, runtime.fetch(:attempt_store).scan.records.size
       attempt = runtime.fetch(:attempt_store).scan.records.first
@@ -95,7 +95,7 @@ class ModulesDispatcherTest < Minitest::Test
         module_name: "demo", hook_id: "task", event: runtime.fetch(:event)
       )
 
-      assert recovered.launched?
+      assert_equal "launch", recovered.decision.fetch("outcome")
       assert_equal admitted.attempt.attempt_id, recovered.decision.fetch("attempt_id")
       assert_equal "recovered_launch", recovered.attempt_result.reason
       assert_equal 1, runtime.fetch(:attempt_store).scan.records.size
@@ -143,7 +143,7 @@ class ModulesDispatcherTest < Minitest::Test
         runtime.fetch(:store).runtime_path("demo"), "runs", "#{hook_attempt.run_id}.json"
       )))
 
-      assert recovered.launched?
+      assert_equal "launch", recovered.decision.fetch("outcome")
       assert_equal :terminal_replay, recovered.attempt_result.status
       assert_equal "running", run.fetch("status")
       assert_equal admitted.attempt.attempt_id, run.fetch("attempt_id")
@@ -186,7 +186,7 @@ class ModulesDispatcherTest < Minitest::Test
         module_name: "demo", hook_id: "task", event: runtime.fetch(:event), dry_run: true
       )
 
-      assert result.launched?
+      assert_equal "launch", result.decision.fetch("outcome")
       assert_nil result.decision.fetch("decision_id")
       assert_empty runtime.fetch(:journal).all
       assert_empty runtime.fetch(:attempt_store).scan.records
@@ -202,7 +202,7 @@ class ModulesDispatcherTest < Minitest::Test
 
       dispatched = runtime.fetch(:dispatcher).dispatch_event(runtime.fetch(:event))
       assert_equal 1, dispatched.size
-      assert dispatched.first.launched?
+      assert_equal "launch", dispatched.first.decision.fetch("outcome")
       assert_equal 1, runtime.fetch(:attempt_store).scan.records.size
     end
   end
@@ -279,7 +279,7 @@ class ModulesDispatcherTest < Minitest::Test
           module_name: "demo", hook_id: "task", event: runtime.fetch(:event)
         )
 
-        assert result.launched?
+        assert_equal "launch", result.decision.fetch("outcome")
         refute_includes JSON.generate(result.decision), "available"
         refute_includes JSON.generate(result.decision), "MODULE_TEST_TOKEN"
       end

--- a/wiki/log.d/2026-08-13-remove-unused-module-launch-predicate.md
+++ b/wiki/log.d/2026-08-13-remove-unused-module-launch-predicate.md
@@ -1,0 +1,6 @@
+# Remove unused module launch predicate
+
+- Removed `Modules::ModuleDispatchResult#launched?`, which had no production
+  caller.
+- Retargeted module unit, integration, and E2E assertions to the authoritative
+  persisted decision outcome while keeping attempt-admission checks intact.


### PR DESCRIPTION
## Summary

- Remove unused module launch predicate
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.