### PR TITLE
fix(web): keep waiting questions answerable

### DIFF
--- a/lib/hive/task_workspace/builder.rb
+++ b/lib/hive/task_workspace/builder.rb
@@ -33,8 +33,7 @@ module Hive
                      cursor_codec:, limits: Limits.new, attempt_store: nil,
                      projection_store: nil, projection_read: nil,
                      event_reader: nil, journal_reader: nil, usage_reader: Hive::UsageDb,
-                     current_context_observation: nil, questions_count: nil,
-                     questions: nil,
+                     current_context_observation: nil, questions: nil,
                      daemon_enabled: true, archive: false,
                      clock: -> { Time.now.utc })
         @task = task
@@ -55,7 +54,6 @@ module Hive
         @journal_reader = journal_reader
         @usage_reader = usage_reader
         @current_context_observation = current_context_observation
-        @questions_count = questions_count
         @questions = questions
         @daemon_enabled = daemon_enabled == true
         @archive = archive == true
@@ -95,6 +93,8 @@ module Hive
           "artifacts" => artifacts
         }
         status = status_payload(read)
+        operator = operator_payload
+        answerable_questions = status["freshness"] == "fresh" ? operator.fetch("questions") : []
         action_evidence_current = status["state"] == "current" &&
                                   decision_panels_current?(attempts, resources)
 
@@ -107,10 +107,11 @@ module Hive
               task_value("condition_task_generation") || task_value("task_generation")
           },
           status: status,
-          operator: operator_payload,
+          operator: operator,
           decision: decision_payload(
             attempts: attempts, resources: resources,
-            action_evidence_current: action_evidence_current
+            action_evidence_current: action_evidence_current,
+            answerable_questions: answerable_questions
           ),
           panels: panels
         )
@@ -355,16 +356,22 @@ module Hive
         }
       end
 
-      def decision_payload(attempts:, resources:, action_evidence_current:)
+      def decision_payload(attempts:, resources:, action_evidence_current:,
+                           answerable_questions:)
         action_kind = task_value("action")&.to_s
         action_label = task_value("action_label")&.to_s
-        enabled, action_reason = action_enabled(evidence_current: action_evidence_current)
+        answer_evidence_current = answerable_questions.any?
+        enabled, action_reason = action_enabled(
+          evidence_current: action_evidence_current,
+          answer_evidence_current: answer_evidence_current
+        )
         posture, reason = if @archive
           [ "investigate", "Archived task evidence is read-only." ]
+        elsif answer_evidence_current
+          count = answerable_questions.length
+          [ "answer", "#{count} required #{count == 1 ? 'question is' : 'questions are'} unanswered." ]
         elsif !action_evidence_current
           [ "investigate", "Action-driving workspace evidence is degraded or incomplete." ]
-        elsif question_count.positive?
-          [ "answer", "#{question_count} required #{question_count == 1 ? 'question is' : 'questions are'} unanswered." ]
         elsif task_predicate(:passable?)
           [ "approve", "The current stage has a canonical completion marker." ]
         elsif task_predicate(:recovery_action_visible?) && task_predicate(:recovery_action_enabled?)
@@ -448,12 +455,12 @@ module Hive
         nil_if_empty && text.empty? ? nil : text
       end
 
-      def action_enabled(evidence_current:)
+      def action_enabled(evidence_current:, answer_evidence_current:)
         return [ false, "Archived tasks are read-only." ] if @archive
+        return [ true, nil ] if answer_evidence_current
         unless evidence_current
           return [ false, "Refresh complete workspace evidence before acting." ]
         end
-        return [ true, nil ] if question_count.positive?
         return [ true, nil ] if task_predicate(:passable?)
         if task_predicate(:recovery_action_visible?)
           return task_predicate(:recovery_action_enabled?) ? [ true, nil ] :
@@ -490,14 +497,6 @@ module Hive
         return "The task is on an authorized hold." if task_value("held")
 
         "The canonical task action reports an active agent."
-      end
-
-      def question_count
-        return Integer(@questions_count) unless @questions_count.nil?
-
-        Integer(task_value("unanswered_questions") || 0)
-      rescue ArgumentError, TypeError
-        0
       end
 
       def task_predicate(name)

