### PR TITLE
perf(daemon): cache unchanged Patrol admission records

### DIFF
--- a/lib/hive/daemon/patrol_fix_runtime.rb
+++ b/lib/hive/daemon/patrol_fix_runtime.rb
@@ -33,6 +33,7 @@ module Hive
         @decision_runner_factory = decision_runner_factory || lambda do |**arguments|
           Hive::Daemon::PatrolFixSemanticDecisionRunner.new(**arguments)
         end
+        @admission_stores = {}
       end
 
       # The project registry is mutable while the one production daemon stays
@@ -96,14 +97,20 @@ module Hive
       end
 
       def build_sources(entries)
-        entries.map do |entry|
+        active_roots = {}
+        sources = entries.map do |entry|
+          admission_root = File.join(
+            entry.fetch("hive_state_path"), "patrol-fix", "admissions"
+          )
+          active_roots[admission_root] = true
           Source.new(
             entry: entry,
-            store: Hive::PatrolFix::AdmissionStore.new(
-              root: File.join(entry.fetch("hive_state_path"), "patrol-fix", "admissions")
-            )
+            store: (@admission_stores[admission_root] ||=
+              Hive::PatrolFix::AdmissionStore.new(root: admission_root))
           )
         end
+        @admission_stores.delete_if { |root, _store| !active_roots.key?(root) }
+        sources
       end
 
       def normalize_entry(raw)

--- a/lib/hive/patrol_fix/admission_store.rb
+++ b/lib/hive/patrol_fix/admission_store.rb
@@ -14,6 +14,8 @@ module Hive
       SCHEMA_VERSION = 2
       MAX_RECORD_BYTES = 512 * 1024
       MAX_RECORDS = 8_192
+      MAX_CACHE_BYTES = 16 * 1024 * 1024
+      MAX_CACHE_RECORDS = 512
       MAX_CANDIDATES = 64
       MAX_CANDIDATE_BYTES = 6 * 1024
       MAX_CANDIDATE_CONTEXT_BYTES = 192 * 1024
@@ -43,6 +45,8 @@ module Hive
       def initialize(root:)
         @root = File.expand_path(root)
         @directory = Hive::ManagedDirectory.new(root: @root, label: "Patrol-fix admission store")
+        @record_cache = {}
+        @record_cache_bytes = 0
       end
 
       def reserve!(occurrence_id:, snapshot:, now: Time.now.utc)
@@ -75,7 +79,12 @@ module Hive
       def fetch(occurrence_id)
         id = occurrence_id!(occurrence_id)
         bytes = @directory.read(record_path(id), max_bytes: MAX_RECORD_BYTES, missing: true)
-        bytes && parse_record(bytes, expected_id: id)
+        unless bytes
+          delete_cached_record(id)
+          return
+        end
+
+        validated_record(id, bytes)
       end
 
       def prepare_decision!(occurrence_id, candidates:, current_head:, inventory: nil,
@@ -440,22 +449,26 @@ module Hive
           record = parse_record(bytes, expected_id: id)
           next unless record.fetch("status") == "acknowledged"
 
-          [ record.dig("acknowledgement", "acknowledged_at"), record.fetch("created_at"), name, bytes ]
+          [
+            record.dig("acknowledgement", "acknowledged_at"),
+            record.fetch("created_at"), id, name, bytes
+          ]
         end.sort
         if removable.length < required
           conflict!("admission capacity contains active work")
         end
         selected = removable.first(required)
         index, index_bytes = read_pending_index
-        selected.each do |_acknowledged_at, _created_at, name, _bytes|
-          set_pending_index_entry(index, name.delete_suffix(".json"), UNINDEXED)
+        selected.each do |_acknowledged_at, _created_at, id, _name, _bytes|
+          set_pending_index_entry(index, id, UNINDEXED)
         end
         write_pending_index(index, previous_bytes: index_bytes)
-        selected.each do |_acknowledged_at, _created_at, name, bytes|
+        selected.each do |_acknowledged_at, _created_at, id, name, bytes|
           @directory.unlink(
             File.join("records", name),
             expected_digest: Digest::SHA256.hexdigest(bytes), max_bytes: MAX_RECORD_BYTES
           )
+          delete_cached_record(id)
         end
       end
 
@@ -492,7 +505,7 @@ module Hive
             max_bytes: MAX_RECORD_BYTES, missing: true
           ).map do |name, bytes|
             id = name.delete_suffix(".json")
-            bytes && parse_record(bytes, expected_id: id)
+            bytes && validated_record(id, bytes)
           end
         end || []
       end
