### PR TITLE
Remove unused suppression key projection

### DIFF
--- a/lib/hive/stages/review/suppression.rb
+++ b/lib/hive/stages/review/suppression.rb
@@ -120,10 +120,6 @@ module Hive
           ::Digest::SHA256.hexdigest("#{severity_key}\x01#{files}\x01#{title}")[0, 16]
         end
 
-        def read_active_keys(ctx)
-          read_active_entries(ctx).keys.to_set
-        end
-
         def read_active_entries(ctx)
           read_entries(suppressed_path(ctx)).select(&:active).to_h { |entry| [ entry.key, entry ] }
         rescue SuppressedDocReadError => e

--- a/test/unit/stages/review/suppression_test.rb
+++ b/test/unit/stages/review/suppression_test.rb
@@ -194,7 +194,7 @@ class ReviewSuppressionTest < Minitest::Test
     end
   end
 
-  def test_read_active_keys_counts_checked_and_ignores_unchecked_tombstones
+  def test_read_active_entries_counts_checked_and_ignores_unchecked_tombstones
     with_suppression_task do |ctx|
       key = Suppression.key_for("lib/foo.rb leaks stale state", severity: "high")
       other = Suppression.key_for("lib/bar.rb stale tombstone", severity: "medium")
@@ -208,21 +208,21 @@ class ReviewSuppressionTest < Minitest::Test
         - [ ] Medium: lib/bar.rb stale tombstone <!-- fp=#{other} first-pass=01 -->
       MD
 
-      keys = Suppression.read_active_keys(ctx)
+      keys = Suppression.read_active_entries(ctx).keys.to_set
 
       assert_includes keys, key
       refute_includes keys, other
     end
   end
 
-  def test_read_active_keys_returns_empty_for_unreadable_suppression_doc
+  def test_read_active_entries_returns_empty_for_unreadable_suppression_doc
     with_suppression_task do |ctx|
       FileUtils.rm_f(Suppression.suppressed_path(ctx))
       FileUtils.mkdir_p(Suppression.suppressed_path(ctx))
 
       keys = nil
       _out, err = capture_io do
-        keys = Suppression.read_active_keys(ctx)
+        keys = Suppression.read_active_entries(ctx).keys.to_set
       end
 
       assert_empty keys
@@ -274,7 +274,7 @@ class ReviewSuppressionTest < Minitest::Test
     end
   end
 
-  def test_read_active_keys_hashes_operator_added_line_without_fp
+  def test_read_active_entries_hashes_operator_added_line_without_fp
     with_suppression_task do |ctx|
       expected = Suppression.key_for("lib/foo.rb leaks stale state", severity: "high")
       File.write(Suppression.suppressed_path(ctx), <<~MD)
@@ -284,11 +284,11 @@ class ReviewSuppressionTest < Minitest::Test
         - [x] High: lib/foo.rb leaks stale state
       MD
 
-      assert_includes Suppression.read_active_keys(ctx), expected
+      assert_includes Suppression.read_active_entries(ctx).keys, expected
     end
   end
 
-  def test_read_active_keys_uses_section_severity_for_operator_line_without_inline_severity
+  def test_read_active_entries_uses_section_severity_for_operator_line_without_inline_severity
     with_suppression_task do |ctx|
       expected = Suppression.key_for("lib/foo.rb leaks stale state", severity: "high")
       File.write(Suppression.suppressed_path(ctx), <<~MD)
@@ -298,7 +298,7 @@ class ReviewSuppressionTest < Minitest::Test
         - [x] lib/foo.rb leaks stale state
       MD
 
-      assert_includes Suppression.read_active_keys(ctx), expected
+      assert_includes Suppression.read_active_entries(ctx).keys, expected
     end
   end
 
@@ -495,7 +495,7 @@ class ReviewSuppressionTest < Minitest::Test
         - [x] Critical: lib/foo.rb bad
       MD
 
-      refute_empty Suppression.read_active_keys(ctx)
+      refute_empty Suppression.read_active_entries(ctx)
 
       reviewer = File.join(ctx.task_folder, "reviews", "stub-reviewer-01.md")
       File.write(reviewer, "## High\n- [x] RESOLVED/NO-FIX: lib/other.rb thing: rationale\n")

--- a/wiki/log.d/2026-08-13-remove-unused-suppression-key-projection.md
+++ b/wiki/log.d/2026-08-13-remove-unused-suppression-key-projection.md
@@ -1,0 +1,6 @@
+# Remove unused suppression-key projection
+
+- Removed `Review::Suppression.read_active_keys`, which had no production
+  caller.
+- Retargeted checked-entry, operator-entry, and unreadable-document tests to
+  `read_active_entries`, the query used by live suppression filtering.


### PR DESCRIPTION
## Summary

- Remove unused suppression key projection
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.