### PR TITLE
Fix Patrol finding: patrol-transient-read-error-resets-shared-state-44383c8db2

### DIFF
--- a/lib/hive/update_check/state.rb
+++ b/lib/hive/update_check/state.rb
@@ -9,7 +9,10 @@ module Hive
     # GitHub (throttle), the last version it notified about (de-dupe), and the
     # active nudge payload the TUI footer renders. JSON on disk, atomic write,
     # fail-closed load (a corrupt file degrades to empty rather than raising).
-    # Mirrors Hive::Bot::AlertStore's persistence discipline.
+    # A *transient* read error (EIO etc.) is not corruption: the last-known
+    # in-memory state is kept and writes are suspended until a load succeeds,
+    # so a read-modify-write can never persist reset state over an intact
+    # file. Mirrors Hive::Bot::AlertStore's persistence discipline.
     #
     # This file is shared across processes: the daemon writes `nudge` +
     # `last_check_at`, the bot writes `last_notified_version`, and the TUI
@@ -171,7 +174,7 @@ module Hive
         raw = begin
           File.read(@path)
         rescue SystemCallError, IOError => e
-          handle_corrupt!(e)
+          handle_read_error!(e)
           return
         end
 
@@ -199,6 +202,19 @@ module Hive
         @logger&.event(:update_check_state_corrupt, path: @path,
                                                      error_class: error.class.name, message: error.message)
         @data = empty_data
+      end
+
+      # The file exists but couldn't be read (transient EIO, momentary FS
+      # hiccups). That says nothing about its contents — resetting @data here
+      # would let the caller's read-modify-write persist emptied state over a
+      # good file (losing last_notified_version/nudge). Instead: keep the
+      # last-known @data and suspend writes until the next successful load!,
+      # which clears the flag. This tick's mutation is dropped; the next one
+      # retries against freshly-read state.
+      def handle_read_error!(error)
+        @logger&.event(:update_check_state_read_error, path: @path,
+                                                       error_class: error.class.name, message: error.message)
+        @suspend_writes = true
       end
 
       # SIGKILL/power-loss between write(tmp) and rename leaves a hidden tmp

--- a/test/unit/update_check_state_test.rb
+++ b/test/unit/update_check_state_test.rb
@@ -195,15 +195,52 @@ class UpdateCheckStateTest < Minitest::Test
     assert(logger.events.any? { |name, _| name == :update_check_state_write_error })
   end
 
-  def test_unreadable_file_is_treated_as_corrupt
+  def test_unreadable_file_degrades_without_raising_and_without_clobbering
     logger = RecordingLogger.new
-    File.write(@path, JSON.generate({ "schema_version" => 1, "last_notified_version" => "9.9.9" }))
+    state.record_notified!("9.9.9")
     File.chmod(0o000, @path)
     s = Hive::UpdateCheck::State.new(path: @path, logger: logger)
-    assert s.should_notify?("0.1.7"), "an unreadable file degrades to empty (corrupt), never raises"
-    assert(logger.events.any? { |name, _| name == :update_check_state_corrupt })
+    # Fresh instance has no last-known state, so it behaves as empty — but a
+    # mutation must NOT persist that emptied view over the unreadable file.
+    assert s.should_notify?("0.1.7"), "an unreadable file degrades to last-known (here: empty), never raises"
+    s.record_check!(@now)
+    File.chmod(0o644, @path)
+    on_disk = JSON.parse(File.read(@path))
+    assert_equal "9.9.9", on_disk["last_notified_version"], "read error must not reset shared state on disk"
+    assert_nil on_disk["last_check_at"], "write must be suspended while the file is unreadable"
+    assert(logger.events.any? { |name, _| name == :update_check_state_read_error })
   ensure
     File.chmod(0o644, @path) if @path && File.exist?(@path)
