### PR TITLE
Bound per-task projection work in status scans

### DIFF
--- a/lib/hive/commands/status.rb
+++ b/lib/hive/commands/status.rb
@@ -1433,7 +1433,7 @@ module Hive
         attempt_store = status_attempt_store
         projection = Hive::TaskProjection::Store.new(
           task_folder: task.folder, attempt_store: attempt_store
-        ).read(marker: marker)
+        ).read_cached(marker: marker)
         project ||= project_name_for(task)
         closure = Hive::TaskClosure.projection(
           task, project: project, attempt_store: attempt_store

--- a/lib/hive/task_projection/store.rb
+++ b/lib/hive/task_projection/store.rb
@@ -61,6 +61,17 @@ module Hive
         replay(journal_binding(bytes), marker: marker)
       end
 
+      # Status may consume an exact, unchanged bounded checkpoint. Any
+      # append, partial result, or unverifiable cache falls back to #read.
+      def read_cached(marker: nil, limits: Hive::TaskWorkspace::Limits.new)
+        bounded = read_bounded(marker: marker, limits: limits)
+        projection = bounded.projection
+        journal_hash = projection && projection["journal"]["hash"]
+        return projection if bounded.state == "current" && journal_hash
+
+        read(marker: marker)
+      end
+
       def rebuild!(marker: nil)
         snapshot = read_snapshot
         bytes = journal_bytes
@@ -191,7 +202,8 @@ module Hive
       def read_from_checkpoint(checkpoint, marker:, suffix_limit:, event_limit:)
         journal = checkpoint.fetch("journal")
         cursor = Integer(journal.fetch("cursor"))
-        base_projection = Hive::TaskProjection.from_data(checkpoint.fetch("snapshot"))
+        snapshot = checkpoint.fetch("snapshot")
+        base_projection = Hive::TaskProjection.from_data(snapshot)
         return degraded_from_projection(
           base_projection, reason: "checkpoint_prefix_changed", state: "stale", cursor: cursor
         ) unless checkpoint_prefix_valid?(journal, cursor)
@@ -213,7 +225,9 @@ module Hive
             cursor: cursor
           )
         end
-        if suffix.empty?
+        attempts = refreshed_attempt_bindings(snapshot)
+        raise Hive::TaskProjection::InvalidJournal, "checkpoint attempt bindings are unavailable" unless attempts
+        if suffix.empty? && attempts == snapshot.dig("journal", "attempts")
           projection = marker ? base_projection.with_marker(marker) : base_projection
           return BoundedRead.new(
             projection: projection, state: "current", diagnostics: [],
@@ -232,8 +246,14 @@ module Hive
           )
         end
 
-        replayed = Hive::TaskProjection.replay_journal(suffix, attempt_store: @attempt_store)
-        records = checkpoint_seed_records(base_projection) + replayed.records
+        replayed_records = if suffix.empty?
+          []
+        else
+          Hive::TaskProjection.replay_journal(
+            suffix, attempt_store: @attempt_store
+          ).records
+        end
+        records = checkpoint_seed_records(base_projection, attempts: attempts) + replayed_records
         projection = @projector.project(
           records: records,
           cursor: current_size,
@@ -243,16 +263,18 @@ module Hive
           marker: marker
         )
         projection_data = projection.to_h
+        projection_data["journal"]["event_id"] = snapshot.dig("journal", "event_id") if
+          suffix.empty?
         projection_data["provenance"]["authoritative_event_count"] =
           base_projection.to_h.dig("provenance", "authoritative_event_count").to_i +
-          replayed.records.length
+          replayed_records.length
         projection_data["provenance"]["legacy_event_count"] =
           base_projection.to_h.dig("provenance", "legacy_event_count").to_i
         projection = Hive::TaskProjection.from_data(projection_data)
         BoundedRead.new(
           projection: projection, state: "current", diagnostics: [],
           truncated: false, journal_cursor: current_size,
-          journal_records: replayed.records.map do |record|
+          journal_records: replayed_records.map do |record|
             record.reject { |key, _| key.to_s.start_with?("__") }
           end
         )
@@ -318,6 +340,12 @@ module Hive
             stat.dev == path_stat.dev && stat.ino == path_stat.ino
           return false unless journal["device"].nil? || stat.dev == journal["device"]
           return false unless journal["inode"].nil? || stat.ino == journal["inode"]
