### PR TITLE
fix(opencode): retain bounded long session exports

### DIFF
--- a/components/agent-cli-runtime/lib/agent_cli_runtime/opencode/result_parser.rb
+++ b/components/agent-cli-runtime/lib/agent_cli_runtime/opencode/result_parser.rb
@@ -4,7 +4,9 @@ module AgentCliRuntime
   module OpenCode
     module ResultParser
       MAX_RUN_BYTES = 4 * 1024 * 1024
-      MAX_EXPORT_BYTES = 4 * 1024 * 1024
+      # Sanitized exports contain the complete session and every tool result,
+      # so their bounded limit must accommodate long implementation sessions.
+      MAX_EXPORT_BYTES = 64 * 1024 * 1024
       MAX_FINAL_MESSAGE_BYTES = 1024 * 1024
       MAX_EVENTS = 10_000
       MAX_UNKNOWN_EVENTS = 16
@@ -169,18 +171,21 @@ module AgentCliRuntime
         messages = export["messages"]
         malformed!("OpenCode sanitized export messages must be an array") unless
           messages.is_a?(Array)
-        matches = messages.filter_map do |message|
+        assistant = nil
+        messages.each do |message|
           next unless message.is_a?(Hash) && message["info"].is_a?(Hash)
 
           record = message.fetch("info")
           next unless record["id"] == message_id
 
-          record
+          if assistant
+            malformed!("OpenCode sanitized export must contain one terminal assistant record")
+          end
+          assistant = record
         end
-        unless matches.one?
+        unless assistant
           malformed!("OpenCode sanitized export must contain one terminal assistant record")
         end
-        assistant = matches.fetch(0)
         unless assistant["role"] == "assistant" &&
                assistant["sessionID"] == session_id
           malformed!("OpenCode sanitized export terminal record is not correlated")

--- a/lib/hive/agent.rb
+++ b/lib/hive/agent.rb
@@ -24,6 +24,8 @@ module Hive
     OPENCODE_INSPECTION_TIMEOUT_SECONDS = 10
     OPENCODE_CAPTURE_BYTES =
       AgentCliRuntime::OpenCode::ResultParser::MAX_RUN_BYTES + 1
+    OPENCODE_EXPORT_CAPTURE_BYTES =
+      AgentCliRuntime::OpenCode::ResultParser::MAX_EXPORT_BYTES + 1
     TOKEN_LIMIT_REASON = "token_limit".freeze
     TURN_LIMIT_REASON = "turn_limit".freeze
     MODEL_OUTPUT_LIMIT_REASON = "model_output_limit".freeze
@@ -907,8 +909,9 @@ module Hive
       end
     end
 
-    def wait_for_opencode_process(pid, pgid)
-      deadline = Time.now + @timeout_sec
+    def wait_for_opencode_process(pid, pgid, timeout_sec: @timeout_sec,
+                                  poll_interval: 0.1)
+      deadline = Time.now + timeout_sec
       loop do
         remaining = deadline - Time.now
         if remaining <= 0
@@ -924,75 +927,55 @@ module Hive
         captured = Process.wait2(pid, Process::WNOHANG)
         return [ false, captured.last ] if captured
 
-        sleep [ remaining, 0.1 ].min
+        sleep [ remaining, poll_interval ].min
       end
     end
 
     def capture_opencode_inspection(inspection)
