### PR TITLE
fix(bench): seal agent runtime from candidates

### DIFF
--- a/templates/builtins/bench/generate.md
+++ b/templates/builtins/bench/generate.md
@@ -127,6 +127,9 @@ ruby -ryaml -rjson -e '
   end
   isolation = data.fetch("isolation", {})
   abort("isolation must be a mapping") unless isolation.is_a?(Hash)
+  if isolation.key?("sealed_agent_runtime")
+    abort("isolation.sealed_agent_runtime must be true or false") unless [true, false].include?(isolation["sealed_agent_runtime"])
+  end
   if isolation["require_provider_egress"] == true
     network = isolation["docker_network"]
     proxy = isolation["https_proxy"]
@@ -266,6 +269,7 @@ ruby -ryaml -rshellwords -rjson -e '
       # when unset, harness defaults apply, as campaign.yml.example documents.
       env << "HB_HIVE_TIMEOUT=#{hive_timeout}" if hive_timeout
       isolation = data.fetch("isolation", {})
+      env << "HB_REQUIRE_SEALED_AGENT_RUNTIME=1" if isolation["sealed_agent_runtime"] == true
       if isolation["require_provider_egress"] == true
         env << "HB_REQUIRE_EGRESS_ALLOWLIST=1"
         env << "HB_GEN_NETWORK=#{isolation.fetch("docker_network")}"

--- a/templates/builtins/bench/runtime/Dockerfile.runner
+++ b/templates/builtins/bench/runtime/Dockerfile.runner
@@ -21,6 +21,10 @@ ARG CLAUDE_VERSION=2.1.191
 ARG CODEX_VERSION=0.142.2
 ARG OPENCODE_VERSION=1.18.18
 ARG COMPOUND_ENGINEERING_VERSION=3.22.4
+ARG HIVE_BUILD_SHA=unknown
+
+LABEL io.hive.bench.hive-build-sha="${HIVE_BUILD_SHA}" \
+      io.hive.bench.runtime-visibility="sealed-control-bundle-v1"
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends git ca-certificates curl xz-utils libatomic1 \
@@ -81,8 +85,19 @@ RUN mkdir -p /tmp/hive-build \
   && cd /tmp/hive-build \
   && gem build hive.gemspec \
   && gem install ./hive-cli-*.gem --no-document \
-  && ln -sf /usr/local/bundle/bin/hive /usr/local/bin/hive \
-  && hive --version \
+  && mkdir -p /opt/hb \
+  && mv /usr/local/bundle /opt/hb/control-bundle \
+  && cp -a /opt/hb/control-bundle /usr/local/bundle \
+  && rm -rf /usr/local/bundle/gems/hive-cli-* \
+            /usr/local/bundle/specifications/hive-cli-*.gemspec \
+            /usr/local/bundle/cache/hive-cli-*.gem \
+  && rm -f /usr/local/bundle/bin/hive \
+  && ! find /usr/local/bundle -iname '*hive-cli*' -print -quit | grep -q . \
+  && chmod -R go-rwx /opt/hb/control-bundle \
+  && ln -sf /opt/hb/control-bundle/bin/hive /usr/local/bin/hive \
+  && GEM_HOME=/opt/hb/control-bundle \
+     GEM_PATH=/opt/hb/control-bundle:/usr/local/bundle:/usr/local/lib/ruby/gems/3.4.0 \
+     /opt/hb/control-bundle/bin/hive --version \
   && rm -rf /tmp/hive-build /tmp/hive-src.tar
 
 # Non-root: the candidate's code and the gate's tests run unprivileged. uid 1000

--- a/templates/builtins/bench/runtime/campaign.yml.example
+++ b/templates/builtins/bench/runtime/campaign.yml.example
@@ -23,16 +23,14 @@ effort_pins: {}
 # cannot enter judging. The default keeps paid-patch recovery compatibility.
 require_successful_execution: false
 
-# Published local campaigns should use a Docker `--internal` network whose only
-# dual-homed peer is a CONNECT proxy that permits the configured model provider
-# and denies GitHub/the public internet. With this enabled, generation fails
-# closed unless both values are present; each cell records `provider-allowlist`
-# in its generation identity. Candidate repositories are independently created
-# as depth-one, base-only clones so future/reference Git objects are absent.
+# Publication-grade local campaigns seal the controller runtime from the model,
+# use a base-only shallow repository, and attach to a provider-only Docker
+# network. The runner image must be built from the exact active Hive commit.
 isolation:
