### PR TITLE
fix(patrol): recover OpenCode reports and stalled tasks

### DIFF
--- a/lib/hive/agent.rb
+++ b/lib/hive/agent.rb
@@ -746,13 +746,14 @@ module Hive
     def prepare_opencode_invocation
       validate_opencode_launch_channels!
       model, effort = opencode_route_and_effort
+      executable = isolated_executable(@runtime_policy&.executable || @profile.bin)
       request = AgentCliRuntime::Request.new(
         profile: @profile.runtime_profile,
         prompt: @prompt,
         permission_mode: @permission_mode,
         model: model,
         effort: effort,
-        executable: @runtime_policy&.executable || @profile.bin,
+        executable: executable,
         command_prefix: @runtime_policy&.command_prefix || []
       )
       root = @opencode_invocation_root || File.join(

--- a/lib/hive/artifact_firewall.rb
+++ b/lib/hive/artifact_firewall.rb
@@ -316,8 +316,13 @@ module Hive
     class AgentCustody
       attr_reader :report
 
-      def initialize(manifest)
+      def initialize(manifest, before_validation: nil)
+        if before_validation && !before_validation.respond_to?(:call)
+          raise ArgumentError, "before_validation must respond to call"
+        end
+
         @manifest = manifest
+        @before_validation = before_validation
         @called = false
         @report = nil
       end
@@ -329,7 +334,9 @@ module Hive
         @called = true
         snapshot = ArtifactFirewall.capture(@manifest)
         begin
-          yield
+          result = yield
+          @before_validation&.call(result)
+          result
         ensure
           @report = ArtifactFirewall.validate_and_restore(@manifest, snapshot)
         end

--- a/lib/hive/daemon/concurrency_controller.rb
+++ b/lib/hive/daemon/concurrency_controller.rb
@@ -210,8 +210,9 @@ module Hive
       # `:record_baseline` on a first-sight `kind: edit` row, the
       # dispatcher seeds the controller with the current mtime so the
       # next tick has something to compare against; (b) when durable
-      # admission returns a successful terminal replay, the dispatcher
-      # records the generation's consumed mtime; (c) post-child-completion,
+      # admission accepts a run or returns a successful terminal replay, the
+      # dispatcher records the generation's consumed mtime; (c)
+      # post-child-completion,
       # the dispatcher refreshes the recorded mtime to the
       # current state-file mtime so the agent's own `_WAITING`-marker
       # write (which moves mtime past the at-dispatch value) doesn't

--- a/lib/hive/daemon/dispatcher.rb
+++ b/lib/hive/daemon/dispatcher.rb
@@ -1486,12 +1486,19 @@ module Hive
         baseline_mtime = @controller.last_dispatched_state_file_mtime_for(
           project: row.project, slug: row.slug
         )
-        if brainstorm_answers.fetch(:complete) &&
-           @controller.restored_dispatch_baseline_for?(project: row.project, slug: row.slug)
-          # Older daemons could persist a fully answered brainstorm as the
-          # first-sight baseline and strand it forever. Treat a restored,
-          # uncorroborated baseline as first sight exactly once; a successful
-          # dispatch records it in this process and restores the normal brake.
+        restored_baseline = @controller.restored_dispatch_baseline_for?(
+          project: row.project, slug: row.slug
+        )
+        restored_generic_run = row.action == "ready_to_run" &&
+                               row.state_file_mtime && baseline_mtime &&
+                               row.state_file_mtime < baseline_mtime
+        if restored_baseline &&
+           (brainstorm_answers.fetch(:complete) || restored_generic_run)
+          # A baseline loaded from disk may describe an older daemon's
+          # first-sight observation or a replaced workflow state file. Treat
+          # only that uncorroborated baseline as first sight exactly once.
+          # Same-process observations clear restored provenance, so a newer
+          # sibling artifact can never re-arm an unchanged markerless run.
           baseline_mtime = nil
         end
         decision = Policy.decide(
@@ -1753,14 +1760,14 @@ module Hive
         )
         remember_routing_observation(row, dispatch_result)
         outcome = dispatch_outcome(dispatch_result)
-        if outcome == :attempt_terminal_replay
-          # A successful durable attempt already consumed this exact task
-          # generation. Refresh the edit/run baseline just as a locally
-          # reaped child would, so an unchanged waiting marker does not ask
-          # the attempts layer for the same terminal receipt every tick.
-          # The baseline is persisted by the controller, making the brake
-          # survive daemon restarts while a genuine later edit (newer mtime)
-          # remains eligible for dispatch.
+        if dispatch_result.is_a?(Hive::Attempts::DispatchResult) &&
+           (dispatch_result.accepted? || dispatch_result.status == :terminal_replay)
+          # Durable attempts never enter ChildSupervisor, so consume their
+          # state-file mtime here just as record_dispatch does for a local
+          # child. Acceptance immediately replaces a stale restored baseline;
+          # terminal replay covers a daemon that missed that acceptance. The
+          # persisted brake survives restart while a genuine later edit stays
+          # eligible.
           @controller.observe_state_file_mtime(
             project: row.project, slug: row.slug, mtime: row.state_file_mtime
           )

--- a/lib/hive/daemon/policy.rb
+++ b/lib/hive/daemon/policy.rb
@@ -269,11 +269,11 @@ module Hive
       end
 
       # Generic-stage run decision. First sight (no prior dispatch) runs the
-      # stage once. After that, only re-dispatch when the operator has
-      # touched the state file since the last dispatch (mtime advanced past
-      # the recorded baseline, then settled past the debounce window) — so a
-      # markerless agent run (marker stays `:none` → `ready_to_run` again)
-      # cannot re-spawn `hive run` on every tick.
+      # stage once. After that, only re-dispatch when the operator has touched
+      # the state file since the last dispatch (mtime advanced past the
+      # recorded baseline, then settled past the debounce window) -- so a
+      # markerless agent run cannot re-spawn on every tick. Recovery from a
+      # restored baseline is provenance-sensitive and belongs in Dispatcher.
       def decide_run(state_file_mtime:, last_dispatched:, now:, debounce_sec:)
         return :dispatch if last_dispatched.nil?
         return :skip if state_file_mtime.nil?

--- a/lib/hive/stages/managed_agent_custody.rb
+++ b/lib/hive/stages/managed_agent_custody.rb
@@ -29,9 +29,16 @@ module Hive
         fix = cfg.dig("patrol", "fix")
         fix = {} unless fix.is_a?(Hash)
         fix_agent = fix["agent"]
+        fixing = actor == "patrol_fix"
         profile = Hive::Stages::Base.stage_profile(
-          cfg, "patrol", explicit_agent: fix_agent
+          cfg, "patrol", explicit_agent: fixing ? fix_agent : nil
         )
+        model_actor = fixing ? "patrol_fix" : actor
+        model_current = if fixing
+          fix_model_routing_current(cfg, fix, fix_agent)
+        else
+          Hive::Stages::Base.model_routing_current(cfg["patrol"])
+        end
         prompt = <<~PROMPT
           #{prompt.rstrip}
 
@@ -69,8 +76,7 @@ module Hive
           ),
           log_label: log_label, profile: profile,
           **Hive::Stages::Base.model_launch_arguments(
-            cfg, "patrol_fix", profile,
-            current: fix_model_routing_current(cfg, fix, fix_agent)
+            cfg, model_actor, profile, current: model_current
           ),
           **Hive::Stages::Base.tool_scope_kwargs(scope),
           status_mode: :exit_code_only, cfg: cfg, agent_custody: custody

