### PR TITLE
fix(approve): scope receipts to task ownership

### DIFF
--- a/lib/hive/commands/approve.rb
+++ b/lib/hive/commands/approve.rb
@@ -153,7 +153,9 @@ module Hive
         rejection = direction == "backward"
         activity.begin_operation(
           kind: rejection ? "rejection_recorded" : "approval_recorded",
-          operation_id: "#{rejection ? 'reject' : 'approve'}:#{task.stage_index}-#{task.stage_name}:#{destination}:#{direction}",
+          operation_id: approval_operation_id(
+            activity, task, destination, direction, rejection: rejection
+          ),
           source: "command_service",
           reason: rejection ? "task stage rejection recorded" : "task stage approval recorded",
           precondition: {
@@ -162,6 +164,19 @@ module Hive
           },
           expected_postcondition: { "stage" => destination }
         )
+      end
+
+      def approval_operation_id(activity, task, destination, direction, rejection:)
+        binding = activity.binding
+        identity = Hive::TaskActivity.fingerprint(
+          "stage" => "#{task.stage_index}-#{task.stage_name}",
+          "destination" => destination,
+          "direction" => direction,
+          "task_generation" => binding.fetch("task_generation"),
+          "ownership_generation" => binding.fetch("ownership_generation")
+        )
+        verb = rejection ? "reject" : "approve"
+        "#{verb}:#{identity}"
       end
 
       def complete_approval_operation(operation, new_folder, destination, direction)

--- a/test/unit/commands/approve_test.rb
+++ b/test/unit/commands/approve_test.rb
@@ -467,6 +467,9 @@ class HiveCommandsApproveTest < Minitest::Test
   def test_backward_move_records_a_rejection_operation
     recorded = nil
     activity = Object.new
+    activity.define_singleton_method(:binding) do
+      { "task_generation" => 0, "ownership_generation" => "ownership-1" }
+    end
     activity.define_singleton_method(:begin_operation) { |**attributes| recorded = attributes }
     current = task(stage_index: 4, stage_name: "execute")
 
@@ -478,6 +481,125 @@ class HiveCommandsApproveTest < Minitest::Test
     assert_equal "rejection_recorded", recorded.fetch(:kind)
     assert_equal "task stage rejection recorded", recorded.fetch(:reason)
     assert_match(/\Areject:/, recorded.fetch(:operation_id))
+  end
+
+  def test_approval_operation_identity_changes_only_when_task_ownership_changes
+    operation_ids = []
+    activity_for = lambda do |ownership_generation|
+      Object.new.tap do |activity|
+        activity.define_singleton_method(:binding) do
+          {
+            "task_generation" => 0,
+            "ownership_generation" => ownership_generation
+          }
+        end
+        activity.define_singleton_method(:begin_operation) do |**attributes|
+          operation_ids << attributes.fetch(:operation_id)
+        end
+      end
+    end
+    current = task(stage_index: 2, stage_name: "fix")
+    marker = Struct.new(:name).new(:complete)
+
+    command.send(
+      :begin_approval_operation, activity_for.call("ownership-1"), current,
+      "3-validate", marker, "forward"
+    )
+    command.send(
+      :begin_approval_operation, activity_for.call("ownership-1"), current,
+      "3-validate", marker, "forward"
+    )
+    command.send(
+      :begin_approval_operation, activity_for.call("ownership-2"), current,
+      "3-validate", marker, "forward"
+    )
+
+    assert_equal operation_ids[0], operation_ids[1],
+                 "attempt retries in one task ownership must stay idempotent"
+    refute_equal operation_ids[0], operation_ids[2],
+                 "a revisited stage must not collide with its completed approval receipt"
+  end
+
+  def test_revisited_approval_route_keeps_completed_receipt_and_starts_new_operation
+    with_tmp_dir do |folder|
+      now = Time.utc(2026, 8, 25, 10, 0, 0)
+      store = Hive::Attempts::Store.new(root: File.join(folder, "attempts"))
+      first = store.create_launching(
+        attempt_id: "attempt-1", request_id: "request-1", predecessor_attempt_id: nil,
+        task_id: "42", project: "demo", task_slug: "durable-task",
+        intended_stage: "2-fix", task_generation: "ownership-1",
+        ownership_generation: "ownership-1", task_input_epoch: 0,
+        progress_token: "progress-1", provider: "pi", starting_revision: nil,
+        worker_argv: [ "hive", "run", "durable-task" ],
+        claim_capability_digest: Hive::Attempts::Capability.digest("c" * 64),
+        retry_charge: 0, inherited_outputs: [], launch_timeout_sec: 30, now: now
+      )
+      claimed = store.claim(
+        first, owner: { "pid" => Process.pid }, claim_capability: "c" * 64,
+        first_heartbeat_timeout_sec: 30, now: now
+      )
+      store.first_heartbeat(claimed, stale_sec: 30, now: now)
+      store.create_launching(
+        attempt_id: "attempt-2", request_id: "request-2",
+        predecessor_attempt_id: "attempt-1", task_id: "42", project: "demo",
+        task_slug: "durable-task", intended_stage: "2-fix",
+        task_generation: "ownership-2", ownership_generation: "ownership-2",
+        task_input_epoch: 0, progress_token: "progress-2", provider: "pi",
+        starting_revision: nil, worker_argv: [ "hive", "run", "durable-task" ],
+        claim_capability_digest: Hive::Attempts::Capability.digest("d" * 64),
+        retry_charge: 1, inherited_outputs: [], launch_timeout_sec: 30, now: now
+      )
+      sequence = 0
+      writer = Hive::TaskJournal::Writer.new(
+        task_folder: folder, attempt_store: store, clock: -> { now },
+        id_generator: -> { sequence += 1; "event-#{sequence}" }
+      )
+      activity_for = lambda do |attempt_id, ownership_generation|
+        Hive::TaskActivity.new(
+          task_folder: folder, task: { "id" => "42", "slug" => "durable-task" },
+          workflow: "patrol", stage: "2-fix", attempt_id: attempt_id,
+          task_generation: 0, ownership_generation: ownership_generation,
+          commit_generation: 0, writer: writer, clock: -> { now }
+        )
+      end
+      current = task(stage_index: 2, stage_name: "fix")
+      marker = Struct.new(:name).new(:complete)
+
+      historical = command.send(
+        :begin_approval_operation, activity_for.call("attempt-1", "ownership-1"),
+        current, "3-validate", marker, "forward"
+      )
+      historical.complete!(result: { "stage" => "3-validate" }, occurred_at: now)
+      revisited = command.send(
+        :begin_approval_operation, activity_for.call("attempt-2", "ownership-2"),
+        current, "3-validate", marker, "forward"
+      )
+
+      refute_equal historical.operation_id, revisited.operation_id
+      assert historical.complete?
+      assert_equal "pending", revisited.receipt.fetch("state")
+      assert_equal 2,
+                   Dir[File.join(folder, Hive::TaskActivity::OPERATION_DIRECTORY, "*.json")].length
+    end
+  end
+
+  def test_approval_operation_identity_stays_bounded_for_long_stage_names
+    operation_id = nil
+    activity = Object.new
+    activity.define_singleton_method(:binding) do
+      { "task_generation" => 0, "ownership_generation" => "ownership-1" }
+    end
+    activity.define_singleton_method(:begin_operation) do |**attributes|
+      operation_id = attributes.fetch(:operation_id)
+    end
+    current = task(stage_index: 2, stage_name: "f" * 90)
+
+    command.send(
+      :begin_approval_operation, activity, current, "3-#{'v' * 90}",
+      Struct.new(:name).new(:complete), "forward"
+    )
+
+    assert_operator operation_id.bytesize, :<=, Hive::TaskActivity::MAX_IDENTIFIER_BYTES
   end
 
   def test_approval_reconciliation_selects_both_forward_and_backward_event_kinds

