### PR TITLE
perf(daemon): bound fast ticks to changed tasks

### DIFF
--- a/lib/hive/cli.rb
+++ b/lib/hive/cli.rb
@@ -1274,6 +1274,8 @@ module Hive
                          desc: "emit the agent-first operational status view (combine with --json for its v1 envelope)"
     option :full, type: :boolean, default: false,
                   desc: "show the detailed human task table (cannot be combined with --json or --operational)"
+    option :daemon_task, type: :array,
+                         desc: "internal: emit bounded project:slug rows for a daemon fast tick"
     def status
       require "hive/commands/status"
       Hive::Commands::Status.new(
@@ -1284,7 +1286,8 @@ module Hive
         write: options[:write],
         force: options[:force],
         operational: options[:operational],
-        full: options[:full]
+        full: options[:full],
+        daemon_tasks: options[:daemon_task]
       ).call
     end
 

--- a/lib/hive/commands/status.rb
+++ b/lib/hive/commands/status.rb
@@ -99,7 +99,7 @@ module Hive
       ].freeze
 
       def initialize(json: false, diagnose: nil, project: nil, stage: nil, write: false, force: false, archive: false,
-                     operational: false, full: false)
+                     operational: false, full: false, daemon_tasks: nil)
         @json = json
         @diagnose = diagnose
         @project = project
@@ -109,6 +109,7 @@ module Hive
         @archive = archive
         @operational = operational
         @full = full
+        @daemon_tasks = Array(daemon_tasks).compact
         @next_retention_boundary = nil
       end
 
@@ -149,6 +150,11 @@ module Hive
       def do_call
         projects = Hive::Config.registered_projects
         refresh_now = Time.now.utc
+        if daemon_task_mode?
+          puts JSON.generate(daemon_task_payload(projects, now: refresh_now))
+          @stdout_written = true
+          return
+        end
         if concise_operational_mode?
           payload = operational_payload(projects, now: refresh_now)
           if @json
@@ -246,6 +252,11 @@ module Hive
       end
 
       def validate_mode_combinations!
+        if daemon_task_mode? && (!@json || @diagnose || @project || @stage || @write || @force ||
+                                 @archive || @operational || @full)
+          raise Hive::InvalidTaskPath,
+                "--daemon-task is internal and requires plain --json status mode"
+        end
         if @full && @json
           raise Hive::InvalidTaskPath, "--full cannot be combined with --json; omit --full for hive-status.v7"
         end
@@ -261,6 +272,10 @@ module Hive
 
       def concise_operational_mode?
         @operational || (!@full && !@json && !@archive)
+      end
+
+      def daemon_task_mode?
+        !@daemon_tasks.empty?
       end
 
       def render_operational_issues(issues)
@@ -402,6 +417,35 @@ module Hive
         }
       end
 
+      # Internal fast-tick payload. It resolves exact project/slug identities
+      # without walking every task directory or rebuilding the fleet-wide
+      # dependency graph. Rows with dependencies fail closed until the next
+      # authoritative full scan.
+      def daemon_task_payload(projects, now: Time.now.utc)
+        targets = daemon_task_targets(projects)
+        selected = projects.select { |project| targets.key?(project.fetch("name")) }
+        workflow_generations = capture_workflow_generations(selected)
+        archive_backfiller = shared_archive_backfiller
+        {
+          "schema" => "hive-status",
+          "schema_version" => Hive::Schemas::SCHEMA_VERSIONS.fetch("hive-status"),
+          "ok" => true,
+          "generated_at" => now.utc.iso8601,
+          "partial" => true,
+          "projects" => selected.map do |project|
+            project_payload_or_degraded(
+              project,
+              project_count: projects.size,
+              admission_context: nil,
+              now: now.utc,
+              workflow_generation: workflow_generation_for(project, workflow_generations),
+              archive_backfiller: archive_backfiller,
+              task_slugs: targets.fetch(project.fetch("name"))
+            )
+          end
+        }
+      end
+
       # Isolate per-project failures. A single project with a malformed
       # config.yml (e.g. an invalid `dependency_gate_stage`) used to raise
       # out of `project_payload` and abort the entire `hive status --json`;
@@ -413,7 +457,7 @@ module Hive
       def project_payload_or_degraded(project, project_count:, stages: nil, exclude_archived: false,
                                       admission_context: nil, now: Time.now.utc,
                                       workflow_generation: nil, archive_backfiller: nil,
-                                      include_archive_index: false)
+                                      include_archive_index: false, task_slugs: nil)
         project_payload(
           project,
           project_count: project_count,
@@ -423,7 +467,8 @@ module Hive
           now: now,
           workflow_generation: workflow_generation,
           archive_backfiller: archive_backfiller,
-          include_archive_index: include_archive_index
+          include_archive_index: include_archive_index,
+          task_slugs: task_slugs
         )
       rescue Hive::UnsupportedProjectConfigError
         raise
@@ -447,7 +492,7 @@ module Hive
       def project_payload(project, project_count:, stages: nil, exclude_archived: false,
                           admission_context: nil, now: Time.now.utc,
                           workflow_generation: nil, archive_backfiller: nil,
-                          include_archive_index: false)
+                          include_archive_index: false, task_slugs: nil)
         path = project["path"]
         hive_state = project["hive_state_path"]
         base = {
@@ -455,6 +500,7 @@ module Hive
           "path" => path,
           "hive_state_path" => hive_state
         }
+        incremental = !task_slugs.nil?
         if !File.directory?(path)
           project_error_payload(base, "missing_project_path")
         elsif !File.directory?(hive_state)
@@ -481,7 +527,8 @@ module Hive
                 exclude_archived: exclude_archived,
                 now: now,
                 workflow_generation: workflow_generation,
-                project_name: project["name"]
+                project_name: project["name"],
+                task_slugs: task_slugs
               ),
               config
             )
@@ -489,9 +536,13 @@ module Hive
               rows,
               project, project_count, config: config, with_diagnostic: true
             )
-            rows = annotate_dependencies(
-              rows, project, admission_context: admission_context
-            )
+            rows = if incremental
+              annotate_incremental_dependencies(
+                rows, project, config: config, workflow_generation: workflow_generation
+              )
+            else
+              annotate_dependencies(rows, project, admission_context: admission_context)
+            end
             projection = Hive::ArchiveFilter.project(
               rows, now: now,
               backfiller: archive_backfiller || Hive::CompletedAtBackfiller.new,
@@ -513,7 +564,7 @@ module Hive
                   !config.is_a?(Hash) || config.dig("stages", "ensure_clean_on_exit") != false
               }
             }
-            out["hidden_archived_task_count"] = projection.hidden_count unless @archive
+            out["hidden_archived_task_count"] = incremental ? 0 : projection.hidden_count unless @archive
             if include_archive_index
               # Internal cache handoff only. StateSource removes this key
               # before publishing the ordinary payload, so the public status
@@ -524,9 +575,11 @@ module Hive
             # Always emit `legacy_stage_dirs` (default empty array) so
             # consumers can branch on `.empty?` without a `key?` probe and
             # the schema's optional-but-never-undefined contract holds.
-            legacy_stage_dirs = detect_legacy_stage_dirs(
-              hive_state, workflow_generation: workflow_generation
-            )
+            legacy_stage_dirs = if incremental
+              []
+            else
+              detect_legacy_stage_dirs(hive_state, workflow_generation: workflow_generation)
+            end
             out["legacy_stage_dirs"] = legacy_stage_dirs
             # `legacy_migrate_command` is the machine-readable parity of the
             # text-mode "run `hive migrate`" recovery hint. Agents reading
@@ -1170,19 +1223,29 @@ module Hive
       end
 
       def collect_rows(hive_state, stages: nil, exclude_archived: false, now: Time.now.utc,
-                       workflow_generation: nil, project_name: nil)
+                       workflow_generation: nil, project_name: nil, task_slugs: nil)
         rows = []
         known_stage_dirs = workflow_stage_dirs(workflow_generation)
         terminal_stage_dirs = workflow_terminal_stage_dirs(workflow_generation)