--- a/lib/hive/stages/managed_agent_custody.rb
+++ b/lib/hive/stages/managed_agent_custody.rb
@@ -1,4 +1,6 @@
 require "open3"
+require "json"
+require "hive/atomic_file"
 require "hive/artifact_firewall"
 require "hive/stages/base"
 
@@ -30,6 +32,13 @@ module Hive
         profile = Hive::Stages::Base.stage_profile(
           cfg, "patrol", explicit_agent: fix_agent
         )
+        prompt = <<~PROMPT
+          #{prompt.rstrip}
+
+          After writing the required report, stop using tools.
+          Return that same JSON object as your complete final response.
+          Do not wrap it in Markdown or add prose.
+        PROMPT
         prompt, scope = if profile.name == :opencode
           [ prompt, opencode_scope(task, actor, cwd, add_dirs, output_path) ]
         else
@@ -48,7 +57,10 @@ module Hive
             root: task.folder, worktree_path: cwd,
             protected_task_paths: protected_task_paths,
             required_outputs: { output_label => output_path }
-          )
+          ),
+          before_validation: lambda { |result|
+            materialize_exact_final_json(result, output_path)
+          }
         )
         result = Hive::Stages::Base.spawn_agent(
           task, prompt: prompt, add_dirs: scope.fetch(:add_dirs), cwd: cwd,
@@ -77,6 +89,20 @@ module Hive
           diagnostic: report&.diagnostic
         }
       end
