### PR TITLE
perf(daemon): skip inert recovery replay

### DIFF
--- a/lib/hive/daemon/recovery_coordinator.rb
+++ b/lib/hive/daemon/recovery_coordinator.rb
@@ -156,6 +156,9 @@ module Hive
       RETRY_BACKOFF_SEC = [ 5, 10, 60, 300, 900, 3600 ].freeze
       DETERMINISTIC_FAILURE_THRESHOLD = 3
       FAILURE_HISTORY_LIMIT = 64
+      INERT_BLOCK_REASONS = %w[
+        deterministic_failure generation_conflict task_identity_conflict
+      ].freeze
 
       # A deliberate human retry is not the automatic sweep. The cooldown
       # paces Hive's own retries; gating an operator on it leaves a task idle
@@ -611,6 +614,10 @@ module Hive
         recovery = request.recovery
         return unavailable_request(request, "request_has_no_recovery_transition") unless recovery.is_a?(Hash)
         return receipt_for_request(request, now: now) if %w[dispatched terminal].include?(recovery["phase"])
+        return receipt_for_request(request, now: now) if
+          INERT_BLOCK_REASONS.include?(recovery["blocked_reason"])
+        return receipt_for_request(request, now: now) if
+          recovery["blocked_reason"].nil? && !recovery_due?(recovery, now: now)
 
         task = resolve_task_for(row)
         Hive::Lock.with_task_lock(task.folder, "operation" => "recovery_transition") do
@@ -621,7 +628,9 @@ module Hive
             recovery = current_request.recovery
             return receipt_for_request(current_request, now: now) if %w[dispatched terminal].include?(recovery["phase"])
             return receipt_for_request(current_request, now: now) if
-              recovery["blocked_reason"] == "deterministic_failure"
+              INERT_BLOCK_REASONS.include?(recovery["blocked_reason"])
+            return receipt_for_request(current_request, now: now) if
+              recovery["blocked_reason"].nil? && !recovery_due?(recovery, now: now)
 
             locked_task = resolve_task_for(row)
             unless same_task_identity?(task, locked_task) &&

--- a/test/unit/daemon/recovery_coordinator_test.rb
+++ b/test/unit/daemon/recovery_coordinator_test.rb
@@ -566,6 +566,21 @@ class HiveDaemonRecoveryCoordinatorTest < Minitest::Test
       assert_equal "admitted",
                    Q.fetch(request.request_id, state_home: state_home)
                      .recovery.fetch("phase")
+
+      # A safety block is not inert: the sweep must re-inspect the task
+      # instead of parking it, because an operator cleaning the credential
+      # out of the state file should free the retry without a manual nudge.
+      # Re-inspecting must still be write-idempotent while the reason holds.
+      blocked_path = Q.fetch(request.request_id, state_home: state_home).path
+      blocked_inode = File.stat(blocked_path).ino
+
+      replayed = coordinator.resume(request: request, row: row)
+
+      assert_equal "blocked", replayed.status
+      assert_equal "safety_blocked", replayed.reason
+      assert_equal "operator", replayed.owner
+      assert_equal blocked_inode, File.stat(blocked_path).ino,
+                   "an unchanged safety block must not rewrite the queue file"
     end
   end
 

--- a/test/unit/daemon/recovery_coordinator_test.rb
+++ b/test/unit/daemon/recovery_coordinator_test.rb
@@ -1046,6 +1046,62 @@ class HiveDaemonRecoveryCoordinatorTest < Minitest::Test
     )
   end
 
