### PR TITLE
Remove unused task closure predicate

### DIFF
--- a/lib/hive/task_closure.rb
+++ b/lib/hive/task_closure.rb
@@ -146,12 +146,6 @@ module Hive
         }
       end
 
-      def valid_for_transition?(task, receipt_digest:, project: nil)
-        !transition_evidence(
-          task, receipt_digest: receipt_digest, project: project
-        ).nil?
-      end
-
       def transition_evidence(task, receipt_digest:, project: nil)
         result = read(task, project: project)
         return nil unless result.valid?

--- a/test/unit/task_closure_test.rb
+++ b/test/unit/task_closure_test.rb
@@ -697,29 +697,6 @@ class TaskClosureTest < Minitest::Test
     end
 
     with_closure_project do |task, project|
-      input = input_for("acme/app#42")
-      preview = Hive::TaskClosure.preview(
-        task: task, project: project, input: input, gh: FakeGh.new
-      )
-      receipt = Hive::TaskClosure.confirm!(
-        task: task,
-        project: project,
-        input: input,
-        preview_digest: preview.preview_digest,
-        operator: "tester",
-        channel: "cli",
-        authorized: true,
-        gh: FakeGh.new
-      )
-      archived = Hive::TaskResolver.new(task.slug, project_filter: project).resolve
-      assert Hive::TaskClosure.valid_for_transition?(
-        archived,
-        receipt_digest: receipt.fetch("receipt_digest"),
-        project: project
-      )
-    end
-
-    with_closure_project do |task, project|
       receipt = {
         "receipt_digest" => "a" * 64,
         "observation" => {

--- a/test/unit/task_closure_test.rb
+++ b/test/unit/task_closure_test.rb
@@ -674,16 +674,16 @@ class TaskClosureTest < Minitest::Test
     end
 
     with_closure_project do |task, project|
-      service = service_for
       input = input_for("acme/app#42")
       assert_raises(Hive::TaskClosure::StalePreview) do
-        service.confirm!(
+        Hive::TaskClosure.confirm!(
           task: task, project: project, input: input,
           preview_digest: "short", operator: "tester", channel: "cli",
-          authorized: true
+          authorized: true, gh: FakeGh.new
         )
       end
 
+      service = service_for
       invalid = service.preview(
         task: task, project: project, input: input_for("not-evidence")
       )

--- a/wiki/log.d/20260813T235600Z-unused-task-closure-transition-predicate.md
+++ b/wiki/log.d/20260813T235600Z-unused-task-closure-transition-predicate.md
@@ -3,4 +3,5 @@
 - Removed the cleanup target after tracked callsite, reflective-dispatch,
   documentation, and available-history searches found no production consumer.
 - Retained focused coverage for the live behavior surrounding the orphaned
-  surface; untracked external Ruby callers remain the compatibility boundary.
+  surface, including the CLI/bot-facing class confirmation boundary; untracked
+  external Ruby callers remain the compatibility boundary.

--- a/wiki/log.d/20260813T235600Z-unused-task-closure-transition-predicate.md
+++ b/wiki/log.d/20260813T235600Z-unused-task-closure-transition-predicate.md
@@ -1,0 +1,6 @@
+## Remove unused task-closure predicate
+
+- Removed the cleanup target after tracked callsite, reflective-dispatch,
+  documentation, and available-history searches found no production consumer.
+- Retained focused coverage for the live behavior surrounding the orphaned
+  surface; untracked external Ruby callers remain the compatibility boundary.


### PR DESCRIPTION
## Summary

- Remove unused task closure predicate
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.