### PR TITLE
Fix Patrol worktree base provenance

### DIFF
--- a/lib/hive/patrol_fix/worktree_receipt.rb
+++ b/lib/hive/patrol_fix/worktree_receipt.rb
@@ -22,16 +22,18 @@ module Hive
         @path = File.join(@task_folder, FILENAME)
       end
 
-      def prepare!(generation:, evidence_digest:, base_revision:)
-        expected = identity(generation, evidence_digest, base_revision)
+      def prepare!(generation:, evidence_digest:, base_revision: nil)
         if File.exist?(@path) || File.symlink?(@path)
           current = read
-          reusable = current.values_at("generation", "evidence_digest", "base_revision") ==
-            [ generation, evidence_digest, base_revision ]
+          reusable = current.values_at("generation", "evidence_digest") ==
+            [ generation, evidence_digest ]
+          reusable &&= current.fetch("base_revision") == base_revision if base_revision
           invalid!("worktree ownership conflicts with the current generation") unless reusable
           validate!(current)
           return current
         end
+        base_revision ||= yield if block_given?
+        expected = identity(generation, evidence_digest, base_revision)
         worktree(expected).create_exact!(expected.fetch("branch"), base_sha: base_revision)
         validate!(expected)
         Hive::AtomicFile.write(@path, Hive::PatrolFix.canonical_json(expected), mode: 0o600)

--- a/lib/hive/stages/patrol_fix/fix.rb
+++ b/lib/hive/stages/patrol_fix/fix.rb
@@ -4,9 +4,11 @@ require "hive/patrol_fix/fix_report"
 require "hive/patrol_fix/receipt_store"
 require "hive/patrol_fix/task_manifest"
 require "hive/patrol_fix/worktree_receipt"
+require "hive/git_ops"
 require "hive/stages/base"
 require "hive/stages/managed_agent_custody"
 require "hive/stages/patrol_fix/inbox"
+require "hive/worktree"
 
 module Hive
   module Stages
@@ -19,7 +21,7 @@ module Hive
         def run!(task, cfg = {}, agent_runner: nil, worktree_root: nil)
           manifest = Hive::PatrolFix::TaskManifest.new(task_folder: task.folder).read
           receipts = Hive::PatrolFix::ReceiptStore.new(task_folder: task.folder)
-          decision, rework = fix_authorization(receipts, manifest)
+          rework = fix_authorization(receipts, manifest)
           existing = current(receipts, manifest, "fix", "fix")
           return complete(existing) if existing
 
@@ -38,9 +40,8 @@ module Hive
           else
             custody.prepare!(
               generation: manifest.dig("task", "generation"),
-              evidence_digest: manifest.dig("evidence_revision", "digest"),
-              base_revision: decision.dig("payload", "head_revision")
-            )
+              evidence_digest: manifest.dig("evidence_revision", "digest")
+            ) { strict_origin_base!(task, cfg) }
           end
           output = File.join(task.folder, REPORT_FILENAME)
           prompt = render_prompt(task, manifest, owner, output)
@@ -102,9 +103,17 @@ module Hive
           store.read_all.find { |r| r["kind"] == kind && r["stage"] == stage && r["task"] == manifest["task"] && r["evidence_revision"] == manifest["evidence_revision"] }
         end
         private_class_method :current
+        def strict_origin_base!(task, cfg)
+          branch = (cfg || {})["default_branch"] ||
+            Hive::GitOps.new(task.project_root).detect_default_branch
+          Hive::Worktree.new(task.project_root, task.slug).fetch_strict_origin_base!(branch)
+        rescue Hive::GitError, Hive::WorktreeError => e
+          raise Hive::StageError, "Patrol Fix worktree base is unavailable: #{e.message}"
+        end
+        private_class_method :strict_origin_base!
         def fix_authorization(store, manifest)
           inbox = current(store, manifest, "decision", "inbox")
-          return [ inbox, false ] if inbox&.dig("payload", "route") == "fix"
+          return false if inbox&.dig("payload", "route") == "fix"
 
           reopen = current(store, manifest, "reopen", "review")
           prior = store.read_all.find do |row|
