### PR TITLE
Remove unused review scope validator

### DIFF
--- a/lib/hive/config.rb
+++ b/lib/hive/config.rb
@@ -2571,13 +2571,6 @@ module Hive
       auto_commit
     end
 
-    def validate_review_fix_auto_commit_scope!(cfg, source_path)
-      auto_commit = review_fix_auto_commit_config(cfg, source_path)
-      return if auto_commit.nil?
-
-      validate_review_fix_auto_commit_scope_config!(auto_commit["scope_check"], source_path)
-    end
-
     def validate_review_fix_auto_commit_scope_config!(scope, source_path)
       return if scope.nil?
 

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -3099,31 +3099,6 @@ class ConfigTest < Minitest::Test
     end
   end
 
-  def test_auto_commit_scope_validation_allows_missing_legacy_scope
-    cfg = { "review" => { "fix" => {} } }
-
-    Hive::Config.send(:validate_review_fix_auto_commit_scope!, cfg, "test")
-    assert_nil Hive::Config.send(:validate_path_glob_list!, nil, "review.fix.auto_commit.scope_check.allowed_paths", "test")
-  end
-
-  def test_auto_commit_scope_direct_validator_accepts_scope_config
-    cfg = {
-      "review" => {
-        "fix" => {
-          "auto_commit" => {
-            "scope_check" => {
-              "enabled" => true,
-              "allowed_paths" => [ "lib/**" ],
-              "denied_paths" => [ "config/**" ]
-            }
-          }
-        }
-      }
-    }
-
-    Hive::Config.send(:validate_review_fix_auto_commit_scope!, cfg, "test")
-  end
-
   def test_load_accepts_max_attempts_one_and_three
     with_tmp_dir do |dir|
       FileUtils.mkdir_p(File.join(dir, ".hive-state"))

--- a/wiki/log.d/2026-08-13-remove-unused-review-scope-validator.md
+++ b/wiki/log.d/2026-08-13-remove-unused-review-scope-validator.md
@@ -1,0 +1,7 @@
+# Remove unused review scope validator
+
+- Removed the unused module-function
+  `Config.validate_review_fix_auto_commit_scope!`; tracked and reflective
+  searches found no production caller.
+- Kept valid-override, malformed-scope, and malformed-container coverage through
+  the full config loader and its live `validate_review_fix_auto_commit!` path.


### PR DESCRIPTION
## Summary

- Remove unused review scope validator
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.