### PR TITLE
Fix Patrol finding: carry-the-already-resolved-executable-on-the-pro-31047db365aa

### DIFF
--- a/components/agent-cli-runtime/CHANGELOG.md
+++ b/components/agent-cli-runtime/CHANGELOG.md
@@ -8,6 +8,16 @@
   overlay so callers can supply the same deny-first rules through native
   per-process configuration without duplicating policy generation.
 
+- Carry the already-resolved OpenCode executable on `ProbeRequest` (`executable:`)
+  instead of re-encoding it as the `AGENT_CLI_RUNTIME_OPENCODE_BIN` environment
+  override. The route-aware probe now resolves the executable once — honoring a
+  caller-supplied value first — and threads that single value through the
+  installation check, version check, every local inspection command, and the
+  reported result executable. `Profile#binary_installed?`,
+  `Profile#check_version!`, and `Profile#capture_local` accept an optional
+  `executable:` override; existing environment-based resolution is unchanged
+  when no explicit value is carried.
+
 ## 0.2.3 - 2026-08-21
 
 - Classify extracted provider failures once at the runtime boundary as

--- a/components/agent-cli-runtime/lib/agent_cli_runtime/opencode/overlay.rb
+++ b/components/agent-cli-runtime/lib/agent_cli_runtime/opencode/overlay.rb
@@ -105,9 +105,6 @@ module AgentCliRuntime
           )
           executable =
             preparation.request.executable || profile.bin(env: env)
-          probe_env = env.to_h.merge(
-            "AGENT_CLI_RUNTIME_OPENCODE_BIN" => executable
-          )
           probe_request = ProbeRequest.new(
             profile: profile,
             route: requested_route,
@@ -119,9 +116,10 @@ module AgentCliRuntime
                 staged_credential.last, requested_route.provider
               ),
             configured_variants:
-              configured_variants(source_config, requested_route)
+              configured_variants(source_config, requested_route),
+            executable: executable
           )