+  end
+
+  def test_transient_read_error_does_not_reset_shared_state
+    # Patrol regression: a good file {last_check_at:T, last_notified_version:
+    # "1.2.4", nudge:N}; File.read raises Errno::EIO during record_check!'s
+    # load!. handle_corrupt! used to empty @data and the subsequent
+    # persist_locked! renamed that emptied state over the intact file,
+    # permanently losing the bot's de-dupe key and the daemon's nudge.
+    logger = RecordingLogger.new
+    s = Hive::UpdateCheck::State.new(path: @path, logger: logger)
+    s.record_notified!("1.2.4")
+    s.set_nudge(latest: "1.2.4", channel: "brew", command: "brew upgrade x")
+
+    with_replaced_singleton_method(File, :read, ->(*_a, **_k) { raise Errno::EIO }) do
+      s.record_check!(@now) # read fails mid-read-modify-write; write must be suspended
+    end
+
+    on_disk = JSON.parse(File.read(@path))
+    assert_equal "1.2.4", on_disk["last_notified_version"], "transient EIO must not erase the de-dupe key"
+    assert on_disk["nudge"], "transient EIO must not erase the nudge payload"
+    assert_nil on_disk["last_check_at"], "the tick's timestamp is dropped rather than persisted from reset state"
+    assert(logger.events.any? { |name, _| name == :update_check_state_read_error })
+    refute(logger.events.any? { |name, _| name == :update_check_state_write_error })
+
+    # Next successful load! clears the suspend flag; normal operation resumes.
+    s.record_check!(@now + 3600)
+    on_disk = JSON.parse(File.read(@path))
+    assert_equal (@now + 3600).utc.iso8601, on_disk["last_check_at"]
+    assert_equal "1.2.4", on_disk["last_notified_version"]
+    assert on_disk["nudge"], "recovered writes must preserve earlier keys"
   end
 
   def test_release_lock_swallows_errors

--- a/wiki/log.d/20260826T070000Z-transient-read-error-preserves-update-check-state.md
+++ b/wiki/log.d/20260826T070000Z-transient-read-error-preserves-update-check-state.md
@@ -1,0 +1,17 @@
+---
+date: 2026-08-26
+title: Transient read errors no longer reset update_check shared state
+tags: [update, state, patrol, durability]
+---
+
+- `Hive::UpdateCheck::State#load!` previously funneled both `File.read`
+  I/O errors and JSON parse errors into `handle_corrupt!`, which resets
+  `@data` to empty. A transient read failure (e.g. `Errno::EIO`) during a
+  locked read-modify-write therefore persisted emptied state over an intact
+  file, permanently erasing `last_notified_version` and `nudge` and causing
+  duplicate release notifications.
+- Read errors are now handled separately (`handle_read_error!`, event
+  `:update_check_state_read_error`): the last-known in-memory state is kept
+  and writes are suspended until the next successful load clears the flag,
+  so that tick's mutation is dropped instead of clobbering shared state.
+  Genuinely corrupt JSON still degrades to empty as before.

--- a/wiki/update-flow.md
+++ b/wiki/update-flow.md
@@ -3,7 +3,7 @@ title: Update flow (daemon-driven version check + nudge)
 type: feature
 source: lib/hive/update_check.rb, lib/hive/update_check/state.rb, lib/hive/daemon/dispatcher.rb, lib/hive/bot/supervisor.rb, lib/hive/tui/bubble_model.rb
 created: 2026-05-27
-updated: 2026-08-03
+updated: 2026-08-26
 tags: [architecture, daemon, bot, tui, update, decision]
 ---
 
@@ -15,7 +15,7 @@ reported. See [[commands/update]] and [[commands/migrate]].
 ## Pieces
 
 - **`Hive::UpdateCheck.latest`** — probes `https://api.github.com/repos/ivankuznetsov/hive/releases/latest`, parses `tag_name`, compares to `Hive::VERSION`. Returns a `Result(current, latest, behind)` or `nil` on **any** failure (offline, rate-limit, malformed JSON, unparseable version). Never raises — the daemon calls it on a tick and must not crash.