-      stdout_reader, stdout_writer = IO.pipe
-      stderr_reader, stderr_writer = IO.pipe
-      stdout_capture = { data: +"", truncated: false }
-      stderr_capture = { data: +"", truncated: false }
-      stdout_thread = capture_bounded_stream(
-        stdout_reader, stdout_capture,
-        AgentCliRuntime::OpenCode::ResultParser::MAX_EXPORT_BYTES + 1
-      )
-      stderr_thread = capture_bounded_stream(
-        stderr_reader, stderr_capture, FINAL_MESSAGE_TAIL_BYTES
-      )
-      pid = Process.spawn(
-        inspection.environment_for(env: opencode_preparation_environment)
-          .merge(selected_base_environment),
-        *inspection.argv,
-        chdir: @cwd, pgroup: true, out: stdout_writer, err: stderr_writer,
-        unsetenv_others: true
-      )
-      stdout_writer.close
-      stderr_writer.close
-      pgid = begin
-        Process.getpgid(pid)
-      rescue Errno::ESRCH
-        pid
-      end
-      deadline = Time.now + OPENCODE_INSPECTION_TIMEOUT_SECONDS
-      status = nil
-      until status
-        captured = Process.wait2(pid, Process::WNOHANG)
-        status = captured.last if captured
-        break if status
-        if Time.now >= deadline
-          kill_group(pgid)
-          sleep_grace_then_kill(pgid, pid)
-          status = begin
-            Process.wait2(pid).last
-          rescue Errno::ECHILD
-            nil
+      Tempfile.create([ "hive-opencode-export-", ".json" ]) do |stdout_file|
+        Tempfile.create([ "hive-opencode-export-", ".stderr" ]) do |stderr_file|
+          capture_limit = OPENCODE_EXPORT_CAPTURE_BYTES
+          pid = Process.spawn(
+            opencode_child_environment(inspection),
+            *inspection.argv,
+            chdir: @cwd, pgroup: true, out: stdout_file, err: stderr_file,
+            unsetenv_others: true,
+            rlimit_fsize: [ capture_limit, capture_limit ]
+          )
+          pgid = begin
+            Process.getpgid(pid)
+          rescue Errno::ESRCH
+            pid
           end
-          break
+          _, status = wait_for_opencode_process(
+            pid, pgid,
+            timeout_sec: OPENCODE_INSPECTION_TIMEOUT_SECONDS,
+            poll_interval: 0.05
+          )
+
+          stdout_file.rewind
+          stdout = stdout_file.read(capture_limit).to_s
+          stdout_oversized =
+            stdout.bytesize >= capture_limit || !stdout_file.eof?
+          stderr_oversized = stderr_file.size >= capture_limit
+          stderr_file.rewind
+          stderr = stderr_file.read(FINAL_MESSAGE_TAIL_BYTES).to_s
+          oversized_stream =
+            stdout_oversized ? "stdout" : ("stderr" if stderr_oversized)
+          success = status&.success? == true && !oversized_stream
+          diagnostic = unless success
+            message = if oversized_stream
+              "OpenCode sanitized export inspection #{oversized_stream} " \
+                "exceeded #{capture_limit - 1} bytes"
+            elsif stderr.empty?
+              "OpenCode sanitized export inspection failed"
+            else
+              stderr
+            end
+            AgentCliRuntime::Redactor.diagnostic(message)
+          end
+          return { success:, stdout:, diagnostic: }
         end
-        sleep 0.05
-      end
-      finish_capture_thread(stdout_thread, stdout_reader)
-      finish_capture_thread(stderr_thread, stderr_reader)
-      success = status&.success? == true && !stdout_capture.fetch(:truncated)
-      diagnostic = unless success
-        AgentCliRuntime::Redactor.diagnostic(
-          stderr_capture.fetch(:data).empty? ?
-            "OpenCode sanitized export inspection failed" :
-            stderr_capture.fetch(:data)
-        )
-      end
-      {
-        success: success,
-        stdout: stdout_capture.fetch(:data),
-        diagnostic: diagnostic
-      }
-    ensure
-      close_opencode_ios(
-        stdout_writer, stderr_writer, stdout_reader, stderr_reader
-      )
-      [ stdout_thread, stderr_thread ].each do |thread|
-        thread.kill if thread&.alive?
       end
     end
 

--- a/test/unit/opencode_agent_lifecycle_test.rb
+++ b/test/unit/opencode_agent_lifecycle_test.rb
@@ -367,6 +367,55 @@ class OpenCodeAgentLifecycleTest < Minitest::Test
     end
   end
 
