### PR TITLE
fix(patrol): tolerate in-flight atomic job writes

### DIFF
--- a/lib/hive/managed_directory.rb
+++ b/lib/hive/managed_directory.rb
@@ -28,7 +28,16 @@ module Hive
     ACTIVE_SESSIONS_KEY = :hive_managed_directory_sessions
     private_constant :ACTIVE_SESSIONS_KEY
 
+    ATOMIC_WRITE_TEMPORARY =
+      /\A\.(?<target>[^\/]+)\.tmp\.[1-9][0-9]*\.[0-9a-f]{12}\z/
+    private_constant :ATOMIC_WRITE_TEMPORARY
+
     attr_reader :root
+
+    def self.atomic_write_temporary_target(name)
+      match = ATOMIC_WRITE_TEMPORARY.match(name)
+      match && match[:target]
+    end
 
     def initialize(root:, label:, anchor: nil)
       @root = File.expand_path(root).freeze
@@ -76,7 +85,7 @@ module Hive
             :directory
           rescue Errno::ENOTDIR
             file = @native.open_file(
-              parent.directory, name, File::RDONLY
+              parent.directory, name, File::RDONLY | File::NONBLOCK
             )
             validate_regular!(file.stat)
             :regular
@@ -213,8 +222,7 @@ module Hive
             )
           end
 
