### PR TITLE
fix(bench): validate dogfood OpenCode runtime

### DIFF
--- a/templates/builtins/bench/runtime/harness/lib/hive_config.rb
+++ b/templates/builtins/bench/runtime/harness/lib/hive_config.rb
@@ -86,8 +86,7 @@ module HiveBench
               }
             },
             "credential_env" => ["OPENROUTER_API_KEY"],
-            "plugins" => [OPENCODE_PLUGIN],
-            "isolation" => "hermetic"
+            "plugins" => [OPENCODE_PLUGIN]
           }
         }
       end

--- a/templates/builtins/bench/runtime/harness/lib/hive_driver.rb
+++ b/templates/builtins/bench/runtime/harness/lib/hive_driver.rb
@@ -419,7 +419,7 @@ module HiveBench
     end
 
     def active_hive_runtime
-      bin = File.realpath(ENV.fetch("HB_HIVE_BIN") { find_hive_executable })
+      bin = active_hive_binary
       root = File.expand_path("..", File.dirname(bin))
       canonical_bin = File.join(root, "bin", "hive")
       hive_lib = File.join(root, "lib", "hive.rb")
@@ -440,6 +440,61 @@ module HiveBench
       { root:, gem_home:, version: }.freeze
     rescue Errno::ENOENT, Errno::EACCES => e
       raise "active hive runtime is unavailable: #{e.message}"
+    end
+
+    # A normal installation puts `hive` beside lib/hive.rb. Dogfood instead
+    # exposes a stable PATH wrapper which selects an immutable deployment and
+    # exports its identity before exec. Preserve explicit HB_HIVE_BIN behavior,
+    # but when PATH resolves to that wrapper, recover the exact deployment named
+    # by the inherited identity rather than following the mutable current link.
+    def active_hive_binary
+      explicit = ENV["HB_HIVE_BIN"].to_s.strip
+      return File.realpath(explicit) unless explicit.empty?
+
+      discovered = File.realpath(find_hive_executable)
+      return discovered if complete_runtime_binary?(discovered)
+
+      dogfood_runtime_binary || discovered
+    end
+
+    def complete_runtime_binary?(bin)
+      root = File.expand_path("..", File.dirname(bin))
+      File.file?(File.join(root, "bin", "hive")) &&
+        File.executable?(File.join(root, "bin", "hive")) &&
+        File.file?(File.join(root, "lib", "hive.rb"))
+    end
+
+    def dogfood_runtime_binary
+      return unless ENV["HIVE_RUNTIME_CHANNEL"] == "dogfood"
+
+      deployment_id = ENV["HIVE_RUNTIME_DEPLOYMENT_ID"].to_s
+      build_sha = ENV["HIVE_RUNTIME_BUILD_SHA"].to_s
+      unless deployment_id.match?(/\Ahive-dogfood-[0-9a-f]{9}\z/) &&
+             build_sha.match?(/\A[0-9a-f]{40}\z/) &&
+             deployment_id == "hive-dogfood-#{build_sha[0, 9]}"
+        raise "dogfood hive runtime identity is invalid"
+      end
+
+      state_root = ENV["HIVE_DOGFOOD_STATE_ROOT"].to_s
+      if state_root.empty?
+        state_home = ENV["XDG_STATE_HOME"].to_s
+        state_home = File.expand_path("~/.local/state") if state_home.empty?
+        state_root = File.join(state_home, "hive")
+      end
+      deployments = File.realpath(File.join(state_root, "deployments"))
+      root = File.realpath(File.join(deployments, deployment_id))
+      unless File.dirname(root) == deployments && File.basename(root) == deployment_id
+        raise "dogfood hive runtime escapes managed deployments: #{root}"
+      end
+
+      out, err, status = Open3.capture3("git", "-C", root, "rev-parse", "--verify", "HEAD^{commit}")
+      actual_sha = out.strip
+      unless status.success? && actual_sha == build_sha
+        detail = err.strip.empty? ? actual_sha : err.strip
+        raise "dogfood hive runtime identity mismatch: #{detail}"
+      end
+
+      File.join(root, "bin", "hive")
     end
 
     def find_hive_executable

--- a/test/unit/workflows/bench_test.rb
+++ b/test/unit/workflows/bench_test.rb
@@ -175,6 +175,82 @@ class WorkflowsBenchTest < Minitest::Test
     assert_equal [ "Read", "Write", "Edit", "Bash(*)" ], permissions.fetch("tools")
   end
 