+          if stat.size == cursor
+            checkpoint_stat = File.lstat(checkpoint_path)
+            return false unless checkpoint_stat.file? && !checkpoint_stat.symlink?
+            return false unless stat.mtime <= checkpoint_stat.mtime
+            return false unless stat.ctime <= checkpoint_stat.ctime
+          end
 
           head = io.pread([ cursor, CHECKPOINT_ANCHOR_BYTES ].min, 0).to_s
           tail_offset = [ cursor - CHECKPOINT_ANCHOR_BYTES, 0 ].max
@@ -329,9 +357,9 @@ module Hive
         false
       end
 
-      def checkpoint_seed_records(projection)
+      def checkpoint_seed_records(projection, attempts: nil)
         data = projection.to_h
-        attempts = Array(data.dig("journal", "attempts"))
+        attempts ||= Array(data.dig("journal", "attempts"))
         task = data["task"]
         conditions = (Array(data.dig("conditions", "current")) +
                       Array(data.dig("conditions", "history"))).sort_by do |fact|
@@ -584,26 +612,47 @@ module Hive
         bindings = snapshot.dig("journal", "attempts")
         return false unless bindings.is_a?(Array)
 
-        bindings.all? do |binding|
-          next false unless binding.is_a?(Hash) && @attempt_store
+        refreshed = refreshed_attempt_bindings(snapshot)
+        refreshed && bindings.zip(refreshed).all? do |expected, current|
+          expected.values_at("state", "outcome", "lease_version") ==
+            current.values_at("state", "outcome", "lease_version")
+        end
+      end
+
+      def refreshed_attempt_bindings(snapshot)
+        bindings = snapshot.dig("journal", "attempts")
+        return nil unless bindings.is_a?(Array)
+        return [] if bindings.empty?
+        return nil unless @attempt_store
+
+        bindings.map do |binding|
+          return nil unless binding.is_a?(Hash)
 
           attempt = fetch_attempt_binding(binding["attempt_id"])
-          task = binding["task"]
-          attempt && task.is_a?(Hash) &&
-            attempt["task_slug"] == task["slug"] &&
-            (task["id"].nil? || attempt["task_id"].to_s == task["id"].to_s) &&
-            attempt["intended_stage"] == binding["stage"] &&
-            attempt_value(attempt, :task_input_epoch) == binding["task_generation"] &&
-            attempt_value(attempt, :state) == binding["state"] &&
-            attempt_value(attempt, :outcome) == binding["outcome"] &&
-            attempt_value(attempt, :lease_version) == binding["lease_version"] &&
-            attempt["accepted_at"] == binding["accepted_at"] &&
-            attempt["predecessor_attempt_id"] == binding["predecessor_attempt_id"] &&
-            (binding["ownership_generation"].nil? ||
-             attempt_value(attempt, :ownership_generation) == binding["ownership_generation"])
+          return nil unless attempt
+
+          current = Hive::TaskProjection.durable_attempt_metadata(attempt)
+          return nil unless same_attempt_identity?(binding, current)
+
+          current
         end
       rescue Hive::Error, SystemCallError, IOError
-        false
+        nil
+      end
+
+      def same_attempt_identity?(expected, current)
+        expected_task = expected["task"]
+        current_task = current["task"]
+        expected_task.is_a?(Hash) && current_task.is_a?(Hash) &&
+          expected["attempt_id"] == current["attempt_id"] &&
+          expected_task["slug"] == current_task["slug"] &&
+          (expected_task["id"].nil? || expected_task["id"].to_s == current_task["id"].to_s) &&
+          expected["stage"] == current["stage"] &&
+          expected["task_generation"] == current["task_generation"] &&
+          (expected["ownership_generation"].nil? ||
+           expected["ownership_generation"] == current["ownership_generation"]) &&
+          expected["accepted_at"] == current["accepted_at"] &&
+          expected["predecessor_attempt_id"] == current["predecessor_attempt_id"]
       end
 
       def fetch_attempt_binding(attempt_id)
@@ -612,10 +661,6 @@ module Hive
         else
           @attempt_store.fetch(attempt_id)
         end
-      end
-
-      def attempt_value(attempt, name)
-        attempt.respond_to?(name) ? attempt.public_send(name) : attempt[name.to_s]
       end
 
       def durable_handoff_snapshot?(snapshot)

