### PR TITLE
Remove unused status feed predicates

### DIFF
--- a/lib/hive/web/status_feed.rb
+++ b/lib/hive/web/status_feed.rb
@@ -117,8 +117,6 @@ module Hive
         :payload, :availability, :token, :last_success_at, :error,
         :scan_count, :generation
       ) do
-        def fresh? = availability == "fresh"
-        def degraded? = availability == "degraded"
         def unavailable? = availability == "unavailable"
 
         def to_h

--- a/test/unit/web/status_feed_test.rb
+++ b/test/unit/web/status_feed_test.rb
@@ -862,7 +862,7 @@ class StatusFeedTest < Minitest::Test
       assert_equal 1, status.max_active
       assert_equal 1, feed.scan_count
       delivered = 6.times.map { states.pop(true) }
-      assert delivered.all?(&:fresh?)
+      assert delivered.all? { |state| state.availability == "fresh" }
       assert_equal 1, delivered.map(&:token).uniq.size
     ensure
       threads&.each(&:kill)
@@ -895,12 +895,12 @@ class StatusFeedTest < Minitest::Test
     _out, _err = capture_io { @degraded_state = feed.snapshot_state }
     recovered = feed.snapshot_state
 
-    assert fresh.fresh?
-    assert @degraded_state.degraded?
+    assert_equal "fresh", fresh.availability
+    assert_equal "degraded", @degraded_state.availability
     assert_same first, @degraded_state.payload
     assert_equal fresh.last_success_at, @degraded_state.last_success_at
     refute_equal fresh.token, @degraded_state.token
-    assert recovered.fresh?
+    assert_equal "fresh", recovered.availability
     assert_same second, recovered.payload
     refute_equal @degraded_state.token, recovered.token
     assert_equal 3, feed.scan_count
@@ -920,7 +920,7 @@ class StatusFeedTest < Minitest::Test
         refute subscriber.alive?
       end
 
-      assert first.fresh?
+      assert_equal "fresh", first.availability
       assert_equal 1, status.calls
       assert_equal 1, feed.scan_count
     ensure

--- a/wiki/log.d/2026-08-13-remove-unused-status-feed-predicates.md
+++ b/wiki/log.d/2026-08-13-remove-unused-status-feed-predicates.md
@@ -1,0 +1,7 @@
+# Remove unused status-feed predicates
+
+- Removed `Web::StatusFeed::State#fresh?` and `#degraded?`, which had no
+  production callers.
+- Retargeted transition and subscriber tests to the canonical `availability`
+  value consumed by `StatusBroadcaster`; unavailable-state behavior is
+  unchanged.


### PR DESCRIPTION
## Summary

- Remove unused status feed predicates
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.