### PR TITLE
Remove unused protected file restore wrapper

### DIFF
--- a/lib/hive/protected_files.rb
+++ b/lib/hive/protected_files.rb
@@ -88,12 +88,6 @@ module Hive
       true
     end
 
-    def restore_safely(root, captured, names)
-      [ restore(root, captured, names), nil ]
-    rescue StandardError => e
-      [ false, "#{e.class}: #{e.message}" ]
-    end
-
     def restore_paths_safely(paths, captured, labels)
       [ restore_paths(paths, captured, labels), nil ]
     rescue StandardError => e

--- a/test/unit/protected_files_test.rb
+++ b/test/unit/protected_files_test.rb
@@ -137,12 +137,11 @@ class ProtectedFilesTest < Minitest::Test
       FileUtils.rm_f(File.join(dir, "task.md"))
       File.write(File.join(dir, "worktree.yml"), "path: /attacker\n")
 
-      restored, error = Hive::ProtectedFiles.restore_safely(
+      restored = Hive::ProtectedFiles.restore(
         dir, captured, %w[plan.md task.md worktree.yml]
       )
 
       assert_equal true, restored
-      assert_nil error
       assert_equal "trusted plan\n", File.read(File.join(dir, "plan.md"))
       assert_equal "trusted task\n", File.read(File.join(dir, "task.md"))
       refute File.exist?(File.join(dir, "worktree.yml"))
@@ -154,12 +153,11 @@ class ProtectedFilesTest < Minitest::Test
       captured = Hive::ProtectedFiles.capture(dir, [ "plan.md" ])
       FileUtils.mkdir_p(File.join(dir, "plan.md", "nested"))
 
-      restored, error = Hive::ProtectedFiles.restore_safely(
-        dir, captured, [ "plan.md" ]
-      )
+      error = assert_raises(Hive::ProtectedFiles::RestoreError) do
+        Hive::ProtectedFiles.restore(dir, captured, [ "plan.md" ])
+      end
 
-      assert_equal false, restored
-      assert_includes error, "refusing to replace protected path directory"
+      assert_includes error.message, "refusing to replace protected path directory"
       assert File.directory?(File.join(dir, "plan.md"))
     end
   end
@@ -187,20 +185,18 @@ class ProtectedFilesTest < Minitest::Test
       File.symlink(target, File.join(dir, "plan.md"))
       captured = Hive::ProtectedFiles.capture(dir, [ "plan.md" ])
 
-      restored, error = Hive::ProtectedFiles.restore_safely(
-        dir, captured, [ "plan.md" ]
-      )
-      assert_equal false, restored
-      assert_includes error, "non-file path cannot be reconstructed"
+      error = assert_raises(Hive::ProtectedFiles::RestoreError) do
+        Hive::ProtectedFiles.restore(dir, captured, [ "plan.md" ])
+      end
+      assert_includes error.message, "non-file path cannot be reconstructed"
 
       unknown = {
         "task.md" => { kind: :future_capture_type, fingerprint: nil }
       }
-      restored, error = Hive::ProtectedFiles.restore_safely(
-        dir, unknown, [ "task.md" ]
-      )
-      assert_equal false, restored
-      assert_includes error, "unknown protected capture type"
+      error = assert_raises(Hive::ProtectedFiles::RestoreError) do
+        Hive::ProtectedFiles.restore(dir, unknown, [ "task.md" ])
+      end
+      assert_includes error.message, "unknown protected capture type"
     end
   end
 

--- a/wiki/log.d/20260813041000-remove-unused-protected-restore-wrapper.md
+++ b/wiki/log.d/20260813041000-remove-unused-protected-restore-wrapper.md
@@ -1,0 +1,11 @@
+---
+title: Remove unused protected-file restore wrapper
+date: 2026-08-13
+---
+
+- Removed the uncalled `Hive::ProtectedFiles.restore_safely` compatibility
+  wrapper. Live Artifact Firewall recovery continues through the absolute-path
+  `restore_paths_safely` API.
+- Retargeted relative protected-file restoration tests to the underlying
+  `restore` operation so success and fail-closed reconstruction semantics remain
+  covered.


### PR DESCRIPTION
## Summary

- Remove unused protected file restore wrapper
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.