### PR TITLE
Remove unused protected path snapshot helper

### DIFF
--- a/lib/hive/protected_files.rb
+++ b/lib/hive/protected_files.rb
@@ -34,14 +34,6 @@ module Hive
       end
     end
 
-    # Snapshot a small labeled set of absolute controller paths. Managed
-    # worktree agents can legitimately mutate refs and indexes through Git,
-    # but the .git pointer and repository configuration remain controller
-    # trust anchors and must not change across the spawn.
-    def snapshot_paths(paths)
-      paths.to_h { |label, path| [ label, fingerprint(path) ] }
-    end
-
     # Structured no-follow identities used by the Artifact Firewall. The
     # legacy #snapshot shape remains content-digest compatible, while this
     # richer observation also detects mode and file-type substitutions.

--- a/test/unit/protected_files_test.rb
+++ b/test/unit/protected_files_test.rb
@@ -113,18 +113,6 @@ class ProtectedFilesTest < Minitest::Test
     end
   end
 
-  def test_snapshot_paths_detects_labeled_absolute_control_file_changes
-    with_tmp_dir do |dir|
-      config = File.join(dir, "config")
-      File.write(config, "safe\n")
-      before = Hive::ProtectedFiles.snapshot_paths("repository config" => config)
-      File.write(config, "unsafe\n")
-      after = Hive::ProtectedFiles.snapshot_paths("repository config" => config)
-
-      assert_equal [ "repository config" ], Hive::ProtectedFiles.diff(before, after)
-    end
-  end
-
   def test_capture_restores_changed_deleted_and_new_files
     with_tmp_dir do |dir|
       File.write(File.join(dir, "plan.md"), "trusted plan\n")

--- a/wiki/log.d/20260813040600-remove-unused-protected-snapshot-paths.md
+++ b/wiki/log.d/20260813040600-remove-unused-protected-snapshot-paths.md
@@ -1,0 +1,9 @@
+---
+title: Remove unused protected-path snapshot helper
+date: 2026-08-13
+---
+
+- Removed the uncalled `Hive::ProtectedFiles.snapshot_paths` digest helper.
+  Absolute protected anchors continue through the Artifact Firewall's richer
+  `observe_paths` identity boundary, which detects content, mode, and file-type
+  substitution without following links.


### PR DESCRIPTION
## Summary

- Remove unused protected path snapshot helper
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.