### PR TITLE
perf(status): reuse daemon graph for concise status

### DIFF
--- a/lib/hive/commands/daemon.rb
+++ b/lib/hive/commands/daemon.rb
@@ -295,6 +295,9 @@ module Hive
           store: Hive::Daemon::OperationalSnapshot::Store.new(
             path: Hive::Paths.operational_snapshot_path(@hive_home)
           ),
+          status_cache_store: Hive::Daemon::OperationalSnapshot::StatusCache::Store.new(
+            path: Hive::Paths.operational_status_cache_path(@hive_home)
+          ),
           daemon_identity: Hive::Daemon::OperationalSnapshot.daemon_identity(
             pid: Process.pid, process_start_time: own_start_time
           ),

--- a/lib/hive/commands/status.rb
+++ b/lib/hive/commands/status.rb
@@ -230,8 +230,13 @@ module Hive
         summary = payload.fetch("summary")
         completeness = %w[complete partial unknown].include?(payload["completeness"]) ?
           payload.fetch("completeness") : "unknown"
-        puts "SNAPSHOT #{completeness.upcase} — " \
-             "#{summary.fetch('active')} active · #{summary.fetch('archived')} archived"
+        heading = "SNAPSHOT #{completeness.upcase} — " \
+                  "#{summary.fetch('active')} active · #{summary.fetch('archived')} archived"
+        task_graph = payload.dig("source", "task_graph") || {}
+        if task_graph["provenance"] == "daemon_cache"
+          heading += " · task graph cached #{task_graph.fetch('age_seconds').round}s ago"
+        end
+        puts heading
         hidden_count = summary.fetch("hidden_archived_task_count", 0)
         render_archived_hidden_summary(hidden_count) if hidden_count.positive?
         render_operational_issues(payload.fetch("issues"))
@@ -374,24 +379,64 @@ module Hive
       end
 
       def operational_status(projects, scheduler_snapshot:, status_payload:, now: Time.now.utc)
-        workflow_generations = capture_workflow_generations(projects) unless status_payload
-        source = status_payload || json_payload(
+        if scheduler_snapshot.equal?(AUTO_SCHEDULER_SNAPSHOT)
+          scheduler_snapshot = Hive::Daemon::OperationalSnapshot::Reader.new.read(now: now)
+        end
+        cache = status_payload ? nil : current_status_cache(
+          projects, scheduler_snapshot, now: now
+        )
+        source = status_payload || cache&.fetch("payload", nil)
+        workflow_generations = capture_workflow_generations(projects) unless source
+        source ||= json_payload(
           projects, now: now, workflow_generations: workflow_generations
         )
         project_context = operational_project_context(
           projects, workflow_generations: workflow_generations
         )
-        if scheduler_snapshot.equal?(AUTO_SCHEDULER_SNAPSHOT)
-          scheduler_snapshot = if project_context.any? { |_name, context| context["daemon_enabled"] == true }
-            Hive::Daemon::OperationalSnapshot::Reader.new.read(now: now)
-          end
-        end
         Hive::OperationalStatus.new(
           status_payload: source,
           project_context: project_context,
           scheduler_snapshot: scheduler_snapshot,
+          status_payload_tick_sequence: cache&.fetch("tick_sequence", nil),
           now: now
         )
+      end
+
+      def current_status_cache(projects, snapshot, now:)
+        return unless snapshot.is_a?(Hash)
+        return unless %w[current unavailable].include?(snapshot["status"])
+
+        cache = status_cache_record(snapshot, now: now)
+        return unless cache.is_a?(Hash)
+        sequence = cache["tick_sequence"]
+        snapshot_sequence = snapshot["tick_sequence"]
+        return unless sequence.is_a?(Integer) && sequence.positive? &&
+                      snapshot_sequence.is_a?(Integer) && sequence <= snapshot_sequence
+        return if Time.iso8601(cache.fetch("valid_until")) < now
+
+        payload = cache.fetch("payload")
+        current_version = Hive::Schemas::SCHEMA_VERSIONS.fetch("hive-status")
+        return unless payload.is_a?(Hash) && payload["schema"] == "hive-status" &&
+                      payload["schema_version"] == current_version && payload["ok"] == true &&
+                      payload["projects"].is_a?(Array)
+        Time.iso8601(payload.fetch("generated_at"))
+        return unless project_identities(payload.fetch("projects")) == project_identities(projects)
+
+        cache
+      rescue ArgumentError, TypeError, KeyError
+        nil
+      end
+
+      def status_cache_record(snapshot, now:)
+        Hive::Daemon::OperationalSnapshot::StatusCache::Reader.new.read(
+          snapshot: snapshot, now: now
+        )
+      end
+
+      def project_identities(projects)
+        Array(projects).map do |project|
+          [ project.fetch("name").to_s, File.expand_path(project.fetch("path").to_s) ]
+        end.sort
       end
 
       # Stable schema for agent / wrapper consumption. Adding new keys is

--- a/lib/hive/daemon/dispatcher.rb
+++ b/lib/hive/daemon/dispatcher.rb
@@ -525,6 +525,7 @@ module Hive
         publish_complete_operational_snapshot(
           rows: result.rows,
           hidden_archived_task_count: result.hidden_archived_task_count,
+          status_payload: result.status_payload,
           now: now
         )
 
@@ -1858,7 +1859,8 @@ module Hive
         log_operational_snapshot_failure(phase: "observe", error: e)
       end
 
-      def publish_complete_operational_snapshot(rows:, hidden_archived_task_count: 0, now:)
+      def publish_complete_operational_snapshot(rows:, hidden_archived_task_count: 0,
+                                                status_payload: nil, now:)
         return unless @operational_snapshot
 
         completed_at = operational_snapshot_now
@@ -1868,6 +1870,7 @@ module Hive
           phase: "complete",
           rows: rows,
           hidden_archived_task_count: hidden_archived_task_count,
+          status_payload: status_payload,
           controller: @controller.operational_snapshot(now: completed_at),
           queue: operational_queue_snapshot(now: completed_at, queue_state: queue_state),
           recoveries: operational_recovery_snapshot(queue_state: queue_state),

--- a/lib/hive/daemon/operational_snapshot.rb
+++ b/lib/hive/daemon/operational_snapshot.rb
@@ -36,6 +36,29 @@ module Hive
         }
       end
 
+      def daemon_identity_matches?(actual, expected)
+        return false unless actual.is_a?(Hash) && expected.is_a?(Hash)
+
+        %w[generation pid process_start_time].all? do |key|
+          actual[key].to_s == expected[key].to_s
+        end
+      end
+
+      def validate_read_path!(path, label: "snapshot")
+        parent_stat = File.lstat(File.dirname(path))
+        raise SecurityError, "#{label} directory is a symlink" if parent_stat.symlink?
+        raise SecurityError, "#{label} parent is not a directory" unless parent_stat.directory?
+        raise SecurityError, "#{label} directory has unsafe ownership" unless parent_stat.uid == Process.uid
+        raise SecurityError, "#{label} directory is not owner-private" unless (parent_stat.mode & 0o077).zero?
+
+        stat = File.lstat(path)
+        raise SecurityError, "#{label} file is a symlink" if stat.symlink?
+        raise SecurityError, "#{label} path is not a regular file" unless stat.file?
+        raise SecurityError, "#{label} file has multiple hard links" unless stat.nlink == 1
+        raise SecurityError, "#{label} file has unsafe ownership" unless stat.uid == Process.uid
+        raise SecurityError, "#{label} file is not owner-private" unless (stat.mode & 0o077).zero?
+      end
+
       # Owner-private atomic persistence. The dedicated parent directory and
       # final inode are both checked before and after replacement so a symlink
       # or permissive path never becomes an authority source.
@@ -95,6 +118,91 @@ module Hive
         end
       end
 