--- a/test/unit/commands/setup/orchestrator_test.rb
+++ b/test/unit/commands/setup/orchestrator_test.rb
@@ -10,6 +10,7 @@ require "hive/invoked_binary"
 require "hive/commands/init"
 require "hive/commands/daemon"
 require "hive/commands/daemon/service_installer"
+require "hive/commands/babysit"
 require "hive/commands/babysit/service_installer"
 require "hive/commands/web/service_installer"
 

--- a/test/unit/task_workspace/builder_coverage_gaps_test.rb
+++ b/test/unit/task_workspace/builder_coverage_gaps_test.rb
@@ -160,22 +160,28 @@ class TaskWorkspaceBuilderCoverageGapsTest < Minitest::Test
 
       task.values["action"] = "ready_execute"
       decision = subject.send(
-        :decision_payload, attempts: {}, resources: {}, action_evidence_current: true
+        :decision_payload, attempts: {}, resources: {}, action_evidence_current: true,
+        answerable_questions: []
       )
       assert_equal "wait", decision.fetch("posture")
 
       archived = builder(task, native, archive: true).send(
-        :decision_payload, attempts: {}, resources: {}, action_evidence_current: true
+        :decision_payload, attempts: {}, resources: {}, action_evidence_current: true,
+        answerable_questions: []
       )
       assert_equal "investigate", archived.fetch("posture")
 
       task.values.merge!("recovery_visible" => true, "recovery_enabled" => false)
-      disabled = subject.send(:action_enabled, evidence_current: true)
+      disabled = subject.send(
+        :action_enabled, evidence_current: true, answer_evidence_current: false
+      )
       assert_equal false, disabled.first
       task.values["recovery_visible"] = false
       task.values["dispatch_action"] = "execute"
       no_daemon = builder(task, native, daemon_enabled: false)
-      assert_equal [ true, nil ], no_daemon.send(:action_enabled, evidence_current: true)
+      assert_equal [ true, nil ], no_daemon.send(
+        :action_enabled, evidence_current: true, answer_evidence_current: false
+      )
 
       task.recovery_value = { "status" => "queued" }
       payload = subject.send(:operator_payload)
@@ -184,8 +190,6 @@ class TaskWorkspaceBuilderCoverageGapsTest < Minitest::Test
       question = Object.new
       question.define_singleton_method(:[]) { |*| raise "bad question" }
       assert_nil subject.send(:question_value, question, :n)
-      subject.instance_variable_set(:@questions_count, "bad")
-      assert_equal 0, subject.send(:question_count)
       task.predicate_error = true
       refute subject.send(:task_predicate, :passable?)
 

--- a/test/unit/task_workspace/builder_test.rb
+++ b/test/unit/task_workspace/builder_test.rb
@@ -64,7 +64,7 @@ class TaskWorkspaceBuilderTest < Minitest::Test
     end
   end
 
-  def test_partial_projection_evidence_disables_actions_even_with_a_fresh_status_feed
+  def test_partial_projection_evidence_preserves_bound_answer_action_with_a_fresh_status_feed
     with_fixture do |native, task|
       snapshot = builder(
         native, task, questions: 1, projection_state: "partial",
@@ -75,14 +75,34 @@ class TaskWorkspaceBuilderTest < Minitest::Test
       ).call
 
       assert_equal "partial", snapshot.dig("status", "state")
-      assert_equal "investigate", snapshot.dig("decision", "posture")
-      refute snapshot.dig("decision", "action", "enabled")
+      assert_equal "answer", snapshot.dig("decision", "posture")
+      assert snapshot.dig("decision", "action", "enabled")
     end
   end
 
-  def test_truncated_projection_evidence_disables_actions_even_when_marked_current
+  def test_truncated_projection_evidence_preserves_bound_answer_action
     with_fixture do |native, task|
       snapshot = builder(native, task, questions: 1, projection_truncated: true).call
