### PR TITLE
refactor(patrol): remove unused jobs directory helper

### DIFF
--- a/lib/hive/refactor_patrol/job_store.rb
+++ b/lib/hive/refactor_patrol/job_store.rb
@@ -2163,10 +2163,6 @@ module Hive
         atomic_write(path, evidence)
       end
 
-      def jobs_dir
-        File.join(root, "jobs")
-      end
-
       def job_path(job_id)
         @job_files.job_path(validate_id!(job_id))
       end

--- a/test/unit/refactor_patrol/job_store_test.rb
+++ b/test/unit/refactor_patrol/job_store_test.rb
@@ -2709,8 +2709,6 @@ class RefactorPatrolJobStoreTest < Minitest::Test
           )
         end
       end
-      assert_equal File.join(store.root, "jobs"),
-                   store.send(:jobs_dir)
     end
   end
 

--- a/wiki/log.d/20260813T210000Z-remove-unused-job-store-jobs-dir.md
+++ b/wiki/log.d/20260813T210000Z-remove-unused-job-store-jobs-dir.md
@@ -1,0 +1,7 @@
+## Remove unused JobStore jobs-directory helper
+
+- Removed the private `RefactorPatrol::JobStore#jobs_dir` helper, whose only
+  caller was a reflective unit-test assertion left behind by the v3 storage
+  rewrite.
+- Runtime job paths and traversal continue through the descriptor-confined
+  `JobStoreFiles` collaborator, with its focused storage tests unchanged.


### PR DESCRIPTION
## Summary

- refactor(patrol): remove unused jobs directory helper
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.