-  require_provider_egress: false
-  # docker_network: hive-bench-provider-only
-  # https_proxy: http://hive-bench-egress-proxy:3128
+  sealed_agent_runtime: true
+  require_provider_egress: true
+  docker_network: hive-bench-provider-only
+  https_proxy: http://hive-bench-egress-proxy:3128
 
 # Judge samples. Use at least 3 for published results.
 seeds: 3

--- a/templates/builtins/bench/runtime/harness/build_runner.sh
+++ b/templates/builtins/bench/runtime/harness/build_runner.sh
@@ -17,8 +17,9 @@ HIVE_SRC="${HIVE_SRC:-$HOME/Dev/hive}"
 cd "$(dirname "$0")/.."
 
 [ -e "$HIVE_SRC/.git" ] || { echo "HIVE_SRC=$HIVE_SRC is not a git checkout" >&2; exit 1; }
-rev="$(git -C "$HIVE_SRC" rev-parse --short HEAD)"
-echo "pinning hive tool from $HIVE_SRC @ $rev"
+full_rev="$(git -C "$HIVE_SRC" rev-parse HEAD)"
+short_rev="$(git -C "$HIVE_SRC" rev-parse --short HEAD)"
+echo "pinning hive tool from $HIVE_SRC @ $short_rev"
 
 # Clean source only (no vendor/bundle, .hive-state, worktrees) — see .dockerignore.
 git -C "$HIVE_SRC" archive --format=tar HEAD >hive-src.tar
@@ -31,5 +32,6 @@ image_tag_args=(-t "$IMAGE_TAG")
 if [ -n "$OPENCODE_IMAGE_TAG" ] && [ "$OPENCODE_IMAGE_TAG" != "$IMAGE_TAG" ]; then
   image_tag_args+=(-t "$OPENCODE_IMAGE_TAG")
 fi
-docker build -f Dockerfile.runner "${image_tag_args[@]}" "${image_build_args[@]}" .
-echo "built ${IMAGE_TAG}${OPENCODE_IMAGE_TAG:+ and ${OPENCODE_IMAGE_TAG}} with hive tool @ $rev"
+docker build -f Dockerfile.runner --build-arg "HIVE_BUILD_SHA=$full_rev" \
+  "${image_tag_args[@]}" "${image_build_args[@]}" .
+echo "built ${IMAGE_TAG}${OPENCODE_IMAGE_TAG:+ and ${OPENCODE_IMAGE_TAG}} with hive tool @ $short_rev"

--- a/templates/builtins/bench/runtime/harness/lib/hive_driver.rb
+++ b/templates/builtins/bench/runtime/harness/lib/hive_driver.rb
@@ -34,6 +34,7 @@ module HiveBench
     STAGES_SH = File.expand_path("hive_stages.sh", __dir__)
     RESUME_EXECUTE_SH = File.expand_path("hive_resume_execute.sh", __dir__)
     OPENCODE_BENCH_RUNTIME = File.expand_path("opencode_bench_runtime.rb", __dir__)
+    OPENCODE_BENCH_LAUNCHER = File.expand_path("opencode_bench_launcher.sh", __dir__)
     PI_BENCH_LAUNCHER = File.expand_path("pi_bench_launcher.sh", __dir__)
     PI_TOOL_STREAM = File.expand_path("pi_tool_stream.ts", __dir__)
     PI_OPENROUTER_MODELS = File.expand_path("../profiles/pi_openrouter_models.json", __dir__)
@@ -41,6 +42,9 @@ module HiveBench
     HOME = "/home/asterio"
     HIVE_RUNTIME_CONTAINER_ROOT = "/opt/hb/hive-current"
     HIVE_GEM_HOME_CONTAINER_ROOT = "/usr/local/bundle"