-        Array(
-          stages || default_stage_dirs(
+        selected_stages = if stages
+          stages
+        elsif task_slugs
+          workflow_stage_dirs(workflow_generation)
+        else
+          default_stage_dirs(
             hive_state, exclude_archived, workflow_generation: workflow_generation
           )
-        ).each do |stage|
+        end
+        Array(selected_stages).each do |stage|
           stage_dir = File.join(hive_state, "stages", stage)
           next unless File.directory?(stage_dir)
 
-          stage_task_entries(stage_dir).each do |entry|
+          entries = if task_slugs
+            task_slugs.map { |slug| File.join(stage_dir, slug) }
+          else
+            stage_task_entries(stage_dir)
+          end
+          entries.each do |entry|
             next unless File.directory?(entry)
 
             slug = File.basename(entry)
@@ -1354,6 +1417,67 @@ module Hive
         context = admission_context || build_admission_context([ project ])
         rows.each { |row| apply_dependency_verdict(row, context, project) }
         rows
+      end
+
+      def annotate_incremental_dependencies(rows, project, config:, workflow_generation:)
+        snapshots = rows.filter_map do |row|
+          next if row[:invalid]
+
+          Hive::DependencySnapshot.admission_task(
+            project.fetch("path"), row.fetch(:folder), config,
+            project_name: project.fetch("name"), workflow_generation: workflow_generation
+          )
+        end
+        project_snapshot = Hive::DependencyAdmission::ProjectSnapshot.new(
+          name: project.fetch("name"),
+          path: project.fetch("path"),
+          repository_identity: project["repository_identity"],
+          live_repository_identity: nil,
+          dependency_gate_stage: config.fetch(
+            "dependency_gate_stage", Hive::Config::DEFAULTS.fetch("dependency_gate_stage")
+          ),
+          tasks: snapshots,
+          validation_error: workflow_generation&.admission_config_error
+        )
+        context = Hive::DependencyAdmission::Context.new(projects: [ project_snapshot ])
+        rows.each do |row|
+          apply_dependency_verdict(row, context, project)
+          hold_incremental_dependency(row, project) if row[:depends_on]
+        end
+        rows
+      rescue StandardError => e
+        warn "hive: status: bounded dependency admission failed " \
+             "(#{e.class}: #{e.message}); holding changed rows until the next full scan"
+        rows.each { |row| hold_incremental_dependency(row, project) }
+        rows
+      end
+
+      def hold_incremental_dependency(row, project)
+        error = Hive::DependencyAdmission::AdmissionError.new(
+          reason_code: "dependency_validation_failed",
+          offending_ref: "#{project['name']}:#{row[:slug]}",
+          safe_correction: "Wait for the daemon's next authoritative full dependency scan."
+        )
+        row[:blocked_by] = nil
+        row[:dependency_stage] = nil
+        row[:blocked] = true
+        row[:admission_error] = error
+        row[:action_key] = Hive::Schemas::TaskActionKind::ADMISSION_ERROR
+        row[:action_label] = "Admission error"
+        row[:suggested_command] = nil
+        row[:next_action] = nil
+      end
+
+      def daemon_task_targets(projects)
+        known = projects.to_h { |project| [ project.fetch("name"), project ] }
+        @daemon_tasks.each_with_object({}) do |reference, targets|
+          project_name, separator, slug = reference.to_s.partition(":")
+          unless separator == ":" && known.key?(project_name) && Hive::Stages.task_slug?(slug)
+            raise Hive::InvalidTaskPath,
+                  "invalid --daemon-task #{reference.inspect}; expected registered-project:task-slug"
+          end
+          (targets[project_name] ||= []) << slug unless Array(targets[project_name]).include?(slug)
+        end
       end
 
       def build_admission_context(projects, exclude_archived: false, workflow_generations: nil)

--- a/lib/hive/daemon/dispatcher.rb
+++ b/lib/hive/daemon/dispatcher.rb
@@ -1,6 +1,7 @@
 require "digest"
 require "fileutils"
 require "json"
+require "set"
 require "shellwords"
 require "time"
 require "hive/config"
@@ -54,7 +55,9 @@ module Hive
       attr_reader :controller, :supervisor, :logger
 
       OperationalQueueState = Data.define(:pending, :claimed, :malformed, :error)
+      FastProbe = Data.define(:task_keys, :full_tick)
       TERMINAL_RECOVERY_PRUNE_INTERVAL_SEC = 60 * 60
+      STATE_FILE_PROBE_BATCH_SIZE = 64
 
       # Stage dir whose `needs_input` rows carry a brainstorm Q&A file the
       # daemon gates auto-resume on (see `brainstorm_answer_state`).
@@ -188,7 +191,11 @@ module Hive
         @last_reexec_at = nil
         @started_at = nil
         @last_tick_at = nil
-        @tracked_state_file_mtimes = {}
+        @tracked_state_files = {}
+        @tracked_state_file_order = []
+        @tracked_state_file_order_members = Set.new
+        @tracked_state_file_cursor = 0
+        @known_rows_by_key = {}
         @dispatched_today = 0
         reset_active_agent_snapshot
         # Per-tick enable cache. Populated lazily within one tick so
@@ -349,7 +356,7 @@ module Hive
         refresh_legacy_layout_projects(result.projects)
         refresh_active_agent_snapshot(result.rows)
 
-        observe_external_running_rows(result.rows)
+        apply_external_running_counts
 
         # Recovery requests require the immutable task id. Assign ids before
         # the healer observes failures so an externally-created legacy task can
@@ -509,7 +516,7 @@ module Hive
           result.rows.map { |row| [ row.project, row.slug ] },
           scope_projects: Array(result.projects).map(&:name)
         )
