### PR TITLE
perf(status): reuse captured project config

### DIFF
--- a/lib/hive/commands/status.rb
+++ b/lib/hive/commands/status.rb
@@ -349,10 +349,16 @@ module Hive
         Hive::TerminalText.escape(value)
       end
 
-      def operational_project_context(projects)
+      def operational_project_context(projects, workflow_generations: nil)
         projects.to_h do |project|
           enabled = begin
-            Hive::Config.load(project.fetch("path")).dig("daemon", "enabled") == true
+            generation = workflow_generation_for(project, workflow_generations) if workflow_generations
+            config = if generation && !generation.is_a?(Exception)
+              generation.config
+            else
+              Hive::Config.load(project.fetch("path"))
+            end
+            config&.dig("daemon", "enabled") == true
           rescue Hive::UnsupportedProjectConfigError
             raise
           rescue Hive::Error, SystemCallError
@@ -368,8 +374,13 @@ module Hive
       end
 
       def operational_status(projects, scheduler_snapshot:, status_payload:, now: Time.now.utc)
-        source = status_payload || json_payload(projects, now: now)
-        project_context = operational_project_context(projects)
+        workflow_generations = capture_workflow_generations(projects) unless status_payload
+        source = status_payload || json_payload(
+          projects, now: now, workflow_generations: workflow_generations
+        )
+        project_context = operational_project_context(
+          projects, workflow_generations: workflow_generations
+        )
         if scheduler_snapshot.equal?(AUTO_SCHEDULER_SNAPSHOT)
           scheduler_snapshot = if project_context.any? { |_name, context| context["daemon_enabled"] == true }
             Hive::Daemon::OperationalSnapshot::Reader.new.read(now: now)

--- a/test/unit/commands/status_operational_test.rb
+++ b/test/unit/commands/status_operational_test.rb
@@ -82,6 +82,41 @@ class CommandsStatusOperationalTest < Minitest::Test
     end
   end
 
+  def test_supplied_status_payload_skips_workflow_generation_capture
+    with_tmp_dir do |project_root|
+      hive_state = File.join(project_root, ".hive-state")
+      FileUtils.mkdir_p(hive_state)
+      File.write(
+        File.join(hive_state, "config.yml"),
+        { "daemon" => { "enabled" => true } }.to_yaml
+      )
+      project = { "name" => "demo", "path" => project_root, "hive_state_path" => hive_state }
+      command = Hive::Commands::Status.new(json: true)
+      source = command.json_payload([ project ])
+      command.define_singleton_method(:capture_workflow_generations) do |_projects|
+        raise "supplied payload must not trigger generation capture"
+      end
+      original_load = Hive::Config.method(:load)
+      config_loads = 0
+
+      payload = with_replaced_singleton_method(
+        Hive::Config,
+        :load,
+        lambda do |path|
+          config_loads += 1
+          original_load.call(path)
+        end
+      ) do
+        command.operational_payload(
+          [ project ], status_payload: source, scheduler_snapshot: nil
+        )
+      end
+
+      assert_equal "unavailable", payload.dig("scheduler", "status")
+      assert_equal 1, config_loads
+    end
+  end
+
   def test_operational_call_uses_its_own_error_schema
     command = Hive::Commands::Status.new(json: true, operational: true)
 

--- a/test/unit/commands/status_test.rb
+++ b/test/unit/commands/status_test.rb
@@ -2802,6 +2802,91 @@ class CommandsStatusTest < Minitest::Test
     assert_equal false, context.dig("demo", "daemon_enabled")
   end
 
+  def test_operational_payload_reuses_captured_project_config_for_daemon_context
+    with_tmp_dir do |project_root|
+      hive_state = File.join(project_root, ".hive-state")
+      FileUtils.mkdir_p(hive_state)
+      File.write(
+        File.join(hive_state, "config.yml"),
+        { "daemon" => { "enabled" => true } }.to_yaml
+      )
+      project = status_project(project_root, hive_state)
+      original_load = Hive::Config.method(:load)
+      config_loads = 0
+
+      payload = with_replaced_singleton_method(
+        Hive::Config,
+        :load,
+        lambda do |path|
+          config_loads += 1
+          original_load.call(path)
+        end
+      ) do
+        Hive::Commands::Status.new.operational_payload(
+          [ project ], scheduler_snapshot: nil
+        )
+      end
+
+      assert_equal "unavailable", payload.dig("scheduler", "status")
+      assert_equal 1, config_loads,
+                   "a full operational scan must parse each project config once"
+    end
+  end
+
+  def test_operational_payload_falls_back_to_config_after_generation_capture_failure
+    with_tmp_dir do |project_root|
+      hive_state = File.join(project_root, ".hive-state")
+      FileUtils.mkdir_p(hive_state)
+      File.write(
+        File.join(hive_state, "config.yml"),
+        { "daemon" => { "enabled" => true } }.to_yaml
+      )
+      project = status_project(project_root, hive_state)
+      command = Hive::Commands::Status.new
+      command.define_singleton_method(:capture_workflow_generations) do |_projects|
+        { File.expand_path(project_root) => RuntimeError.new("generation failed") }
+      end
+      original_load = Hive::Config.method(:load)
+      config_loads = 0
+
+      payload = with_replaced_singleton_method(
+        Hive::Config,
+        :load,
+        lambda do |path|
+          config_loads += 1
+          original_load.call(path)
+        end
+      ) do
+        command.operational_payload([ project ], scheduler_snapshot: nil)
+      end
+
+      assert_equal "unavailable", payload.dig("scheduler", "status")
+      assert_equal 1, config_loads
+    end
+  end
+
+  def test_operational_payload_falls_back_to_config_when_generation_capture_skips_project
+    with_tmp_dir do |project_root|
+      hive_state = File.join(project_root, ".hive-state")
+      FileUtils.mkdir_p(hive_state)
+      config_path = File.join(hive_state, "config.yml")
+      File.write(config_path, { "daemon" => { "enabled" => true } }.to_yaml)
+      project = status_project(
+        project_root, File.join(project_root, "missing-state")
+      )
+      command = Hive::Commands::Status.new
+
+      payload = command.operational_payload([ project ], scheduler_snapshot: nil)
+
+      assert_equal "unavailable", payload.dig("scheduler", "status")
+
+      File.write(config_path, { "unsupported_root_key" => true }.to_yaml)
+      assert_raises(Hive::UnsupportedProjectConfigError) do
+        command.operational_payload([ project ], scheduler_snapshot: nil)
+      end
+    end
+  end
+
   # Retry policy is no longer read from global config here, so a broken global
   # file must not be able to influence a project's daemon_enabled verdict.
   def test_operational_project_context_ignores_unreadable_global_config

