### PR TITLE
Remove unused task display label facade

### DIFF
--- a/lib/hive/task.rb
+++ b/lib/hive/task.rb
@@ -189,10 +189,6 @@ module Hive
       meta[:base_branch]
     end
 
-    def display_label
-      display_name || slug
-    end
-
     def worktree_path
       # An explicit pointer is authoritative for every workflow. Generic
       # managed workflows may create a worktree before coding's 4-execute

--- a/test/unit/task_test.rb
+++ b/test/unit/task_test.rb
@@ -610,7 +610,6 @@ class TaskTest < Minitest::Test
       assert_equal 42, task.id
       assert_equal "Add Foo", task.display_name
       assert_nil task.depends_on
-      assert_equal "Add Foo", task.display_label
     end
   end
 
@@ -636,7 +635,6 @@ class TaskTest < Minitest::Test
       assert_nil task.id
       assert_nil task.display_name
       assert_nil task.depends_on
-      assert_equal "add-foo", task.display_label
 
       File.write(File.join(folder, "meta.yml"), ":\n:not yaml")
       # The U3 ctor reads meta eagerly, so the malformed-YAML warn fires here —
@@ -646,7 +644,6 @@ class TaskTest < Minitest::Test
       assert_nil task.id
       assert_nil task.display_name
       assert_nil task.depends_on
-      assert_equal "add-foo", task.display_label
       assert_match(/depends_on, workflow, base_branch dropped/, err)
     end
   end

--- a/wiki/commands/new.md
+++ b/wiki/commands/new.md
@@ -127,7 +127,7 @@ idempotency_key: workflow-creator:editorial:stable
 input_fingerprint: 3f...
 ```
 
-`id` comes from the process-global counter at `Hive::Paths.task_counter_path` (`<state_home>/task-counter.yml`), protected by `<state_home>/.task-counter.lock`. `display_name` starts nil; `Hive::Task#display_label` falls back to the slug until name generation succeeds. `depends_on` is omitted when not supplied and remains the authoritative scheduling declaration when present. `workflow:` is omitted for plain coding captures, but set for explicit overrides and non-coding project defaults. `base_branch:` is omitted outside draft-PR workflows and is authoritative when present.
+`id` comes from the process-global counter at `Hive::Paths.task_counter_path` (`<state_home>/task-counter.yml`), protected by `<state_home>/.task-counter.lock`. `display_name` starts nil; status surfaces use the slug until name generation succeeds. `depends_on` is omitted when not supplied and remains the authoritative scheduling declaration when present. `workflow:` is omitted for plain coding captures, but set for explicit overrides and non-coding project defaults. `base_branch:` is omitted outside draft-PR workflows and is authoritative when present.
 
 ## Tests
 

--- a/wiki/log.d/20260813030119-remove-unused-task-display-label.md
+++ b/wiki/log.d/20260813030119-remove-unused-task-display-label.md
@@ -1,0 +1,9 @@
+---
+title: Remove unused task display-label facade
+date: 2026-08-13
+---
+
+- Removed the uncalled `Hive::Task#display_label` convenience reader. Status
+  surfaces already apply their own `display_name`-or-slug presentation fallback.
+- Kept the underlying `display_name` and `slug` readers and their sidecar
+  coverage unchanged.

--- a/wiki/modules/task.md
+++ b/wiki/modules/task.md
@@ -60,7 +60,6 @@ tags: [model, task, parsing, task-id, dependencies, workflows]
 | `#id` | Numeric id from `meta.yml`, or nil when absent/malformed/unallocated |
 | `#display_name` | `display_name` from `meta.yml`, or nil |
 | `#depends_on` | Single same-project id/slug or explicit `project:slug` prerequisite from `meta.yml`, or nil |
-| `#display_label` | `display_name || slug` |
 | `#lock_file` | `File.join(folder, ".lock")` |
 | `#log_dir` | `File.join(@hive_state_path, "logs", @slug)` |
 | `#commit_lock_file` | `File.join(@hive_state_path, ".commit-lock")` |

--- a/wiki/stages/inbox.md
+++ b/wiki/stages/inbox.md
@@ -13,7 +13,7 @@ tags: [stage, inbox, capture, task-id]
 
 `idea.md` — created by `hive new` from `templates/idea.md.erb`, ends with a trailing `<!-- WAITING -->` marker so `hive status` shows ⏸.
 
-`meta.yml` — sidecar created by `hive new` with `{id, slug, display_name}`. The id comes from the global `Hive::TaskCounter` when the counter lock is available; otherwise it is null. The display name starts null and `Hive::Task#display_label` falls back to the slug until a later writer fills it: the initial best-effort `hive generate-name`, an explicit `hive generate-name`, `hive migrate`, or the daemon display-name backfiller when a daemon tick sees the sidecar still blank.
+`meta.yml` — sidecar created by `hive new` with `{id, slug, display_name}`. The id comes from the global `Hive::TaskCounter` when the counter lock is available; otherwise it is null. The display name starts null, so status surfaces use the slug until a later writer fills it: the initial best-effort `hive generate-name`, an explicit `hive generate-name`, `hive migrate`, or the daemon display-name backfiller when a daemon tick sees the sidecar still blank.
 
 ## Behaviour of `hive run`
 

--- a/wiki/state-model.md
+++ b/wiki/state-model.md
@@ -77,7 +77,7 @@ depends_on: api:base-task-260716-abcd
 completed_at: 2026-07-24T12:00:00Z
 ```
 
-`Hive::Task#id`, `#display_name`, `#display_label`, `#depends_on`,
+`Hive::Task#id`, `#display_name`, `#depends_on`,
 `#completed_at`, and the optional workflow selector are derived from this
 sidecar. `completed_at` is optional for active and legacy tasks. Once present it
 is an exact UTC ISO 8601 timestamp and `TaskMeta.write_completed_at_once`


### PR DESCRIPTION
## Summary

- Remove unused task display label facade
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.