### PR TITLE
fix(git-gate): accept signal death on proven overflow reads

### DIFF
--- a/lib/hive/agent_git_gate.rb
+++ b/lib/hive/agent_git_gate.rb
@@ -40,7 +40,18 @@ module Hive
           raise InvalidRequest, "read result overflow state is invalid"
         end
 
-        status = Integer(exitstatus)
+        # A bounded capture kills an overflowing child, so the process may
+        # die by signal and report no exit status at all. That is expected
+        # exactly when overflow was proven; otherwise a missing status stays
+        # invalid.
+        status =
+          begin
+            Integer(exitstatus)
+          rescue ArgumentError, TypeError
+            raise InvalidRequest, "read result exit status is invalid" unless overflow == true
+
+            0
+          end
         raise InvalidRequest, "read result exit status is invalid" if status.negative?
 
         super(
@@ -50,12 +61,10 @@ module Hive
           exitstatus: status,
           overflow: overflow
         )
-      rescue ArgumentError, TypeError
-        raise InvalidRequest, "read result exit status is invalid"
       end
 
       def success?
-        exitstatus.zero? && !overflow
+        exitstatus.to_i.zero? && !overflow
       end
     end
 

--- a/test/unit/agent_git_gate_test.rb
+++ b/test/unit/agent_git_gate_test.rb
@@ -636,7 +636,8 @@ class AgentGitGateTest < Minitest::Test
       valid_read.merge(stdout: Object.new),
       valid_read.merge(overflow: nil),
       valid_read.merge(exitstatus: -1),
-      valid_read.merge(exitstatus: Object.new)
+      valid_read.merge(exitstatus: Object.new),
+      valid_read.merge(exitstatus: nil)
     ].each do |attributes|
       assert_raises(Hive::AgentGitGate::InvalidRequest) do
         Hive::AgentGitGate::ReadResult.new(**attributes)
@@ -689,6 +690,22 @@ class AgentGitGateTest < Minitest::Test
       assert_raises(Hive::AgentGitGate::InvalidRequest) do
         Hive::AgentGitGate::PublicationReceipt.new(**attributes)
       end
+    end
+  end
+
+  def test_signal_death_is_valid_exactly_when_overflow_was_proven
+    killed = Hive::AgentGitGate::ReadResult.new(
+      operation: :object_content, stdout: "a", stderr: "",
+      exitstatus: nil, overflow: true
+    )
+
+    refute_predicate killed, :success?
+
+    assert_raises(Hive::AgentGitGate::InvalidRequest) do
+      Hive::AgentGitGate::ReadResult.new(
+        operation: :object_content, stdout: "", stderr: "",
+        exitstatus: nil, overflow: false
+      )
     end
   end
 


### PR DESCRIPTION
## Summary

`Hive::ManagedGit.capture3_bounded` kills the process group once stdout overflows the configured cap. When the KILL lands before `git` exits on its own, the child dies by signal and `Process::Status#exitstatus` is `nil`. `AgentGitGate::ReadResult` treated any non-Integer status as invalid, so callers of bounded reads (e.g. `DraftPrHandoff.git_binary!`) intermittently received `IdentityError("read result exit status is invalid")` instead of the expected `QuarantineError`. This made `test_bounded_git_capture_stops_retaining_output_at_the_limit` flake at roughly 30% on repeated runs and has been failing random CI shards across open PRs.

A missing exit status is now accepted **only** when `overflow: true` was proven (normalized to `0`; `success?` still requires `!overflow`, so semantics are unchanged). Missing status without overflow remains invalid, and negative statuses remain invalid in all cases.

## Validation

- `test/unit/agent_git_gate_test.rb`: 20 runs, 0 failures (new deterministic test covers both nil-status paths).
- `test/unit/stages/draft_pr_handoff_test.rb`: 6 consecutive full-file runs, 0 failures (previously ~30% flake rate).
- Downstream ReadResult consumers (`task_closure`, `agent_report`, `pr_merge_watcher`) pass.
- RuboCop clean on both files.