### PR TITLE
perf(patrol): bound admission inventory scan traversal

### DIFF
--- a/lib/hive/managed_directory.rb
+++ b/lib/hive/managed_directory.rb
@@ -149,6 +149,27 @@ module Hive
       unsafe!
     end
 
+    # Reuses one verified, non-creating root session across nested reads.
+    def with_read_session(missing: false)
+      with_session(create_root: false) do
+        begin
+          yield
+        rescue SystemCallError, IOError, ArgumentError, TypeError => error
+          raise YieldFailure.new(error)
+        end
+      end
+    rescue YieldFailure => failure
+      raise failure.error
+    rescue MissingEntry
+      return nil if missing
+
+      unsafe!
+    rescue Hive::ConfigError
+      raise
+    rescue SystemCallError, IOError, ArgumentError, TypeError
+      unsafe!
+    end
+
     def read(relative, max_bytes:, missing: false)
       snapshot = read_with_metadata(
         relative, max_bytes: max_bytes, missing: missing
@@ -166,29 +187,43 @@ module Hive
 
       with_session(create_root: false) do |session|
         session.with_directory(parent_components, missing: missing) do |parent|
-          opened = session.open_regular(parent, name, missing: missing)
-          next nil unless opened
+          read_snapshot(session, parent, name, limit, missing: missing)
+        end
+      end
+    rescue MissingEntry
+      return nil if missing
 
-          file, before = opened
-          begin
-            unsafe! if before.size > limit
-            bytes = file.read(limit + 1)
-            bytes = "".b if bytes.nil? && before.size.zero?
-            after = file.stat
-            unsafe! unless unchanged_file?(before, after)
-            unsafe! if bytes.nil? || bytes.bytesize > limit
-            unsafe! unless regular_snapshot(before) ==
-              session.regular_snapshot_at(parent, name)
-            {
-              bytes: bytes.b.freeze,
-              mode: before.mode & 0o777,
-              mtime: before.mtime.utc
-            }.freeze
-          ensure
-            file.close
+      unsafe!
+    rescue Errno::ENOENT
+      unsafe!
+    rescue Hive::ConfigError
+      raise
+    rescue SystemCallError, IOError, ArgumentError, TypeError
+      unsafe!
+    end
+
+    # Streams a caller-validated list through one opened parent directory.
+    # This keeps per-file validation identical to #read_with_metadata without
+    # reopening the directory path for every child.
+    def read_children(relative, names:, max_bytes:, missing: false)
+      return enum_for(
+        __method__, relative, names: names, max_bytes: max_bytes, missing: missing
+      ) unless block_given?
+
+      limit = Integer(max_bytes)
+      unsafe! if limit.negative?
+      children = Array(names).map { |name| validated_child_name(name) }.freeze
+      components = relative_components(relative)
+
+      with_session(create_root: false) do |session|
+        session.with_directory(components, missing: missing) do |parent|
+          children.each do |name|
+            snapshot = read_snapshot(session, parent, name, limit, missing: missing)
+            yield name, snapshot && snapshot.fetch(:bytes)
           end
         end
       end
+      nil
     rescue MissingEntry
       return nil if missing
 
@@ -364,6 +399,37 @@ module Hive
     end
 
     private
+
+    def read_snapshot(session, parent, name, limit, missing:)
+      opened = session.open_regular(parent, name, missing: missing)
+      return nil unless opened
+
+      file, before = opened
+      begin
+        unsafe! if before.size > limit
+        bytes = file.read(limit + 1)
+        bytes = "".b if bytes.nil? && before.size.zero?
+        after = file.stat
+        unsafe! unless unchanged_file?(before, after)
+        unsafe! if bytes.nil? || bytes.bytesize > limit
+        unsafe! unless regular_snapshot(before) ==
+          session.regular_snapshot_at(parent, name)
+        {
+          bytes: bytes.b.freeze,
+          mode: before.mode & 0o777,
+          mtime: before.mtime.utc
+        }.freeze
+      ensure
+        file.close
+      end
+    end
+
+    def validated_child_name(name)
+      components = relative_components(name)
+      unsafe! unless components.length == 1
+
+      components.fetch(0)
+    end
 
     def atomic_write_temporary_name(target)
       ".#{target}.tmp.#{Process.pid}.#{SecureRandom.hex(6)}"

--- a/lib/hive/patrol_fix/admission_store.rb
+++ b/lib/hive/patrol_fix/admission_store.rb
@@ -423,15 +423,24 @@ module Hive
       end
 
       def each_record
-        records = []
-        @directory.each_child("records", missing: true) do |name|
-          next if name.end_with?(".lock")
-          match = /\A(.+)\.json\z/.match(name)
-          corrupt!("admission inventory contains an unknown entry") unless match
-          records << match[1]
-          corrupt!("admission inventory exceeds the bounded limit") if records.length > MAX_RECORDS
-        end
-        records.sort.map { |id| fetch(id) }
+        @directory.with_read_session(missing: true) do
+          records = []
+          @directory.each_child("records", missing: true) do |name|
+            next if name.end_with?(".lock")
+            match = /\A(.+)\.json\z/.match(name)
+            corrupt!("admission inventory contains an unknown entry") unless match
+            records << match[1]
+            corrupt!("admission inventory exceeds the bounded limit") if records.length > MAX_RECORDS
+          end
+          names = records.sort.map { |id| "#{occurrence_id!(id)}.json" }
+          @directory.read_children(
+            "records", names: names,
+            max_bytes: MAX_RECORD_BYTES, missing: true
+          ).map do |name, bytes|
+            id = name.delete_suffix(".json")
+            bytes && parse_record(bytes, expected_id: id)
+          end
+        end || []
       end
 
       def mutate(occurrence_id, create: false)

--- a/test/unit/managed_directory_test.rb
+++ b/test/unit/managed_directory_test.rb
@@ -582,6 +582,9 @@ class ManagedDirectoryTest < Minitest::Test
         root: root, anchor: anchor, label: "test state"
       )
 
