### PR TITLE
refactor(attempts): remove unused safe-group predicate

### DIFF
--- a/lib/hive/attempts/process_identity.rb
+++ b/lib/hive/attempts/process_identity.rb
@@ -77,19 +77,6 @@ module Hive
         :unverifiable
       end
 
-      def safe_group?(wrapper:, worker: nil)
-        return false unless status(wrapper) == :matching
-
-        wrapper_session = wrapper["session_id"] || wrapper[:session_id]
-        wrapper_group = wrapper["process_group_id"] || wrapper[:process_group_id]
-        return false unless wrapper_session && wrapper_group && wrapper_session == wrapper_group
-        return true unless worker
-        return false unless status(worker) == :matching
-
-        worker_session = worker["session_id"] || worker[:session_id]
-        worker_session == wrapper_session
-      end
-
       # Cleanup for the one supported orphan case: the authoritative wrapper
       # is gone but its recorded worker group is still alive in that wrapper's
       # session. Identity is rechecked before TERM and again before KILL.

--- a/test/unit/attempts/process_identity_test.rb
+++ b/test/unit/attempts/process_identity_test.rb
@@ -33,16 +33,6 @@ class AttemptsProcessIdentityTest < Minitest::Test
     assert_equal :unverifiable, checker.status(identity(start: ""))
   end
 
-  def test_group_safety_rejects_non_session_leader_and_foreign_worker
-    verifier = checker
-    assert verifier.safe_group?(wrapper: identity)
-    refute verifier.safe_group?(wrapper: identity(group: 11))
-    refute verifier.safe_group?(
-      wrapper: identity,
-      worker: identity.merge("pid" => 456, "session_id" => 99)
-    )
-  end
-
   def test_orphan_cleanup_rechecks_identity_and_signals_only_verified_group
     alive = true
     signals = []
@@ -130,10 +120,9 @@ class AttemptsProcessIdentityTest < Minitest::Test
     assert_nil checker.capture("not-a-pid")
   end
 
-  def test_status_maps_reader_errors_and_safe_worker_matches
+  def test_status_maps_reader_errors
     expected = identity
     assert_equal :unverifiable, checker.status("bad")
-    assert checker.safe_group?(wrapper: expected, worker: expected.merge("pid" => 456))
 
     esrch = Hive::Attempts::ProcessIdentity.new(
       start_reader: ->(_pid) { raise Errno::ESRCH }, signaler: ->(_signal, _pid) { },

--- a/wiki/log.d/20260813T235000Z-unused-process-safe-group.md
+++ b/wiki/log.d/20260813T235000Z-unused-process-safe-group.md
@@ -1,0 +1,6 @@
+## Remove unused process safe-group predicate
+
+- Removed the cleanup target after tracked callsite, reflective-dispatch,
+  documentation, and available-history searches found no production consumer.
+- Retained focused coverage for the live behavior surrounding the orphaned
+  surface; untracked external Ruby callers remain the compatibility boundary.


### PR DESCRIPTION
## Summary

- refactor(attempts): remove unused safe-group predicate
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.