### PR TITLE
Fix Patrol finding: make-initsetup-authoritative-for-the-workflow-fi-91ec953736f0

### DIFF
--- a/web/app/controllers/repos_controller.rb
+++ b/web/app/controllers/repos_controller.rb
@@ -18,8 +18,11 @@ class ReposController < ApplicationController
     project = @project_name && registered_projects.find { |entry| entry.name == @project_name }
     return unless project
 
-    @workflows = project.workflows
     @current_workflow = project.default_workflow || @current_workflow
+    # InitSetup owns the form-facing enumeration, including preserving a
+    # persisted default that is no longer registry-valid in the option list.
+    @workflows = InitSetup.workflow_options(project_root: project.path,
+                                            persisted: @current_workflow)
   end
 
   def create

--- a/web/app/models/init_setup.rb
+++ b/web/app/models/init_setup.rb
@@ -44,6 +44,18 @@ class InitSetup
       end
     end
 
+    # Form-facing enumeration for the /repos/new workflow select: every
+    # currently valid name PLUS any persisted default that valid_names dropped
+    # (its descriptor was deleted/renamed). Unioning here — not in the view —
+    # keeps "a bare Apply must not silently rebind the project to coding" in
+    # the same class that owns workflow choice enumeration; callers only say
+    # which value should stay selected.
+    def workflow_options(project_root: nil, persisted: nil)
+      options = workflows(project_root)
+      persisted = persisted.to_s
+      persisted.present? ? options | [ persisted ] : options
+    end
+
     def workflow(value)
       value = value.to_s.strip.presence
       return if value.nil?

--- a/web/app/models/project.rb
+++ b/web/app/models/project.rb
@@ -39,10 +39,6 @@ class Project
     attributes.fetch(...)
   end
 
-  def workflows
-    InitSetup.workflows(path)
-  end
-
   def config
     return @config if defined?(@config)
     raise @config_error if defined?(@config_error)

--- a/web/app/views/repos/new.html.erb
+++ b/web/app/views/repos/new.html.erb
@@ -36,13 +36,13 @@
       </div>
       <div class="form-row">
         <%= label_tag "settings_workflow", "Workflow" %>
-        <%# Union the persisted default into the options so a non-coding
-            `default_workflow` that's no longer in the list (its descriptor was
-            deleted/renamed, so valid_names dropped it) stays SELECTED rather
+        <%# InitSetup.workflow_options already unions any persisted default that
+            is no longer registry-valid (its descriptor was deleted or renamed,
+            so valid_names dropped it) into the list, so it stays SELECTED rather
             than letting the browser auto-pick the first option (coding) and a
             bare Apply silently downgrade the project. A genuinely unbindable id
             then surfaces a 422 from reinit!, not a silent rebind. %>
-        <%= select_tag "settings[workflow]", options_for_select(@workflows | [ @current_workflow ], @current_workflow) %>
+        <%= select_tag "settings[workflow]", options_for_select(@workflows, @current_workflow) %>
       </div>
       <div class="form-row">
         <%= label_tag "settings_claude_mode", "Claude launch mode" %>