+
+      def materialize_exact_final_json(result, output_path)
+        return unless result.is_a?(Hash) && result[:status] == :ok
+        return if result[:final_message_truncated] == true
+        return if File.exist?(output_path) || File.symlink?(output_path)
+
+        value = JSON.parse(result[:final_message].to_s)
+        return unless value.is_a?(Hash)
+
+        Hive::AtomicFile.write(output_path, JSON.generate(value) + "\n", mode: 0o600)
+      rescue JSON::ParserError
+        nil
+      end
+      private_class_method :materialize_exact_final_json
 
       def fix_model_routing_current(cfg, fix, fix_agent)
         patrol = Hive::Stages::Base.model_routing_current(cfg["patrol"])

--- a/test/unit/agent_test.rb
+++ b/test/unit/agent_test.rb
@@ -193,6 +193,44 @@ class AgentTest < Minitest::Test
     end
   end
 
+  def test_prepared_opencode_resolves_tool_manager_launcher_before_hermetic_spawn
+    with_tmp_dir do |dir|
+      launcher_dir = File.join(dir, "launchers")
+      concrete_dir = File.join(dir, "concrete")
+      FileUtils.mkdir_p([ launcher_dir, concrete_dir ])
+      launcher = File.join(launcher_dir, "opencode")
+      concrete = File.join(concrete_dir, "opencode")
+      File.write(launcher, <<~SH)
+        #!/bin/sh
+        printf '%s\n' 'tool-manager startup noise'
+        exec mise x opencode -- opencode "$@"
+      SH
+      File.write(concrete, "#!/bin/sh\nexit 0\n")
+      FileUtils.chmod(0o755, [ launcher, concrete ])
+
+      captured = nil
+      with_env(
+        "PATH" => [ launcher_dir, concrete_dir ].join(File::PATH_SEPARATOR),
+        "HIVE_OPENCODE_BIN" => "opencode"
+      ) do
+        profile = Hive::AgentProfiles.lookup(:opencode)
+        agent = Hive::Agent.new(
+          task: make_task(dir), prompt: "inspect", max_budget_usd: nil,
+          timeout_sec: 5, profile: profile, status_mode: :exit_code_only
+        )
+        replacement = lambda do |request, **|
+          captured = request
+          :prepared
+        end
+        with_replaced_singleton_method(Hive::AgentRuntime, :prepare!, replacement) do
+          agent.send(:prepare_opencode_invocation)
+        end
+      end
+
+      assert_equal concrete, captured.request.executable
+    end
+  end
+
   def test_isolated_executable_fails_closed_on_unreadable_launcher_candidates
     with_tmp_dir do |dir|
       launcher_dir = File.join(dir, "launchers")

--- a/test/unit/artifact_firewall_test.rb
+++ b/test/unit/artifact_firewall_test.rb
@@ -765,6 +765,19 @@ class ArtifactFirewallTest < Minitest::Test
     end
   end
 
+  def test_agent_custody_rejects_a_non_callable_before_validation_hook
+    with_tmp_dir do |dir|
+      error = assert_raises(ArgumentError) do
+        Hive::ArtifactFirewall::AgentCustody.new(
+          build_manifest(dir),
+          before_validation: Object.new
+        )
+      end
+
+      assert_equal "before_validation must respond to call", error.message
+    end
+  end
+
   def test_manifest_accepts_a_larger_explicit_entry_limit
     with_tmp_dir do |dir|
       count = Hive::ArtifactFirewall::MAX_ENTRIES + 5

--- a/test/unit/daemon/dispatcher_test.rb
+++ b/test/unit/daemon/dispatcher_test.rb
@@ -2141,6 +2141,94 @@ class HiveDaemonDispatcherTest < Minitest::Test
     refute events_include?(logger, :dispatched)
   end
 
