### PR TITLE
perf(daemon): space full scans from completion

### DIFF
--- a/lib/hive/daemon/dispatcher.rb
+++ b/lib/hive/daemon/dispatcher.rb
@@ -249,9 +249,12 @@ module Hive
       # handling, no sleep. Public so tests can drive a single tick
       # deterministically.
       def tick(now: Time.now)
+        tick_started = false
+        tick_clock_started_at = nil
         return unless admission_open?
 
-        @last_tick_at = now
+        tick_clock_started_at = full_tick_clock_time
+        tick_started = true
         publish_operational_snapshot(:begin_tick, phase: "started", now: now)
         # PR-40 follow-up #2: clear the per-tick enable cache so a
         # `daemon.enabled` flip in `<project>/.hive-state/config.yml`
@@ -527,6 +530,12 @@ module Hive
 
         @logger.event(:tick_end, now: Time.now.utc.iso8601,
                                  in_flight: @controller.in_flight_count)
+      ensure
+        if tick_started
+          @last_tick_at = full_tick_completion_time(
+            started_at: now, clock_started_at: tick_clock_started_at
+          )
+        end
       end
 
       # A fast tick is intentionally task-local. It refreshes only rows whose
@@ -824,6 +833,15 @@ module Hive
 
       def full_tick_due?(now)
         @last_tick_at.nil? || (now - @last_tick_at) >= @poll_interval_sec
+      end
+
+      def full_tick_completion_time(started_at:, clock_started_at:)
+        elapsed = [ full_tick_clock_time - clock_started_at, 0 ].max
+        started_at.utc + elapsed
+      end
+
+      def full_tick_clock_time
+        @clock ? @clock.call.utc : Time.now.utc
       end
 
       def cheap_probe(now:)

--- a/test/unit/daemon/dispatcher_test.rb
+++ b/test/unit/daemon/dispatcher_test.rb
@@ -4512,13 +4512,78 @@ end
 
 def test_changed_task_ticks_do_not_delay_the_periodic_full_repair_scan
   status_row = row(action: nil, command: nil)
-  dispatcher, = make_dispatcher(rows: [ status_row ])
+  dispatcher, = make_dispatcher(rows: [ status_row ], clock: -> { T0 })
 
   dispatcher.tick(now: T0)
   dispatcher.tick_changed(task_keys: [ [ "p1", "s1" ] ], now: T0 + 10)
 
   refute dispatcher.send(:full_tick_due?, T0 + 29)
   assert dispatcher.send(:full_tick_due?, T0 + 30)
+end
+
+def test_full_repair_interval_starts_after_a_long_full_tick_completes
+  completed_at = T0 + 45
+  current_time = T0
+  dispatcher, = make_dispatcher(rows: [], clock: -> { current_time })
+  status = dispatcher.instance_variable_get(:@status_consumer)
+  original_fetch = status.method(:fetch)
+  status.define_singleton_method(:fetch) do
+    result = original_fetch.call
+    current_time = completed_at
+    result
+  end
+
+  dispatcher.tick(now: T0)
+
+  refute dispatcher.send(:full_tick_due?, completed_at + 29),
+         "a slow full scan must not cause an immediate replacement scan"
+  assert dispatcher.send(:full_tick_due?, completed_at + 30)
+end
+
+def test_failed_full_repair_also_waits_from_completion_before_retrying
+  completed_at = T0 + 45
+  current_time = T0
+  failed = Hive::Daemon::StatusConsumer::Result.new(
+    ok: false, rows: [], projects: [], error: "status failed"
+  )
+  dispatcher, = make_dispatcher(status_result: failed, clock: -> { current_time })
+  status = dispatcher.instance_variable_get(:@status_consumer)
+  original_fetch = status.method(:fetch)
+  status.define_singleton_method(:fetch) do
+    result = original_fetch.call
+    current_time = completed_at
+    result
+  end
+
+  dispatcher.tick(now: T0)
+
+  refute dispatcher.send(:full_tick_due?, completed_at + 29),
+         "a failed scan must not create a status-failure retry storm"
+  assert dispatcher.send(:full_tick_due?, completed_at + 30)
+end
+
+def test_clockless_full_tick_keeps_completion_on_the_callers_timeline
+  completed_at = T0 + 45
+  current_time = T0
+  dispatcher, = make_dispatcher(rows: [])
+  status = dispatcher.instance_variable_get(:@status_consumer)
+  original_fetch = status.method(:fetch)
+  status.define_singleton_method(:fetch) do
+    result = original_fetch.call
+    current_time = completed_at
+    result
+  end
+
+  original_now = Time.method(:now)
+  Time.define_singleton_method(:now) { current_time }
+  begin
+    dispatcher.tick(now: T0)
+  ensure
+    Time.define_singleton_method(:now, original_now)
+  end
+
+  refute dispatcher.send(:full_tick_due?, completed_at + 29)
+  assert dispatcher.send(:full_tick_due?, completed_at + 30)
 end
 
 def test_changed_task_ticks_leave_global_schedulers_to_the_full_scan