+  def test_packaged_runtime_emits_a_hive_valid_opencode_config
+    harness = File.join(Hive::Workflows::Bench::RUNTIME_DIR, "harness")
+    script = <<~'RUBY'
+      require "profiles/candidates"
+      require "lib/hive_config"
+      puts HiveBench::HiveConfig.to_yaml(
+        HiveBench::Candidates.by_id("all-ox-alpha-opencode@high")
+      )
+    RUBY
+    out, err, status = Open3.capture3(RbConfig.ruby, "-I#{harness}", "-e", script)
+    assert status.success?, out + err
+
+    Dir.mktmpdir("hive-bench-opencode-config") do |project|
+      state = File.join(project, ".hive-state")
+      FileUtils.mkdir_p(state)
+      File.write(File.join(state, "config.yml"), out)
+
+      previous = ENV["HIVE_BENCH_ALLOW_DISABLED_PLAN_REVIEW"]
+      ENV["HIVE_BENCH_ALLOW_DISABLED_PLAN_REVIEW"] = "1"
+      config = Hive::Config.load(project)
+
+      assert_equal [ "Read", "Write", "Edit", "Bash(*)" ], config.dig("permissions", "tools")
+      refute config.dig("agents", "opencode").key?("isolation")
+    ensure
+      ENV["HIVE_BENCH_ALLOW_DISABLED_PLAN_REVIEW"] = previous
+    end
+  end
+
+  def test_packaged_runtime_resolves_the_immutable_inherited_dogfood_deployment
+    harness = File.join(Hive::Workflows::Bench::RUNTIME_DIR, "harness")
+    Dir.mktmpdir("hive-bench-dogfood-runtime") do |tmp|
+      state_root = File.join(tmp, "state", "hive")
+      staging = File.join(state_root, "deployments", "staging")
+      gem_home = File.join(tmp, "gem-home")
+      wrapper_dir = File.join(tmp, "bin")
+      FileUtils.mkdir_p([File.join(staging, "bin"), File.join(staging, "lib"), gem_home, wrapper_dir])
+      File.write(File.join(staging, "bin", "hive"), "#!/bin/sh\nprintf '0.7.2\\n'\n")
+      FileUtils.chmod(0o755, File.join(staging, "bin", "hive"))
+      File.write(File.join(staging, "lib", "hive.rb"), "# complete runtime\n")
+      File.write(File.join(wrapper_dir, "hive"), "#!/bin/sh\nexit 1\n")
+      FileUtils.chmod(0o755, File.join(wrapper_dir, "hive"))
+      system("git", "-C", staging, "init", "-q", "-b", "main", exception: true)
+      system("git", "-C", staging, "config", "user.email", "bench@example.com", exception: true)
+      system("git", "-C", staging, "config", "user.name", "Bench Test", exception: true)
+      system("git", "-C", staging, "add", ".", exception: true)
+      system("git", "-C", staging, "commit", "-qm", "dogfood runtime", exception: true)
+      build_sha, = Open3.capture2("git", "-C", staging, "rev-parse", "HEAD")
+      build_sha = build_sha.strip
+      deployment_id = "hive-dogfood-#{build_sha[0, 9]}"
+      deployment = File.join(state_root, "deployments", deployment_id)
+      FileUtils.mv(staging, deployment)
+
+      script = <<~'RUBY'
+        require "json"
+        require "lib/hive_driver"
+        puts JSON.generate(HiveBench::HiveDriver.allocate.send(:active_hive_runtime))
+      RUBY
+      env = {
+        "PATH" => "#{wrapper_dir}:#{ENV.fetch("PATH")}",
+        "HB_HIVE_BIN" => nil,
+        "HB_HIVE_GEM_HOME" => gem_home,
+        "HIVE_RUNTIME_CHANNEL" => "dogfood",
+        "HIVE_RUNTIME_DEPLOYMENT_ID" => deployment_id,
+        "HIVE_RUNTIME_BUILD_SHA" => build_sha,
+        "HIVE_DOGFOOD_STATE_ROOT" => state_root
+      }
+      out, err, status = Open3.capture3(env, RbConfig.ruby, "-I#{harness}", "-e", script)
+
+      assert status.success?, out + err
+      runtime = JSON.parse(out)
+      assert_equal deployment, runtime.fetch("root")
+      assert_equal gem_home, runtime.fetch("gem_home")
+      assert_equal "0.7.2", runtime.fetch("version")
+    end
+  end
+
   def test_packaged_runtime_gives_candidates_only_the_historical_base_git_object
     harness = File.join(Hive::Workflows::Bench::RUNTIME_DIR, "harness")
     Dir.mktmpdir("hive-bench-source-history") do |source|