--- a/web/test/models/init_setup_test.rb
+++ b/web/test/models/init_setup_test.rb
@@ -1,0 +1,44 @@
+require "test_helper"
+
+class InitSetupTest < ActiveSupport::TestCase
+  test "workflow_options without a project lists only the built-in workflows" do
+    options = InitSetup.workflow_options
+
+    assert_equal InitSetup.workflows, options
+    assert_equal "coding", options.first
+  end
+
+  test "workflow_options preserves a persisted default that is no longer registry-valid" do
+    # The policy that keeps a bare Apply from silently rebinding the project to
+    # coding lives HERE, in the class that owns workflow enumeration — not in
+    # the /repos/new view, which must render the list it is given verbatim.
+    name = create_hive_project!("initsetup-orphan-app")
+    dir = File.join(ENV["HIVE_TEST_HOME_ROOT"], "repos", name)
+    capture_io { Hive::Commands::Init.new(dir, new_workflow: "writing", force: true).call }
+    FileUtils.rm_rf(File.join(dir, ".hive-state", "workflows", "writing.yml"))
+    FileUtils.rm_rf(File.join(dir, ".hive-state", "workflows", "writing"))
+    # The per-root workflow overlay is process-memoized; force a fresh disk read.
+    Hive::Workflows::Project.reset!
+
+    assert_not_includes InitSetup.workflows(dir), "writing",
+                        "the plain enumeration must reflect registry validity"
+    options = InitSetup.workflow_options(project_root: dir, persisted: "writing")
+
+    assert_includes options, "writing",
+                    "the form enumeration must preserve an unloadable persisted default"
+    assert_includes options, "coding"
+  ensure
+    Hive::Workflows::Project.reset!
+  end
+
+  test "workflow_options with no persisted value adds nothing beyond valid names" do
+    name = create_hive_project!("initsetup-clean-app")
+    dir = File.join(ENV["HIVE_TEST_HOME_ROOT"], "repos", name)
+    Hive::Workflows::Project.reset!
+
+    assert_equal InitSetup.workflows(dir), InitSetup.workflow_options(project_root: dir)
+    assert_equal InitSetup.workflows(dir), InitSetup.workflow_options(project_root: dir, persisted: "")
+  ensure
+    Hive::Workflows::Project.reset!
+  end
+end


### PR DESCRIPTION
## Patrol Fix

This pull request repairs one finding tracked by Hive's Patrol Fix workflow.

### Sources

- architecture_patrol: pr-1015-8181522c6a7dcff1:centralize-web-workflow-selection-policy

### Finding evidence

- {"file":"web/app/views/repos/new.html.erb","snippet":"options_for_select(@workflows | [ @current_workflow ], @current_workflow)","claim":"the view performs the policy-bearing union needed to preserve a persisted workflow that is no longer registry-valid"}
- {"file":"web/app/models/init_setup.rb","line":33,"snippet":"def workflows(project_root = nil)","claim":"InitSetup already owns workflow choice enumeration, but its project branch returns only WorkflowSelection.valid_names and leaves persisted-value preservation to the view"}
- {"file":"web/test/integration/repos_test.rb","line":331,"snippet":"test \"rerun setup keeps an unloadable persisted default selected instead of downgrading to coding\"","claim":"the regression test records the concrete consequence of the split policy: valid-only rendering previously allowed a bare Apply to silently rebind the project to coding"}

### Independent review

The patch correctly centralizes form-facing workflow option preservation in InitSetup without changing the established fresh-setup or re-run behavior. Focused regression, integration, formatting, and code review checks are clean. The controller's broad-suite failure is unrelated host-environment contamination in an untouched Agent CLI Runtime test.

- The clean checkout is at controller-selected HEAD 3aabd57db8f1a94c49b27abb9b4e94fee3898058; the diff from base b07b869635e47d986370b19d0dfe583d54143e79 is confined to the repo setup controller, InitSetup, Project, the setup view, and a new InitSetup model test, and git diff --check passes.
- Code inspection confirms ReposController now obtains project-specific form options through InitSetup.workflow_options, which unions the persisted default with registry-valid names; the ERB renders that supplied list verbatim and the unused Project#workflows delegate is removed.
- An independent Rails run of test/models/init_setup_test.rb and test/integration/repos_test.rb passed: 23 runs, 128 assertions, 0 failures, 0 errors, and 0 skips.
- An independent RuboCop run over the four changed Ruby files reported 4 files inspected and no offenses.
- The broad-suite failure is outside the patch: no Agent CLI Runtime files changed, the host exports HIVE_GROK_BIN so the untouched argv test receives an absolute binary path, and that exact test passes with the override unset: 1 run, 6 assertions, 0 failures.

### Validation

Verdict: failed
- architecture:test: exit 1
- agent:unit-regression-workflow-options: exit 0
- agent:integration-rerun-setup-preserved-default: exit 0

<!-- hive-publication:v1 id=pub-441a2c59e3cc8b21fc81a0c573f62fd1 base=b07b869635e47d986370b19d0dfe583d54143e79 -->
