### PR TITLE
Remove unused managed permission scope facade

### DIFF
--- a/lib/hive/permission_scope.rb
+++ b/lib/hive/permission_scope.rb
@@ -191,13 +191,10 @@ module Hive
     # Managed workflow runners have a second enforcement boundary in
     # WorkflowPackage::RuntimePolicy. That compiler needs the same normalized
     # permission scope without prematurely applying the legacy Claude-only
-    # runner gate above. Keeping this as a separate entrypoint prevents an
-    # ordinary project stage from treating a non-Claude profile as scoped
-    # merely because the descriptor parsed.
-    def resolve_managed(spec, task_folder:, stage: nil)
-      resolve_managed_spec(spec, task_folder: task_folder, stage: stage).first
-    end
-
+    # runner gate above. Returning both the scope and parsed spec lets that
+    # boundary validate portable profile support without making an ordinary
+    # project stage treat a non-Claude profile as scoped merely because the
+    # descriptor parsed.
     def resolve_managed_spec(spec, task_folder:, stage: nil)
       parsed = parse_spec(spec, stage: stage)
       [ resolve_parsed(parsed, task_folder: task_folder, stage: stage), parsed.freeze ].freeze

--- a/test/unit/permission_scope_test.rb
+++ b/test/unit/permission_scope_test.rb
@@ -54,9 +54,9 @@ class PermissionScopeTest < Minitest::Test
     end
   end
 
-  def test_managed_resolution_returns_the_scope_without_the_legacy_claude_gate
+  def test_managed_spec_resolution_returns_the_scope_without_the_legacy_claude_gate
     with_tmp_dir do |dir|
-      scope = Hive::PermissionScope.resolve_managed(
+      scope, parsed = Hive::PermissionScope.resolve_managed_spec(
         {
           "preset" => "scoped",
           "tools" => [ "Read", "Edit(./article.md)" ]
@@ -70,6 +70,7 @@ class PermissionScopeTest < Minitest::Test
         "Read",
         "Edit(//#{File.expand_path("article.md", dir).delete_prefix("/")})"
       ], scope.allowed_tools
+      assert_equal "scoped", parsed.fetch("preset")
     end
   end
 

--- a/wiki/log.d/20260813030800-remove-unused-permission-scope-managed.md
+++ b/wiki/log.d/20260813030800-remove-unused-permission-scope-managed.md
@@ -1,0 +1,11 @@
+---
+title: Remove unused managed permission-scope facade
+date: 2026-08-13
+---
+
+- Removed the uncalled `Hive::PermissionScope.resolve_managed` convenience
+  entrypoint. Managed workflow compilation already uses
+  `resolve_managed_spec`, which returns both the normalized scope and parsed
+  permission declaration required by its runtime policy.
+- Retained direct coverage that managed scope resolution bypasses the legacy
+  Claude-only gate while preserving the parsed declaration.


### PR DESCRIPTION
## Summary

- Remove unused managed permission scope facade
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.