### PR TITLE
Fix Patrol finding: introduce-internal-typed-invalidtaskpath-subclas-9456bce6da42

### DIFF
--- a/lib/hive/commands/approve.rb
+++ b/lib/hive/commands/approve.rb
@@ -246,8 +246,10 @@ module Hive
       # workflow is rejected at this early gate (see validate_stage_refs!).
       def known_stage_ref?(ref)
         !Hive::Workflows.resolve_stage_ref_across_workflows(ref).nil?
-      rescue Hive::InvalidTaskPath => e
-        e.message.start_with?("ambiguous stage")
+      rescue Hive::Workflows::AmbiguousStageRef
+        true
+      rescue Hive::InvalidTaskPath
+        false
       end
 
       # ── Destination resolution ──────────────────────────────────────────

--- a/lib/hive/workflows.rb
+++ b/lib/hive/workflows.rb
@@ -19,6 +19,17 @@ module Hive
     # ⟹ coding" defaulting rule gates every coding-only daemon/bot branch,
     # so it lives here once instead of being re-spelled at each consumer.
     CODING_ID = :coding
+
+    # Internal typed specializations of Hive::InvalidTaskPath raised by
+    # `resolve_stage_ref_across_workflows`. They let internal callers classify
+    # a failed stage-ref resolution by CLASS (`rescue AmbiguousStageRef`)
+    # instead of parsing user-facing exception text
+    # (`e.message.start_with?("ambiguous stage")`) — the message stays a
+    # diagnostic, never an API. Both remain `Hive::InvalidTaskPath` instances,
+    # so public rescue clauses and exit-code mapping (USAGE) are unchanged.
+    class AmbiguousStageRef < Hive::InvalidTaskPath; end
+    class UnknownStageRef < Hive::InvalidTaskPath; end
+
     # Optional `interactive: true` flag marks verbs that need the user's
     # tty during execution (stdin prompts, interactive `gh pr create`,
     # claude tool-permission asks). The TUI's `BubbleModel#dispatch_command`
@@ -200,10 +211,10 @@ module Hive
       return matches.first if matches.one?
 
       if matches.size > 1
-        raise Hive::InvalidTaskPath, "ambiguous stage '#{stage_ref}'; matches: #{matches.join(', ')}"
+        raise AmbiguousStageRef, "ambiguous stage '#{stage_ref}'; matches: #{matches.join(', ')}"
       end
 
-      raise Hive::InvalidTaskPath,
+      raise UnknownStageRef,
             "unknown stage '#{stage_ref}'; valid: #{stage_ref_hint}"
     end
 
@@ -237,9 +248,9 @@ module Hive
         resolved = resolve_stage_ref_across_workflows(stage_filter)
         resolved ? [ resolved ] : []
       end
-    rescue Hive::InvalidTaskPath => e
-      raise if e.message.start_with?("ambiguous stage")
-
+    rescue Hive::Workflows::AmbiguousStageRef
+      raise
+    rescue Hive::InvalidTaskPath
       []
     end
 
@@ -260,9 +271,9 @@ module Hive
         Hive::Workflows::Project.synchronize do
           Hive::Workflows::Project.load!(project["path"])
           !resolve_stage_ref_across_workflows(stage_filter).nil?
-        rescue Hive::InvalidTaskPath => e
-          raise if e.message.start_with?("ambiguous stage")
-
+        rescue Hive::Workflows::AmbiguousStageRef
+          raise
+        rescue Hive::InvalidTaskPath
           false
         end
       end

--- a/test/unit/workflows/project_test.rb
+++ b/test/unit/workflows/project_test.rb
@@ -428,8 +428,9 @@ class WorkflowsProjectTest < Minitest::Test
       project = { "path" => project_root, "hive_state_path" => File.join(project_root, ".hive-state") }
 
       # `done` is the terminal short name of BOTH built-ins (coding 9-done,
-      # content 6-done): ambiguous refs re-raise through stages_for_project.
-      error = assert_raises(Hive::InvalidTaskPath) do
+      # content 6-done): ambiguous refs re-raise through stages_for_project —
+      # classified by TYPE (AmbiguousStageRef), not by exception-message text.
+      error = assert_raises(Hive::Workflows::AmbiguousStageRef) do
         Hive::Workflows.stages_for_project(project, stage_filter: "done")
       end
 

--- a/test/unit/workflows_test.rb
+++ b/test/unit/workflows_test.rb
@@ -225,10 +225,11 @@ class WorkflowsTest < Minitest::Test
     )
 
     with_registered_workflow(descriptor) do
-      error = assert_raises(Hive::InvalidTaskPath) do
+      error = assert_raises(Hive::Workflows::AmbiguousStageRef) do
         Hive::Workflows.resolve_stage_ref_across_workflows("plan")
       end
 
+      assert_kind_of Hive::InvalidTaskPath, error
       assert_includes error.message, "ambiguous stage 'plan'"
       assert_includes error.message, "3-plan"
       assert_includes error.message, "1-plan"
@@ -249,5 +250,39 @@ class WorkflowsTest < Minitest::Test
     assert_includes error.message, "ambiguous stage 'done'"
     assert_includes error.message, "9-done"
     assert_includes error.message, "6-done"
