### PR TITLE
Fix Patrol finding: github-device-flow-slow-down-leaves-the-polling-6497d1295389

### DIFF
--- a/lib/hive/web/github_auth.rb
+++ b/lib/hive/web/github_auth.rb
@@ -26,6 +26,10 @@ module Hive
       OPEN_TIMEOUT_SEC = 5
       READ_TIMEOUT_SEC = 10
 
+      # RFC 8628 §3.5: how many seconds a `slow_down` response adds to the
+      # client's current polling interval.
+      SLOW_DOWN_PENALTY = 5
+
       # Transport failures GitHub being slow/unreachable can produce. Mapped
       # to Hive::Error so the operator sees the friendly 422 error page
       # ("could not reach GitHub") instead of a blank 500 — the same policy
@@ -71,8 +75,9 @@ module Hive
 
       # Poll the token endpoint once for the device grant. Returns:
       #   { state: :ok, login: "alice", token: "gho_..." } — authorized
-      #   { state: :pending }                  — operator hasn't approved yet
-      #   { state: :slow_down, interval: 10 }  — back off to the new interval
+      #   { state: :pending }                       — operator hasn't approved yet
+      #   { state: :slow_down, increase_by: 5 }     — add this many seconds
+      #                                               to the current interval
       #   { state: :denied }                   — operator cancelled the grant
       #   { state: :expired }                  — device code expired; restart
       # Anything else raises Hive::Error. GitHub reports all of these as HTTP
@@ -90,7 +95,12 @@ module Hive
 
           { state: :ok, login: login_for_token(token), token: token }
         when "authorization_pending" then { state: :pending }
-        when "slow_down" then { state: :slow_down, interval: body.fetch("interval", 5).to_i }
+        # RFC 8628 §3.5: `slow_down` is an ADDITIVE signal — the client must
+        # raise its polling interval by SLOW_DOWN_PENALTY seconds. GitHub's
+        # response carries no usable absolute interval (typically no `interval`
+        # member at all), so the caller — which knows its current interval —
+        # applies the penalty itself.
+        when "slow_down" then { state: :slow_down, increase_by: SLOW_DOWN_PENALTY }
         when "access_denied" then { state: :denied }
         when "expired_token" then { state: :expired }
         else

--- a/test/unit/web/github_auth_test.rb
+++ b/test/unit/web/github_auth_test.rb
@@ -118,8 +118,16 @@ class GithubAuthTest < Minitest::Test
       assert_equal expected, auth.poll_device_flow("dev-1"), "GitHub error #{error} must map to #{expected[:state]}"
     end
 
+    # RFC 8628 §3.5: slow_down is additive, so the payload's own `interval`
+    # (when GitHub sends one) must be ignored in favor of the fixed penalty.
     auth, = build_auth(token: JSON.generate("error" => "slow_down", "interval" => 11))
-    assert_equal({ state: :slow_down, interval: 11 }, auth.poll_device_flow("dev-1"))
+    assert_equal({ state: :slow_down, increase_by: Hive::Web::GithubAuth::SLOW_DOWN_PENALTY },
+                 auth.poll_device_flow("dev-1"),
+                 "slow_down must report the additive penalty, not an absolute interval")
+
+    auth, = build_auth(token: JSON.generate("error" => "slow_down"))
+    assert_equal({ state: :slow_down, increase_by: 5 }, auth.poll_device_flow("dev-1"),
+                 "slow_down without an interval member still reports the +5 penalty")
   end
 
   def test_poll_raises_on_unknown_error_payload

--- a/web/app/controllers/sessions_controller.rb
+++ b/web/app/controllers/sessions_controller.rb
@@ -69,7 +69,10 @@ class SessionsController < ApplicationController
         return render "errors/show", status: :forbidden,
                       locals: { heading: "Sign-in failed", message: "The device code expired. Start again." }
       when :slow_down
-        device["interval"] = result[:interval]
+        # RFC 8628 §3.5 makes slow_down additive: grow OUR interval by the
+        # reported penalty instead of adopting an absolute value GitHub does
+        # not actually send.
+        device["interval"] = device["interval"].to_i + result.fetch(:increase_by)
       end
       device["next_poll_at"] = now + device["interval"].to_i
       session[:github_device] = device

--- a/web/test/integration/sessions_flow_test.rb
+++ b/web/test/integration/sessions_flow_test.rb
@@ -74,10 +74,10 @@ class SessionsFlowTest < ActionDispatch::IntegrationTest
     res
   end
 
-  def install_auth(login: "alice", token_body: nil)
+  def install_auth(login: "alice", token_body: nil, device_body: nil)
     token_body ||= JSON.generate("access_token" => "gho_test")
     SessionsController.http_client = FakeHttp.new(
-      device: http_ok(DEVICE_BODY),
+      device: http_ok(device_body || DEVICE_BODY),
       token: http_ok(token_body),
       user: http_ok(JSON.generate("login" => login))
     )
@@ -129,6 +129,31 @@ class SessionsFlowTest < ActionDispatch::IntegrationTest
 
     assert_response :forbidden
     assert_match(/expired/i, response.body)