+  def test_resume_replays_inert_blocks_without_reopening_the_task
+    task_resolutions = 0
+    coordinator = Hive::Daemon::RecoveryCoordinator.new(
+      task_resolver: lambda do |**|
+        task_resolutions += 1
+        raise "inert recovery must not resolve its task"
+      end,
+      attempt_store: Object.new
+    )
+
+    Hive::Daemon::RecoveryCoordinator::INERT_BLOCK_REASONS.each do |reason|
+      request = request_for_helpers(
+        recovery: {
+          "phase" => "cleared",
+          "failure_origin" => "timeout",
+          "next_eligible_at" => (NOW - 60).iso8601(6),
+          "owner" => "operator",
+          "blocked_reason" => reason,
+          "blocked_remediation" => "refresh status"
+        }
+      )
+
+      receipt = coordinator.resume(request: request, row: Object.new, now: NOW)
+
+      assert_equal "blocked", receipt.status
+      assert_equal reason, receipt.reason
+    end
+    assert_equal 0, task_resolutions
+  end
+
+  def test_resume_replays_cooldown_without_reopening_the_task
+    task_resolutions = 0
+    coordinator = Hive::Daemon::RecoveryCoordinator.new(
+      task_resolver: lambda do |**|
+        task_resolutions += 1
+        raise "cooldown recovery must not resolve its task"
+      end,
+      attempt_store: Object.new
+    )
+    request = request_for_helpers(
+      recovery: {
+        "phase" => "cleared",
+        "failure_origin" => "timeout",
+        "next_eligible_at" => (NOW + 60).iso8601(6),
+        "owner" => "scheduler",
+        "blocked_reason" => nil,
+        "blocked_remediation" => nil
+      }
+    )
+
+    receipt = coordinator.resume(request: request, row: Object.new, now: NOW)
+
+    assert_equal "cooldown", receipt.status
+    assert_equal 0, task_resolutions
+  end
+
   def test_post_clear_dispatch_failure_uses_the_shared_retry_ladder
     with_fixture do |coordinator, row, state_home|
       coordinator.request(

--- a/wiki/log.d/20260823T203134Z-inert-recovery-replay.md
+++ b/wiki/log.d/20260823T203134Z-inert-recovery-replay.md
@@ -1,0 +1,13 @@
+# Stop replaying inert recovery work
+
+**Action:** Recovery resume now returns persisted receipts immediately for
+cooling requests and immutable operator-owned blockers.
+
+**Reason:** A live daemon with 93 durable recovery requests spent more than a
+minute reopening tasks whose requests were already parked as generation,
+identity, or deterministic conflicts. Patrol admission could not run until the
+whole historical queue had been replayed.
+
+**Verification:** Added focused coordinator coverage proving inert blockers and
+future cooldowns perform no task resolution. In the live queue, the 81 already
+parked requests became receipt-only work instead of guarded task transitions.

--- a/wiki/modules/daemon.md
+++ b/wiki/modules/daemon.md
@@ -494,6 +494,15 @@ advances a workflow stage directly:
    recovery request and generation, returns it to scheduler ownership, and
    starts the next observed failure series from fresh evidence.
 
+   Recovery replay rejects non-actionable work before reopening the task.
+   Cooling requests return their existing cooldown receipt, while immutable
+   `generation_conflict`, `task_identity_conflict`, and
+   `deterministic_failure` blockers return their parked receipt without task
+   resolution, task locking, or generation reconstruction. Safety and health
+   blockers remain actionable because their external condition can recover.
+   This keeps a historical recovery queue from turning each daemon tick into
+   one full task reconstruction per parked request.
+
    `StaleAgentHealer` is only the automatic scheduler for those durable errors.
    After the shared marker-age cooldown it submits the observed row to
    `RecoveryCoordinator`; it never clears a recoverable marker itself and has


### PR DESCRIPTION
## Summary

- Parked recovery requests and future cooldowns now return their persisted receipt before task resolution, locking, and generation reconstruction.
- Safety and health blockers still re-evaluate because their external conditions can recover.

## Test plan

- [x] `mise exec ruby@3.4.7 -- bundle exec ruby -Itest test/unit/daemon/recovery_coordinator_test.rb`
- [x] `mise exec ruby@3.4.7 -- bundle exec ruby -Itest test/unit/daemon/dispatcher_test.rb`
- [x] Live 93-request daemon queue: 81 already parked requests became receipt-only work; the request phase completed instead of blocking Patrol admission for minutes.

## Notes for reviewer

Before this change, the exact-main daemon stayed near one CPU core and did not finish its first tick after more than two minutes. This PR keeps durable recovery evidence unchanged; it only avoids re-running transitions that cannot progress without a fresh operator action.