@@ -112,7 +121,7 @@ module Hive
           end
           if reopen&.dig("payload", "operator") == "controller:review" &&
              prior&.dig("payload", "route") == "rework"
-            return [ prior, true ]
+            return true
           end
           raise Hive::StageError, "fix requires a current inbox fix or controller rework authorization"
         end

--- a/test/integration/patrol_fix_lifecycle_test.rb
+++ b/test/integration/patrol_fix_lifecycle_test.rb
@@ -114,6 +114,11 @@ class PatrolFixLifecycleIntegrationTest < Minitest::Test
         runtime_root = Dir.mktmpdir("patrol-fix-lifecycle")
         (@runtime_roots ||= []) << runtime_root
         worktree_root = File.join(runtime_root, "worktrees")
+        remote = File.join(runtime_root, "remote.git")
+        capture("git", "init", "--bare", remote)
+        git(project, "remote", "add", "origin", remote)
+        base_branch = git(project, "branch", "--show-current").strip
+        git(project, "push", "origin", base_branch)
         run_fix(task, worktree_root, "puts :fixed_once\n")
         task = advance(task, "3-validate")
         run_validation(task, worktree_root)
@@ -130,11 +135,6 @@ class PatrolFixLifecycleIntegrationTest < Minitest::Test
         run_review(task, worktree_root, "publish")
         task = advance(task, "5-publish")
 
-        remote = File.join(runtime_root, "remote.git")
-        capture("git", "init", "--bare", remote)
-        git(project, "remote", "add", "origin", remote)
-        base_branch = git(project, "branch", "--show-current").strip
-        git(project, "push", "origin", base_branch)
         git_gateway = LocalGit.new
         github = FakeGithub.new
         first = Hive::Stages::PatrolFix::Publish.run!(

--- a/test/unit/patrol_fix/worktree_receipt_test.rb
+++ b/test/unit/patrol_fix/worktree_receipt_test.rb
@@ -15,7 +15,9 @@ class PatrolFixWorktreeReceiptTest < Minitest::Test
       )
 
       first = store.prepare!(generation: 1, evidence_digest: "a" * 64, base_revision: base)
-      second = store.prepare!(generation: 1, evidence_digest: "a" * 64, base_revision: base)
+      second = store.prepare!(generation: 1, evidence_digest: "a" * 64) do
+        flunk "must not resolve a new base for existing custody"
+      end
 
       assert_equal first, second
       assert_equal base, first.fetch("base_revision")

--- a/test/unit/stages/patrol_fix/fix_test.rb
+++ b/test/unit/stages/patrol_fix/fix_test.rb
@@ -68,6 +68,61 @@ class PatrolFixFixStageTest < Minitest::Test
     end
   end
 
