### PR TITLE
perf(status): skip final attempt rereads

### DIFF
--- a/lib/hive/task_projection/store.rb
+++ b/lib/hive/task_projection/store.rb
@@ -627,6 +627,7 @@ module Hive
 
         bindings.map do |binding|
           return nil unless binding.is_a?(Hash)
+          next binding if Hive::Attempts::Record::FINAL_STATES.include?(binding["state"])
 
           attempt = fetch_attempt_binding(binding["attempt_id"])
           return nil unless attempt

--- a/test/unit/task_projection/store_test.rb
+++ b/test/unit/task_projection/store_test.rb
@@ -282,6 +282,35 @@ class TaskProjectionStoreTest < Minitest::Test
     end
   end
 
+  def test_cached_read_trusts_final_attempt_binding_without_an_attempt_store_read
+    with_tmp_dir do |dir|
+      attempt = durable_attempt.merge(
+        "state" => "terminal", "outcome" => "failed", "lease_version" => 2
+      )
+      reads = 0
+      attempt_store = Object.new
+      attempt_store.define_singleton_method(:fetch_projection_binding) do |attempt_id|
+        reads += 1
+        attempt if attempt_id == "attempt-1"
+      end
+      attempt_store.define_singleton_method(:fetch) do |attempt_id|
+        attempt if attempt_id == "attempt-1"
+      end
+      store = Hive::TaskProjection::Store.new(
+        task_folder: dir, attempt_store: attempt_store
+      )
+      write_journal(dir, [ condition_event("event-1") ])
+      store.rebuild!
+      reads = 0
+
+      projection = store.read_cached
+
+      assert_equal 0, reads
+      assert_equal "attempt_terminal_failed",
+                   projection.current_condition("AgentHealthy").fetch("reason")
+    end
+  end
+
   def test_cached_read_falls_back_to_the_full_journal_after_an_append
     with_tmp_dir do |dir|
       write_journal(dir, [ condition_event("event-1") ])

--- a/wiki/commands/status.md
+++ b/wiki/commands/status.md
@@ -390,6 +390,13 @@ missing/stale/partial checkpoint, invalid attempt identity, or any bounded-read
 failure falls back to the authoritative full-journal `read`; status never
 publishes the partial workspace projection as exact task state.
 
+Terminal and lost attempt bindings in a validated checkpoint are final,
+permanent-proof metadata and are therefore reused without another global
+attempt-store point read. Only non-final bindings are refreshed on each scan,
+which preserves live running-to-terminal reconciliation while keeping status
+cost proportional to active attempts instead of every historical attempt named
+by every task.
+
 Stage moves are treated as a normal filesystem race. If an entry disappears between the stage glob and any in-folder row read, `collect_rows` rescues `Errno::ENOENT`, re-checks the folder path, and skips it only when the folder is gone. The rescue is deliberately folder-level: an `ENOENT` while the task folder still exists is re-raised as a real status command failure, because in-place state-file writers may truncate content but should not make the state file transiently absent inside a surviving folder. A forward stage move can resurface under the later stage in the same scan; a backward move to an already-scanned stage can disappear for one poll and then reappear on the next refresh. After all stages are scanned, `drop_transient_stage_moves` looks only at duplicate-slug groups and removes every duplicate row whose folder no longer exists. If two live folders still share a slug, both rows remain and `annotate_actions` still passes `stage_collision: true` into `Hive::TaskAction`. This keeps `hive status --json` and TUI snapshots from briefly showing an old-stage and new-stage copy during a normal `mv`, without hiding persistent duplicate state.
 
 Rows are then classified by `Hive::TaskAction`, which emits an action key, label, suggested command, and optional row-local `next_action` such as `kind=edit target=<worktree>` for dirty execute worktrees or `kind=run` for `missing_research_output`. `collect_rows` also reads each task `.lock`, verifies the holder PID and recorded process start time through `Hive::Lock`, and passes `live_task_lock: true` to `TaskAction` while `hive run` is active even if the stage has not written an `AGENT_WORKING` or `REVIEW_WORKING` marker yet. If one project has the same slug in multiple stages, workflow commands include `--from <stage>` and generic findings commands include `--stage <stage>`.

--- a/wiki/log.d/20260823T212558Z-final-attempt-checkpoint-reuse.md
+++ b/wiki/log.d/20260823T212558Z-final-attempt-checkpoint-reuse.md
@@ -1,0 +1,17 @@
+## [2026-08-23T21:25:58Z] status — reuse final attempt checkpoint bindings
+
+**Action:** Changed bounded task-projection reads to trust terminal and lost
+attempt bindings already recorded in a validated checkpoint. Those bindings
+come from immutable permanent proof, so status now refreshes only mutable
+attempts that can still transition. This removes repeated global attempt-store
+lookups for historical attempts while preserving running-to-terminal
+reconciliation.
+
+**Verification:** Added a regression proving a cached terminal binding performs
+zero attempt-store reads while the existing mutable-attempt reconciliation test
+continues to pass. On the live 18-project dogfood registry, attempt binding
+reads dropped from 6,751 to 185 and `hive status --json` wall time dropped from
+5.73 seconds to 2.52 seconds before further per-task scan optimization.
+
+**Refreshed pages:**
+- [[commands/status]]


### PR DESCRIPTION
## Summary

- Reuse terminal/lost attempt metadata from validated task-projection checkpoints.
- Refresh only mutable attempts that can still transition.
- Add regression coverage and document the bounded status contract.

## Impact

- Live 18-project status scan: 6,751 -> 185 attempt binding reads.
- Wall time: 5.73s -> 2.52s before the next per-task optimization.

## Verification

- bundle exec ruby -Itest test/unit/task_projection/store_test.rb (29 runs, 97 assertions)
- bundle exec ruby -Itest test/unit/commands/status_test.rb (123 runs, 510 assertions)
- bundle exec rubocop lib/hive/task_projection/store.rb test/unit/task_projection/store_test.rb