### PR TITLE
Remove unused TUI usage footer wrapper

### DIFF
--- a/lib/hive/tui/bubble_model.rb
+++ b/lib/hive/tui/bubble_model.rb
@@ -3001,10 +3001,6 @@ module Hive
         nil
       end
 
-      def usage_footer_line(usable_width = nil)
-        Views::UsageFooter.render(aggregate: usage_footer_aggregate, width: usable_width)
-      end
-
       def usage_footer_aggregate
         scope = derive_usage_scope(@hive_model)
         key = [

--- a/test/unit/tui/bubble_model_test.rb
+++ b/test/unit/tui/bubble_model_test.rb
@@ -352,7 +352,7 @@ class HiveTuiBubbleModelTest < Minitest::Test
       scopes << scope
       Hive::UsageDb.zero_aggregate
     }) do
-      @model.send(:usage_footer_line, 120)
+      @model.send(:default_footer, 120)
     end
 
     assert_equal [ { project_slug: "demo", task_slug: "task-one" } ], scopes
@@ -375,7 +375,7 @@ class HiveTuiBubbleModelTest < Minitest::Test
       scopes << scope
       Hive::UsageDb.zero_aggregate
     }) do
-      @model.send(:usage_footer_line, 120)
+      @model.send(:default_footer, 120)
     end
 
     assert_equal [ { project_slug: "demo" } ], scopes
@@ -407,7 +407,7 @@ class HiveTuiBubbleModelTest < Minitest::Test
       scopes << scope
       Hive::UsageDb.zero_aggregate
     }) do
-      @model.send(:usage_footer_line, 120)
+      @model.send(:default_footer, 120)
     end
 
     assert_equal [ {} ], scopes

--- a/wiki/log.d/20260813034900-remove-unused-tui-usage-footer-wrapper.md
+++ b/wiki/log.d/20260813034900-remove-unused-tui-usage-footer-wrapper.md
@@ -1,0 +1,10 @@
+---
+title: Remove unused TUI usage-footer wrapper
+date: 2026-08-13
+---
+
+- Removed the private, uncalled `Hive::Tui::BubbleModel#usage_footer_line`
+  wrapper. Live footer rendering continues through `default_footer`, which
+  derives the same cached usage aggregate and renders it responsively.
+- Retargeted task, project, and global usage-scope assertions to the live
+  default-footer path.


### PR DESCRIPTION
## Summary

- Remove unused TUI usage footer wrapper
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.