### PR TITLE
Remove unused finding semantic wrapper

### DIFF
--- a/lib/hive/patrol/fingerprint.rb
+++ b/lib/hive/patrol/fingerprint.rb
@@ -142,14 +142,6 @@ module Hive
         end
       end
 
-      # Compare two complete finding records without requiring either one to
-      # have reached the PR/dismissal ledger. Discovery uses this before it
-      # persists a new record, so repeated model wording cannot accumulate as
-      # a second active finding merely because the first item has not shipped.
-      def semantically_same?(left, right)
-        semantically_same_signature?(semantic_signature(left), semantic_signature(right))
-      end
-
       def semantic_signature(finding)
         {
           fingerprint: finding.fingerprint.to_s,

--- a/test/unit/patrol/fingerprint_test.rb
+++ b/test/unit/patrol/fingerprint_test.rb
@@ -101,7 +101,7 @@ class HivePatrolFingerprintTest < Minitest::Test
     end
   end
 
-  def test_complete_findings_can_be_compared_without_a_ledger
+  def test_semantic_signatures_compare_without_a_ledger
     first = finding
     first.fingerprint = ""
     first.root_cause = "The scheduler lease remains claimed after launch rejection."
@@ -110,10 +110,17 @@ class HivePatrolFingerprintTest < Minitest::Test
     second.title = "Nil user crash in the request route"
     second.root_cause = "Launch rejection leaves the scheduler lease claimed."
 
-    assert Hive::Patrol::Fingerprint.semantically_same?(first, second)
+    first_signature = Hive::Patrol::Fingerprint.semantic_signature(first)
+    second_signature = Hive::Patrol::Fingerprint.semantic_signature(second)
+    assert Hive::Patrol::Fingerprint.semantically_same_signature?(
+      first_signature, second_signature
+    )
 
     second.category = "security"
-    refute Hive::Patrol::Fingerprint.semantically_same?(first, second)
+    second_signature = Hive::Patrol::Fingerprint.semantic_signature(second)
+    refute Hive::Patrol::Fingerprint.semantically_same_signature?(
+      first_signature, second_signature
+    )
   end
 
   # ── compatibility pins ─────────────────────────────────────────────────

--- a/wiki/log.d/20260813034100-remove-unused-finding-semantic-wrapper.md
+++ b/wiki/log.d/20260813034100-remove-unused-finding-semantic-wrapper.md
@@ -1,0 +1,10 @@
+---
+title: Remove unused finding semantic wrapper
+date: 2026-08-13
+---
+
+- Removed the uncalled `Hive::Patrol::Fingerprint.semantically_same?`
+  convenience wrapper. The live finding registry continues to precompute
+  signatures and compare them with `semantically_same_signature?`.
+- Retargeted the fuzzy-match and category-boundary assertions to that live
+  signature API.


### PR DESCRIPTION
## Summary

- Remove unused finding semantic wrapper
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.