### PR TITLE
fix(patrol): accept valid UTF-8 review diffs

### DIFF
--- a/lib/hive/patrol_fix/worktree_snapshot.rb
+++ b/lib/hive/patrol_fix/worktree_snapshot.rb
@@ -71,9 +71,13 @@ module Hive
             "reviewed diff changed before publication"
           raise Hive::StageError, message
         end
+        review_diff = diff.stdout.dup.force_encoding(Encoding::UTF_8)
+        unless review_diff.valid_encoding?
+          raise Hive::StageError, "#{phase} diff is not valid UTF-8"
+        end
         {
           "owner" => owner, "worktree" => owner.fetch("worktree"),
-          "head_revision" => head, "diff_digest" => digest, "diff" => diff.stdout
+          "head_revision" => head, "diff_digest" => digest, "diff" => review_diff
         }
       rescue Hive::PatrolFix::WorktreeReceipt::InvalidWorktree => e
         raise Hive::StageError, e.message

--- a/test/unit/patrol_fix/worktree_snapshot_test.rb
+++ b/test/unit/patrol_fix/worktree_snapshot_test.rb
@@ -34,6 +34,26 @@ class PatrolFixWorktreeSnapshotTest < Minitest::Test
     assert_equal DIFF, snapshot.fetch("diff")
   end
 
+  def test_decodes_valid_utf8_diff_bytes_and_rejects_malformed_bytes
+    valid_bytes = "diff --git a/app.rb b/app.rb\n+# fixed — now\n".b
+    valid_fix = deep_copy(FIX)
+    valid_fix.fetch("payload")["diff_digest"] = Digest::SHA256.hexdigest(valid_bytes)
+
+    snapshot = capture(
+      fix: valid_fix, gate: default_gate.merge(diff: ok(valid_bytes))
+    )
+
+    assert_equal Encoding::UTF_8, snapshot.fetch("diff").encoding
+    assert_equal valid_bytes.dup.force_encoding(Encoding::UTF_8), snapshot.fetch("diff")
+
+    invalid_bytes = "diff --git a/app.rb b/app.rb\n+\xFF\n".b
+    invalid_fix = deep_copy(FIX)
+    invalid_fix.fetch("payload")["diff_digest"] = Digest::SHA256.hexdigest(invalid_bytes)
+    assert_stage_error(/diff is not valid UTF-8/) do
+      capture(fix: invalid_fix, gate: default_gate.merge(diff: ok(invalid_bytes)))
+    end
+  end
+
   def test_rejects_every_stale_custody_binding
     stale_owner = OWNER.merge("generation" => 2)
     assert_stage_error(/custody is stale/) { capture(owner: stale_owner) }

--- a/test/unit/stages/patrol_fix/review_test.rb
+++ b/test/unit/stages/patrol_fix/review_test.rb
@@ -46,6 +46,29 @@ class PatrolFixReviewStageTest < Minitest::Test
     end
   end
 
+  def test_valid_utf8_diff_from_bounded_git_capture_reaches_independent_review
+    with_review_task(source: "puts \"fixed — now\"\n") do |task, worktree_root, _manifest, _fix, _validation|
+      captured = nil
+      runner = lambda do |**values|
+        captured = values
+        File.write(values.fetch(:output_path), JSON.generate(
+          "schema" => "hive-patrol-fix-review-report", "schema_version" => 1,
+          "route" => "publish", "rationale" => "The UTF-8 patch is bounded and correct.",
+          "evidence" => [ "The patch addresses the exact defect." ],
+          "blocker_owner" => "review_gate"
+        ))
+        { status: :ok, custody: :clean }
+      end
+
+      result = Hive::Stages::PatrolFix::Review.run!(
+        task, {}, agent_runner: runner, worktree_root: worktree_root
+      )
+
+      assert_equal :complete, result.fetch(:status)
+      assert_includes captured.fetch(:prompt), "fixed — now"
+    end
+  end
+
   def test_changed_worktree_head_after_review_cannot_write_a_decision
     with_review_task do |task, worktree_root, _manifest, _fix, _validation|
       runner = lambda do |**values|
@@ -290,7 +313,7 @@ class PatrolFixReviewStageTest < Minitest::Test
 
   private
 
-  def with_review_task
+  def with_review_task(source: "puts :fixed\n")
     PatrolFixStageFixture.with_task(stage: "4-review") do |task, root, manifest|
       store = Hive::PatrolFix::ReceiptStore.new(task_folder: task.folder)
       store.append!(PatrolFixStageFixture.decision_receipt(manifest, "fix"))
@@ -303,7 +326,7 @@ class PatrolFixReviewStageTest < Minitest::Test
         generation: 1, evidence_digest: "a" * 64,
         base_revision: manifest.fetch("target_revision")
       )
-      File.write(File.join(owner.fetch("worktree"), "app.rb"), "puts :fixed\n")
+      File.write(File.join(owner.fetch("worktree"), "app.rb"), source)
       PatrolFixStageFixture.git(owner.fetch("worktree"), "add", "app.rb")
       PatrolFixStageFixture.git(owner.fetch("worktree"), "commit", "-m", "Fix")
       fix_payload = custody.capture!(generation: 1, evidence_digest: "a" * 64)

--- a/wiki/log.d/20260824T172137Z-patrol-review-utf8-diff.md
+++ b/wiki/log.d/20260824T172137Z-patrol-review-utf8-diff.md
@@ -1,0 +1,7 @@
+## Patrol Fix review accepts valid UTF-8 Git diffs
+
+- Kept Patrol Fix diff custody and SHA-256 identity over the bounded raw Git
+  bytes while decoding a validated copy for the independent review prompt.
+- Valid non-ASCII patch text no longer crashes canonical JSON serialization
+  merely because the bounded Git reader labels process output as binary.
+- Malformed diff bytes still fail closed before the review agent launches.

--- a/wiki/modules/patrol.md
+++ b/wiki/modules/patrol.md
@@ -161,6 +161,11 @@ Artifact Firewall validation. Prose, arrays, truncated output, and any existing
 path are not accepted; in particular, a dangling report symlink remains a
 custody violation rather than being replaced by the fallback.
 
+Independent review hashes the bounded Git diff as raw bytes, then validates and
+labels a copy as UTF-8 before placing it in the canonical prompt context. Valid
+non-ASCII patch text therefore remains reviewable without changing its evidence
+digest; malformed diff bytes fail closed before an agent launches.
+
 `Hive::GithubPublication` is the single PR-publication mechanism used by
 Patrol Fix and the normal coding open-PR path. It owns durable push/create
 intent, remote reconciliation, expected-absence leases, and exact hosted


### PR DESCRIPTION
## Summary

Patrol Fix review now accepts valid UTF-8 patch text from bounded Git capture while preserving the raw-byte evidence digest and rejecting malformed bytes. This unblocks the current Patrol repair campaign, whose first reviewed patch stopped before publication because its diff contained an em dash.

## Validation

- Rebuilt the real blocked task's review prompt: 11,437 bytes, valid UTF-8, with the original diff digest unchanged.
- Focused Patrol Fix suites: 27 tests and 144 assertions passed.
- Self-contained Hive suite: 13,394 runs and 274,410 assertions; its only failure was a child-process mise `bundle` shim lookup, and that test passed in isolation with Ruby 3.4.10 on `PATH`.
- RuboCop inspected 1,736 files with no offenses.
