### PR TITLE
Remove unused TUI subprocess placeholder

### DIFF
--- a/lib/hive/tui/subprocess.rb
+++ b/lib/hive/tui/subprocess.rb
@@ -37,10 +37,9 @@ module Hive
       # the SubprocessRegistry. `Open3.capture3` manages the child
       # internally, and the per-keystroke triage subprocesses are short-
       # lived enough that the user can simply press `r` again on Ctrl-C.
-      # The historical install/restore_traps pairing was dead code: it
-      # registered `:placeholder` and never called `register_real_pgid`,
-      # so the trap blocks always short-circuited and INT forwarding
-      # silently no-op'd anyway. Removing it also closes the concurrent-
+      # The historical install/restore_traps pairing was dead code: it never
+      # registered a real pgid, so the trap blocks always short-circuited and
+      # INT forwarding silently no-op'd anyway. Removing it also closes the concurrent-
       # `run_quiet!` trap-chain race the audit flagged (F5/F9).
       # `dispatch_background` likewise does NOT install signal
       # forwarding — the child is detached into its own pgroup, and the

--- a/lib/hive/tui/subprocess_registry.rb
+++ b/lib/hive/tui/subprocess_registry.rb
@@ -3,10 +3,8 @@ require "monitor"
 module Hive
   module Tui
     # Process-local registry for the single in-flight workflow-verb child the
-    # TUI may spawn at a time. Holds either nil, a `:placeholder` sentinel
-    # (between `Process.spawn` start and `getpgid` return), or an Integer
-    # pgid. Read by the SIGHUP cleanup hook in U9; written by Subprocess
-    # before/after the spawn.
+    # TUI may spawn at a time. Holds either nil or an Integer pgid. Read by the
+    # SIGHUP cleanup hook in U9.
     #
     # A `Monitor` (re-entrant) — not a plain Mutex — guards the slot so a
     # signal trap firing while #register is mid-flight on the same thread
@@ -21,10 +19,6 @@ module Hive
       @slot = nil
 
       module_function
-
-      def register_placeholder
-        MONITOR.synchronize { @slot = :placeholder }
-      end
 
       def register(pgid)
         MONITOR.synchronize { @slot = pgid }

--- a/test/integration/tui_signals_test.rb
+++ b/test/integration/tui_signals_test.rb
@@ -3,9 +3,8 @@ require "hive/tui/subprocess_registry"
 
 # Pins the SubprocessRegistry invariants the SIGHUP cleanup hook in
 # `Hive::Tui::App.run_charm` depends on: `kill_inflight!` must never
-# raise even when the registry is empty or holds the `:placeholder`
-# sentinel, because the trap fires from arbitrary signal-handler
-# context where exceptions would tear down the parent process.
+# raise when the registry is empty, because the trap fires from arbitrary
+# signal-handler context where exceptions would tear down the parent process.
 #
 # Pre-U11 this file also tested `Hive::Tui.install_terminal_safety_hooks`
 # (curses backend's at_exit + SIGHUP wiring). U11 deleted the curses
@@ -21,13 +20,6 @@ class TuiSignalsTest < Minitest::Test
   def test_subprocess_registry_kill_inflight_is_safe_when_empty
     Hive::Tui::SubprocessRegistry.clear
     Hive::Tui::SubprocessRegistry.kill_inflight! # must not raise
-  end
-
-  def test_subprocess_registry_kill_inflight_is_safe_with_placeholder
-    Hive::Tui::SubprocessRegistry.register_placeholder
-    Hive::Tui::SubprocessRegistry.kill_inflight! # placeholder → no-op + clear
-    assert_nil Hive::Tui::SubprocessRegistry.current,
-               "kill_inflight! must clear the slot after handling placeholder"
   end
 
   def test_subprocess_registry_kill_inflight_terminates_registered_process_group

--- a/test/integration/tui_subprocess_test.rb
+++ b/test/integration/tui_subprocess_test.rb
@@ -157,12 +157,10 @@ class TuiSubprocessTest < Minitest::Test
   end
 
   # F9: run_quiet! no longer touches the global INT/TERM trap chain.
-  # The previous install/restore pair only ever registered a
-  # `:placeholder` pgid (register_real_pgid was never called from
-  # this path), so the trap block always short-circuited and INT
-  # forwarding silently no-op'd anyway. Removing the install/restore
-  # also closes the concurrent-run_quiet! trap-chain race the
-  # /ce-code-review walkthrough flagged.
+  # The previous install/restore pair never registered a real pgid, so the
+  # trap block always short-circuited and INT forwarding silently no-op'd
+  # anyway. Removing the install/restore also closes the concurrent-run_quiet!
+  # trap-chain race the /ce-code-review walkthrough flagged.
   def test_run_quiet_does_not_modify_int_and_term_traps
     sentinel_int = proc { :sentinel_int }
     sentinel_term = proc { :sentinel_term }
@@ -183,9 +181,9 @@ class TuiSubprocessTest < Minitest::Test
   end
 
   def test_run_quiet_does_not_touch_subprocess_registry
-    Hive::Tui::SubprocessRegistry.register_placeholder
+    Hive::Tui::SubprocessRegistry.register(12_345)
     Hive::Tui::Subprocess.run_quiet!([ FAKE_CHILD ])
-    assert_equal :placeholder, Hive::Tui::SubprocessRegistry.current,
+    assert_equal 12_345, Hive::Tui::SubprocessRegistry.current,
       "run_quiet! must not write to or clear the registry — Open3 owns the child"
   ensure
     Hive::Tui::SubprocessRegistry.clear
@@ -206,17 +204,9 @@ class TuiSubprocessTest < Minitest::Test
       "kill_inflight! on empty registry should be a no-op returning nil"
   end
 
-  def test_registry_kill_inflight_is_noop_for_placeholder
-    Hive::Tui::SubprocessRegistry.register_placeholder
-    assert_nil Hive::Tui::SubprocessRegistry.kill_inflight!,
-      "kill_inflight! on :placeholder should not raise and should clear"
-    assert_nil Hive::Tui::SubprocessRegistry.current,
-      "kill_inflight! should clear the slot even when placeholder"
-  end
-
-  def test_registry_register_overwrites_placeholder
-    Hive::Tui::SubprocessRegistry.register_placeholder
-    assert_equal :placeholder, Hive::Tui::SubprocessRegistry.current
+  def test_registry_register_overwrites_previous_process_group
+    Hive::Tui::SubprocessRegistry.register(12_344)
+    assert_equal 12_344, Hive::Tui::SubprocessRegistry.current
     Hive::Tui::SubprocessRegistry.register(12_345)
     assert_equal 12_345, Hive::Tui::SubprocessRegistry.current
   ensure

--- a/wiki/log.d/20260813041400-remove-unused-subprocess-placeholder.md
+++ b/wiki/log.d/20260813041400-remove-unused-subprocess-placeholder.md
@@ -1,0 +1,9 @@
+---
+title: Remove unused TUI subprocess placeholder
+date: 2026-08-13
+---
+
+- Removed the uncalled `Hive::Tui::SubprocessRegistry.register_placeholder`
+  sentinel path left behind after foreground signal forwarding was retired.
+- Retained empty-registry no-op behavior, real process-group termination, slot
+  clearing, and proof that quiet subprocesses do not mutate the registry.


### PR DESCRIPTION
## Summary

- Remove unused TUI subprocess placeholder
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.