### PR TITLE
perf(daemon): reuse recovery indexes per queue scan

### DIFF
--- a/lib/hive/attempts/generation.rb
+++ b/lib/hive/attempts/generation.rb
@@ -53,7 +53,7 @@ module Hive
         )
       end
 
-      def self.artifact_token(task, state_file_content: nil)
+      def self.artifact_token(task, state_file_content: nil, admission_context: nil)
         digest = ::Digest::SHA256.new
         digest << "hive-progress-v2\0"
         digest << task.state_file.to_s
@@ -68,7 +68,13 @@ module Hive
         end
         if task.respond_to?(:project_root) && task.respond_to?(:slug)
           digest << "\0dependency-admission\0"
-          digest << Hive::DependencySnapshot.admission_fingerprint(task)
+          fingerprint_options = {}
+          if admission_context
+            fingerprint_options[:admission_context] = admission_context
+          end
+          digest << Hive::DependencySnapshot.admission_fingerprint(
+            task, **fingerprint_options
+          )
         end
         digest.hexdigest
       rescue SystemCallError, IOError => e

--- a/lib/hive/daemon/dispatcher.rb
+++ b/lib/hive/daemon/dispatcher.rb
@@ -38,6 +38,7 @@ require "hive/install_channel"
 require "hive/commands/update"
 require "hive/attempts/api"
 require "hive/attempts/generation"
+require "hive/dependency_snapshot"
 require "hive/terminal_outcome"
 
 module Hive
@@ -2364,6 +2365,43 @@ module Hive
         @dispatch_request_log_signatures.delete_if do |(request_id, _event), _signature|
           !current_request_ids.key?(request_id)
         end
+        return if pending.empty?
+
+        begin
+          registered_projects = Hive::Config.registered_projects
+          projects_by_name = {}
+          registered_projects.each do |project|
+            projects_by_name[project.fetch("name").to_s] ||= project
+          end
+          project_lookup = projects_by_name.method(:[])
+        rescue StandardError => e
+          registered_projects = nil
+          project_lookup = ->(_name) { raise e }
+        end
+        rows_by_task = {}
+        rows.each do |row|
+          key = [ row.project.to_s, row.slug.to_s ]
+          rows_by_task[key] ||= row
+        end
+        admission_context = nil
+        admission_context_error = nil
+        admission_context_loaded = false
+        admission_context_loader = lambda do
+          unless admission_context_loaded
+            begin
+              admission_context = Hive::DependencySnapshot.admission_context(
+                registered_projects
+              )
+            rescue StandardError => e
+              admission_context_error = e
+            ensure
+              admission_context_loaded = true
+            end
+          end
+          raise admission_context_error if admission_context_error
+
+          admission_context
+        end
 
         # Per-slug in-flight gate within this tick: if we just spawned
         # for (project, slug) on this tick, defer subsequent requests
@@ -2387,7 +2425,11 @@ module Hive
           # the next tick to retry; the failure is logged for
           # operator visibility. Per R-01 from PR #241 ce-code-review.
           begin