+      assert_raises(Hive::ConfigError) do
+        directory.with_read_session { flunk }
+      end
       assert_nil directory.with_read_session(missing: true) { flunk }
       refute_path_exists root
 
@@ -606,6 +609,26 @@ class ManagedDirectoryTest < Minitest::Test
 
       assert_equal 1, anchor_opens
       assert_nil Thread.current[:hive_managed_directory_sessions]
+
+      storage_error = assert_raises(Errno::EIO) do
+        directory.with_read_session { raise Errno::EIO, "block failure" }
+      end
+      assert_includes storage_error.message, "block failure"
+
+      config_error = assert_raises(Hive::ConfigError) do
+        directory.with_read_session do
+          raise Hive::ConfigError, "unsafe nested read"
+        end
+      end
+      assert_equal "unsafe nested read", config_error.message
+
+      with_replaced_singleton_method(
+        native,
+        :open_absolute_directory,
+        ->(_path) { raise Errno::EIO, "root failure" }
+      ) do
+        assert_raises(Hive::ConfigError) { directory.with_read_session { flunk } }
+      end
     end
   end
 
@@ -624,6 +647,36 @@ class ManagedDirectoryTest < Minitest::Test
         directory.read_children(
           "records", names: [ "../outside" ], max_bytes: 5
         ).to_a
+      end
+
+      missing = Hive::ManagedDirectory.new(
+        root: File.join(root, "missing"), anchor: root, label: "missing state"
+      )
+      assert_empty missing.read_children(
+        ".", names: [ "record" ], max_bytes: 5, missing: true
+      ).to_a
+      assert_raises(Hive::ConfigError) do
+        missing.read_children(
+          ".", names: [ "record" ], max_bytes: 5
+        ).to_a
+      end
+
+      native = directory.instance_variable_get(:@native)
+      original_open = native.method(:open_directory)
+      with_replaced_singleton_method(
+        native,
+        :open_directory,
+        lambda do |parent, name|
+          raise Errno::EIO, name if name == "records"
+
+          original_open.call(parent, name)
+        end
+      ) do
+        assert_raises(Hive::ConfigError) do
+          directory.read_children(
+            "records", names: [ "a" ], max_bytes: 5
+          ).to_a
+        end
       end
     end
   end

--- a/test/unit/managed_directory_test.rb
+++ b/test/unit/managed_directory_test.rb
@@ -575,6 +575,59 @@ class ManagedDirectoryTest < Minitest::Test
     end
   end
 