@@ -510,7 +523,55 @@ module Hive
           records << occurrence_id!(match[1])
           corrupt!("admission inventory exceeds the bounded limit") if records.length > MAX_RECORDS
         end
-        records.sort
+        ids = records.sort
+        live = ids.to_h { |id| [ id, true ] }
+        @record_cache.keys.each do |id|
+          delete_cached_record(id) unless live.key?(id)
+        end
+        ids
+      end
+
+      # Durable bytes remain authoritative on every read. Re-reading the
+      # bounded file detects external writers; unchanged SHA-256 bytes reuse
+      # the already deep-frozen, fully validated record instead of repeating
+      # schema and source validation on every daemon tick.
+      def validated_record(id, bytes)
+        digest = Digest::SHA256.hexdigest(bytes)
+        cached = @record_cache[id]
+        return cached.fetch(:record) if cached && cached.fetch(:digest) == digest
+
+        delete_cached_record(id) if cached
+        record = parse_record(bytes, expected_id: id)
+        cache_record(id, digest, record, bytes.bytesize, evict: !cached.nil?)
+        record
+      end
+
+      # An inventory scan keeps a stable bounded subset instead of churning
+      # through every record once the budget is full. Writes and changed cached
+      # records may evict the oldest entries so active work stays warm.
+      def cache_record(id, digest, record, bytesize, evict: false)
+        delete_cached_record(id)
+        return if bytesize > MAX_CACHE_BYTES
+
+        while evict && cache_full?(bytesize) && !@record_cache.empty?
+          delete_cached_record(@record_cache.each_key.first)
+        end
+        return if cache_full?(bytesize)
+
+        @record_cache[id] = {
+          digest: digest, record: record, bytesize: bytesize
+        }.freeze
+        @record_cache_bytes += bytesize
+      end
+
+      def cache_full?(bytesize)
+        @record_cache.length >= MAX_CACHE_RECORDS ||
+          @record_cache_bytes + bytesize > MAX_CACHE_BYTES
+      end
+
+      def delete_cached_record(id)
+        cached = @record_cache.delete(id)
+        @record_cache_bytes -= cached.fetch(:bytesize) if cached
       end
 
       def mutate(occurrence_id, create: false, &block)
@@ -522,7 +583,7 @@ module Hive
         @directory.with_lock(File.join("records", "#{id}.lock")) do
           relative = record_path(id)
           original = @directory.read(relative, max_bytes: MAX_RECORD_BYTES, missing: true)
-          record = original && parse_record(original, expected_id: id)
+          record = original && validated_record(id, original)
           conflict!("admission occurrence is missing") unless record || create
           replacement = yield(record && PatrolFix.deep_copy(record))
           validate_record!(replacement, expected_id: id)
@@ -556,7 +617,11 @@ module Hive
             set_pending_index_entry(index, id, replacement_entry)
             write_pending_index(index, previous_bytes: index_bytes)
           end
-          PatrolFix.deep_freeze(replacement)
+          frozen = PatrolFix.deep_freeze(replacement)
+          cache_record(
+            id, Digest::SHA256.hexdigest(bytes), frozen, bytes.bytesize, evict: true
+          )
+          frozen
         end
       rescue Hive::ManagedDirectory::UnsafeError => e
         corrupt!(e.message)

--- a/test/unit/daemon/patrol_fix_runtime_test.rb
+++ b/test/unit/daemon/patrol_fix_runtime_test.rb
@@ -27,6 +27,45 @@ class HiveDaemonPatrolFixRuntimeTest < Minitest::Test
     end
   end
 
+  def test_reuses_admission_store_while_registry_entry_is_unchanged
+    with_tmp_dir do |dir|
+      entry = {
+        "name" => "alpha", "path" => File.join(dir, "alpha"),
+        "hive_state_path" => File.join(dir, "alpha", ".hive-state")
+      }
+      runtime = Hive::Daemon::PatrolFixRuntime.new(
+        registry: -> { [ entry ] }, config_loader: ->(_path) { {} }
+      )
+
+      first = runtime.sources.fetch(0).store
+      second = runtime.sources.fetch(0).store
+
+      assert_same first, second,
+                  "full daemon ticks should retain the validated admission-record cache"
+    end
+  end
+
+  def test_discards_admission_store_after_registry_entry_is_removed
+    with_tmp_dir do |dir|
+      entry = {
+        "name" => "alpha", "path" => File.join(dir, "alpha"),
+        "hive_state_path" => File.join(dir, "alpha", ".hive-state")
+      }
+      entries = [ entry ]
+      runtime = Hive::Daemon::PatrolFixRuntime.new(
+        registry: -> { entries }, config_loader: ->(_path) { {} }
+      )
+      original = runtime.sources.fetch(0).store
+
+      entries.clear
+      assert_empty runtime.sources
+      entries << entry
+
+      refute_same original, runtime.sources.fetch(0).store,
+                  "re-registering a project must not revive its discarded record cache"
+    end
+  end
+
   def test_provider_is_constructed_only_by_reserved_child_execution
     with_tmp_git_repo do |project_root|
       hive_state = File.join(project_root, ".hive-state")

