### PR TITLE
fix(patrol): re-admit stale materialization decisions

### DIFF
--- a/lib/hive/daemon/patrol_fix_admission_scheduler.rb
+++ b/lib/hive/daemon/patrol_fix_admission_scheduler.rb
@@ -184,6 +184,11 @@ module Hive
             store: store, source: source, entry: entry, snapshot: snapshot
           )
           result = materializer.call(occurrence_id)
+        rescue Hive::PatrolFix::AdmissionStore::StaleDecision
+          return event(
+            source, occurrence_id, :stale, source_name: source_name,
+            reason: "candidate_digest_changed"
+          )
         rescue StandardError => error
           return defer_failure(
             source, store, occurrence_id, error, source_name: source_name, now: now,

--- a/test/unit/daemon/patrol_fix_admission_scheduler_test.rb
+++ b/test/unit/daemon/patrol_fix_admission_scheduler_test.rb
@@ -331,6 +331,51 @@ class PatrolFixAdmissionSchedulerTest < Minitest::Test
     end
   end
 
+  def test_stale_materialization_reopens_admission_without_retry
+    with_initialized_scheduler_project do |project_root, hive_state, source, entry|
+      admission = Hive::PatrolFix::AdmissionStore.new(
+        root: File.join(hive_state, "patrol-fix", "admissions")
+      )
+      scheduler, services = scheduler_for(
+        project_root, source, admission,
+        decision_provider: lambda do |_input|
+          {
+            "decision" => "distinct", "candidate_identity" => nil,
+            "rationale" => "No shared root", "evidence" => [ "No candidate" ],
+            "model_receipt" => "fake-provider:distinct"
+          }
+        end,
+        materializer_factory: lambda do |**|
+          Object.new.tap do |materializer|
+            materializer.define_singleton_method(:call) do |occurrence_id|
+              admission.reset_decided_stale!(occurrence_id, now: NOW + 2)
+              raise Hive::PatrolFix::AdmissionStore::StaleDecision, "candidate set changed"
+            end
+          end
+        end
+      )
+
+      dispatch = scheduler.tick(now: NOW).fetch(0)
+      services.fetch(0).run_reserved(
+        occurrence_id: dispatch.occurrence_id,
+        reservation_id: dispatch.dispatch_token.fetch(:reservation_id)
+      )
+      scheduler.complete(
+        dispatch_token: dispatch.dispatch_token, exit_code: 0, envelope: { "ok" => true },
+        now: NOW + 1
+      )
+
+      event = scheduler.tick(now: NOW + 2).fetch(0)
+      record = admission.fetch(entry.fetch("occurrence_id"))
+
+      assert_equal :stale, event.status
+      assert_equal "candidate_digest_changed", event.reason
+      assert_equal "pending", record.fetch("status")
+      assert_nil record["retry"]
+      assert_equal [ :decision_dispatch ], scheduler.tick(now: NOW + 3).map(&:status)
+    end
+  end
+
   def test_durable_task_reconciles_when_admission_ack_write_fails_once
     with_initialized_scheduler_project do |project_root, hive_state, source, entry|
       admission = OneShotAcknowledgementFailureStore.new(

--- a/wiki/log.d/20260823T214215Z-stale-patrol-materialization.md
+++ b/wiki/log.d/20260823T214215Z-stale-patrol-materialization.md
@@ -1,0 +1,15 @@
+## [2026-08-23T21:42:15Z] Patrol Fix — re-admit stale materialization decisions
+
+**Action:** Changed Patrol Fix admission scheduling to preserve the
+materializer's stale-candidate reset. When final candidate revalidation moves a
+decided admission back to `pending`, the scheduler now emits a stale event and
+allows a fresh semantic decision instead of incorrectly writing a
+`materialization_failure` retry onto the reset record. Genuine materialization
+failures retain their bounded retry behavior.
+
+**Verification:** Added a regression covering the exact decided-to-pending
+transition and proving that no retry metadata is written before the next
+semantic decision dispatch.
+
+**Refreshed pages:**
+- [[modules/patrol]]

--- a/wiki/modules/patrol.md
+++ b/wiki/modules/patrol.md
@@ -120,6 +120,12 @@ tick rather than blocking the daemon. Existing unindexed stores must be
 initialized explicitly with `hive migrate`; daemon ticks never perform a full
 index rebuild or run a migration watcher.
 
+Task materialization revalidates the semantic candidate set immediately before
+binding. If that set changed, it resets the admission to `pending` and the
+scheduler treats the resulting stale-decision signal as fresh semantic work;
+it never converts that intentional reset into a materialization retry. Genuine
+I/O or task-store failures continue through the bounded `retry_wait` path.
+
 Architecture discovery claims retain PID, process-start-time, process-group,
 lease, heartbeat, owner, and generation. A stale generation cannot checkpoint.
 A new daemon may reclaim a dead exact process; live or unverifiable ownership


### PR DESCRIPTION
## Summary

Patrol admissions whose candidate set changes during materialization now return to `pending` and re-enter semantic decision dispatch on the next tick. They no longer become `retry_wait` materialization failures after the materializer intentionally resets them.

This continues the queue-cost and status-cost reductions already merged. A strict one-time local repair will reset the ten records created by the old transition after this fix is deployed.

## Validation

- Exact transition regression: 18 runs, 102 assertions, 0 failures.
- Targeted RuboCop: 2 files, no offenses.
- The regression proves the stale event, absence of retry metadata, and next-tick `decision_dispatch`.
