### PR TITLE
fix(patrol): keep context receipts out of worktrees

### DIFF
--- a/lib/hive/context_provenance.rb
+++ b/lib/hive/context_provenance.rb
@@ -235,6 +235,9 @@ module Hive
     end
 
     def prompt_appendix(task, context)
+      candidate_path = File.expand_path(
+        candidate_reference(context.attempt_id), task.folder
+      )
       example = {
         "schema" => "hive-context-receipt", "schema_version" => 1,
         "kind" => "agent_selection",
@@ -254,13 +257,14 @@ module Hive
         ## Optional context provenance receipt
 
         This receipt is optional and does not change the required stage artifact, outcome, or terminal marker.
-        If you select repository or Wiki context for this attempt, write one JSON object to the task-relative path
-        `#{candidate_reference(context.attempt_id)}` (maximum #{MAX_RECEIPT_BYTES} bytes) before exiting.
+        If you select repository or Wiki context for this attempt, write one JSON object to the exact task-artifact path
+        `#{candidate_path}` (maximum #{MAX_RECEIPT_BYTES} bytes) before exiting.
         Start from this exact shape (replace the timestamp, rationale, references, and queries):
         `#{JSON.generate(example)}`
         `selection` contains only project-relative selected references (`path`, `kind`, `label`), bounded
         query/result labels, and a short rationale. Do not include file contents, prompts, argv, credentials,
-        tokens, or absolute paths. Hive presents this as an agent assertion, not proof of consumption.
+        tokens, or absolute paths inside the receipt JSON. Hive presents this as an agent assertion, not proof
+        of consumption.
       APPENDIX
     end
 

--- a/test/unit/context_provenance_test.rb
+++ b/test/unit/context_provenance_test.rb
@@ -335,7 +335,9 @@ class ContextProvenanceTest < Minitest::Test
       )
 
       assert decorated.start_with?(prompt)
-      assert_includes decorated, "context-receipts/attempt-1.json.next"
+      candidate = File.join(task.folder, "context-receipts", "attempt-1.json.next")
+      assert_includes decorated, candidate
+      refute_includes decorated, "write one JSON object to the task-relative path"
       assert_includes decorated, "optional"
       assert_includes decorated, "agent assertion"
       assert_includes decorated, "<!-- COMPLETE -->"

--- a/wiki/log.d/20260825T233500Z-context-receipt-task-path.md
+++ b/wiki/log.d/20260825T233500Z-context-receipt-task-path.md
@@ -1,0 +1,9 @@
+## [2026-08-25T23:35:00Z] context provenance — bind agent candidates to the task folder
+
+**Action:** Context provenance prompts now provide the exact task-folder path
+for the optional agent-selection candidate. Agents normally run with an owned
+Git worktree as their cwd, so the former task-relative instruction could create
+`context-receipts/*.json.next` inside that Git worktree, fail clean-worktree
+custody, and repeat on every automatic recovery. Focused coverage pins the
+absolute task-artifact target while receipt contents remain forbidden from
+containing absolute host paths.

--- a/wiki/modules/task_workspace.md
+++ b/wiki/modules/task_workspace.md
@@ -153,7 +153,11 @@ Git result becomes a panel diagnostic; it cannot turn the task route into a
   context.
 
 The agent writes only the candidate
-`context-receipts/<attempt-id>.json.next`. The controller descriptor-opens,
+`context-receipts/<attempt-id>.json.next` under the task folder. Because an
+agent normally runs from its owned implementation worktree, Hive gives it the
+exact task-artifact path instead of a cwd-relative path; this keeps provenance
+out of the Git worktree and available to the controller for promotion. The
+controller descriptor-opens,
 validates allowlisted repository/Wiki field types as well as
 binding/schema/containment/size, rejects absolute host paths in every receipt
 string, redacts, and publishes with filesystem no-replace semantics. Promotion


### PR DESCRIPTION
## Summary

- give agents the exact task-folder target for optional context provenance
- prevent cwd-relative `context-receipts/*.json.next` from dirtying Patrol Fix worktrees
- document and regression-test the task-artifact binding

## Live reproduction

A Pi Patrol Fix worker exited successfully twice for `make-one-internal-pr-checkout-reconciliation-bou-0f5364f55257`, but each run recreated task-bound `context-receipts/*.json.next` under the Git worktree cwd. Worktree custody then rejected the otherwise committed fix as dirty, so native recovery repeated the same failure.

## Validation

- `bundle exec ruby -Itest test/unit/context_provenance_test.rb` (11 runs, 79 assertions)
- `bundle exec ruby -Itest test/unit/stages/base_context_provenance_test.rb` (4 runs, 12 assertions)
- `bundle exec ruby -Itest test/unit/stages/patrol_fix/fix_test.rb` (4 runs, 17 assertions)
- RuboCop on changed Ruby/test files
- `git diff --check`