### PR TITLE
Remove unused origin absence predicate

### DIFF
--- a/lib/hive/repository_identity.rb
+++ b/lib/hive/repository_identity.rb
@@ -42,15 +42,6 @@ module Hive
       nil
     end
 
-    def origin_absent?(project_root, timeout_sec: LOOKUP_TIMEOUT_SECONDS)
-      _stdout, status = capture_origin(
-        File.expand_path(project_root), timeout_sec: timeout_sec
-      )
-      status&.exitstatus == 2
-    rescue SystemCallError, IOError
-      false
-    end
-
     def capture_origin(project_root, timeout_sec:)
       stdout_r, stdout_w = IO.pipe
       pid = Process.spawn(

--- a/test/unit/repository_identity_test.rb
+++ b/test/unit/repository_identity_test.rb
@@ -41,20 +41,6 @@ class RepositoryIdentityTest < Minitest::Test
     end
   end
 
-  def test_origin_absent_distinguishes_a_repository_without_origin_from_lookup_failure
-    with_tmp_git_repo do |repo|
-      assert Hive::RepositoryIdentity.origin_absent?(repo)
-
-      system("git", "-C", repo, "remote", "add", "origin", "https://github.com/acme/widgets.git",
-             exception: true)
-      refute Hive::RepositoryIdentity.origin_absent?(repo)
-    end
-
-    with_tmp_dir do |dir|
-      refute with_env("PATH" => dir) { Hive::RepositoryIdentity.origin_absent?(dir) }
-    end
-  end
-
   def test_current_returns_nil_when_git_cannot_be_spawned
     with_tmp_dir do |dir|
       assert_nil with_env("PATH" => dir) { Hive::RepositoryIdentity.current(dir) }

--- a/wiki/log.d/20260813033600-remove-unused-origin-absent-predicate.md
+++ b/wiki/log.d/20260813033600-remove-unused-origin-absent-predicate.md
@@ -1,0 +1,11 @@
+---
+title: Remove unused origin-absence predicate
+date: 2026-08-13
+---
+
+- Removed the uncalled `Hive::RepositoryIdentity.origin_absent?` predicate,
+  which was left behind when digest registration stopped distinguishing a
+  missing `origin` remote from other lookup failures.
+- Repository identity consumers continue through the bounded
+  `RepositoryIdentity.current` lookup; its missing-origin, spawn-failure, and
+  timeout behavior remains covered.


### PR DESCRIPTION
## Summary

- Remove unused origin absence predicate
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.