### PR TITLE
refactor(recovery): remove unused receipt lookup facade

### DIFF
--- a/lib/hive/daemon/recovery_coordinator.rb
+++ b/lib/hive/daemon/recovery_coordinator.rb
@@ -805,11 +805,6 @@ module Hive
         )
       end
 
-      def receipt_for_id(request_id)
-        request = @request_queue.fetch(request_id, state_home: @state_home)
-        request && receipt_for_request(request)
-      end
-
       def observation_token_for(row)
         self.class.observation_token(row)
       end

--- a/test/unit/daemon/recovery_coordinator_test.rb
+++ b/test/unit/daemon/recovery_coordinator_test.rb
@@ -601,7 +601,7 @@ class HiveDaemonRecoveryCoordinatorTest < Minitest::Test
     end
   end
 
-  def test_receipt_helpers_fail_closed_for_unknown_or_missing_requests
+  def test_receipt_helper_fails_closed_for_unknown_requests
     request = Q::Request.new(
       request_id: "unknown-phase",
       recovery: {
@@ -616,7 +616,6 @@ class HiveDaemonRecoveryCoordinatorTest < Minitest::Test
     )
 
     assert_equal "unavailable", coordinator.receipt_for_request(request).status
-    assert_nil coordinator.receipt_for_id("missing")
   end
 
   def test_defensive_recovery_helpers_keep_the_closed_contract

--- a/wiki/log.d/20260813T235300Z-unused-recovery-receipt-lookup.md
+++ b/wiki/log.d/20260813T235300Z-unused-recovery-receipt-lookup.md
@@ -1,0 +1,6 @@
+## Remove unused recovery receipt facade
+
+- Removed the cleanup target after tracked callsite, reflective-dispatch,
+  documentation, and available-history searches found no production consumer.
+- Retained focused coverage for the live behavior surrounding the orphaned
+  surface; untracked external Ruby callers remain the compatibility boundary.


### PR DESCRIPTION
## Summary

- refactor(recovery): remove unused receipt lookup facade
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.