+  def test_read_session_reuses_the_anchor_without_creating_missing_state
+    with_tmp_dir do |anchor|
+      root = File.join(anchor, "state")
+      directory = Hive::ManagedDirectory.new(
+        root: root, anchor: anchor, label: "test state"
+      )
+
+      assert_nil directory.with_read_session(missing: true) { flunk }
+      refute_path_exists root
+
+      directory.prepare!
+      native = directory.instance_variable_get(:@native)
+      original_open = native.method(:open_absolute_directory)
+      anchor_opens = 0
+
+      with_replaced_singleton_method(
+        native,
+        :open_absolute_directory,
+        lambda do |path|
+          anchor_opens += 1
+          original_open.call(path)
+        end
+      ) do
+        directory.with_read_session do
+          directory.each_child(".").to_a
+          assert_nil directory.read("missing", max_bytes: 1, missing: true)
+        end
+      end
+
+      assert_equal 1, anchor_opens
+      assert_nil Thread.current[:hive_managed_directory_sessions]
+    end
+  end
+
+  def test_read_children_streams_named_files_through_one_parent_session
+    with_tmp_dir do |root|
+      directory = Hive::ManagedDirectory.new(root: root, label: "test state")
+      directory.ensure_directory("records")
+      directory.atomic_write("records/a", "alpha")
+      directory.atomic_write("records/b", "beta")
+
+      assert_equal [ [ "b", "beta" ], [ "a", "alpha" ] ],
+                   directory.read_children(
+                     "records", names: %w[b a], max_bytes: 5
+                   ).to_a
+      assert_raises(Hive::ConfigError) do
+        directory.read_children(
+          "records", names: [ "../outside" ], max_bytes: 5
+        ).to_a
+      end
+    end
+  end
+
   def test_missing_root_does_not_leak_the_session_registry
     with_tmp_dir do |anchor|
       directory = Hive::ManagedDirectory.new(
@@ -921,6 +974,26 @@ class ManagedDirectoryTest < Minitest::Test
         ) do
           assert_raises(Hive::ConfigError) do
             directory.read("record", max_bytes: 4, missing: true)
+          end
+        end
+      ensure
+        original_rename.call(parked, root) if File.directory?(parked)
+      end
+
+      begin
+        with_replaced_singleton_method(
+          native,
+          :open_file,
+          lambda do |parent, name, flags, mode: nil|
+            file = original_open_file.call(parent, name, flags, mode: mode)
+            original_rename.call(root, parked) if name == "record"
+            file
+          end
+        ) do
+          assert_raises(Hive::ConfigError) do
+            directory.read_children(
+              ".", names: [ "record" ], max_bytes: 4, missing: true
+            ).to_a
           end
         end
       ensure

--- a/test/unit/patrol_fix/admission_store_test.rb
+++ b/test/unit/patrol_fix/admission_store_test.rb
@@ -4,6 +4,8 @@ require "hive/patrol_fix/admission_store"
 require "hive/patrol_fix/source_snapshot"
 
 class PatrolFixAdmissionStoreTest < Minitest::Test
+  include HiveTestHelper
+
   NOW = Time.utc(2026, 8, 20, 12)
 
   def test_reservation_is_exactly_replayable_and_conflicting_identity_fails_closed
@@ -239,6 +241,139 @@ class PatrolFixAdmissionStoreTest < Minitest::Test
       assert_equal "b-new-work", store.pending(limit: 1, now: NOW).fetch(0).fetch("occurrence_id")
       assert_equal "a-live-decision",
                    store.pending(limit: 1, now: NOW + 61).fetch(0).fetch("occurrence_id")
