### PR TITLE
perf(daemon): remove duplicate full status projection

### DIFF
--- a/lib/hive/commands/status.rb
+++ b/lib/hive/commands/status.rb
@@ -416,7 +416,7 @@ module Hive
           "schema" => "hive-status",
           "schema_version" => Hive::Schemas::SCHEMA_VERSIONS.fetch("hive-status"),
           "ok" => true,
-          "generated_at" => now.iso8601,
+          "generated_at" => now.iso8601(6),
           "projects" => projects.map do |p|
             project_payload_or_degraded(
               p,
@@ -449,7 +449,7 @@ module Hive
           "schema" => "hive-status",
           "schema_version" => Hive::Schemas::SCHEMA_VERSIONS.fetch("hive-status"),
           "ok" => true,
-          "generated_at" => now.utc.iso8601,
+          "generated_at" => now.utc.iso8601(6),
           "partial" => true,
           "projects" => selected.map do |project|
             project_payload_or_degraded(

--- a/lib/hive/daemon/dispatcher.rb
+++ b/lib/hive/daemon/dispatcher.rb
@@ -520,8 +520,8 @@ module Hive
         refresh_status_index(result.rows)
 
         publish_complete_operational_snapshot(
-          initial_rows: result.rows,
-          initial_hidden_archived_task_count: result.hidden_archived_task_count,
+          rows: result.rows,
+          hidden_archived_task_count: result.hidden_archived_task_count,
           now: now
         )
 
@@ -1840,26 +1840,16 @@ module Hive
         log_operational_snapshot_failure(phase: "observe", error: e)
       end
 
-      def publish_complete_operational_snapshot(initial_rows:, initial_hidden_archived_task_count: 0, now:)
+      def publish_complete_operational_snapshot(rows:, hidden_archived_task_count: 0, now:)
         return unless @operational_snapshot
 
-        verification = @status_consumer.fetch
         completed_at = operational_snapshot_now
-        unless verification.ok
-          publish_operational_snapshot(
-            :fail, phase: "failed", reason: "revalidation_status_failure", now: completed_at
-          )
-          return
-        end
-
         queue_state = operational_queue_state
         publish_operational_snapshot(
           :complete,
           phase: "complete",
-          initial_rows: initial_rows,
-          final_rows: verification.rows,
-          initial_hidden_archived_task_count: initial_hidden_archived_task_count,
-          final_hidden_archived_task_count: verification.hidden_archived_task_count,
+          rows: rows,
+          hidden_archived_task_count: hidden_archived_task_count,
           controller: @controller.operational_snapshot(now: completed_at),
           queue: operational_queue_snapshot(now: completed_at, queue_state: queue_state),
           recoveries: operational_recovery_snapshot(queue_state: queue_state),

--- a/lib/hive/daemon/operational_snapshot.rb
+++ b/lib/hive/daemon/operational_snapshot.rb
@@ -96,8 +96,9 @@ module Hive
       end
 
       # Builds one coherent tick record. Decisions are captured in memory as
-      # the dispatcher evaluates rows, then joined only after a second status
-      # read proves the task identity/generation/stage/marker did not change.
+      # the dispatcher evaluates one authoritative status frame. Operational
+      # consumers accept them only from task graphs sampled after completion
+      # and whose task identity/generation/stage/marker fields still match.
       class Assembler
         attr_reader :tick_sequence
 
@@ -166,35 +167,30 @@ module Hive
           )
         end
 
-        def complete(initial_rows:, final_rows:, controller:, queue:, recoveries:,
-                     initial_hidden_archived_task_count: 0,
-                     final_hidden_archived_task_count: 0,
+        def complete(rows:, controller:, queue:, recoveries:,
+                     hidden_archived_task_count: 0,
                      now: Time.now.utc)
-          initial_rows = Array(initial_rows)
-          final_rows = Array(final_rows)
+          rows = Array(rows)
           validate_hidden_count!(
-            initial_hidden_archived_task_count, label: "initial_hidden_archived_task_count"
+            hidden_archived_task_count, label: "hidden_archived_task_count"
           )
-          validate_hidden_count!(
-            final_hidden_archived_task_count, label: "final_hidden_archived_task_count"
-          )
-          duplicate_keys = duplicate_row_keys(initial_rows) | duplicate_row_keys(final_rows)
+          duplicate_keys = duplicate_row_keys(rows)
           unless duplicate_keys.empty?
             identities = duplicate_keys.sort.map { |project, slug| "#{project}:#{slug}" }
             return fail(reason: "duplicate_task_identity: #{identities.join(', ')}", now: now)
           end
 
-          tasks = revalidated_tasks(initial_rows, final_rows)
+          tasks = observed_tasks(rows)
           task_index = tasks.to_h do |task|
             [ [ task.dig("identity", "project"), task.dig("identity", "slug") ], task ]
           end
-          holds = provider_holds(final_rows)
+          holds = provider_holds(rows)
           overlay_provider_dispositions!(task_index, holds)
           overlay_recovery_dispositions!(task_index, recoveries || {})
           @store.write(
             base_record(phase: "complete", now: now).merge(
               "reason" => nil,
-              "hidden_archived_task_count" => final_hidden_archived_task_count,
+              "hidden_archived_task_count" => hidden_archived_task_count,
               "capacity" => controller || {},
               "queue" => queue || {},
               "provider_holds" => holds,
@@ -251,39 +247,19 @@ module Hive
           raise ArgumentError, "#{label} must be a non-negative integer"
         end
 
-        def revalidated_tasks(initial_rows, final_rows)
-          initial = initial_rows.to_h { |row| [ row_key(row), row ] }
-          final = final_rows.to_h { |row| [ row_key(row), row ] }
-          initial_records = initial.transform_values { |row| task_record(row) }
-          final_records = final.transform_values { |row| task_record(row) }
-          (initial.keys | final.keys).sort.map do |key|
-            before = initial[key]
-            after = final[key]
-            before_record = initial_records[key]
-            after_record = final_records[key]
-            disposition = if before.nil?
-              unavailable("added_during_tick")
-            elsif after.nil?
-              unavailable("removed_during_tick")
-            elsif record_fingerprint(before_record) != record_fingerprint(after_record)
-              unavailable("changed_during_tick")
-            else
-              @observations.fetch(
-                key,
-                {
-                  "status" => "available",
-                  "decision" => "not_evaluated",
-                  "owner" => "scheduler",
-                  "reason" => "no dispatch decision was required"
-                }
-              )
-            end
-            (after_record || before_record).merge("disposition" => disposition)
+        def observed_tasks(rows)
+          rows.sort_by { |row| row_key(row) }.map do |row|
+            disposition = @observations.fetch(
+              row_key(row),
+              {
+                "status" => "available",
+                "decision" => "not_evaluated",
+                "owner" => "scheduler",
+                "reason" => "no dispatch decision was required"
+              }
+            )
+            task_record(row).merge("disposition" => disposition)
           end
-        end
-
-        def unavailable(reason)
-          { "status" => "unavailable", "decision" => nil, "owner" => "unknown", "reason" => reason }
         end
 
         def task_record(row)
@@ -309,10 +285,6 @@ module Hive
             "blocked" => value(row, :blocked) == true,
             "admission_error" => canonical_record(value(row, :admission_error))
           }
-        end
-
-        def record_fingerprint(record)
-          ::Digest::SHA256.hexdigest(JSON.generate(record))
         end
 
         def row_key(row)
@@ -593,6 +565,15 @@ module Hive
           raise ArgumentError, "invalid daemon identity" unless record["daemon"].is_a?(Hash)
           Time.parse(record.fetch("observed_at"))
           Time.parse(record.fetch("valid_until"))
+          window = record.fetch("source_window")
+          raise ArgumentError, "invalid source window" unless window.is_a?(Hash)
+
+          Time.parse(window.fetch("started_at"))
+          if record["phase"] == "started"
+            raise ArgumentError, "invalid source window" unless window["completed_at"].nil?
+          else
+            Time.parse(window.fetch("completed_at"))
+          end
         end
 
         def daemon_matches?(record, expected)

--- a/lib/hive/operational_status.rb
+++ b/lib/hive/operational_status.rb
@@ -262,6 +262,11 @@ module Hive
     def scheduler_from_snapshot(snapshot)
       @daemon_snapshot = snapshot
       status = snapshot.fetch("status", "unavailable")
+      reason = snapshot["reason"]
+      if status == "current" && task_graph_predates_snapshot?(snapshot)
+        status = "unavailable"
+        reason = "task_graph_predates_scheduler_snapshot"
+      end
       @scheduler_task_index = if status == "current"
         Array(snapshot["tasks"]).to_h do |task|
           [ [ task.dig("identity", "project"), task.dig("identity", "slug") ], task ]
@@ -273,13 +278,13 @@ module Hive
       unless status == "current"
         issues << issue(
           code: "scheduler_#{status}", source: "scheduler",
-          message: "daemon scheduler observation is #{status}: #{snapshot['reason'] || 'unknown reason'}",
+          message: "daemon scheduler observation is #{status}: #{reason || 'unknown reason'}",
           remediation: "check hive daemon status --json and wait for one complete reconciliation tick"
         )
       end
       {
         "status" => status,
-        "reason" => snapshot["reason"],
+        "reason" => reason,
         "observed_at" => snapshot["observed_at"],
         "valid_until" => snapshot["valid_until"],
         "tick_sequence" => snapshot["tick_sequence"],
@@ -288,6 +293,15 @@ module Hive
         "provider_holds" => Array(snapshot["provider_holds"]),
         "issues" => issues + Array(snapshot["issues"])
       }
+    end
+
+    def task_graph_predates_snapshot?(snapshot)
+      completed_at = snapshot.dig("source_window", "completed_at")
+      return true if completed_at.to_s.empty?
+
+      Time.iso8601(@status_payload.fetch("generated_at")) < Time.iso8601(completed_at)
+    rescue ArgumentError, TypeError, KeyError
+      true
     end
 
     def daemon_payload(projects, scheduler, attempt_storage:)

--- a/test/unit/commands/status_test.rb
+++ b/test/unit/commands/status_test.rb
@@ -6,6 +6,14 @@ require "hive/task_action"
 class CommandsStatusTest < Minitest::Test
   include HiveTestHelper
 
+  def test_status_payloads_preserve_subsecond_generation_time
+    now = Time.utc(2026, 8, 23) + Rational(123_456, 1_000_000)
+    command = Hive::Commands::Status.new(json: true, daemon_tasks: [])
+
+    assert_equal now.iso8601(6), command.json_payload([], now: now).fetch("generated_at")
+    assert_equal now.iso8601(6), command.daemon_task_payload([], now: now).fetch("generated_at")
+  end
+
   def test_daemon_task_payload_reads_only_exact_requested_rows
     with_tmp_dir do |project_root|
       hive_state = File.join(project_root, ".hive-state")

--- a/test/unit/daemon/dispatcher_test.rb
+++ b/test/unit/daemon/dispatcher_test.rb
@@ -1428,10 +1428,10 @@ class HiveDaemonDispatcherTest < Minitest::Test
       dispatcher.tick(now: T0)
 
       assert_equal %i[begin_tick observe complete], snapshot.calls.map(&:first)
+      assert_equal 1, dispatcher.instance_variable_get(:@status_consumer).fetch_count
       assert_equal "dispatched", snapshot.calls[1][1].fetch(:decision).to_s
       complete = snapshot.calls.last.last
-      assert_equal [ observed ], complete.fetch(:initial_rows)
-      assert_equal [ observed ], complete.fetch(:final_rows)
+      assert_equal [ observed ], complete.fetch(:rows)
       assert_equal "current", complete.dig(:queue, "status")
       assert_equal completed_at, complete.fetch(:now)
     end
@@ -1801,24 +1801,16 @@ class HiveDaemonDispatcherTest < Minitest::Test
     end
   end
 
-  def test_operational_snapshot_revalidation_and_assembly_failures_publish_failed_state
+  def test_operational_snapshot_assembly_failure_publishes_failed_state
     snapshot = FakeOperationalSnapshot.new
-    failed = Hive::Daemon::StatusConsumer::Result.new(
-      ok: false, rows: [], projects: [], error: "revalidation failed"
+    dispatcher, _supervisor, _controller, logger = make_dispatcher(
+      operational_snapshot: snapshot
     )
-    dispatcher, = make_dispatcher(status_result: failed, operational_snapshot: snapshot)
+    dispatcher.define_singleton_method(:operational_queue_state) do
+      raise IOError, "queue assembly failed"
+    end
 
-    dispatcher.send(:publish_complete_operational_snapshot, initial_rows: [], now: T0)
-
-    assert_equal :fail, snapshot.calls.last.first
-    assert_equal "revalidation_status_failure", snapshot.calls.last.last.fetch(:reason)
-
-    snapshot = FakeOperationalSnapshot.new
-    dispatcher, _supervisor, _controller, logger = make_dispatcher(operational_snapshot: snapshot)
-    status = dispatcher.instance_variable_get(:@status_consumer)
-    status.define_singleton_method(:fetch) { raise IOError, "status assembly failed" }
-
-    dispatcher.send(:publish_complete_operational_snapshot, initial_rows: [], now: T0)
+    dispatcher.send(:publish_complete_operational_snapshot, rows: [], now: T0)
 
     assert_equal "snapshot_assembly_failure", snapshot.calls.last.last.fetch(:reason)
     assert logger.events.any? { |name, attrs|

--- a/test/unit/daemon/operational_snapshot_test.rb
+++ b/test/unit/daemon/operational_snapshot_test.rb
@@ -78,9 +78,7 @@ class HiveDaemonOperationalSnapshotTest < Minitest::Test
         safety_reason: "worktree clean"
       )
       assembler.complete(
-        initial_rows: [ observed ], final_rows: [ observed ],
-        initial_hidden_archived_task_count: 2,
-        final_hidden_archived_task_count: 2,
+        rows: [ observed ], hidden_archived_task_count: 2,
         controller: { "limits" => { "global" => 2 }, "in_flight" => 2 },
         queue: { "pending" => 1 },
         recoveries: {}, now: T0 + 1
@@ -106,7 +104,7 @@ class HiveDaemonOperationalSnapshotTest < Minitest::Test
     end
   end
 
-  def test_hidden_archive_count_change_is_published_from_revalidated_snapshot
+  def test_hidden_archive_count_is_published_from_the_tick_snapshot
     with_tmp_dir do |dir|
       path = File.join(dir, "private", "operational-snapshot.json")
       _store, assembler, reader = build(path)
@@ -114,9 +112,7 @@ class HiveDaemonOperationalSnapshotTest < Minitest::Test
 
       assembler.begin_tick(now: T0)
       assembler.complete(
-        initial_rows: [ observed ], final_rows: [ observed ],
-        initial_hidden_archived_task_count: 1,
-        final_hidden_archived_task_count: 2,
+        rows: [ observed ], hidden_archived_task_count: 2,
         controller: {}, queue: {}, recoveries: {}, now: T0 + 1
       )
 
@@ -199,7 +195,7 @@ class HiveDaemonOperationalSnapshotTest < Minitest::Test
       assembler.begin_tick(now: T0)
       assembler.reconfigure(poll_interval_sec: 5)
       assembler.complete(
-        initial_rows: [ observed ], final_rows: [ observed ],
+        rows: [ observed ],
         controller: {}, queue: {}, recoveries: {}, now: T0 + 40
       )
 
@@ -255,8 +251,7 @@ class HiveDaemonOperationalSnapshotTest < Minitest::Test
         retry_at: (T0 + 3_600).iso8601(6)
       )
       assembler.complete(
-        initial_rows: [ fresh ],
-        final_rows: [ fresh ],
+        rows: [ fresh ],
         controller: {},
         queue: {},
         recoveries: recoveries,
@@ -299,7 +294,7 @@ class HiveDaemonOperationalSnapshotTest < Minitest::Test
 
       assembler.begin_tick(now: T0)
       assembler.complete(
-        initial_rows: [ completed ], final_rows: [ completed ],
+        rows: [ completed ],
         controller: {}, queue: {}, recoveries: recoveries, now: T0 + 1
       )
 
@@ -344,7 +339,7 @@ class HiveDaemonOperationalSnapshotTest < Minitest::Test
         reason: "a newer durable attempt is running"
       )
       assembler.complete(
-        initial_rows: [ live ], final_rows: [ live ],
+        rows: [ live ],
         controller: {}, queue: {}, recoveries: recoveries, now: T0 + 1
       )
 
@@ -432,7 +427,7 @@ class HiveDaemonOperationalSnapshotTest < Minitest::Test
 
       assembler.begin_tick(now: T0)
       assembler.complete(
-        initial_rows: [ held ], final_rows: [ held ], controller: {}, queue: {},
+        rows: [ held ], controller: {}, queue: {},
         recoveries: {}, now: T0 + 1
       )
 
@@ -455,7 +450,7 @@ class HiveDaemonOperationalSnapshotTest < Minitest::Test
 
       assembler.begin_tick(now: T0)
       assembler.complete(
-        initial_rows: [ held, replacement ], final_rows: [ held, replacement ],
+        rows: [ held, replacement ],
         controller: {}, queue: {}, recoveries: {}, now: T0 + 1
       )
 
@@ -486,84 +481,6 @@ class HiveDaemonOperationalSnapshotTest < Minitest::Test
     end
   end
 
-  def test_changed_row_stays_visible_with_unavailable_disposition
-    with_tmp_dir do |dir|
-      path = File.join(dir, "snapshot", "state.json")
-      _store, assembler, reader = build(path)
-      before = row
-      after = row(stage: "5-open-pr", marker: "complete")
-
-      assembler.begin_tick(now: T0)
-      assembler.observe(before, decision: "dispatched", owner: "scheduler", reason: "dispatched")
-      assembler.complete(
-        initial_rows: [ before ], final_rows: [ after ], controller: {}, queue: {},
-        recoveries: {}, now: T0 + 1
-      )
-
-      disposition = reader.read(now: T0 + 2).dig("tasks", 0, "disposition")
-      assert_equal "unavailable", disposition.fetch("status")
-      assert_equal "changed_during_tick", disposition.fetch("reason")
-      assert_nil disposition["decision"]
-    end
-  end
-
-  def test_policy_bearing_changes_invalidate_the_tick_disposition
-    with_tmp_dir do |dir|
-      path = File.join(dir, "snapshot", "state.json")
-      _store, assembler, reader = build(path)
-      before = row
-      after = row(
-        marker_attrs: { "marker_id" => "marker-2" },
-        state_file_mtime: T0 + 1,
-        action: "admission_error",
-        depends_on: "demo:base",
-        blocked_by: "demo:base",
-        dependency_stage: "7-artifacts",
-        blocked: true,
-        admission_error: {
-          "reason_code" => "dependency_task_missing",
-          "offending_ref" => "demo:base",
-          "safe_correction" => "repair the dependency"
-        }
-      )
-
-      assembler.begin_tick(now: T0)
-      assembler.observe(before, decision: "global_cap", owner: "scheduler", reason: "full")
-      assembler.complete(
-        initial_rows: [ before ], final_rows: [ after ], controller: {}, queue: {},
-        recoveries: {}, now: T0 + 1
-      )
-
-      task = reader.read(now: T0 + 2).fetch("tasks").first
-      assert_equal "unavailable", task.dig("disposition", "status")
-      assert_equal "changed_during_tick", task.dig("disposition", "reason")
-      assert_equal "admission_error", task.fetch("action")
-      assert_equal true, task.fetch("blocked")
-      assert_equal "dependency_task_missing", task.dig("admission_error", "reason_code")
-    end
-  end
-
-  def test_added_and_removed_rows_are_retained_as_unavailable
-    with_tmp_dir do |dir|
-      path = File.join(dir, "snapshot", "state.json")
-      _store, assembler, reader = build(path)
-      removed = row(slug: "removed")
-      added = row(slug: "added")
-
-      assembler.begin_tick(now: T0)
-      assembler.complete(
-        initial_rows: [ removed ], final_rows: [ added ], controller: {}, queue: {},
-        recoveries: {}, now: T0 + 1
-      )
-
-      reasons = reader.read(now: T0 + 2).fetch("tasks").to_h do |task|
-        [ task.dig("identity", "slug"), task.dig("disposition", "reason") ]
-      end
-      assert_equal "added_during_tick", reasons.fetch("added")
-      assert_equal "removed_during_tick", reasons.fetch("removed")
-    end
-  end
-
   def test_reader_rejects_expired_previous_generation_and_corrupt_records
     with_tmp_dir do |dir|
       path = File.join(dir, "snapshot", "state.json")
@@ -571,7 +488,7 @@ class HiveDaemonOperationalSnapshotTest < Minitest::Test
       observed = row
       assembler.begin_tick(now: T0)
       assembler.complete(
-        initial_rows: [ observed ], final_rows: [ observed ], controller: {}, queue: {},
+        rows: [ observed ], controller: {}, queue: {},
         recoveries: {}, now: T0
       )
 
@@ -585,6 +502,25 @@ class HiveDaemonOperationalSnapshotTest < Minitest::Test
 
       File.write(path, "not json")
       assert_equal "invalid", reader.read(now: T0 + 1).fetch("status")
+    end
+  end
+
+  def test_reader_rejects_a_complete_record_without_a_source_window
+    with_tmp_dir do |dir|
+      path = File.join(dir, "snapshot", "state.json")
+      _store, assembler, reader = build(path)
+      assembler.begin_tick(now: T0)
+      assembler.complete(
+        rows: [ row ], controller: {}, queue: {}, recoveries: {}, now: T0 + 1
+      )
+      record = JSON.parse(File.read(path))
+      record.delete("source_window")
+      File.write(path, JSON.generate(record))
+
+      snapshot = reader.read(now: T0 + 2)
+
+      assert_equal "invalid", snapshot.fetch("status")
+      assert_equal "snapshot_invalid", snapshot.fetch("reason")
     end
   end
 
@@ -699,14 +635,12 @@ class HiveDaemonOperationalSnapshotTest < Minitest::Test
 
       error = assert_raises(ArgumentError) do
         assembler.complete(
-          initial_rows: [], final_rows: [],
-          initial_hidden_archived_task_count: -1,
-          final_hidden_archived_task_count: 0,
+          rows: [], hidden_archived_task_count: -1,
           controller: {}, queue: {}, recoveries: {}, now: T0 + 1
         )
       end
 
-      assert_includes error.message, "initial_hidden_archived_task_count"
+      assert_includes error.message, "hidden_archived_task_count"
       assert_includes error.message, "non-negative integer"
     end
   end

--- a/test/unit/operational_status_test.rb
+++ b/test/unit/operational_status_test.rb
@@ -478,6 +478,122 @@ class OperationalStatusTest < Minitest::Test
     assert_includes result.fetch("issues").map { |issue| issue.fetch("code") }, "scheduler_stale"
   end
 
+  def test_task_graph_sampled_before_snapshot_completion_rejects_scheduler_dispositions
+    source_task = task(action: "ready_to_plan", slug: "older-task-graph")
+    snapshot = scheduler_snapshot_for(
+      source_task,
+      decision: "global_cap",
+      reason: "global dispatch capacity is exhausted"
+    )
+    snapshot["source_window"] = {
+      "started_at" => "2026-07-20T09:59:59Z",
+      "completed_at" => "2026-07-20T10:00:01Z"
+    }
+
+    result = project(
+      status_payload(source_task),
+      project_context: { "demo" => { "daemon_enabled" => true } },
+      scheduler_snapshot: snapshot
+    )
+
+    assert_equal "partial", result.fetch("completeness")
+    assert_equal "unavailable", result.dig("scheduler", "status")
+    assert_equal "task_graph_predates_scheduler_snapshot",
+                 result.dig("scheduler", "reason")
+    assert_equal "unavailable", result.dig("tasks", 0, "freshness", "scheduler_status")
+  end
+
+  def test_task_graph_sampled_after_snapshot_completion_accepts_scheduler_dispositions
+    source_task = task(action: "ready_to_plan", slug: "newer-task-graph")
+    snapshot = scheduler_snapshot_for(
+      source_task,
+      decision: "global_cap",
+      reason: "global dispatch capacity is exhausted"
+    )
+    snapshot["source_window"] = {
+      "started_at" => "2026-07-20T09:59:58Z",
+      "completed_at" => "2026-07-20T09:59:59Z"
+    }
+
+    result = project(
+      status_payload(source_task),
+      project_context: { "demo" => { "daemon_enabled" => true } },
+      scheduler_snapshot: snapshot
+    )
+
+    assert_equal "complete", result.fetch("completeness")
+    assert_equal "current", result.dig("scheduler", "status")
+    assert_equal "global_cap", result.dig("tasks", 0, "reasons", 0, "code")
+  end
+
+  def test_malformed_snapshot_completion_time_fails_the_temporal_fence_closed
+    source_task = task(action: "ready_to_plan", slug: "invalid-source-window")
+    snapshot = scheduler_snapshot_for(
+      source_task,
+      decision: "global_cap",
+      reason: "global dispatch capacity is exhausted"
+    )
+    snapshot["source_window"] = {
+      "started_at" => "2026-07-20T09:59:59Z",
+      "completed_at" => "not-a-time"
+    }
+
+    result = project(
+      status_payload(source_task),
+      project_context: { "demo" => { "daemon_enabled" => true } },
+      scheduler_snapshot: snapshot
+    )
+
+    assert_equal "unavailable", result.dig("scheduler", "status")
+    assert_equal "task_graph_predates_scheduler_snapshot",
+                 result.dig("scheduler", "reason")
+  end
+
+  def test_missing_snapshot_source_window_fails_the_temporal_fence_closed
+    source_task = task(action: "ready_to_plan", slug: "missing-source-window")
+    snapshot = scheduler_snapshot_for(
+      source_task,
+      decision: "global_cap",
+      reason: "global dispatch capacity is exhausted"
+    )
+    snapshot.delete("source_window")
+
+    result = project(
+      status_payload(source_task),
+      project_context: { "demo" => { "daemon_enabled" => true } },
+      scheduler_snapshot: snapshot
+    )
+
+    assert_equal "unavailable", result.dig("scheduler", "status")
+    assert_equal "task_graph_predates_scheduler_snapshot",
+                 result.dig("scheduler", "reason")
+  end
+
+  def test_same_second_task_graph_sampled_after_completion_passes_the_temporal_fence
+    source_task = task(action: "ready_to_plan", slug: "same-second-ordering")
+    snapshot = scheduler_snapshot_for(
+      source_task,
+      decision: "global_cap",
+      reason: "global dispatch capacity is exhausted"
+    )
+    snapshot["source_window"] = {
+      "started_at" => "2026-07-20T10:00:00.100000Z",
+      "completed_at" => "2026-07-20T10:00:00.800000Z"
+    }
+    payload = status_payload(source_task)
+    payload["generated_at"] = "2026-07-20T10:00:00.900000Z"
+
+    result = project(
+      payload,
+      project_context: { "demo" => { "daemon_enabled" => true } },
+      scheduler_snapshot: snapshot
+    )
+
+    assert_equal "complete", result.fetch("completeness")
+    assert_equal "current", result.dig("scheduler", "status")
+    assert_equal "global_cap", result.dig("tasks", 0, "reasons", 0, "code")
+  end
+
   def test_current_scheduler_snapshot_reports_a_missing_task
     source_task = task(action: "ready_to_plan", slug: "missing-from-snapshot")
     snapshot = scheduler_snapshot_for(
@@ -1141,8 +1257,12 @@ class OperationalStatusTest < Minitest::Test
     {
       "status" => "current",
       "phase" => "complete",
-      "observed_at" => "2026-07-20T10:00:01Z",
+      "observed_at" => "2026-07-20T09:59:59.500000Z",
       "valid_until" => "2026-07-20T10:01:31Z",
+      "source_window" => {
+        "started_at" => "2026-07-20T09:59:58.000000Z",
+        "completed_at" => "2026-07-20T09:59:59.500000Z"
+      },
       "tick_sequence" => 7,
       "daemon" => {
         "generation" => "daemon-generation-1",

--- a/wiki/log.d/20260823T165210Z-single-status-projection.md
+++ b/wiki/log.d/20260823T165210Z-single-status-projection.md
@@ -1,0 +1,23 @@
+---
+title: Daemon full ticks use one status projection
+type: log
+date: 2026-08-23
+---
+
+**Changed:** Removed the daemon's duplicate end-of-tick full `hive status`
+projection. Scheduler decisions now publish from the tick's authoritative
+source frame, while operational consumers fail closed unless their task graph
+was sampled after snapshot completion and still matches every scheduler join
+field.
+
+**Why:** On the local 221-task dogfood fleet, each full status projection costs
+about 2.9 seconds of CPU-heavy work. The second projection repeated that cost
+every 30 seconds even though later operational status already rejoined task
+identity and policy fields.
+
+**Verification:** Focused dispatcher, operational snapshot, and operational
+status tests pin one full status fetch per tick, temporal race rejection,
+subsecond ordering, malformed-window rejection, and the unchanged field-level
+join contract. An exact-branch dry-run completed three 221-task ticks with one
+status fetch each: 18.91 seconds cold, then 12.72 and 12.94 seconds steady,
+with no fatal, snapshot, or tick errors.

--- a/wiki/modules/daemon.md
+++ b/wiki/modules/daemon.md
@@ -199,18 +199,20 @@ request creation time and attempt claim deadline; otherwise later rows could
 be born with already-expired claim windows and fail every detached handoff as
 `launch_handoff_failed`.
 
-Scheduler decisions are captured in memory as each row is evaluated. At the
-end of the tick the dispatcher fetches status a second time and publishes a
-`complete` snapshot only after matching task identity, generation, stage,
-marker/attrs, attempt, state-file mtime, action, dependency/admission policy,
-and blocked state across that source window. Added, removed, or policy-changed
-rows receive an unavailable disposition instead of a stale decision. The
-assembler rejects the entire tick as `duplicate_task_identity` when either
-source frame still contains multiple physical rows for one project/slug, so a
-provider hold or dispatch decision from one row cannot be attached to another.
-The status-side join rechecks the same fields, so a decision cannot remain
-authoritative after a change between the completed daemon tick and a later
-status read. The record also carries daemon generation/PID/start identity,
+Scheduler decisions are captured in memory as each row is evaluated from the
+tick's one authoritative status frame. The dispatcher publishes that frame at
+completion without running a duplicate fleet projection. A status-side
+temporal fence accepts the snapshot only when the current task graph was
+sampled at or after snapshot completion; it then rechecks task identity,
+generation, stage, marker/attrs, attempt, state-file mtime, action,
+dependency/admission policy, and blocked state. A decision therefore cannot
+remain authoritative after a change during the tick or before a later status
+read. Status generation timestamps retain microseconds for same-second
+ordering, and missing or malformed source-window timestamps fail closed. The
+assembler still rejects a source frame containing multiple physical
+rows for one project/slug as `duplicate_task_identity`, so a provider hold or
+dispatch decision from one row cannot be attached to another. The record also
+carries daemon generation/PID/start identity,
 sequence and validity window, capacity, queue counters, provider holds,
 coordinator recovery receipts, and per-task owner/reason.
 An explicit admission also contributes its exact sanitized routing decision to
@@ -223,8 +225,7 @@ Retry dispositions additionally carry the exact marker-age `retry_at`,
 whether the boundary is due, the current safety verdict, and its reason.
 `retry_cooldown` is scheduler-owned, `retry_in_flight` is agent-owned, and
 `retry_safety_blocked` is operator-owned (or Hive-owned when inspection itself
-failed). Failed reconciliation/status
-or failed revalidation publishes `failed`. Snapshot age starts at the actual
+failed). Failed reconciliation/status publishes `failed`. Snapshot age starts at the actual
 completion sample rather than the tick-start sample, and a SIGHUP poll-interval
 reload immediately reconfigures the assembler's next validity window.
 


### PR DESCRIPTION
## Summary

- publish scheduler decisions from the authoritative full-tick status frame
- remove the second full fleet status projection and the obsolete two-frame assembler machinery
- fail closed through a task-graph temporal fence plus the existing field-level task join
- retain microsecond status timestamps and reject missing or malformed snapshot source windows

## Stack

This PR is stacked on #1182 and contains only the next daemon optimization commit. Review the diff against `perf/recovery-queue-cooldown`.

## Verification

- focused status, dispatcher, snapshot, and operational-status tests: 481 runs, 1,882 assertions, 0 failures
- focused coverage: changed snapshot and operational-status files at 100%; changed dispatcher completion path covered
- RuboCop: 8 files, no offenses
- broad core suite: 13,324 runs, 274,153 assertions, 0 failures, 0 errors
- exact-branch dry-run on 221 active tasks: three complete ticks, one status fetch per tick; 18.91s cold, 12.72s and 12.94s steady
- daemon log: no fatal, snapshot, status-failure, or tick-error events; daemon stopped natively and user service remained inactive

The umbrella local rake task still encounters the existing host-only OpenCode offline-smoke inventory failure for `openrouter/stealth/ox-alpha` before core tests; the core task was then run directly to completion.