### PR TITLE
Remove unused intent receipt query

### DIFF
--- a/lib/hive/modules/migration/evidence_store.rb
+++ b/lib/hive/modules/migration/evidence_store.rb
@@ -87,13 +87,6 @@ module Hive
           )
         end
 
-        def receipts_for_intent(intent_id, limit: MAX_PAGE_SIZE, cursor: nil)
-          indexed_receipts(
-            :intent, validated_id(intent_id, :intent),
-            limit: limit, cursor: cursor
-          )
-        end
-
         # Existing stores can acquire the bounded indices without one
         # history-wide allocation. Callers persist +next_cursor+ and continue
         # in later repair ticks; an incomplete page is never presented as a

--- a/test/unit/daemon/refactor_patrol_scheduler_test.rb
+++ b/test/unit/daemon/refactor_patrol_scheduler_test.rb
@@ -544,7 +544,9 @@ class HiveDaemonRefactorPatrolSchedulerTest < Minitest::Test
           "migration",
           "patrol-evidence"
         )
-      ).receipts_for_intent(failed_intent.intent_id).records
+      ).receipts.select do |receipt|
+        receipt.intent.intent_id == failed_intent.intent_id
+      end
       assert_equal [ "reconciled" ],
                    receipts.map(&:status).uniq
       assert_nil restarted_store.occurrence_for_job("job-7"),

--- a/test/unit/modules/migration/evidence_store_test.rb
+++ b/test/unit/modules/migration/evidence_store_test.rb
@@ -80,7 +80,7 @@ class ModulesMigrationEvidenceStoreTest < Minitest::Test
     end
   end
 
-  def test_occurrence_and_intent_indexes_avoid_history_scans
+  def test_occurrence_index_avoids_history_scans
     with_tmp_dir do |root|
       store = Hive::Modules::Migration::EvidenceStore.new(root: root)
       first = receipt_for(
@@ -97,15 +97,11 @@ class ModulesMigrationEvidenceStoreTest < Minitest::Test
       page = store.receipts_for_occurrence(first.intent.occurrence_id)
       assert_equal [ first ], page.records
       assert_nil page.next_cursor
-      assert_equal [ first ], store.receipts_for_intent(first.intent.intent_id).records
       assert File.file?(
         File.join(
           root, "indexes", "occurrences",
           "#{first.intent.occurrence_id}.json"
         )
-      )
-      assert File.file?(
-        File.join(root, "indexes", "intents", "#{first.intent.intent_id}.json")
       )
     end
   end

--- a/wiki/log.d/2026-08-13-remove-unused-intent-receipt-query.md
+++ b/wiki/log.d/2026-08-13-remove-unused-intent-receipt-query.md
@@ -1,0 +1,7 @@
+# Remove unused intent receipt query
+
+- Removed `Modules::Migration::EvidenceStore#receipts_for_intent`, which had no
+  production caller.
+- Retained restart reconciliation coverage by filtering the production receipt
+  collection, and kept bounded occurrence-index query coverage used by module
+  adapters.


### PR DESCRIPTION
## Summary

- Remove unused intent receipt query
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.