-        refresh_tracked_state_file_mtimes(result.rows)
+        refresh_status_index(result.rows)
 
         publish_complete_operational_snapshot(
           initial_rows: result.rows,
@@ -519,6 +526,84 @@ module Hive
 
         @logger.event(:tick_end, now: Time.now.utc.iso8601,
                                  in_flight: @controller.in_flight_count)
+      end
+
+      # A fast tick is intentionally task-local. It refreshes only rows whose
+      # state files changed and applies the ordinary row policy. Dependency
+      # rows fail closed in the bounded status projection, so no dependency
+      # graph is needed here. Fleet-wide schedulers, pruning, and operational
+      # publication remain on the 30-second authoritative full tick.
+      def tick_changed(task_keys:, now: Time.now)
+        return false unless admission_open?
+
+        keys = Array(task_keys).map do |project, slug|
+          [ project.to_s, slug.to_s ]
+        end.uniq
+        return true if keys.empty?
+
+        @enabled_cache.clear
+        @logger.event(:tick_begin, now: now.utc.iso8601, scope: "changed_tasks", tasks: keys.length)
+        result = @status_consumer.fetch_tasks(keys)
+        return false unless admission_open?
+        unless result.ok
+          @logger.event(:status_failure, error: result.error, scope: "changed_tasks")
+          @logger.event(:tick_end, now: Time.now.utc.iso8601,
+                                   action: "incremental_status_failure")
+          return false
+        end
+        @logger.event(:status_warning, message: result.warning) if result.warning
+
+        # Agent heartbeat rows carry positive liveness and cannot dispatch.
+        # Reuse the last full attempt snapshot for them. Any row that could
+        # heal or dispatch refreshes attempt ownership first, preserving the
+        # capacity gate without scanning attempt history on every heartbeat.
+        if result.rows.any? { |row| !active_agent_row?(row) } && !reconcile_attempts(now: now)
+          @logger.event(:tick_end, now: Time.now.utc.iso8601,
+                                   action: "incremental_attempt_reconciliation_failed")
+          return false
+        end
+        return false unless admission_open?
+
+        replace_incremental_status_rows(keys, result.rows)
+        apply_external_running_counts
+
+        begin
+          @task_id_backfiller.backfill(result.rows, now: now)
+        rescue StandardError => e
+          @logger.event(:fatal,
+                        message: "task_id_backfiller raised: #{e.class}: #{e.message}",
+                        keeping_previous: true)
+        end
+        begin
+          @stale_agent_healer.heal(
+            rows_eligible_for_error_recovery(result.rows),
+            now: now,
+            legacy_layout_projects: @legacy_layout_projects,
+            daemon_enabled_projects: daemon_enabled_projects_for(result.rows)
+          )
+        rescue StandardError => e
+          @logger.event(:fatal,
+                        message: "stale_agent_healer raised: #{e.class}: #{e.message}",
+                        keeping_previous: true)
+        end
+        begin
+          @display_name_backfiller.backfill(result.rows, now: now)
+        rescue StandardError => e
+          @logger.event(:fatal,
+                        message: "display_name_backfiller raised: #{e.class}: #{e.message}",
+                        keeping_previous: true)
+        end
+
+        dispatch_priority_order(result.rows).each do |row|
+          break unless admission_open?
+
+          handle_row(row, now: now)
+        end
+        @logger.event(:tick_end, now: Time.now.utc.iso8601,
+                                 action: "incremental",
+                                 in_flight: @controller.in_flight_count,
+                                 tasks: result.rows.length)
+        true
       end
 
       # Run forever: install signal traps, loop tick + interruptible
@@ -565,8 +650,15 @@ module Hive
           end
           if full_tick
             tick(now: now)
-          elsif cheap_probe_requires_full_tick?(now: now)
-            tick(now: Time.now) unless @shutdown || @reload
+          else
+            probe = cheap_probe(now: now)
+            unless @shutdown || @reload
+              if probe.full_tick
+                tick(now: Time.now)
+              elsif !probe.task_keys.empty?
+                tick_changed(task_keys: probe.task_keys, now: Time.now)
+              end
+            end
           end
           interruptible_sleep(@fast_poll_sec)
         end
@@ -733,28 +825,28 @@ module Hive
         @last_tick_at.nil? || (now - @last_tick_at) >= @poll_interval_sec
       end
 
-      def cheap_probe_requires_full_tick?(now:)
-        # When this returns true via `child_exited`, the follow-up `tick`
-        # calls `reap_completed` again. That second sweep is a benign
-        # waitpid no-op: the children were already reaped (and their
-        # completions recorded) here, so `reap_all` finds nothing and
-        # `record_completion` does not re-fire. The redundancy is
-        # intentional — the probe must reap to *learn* whether a full
-        # tick is warranted — not a missed dedup.
-        #
-        # Asymmetry: this probe only reaps real children via
-        # `reap_completed`; `reap_dry_run` runs solely inside the full
-        # `tick`. So dry-run pseudo-child completions are not accelerated
-        # by the fast probe and advance only on the `@poll_interval_sec`
-        # backstop. Harmless — dry-run is not the latency path the AC
-        # targets — but noted to prevent future confusion.
-        child_exited = reap_completed(now: now)
-        state_file_changed = tracked_state_file_mtime_changed?
-        child_exited || state_file_changed
+      def cheap_probe(now:)
+        entries = reap_completed_entries(now: now)
+        matched_entries = entries.filter_map do |entry|
+          key = [ entry.project.to_s, entry.slug.to_s ]
+          key if @known_rows_by_key.key?(key)
+        end
+        changed = matched_entries.dup
+        changed.concat(tracked_state_file_changes)
+        FastProbe.new(
+          task_keys: changed.uniq,
+          full_tick: entries.length != matched_entries.length
+        )
       end
 
       def reap_completed(now:)
-        record_completed(@supervisor.reap_all(now: now), now: now)
+        reap_completed_entries(now: now).any?
+      end
+
+      def reap_completed_entries(now:)
+        entries = Array(@supervisor.reap_all(now: now))
+        record_completed(entries, now: now)
+        entries
       end
 
       def record_completed(entries, now:)
@@ -1114,35 +1206,87 @@ module Hive
         @logger.event(:fatal, message: "#{label} raised: #{signature}", keeping_previous: true)
       end
 
-      # Snapshot each tracked state file's on-disk mtime so the next fast
-      # probe can detect a write. Store the raw `safe_mtime` (which is nil
-      # when the file is absent) rather than falling back to the status
-      # row's mtime: `tracked_state_file_mtime_changed?` re-stats with the
-      # same `safe_mtime`, so a `nil` baseline compares stable against a
-      # `nil` re-stat. Falling back to `row.state_file_mtime` (a Time) for
-      # an absent file made every probe see `Time != nil` and fire a full
-      # tick every second until a full tick re-baselined.
-      #
-      # NOTE: these mtimes are captured POST-dispatch, so a slug freshly
-      # spawned this tick has its pre-dispatch mtime recorded here. When
-      # the spawned agent writes its AGENT_WORKING marker (~1s later) the
-      # next probe sees the bump and forces one redundant full tick. That
-      # re-evaluation is correct (the marker really did change) and
-      # low-frequency, so it's left as-is rather than special-cased.
-      def refresh_tracked_state_file_mtimes(rows)
-        @tracked_state_file_mtimes = {}
+      # Rebuild the bounded fast-probe inventory after an authoritative full
+      # scan. Each one-second probe rotates through at most
+      # STATE_FILE_PROBE_BATCH_SIZE entries, so idle stat work stays constant
+      # as task history grows. The 30-second full tick repairs new, removed,
+      # or otherwise unobserved tasks.
+      def refresh_status_index(rows)
+        previous_cursor = @tracked_state_file_cursor
+        @tracked_state_files = {}
+        @tracked_state_file_order = []
+        @tracked_state_file_order_members = Set.new
         rows.each do |row|
           next if row.state_file.nil? || row.state_file.empty?
 
-          @tracked_state_file_mtimes[row.state_file] = safe_mtime(row.state_file)
+          key = task_key(row)
+          @tracked_state_files[key] = {
+            path: row.state_file, mtime: safe_mtime(row.state_file)
+          }
+          @tracked_state_file_order << key
+          @tracked_state_file_order_members << key
         end
+        @tracked_state_file_cursor = if @tracked_state_file_order.empty?
+          0
+        else
+          previous_cursor % @tracked_state_file_order.length
+        end
+        @known_rows_by_key = rows.to_h { |row| [ task_key(row), row ] }
       end
 
-      def tracked_state_file_mtime_changed?
-        @tracked_state_file_mtimes.any? do |path, previous_mtime|
-          current_mtime = safe_mtime(path)
-          current_mtime != previous_mtime
+      def tracked_state_file_changes
+        size = @tracked_state_file_order.length
+        return [] if size.zero?
+
+        changed = []
+        [ size, STATE_FILE_PROBE_BATCH_SIZE ].min.times do
+          key = @tracked_state_file_order.fetch(@tracked_state_file_cursor % size)
+          @tracked_state_file_cursor = (@tracked_state_file_cursor + 1) % size
+          entry = @tracked_state_files[key]
+          next unless entry
+
+          current_mtime = safe_mtime(entry.fetch(:path))
+          next if current_mtime == entry.fetch(:mtime)
+
+          changed << key
         end
+        changed
+      end
+
+      def replace_incremental_status_rows(task_keys, rows)
+        keys = task_keys.map { |project, slug| [ project.to_s, slug.to_s ] }.uniq
+        keys.each { |key| @known_rows_by_key.delete(key) }
+        rows.each { |row| @known_rows_by_key[task_key(row)] = row }
+
+        keys.each { |key| @tracked_state_files.delete(key) }
+        rows.each do |row|
+          next if row.state_file.nil? || row.state_file.empty?
+
+          key = task_key(row)
+          unless @tracked_state_file_order_members.include?(key)
+            @tracked_state_file_order << key
+            @tracked_state_file_order_members << key
+          end
+          @tracked_state_files[key] = {
+            path: row.state_file, mtime: safe_mtime(row.state_file)
+          }
+        end
+        removed = keys.reject { |key| @tracked_state_files.key?(key) }
+        unless removed.empty?
+          removed_set = removed.to_set
+          @tracked_state_file_order.reject! { |key| removed_set.include?(key) }
+          @tracked_state_file_order_members.subtract(removed_set)
+          @tracked_state_file_cursor = if @tracked_state_file_order.empty?
+            0
+          else
+            @tracked_state_file_cursor % @tracked_state_file_order.length
+          end
+        end
+        update_active_agent_snapshot(keys, rows)
+      end
+
+      def task_key(row)
+        [ row.project.to_s, row.slug.to_s ]
       end
 
       def safe_mtime(path)
@@ -1877,11 +2021,9 @@ module Hive
         Hive::Workflows.all_stage_dirs.index(stage.to_s) || -1
       end
 
-      def observe_external_running_rows(rows)
+      def apply_external_running_counts
         per_project = Hash.new(0)
-        rows.each do |row|
-          next unless externally_running?(row)
-          next if @controller.running_task?(project: row.project, slug: row.slug)
+        @external_active_rows.each_value do |row|
           next if durable_row?(row)
 
           per_project[row.project] += 1
@@ -3288,6 +3430,7 @@ module Hive
       end
 
       def reset_active_agent_snapshot
+        @external_active_rows = {}
         @external_active_agent_total = 0
         @external_active_agent_counts = Hash.new(0)
       end
@@ -3321,7 +3464,26 @@ module Hive
           next unless active_agent_row?(row)
           next if @controller.running_task?(project: row.project, slug: row.slug)
 
-          @external_active_agent_total += 1
+          @external_active_rows[task_key(row)] = row
+        end
+        recalculate_active_agent_counts
+      end
+
+      def update_active_agent_snapshot(task_keys, rows)
+        task_keys.each { |key| @external_active_rows.delete(key) }
+        rows.each do |row|
+          next unless active_agent_row?(row)
+          next if @controller.running_task?(project: row.project, slug: row.slug)
+
+          @external_active_rows[task_key(row)] = row
+        end
+        recalculate_active_agent_counts
+      end
+
+      def recalculate_active_agent_counts
+        @external_active_agent_total = @external_active_rows.length
+        @external_active_agent_counts = Hash.new(0)
+        @external_active_rows.each_value do |row|
           @external_active_agent_counts[row.project] += 1
         end
       end
@@ -3344,7 +3506,9 @@ module Hive
       # strict "claude_pid_alive == true" path (which silently dropped
       # live_task_lock-only rows during the pre-claude window).
       def externally_running?(row)
-        return false unless row.action == Hive::Schemas::TaskActionKind::AGENT_RUNNING
+        active_action = row.action == Hive::Schemas::TaskActionKind::AGENT_RUNNING
+        fail_closed_action = !row.admission_error.nil?
+        return false unless active_action || fail_closed_action
 
         row.claude_pid_alive == true || row.live_task_lock == true
       end

--- a/lib/hive/daemon/status_consumer.rb
+++ b/lib/hive/daemon/status_consumer.rb
@@ -82,7 +82,26 @@ module Hive
       end
 
       def fetch
-        out, err, status = Open3.capture3(@extra_env, @hive_bin, "status", "--json")
+        fetch_command("status", "--json")
+      end
+
+      def fetch_tasks(task_keys)
+        keys = Array(task_keys).map do |project, slug|
+          [ project.to_s, slug.to_s ]
+        end.uniq
+        references = keys.map { |project, slug| "#{project}:#{slug}" }
+        return Result.new(ok: true) if references.empty?
+
+        fetch_command(
+          "status", "--json", "--daemon-task", *references,
+          require_partial: true, expected_task_keys: keys
+        )
+      end
+
+      private
+
+      def fetch_command(*argv, require_partial: false, expected_task_keys: nil)
+        out, err, status = Open3.capture3(@extra_env, @hive_bin, *argv)
         unless status.success?
           return Result.new(
             ok: false, rows: [], projects: [], hidden_archived_task_count: 0,
@@ -97,6 +116,10 @@ module Hive
         # it into the skew degrade would relabel a genuine "ok=false:
         # <reason>" as a misleading "restart to pick up the new version".
         validate_envelope!(doc)
+        if require_partial && doc["partial"] != true
+          raise ArgumentError, "bounded status response is missing partial=true"
+        end
+        validate_bounded_projects!(doc, expected_task_keys) if require_partial
         skew = schema_skew(doc)
         # An OLDER payload (a stale `hive` on PATH than this daemon
         # expects) can't be trusted to carry the fields the dispatcher
@@ -114,6 +137,7 @@ module Hive
 
         begin
           rows = extract_rows(doc)
+          validate_bounded_rows!(rows, expected_task_keys) if require_partial
           projects = extract_projects(doc)
         rescue StandardError => e
           # ONLY a failure inside best-effort EXTRACTION degrades. On a
@@ -148,8 +172,6 @@ module Hive
         )
       end
 
-      private
-
       # Envelope-shape validation (hard errors) ONLY. A missing/wrong
       # `schema` key or `ok=false` is a malformed/failed envelope and must
       # still raise. Schema VERSION skew is NOT validated here — it is
@@ -162,6 +184,33 @@ module Hive
         return if doc["ok"] == true
 
         raise ArgumentError, "envelope ok=false: #{doc['error_class']} #{doc['message']}"
+      end
+
+      def validate_bounded_projects!(doc, expected_task_keys)
+        expected_projects = Array(expected_task_keys).map(&:first).uniq.sort
+        projects = Array(doc["projects"])
+        actual_projects = projects.map { |project| project["name"].to_s }.uniq.sort
+        unless actual_projects == expected_projects
+          raise ArgumentError,
+                "bounded status response projects do not match requested projects"
+        end
+
+        failed = projects.find { |project| project["error"] }
+        return unless failed
+
+        raise ArgumentError,
+              "bounded status project #{failed['name']} failed: #{failed['error']}"
+      end
+
+      def validate_bounded_rows!(rows, expected_task_keys)
+        expected = Array(expected_task_keys).each_with_object({}) do |key, index|
+          index[key] = true
+        end
+        unexpected = rows.find { |row| !expected[[ row.project.to_s, row.slug.to_s ]] }
+        return unless unexpected
+
+        raise ArgumentError,
+              "bounded status returned unrequested task #{unexpected.project}:#{unexpected.slug}"
       end
 
       # Classify the envelope's schema_version against what THIS daemon was

--- a/schemas/hive-status.v7.json
+++ b/schemas/hive-status.v7.json
@@ -16,6 +16,7 @@
         "schema_version": { "const": 7 },
         "ok": { "const": true },
         "generated_at": { "type": "string", "format": "date-time" },
+        "partial": { "type": "boolean" },
         "projects": { "type": "array", "items": { "$ref": "#/$defs/Project" } }
       }
     },

