### PR TITLE
chore(agent-runtime): prepare 0.2.0 OpenCode release

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     hive-cli (0.7.2)
-      agent-cli-runtime (~> 0.1.1)
+      agent-cli-runtime (>= 0.1.1, < 0.3.0)
       base64 (>= 0.2)
       bubbletea (= 0.1.4)
       bundler (= 2.7.2)
@@ -22,7 +22,7 @@ PATH
 PATH
   remote: components/agent-cli-runtime
   specs:
-    agent-cli-runtime (0.1.1)
+    agent-cli-runtime (0.2.0)
       json (>= 2.7, < 3.0)
       open3 (~> 0.2)
       timeout (>= 0.4, < 1.0)

--- a/components/agent-cli-runtime/CHANGELOG.md
+++ b/components/agent-cli-runtime/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.2.0 - 2026-08-15
+
 - Add OpenCode `1.18.16+` as a fifth immutable built-in profile with exact
   `provider/model` routing and faithful model-variant validation.
 - Add route-aware offline probing for the required run/export flags, selected

--- a/components/agent-cli-runtime/README.md
+++ b/components/agent-cli-runtime/README.md
@@ -11,14 +11,14 @@ normalizer while leaving process supervision with the caller.
 ## Install
 
 ```ruby
-gem "agent-cli-runtime", "~> 0.1.1"
+gem "agent-cli-runtime", "~> 0.2.0"
 ```
 
 ```ruby
 require "agent_cli_runtime"
 ```
 
-Ruby 3.4 or newer is required. The 0.1.x line is tested on Linux and macOS.
+Ruby 3.4 or newer is required. The 0.2.x line is tested on Linux and macOS.
 
 ## Compile an invocation
 

--- a/components/agent-cli-runtime/lib/agent_cli_runtime/version.rb
+++ b/components/agent-cli-runtime/lib/agent_cli_runtime/version.rb
@@ -1,3 +1,3 @@
 module AgentCliRuntime
-  VERSION = "0.1.1".freeze
+  VERSION = "0.2.0".freeze
 end

--- a/components/agent-cli-runtime/mirror/mirror-release.yml
+++ b/components/agent-cli-runtime/mirror/mirror-release.yml
@@ -197,6 +197,7 @@ jobs:
           VERSION: ${{ inputs.version }}
         shell: bash
         run: |
+          set -euo pipefail
           snapshot="$RUNNER_TEMP/release-snapshot"
           mkdir -p "$snapshot"
           git -C mirror archive "$VERSION" | tar -x -C "$snapshot"
@@ -213,6 +214,17 @@ jobs:
             "$RUNNER_TEMP/gem-home/bin/agent-runtime" --version |
             grep -Fx "${{ steps.release.outputs.version }}"
 
