### PR TITLE
refactor(agent-profile): remove unused binary predicate

### DIFF
--- a/lib/hive/agent_profile.rb
+++ b/lib/hive/agent_profile.rb
@@ -642,20 +642,6 @@ module Hive
         key ? env.fetch(key) : @bin_default_override
       end
 
-      def binary_installed?(env: ENV)
-        executable = bin(env:)
-        if executable.include?(File::SEPARATOR)
-          return File.file?(executable) && File.executable?(executable)
-        end
-
-        env.fetch("PATH", "").split(File::PATH_SEPARATOR).any? do |directory|
-          candidate = File.join(directory, executable)
-          File.file?(candidate) && File.executable?(candidate)
-        end
-      rescue ArgumentError
-        false
-      end
-
       def check_version!(env: ENV)
         profile = AgentCliRuntime::Profile.new(
           name: name, bin_default: @bin_default_override,

--- a/test/unit/agent_profile_test.rb
+++ b/test/unit/agent_profile_test.rb
@@ -927,7 +927,7 @@ class AgentProfileTest < Minitest::Test
     assert overridden.frozen?
   end
 
-  def test_runtime_override_probes_binary_paths_path_entries_and_capabilities
+  def test_runtime_override_inherits_binary_probe_and_checks_capabilities
     with_tmp_dir do |dir|
       binary = capability_binary(dir, help: "--safe-mode")
       profile = make_profile(

--- a/wiki/log.d/20260813T220000Z-remove-unused-runtime-binary-installed-predicate.md
+++ b/wiki/log.d/20260813T220000Z-remove-unused-runtime-binary-installed-predicate.md
@@ -1,0 +1,8 @@
+## Remove unused runtime override binary predicate
+
+- Removed `AgentProfile::RuntimeProfileOverride#binary_installed?`, whose only
+  callers were direct unit assertions. Hive runtime code does not probe the
+  compatibility override through this predicate.
+- Retained the override's binary, version, and CLI-capability preflight
+  assertions. They now prove the inherited `agent-cli-runtime` probe respects
+  Hive's overridden executable selection and fail-soft behavior.


### PR DESCRIPTION
## Summary

- refactor(agent-profile): remove unused binary predicate
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.