### PR TITLE
Fix packaged Ox Alpha disclosed model route

### DIFF
--- a/templates/builtins/bench/runtime/harness/lib/hive_config.rb
+++ b/templates/builtins/bench/runtime/harness/lib/hive_config.rb
@@ -27,15 +27,16 @@ module HiveBench
     DEFAULT_BRANCH = "main"
     PARALLEL_ATTEMPT_STARTUP_TIMEOUT_SEC = 300
     OPENCODE_PLUGIN = "/opt/compound-engineering"
+    OPENCODE_OX_ALPHA_MODEL_ID = "z-ai/glm-5.3-flash"
     OPENCODE_OX_ALPHA_MODEL = {
-      "name" => "Ox Alpha",
-      "family" => "alpha",
-      "release_date" => "2026-08-20",
+      "name" => "Ox Alpha (Z.ai GLM 5.3 Flash)",
+      "family" => "glm",
+      "release_date" => "2026-08-26",
       "attachment" => true,
       "reasoning" => true,
       "temperature" => true,
       "tool_call" => true,
-      "cost" => { "input" => 0, "output" => 0 },
+      "cost" => { "input" => 0.075, "output" => 0.25 },
       "limit" => { "context" => 1_048_576, "output" => 131_072 },
       "modalities" => { "input" => %w[text image], "output" => ["text"] },
       "status" => "active",
@@ -81,7 +82,7 @@ module HiveBench
             "config" => {
               "provider" => {
                 "openrouter" => {
-                  "models" => { "stealth/ox-alpha" => OPENCODE_OX_ALPHA_MODEL }
+                  "models" => { OPENCODE_OX_ALPHA_MODEL_ID => OPENCODE_OX_ALPHA_MODEL }
                 }
               }
             },

--- a/templates/builtins/bench/runtime/harness/profiles/candidates.rb
+++ b/templates/builtins/bench/runtime/harness/profiles/candidates.rb
@@ -25,9 +25,12 @@ module HiveBench
     OPUS = "opus"
     SOL = "gpt-5.6-sol"
     TERRA = "gpt-5.6-terra"
-    PI_OX_ALPHA = "openrouter/stealth/ox-alpha:high"
-    PI_OX_ALPHA_MAX = "openrouter/stealth/ox-alpha:max"
-    OPENCODE_OX_ALPHA = "openrouter/stealth/ox-alpha"
+    # OpenRouter disclosed and retired the stealth route on 2026-08-26. Keep
+    # the Ox Alpha candidate ids for benchmark lineage, but route the revealed
+    # model through its stable public id.
+    PI_OX_ALPHA = "openrouter/z-ai/glm-5.3-flash:high"
+    PI_OX_ALPHA_MAX = "openrouter/z-ai/glm-5.3-flash:max"
+    OPENCODE_OX_ALPHA = "openrouter/z-ai/glm-5.3-flash"
 
     def all
       [all_opus, all_codex, opus_plan_codex_exec,
@@ -258,7 +261,7 @@ module HiveBench
                                   "execute" => PI_OX_ALPHA,
                                   "review" => PI_OX_ALPHA
                                 },
-                                model_version: "ox-alpha-high")
+                                model_version: "glm-5.3-flash-high")
     end
 
     # A separate Pi-only row at Ox Alpha's maximum reasoning tier. Keeping the
@@ -271,7 +274,7 @@ module HiveBench
                                  "execute" => PI_OX_ALPHA_MAX,
                                  "review" => PI_OX_ALPHA_MAX
                                },
-                               model_version: "ox-alpha-max")
+                               model_version: "glm-5.3-flash-max")
     end
 
     # Same model and reasoning tier through Hive's OpenCode profile. The
@@ -284,7 +287,7 @@ module HiveBench
              "execute" => OPENCODE_OX_ALPHA,
              "review" => OPENCODE_OX_ALPHA
            },
-           opencode_effort: "high", model_version: "ox-alpha-high")
+           opencode_effort: "high", model_version: "glm-5.3-flash-high")
     end
   end
 end

