### PR TITLE
fix(status): exclude parked Patrol outcomes from decisions

### DIFF
--- a/lib/hive/operational_status.rb
+++ b/lib/hive/operational_status.rb
@@ -27,6 +27,7 @@ module Hive
     PLAN_REVIEW_WAIT_ACTIONS = %w[plan_reviewing plan_review_retry].freeze
     PLAN_REVIEW_REPAIR_ACTIONS = %w[plan_review_unsupported plan_review_blocked].freeze
     CODING_PLAN_STAGE = Hive::Workflows::Registry.default.stage_named("plan").dir.freeze
+    PATROL_FIX_WORKFLOW = Hive::PatrolFix::WORKFLOW_ID.to_s.freeze
 
     def initialize(status_payload:, project_context: {}, scheduler_snapshot: nil,
                    status_payload_tick_sequence: nil,
@@ -611,6 +612,7 @@ module Hive
       return [ "waiting_on_provider_or_scheduler", "scheduler" ] if automatic_error_retry?(project, row)
       return [ "needs_repair", "operator" ] if repair?(row)
       return [ "waiting_on_provider_or_scheduler", "provider" ] if row["held"]
+      return [ "completion_ready", "none" ] if terminal_parked?(row)
       if human_input?(row)
         return [ "waiting_on_provider_or_scheduler", "scheduler" ] if daemon_plan_approval?(project, row)
 
@@ -876,6 +878,12 @@ module Hive
       HUMAN_ACTIONS.include?(row["action"])
     end
 
+    def terminal_parked?(row)
+      row["workflow"] == PATROL_FIX_WORKFLOW && row["action"] == "needs_input" &&
+        row["marker"] == "none" &&
+        row["suggested_command"].to_s.empty?
+    end
+
     def daemon_plan_approval?(project, row)
       daemon_enabled?(project["name"]) && row["workflow"] == "coding" && row["stage"] == CODING_PLAN_STAGE
     end
@@ -930,6 +938,8 @@ module Hive
         reasons << reason("provider_quota", "#{provider} quota hold#{retry_text}", "provider")
       elsif daemon_plan_approval?(project, row)
         reasons << reason("daemon_plan_approval", "daemon owns plan approval for this enrolled project", "scheduler")
+      elsif terminal_parked?(row)
+        reasons << reason("terminal_parked", row["action_label"] || "task reached a parked outcome", "task")
       elsif human_input?(row)
         unanswered = row["unanswered_questions"].to_i
         message = unanswered.positive? ? "#{unanswered} unanswered questions" : row["action_label"]

--- a/test/unit/operational_status_test.rb
+++ b/test/unit/operational_status_test.rb
@@ -208,6 +208,25 @@ class OperationalStatusTest < Minitest::Test
     assert_equal "operator", manual.fetch("blocker_owner")
   end
 
+  def test_parked_patrol_fix_outcomes_are_completion_ready_without_an_operator_blocker
+    rows = [
+      [ "rejected", "Rejected (parked)" ],
+      [ "blocked", "Blocked (parked)" ],
+      [ "escalated", "Escalated (parked)" ]
+    ].map do |slug, label|
+      task(action: "needs_input", slug:, marker: "none").merge(
+        "workflow" => "patrol-fix", "action_label" => label, "suggested_command" => nil
+      )
+    end
+
+    projected = project(status_payload(*rows)).fetch("tasks")
+
+    assert_equal [ "completion_ready" ], projected.map { |row| row.fetch("state") }.uniq
+    assert_equal [ "none" ], projected.map { |row| row.fetch("blocker_owner") }.uniq
+    assert_equal [ "terminal_parked" ], projected.map { |row| row.dig("reasons", 0, "code") }.uniq
+    assert_equal rows.map { |row| row.fetch("action_label") }, projected.map { |row| row.fetch("reason") }
+  end
+
   def test_plan_review_state_owner_reason_and_projection_are_preserved
     review = {
       "applicable" => true,

--- a/test/unit/patrol_fix/task_action_test.rb
+++ b/test/unit/patrol_fix/task_action_test.rb
@@ -88,6 +88,9 @@ class PatrolFixTaskActionTest < Minitest::Test
         now: Time.utc(2026, 8, 20, 12, 5)
       ).fetch("tasks").first
       refute operational.key?("patrol_fix")
+      assert_equal "completion_ready", operational.fetch("state")
+      assert_equal "none", operational.fetch("blocker_owner")
+      assert_equal "terminal_parked", operational.dig("reasons", 0, "code")
 
       tui_row = Hive::Tui::Snapshot.from_payload(payload).rows.first
       assert_equal "needs_input", tui_row.action_key

--- a/wiki/commands/status.md
+++ b/wiki/commands/status.md
@@ -133,6 +133,13 @@ Explicit human input still has higher precedence, so a row that is both
 dependency-blocked and waiting for answers remains `waiting_on_you` while the
 dependency reason stays secondary.
 
+Patrol Fix outcomes parked by the controller are terminal, non-runnable rows.
+The hidden compatibility graph continues to expose their action as
+`needs_input`, but operational status recognizes the closed Patrol shape
+(`marker: none`, no suggested command) and reports `completion_ready` with
+`blocker_owner: none`. Rejected, blocked, and escalated findings therefore
+remain visible for audit without inflating the operator-decision count.
+
 For a daemon-enrolled project with global automatic retry enabled, a real
 `ERROR` or `REVIEW_ERROR` defaults to
 `waiting_on_provider_or_scheduler` with `blocker_owner: scheduler`: Hive owns

--- a/wiki/log.d/20260825T160642Z-patrol-parked-operational-status.md
+++ b/wiki/log.d/20260825T160642Z-patrol-parked-operational-status.md
@@ -1,0 +1,12 @@
+---
+title: Keep parked Patrol outcomes out of operator decisions
+type: change
+date: 2026-08-25
+---
+
+`hive status --operational` no longer classifies rejected, blocked, or
+escalated Patrol Fix outcomes as `waiting_on_you`. The hidden v7 compatibility
+graph still publishes their non-runnable `needs_input` action, while the
+operational projection recognizes the terminal parked shape and reports
+`completion_ready` with no blocker owner. Ordinary editable `needs_input` rows
+remain operator-owned.


### PR DESCRIPTION
## Summary

- Parked rejected, blocked, and escalated Patrol Fix outcomes now report `completion_ready` with no blocker owner instead of inflating `waiting_on_you`.
- The hidden `hive-status.v7` compatibility action remains `needs_input`, and ordinary editable input rows keep their existing operator-owned behavior.

## Test plan

- [x] `test/unit/operational_status_test.rb` - 58 runs, 265 assertions
- [x] `test/unit/patrol_fix/task_action_test.rb` - 4 runs, 27 assertions
- [x] `test/unit/commands/status_operational_test.rb` - 6 runs, 18 assertions
- [x] `test/unit/schema_files_test.rb` - 161 runs, 910 assertions

## Notes for reviewer

The classification is deliberately limited to the closed Patrol Fix shape: `workflow: patrol-fix`, compatibility action `needs_input`, `marker: none`, and no suggested command. The producer-level test pins that hidden-v7 boundary as well as the operational result.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