--- a/test/unit/commands/status_test.rb
+++ b/test/unit/commands/status_test.rb
@@ -1383,7 +1383,7 @@ class CommandsStatusTest < Minitest::Test
       task = Hive::Task.new(folder)
       marker = Hive::Markers.current(task.state_file)
       broken_store = Object.new
-      broken_store.define_singleton_method(:read) { |**| raise Errno::EACCES, "blocked" }
+      broken_store.define_singleton_method(:read_cached) { |**| raise Errno::EACCES, "blocked" }
 
       _out, err = capture_io do
         with_replaced_singleton_method(

--- a/test/unit/task_projection/store_test.rb
+++ b/test/unit/task_projection/store_test.rb
@@ -54,6 +54,22 @@ class TaskProjectionStoreTest < Minitest::Test
     end
   end
 
+  def test_cached_read_uses_the_bounded_checkpoint_without_reading_the_full_journal
+    with_tmp_dir do |dir|
+      write_journal(dir, [ condition_event("event-1") ])
+      store = projection_store(dir)
+      expected = store.rebuild!
+
+      projection = with_replaced_singleton_method(
+        store, :journal_bytes, -> { raise "full journal read must not run" }
+      ) do
+        store.read_cached
+      end
+
+      assert_equal expected.to_h, projection.to_h
+    end
+  end
+
   def test_valid_snapshot_uses_narrow_attempt_binding_read_when_available
     with_tmp_dir do |dir|
       attempt = durable_attempt
@@ -192,8 +208,12 @@ class TaskProjectionStoreTest < Minitest::Test
         task_folder: dir, attempt_store: exploding_store
       )
 
-      error = assert_raises(Hive::TaskProjection::InvalidJournal) { store.read }
-      assert_includes error.message, "attempt store unavailable"
+      %i[read read_cached].each do |method_name|
+        error = assert_raises(Hive::TaskProjection::InvalidJournal) do
+          store.public_send(method_name)
+        end
+        assert_includes error.message, "attempt store unavailable"
+      end
     end
   end
 
@@ -219,6 +239,119 @@ class TaskProjectionStoreTest < Minitest::Test
       assert_equal "unsatisfied", health.fetch("state")
       assert_equal "attempt_terminal_failed", health.fetch("reason")
       assert_equal true, health.dig("provenance", "projection_reconciled_attempt_state")
+    end
+  end
+
+  def test_cached_read_reconciles_terminal_attempt_without_reading_the_full_journal
+    with_tmp_dir do |dir|
+      attempt = durable_attempt
+      attempt_store = Object.new
+      attempt_store.define_singleton_method(:fetch_projection_binding) do |attempt_id|
+        attempt if attempt_id == "attempt-1"
+      end
+      attempt_store.define_singleton_method(:fetch) do |attempt_id|
+        attempt if attempt_id == "attempt-1"
+      end
+      store = Hive::TaskProjection::Store.new(
+        task_folder: dir, attempt_store: attempt_store
+      )
+      write_journal(dir, [ condition_event("event-1") ])
+      store.rebuild!
+      attempt["state"] = "terminal"
+      attempt["outcome"] = "failed"
+      attempt["lease_version"] = 2
+      expected = store.read.to_h
+
+      bounded = with_replaced_singleton_method(
+        store, :journal_bytes, -> { raise "full journal read must not run" }
+      ) do
+        store.read_bounded
+      end
+
+      assert_equal "current", bounded.state
+      assert_equal expected, bounded.projection.to_h
+      assert_equal "attempt_terminal_failed",
+                   bounded.projection.current_condition("AgentHealthy").fetch("reason")
+
+      projection = with_replaced_singleton_method(
+        store, :journal_bytes, -> { raise "full journal read must not run" }
+      ) do
+        store.read_cached
+      end
+      assert_equal expected, projection.to_h
+    end
+  end
+
+  def test_cached_read_falls_back_to_the_full_journal_after_an_append
+    with_tmp_dir do |dir|
+      write_journal(dir, [ condition_event("event-1") ])
+      store = projection_store(dir)
+      store.rebuild!
+      File.open(store.journal_path, "a") do |journal|
+        journal.write("#{JSON.generate(condition_event('event-2', state: 'unsatisfied'))}\n")
+      end
+      full_reads = 0
+      store.define_singleton_method(:journal_bytes) do
+        full_reads += 1
+        File.binread(journal_path)
+      end
+
+      projection = store.read_cached
+
+      assert_equal 1, full_reads
+      assert_equal "unsatisfied", projection.current_condition("AgentHealthy").fetch("state")
+    end
+  end
+
+  def test_cached_read_falls_back_after_same_size_journal_mutation
+    with_tmp_dir do |dir|
+      records = 100.times.map { |index| condition_event("event-#{index}") }
+      write_journal(dir, records)
+      store = projection_store(dir)
+      store.rebuild!
+      bytes = File.binread(store.journal_path)
+      replacement = bytes.sub('"event_id":"event-50"', '"event_id":"event-x0"')
+      assert_equal bytes.bytesize, replacement.bytesize
+      refute_equal bytes, replacement
+      File.binwrite(store.journal_path, replacement)
+      changed_at = Time.now + 1
+      File.utime(changed_at, changed_at, store.journal_path)
+      full_reads = 0
+      store.define_singleton_method(:journal_bytes) do
+        full_reads += 1
+        File.binread(journal_path)
+      end
+
+      projection = store.read_cached
+
+      assert_equal 1, full_reads
+      assert_equal Digest::SHA256.hexdigest(replacement), projection["journal"].fetch("hash")
+    end
+  end
+
+  def test_cached_read_fails_closed_after_attempt_identity_changes
+    with_tmp_dir do |dir|
+      attempt = durable_attempt
+      attempt_store = Object.new
+      attempt_store.define_singleton_method(:fetch_projection_binding) do |attempt_id|
+        attempt if attempt_id == "attempt-1"
+      end
+      store = Hive::TaskProjection::Store.new(
+        task_folder: dir, attempt_store: attempt_store
+      )
+      write_journal(dir, [ condition_event("event-1") ])
+      store.rebuild!
+      attempt["task_slug"] = "forged-task"
+      full_reads = 0
+      store.define_singleton_method(:journal_bytes) do
+        full_reads += 1
+        File.binread(journal_path)
+      end
+
+      error = assert_raises(Hive::TaskProjection::InvalidJournal) { store.read_cached }
+
+      assert_equal 1, full_reads
+      assert_includes error.message, "durable attempt mismatch: task"
     end
   end
 