+  end
+
+  def test_resolve_stage_ref_across_workflows_rejects_ambiguous_refs_with_typed_error
+    # Regression: the ambiguity classification must be by TYPE, not by parsing
+    # `e.message.start_with?("ambiguous stage")` at internal rescue sites.
+    error = assert_raises(Hive::Workflows::AmbiguousStageRef) do
+      Hive::Workflows.resolve_stage_ref_across_workflows("done")
+    end
+
+    assert_kind_of Hive::InvalidTaskPath, error
+    assert_includes error.message, "ambiguous stage 'done'"
+  end
+
+  def test_resolve_stage_ref_across_workflows_rejects_unknown_refs_with_typed_error
+    error = assert_raises(Hive::Workflows::UnknownStageRef) do
+      Hive::Workflows.resolve_stage_ref_across_workflows("no-such-stage")
+    end
+
+    # The typed subclasses must stay InvalidTaskPath instances: public rescue
+    # clauses and the USAGE exit-code mapping depend on that compatibility.
+    assert_kind_of Hive::InvalidTaskPath, error
+    assert_equal Hive::ExitCodes::USAGE, error.exit_code
+    assert_includes error.message, "unknown stage 'no-such-stage'"
+  end
+
+  def test_stages_for_project_classifies_by_type_not_message_text
+    # Regression for the message-based classification: an ambiguous ref whose
+    # MESSAGE were reworded (or localized) must still propagate through
+    # stages_for_project. Pin the typed contract directly.
+    error = assert_raises(Hive::Workflows::AmbiguousStageRef) do
+      Hive::Workflows.stages_for_project({ "path" => Dir.pwd }, stage_filter: "done")
+    end
+
+    assert_includes error.message, "ambiguous stage 'done'"
   end
 end

--- a/wiki/log.d/20260809-typed-invalidtaskpath-stage-ref-subclasses.md
+++ b/wiki/log.d/20260809-typed-invalidtaskpath-stage-ref-subclasses.md
@@ -1,0 +1,32 @@
+# 2026-08-09 — Typed InvalidTaskPath subclasses for stage-ref resolution
+
+## What changed
+
+`Hive::Workflows.resolve_stage_ref_across_workflows` now raises typed
+internal exceptions instead of plain `Hive::InvalidTaskPath`:
+
+- `Hive::Workflows::AmbiguousStageRef` — ref matches >1 workflow
+- `Hive::Workflows::UnknownStageRef` — ref matches no workflow
+
+Both subclass `Hive::InvalidTaskPath`, so public rescues, error envelopes,
+and the `USAGE` exit-code mapping are unchanged. Messages are identical.
+
+Internal classifiers (`Workflows.stages_for_project`,
+`Workflows.assert_known_stage_filter!`, `Approve#known_stage_ref?`) now
+rescue by class instead of parsing exception text
+(`e.message.start_with?("ambiguous stage")`). Exception messages are no
+longer an internal API.
+
+## Why
+
+Message-based classification breaks silently if a diagnostic string is
+reworded, and it couples user-facing copy to control flow. The architecture
+patrol flagged this pattern (finding
+`pr-1166-86c364158108491b:replace-stage-error-message-parsing-with-typed-errors`).
+
+## Tests
+
+- `test/unit/workflows_test.rb`: pins both typed raises and their
+  `InvalidTaskPath` compatibility.
+- `test/unit/workflows/project_test.rb`: ambiguous filter re-raises as
+  `AmbiguousStageRef` through `stages_for_project`.


### PR DESCRIPTION
## Patrol Fix

This pull request repairs one finding tracked by Hive's Patrol Fix workflow.

### Sources

- architecture_patrol: pr-1166-86c364158108491b:replace-stage-error-message-parsing-with-typed-errors

### Finding evidence

- {"file":"lib/hive/workflows.rb","snippet":"rescue Hive::InvalidTaskPath => e\n      raise if e.message.start_with?(\"ambiguous stage\")","claim":"stages_for_project branches on user-facing exception text to distinguish an ambiguity that must propagate from an unknown stage that should be tolerated"}
- {"file":"lib/hive/workflows.rb","snippet":"rescue Hive::InvalidTaskPath => e\n          raise if e.message.start_with?(\"ambiguous stage\")","claim":"assert_known_stage_filter! independently repeats the same message-based classification decision"}
- {"file":"test/unit/workflows_test.rb","snippet":"assert_raises(Hive::InvalidTaskPath)","claim":"existing tests pin the public InvalidTaskPath compatibility and ambiguity diagnostics, providing a baseline for preserving behavior while specializing internal exception types"}

### Independent review

The exact-head patch is scoped to typed stage-reference resolution errors and removes message-based control flow while preserving public InvalidTaskPath behavior, diagnostics, and USAGE exit codes. Focused resolver, workflow, project, and approve tests support the change. The controller's failed broad check is caused by the host HIVE_GROK_BIN override in unchanged agent-runtime code, not by this patch.

- HEAD is f21669fac06d64f7c7bfd565bf87a01d7b98e237 with a clean worktree; the five-file commit changes workflows, approve, focused tests, and one wiki log fragment, and git diff --check passes.
- All executable ambiguous-stage message-prefix parsing is removed: resolve_stage_ref_across_workflows raises AmbiguousStageRef or UnknownStageRef, both subclasses of Hive::InvalidTaskPath, and the three internal classifiers rescue by class.
- Independent focused runs passed: workflows_test 32 runs and 89 assertions, task_resolver_test 7 runs and 25 assertions, approve_test 44 runs and 153 assertions, plus the typed-error, ambiguity propagation, and standalone require-order checks.
- The reported agent-cli-runtime failure was independently reproduced with HIVE_GROK_BIN set and passed when that override was unset; all agent-cli-runtime blobs are identical between the patch parent and HEAD.

### Validation

Verdict: failed
- architecture:test: exit 1
- agent:typed-subclass-contract-and-regression-tests: exit 0
- agent:cross-project-stage-filter-resolution-consumers: exit 0

<!-- hive-publication:v1 id=pub-2eb3d9353435ba2cfcc09b5ade58a14e base=b07b869635e47d986370b19d0dfe583d54143e79 -->