-          probe_result = OpenCode::Probe.call!(probe_request, env: probe_env)
+          probe_result = OpenCode::Probe.call!(probe_request, env: env)
           invocation = compile_invocation(
             preparation, profile, requested_route, roots,
             executable:, pure: pure,

--- a/components/agent-cli-runtime/lib/agent_cli_runtime/opencode/probe.rb
+++ b/components/agent-cli-runtime/lib/agent_cli_runtime/opencode/probe.rb
@@ -20,11 +20,11 @@ module AgentCliRuntime
         call!(request, env:)
       rescue Error => e
         profile = Profiles.resolve(request.profile)
-        executable = profile.bin(env:)
+        executable = request.executable || profile.bin(env:)
         RouteProbeResult.new(
           provider: profile.name,
           ready: false,
-          installed: profile.binary_installed?(env:),
+          installed: profile.binary_installed?(env:, executable:),
           executable: executable,
           version: nil,
           minimum_version: profile.min_version,
@@ -55,20 +55,25 @@ module AgentCliRuntime
           raise ArgumentError,
                 "route-aware ProbeRequest currently requires profile :opencode"
         end
-        installed = profile.binary_installed?(env:)
+        installed = profile.binary_installed?(env:, executable: request.executable)
         unless installed
           raise BinaryUnavailable,
-                "opencode binary not runnable: #{profile.bin(env:)}"
+                "opencode binary not runnable: " \
+                "#{request.executable || profile.bin(env:)}"
         end
 
         child_env = child_environment(profile, request, env:)
-        version = profile.check_version!(env: child_env)
+        version = profile.check_version!(
+          env: child_env, executable: request.executable
+        )
         evidence = [
           evidence(profile, :installation),
           evidence(profile, :version, [ version ])
         ]
 
-        run_help = capture!(profile, child_env, "run", "--help")
+        run_help = capture!(
+          profile, child_env, "run", "--help", executable: request.executable
+        )
         missing = REQUIRED_RUN_FLAGS.reject { |flag| advertised?(run_help, flag) }
         unless missing.empty?
           raise UnsupportedCapability,
@@ -78,14 +83,18 @@ module AgentCliRuntime
           evidence(profile, capability_for(flag), [ flag ])
         end)
 
-        export_help = capture!(profile, child_env, "export", "--help")
+        export_help = capture!(
+          profile, child_env, "export", "--help", executable: request.executable
+        )
         unless advertised?(export_help, "--sanitize")
           raise UnsupportedCapability,
                 "OpenCode export is missing required --sanitize capability"
         end
         evidence << evidence(profile, :sanitized_export, [ "--sanitize" ])
 
-        auth_output = capture!(profile, child_env, "auth", "list")
+        auth_output = capture!(
+          profile, child_env, "auth", "list", executable: request.executable
+        )
         configured_key = request.credential_environment_keys.find do |key|
           !env[key].to_s.empty?
         end
@@ -111,6 +120,7 @@ module AgentCliRuntime
         inventory_variants = if configured_variants.nil?
           models_output = capture!(
             profile, child_env, "models", request.route.provider, "--verbose",
+            executable: request.executable,
             timeout_sec: MODEL_INVENTORY_TIMEOUT_SECONDS
           )
           variants_for(models_output, request.route.to_s)
@@ -137,7 +147,7 @@ module AgentCliRuntime
           provider: profile.name,
           ready: true,
           installed: true,
-          executable: profile.bin(env: child_env),
+          executable: request.executable || profile.bin(env: child_env),
           version: version,
           minimum_version: profile.min_version,
           auth_configuration: auth,
@@ -176,8 +186,9 @@ module AgentCliRuntime
       end
       private_class_method :child_environment
 
-      def capture!(profile, environment, *arguments, timeout_sec: nil)
-        options = { env: environment }
+      def capture!(profile, environment, *arguments, executable: nil,
+                   timeout_sec: nil)
+        options = { env: environment, executable: executable }
         options[:timeout_sec] = timeout_sec if timeout_sec
         out, err, status = profile.capture_local(*arguments, **options)
         unless status.success?

--- a/components/agent-cli-runtime/lib/agent_cli_runtime/profile.rb
+++ b/components/agent-cli-runtime/lib/agent_cli_runtime/profile.rb
@@ -161,8 +161,8 @@ module AgentCliRuntime
       @raw_cli_arguments_supported
     end
 
-    def binary_installed?(env: ENV)
-      executable = bin(env:)
+    def binary_installed?(env: ENV, executable: nil)
+      executable ||= bin(env:)
       return File.file?(executable) && File.executable?(executable) if executable.include?(File::SEPARATOR)
 
       env.fetch("PATH", "").split(File::PATH_SEPARATOR).any? do |directory|
@@ -173,8 +173,8 @@ module AgentCliRuntime
       false
     end
 
-    def check_version!(env: ENV)
-      executable = bin(env:)
+    def check_version!(env: ENV, executable: nil)
+      executable ||= bin(env:)
       out, _err, status = bounded_capture3(
         executable, @version_flag, timeout_sec: @version_check_timeout_sec, env: env
       )
@@ -292,9 +292,10 @@ module AgentCliRuntime
       flags.dup
     end
 
-    def capture_local(*arguments, env: ENV, timeout_sec: CAPTURE_TIMEOUT_SECONDS)
+    def capture_local(*arguments, env: ENV, timeout_sec: CAPTURE_TIMEOUT_SECONDS,
+                      executable: nil)
       bounded_capture3(
-        bin(env:), *arguments, timeout_sec: timeout_sec, env: env
+        executable || bin(env:), *arguments, timeout_sec: timeout_sec, env: env
       )
     end
 

--- a/components/agent-cli-runtime/lib/agent_cli_runtime/values.rb
+++ b/components/agent-cli-runtime/lib/agent_cli_runtime/values.rb
@@ -331,12 +331,13 @@ module AgentCliRuntime
   ProbeRequest = Data.define(
     :profile, :route, :variant, :environment,
     :credential_environment_keys, :credential_file_staged,
-    :configured_variants
+    :configured_variants, :executable
   ) do
     def initialize(profile:, route:, variant: nil, environment: {},
                    credential_environment_keys: [],
                    credential_file_staged: false,
-                   configured_variants: nil)
+                   configured_variants: nil,
+                   executable: nil)
       parsed_route = route.is_a?(Route) ? route : Route.parse(route)
       super(
         profile: profile,
@@ -347,7 +348,8 @@ module AgentCliRuntime
           Immutable.strings(credential_environment_keys),
         credential_file_staged: credential_file_staged == true,
         configured_variants:
-          configured_variants.nil? ? nil : Immutable.strings(configured_variants)
+          configured_variants.nil? ? nil : Immutable.strings(configured_variants),
+        executable: executable.nil? ? nil : Immutable.string(executable)
       )
     end
   end