--- a/wiki/commands/status.md
+++ b/wiki/commands/status.md
@@ -1,7 +1,7 @@
 ---
 title: hive status
 type: command
-source: lib/hive/commands/status.rb, lib/hive/task_closure.rb, lib/hive/operational_status.rb, lib/hive/operational_action.rb, lib/hive/daemon/operational_snapshot.rb, lib/hive/diagnostic_evidence.rb
+source: lib/hive/commands/status.rb, lib/hive/task_projection/store.rb, lib/hive/task_closure.rb, lib/hive/operational_status.rb, lib/hive/operational_action.rb, lib/hive/daemon/operational_snapshot.rb, lib/hive/diagnostic_evidence.rb
 created: 2026-04-25
 updated: 2026-08-23
 tags: [command, status, operational, agents, observability, json, diagnostics, archive, closure, blocked, plan-review, terminal-outcomes, dependencies, scheduler]
@@ -378,6 +378,17 @@ process-global, so a later scan still observes fresh durable attempt data. The
 internal `--daemon-task` fast-tick scan shares one store and one reader the
 same way, across every requested project, so a bounded daemon tick never
 rebuilds them per project.
+
+Each task row first reads its bounded projection checkpoint instead of hashing
+and replaying the task's complete journal. A checkpoint is usable for exact
+status only when it is current, its journal identity/size/metadata and bounded
+head/tail anchors still match, and every durable attempt identity still
+matches. Mutable attempt state is refreshed through the scan-scoped attempt
+reader and reprojected from checkpoint seed facts, so a terminal or lost
+attempt is visible without replaying old journal history. A journal append,
+missing/stale/partial checkpoint, invalid attempt identity, or any bounded-read
+failure falls back to the authoritative full-journal `read`; status never
+publishes the partial workspace projection as exact task state.
 
 Stage moves are treated as a normal filesystem race. If an entry disappears between the stage glob and any in-folder row read, `collect_rows` rescues `Errno::ENOENT`, re-checks the folder path, and skips it only when the folder is gone. The rescue is deliberately folder-level: an `ENOENT` while the task folder still exists is re-raised as a real status command failure, because in-place state-file writers may truncate content but should not make the state file transiently absent inside a surviving folder. A forward stage move can resurface under the later stage in the same scan; a backward move to an already-scanned stage can disappear for one poll and then reappear on the next refresh. After all stages are scanned, `drop_transient_stage_moves` looks only at duplicate-slug groups and removes every duplicate row whose folder no longer exists. If two live folders still share a slug, both rows remain and `annotate_actions` still passes `stage_collision: true` into `Hive::TaskAction`. This keeps `hive status --json` and TUI snapshots from briefly showing an old-stage and new-stage copy during a normal `mv`, without hiding persistent duplicate state.
 

