### PR TITLE
refactor(daemon): remove unused merge backlog count

### DIFF
--- a/lib/hive/daemon/pr_merge_watcher.rb
+++ b/lib/hive/daemon/pr_merge_watcher.rb
@@ -741,10 +741,6 @@ module Hive
         []
       end
 
-      def each_candidate
-        @contexts.keys.flat_map { |project| candidates_for(project) }
-      end
-
       def parse_pr_url(value)
         Hive::Gh.parse_pull_request_url(value)
       end

--- a/lib/hive/daemon/pr_merge_watcher.rb
+++ b/lib/hive/daemon/pr_merge_watcher.rb
@@ -126,12 +126,6 @@ module Hive
         end
       end
 
-      def pending_count
-        each_candidate.count do |candidate|
-          !%w[archived superseded].include?(candidate.dig("archive", "status"))
-        end
-      end
-
       def watching?(project:, slug:)
         candidates_for(project).any? do |candidate|
           candidate.dig("task", "slug") == slug.to_s &&

--- a/test/unit/daemon/pr_merge_watcher_test.rb
+++ b/test/unit/daemon/pr_merge_watcher_test.rb
@@ -106,7 +106,6 @@ class HiveDaemonPrMergeWatcherTest < Minitest::Test
       results = watcher.observe(tasks.map { |task| row_for(task) }, now: T0)
 
       assert_equal [ :observed ], results.map { |result| result.fetch(:status) }.uniq
-      assert_equal 4, watcher.pending_count
       state = store.load(identity_for(tasks.first.project_root))
       assert_equal 4, state.fetch("candidates").length
       assert_equal true, state.dig("backlog", "complete")
@@ -147,7 +146,6 @@ class HiveDaemonPrMergeWatcherTest < Minitest::Test
 
       assert_equal :observed, result.fetch(:status)
       assert_equal 2, result.fetch(:candidates)
-      assert_equal 2, watcher.pending_count
       assert_empty watcher.tick(now: T0)
       candidates = store.load(identity_for(tasks.first.project_root))
                         .fetch("candidates").values
@@ -183,7 +181,6 @@ class HiveDaemonPrMergeWatcherTest < Minitest::Test
       assert_equal :blocked, blocked.fetch(:status)
       assert_equal tasks.first.slug, blocked.fetch(:slug)
       assert_match(/canonical GitHub pull request/, blocked.fetch(:reason))
-      assert_equal 1, watcher.pending_count
       outcomes = store.load(identity_for(tasks.first.project_root))
                       .dig("backlog", "outcomes").values
       rejected = outcomes.find { |outcome| outcome.fetch("slug") == tasks.first.slug }

--- a/wiki/log.d/20260813T230000Z-remove-unused-pr-merge-pending-count.md
+++ b/wiki/log.d/20260813T230000Z-remove-unused-pr-merge-pending-count.md
@@ -1,0 +1,6 @@
+## Remove unused PR merge backlog count
+
+- Removed `Daemon::PrMergeWatcher#pending_count`, whose only callers were
+  three direct unit assertions.
+- Retained the surrounding durable candidate, held-row, invalid-URL, backlog,
+  and outcome assertions through the watcher's live observation surfaces.

--- a/wiki/log.d/20260813T230000Z-remove-unused-pr-merge-pending-count.md
+++ b/wiki/log.d/20260813T230000Z-remove-unused-pr-merge-pending-count.md
@@ -1,6 +1,7 @@
 ## Remove unused PR merge backlog count
 
 - Removed `Daemon::PrMergeWatcher#pending_count`, whose only callers were
-  three direct unit assertions.
+  three direct unit assertions, together with its now-unreachable private
+  `each_candidate` traversal.
 - Retained the surrounding durable candidate, held-row, invalid-URL, backlog,
   and outcome assertions through the watcher's live observation surfaces.


### PR DESCRIPTION
## Summary

- refactor(daemon): remove unused merge backlog count
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.