### PR TITLE
Fix Patrol finding: make-each-concrete-adapter-authoritative-for-its-a5d7508bcaae

### DIFF
--- a/lib/hive/agent_skills/adapters/base.rb
+++ b/lib/hive/agent_skills/adapters/base.rb
@@ -252,10 +252,9 @@ module Hive
         end
 
         def alias_path(alias_spec)
-          home = @environment["HOME"] || Dir.home
-          config_root = @environment["CLAUDE_CONFIG_DIR"].to_s
-          config_root = File.join(home, ".claude") if config_root.empty?
-          File.join(config_root, alias_spec.path.delete_prefix(".claude/"))
+          profile = Hive::AgentProfiles.lookup(agent)
+          relative = alias_spec.path.delete_prefix("#{profile.default_configuration_directory}/")
+          File.join(profile.configuration_directory(environment: @environment), relative)
         end
 
         def execute_alias(operation)

--- a/lib/hive/agent_skills/inspector.rb
+++ b/lib/hive/agent_skills/inspector.rb
@@ -417,7 +417,7 @@ module Hive
         alias_path = nil
         invocation = contract.invocation
         if contract.alias_spec
-          alias_path = alias_path_for(contract.alias_spec)
+          alias_path = alias_path_for(contract.alias_spec, agent: contract.agent)
           if File.exist?(alias_path)
             actual = File.read(alias_path)
             unless actual == Manifest.alias_content(contract.alias_spec)
@@ -643,12 +643,10 @@ module Hive
         )
       end
 
-      def alias_path_for(alias_spec)
-        home = @environment["HOME"] || Dir.home
-        config_root = @environment["CLAUDE_CONFIG_DIR"].to_s
-        config_root = File.join(home, ".claude") if config_root.empty?
-        relative = alias_spec.path.delete_prefix(".claude/")
-        File.join(config_root, relative)
+      def alias_path_for(alias_spec, agent:)
+        profile = Hive::AgentProfiles.lookup(agent)
+        relative = alias_spec.path.delete_prefix("#{profile.default_configuration_directory}/")
+        File.join(profile.configuration_directory(environment: @environment), relative)
       end
 
       def resolution_hash(resolution)

--- a/test/unit/agent_skills/adapters/adapters_test.rb
+++ b/test/unit/agent_skills/adapters/adapters_test.rb
@@ -392,6 +392,24 @@ class AgentSkillAdaptersTest < Minitest::Test
     end
   end
 
