### PR TITLE
fix(dev): load matching agent runtime in source checkouts

### DIFF
--- a/bin/hive
+++ b/bin/hive
@@ -1,5 +1,12 @@
 #!/usr/bin/env ruby
 
+source_agent_runtime_lib = File.expand_path(
+  "../components/agent-cli-runtime/lib",
+  __dir__
+)
+if File.file?(File.join(source_agent_runtime_lib, "agent_cli_runtime.rb"))
+  $LOAD_PATH.unshift(source_agent_runtime_lib)
+end
 $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
 
 require "hive"

--- a/test/integration/cli_version_test.rb
+++ b/test/integration/cli_version_test.rb
@@ -14,6 +14,22 @@ class CliVersionTest < Minitest::Test
     assert_equal "#{Hive::VERSION}\n", out
   end
 
+  def test_source_bin_prefers_the_checkout_agent_cli_runtime_component
+    script = <<~'RUBY'
+      at_exit do
+        parameters = AgentCliRuntime::OpenCodePreparationRequest
+          .instance_method(:initialize).parameters
+        puts "source-agent-cli-runtime=#{parameters.include?([:key, :bash_patterns])}"
+      end
+      ARGV.replace(["--version"])
+      load File.expand_path("bin/hive", Dir.pwd)
+    RUBY
+
+    out = run!(RbConfig.ruby, "-e", script)
+
+    assert_includes out, "source-agent-cli-runtime=true\n"
+  end
+
   def test_strict_no_write_routes_skip_scheduler_reconciliation
     with_tmp_global_config do |home|
       with_tmp_git_repo do |project_root|

--- a/wiki/log.d/20260822T145205Z-source-agent-runtime.md
+++ b/wiki/log.d/20260822T145205Z-source-agent-runtime.md
@@ -1,0 +1,15 @@
+# Bind source Hive to its matching agent runtime component
+
+**Action:** `bin/hive` now prepends the monorepo
+`components/agent-cli-runtime/lib` directory when that source-only component is
+present, before loading Hive.
+
+**Reason:** A dogfood OpenCode benchmark clone loaded the separately installed
+`agent-cli-runtime` gem instead of the component from the cloned commit. The
+installed gem did not yet accept Hive's `bash_patterns` preparation keyword,
+so planning failed before OpenCode could run.
+
+**Verification:** Added a subprocess regression proving a source `bin/hive`
+loads an `OpenCodePreparationRequest` with the checkout's `bash_patterns`
+contract even when the installed gem is older. Reproduced the test red before
+the load-path change and green afterward.

--- a/wiki/modules/agent_cli_runtime.md
+++ b/wiki/modules/agent_cli_runtime.md
@@ -3,7 +3,7 @@ title: Agent CLI Runtime component
 type: module
 source: components/agent-cli-runtime, components/agent-cli-runtime/mirror, .github/workflows/agent-cli-runtime-release.yml
 created: 2026-07-26
-updated: 2026-08-21
+updated: 2026-08-22
 tags: [agent, runtime, component, gem, cli]
 ---
 
@@ -35,6 +35,12 @@ authentication mode.
 Hive uses that inventory to remove ambient API credentials from child launches
 and select CLI subscription/session state. That is Hive policy, not a package
 restriction for independent consumers.
+
+`bin/hive` prefers `components/agent-cli-runtime/lib` when it is present in a
+source checkout. This keeps dogfood and benchmark clones on the component
+contract reviewed in the same commit, even when the operator also has an older
+published `agent-cli-runtime` gem installed. Packaged Hive remains unchanged
+because its gem does not include the monorepo component directory.
 
 Compilation returns argv and optional stdin without executing a process.
 Requested controls fail closed with `UnsupportedCapability` when a profile


### PR DESCRIPTION
## Summary

- Source checkouts now load the agent runtime component reviewed in the same commit, so OpenCode workers no longer fail on `bash_patterns` when an older published gem is installed.
- Packaged Hive remains unchanged because it does not contain the monorepo component path.

## Test plan

- [x] `mise exec ruby@3.4.7 -- bundle exec ruby -Itest test/integration/cli_version_test.rb`
- [x] Source `bin/hive` reports an `OpenCodePreparationRequest` initializer with the `bash_patterns` keyword.

## Notes for reviewer

This is the source-checkout follow-up to #1170. The live Patrol failure reproduced before the fix as `ArgumentError: unknown keyword: :bash_patterns` before OpenCode could launch.