+      # Large full-graph cache published once per successful daemon scan.
+      # It is deliberately separate from the scheduler snapshot: web/watch
+      # consumers read the small snapshot, while concise status opts into this
+      # file and joins it only to a generation-bound scheduler record.
+      module StatusCache
+        SCHEMA = "hive-daemon-status-cache".freeze
+        SCHEMA_VERSION = 1
+
+        class Store < OperationalSnapshot::Store
+          def initialize(path: Hive::Paths.operational_status_cache_path)
+            super
+          end
+        end
+
+        class Reader
+          def initialize(path: Hive::Paths.operational_status_cache_path)
+            @path = File.expand_path(path)
+          end
+
+          def read(snapshot:, now: Time.now.utc)
+            return unless eligible_snapshot?(snapshot, now)
+
+            OperationalSnapshot.validate_read_path!(@path, label: "cache")
+            record = JSON.parse(File.read(@path))
+            validate_record!(record)
+            return unless OperationalSnapshot.daemon_identity_matches?(
+              record.fetch("daemon"), snapshot.fetch("daemon")
+            )
+            return unless record.fetch("tick_sequence") <= snapshot.fetch("tick_sequence")
+
+            deadline = effective_deadline(record, snapshot)
+            return if deadline < now
+
+            record.merge("valid_until" => deadline.iso8601(6))
+          rescue Errno::ENOENT, SecurityError, JSON::ParserError, ArgumentError,
+                 TypeError, KeyError, SystemCallError, IOError
+            nil
+          end
+
+          private
+
+          def eligible_snapshot?(snapshot, now)
+            return false unless snapshot.is_a?(Hash)
+            return false unless %w[current unavailable].include?(snapshot["status"])
+            return false if snapshot["shutdown"].is_a?(Hash)
+            return false unless snapshot["tick_sequence"].is_a?(Integer)
+            return false unless snapshot["daemon"].is_a?(Hash)
+
+            Time.iso8601(snapshot.fetch("valid_until")) >= now
+          rescue ArgumentError, TypeError, KeyError
+            false
+          end
+
+          def validate_record!(record)
+            raise ArgumentError, "cache must be an object" unless record.is_a?(Hash)
+            raise ArgumentError, "wrong cache schema" unless record["schema"] == SCHEMA
+            raise ArgumentError, "unsupported cache schema version" unless
+              record["schema_version"] == SCHEMA_VERSION
+            raise ArgumentError, "invalid cache daemon" unless record["daemon"].is_a?(Hash)
+            raise ArgumentError, "invalid cache tick" unless
+              record["tick_sequence"].is_a?(Integer) && record["tick_sequence"].positive?
+
+            Time.iso8601(record.fetch("published_at"))
+            Time.iso8601(record.fetch("valid_until"))
+            payload = record.fetch("payload")
+            unless payload.is_a?(Hash) && payload["schema"] == "hive-status" &&
+                   payload["ok"] == true && payload["schema_version"].is_a?(Integer) &&
+                   payload["projects"].is_a?(Array)
+              raise ArgumentError, "invalid cache payload"
+            end
+            Time.iso8601(payload.fetch("generated_at"))
+          end
+
+          def effective_deadline(record, snapshot)
+            cache_deadline = Time.iso8601(record.fetch("valid_until"))
+            published_at = Time.iso8601(record.fetch("published_at"))
+            snapshot_validity = Time.iso8601(snapshot.fetch("valid_until")) -
+              Time.iso8601(snapshot.fetch("observed_at"))
+            raise ArgumentError, "invalid snapshot validity" unless snapshot_validity.positive?
+
+            [ cache_deadline, published_at + snapshot_validity ].min
+          end
+        end
+      end
+
       # Builds one coherent tick record. Decisions are captured in memory as
       # the dispatcher evaluates one authoritative status frame. Operational
       # consumers accept them only from task graphs sampled after completion
@@ -102,8 +210,9 @@ module Hive
       class Assembler
         attr_reader :tick_sequence
 
-        def initialize(store:, daemon_identity:, poll_interval_sec:)
+        def initialize(store:, daemon_identity:, poll_interval_sec:, status_cache_store: nil)
           @store = store
+          @status_cache_store = status_cache_store
           @daemon_identity = stringify_keys(daemon_identity)
           reconfigure(poll_interval_sec: poll_interval_sec)
           @tick_sequence = 0