+      - name: Prepare snapshot-bound release notes
+        env:
+          VERSION: ${{ inputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          ruby hive/components/agent-cli-runtime/mirror/release-notes.rb \
+            "$VERSION" \
+            "$RUNNER_TEMP/release-snapshot/CHANGELOG.md" \
+            "$RUNNER_TEMP/release-notes.md"
+
       - name: Push the verified release snapshot tag
         env:
           VERSION: ${{ inputs.version }}
@@ -227,23 +239,13 @@ jobs:
           VERSION: ${{ inputs.version }}
         shell: bash
         run: |
+          set -euo pipefail
           if gh release view "$VERSION" \
             --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             echo "Mirror release $VERSION already exists."
             exit 0
           fi
           notes="$RUNNER_TEMP/release-notes.md"
-          printf '%s\n' \
-            "Read-only source snapshot of the component release from the Hive monorepo." \
-            "" \
-            "Install from RubyGems:" \
-            "" \
-            '```sh' \
-            "gem install agent-cli-runtime --version ${{ steps.release.outputs.version }}" \
-            '```' \
-            "" \
-            "Canonical development and release authority remain in https://github.com/ivankuznetsov/hive." \
-            > "$notes"
           gh release create "$VERSION" \
             --repo "$GITHUB_REPOSITORY" \
             --verify-tag \

--- a/components/agent-cli-runtime/mirror/release-notes.rb
+++ b/components/agent-cli-runtime/mirror/release-notes.rb
@@ -1,0 +1,70 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+module AgentCliRuntimeMirrorReleaseNotes
+  VERSION = /\Av\d+\.\d+\.\d+\z/
+
+  module_function
+
+  def run(arguments)
+    version, changelog_path, output_path, *extra = arguments
+    usage! unless version && changelog_path && output_path && extra.empty?
+    abort "invalid version: #{version.inspect}" unless version.match?(VERSION)
+
+    release_version = version.delete_prefix("v")
+    highlights = extract_highlights(changelog_path, release_version)
+    File.write(output_path, release_notes(release_version, highlights))
+  end
+
+  def usage!
+    abort "usage: release-notes.rb VERSION CHANGELOG OUTPUT"
+  end
+
+  def extract_highlights(changelog_path, version)
+    heading = "## #{version}"
+    found = false
+    lines = []
+
+    File.foreach(changelog_path) do |line|
+      title = line.chomp
+      if !found && (title == heading || title.start_with?("#{heading} - "))
+        found = true
+        next
+      end
+      break if found && title.start_with?("## ")
+
+      lines << line if found
+    end
+
+    abort "CHANGELOG.md has no section for #{version}" unless found
+
+    first_content = lines.index { |line| line.match?(/[^\p{Space}]/) }
+    abort "CHANGELOG.md section for #{version} has no content" unless first_content
+
+    last_content = lines.rindex { |line| line.match?(/[^\p{Space}]/) }
+
+    lines[first_content..last_content].join.chomp
+  end
+
+  def release_notes(version, highlights)
+    <<~MARKDOWN
+      Read-only source snapshot of the component release from the Hive monorepo.
+
+      ## Highlights
+
+      #{highlights}
+
+      ## Install
+
+      ```sh
+      gem install agent-cli-runtime --version #{version}
+      ```
+
+      Canonical development and release authority remain in https://github.com/ivankuznetsov/hive.
+    MARKDOWN
+  end
+end
+
+if $PROGRAM_NAME == __FILE__
+  AgentCliRuntimeMirrorReleaseNotes.run(ARGV)
+end

--- a/components/agent-cli-runtime/test/gemspec_test.rb
+++ b/components/agent-cli-runtime/test/gemspec_test.rb
@@ -8,7 +8,7 @@ class AgentCliRuntimeGemspecTest < Minitest::Test
     spec = Gem::Specification.load(GEMSPEC)
 
     assert_equal "agent-cli-runtime", spec.name
-    assert_equal Gem::Version.new("0.1.1"), spec.version
+    assert_equal Gem::Version.new("0.2.0"), spec.version
     assert_equal Gem::Requirement.new(">= 3.4.0"), spec.required_ruby_version
     assert_equal [ "agent-runtime" ], spec.executables
     assert_equal "MIT", spec.license
@@ -32,11 +32,14 @@ class AgentCliRuntimeGemspecTest < Minitest::Test
     readme = File.read(File.join(ROOT, "README.md"))
     changelog = File.read(File.join(ROOT, "CHANGELOG.md"))
 
-    assert_includes readme, 'gem "agent-cli-runtime", "~> 0.1.1"'
+    assert_includes readme, 'gem "agent-cli-runtime", "~> 0.2.0"'
     assert_includes readme, "OpenCode `1.18.16+`"
     assert_includes readme, "PreparedInvocation#cleanup!"
-    refute_match(/~> 0\.1\.0/, readme)
-    assert_match(/\A# Changelog\n\n## Unreleased\n/, changelog)
+    refute_match(/~> 0\.1\./, readme)
+    assert_match(
+      /\A# Changelog\n\n## Unreleased\n\n## 0\.2\.0 - 2026-08-15\n/,
+      changelog
+    )
   end
 
   def test_public_links_use_the_distribution_mirror_and_canonical_issue_tracker

--- a/components/agent-cli-runtime/test/mirror_test.rb
+++ b/components/agent-cli-runtime/test/mirror_test.rb
@@ -9,6 +9,7 @@ class AgentCliRuntimeMirrorTest < Minitest::Test
   SYNC = File.join(MIRROR, "sync.rb")
   WORKFLOW = File.join(MIRROR, "sync-from-hive.yml")
   RELEASE_WORKFLOW = File.join(MIRROR, "mirror-release.yml")
+  RELEASE_NOTES = File.join(MIRROR, "release-notes.rb")
   SOURCE_SHA = "a" * 40
   CHECKOUT_ACTION = "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
   RUBY_ACTION = "ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b"
@@ -212,7 +213,7 @@ class AgentCliRuntimeMirrorTest < Minitest::Test
       manifest = JSON.parse(build_out.lines.last)
       refute manifest.fetch("source_dirty")
       gem_path = manifest.fetch("gem_path")
-      assert_equal "agent-cli-runtime-0.1.1.gem", File.basename(gem_path)
+      assert_equal "agent-cli-runtime-0.2.0.gem", File.basename(gem_path)
 
       verify_out, verify_err, verify_status = Open3.capture3(
         unbundled_environment,
@@ -220,8 +221,95 @@ class AgentCliRuntimeMirrorTest < Minitest::Test
         gem_path, manifest.fetch("sha256")
       )
       assert verify_status.success?, "#{verify_out}\n#{verify_err}"
-      assert_equal "0.1.1", JSON.parse(verify_out).fetch("version")
+      assert_equal "0.2.0", JSON.parse(verify_out).fetch("version")
     end
+  end
+
+  def test_release_notes_extract_matching_dated_version
+    changelog = <<~MARKDOWN
+      # Changelog
+
+      ## Unreleased
+
+      - Future work.
+
+      ## 0.2.0 - 2026-08-15
+
+      - Add first-class OpenCode compatibility.
+      - Preserve nullable usage evidence.
+
+      ## 0.1.1 - 2026-08-12
+
+      - Older work.
+    MARKDOWN
+
+    notes, out, err, status = build_release_notes(changelog, "v0.2.0")
+
+    assert status.success?, "#{out}\n#{err}"
+    assert_includes notes, "## Highlights"
+    assert_includes notes, "Add first-class OpenCode compatibility."
+    assert_includes notes, "Preserve nullable usage evidence."
+    assert_includes notes, "gem install agent-cli-runtime --version 0.2.0"
+    refute_includes notes, "Future work."
+    refute_includes notes, "Older work."
+  end
+
+  def test_release_notes_accept_exact_version_heading
+    changelog = <<~MARKDOWN
+      # Changelog
+
+      ## 0.2.0
+
+      - Exact heading notes.
+    MARKDOWN
+
+    notes, out, err, status = build_release_notes(changelog, "v0.2.0")
+
+    assert status.success?, "#{out}\n#{err}"
+    assert_includes notes, "Exact heading notes."
+  end
+
+  def test_release_notes_reject_absent_version
+    notes, _out, err, status = build_release_notes(
+      "## 0.1.1\n\n- Older work.\n",
+      "v0.2.0"
+    )
+
+    refute status.success?
+    assert_nil notes
+    assert_match(/no section for 0\.2\.0/, err)
+  end
+
+  def test_release_notes_reject_whitespace_only_section
+    changelog = "## 0.2.0 - 2026-08-15\n \t \n\n" \
+                "## 0.1.1\n\n- Older work.\n"
+
+    notes, _out, err, status = build_release_notes(changelog, "v0.2.0")
+
+    refute status.success?
+    assert_nil notes
+    assert_match(/section for 0\.2\.0 has no content/, err)
+  end
+
+  def test_release_notes_stop_at_next_version_boundary
+    changelog = <<~MARKDOWN
+      ## 0.2.0 - 2026-08-15
+
+      ### OpenCode
+
+      - Selected work.
+
+      ## 0.1.1 - 2026-08-12
+
+      - Must not cross the version boundary.
+    MARKDOWN
+
+    notes, out, err, status = build_release_notes(changelog, "v0.2.0")
+
+    assert status.success?, "#{out}\n#{err}"
+    assert_includes notes, "### OpenCode"
+    assert_includes notes, "Selected work."
+    refute_includes notes, "Must not cross the version boundary."
   end
 
   def test_workflow_is_one_way_and_repository_scoped
@@ -284,6 +372,15 @@ class AgentCliRuntimeMirrorTest < Minitest::Test
     assert_includes release_workflow, '--notes-file "$notes"'
     assert_includes(
       release_workflow,
+      "hive/components/agent-cli-runtime/mirror/release-notes.rb"
+    )
+    assert_includes(
+      release_workflow,
+      '"$RUNNER_TEMP/release-snapshot/CHANGELOG.md"'
+    )
+    refute_includes release_workflow, "mirror/CHANGELOG.md"
+    assert_includes(
+      release_workflow,
       "https://rubygems.org/api/v1/versions/agent-cli-runtime.json"
     )
     assert_includes release_workflow, "--connect-timeout 5"
@@ -344,9 +441,38 @@ class AgentCliRuntimeMirrorTest < Minitest::Test
       "- name: Verify the release snapshot",
       tag_push
     )
+    assert_before(
+      release_workflow,
+      "Existing mirror tag $VERSION exactly matches the canonical snapshot.",
+      "- name: Prepare snapshot-bound release notes"
+    )
+    assert_before(
+      release_workflow,
+      "- name: Prepare snapshot-bound release notes",
+      tag_push
+    )
+    assert_before release_workflow, tag_push, "gh release create"
   end
 
   private
+
+  def build_release_notes(changelog, version)
+    Dir.mktmpdir("agent-cli-runtime-release-notes") do |dir|
+      changelog_path = File.join(dir, "CHANGELOG.md")
+      output_path = File.join(dir, "release-notes.md")
+      File.write(changelog_path, changelog)
+
+      out, err, status = Open3.capture3(
+        RbConfig.ruby,
+        RELEASE_NOTES,
+        version,
+        changelog_path,
+        output_path
+      )
+      notes = File.read(output_path) if File.file?(output_path)
+      return [ notes, out, err, status ]
+    end
+  end
 
   def expected_projection
     expected = {}

--- a/components/agent-cli-runtime/test/package_test.rb
+++ b/components/agent-cli-runtime/test/package_test.rb
@@ -19,7 +19,7 @@ class AgentCliRuntimePackageTest < Minitest::Test
       manifest = JSON.parse(out.lines.last)
       gem_path = manifest.fetch("gem_path")
       assert File.file?(gem_path)
-      assert_equal "agent-cli-runtime-0.1.1.gem", File.basename(gem_path)
+      assert_equal "agent-cli-runtime-0.2.0.gem", File.basename(gem_path)
       assert_equal Digest::SHA256.file(gem_path).hexdigest,
                    manifest.fetch("sha256")
       assert_equal !dirty.empty?, manifest.fetch("source_dirty")
@@ -53,7 +53,7 @@ class AgentCliRuntimePackageTest < Minitest::Test
       end
 
       _out, err, status = run_preflight(
-        component, "components/agent-cli-runtime/v0.1.1",
+        component, "components/agent-cli-runtime/v0.2.0",
         commit[0, 12], "main"
       )
       refute status.success?
@@ -110,7 +110,7 @@ class AgentCliRuntimePackageTest < Minitest::Test
       git!(repository, "add", ".")
       commit_fixture!(repository, "fixture")
       commit = git!(repository, "rev-parse", "HEAD").strip
-      tag = "components/agent-cli-runtime/v0.1.1"
+      tag = "components/agent-cli-runtime/v0.2.0"
       git!(repository, "tag", tag)
 
       yield repository, component, commit, tag

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -64,9 +64,12 @@ To publish an approved version:
    verifier.
 2. Merge the source feature without selecting a release version. Once a
    component release is explicitly authorized, update its version and
-   changelog, publish the verified bytes, then advance Hive's dependency in a
-   separate compatibility change. This keeps packaged Web installs resolvable
-   from RubyGems throughout the sequence.
+   changelog. During that release-prep PR, Hive may admit both the currently
+   published line and the candidate line (for example `>= 0.1.1, < 0.3.0`) so
+   the monorepo path gem remains testable without raising the installed floor
+   to an unpublished version. Publish the verified bytes, then narrow Hive's
+   dependency to the new line in a separate compatibility change. This keeps
+   packaged Web installs resolvable from RubyGems throughout the sequence.
 3. Record the full protected-`main` commit and verify that the version is not
    already present on RubyGems. Confirm the component tag ruleset is active and
    that `agent-cli-runtime-release` still requires the intended reviewers and

--- a/hive.gemspec
+++ b/hive.gemspec
@@ -59,7 +59,10 @@ Gem::Specification.new do |spec|
 
   # Runtime dependencies. Dev/test dependencies stay in the Gemfile because
   # they have no business being installed for end users.
-  spec.add_dependency "agent-cli-runtime", "~> 0.1.1"
+  # Release-prep commits must load the new local component before those bytes
+  # exist on RubyGems. Keep the published 0.1.1 floor until the separately
+  # verified cutover, while admitting this release line in source checkouts.
+  spec.add_dependency "agent-cli-runtime", ">= 0.1.1", "< 0.3.0"
   spec.add_dependency "base64", ">= 0.2"
   spec.add_dependency "bubbletea", "= 0.1.4"
   # Managed installs isolate GEM_HOME/GEM_PATH from the operator's gems. Keep

--- a/test/unit/agent_cli_runtime_component_test.rb
+++ b/test/unit/agent_cli_runtime_component_test.rb
@@ -38,7 +38,7 @@ class AgentCliRuntimeComponentTest < Minitest::Test
     script = <<~'RUBY'
       require "agent_cli_runtime"
       abort "loaded Hive unexpectedly" if defined?(Hive)
-      abort "wrong version" unless AgentCliRuntime::VERSION == "0.1.1"
+      abort "wrong version" unless AgentCliRuntime::VERSION == "0.2.0"
       puts AgentCliRuntime::Profiles.names.join(",")
     RUBY
     out, err, status = Bundler.with_unbundled_env do
@@ -323,7 +323,7 @@ class AgentCliRuntimeComponentTest < Minitest::Test
     end
   end
 
-  def test_hive_dependency_stays_on_the_published_line_until_release_authority
+  def test_hive_dependency_accepts_candidate_without_raising_published_floor
     spec = Gem::Specification.load(File.expand_path("../../hive.gemspec", __dir__))
     dependency = spec.runtime_dependencies.find do |candidate|
       candidate.name == "agent-cli-runtime"
@@ -331,7 +331,8 @@ class AgentCliRuntimeComponentTest < Minitest::Test
 
     refute_nil dependency
     assert dependency.requirement.satisfied_by?(Gem::Version.new("0.1.1"))
-    refute dependency.requirement.satisfied_by?(Gem::Version.new("0.2.0"))
+    assert dependency.requirement.satisfied_by?(Gem::Version.new("0.2.0"))
+    refute dependency.requirement.satisfied_by?(Gem::Version.new("0.3.0"))
     assert File.read(File.expand_path("../../lib/hive.rb", __dir__))
                .include?('require "agent_cli_runtime"')
     %i[claude codex pi grok opencode].each do |provider|

--- a/web/Gemfile.lock
+++ b/web/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../components/agent-cli-runtime
   specs:
-    agent-cli-runtime (0.1.1)
+    agent-cli-runtime (0.2.0)
       json (>= 2.7, < 3.0)
       open3 (~> 0.2)
       timeout (>= 0.4, < 1.0)
@@ -10,7 +10,7 @@ PATH
   remote: ..
   specs:
     hive-cli (0.7.2)
-      agent-cli-runtime (~> 0.1.1)
+      agent-cli-runtime (>= 0.1.1, < 0.3.0)
       base64 (>= 0.2)
       bubbletea (= 0.1.4)
       bundler (= 2.7.2)

--- a/wiki/log.d/20260815T123435Z-agent-cli-runtime-0-2-0.md
+++ b/wiki/log.d/20260815T123435Z-agent-cli-runtime-0-2-0.md
@@ -1,0 +1,20 @@
+# Prepare agent-cli-runtime 0.2.0
+
+**Action:** Prepared the independently versioned `agent-cli-runtime` 0.2.0
+release for its new first-class OpenCode compatibility surface. The package
+changelog now records the exact OpenCode profile, route-aware offline probe,
+invocation-owned overlay, strict run/export normalization, typed termination
+outcomes, and honest nullable usage evidence. Consumer installation guidance
+targets the 0.2.x line while Hive's RubyGems dependency remains on 0.1.1 until
+the separately verified post-publication compatibility cutover. Release prep
+admits both 0.1.1 and 0.2.x in Hive's source dependency window so Bundler can
+exercise the path gem without making an unpublished version the installed
+minimum; the later cutover narrows that window after public verification.
+
+**Distribution:** The mirror release workflow now lifts the matching version
+section from the verified local tag's `CHANGELOG.md` into the GitHub release
+body, followed by the exact RubyGems installation command. A shared checked
+extractor rejects missing and whitespace-only version notes before the remote
+immutable tag is pushed, persists the validated release body for release
+creation, and keeps existing-tag retries bound to the released snapshot rather
+than mutable mirror `main`.

--- a/wiki/modules/agent_cli_runtime.md
+++ b/wiki/modules/agent_cli_runtime.md
@@ -3,7 +3,7 @@ title: Agent CLI Runtime component
 type: module
 source: components/agent-cli-runtime, components/agent-cli-runtime/mirror, .github/workflows/agent-cli-runtime-release.yml
 created: 2026-07-26
-updated: 2026-08-12
+updated: 2026-08-15
 tags: [agent, runtime, component, gem, cli]
 ---
 
@@ -122,10 +122,12 @@ budgets, or contain Hive defaults and skills. It can load and run without
 `hive-cli` or Hive constants. Direct standard-library gem dependencies are
 declared in its gemspec.
 
-Hive source declares the published `agent-cli-runtime ~> 0.1.1` line and
-resolves the unreleased monorepo component path during development. Version
-selection, component publication, and the later Hive dependency cutover remain
-separately authorized. `Hive::AgentRuntime` preserves its
+Hive source admits `agent-cli-runtime >= 0.1.1, < 0.3.0` during release prep and
+resolves the monorepo component path during development. The unchanged 0.1.1
+floor keeps installed Hive resolvable while the authorized 0.2.0 component
+release adds the public OpenCode contract; component publication and the later
+Hive dependency cutover remain separate operations. `Hive::AgentRuntime`
+preserves its
 public request, probe, error, and result names as a forwarding facade, while
 `Hive::AgentProfile` wraps package profiles with only Hive-owned skill, model
 routing, default-model, status, and policy metadata. The five source-built Hive
@@ -152,8 +154,9 @@ state, checksums it, installs it into a private gem home, proves a clean require
 and exercises the executable. Root parity fixtures cover non-default
 compilation, local probes, named capability evidence, provider usage variants,
 and observable normalization/redaction across all five built-ins. The
-unreleased source candidate adds OpenCode without authorizing a version, tag,
-publication, mirror release, deployment, or Hive release.
+0.2.0 release promotes OpenCode to the public compatibility surface without
+changing the component's caller-owned process-supervision boundary or
+authorizing a Hive release.
 `bin/release-preflight` remains
 tag-bound and is not run against a fabricated tag during candidate work.
 
@@ -183,20 +186,23 @@ approved, fully qualified component tag to an orphan `vX.Y.Z` source-snapshot
 tag. It reuses the component release preflight, verifies the exact version is
 already on RubyGems, compares the projected tree with an independently archived
 canonical tree, requires a live immutable `refs/tags/v*` ruleset, verifies the
-local tag as an installable gem, and only then pushes it and creates the focused
-GitHub release. Neither mirror workflow can modify Hive, publish RubyGems
+local tag as an installable gem, and builds the focused GitHub release notes
+from that verified tag's `CHANGELOG.md`. A checked extractor rejects missing or
+whitespace-only version sections before the immutable tag is pushed, and the
+release step consumes that already validated file. This ordering also makes a
+retry with an existing matching tag independent of mutable mirror `main`.
+Neither mirror workflow can modify Hive, publish RubyGems
 bytes, or choose a version; issues, pull requests, and release authority stay
 here.
 
 ## Compatibility
 
-The published line remains 0.1.x; the unreleased source candidate runs on Ruby
-3.4 or newer and is tested on Linux and macOS. An authorized release must pick
-a version that accounts for the additive prepared-invocation, route-probe,
-strict-parser, identity, and usage contracts. Removing or changing an existing
-public field, flag mapping, event meaning, or executable contract requires a
-minor release while pre-1.0. A published bad version is fixed forward; yanking
-or ownership changes are separate operator decisions.
+The 0.2.x line runs on Ruby 3.4 or newer and is tested on Linux and macOS.
+Version 0.2.0 accounts for the additive OpenCode prepared-invocation,
+route-probe, strict-parser, identity, and usage contracts. Removing or changing
+an existing public field, flag mapping, event meaning, or executable contract
+requires a minor release while pre-1.0. A published bad version is fixed
+forward; yanking or ownership changes are separate operator decisions.
 
 Related context: [[component-boundaries]], [[modules/agent_profile]], and
 ADR-038 in [[decisions]].


### PR DESCRIPTION
## Summary

- Prepare `agent-cli-runtime` 0.2.0 as the public release of the first-class OpenCode support landed in #998, with one version, changelog, install contract, and verified candidate.
- Keep source checkouts testable before publication without making the unpublished line Hive's installed minimum. A separate post-publication change will narrow Hive to `~> 0.2.0`.
- Generate mirror release highlights from the verified immutable snapshot and validate meaningful notes before any public mirror tag is pushed.

Related: #998

## Test plan

- [x] `bundle exec rake test` - 96 runs, 1,071 assertions, 0 failures, 0 errors, 1 intentional live-provider skip
- [x] mirror release tests - 14 runs, 238 assertions, 0 failures
- [x] RuboCop on all changed Ruby files - no offenses
- [x] workflow YAML parse and `git diff --check`
- [x] clean candidate build and install verification at `94145cdd648462e259ce63eaa2a5c055882d7c3a`
- [x] candidate SHA-256: `b813b54d0dded7ecab2a7aa569d997c7d4c24666b76ba675196cb30e10e08320`
- [x] hosted CI and release-adjacent merge gates

## Notes for reviewer

- This PR does not publish a gem or create a tag. The protected component tag is created only after this commit reaches protected `main`.
- The temporary `>= 0.1.1, < 0.3.0` Hive dependency window is release plumbing, not the final consumer contract. Hive itself must not be released until the post-publication cutover narrows the dependency.
- Structured code review completed with four independently corroborated release-safety findings. All four were applied and re-verified.

## Post-Deploy Monitoring & Validation

- Owner and window: the release operator watches from component-tag creation until RubyGems, a fresh public install, and the mirror GitHub release all match.
- Healthy signals: GitHub Actions completes `candidate -> install (Linux/macOS) -> publish`; RubyGems 0.2.0 has the retained candidate SHA; `agent-runtime --version` and the OpenCode JSON probe pass in a clean gem home; the mirror `v0.2.0` release contains the changelog highlights.
- Failure signals: any failed or non-terminal release job, checksum mismatch, missing RubyGems version, clean-install/probe failure, or mirror note/tag mismatch.
- Mitigation: stop before the mirror release and Hive dependency cutover, retain the candidate artifact and workflow logs, and fix forward from protected `main`. Do not publish or release Hive while validation is incomplete.
- Search terms and surfaces: the `Agent CLI Runtime Release` workflow jobs (`candidate`, `install`, `publish`), RubyGems version metadata, and the mirror workflow run for `v0.2.0`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

