### PR TITLE
Remove unused publish GC predicate

### DIFF
--- a/lib/hive/workflow_package/publish_store.rb
+++ b/lib/hive/workflow_package/publish_store.rb
@@ -148,11 +148,6 @@ module Hive
         raise PublishRecoveryError, "publication bundle could not be marked GC-eligible"
       end
 
-      def bundle_gc_eligible?(package_digest)
-        path = File.join(gc_eligible_root, "#{package_digest}.json")
-        File.file?(path) && !File.symlink?(path)
-      end
-
       private
 
       def ensure_layout!

--- a/test/unit/workflow_package/publish_store_test.rb
+++ b/test/unit/workflow_package/publish_store_test.rb
@@ -114,7 +114,6 @@ class WorkflowPackagePublishStoreTest < Minitest::Test
 
         marker = store.mark_bundle_gc_eligible(listed)
 
-        assert store.bundle_gc_eligible?(package.package_digest)
         assert_equal 0o600, File.stat(marker).mode & 0o777
         assert File.directory?(store.bundle_path(package.package_digest))
         assert_equal listed.data, store.load("owner/registry", "demo", "1.2.3").data

--- a/wiki/log.d/20260813T235100Z-unused-publish-gc-predicate.md
+++ b/wiki/log.d/20260813T235100Z-unused-publish-gc-predicate.md
@@ -1,0 +1,6 @@
+## Remove unused publish GC predicate
+
+- Removed the cleanup target after tracked callsite, reflective-dispatch,
+  documentation, and available-history searches found no production consumer.
+- Retained focused coverage for the live behavior surrounding the orphaned
+  surface; untracked external Ruby callers remain the compatibility boundary.


### PR DESCRIPTION
## Summary

- Remove unused publish GC predicate
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.