+    HIVE_CONTROL_GEM_HOME = "/opt/hb/control-bundle"
+    CANDIDATE_GEM_HOME = "/usr/local/bundle"
+    SEALED_RUNTIME_VISIBILITY = "sealed-control-bundle-v1"
     HIVE_RUNTIME_RUBYLIB = [
       "#{HIVE_RUNTIME_CONTAINER_ROOT}/components/agent-cli-runtime/lib",
       "#{HIVE_RUNTIME_CONTAINER_ROOT}/lib"
@@ -67,10 +71,11 @@ module HiveBench
     PLAN_TIMEOUT = Integer(ENV.fetch("HB_HIVE_TIMEOUT", "5400")) # per container run, sec
 
     def initialize(reuse_existing:, reuse_unverified:, clock: -> { Time.now.utc }, runner: nil,
-                   hive_runtime: nil)
+                   hive_runtime: nil, image_inspector: nil)
       @clock = clock
       @runner = runner # injectable container runner for tests; default shells docker
       @hive_runtime = hive_runtime
+      @image_inspector = image_inspector
       @reuse_existing = reuse_existing
       @reuse_unverified = reuse_unverified
     end
@@ -243,15 +248,18 @@ module HiveBench
 
     def generation_identity(entry, candidate, base, hive_runtime: resolved_hive_runtime)
       egress = generation_egress
+      runtime = { "version" => hive_runtime.fetch(:version) }
+      runtime["build_sha"] = hive_runtime[:build_sha] if hive_runtime[:build_sha]
       JSON.parse(JSON.generate(
                    "schema" => "hive-bench-generation-identity",
-                   "schema_version" => 2,
+                   "schema_version" => 3,
                    "task_id" => entry.fetch("task_id"),
                    "base_commit" => base,
-                   "hive_runtime" => { "version" => hive_runtime.fetch(:version) },
+                   "hive_runtime" => runtime,
                    "isolation" => {
                      "source_history" => "base-only-shallow",
-                     "generation_egress" => egress.fetch(:mode)
+                     "generation_egress" => egress.fetch(:mode),
+                     "runtime_visibility" => sealed_agent_runtime? ? SEALED_RUNTIME_VISIBILITY : "host-mounted"
                    },
                    "candidate" => candidate.to_h
                  ))
@@ -366,6 +374,7 @@ module HiveBench
     def run_container(slug, base, work, candidate, out_dir, resume_marker_id: nil,
                       resume_review: false,
                       hive_runtime: resolved_hive_runtime)