-          temporary_name =
-            ".#{name}.tmp.#{Process.pid}.#{SecureRandom.hex(6)}"
+          temporary_name = atomic_write_temporary_name(name)
           flags = File::WRONLY | File::CREAT | File::EXCL
           file = @native.open_file(
             parent.directory,
@@ -349,6 +357,10 @@ module Hive
     end
 
     private
+
+    def atomic_write_temporary_name(target)
+      ".#{target}.tmp.#{Process.pid}.#{SecureRandom.hex(6)}"
+    end
 
     DirectoryHandle = Struct.new(
       :directory,

--- a/lib/hive/refactor_patrol/job_store_files.rb
+++ b/lib/hive/refactor_patrol/job_store_files.rb
@@ -11,7 +11,7 @@ module Hive
       MAX_JOB_BYTES = 8 * 1024 * 1024
       MAX_JSON_BYTES = 64 * 1024 * 1024
       MAX_JOB_ENTRIES = 8_192
-      MAX_JOB_FILES = MAX_JOB_ENTRIES * 2
+      MAX_JOB_FILES = MAX_JOB_ENTRIES * 3
       JOB_ID_SOURCE = "[a-zA-Z0-9][a-zA-Z0-9_.-]{0,127}".freeze
       JOB_ID = /\A#{JOB_ID_SOURCE}\z/
       JOB_JSON = /\A(#{JOB_ID_SOURCE})\.json\z/
@@ -51,12 +51,14 @@ module Hive
         regular?(job_relative(job_id))
       end
 
-      def with_job_lock(job_id, &block)
+      def with_job_lock(job_id)
         id = validated_job_id(job_id)
         directory.with_lock(
-          File.join("jobs", "#{id}.json.lock"),
-          &block
-        )
+          File.join("jobs", "#{id}.json.lock")
+        ) do
+          remove_job_temporaries(id)
+          yield
+        end
       end
 
       # New authoritative jobs are admitted under one store-wide capacity
@@ -112,6 +114,7 @@ module Hive
           match = JOB_JSON.match(name)
           next match[1] if match
           next if name.match?(JOB_LOCK)
+          next if managed_job_temporary?(name)
 
           corrupt!(
             "refactor patrol job inventory contains an unknown entry",
@@ -163,6 +166,40 @@ module Hive
       end
 
       private
+
+      def managed_job_temporary?(name)
+        target = Hive::ManagedDirectory.atomic_write_temporary_target(name)
+        return false unless target&.match?(JOB_JSON)
+
+        relative = File.join("jobs", name)
+        type = directory.entry_type(relative, missing: true)
+        return true if type.nil? || type == :regular
+
+        corrupt!(
+          "refactor patrol job temporary entry is not a regular file",
+          relative
+        )
+      end
+
+      def remove_job_temporaries(job_id)
+        target = "#{job_id}.json"
+        directory.each_child("jobs", missing: true) do |name|
+          next unless Hive::ManagedDirectory.atomic_write_temporary_target(
+            name
+          ) == target
+
+          relative = File.join("jobs", name)
+          type = directory.entry_type(relative, missing: true)
+          next unless type
+          unless type == :regular
+            corrupt!(
+              "refactor patrol job temporary entry is not a regular file",
+              relative
+            )
+          end
+          directory.unlink(relative, missing: true)
+        end
+      end
 
       def job_relative(job_id)
         File.join("jobs", "#{validated_job_id(job_id)}.json")

--- a/test/unit/managed_directory_test.rb
+++ b/test/unit/managed_directory_test.rb
@@ -5,6 +5,49 @@ require "hive/managed_directory"
 class ManagedDirectoryTest < Minitest::Test
   include HiveTestHelper
 
+  def test_atomic_write_temporary_target_recognizes_only_writer_owned_names
+    assert_equal "record.json",
+                 Hive::ManagedDirectory.atomic_write_temporary_target(
+                   ".record.json.tmp.123.#{'a' * 12}"
+                 )
+    assert_nil Hive::ManagedDirectory.atomic_write_temporary_target(
+      ".record.json.tmp.0.#{'a' * 12}"
+    )
+    assert_nil Hive::ManagedDirectory.atomic_write_temporary_target(
+      ".record.json.tmp.123.#{'A' * 12}"
+    )
+    assert_nil Hive::ManagedDirectory.atomic_write_temporary_target(
+      "record.json.tmp.123.#{'a' * 12}"
+    )
+  end
+
+  def test_atomic_write_temporary_name_round_trips_through_classifier
+    with_tmp_dir do |root|
+      directory = Hive::ManagedDirectory.new(
+        root: root, label: "test state"
+      )
+      native = directory.instance_variable_get(:@native)
+      original = native.method(:open_file)
+      temporary = nil
+
+      with_replaced_singleton_method(
+        native,
+        :open_file,
+        lambda do |parent, name, flags, mode: nil|
+          temporary = name if name.start_with?(".record.json.tmp.")
+          original.call(parent, name, flags, mode: mode)
+        end
+      ) do
+        directory.atomic_write("record.json", "payload")
+      end
+
+      assert_equal "record.json",
+                   Hive::ManagedDirectory.atomic_write_temporary_target(
+                     temporary
+                   )
+    end
+  end
+
   def test_prepares_private_directories_and_reads_atomic_writes
     with_tmp_dir do |anchor|
       root = File.join(anchor, "state", "evidence")

--- a/test/unit/refactor_patrol/job_store_files_test.rb
+++ b/test/unit/refactor_patrol/job_store_files_test.rb
@@ -248,6 +248,18 @@ class RefactorPatrolJobStoreFilesTest < Minitest::Test
     end
   end
 
+  def test_job_lock_rejects_a_nonregular_previous_writer_temporary
+    with_files do |files, root, _outside|
+      temporary = ".job-1.json.tmp.#{Process.pid}.#{'f' * 12}"
+      FileUtils.mkdir_p(File.join(root, "jobs", temporary))
+
+      error = assert_raises(CorruptRecord) do
+        files.with_job_lock("job-1") { flunk }
+      end
+      assert_match(/temporary entry is not a regular file/, error.message)
+    end
+  end
+
   def test_inventory_translates_a_job_that_disappears_after_enumeration
     with_files do |files, _root, _outside|
       files.write_job("job-1", "{}\n")

--- a/test/unit/refactor_patrol/job_store_files_test.rb
+++ b/test/unit/refactor_patrol/job_store_files_test.rb
@@ -1,5 +1,6 @@
 require "test_helper"
 require "json"
+require "timeout"
 require "hive/refactor_patrol/job_store_files"
 
 class RefactorPatrolJobStoreFilesTest < Minitest::Test
@@ -111,6 +112,13 @@ class RefactorPatrolJobStoreFilesTest < Minitest::Test
     end
   end
 
+  def test_job_inventory_reserves_one_temporary_slot_per_job
+    assert_equal(
+      Hive::RefactorPatrol::JobStoreFiles::MAX_JOB_ENTRIES * 3,
+      Hive::RefactorPatrol::JobStoreFiles::MAX_JOB_FILES
+    )
+  end
+
   def test_job_read_write_helpers_round_trip_exact_bytes
     with_files do |files, _root, _outside|
       bytes = "{\"job_id\":\"job-1\"}\n"
@@ -139,6 +147,104 @@ class RefactorPatrolJobStoreFilesTest < Minitest::Test
         files.regular?("jobs/job-dir.json")
       end
       assert_match(/not a regular file/, error.message)
+    end
+  end
+
+  def test_inventory_ignores_only_regular_managed_job_temporary_files
+    with_files do |files, root, _outside|
+      files.write_job("job-1", "{}\n")
+      temporary = ".job-2.json.tmp.#{Process.pid}.#{'a' * 12}"
+      temporary_path = File.join(root, "jobs", temporary)
+      File.binwrite(temporary_path, "partial")
+
+      assert_equal [ "job-1" ], files.each_job_id.to_a
+
+      FileUtils.rm_f(temporary_path)
+      FileUtils.mkdir_p(temporary_path)
+      error = assert_raises(CorruptRecord) { files.each_job_id.to_a }
+      assert_match(/temporary entry is not a regular file/, error.message)
+    end
+  end
+
+  def test_inventory_rejects_non_job_and_special_temporary_lookalikes
+    with_files do |files, root, _outside|
+      files.write_job("job-1", "{}\n")
+      jobs = File.join(root, "jobs")
+      non_job = ".notes.txt.tmp.#{Process.pid}.#{'d' * 12}"
+      File.binwrite(File.join(jobs, non_job), "partial")
+
+      error = assert_raises(CorruptRecord) { files.each_job_id.to_a }
+      assert_match(/unknown entry/, error.message)
+
+      FileUtils.rm_f(File.join(jobs, non_job))
+      fifo = ".job-1.json.tmp.#{Process.pid}.#{'e' * 12}"
+      File.mkfifo(File.join(jobs, fifo))
+      Timeout.timeout(1) do
+        assert_raises(Hive::ConfigError) { files.each_job_id.to_a }
+      end
+    end
+  end
+
+  def test_inventory_capacity_includes_one_managed_temporary_per_job
+    with_files do |files, root, _outside|
+      files.write_job("job-1", "{}\n")
+      files.with_job_lock("job-1") { nil }
+      temporary = ".job-1.json.tmp.#{Process.pid}.#{'c' * 12}"
+      File.binwrite(File.join(root, "jobs", temporary), "partial")
+
+      with_constant(
+        Hive::RefactorPatrol::JobStoreFiles,
+        :MAX_JOB_ENTRIES,
+        1
+      ) do
+        with_constant(
+          Hive::RefactorPatrol::JobStoreFiles,
+          :MAX_JOB_FILES,
+          3
+        ) do
+          assert_equal [ "job-1" ], files.each_job_id.to_a
+        end
+      end
+    end
+  end
+
+  def test_inventory_allows_a_managed_job_temporary_to_finish_renaming
+    with_files do |files, root, _outside|
+      files.write_job("job-1", "{}\n")
+      temporary = ".job-2.json.tmp.#{Process.pid}.#{'b' * 12}"
+      temporary_path = File.join(root, "jobs", temporary)
+      File.binwrite(temporary_path, "partial")
+      original = files.directory.method(:entry_type)
+
+      with_replaced_singleton_method(
+        files.directory,
+        :entry_type,
+        lambda do |relative, missing: false|
+          if relative == File.join("jobs", temporary)
+            FileUtils.rm_f(temporary_path)
+            nil
+          else
+            original.call(relative, missing: missing)
+          end
+        end
+      ) do
+        assert_equal [ "job-1" ], files.each_job_id.to_a
+      end
+    end
+  end
+
+  def test_job_lock_reclaims_a_previous_writer_temporary
+    with_files do |files, root, _outside|
+      files.write_job("job-1", "{}\n")
+      temporary = ".job-1.json.tmp.#{Process.pid}.#{'f' * 12}"
+      temporary_path = File.join(root, "jobs", temporary)
+      File.binwrite(temporary_path, "partial")
+
+      files.with_job_lock("job-1") do
+        refute_path_exists temporary_path
+      end
+
+      assert_equal [ "job-1" ], files.each_job_id.to_a
     end
   end
 

--- a/wiki/log.d/20260815T210532Z-refactor-patrol-job-temp-inventory.md
+++ b/wiki/log.d/20260815T210532Z-refactor-patrol-job-temp-inventory.md
@@ -1,0 +1,19 @@
+---
+title: Architecture Patrol tolerates its own atomic job temporaries
+type: fix
+created: 2026-08-15
+tags: [refactor-patrol, jobstore, atomic-write, recovery]
+---
+
+`JobStoreFiles` now distinguishes ManagedDirectory's exact writer-owned job
+temporary names from unknown inventory entries. A regular temporary, or one
+that vanishes while its rename completes, is ignored by authoritative job
+enumeration; a non-regular temporary and every other unknown name still fail
+closed. ManagedDirectory owns the shared temporary-name classifier, and the
+bounded inventory reserves one temporary slot per admitted job. This prevents
+concurrent v4 job publication from surfacing as
+`repository_identity_unresolved`, including at capacity, and blocking
+unrelated Architecture Patrol jobs. Non-directory descriptor probes are also
+nonblocking, so a temp-shaped FIFO fails closed instead of hanging inventory.
+Each job-lock holder removes exact temporaries left by the previous writer,
+bounding crash residue to one temporary per admitted job.

--- a/wiki/modules/patrol.md
+++ b/wiki/modules/patrol.md
@@ -382,7 +382,14 @@ remain unproven.
 - Live v4 jobs, query sidecars, quarantine evidence, and action locks are
   accessed only through one descriptor-confined `JobStoreFiles` port. A
   store-wide admission lock enforces the 8,192-job bound before any new
-  per-job lock or query membership is created.
+  per-job lock or query membership is created. Inventory accepts the exact
+  writer-owned `.JOB.json.tmp.PID.HEX` name only while it is a regular file or
+  has vanished during the atomic rename; every other unknown or non-regular
+  entry still fails closed, and special-file probes are nonblocking. The
+  next holder of a job's exclusive lock removes any temporary left by its
+  previous writer, so the bounded inventory can reserve exactly one temporary
+  slot per admitted job. A concurrent job write therefore cannot be
+  misreported as unresolved repository identity, including at store capacity.
 - Cutover and rollback quiescence include ordinary active occurrences, architecture active occurrences, and incomplete v4 jobs before advancing an ownership epoch.
 - Ordinary and architecture projection/recovery failures emit bounded project/occurrence/job diagnostics with retry count and next backoff time; durable outbox or exact-transition recovery remains pending while the scheduler backs off.
 - Closed-unmerged patrol PRs become dismissals and are skipped on future cycles.

--- a/wiki/state-model.md
+++ b/wiki/state-model.md
@@ -704,6 +704,16 @@ reserves an immutable monotonic entry/pointer pair before its job write;
 quarantine evidence, and locks. Its store-wide admission lock checks the
 bounded authoritative inventory before creating a per-job lock, so concurrent
 writers cannot persist an 8,193rd job or leave an over-capacity orphan lock.
+The inventory recognizes only ManagedDirectory's exact job-temporary filename
+grammar and verifies that a visible temporary is a regular file; a temporary
+that completes its rename between enumeration and inspection is also benign.
+Non-directory probes use nonblocking descriptor opens, so a temp-shaped FIFO
+or device fails closed instead of hanging inventory. Before a job-lock holder
+writes, it removes exact writer temporaries left by the previous holder; a
+crash can therefore leave at most one temporary per admitted job. The bounded
+directory inventory reserves that slot. All other unknown and non-regular
+entries remain corruption, so an in-flight atomic write cannot masquerade as
+a repository-identity failure without weakening the store boundary.
 An exact retry can adopt the next fully written membership after a crash, while
 a permanent hole keeps later entries invisible until an explicit authoritative
 rebuild. Rebuild scans while holding the writer lock, prepares a complete new


### PR DESCRIPTION
## Summary

Architecture Patrol no longer misreports Hive's own in-flight or crash-left job writes as `repository_identity_unresolved`. Job inventory recognizes only ManagedDirectory's exact temporary names, probes special files without blocking, and removes a previous writer's residue while holding the matching job lock. Unknown and non-regular entries still fail closed, including at the 8,192-job capacity boundary.

## Validation

- 218 focused runs and 1,074 assertions passed across ManagedDirectory, JobStore, repository ownership, and the Architecture Patrol scheduler.
- RuboCop and `git diff --check` passed.
- The broad suite completed 13,545 runs and 192,204 assertions. Its only 2 failures and 2 errors were isolated to packaged-browser tests because this host's `npm` mise shim is unavailable.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