--- a/test/unit/workflows/bench_test.rb
+++ b/test/unit/workflows/bench_test.rb
@@ -210,7 +210,7 @@ class WorkflowsBenchTest < Minitest::Test
       staging = File.join(state_root, "deployments", "staging")
       gem_home = File.join(tmp, "gem-home")
       wrapper_dir = File.join(tmp, "bin")
-      FileUtils.mkdir_p([File.join(staging, "bin"), File.join(staging, "lib"), gem_home, wrapper_dir])
+      FileUtils.mkdir_p([ File.join(staging, "bin"), File.join(staging, "lib"), gem_home, wrapper_dir ])
       File.write(File.join(staging, "bin", "hive"), "#!/bin/sh\nprintf '0.7.2\\n'\n")
       FileUtils.chmod(0o755, File.join(staging, "bin", "hive"))
       File.write(File.join(staging, "lib", "hive.rb"), "# complete runtime\n")

--- a/wiki/log.d/20260826T130500Z-bench-dogfood-opencode-config.md
+++ b/wiki/log.d/20260826T130500Z-bench-dogfood-opencode-config.md
@@ -1,0 +1,8 @@
+# Validate benchmark dogfood and OpenCode runtime configuration
+
+- Removed the retired `agents.opencode.isolation` field from benchmark-generated
+  configs; containment remains the runner container plus provider-only network.
+- Added an end-to-end config regression through `Hive::Config.load` while
+  retaining the scoped `Bash(*)` parity grant and Compound Engineering plugin.
+- Resolve a dogfood wrapper to the exact deployment id and build SHA inherited
+  from its launch, then mount that immutable runtime into candidate cells.

--- a/wiki/modules/workflows.md
+++ b/wiki/modules/workflows.md
@@ -173,6 +173,11 @@ the harness recovers its normalized input, output, cache-read, and cache-write
 totals from the cell-local Hive usage database when no stream tokens exist.
 The runner image carries the pinned OpenCode CLI and Compound Engineering
 package, while Pi receives the minimal pinned OpenRouter model catalog.
+The generated OpenCode profile uses only Hive-supported override keys; OS and
+network containment belong to the disposable runner rather than the retired
+`agents.opencode.isolation` setting. Its scoped permission document grants the
+qualified `Bash(*)` tool so OpenCode and Pi can both run repository diagnostics
+and tests.
 Candidate source preparation fetches only the exact historical base at depth
 one. This keeps descendant/reference objects, source refs, tags, and reflogs out
 of the candidate repository instead of relying on `remote remove` to hide them.
@@ -181,6 +186,13 @@ attaches to a named internal Docker network and receives a credential-free
 CONNECT-proxy URL; partial or missing strict configuration fails before model
 spend. The base-only and egress modes are bound into generation identity, so an
 older unrestricted artifact cannot be silently reused as strict evidence.
+When the control plane is invoked through the dogfood wrapper, the packaged
+driver resolves the exact immutable deployment named by
+`HIVE_RUNTIME_DEPLOYMENT_ID` and verifies its full commit against
+`HIVE_RUNTIME_BUILD_SHA`. It does not treat the stable wrapper as a source
+runtime or follow the mutable `dogfood-current` pointer after the task starts;
+an explicit `HB_HIVE_BIN` override still takes precedence and fails closed.
+
 
 `hive workflow new ID` (see [[commands/workflow]]) scaffolds the minimal `inbox -> work -> done` descriptor plus `work.md` instruction and commits those initial files to `hive/state`. After editing, the natural-language creator validates and invokes `hive workflow commit ID`, which commits the populated descriptor/instruction directory under the shared state commit lock before it reports success or creates a task. The only richer shipped scaffold is `--template research`; Architecture and Writing are installed as full reviewed Honeycomb packages so their agent-slot configuration remains operator-owned.
 


### PR DESCRIPTION
## Summary
- remove the retired OpenCode isolation override from generated benchmark configs
- resolve dogfood wrappers to their inherited immutable deployment identity
- validate the generated OpenCode config through Hive and cover dogfood resolution

## Tests
- `bundle exec ruby -Itest test/unit/workflows/bench_test.rb`
- `bundle exec ruby -Itest test/integration/bench_workflow_install_test.rb`