--- a/components/agent-cli-runtime/test/opencode_preparation_test.rb
+++ b/components/agent-cli-runtime/test/opencode_preparation_test.rb
@@ -28,13 +28,19 @@ class AgentCliRuntimeOpenCodePreparationTest < Minitest::Test
     success.define_singleton_method(:success?) { true }
     profile = Object.new
     profile.define_singleton_method(:name) { :opencode }
-    profile.define_singleton_method(:binary_installed?) { |env:| !env.nil? }
+    profile.define_singleton_method(:binary_installed?) do |env:, executable: nil|
+      !env.nil?
+    end
     profile.define_singleton_method(:bin) { |env:| env && "opencode" }
-    profile.define_singleton_method(:check_version!) { |env:| env && "1.18.18" }
+    profile.define_singleton_method(:check_version!) do |env:, executable: nil|
+      env && "1.18.18"
+    end
     profile.define_singleton_method(:min_version) { "1.18.16" }
     profile.define_singleton_method(:launcher_identity) { "opencode-cli/v1" }
     profile.define_singleton_method(:env_bin_override_keys) { [] }
-    profile.define_singleton_method(:capture_local) do |*arguments, env:, timeout_sec: 10|
+    profile.define_singleton_method(:capture_local) do |*arguments, env:,
+                                                             timeout_sec: 10,
+                                                             executable: nil|
       calls << [ arguments, timeout_sec, env ]
       output = case arguments
       when [ "run", "--help" ]
@@ -644,6 +650,73 @@ class AgentCliRuntimeOpenCodePreparationTest < Minitest::Test
     refute_includes result.diagnostic, "secret-canary"
   end
 
+  def test_route_probe_carries_the_caller_resolved_executable
+    with_fixture_cli do |fixture|
+      bin = fixture.fetch(:bin)
+      request = AgentCliRuntime::ProbeRequest.new(
+        profile: :opencode,
+        route: "anthropic/claude-sonnet-4-5",
+        environment: {},
+        credential_environment_keys: [ "ANTHROPIC_API_KEY" ],
+        executable: bin
+      )
+      env = {
+        "ANTHROPIC_API_KEY" => "secret-canary",
+        "PATH" => "/usr/bin:/bin"
+      }
+
+      result = AgentCliRuntime::OpenCode::Probe.call!(request, env: env)
+
+      assert result.ready
+      assert_equal bin, result.executable
+    end
+  end
+
+  def test_route_probe_fail_soft_reports_the_carried_executable
+    request = AgentCliRuntime::ProbeRequest.new(
+      profile: :opencode,
+      route: "anthropic/claude-sonnet-4-5",
+      environment: {},
+      credential_environment_keys: [ "ANTHROPIC_API_KEY" ],
+      executable: "/missing/carried-opencode"
+    )
+
+    result = AgentCliRuntime.probe(request, env: { "PATH" => "/usr/bin:/bin" })
+
+    refute result.ready
+    refute result.installed
+    assert_equal "/missing/carried-opencode", result.executable
+    assert_match(/carried-opencode/, result.diagnostic)
+  end
+
+  def test_preparation_probe_and_invocation_share_one_resolved_executable
+    with_fixture_cli do |fixture|
+      Dir.mktmpdir do |dir|
+        work = File.join(dir, "work")
+        FileUtils.mkdir_p(work)
+        source = selected_config(dir)
+        env = fixture.fetch(:env).dup
+        %w[
+          AGENT_CLI_RUNTIME_OPENCODE_BIN HIVE_OPENCODE_BIN
+        ].each { |key| env.delete(key) }
+        bin = fixture.fetch(:bin)
+
+        prepared = AgentCliRuntime.prepare!(
+          preparation_request(
+            work:, root: File.join(dir, "invocation"), source:,
+            executable: bin
+          ),
+          env:
+        )
+
+        assert prepared.probe_result.ready
+        assert_equal bin, prepared.invocation.argv.first
+        assert_equal prepared.probe_result.executable,
+                     prepared.invocation.argv.first
+      end
+    end
+  end
+
   def test_preparation_rejects_unsafe_roots_and_secret_inline_configuration
     with_fixture_cli do |fixture|
       Dir.mktmpdir do |dir|
