### PR TITLE
docs(wiki): document patrol agent identity resolution

### DIFF
--- a/wiki/log.d/20260817T190000Z-patrol-agent-identity-resolution.md
+++ b/wiki/log.d/20260817T190000Z-patrol-agent-identity-resolution.md
@@ -1,0 +1,19 @@
+---
+title: Document patrol agent identity resolution
+date: 2026-08-17
+tags: [patrol, refactor-patrol, config, model-routing]
+---
+
+Added an "Agent identity resolution" section to [[modules/patrol]]: ordinary
+patrol launches route model/effort through `models.patrol` (registry parents
+`patrol_review`/`patrol_fix`), while `RefactorPatrol::AgentIdentity` inherits
+review from the **execute** identity and auto-fix from review. Documented the
+operational consequences observed 2026-08-15..17 on the dogfood box: with
+`execute.agent: codex` and no `refactor_patrol.agent`, every architecture
+review/fix launch rode codex's exhausted subscription quota and died in
+seconds; and a provider-switch override without an explicit `model:` fails
+closed when the provider settings file exposes a non-concrete model value
+(`claude-fable-5[1m]` in `.claude/settings.json`). Grounded in
+`lib/hive/refactor_patrol/agent_identity.rb`,
+`lib/hive/implementation_identity.rb` (`NativeDefaults`), and
+`lib/hive/patrol/fixer.rb` launch sites.

--- a/wiki/modules/patrol.md
+++ b/wiki/modules/patrol.md
@@ -201,6 +201,26 @@ its default human review surface, with an explicit
 `issue_filing.enabled: false` opt-out; neither system can consume the other's
 state as proof of completion.
 
+## Agent identity resolution
+
+Ordinary patrol reads `patrol.agent` (default `claude`); its review/fix
+launches take model/effort from the `models.patrol_review`/`models.patrol_fix`
+routing registry (parent key `models.patrol`), falling back to the global
+provider block (e.g. `claude.model`) when no routing entry is active —
+`patrol.model` feeds routing *validation* only, not the launch argv.
+Architecture patrol is different: `Hive::RefactorPatrol::AgentIdentity`
+resolves its review identity as a child of the **execute** identity
+(`refactor_patrol.agent`/`model`/`effort` override; omitted fields inherit
+from `execute.*`), and auto-fix inherits from review
+(`refactor_patrol.auto_fix.*` override). A project that pins
+`execute.agent: codex` therefore runs all architecture patrol agents on codex
+unless `refactor_patrol.agent` is set. On a provider *switch* with no explicit
+`model`, the profile's concrete default model comes from the provider's own
+settings (for Claude: `model` in `.claude/settings.json`), which fails closed
+via `normalize_model(concrete: true)` if that value is not a plain model
+identifier (e.g. `claude-fable-5[1m]`) — so an agent override should carry an
+explicit `model:`.
+
 ## Daemon triggers
 
 Patrol is **opt-in**. A project with **no patrol section at all** (or a patrol section that omits `mode:`) resolves to `enabled: false` — [[modules/config]] only derives mode knobs when `mode:` is **explicitly present** in the raw config. `medium` is the default offered by the `hive init` *prompt* (which writes an explicit `mode: "medium"` into the rendered template), never a config-resolution default, so legacy projects without a patrol block are never silently enabled.


### PR DESCRIPTION
## Why

While diagnosing why patrol shipped zero fix PRs Aug 15–17, two behaviors proved invisible from the wiki: architecture patrol's review identity inherits from the **execute** identity (`refactor_patrol.agent` unset + `execute.agent: codex` meant every architecture launch rode codex's exhausted quota), and a provider-switch override without an explicit `model:` fails closed when the provider settings expose a non-concrete value (`claude-fable-5[1m]` in `~/.claude/settings.json`).

## What

Adds an "Agent identity resolution" section to `wiki/modules/patrol.md` covering ordinary patrol's `models.patrol` routing (and that `patrol.model` feeds validation only, not the launch argv), `RefactorPatrol::AgentIdentity`'s execute → review → auto_fix inheritance chain, and the explicit-`model:` requirement on provider switches. Plus the matching `wiki/log.d/` fragment. Grounded in `lib/hive/refactor_patrol/agent_identity.rb`, `lib/hive/implementation_identity.rb` (NativeDefaults), and the fixer/reviewer launch sites.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)