@@ -169,6 +278,7 @@ module Hive
 
         def complete(rows:, controller:, queue:, recoveries:,
                      hidden_archived_task_count: 0,
+                     status_payload: nil,
                      now: Time.now.utc)
           rows = Array(rows)
           validate_hidden_count!(
@@ -187,17 +297,17 @@ module Hive
           holds = provider_holds(rows)
           overlay_provider_dispositions!(task_index, holds)
           overlay_recovery_dispositions!(task_index, recoveries || {})
-          @store.write(
-            base_record(phase: "complete", now: now).merge(
-              "reason" => nil,
-              "hidden_archived_task_count" => hidden_archived_task_count,
-              "capacity" => controller || {},
-              "queue" => queue || {},
-              "provider_holds" => holds,
-              "recoveries" => recoveries || {},
-              "tasks" => tasks
-            )
+          publish_status_cache(status_payload, now: now)
+          record = base_record(phase: "complete", now: now).merge(
+            "reason" => nil,
+            "hidden_archived_task_count" => hidden_archived_task_count,
+            "capacity" => controller || {},
+            "queue" => queue || {},
+            "provider_holds" => holds,
+            "recoveries" => recoveries || {},
+            "tasks" => tasks
           )
+          @store.write(record)
         end
 
         # Written only by Dispatcher after it has stopped admitting work and
@@ -239,6 +349,34 @@ module Hive
             "hidden_archived_task_count" => nil,
             "attempt_storage" => @attempt_storage
           }
+        end
+
+        def publish_status_cache(payload, now:)
+          return unless @status_cache_store && valid_status_cache_payload?(payload)
+
+          instant = now.utc
+          @status_cache_store.write(
+            "schema" => StatusCache::SCHEMA,
+            "schema_version" => StatusCache::SCHEMA_VERSION,
+            "daemon" => @daemon_identity,
+            "tick_sequence" => tick_sequence,
+            "published_at" => instant.iso8601(6),
+            "valid_until" => (instant + @validity_sec).iso8601(6),
+            "payload" => payload
+          )
+        rescue StandardError
+          nil
+        end
+
+        def valid_status_cache_payload?(payload)
+          return false unless payload.is_a?(Hash) && payload["schema"] == "hive-status" &&
+                              payload["ok"] == true && payload["schema_version"].is_a?(Integer) &&
+                              payload["projects"].is_a?(Array)
+
+          Time.iso8601(payload.fetch("generated_at"))
+          true
+        rescue ArgumentError, TypeError, KeyError
+          false
         end
 
         def validate_hidden_count!(value, label:)
@@ -471,10 +609,11 @@ module Hive
           expected = expected_daemon
           return unavailable("daemon_not_running") if expected == :unavailable
 
-          validate_path!
+          OperationalSnapshot.validate_read_path!(@path)
           record = JSON.parse(File.read(@path))
           validate_record!(record)
-          return invalid("daemon_generation_mismatch", record) unless daemon_matches?(record, expected)
+          return invalid("daemon_generation_mismatch", record) unless
+            OperationalSnapshot.daemon_identity_matches?(record.fetch("daemon"), expected)
           return unavailable(record["reason"] || "tick_#{record.fetch('phase')}", record) unless
             record["phase"] == "complete"
           return stale("snapshot_expired", record) if Time.parse(record.fetch("valid_until")) < now
@@ -494,10 +633,12 @@ module Hive
         # expected generation is captured from the verified live PID before
         # shutdown, so a stale receipt cannot authorize package replacement.
         def shutdown_acknowledgement(expected_daemon:, now: Time.now.utc)
-          validate_path!
+          OperationalSnapshot.validate_read_path!(@path)
           record = JSON.parse(File.read(@path))
           validate_record!(record)
-          return nil unless daemon_matches?(record, expected_daemon)
+          return nil unless OperationalSnapshot.daemon_identity_matches?(
+            record.fetch("daemon"), expected_daemon
+          )
           return nil unless record["phase"] == "complete"
           return nil if Time.parse(record.fetch("valid_until")) < now
 
@@ -540,22 +681,6 @@ module Hive
           :unavailable
         end
 
-        def validate_path!
-          parent = File.dirname(@path)
-          parent_stat = File.lstat(parent)
-          raise SecurityError, "snapshot directory is a symlink" if parent_stat.symlink?
-          raise SecurityError, "snapshot parent is not a directory" unless parent_stat.directory?
-          raise SecurityError, "snapshot directory has unsafe ownership" unless parent_stat.uid == Process.uid
-          raise SecurityError, "snapshot directory is not owner-private" unless (parent_stat.mode & 0o077).zero?
-
-          stat = File.lstat(@path)
-          raise SecurityError, "snapshot file is a symlink" if stat.symlink?
-          raise SecurityError, "snapshot path is not a regular file" unless stat.file?
-          raise SecurityError, "snapshot file has multiple hard links" unless stat.nlink == 1
-          raise SecurityError, "snapshot file has unsafe ownership" unless stat.uid == Process.uid
-          raise SecurityError, "snapshot file is not owner-private" unless (stat.mode & 0o077).zero?
-        end
-
         def validate_record!(record)
           raise ArgumentError, "record must be an object" unless record.is_a?(Hash)
           raise ArgumentError, "wrong snapshot schema" unless record["schema"] == SCHEMA
@@ -573,14 +698,6 @@ module Hive
             raise ArgumentError, "invalid source window" unless window["completed_at"].nil?
           else
             Time.parse(window.fetch("completed_at"))
-          end
-        end
-
-        def daemon_matches?(record, expected)
-          return false unless expected.is_a?(Hash)
-
-          %w[generation pid process_start_time].all? do |key|
-            record.dig("daemon", key).to_s == expected[key].to_s
           end
         end
 

--- a/lib/hive/daemon/status_consumer.rb
+++ b/lib/hive/daemon/status_consumer.rb
@@ -58,9 +58,12 @@ module Hive
       # status command, so it never reaches this channel.)
       # Surfacing it here makes those breadcrumbs observable in daemon.log
       # instead of being silently discarded. nil on a clean fetch.
+      # Full reads also retain the validated source payload so the daemon can
+      # publish the graph it already paid to collect; bounded reads leave it
+      # nil because they are not an authoritative fleet snapshot.
       Result = Struct.new(
         :ok, :rows, :projects, :error, :warning,
-        :hidden_archived_task_count,
+        :hidden_archived_task_count, :status_payload,
         keyword_init: true
       ) do
         def initialize(
@@ -69,7 +72,8 @@ module Hive
           projects: [],
           error: nil,
           warning: nil,
-          hidden_archived_task_count: 0
+          hidden_archived_task_count: 0,
+          status_payload: nil
         )
           super
         end
@@ -158,7 +162,8 @@ module Hive
         Result.new(
           ok: true, rows: rows, projects: projects, error: nil,
           warning: success_warning(skew, doc, err),
-          hidden_archived_task_count: projects.sum(&:hidden_archived_task_count)
+          hidden_archived_task_count: projects.sum(&:hidden_archived_task_count),
+          status_payload: require_partial ? nil : doc
         )
       rescue JSON::ParserError => e
         Result.new(

--- a/lib/hive/operational_status.rb
+++ b/lib/hive/operational_status.rb
@@ -28,10 +28,12 @@ module Hive
     PLAN_REVIEW_REPAIR_ACTIONS = %w[plan_review_unsupported plan_review_blocked].freeze
     CODING_PLAN_STAGE = Hive::Workflows::Registry.default.stage_named("plan").dir.freeze
 
-    def initialize(status_payload:, project_context: {}, scheduler_snapshot: nil, now: Time.now.utc)
+    def initialize(status_payload:, project_context: {}, scheduler_snapshot: nil,
+                   status_payload_tick_sequence: nil, now: Time.now.utc)
       @status_payload = status_payload
       @project_context = project_context
       @scheduler_snapshot = scheduler_snapshot
+      @status_payload_tick_sequence = status_payload_tick_sequence
       @now = now.utc
     end
 
@@ -71,6 +73,8 @@ module Hive
             "schema" => @status_payload.fetch("schema"),
             "schema_version" => @status_payload.fetch("schema_version"),
             "generated_at" => @status_payload.fetch("generated_at"),
+            "provenance" => @status_payload_tick_sequence ? "daemon_cache" : "fresh_scan",
+            "age_seconds" => task_graph_age_seconds,
             "status" => task_source_status,
             "projects_total" => projects.size,
             "projects_healthy" => projects.count { |project| project["error"].nil? }
@@ -127,6 +131,10 @@ module Hive
     end
 
     private
+
+    def task_graph_age_seconds
+      [ @now - Time.iso8601(@status_payload.fetch("generated_at")), 0 ].max.round(3)
+    end
 
     def validate_source!
       current_version = Hive::Schemas::SCHEMA_VERSIONS.fetch("hive-status")
@@ -296,12 +304,20 @@ module Hive
     end
 
     def task_graph_predates_snapshot?(snapshot)
+      return false if task_graph_bound_to_snapshot?(snapshot)
+
       completed_at = snapshot.dig("source_window", "completed_at")
       return true if completed_at.to_s.empty?
 
       Time.iso8601(@status_payload.fetch("generated_at")) < Time.iso8601(completed_at)
     rescue ArgumentError, TypeError, KeyError
       true
+    end
+
+    def task_graph_bound_to_snapshot?(snapshot)
+      sequence = @status_payload_tick_sequence
+      sequence.is_a?(Integer) &&
+        sequence == snapshot["tick_sequence"]
     end
 
     def daemon_payload(projects, scheduler, attempt_storage:)

--- a/lib/hive/paths.rb
+++ b/lib/hive/paths.rb
@@ -34,6 +34,12 @@ module Hive
       File.join(root, "operational", "daemon-snapshot.json")
     end
 
+    # The daemon's last validated full status graph. Kept separate from the
+    # small scheduler snapshot so unrelated readers never parse the fleet.
+    def operational_status_cache_path(root = state_home)
+      File.join(root, "operational", "daemon-status-cache.json")
+    end
+
     # Owner-private, host-global provider-account and exact-model health.
     # Explicit routing alone consults this state; legacy attempts bypass it.
     def provider_health_root

--- a/schemas/hive-operational-status.v4.json
+++ b/schemas/hive-operational-status.v4.json
@@ -28,11 +28,13 @@
         "task_graph": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["schema", "schema_version", "generated_at", "status", "projects_total", "projects_healthy"],
+          "required": ["schema", "schema_version", "generated_at", "provenance", "age_seconds", "status", "projects_total", "projects_healthy"],
           "properties": {
             "schema": { "const": "hive-status" },
             "schema_version": { "type": "integer", "minimum": 1 },
             "generated_at": { "type": "string", "format": "date-time" },
+            "provenance": { "type": "string", "enum": ["fresh_scan", "daemon_cache"] },
+            "age_seconds": { "type": "number", "minimum": 0 },
             "status": { "$ref": "#/$defs/Completeness" },
             "projects_total": { "type": "integer", "minimum": 0 },
             "projects_healthy": { "type": "integer", "minimum": 0 }

--- a/test/unit/commands/status_test.rb
+++ b/test/unit/commands/status_test.rb
@@ -2799,6 +2799,27 @@ class CommandsStatusTest < Minitest::Test
     end
   end
 
+  def test_operational_heading_exposes_cached_graph_age
+    payload = {
+      "completeness" => "complete",
+      "source" => {
+        "task_graph" => { "provenance" => "daemon_cache", "age_seconds" => 31.6 }
+      },
+      "summary" => {
+        "projects_total" => 0, "active" => 0, "archived" => 0,
+        "hidden_archived_task_count" => 0
+      },
+      "issues" => [], "tasks" => []
+    }
+
+    output, = capture_io do
+      Hive::Commands::Status.new.send(:render_operational, payload)
+    end
+
+    assert_includes output,
+                    "SNAPSHOT COMPLETE — 0 active · 0 archived · task graph cached 32s ago"
+  end
+
   def test_operational_project_context_fails_closed_when_config_is_unreadable
     project = { "name" => "demo", "path" => "/tmp/unreadable-hive-project" }
     context = with_replaced_singleton_method(
@@ -2839,6 +2860,203 @@ class CommandsStatusTest < Minitest::Test
       assert_equal 1, config_loads,
                    "a full operational scan must parse each project config once"
     end
+  end
+
+  def test_operational_payload_reuses_the_daemon_full_status_cache_without_rescanning_tasks
+    now = Time.utc(2026, 8, 24, 10, 0, 2)
+    cached_payload = {
+      "schema" => "hive-status",
+      "schema_version" => Hive::Schemas::SCHEMA_VERSIONS.fetch("hive-status"),
+      "ok" => true,
+      "generated_at" => (now - 2).iso8601(6),
+      "projects" => [ {
+        "name" => "demo", "path" => "/tmp/demo",
+        "hive_state_path" => "/tmp/demo/.hive-state",
+        "legacy_stage_dirs" => [], "hidden_archived_task_count" => 0,
+        "tasks" => []
+      } ]
+    }
+    snapshot = {
+      "status" => "current", "phase" => "complete", "tick_sequence" => 9,
+      "observed_at" => (now - 1).iso8601(6),
+      "valid_until" => (now + 60).iso8601(6),
+      "source_window" => {
+        "started_at" => (now - 3).iso8601(6),
+        "completed_at" => (now - 1).iso8601(6)
+      },
+      "capacity" => {}, "queue" => {}, "provider_holds" => [], "tasks" => [],
+      "status_cache" => {
+        "tick_sequence" => 9,
+        "valid_until" => (now + 60).iso8601(6),
+        "payload" => cached_payload
+      }
+    }
+    project = { "name" => "demo", "path" => "/tmp/demo" }
+    command = Hive::Commands::Status.new(operational: true)
+    command.define_singleton_method(:status_cache_record) do |_snapshot, now:|
+      snapshot.fetch("status_cache")
+    end
+    command.define_singleton_method(:json_payload) do |*|
+      raise "concise status must not rescan task folders when the daemon cache is current"
+    end
+
+    payload = with_replaced_singleton_method(
+      Hive::Config, :load, ->(_path) { { "daemon" => { "enabled" => true } } }
+    ) do
+      command.operational_payload(
+        [ project ], scheduler_snapshot: snapshot, now: now
+      )
+    end
+
+    assert_equal "complete", payload.fetch("completeness")
+    assert_equal "current", payload.dig("scheduler", "status")
+    assert_equal cached_payload.fetch("generated_at"),
+                 payload.dig("source", "task_graph", "generated_at")
+    assert_equal "daemon_cache", payload.dig("source", "task_graph", "provenance")
+    assert_equal 2.0, payload.dig("source", "task_graph", "age_seconds")
+  end
+
+  def test_operational_payload_falls_back_to_a_fresh_scan_after_the_daemon_cache_expires
+    now = Time.utc(2026, 8, 24, 10, 0, 2)
+    snapshot = {
+      "status" => "stale", "reason" => "snapshot_expired",
+      "status_cache" => {
+        "tick_sequence" => 8,
+        "valid_until" => (now - 1).iso8601(6),
+        "payload" => { "schema" => "hive-status", "ok" => true }
+      }
+    }
+    fresh_payload = {
+      "schema" => "hive-status",
+      "schema_version" => Hive::Schemas::SCHEMA_VERSIONS.fetch("hive-status"),
+      "ok" => true, "generated_at" => now.iso8601(6), "projects" => []
+    }
+    command = Hive::Commands::Status.new(operational: true)
+    scans = 0
+    command.define_singleton_method(:json_payload) do |*_args, **_kwargs|
+      scans += 1
+      fresh_payload
+    end
+
+    payload = command.operational_payload([], scheduler_snapshot: snapshot, now: now)
+
+    assert_equal 1, scans
+    assert_equal fresh_payload.fetch("generated_at"),
+                 payload.dig("source", "task_graph", "generated_at")
+  end
+
+  def test_operational_payload_rejects_a_cache_from_an_invalid_snapshot
+    now = Time.utc(2026, 8, 24, 10, 0, 2)
+    cached_payload = {
+      "schema" => "hive-status",
+      "schema_version" => Hive::Schemas::SCHEMA_VERSIONS.fetch("hive-status"),
+      "ok" => true, "generated_at" => (now - 2).iso8601(6), "projects" => []
+    }
+    snapshot = {
+      "status" => "invalid", "reason" => "snapshot_invalid",
+      "tick_sequence" => 1,
+      "status_cache" => {
+        "tick_sequence" => 2,
+        "valid_until" => (now + 60).iso8601(6),
+        "payload" => cached_payload
+      }
+    }
+    fresh_payload = cached_payload.merge("generated_at" => now.iso8601(6))
+    command = Hive::Commands::Status.new(operational: true)
+    scans = 0
+    command.define_singleton_method(:json_payload) do |*_args, **_kwargs|
+      scans += 1
+      fresh_payload
+    end
+
+    payload = command.operational_payload([], scheduler_snapshot: snapshot, now: now)
+
+    assert_equal 1, scans
+    assert_equal fresh_payload.fetch("generated_at"),
+                 payload.dig("source", "task_graph", "generated_at")
+  end
+
+  def test_operational_payload_uses_the_prior_cache_while_the_next_tick_is_running
+    now = Time.utc(2026, 8, 24, 10, 0, 2)
+    cached_payload = {
+      "schema" => "hive-status",
+      "schema_version" => Hive::Schemas::SCHEMA_VERSIONS.fetch("hive-status"),
+      "ok" => true, "generated_at" => (now - 31).iso8601(6),
+      "projects" => [ {
+        "name" => "demo", "path" => "/tmp/demo",
+        "hive_state_path" => "/tmp/demo/.hive-state",
+        "legacy_stage_dirs" => [], "hidden_archived_task_count" => 0,
+        "tasks" => []
+      } ]
+    }
+    snapshot = {
+      "status" => "unavailable", "reason" => "tick_started",
+      "phase" => "started", "tick_sequence" => 10,
+      "status_cache" => {
+        "tick_sequence" => 9,
+        "valid_until" => (now + 59).iso8601(6),
+        "payload" => cached_payload
+      }
+    }
+    command = Hive::Commands::Status.new(operational: true)
+    command.define_singleton_method(:status_cache_record) do |_snapshot, now:|
+      snapshot.fetch("status_cache")
+    end
+    command.define_singleton_method(:json_payload) do |*|
+      raise "a valid prior graph must remain cheap during the next full scan"
+    end
+
+    payload = with_replaced_singleton_method(
+      Hive::Config, :load, ->(_path) { { "daemon" => { "enabled" => true } } }
+    ) do
+      command.operational_payload(
+        [ { "name" => "demo", "path" => "/tmp/demo" } ],
+        scheduler_snapshot: snapshot, now: now
+      )
+    end
+
+    assert_equal cached_payload.fetch("generated_at"),
+                 payload.dig("source", "task_graph", "generated_at")
+    assert_equal "unavailable", payload.dig("scheduler", "status")
+  end
+
+  def test_operational_payload_falls_back_when_cached_projects_do_not_match_the_registry
+    now = Time.utc(2026, 8, 24, 10, 0, 2)
+    cached_payload = {
+      "schema" => "hive-status",
+      "schema_version" => Hive::Schemas::SCHEMA_VERSIONS.fetch("hive-status"),
+      "ok" => true, "generated_at" => (now - 2).iso8601(6),
+      "projects" => [ { "name" => "old", "path" => "/tmp/old", "tasks" => [] } ]
+    }
+    snapshot = {
+      "status" => "current", "tick_sequence" => 9,
+      "status_cache" => {
+        "tick_sequence" => 9, "valid_until" => (now + 60).iso8601(6),
+        "payload" => cached_payload
+      }
+    }
+    fresh_payload = cached_payload.merge(
+      "generated_at" => now.iso8601(6),
+      "projects" => [ { "name" => "new", "path" => "/tmp/new", "tasks" => [] } ]
+    )
+    command = Hive::Commands::Status.new(operational: true)
+    command.define_singleton_method(:status_cache_record) do |_snapshot, now:|
+      snapshot.fetch("status_cache")
+    end
+    scans = 0
+    command.define_singleton_method(:json_payload) do |*_args, **_kwargs|
+      scans += 1
+      fresh_payload
+    end
+
+    payload = command.operational_payload(
+      [ { "name" => "new", "path" => "/tmp/new" } ],
+      scheduler_snapshot: snapshot, now: now
+    )
+
+    assert_equal 1, scans
+    assert_equal "fresh_scan", payload.dig("source", "task_graph", "provenance")
+    assert_equal 1, payload.dig("summary", "projects_total")
   end
 
   def test_operational_payload_falls_back_to_config_after_generation_capture_failure

--- a/test/unit/commands/status_test.rb
+++ b/test/unit/commands/status_test.rb
@@ -2976,6 +2976,41 @@ class CommandsStatusTest < Minitest::Test
                  payload.dig("source", "task_graph", "generated_at")
   end
 
+  def test_operational_payload_falls_back_when_cache_metadata_is_malformed
+    now = Time.utc(2026, 8, 24, 10, 0, 2)
+    snapshot = {
+      "status" => "current", "tick_sequence" => 1,
+      "status_cache" => {
+        "tick_sequence" => 1, "valid_until" => (now + 60).iso8601(6),
+        "payload" => {
+          "schema" => "hive-status",
+          "schema_version" => Hive::Schemas::SCHEMA_VERSIONS.fetch("hive-status"),
+          "ok" => true, "generated_at" => "not-a-time", "projects" => []
+        }
+      }
+    }
+    fresh_payload = {
+      "schema" => "hive-status",
+      "schema_version" => Hive::Schemas::SCHEMA_VERSIONS.fetch("hive-status"),
+      "ok" => true, "generated_at" => now.iso8601(6), "projects" => []
+    }
+    command = Hive::Commands::Status.new(operational: true)
+    command.define_singleton_method(:status_cache_record) do |_snapshot, now:|
+      snapshot.fetch("status_cache")
+    end
+    scans = 0
+    command.define_singleton_method(:json_payload) do |*_args, **_kwargs|
+      scans += 1
+      fresh_payload
+    end
+
+    payload = command.operational_payload([], scheduler_snapshot: snapshot, now: now)
+
+    assert_equal 1, scans
+    assert_equal fresh_payload.fetch("generated_at"),
+                 payload.dig("source", "task_graph", "generated_at")
+  end
+
   def test_operational_payload_uses_the_prior_cache_while_the_next_tick_is_running
     now = Time.utc(2026, 8, 24, 10, 0, 2)
     cached_payload = {

--- a/test/unit/daemon/dispatcher_test.rb
+++ b/test/unit/daemon/dispatcher_test.rb
@@ -1417,9 +1417,16 @@ class HiveDaemonDispatcherTest < Minitest::Test
   def test_operational_snapshot_publishes_started_disposition_and_revalidated_complete
     observed = row(action: "ready_to_plan", command: "hive plan s1 --from 2-brainstorm")
     snapshot = FakeOperationalSnapshot.new
+    status_payload = {
+      "schema" => "hive-status", "schema_version" => 7, "ok" => true,
+      "generated_at" => T0.iso8601(6), "projects" => []
+    }
     with_tmp_dir do |state_home|
       dispatcher, = make_dispatcher(
-        rows: [ observed ], operational_snapshot: snapshot,
+        operational_snapshot: snapshot,
+        status_result: Hive::Daemon::StatusConsumer::Result.new(
+          ok: true, rows: [ observed ], status_payload: status_payload
+        ),
         dispatch_request_state_home: state_home
       )
       completed_at = T0 + 5
@@ -1432,6 +1439,7 @@ class HiveDaemonDispatcherTest < Minitest::Test
       assert_equal "dispatched", snapshot.calls[1][1].fetch(:decision).to_s
       complete = snapshot.calls.last.last
       assert_equal [ observed ], complete.fetch(:rows)
+      assert_equal status_payload, complete.fetch(:status_payload)
       assert_equal "current", complete.dig(:queue, "status")
       assert_equal completed_at, complete.fetch(:now)
     end

--- a/test/unit/daemon/operational_snapshot_test.rb
+++ b/test/unit/daemon/operational_snapshot_test.rb
@@ -227,13 +227,58 @@ class HiveDaemonOperationalSnapshotTest < Minitest::Test
 
       assembler.complete(
         rows: [], controller: {}, queue: {}, recoveries: {},
-        status_payload: { "schema" => "hive-status", "ok" => true },
+        status_payload: {
+          "schema" => "hive-status", "schema_version" => 7, "ok" => true,
+          "generated_at" => "not-a-time", "projects" => []
+        },
         now: T0 + 1
       )
 
       snapshot = reader.read(now: T0 + 2)
       assert_equal "current", snapshot.fetch("status")
       assert_nil cache_reader.read(snapshot: snapshot, now: T0 + 2)
+    end
+  end
+
+  def test_status_cache_write_failure_does_not_prevent_the_scheduler_snapshot
+    with_tmp_dir do |dir|
+      path = File.join(dir, "private", "operational-snapshot.json")
+      store = Hive::Daemon::OperationalSnapshot::Store.new(path: path)
+      failing_cache_store = Object.new
+      failing_cache_store.define_singleton_method(:write) { |_record| raise Errno::EIO, "full" }
+      assembler = Hive::Daemon::OperationalSnapshot::Assembler.new(
+        store: store, status_cache_store: failing_cache_store,
+        daemon_identity: IDENTITY, poll_interval_sec: 30
+      )
+      reader = Hive::Daemon::OperationalSnapshot::Reader.new(
+        path: path, expected_daemon: IDENTITY
+      )
+      payload = {
+        "schema" => "hive-status", "schema_version" => 7, "ok" => true,
+        "generated_at" => T0.iso8601(6), "projects" => []
+      }
+
+      assembler.begin_tick(now: T0)
+      assembler.complete(
+        rows: [], controller: {}, queue: {}, recoveries: {},
+        status_payload: payload, now: T0 + 1
+      )
+
+      assert_equal "current", reader.read(now: T0 + 2).fetch("status")
+    end
+  end
+
+  def test_status_cache_reader_rejects_malformed_snapshot_deadline
+    with_tmp_dir do |dir|
+      cache_reader = Hive::Daemon::OperationalSnapshot::StatusCache::Reader.new(
+        path: File.join(dir, "missing-cache.json")
+      )
+      snapshot = {
+        "status" => "current", "tick_sequence" => 1, "daemon" => IDENTITY,
+        "observed_at" => T0.iso8601(6), "valid_until" => "not-a-time"
+      }
+
+      assert_nil cache_reader.read(snapshot: snapshot, now: T0)
     end
   end
 

--- a/test/unit/daemon/operational_snapshot_test.rb
+++ b/test/unit/daemon/operational_snapshot_test.rb
@@ -40,13 +40,27 @@ class HiveDaemonOperationalSnapshotTest < Minitest::Test
 
   def build(path)
     store = Hive::Daemon::OperationalSnapshot::Store.new(path: path)
+    cache_path = "#{path}.status-cache"
     assembler = Hive::Daemon::OperationalSnapshot::Assembler.new(
-      store: store, daemon_identity: IDENTITY, poll_interval_sec: 30
+      store: store,
+      status_cache_store: Hive::Daemon::OperationalSnapshot::StatusCache::Store.new(
+        path: cache_path
+      ),
+      daemon_identity: IDENTITY, poll_interval_sec: 30
     )
     reader = Hive::Daemon::OperationalSnapshot::Reader.new(
       path: path, expected_daemon: IDENTITY
     )
-    [ store, assembler, reader ]
+    cache_reader = Hive::Daemon::OperationalSnapshot::StatusCache::Reader.new(
+      path: cache_path
+    )
+    [ store, assembler, reader, cache_reader ]
+  end
+
+  def cache_store(path)
+    Hive::Daemon::OperationalSnapshot::StatusCache::Store.new(
+      path: "#{path}.status-cache"
+    )
   end
 
   def test_complete_record_is_private_atomic_and_current
@@ -119,6 +133,130 @@ class HiveDaemonOperationalSnapshotTest < Minitest::Test
       snapshot = reader.read(now: T0 + 2)
       assert_equal "current", snapshot.fetch("status")
       assert_equal 2, snapshot.fetch("hidden_archived_task_count")
+    end
+  end
+
+  def test_full_status_cache_is_bound_to_the_completed_tick_and_retained_while_the_next_tick_runs
+    with_tmp_dir do |dir|
+      path = File.join(dir, "private", "operational-snapshot.json")
+      _store, assembler, reader, cache_reader = build(path)
+      payload = {
+        "schema" => "hive-status", "schema_version" => 7, "ok" => true,
+        "generated_at" => T0.iso8601(6), "projects" => []
+      }
+
+      assembler.begin_tick(now: T0)
+      assembler.complete(
+        rows: [], controller: {}, queue: {}, recoveries: {},
+        status_payload: payload, now: T0 + 1
+      )
+
+      complete = reader.read(now: T0 + 2)
+      cache = cache_reader.read(snapshot: complete, now: T0 + 2)
+      refute complete.key?("status_cache")
+      assert_equal payload, cache.fetch("payload")
+      assert_equal 1, cache.fetch("tick_sequence")
+      assert_equal (T0 + 91).iso8601(6), cache.fetch("valid_until")
+
+      assembler.begin_tick(now: T0 + 31)
+      started = reader.read(now: T0 + 32)
+      retained = cache_reader.read(snapshot: started, now: T0 + 32)
+      assert_equal "unavailable", started.fetch("status")
+      assert_equal "tick_started", started.fetch("reason")
+      refute started.key?("status_cache")
+      assert_equal payload, retained.fetch("payload")
+      assert_equal 1, retained.fetch("tick_sequence")
+      assert_equal 2, started.fetch("tick_sequence")
+    end
+  end
+
+  def test_reader_rejects_a_malformed_status_cache
+    with_tmp_dir do |dir|
+      path = File.join(dir, "private", "operational-snapshot.json")
+      _store, assembler, reader, cache_reader = build(path)
+      assembler.begin_tick(now: T0)
+      assembler.complete(rows: [], controller: {}, queue: {}, recoveries: {}, now: T0 + 1)
+      cache_store(path).write(
+        "schema" => Hive::Daemon::OperationalSnapshot::StatusCache::SCHEMA,
+        "schema_version" => 1,
+        "daemon" => IDENTITY,
+        "tick_sequence" => 1,
+        "published_at" => (T0 + 1).iso8601(6),
+        "valid_until" => (T0 + 90).iso8601(6),
+        "payload" => { "schema" => "wrong", "ok" => true }
+      )
+
+      snapshot = reader.read(now: T0 + 1)
+
+      assert_equal "current", snapshot.fetch("status")
+      assert_nil cache_reader.read(snapshot: snapshot, now: T0 + 1)
+    end
+  end
+
+  def test_reader_rejects_a_status_cache_from_a_future_tick
+    with_tmp_dir do |dir|
+      path = File.join(dir, "private", "operational-snapshot.json")
+      _store, assembler, reader, cache_reader = build(path)
+      assembler.begin_tick(now: T0)
+      assembler.complete(rows: [], controller: {}, queue: {}, recoveries: {}, now: T0 + 1)
+      cache_store(path).write(
+        "schema" => Hive::Daemon::OperationalSnapshot::StatusCache::SCHEMA,
+        "schema_version" => 1,
+        "daemon" => IDENTITY,
+        "tick_sequence" => 2,
+        "published_at" => (T0 + 1).iso8601(6),
+        "valid_until" => (T0 + 90).iso8601(6),
+        "payload" => {
+          "schema" => "hive-status", "schema_version" => 7, "ok" => true,
+          "generated_at" => T0.iso8601(6), "projects" => []
+        }
+      )
+
+      snapshot = reader.read(now: T0 + 1)
+
+      assert_equal "current", snapshot.fetch("status")
+      assert_nil cache_reader.read(snapshot: snapshot, now: T0 + 1)
+    end
+  end
+
+  def test_malformed_status_payload_does_not_prevent_the_scheduler_snapshot
+    with_tmp_dir do |dir|
+      path = File.join(dir, "private", "operational-snapshot.json")
+      _store, assembler, reader, cache_reader = build(path)
+      assembler.begin_tick(now: T0)
+
+      assembler.complete(
+        rows: [], controller: {}, queue: {}, recoveries: {},
+        status_payload: { "schema" => "hive-status", "ok" => true },
+        now: T0 + 1
+      )
+
+      snapshot = reader.read(now: T0 + 2)
+      assert_equal "current", snapshot.fetch("status")
+      assert_nil cache_reader.read(snapshot: snapshot, now: T0 + 2)
+    end
+  end
+
+  def test_current_snapshot_validity_clamps_a_cache_created_before_reconfigure
+    with_tmp_dir do |dir|
+      path = File.join(dir, "private", "operational-snapshot.json")
+      _store, assembler, reader, cache_reader = build(path)
+      payload = {
+        "schema" => "hive-status", "schema_version" => 7, "ok" => true,
+        "generated_at" => T0.iso8601(6), "projects" => []
+      }
+      assembler.reconfigure(poll_interval_sec: 300)
+      assembler.begin_tick(now: T0)
+      assembler.complete(
+        rows: [], controller: {}, queue: {}, recoveries: {},
+        status_payload: payload, now: T0 + 1
+      )
+      assembler.reconfigure(poll_interval_sec: 30)
+      assembler.begin_tick(now: T0 + 61)
+
+      started = reader.read(now: T0 + 92)
+      assert_equal "unavailable", started.fetch("status")
+      assert_nil cache_reader.read(snapshot: started, now: T0 + 92)
     end
   end
 

--- a/test/unit/daemon/status_consumer_test.rb
+++ b/test/unit/daemon/status_consumer_test.rb
@@ -94,6 +94,7 @@ class HiveDaemonStatusConsumerTest < Minitest::Test
       assert_equal "hive brainstorm slug", row.suggested_command
       assert_equal "https://github.com/acme/writero/pull/42", row.pr_url
       assert_equal plan_review, row.plan_review
+      assert_equal payload, result.status_payload
       assert_equal 3, result.hidden_archived_task_count
       assert_equal 3, result.projects.first.hidden_archived_task_count
     end
@@ -113,6 +114,8 @@ class HiveDaemonStatusConsumerTest < Minitest::Test
 
       assert result.ok
       assert_equal [ "changed" ], result.rows.map(&:slug)
+      assert_nil result.status_payload,
+                 "bounded task reads must not replace the daemon's authoritative full graph"
     end
 
     without_partial = payload.reject { |key, _value| key == "partial" }

--- a/test/unit/operational_status_test.rb
+++ b/test/unit/operational_status_test.rb
@@ -503,6 +503,32 @@ class OperationalStatusTest < Minitest::Test
     assert_equal "unavailable", result.dig("tasks", 0, "freshness", "scheduler_status")
   end
 
+  def test_status_cache_from_the_same_tick_accepts_its_scheduler_dispositions
+    source_task = task(action: "ready_to_plan", slug: "cached-task-graph")
+    snapshot = scheduler_snapshot_for(
+      source_task,
+      decision: "global_cap",
+      reason: "global dispatch capacity is exhausted"
+    )
+    snapshot["source_window"] = {
+      "started_at" => "2026-07-20T09:59:59Z",
+      "completed_at" => "2026-07-20T10:00:01Z"
+    }
+    cached_payload = status_payload(source_task)
+
+    result = Hive::OperationalStatus.new(
+      status_payload: cached_payload,
+      status_payload_tick_sequence: snapshot.fetch("tick_sequence"),
+      project_context: { "demo" => { "daemon_enabled" => true } },
+      scheduler_snapshot: snapshot,
+      now: Time.utc(2026, 7, 20, 10, 0, 2)
+    ).to_h
+
+    assert_equal "complete", result.fetch("completeness")
+    assert_equal "current", result.dig("scheduler", "status")
+    assert_equal "global_cap", result.dig("tasks", 0, "reasons", 0, "code")
+  end
+
   def test_task_graph_sampled_after_snapshot_completion_accepts_scheduler_dispositions
     source_task = task(action: "ready_to_plan", slug: "newer-task-graph")
     snapshot = scheduler_snapshot_for(

--- a/wiki/commands/status.md
+++ b/wiki/commands/status.md
@@ -3,7 +3,7 @@ title: hive status
 type: command
 source: lib/hive/commands/status.rb, lib/hive/task_projection/store.rb, lib/hive/task_closure.rb, lib/hive/operational_status.rb, lib/hive/operational_action.rb, lib/hive/daemon/operational_snapshot.rb, lib/hive/diagnostic_evidence.rb
 created: 2026-04-25
-updated: 2026-08-23
+updated: 2026-08-24
 tags: [command, status, operational, agents, observability, json, diagnostics, archive, closure, blocked, plan-review, terminal-outcomes, dependencies, scheduler]
 ---
 
@@ -29,6 +29,31 @@ table.
 
 `--full` cannot be combined with `--json` or `--operational`. Archive mode and
 diagnosis retain their established contracts.
+
+Concise status does not rescan every task when the live daemon already has an
+authoritative full graph. Each completed full daemon tick publishes that exact
+`hive-status` payload once in a dedicated owner-private atomic cache, separate
+from the small operational scheduler snapshot. Bare status and `--operational`
+are the only readers that opt into the large cache. They accept it only when
+its daemon generation, tick, deadline, schema, and registered project identities
+match the live scheduler observation and registry. An absent, invalid, expired,
+or mismatched cache falls back to the ordinary fresh graph scan. `--json`,
+`--full`, archive, diagnosis, and the internal `--daemon-task` surface keep
+their existing fresh-read contracts; the daemon's own `hive status --json`
+therefore remains the cache producer and cannot consume its own cache
+recursively.
+
+The cache is a bounded freshness optimization, not a second source of truth.
+When it belongs to the same completed tick as the scheduler record, the shared
+tick sequence proves that it is the graph on which those scheduler decisions
+were made. A retained cache from the previous tick can still provide cheap
+task visibility while a new tick is running, but scheduler completeness
+remains unavailable until that tick completes. Independently supplied status
+graphs still pass the timestamp and per-task scheduler-join fences.
+The concise human heading reports the cached graph's age. Run `hive status
+--full` when an operator needs to force an immediate fresh human read after a
+task mutation. The JSON task-graph source reports `provenance` (`fresh_scan` or
+`daemon_cache`) and `age_seconds` separately from the projection timestamp.
 
 The operational document projects every non-archived task into exactly one of
 seven states: `running`, `needs_repair`, `waiting_on_you`,

--- a/wiki/log.d/20260824T000301Z-daemon-status-cache.md
+++ b/wiki/log.d/20260824T000301Z-daemon-status-cache.md
@@ -1,0 +1,31 @@
+---
+title: Reuse the daemon full graph for concise status
+type: log
+date: 2026-08-24
+---
+
+**Changed:** Full daemon status results now retain their validated source
+payload and publish it once in a dedicated owner-private atomic cache. Bare
+`hive status` and `--operational` reuse a current tick-bound payload instead of
+rescanning every task. Bounded changed-task reads cannot replace the full
+cache, and compatibility JSON, full, archive, and diagnosis modes remain fresh.
+The large payload is not embedded in scheduler phase records, so web, watch,
+and other operational-snapshot readers do not parse or retain it.
+
+**Safety:** The cache has its own short deadline and source tick sequence. A
+same-tick graph can join scheduler decisions directly; a prior-tick graph used
+during an in-progress scan keeps the scheduler unavailable, while absent,
+malformed, generation-mismatched, project-mismatched, or expired cache data
+falls back to a fresh scan. Cache publication failure cannot suppress the
+small scheduler snapshot. The human heading and JSON source expose cache age
+and provenance; `hive status --full` forces a fresh human read.
+
+**Measured:** On the live 18-project payload, the cached graph is 1.50 MB. A
+single atomic cache write took 4.60 ms, a validated opt-in read averaged 10.44
+ms, and the operational projection averaged 20.03 ms. The small scheduler
+snapshot remains independent. The former fresh command path spent about 2.8
+seconds of CPU-heavy task scanning.
+
+**Refreshed pages:**
+- [[commands/status]]
+- [[modules/daemon]]

--- a/wiki/modules/daemon.md
+++ b/wiki/modules/daemon.md
@@ -3,7 +3,7 @@ title: Hive::Daemon
 type: module
 source: lib/hive/daemon/
 created: 2026-05-06
-updated: 2026-08-23
+updated: 2026-08-24
 tags: [daemon, module, automation, dispatcher, operational-status, snapshots, terminal-outcomes, recovery, plan-review, bounded-storage]
 ---
 
@@ -17,9 +17,12 @@ agents are detached durable attempts observed by the daemon;
 `ChildSupervisor` owns ancillary work only. The daemon also owns merge intake,
 fair scheduling, and fenced completion for the
 language-neutral [[commands/refactor-patrol]] lifecycle. Each full tick also
-publishes an owner-private, atomic operational snapshot. `hive status
---operational --json` and [[commands/watch]] join that scheduler evidence to
-the task graph without making status itself perform daemon reconciliation. The
+publishes an owner-private, atomic operational snapshot. The completed record
+also retains the exact full status graph that the tick already collected, so
+concise `hive status` and `hive status --operational --json` can project it
+without another fleet scan. [[commands/watch]] and callers with their own graph
+still join scheduler evidence without making status itself perform daemon
+reconciliation. The
 Patrol Fix runtime re-reads the project registry when the admission
 scheduler asks for source ports, so projects registered after daemon start are
 admitted without a restart. Each active project retains one `AdmissionStore`
@@ -70,8 +73,8 @@ Valid snapshots keep polling cheap. See [[modules/conditions]].
 | `Hive::Daemon::Policy` | `lib/hive/daemon/policy.rb` | Pure switch over action, admission/dependency state, stage/workflow context, mtime debounce, and the brainstorm `answers_pending` / `answers_complete` signals. Structured admission errors return `:admission_error` before every stage branch; ordinary blocked rows cannot dispatch or poll for merge. |
 | `Hive::Daemon::ConcurrencyController` | `lib/hive/daemon/concurrency_controller.rb` | In-memory budget gate: caps (global / per-project / per-day rate plus per-project patrol scans), WRONG_STAGE protective backoff, transient backoff schedule, quarantine, dropped projects, last-dispatched mtime tracking. `Dispatcher#reload_config!` applies reloaded limits through `update_limits` on this same object so SIGHUP changes admission immediately without discarding runtime state. SUCCESS exits do not cool down; the next stage may dispatch immediately. The last-dispatched mtime map is write-through-persisted via an injected `DispatchBaselines` store so it survives restart (see "Persisted dispatch baselines" below); restored keys retain one-process provenance until a real observation or dispatch consumes them. Everything else is intentionally in-memory. |
 | `Hive::Daemon::DispatchBaselines` | `lib/hive/daemon/dispatch_baselines.rb` | Crash-safe JSON store for the `[project, slug] → state_file_mtime` baseline map (`daemon_dispatch_baselines.json` under the state home). Atomic write + fail-closed load; mirrors `Hive::UpdateCheck::State`. Stops answered `needs_input` tasks being re-stranded across a daemon restart. |
-| `Hive::Daemon::StatusConsumer` | `lib/hive/daemon/status_consumer.rb` | Wraps ordinary full `hive status --json` reads and internal bounded `--daemon-task project:slug` reads. Both return typed visible rows including `workflow`, canonical `pr_url`, and structured `admission_error`; full results also carry project information and the summed `hidden_archived_task_count`. Bounded responses must declare `partial: true`, match the requested project/task identities, and contain no project error; a mismatch fails without replacing cached daemon state. Missing or malformed admission state is converted to `dependency_validation_failed`, `blocked: true`, action `admission_error`, and no command. Envelope shape and hidden-count types are hard-validated while forward schema versions remain best-effort. |
-| `Hive::Daemon::OperationalSnapshot` | `lib/hive/daemon/operational_snapshot.rb` | Private daemon-to-status observation channel. `Assembler` first publishes a generation-bound `runtime_ready` acknowledgement after signal installation and inherited-claim recovery, then retains that flag on `started`, `failed`, revalidated `complete`, and shutdown records. Tick completion includes the final aggregate hidden-archive count; SIGHUP recalculates validity from the reloaded poll interval, and recovery receipts are overlaid only when task, stage, marker identity, and lifecycle still match. `Store` atomically persists records under owner-private path/inode checks; the ordinary `Reader` accepts only live-generation complete observations and degrades every other condition to explicit unavailable/stale/invalid evidence. |
+| `Hive::Daemon::StatusConsumer` | `lib/hive/daemon/status_consumer.rb` | Wraps ordinary full `hive status --json` reads and internal bounded `--daemon-task project:slug` reads. Both return typed visible rows including `workflow`, canonical `pr_url`, and structured `admission_error`; full results also carry the validated source payload, project information, and the summed `hidden_archived_task_count`. Bounded responses never carry a fleet payload: they must declare `partial: true`, match the requested project/task identities, and contain no project error; a mismatch fails without replacing cached daemon state. Missing or malformed admission state is converted to `dependency_validation_failed`, `blocked: true`, action `admission_error`, and no command. Envelope shape and hidden-count types are hard-validated while forward schema versions remain best-effort. |
+| `Hive::Daemon::OperationalSnapshot` | `lib/hive/daemon/operational_snapshot.rb` | Private daemon-to-status observation channel. `Assembler` first publishes a generation-bound `runtime_ready` acknowledgement after signal installation and inherited-claim recovery, then retains that flag on `started`, `failed`, revalidated `complete`, and shutdown records. Tick completion includes the final aggregate hidden-archive count. The large source `hive-status` graph is published once in a separate `StatusCache` file, so the ordinary scheduler `Reader`, web, and watch never parse or retain it; concise status explicitly reads and generation/tick/deadline-validates the cache. SIGHUP recalculates validity from the reloaded poll interval, and recovery receipts are overlaid only when task, stage, marker identity, and lifecycle still match. Both stores atomically persist owner-private records. |
 | `Hive::Daemon::PatrolFixCandidateInventory` | `lib/hive/daemon/patrol_fix_candidate_inventory.rb` | Opens only exact `patrol-fix-manifest.json` files under workflow stage/task owners. It binds every owned manifest's canonical bytes into one full inventory count/digest, fails on owned corruption, ignores unrelated task metadata, and selects one deterministic relevance-ranked context of at most 64 rows and 192 KiB. Exact source identity, alias, and semantic-lineage overlap rank before path/lexical fallback; each selected row carries bounded secret-scanned remediation evidence and its own context digest. |
 | `Hive::Daemon::ActivationLock` | `lib/hive/daemon/activation_lock.rb` | Stable, owner-bound, never-unlinked profile flock held by daemon startup through generation-bound runtime readiness. Unsafe paths, replacement inodes, and bounded contention fail closed. |
 | `Hive::Daemon::StatusReport` | `lib/hive/daemon/status_report.rb` | Shared read-only `hive-daemon-status` producer for `hive daemon status --json` and hivebox. Builds the PID/service/binary/update-nudge envelope as a plain hash, exposes `running_state`, `payload`, and web-safe `safe_payload`, suppresses update-state orphan cleanup, bounds `installed_binary --version` probes to 10s, treats a stable service symlink and its current deployment target as the same binary by filesystem identity, and owns `BINARY_DRIFT_STATES` / `BINARY_DRIFT_ACTIONABLE` so the CLI producer and web repair affordance read the same enum source. |
@@ -205,13 +208,22 @@ be born with already-expired claim windows and fail every detached handoff as
 
 Scheduler decisions are captured in memory as each row is evaluated from the
 tick's one authoritative status frame. The dispatcher publishes that frame at
-completion without running a duplicate fleet projection. A status-side
-temporal fence accepts the snapshot only when the current task graph was
-sampled at or after snapshot completion; it then rechecks task identity,
+completion without running a duplicate fleet projection and writes the exact
+validated source payload once to a separate owner-private atomic cache. This
+keeps scheduler phase writes and unrelated readers bounded to the small
+operational record. Concise status accepts the cache only while its effective
+deadline under the current poll interval is current and its live registry
+project identities still match. A matching cache/snapshot tick sequence binds it to the scheduler
+decisions made from that graph; an independently collected graph still has to
+be sampled at or after snapshot completion. The join then rechecks task identity,
 generation, stage, marker/attrs, attempt, state-file mtime, action,
-dependency/admission policy, and blocked state. A decision therefore cannot
-remain authoritative after a change during the tick or before a later status
-read. Status generation timestamps retain microseconds for same-second
+dependency/admission policy, and blocked state. A cache retained from the
+previous completed tick keeps task visibility cheap during a new `started`
+record, but cannot make that in-progress scheduler frame complete. Invalid,
+generation-mismatched, project-mismatched, or expired cache data falls back to
+a fresh task scan. Cache rejection cannot prevent publication of scheduler
+evidence. Status generation
+timestamps retain microseconds for independently collected same-second
 ordering, and missing or malformed source-window timestamps fail closed. The
 assembler still rejects a source frame containing multiple physical
 rows for one project/slug as `duplicate_task_identity`, so a provider hold or


### PR DESCRIPTION
## Summary

Concise `hive status` now reuses the live daemon's last validated full graph instead of scanning every task again. Fresh compatibility, full, archive, diagnostic, and internal daemon status modes keep their existing read behavior.

This is the next isolated status-scaling slice after #1190. Other scan optimizations remain separate.

## Design

- The daemon remains the only full-graph producer.
- The 1.5 MB graph has its own atomic, owner-private cache. Small scheduler snapshots, web, and watch do not parse or retain it.
- Cache reads fail closed on daemon generation, tick, validity, schema, or registered-project drift.
- Same-tick cache data can join the scheduler decisions produced from that graph. Prior-tick data remains usable during the next scan without claiming current scheduler evidence.
- Human and JSON output expose cache provenance and age. `hive status --full` forces a fresh human read.

## Performance

| Measurement | Before | After |
|---|---:|---:|
| Concise status source | ~2.8 s fresh fleet scan | 9.16 ms average validated cache read |
| Operational projection | included in fresh scan path | 20.03 ms average |
| Scheduler phase record | coupled to graph in the first draft | 765 bytes |
| Cached graph | n/a | 1,512,379 bytes, written once per completed full tick |

## Validation

- 602 focused runs and 2,312 assertions pass with no failures or skips.
- RuboCop passes for all 12 changed Ruby files.
- Schema JSON validation and `git diff --check` pass.
- The broad local checkpoint reaches 112 runs and 1,151 assertions, then stops on the host's unrelated OpenCode offline smoke test because the configured route is absent from the installed model inventory.
