### PR TITLE
Fix Patrol finding: make-one-repository-internal-conformance-suite-a-6d967b3261e9

### DIFF
--- a/components/agent-cli-runtime/bin/verify-candidate
+++ b/components/agent-cli-runtime/bin/verify-candidate
@@ -10,6 +10,7 @@ require "tmpdir"
 ROOT = File.expand_path("..", __dir__)
 $LOAD_PATH.unshift File.join(ROOT, "lib")
 require "agent_cli_runtime/version"
+require_relative "../test/support/conformance"
 
 gem_path = File.expand_path(ARGV.fetch(0) {
   abort "usage: verify-candidate PATH_TO_GEM [EXPECTED_SHA256]"
@@ -84,7 +85,7 @@ Dir.mktmpdir("agent-cli-runtime-candidate") do |sandbox|
     abort "wrong version" unless
       AgentCliRuntime::VERSION == #{AgentCliRuntime::VERSION.dump}
     abort "wrong providers" unless
-      AgentCliRuntime::Profiles.names == %i[claude codex pi grok opencode]
+      AgentCliRuntime::Profiles.names == #{AgentCliRuntime::Conformance::PROVIDER_NAMES.inspect}
   RUBY
   _out, err, status = Open3.capture3(
     runtime_env, Gem.ruby, "-e", require_script
@@ -122,9 +123,9 @@ Dir.mktmpdir("agent-cli-runtime-candidate") do |sandbox|
     when ["--version"]
       puts "opencode 1.18.16"
     when ["run", "--help"]
-      puts "--model --variant --format --dir --pure --auto"
+      puts #{AgentCliRuntime::Conformance.opencode_run_help.dump}
     when ["export", "--help"]
-      puts "--sanitize"
+      puts #{AgentCliRuntime::Conformance.opencode_export_help.dump}
     when ["auth", "list"]
       puts "anthropic"
     when ["models", "anthropic", "--verbose"]

--- a/components/agent-cli-runtime/test/cli_test.rb
+++ b/components/agent-cli-runtime/test/cli_test.rb
@@ -33,7 +33,7 @@ class AgentCliRuntimeCliTest < Minitest::Test
 
     assert_includes [ 0, 1 ], status.exitstatus
     payload = JSON.parse(out)
-    assert_equal %w[claude codex pi grok opencode],
+    assert_equal AgentCliRuntime::Conformance::PROVIDER_NAMES.map(&:to_s),
                  payload.fetch("probes").map { |probe| probe.fetch("provider") }
   end
 
@@ -52,7 +52,9 @@ class AgentCliRuntimeCliTest < Minitest::Test
 
     assert_equal 64, status.exitstatus
     assert_match(/unknown provider/, err)
-    assert_match(/claude, codex, pi, grok, opencode/, err)
+    assert_match(
+      /#{AgentCliRuntime::Conformance::PROVIDER_NAMES.join(', ')}/, err
+    )
     assert_match(/Usage:/, err)
   end
 

--- a/components/agent-cli-runtime/test/conformance_suite_test.rb
+++ b/components/agent-cli-runtime/test/conformance_suite_test.rb
@@ -1,0 +1,52 @@
+require_relative "test_helper"
+
+class AgentCliRuntimeConformanceSuiteTest < Minitest::Test
+  ROOT = File.expand_path("..", __dir__)
+  VERIFIER = File.join(ROOT, "bin", "verify-candidate")
+
+  def test_provider_inventory_is_one_internal_decision_matching_the_package
+    assert_equal AgentCliRuntime::Profiles.names,
+                 AgentCliRuntime::Conformance::PROVIDER_NAMES
+  end
+
+  def test_opencode_capability_inventory_matches_the_shipped_probe_contract
+    assert_equal AgentCliRuntime::OpenCode::Probe::REQUIRED_RUN_FLAGS.sort,
+                 AgentCliRuntime::Conformance::OPENCODE_RUN_FLAGS.sort
+    assert_equal %w[--sanitize],
+                 AgentCliRuntime::Conformance::OPENCODE_EXPORT_FLAGS
+  end
+
+  def test_stub_help_payloads_advertise_exactly_the_required_inventory
+    run_help = AgentCliRuntime::Conformance.opencode_run_help
+    export_help = AgentCliRuntime::Conformance.opencode_export_help
+
+    assert_equal AgentCliRuntime::Conformance::OPENCODE_RUN_FLAGS,
+                 run_help.split
+    assert_equal AgentCliRuntime::Conformance::OPENCODE_EXPORT_FLAGS,
+                 export_help.split
+  end
+
+  def test_verifier_consumes_the_shared_suite_instead_of_its_own_copies
+    source = File.read(VERIFIER)
+
+    assert_includes source,
+                    'require_relative "../test/support/conformance"'
+    refute_match(/%i\[claude/, source)
+    refute_match(/puts "--(?:pure|model|variant|format|dir|sanitize)/, source)
+  end
+
+  def test_no_consumer_keeps_its_own_copy_of_the_decisions
+    consumers = Dir.glob(File.join(ROOT, "test", "*_test.rb")) +
+                [ VERIFIER ]
+
+    consumers.each do |path|
+      source = File.read(path)
+      refute_match(
+        /%[iwi]\[claude codex pi grok opencode\]/, source, path
+      )
+      refute_match(
+        /--(?:model --variant|pure --model)[^"\n]*--auto/, source, path
+      )
+    end
+  end
+end

--- a/components/agent-cli-runtime/test/opencode_contract_test.rb
+++ b/components/agent-cli-runtime/test/opencode_contract_test.rb
@@ -15,11 +15,13 @@ class AgentCliRuntimeOpenCodeContractTest < Minitest::Test
     help = fixture("run-help.txt")
 
     assert_includes help, "opencode run [message..]"
-    %w[--pure --model --format --dir --variant --auto].each do |flag|
+    AgentCliRuntime::Conformance::OPENCODE_RUN_FLAGS.each do |flag|
       assert_includes help, flag
     end
     assert_includes help, "provider/model"
-    assert_includes fixture("export-help.txt"), "--sanitize"
+    AgentCliRuntime::Conformance::OPENCODE_EXPORT_FLAGS.each do |flag|
+      assert_includes fixture("export-help.txt"), flag
+    end
   end
 
   def test_local_inventory_fixtures_are_sanitized_and_exact

--- a/components/agent-cli-runtime/test/opencode_preparation_test.rb
+++ b/components/agent-cli-runtime/test/opencode_preparation_test.rb
@@ -2,7 +2,8 @@ require_relative "test_helper"
 
 class AgentCliRuntimeOpenCodePreparationTest < Minitest::Test
   def test_builtin_profile_is_appended_without_changing_legacy_transports
-    assert_equal %i[claude codex pi grok opencode], AgentCliRuntime::Profiles.names
+    assert_equal AgentCliRuntime::Conformance::PROVIDER_NAMES,
+                 AgentCliRuntime::Profiles.names
 
     profile = AgentCliRuntime::Profiles.fetch(:opencode)
     assert_equal "1.18.16", profile.min_version
@@ -38,9 +39,9 @@ class AgentCliRuntimeOpenCodePreparationTest < Minitest::Test
       calls << [ arguments, timeout_sec, env ]
       output = case arguments
       when [ "run", "--help" ]
-        "--model --variant --format --dir --pure --auto"
+        AgentCliRuntime::Conformance.opencode_run_help
       when [ "export", "--help" ]
-        "--sanitize"
+        AgentCliRuntime::Conformance.opencode_export_help
       when [ "auth", "list" ]
         "openrouter\n"
       when [ "models", "openrouter", "--verbose" ]

--- a/components/agent-cli-runtime/test/probe_test.rb
+++ b/components/agent-cli-runtime/test/probe_test.rb
@@ -181,7 +181,8 @@ class AgentCliRuntimeProbeTest < Minitest::Test
   def test_probe_all_uses_stable_provider_order
     results = AgentCliRuntime.probe_all
 
-    assert_equal %i[claude codex pi grok opencode], results.map(&:provider)
+    assert_equal AgentCliRuntime::Conformance::PROVIDER_NAMES,
+                 results.map(&:provider)
   end
 
   def test_opencode_version_check_has_cold_start_headroom

--- a/components/agent-cli-runtime/test/runtime_test.rb
+++ b/components/agent-cli-runtime/test/runtime_test.rb
@@ -2,7 +2,8 @@ require_relative "test_helper"
 
 class AgentCliRuntimeRuntimeTest < Minitest::Test
   def test_builtin_provider_order_and_profiles_are_immutable
-    assert_equal %i[claude codex pi grok opencode], AgentCliRuntime::Profiles.names
+    assert_equal AgentCliRuntime::Conformance::PROVIDER_NAMES,
+                 AgentCliRuntime::Profiles.names
     assert_predicate AgentCliRuntime::Profiles.names, :frozen?
     assert AgentCliRuntime::Profiles.names.all? do |name|
       AgentCliRuntime::Profiles.fetch(name).frozen?

--- a/components/agent-cli-runtime/test/support/conformance.rb
+++ b/components/agent-cli-runtime/test/support/conformance.rb
@@ -1,0 +1,44 @@
+# Repository-internal conformance suite for agent-cli-runtime.
+#
+# This file is the single owner of the candidate conformance decisions that
+# both the source test suite and bin/verify-candidate must agree on:
+#
+#   * the complete ordered provider inventory of the package, and
+#   * the OpenCode non-interactive capability inventory that the pinned CLI
+#     surface, fixture corpus, synthetic probe stub, and installed-candidate
+#     probe must all advertise.
+#
+# It deliberately lives under test/support so the gem never packages it;
+# bin/verify-candidate loads it from the repository checkout and the test
+# suite loads it through test/test_helper.rb. Shipped library behavior keeps
+# its own public definitions; test/conformance_suite_test.rb proves this
+# internal declaration and every consumer stay in agreement.
+
+module AgentCliRuntime
+  module Conformance
+    # Complete ordered built-in provider inventory of the installed candidate
+    # and the source CLI contract.
+    PROVIDER_NAMES = %i[claude codex pi grok opencode].freeze
+
+    # OpenCode "run --help" capabilities required by the pinned v1.18.16
+    # contract. Order matches the fixture corpus rendering.
+    OPENCODE_RUN_FLAGS = %w[--pure --model --format --dir --variant --auto].freeze
+
+    # OpenCode "export --help" capabilities required by the same contract.
+    OPENCODE_EXPORT_FLAGS = %w[--sanitize].freeze
+
+    module_function
+
+    # Renders the synthetic OpenCode "run --help" payload used by the
+    # bin/verify-candidate probe stub. Only advertised flag tokens are
+    # contractual; surrounding text is opaque to the probe.
+    def opencode_run_help
+      OPENCODE_RUN_FLAGS.join(" ")
+    end
+
+    # Renders the synthetic OpenCode "export --help" payload.
+    def opencode_export_help
+      OPENCODE_EXPORT_FLAGS.join(" ")
+    end
+  end
+end

--- a/components/agent-cli-runtime/test/test_helper.rb
+++ b/components/agent-cli-runtime/test/test_helper.rb
@@ -8,6 +8,7 @@ require "digest"
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 
 require "agent_cli_runtime"
+require_relative "support/conformance"
 
 module AgentCliRuntimeTestHelpers
   def write_executable(path, body)

--- a/wiki/log.d/20260825T130249Z-agent-cli-runtime-internal-conformance-suite.md
+++ b/wiki/log.d/20260825T130249Z-agent-cli-runtime-internal-conformance-suite.md
@@ -1,0 +1,51 @@
+# 2026-08-25 — agent-cli-runtime: one repository-internal conformance suite
+
+## Summary
+
+Patrol finding
+`pr-1127-2c7346544a5540c5:centralize-agent-runtime-candidate-conformance`
+(generation 1): the release verifier `bin/verify-candidate` hard-coded the
+installed candidate's complete provider inventory
+(`%i[claude codex pi grok opencode]`) and its own synthetic OpenCode capability
+contract (`run --help` / `export --help` flag lines), while the source contract
+suite (`test/cli_test.rb`, `test/opencode_contract_test.rb`) independently owned
+the same ordered decisions. Two owners for one decision meant the candidate
+verifier could silently drift from the source contract.
+
+## Change
+
+- Added `components/agent-cli-runtime/test/support/conformance.rb` as the
+  single repository-internal owner of two cross-cutting conformance decisions:
+  `Conformance::PROVIDER_NAMES` (ordered built-in provider inventory) and
+  `Conformance::OPENCODE_RUN_FLAGS` / `OPENCODE_EXPORT_FLAGS` plus stub-help
+  renderers. It lives under `test/support` so the gem never packages it;
+  `bin/verify-candidate` requires it from the checkout and the suite loads it
+  through `test/test_helper.rb`.
+- `bin/verify-candidate` now derives its installed-provider assertion and its
+  synthetic OpenCode probe-stub help payloads from the shared suite.
+- `test/cli_test.rb`, `test/opencode_contract_test.rb`,
+  `test/runtime_test.rb`, `test/probe_test.rb`, and
+  `test/opencode_preparation_test.rb` consume the shared constants instead of
+  local copies.
+- Added `test/conformance_suite_test.rb`: parity between the internal
+  declaration and shipped library behavior (`Profiles.names`,
+  `OpenCode::Probe::REQUIRED_RUN_FLAGS`, `--sanitize`), stub payload shape,
+  and a drift guard asserting no test or the verifier keeps its own copy of
+  either decision.
+
+## Validation
+
+- Focused: cli, opencode_contract, conformance_suite, runtime, probe,
+  opencode_preparation tests.
+- End-to-end: `test/mirror_test.rb` projection builds, installs, and runs
+  `bin/verify-candidate` against a standalone tree containing the shared file.
+- Full component `bundle exec rake test`: only pre-existing environment failure
+  (`runtime_test` grok PATH shim on the development machine), reproduced on a
+  clean stash of the branch.
+
+## Notes
+
+Shipped library definitions (`Profiles.names`, `OpenCode::Probe::REQUIRED_RUN_FLAGS`)
+remain the public SemVer-governed behavior; the internal suite pins the
+repository-level decision and the parity test proves agreement. The gem file
+list is unchanged.

--- a/wiki/modules/agent_cli_runtime.md
+++ b/wiki/modules/agent_cli_runtime.md
@@ -194,7 +194,12 @@ JSON probe checks matched the retained workflow artifact before Hive's cutover.
 Package tests run directly from the subtree and through the root `rake test`
 task. Candidate tooling builds one gem, records its source commit and dirty
 state, checksums it, installs it into a private gem home, proves a clean require,
-and exercises the executable. Root parity fixtures cover non-default
+and exercises the executable. The repository keeps one internal conformance
+suite at `test/support/conformance.rb` as the single owner of the ordered
+provider inventory and the OpenCode capability contract; `bin/verify-candidate`,
+the source contract tests, and its synthetic probe stub all consume it, and
+`test/conformance_suite_test.rb` guards parity with shipped library behavior.
+Root parity fixtures cover non-default
 compilation, local probes, named capability evidence, provider usage variants,
 and observable normalization/redaction across all five built-ins. The
 0.2.0 release promotes OpenCode to the public compatibility surface without


### PR DESCRIPTION
## Patrol Fix

This pull request repairs one finding tracked by Hive's Patrol Fix workflow.

### Sources

- architecture_patrol: pr-1127-2c7346544a5540c5:centralize-agent-runtime-candidate-conformance

### Finding evidence

- {"file":"components/agent-cli-runtime/bin/verify-candidate","snippet":"AgentCliRuntime::Profiles.names == %i[claude codex pi grok opencode]","claim":"the release verifier hard-codes the installed candidate's complete provider inventory"}
- {"file":"components/agent-cli-runtime/test/cli_test.rb","line":36,"snippet":"assert_equal %w[claude codex pi grok opencode],","claim":"the source CLI contract independently owns the same ordered provider decision"}
- {"file":"components/agent-cli-runtime/bin/verify-candidate","snippet":"puts \"--model --variant --format --dir --pure --auto\"","claim":"the release verifier embeds its own synthetic OpenCode capability contract and lifecycle scenario"}
- {"file":"components/agent-cli-runtime/test/opencode_contract_test.rb","line":17,"snippet":"%w[--pure --model --format --dir --variant --auto].each do |flag|","claim":"the source contract suite independently specifies the same required OpenCode capability inventory"}

### Independent review

The patch centralizes the current provider and OpenCode conformance consumers, preserves repository-only support outside the gem, and introduces no actionable defect. The controller's red aggregate result is caused solely by the inherited HIVE_GROK_BIN host override; the same runtime and full component tests pass when that unrelated override is removed. Lexical drift-guard limitations are bounded future hardening, not a current conformance failure.

- The reviewed worktree is exactly HEAD b7100b8aa24e02b47bd18c783d80c97340441bd9 with parent b07b869635e47d986370b19d0dfe583d54143e79, a clean 11-file patch, and no diff-check errors.
- The focused conformance suite passed 5 runs and 71 assertions; the standalone mirror suite passed 14 runs and 238 assertions, including projected build, gem install, and verify-candidate execution.
- With HIVE_GROK_BIN unset, the full agent-cli-runtime suite passed 120 runs and 1253 assertions with one skip, and the root component unit suite passed 11 runs and 106 assertions.
- The environment failure was independently reproduced: inherited HIVE_GROK_BIN fails runtime_test because the compiled command correctly uses the configured absolute Grok executable, while unsetting it passes all 16 runtime tests.
- Correctness, project-standards, testing, maintainability, and an independent Claude adversarial pass found no current runtime, packaging, standards, or actionable conformance defect.

### Validation

Verdict: failed
- architecture:test: exit 1
- agent:agent-cli-runtime internal conformance suite (regression guard): exit 0
- agent:agent-cli-runtime full component test suite: exit 0
- agent:monorepo unit test for the agent-cli-runtime component: exit 0

<!-- hive-publication:v1 id=pub-5e913ac5e5f100ba840e317622625f93 base=b07b869635e47d986370b19d0dfe583d54143e79 -->