+
+      assert_equal "partial", snapshot.dig("status", "state")
+      assert_equal "answer", snapshot.dig("decision", "posture")
+      assert snapshot.dig("decision", "action", "enabled")
+    end
+  end
+
+  def test_attempt_or_resource_integrity_degradation_preserves_bound_answer_action
+    with_fixture do |native, task|
+      snapshot = builder(native, task, questions: 1, usage_available: false).call
+
+      assert_equal "partial", snapshot.dig("panels", "resources", "state")
+      assert_equal "answer", snapshot.dig("decision", "posture")
+      assert snapshot.dig("decision", "action", "enabled")
+    end
+  end
+
+  def test_partial_projection_evidence_still_disables_non_answer_actions
+    with_fixture do |native, task|
+      snapshot = builder(native, task, questions: 0, projection_state: "partial").call
 
       assert_equal "partial", snapshot.dig("status", "state")
       assert_equal "investigate", snapshot.dig("decision", "posture")
@@ -90,11 +110,17 @@ class TaskWorkspaceBuilderTest < Minitest::Test
     end
   end
 
-  def test_attempt_or_resource_integrity_degradation_fails_actions_closed
+  def test_partial_projection_does_not_enable_an_unbound_question
     with_fixture do |native, task|
-      snapshot = builder(native, task, questions: 1, usage_available: false).call
+      malformed_question = {
+        "n" => 1, "text" => "Scope?", "binding" => "", "ordinal" => 0
+      }
+      snapshot = builder(
+        native, task, questions: 1, questions_payload: [ malformed_question ],
+        projection_state: "partial"
+      ).call
 
-      assert_equal "partial", snapshot.dig("panels", "resources", "state")
+      assert_empty snapshot.dig("operator", "questions")
       assert_equal "investigate", snapshot.dig("decision", "posture")
       refute snapshot.dig("decision", "action", "enabled")
     end
@@ -213,6 +239,12 @@ class TaskWorkspaceBuilderTest < Minitest::Test
               status_availability: "fresh", status_error: nil,
               projection_state: "current", projection_diagnostics: [],
               projection_truncated: false, usage_available: true, questions_payload: nil)
+    questions_payload ||= Array.new(questions) do |index|
+      {
+        "n" => index + 1, "text" => "Question #{index + 1}?",
+        "binding" => "binding-#{index + 1}", "ordinal" => index
+      }
+    end
     events = Array.new(@material_events || 1) do |index|
       {
         "schema" => "hive-task-journal-event", "schema_version" => 1,
@@ -271,7 +303,7 @@ class TaskWorkspaceBuilderTest < Minitest::Test
         "observed_at" => "2026-08-12T12:00:00Z",
         "repository" => nil, "wiki" => nil
       },
-      questions_count: questions, questions: questions_payload, daemon_enabled: true,
+      questions: questions_payload, daemon_enabled: true,
       clock: -> { Time.utc(2026, 8, 12, 12) }
     )
   end

--- a/web/app/controllers/tasks/base_controller.rb
+++ b/web/app/controllers/tasks/base_controller.rb
@@ -41,7 +41,7 @@ class Tasks::BaseController < ApplicationController
     raise Hive::Error, "archived tasks are read-only"
   end
 
