### PR TITLE
Remove unused shadow comparison page facade

### DIFF
--- a/lib/hive/modules/migration/shadow_comparator.rb
+++ b/lib/hive/modules/migration/shadow_comparator.rb
@@ -14,7 +14,6 @@ module Hive
       class ShadowComparator
         class IdentityConflict < Hive::ConfigError; end
 
-        ShadowPage = Data.define(:records, :next_cursor)
         MODULES = PatrolEvidence::MODULES
         MAX_RECORD_BYTES = 512 * 1024
         MAX_RECORDS = 4_096
@@ -106,23 +105,6 @@ module Hive
             }
             record["semantic_digest"] = semantic_digest(record)
             persist(record)
-          end
-        end
-
-        def records_page(module_name:, limit: MAX_PAGE_SIZE, cursor: nil)
-          module_name = validated_module_name(module_name)
-          limit = validated_page_size(limit)
-          @admission_lock.call(shared: true) do
-            page = inventory_for(module_name).page(
-              limit: limit,
-              cursor: cursor
-            )
-            ShadowPage.new(
-              records: page.names.map do |name|
-                read(File.join(root, module_name, name))
-              end.freeze,
-              next_cursor: page.next_cursor
-            ).freeze
           end
         end
 

--- a/test/unit/modules/migration/shadow_comparator_test.rb
+++ b/test/unit/modules/migration/shadow_comparator_test.rb
@@ -636,7 +636,7 @@ class ModulesMigrationShadowComparatorTest < Minitest::Test
     end
   end
 
-  def test_history_pages_are_lexicographic_and_restart_portable
+  def test_history_iteration_is_lexicographic_and_restart_portable
     with_tmp_dir do |root|
       comparator = Hive::Modules::Migration::ShadowComparator.new(root: root)
       3.times do |index|
@@ -652,26 +652,22 @@ class ModulesMigrationShadowComparatorTest < Minitest::Test
         )
       end
 
-      first = comparator.records_page(module_name: "patrol", limit: 1)
-      assert_equal 1, first.records.size
-      refute_nil first.next_cursor
+      first = comparator.each_record("patrol", page_size: 1).to_a
+      assert_equal 3, first.size
       restarted = Hive::Modules::Migration::ShadowComparator.new(root: root)
-      second = restarted.records_page(
-        module_name: "patrol", limit: 2, cursor: first.next_cursor
-      )
-      assert_equal 2, second.records.size
-      assert_nil second.next_cursor
-      ids = (first.records + second.records).map { |record| record.fetch("decision_id") }
+      second = restarted.each_record("patrol", page_size: 2).to_a
+      assert_equal first, second
+      ids = second.map { |record| record.fetch("decision_id") }
       assert_equal ids.sort, ids
       refute_respond_to comparator, :records
       assert_raises(Hive::ConfigError) do
-        comparator.records_page(module_name: "unknown", limit: 1)
+        comparator.each_record("unknown", page_size: 1).to_a
       end
       assert_raises(Hive::ConfigError) do
-        comparator.records_page(module_name: "patrol", limit: 0)
+        comparator.each_record("patrol", page_size: 0).to_a
       end
       assert_raises(Hive::ConfigError) do
-        comparator.records_page(module_name: "patrol", limit: "many")
+        comparator.each_record("patrol", page_size: "many").to_a
       end
     end
   end

--- a/wiki/log.d/20260813033200-remove-unused-shadow-records-page.md
+++ b/wiki/log.d/20260813033200-remove-unused-shadow-records-page.md
@@ -1,0 +1,11 @@
+---
+title: Remove unused shadow comparison page facade
+date: 2026-08-13
+---
+
+- Removed the uncalled
+  `Hive::Modules::Migration::ShadowComparator#records_page` API and its private
+  result type. Migration commands and reports continue to stream validated
+  comparison history through `each_record`.
+- Retargeted restart, ordering, bounded page-size, and invalid-input coverage to
+  the live iterator.


### PR DESCRIPTION
## Summary

- Remove unused shadow comparison page facade
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.