-- **`Hive::UpdateCheck::State`** — JSON state under `Paths.state_home/update_check.json`. Holds `last_check_at` (throttle), `last_notified_version` (de-dupe), and the active `nudge` payload (`latest`/`channel`/`command`). Atomic write, fail-closed load. **Shared across processes**: the daemon writes `nudge` + `last_check_at`; the bot writes `last_notified_version`; the TUI reads `nudge`. Every operation re-reads the file first so one process can't clobber another's keys with a stale in-memory copy.
+- **`Hive::UpdateCheck::State`** — JSON state under `Paths.state_home/update_check.json`. Holds `last_check_at` (throttle), `last_notified_version` (de-dupe), and the active `nudge` payload (`latest`/`channel`/`command`). Atomic write, fail-closed load (corrupt JSON degrades to empty). A transient read error (EIO etc.) is *not* corruption: the last-known in-memory state is kept and writes are suspended (`:update_check_state_read_error`) until the next successful load, so a read-modify-write can never persist reset state over an intact file. **Shared across processes**: the daemon writes `nudge` + `last_check_at`; the bot writes `last_notified_version`; the TUI reads `nudge`. Every operation re-reads the file first so one process can't clobber another's keys with a stale in-memory copy.
 - **Dispatcher integration** (`maybe_check_for_update`) — runs at the top of each `tick`, throttled by `state.due?`. Branches on `InstallChannel.detect`: `dev` → clear nudge + skip; brew/aur/bash → set the nudge with `Update.nudge_command(channel)` and log `:update_available`. Resilient: wrapped so an error logs `:update_check_error` and never breaks the tick. Runs only when an `update_state` is injected (the daemon does; unit tests stay inert/offline).
 - **TUI footer** (`bubble_model.rb`) — reads `state.nudge` on a 10s TTL cache and prepends `update <ver>: <command>` to the hint line (prepended so truncation trims the hint, not the notice).
 - **Bot push** (`supervisor.rb` `push_update_nudge`, called from `status_loop`) — reads `state.nudge`; if `should_notify?(latest)`, sends to the `chat_id_allowlist` and records notified **only after a delivery succeeds** (all-failed pushes retry next tick). Once per version.


### PR DESCRIPTION
## Patrol Fix

This pull request repairs one finding tracked by Hive's Patrol Fix workflow.

### Sources

- ordinary_patrol: architecture-lib-hive-update-check-20260817T025347Z-80049da2-1

### Finding evidence

- {"file":"lib/hive/update_check/state.rb","line":170,"snippet":"rescue SystemCallError, IOError => e","role":"trigger"}
- {"file":"lib/hive/update_check/state.rb","line":198,"snippet":"@data = empty_data","role":"root_cause"}
- {"file":"lib/hive/update_check/state.rb","line":232,"snippet":"f.write(JSON.pretty_generate(@data))","role":"impact"}

### Independent review

The exact patch fixes the reported destructive read-modify-write path by preserving last-known state and suppressing persistence after File.read errors; the focused and consumer-level checks are green, while both controller failures are bounded outside the changed behavior.

- HEAD is exactly 539ddefc634b1d3b1f4c4a8640d588bd90382cd9 on the controller-selected branch, the worktree is clean, and git diff --check reports no errors.
- The code separates SystemCallError and IOError from JSON corruption, leaves @data intact, sets @suspend_writes before persistence can run, and clears suspension only when a later load succeeds.
- Focused checks passed: update_check_state 24 runs and 46 assertions; update_check 17 and 26; dispatcher update flow 11 and 34; bot nudge 9 and 29; TUI nudge 7 and 11, all with zero failures.
- The cross-process state test passed with 1 run and 3 assertions when GEM_PATH was explicitly preserved; its default failure reproduces as Bundler::GemNotFound in spawned children after test_helper replaces HOME, before either child exercises State.
- The controller aggregate failure is AgentCliRuntimeRuntimeTest expecting a bare grok command while observing a resolved executable path; the patch changes only update-check state, its unit test, and wiki documentation.

### Validation

Verdict: failed
- ordinary:test: exit 1
- agent:unit-update-check-state: exit 0
- agent:integration-update-check-cross-process: exit 1
- agent:unit-update-check: exit 0

<!-- hive-publication:v1 id=pub-9703024001efa1e49827fc9a9eeb1e99 base=453ec4c9df9cd39447911f4e1e34111d2ba7a146 -->