--- a/test/unit/cli_test.rb
+++ b/test/unit/cli_test.rb
@@ -803,8 +803,17 @@ class HiveCliTest < Minitest::Test
       Hive::CLI.start([ "status", "--diagnose", "slug", "--project", "proj", "--stage", "2-gather", "--write", "--force", "--json" ])
       assert_equal({
         json: true, diagnose: "slug", project: "proj", stage: "2-gather",
-        write: true, force: true, operational: false, full: false
+        write: true, force: true, operational: false, full: false,
+        daemon_tasks: nil
       }, calls.first.fetch(:kwargs))
+    end
+
+    with_command_new_stub(Hive::Commands::Status) do |calls|
+      Hive::CLI.start([
+        "status", "--json", "--daemon-task", "demo:first-task", "demo:second-task"
+      ])
+      assert_equal [ "demo:first-task", "demo:second-task" ],
+                   calls.first.dig(:kwargs, :daemon_tasks)
     end
 
     with_command_new_stub(Hive::Commands::Status) do |calls|

--- a/test/unit/commands/status_test.rb
+++ b/test/unit/commands/status_test.rb
@@ -6,6 +6,83 @@ require "hive/task_action"
 class CommandsStatusTest < Minitest::Test
   include HiveTestHelper
 
+  def test_daemon_task_payload_reads_only_exact_requested_rows
+    with_tmp_dir do |project_root|
+      hive_state = File.join(project_root, ".hive-state")
+      requested = "requested-task-260823-abcd"
+      write_status_task(
+        hive_state, "1-inbox", requested, state_file: "idea.md", marker: "WAITING"
+      )
+      write_status_task(
+        hive_state, "1-inbox", "unrelated-task-260823-abcd",
+        state_file: "idea.md", marker: "WAITING"
+      )
+      command_class = Class.new(Hive::Commands::Status) do
+        def stage_task_entries(_stage_dir)
+          raise "bounded daemon status must not enumerate stage children"
+        end
+      end
+      command = command_class.new(json: true, daemon_tasks: [ "demo:#{requested}" ])
+
+      payload = command.daemon_task_payload(
+        [ status_project(project_root, hive_state) ], now: Time.utc(2026, 8, 23)
+      )
+
+      assert_equal true, payload.fetch("partial")
+      assert_equal [ requested ], payload.dig("projects", 0, "tasks").map { |row| row.fetch("slug") }
+      assert_equal false, payload.dig("projects", 0, "tasks", 0, "blocked")
+      schema = JSONSchemer.schema(JSON.parse(File.read(Hive::Schemas.schema_path("hive-status"))))
+      assert_empty schema.validate(payload).to_a
+    end
+  end
+
+  def test_daemon_task_payload_holds_dependencies_for_the_authoritative_full_scan
+    with_tmp_dir do |project_root|
+      hive_state = File.join(project_root, ".hive-state")
+      dependent = "dependent-task-260823-abcd"
+      folder = write_status_task(
+        hive_state, "1-inbox", dependent, state_file: "idea.md", marker: "WAITING"
+      )
+      Hive::TaskMeta.write(
+        folder, id: 2, slug: dependent, display_name: nil,
+        depends_on: "prerequisite-task-260823-abcd"
+      )
+      write_status_task(
+        hive_state, "9-done", "prerequisite-task-260823-abcd",
+        state_file: "done.md", marker: "COMPLETE"
+      )
+      command = Hive::Commands::Status.new(
+        json: true, daemon_tasks: [ "demo:#{dependent}" ]
+      )
+
+      payload = command.daemon_task_payload([ status_project(project_root, hive_state) ])
+      row = payload.dig("projects", 0, "tasks", 0)
+
+      assert_equal dependent, row.fetch("slug")
+      assert_equal true, row.fetch("blocked")
+      assert_equal "admission_error", row.fetch("action")
+      assert_equal "dependency_validation_failed",
+                   row.dig("admission_error", "reason_code")
+      assert_includes row.dig("admission_error", "safe_correction"), "full dependency scan"
+    end
+  end
+
+  def test_daemon_task_mode_requires_json_and_registered_project_slug_identity
+    command = Hive::Commands::Status.new(daemon_tasks: [ "demo:task-260823-abcd" ])
+    error = assert_raises(Hive::InvalidTaskPath) do
+      command.send(:validate_mode_combinations!)
+    end
+    assert_includes error.message, "requires plain --json"
+
+    invalid = Hive::Commands::Status.new(
+      json: true, daemon_tasks: [ "missing:task-260823-abcd" ]
+    )
+    error = assert_raises(Hive::InvalidTaskPath) do
+      invalid.send(:daemon_task_targets, [])
+    end
+    assert_includes error.message, "registered-project:task-slug"
+  end
+
   def test_json_payload_exposes_resolved_clean_exit_config
     with_tmp_dir do |project_root|
       hive_state = File.join(project_root, ".hive-state")

--- a/test/unit/commands/status_test.rb
+++ b/test/unit/commands/status_test.rb
@@ -36,6 +36,31 @@ class CommandsStatusTest < Minitest::Test
     end
   end
 
+  def test_daemon_task_call_emits_the_partial_envelope
+    with_tmp_dir do |project_root|
+      hive_state = File.join(project_root, ".hive-state")
+      slug = "changed-task-260823-abcd"
+      write_status_task(
+        hive_state, "1-inbox", slug, state_file: "idea.md", marker: "WAITING"
+      )
+      project = status_project(project_root, hive_state)
+      command = Hive::Commands::Status.new(
+        json: true, daemon_tasks: [ "demo:#{slug}" ]
+      )
+
+      output, error = with_replaced_singleton_method(
+        Hive::Config, :registered_projects, -> { [ project ] }
+      ) do
+        capture_io { command.call }
+      end
+
+      payload = JSON.parse(output)
+      assert_equal true, payload.fetch("partial")
+      assert_equal [ slug ], payload.dig("projects", 0, "tasks").map { |row| row.fetch("slug") }
+      assert_equal "", error
+    end
+  end
+
   def test_daemon_task_payload_holds_dependencies_for_the_authoritative_full_scan
     with_tmp_dir do |project_root|
       hive_state = File.join(project_root, ".hive-state")
@@ -64,6 +89,33 @@ class CommandsStatusTest < Minitest::Test
       assert_equal "dependency_validation_failed",
                    row.dig("admission_error", "reason_code")
       assert_includes row.dig("admission_error", "safe_correction"), "full dependency scan"
+    end
+  end
+
+  def test_daemon_task_payload_fails_closed_when_dependency_projection_raises
+    with_tmp_dir do |project_root|
+      hive_state = File.join(project_root, ".hive-state")
+      slug = "changed-task-260823-cdef"
+      write_status_task(
+        hive_state, "1-inbox", slug, state_file: "idea.md", marker: "WAITING"
+      )
+      command = Hive::Commands::Status.new(
+        json: true, daemon_tasks: [ "demo:#{slug}" ]
+      )
+      command.define_singleton_method(:apply_dependency_verdict) do |*|
+        raise "synthetic dependency failure"
+      end
+
+      payload = nil
+      _output, error = capture_io do
+        payload = command.daemon_task_payload([ status_project(project_root, hive_state) ])
+      end
+      row = payload.dig("projects", 0, "tasks", 0)
+
+      assert_equal true, row.fetch("blocked")
+      assert_equal "dependency_validation_failed",
+                   row.dig("admission_error", "reason_code")
+      assert_includes error, "holding changed rows until the next full scan"
     end
   end
 

--- a/test/unit/daemon/dispatcher_test.rb
+++ b/test/unit/daemon/dispatcher_test.rb
@@ -33,16 +33,25 @@ class HiveDaemonDispatcherTest < Minitest::Test
   # ── fakes ─────────────────────────────────────────────────────────────
 
   class FakeStatusConsumer
-    attr_reader :fetch_count
-    attr_writer :next_result
+    attr_reader :fetch_count, :fetch_task_count, :task_fetches
+    attr_writer :next_result, :next_task_result
 
     def initialize
       @fetch_count = 0
+      @fetch_task_count = 0
+      @task_fetches = []
     end
 
     def fetch
       @fetch_count += 1
       @next_result || Hive::Daemon::StatusConsumer::Result.new(ok: true, rows: [], error: nil)
+    end
+
+    def fetch_tasks(task_keys)
+      @fetch_task_count += 1
+      @task_fetches << task_keys
+      @next_task_result || @next_result ||
+        Hive::Daemon::StatusConsumer::Result.new(ok: true, rows: [], error: nil)
     end
   end
 
@@ -4002,24 +4011,21 @@ def test_run_forever_marks_signal_reaped_terminal_recovery_failed
   end
 end
 
-def test_run_forever_escalates_to_full_tick_when_cheap_probe_detects_change
-  # Drive the fast-poll escalation branch in run_forever (dispatcher.rb
-  # 323-324): on a fast poll where no full tick is due, a cheap probe
-  # that detects a change must run a full `tick`. The full tick is
-  # observable via the real per-row dispatch spawning a child.
+def test_run_forever_refreshes_only_changed_tasks_when_the_fast_probe_detects_change
   rows = [ row(action: "ready_to_plan", command: "hive plan s1 --from 2-brainstorm") ]
   dispatcher, supervisor, _ctrl, logger, _mw = make_dispatcher(rows: rows)
+  status = dispatcher.instance_variable_get(:@status_consumer)
 
   dispatcher.define_singleton_method(:install_signal_handlers!) { true }
   dispatcher.define_singleton_method(:recover_dispatch_claims) { |now:| nil }
 
