### PR TITLE
Remove unused publication secure file wrapper

### DIFF
--- a/lib/hive/workflow_package/publish_store.rb
+++ b/lib/hive/workflow_package/publish_store.rb
@@ -268,13 +268,6 @@ module Hive
         raise PublishRecoveryError, "publication bundle is missing or unreadable"
       end
 
-      def secure_file!(path)
-        read_secure_file(
-          path, max_bytes: Manifest::MAX_FILE_BYTES,
-          message: "publication state file is linked, special, or not owned by the current user"
-        ).last
-      end
-
       def read_secure_file(path, max_bytes:, message:, mode: nil)
         SafeFile.read(
           path, max_bytes: max_bytes, error_class: PublishRecoveryError,

--- a/test/unit/workflow_package/publish_store_test.rb
+++ b/test/unit/workflow_package/publish_store_test.rb
@@ -271,10 +271,6 @@ class WorkflowPackagePublishStoreTest < Minitest::Test
         assert_raises(Hive::WorkflowPackage::PublishRecoveryError) do
           store.verify_bundle(receipt)
         end
-        assert_raises(Hive::WorkflowPackage::PublishRecoveryError) do
-          store.send(:secure_file!, File.join(state, "missing-state"))
-        end
-
         assert_equal receipt.identity.transform_keys(&:to_sym), store.send(:symbol_identity, receipt)
       end
     end

--- a/wiki/log.d/20260813041900-remove-unused-publish-secure-file-wrapper.md
+++ b/wiki/log.d/20260813041900-remove-unused-publish-secure-file-wrapper.md
@@ -1,0 +1,9 @@
+---
+title: Remove unused publication secure-file wrapper
+date: 2026-08-13
+---
+
+- Removed the private, uncalled
+  `Hive::WorkflowPackage::PublishStore#secure_file!` wrapper. Live publication
+  bundle and receipt reads continue through `read_secure_file`, with each call
+  supplying its exact size, ownership, mode, and diagnostic constraints.


### PR DESCRIPTION
## Summary

- Remove unused publication secure file wrapper
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.