+    end
+  end
+
+  def test_pending_reads_the_inventory_with_one_native_anchor_open
+    Dir.mktmpdir do |dir|
+      store = Hive::PatrolFix::AdmissionStore.new(root: dir)
+      %w[c-pending a-pending b-pending].each_with_index do |occurrence, index|
+        store.reserve!(
+          occurrence_id: occurrence,
+          snapshot: source_snapshot(identity: "finding-#{index}"),
+          now: NOW
+        )
+      end
+      directory = store.instance_variable_get(:@directory)
+      native = directory.instance_variable_get(:@native)
+      original_open = native.method(:open_absolute_directory)
+      anchor_opens = 0
+
+      pending = with_replaced_singleton_method(
+        native,
+        :open_absolute_directory,
+        lambda do |path|
+          anchor_opens += 1
+          original_open.call(path)
+        end
+      ) do
+        store.pending
+      end
+
+      assert_equal %w[a-pending b-pending c-pending],
+                   pending.map { |record| record.fetch("occurrence_id") }
+      assert_equal 1, anchor_opens
+    end
+  end
+
+  def test_pending_does_not_create_a_missing_store
+    Dir.mktmpdir do |dir|
+      root = File.join(dir, "admissions")
+      store = Hive::PatrolFix::AdmissionStore.new(root: root)
+
+      assert_empty store.pending
+      refute_path_exists root
+    end
+  end
+
+  def test_pending_directory_traversal_does_not_grow_with_inventory
+    Dir.mktmpdir do |dir|
+      store = Hive::PatrolFix::AdmissionStore.new(root: dir)
+      store.reserve!(occurrence_id: "a-pending", snapshot: source_snapshot, now: NOW)
+      directory = store.instance_variable_get(:@directory)
+      native = directory.instance_variable_get(:@native)
+      original_open = native.method(:open_directory)
+
+      measure_opens = lambda do
+        opens = 0
+        with_replaced_singleton_method(
+          native,
+          :open_directory,
+          lambda do |parent, name|
+            opens += 1
+            original_open.call(parent, name)
+          end
+        ) { store.pending }
+        opens
+      end
+
+      one_record_opens = measure_opens.call
+      %w[b-pending c-pending].each_with_index do |occurrence, index|
+        store.reserve!(
+          occurrence_id: occurrence,
+          snapshot: source_snapshot(identity: "finding-extra-#{index}"),
+          now: NOW
+        )
+      end
+
+      assert_equal one_record_opens, measure_opens.call
+    end
+  end
+
+  def test_pending_rejects_unknown_inventory_entries_before_reading_records
+    Dir.mktmpdir do |dir|
+      store = Hive::PatrolFix::AdmissionStore.new(root: dir)
+      store.reserve!(occurrence_id: "known", snapshot: source_snapshot, now: NOW)
+      File.binwrite(File.join(dir, "records", "unknown-entry"), "unexpected")
+      directory = store.instance_variable_get(:@directory)
+      reads = []
+      original_read = directory.method(:read_children)
+
+      error = with_replaced_singleton_method(
+        directory,
+        :read_children,
+        lambda do |*args, **kwargs, &block|
+          reads << args
+          original_read.call(*args, **kwargs, &block)
+        end
+      ) do
+        assert_raises(Hive::PatrolFix::AdmissionStore::CorruptRecord) { store.pending }
+      end
+
+      assert_match(/unknown entry/, error.message)
+      assert_empty reads
+    end
+  end
+
+  def test_pending_rejects_inventory_overflow_before_reading_records
+    Dir.mktmpdir do |dir|
+      store = Hive::PatrolFix::AdmissionStore.new(root: dir)
+      3.times do |index|
+        store.reserve!(
+          occurrence_id: "pending-#{index}",
+          snapshot: source_snapshot(identity: "finding-#{index}"),
+          now: NOW
+        )
+      end
+      directory = store.instance_variable_get(:@directory)
+      reads = []
+      original_read = directory.method(:read_children)
+
+      error = with_replaced_singleton_method(
+        directory,
+        :read_children,
+        lambda do |*args, **kwargs, &block|
+          reads << args
+          original_read.call(*args, **kwargs, &block)
+        end
+      ) do
+        with_max_records(2) do
+          assert_raises(Hive::PatrolFix::AdmissionStore::CorruptRecord) { store.pending }
+        end
+      end
+
+      assert_match(/bounded limit/, error.message)
+      assert_empty reads
     end
   end
 

--- a/wiki/log.d/20260822T195616Z-patrol-admission-bounded-scan.md
+++ b/wiki/log.d/20260822T195616Z-patrol-admission-bounded-scan.md
@@ -1,0 +1,47 @@
+---
+title: Bound Patrol admission inventory traversal
+type: change
+date: 2026-08-22
+tags: [daemon, patrol-fix, admission, performance, managed-directory]
+---
+
+`AdmissionStore#each_record` now uses one non-creating `ManagedDirectory` read
+session. It fully enumerates the inventory and rejects unknown entries or
+`MAX_RECORDS` overflow before reading any record. After occurrence IDs are
+validated and sorted, `ManagedDirectory#read_children` streams the
+caller-validated names through one opened parent directory. Canonical record
+parsing, full record validation, and descriptor/name-binding validation still
+run per record. The optimization makes root opening and directory traversal
+constant as the record count rises; bounded record reads and validation remain
+linear. Reads remain lock-free and do not create an absent store.
+
+This is only a storage-local scan optimization. It adds no migration, daemon
+watcher, cache, schema, scheduler-policy, capacity, or task-materialization
+behavior.
+
+The measured dogfood workload had four registered projects and 221 tasks. The
+Hive project's admission store contained 54 JSON records. On exact
+`origin/main`, one daemon tick used 10.917531574 seconds of process CPU; the
+repeated `AdmissionStore#fetch` to `ManagedDirectory#open_root!` stack accounted
+for 3.53678 seconds. The optimized daemon tick no longer contained the repeated
+`each_record`/`fetch`/root-open stack. Whole-tick CPU was noisy and did not
+establish a total-tick reduction, so no total-tick improvement is claimed.
+
+Two isolated same-store comparisons ran three full pending scans per head:
+
+- Comparison 1: `origin/main` used 14.312698077 CPU seconds and the branch used
+  13.385584423 seconds.
+- Comparison 2: `origin/main` used 11.590105895 CPU seconds and the branch used
+  11.470292061 seconds.
+- Aggregate: `origin/main` used 25.902803972 CPU seconds and the branch used
+  24.855876484 seconds, about 4.0% lower.
+
+After review replaced the read-side inventory lock with the final non-creating
+read session, another three-scan branch run over the same 54 records used
+11.011560469 CPU seconds. This is a consistency check, not a new comparative
+claim.
+
+Direct regression tests prove one absolute root open per pending inventory scan
+and constant directory traversal as the record count rises. Separate assertions
+retain the requirement that unknown entries and inventory overflow fail before
+record reads.