-            process_dispatch_request_iteration(req, now: now, rows: rows)
+            process_dispatch_request_iteration(
+              req, now: now, rows: rows,
+              row_index: rows_by_task, project_lookup: project_lookup,
+              admission_context_loader: admission_context_loader
+            )
           rescue StandardError => e
             recovery_receipt = defer_recovery_after_dispatch_failure(req, now: now)
             @logger.event(:dispatch_request_rejected,
@@ -2434,7 +2476,9 @@ module Hive
       # process_dispatch_requests captures any error from the gate
       # checks AND the actual spawn. Returns nil; side effects via
       # @controller, @logger, and the queue's remove() call.
-      def process_dispatch_request_iteration(req, now:, rows:)
+      def process_dispatch_request_iteration(req, now:, rows:, row_index: nil,
+                                             project_lookup: nil,
+                                             admission_context_loader: nil)
         return unless admission_open?
 
         unless Hive::Daemon::DispatchRequestQueue.valid_argv?(req.argv)
@@ -2452,7 +2496,12 @@ module Hive
           return
         end
 
-        unless Hive::Config.find_project(req.project)
+        project = if project_lookup
+          project_lookup.call(req.project.to_s)
+        else
+          Hive::Config.find_project(req.project)
+        end
+        unless project
           if req.recovery.is_a?(Hash)
             log_dispatch_request_once(
               :dispatch_request_blocked,
@@ -2484,11 +2533,15 @@ module Hive
           return
         end
 
-        if req.recovery.is_a?(Hash)
-          row = rows.find do |candidate|
+        row = if row_index
+          row_index[[ req.project.to_s, req.slug.to_s ]]
+        else
+          rows.find do |candidate|
             candidate.project.to_s == req.project.to_s &&
               candidate.slug.to_s == req.slug.to_s
           end
+        end
+        if req.recovery.is_a?(Hash)
           unless row
             log_dispatch_request_once(
               :dispatch_request_blocked,
@@ -2497,7 +2550,21 @@ module Hive
             )
             return
           end
-          recovery_receipt = @recovery_coordinator.resume(request: req, row: row, now: now)
+          resume_options = { request: req, row: row, now: now }
+          if admission_context_loader
+            begin
+              resume_options[:admission_context] = admission_context_loader.call
+            rescue StandardError => e
+              log_dispatch_request_once(
+                :dispatch_request_blocked,
+                request_id: req.request_id, project: req.project,
+                slug: req.slug, reason: "admission_context_unavailable",
+                error: "#{e.class}: #{e.message[0, 200]}"
+              )
+              return
+            end
+          end
+          recovery_receipt = @recovery_coordinator.resume(**resume_options)
           unless recovery_receipt.status == "queued" &&
                  recovery_receipt.phase == "cleared"
             log_dispatch_request_once(
@@ -2516,7 +2583,6 @@ module Hive
         end
 
         if dependency_gated_request?(req)
-          row = rows.find { |candidate| candidate.project == req.project && candidate.slug == req.slug }
           if row&.admission_error
             log_dispatch_request_once(
               :dispatch_request_blocked,

--- a/lib/hive/daemon/dispatcher.rb
+++ b/lib/hive/daemon/dispatcher.rb
@@ -2496,10 +2496,20 @@ module Hive
           return
         end
 
-        project = if project_lookup
-          project_lookup.call(req.project.to_s)
-        else
-          Hive::Config.find_project(req.project)
+        project = begin
+          if project_lookup
+            project_lookup.call(req.project.to_s)
+          else
+            Hive::Config.find_project(req.project)
+          end
+        rescue StandardError => e
+          log_dispatch_request_once(
+            :dispatch_request_blocked,
+            request_id: req.request_id, project: req.project,
+            slug: req.slug, reason: "project_registry_unavailable",
+            error: "#{e.class}: #{e.message[0, 200]}"
+          )
+          return
         end
         unless project
           if req.recovery.is_a?(Hash)

--- a/lib/hive/daemon/recovery_coordinator.rb
+++ b/lib/hive/daemon/recovery_coordinator.rb
@@ -606,7 +606,7 @@ module Hive
       # daemon immediately before ordinary attempt admission. It can recover a
       # crash after the marker rewrite because the expected markerless
       # fingerprint was persisted before mutation.
-      def resume(request:, row:, now: Time.now.utc)
+      def resume(request:, row:, now: Time.now.utc, admission_context: nil)
         now = now.utc
         recovery = request.recovery
         return unavailable_request(request, "request_has_no_recovery_transition") unless recovery.is_a?(Hash)
@@ -663,7 +663,9 @@ module Hive
               )
             end
 
-            generation = generation_for_current(locked_task, current_request)
+            generation = generation_for_current(
+              locked_task, current_request, admission_context: admission_context
+            )
             if recovery["phase"] == "admitted"
               if admission_failure_recovery?(recovery)
                 return block_request(
@@ -685,11 +687,11 @@ module Hive
                   expected_attrs_match?(marker, recovery.fetch("expected_marker_attrs"))
 
                 markerless = Hive::Markers.without_markers(File.binread(locked_task.state_file))
-                predicted = @generation_resolver.call(
-                  locked_task,
-                  project: current_request.project,
+                predicted = call_generation_resolver(
+                  locked_task, project: current_request.project,
                   intended_stage: current_request.expected_stage,
-                  state_file_content: markerless
+                  state_file_content: markerless,
+                  admission_context: admission_context
                 )
                 return block_request(
                   current_request, "generation_conflict",
@@ -705,7 +707,9 @@ module Hive
                   current_request, "generation_conflict",
                   owner: "operator", request_locked: true
                 ) unless cleared
-                generation = generation_for_current(locked_task, current_request)
+                generation = generation_for_current(
+                  locked_task, current_request, admission_context: admission_context
+                )
                 return block_request(
                   current_request, "generation_conflict",
                   owner: "operator", request_locked: true
@@ -1273,9 +1277,11 @@ module Hive
         Hive::TaskResolver.new(target, project_filter: project, stage_filter: stage).resolve
       end
 
-      def resolve_generation(task, project:, intended_stage:, state_file_content:)
+      def resolve_generation(task, project:, intended_stage:, state_file_content:,
+                             admission_context: nil)
         progress = Hive::Attempts::Generation.artifact_token(
-          task, state_file_content: state_file_content
+          task, state_file_content: state_file_content,
+          admission_context: admission_context
         )
         Hive::Attempts::Generation.resolve(
           task: task,
@@ -1285,13 +1291,24 @@ module Hive
         )
       end
 
-      def generation_for_current(task, request)
-        @generation_resolver.call(
-          task,
-          project: request.project,
+      def generation_for_current(task, request, admission_context: nil)
+        call_generation_resolver(
+          task, project: request.project,
           intended_stage: request.expected_stage,
-          state_file_content: File.binread(task.state_file)
+          state_file_content: File.binread(task.state_file),
+          admission_context: admission_context
         )
+      end
+
+      def call_generation_resolver(task, project:, intended_stage:, state_file_content:,
+                                   admission_context: nil)
+        options = {
+          project: project,
+          intended_stage: intended_stage,
+          state_file_content: state_file_content
+        }
+        options[:admission_context] = admission_context if admission_context
+        @generation_resolver.call(task, **options)
       end
 
       def generation_matches?(generation, recovery)

--- a/lib/hive/dependency_admission.rb
+++ b/lib/hive/dependency_admission.rb
@@ -77,6 +77,10 @@ module Hive
         matches.one? ? matches.first : nil
       end
 
+      def project_path_match_count(path)
+        (@projects_by_path[File.expand_path(path)] || []).length
+      end
+
       # Read-only presentation inventory. Active snapshots precede fallback
       # snapshots so consumers can preserve the same active-shadows-archive
       # semantics without reaching into Context's private indexes or

--- a/lib/hive/dependency_snapshot.rb
+++ b/lib/hive/dependency_snapshot.rb
@@ -196,23 +196,35 @@ module Hive
     # holds, but it must not mask a later wait->clear (or validation) change.
     # Hash only the verdict for this task so unrelated fleet movement does not
     # create a fresh generation.
-    def admission_fingerprint(task, registry_entries: Hive::Config.registered_projects)
+    def admission_fingerprint(task, registry_entries: nil, admission_context: nil)
       root = File.expand_path(task.project_root)
-      matches = registry_entries.select do |entry|
-        File.expand_path(entry.fetch("path")) == root
-      end
-      payload = if matches.one?
-        project = matches.first.fetch("name")
-        verdict = admission_context(registry_entries).verdict(project: project, slug: task.slug)
-        error = verdict.admission_error
-        [
-          "hive-dependency-admission-v1", project, task.slug.to_s,
-          verdict.state.to_s, verdict.blocked_by.to_s, verdict.dependency_stage.to_s,
-          error&.reason_code.to_s, error&.offending_ref.to_s, error&.safe_correction.to_s
-        ]
+      if admission_context
+        match_count = admission_context.project_path_match_count(root)
+        project = admission_context.project_for_path(root)&.name
       else
-        [ "hive-dependency-admission-v1", "project_enrollment", matches.length, root, task.slug.to_s ]
+        registry_entries ||= Hive::Config.registered_projects
+        matches = registry_entries.select do |entry|
+          File.expand_path(entry.fetch("path")) == root
+        end
+        match_count = matches.length
+        project = matches.first.fetch("name") if matches.one?
       end
+      unless project
+        payload = [
+          "hive-dependency-admission-v1", "project_enrollment",
+          match_count, root, task.slug.to_s
+        ]
+        return ::Digest::SHA256.hexdigest(JSON.generate(payload))
+      end
+
+      admission_context ||= self.admission_context(registry_entries)
+      verdict = admission_context.verdict(project: project, slug: task.slug)
+      error = verdict.admission_error
+      payload = [
+        "hive-dependency-admission-v1", project, task.slug.to_s,
+        verdict.state.to_s, verdict.blocked_by.to_s, verdict.dependency_stage.to_s,
+        error&.reason_code.to_s, error&.offending_ref.to_s, error&.safe_correction.to_s
+      ]
       ::Digest::SHA256.hexdigest(JSON.generate(payload))
     rescue StandardError => e
       ::Digest::SHA256.hexdigest(

--- a/test/integration/content_workflow_daemon_e2e_test.rb
+++ b/test/integration/content_workflow_daemon_e2e_test.rb
@@ -1,17 +1,16 @@
 require "test_helper"
-require "json"
 require "shellwords"
 require "hive/cli"
 require "hive/attempts/context"
 require "hive/commands/init"
 require "hive/commands/new"
-require "hive/daemon/child_supervisor"
 require "hive/daemon/concurrency_controller"
 require "hive/daemon/dispatcher"
-require "hive/daemon/status_consumer"
+require_relative "../support/daemon_e2e_harness"
 
 class ContentWorkflowDaemonE2ETest < Minitest::Test
   include HiveTestHelper
+  include HiveDaemonE2EHarness
 
   def test_content_fixture_advances_from_init_new_to_terminal_stage
     descriptor = content_workflow
@@ -33,6 +32,7 @@ class ContentWorkflowDaemonE2ETest < Minitest::Test
               supervisor = InlineSupervisor.new(
                 run: ->(command) { capture_io { Hive::CLI.start(Shellwords.split(command).drop(1)) }; 0 }
               )
+              logger = CollectingLogger.new
               dispatcher = Hive::Daemon::Dispatcher.new(
                 config: { "daemon" => { "edit_debounce_sec" => 0, "poll_interval_sec" => 30 } },
                 controller: Hive::Daemon::ConcurrencyController.new(
@@ -41,30 +41,20 @@ class ContentWorkflowDaemonE2ETest < Minitest::Test
                   max_runs_per_day_per_project: 100
                 ),
                 supervisor: supervisor,
-                status_consumer: LiveStatusConsumer.new(
-                  fetch: lambda do
-                    out, = capture_io { Hive::CLI.start([ "status", "--json" ]) }
-                    doc = JSON.parse(out)
-                    mapper = Hive::Daemon::StatusConsumer.new
-                    Hive::Daemon::StatusConsumer::Result.new(
-                      ok: true,
-                      rows: mapper.send(:extract_rows, doc),
-                      projects: mapper.send(:extract_projects, doc),
-                      error: nil
-                    )
-                  end
-                ),
-                logger: CollectingLogger.new
+                status_consumer: LiveStatusConsumer.new(fetch: method(:status_snapshot)),
+                logger: logger
               )
+              name_generation_requests = install_inline_display_name_backfiller(dispatcher, logger: logger)
 
               24.times do
                 break if File.file?(File.join(task_folder(project_root, "4-done", slug), "done.md"))
 
-                now = Time.now
-                supervisor.now = now
-                dispatcher.tick(now: now)
+                advance_tick(dispatcher, supervisor)
               end
 
+              assert_equal %w[1-inbox 2-research 3-draft 4-done],
+                           name_generation_requests.map { |folder| File.basename(File.dirname(folder)) },
+                           "daemon E2E must exercise display-name backfill without external child processes"
               @spawned_commands = supervisor.spawned.map { |s| s[:command] }
             end
           end
@@ -93,76 +83,5 @@ class ContentWorkflowDaemonE2ETest < Minitest::Test
         end
       end
     end
-  end
-
-  private
-
-  class CollectingLogger
-    def event(_name, **_attrs); end
-    def close; end
-  end
-
-  class LiveStatusConsumer
-    def initialize(fetch:)
-      @fetch = fetch
-    end
-
-    def fetch
-      @fetch.call
-    end
-  end
-
-  class InlineSupervisor
-    ChildExit = Hive::Daemon::ChildSupervisor::ChildExit
-
-    attr_reader :spawned
-    attr_accessor :now
-
-    def initialize(run:)
-      @run = run
-      @spawned = []
-      @pending = []
-      @next_pid = 6000
-      @now = Time.now
-    end
-
-    def spawn(command_string:, project:, slug:, stage:,
-              log_state_path: nil, state_file_path: nil, dry_run: nil, request_id: nil)
-      pid = (@next_pid += 1)
-      @spawned << { command: command_string, project: project, slug: slug, stage: stage }
-      exit_code = @run.call(command_string)
-      @pending << ChildExit.new(
-        pid: pid,
-        exit_code: exit_code,
-        project: project,
-        slug: slug,
-        stage: stage,
-        command: command_string,
-        state_file_path: state_file_path,
-        started_at: @now,
-        finished_at: @now,
-        json_envelope: nil
-      )
-      pid
-    end
-
-    def reap_all(now: Time.now)
-      pending = @pending
-      @pending = []
-      pending
-    end
-
-    def reap_dry_run(now: Time.now)
-      []
-    end
-
-    def terminate_all(grace_sec: 600); end
-    def update_timeouts(**); end
-    def enforce_timeouts(now:) = []
-    def in_flight_count = @pending.size
-  end
-
-  def task_folder(project_root, stage, slug)
-    File.join(project_root, ".hive-state", "stages", stage, slug)
   end
 end

--- a/test/integration/dispatch_request_concurrency_test.rb
+++ b/test/integration/dispatch_request_concurrency_test.rb
@@ -92,19 +92,27 @@ class HiveDispatchRequestConcurrencyTest < Minitest::Test
     )
     @dispatcher.define_singleton_method(:project_enabled?) { |_| true }
     @original_find_project = Hive::Config.method(:find_project)
+    @original_registered_projects = Hive::Config.method(:registered_projects)
     project = @project
     state_home = @state_home
     hive_state = @hive_state_path
+    project_entry = { "name" => project, "path" => state_home, "hive_state_path" => hive_state }
     Hive::Config.define_singleton_method(:find_project) do |name|
       next nil unless name == project
 
-      { "name" => project, "path" => state_home, "hive_state_path" => hive_state }
+      project_entry
     end
+    Hive::Config.define_singleton_method(:registered_projects) { [ project_entry ] }
   end
 
   def teardown
     FileUtils.remove_entry(@state_home) if @state_home && File.exist?(@state_home)
     Hive::Config.define_singleton_method(:find_project, @original_find_project) if @original_find_project
+    if @original_registered_projects
+      Hive::Config.define_singleton_method(
+        :registered_projects, @original_registered_projects
+      )
+    end
   end
 
   def queue_files

--- a/test/integration/dispatch_request_roundtrip_test.rb
+++ b/test/integration/dispatch_request_roundtrip_test.rb
@@ -121,18 +121,26 @@ class HiveDispatchRequestRoundtripTest < Minitest::Test
 
   def stub_find_project!
     @original_find_project = Hive::Config.method(:find_project)
+    @original_registered_projects = Hive::Config.method(:registered_projects)
     state_home = @state_home
     project = @project
     hive_state = @hive_state_path
+    project_entry = { "name" => project, "path" => state_home, "hive_state_path" => hive_state }
     Hive::Config.define_singleton_method(:find_project) do |name|
       next nil unless name == project
 
-      { "name" => project, "path" => state_home, "hive_state_path" => hive_state }
+      project_entry
     end
+    Hive::Config.define_singleton_method(:registered_projects) { [ project_entry ] }
   end
 
   def restore_find_project!
     Hive::Config.define_singleton_method(:find_project, @original_find_project) if @original_find_project
+    if @original_registered_projects
+      Hive::Config.define_singleton_method(
+        :registered_projects, @original_registered_projects
+      )
+    end
   end
 
   def needs_input_row(mtime:)

--- a/test/integration/dispatch_request_uniqueness_test.rb
+++ b/test/integration/dispatch_request_uniqueness_test.rb
@@ -72,16 +72,26 @@ class HiveDispatchRequestUniquenessTest < Minitest::Test
     )
     @dispatcher.define_singleton_method(:project_enabled?) { |_| true }
     @original_find_project = Hive::Config.method(:find_project)
+    @original_registered_projects = Hive::Config.method(:registered_projects)
     project = @project
     state_home = @state_home
+    project_entry = {
+      "name" => project, "path" => state_home, "hive_state_path" => state_home
+    }
     Hive::Config.define_singleton_method(:find_project) do |name|
-      name == project ? { "name" => project, "path" => state_home, "hive_state_path" => state_home } : nil
+      name == project ? project_entry : nil
     end
+    Hive::Config.define_singleton_method(:registered_projects) { [ project_entry ] }
   end
 
   def teardown
     FileUtils.remove_entry(@state_home) if @state_home && File.exist?(@state_home)
     Hive::Config.define_singleton_method(:find_project, @original_find_project) if @original_find_project
+    if @original_registered_projects
+      Hive::Config.define_singleton_method(
+        :registered_projects, @original_registered_projects
+      )
+    end
   end
 
   def queue_files

--- a/test/integration/regression_redundant_redispatch_test.rb
+++ b/test/integration/regression_redundant_redispatch_test.rb
@@ -119,19 +119,27 @@ class HiveRegressionRedundantRedispatchTest < Minitest::Test
     )
     @dispatcher.define_singleton_method(:project_enabled?) { |_| true }
     @original_find_project = Hive::Config.method(:find_project)
+    @original_registered_projects = Hive::Config.method(:registered_projects)
     project = @project
     state_home = @state_home
     hive_state = @hive_state_path
+    project_entry = { "name" => project, "path" => state_home, "hive_state_path" => hive_state }
     Hive::Config.define_singleton_method(:find_project) do |name|
       next nil unless name == project
 
-      { "name" => project, "path" => state_home, "hive_state_path" => hive_state }
+      project_entry
     end
+    Hive::Config.define_singleton_method(:registered_projects) { [ project_entry ] }
   end
 
   def teardown
     FileUtils.remove_entry(@state_home) if @state_home && File.exist?(@state_home)
     Hive::Config.define_singleton_method(:find_project, @original_find_project) if @original_find_project
+    if @original_registered_projects
+      Hive::Config.define_singleton_method(
+        :registered_projects, @original_registered_projects
+      )
+    end
   end
 
   def needs_input_row(mtime:)

--- a/test/unit/daemon/dispatcher_test.rb
+++ b/test/unit/daemon/dispatcher_test.rb
@@ -838,6 +838,40 @@ class HiveDaemonDispatcherTest < Minitest::Test
     refute logger.events.any? { |name, _| name == :dispatch_request_rejected }
   end
 
+  def test_dispatch_request_scan_caches_registry_failure_without_pacing_recoveries
+    coordinator = FakeRecoveryCoordinator.new(status: "blocked")
+    dispatcher, _supervisor, _controller, logger = make_dispatcher(
+      rows: [], recovery_coordinator: coordinator
+    )
+    requests = recovery_scan_requests("s1", "s2")
+    rows = recovery_scan_rows("s1", "s2")
+    registry_reads = 0
+
+    with_replaced_singleton_method(Q, :pending, ->(**) { requests }) do
+      with_replaced_singleton_method(
+        Hive::Config, :registered_projects,
+        lambda do
+          registry_reads += 1
+          raise "project registry unavailable"
+        end
+      ) do
+        dispatcher.send(:process_dispatch_requests, now: T0, rows: rows)
+      end
+    end
+
+    assert_equal 1, registry_reads
+    assert_empty coordinator.resumes
+    assert_empty coordinator.deferred
+    blocked = logger.events.filter_map do |name, attributes|
+      next unless name == :dispatch_request_blocked
+      next unless attributes[:reason] == "project_registry_unavailable"
+
+      attributes[:request_id]
+    end
+    assert_equal %w[recovery-s1 recovery-s2], blocked
+    refute logger.events.any? { |name, _| name == :dispatch_request_rejected }
+  end
+
   def test_recovery_request_waits_when_the_status_observation_is_missing
     coordinator = FakeRecoveryCoordinator.new(status: "queued")
     dispatcher, supervisor, _controller, logger = make_dispatcher(

--- a/test/unit/daemon/dispatcher_test.rb
+++ b/test/unit/daemon/dispatcher_test.rb
@@ -339,8 +339,11 @@ class HiveDaemonDispatcherTest < Minitest::Test
       }
     end
 
-    def resume(request:, row:, now: nil)
-      @resumes << { request: request, row: row, now: now }
+    def resume(request:, row:, now: nil, admission_context: nil)
+      @resumes << {
+        request: request, row: row, now: now,
+        admission_context: admission_context
+      }
       Hive::Daemon::RecoveryCoordinator::Receipt.new(
         status: @status,
         request_id: request.request_id,
@@ -742,6 +745,97 @@ class HiveDaemonDispatcherTest < Minitest::Test
     assert_equal 3, coordinator.resumes.size
     assert_empty supervisor.spawned
     assert_equal 0, controller.daily_count_for("p1", T0)
+  end
+
+  def test_dispatch_request_scan_reuses_one_admission_context_for_all_recoveries
+    coordinator = FakeRecoveryCoordinator.new(status: "blocked")
+    dispatcher, = make_dispatcher(rows: [], recovery_coordinator: coordinator)
+    requests = recovery_scan_requests("s1", "s2")
+    rows = recovery_scan_rows("s1", "s2")
+    rows.define_singleton_method(:find) do |*|
+      raise "dispatch scan must use its row index"
+    end
+    admission_context = Hive::DependencyAdmission::Context.new(projects: [])
+    context_builds = 0
+    registry_reads = 0
+
+    with_replaced_singleton_method(Q, :pending, ->(**) { requests }) do
+      with_replaced_singleton_method(
+        Hive::Config, :registered_projects,
+        lambda do
+          registry_reads += 1
+          [ { "name" => "p1", "path" => "/tmp/p1" } ]
+        end
+      ) do
+        with_replaced_singleton_method(
+          Hive::DependencySnapshot, :admission_context,
+          lambda do |_projects|
+            context_builds += 1
+            admission_context
+          end
+        ) do
+          dispatcher.send(:process_dispatch_requests, now: T0, rows: rows)
+        end
+      end
+    end
+
+    assert_equal 1, registry_reads
+    assert_equal 1, context_builds
+    assert_equal [ admission_context, admission_context ],
+                 coordinator.resumes.map { |entry| entry.fetch(:admission_context) }
+  end
+
+  def test_empty_dispatch_request_scan_skips_global_index_work
+    dispatcher, = make_dispatcher(rows: [])
+    rows = Object.new
+    rows.define_singleton_method(:each) { raise "empty queue must not index status rows" }
+
+    with_replaced_singleton_method(Q, :pending, ->(**) { [] }) do
+      with_replaced_singleton_method(
+        Hive::Config, :registered_projects,
+        -> { raise "empty queue must not read the registry" }
+      ) do
+        dispatcher.send(:process_dispatch_requests, now: T0, rows: rows)
+      end
+    end
+  end
+
+  def test_dispatch_request_scan_caches_context_build_failure_and_continues
+    coordinator = FakeRecoveryCoordinator.new(status: "blocked")
+    dispatcher, _supervisor, _controller, logger = make_dispatcher(
+      rows: [], recovery_coordinator: coordinator
+    )
+    requests = recovery_scan_requests("s1", "s2")
+    rows = recovery_scan_rows("s1", "s2")
+    context_builds = 0
+
+    with_replaced_singleton_method(Q, :pending, ->(**) { requests }) do
+      with_replaced_singleton_method(
+        Hive::Config, :registered_projects,
+        -> { [ { "name" => "p1", "path" => "/tmp/p1" } ] }
+      ) do
+        with_replaced_singleton_method(
+          Hive::DependencySnapshot, :admission_context,
+          lambda do |_projects|
+            context_builds += 1
+            raise "fleet snapshot unavailable"
+          end
+        ) do
+          dispatcher.send(:process_dispatch_requests, now: T0, rows: rows)
+        end
+      end
+    end
+
+    assert_equal 1, context_builds
+    assert_empty coordinator.resumes
+    blocked = logger.events.filter_map do |name, attributes|
+      next unless name == :dispatch_request_blocked
+      next unless attributes[:reason] == "admission_context_unavailable"
+
+      attributes[:request_id]
+    end
+    assert_equal %w[recovery-s1 recovery-s2], blocked
+    refute logger.events.any? { |name, _| name == :dispatch_request_rejected }
   end
 
   def test_recovery_request_waits_when_the_status_observation_is_missing
@@ -6363,8 +6457,18 @@ end
 
   def stub_find_project!(dispatcher, project_name)
     Hive::Config.singleton_class.alias_method(:__orig_find_project, :find_project) unless Hive::Config.singleton_class.method_defined?(:__orig_find_project)
+    Hive::Config.singleton_class.alias_method(:__orig_registered_projects, :registered_projects) unless Hive::Config.singleton_class.method_defined?(:__orig_registered_projects)
     Hive::Config.define_singleton_method(:find_project) do |name|
       name == project_name ? { "name" => project_name, "path" => "/tmp/nonexistent", "hive_state_path" => "/tmp/nonexistent/.hive-state" } : nil
+    end
+    Hive::Config.define_singleton_method(:registered_projects) do
+      [
+        {
+          "name" => project_name,
+          "path" => "/tmp/nonexistent",
+          "hive_state_path" => "/tmp/nonexistent/.hive-state"
+        }
+      ]
     end
     dispatcher
   end
@@ -6372,6 +6476,11 @@ end
   def restore_find_project!
     if Hive::Config.singleton_class.method_defined?(:__orig_find_project)
       Hive::Config.define_singleton_method(:find_project, Hive::Config.method(:__orig_find_project))
+    end
+    if Hive::Config.singleton_class.method_defined?(:__orig_registered_projects)
+      Hive::Config.define_singleton_method(
+        :registered_projects, Hive::Config.method(:__orig_registered_projects)
+      )
     end
   end
 
@@ -7876,6 +7985,30 @@ end
   end
 
   private
+
+  def recovery_scan_requests(*slugs)
+    slugs.map do |slug|
+      Hive::Daemon::DispatchRequestQueue::Request.new(
+        request_id: "recovery-#{slug}", created_at: T0,
+        project: "p1", slug: slug,
+        argv: [ "hive", "run", slug, "--stage", "4-execute", "--project", "p1", "--json" ],
+        requestor: "web", trigger: "recovery",
+        task_generation: "c" * 64, task_id: 1,
+        expected_stage: "4-execute", expected_marker_name: "error",
+        expected_marker_id: "m1", recovery: dispatcher_recovery,
+        schema_version: 5
+      )
+    end
+  end
+
+  def recovery_scan_rows(*slugs)
+    slugs.map do |slug|
+      row(
+        slug: slug, stage: "4-execute", marker: "error", action: "error",
+        marker_attrs: { "reason" => "timeout", "marker_id" => "m1" }
+      )
+    end
+  end
 
   def dispatcher_recovery(phase: "admitted")
     {

--- a/test/unit/daemon/recovery_coordinator_test.rb
+++ b/test/unit/daemon/recovery_coordinator_test.rb
@@ -354,6 +354,40 @@ class HiveDaemonRecoveryCoordinatorTest < Minitest::Test
     end
   end
 
+  def test_resume_reuses_the_scan_admission_context_for_every_generation_check
+    observed_contexts = []
+    resolver = lambda do |resolved_task, project:, intended_stage:, state_file_content:,
+                          admission_context: nil|
+      observed_contexts << admission_context
+      progress = Digest::SHA256.hexdigest(
+        [ resolved_task.state_file, state_file_content ].join("\0")
+      )
+      FakeGeneration.new(
+        progress_token: progress,
+        task_generation: Digest::SHA256.hexdigest(
+          [ project, intended_stage, progress ].join("\0")
+        )
+      )
+    end
+
+    with_fixture(generation_resolver: resolver) do |coordinator, row, state_home|
+      coordinator.request(
+        row: row, requestor: "web", request_id: "recover-context", now: NOW
+      )
+      request = Q.pending(state_home: state_home).fetch(0)
+      observed_contexts.clear
+      admission_context = Object.new
+
+      resumed = coordinator.resume(
+        request: request, row: row, admission_context: admission_context
+      )
+
+      assert_equal "cleared", resumed.phase
+      refute_empty observed_contexts
+      assert observed_contexts.all? { |context| context.equal?(admission_context) }
+    end
+  end
+
   def test_resume_matches_unicode_marker_attrs_after_json_round_trip
     attrs = {
       "reason" => "implementer_failed",
@@ -1784,7 +1818,8 @@ class HiveDaemonRecoveryCoordinatorTest < Minitest::Test
   end
 
   def with_fixture(marker_attrs: nil, marker_name: "ERROR", mtime: NOW - 3600,
-                   safety: nil, task_resolver_builder: nil, task_id: 817)
+                   safety: nil, task_resolver_builder: nil, task_id: 817,
+                   generation_resolver: nil)
     Dir.mktmpdir("hive-recovery-coordinator") do |dir|
       folder = File.join(dir, "task")
       FileUtils.mkdir_p(folder)
@@ -1812,7 +1847,7 @@ class HiveDaemonRecoveryCoordinatorTest < Minitest::Test
         state_home: dir,
         task_resolver: task_resolver,
         safety: safety || ->(_row) { [ true, "safe" ] },
-        generation_resolver: lambda do |resolved_task, project:, intended_stage:, state_file_content:|
+        generation_resolver: generation_resolver || lambda do |resolved_task, project:, intended_stage:, state_file_content:|
           progress = Digest::SHA256.hexdigest(
             [ resolved_task.state_file, state_file_content ].join("\0")
           )

--- a/test/unit/dependency_snapshot_test.rb
+++ b/test/unit/dependency_snapshot_test.rb
@@ -148,6 +148,65 @@ class DependencySnapshotTest < Minitest::Test
     end
   end
 
+  def test_admission_fingerprint_reuses_a_supplied_context
+    with_tmp_dir do |root|
+      slug = "independent-task"
+      write_task_meta(root, "4-execute", slug, id: 1)
+      project = File.basename(root)
+      task = FakeTask.new(slug: slug, id: 1, folder: execute_folder(root, slug),
+                          project_root: root, project_name: project)
+      registry_entries = [
+        { "name" => project, "path" => root, "repository_identity" => nil }
+      ]
+      context = Hive::DependencySnapshot.admission_context(registry_entries)
+
+      fingerprint = with_replaced_singleton_method(
+        Hive::DependencySnapshot, :admission_context,
+        ->(*) { raise "supplied context must avoid another fleet snapshot" }
+      ) do
+        Hive::DependencySnapshot.admission_fingerprint(
+          task, admission_context: context
+        )
+      end
+      expected_payload = [
+        "hive-dependency-admission-v1", project, slug,
+        "clear", "", "", "", "", ""
+      ]
+
+      assert_equal Digest::SHA256.hexdigest(JSON.generate(expected_payload)), fingerprint
+    end
+  end
+
+  def test_supplied_context_preserves_project_enrollment_fingerprints
+    with_tmp_dir do |root|
+      slug = "independent-task"
+      write_task_meta(root, "4-execute", slug, id: 1)
+      task = FakeTask.new(
+        slug: slug, id: 1, folder: execute_folder(root, slug),
+        project_root: root, project_name: File.basename(root)
+      )
+      registries = [
+        [],
+        [
+          { "name" => "first", "path" => root, "repository_identity" => nil },
+          { "name" => "second", "path" => root, "repository_identity" => nil }
+        ]
+      ]
+
+      registries.each do |registry_entries|
+        context = Hive::DependencySnapshot.admission_context(registry_entries)
+        without_context = Hive::DependencySnapshot.admission_fingerprint(
+          task, registry_entries: registry_entries
+        )
+        with_context = Hive::DependencySnapshot.admission_fingerprint(
+          task, admission_context: context
+        )
+
+        assert_equal without_context, with_context
+      end
+    end
+  end
+
   def test_semantic_fingerprint_is_order_independent_and_includes_fallback_layers
     task = lambda do |slug, depends_on = nil|
       Hive::DependencyAdmission::TaskSnapshot.new(

--- a/wiki/log.d/20260823T134615Z-dispatch-recovery-admission-context.md
+++ b/wiki/log.d/20260823T134615Z-dispatch-recovery-admission-context.md
@@ -1,0 +1,22 @@
+---
+title: Reuse dependency admission context across recovery requests
+type: change
+date: 2026-08-23
+tags: [daemon, recovery, dependencies, performance]
+---
+
+The daemon now builds at most one dependency-admission context while draining
+a dispatch-request queue snapshot and passes it through every recovery
+generation check. The context's project/task indexes and verdict cache replace
+one full fleet traversal per recovery request, while task identity and state
+files remain revalidated under each task lock. A failed context build is also
+cached for that scan so an unhealthy fleet cannot restore the N+1 path; affected
+requests remain queued with an `admission_context_unavailable` block instead of
+being paced as spawn failures. Empty queues skip index setup entirely, and the
+context path preserves zero/duplicate project-enrollment fingerprints through
+its existing path index.
+
+On the live local corpus, 92 recovery requests shared a 1.657-second context;
+resolving and hashing the 68 still-present tasks took 3.075 seconds total. The
+earlier daemon profile spent about 25 seconds in repeated generation-context
+construction for the same queue phase.

--- a/wiki/log.d/20260823T134615Z-dispatch-recovery-admission-context.md
+++ b/wiki/log.d/20260823T134615Z-dispatch-recovery-admission-context.md
@@ -14,7 +14,9 @@ cached for that scan so an unhealthy fleet cannot restore the N+1 path; affected
 requests remain queued with an `admission_context_unavailable` block instead of
 being paced as spawn failures. Empty queues skip index setup entirely, and the
 context path preserves zero/duplicate project-enrollment fingerprints through
-its existing path index.
+its existing path index. A failed project-registry read is also cached once per
+scan and blocks project-scoped requests as `project_registry_unavailable`
+without pacing recoveries as failed spawns.
 
 On the live local corpus, 92 recovery requests shared a 1.657-second context;
 resolving and hashing the 68 still-present tasks took 3.075 seconds total. The

--- a/wiki/modules/daemon.md
+++ b/wiki/modules/daemon.md
@@ -756,6 +756,16 @@ recovery receipts remain durable for history, while filesystem pruning is
 throttled to one pass per hour so a five-second dispatcher loop does not
 rescan and rewrite retention state continuously.
 
+Recovery generation checks also share one immutable dependency-admission
+context per queue scan. The dispatcher creates it lazily only when a recovery
+request reaches the coordinator, then reuses its global project/task indexes
+and verdict cache for every later request in that scan. Each request still
+re-resolves its canonical task and reads that task's state file under the task
+lock. Empty request queues skip all global-index setup. A context-build failure
+is retained for the rest of the scan and blocks each affected request as
+`admission_context_unavailable`, without repeating the fleet traversal or
+misclassifying the failure as a spawn error.
+
 ```
 :dispatch_request_observed   request_id=… project=… slug=…
 :dispatch_request_dispatched pid=… command=…   (only when dispatched)

--- a/wiki/modules/daemon.md
+++ b/wiki/modules/daemon.md
@@ -764,7 +764,10 @@ re-resolves its canonical task and reads that task's state file under the task
 lock. Empty request queues skip all global-index setup. A context-build failure
 is retained for the rest of the scan and blocks each affected request as
 `admission_context_unavailable`, without repeating the fleet traversal or
-misclassifying the failure as a spawn error.
+misclassifying the failure as a spawn error. A project-registry read failure is
+likewise read once and blocks project-scoped requests as
+`project_registry_unavailable`; recovery requests remain queued without
+dispatch-failure pacing.
 
 ```
 :dispatch_request_observed   request_id=… project=… slug=…

--- a/wiki/modules/task_dependencies.md
+++ b/wiki/modules/task_dependencies.md
@@ -153,6 +153,12 @@ metadata reads. File-backed dispatch requests for run/advance/archive verbs
 are checked against the same tick's status row before spawn and remain queued
 on a dependency wait or admission error. `hive markers ...` repair requests
 are deliberately exempt so an operator can repair stale/corrupt marker state.
+A full dispatch-request scan constructs one immutable admission context for
+recovery generation validation. Its indexed verdicts are reused across queued
+requests; per-task state files and task identity are still revalidated under
+each task lock. Fingerprints resolve the task's project from the context's path
+index, preserving the same zero/duplicate-enrollment payload as the uncached
+path without rescanning the fleet.
 A task-local admission error exits 78 without dropping the entire enrolled
 project from daemon scheduling.
 


### PR DESCRIPTION
## Summary

- Build the dispatch-request project and row indexes once per queue scan instead of repeating global lookups for every recovery request.
- Build one lazy dependency-admission context and pass it through every recovery generation check while preserving per-task locked reads and enrollment fingerprints.
- Skip all global setup on an empty queue and keep context or registry failures cached, explicit, and request-safe.

## Test plan

- [x] Focused unit tests: dispatcher 285 runs / 1,034 assertions; recovery 53 / 318; dependency snapshot 25 / 71; dependency admission 17 / 80; generation 11 / 32.
- [x] Request integration tests: 6 runs / 41 assertions across concurrency, roundtrip, uniqueness, and redundant-redispatch behavior.
- [x] Coverage shard 1 replay: 3,388 runs / 221,755 assertions, with a stable manifest matching all 496 process results after collection settled.
- [x] RuboCop clean for all 13 changed Ruby source/test files; `git diff --check` clean.
- [x] Broad default checkpoint completed 13,315 runs / 274,106 assertions. It found three fixtures still stubbing the removed per-request lookup; all were corrected and their affected integration files are green.
- [ ] Hosted exact-head CI, coverage, and dedicated merge gates green.

## Notes for reviewer

The live queue had 92 recovery requests. Before this change, the recovery phase spent about 25 seconds rebuilding fleet dependency context per request. A read-only profile of the bounded path built one context in 1.657 seconds and resolved/fingerprinted the 68 still-present tasks in 3.075 seconds total; 24 stale request paths did not resolve.

The context is immutable for one queue scan. Every task is still resolved canonically and its state file is read under the task lock. Final command-side dependency admission remains the safety boundary. A context-build failure is cached for the scan and reports `admission_context_unavailable` without repeated fleet traversals or spawn-failure pacing. A project-registry read failure is likewise read once and reports `project_registry_unavailable` without rewriting every recovery as a failed spawn.

The first hosted run exposed an older daemon E2E test that launched a detached `hive generate-name` child after its coverage manifest was sealed. That test now uses the repository's shared process-local daemon harness; the exact local shard replay proved the sealed manifest remained stable.

The full `bundle exec rake test` prerequisite remains locally blocked before the default suite by the known OpenCode inventory error for `openrouter/stealth/ox-alpha`; hosted CI is the exact-head authority for that separate runtime gate.