+  def test_first_generation_uses_exact_origin_base_instead_of_inbox_local_head
+    PatrolFixStageFixture.with_task(stage: "2-fix") do |task, root, manifest|
+      PatrolFixStageFixture.add_origin(task.project_root, root)
+      File.write(File.join(task.project_root, "local-only.rb"), "puts :unrelated\n")
+      git(task.project_root, "add", "local-only.rb")
+      git(task.project_root, "commit", "-m", "Unrelated local work")
+      local_head = git(task.project_root, "rev-parse", "HEAD").strip
+      remote_head = manifest.fetch("target_revision")
+      Hive::PatrolFix::ReceiptStore.new(task_folder: task.folder).append!(
+        PatrolFixStageFixture.decision_receipt(
+          manifest, "fix", head_revision: local_head
+        )
+      )
+      runner = lambda do |**kwargs|
+        worktree = kwargs.fetch(:owner).fetch("worktree")
+        refute File.exist?(File.join(worktree, "local-only.rb"))
+        File.write(File.join(worktree, "app.rb"), "puts :fixed\n")
+        git(worktree, "add", "app.rb")
+        git(worktree, "commit", "-m", "Fix defect")
+        File.write(kwargs.fetch(:output_path), JSON.generate(
+          "schema" => "hive-patrol-fix-fix-report", "schema_version" => 1,
+          "status" => "fixed", "summary" => "Fixed from the remote base.",
+          "validation_commands" => []
+        ))
+        { status: :ok, custody: :clean }
+      end
+
+      result = Hive::Stages::PatrolFix::Fix.run!(
+        task, { "default_branch" => "main" }, agent_runner: runner,
+        worktree_root: File.join(root, "worktrees")
+      )
+
+      assert_equal remote_head, result.dig(:receipt, "payload", "base_revision")
+      assert_equal remote_head,
+                   git(task.project_root, "rev-parse", "refs/remotes/origin/main").strip
+      refute_equal local_head, result.dig(:receipt, "payload", "base_revision")
+    end
+  end
+
+  def test_first_generation_has_no_local_fallback_when_origin_is_unavailable
+    with_fix_task do |task, worktree_root|
+      git(task.project_root, "remote", "remove", "origin")
+
+      error = assert_raises(Hive::StageError) do
+        Hive::Stages::PatrolFix::Fix.run!(
+          task, { "default_branch" => "main" },
+          agent_runner: ->(**) { flunk "must not launch without an exact remote base" },
+          worktree_root: worktree_root
+        )
+      end
+
+      assert_match(/strict worktree requires exactly one origin remote/, error.message)
+    end
+  end
+
   def test_fix_requires_current_controller_authorization
     store = Struct.new(:rows) { def read_all = rows }.new([])
     manifest = {
@@ -100,7 +155,7 @@ class PatrolFixFixStageTest < Minitest::Test
       manifest_store.write!(manifest)
 
       with_replaced_singleton_method(
-        Hive::Stages::PatrolFix::Fix, :fix_authorization, ->(*) { [ Object.new, true ] }
+        Hive::Stages::PatrolFix::Fix, :fix_authorization, ->(*) { true }
       ) do
         error = assert_raises(Hive::StageError) do
           Hive::Stages::PatrolFix::Fix.run!(task, {}, worktree_root: worktree_root)
@@ -114,6 +169,7 @@ class PatrolFixFixStageTest < Minitest::Test
 
   def with_fix_task
     PatrolFixStageFixture.with_task(stage: "2-fix") do |task, root, manifest|
+      PatrolFixStageFixture.add_origin(task.project_root, root)
       Hive::PatrolFix::ReceiptStore.new(task_folder: task.folder).append!(
         PatrolFixStageFixture.decision_receipt(manifest, "fix")
       )
@@ -145,10 +201,15 @@ module PatrolFixStageFixture
       yield Hive::Task.new(folder), dir, manifest
     end
   end
-  def decision_receipt(manifest, route)
+  def add_origin(repo, root)
+    origin = File.join(root, "origin.git")
+    git(root, "clone", "--bare", repo, origin)
+    git(repo, "remote", "add", "origin", origin)
+  end
+  def decision_receipt(manifest, route, head_revision: manifest.fetch("target_revision"))
     { "schema" => "hive-patrol-fix-receipt", "schema_version" => 1, "receipt_id" => "decision-1", "kind" => "decision", "stage" => "inbox",
       "task" => manifest.fetch("task"), "evidence_revision" => manifest.fetch("evidence_revision"), "recorded_at" => "2026-08-20T12:00:00Z",
-      "payload" => { "route" => route, "rationale" => "current", "evidence" => [ "current" ], "blocker_owner" => "inbox_gate", "head_revision" => manifest.fetch("target_revision") } }
+      "payload" => { "route" => route, "rationale" => "current", "evidence" => [ "current" ], "blocker_owner" => "inbox_gate", "head_revision" => head_revision } }
   end
   def git(path, *args)
     out, err, status = Open3.capture3("git", "-C", path, *args); raise err unless status.success?; out

--- a/wiki/gaps.md
+++ b/wiki/gaps.md
@@ -53,6 +53,14 @@ Keep release/dogfood incomplete until the opt-in historical corpus has actual
 provider/model receipts and one naturally discovered finding reaches `done`
 with an exact PR and zero duplicate replay.
 