--- a/test/unit/patrol_fix/admission_store_test.rb
+++ b/test/unit/patrol_fix/admission_store_test.rb
@@ -615,6 +615,80 @@ class PatrolFixAdmissionStoreTest < Minitest::Test
     end
   end
 
+  def test_pending_reuses_validated_records_when_durable_bytes_are_unchanged
+    Dir.mktmpdir do |dir|
+      writer = Hive::PatrolFix::AdmissionStore.new(root: dir)
+      3.times do |index|
+        writer.reserve!(
+          occurrence_id: "cached-finding-#{index}",
+          snapshot: source_snapshot(identity: "finding-#{index}"), now: NOW
+        )
+      end
+      reader = Hive::PatrolFix::AdmissionStore.new(root: dir)
+      parse_calls = 0
+      original = reader.method(:parse_record)
+      reader.define_singleton_method(:parse_record) do |bytes, expected_id:|
+        parse_calls += 1
+        original.call(bytes, expected_id: expected_id)
+      end
+
+      first = reader.pending(now: NOW)
+      second = reader.pending(now: NOW + 1)
+
+      assert_equal first, second
+      assert_equal 3, parse_calls,
+                   "unchanged admission records should be validated only once per store"
+
+      path = File.join(dir, "records", "cached-finding-1.json")
+      changed = JSON.parse(File.binread(path))
+      changed["updated_at"] = (NOW + 2).iso8601
+      File.binwrite(path, Hive::PatrolFix.canonical_json(changed))
+
+      refreshed = reader.pending(now: NOW + 2)
+
+      assert_equal (NOW + 2).iso8601,
+                   refreshed.find { |record| record["occurrence_id"] == "cached-finding-1" }
+                            .fetch("updated_at")
+      assert_equal 4, parse_calls,
+                   "changed durable bytes must invalidate the validated-record cache"
+    end
+  end
+
+  def test_record_cache_respects_entry_and_byte_budgets_without_scan_churn
+    Dir.mktmpdir do |dir|
+      writer = Hive::PatrolFix::AdmissionStore.new(root: dir)
+      3.times do |index|
+        writer.reserve!(
+          occurrence_id: "bounded-cache-#{index}",
+          snapshot: source_snapshot(identity: "finding-#{index}"), now: NOW
+        )
+      end
+      paths = Dir[File.join(dir, "records", "*.json")].sort
+      byte_budget = paths.first(2).sum { |path| File.size(path) }
+
+      with_cache_limits(records: 2, bytes: byte_budget) do
+        reader = Hive::PatrolFix::AdmissionStore.new(root: dir)
+        parse_calls = 0
+        original = reader.method(:parse_record)
+        reader.define_singleton_method(:parse_record) do |bytes, expected_id:|
+          parse_calls += 1
+          original.call(bytes, expected_id: expected_id)
+        end
+
+        reader.pending(now: NOW)
+        cache = reader.instance_variable_get(:@record_cache)
+
+        assert_equal 2, cache.length
+        assert_operator cache.sum { |_id, entry| entry.fetch(:bytesize) }, :<=, byte_budget
+
+        reader.pending(now: NOW + 1)
+
+        assert_equal 4, parse_calls,
+                     "a bounded full scan should retain its cached subset without churn"
+      end
+    end
+  end
+
   def test_capacity_compacts_only_acknowledged_records_before_reserving
     with_max_records(1) do
       Dir.mktmpdir do |dir|
@@ -625,6 +699,7 @@ class PatrolFixAdmissionStoreTest < Minitest::Test
           occurrence_id: "new-pending", snapshot: source_snapshot(identity: "finding-2"), now: NOW
         )
 
+        refute store.instance_variable_get(:@record_cache).key?("old-terminal")
         assert_nil store.fetch("old-terminal")
         assert_equal "new-pending", current.fetch("occurrence_id")
         assert_equal [ "new-pending" ], store.pending.map { |record| record.fetch("occurrence_id") }
@@ -1005,6 +1080,21 @@ class PatrolFixAdmissionStoreTest < Minitest::Test
   ensure
     Hive::PatrolFix::AdmissionStore.send(:remove_const, :MAX_RECORDS)
     Hive::PatrolFix::AdmissionStore.const_set(:MAX_RECORDS, original)