+  def test_long_session_export_larger_than_the_old_four_megabyte_cap_completes
+    with_fixture(mode: :large_export) do |fixture|
+      task = make_task(fixture.fetch(:dir), slug: "large-export-260822-aaaa")
+      result = with_env("ANTHROPIC_API_KEY" => "secret-canary") do
+        build_agent(
+          task, fixture,
+          invocation_root: File.join(fixture.fetch(:dir), "invocation-large-export")
+        ).run!
+      end
+
+      assert_equal :ok, result.fetch(:status)
+      assert_equal :completed, result.fetch(:normalized_outcome_kind)
+      assert_equal ROUTE, result.fetch(:actual_opencode_route)
+    end
+  end
+
+  def test_export_inspection_caps_oversized_stdout_and_stderr
+    capture_limit = 4 * 1024
+    {
+      oversized_export: [ "stdout", "stderr" ],
+      oversized_export_stderr: [ "stderr", "stdout" ]
+    }.each do |mode, (oversized_stream, bounded_stream)|
+      with_fixture(mode:) do |fixture|
+        task = make_task(
+          fixture.fetch(:dir), slug: "#{mode.to_s.tr('_', '-')}-260824-aaaa"
+        )
+        result = with_agent_constant(
+          :OPENCODE_EXPORT_CAPTURE_BYTES, capture_limit
+        ) do
+          with_env("ANTHROPIC_API_KEY" => "secret-canary") do
+            build_agent(
+              task, fixture,
+              invocation_root: File.join(
+                fixture.fetch(:dir), "invocation-#{mode}"
+              )
+            ).run!
+          end
+        end
+
+        assert_equal :error, result.fetch(:status), mode
+        sizes = JSON.parse(File.read(fixture.fetch(:capture_sizes)))
+        assert_equal capture_limit, sizes.fetch(oversized_stream), mode
+        assert_operator sizes.fetch(bounded_stream), :<, capture_limit, mode
+        assert_match(/#{oversized_stream} exceeded #{capture_limit - 1} bytes/,
+                     result.fetch(:inspection_diagnostic), mode)
+      end
+    end
+  end
+
   def test_process_status_fallbacks_and_marker_failure_diagnostic
     with_fixture do |fixture|
       task = make_task(fixture.fetch(:dir), slug: "status-fallback-260812-aaaa")
@@ -516,6 +565,7 @@ class OpenCodeAgentLifecycleTest < Minitest::Test
       calls = File.join(dir, "calls.log")
       stdin = File.join(dir, "stdin.log")
       environment = File.join(dir, "environment.json")