+      verify_sealed_runtime!(candidate, hive_runtime) if sealed_agent_runtime?
       cmd = ["docker", "run", "--rm",
              "-e", "HOME=#{HOME}",
              "-e", "HIVE_HOME=#{HIVE_HOME}",
@@ -380,6 +389,7 @@ module HiveBench
              "--cpus", ENV.fetch("HB_CPUS", "4"),
              "--memory", ENV.fetch("HB_MEMORY", "8g"),
              "--pids-limit", ENV.fetch("HB_PIDS", "4096"),
+             *(sealed_agent_runtime? ? ["--user", "0:0", "--security-opt", "no-new-privileges:true"] : []),
              *network_args,
              "--tmpfs", "#{HOME}:exec,mode=1777",
              # .claude must be WRITABLE (claude's Bash tool mkdir's session-env
@@ -389,7 +399,7 @@ module HiveBench
              "-v", "#{STAGES_SH}:/hive_stages.sh:ro",
              "-v", "#{RESUME_EXECUTE_SH}:/hive_resume_execute.sh:ro",
              "-v", "#{work}:/work",
-             *hive_runtime_mounts(hive_runtime),
+             *hive_runtime_args(hive_runtime),
              *opencode_runtime_args(candidate),
              *auth_mounts(candidate, out_dir),
              *env_args(candidate),
@@ -402,9 +412,22 @@ module HiveBench
       (@runner || method(:capture)).call(cmd)
     end
 
-    # The image owns the OS and toolchain. Mount the selected host Hive runtime
-    # so a cell cannot silently execute an older gem baked into the image.
-    def hive_runtime_mounts(runtime = resolved_hive_runtime)
+    # Legacy campaigns mount the active runtime. Strict campaigns instead use a
+    # commit-labelled, root-only bundle baked into the image: the controller can
+    # run Hive, while the uid-1000 model processes cannot read its implementation.
+    def hive_runtime_args(runtime = resolved_hive_runtime)
+      if sealed_agent_runtime?
+        build_sha = runtime.fetch(:build_sha)
+        return [
+          "-e", "GEM_HOME=#{HIVE_CONTROL_GEM_HOME}",
+          "-e", "GEM_PATH=#{HIVE_CONTROL_GEM_HOME}:#{CANDIDATE_GEM_HOME}:/usr/local/lib/ruby/gems/3.4.0",
+          "-e", "HB_HIVE_VERSION=#{runtime.fetch(:version)}",
+          "-e", "HB_HIVE_BUILD_SHA=#{build_sha}",
+          "-e", "HB_SEALED_AGENT_RUNTIME=1",
+          "-e", "HIVE_BENCH_ALLOW_DISABLED_PLAN_REVIEW=1"
+        ]
+      end
+
       [
         "-v", "#{runtime.fetch(:root)}:#{HIVE_RUNTIME_CONTAINER_ROOT}:ro",
         "-v", "#{runtime.fetch(:gem_home)}:#{HIVE_GEM_HOME_CONTAINER_ROOT}:ro",
@@ -437,7 +460,8 @@ module HiveBench
         raise "cannot identify active hive runtime version: #{detail}"
       end
 
-      { root:, gem_home:, version: }.freeze
+      build_sha = runtime_build_sha(root)
+      { root:, gem_home:, version:, build_sha: }.compact.freeze
     rescue Errno::ENOENT, Errno::EACCES => e
       raise "active hive runtime is unavailable: #{e.message}"
     end
@@ -503,6 +527,53 @@ module HiveBench
         return candidate if File.file?(candidate) && File.executable?(candidate)
       end
       raise "active hive executable is not on PATH (set HB_HIVE_BIN)"
+    end
+
+    def runtime_build_sha(root)
+      out, _err, status = Open3.capture3("git", "-C", root, "rev-parse", "--verify", "HEAD^{commit}")
+      sha = out.strip
+      status.success? && sha.match?(/\A[0-9a-f]{40}\z/) ? sha : nil
+    end
+
+    def sealed_agent_runtime?
+      ENV["HB_REQUIRE_SEALED_AGENT_RUNTIME"] == "1"
+    end
+
+    def verify_sealed_runtime!(candidate, runtime)
+      build_sha = runtime[:build_sha].to_s
+      unless build_sha.match?(/\A[0-9a-f]{40}\z/)
+        raise "sealed benchmark runtime requires an exact 40-character Hive build SHA"
+      end
+
+      unsupported = agent_ids(candidate) - %w[pi opencode]
+      unless unsupported.empty?
+        raise "sealed benchmark runtime does not yet support candidate agent(s): #{unsupported.join(", ")}"
+      end
+
+      image = runner_image(candidate)
+      labels = inspect_image_labels(image)
+      actual_sha = labels["io.hive.bench.hive-build-sha"].to_s
+      visibility = labels["io.hive.bench.runtime-visibility"].to_s
+      unless actual_sha == build_sha && visibility == SEALED_RUNTIME_VISIBILITY
+        raise "runner image #{image} is not the sealed Hive build #{build_sha}: " \
+              "build_sha=#{actual_sha.inspect} runtime_visibility=#{visibility.inspect}"
+      end
+    end
+
+    def inspect_image_labels(image)
+      return @image_inspector.call(image) if @image_inspector
+
+      out, err, status = Open3.capture3(
+        "docker", "image", "inspect", "--format", "{{json .Config.Labels}}", image
+      )
+      raise "cannot inspect benchmark runner image #{image}: #{err.strip}" unless status.success?
+
+      labels = JSON.parse(out)
+      raise "benchmark runner image #{image} has no labels" unless labels.is_a?(Hash)
+
+      labels
+    rescue JSON::ParserError => e
+      raise "cannot parse benchmark runner image labels for #{image}: #{e.message}"
     end
 
     # Generation needs model-API egress, so `--network none` is impossible. A
@@ -701,6 +772,8 @@ module HiveBench
 
       [
         "-v", "#{OPENCODE_BENCH_RUNTIME}:/opt/hb/opencode_bench_runtime.rb:ro",
+        "-v", "#{OPENCODE_BENCH_LAUNCHER}:/opt/hb/opencode-bench-launcher:ro",
+        "-e", "HIVE_OPENCODE_BIN=/opt/hb/opencode-bench-launcher",
         "-e", "HB_OPENCODE_CE_PREFLIGHT=1",
         "-e", "HB_OPENCODE_PROBE_TIMEOUT_SEC=300",
         "-e", "RUBYOPT=-r/opt/hb/opencode_bench_runtime"
@@ -708,11 +781,15 @@ module HiveBench
     end
 
     def uses?(candidate, agent)
+      agent_ids(candidate).include?(agent)
+    end
+
+    def agent_ids(candidate)
       stage_agents = [candidate.plan, candidate.execute, candidate.review]
       reviewer_agents = Array(candidate.reviewers).filter_map do |reviewer|
         reviewer.is_a?(Hash) ? (reviewer["agent"] || reviewer[:agent]) : nil
       end
-      (stage_agents + reviewer_agents).include?(agent)
+      (stage_agents + reviewer_agents).compact.map(&:to_s).uniq
     end
 
     # Candidate model and effort live in Hive's stage routes, not the operator's

--- a/templates/builtins/bench/runtime/harness/lib/hive_stages.sh
+++ b/templates/builtins/bench/runtime/harness/lib/hive_stages.sh
@@ -17,7 +17,22 @@ BASE="$2"
 export HOME=/home/asterio
 git config --global --add safe.directory '*' 2>/dev/null
 mkdir -p /work/.hb/bin
-HIVE_RUNTIME_BIN=/opt/hb/hive-current/bin
+if [ "${HB_SEALED_AGENT_RUNTIME:-0}" = "1" ]; then
+  HIVE_RUNTIME_BIN=/opt/hb/control-bundle/bin
+  if [ -z "${HB_HIVE_BUILD_SHA:-}" ]; then
+    echo "HB_ERROR hive_runtime_build_missing" >&2
+    exit 4
+  fi
+  if setpriv --reuid=1000 --regid=1000 --init-groups \
+       --bounding-set=-all --inh-caps=-all --ambient-caps=-all \
+       test -r "$HIVE_RUNTIME_BIN/hive" 2>/dev/null; then
+    echo "HB_ERROR hive_runtime_visible_to_candidate" >&2
+    exit 4
+  fi
+  echo "HB_NOTE hive_runtime_visibility sealed build=$HB_HIVE_BUILD_SHA"
+else
+  HIVE_RUNTIME_BIN=/opt/hb/hive-current/bin
+fi
 if [ ! -x "$HIVE_RUNTIME_BIN/hive" ] || [ -z "${HB_HIVE_VERSION:-}" ]; then
   echo "HB_ERROR hive_runtime_missing" >&2
   exit 4
@@ -51,13 +66,13 @@ preflight_opencode_ce_skills() {
 
   if ! timeout 90 env \
     OPENCODE_CONFIG_CONTENT='{"plugin":["/opt/compound-engineering"]}' \
-    opencode debug config >"$config_out"; then
+    "${HIVE_OPENCODE_BIN:-opencode}" debug config >"$config_out"; then
     echo "HB_ERROR opencode_ce_skills config_probe_failed" >&2
     return 1
   fi
   if ! timeout 90 env \
     OPENCODE_CONFIG_CONTENT='{"plugin":["/opt/compound-engineering"]}' \
-    opencode debug skill >"$skills_out"; then
+    "${HIVE_OPENCODE_BIN:-opencode}" debug skill >"$skills_out"; then
     echo "HB_ERROR opencode_ce_skills discovery_probe_failed" >&2
     return 1
   fi

--- a/templates/builtins/bench/runtime/harness/lib/opencode_bench_launcher.sh
+++ b/templates/builtins/bench/runtime/harness/lib/opencode_bench_launcher.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Hive stays root in sealed benchmark containers so it can read its protected
+# control bundle. Every real OpenCode process crosses this launcher and drops
+# to the unprivileged candidate identity before it can inspect the filesystem.
+set -uo pipefail
+
+REAL_OPENCODE="${HB_OPENCODE_REAL_BIN:-/usr/local/bin/opencode}"
+
+if [ "${HB_SEALED_AGENT_RUNTIME:-0}" != "1" ]; then
+  exec "$REAL_OPENCODE" "$@"
+fi
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo "opencode benchmark launcher: sealed mode requires the root controller" >&2
+  exit 1
+fi
+
+candidate_uid="${HB_CANDIDATE_UID:-1000}"
+candidate_gid="${HB_CANDIDATE_GID:-1000}"
+chown -R "$candidate_uid:$candidate_gid" /work 2>/dev/null || {
+  echo "opencode benchmark launcher: cannot hand the worktree to the candidate user" >&2
+  exit 1
+}
+
+exec setpriv --reuid="$candidate_uid" --regid="$candidate_gid" --init-groups \
+  --bounding-set=-all --inh-caps=-all --ambient-caps=-all \
+  env -u BUNDLE_GEMFILE \
+    GEM_HOME=/usr/local/bundle \
+    GEM_PATH=/usr/local/bundle:/usr/local/lib/ruby/gems/3.4.0 \
+    PATH=/usr/local/bin:/usr/bin:/bin \
+    "$REAL_OPENCODE" "$@"

--- a/templates/builtins/bench/runtime/harness/lib/pi_bench_launcher.sh
+++ b/templates/builtins/bench/runtime/harness/lib/pi_bench_launcher.sh
@@ -17,4 +17,24 @@ if [ "$#" -eq 1 ] && [ "$1" = "--version" ]; then
   exit 0
 fi
 
+if [ "${HB_SEALED_AGENT_RUNTIME:-0}" = "1" ]; then
+  if [ "$(id -u)" -ne 0 ]; then
+    echo "pi benchmark launcher: sealed mode requires the root controller" >&2
+    exit 1
+  fi
+  candidate_uid="${HB_CANDIDATE_UID:-1000}"
+  candidate_gid="${HB_CANDIDATE_GID:-1000}"
+  chown -R "$candidate_uid:$candidate_gid" /work "$HOME/.pi" 2>/dev/null || {
+    echo "pi benchmark launcher: cannot hand the worktree to the candidate user" >&2
+    exit 1
+  }
+  exec setpriv --reuid="$candidate_uid" --regid="$candidate_gid" --init-groups \
+    --bounding-set=-all --inh-caps=-all --ambient-caps=-all \
+    env -u BUNDLE_GEMFILE \
+      GEM_HOME=/usr/local/bundle \
+      GEM_PATH=/usr/local/bundle:/usr/local/lib/ruby/gems/3.4.0 \
+      PATH=/usr/local/bin:/usr/bin:/bin \
+      "$REAL_PI" "$@"
+fi
+
 exec "$REAL_PI" "$@"

--- a/test/unit/workflows/bench_test.rb
+++ b/test/unit/workflows/bench_test.rb
@@ -81,6 +81,7 @@ class WorkflowsBenchTest < Minitest::Test
     assert_path_exists File.join(runtime, "harness", "hive_run.rb")
     assert_path_exists File.join(runtime, "harness", "lib", "judge_slate.rb")
     assert_path_exists File.join(runtime, "harness", "lib", "opencode_bench_runtime.rb")
+    assert_path_exists File.join(runtime, "harness", "lib", "opencode_bench_launcher.sh")
     assert_path_exists File.join(runtime, "harness", "lib", "pi_bench_launcher.sh")
     assert_path_exists File.join(runtime, "harness", "lib", "provider_egress_proxy.rb")
     assert_path_exists File.join(runtime, "harness", "lib", "token_report.rb")
@@ -173,6 +174,67 @@ class WorkflowsBenchTest < Minitest::Test
     permissions = JSON.parse(out)
     assert_equal "scoped", permissions.fetch("preset")
     assert_equal [ "Read", "Write", "Edit", "Bash(*)" ], permissions.fetch("tools")
+  end
+
+  def test_packaged_runtime_seals_hive_source_from_pi_and_opencode
+    runtime = Hive::Workflows::Bench::RUNTIME_DIR
+    dockerfile = File.read(File.join(runtime, "Dockerfile.runner"))
+    driver = File.read(File.join(runtime, "harness", "lib", "hive_driver.rb"))
+    stages = File.read(File.join(runtime, "harness", "lib", "hive_stages.sh"))
+    pi_launcher = File.read(File.join(runtime, "harness", "lib", "pi_bench_launcher.sh"))
+    opencode_launcher = File.read(File.join(runtime, "harness", "lib", "opencode_bench_launcher.sh"))
+
+    assert_includes dockerfile, 'io.hive.bench.hive-build-sha="${HIVE_BUILD_SHA}"'
+    assert_includes dockerfile, "chmod -R go-rwx /opt/hb/control-bundle"
+    assert_includes dockerfile, "rm -rf /usr/local/bundle/gems/hive-cli-*"
+    assert_includes driver, "HB_REQUIRE_SEALED_AGENT_RUNTIME"
+    assert_includes driver, 'runner image #{image} is not the sealed Hive build'
+    assert_includes driver, '"--user", "0:0"'
+    assert_includes stages, "HB_ERROR hive_runtime_visible_to_candidate"
+    [ pi_launcher, opencode_launcher ].each do |launcher|
+      assert_includes launcher, "--bounding-set=-all --inh-caps=-all --ambient-caps=-all"
+      assert_includes launcher, "GEM_HOME=/usr/local/bundle"
+    end
+
+    harness = File.join(runtime, "harness")
+    script = <<~'RUBY'
+      require "json"
+      require "profiles/candidates"
+      require "lib/hive_driver"
+      sha = "a" * 40
+      labels = {
+        "io.hive.bench.hive-build-sha" => sha,
+        "io.hive.bench.runtime-visibility" => "sealed-control-bundle-v1"
+      }
+      hive_runtime = { root: "/host/hive", gem_home: "/host/gems", version: "0.7.2", build_sha: sha }
+      driver = HiveBench::HiveDriver.new(
+        reuse_existing: false,
+        reuse_unverified: false,
+        hive_runtime: hive_runtime,
+        image_inspector: ->(_image) { labels }
+      )
+      candidate = HiveBench::Candidates.by_id("all-ox-alpha@max")
+      driver.send(:verify_sealed_runtime!, candidate, hive_runtime)
+      puts JSON.generate(driver.send(:hive_runtime_args, hive_runtime))
+    RUBY
+    out, err, status = Open3.capture3(
+      { "HB_REQUIRE_SEALED_AGENT_RUNTIME" => "1" },
+      RbConfig.ruby, "-I#{harness}", "-e", script
+    )
+
+    assert status.success?, err
+    args = JSON.parse(out)
+    assert_includes args, "GEM_HOME=/opt/hb/control-bundle"
+    assert_includes args, "HB_SEALED_AGENT_RUNTIME=1"
+    refute args.any? { |arg| arg.include?("/host/hive") || arg.include?("/host/gems") }
+  end
+
+  def test_generate_exports_campaign_sealed_runtime_requirement
+    instruction = File.read(stages_by_name.fetch("generate").instruction)
+
+    assert_includes instruction, "isolation.sealed_agent_runtime must be true or false"
+    assert_includes instruction,
+                    'env << "HB_REQUIRE_SEALED_AGENT_RUNTIME=1" if isolation["sealed_agent_runtime"] == true'
   end
 
   def test_packaged_runtime_emits_a_hive_valid_opencode_config
@@ -327,9 +389,10 @@ class WorkflowsBenchTest < Minitest::Test
       assert_includes proxy_env, "#{name}=http://bench-egress:3128"
     end
     assert_includes proxy_env, "NODE_USE_ENV_PROXY=1"
-    assert_equal 2, payload.dig("identity", "schema_version")
+    assert_equal 3, payload.dig("identity", "schema_version")
     assert_equal "base-only-shallow", payload.dig("identity", "isolation", "source_history")
     assert_equal "provider-allowlist", payload.dig("identity", "isolation", "generation_egress")
+    assert_equal "host-mounted", payload.dig("identity", "isolation", "runtime_visibility")
 
     _out, missing_err, missing_status = Open3.capture3(
       { "HB_REQUIRE_EGRESS_ALLOWLIST" => "1", "HB_GEN_NETWORK" => nil,

--- a/wiki/gaps.md
+++ b/wiki/gaps.md
@@ -126,15 +126,26 @@ provider-only proxy egress into generation identity. Training-time memorization
 of a public solution remains outside container control; post-run patch
 similarity and private/newer corpus tasks are still needed for that risk.
 
+The first post-audit replacement attempt still exposed a second local answer
+surface: the active dogfood Hive checkout was bind-mounted read-only and the
+runner's normal gem tree contained the installed `hive-cli` source. Candidate
+uid 1000 could read both even though logs show no Pi command opening the active
+checkout. Sealed campaigns now use a commit-labelled, root-only Hive control
+bundle, remove `hive-cli` from the candidate bundle, and drop Pi/OpenCode to an
+uncapable uid 1000 process. A real container proof established that boundary;
+the remaining gap is a fresh six-cell Pi/OpenCode generation and judgment run
+created after the sealed dogfood deployment.
+
 The same audit found a separate OpenCode fairness defect in the completed high
 campaign: its benchmark config granted only `Read`, `Write`, and `Edit`, while
 Pi retained shell access inside the disposable generation container. OpenCode
 could change files but could not run tests, inspect repository state through
 normal shell diagnostics, or verify its work; all six review attempts ended
 without an accepted review patch. The packaged runtime now adds the explicitly
-qualified `Bash(*)` permission. The container, exact-base checkout, and
-provider-only proxy remain the isolation boundary. The old OpenCode score is
-superseded pending a clean six-cell rerun with that parity grant.
+qualified `Bash(*)` permission. The container, exact-base checkout,
+provider-only proxy, and sealed controller bundle remain the isolation
+boundary. The old OpenCode score is superseded pending a sealed six-cell rerun
+with that parity grant.
 
 ## Parallel Hive web CI exact-head evidence (2026-08-14)
 

--- a/wiki/log.d/20260826T133911Z-bench-sealed-agent-runtime.md
+++ b/wiki/log.d/20260826T133911Z-bench-sealed-agent-runtime.md
@@ -1,0 +1,16 @@
+---
+title: Seal benchmark controller runtime from candidates
+category: security
+date: 2026-08-26
+---
+
+- Packaged the canonical benchmark's root-only, commit-labelled Hive control
+  bundle and Hive-free candidate gem tree.
+- Added Pi and OpenCode launchers that hand off `/work` to uid 1000, clear Linux
+  capabilities, and prevent the model from reading controller implementation.
+- Added `isolation.sealed_agent_runtime` campaign validation and propagation;
+  the driver fails before model spend on a stale image SHA or unsupported agent.
+- Bound runtime visibility into generation identity alongside depth-one source
+  history and provider-only egress, preventing reuse of older exposed artifacts.
+- Left fresh sealed Ox Alpha Pi/OpenCode generation, judging, deliberation, and
+  publication as live follow-through after the new commit is dogfooded.

--- a/wiki/modules/workflows.md
+++ b/wiki/modules/workflows.md
@@ -186,6 +186,15 @@ attaches to a named internal Docker network and receives a credential-free
 CONNECT-proxy URL; partial or missing strict configuration fails before model
 spend. The base-only and egress modes are bound into generation identity, so an
 older unrestricted artifact cannot be silently reused as strict evidence.
+Campaigns can additionally require `isolation.sealed_agent_runtime: true`.
+The runner image is labelled with the exact Hive build SHA and splits Ruby gems
+into a root-only Hive control bundle plus a candidate bundle with `hive-cli`
+removed. The container controller runs as root, but the Pi/OpenCode launchers
+chown `/work`, drop the model process to uid 1000, remove its Linux capabilities,
+and reset its gem path. The driver omits all host Hive source/gem mounts and
+refuses model spend when the image label does not match the active immutable
+dogfood deployment. Runtime visibility joins base history and egress in the
+generation identity, so unsealed artifacts cannot satisfy a sealed campaign.
 When the control plane is invoked through the dogfood wrapper, the packaged
 driver resolves the exact immutable deployment named by
 `HIVE_RUNTIME_DEPLOYMENT_ID` and verifies its full commit against


### PR DESCRIPTION
## Summary
- package Hive in a root-only, exact-SHA-labelled control bundle and remove hive-cli from candidate gems
- drop Pi/OpenCode model processes to uid 1000 with no Linux capabilities and no host runtime mounts
- validate/propagate campaign `isolation.sealed_agent_runtime` and bind visibility into generation identity
- preserve depth-one history, provider-only egress, OpenCode Bash parity, and dogfood exact-runtime resolution

## Verification
- `bundle exec ruby -Itest test/unit/workflows/bench_test.rb` (44 runs, 430 assertions)
- `bundle exec rake test` (13,621 runs, 275,770 assertions, 0 failures, 0 errors)
- focused RuboCop: no offenses
- canonical hive-bench Docker proof: root Hive works; uid 1000 cannot read controller source or `/proc/1/root`, has no hive-cli and CapEff=0, retains normal dependencies