+  end
+
+  def with_cache_limits(records:, bytes:)
+    klass = Hive::PatrolFix::AdmissionStore
+    originals = {
+      MAX_CACHE_RECORDS: klass::MAX_CACHE_RECORDS,
+      MAX_CACHE_BYTES: klass::MAX_CACHE_BYTES
+    }
+    originals.each_key { |name| klass.send(:remove_const, name) }
+    klass.const_set(:MAX_CACHE_RECORDS, records)
+    klass.const_set(:MAX_CACHE_BYTES, bytes)
+    yield
+  ensure
+    originals&.each_key { |name| klass.send(:remove_const, name) if klass.const_defined?(name, false) }
+    originals&.each { |name, value| klass.const_set(name, value) }
   end
 
   def source_snapshot(identity: "finding-1")

--- a/test/unit/patrol_fix/admission_store_test.rb
+++ b/test/unit/patrol_fix/admission_store_test.rb
@@ -685,6 +685,13 @@ class PatrolFixAdmissionStoreTest < Minitest::Test
 
         assert_equal 4, parse_calls,
                      "a bounded full scan should retain its cached subset without churn"
+
+        reader.prepare_decision!(
+          "bounded-cache-1", candidates: [], current_head: "2" * 40, now: NOW + 2
+        )
+
+        assert_equal [ "bounded-cache-1" ],
+                     reader.instance_variable_get(:@record_cache).keys
       end
     end
   end

--- a/wiki/log.d/20260823T153257Z-patrol-admission-record-cache.md
+++ b/wiki/log.d/20260823T153257Z-patrol-admission-record-cache.md
@@ -5,10 +5,11 @@ tags: [daemon, patrol-fix, performance, admission]
 ---
 
 The daemon now retains one Patrol Fix admission store per active project.
-Admission scans still reread each bounded durable record, but reuse its frozen
-validated projection when the SHA-256 digest is unchanged. External writes
-invalidate the cache and receive the full schema, source, candidate, and state
-validation before use; removed project stores are evicted. A store retains no
-more than 512 records or 16 MiB of their serialized bytes, keeps a stable subset
-during oversized scans, and immediately removes entries deleted by capacity
-compaction.
+Runtime pending scans reread only the index-selected due records and reuse each
+frozen validated projection when its SHA-256 digest is unchanged. Full
+inventory consumers also reuse unchanged projections while retaining their
+single-session reads. External writes invalidate the cache and receive the full
+schema, source, candidate, and state validation before use; removed project
+stores are evicted. A store retains no more than 512 records or 16 MiB of their
+serialized bytes, keeps a stable subset during oversized scans, and immediately
+removes entries deleted by capacity compaction.

--- a/wiki/log.d/20260823T153257Z-patrol-admission-record-cache.md
+++ b/wiki/log.d/20260823T153257Z-patrol-admission-record-cache.md
@@ -1,0 +1,14 @@
+---
+title: Patrol admission reuses unchanged validated records
+type: change
+tags: [daemon, patrol-fix, performance, admission]
+---
+
+The daemon now retains one Patrol Fix admission store per active project.
+Admission scans still reread each bounded durable record, but reuse its frozen
+validated projection when the SHA-256 digest is unchanged. External writes
+invalidate the cache and receive the full schema, source, candidate, and state
+validation before use; removed project stores are evicted. A store retains no
+more than 512 records or 16 MiB of their serialized bytes, keeps a stable subset
+during oversized scans, and immediately removes entries deleted by capacity
+compaction.

--- a/wiki/modules/daemon.md
+++ b/wiki/modules/daemon.md
@@ -23,28 +23,29 @@ the task graph without making status itself perform daemon reconciliation. The
 Patrol Fix runtime re-reads the project registry when the admission
 scheduler asks for source ports, so projects registered after daemon start are
 admitted without a restart. Each active project retains one `AdmissionStore`
-instance across ticks. Every record read still comes from descriptor-safe
+instance across ticks. Every selected record still comes from descriptor-safe
 durable bytes, but an unchanged SHA-256 digest reuses the already frozen,
 fully validated record; changed bytes are parsed and validated again, and
 stores for removed registrations are evicted. Each store retains at most 512