+      capture_sizes = File.join(dir, "capture-sizes.json")
       configuration = File.join(dir, "selected-config.json")
       selected_config = {
         "provider" => { "anthropic" => { "npm" => "@ai-sdk/anthropic" } }
@@ -524,14 +574,18 @@ class OpenCodeAgentLifecycleTest < Minitest::Test
       File.write(configuration, JSON.generate(selected_config))
       bin = File.join(dir, "opencode")
       File.write(bin, fixture_script(
-        mode:, calls:, stdin:, environment:, source_root: dir
+        mode:, calls:, stdin:, environment:, capture_sizes:, source_root: dir
       ))
       File.chmod(0o755, bin)
-      yield({ dir:, work:, calls:, stdin:, environment:, configuration:, bin: })
+      yield({
+        dir:, work:, calls:, stdin:, environment:, capture_sizes:,
+        configuration:, bin:
+      })
     end
   end
 
-  def fixture_script(mode:, calls:, stdin:, environment:, source_root:)
+  def fixture_script(mode:, calls:, stdin:, environment:, capture_sizes:,
+                     source_root:)
     run_help = File.read(File.join(
       source_root_for_fixtures,
       "run-help.txt"
@@ -548,6 +602,12 @@ class OpenCodeAgentLifecycleTest < Minitest::Test
     <<~RUBY
       #!/usr/bin/ruby --disable-gems
       require "json"
+      def record_capture_sizes(path)
+        File.write(path, JSON.generate({
+          "stdout" => STDOUT.stat.size, "stderr" => STDERR.stat.size
+        }))
+      end
+
       File.open(#{calls.dump}, "a") { |file| file.puts(ARGV.join(" ")) }
       case ARGV
       when ["--version"]
@@ -587,7 +647,35 @@ class OpenCodeAgentLifecycleTest < Minitest::Test
             warn "export unavailable"
             exit 1
           end
-          print #{export_output.dump}
+          if #{mode == :large_export}
+            export = JSON.parse(#{export_output.dump})
+            export["bounded_test_padding"] = "x" * (5 * 1024 * 1024)
+            print JSON.generate(export)
+          elsif #{mode == :oversized_export}
+            Signal.trap("XFSZ", "IGNORE") if Signal.list.key?("XFSZ")
+            export = JSON.parse(#{export_output.dump})
+            export["bounded_test_padding"] = "x" * (8 * 1024)
+            begin
+              print JSON.generate(export)
+            rescue Errno::EFBIG
+              nil
+            end
+            STDOUT.flush
+            record_capture_sizes(#{capture_sizes.dump})
+          elsif #{mode == :oversized_export_stderr}
+            Signal.trap("XFSZ", "IGNORE") if Signal.list.key?("XFSZ")
+            begin
+              STDERR.write("x" * (8 * 1024))
+            rescue Errno::EFBIG
+              nil
+            end
+            print #{export_output.dump}
+            STDOUT.flush
+            STDERR.flush
+            record_capture_sizes(#{capture_sizes.dump})
+          else
+            print #{export_output.dump}
+          end
         else
           warn "unexpected argv: #{ARGV.inspect}"
           exit 64

--- a/wiki/log.d/20260822T163500Z-opencode-long-session-export.md
+++ b/wiki/log.d/20260822T163500Z-opencode-long-session-export.md
@@ -1,0 +1,14 @@
+# OpenCode long-session exports remain inspectable
+
+OpenCode completion still requires a sanitized session export correlated to
+the terminal assistant message. Hive now captures that export in owner-private
+temporary files and accepts it through a 64 MiB bound enforced on the child
+before it starts and again when Hive reads the result. The prior 4 MiB pipe
+capture was sized for short fixtures, not hour-long implementation and review
+sessions whose exports include every tool result; its timed drain could also
+surface a truncated capture as malformed JSON under host I/O pressure.
+
+Malformed, over-bound, uncorrelated, or incomplete exports continue to fail
+closed. Lifecycle regressions prove that a valid export larger than the old
+limit preserves actual route evidence and completion, while stdout and stderr
+floods stop at the new capture boundary.

--- a/wiki/modules/agent_profile.md
+++ b/wiki/modules/agent_profile.md
@@ -245,7 +245,13 @@ generation/selection policy and `Reconstructor` retains recovery policy.
   when the fetch-disabled bundled catalog is stale, while an undeclared route
   missing from the CLI inventory still fails closed. A successful run is
   complete only after its terminal message correlates with sanitized session
-  export.
+  export. That export is captured in owner-private temporary files rather than
+  a timed pipe-drain thread. The export child receives a 64 MiB file-size limit
+  for both stdout and stderr before it starts, and Hive reads through the same
+  bound after it exits. Long review and implementation sessions carry every
+  tool result and legitimately exceed the former 4 MiB short-session ceiling,
+  while malformed or larger evidence still fails closed without unbounded
+  temporary-file growth.
   `Hive::SkillCheck::OpenCode` resolves project/user skills and explicitly
   configured plugin roots. Setup can atomically add the pinned Compound
   Engineering `3.21.4` plugin entry. Skill-bearing roles verify the selected


### PR DESCRIPTION
## Summary

Long OpenCode fix and review sessions now preserve their sanitized completion evidence instead of being rejected at the old 4 MiB capture ceiling. Capture remains fail-closed and bounded: the export child writes to owner-private temporary files capped at 64 MiB per stream, and Hive validates the same bound again before parsing.

This unblocks the one-at-a-time migrated Patrol fix run that produced a valid report but failed after OpenCode exited 0. It does not change Patrol admission or daemon scheduling.

## Design

- Private files remove the pipe-drain timeout and backpressure race for long exports.
- A child-side file-size limit bounds both stdout and stderr before either can consume unbounded temporary storage.
- Session, terminal-message, route, and completion correlation remain mandatory. Duplicate terminal records now fail immediately.

## Validation

- OpenCode lifecycle, parser, and agent tests: 136 runs, 734 assertions, zero failures or errors.
- RuboCop: 3 files inspected, no offenses.
- The broad local checkpoint still stops at the pre-existing `AgentCliRuntimeOpenCodeOfflineSmokeTest` route-inventory failure. The same `RouteUnavailable` failure reproduces on clean `origin/main`; hosted CI remains the authoritative broad result.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