+  end
+
+  test "a slow_down grant raises our polling interval by five over its current value" do
+    # GitHub's slow_down payload carries no usable `interval`; the flow must
+    # grow its OWN interval (started at 5) by the additive penalty to 10.
+    install_auth(
+      device_body: JSON.generate(
+        "device_code" => "dev-1", "user_code" => "ABCD-1234",
+        "verification_uri" => "https://github.com/login/device",
+        "expires_in" => 900, "interval" => 5
+      ),
+      token_body: JSON.generate("error" => "slow_down")
+    )
+    begin_device_flow
+    assert_equal 5, session[:github_device]["interval"]
+
+    # The first poll is gated until next_poll_at (start interval = 5s).
+    sleep 5.2
+    get "/auth/github/wait"
+
+    assert_response :success, "a slow_down grant must keep showing the waiting page"
+    assert_equal 10, session[:github_device]["interval"],
+                 "RFC 8628 slow_down is additive: interval must grow from 5 to 5+5, not reset to a payload value"
+    assert session[:github_device]["next_poll_at"] >= Time.now.to_i + 9,
+                 "the next poll must be pushed back by the raised interval"
   end
 
   test "an owner change evicts existing sessions" do

--- a/wiki/log.d/20260825T111200Z-device-flow-slow-down-additive.md
+++ b/wiki/log.d/20260825T111200Z-device-flow-slow-down-additive.md
@@ -1,0 +1,30 @@
+# Device flow: `slow_down` is additive (RFC 8628 §3.5), not absolute
+
+Date: 2026-08-25
+Area: lib/hive/web/github_auth.rb, web/app/controllers/sessions_controller.rb
+
+## What changed
+
+`GithubAuth#poll_device_flow` used to map GitHub's `slow_down` token-endpoint
+response to `{ state: :slow_down, interval: body.fetch("interval", 5).to_i }`,
+treating it as an absolute server-supplied interval. RFC 8628 §3.5 defines
+`slow_down` as an ADDITIVE signal: raise your current polling interval by 5
+seconds. GitHub's response typically carries no `interval` member at all, so a
+flow started at interval 5 stayed stuck at 5 after `slow_down` instead of back-
+ing off to 10.
+
+Now:
+
+- `GithubAuth` exposes `SLOW_DOWN_PENALTY = 5` and returns
+  `{ state: :slow_down, increase_by: SLOW_DOWN_PENALTY }`, ignoring any payload
+  `interval`.
+- `SessionsController#wait` applies it additively:
+  `device["interval"] += result.fetch(:increase_by)` before recomputing
+  `next_poll_at`.
+
+## Tests
+
+- `test/unit/web/github_auth_test.rb`: slow_down maps to the fixed +5 penalty
+  with or without an `interval` member in the payload.
+- `web/test/integration/sessions_flow_test.rb`: a flow started at interval 5
+  that receives `slow_down` re-gates its next poll at +10 seconds.


### PR DESCRIPTION
## Patrol Fix

This pull request repairs one finding tracked by Hive's Patrol Fix workflow.

### Sources

- ordinary_patrol: architecture-lib-hive-web-part-2-20260824T011817Z-e8ae03ad-1

### Finding evidence

- {"file":"lib/hive/web/github_auth.rb","line":93,"snippet":"when \"slow_down\" then { state: :slow_down, interval: body.fetch(\"interval\", 5).to_i }","role":"root_cause"}
- {"file":"web/app/controllers/sessions_controller.rb","line":72,"snippet":"device[\"interval\"] = result[:interval]","role":"trigger"}
- {"file":"web/app/controllers/sessions_controller.rb","line":74,"snippet":"device[\"next_poll_at\"] = now + device[\"interval\"].to_i","role":"impact"}

### Independent review

Publish: the exact-head patch correctly makes each slow_down response add five seconds to the session-owned polling interval and reschedules from the increased value. The aggregate failure is independently reproducible in an untouched component and is unrelated to this patch.

- Checkout is clean at controller HEAD 109f2e5e02600131409e38071f57563c60523a3c; diff inspection and call-site search found no stale consumer of the former result[:interval] contract.
- RFC 8628 section 3.5 states that slow_down must increase the polling interval by 5 seconds for the current and all subsequent requests; the implementation accumulates that penalty in session state.
- Independent focused validation passed: GithubAuthTest 11 runs and 44 assertions; SessionsFlowTest 19 runs and 165 assertions; both had zero failures and errors.
- The aggregate failure reproduces only in AgentCliRuntimeRuntimeTest, where ambient Grok resolution returns an absolute mise path instead of the expected literal grok; no agent-cli-runtime file is changed by this patch.

### Validation

Verdict: failed
- ordinary:test: exit 1
- agent:architecture-lib-hive-web-part-2-20260824T011817Z-e8ae03ad-1:unit-github-auth: exit 0
- agent:architecture-lib-hive-web-part-2-20260824T011817Z-e8ae03ad-1:integration-sessions-flow: exit 0

<!-- hive-publication:v1 id=pub-17d06e0356d5298245a7b1ee0352fab9 base=b07b869635e47d986370b19d0dfe583d54143e79 -->