-records and 16 MiB of their serialized durable bytes. Inventory scans keep a
-stable subset when that budget is full, while writes can evict older entries so
-active work remains warm. Capacity compaction removes its cache entry with the
-durable file. This keeps an unchanged admission inventory from repeating full
-schema/source validation every 30 seconds without making daemon memory scale to
-the maximum durable backlog. One corrupt store produces a bounded failed event
-while the remaining project ports continue.
+records and 16 MiB of their serialized durable bytes. Full inventory scans keep
+a stable subset when that budget is full, while writes can evict older entries
+so active work remains warm. Capacity compaction removes its cache entry with
+the durable file. This keeps unchanged admissions from repeating full
+schema/source validation without making daemon memory scale to the maximum
+durable backlog. One corrupt store produces a bounded failed event while the
+remaining project ports continue.
 Patrol Fix otherwise uses the standard task/status contracts and adds no daemon
 operational projection.
 
-Each Patrol Fix admission scan uses one non-creating managed-directory read
-session. It validates the complete bounded filename inventory before streaming
-the caller-validated record names through one opened parent directory;
-canonical record and descriptor/name-binding validation stay per record.
-Directory traversal is therefore constant as the record count rises, while
-bounded record reads and validation remain linear. Reads remain lock-free and
-do not create an absent store. This changes no migration, watcher, cache,
-schema, scheduler policy, capacity, or task materialization behavior.
+Runtime Patrol Fix admission scans acquire the inventory lock without waiting,
+read the durable pending index once, and open only the selected due records (at
+most the bounded scheduler batch). Explicit migration rebuilds and historical
+source-evidence lookups still need the complete inventory; those paths use one
+non-creating managed-directory read session, validate all bounded filenames,
+and stream the validated names through one opened parent directory. Canonical
+record and descriptor/name-binding validation stay per record. Full-scan
+directory traversal is therefore constant as the record count rises, while its
+record reads remain linear. An absent store is not created.
 
 Daemon and bot startup never run storage migrations. Operators perform every
 global and project cutover explicitly through `hive migrate` or

--- a/wiki/modules/daemon.md
+++ b/wiki/modules/daemon.md
@@ -22,8 +22,18 @@ publishes an owner-private, atomic operational snapshot. `hive status
 the task graph without making status itself perform daemon reconciliation. The
 Patrol Fix runtime re-reads the project registry when the admission
 scheduler asks for source ports, so projects registered after daemon start are
-admitted without a restart. Each project has one `AdmissionStore`; one corrupt
-store produces a bounded failed event while the remaining project ports continue.
+admitted without a restart. Each active project retains one `AdmissionStore`
+instance across ticks. Every record read still comes from descriptor-safe
+durable bytes, but an unchanged SHA-256 digest reuses the already frozen,
+fully validated record; changed bytes are parsed and validated again, and
+stores for removed registrations are evicted. Each store retains at most 512
+records and 16 MiB of their serialized durable bytes. Inventory scans keep a
+stable subset when that budget is full, while writes can evict older entries so
+active work remains warm. Capacity compaction removes its cache entry with the
+durable file. This keeps an unchanged admission inventory from repeating full
+schema/source validation every 30 seconds without making daemon memory scale to
+the maximum durable backlog. One corrupt store produces a bounded failed event
+while the remaining project ports continue.
 Patrol Fix otherwise uses the standard task/status contracts and adds no daemon
 operational projection.
 


### PR DESCRIPTION
## Summary

Patrol admission no longer repeats full schema and source validation for unchanged durable findings on every daemon tick. It still rereads each bounded record and fully validates any changed bytes.

This is the next daemon CPU slice after scan-scoped Attempts state and recovery-queue indexes. Duplicate status projection remains separate follow-up work.

## Performance

Measured with the exact worktree in service-equivalent dry-run mode against the live 64-record Patrol admission inventory:

| Metric | Before | After steady state |
|---|---:|---:|
| Patrol admission scheduler | 3.81-3.85 s | 0.057-0.109 s |
| Record parses per tick | 54-64 | 0 |
| Durable record reads per tick | 64 | 64 |

The cache is bounded to 512 records and 16 MiB of serialized bytes per active project. Oversized scans retain a stable subset instead of churning the cache.

## Safety

- Changed durable bytes invalidate the cached projection and run the complete schema, source, candidate, and state validation path.
- Deleted records, capacity compaction, and removed project registrations evict retained state.
- Active writes can replace older cache entries so current admission work remains warm.

## Test plan

- `test/unit/patrol_fix/admission_store_test.rb`: 18 runs, 92 assertions
- `test/unit/daemon/patrol_fix_runtime_test.rb`: 8 runs, 21 assertions
- `test/unit/daemon/patrol_fix_admission_scheduler_test.rb`: 17 runs, 97 assertions
- RuboCop on the four changed Ruby files: clean
- Five live dry-run daemon ticks; the final three completed Patrol admission in 0.057-0.070 seconds with zero record parses