+  def test_generic_ready_to_run_does_not_treat_same_process_newer_baseline_as_replacement
+    current_mtime = T0 - 600
+    rows = [ row(slug: "g1", stage: "1-inbox", workflow: "patrol-fix",
+                 action: "ready_to_run", command: "hive run g1",
+                 marker: "none", mtime: current_mtime) ]
+    dispatcher, sup, ctrl, logger, _mw = make_dispatcher(rows: rows)
+    ctrl.observe_state_file_mtime(project: "p1", slug: "g1", mtime: T0 - 60)
+
+    dispatcher.tick(now: T0)
+
+    assert_empty sup.spawned,
+                 "a newer sibling observed by this daemon must not re-arm the task"
+    assert_equal T0 - 60,
+                 ctrl.last_dispatched_state_file_mtime_for(project: "p1", slug: "g1")
+    assert events_include?(logger, :markerless_stalled)
+    refute events_include?(logger, :dispatched)
+  end
+
+  def test_generic_ready_to_run_replaces_a_newer_restored_dispatch_baseline
+    Dir.mktmpdir("restored-generic-run-baseline") do |dir|
+      path = File.join(dir, "baselines.json")
+      current_mtime = T0 - 600
+      Hive::Daemon::DispatchBaselines.new(path: path).write(
+        { [ "p1", "g1" ] => T0 - 60 }
+      )
+      rows = [ row(slug: "g1", stage: "1-inbox", workflow: "patrol-fix",
+                   action: "ready_to_run", command: "hive run g1",
+                   marker: "none", mtime: current_mtime) ]
+      dispatcher, sup, ctrl, logger, _mw = make_dispatcher(
+        rows: rows,
+        dispatch_state: Hive::Daemon::DispatchBaselines.new(path: path)
+      )
+
+      dispatcher.tick(now: T0)
+
+      assert_equal 1, sup.spawned.size,
+                   "an older state file may recover once from a baseline restored from disk"
+      assert_equal current_mtime,
+                   ctrl.last_dispatched_state_file_mtime_for(project: "p1", slug: "g1")
+      refute ctrl.restored_dispatch_baseline_for?(project: "p1", slug: "g1")
+      assert events_include?(logger, :dispatched)
+      refute events_include?(logger, :markerless_stalled)
+    end
+  end
+
+  def test_durable_ready_to_run_replaces_a_newer_stale_dispatch_baseline_on_acceptance
+    attempt = Struct.new(:attempt_id, :task_generation, :state)
+                    .new("attempt-1", "generation-1", "running")
+    result = Hive::Attempts::DispatchResult.new(
+      status: :accepted, attempt: attempt, receipt: nil,
+      attach_descriptor: nil, reason: nil
+    )
+    dispatch_calls = 0
+    attempt_dispatcher = Object.new
+    attempt_dispatcher.define_singleton_method(:dispatch_request) do |*_args, **_options|
+      dispatch_calls += 1
+      result
+    end
+    Dir.mktmpdir("restored-durable-run-baseline") do |dir|
+      path = File.join(dir, "baselines.json")
+      current_mtime = T0 - 600
+      Hive::Daemon::DispatchBaselines.new(path: path).write(
+        { [ "p1", "g1" ] => T0 - 60 }
+      )
+      rows = [ row(slug: "g1", stage: "1-inbox", workflow: "patrol-fix",
+                   action: "ready_to_run", command: "hive run g1 --json",
+                   marker: "none", mtime: current_mtime) ]
+      dispatcher, _sup, ctrl, logger, _mw = make_dispatcher(
+        rows: rows, attempt_dispatcher: attempt_dispatcher,
+        dispatch_state: Hive::Daemon::DispatchBaselines.new(path: path)
+      )
+
+      dispatcher.tick(now: T0)
+
+      assert_equal current_mtime,
+                   ctrl.last_dispatched_state_file_mtime_for(project: "p1", slug: "g1"),
+                   "durable acceptance must consume the restored baseline"
+      assert events_include?(logger, :attempt_accepted)
+      assert events_include?(logger, :dispatched)
+
+      dispatcher.tick(now: T0 + 30)
+
+      assert_equal 1, dispatch_calls,
+                   "the consumed baseline must brake the unchanged row on the next tick"
+      assert_equal 1, logger.events.count { |name, _attrs| name == :dispatched }
+    end
+  end
+
   # High #1 regression: after a generic `hive approve` moves a task into a
   # non-coding dir (research's `2-gather`), the post-completion refresh must
   # locate it through the runtime union (`Workflows.all_stage_dirs`), NOT the