@@ -738,14 +811,15 @@ class AgentCliRuntimeOpenCodePreparationTest < Minitest::Test
                           permission_mode: "read-only", permission_policy: nil,
                           additional_read_roots: [], additional_write_roots: [],
                           edit_patterns: [], bash_patterns: [],
-                          prompt: "make the atomic edit")
+                          prompt: "make the atomic edit", executable: nil)
     AgentCliRuntime::OpenCodePreparationRequest.new(
       request: AgentCliRuntime::Request.new(
         profile: :opencode,
         prompt:,
         permission_mode:,
         model:,
-        effort: "high"
+        effort: "high",
+        executable:
       ),
       working_directory: work,
       invocation_root: root,

--- a/wiki/log.d/20260822T121500Z-opencode-carried-probe-executable.md
+++ b/wiki/log.d/20260822T121500Z-opencode-carried-probe-executable.md
@@ -1,0 +1,35 @@
+---
+created: 2026-08-22
+tags: [agent-cli-runtime, opencode, probe, patrol-fix]
+---
+
+# OpenCode probe carries the caller-resolved executable
+
+Patrol finding
+`pr-998-05225eb9e83d4386:consolidate-opencode-executable-resolution-ownership`
+(generation 1) identified that `OpenCode::Overlay.prepare!` resolved the
+executable, then re-encoded it as the `AGENT_CLI_RUNTIME_OPENCODE_BIN`
+environment override to reach `OpenCode::Probe.call!`, because the probe had no
+parameter for it. The probe then re-resolved the executable three separate
+times: `profile.binary_installed?`, the `BinaryUnavailable` message, and the
+result's `executable` (from the filtered child environment).
+
+## Change
+
+- `ProbeRequest` gained an optional `executable:` field.
+- `OpenCode::Probe.call!/call` resolve the executable once
+  (`request.executable || profile.bin(env:)`) and thread it through the
+  installation check, version check, all inspection captures, and the reported
+  result executable — including the fail-soft path.
+- `Profile#binary_installed?`, `#check_version!`, and `#capture_local` accept an
+  optional `executable:` override; without it, environment-based resolution is
+  unchanged for legacy callers.
+- `prepare!` passes the resolved executable on the probe request and no longer
+  mutates the probe environment.
+
+## Invariants
+
+- The executable the probe validated and reports is exactly the executable the
+  compiled invocation runs.
+- Callers with an already-resolved executable never depend on environment key
+  precedence to communicate it to the probe.

--- a/wiki/modules/agent_cli_runtime.md
+++ b/wiki/modules/agent_cli_runtime.md
@@ -78,7 +78,10 @@ shared with the component.
 The OpenCode route-aware probe requires `1.18.16+`, all pinned run/export
 flags, a selected authentication source, and an exact `provider/model` plus
 requested variant while remote model fetching and ambient project
-configuration are disabled. An exact route declared by the selected overlay is
+configuration are disabled. The probe accepts the caller's already-resolved
+executable on `ProbeRequest.executable` and otherwise falls back to declared
+environment overrides; either way it validates and reports exactly the
+executable the compiled invocation runs. An exact route declared by the selected overlay is
 authoritative and skips the large verbose CLI inventory; an undeclared route
 must still exist in that bounded local inventory. Generic `probe(profile)` and
 `prepare!(profile)` remain compatible for legacy profiles. OpenCode's ordinary


### PR DESCRIPTION
## Patrol Fix

This pull request repairs one finding tracked by Hive's Patrol Fix workflow.

### Sources

- architecture_patrol: pr-998-05225eb9e83d4386:consolidate-opencode-executable-resolution-ownership

### Finding evidence

- {"file":"components/agent-cli-runtime/lib/agent_cli_runtime/opencode/overlay.rb","line":93,"snippet":"preparation.request.executable || profile.bin(env: env)","claim":"preparation already holds the fully resolved executable before it calls the probe"}
- {"file":"components/agent-cli-runtime/lib/agent_cli_runtime/opencode/overlay.rb","line":95,"snippet":"\"AGENT_CLI_RUNTIME_OPENCODE_BIN\" => executable","claim":"the caller re-encodes that resolved value as a hard-coded environment override to reach OpenCode::Probe.call! on line 108, because the probe exposes no parameter for it"}
- {"file":"components/agent-cli-runtime/lib/agent_cli_runtime/opencode/probe.rb","line":57,"snippet":"installed = profile.binary_installed?(env:)","claim":"the probe re-resolves the executable from the environment it was handed rather than accepting the caller's resolved value, and reports it again in the failure message on line 60"}
- {"file":"components/agent-cli-runtime/lib/agent_cli_runtime/opencode/probe.rb","line":129,"snippet":"executable: profile.bin(env: child_env)","claim":"the probe result reports an executable resolved a third time, from the filtered child environment built by child_environment, not from the value the invocation will run"}
- {"file":"components/agent-cli-runtime/lib/agent_cli_runtime/profile.rb","line":90,"snippet":"key = @env_bin_override_keys.find do |candidate|","claim":"bin returns the first non-empty declared override key, so the literal key Overlay injects only wins when no earlier declared override key is already set in the caller's env"}
- {"file":"components/agent-cli-runtime/lib/agent_cli_runtime/opencode/overlay.rb","line":551,"snippet":"executable: executable,","claim":"the compiled invocation runs the Overlay-resolved executable, independent of the executable the probe validated and reported"}

### Independent review

The patch correctly carries the preparation-resolved executable into the route-aware probe and consistently uses it for installation, version, local capability inspection, fail-soft reporting, and invocation compilation. Patch-scoped tests pass. The controller's sole broad-checkpoint failure is an unrelated ambient Grok executable override; the same checkpoint passes when that external override is removed.

- Worktree HEAD is exactly 94d4da4320fa7a06cabfdc5609932130f36fc660, its merge base is the declared b07b869635e47d986370b19d0dfe583d54143e79, the worktree is clean, and git diff --check passes.
- ProbeRequest now immutably carries executable; Overlay passes its already-resolved value; Probe uses that value for binary_installed?, check_version!, every capture_local call, the success result, and the fail-soft result; compile_invocation receives the same value.
- The four declared patch-scoped validations independently pass: 26 runs/186 assertions, 10/38, 1/17, and 11/106, with zero failures or errors.
- Regression tests cover an explicit executable absent from PATH, a missing carried executable in the fail-soft path, and equality between the probed executable and invocation argv[0].
- The controller failure expected the literal grok command but received the path from ambient HIVE_GROK_BIN; that variable is present on the host and unrelated to this OpenCode-only diff.
- With HIVE_GROK_BIN removed, bundle exec rake test:agent_cli_runtime passes 118 runs and 1192 assertions with zero failures or errors and one documented skip.

### Validation

Verdict: failed
- architecture:test: exit 1
- agent:pr-998-05225eb9e83d4386:consolidate-opencode-executable-resolution-ownership: exit 0
- agent:pr-998-05225eb9e83d4386:consolidate-opencode-executable-resolution-ownership: exit 0
- agent:pr-998-05225eb9e83d4386:consolidate-opencode-executable-resolution-ownership: exit 0
- agent:pr-998-05225eb9e83d4386:consolidate-opencode-executable-resolution-ownership: exit 0

<!-- hive-publication:v1 id=pub-b4f62b65287e73b6e5500184349a84e9 base=b07b869635e47d986370b19d0dfe583d54143e79 -->