--- a/wiki/commands/approve.md
+++ b/wiki/commands/approve.md
@@ -142,6 +142,13 @@ hive approve <slug> --from 2-brainstorm
 
 If the task is at `2-brainstorm`, advance to `3-plan` as usual. If it's at any other stage (because a prior call already advanced it, or because the user mv'd it manually), raise `Hive::WrongStage` (exit 4) with `task is at <actual> but --from expected 2-brainstorm`. Pass `--from` on every retry so a network blip mid-call doesn't silently advance the task two stages on the next attempt.
 
+The durable approval-operation identity is a bounded digest of the transition
+route, task's numeric input epoch, and opaque ownership generation. Attempts
+that retry the same lifecycle visit therefore reuse one operation receipt,
+while a workflow rework that legitimately revisits the same stage-to-stage
+route receives a distinct receipt instead of conflicting with the completed
+receipt from the earlier visit.
+
 ## Exit codes
 
 | Condition | Exit | Class |

--- a/wiki/log.d/20260825T110035Z-generation-scoped-approval-operations.md
+++ b/wiki/log.d/20260825T110035Z-generation-scoped-approval-operations.md
@@ -1,0 +1,17 @@
+---
+title: Scope durable approval operations to one task lifecycle visit
+type: fix
+date: 2026-08-25
+---
+
+**Problem:** A workflow rework could return a task to a stage transition that
+had already completed. `hive approve` reused the route-only operation ID, so
+the retained receipt from the earlier ownership generation conflicted with the
+new attempt and the daemon retried the same failed transition indefinitely.
+
+**Action:** Approval and rejection operation IDs are now bounded deterministic
+digests of the transition route, numeric task input epoch, and opaque ownership
+generation. Retries inside one lifecycle visit remain idempotent, while a
+legitimate revisit creates a separate durable operation receipt. Added focused
+coverage for stable same-ownership identity, a real completed-receipt revisit,
+distinct rework identity, and the operation-ID size limit.


### PR DESCRIPTION
## Summary

Reworked Patrol tasks can now revisit the same approval transition without colliding with a completed receipt from an earlier ownership generation. This stops the daemon from repeatedly dispatching a deterministic `conflicting operation receipt` failure.

The operation ID remains stable inside one lifecycle visit and stays below Hive's identifier limit. Historical receipts remain intact, so this change needs no migration.

Related: #1204

## Validation

- Approve command: 44 tests, 153 assertions
- Task activity: 18 tests, 78 assertions
- RuboCop: clean
- `git diff --check`: clean

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