--- a/test/unit/daemon/policy_test.rb
+++ b/test/unit/daemon/policy_test.rb
@@ -543,6 +543,15 @@ class HiveDaemonPolicyTest < Minitest::Test
                         answers_complete: true)
   end
 
+  def test_ready_to_run_stays_braked_when_baseline_is_newer_than_current_state
+    assert_equal :markerless_stalled,
+                 decide(action: "ready_to_run",
+                        command: "hive run slug-a --json",
+                        state_file_mtime: T0 - 600,
+                        last_dispatched_state_file_mtime: T0 - 60),
+                 "Policy cannot infer replacement from mtime ordering alone"
+  end
+
   def test_blocked_takes_precedence_over_answers_pending_on_debounced_resume
     # A debounced edit-resume row that is BOTH dependency-blocked and has
     # unanswered Q&A must resolve to the dependency gate, not the Q&A hold —

--- a/test/unit/stages/managed_agent_custody_test.rb
+++ b/test/unit/stages/managed_agent_custody_test.rb
@@ -140,10 +140,23 @@ class ManagedAgentCustodyTest < Minitest::Test
     end
   end
 
-  def test_opencode_review_can_write_only_its_report_without_shell
+  def test_review_does_not_inherit_a_distinct_fix_agent
     with_task do |task|
       output = File.join(task.folder, "patrol-fix-inbox-report.json")
       captured = capture_launch(task, output, cfg: opencode_config)
+
+      assert_equal :codex, captured.fetch(:profile).name
+    end
+  end
+
+  def test_opencode_review_can_write_only_its_report_without_shell
+    with_task do |task|
+      output = File.join(task.folder, "patrol-fix-inbox-report.json")
+      cfg = opencode_config
+      cfg.fetch("patrol")["agent"] = "opencode"
+      cfg.fetch("patrol")["model"] = "openrouter/stealth/ox-alpha"
+      cfg.fetch("patrol")["effort"] = "high"
+      captured = capture_launch(task, output, cfg: cfg)
 
       assert_equal "workspace-write", captured.fetch(:permission_mode)
       assert_equal :opencode, captured.fetch(:profile).name

--- a/test/unit/stages/managed_agent_custody_test.rb
+++ b/test/unit/stages/managed_agent_custody_test.rb
@@ -31,6 +31,8 @@ class ManagedAgentCustodyTest < Minitest::Test
       assert_equal :exit_code_only, captured.fetch(:status_mode)
       assert_includes captured.fetch(:add_dirs), task.project_root
       assert_includes captured.fetch(:add_dirs), task.folder
+      assert_includes captured.fetch(:prompt),
+                      "Return that same JSON object as your complete final response"
     end
   end
 
@@ -48,6 +50,52 @@ class ManagedAgentCustodyTest < Minitest::Test
       assert_equal :ok, result.fetch(:status)
       assert_equal :invalid_output, result.fetch(:custody)
       assert_includes result.fetch(:diagnostic), "required output"
+    end
+  end
+
+  def test_launch_agent_materializes_an_exact_final_json_report_before_validation
+    with_task do |task|
+      output = File.join(task.folder, "patrol-fix-inbox-report.json")
+      report = {
+        "schema" => "hive-patrol-fix-inbox-report",
+        "schema_version" => 1,
+        "route" => "reject"
+      }
+      spawn = lambda do |_task, agent_custody:, **|
+        agent_custody.call do
+          {
+            status: :ok,
+            final_message: JSON.generate(report),
+            final_message_truncated: false
+          }
+        end
+      end
+
+      result = with_replaced_singleton_method(Hive::Stages::Base, :spawn_agent, spawn) do
+        launch(task, output)
+      end
+
+      assert_equal :clean, result.fetch(:custody)
+      assert_equal report, JSON.parse(File.read(output))
+    end
+  end
+
+  def test_launch_agent_does_not_replace_a_dangling_report_symlink_from_final_json
+    with_task do |task|
+      output = File.join(task.folder, "patrol-fix-inbox-report.json")
+      spawn = lambda do |_task, agent_custody:, **|
+        agent_custody.call do
+          File.symlink(File.join(task.folder, "missing-target"), output)
+          { status: :ok, final_message: "{}", final_message_truncated: false }
+        end
+      end
+
+      result = with_replaced_singleton_method(Hive::Stages::Base, :spawn_agent, spawn) do
+        launch(task, output)
+      end
+
+      assert_equal :invalid_output, result.fetch(:custody)
+      assert File.symlink?(output)
     end
   end
 

