### PR TITLE
Remove unused workflow bundle path

### DIFF
--- a/lib/hive/paths.rb
+++ b/lib/hive/paths.rb
@@ -82,10 +82,6 @@ module Hive
       File.join(workflow_publish_root, "receipts")
     end
 
-    def workflow_publish_bundles_root
-      File.join(workflow_publish_root, "bundles")
-    end
-
     def workflow_publish_locks_root
       File.join(workflow_publish_root, "locks")
     end

--- a/test/unit/paths_test.rb
+++ b/test/unit/paths_test.rb
@@ -46,7 +46,6 @@ class PathsTest < Minitest::Test
         publish = File.join(dir, "state", "hive", "workflow-publish", "v1")
         assert_equal publish, Hive::Paths.workflow_publish_root
         assert_equal File.join(publish, "receipts"), Hive::Paths.workflow_publish_receipts_root
-        assert_equal File.join(publish, "bundles"), Hive::Paths.workflow_publish_bundles_root
         assert_equal File.join(publish, "locks"), Hive::Paths.workflow_publish_locks_root
         assert_equal File.join(publish, "objects"), Hive::Paths.workflow_publish_objects_root
       end

--- a/wiki/log.d/20260813T231800Z-unused-workflow-publish-bundles-path.md
+++ b/wiki/log.d/20260813T231800Z-unused-workflow-publish-bundles-path.md
@@ -1,0 +1,6 @@
+## Remove unused workflow bundle path
+
+- Removed the cleanup target after tracked callsite, reflective-dispatch,
+  documentation, and available-history searches found no production consumer.
+- Retained focused coverage for the live behavior surrounding the orphaned
+  surface; untracked external Ruby callers remain the compatibility boundary.


### PR DESCRIPTION
## Summary

- Remove unused workflow bundle path
- Adds the required project-wiki cleanup record.

## Evidence

- Tracked callsite, reflective-dispatch, documentation, and available-history searches found no production consumer.
- Focused tests for the affected subsystem passed locally; adjacent live behavior remains covered.
- Independent review returned no blocking findings.

## Risk

- Where the removed Ruby surface was public, untracked external callers remain the compatibility boundary.

## Test plan

- See the focused validation and durable evidence in this branch’s wiki/log.d fragment.