--- a/wiki/modules/daemon.md
+++ b/wiki/modules/daemon.md
@@ -27,6 +27,15 @@ store produces a bounded failed event while the remaining project ports continue
 Patrol Fix otherwise uses the standard task/status contracts and adds no daemon
 operational projection.
 
+Each Patrol Fix admission scan uses one non-creating managed-directory read
+session. It validates the complete bounded filename inventory before streaming
+the caller-validated record names through one opened parent directory;
+canonical record and descriptor/name-binding validation stay per record.
+Directory traversal is therefore constant as the record count rises, while
+bounded record reads and validation remain linear. Reads remain lock-free and
+do not create an absent store. This changes no migration, watcher, cache,
+schema, scheduler policy, capacity, or task materialization behavior.
+
 Daemon and bot startup never run storage migrations. Operators perform every
 global and project cutover explicitly through `hive migrate` or
 `hive migrate --all` while those processes are stopped. Startup opens only the


### PR DESCRIPTION
## Summary

Patrol admission polling now opens its managed anchor once and keeps directory traversal constant as the record inventory grows. Missing stores remain read-only, record scans remain lock-free, and all existing ordering, bounds, canonical validation, and fail-closed behavior stay intact.

This is the first of the separate daemon-scan optimization PRs. Project configuration caching, Attempts index caching, admission-only imported findings, and changed-task incremental scans remain follow-up changes.

## Design

- One non-creating read session owns the verified root descriptor for the full scan.
- The complete bounded filename inventory is validated before any record is read.
- Caller-validated record names reuse one opened parent directory; per-record reads and full validation remain linear.
- No cache, migration, migration watcher, schema, scheduler-policy, capacity, or task-materialization behavior is added.

Planning selected a one-session design without caching or buffering. Independent review showed that using the inventory lock as that session boundary would create absent stores and convoy readers with writers, so this PR uses a smaller non-creating read-session boundary instead.

## Performance evidence

The dogfood admission store contained 54 records. Each comparison ran three complete `pending` scans.

| Measurement | `origin/main` CPU seconds | Branch CPU seconds | Change |
|---|---:|---:|---:|
| Comparison 1 | 14.312698077 | 13.385584423 | -6.5% |
| Comparison 2 | 11.590105895 | 11.470292061 | -1.0% |
| Aggregate | 25.902803972 | 24.855876484 | -4.0% |

The repeated `AdmissionStore#fetch -> ManagedDirectory#open_root!` stack also disappeared from the daemon profile. Whole-tick CPU was noisy, so this PR makes no total-tick improvement claim. Direct regression tests prove one anchor open per inventory scan and constant parent-directory traversal as record count rises.

## Validation

- Managed directory: 32 runs, 138 assertions, 0 failures
- Admission store: 21 runs, 99 assertions, 0 failures
- Admission scheduler: 17 runs, 97 assertions, 0 failures
- RuboCop: 4 files, no offenses
- Broad checkpoint: 112 runs, 1,151 assertions, 0 failures, 1 error, 1 skip

The broad checkpoint's only error is the unavailable local OpenCode route in `opencode_offline_smoke_test.rb`. The same error reproduces on exact `origin/main`, so it is environment-specific and not introduced by this branch.

Browser testing: skipped because this storage-only change affects no browser route.