-  def task_workspace_builder(questions_count: nil, questions: nil, daemon_enabled: nil)
+  def task_workspace_builder(questions: nil, daemon_enabled: nil)
     Hive::TaskWorkspace::Builder.new(
       task: @task, native_task: @native_task, project: @project.name,
       status_availability: @status_availability,
@@ -50,7 +50,6 @@ class Tasks::BaseController < ApplicationController
       dependency_context: StatusBroadcaster.dependency_context_snapshot&.fetch(:context),
       publication_cache: publication_cache_for_current_credential,
       cursor_codec: task_workspace_cursor_codec,
-      questions_count: questions_count,
       questions: questions,
       daemon_enabled: daemon_enabled.nil? ? @project.daemon_enabled? : daemon_enabled,
       archive: @task_source.present?

--- a/web/app/controllers/tasks_controller.rb
+++ b/web/app/controllers/tasks_controller.rb
@@ -3,10 +3,14 @@ class TasksController < Tasks::BaseController
     questions = @task.open_questions
     @daemon_enabled = @project.daemon_enabled?
     @workspace = task_workspace_builder(
-      questions_count: questions.length, questions: questions, daemon_enabled: @daemon_enabled
+      questions: questions, daemon_enabled: @daemon_enabled
     ).call
     @workspace_action_evidence_current = @task_source.nil? &&
                                          @workspace.dig("status", "state") == "current"
+    # Bound questions are revalidated by Hive::Commands::Answer on write; the
+    # workspace decision keeps their readiness independent of execution evidence.
+    @answer_input_enabled = @workspace.dig("decision", "posture") == "answer" &&
+                            @workspace.dig("decision", "action", "enabled") == true
     @artifact_panel = @workspace.dig("panels", "artifacts")
     @publication_refresh_available = @task_source.nil? &&
                                      session[:github_token].present? &&

--- a/web/app/javascript/controllers/answers_controller.js
+++ b/web/app/javascript/controllers/answers_controller.js
@@ -6,10 +6,10 @@ import { Controller } from "@hotwired/stimulus"
 // form lingering beside the new one — caught live by a system test. Instead
 // the forms morph freely (server HTML renders them empty) and this
 // controller restores the operator's typed-but-unsent text and caret after
-// each morph, keyed by field NAME. A new round renders different names
-// (each field carries its opaque identity binding), so nothing restores onto
-// a changed slot even when a later round reuses the same question number. Old
-// bindings remain bounded and cannot restore into a different round.
+// each morph, keyed by opaque draft identity. Answer fields carry that identity
+// in their names; the free-form intervention field uses data-draft-key while
+// retaining name=message for the POST contract. A new round therefore cannot
+// restore a draft onto a changed slot even when it reuses the question number.
 const drafts = new Map()
 let pendingFocus = null
 
@@ -36,7 +36,7 @@ export default class extends Controller {
     })
     const active = document.activeElement
     if (active && this.element.contains(active) && active.matches("textarea")) {
-      pendingFocus = { name: active.name, start: active.selectionStart, end: active.selectionEnd }
+      pendingFocus = { key: this.fieldKey(active), start: active.selectionStart, end: active.selectionEnd }
     }
   }
 
