### PR TITLE
test: isolate daemon E2E name backfill

### DIFF
--- a/test/integration/content_workflow_e2e_test.rb
+++ b/test/integration/content_workflow_e2e_test.rb
@@ -43,6 +43,10 @@ class ContentWorkflowE2ETest < Minitest::Test
               status_consumer: LiveStatusConsumer.new(fetch: method(:status_snapshot)),
               logger: logger
             )
+            name_generation_requests = install_inline_display_name_backfiller(
+              dispatcher,
+              logger: logger
+            )
 
             30.times do
               break if File.file?(File.join(task_folder(project_root, "6-done", slug), "article.md"))
@@ -62,6 +66,9 @@ class ContentWorkflowE2ETest < Minitest::Test
                          "terminal done stage must not re-dispatch an agent after article.md exists"
             assert_equal spawned_at_rest, supervisor.spawned.size,
                          "terminal done stage must not spawn another command after article.md exists"
+            assert_equal %w[1-inbox 2-research 3-outline 4-draft 5-critique 6-done],
+                         name_generation_requests.map { |folder| File.basename(File.dirname(folder)) },
+                         "daemon E2E must exercise display-name backfill without external child processes"
 
             @spawned_commands = supervisor.spawned.map { |spawn| spawn.fetch(:command) }
             @logged_event_names = logger.events.map { |entry| entry.fetch(:name) }

--- a/test/support/daemon_e2e_harness.rb
+++ b/test/support/daemon_e2e_harness.rb
@@ -1,6 +1,7 @@
 require "json"
 require "hive/cli"
 require "hive/daemon/child_supervisor"
+require "hive/daemon/display_name_backfiller"
 require "hive/daemon/status_consumer"
 
 # In-process daemon scaffolding shared by the content-workflow end-to-end
@@ -99,6 +100,25 @@ module HiveDaemonE2EHarness
     now = Time.now
     supervisor.now = now
     dispatcher.tick(now: now)
+  end
+
+  # Keep daemon E2E tests process-local while still exercising the real
+  # display-name backfill projection. The production collaborator starts a
+  # detached `hive generate-name` child; those children can outlive Minitest
+  # and race process-level coverage collection. Returning the current process
+  # pid models an inflight child without forking and records each folder the
+  # dispatcher would have backfilled.
+  def install_inline_display_name_backfiller(dispatcher, logger:)
+    requested_folders = []
+    backfiller = Hive::Daemon::DisplayNameBackfiller.new(
+      logger: logger,
+      spawn: lambda do |folder|
+        requested_folders << folder
+        Process.pid
+      end
+    )
+    dispatcher.instance_variable_set(:@display_name_backfiller, backfiller)
+    requested_folders
   end
 
   # Build a StatusConsumer::Result from a live `hive status --json` snapshot —

--- a/wiki/log.d/20260823T120110Z-daemon-e2e-name-backfill-isolation.md
+++ b/wiki/log.d/20260823T120110Z-daemon-e2e-name-backfill-isolation.md
@@ -1,0 +1,17 @@
+# Daemon E2E display-name backfill no longer leaks child processes
+
+**Date:** 2026-08-23
+**Scope:** `test/support/daemon_e2e_harness.rb`,
+`test/integration/content_workflow_e2e_test.rb`
+
+The in-process daemon E2E harness now injects an inline spawn collaborator for
+`DisplayNameBackfiller`. It still exercises the real backfill projection and
+asserts that every content-workflow stage requests name generation, but models
+the inflight child with the current process pid instead of starting detached
+`hive generate-name` commands.
+
+Previously the content workflow E2E started one real name-generation child at
+each stage transition. Those children inherited coverage collection and could
+finish after Minitest wrote its shard manifest, making the strict aggregate gate
+correctly reject an extra process result even though all tests passed. Daemon
+production behavior is unchanged; only the process-local E2E boundary changed.


### PR DESCRIPTION
## Summary

- keep the daemon E2E harness process-local while exercising the real display-name backfill projection
- replace detached `hive generate-name` children with an inline inflight collaborator
- assert all six content-workflow stages request name generation

## Root cause

The content workflow E2E launched detached name-generation children on each stage transition. Those children inherited coverage and could finish after the shard manifest was written, so the strict aggregate gate correctly rejected late process results. Production daemon behavior is unchanged.

## Verification

- `bundle exec ruby -Itest test/unit/daemon/display_name_backfiller_test.rb test/integration/content_workflow_e2e_test.rb --seed 5463` (20 runs, 77 assertions)
- six-way owning partition: 1,474 runs, 8,424 assertions, 0 failures
- coverage manifest: 195 expected, 195 actual, 0 extra, 0 missing
- generated-name coverage children: 0