+  def test_claude_alias_path_follows_the_profile_configuration_root
+    with_tmp_dir do |dir|
+      override = File.join(dir, "custom", "claude")
+      row = inspection(agent: "claude", capability: "wiki-plan", package: "llm-wiki",
+                       health: "missing", bin: "/fake/claude")
+      prerequisite = inspection(
+        agent: "claude", capability: "ce-brainstorm", package: "compound-engineering",
+        health: "healthy", bin: "/fake/claude"
+      )
+      adapter = adapter(Hive::AgentSupport.for(:claude)::SetupAdapter, dir: dir,
+                        environment: { "CLAUDE_CONFIG_DIR" => override })
+      plan = adapter.plan([ prerequisite, row ])
+      alias_operation = plan.operations.find { |operation| operation.kind == "alias_write" }
+
+      assert_equal [ File.join(override, "commands", "plan.md") ], alias_operation.files
+    end
+  end
+
   def test_declared_package_prerequisite_orders_llm_wiki_after_compound_engineering
     with_tmp_dir do |dir|
       ce = inspection(agent: "claude", capability: "ce-brainstorm", package: "compound-engineering",

--- a/test/unit/agent_skills/adapters/adapters_test.rb
+++ b/test/unit/agent_skills/adapters/adapters_test.rb
@@ -317,6 +317,46 @@ class AgentSkillAdaptersTest < Minitest::Test
     end
   end
 
+  def test_each_agent_profile_owns_its_default_config_root
+    expected = {
+      "claude" => ".claude",
+      "codex" => ".codex",
+      "pi" => File.join(".pi", "agent"),
+      "grok" => ".grok",
+      "opencode" => File.join(".config", "opencode")
+    }
+    manifest = Hive::AgentSkills::Manifest.load
+
+    expected.each do |agent, relative_root|
+      with_tmp_dir do |dir|
+        native_spec = manifest.package("compound-engineering").native_for(agent)
+        klass = Hive::AgentProfiles.support_for(agent).const_get(:SetupAdapter, false)
+        instance = adapter(klass, dir: dir)
+
+        assert_equal File.join(dir, relative_root),
+                     Hive::AgentProfiles.lookup(agent).configuration_directory(
+                       environment: { "HOME" => dir }
+                     )
+        assert_equal File.join(dir, relative_root),
+                     instance.send(:config_root, native_spec)
+      end
+    end
+  end
+
+  def test_config_root_still_honors_the_provider_config_home_override
+    with_tmp_dir do |dir|
+      override = File.join(dir, "custom", "claude")
+      native_spec = Hive::AgentSkills::Manifest.load
+                    .package("compound-engineering").native_for("claude")
+      instance = adapter(
+        Hive::AgentSupport.for(:claude)::SetupAdapter, dir: dir,
+        environment: { "CLAUDE_CONFIG_DIR" => override }
+      )
+
+      assert_equal override, instance.send(:config_root, native_spec)
+    end
+  end
+
   def test_registry_exposes_opencode_adapter
     with_tmp_dir do |dir|
       registry = Hive::AgentSkills::Adapters::Registry.new(

--- a/wiki/log.d/20260822T120000Z-adapter-owned-config-root-defaults.md
+++ b/wiki/log.d/20260822T120000Z-adapter-owned-config-root-defaults.md
@@ -1,0 +1,24 @@
+# 2026-08-22 — Each agent profile owns its default config root
+
+## Summary
+
+`Hive::AgentSkills::Adapters::Base#config_root` no longer branches over the
+closed provider set (`claude`, `codex`, `pi`, `grok`, `opencode`) to pick a
+default filesystem root. It delegates to the selected `AgentProfile`, whose
+agent-cli-runtime profile owns both the default root and its environment
+override. This stronger profile boundary supersedes the earlier per-adapter
+constant design while preserving the finding's single-owner requirement.
+
+## Motivation
+
+The base adapter duplicated provider knowledge: adding or renaming a provider
+required changing both provider registration and a central `case` statement.
+Delegating to the profile keeps each provider's filesystem defaults beside
+its other native runtime facts.
+
+## Behavior
+
+Observable paths are unchanged. Regression tests assert every registered
+profile and its setup adapter resolve the same expected root when the override
+is unset, and still honor the profile's override (for example
+`CLAUDE_CONFIG_DIR`) when set.

--- a/wiki/log.d/20260825T121500Z-alias-path-profile-delegation.md
+++ b/wiki/log.d/20260825T121500Z-alias-path-profile-delegation.md
@@ -1,0 +1,29 @@
+# 2026-08-25 — Alias resolution delegates to the profile config root
+
+## Summary
+
+The last two provider-neutral hardcodes of Claude's filesystem default are
+gone. `Hive::AgentSkills::Adapters::Base#alias_path` and
+`Hive::AgentSkills::Inspector#alias_path_for` no longer branch on
+`CLAUDE_CONFIG_DIR` / `~/.claude` themselves; both derive the alias directory
+from the selected `AgentProfile` (`default_configuration_directory` plus
+`configuration_directory`), the same single authority that already owns every
+other adapter config root.
+
+## Motivation
+
+`Base#config_root` had already been reduced to profile delegation, but alias
+path resolution kept a private copy of the provider default in shared code.
+A provider renaming its config directory or override key would have had to be
+re-taught to the neutral base and inspector, recreating the duplication this
+boundary work removed.
+
+## Behavior
+
+Observable paths are unchanged for the shipped manifest (aliases are declared
+relative to each provider's default configuration directory and validated
+against that provider's `skill_alias_root`). The only semantic tightening:
+an override environment value must be absolute, matching how
+`AgentCliRuntime::Profile#configuration_directory` already treats overrides
+for non-alias roots. Regression test: alias planning honors the profile's
+override (`test_claude_alias_path_follows_the_profile_configuration_root`).


### PR DESCRIPTION
## Patrol Fix

This pull request repairs one finding tracked by Hive's Patrol Fix workflow.

### Sources

- architecture_patrol: pr-998-05225eb9e83d4386:move-config-root-defaults-to-provider-adapters

### Finding evidence

- {"file":"lib/hive/agent_skills/adapters/base.rb","snippet":"case native_spec.provider\n          when \"claude\" then File.join(home, \".claude\")\n          when \"codex\" then File.join(home, \".codex\")\n          when \"pi\" then File.join(home, \".pi\", \"agent\")\n          when \"grok\" then File.join(home, \".grok\")\n          when \"opencode\" then File.join(home, \".config\", \"opencode\")\n          end","claim":"the provider-neutral base branches over all five concrete providers to decide their private filesystem defaults"}
- {"file":"lib/hive/agent_skills/adapters/registry.rb","snippet":"ADAPTERS = {\n          \"claude\" => Claude,\n          \"codex\" => Codex,\n          \"grok\" => Grok,\n          \"pi\" => Pi,\n          \"opencode\" => OpenCode\n        }.freeze","claim":"adapter population is already owned by a separate registry, confirming that Base carries a second dependency on the same closed provider set"}
- {"file":"test/unit/agent_skills/adapters/adapters_test.rb","snippet":"def test_opencode_setup_uses_default_config_root_and_skips_current_pin","claim":"existing adapter behavior tests characterize provider default-root behavior, enabling delegation to move without changing observable paths"}

### Independent review

Exact HEAD verified. The current patch state delegates configuration and alias-root ownership to AgentProfile, removes the remaining Claude-specific root logic from shared setup and inspection code, and preserves shipped paths. Focused validation is green; the controller failure is bounded to an ambient Grok binary override outside this diff. No correctness, ownership, or regression blocker was found.

- Reviewed generation 3 at exact HEAD 0b491ee319d167dd923891fadcb9080333b73f53; git diff --check is clean.
- Base#config_root was already profile-owned at the fix base; this diff removes the remaining CLAUDE_CONFIG_DIR/.claude duplication from Base#alias_path and Inspector#alias_path_for.
- Manifest validation confines the shipped alias to the Claude alias root, and AgentCliRuntime::Profile validates default directories plus absolute configuration overrides.
- Independent focused validation passed: adapters 32 runs/126 assertions, inspector 40/158, manifest 10/212, and agent profile 78/302.
- The controller architecture:test component passes independently at 16 runs/115 assertions when ambient HIVE_GROK_BIN is unset; components/agent-cli-runtime is unchanged by this diff.

### Validation

Verdict: failed
- architecture:test: exit 1
- agent:adapter-config-root-regressions: exit 0
- agent:inspector-alias-path-delegation: exit 0
- agent:fix-commits-present-on-branch: exit 0
- agent:no-provider-case-left-in-shared-skills-code: exit 0

<!-- hive-publication:v1 id=pub-b8a8a06ea4735cffe52bd45c1ec1899b base=b07b869635e47d986370b19d0dfe583d54143e79 -->