--- a/wiki/commands/daemon.md
+++ b/wiki/commands/daemon.md
@@ -3,7 +3,7 @@ title: hive daemon
 type: command
 source: lib/hive/commands/daemon.rb, lib/hive/daemon/*
 created: 2026-05-06
-updated: 2026-08-23
+updated: 2026-08-24
 tags: [command, daemon, automation, plan-review, json]
 ---
 
@@ -91,6 +91,7 @@ stage.
 | `ready_for_review`    | Dispatch `hive review <slug> --from 5-open-pr` (5→6) |
 | `ready_to_artifacts`  | Dispatch `hive artifacts <slug> --from 6-review` (6→7) |
 | `ready_to_finalize`   | Dispatch `hive finalize <slug> --from 7-artifacts` (7→8) |
+| `ready_to_run` | Dispatch a generic workflow stage once. An unchanged state-file mtime after dispatch is surfaced as `markerless_stalled`. After a daemon restart, an older current mtime can recover once only when the baseline was loaded from the persisted store; same-process observations never gain that recovery authority. |
 | Any coding task with `pr_url` in stages `5-open-pr` through `8-finalize` | **Observe before policy dispatch.** Persist the exact task generation and PR binding, poll with per-candidate durable backoff, verify the observed head and reachable merge SHA, checkpoint required architecture intake, then use a daemon-owned `remote_merge` closure receipt to move the same generation to `9-done`. This includes recoverable error rows; no marker-reason allowlist or archive child exists. |
 | Held PR-bearing task | Keep the candidate in `pr-merge-reconciliation.json` with its hold reason. Current dependency, admission, repository, and PR-identity holds take precedence over historical head drift and do not poll or archive until a later status observation clears them. An `observed_head_changed` hold may poll only the identity-matched bound PR's remote state: `OPEN` or closed-unmerged releases ordinary error recovery so the new generation can be reviewed, while merged, delivered-elsewhere, or ambiguous evidence remains durably blocked before architecture intake or automatic archive and is not polled again. |
 | `plan_reviewing` or due `plan_review_retry` at coding `3-plan` | Dispatch `hive plan-review-run ...`. This automation can start/retry critique, perform an already-authorized revision, and verify, but cannot create approvals, answers, waivers, or mandatory downgrades. |

--- a/wiki/log.d/20260824T083401Z-patrol-opencode-report-recovery.md
+++ b/wiki/log.d/20260824T083401Z-patrol-opencode-report-recovery.md
@@ -1,0 +1,12 @@
+---
+title: Patrol Fix OpenCode report recovery
+type: change
+date: 2026-08-24
+tags: [patrol-fix, opencode, artifact-custody]
+---
+
+Prepared OpenCode launches now bypass stdout-producing tool-manager shims so
+their strict JSONL result stream remains parseable. Managed Patrol Fix stages
+also retain Artifact Firewall custody while accepting an absent report only
+when the successful agent returned the exact, untruncated JSON object as its
+final response; existing paths and symlinks remain fail-closed.

--- a/wiki/log.d/20260824T093500Z-patrol-fix-actor-routing.md
+++ b/wiki/log.d/20260824T093500Z-patrol-fix-actor-routing.md
@@ -1,0 +1,8 @@
+## Patrol Fix actor routing
+
+- Restored independent `patrol.agent` and `models.patrol_review` routing for
+  Patrol Fix inbox and review adjudication.
+- Reserved `patrol.fix.agent` and `models.patrol_fix` for admitted repair work,
+  so choosing OpenCode/Ox Alpha as the fix agent no longer moves semantic
+  admission onto that provider.
+- Added focused coverage for distinct review and fix agents.

--- a/wiki/log.d/20260824T105433Z-stale-run-baseline-recovery.md
+++ b/wiki/log.d/20260824T105433Z-stale-run-baseline-recovery.md
@@ -1,0 +1,19 @@
+# Recover replaced generic workflow state from stale dispatch baselines
+
+## [2026-08-24T10:54:33Z] daemon — admit an older replacement state file once
+
+- Changed generic `ready_to_run` dispatch so a current state-file mtime older
+  than a `[project, slug]` baseline loaded from the persisted store is treated
+  as a replaced or restored state file, not as a markerless agent exit.
+- Gated recovery on the controller's existing restored-baseline provenance.
+  A same-process refresh from a newer sibling artifact therefore cannot create
+  a redispatch loop merely because its timestamp is newer than the state file.
+- Durable attempt acceptance now consumes the observed mtime immediately,
+  matching local child dispatch and preventing repeated admission checks;
+  terminal replay remains the restart-safe fallback.
+- Kept all same-process older/equal mtimes on the existing
+  `markerless_stalled` brake, so unchanged markerless stages cannot redispatch
+  every daemon tick.
+- Added focused policy and dispatcher regressions for local and durable
+  dispatch paths. This unstrands the migrated Patrol Fix manifests whose
+  persisted baselines were newer than their current workflow state.

--- a/wiki/modules/agent.md
+++ b/wiki/modules/agent.md
@@ -196,6 +196,12 @@ customizations; unrelated Claude launches do not receive it. Discovery still
 uses Claude's positional prompt, while Codex's normal and workspace-write
 launches send the prompt through stdin with `-` in argv.
 
+Prepared OpenCode launches resolve a bare executable to the concrete installed
+binary before building the hermetic overlay. Tool-manager shims are not allowed
+to sit on this JSONL protocol boundary: startup notices written by a shim to
+stdout would otherwise turn an otherwise valid OpenCode event stream into a
+typed `malformed_output` failure.
+
 ## `spawn_and_wait` (the long part)
 
 1. Open an owner-private (`0600`), no-follow logfile (`<task.log_dir>/<label>-<UTC-ts>.log`). Append only bounded launch metadata (`cwd`, profile, executable basename, argv count); never serialize argv because positional profiles carry the complete prompt there. Event messages pass through the same shared secret redactor before persistence.

--- a/wiki/modules/daemon.md
+++ b/wiki/modules/daemon.md
@@ -692,6 +692,15 @@ AND prune — so there is no batched loss window for the critical value. A termi
 durable attempts layer already completed that exact task generation; recording
 the observed state-file mtime prevents the unchanged waiting marker from being
 readmitted on every daemon tick, while a later edit still becomes eligible.
+Generic `ready_to_run` stages also recover when their current state-file mtime
+is older than a baseline restored from the persisted store. The controller
+tracks that uncorroborated provenance in memory, so Dispatcher can admit the
+row once without treating timestamp direction as state-file identity. Any
+same-process observation clears restored provenance; a newer sibling artifact
+therefore cannot re-arm an unchanged markerless run. Durable-attempt acceptance
+consumes the current mtime immediately (matching a local child dispatch), and
+terminal replay covers a daemon that missed the acceptance; an unchanged
+current mtime is then braked normally as `markerless_stalled`.
 Mtimes are stored at microsecond resolution and
 `hive status --json` emits task `mtime` / `folder_mtime` with matching
 microsecond precision. Do not truncate status JSON mtimes: an operator

--- a/wiki/modules/patrol.md
+++ b/wiki/modules/patrol.md
@@ -153,6 +153,13 @@ to reproduce, test, and commit the repair. This full-shell grant has the
 authority of the Hive OS user; artifact custody and Git validation remain the
 outcome boundary.
 
+Every managed Patrol Fix agent is also told to return its report as the exact
+final JSON object. If the agent exits successfully without creating the report,
+the controller may materialize only that exact, untruncated JSON object before
+Artifact Firewall validation. Prose, arrays, truncated output, and any existing
+path are not accepted; in particular, a dangling report symlink remains a
+custody violation rather than being replaced by the fallback.
+
 `Hive::GithubPublication` is the single PR-publication mechanism used by
 Patrol Fix and the normal coding open-PR path. It owns durable push/create
 intent, remote reconciliation, expected-absence leases, and exact hosted

--- a/wiki/modules/patrol.md
+++ b/wiki/modules/patrol.md
@@ -142,16 +142,17 @@ Patrol Fix owns the repair workflow:
 4. Review records an independent route decision.
 5. Publish uses `Hive::GithubPublication`.
 
-`patrol.fix` is the one coherent identity for every unified Patrol Fix stage;
-ordinary and Architecture Patrol discovery continue to use their own agents.
-For example, `agent: opencode`, `model: openrouter/stealth/ox-alpha`, and
-`effort: high` select OpenCode only for repair work. The controller supplies
-the bounded OpenCode permission policy directly. Inbox/review may write only
-their exact report and receive no shell permission. Fix may edit the owned
-worktree and its exact report and receives the explicit `Bash(*)` grant needed
-to reproduce, test, and commit the repair. This full-shell grant has the
-authority of the Hive OS user; artifact custody and Git validation remain the
-outcome boundary.
+Inbox and review use the independent `patrol.agent` identity and the
+`models.patrol_review` route. Only the fix stage uses `patrol.fix.agent` and the
+`models.patrol_fix` route. For example, `patrol.fix.agent: opencode` with
+`model: openrouter/stealth/ox-alpha` and `effort: high` selects OpenCode only
+after a finding is admitted for repair. The controller supplies the bounded
+OpenCode permission policy directly. Inbox/review may write only their exact
+report and receive no shell permission when OpenCode is deliberately selected
+as the Patrol review agent. Fix may edit the owned worktree and its exact report
+and receives the explicit `Bash(*)` grant needed to reproduce, test, and commit
+the repair. This full-shell grant has the authority of the Hive OS user;
+artifact custody and Git validation remain the outcome boundary.
 
 Every managed Patrol Fix agent is also told to return its report as the exact
 final JSON object. If the agent exits successfully without creating the report,


### PR DESCRIPTION
## Summary

Patrol Fix can now recover both sides of the stalled dogfood flow: OpenCode may supply an exact successful final JSON report when it did not create the managed file, and the daemon may re-admit a migrated task once when its dispatch baseline came from an older persisted generation.

- Inbox and review keep their independent Patrol route. OpenCode with `openrouter/stealth/ox-alpha` at high reasoning is reserved for admitted fix work.
- OpenCode report recovery remains inside Artifact Firewall custody. It rejects prose, arrays, truncated output, existing paths, and symlinks.
- Prepared OpenCode launches use the concrete executable, so tool-manager startup output cannot corrupt strict JSONL.
- Restored-baseline recovery uses existing persisted-state provenance. Same-process sibling writes cannot re-arm an unchanged task, and durable acceptance restores the normal markerless-run brake immediately.

## Test plan

- [x] `test/unit/agent_test.rb` - 105 runs, 507 assertions
- [x] `test/unit/stages/managed_agent_custody_test.rb` - 9 runs, 36 assertions
- [x] `test/unit/artifact_firewall_test.rb` - 32 runs, 158 assertions
- [x] `test/integration/opencode_execution_test.rb` - 2 runs, 44 assertions
- [x] `test/unit/patrol/reviewer_test.rb` - 32 runs, 167 assertions
- [x] `test/unit/daemon/policy_test.rb` - 64 runs, 107 assertions
- [x] `test/unit/daemon/dispatcher_test.rb` - 291 runs, 1,054 assertions
- [x] `test/unit/daemon/concurrency_controller_test.rb` - 53 runs, 116 assertions
- [x] `test/unit/wiki_log_test.rb` - 7 runs, 27 assertions
- [x] OpenCode Ox Alpha preparation probe resolved `openrouter/stealth/ox-alpha` with `high`, `low`, and `max` variants
- [ ] Exact-head hosted CI and merge gates

## Notes for reviewer

The broad local checkpoint completed 13,391 runs and 274,330 assertions with 6 failures and 9 errors. All 15 were `HivePatrolReviewerTest` order/global-state pollution; that file passes alone with 32 runs and 167 assertions. Hosted CI remains the broad merge authority.

The independent adversarial review found and prevented a timestamp-only redispatch loop before push. The final daemon change recovers only baselines restored from disk; it does not add Patrol-specific migration or watcher machinery.