@@ -45,12 +45,12 @@ export default class extends Controller {
   }
 
   restoreFields() {
-    drafts.forEach((value, name) => {
-      const field = this.element.querySelector(`textarea[name="${CSS.escape(name)}"]`)
+    drafts.forEach((value, key) => {
+      const field = this.fieldForKey(key)
       if (field && !field.value) field.value = value
     })
     if (pendingFocus) {
-      const field = this.element.querySelector(`textarea[name="${CSS.escape(pendingFocus.name)}"]`)
+      const field = this.fieldForKey(pendingFocus.key)
       if (field) {
         field.focus()
         field.setSelectionRange(pendingFocus.start, pendingFocus.end)
@@ -63,25 +63,35 @@ export default class extends Controller {
     if (!field.matches("textarea") || !this.element.contains(field)) return
 
     this.remember(field)
-    pendingFocus = { name: field.name, start: field.selectionStart, end: field.selectionEnd }
+    pendingFocus = { key: this.fieldKey(field), start: field.selectionStart, end: field.selectionEnd }
   }
 
   trackFocus(event) {
     const field = event.target
     pendingFocus = field.matches("textarea") && this.element.contains(field)
-      ? { name: field.name, start: field.selectionStart, end: field.selectionEnd }
+      ? { key: this.fieldKey(field), start: field.selectionStart, end: field.selectionEnd }
       : null
   }
 
   remember(field) {
-    if (!field.name) return
+    const key = this.fieldKey(field)
+    if (!key) return
     if (!field.value) {
-      drafts.delete(field.name)
+      drafts.delete(key)
       return
     }
 
-    drafts.delete(field.name)
-    drafts.set(field.name, field.value)
+    drafts.delete(key)
+    drafts.set(key, field.value)
     if (drafts.size > 100) drafts.delete(drafts.keys().next().value)
+  }
+
+  fieldKey(field) {
+    return field.dataset.draftKey || field.name
+  }
+
+  fieldForKey(key) {
+    return Array.from(this.element.querySelectorAll("textarea"))
+      .find((field) => this.fieldKey(field) === key)
   }
 }

--- a/web/app/views/tasks/_state.html.erb
+++ b/web/app/views/tasks/_state.html.erb
@@ -113,7 +113,7 @@
                 would render as a first-line indent. %>
             <p class="qa-question"><span class="qa-number">Q<%= question.fetch("n") %></span><%= question.fetch("text") %></p>
             <%= text_area_tag "answers[#{question.fetch("binding")}]", "", placeholder: "Your answer…",
-                  disabled: !@status_fresh || !@workspace_action_evidence_current,
+                  disabled: !@answer_input_enabled,
                   data: {
                     question_number: question.fetch("n"),
                     action: "input->answers#recordField select->answers#recordField"
@@ -121,7 +121,7 @@
                   aria: { label: "Answer to question #{question.fetch("n")}" } %>
           </div>
         <% end %>
-        <p><%= f.submit "Send answers", disabled: !@status_fresh || !@workspace_action_evidence_current,
+        <p><%= f.submit "Send answers", disabled: !@answer_input_enabled,
               data: { turbo_submits_with: "Sending…" } %></p>
       <% end %>
     </section>
@@ -137,10 +137,13 @@
             id: "intervene-form" do |f| %>
         <%= hidden_field_tag :binding, questions.first.fetch("binding") %>
         <%= f.text_area :message, required: true,
-              disabled: !@status_fresh || !@workspace_action_evidence_current,
-              data: { action: "input->answers#recordField select->answers#recordField" },
+              disabled: !@answer_input_enabled,
+              data: {
+                action: "input->answers#recordField select->answers#recordField",
+                draft_key: questions.first.fetch("binding")
+              },
               placeholder: "Written verbatim as the answer to Q#{questions.first.fetch("n")}…" %>
-        <p><%= f.submit "Send", disabled: !@status_fresh || !@workspace_action_evidence_current,
+        <p><%= f.submit "Send", disabled: !@answer_input_enabled,
               data: { turbo_submits_with: "Sending…" } %></p>
       <% end %>
     </details>

--- a/web/test/integration/tasks_test.rb
+++ b/web/test/integration/tasks_test.rb
@@ -1001,8 +1001,12 @@ class TasksTest < ActionDispatch::IntegrationTest
     folder.join("brainstorm.md").write("### Q1. Scope?\n\n### A1.\n\n### Q2. Acceptance?\n\n### A2.\n\n")
 
     get task_path(@project, @slug, format: :json)
-    operator_questions = response.parsed_body.dig("operator", "questions")
+    workspace = response.parsed_body
+    operator_questions = workspace.dig("operator", "questions")
     assert_equal [ "Scope?", "Acceptance?" ], operator_questions.map { |row| row.fetch("text") }
+    assert_equal "partial", workspace.dig("status", "state")
+    assert_equal "answer", workspace.dig("decision", "posture")
+    assert workspace.dig("decision", "action", "enabled")
 
     get "/tasks/#{@project}/#{@slug}"
 
@@ -1010,9 +1014,10 @@ class TasksTest < ActionDispatch::IntegrationTest
     assert_select ".qa-item", 2, "each open question must get its own answer field"
     operator_questions.each do |question|
       assert_select ".qa-question", text: /#{Regexp.escape(question.fetch("text"))}/
-      assert_select "textarea[data-question-number=?][name=?]",
+      assert_select "textarea[data-question-number=?][name=?]:not([disabled])",
                     question.fetch("n").to_s, "answers[#{question.fetch('binding')}]", count: 1
     end
+    assert_select "form[id^='qa-form-'] input[type='submit']:not([disabled])", 1
   end
 
   test "submitted answers land under the right question headers" do

--- a/web/test/system/pipeline_flow_test.rb
+++ b/web/test/system/pipeline_flow_test.rb
@@ -663,6 +663,8 @@ class PipelineFlowTest < ApplicationSystemTestCase
     visit "/tasks/#{@project}/#{folder.basename}"
     assert_selector "form[id='qa-form-1']", wait: 5
     wait_for_live_status
+    find("details.intervene summary").click
+    find("#intervene-form textarea[name='message']").fill_in with: "Answer for Q1 only"
 
     # The agent answers Q1 and asks Q2 — the open set changes [1] → [2].
     folder.join("brainstorm.md").write(
@@ -676,24 +678,26 @@ class PipelineFlowTest < ApplicationSystemTestCase
     assert_selector "form[id='qa-form-1']", count: 0
     assert_selector "form[id^='qa-form-']", count: 1
     assert_selector ".qa-question", text: /Deadline/
+    assert_equal "", find("#intervene-form textarea[name='message']", visible: :all).value
   end
 
-  test "degraded Q&A controls remain disabled across a pushed morph refresh" do
+  test "checkpoint-less Q&A remains enabled across a pushed morph refresh" do
     folder = move_to_brainstorm(create_task!(@project, "Focus probe"))
     folder.join("brainstorm.md").write("### Q1. Scope?\n\n### A1.\n\n<!-- WAITING -->\n")
     sign_in!
     visit "/tasks/#{@project}/#{folder.basename}"
 
-    assert_field "Answer to question 1", disabled: true, wait: 5
+    field = find_field("Answer to question 1", disabled: false, wait: 5)
     wait_for_live_status
+    field.fill_in with: "typing slowly"
     # Change the task's OWN visible context without changing the bound question,
     # then force a broadcast → morph. Waiting for that updated context proves the
-    # morph actually landed before we assert the safety state survives.
+    # morph actually landed before we assert the bound answer remains usable.
     idea_path = folder.join("idea.md")
     idea_path.write(idea_path.read.gsub("Focus probe", "Context refreshed"))
     create_task!(@project, "Refresh trigger")
     assert_selector ".idea-text", text: /Context refreshed/, wait: 10
-    assert_field "Answer to question 1", disabled: true, with: ""
+    assert_field "Answer to question 1", disabled: false, with: "typing slowly"
   end
 
   test "pasting an image attaches it like the TUI" do

--- a/wiki/commands/web.md
+++ b/wiki/commands/web.md
@@ -456,14 +456,19 @@ Honeycomb projections.
   brainstorm Q&A (the original idea shown above the form; every textarea and
   free-form intervention carries the opaque slot binding from
   `Hive::Commands::Answer`, and writes return through that shared identity-bound
-  seam. Blank intervention bindings are rejected, multi-answer forms preflight
-  every submitted binding before the first write, and lock contention returns
-  retry-later copy rather than claiming the question changed. Non-brainstorm
-  task pages skip answer inventory entirely. The forms are not
+  seam. Fresh bound questions remain answerable when execution-attempt or
+  resource evidence is partial (including legacy tasks without a projection
+  checkpoint); those evidence gates still fail Approve, Retry, Run, and other
+  execution-dependent controls closed. Blank intervention bindings are
+  rejected, multi-answer forms preflight every submitted binding before the
+  first write, and lock contention returns retry-later copy rather than
+  claiming the question changed. Non-brainstorm task pages skip answer
+  inventory entirely. The forms are not
   `data-turbo-permanent`, and the answers controller
-  snapshots/restores typed text plus caret across morphs, keyed by binding-bearing
-  textarea name, so a changed question or new round replaces the old field
-  without carrying stale drafts forward), artifacts rendered as sanitized markdown
+  snapshots/restores typed text plus caret across morphs, keyed by opaque binding
+  (the Q&A textarea name or the intervention field's draft key), so a changed
+  question or new round replaces the old field without carrying stale drafts
+  forward), artifacts rendered as sanitized markdown
   (redcarpet, GFM tables/fenced code; raw HTML escaped at render AND
   sanitized after; leading YAML front matter and standalone
   `Hive::Markers::MARKER_RE` comments dropped, while non-marker comments and

--- a/wiki/log.d/20260816T133039Z-bound-answer-readiness.md
+++ b/wiki/log.d/20260816T133039Z-bound-answer-readiness.md
@@ -1,0 +1,15 @@
+---
+title: Keep bound brainstorm answers available without execution checkpoints
+date: 2026-08-16
+---
+
+Hive Web now treats exact, binding-backed brainstorm questions as their own
+mutation boundary. A fresh waiting task can accept answers even when its
+task-workspace projection is partial because a legacy projection checkpoint,
+current attempt, or resource record is missing. `Hive::Commands::Answer` still
+revalidates every opaque binding at write time, while Approve, Retry, Run, and
+other execution-dependent controls retain the stricter workspace-evidence gate.
+
+Focused unit, Rails integration, and Playwright regression coverage exercises
+the checkpoint-less task path, preserves typed input across pushed morphs for
+the same binding, and rejects free-form drafts after a question-round change.

--- a/wiki/modules/task_workspace.md
+++ b/wiki/modules/task_workspace.md
@@ -58,6 +58,16 @@ state vocabulary is `current`, `stale`, `partial`, `missing`, `conflicting`,
 symbolic source, safe task-relative evidence reference, observation time,
 quality label, retained conflicts, and truncation flag.
 
+Answer readiness is intentionally narrower than execution-action readiness. A
+fresh status observation plus at least one exact task-local opaque question
+binding establishes the `answer` posture even when the bounded task projection,
+attempt, or resource panels are partial or missing. Every answer write
+revalidates that binding through `Hive::Commands::Answer`, so a replaced round,
+changed question, or moved task still fails closed. Approve, Retry, Run, and
+other execution-dependent controls continue to require current projection,
+attempt, and resource evidence; archived or stale-status task pages remain
+read-only.
+
 Source precedence is deterministic: canonical task projection and task journal
 own lifecycle identity; attempt records own attempt lineage; controller and
 agent receipts own captured context; runtime receipts own actual session/model

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -1217,14 +1217,19 @@ Rails model/integration tests assert authenticated HTML/JSON operator-state
 parity, exact target resolution, every archived mutation route's read-only
 boundary, per-panel degradation, signed
 timeline pagination, canonical action routes, publication refresh auth/CSRF,
-and zero remote reads from ordinary page/JSON/broadcast paths. The Playwright
+zero remote reads from ordinary page/JSON/broadcast paths, and enabled
+binding-backed Q&A on legacy tasks whose execution projection has no checkpoint.
+The Playwright
 `task_workspace_test.rb` plus existing pipeline and kanban suites exercise
 1280x800, 3840x1400, 375x812, and real Chromium 400% device-scale emulation at
 an effective 320-CSS-pixel viewport;
 keyboard traversal, 24-pixel targets, dependency forest/table parity,
 focus/exact-selection/disclosure/scroll preservation, permanent log/diff and
 timeline-inspection frames, morph-owned publication facts, and non-repeating
-material announcements.
+material announcements. Pipeline coverage keeps a typed answer enabled and
+intact across a pushed morph while the task workspace remains partial, rejects
+an intervention draft when its opaque binding changes between rounds, and unit
+coverage separately proves non-answer actions still fail closed.
 
 During implementation, run the smallest named files first. Before handoff run
 `bundle exec rake test` from the repository root, then the Web application's


### PR DESCRIPTION
## Summary

A task waiting on bound questions no longer disables its answer controls only because legacy execution checkpoint, attempt, or resource evidence is incomplete. Answer readiness now follows fresh native status plus exact question bindings, while execution actions remain fail-closed. Draft restoration is scoped to the opaque question binding, so a new question round cannot inherit an answer from the previous round. This also corrects the browser-test oracle that had encoded the disabled state as expected behavior, and makes the setup-orchestrator test load the command it stubs instead of depending on test order.

## Validation

- Builder regressions: 15 runs, 78 assertions, no failures
- Web integration: 94 runs, 556 assertions, no failures
- Focused browser regressions: 2 runs, 16 assertions, no failures
- Focused setup orchestrator: 45 runs, 208 assertions, no failures
- Hosted coverage-shard failure reproduced locally with its exact seed; the repaired shard passed with 1,718 runs and 9,064 assertions
- JavaScript syntax check: passed
- Broad checkpoint: 13,554 runs and 192,226 assertions; four transient failures came from the unchanged browser-bundle test losing access to `npm` during the combined run. Its isolated rerun passed with 7 runs and 41 assertions.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