-  # No full tick is due on this iteration; the cheap probe says a change
-  # was detected, so the elsif branch must fire a full tick.
   dispatcher.define_singleton_method(:full_tick_due?) { |_now| false }
   probe_calls = 0
-  dispatcher.define_singleton_method(:cheap_probe_requires_full_tick?) do |now:|
+  dispatcher.define_singleton_method(:cheap_probe) do |now:|
     probe_calls += 1
-    true
+    Hive::Daemon::Dispatcher::FastProbe.new(
+      task_keys: [ [ "p1", "s1" ] ], full_tick: false
+    )
   end
   # Stop after the single escalated tick so the loop terminates.
   dispatcher.define_singleton_method(:interruptible_sleep) do |_seconds|
@@ -4029,26 +4035,28 @@ def test_run_forever_escalates_to_full_tick_when_cheap_probe_detects_change
   dispatcher.run_forever
 
   assert_equal 1, probe_calls, "the cheap probe must be consulted on the fast-poll iteration"
+  assert_equal 0, status.fetch_count, "a changed task must not trigger a full status scan"
+  assert_equal 1, status.fetch_task_count
+  assert_equal [ [ [ "p1", "s1" ] ] ], status.task_fetches
   assert_equal 1, supervisor.spawned.size,
-               "a cheap probe detecting a change must escalate to a full tick that dispatches"
+               "a changed-task tick must still dispatch the ready row"
   assert_equal "hive plan s1 --from 2-brainstorm", supervisor.spawned.first[:command]
   assert events_include?(logger, :dispatched)
 end
 
-def test_run_forever_skips_escalated_tick_when_shutdown_requested_mid_probe
-  # The escalated tick is guarded by `unless @shutdown || @reload`
-  # (dispatcher.rb 324): if shutdown is requested while the cheap probe
-  # runs, the full tick must NOT fire.
+def test_run_forever_skips_changed_task_tick_when_shutdown_requested_mid_probe
   rows = [ row(action: "ready_to_plan", command: "hive plan s1 --from 2-brainstorm") ]
   dispatcher, supervisor, _ctrl, _logger, _mw = make_dispatcher(rows: rows)
 
   dispatcher.define_singleton_method(:install_signal_handlers!) { true }
   dispatcher.define_singleton_method(:recover_dispatch_claims) { |now:| nil }
   dispatcher.define_singleton_method(:full_tick_due?) { |_now| false }
-  dispatcher.define_singleton_method(:cheap_probe_requires_full_tick?) do |now:|
+  dispatcher.define_singleton_method(:cheap_probe) do |now:|
     # Simulate a shutdown signal landing while the probe runs.
     request_shutdown!
-    true
+    Hive::Daemon::Dispatcher::FastProbe.new(
+      task_keys: [ [ "p1", "s1" ] ], full_tick: false
+    )
   end
   dispatcher.define_singleton_method(:interruptible_sleep) { |_seconds| nil }
 
@@ -4198,11 +4206,12 @@ def test_fast_probe_does_not_fetch_status_when_idle_and_mtimes_unchanged
   dispatcher.tick(now: T0)
   assert_equal 1, status.fetch_count
 
-  refute dispatcher.send(:cheap_probe_requires_full_tick?, now: T0 + 1)
+  assert_empty dispatcher.send(:cheap_probe, now: T0 + 1).task_keys
   assert_equal 1, status.fetch_count, "fast probe must not run the expensive status scan"
+  assert_equal 0, status.fetch_task_count
 end
 
-def test_fast_probe_requests_full_tick_when_tracked_state_file_mtime_changes
+def test_fast_probe_returns_the_exact_task_when_a_tracked_state_file_changes
   folder = make_existing_row_folder(project: "p1", stage: "2-brainstorm", slug: "s1")
   state_file = File.join(folder, "brainstorm.md")
   File.write(state_file, "WAITING\n")
@@ -4216,12 +4225,16 @@ def test_fast_probe_requests_full_tick_when_tracked_state_file_mtime_changes
   dispatcher.tick(now: T0)
   File.utime(Time.now + 5, Time.now + 5, state_file)
 
-  assert dispatcher.send(:cheap_probe_requires_full_tick?, now: T0 + 1)
-  assert_equal 1, status.fetch_count, "mtime probe should request a full tick without fetching itself"
+  assert_equal [ [ "p1", "s1" ] ],
+               dispatcher.send(:cheap_probe, now: T0 + 1).task_keys
+  assert_equal 1, status.fetch_count, "mtime probe must not fetch status itself"
+  assert_equal 0, status.fetch_task_count
 end
 