--- a/wiki/commands/daemon.md
+++ b/wiki/commands/daemon.md
@@ -164,7 +164,7 @@ All under `daemon:` in `~/Dev/hive/config.yml`:
 
 | Key | Default | Purpose |
 |-----|---------|---------|
-| `poll_interval_sec` | 30 | Backstop cadence for full status scans. Min 5. |
+| `poll_interval_sec` | 30 | Minimum completion-to-start interval between periodic full status repair scans. Min 5. Slow periodic scans cannot chain; ancillary completion can still request an immediate follow-up scan. |
 | `fast_poll_sec` | 1 | Cheap wake cadence for child reaps and a rotating batch of at most 64 tracked state-file mtime probes between full scans. Only exact changed task rows refresh; dependency-bearing rows wait for the full scan. Min 1. |
 | `auto_retry.enabled` | — | **Inert.** Retired as a kill switch: `ERROR` / `REVIEW_ERROR` retries are unconditional and follow one backoff ladder. The key is still shape-validated so a typo fails loudly, but setting it changes nothing. Pause a project with `daemon.enabled: false` instead. |
 | `edit_debounce_sec` | 30 | Settle window for `kind: edit` resumes. 0 disables debounce. |

--- a/wiki/log.d/20260823T230000Z-daemon-full-scan-completion-cadence.md
+++ b/wiki/log.d/20260823T230000Z-daemon-full-scan-completion-cadence.md
@@ -1,0 +1,18 @@
+---
+title: Bound slow daemon full-scan duty cycle
+type: change
+date: 2026-08-23
+tags: [daemon, status, performance, scheduling]
+---
+
+The daemon now starts `poll_interval_sec` when a full repair scan completes,
+instead of when it begins. A slow periodic scan therefore cannot make its
+periodic replacement immediately overdue, even when retained task growth makes
+the scan itself exceed 30 seconds. Previously, any periodic scan longer than
+the interval could pin the dispatcher in continuous fleet-wide projection
+work. Ancillary completion can still request an immediate full follow-up scan
+by design.
+
+Changed-task ticks still do not move the full-repair deadline. A regression
+models a 45-second scan and proves the next full scan is due 30 seconds after
+completion, not immediately.

--- a/wiki/modules/daemon.md
+++ b/wiki/modules/daemon.md
@@ -155,8 +155,12 @@ row triggers an immediate full tick so Patrol and digest follow-up keeps its
 existing wake behavior. `daemon.poll_interval_sec`
 (default 30s) remains the full-scan repair cadence for fleet schedulers, new or
 removed tasks, metadata/config changes, dependency release, archive counts,
-and operational snapshot publication. Incremental ticks do not move that
-deadline, so continuous edits cannot starve repair.
+and operational snapshot publication. The periodic interval starts when a full
+scan finishes, so a periodic scan that grows beyond 30 seconds cannot make its
+periodic replacement immediately overdue and pin the dispatcher in continuous
+fleet scans. Incremental ticks do not move that deadline, so continuous edits
+cannot starve repair. Ancillary completion can still request an immediate full
+follow-up scan.
 
 On graceful shutdown, the supervisor snapshots each ancillary child's verified
 descendant tree and original process group before sending TERM, then escalates


### PR DESCRIPTION
## Summary

- start the periodic full-repair interval when a full scan completes
- preserve immediate ancillary follow-up and changed-task fast ticks
- keep deterministic and clockless callers on their own time line
- document the completion-to-start cadence

## Why

A full status scan that exceeded poll_interval_sec made its next periodic replacement immediately overdue. As retained tasks grew, the daemon could run fleet-wide scans continuously and saturate a CPU.

## Verification

- dispatcher: 288 runs, 1,038 assertions, 0 failures
- broad suite: 13,368 runs, 274,349 assertions, 0 failures, 0 errors
- RuboCop: clean
- live dry-run: 12-second scan completed, then the next periodic scan started 30 seconds later rather than immediately
- independent code review and validator: no unresolved findings