--- a/templates/builtins/bench/runtime/harness/profiles/pi_openrouter_models.json
+++ b/templates/builtins/bench/runtime/harness/profiles/pi_openrouter_models.json
@@ -3,17 +3,17 @@
     "openrouter": {
       "models": [
         {
-          "id": "stealth/ox-alpha",
-          "name": "Ox Alpha",
+          "id": "z-ai/glm-5.3-flash",
+          "name": "Ox Alpha (Z.ai GLM 5.3 Flash)",
           "api": "openai-completions",
           "reasoning": true,
           "input": ["text"],
           "contextWindow": 1048576,
           "maxTokens": 131072,
           "cost": {
-            "input": 0,
-            "output": 0,
-            "cacheRead": 0,
+            "input": 0.075,
+            "output": 0.25,
+            "cacheRead": 0.015,
             "cacheWrite": 0
           },
           "compat": {

--- a/templates/builtins/bench/runtime/harness/verify_models.rb
+++ b/templates/builtins/bench/runtime/harness/verify_models.rb
@@ -29,9 +29,9 @@ module HiveBench
       "all_glm_5_2" => /glm-5\.2/,
       "all_kimi_k2_7_code" => /kimi-k2\.7-code/,
       "glm_plan_kimi_exec" => /glm-5\.2|kimi-k2\.7-code/,
-      "all_ox_alpha_high" => /stealth\/ox-alpha/,
-      "all_ox_alpha_max" => /stealth\/ox-alpha/,
-      "all_ox_alpha_opencode_high" => /stealth\/ox-alpha/
+      "all_ox_alpha_high" => %r{stealth/ox-alpha|z-ai/glm-5\.3-flash},
+      "all_ox_alpha_max" => %r{stealth/ox-alpha|z-ai/glm-5\.3-flash},
+      "all_ox_alpha_opencode_high" => %r{stealth/ox-alpha|z-ai/glm-5\.3-flash}
     }.freeze
 
     # Models a CLI may invoke for its own utilities regardless of the pin.

--- a/test/unit/workflows/bench_test.rb
+++ b/test/unit/workflows/bench_test.rb
@@ -110,10 +110,10 @@ class WorkflowsBenchTest < Minitest::Test
     payload = JSON.parse(out)
     candidate = payload.fetch("candidate")
     config = payload.fetch("config")
-    assert_equal "ox-alpha-max", candidate.fetch("model_version")
+    assert_equal "glm-5.3-flash-max", candidate.fetch("model_version")
     assert_equal %w[pi pi pi], candidate.values_at("plan", "execute", "review")
     %w[plan execute open_pr review_ci review_triage review_fix].each do |stage|
-      assert_equal "openrouter/stealth/ox-alpha:max", config.dig("models", stage, "model")
+      assert_equal "openrouter/z-ai/glm-5.3-flash:max", config.dig("models", stage, "model")
     end
     assert_equal false, config.dig("plan_review", "enabled")
   end
@@ -174,6 +174,25 @@ class WorkflowsBenchTest < Minitest::Test
     permissions = JSON.parse(out)
     assert_equal "scoped", permissions.fetch("preset")
     assert_equal [ "Read", "Write", "Edit", "Bash(*)" ], permissions.fetch("tools")
+  end
+
+  def test_packaged_runtime_routes_ox_alpha_opencode_through_disclosed_model
+    harness = File.join(Hive::Workflows::Bench::RUNTIME_DIR, "harness")
+    script = <<~'RUBY'
+      require "json"
+      require "profiles/candidates"
+      require "lib/hive_config"
+      candidate = HiveBench::Candidates.by_id("all-ox-alpha-opencode@high")
+      puts JSON.generate(HiveBench::HiveConfig.to_h(candidate))
+    RUBY
+
+    out, err, status = Open3.capture3(RbConfig.ruby, "-I#{harness}", "-e", script)
+
+    assert status.success?, out + err
+    config = JSON.parse(out)
+    assert config.dig("agents", "opencode", "config", "provider", "openrouter", "models", "z-ai/glm-5.3-flash")
+    assert_equal "openrouter/z-ai/glm-5.3-flash", config.dig("models", "plan", "model")
+    assert_equal "high", config.dig("models", "plan", "effort")
   end
 
   def test_packaged_runtime_seals_hive_source_from_pi_and_opencode

--- a/wiki/log.d/20260826T143300Z-bench-ox-alpha-disclosed-route.md
+++ b/wiki/log.d/20260826T143300Z-bench-ox-alpha-disclosed-route.md
@@ -1,0 +1,7 @@
+# Package the disclosed Ox Alpha route
+
+- Updated the packaged Pi and OpenCode Ox Alpha profiles from the retired
+  `stealth/ox-alpha` preview id to the disclosed `z-ai/glm-5.3-flash` id.
+- Preserved candidate ids for benchmark lineage while making model-version
+  receipts, offline catalogs, capability metadata, pricing, verification, and
+  tests name the actual served model.

--- a/wiki/modules/workflows.md
+++ b/wiki/modules/workflows.md
@@ -173,6 +173,10 @@ the harness recovers its normalized input, output, cache-read, and cache-write
 totals from the cell-local Hive usage database when no stream tokens exist.
 The runner image carries the pinned OpenCode CLI and Compound Engineering
 package, while Pi receives the minimal pinned OpenRouter model catalog.
+OpenRouter disclosed Ox Alpha as Z.ai GLM 5.3 Flash and retired the stealth
+inference route on 2026-08-26. The maintained profiles therefore keep their Ox
+Alpha candidate ids for lineage while routing the revealed model through
+`z-ai/glm-5.3-flash`; model-version receipts name GLM 5.3 Flash explicitly.
 The generated OpenCode profile uses only Hive-supported override keys; OS and
 network containment belong to the disposable runner rather than the retired
 `agents.opencode.isolation` setting. Its scoped permission document grants the


### PR DESCRIPTION
## Summary

- package the disclosed z-ai/glm-5.3-flash route for Ox Alpha Pi and OpenCode candidates
- retain benchmark lineage while recording the actual model version and current capability metadata
- cover Pi max and OpenCode high routing in packaged workflow tests

## Verification

- focused tests: 45 runs, 434 assertions, 0 failures
- packaged model catalog parses successfully
- OpenRouter API confirms the replacement route and reasoning-effort support