+An August 26 dogfood run exercised the real Pi/Ox Alpha Fix launch and durable
+markerless recovery, but exposed that pre-fix first-generation worktrees had
+treated Inbox's local checkout `HEAD` as their creation base. On a divergent
+operator checkout this carried unrelated local commits into the resulting PR.
+New first generations now fail closed onto exact `origin/<default>` OIDs; the
+remaining live-delivery proof must come from a task admitted after that cutover
+and reach one focused hosted PR.
+
 **TLDR**: The wiki has broad domain coverage for the current `lib/`, command, stage, TUI, daemon, bot, native Hive web, Hivebox container, testing/static-analysis, template/prompt, and release surfaces, but the source-file map below is representative rather than an automatically verified one-file-per-source audit. Remaining gaps are mainly live behavioral verification and a few deeper reference pages.
 
 ## OpenCode live validation (updated 2026-08-21)

--- a/wiki/log.d/20260826T014800Z-patrol-strict-origin-base.md
+++ b/wiki/log.d/20260826T014800Z-patrol-strict-origin-base.md
@@ -1,0 +1,16 @@
+---
+title: Anchor Patrol fixes to the exact remote default branch
+type: fix
+date: 2026-08-26
+tags: [patrol-fix, worktree, git, dogfood]
+---
+
+First-generation Patrol Fix worktrees now fetch the configured default branch
+from `origin` and use that exact OID as their controller-owned base. Inbox's
+local `HEAD` remains decision evidence and no longer controls branch ancestry.
+
+The stage fails before agent launch when the remote base cannot be fetched;
+there is no local fallback. Same-generation retries and rework keep their
+existing generation-bound custody without refetching a moving remote branch.
+Regression coverage models a local checkout with an unrelated commit and
+proves that the fix worktree contains only the remote base.

--- a/wiki/modules/workflows.md
+++ b/wiki/modules/workflows.md
@@ -254,7 +254,12 @@ action, and stage-wrapper paths, so those paths do not carry a parallel
 `patrol_fix_id?` predicate. Review and publication share one exact worktree
 snapshot helper for custody, HEAD, cleanliness, bounded diff, and digest
 validation; Inbox and Review output readers share the same strict JSON reader
-while retaining their route and schema ownership.
+while retaining their route and schema ownership. On the first Fix generation,
+the controller fetches the configured default branch from `origin` and records
+that exact remote OID as the worktree base. The local `HEAD` observed by Inbox
+is decision evidence only. There is no local-base fallback, while rework keeps
+the already-owned checkout and base. A same-generation retry also reuses that
+custody without refetching a moving remote branch.
 
 ## Durable human stages
 

--- a/wiki/modules/worktree.md
+++ b/wiki/modules/worktree.md
@@ -173,6 +173,16 @@ reattaches the already-validated branch. A symlinked path, failed quarantine,
 registration that remains after targeted removal, or a second unresolved
 quarantine for the same slug fails closed instead of growing disk use.
 
+Patrol Fix resolves a first-generation coding checkout through
+`fetch_strict_origin_base!` before passing the returned OID to `create_exact!`.
+The inbox decision's observed local `HEAD` remains evidence about the snapshot
+the reviewer saw; it is never branch ancestry authority. A missing origin or
+failed fetch parks the stage without launching an agent, so dirty, stale, or
+locally divergent primary checkouts cannot leak unrelated commits into a fix
+branch. Same-generation retries and rework continue in the exact worktree bound
+by the existing custody receipt rather than refetching or moving its recorded
+base.
+
 ## `exists?`
 
 Two checks: `File.directory?(path)` AND `path ∈ git worktree list --porcelain`. Both must be true. This catches the "directory deleted via Finder/`rm -rf`" case where git still thinks the worktree exists but the filesystem doesn't, and also the inverse (filesystem dir but no git registration).


### PR DESCRIPTION
## Summary

- anchor first-generation Patrol Fix worktrees to the exact fetched origin default-branch OID
- keep Inbox local HEAD as evidence only, with no local fallback
- preserve immutable custody across same-generation retries and rework

## Verification

- `test/unit/stages/patrol_fix/*_test.rb`: 44 runs, 203 assertions
- `test/unit/patrol_fix/*_test.rb`: 153 runs, 681 assertions
- `test/unit/worktree_test.rb`: 72 runs, 243 assertions
- `test/integration/patrol_fix_lifecycle_test.rb`: 1 run, 29 assertions
- focused syntax and diff checks

The all-suite local checkpoint was stopped after unrelated integration/TUI coverage entered prolonged I/O waits; hosted CI is the broad exact-head gate.