### PR TITLE
refactor(daemon): remove unused watcher timeout adapter

### DIFF
--- a/lib/hive/daemon/refactor_patrol_merge_reconciler.rb
+++ b/lib/hive/daemon/refactor_patrol_merge_reconciler.rb
@@ -212,25 +212,6 @@ module Hive
         @progress_store.path(project_root)
       end
 
-      # Gives PrMergeWatcher a bounded slice of this dispatcher's shared
-      # architecture-intake deadline before it starts its own gh state poll.
-      # Projects without enabled architecture intake retain the watcher's
-      # bounded fallback because their archive path does not consume this
-      # reconciler's budget.
-      def watcher_poll_timeout(project:, now:, maximum:)
-        limit = positive_float!(maximum, "watcher poll timeout")
-        entry = Array(@registry.call).find { |candidate| candidate["name"] == project.to_s }
-        return limit unless entry
-
-        cfg = @config_loader.call(entry.fetch("path"))
-        return limit unless intake_enabled?(cfg)
-
-        timeout = timeout_for_deadline(shared_tick_deadline(now))
-        timeout && [ timeout, limit ].min
-      rescue StandardError
-        limit || Float(maximum)
-      end
-
       private
 
       def hive_state_path_for(project_root)

--- a/test/unit/daemon/refactor_patrol_merge_reconciler_test.rb
+++ b/test/unit/daemon/refactor_patrol_merge_reconciler_test.rb
@@ -563,14 +563,12 @@ class HiveDaemonRefactorPatrolMergeReconcilerTest < Minitest::Test
       assert_equal :seeded, intake.tick(now: T0).fetch(0).fetch(:status)
       gh.details = { 7 => details(7, at: T0) }
 
-      assert_nil intake.watcher_poll_timeout(project: "demo", now: T0, maximum: 60)
       assert_equal :deferred, intake.ingest(
         project: "demo", pr: "https://github.com/acme/demo/pull/7", now: T0
       )
       assert_empty gh.detail_calls,
                    "immediate hydration must not start after catch-up spent the shared deadline"
 
-      assert_in_delta 2, intake.watcher_poll_timeout(project: "demo", now: T0 + 1, maximum: 60)
       aggregate = intake.ingest(
         project: "demo", pr: "https://github.com/acme/demo/pull/7", now: T0 + 1
       )
@@ -889,19 +887,6 @@ class HiveDaemonRefactorPatrolMergeReconcilerTest < Minitest::Test
       assert_equal :deferred, result.fetch(:status)
       assert_empty gh.page_calls
       assert_equal progress_path(dir), intake.progress_path(dir)
-    end
-  end
-
-  def test_watcher_timeout_falls_back_when_enabled_project_config_fails
-    with_tmp_dir do |dir|
-      entry = entry_for(dir)
-      intake = Hive::Daemon::RefactorPatrolMergeReconciler.new(
-        registry: -> { [ entry ] },
-        config_loader: ->(_path) { raise Hive::ConfigError, "broken" },
-        gh: FakeGh.new, github_gateway: FakeGh.new, poll_interval_sec: 0
-      )
-
-      assert_equal 3.0, intake.watcher_poll_timeout(project: "demo", now: T0, maximum: 3)
     end
   end
 

--- a/wiki/log.d/20260813T235800Z-unused-watcher-timeout-adapter.md
+++ b/wiki/log.d/20260813T235800Z-unused-watcher-timeout-adapter.md
@@ -1,0 +1,6 @@
+## Remove unused watcher timeout adapter
+
+- Removed the cleanup target after tracked callsite, reflective-dispatch,
+  documentation, and available-history searches found no production consumer.
+- Retained focused coverage for the live behavior surrounding the orphaned
+  surface; untracked external Ruby callers remain the compatibility boundary.


### PR DESCRIPTION
## Summary

- refactor(daemon): remove unused watcher timeout adapter
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.