-def test_fast_probe_reaps_child_exit_before_requesting_full_tick
-  dispatcher, sup, controller, logger, _mw = make_dispatcher(rows: [])
+def test_fast_probe_reaps_child_exit_and_returns_its_tracked_task
+  tracked = row(project: "p1", slug: "s1")
+  dispatcher, sup, controller, logger, _mw = make_dispatcher(rows: [ tracked ])
+  dispatcher.send(:refresh_status_index, [ tracked ])
   dispatch_time = T0 - 10
   controller.record_dispatch(
     pid: 123, project: "p1", slug: "s1", stage: "4-execute",
@@ -4235,10 +4248,217 @@ def test_fast_probe_reaps_child_exit_before_requesting_full_tick
   sup.define_singleton_method(:reap_all) { |now:| [ exited ] }
   status = dispatcher.instance_variable_get(:@status_consumer)
 
-  assert dispatcher.send(:cheap_probe_requires_full_tick?, now: T0)
+  assert_equal [ [ "p1", "s1" ] ], dispatcher.send(:cheap_probe, now: T0).task_keys
   assert_equal 0, controller.in_flight_count
   assert_equal 0, status.fetch_count
   assert events_include?(logger, :child_exited)
+end
+
+def test_fast_probe_requests_full_tick_for_an_untracked_ancillary_exit
+  dispatcher, sup, controller = make_dispatcher(rows: [])
+  controller.record_dispatch(
+    pid: 124, project: "p1", slug: "patrol", stage: "patrol",
+    command: "hive patrol p1", started_at: T0 - 10,
+    state_file_mtime: nil
+  )
+  exited = ChildExit.new(
+    pid: 124, exit_code: Hive::ExitCodes::SUCCESS, project: "p1", slug: "patrol",
+    stage: "patrol", command: "hive patrol p1", state_file_path: nil,
+    started_at: T0 - 10, finished_at: T0, json_envelope: nil, request_id: nil
+  )
+  sup.define_singleton_method(:reap_all) { |now:| [ exited ] }
+
+  probe = dispatcher.send(:cheap_probe, now: T0)
+
+  assert probe.full_tick
+  assert_empty probe.task_keys
+end
+
+def test_fast_probe_stats_at_most_one_bounded_batch_as_task_count_grows
+  rows = 200.times.map do |index|
+    row(
+      slug: "task-#{index}",
+      state_file: "/tmp/hive-bounded-probe-#{index}.md"
+    )
+  end
+  dispatcher, = make_dispatcher(rows: rows)
+  dispatcher.send(:refresh_status_index, rows)
+  stats = 0
+  dispatcher.define_singleton_method(:safe_mtime) do |_path|
+    stats += 1
+    nil
+  end
+
+  assert_empty dispatcher.send(:tracked_state_file_changes)
+  assert_equal Hive::Daemon::Dispatcher::STATE_FILE_PROBE_BATCH_SIZE, stats
+
+  dispatcher.send(:tracked_state_file_changes)
+  assert_equal Hive::Daemon::Dispatcher::STATE_FILE_PROBE_BATCH_SIZE * 2, stats
+end
+
+def test_fast_probe_rotation_survives_a_full_status_index_refresh
+  rows = 128.times.map do |index|
+    row(slug: "task-#{index}", state_file: "/tmp/hive-rotation-#{index}.md")
+  end
+  dispatcher, = make_dispatcher(rows: rows)
+  inspected = []
+  dispatcher.define_singleton_method(:safe_mtime) do |path|
+    inspected << path
+    nil
+  end
+  dispatcher.send(:refresh_status_index, rows)
+  inspected.clear
+
+  dispatcher.send(:tracked_state_file_changes)
+  assert_equal rows.first(64).map(&:state_file), inspected
+
+  dispatcher.send(:refresh_status_index, rows)
+  inspected.clear
+  dispatcher.send(:tracked_state_file_changes)
+  assert_equal rows.last(64).map(&:state_file), inspected
+end
+
+def test_failed_changed_task_tick_retries_the_same_mtime_change
+  folder = make_existing_row_folder(project: "p1", stage: "2-brainstorm", slug: "s1")
+  state_file = File.join(folder, "brainstorm.md")
+  File.write(state_file, "WAITING\n")
+  status_row = row(folder: folder, state_file: state_file, mtime: File.mtime(state_file))
+  dispatcher, = make_dispatcher(rows: [ status_row ])
+  status = dispatcher.instance_variable_get(:@status_consumer)
+  dispatcher.send(:refresh_status_index, [ status_row ])
+  File.utime(Time.now + 5, Time.now + 5, state_file)
+
+  changed = dispatcher.send(:cheap_probe, now: T0).task_keys
+  status.next_task_result = Hive::Daemon::StatusConsumer::Result.new(
+    ok: false, error: "synthetic bounded status failure"
+  )
+  refute dispatcher.tick_changed(task_keys: changed, now: T0)
+
+  assert_equal [ [ "p1", "s1" ] ],
+               dispatcher.send(:cheap_probe, now: T0 + 1).task_keys
+end
+
+def test_incremental_row_removal_does_not_leave_a_dead_probe_slot
+  rows = 65.times.map do |index|
+    row(slug: "task-#{index}", state_file: "/tmp/hive-live-slot-#{index}.md")
+  end
+  dispatcher, = make_dispatcher(rows: rows)
+  dispatcher.send(:refresh_status_index, rows)
+
+  removed_key = [ "p1", "task-0" ]
+  dispatcher.send(:replace_incremental_status_rows, [ removed_key ], [])
+
+  order = dispatcher.instance_variable_get(:@tracked_state_file_order)
+  members = dispatcher.instance_variable_get(:@tracked_state_file_order_members)
+  assert_equal 64, order.length
+  refute_includes order, removed_key
+  refute_includes members, removed_key
+end
+
+def test_changed_task_ticks_do_not_delay_the_periodic_full_repair_scan
+  status_row = row(action: nil, command: nil)
+  dispatcher, = make_dispatcher(rows: [ status_row ])
+
+  dispatcher.tick(now: T0)
+  dispatcher.tick_changed(task_keys: [ [ "p1", "s1" ] ], now: T0 + 10)
+
+  refute dispatcher.send(:full_tick_due?, T0 + 29)
+  assert dispatcher.send(:full_tick_due?, T0 + 30)
+end
+
+def test_changed_task_ticks_leave_global_schedulers_to_the_full_scan
+  status_row = row(action: nil, command: nil)
+  dispatcher, = make_dispatcher(rows: [ status_row ])
+  dispatcher.define_singleton_method(:process_dispatch_requests) do |**|
+    raise "incremental tick ran dispatch-request scheduler"
+  end
+  dispatcher.define_singleton_method(:run_patrol_fix_admission_scheduler_tick) do |**|
+    raise "incremental tick ran Patrol admission scheduler"
+  end
+  dispatcher.define_singleton_method(:run_digest_scheduler_tick) do |*|
+    raise "incremental tick ran digest scheduler"
+  end
+
+  assert dispatcher.tick_changed(task_keys: [ [ "p1", "s1" ] ], now: T0)
+end
+
+def test_failed_changed_task_status_keeps_cached_external_capacity
+  running = row(
+    slug: "external", action: "agent_running", command: nil,
+    claude_pid_alive: true
+  )
+  dispatcher, supervisor = make_dispatcher(rows: [ running ])
+  status = dispatcher.instance_variable_get(:@status_consumer)
+  dispatcher.tick(now: T0)
+  assert_equal 1, dispatcher.instance_variable_get(:@external_active_agent_total)
+
+  status.next_task_result = Hive::Daemon::StatusConsumer::Result.new(
+    ok: false, error: "bounded status project p1 failed: project_load_failed"
+  )
+
+  refute dispatcher.tick_changed(
+    task_keys: [ [ "p1", "external" ] ], now: T0 + 1
+  )
+  assert_equal 1, dispatcher.instance_variable_get(:@external_active_agent_total)
+  assert_empty supervisor.spawned
+end
+
+def test_fail_closed_live_row_keeps_capacity_across_changed_task_ticks
+  running = row(
+    slug: "external", action: "agent_running", command: nil,
+    claude_pid_alive: true
+  )
+  dispatcher, supervisor, controller = make_dispatcher(rows: [ running ])
+  controller.update_limits(
+    max_concurrent_runs: 1, max_concurrent_per_project: 1,
+    max_runs_per_day_per_project: 100, max_concurrent_patrol_scans: 1
+  )
+  status = dispatcher.instance_variable_get(:@status_consumer)
+  dispatcher.tick(now: T0)
+
+  dependency_error = Hive::DependencyAdmission::AdmissionError.new(
+    reason_code: "dependency_validation_failed", offending_ref: "p1:base",
+    safe_correction: "Wait for the next full dependency scan."
+  )
+  status.next_task_result = Hive::Daemon::StatusConsumer::Result.new(
+    ok: true,
+    rows: [ row(
+      slug: "external", action: "admission_error", command: nil,
+      blocked: true, admission_error: dependency_error, claude_pid_alive: true
+    ) ]
+  )
+  assert dispatcher.tick_changed(
+    task_keys: [ [ "p1", "external" ] ], now: T0 + 1
+  )
+  assert_equal 1, dispatcher.instance_variable_get(:@external_active_agent_total)
+
+  status.next_task_result = Hive::Daemon::StatusConsumer::Result.new(
+    ok: true,
+    rows: [ row(
+      slug: "candidate", action: "ready_to_plan",
+      command: "hive plan candidate --from 2-brainstorm"
+    ) ]
+  )
+  assert dispatcher.tick_changed(
+    task_keys: [ [ "p1", "candidate" ] ], now: T0 + 2
+  )
+  assert_empty supervisor.spawned
+end
+
+def test_live_heartbeat_tick_does_not_reconcile_attempt_history
+  running = row(
+    slug: "external", action: "agent_running", command: nil,
+    claude_pid_alive: true
+  )
+  reconciler = Object.new
+  reconciler.define_singleton_method(:reconcile) do |now:|
+    raise "heartbeat tick scanned attempt history"
+  end
+  dispatcher, = make_dispatcher(rows: [ running ], attempt_reconciler: reconciler)
+
+  assert dispatcher.tick_changed(
+    task_keys: [ [ "p1", "external" ] ], now: T0 + 1
+  )
 end
 
 def test_request_methods_flip_lifecycle_flags
@@ -4415,7 +4635,7 @@ def test_reaped_success_dispatches_successor_within_2s_wall_budget
   # Plan Unit 2: pin the ≤2s end-to-end latency bound as a single test
   # with an injected clock. The bound is composed of (a) the fast-poll
   # probe detecting the child exit within one fast_poll_sec, and (b) the
-  # triggered full tick reaping the SUCCESS and dispatching its
+  # changed-task tick dispatching the
   # successor in the SAME tick (zero extra wall). fast_poll_sec defaults
   # to 1, so the worst case is one sleep (~1s) plus a same-instant
   # dispatch — comfortably inside 2s.
@@ -4427,6 +4647,7 @@ def test_reaped_success_dispatches_successor_within_2s_wall_budget
   successor = row(stage: "2-brainstorm", action: "ready_to_plan",
                   command: "hive plan s1 --from 2-brainstorm")
   dispatcher, sup, ctrl, _logger, _mw = make_dispatcher(rows: [ successor ])
+  dispatcher.send(:refresh_status_index, [ successor ])
 
   # Predecessor in-flight; its SUCCESS exit is queued for the next reap.
   ctrl.record_dispatch(pid: 777, project: "p1", slug: "s1",
@@ -4446,13 +4667,13 @@ def test_reaped_success_dispatches_successor_within_2s_wall_budget
   # Injected clock: the worst-case probe fires one fast_poll_sec after
   # the child exits (the loop had just slept when the exit landed).
   t_probe = t_exit + fast_poll_sec
-  assert dispatcher.send(:cheap_probe_requires_full_tick?, now: t_probe),
-         "child-exit must trip the cheap probe within one fast-poll tick"
+  changed = dispatcher.send(:cheap_probe, now: t_probe).task_keys
+  assert_equal [ [ "p1", "s1" ] ], changed,
+               "child-exit must identify its task within one fast-poll tick"
 
-  # The probe trips a full tick at the same instant; it dispatches the
-  # successor stage.
+  # The probe drives a bounded changed-task tick at the same instant.
   t_dispatch = t_probe
-  dispatcher.tick(now: t_dispatch)
+  dispatcher.tick_changed(task_keys: changed, now: t_dispatch)
 
   assert_equal 1, sup.spawned.size, "the reaped SUCCESS must dispatch its successor"
   assert_operator (t_dispatch - t_exit), :<=, 2.0,

--- a/test/unit/daemon/dispatcher_test.rb
+++ b/test/unit/daemon/dispatcher_test.rb
@@ -4044,6 +4044,27 @@ def test_run_forever_refreshes_only_changed_tasks_when_the_fast_probe_detects_ch
   assert events_include?(logger, :dispatched)
 end
 
+def test_run_forever_runs_a_full_tick_for_an_ancillary_probe_change
+  dispatcher, = make_dispatcher(rows: [])
+  dispatcher.define_singleton_method(:install_signal_handlers!) { true }
+  dispatcher.define_singleton_method(:recover_dispatch_claims) { |now:| nil }
+  dispatcher.define_singleton_method(:full_tick_due?) { |_now| false }
+  dispatcher.define_singleton_method(:cheap_probe) do |now:|
+    Hive::Daemon::Dispatcher::FastProbe.new(task_keys: [], full_tick: true)
+  end
+  ticks = 0
+  dispatcher.define_singleton_method(:tick) do |now:|
+    ticks += 1
+    request_shutdown!
+    true
+  end
+  dispatcher.define_singleton_method(:interruptible_sleep) { |_seconds| nil }
+
+  dispatcher.run_forever
+
+  assert_equal 1, ticks
+end
+
 def test_run_forever_skips_changed_task_tick_when_shutdown_requested_mid_probe
   rows = [ row(action: "ready_to_plan", command: "hive plan s1 --from 2-brainstorm") ]
   dispatcher, supervisor, _ctrl, _logger, _mw = make_dispatcher(rows: rows)
@@ -4355,6 +4376,20 @@ def test_incremental_row_removal_does_not_leave_a_dead_probe_slot
   refute_includes members, removed_key
 end
 
+def test_incremental_row_removal_resets_an_empty_probe_cursor
+  status_row = row(slug: "only-task", state_file: "/tmp/hive-only-probe.md")
+  dispatcher, = make_dispatcher(rows: [ status_row ])
+  dispatcher.send(:refresh_status_index, [ status_row ])
+  dispatcher.instance_variable_set(:@tracked_state_file_cursor, 1)
+
+  dispatcher.send(
+    :replace_incremental_status_rows, [ [ "p1", "only-task" ] ], []
+  )
+
+  assert_empty dispatcher.instance_variable_get(:@tracked_state_file_order)
+  assert_equal 0, dispatcher.instance_variable_get(:@tracked_state_file_cursor)
+end
+
 def test_changed_task_ticks_do_not_delay_the_periodic_full_repair_scan
   status_row = row(action: nil, command: nil)
   dispatcher, = make_dispatcher(rows: [ status_row ])
@@ -4459,6 +4494,49 @@ def test_live_heartbeat_tick_does_not_reconcile_attempt_history
   assert dispatcher.tick_changed(
     task_keys: [ [ "p1", "external" ] ], now: T0 + 1
   )
+end
+
+def test_changed_task_tick_stops_when_attempt_reconciliation_fails
+  ready = row(action: "ready_to_plan", command: "hive plan s1 --from 2-brainstorm")
+  reconciler = Object.new
+  reconciler.define_singleton_method(:reconcile) do |now:|
+    raise "synthetic attempt reconciliation failure"
+  end
+  dispatcher, supervisor, _controller, logger = make_dispatcher(
+    rows: [ ready ], attempt_reconciler: reconciler
+  )
+
+  refute dispatcher.tick_changed(
+    task_keys: [ [ "p1", "s1" ] ], now: T0 + 1
+  )
+  assert_empty supervisor.spawned
+  assert logger.events.any? { |name, attrs|
+    name == :tick_end && attrs[:action] == "incremental_attempt_reconciliation_failed"
+  }
+end
+
+def test_changed_task_tick_contains_per_task_collaborator_failures
+  status_row = row(action: nil, command: nil)
+  dispatcher, _supervisor, _controller, logger = make_dispatcher(rows: [ status_row ])
+  task_ids = Object.new
+  task_ids.define_singleton_method(:backfill) { |*, **| raise "task id boom" }
+  healer = Object.new
+  healer.define_singleton_method(:heal) { |*, **| raise "healer boom" }
+  names = Object.new
+  names.define_singleton_method(:backfill) { |*, **| raise "name boom" }
+  dispatcher.instance_variable_set(:@task_id_backfiller, task_ids)
+  dispatcher.instance_variable_set(:@stale_agent_healer, healer)
+  dispatcher.instance_variable_set(:@display_name_backfiller, names)
+
+  assert dispatcher.tick_changed(
+    task_keys: [ [ "p1", "s1" ] ], now: T0 + 1
+  )
+  messages = logger.events.filter_map do |name, attrs|
+    attrs[:message] if name == :fatal
+  end
+  assert messages.any? { |message| message.include?("task_id_backfiller raised") }
+  assert messages.any? { |message| message.include?("stale_agent_healer raised") }
+  assert messages.any? { |message| message.include?("display_name_backfiller raised") }
 end
 
 def test_request_methods_flip_lifecycle_flags

--- a/test/unit/daemon/status_consumer_test.rb
+++ b/test/unit/daemon/status_consumer_test.rb
@@ -10,13 +10,13 @@ require "hive/daemon/status_consumer"
 class HiveDaemonStatusConsumerTest < Minitest::Test
   include HiveTestHelper
 
-  def with_fake_status(payload, exit_code: 0, stderr_text: "")
+  def with_fake_status(payload, exit_code: 0, stderr_text: "", expected_args: %w[status --json])
     with_tmp_dir do |dir|
       script = File.join(dir, "fake-hive")
       File.write(script, <<~RUBY)
         #!/usr/bin/env ruby
-        if ARGV != %w[status --json]
-          $stderr.puts "fake-hive: unexpected argv #{ARGV.inspect}"
+        if ARGV != #{expected_args.inspect}
+          $stderr.puts "fake-hive: unexpected argv \#{ARGV.inspect}"
           exit 64
         end
         $stderr.write #{stderr_text.inspect}
@@ -96,6 +96,69 @@ class HiveDaemonStatusConsumerTest < Minitest::Test
       assert_equal plan_review, row.plan_review
       assert_equal 3, result.hidden_archived_task_count
       assert_equal 3, result.projects.first.hidden_archived_task_count
+    end
+  end
+
+  def test_fetch_tasks_requests_and_accepts_only_a_partial_envelope
+    payload = make_envelope(projects: [ {
+      "name" => "p", "path" => "/tmp/p", "hive_state_path" => "/tmp/p/.h",
+      "tasks" => [ task_row(slug: "changed") ]
+    } ]).merge("partial" => true)
+    expected = %w[status --json --daemon-task p:changed p:other]
+
+    with_fake_status(JSON.generate(payload), expected_args: expected) do |bin|
+      result = Hive::Daemon::StatusConsumer.new(hive_bin: bin).fetch_tasks(
+        [ [ "p", "changed" ], [ "p", "other" ] ]
+      )
+
+      assert result.ok
+      assert_equal [ "changed" ], result.rows.map(&:slug)
+    end
+
+    without_partial = payload.reject { |key, _value| key == "partial" }
+    with_fake_status(JSON.generate(without_partial), expected_args: expected) do |bin|
+      result = Hive::Daemon::StatusConsumer.new(hive_bin: bin).fetch_tasks(
+        [ [ "p", "changed" ], [ "p", "other" ] ]
+      )
+
+      refute result.ok
+      assert_includes result.error, "partial=true"
+    end
+  end
+
+  def test_fetch_tasks_skips_the_subprocess_for_an_empty_change_set
+    consumer = Hive::Daemon::StatusConsumer.new(hive_bin: "/definitely/missing/hive")
+
+    result = consumer.fetch_tasks([])
+
+    assert result.ok
+    assert_empty result.rows
+  end
+
+  def test_fetch_tasks_rejects_project_errors_and_unrequested_rows
+    expected = %w[status --json --daemon-task p:changed]
+    failed = make_envelope(projects: [ {
+      "name" => "p", "error" => "project_load_failed", "tasks" => []
+    } ]).merge("partial" => true)
+    with_fake_status(JSON.generate(failed), expected_args: expected) do |bin|
+      result = Hive::Daemon::StatusConsumer.new(hive_bin: bin).fetch_tasks(
+        [ [ "p", "changed" ] ]
+      )
+
+      refute result.ok
+      assert_includes result.error, "project_load_failed"
+    end
+
+    extra = make_envelope(projects: [ {
+      "name" => "p", "tasks" => [ task_row(slug: "other") ]
+    } ]).merge("partial" => true)
+    with_fake_status(JSON.generate(extra), expected_args: expected) do |bin|
+      result = Hive::Daemon::StatusConsumer.new(hive_bin: bin).fetch_tasks(
+        [ [ "p", "changed" ] ]
+      )
+
+      refute result.ok
+      assert_includes result.error, "unrequested task p:other"
     end
   end
 

--- a/test/unit/daemon/status_consumer_test.rb
+++ b/test/unit/daemon/status_consumer_test.rb
@@ -149,6 +149,18 @@ class HiveDaemonStatusConsumerTest < Minitest::Test
       assert_includes result.error, "project_load_failed"
     end
 
+    wrong_project = make_envelope(projects: [ {
+      "name" => "other", "tasks" => []
+    } ]).merge("partial" => true)
+    with_fake_status(JSON.generate(wrong_project), expected_args: expected) do |bin|
+      result = Hive::Daemon::StatusConsumer.new(hive_bin: bin).fetch_tasks(
+        [ [ "p", "changed" ] ]
+      )
+
+      refute result.ok
+      assert_includes result.error, "projects do not match"
+    end
+
     extra = make_envelope(projects: [ {
       "name" => "p", "tasks" => [ task_row(slug: "other") ]
     } ]).merge("partial" => true)

--- a/wiki/commands/daemon.md
+++ b/wiki/commands/daemon.md
@@ -3,14 +3,14 @@ title: hive daemon
 type: command
 source: lib/hive/commands/daemon.rb, lib/hive/daemon/*
 created: 2026-05-06
-updated: 2026-08-21
+updated: 2026-08-23
 tags: [command, daemon, automation, plan-review, json]
 ---
 
 **TLDR**: `hive daemon SUBCOMMAND` is the operator surface for the
 auto-advancing dispatcher (ADR-024). One long-running process wakes
-every 1s for cheap child-exit/state-mtime probes, runs a full
-`hive status --json` scan on change or every 30s as a backstop, dispatches
+every 1s for bounded child-exit/state-mtime probes, refreshes only the changed
+task rows, and runs a full `hive status --json` scan every 30s as repair. It dispatches
 workflow verbs (`hive plan` / `develop` / `open-pr` / `review` /
 `artifacts` / `finalize`) on tasks ready to advance, and
 auto-archives safely delivered coding tasks from any PR-bearing stage 5–8
@@ -165,7 +165,7 @@ All under `daemon:` in `~/Dev/hive/config.yml`:
 | Key | Default | Purpose |
 |-----|---------|---------|
 | `poll_interval_sec` | 30 | Backstop cadence for full status scans. Min 5. |
-| `fast_poll_sec` | 1 | Cheap wake cadence for child reaps and state-file/stage-dir mtime probes between full scans. Min 1. |
+| `fast_poll_sec` | 1 | Cheap wake cadence for child reaps and a rotating batch of at most 64 tracked state-file mtime probes between full scans. Only exact changed task rows refresh; dependency-bearing rows wait for the full scan. Min 1. |
 | `auto_retry.enabled` | — | **Inert.** Retired as a kill switch: `ERROR` / `REVIEW_ERROR` retries are unconditional and follow one backoff ladder. The key is still shape-validated so a typo fails loudly, but setting it changes nothing. Pause a project with `daemon.enabled: false` instead. |
 | `edit_debounce_sec` | 30 | Settle window for `kind: edit` resumes. 0 disables debounce. |
 | `pr_merge_poll_interval_sec` | 300 | Durable per-candidate merge reconciliation cadence. Min 60 to respect GitHub rate limits; failure counts remain uncapped and backoff is persisted. |

--- a/wiki/commands/status.md
+++ b/wiki/commands/status.md
@@ -3,7 +3,7 @@ title: hive status
 type: command
 source: lib/hive/commands/status.rb, lib/hive/task_closure.rb, lib/hive/operational_status.rb, lib/hive/operational_action.rb, lib/hive/daemon/operational_snapshot.rb, lib/hive/diagnostic_evidence.rb
 created: 2026-04-25
-updated: 2026-08-13
+updated: 2026-08-23
 tags: [command, status, operational, agents, observability, json, diagnostics, archive, closure, blocked, plan-review, terminal-outcomes, dependencies, scheduler]
 ---
 
@@ -23,6 +23,7 @@ table.
 | `hive status --operational` | Explicit alias for the same concise human view. |
 | `hive status --operational --json` | `hive-operational-status.v4` agent document. V4 adds a required nullable exact routing decision; superseded v1-v3 are removed after coordinated in-repository migration. |
 | `hive status --json` | Complete `hive-status.v7` graph for daemon, bot, TUI, and current consumers. |
+| `hive status --json --daemon-task PROJECT:SLUG ...` | Internal daemon fast-tick surface. Emits `partial: true`, reads only the named task folders across bounded stage paths, and holds dependency-bearing rows until the next full graph scan. |
 | `hive status --full` | Former grouped detailed human table. |
 | `hive status --diagnose ...` | Existing task diagnostic surface; incompatible with `--operational`/`--full`. |
 

--- a/wiki/log.d/20260823T030000Z-incremental-daemon-status-scans.md
+++ b/wiki/log.d/20260823T030000Z-incremental-daemon-status-scans.md
@@ -1,0 +1,16 @@
+---
+title: Bound daemon fast ticks to changed tasks
+type: change
+date: 2026-08-23
+tags: [daemon, status, performance, dependencies]
+---
+
+The daemon's one-second probe now stats a rotating batch of at most 64 tracked
+state files and refreshes only exact changed `project:slug` rows. Child exits
+feed the same bounded path. Dependency-bearing rows fail closed until the next
+authoritative full dependency scan, so the fast path needs no dependency graph
+or transitive traversal. Bounded response errors or identity mismatches leave
+cached daemon state untouched. The 30-second full tick remains unchanged as
+repair for global
+schedulers, task inventory, dependency release, metadata/config changes,
+archive counts, and operational snapshots; fast ticks never postpone it.

--- a/wiki/modules/daemon.md
+++ b/wiki/modules/daemon.md
@@ -3,7 +3,7 @@ title: Hive::Daemon
 type: module
 source: lib/hive/daemon/
 created: 2026-05-06
-updated: 2026-08-21
+updated: 2026-08-23
 tags: [daemon, module, automation, dispatcher, operational-status, snapshots, terminal-outcomes, recovery, plan-review, bounded-storage]
 ---
 
@@ -45,7 +45,7 @@ Valid snapshots keep polling cheap. See [[modules/conditions]].
 | `Hive::Daemon::Policy` | `lib/hive/daemon/policy.rb` | Pure switch over action, admission/dependency state, stage/workflow context, mtime debounce, and the brainstorm `answers_pending` / `answers_complete` signals. Structured admission errors return `:admission_error` before every stage branch; ordinary blocked rows cannot dispatch or poll for merge. |
 | `Hive::Daemon::ConcurrencyController` | `lib/hive/daemon/concurrency_controller.rb` | In-memory budget gate: caps (global / per-project / per-day rate plus per-project patrol scans), WRONG_STAGE protective backoff, transient backoff schedule, quarantine, dropped projects, last-dispatched mtime tracking. `Dispatcher#reload_config!` applies reloaded limits through `update_limits` on this same object so SIGHUP changes admission immediately without discarding runtime state. SUCCESS exits do not cool down; the next stage may dispatch immediately. The last-dispatched mtime map is write-through-persisted via an injected `DispatchBaselines` store so it survives restart (see "Persisted dispatch baselines" below); restored keys retain one-process provenance until a real observation or dispatch consumes them. Everything else is intentionally in-memory. |
 | `Hive::Daemon::DispatchBaselines` | `lib/hive/daemon/dispatch_baselines.rb` | Crash-safe JSON store for the `[project, slug] → state_file_mtime` baseline map (`daemon_dispatch_baselines.json` under the state home). Atomic write + fail-closed load; mirrors `Hive::UpdateCheck::State`. Stops answered `needs_input` tasks being re-stranded across a daemon restart. |
-| `Hive::Daemon::StatusConsumer` | `lib/hive/daemon/status_consumer.rb` | Wraps `Open3.capture3("hive status --json")`; returns typed visible rows including `workflow`, canonical `pr_url`, structured `admission_error`, project information, and the summed `hidden_archived_task_count`. Missing or malformed admission state is converted to `dependency_validation_failed`, `blocked: true`, action `admission_error`, and no command. Envelope shape and hidden-count types are hard-validated while forward schema versions remain best-effort. |
+| `Hive::Daemon::StatusConsumer` | `lib/hive/daemon/status_consumer.rb` | Wraps ordinary full `hive status --json` reads and internal bounded `--daemon-task project:slug` reads. Both return typed visible rows including `workflow`, canonical `pr_url`, and structured `admission_error`; full results also carry project information and the summed `hidden_archived_task_count`. Bounded responses must declare `partial: true`, match the requested project/task identities, and contain no project error; a mismatch fails without replacing cached daemon state. Missing or malformed admission state is converted to `dependency_validation_failed`, `blocked: true`, action `admission_error`, and no command. Envelope shape and hidden-count types are hard-validated while forward schema versions remain best-effort. |
 | `Hive::Daemon::OperationalSnapshot` | `lib/hive/daemon/operational_snapshot.rb` | Private daemon-to-status observation channel. `Assembler` first publishes a generation-bound `runtime_ready` acknowledgement after signal installation and inherited-claim recovery, then retains that flag on `started`, `failed`, revalidated `complete`, and shutdown records. Tick completion includes the final aggregate hidden-archive count; SIGHUP recalculates validity from the reloaded poll interval, and recovery receipts are overlaid only when task, stage, marker identity, and lifecycle still match. `Store` atomically persists records under owner-private path/inode checks; the ordinary `Reader` accepts only live-generation complete observations and degrades every other condition to explicit unavailable/stale/invalid evidence. |
 | `Hive::Daemon::PatrolFixCandidateInventory` | `lib/hive/daemon/patrol_fix_candidate_inventory.rb` | Opens only exact `patrol-fix-manifest.json` files under workflow stage/task owners. It binds every owned manifest's canonical bytes into one full inventory count/digest, fails on owned corruption, ignores unrelated task metadata, and selects one deterministic relevance-ranked context of at most 64 rows and 192 KiB. Exact source identity, alias, and semantic-lineage overlap rank before path/lexical fallback; each selected row carries bounded secret-scanned remediation evidence and its own context digest. |
 | `Hive::Daemon::ActivationLock` | `lib/hive/daemon/activation_lock.rb` | Stable, owner-bound, never-unlinked profile flock held by daemon startup through generation-bound runtime readiness. Unsafe paths, replacement inodes, and bounded contention fail closed. |
@@ -117,11 +117,21 @@ lineage/audit evidence, not an exhaustion budget; lost-attempt successors keep
 retrying until one is durably dispatched.
 
 `run_forever` wakes at `daemon.fast_poll_sec` (default 1s) for a cheap
-probe: non-blocking child reap plus mtime stats of state files and stage
-directories seen on the last full status scan. A child exit or mtime
-change triggers a full `tick` immediately; otherwise
-`daemon.poll_interval_sec` (default 30s) remains the backstop full-scan
-cadence for changes the cheap probe cannot see.
+probe: non-blocking child reap plus a rotating batch of at most 64 state-file
+mtime stats from the last full status scan. A child exit identifies its exact
+tracked task; an mtime change identifies the task owning that file. The daemon
+then asks status for only those project/slug rows and applies only their
+per-task heal/dispatch path. Every refreshed row with a dependency fails closed
+until authoritative dependency admission runs, so the incremental path does not
+build or traverse a dependency graph. Pure live-agent heartbeat refreshes reuse
+the last full attempt snapshot; a row that could heal or dispatch reconciles
+attempt ownership before policy runs. An ancillary child exit that has no task
+row triggers an immediate full tick so Patrol and digest follow-up keeps its
+existing wake behavior. `daemon.poll_interval_sec`
+(default 30s) remains the full-scan repair cadence for fleet schedulers, new or
+removed tasks, metadata/config changes, dependency release, archive counts,
+and operational snapshot publication. Incremental ticks do not move that
+deadline, so continuous edits cannot starve repair.
 
 On graceful shutdown, the supervisor snapshots each ancillary child's verified
 descendant tree and original process group before sending TERM, then escalates


### PR DESCRIPTION
## Summary

Daemon fast polls now do bounded work as task history grows. A one-second wake stats at most 64 rotating task state files and refreshes only exact changed task rows; the 30-second full scan remains the authoritative repair path.

This is the changed-task scan slice of the daemon CPU work. Patrol admission-count bounding remains isolated in #1178.

## Safety model

- Bounded status responses declare `partial: true` and must match the requested project/task identities before cached state changes.
- Dependency-bearing rows fail closed until the next full graph scan. The fast path builds no reverse-dependency index and performs no transitive fan-out.
- Positive live-agent heartbeats reuse the last attempt snapshot. Any row that could heal or dispatch reconciles attempt ownership first.
- Known child exits refresh their exact task. Unmatched ancillary exits force an immediate full tick for Patrol and digest follow-up.
- Incremental ticks never move the full-scan deadline. Global schedulers, inventory repair, dependency release, archive counts, and operational snapshot publication remain authoritative within the configured full-scan interval.

## Performance

Synthetic status projection over 200 tasks, three iterations:

| Path | Time | Relative |
|---|---:|---:|
| Full status projection | 2.1340s | 1.0x |
| One-task bounded projection | 0.0238s | 89.7x faster |

The fast mtime probe itself is capped at 64 `stat` calls per wake, independent of total task count.

## Validation

- Post-review focused tests: dispatcher 281 runs / 1019 assertions; status 116 / 499; status consumer 29 / 150; CLI 55 / 287; schemas 159 / 897; status envelope integration 5 / 33. All passed.
- Broad checkpoint: 13,248 runs / 273,817 assertions, 0 failures, 0 errors, 10 skips.
- Hosted CI: 32 checks passed on exact head `23cbe5112`, including the 100% line-coverage gate.
- RuboCop inspected all changed Ruby/test files with no offenses.
- `git diff --check` passed.