--- a/wiki/log.d/20260823T181405Z-bounded-status-task-projections.md
+++ b/wiki/log.d/20260823T181405Z-bounded-status-task-projections.md
@@ -1,0 +1,22 @@
+---
+title: Status bounds per-task projection reads
+type: log
+date: 2026-08-23
+---
+
+**Changed:** Full status scans now consume a current per-task projection
+checkpoint when its bounded journal and attempt-identity checks pass. Mutable
+attempt state is refreshed and reprojected without replaying old journal
+history. Appended journals and partial, stale, invalid, or unverifiable
+checkpoints fall back to the unchanged authoritative full-journal reader.
+
+**Why:** The 221-task local fleet held about 5.5 MB of task journals, and full
+status replayed 141 of them on every scan because durable attempt state had
+advanced after snapshot publication. This made work grow with retained
+history, not only with each task's current small artifacts.
+
+**Verification:** Five exact-fleet scans averaged 2.81 seconds on the parent
+and 2.01 seconds with bounded task reads, a 28.5% reduction. Normalized full
+JSON output was byte-identical. Focused tests cover unchanged checkpoints,
+mutable terminal attempts, appends, same-size source changes, forged attempt
+identity, and authoritative fallback.

--- a/wiki/modules/conditions.md
+++ b/wiki/modules/conditions.md
@@ -64,6 +64,15 @@ on read and rebuild, and rebuild cannot overwrite the last snapshot. Markers
 from non-execute stages do not claim this execute-journal handoff. Only
 mutating reconciliation republishes it.
 
+Full status scans have an exact-cache path over the separately bounded
+`task-projection.checkpoint.json`. It verifies the checkpoint against the
+current journal, refreshes mutable durable attempt fields, and reprojects from
+checkpoint seed facts when an attempt changed. It can avoid old-history replay
+only while the journal has not grown and the bounded source checks remain
+current. Otherwise status delegates to the ordinary authoritative read above;
+the bounded workspace API may report partial diagnostics, but status cannot
+turn those into a condition projection.
+
 Selection proceeds by current task generation, then latest compatible attempt
 within each registry family, then exact commit generation/HEAD for branch facts.
 Predecessor lineage outranks wall-clock timestamps, so a clock step backward


### PR DESCRIPTION
## Summary

- make full status scans prefer each task's bounded projection checkpoint instead of hashing and replaying retained journal history
- refresh mutable durable-attempt state through the scan-scoped attempt reader before accepting the checkpoint
- fall back to the unchanged authoritative full-journal read on appends, partial/stale checkpoints, source changes, identity mismatches, or bounded-read failures
- document the exact-cache boundary and add adversarial regression coverage

## Stack

This PR is intentionally based on `perf/daemon-single-status-projection` (PR #1183), which is based on PR #1182. Review the single commit in this PR: `ecf1fa779`.

## Verification

- focused projection/status/workspace tests: 198 runs, 844 assertions, 0 failures, 0 errors
- exact-head broad core suite: 13,329 runs, 274,171 assertions, 0 failures, 0 errors, 10 skips
- RuboCop: 4 changed Ruby files, no offenses
- normalized full-status JSON: byte-identical to the parent across 221 tasks
- five-scan benchmark: parent 2.81s average, branch 2.01s average (28.5% faster)
- adjacent final scan: parent 3.30s, branch 2.03s
- exact-branch daemon dry-run: 3 complete ticks; steady status fetches 2.28s and 2.22s; zero fatal/failed/error events; native stop left no daemon PID and the systemd service inactive

`bundle exec rake test` reaches the local Agent CLI prerequisite and fails because `openrouter/stealth/ox-alpha` is absent from the current OpenCode model inventory. That host-only prerequisite reported 112 runs / 1,151 assertions with one `RouteUnavailable` error. The broad core suite above was then run by removing only `test:agent_cli_runtime` from the Rake prerequisite list.