--- a/wiki/commands/status.md
+++ b/wiki/commands/status.md
@@ -140,10 +140,14 @@ scanning any project's rows, captures one UTC `now`, and then publishes either
 the ordinary or dedicated archive projection. Dependency admission uses those
 same captured generations and is built from the complete
 graph before presentation filtering, so an expired completed dependency still
-satisfies its dependants. Daemon, bot, TUI, and web consume the ordinary
-projection. The TUI separately caches a fresh archive-mode payload for its
-dedicated archive pane and dependency context; it never reconstructs ordinary
-visibility from row timestamps.
+satisfies its dependants. When concise operational status builds that graph, it
+also derives each project's `daemon.enabled` context from the captured
+generation instead of parsing the project config a second time. Callers that
+provide an existing status payload retain the context-only config read and do
+not trigger a new workflow-generation scan. Daemon, bot, TUI, and web consume
+the ordinary projection. The TUI separately caches a fresh archive-mode
+payload for its dedicated archive pane and dependency context; it never
+reconstructs ordinary visibility from row timestamps.
 
 The JSON envelope isolates project-local failures. Missing roots report
 `error: missing_project_path`, missing state roots report

--- a/wiki/log.d/20260822214102-status-project-context-cache.md
+++ b/wiki/log.d/20260822214102-status-project-context-cache.md
@@ -1,0 +1,12 @@
+---
+title: Reuse captured config in operational status
+module: status
+tags: [status, performance, config, daemon]
+---
+
+Concise operational status now derives `daemon.enabled` from the workflow
+generation captured for its full task scan. Each initialized project therefore
+passes through `Hive::Config.load` once per operational scan instead of parsing
+the same project config again for daemon context. Adapters that supply an
+existing status payload keep the context-only read and do not start another
+workflow-generation scan.


### PR DESCRIPTION
## Summary

Concise operational status now reuses the project config captured for its full task graph instead of validating and parsing it again for daemon context. Healthy initialized projects perform one `Hive::Config.load` per operational scan, while missing or failed generation captures retain the prior direct-read fallback and unsupported-config behavior.

This is the second independent status-scan optimization in the series. Related: #1175. Attempts-store reuse, admission-only Patrol materialization, and changed-task incremental scans remain separate follow-up PRs.

## Validation

- Healthy path regression: one `Hive::Config.load` per initialized project.
- Degraded paths: failed and skipped generation capture preserve daemon-enabled context and unsupported-config propagation.
- Supplied payload path: no workflow-generation recapture and one context-only config read.
- 120 status and operational tests, 499 assertions, zero failures.
- 13,241 default-suite tests, 273,780 assertions, zero failures before the review follow-up; the complete post-review status surface is green.
- RuboCop is clean for all changed Ruby files; `git diff --check` is clean.
- Structured code review completed under run `20260822-230130-839447b1`; its one validated P2 was applied and retested, with no actionable residuals.

The installed-CLI OpenCode offline smoke remains host-inventory-limited because its configured default route is absent from this machine. This PR changes no Agent CLI Runtime files; hosted CI provides the current-head clean-room full gate.

## Post-Deploy Monitoring & Validation

- Owner and window: operator, for the first 30 minutes after installing this build.
- Inspect `hive status --operational --json` and daemon logs for `hive: status: project`, `scheduler_unavailable`, and unexpected `not_applicable` scheduler states.
- Healthy: daemon-enabled projects remain visible, status output is unchanged, and operational scans perform no duplicate project-config read.
- Failure or rollback trigger: a daemon-enabled project reports `not_applicable`, unsupported project config stops propagating, or status tick duration regresses. Roll back this commit and retain the previous status path while investigating.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
