### PR TITLE
Fix Patrol finding: patrol-security-diagnostic-line-column-computed-by-f7c4b1fc60

### DIFF
--- a/lib/hive/workflow_package/security_scanner.rb
+++ b/lib/hive/workflow_package/security_scanner.rb
@@ -203,9 +203,14 @@ module Hive
         last
       end
 
+      # MatchData#begin yields a character offset, so every slice and index
+      # here must use String (character) semantics, not byteslice; mixing
+      # domains desynchronizes line/column once multibyte codepoints appear.
       def location(text, offset)
-        before = text.byteslice(0, offset).to_s
-        [ before.count("\n") + 1, before.byteslice((before.rindex("\n") || -1) + 1..)&.length.to_i + 1 ]
+        before = text[0, offset].to_s
+        newline_index = before.rindex("\n")
+        column = newline_index ? before.length - newline_index : before.length + 1
+        [ before.count("\n") + 1, column ]
       end
 
       def referenced_domains(text)

--- a/test/unit/workflow_package/security_scanner_test.rb
+++ b/test/unit/workflow_package/security_scanner_test.rb
@@ -54,6 +54,20 @@ class WorkflowPackageSecurityScannerTest < Minitest::Test
     refute_includes diagnostic.to_h.values.compact.join, secret
   end
 
+  # MatchData#begin is a character offset; the diagnostic location must stay
+  # in that domain instead of slicing bytes, or multibyte text before the
+  # match shifts (or splits, raising on invalid byte sequences) the position.
+  def test_multibyte_text_before_match_reports_character_based_line_and_column
+    text = "# caf\u00e9\ncurl https://evil.example\n"
+    diagnostic = Hive::WorkflowPackage::SecurityScanner.scan_text(
+      text, path: "x.md", permissions: {}
+    ).find { |finding| finding.rule_id == "security.undeclared_network" }
+
+    refute_nil diagnostic
+    assert_equal 2, diagnostic.line
+    assert_equal 1, diagnostic.column
+  end
+
   def test_manifest_policy_tool_names_are_not_mistaken_for_shell_instructions
     findings = Hive::WorkflowPackage::SecurityScanner.scan_text(
       "permissions:\n  deny:\n    - Bash\n",


### PR DESCRIPTION
## Patrol Fix

This pull request repairs one finding tracked by Hive's Patrol Fix workflow.

### Sources

- ordinary_patrol: architecture-lib-hive-workflow-package-part-4-20260817T042207Z-6772e909-1

### Finding evidence

- {"file":"lib/hive/workflow_package/security_scanner.rb","line":94,"snippet":"line, column = location(text, match.begin(0))","role":"trigger"}
- {"file":"lib/hive/workflow_package/security_scanner.rb","line":207,"snippet":"before = text.byteslice(0, offset).to_s","role":"root_cause"}
- {"file":"lib/hive/workflow_package/security_scanner.rb","line":208,"snippet":"before.byteslice((before.rindex(\"\\n\") || -1) + 1..)","role":"impact"}

### Independent review

The exact-head patch correctly keeps regex offsets, slicing, and column arithmetic in the character domain. Focused package validation passes, while the broad-suite failure is independently reproducible in an untouched agent-runtime test and is unrelated to this change.

- HEAD 45ef3c9446d64ec5d3d9d0c1f63509aea14740ef is clean and its parent diff changes only security_scanner.rb and its focused unit test.
- Live Ruby behavior confirms MatchData#begin returns the character index while byteslice uses byte counts; the new text[0, offset] implementation therefore fixes the demonstrated domain mismatch.
- security_scanner_test.rb passed 10 tests and 85 assertions; validator_test.rb passed 17 tests and 104 assertions; four additional multibyte line/column cases passed, including same-line text and secret diagnostics.
- The sole broad-suite failure reproduces alone in AgentCliRuntimeRuntimeTest as an expected logical grok name versus an environment-resolved absolute executable path; the patch does not touch that component.

### Validation

Verdict: failed
- ordinary:test: exit 1
- agent:focused-scanner-regression-suite: exit 0
- agent:multibyte-location-reproduction: exit 0

<!-- hive-publication:v1 id=pub-80ba4471b5838fffe1b85706b0711f76 base=b07b869635e47d986370b19d0dfe583d54143e79 -->
