### PR TITLE
Remove unused publication pre-create predicate

### DIFF
--- a/lib/hive/refactor_patrol/publication_attempt.rb
+++ b/lib/hive/refactor_patrol/publication_attempt.rb
@@ -252,10 +252,6 @@ module Hive
         attempt.is_a?(Hash) && !attempt.key?("superseded")
       end
 
-      def pre_create?(attempt)
-        attempt.is_a?(Hash) && !attempt.key?("pr_create_intent")
-      end
-
       def remote_push_evidence?(attempt)
         attempt.is_a?(Hash) && attempt["push_complete"].is_a?(Hash)
       end

--- a/test/unit/refactor_patrol/publication_attempt_test.rb
+++ b/test/unit/refactor_patrol/publication_attempt_test.rb
@@ -361,7 +361,6 @@ class RefactorPatrolPublicationAttemptTest < Minitest::Test
       Publication.state_for(state, attempt_id)
     )
     assert Publication.phase_evidence?(state)
-    assert Publication.pre_create?(attempt)
     assert Publication.remote_push_evidence?(attempt)
 
     empty = publication_state
@@ -372,9 +371,6 @@ class RefactorPatrolPublicationAttemptTest < Minitest::Test
     terminal = copy(state)
     terminal.dig(Publication::ATTEMPTS_KEY, attempt_id)["superseded"] = {}
     assert_nil Publication.state_for(terminal, attempt_id)
-    terminal.dig(Publication::ATTEMPTS_KEY, attempt_id)["pr_create_intent"] = phase_payload
-    refute Publication.pre_create?(terminal.dig(Publication::ATTEMPTS_KEY, attempt_id))
-    refute Publication.pre_create?(nil)
   end
 
   def test_legacy_phases_copy_only_matching_operations_and_commits

--- a/wiki/log.d/20260813035400-remove-unused-publication-pre-create-predicate.md
+++ b/wiki/log.d/20260813035400-remove-unused-publication-pre-create-predicate.md
@@ -1,0 +1,9 @@
+---
+title: Remove unused publication pre-create predicate
+date: 2026-08-13
+---
+
+- Removed the uncalled
+  `Hive::RefactorPatrol::PublicationAttempt.pre_create?` predicate. Publication
+  recovery continues to use the retained attempt state, phase evidence, and
+  receipt predicates.


### PR DESCRIPTION
## Summary

- Remove unused publication pre-create predicate
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.