### PR TITLE
Fix Patrol finding: patrol-archive-refresher-swaps-process-global-stdou-7a90a407af

### DIFF
--- a/lib/hive/tui/bubble_model.rb
+++ b/lib/hive/tui/bubble_model.rb
@@ -20,6 +20,7 @@ require "hive/stages"
 require "hive/task"
 require "hive/usage_db"
 require "hive/tui/debug"
+require "hive/tui/io_capture"
 require "hive/tui/model"
 require "hive/tui/messages"
 require "hive/tui/key_map"
@@ -2643,16 +2644,13 @@ module Hive
       # Wraps `Hive::Commands::New#call!`'s `puts` lines so they don't
       # corrupt the alt-screen render. Falls back to `$stdout`/`$stderr`
       # redirection — `capture_io` from minitest is not available in
-      # production.
-      def capture_command_io
-        orig_out = $stdout
-        orig_err = $stderr
-        $stdout = StringIO.new
-        $stderr = StringIO.new
-        yield
-      ensure
-        $stdout = orig_out
-        $stderr = orig_err
+      # production. Delegates to the shared, mutex-coordinated `IoCapture`
+      # registry: this runs on the TUI update thread and must not race
+      # `StateSource#capture_status_io`'s identical capture on the archive
+      # refresher thread into restoring a discarded StringIO as the
+      # process-global `$stdout`.
+      def capture_command_io(&block)
+        Hive::Tui::IoCapture.capture(&block)
       end
 
       def rich_new_idea_validation_error(buffer)

--- a/lib/hive/tui/io_capture.rb
+++ b/lib/hive/tui/io_capture.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "stringio"
+
+module Hive
+  module Tui
+    # Suppresses `$stdout`/`$stderr` for the duration of a block without the
+    # process-global save/restore race that plagued the previous per-caller
+    # `orig = $stdout; $stdout = StringIO.new ... $stdout = orig` pattern.
+    #
+    # The old pattern assumed single-threaded nesting. It did not hold:
+    # `StateSource#capture_status_io` runs on the short-lived archive
+    # refresher thread while `BubbleModel#capture_command_io` runs on the
+    # TUI update thread. When both overlapped, one block's `ensure` could
+    # restore the other's throwaway StringIO as the "original" `$stdout`,
+    # leaving every later write — including teardown — silently discarded.
+    #
+    # This module coordinates all captures through one mutex-guarded
+    # registry. Only the FIRST capture under an empty registry records the
+    # current bindings as the base and installs its buffers; only the LAST
+    # capture out restores them. A capture entering while another thread's
+    # capture is active never observes a transient buffer as "original",
+    # and a capture exiting while others remain active hands the binding to
+    # a still-live buffer instead of restoring anything. Output written
+    # inside any active capture is discarded either way, which is the only
+    # contract these suppression buffers ever had.
+    module IoCapture
+      MUTEX = Mutex.new
+      ACTIVE = []
+
+      class << self
+        attr_accessor :base_out, :base_err
+      end
+
+      def self.capture
+        raise ArgumentError, "IoCapture.capture requires a block" unless block_given?
+
+        out_buffer = StringIO.new
+        err_buffer = StringIO.new
+        entry = { out_buffer:, err_buffer: }
+        # Registration and installation happen under one lock hold: the
+        # instant any capture is registered, the global bindings already
+        # point at a live suppression buffer. Installing outside the lock
+        # (as an earlier draft did) left a window where a second capture
+        # could register, run its whole block, and write straight to the
+        # real TTY because the first thread had not swapped yet.
+        MUTEX.synchronize do
+          if ACTIVE.empty?
+            IoCapture.base_out = $stdout
+            IoCapture.base_err = $stderr
+            $stdout = out_buffer
+            $stderr = err_buffer
+          end
+          ACTIVE.push(entry)
+        end
+        begin
+          yield
+        ensure
+          MUTEX.synchronize do
+            ACTIVE.delete(entry)
+            if ACTIVE.empty?
+              $stdout = IoCapture.base_out
+              $stderr = IoCapture.base_err
+              IoCapture.base_out = nil
+              IoCapture.base_err = nil
+            elsif $stdout.equal?(out_buffer)
+              successor = ACTIVE.last
+              $stdout = successor[:out_buffer]
+              $stderr = successor[:err_buffer]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hive/tui/state_source.rb
+++ b/lib/hive/tui/state_source.rb
@@ -5,6 +5,7 @@ require "hive"
 require "hive/commands/status"
 require "hive/config"
 require "hive/tui/debug"
+require "hive/tui/io_capture"
 require "hive/tui/snapshot"
 
 module Hive
@@ -1093,19 +1094,15 @@ module Hive
 
       # Redirect `$stdout`/`$stderr` to throwaway buffers for the duration of
       # the block so an off-thread `Status#json_payload` call can't `warn`
-      # straight onto the alt-screen frame. Mirrors
-      # `BubbleModel#capture_command_io`; `capture_io` from minitest is not
-      # available in production. StateSource itself never `warn`s, so this only
-      # contains Status's degrade-path output.
-      def capture_status_io
-        orig_out = $stdout
-        orig_err = $stderr
-        $stdout = StringIO.new
-        $stderr = StringIO.new
-        yield
-      ensure
-        $stdout = orig_out
-        $stderr = orig_err
+      # straight onto the alt-screen frame. Delegates to the shared,
+      # mutex-coordinated `IoCapture` registry — this runs on the archive
+      # refresher thread and must not race `BubbleModel#capture_command_io`'s
+      # identical capture on the update thread into restoring a discarded
+      # StringIO as the process-global `$stdout`. `capture_io` from minitest
+      # is not available in production. StateSource itself never `warn`s, so
+      # this only contains Status's degrade-path output.
+      def capture_status_io(&block)
+        Hive::Tui::IoCapture.capture(&block)
       end
 
       # Sleep in 0.05s slices so #stop joins quickly. Reading @stop

--- a/test/unit/tui/io_capture_test.rb
+++ b/test/unit/tui/io_capture_test.rb
@@ -1,0 +1,122 @@
+require "test_helper"
+require "stringio"
+require "hive/tui/io_capture"
+
+# IoCapture replaces the per-caller `orig = $stdout; $stdout = StringIO.new;
+# ... $stdout = orig` pattern after Patrol traced a real corruption: the
+# archive refresher thread's `capture_status_io` and the TUI update thread's
+# `capture_command_io` both swapped the process-global `$stdout`, and their
+# `ensure` blocks could restore each other's throwaway buffers as the
+# "original" binding — permanently black-holing all later output. These tests
+# pin the coordinated-registry contract, including the exact interleaving
+# from the finding.
+class TuiIoCaptureTest < Minitest::Test
+  # Deterministic two-thread replay of the reported race: A installs its
+  # buffer, B enters while A is active (under the old pattern B would capture
+  # A's buffer as its "original"), then A exits BEFORE B. The final restore
+  # must land on the true original bindings, never on any capture's buffer.
+  def test_overlapping_captures_restore_original_stdout_when_inner_exits_last
+    original_out = $stdout
+    original_err = $stderr
+
+    a_installed = SizedQueue.new(1)
+    b_entered = SizedQueue.new(1)
+
+    inner = Thread.new do
+      a_installed.pop
+      Hive::Tui::IoCapture.capture do
+        b_entered.push(true)
+        $stdout.puts "inner output discarded"
+      end
+    end
+
+    Hive::Tui::IoCapture.capture do
+      a_installed.push(true)
+      b_entered.pop
+      $stdout.puts "outer output discarded"
+    end
+    # Outer (A) has now fully exited while inner (B) may still be finishing;
+    # join guarantees B's ensure has run too.
+    inner.join
+
+    assert_same original_out, $stdout,
+      "$stdout must be restored to the pre-capture binding"
+    assert_same original_err, $stderr,
+      "$stderr must be restored to the pre-capture binding"
+  end
+
+  # Mirror of the above with the exit order swapped: B (which entered second,
+  # so never installed) exits first while A is still inside its block; A's
+  # own exit must then restore the originals.
+  def test_overlapping_captures_restore_original_stdout_when_inner_exits_first
+    original_out = $stdout
+    original_err = $stderr
+
+    a_installed = SizedQueue.new(1)
+
+    inner = Thread.new do
+      a_installed.pop
+      Hive::Tui::IoCapture.capture do
+        $stdout.puts "inner output discarded"
+      end
+    end
+
+    Hive::Tui::IoCapture.capture do
+      a_installed.push(true)
+      join_within(inner, seconds: 2.0)
+      $stdout.puts "outer output discarded"
+    end
+    inner.join
+
+    assert_same original_out, $stdout
+    assert_same original_err, $stderr
+  end
+
+  def test_sequential_capture_discards_output_and_restores_bindings
+    original_out = $stdout
+    original_err = $stderr
+
+    Hive::Tui::IoCapture.capture do
+      $stdout.puts "discarded out"
+      $stderr.puts "discarded err"
+    end
+
+    assert_same original_out, $stdout
+    assert_same original_err, $stderr
+  end
+
+  def test_capture_requires_block
+    assert_raises(ArgumentError) { Hive::Tui::IoCapture.capture }
+  end
+
+  def test_concurrent_captures_never_leak_a_buffer_into_global_bindings
+    original_out = $stdout
+    original_err = $stderr
+
+    threads = Array.new(8) do
+      Thread.new do
+        25.times do
+          Hive::Tui::IoCapture.capture do
+            $stdout.puts "noise"
+            $stderr.puts "noise"
+          end
+        end
+      end
+    end
+    threads.each(&:join)
+
+    assert_same original_out, $stdout
+    assert_same original_err, $stderr
+  end
+
+  private
+
+  # Project rules forbid unbounded bare sleeps in tests; this bounds a join
+  # so a regression that deadlocks the handoff fails instead of hanging the
+  # suite. The ordering itself comes from the SizedQueue handoff above.
+  def join_within(thread, seconds:)
+    deadline = Time.now + seconds
+    thread.join(deadline - Time.now)
+    flunk("capture thread did not finish within #{seconds}s") if thread.alive?
+  end
+end

--- a/wiki/log.d/20260825T112905Z-tui-io-capture-thread-safe.md
+++ b/wiki/log.d/20260825T112905Z-tui-io-capture-thread-safe.md
@@ -1,0 +1,23 @@
+# TUI stdout suppression is now race-free across threads
+
+`StateSource#capture_status_io` (archive refresher thread) and
+`BubbleModel#capture_command_io` (TUI update thread) both used to swap the
+process-global `$stdout`/`$stderr` with a per-caller
+`orig = $stdout; ... $stdout = orig` restore. Patrol traced a real corruption:
+when a user command's capture overlapped the archive refresher's long
+`json_payload` scan, one block's `ensure` restored the other's throwaway
+StringIO as the "original" binding, permanently black-holing all later TUI
+output including teardown.
+
+Both helpers now delegate to a shared, mutex-coordinated registry in
+`lib/hive/tui/io_capture.rb`. Only the first capture under an empty registry
+records the base bindings and installs its buffers; only the last one out
+restores them, and an exiting capture whose buffer is still bound hands the
+binding to a still-live buffer instead of restoring. Output inside any active
+capture is discarded either way — the only contract these suppression buffers
+ever had.
+
+`test/unit/tui/io_capture_test.rb` pins both exit orderings of the reported
+interleaving plus a concurrent stress pass. `Hive::Bot::Supervisor` still has
+its own single-threaded copy of the old pattern (no cross-thread capture
+partner today); left untouched as out of scope for this fix.


### PR DESCRIPTION
## Patrol Fix

This pull request repairs one finding tracked by Hive's Patrol Fix workflow.

### Sources

- ordinary_patrol: architecture-lib-hive-tui-part-5-20260816T163856Z-c845823c-1

### Finding evidence

- {"file":"lib/hive/tui/state_source.rb","line":544,"snippet":"@archive_refresh_thread = Thread.new(project_entries) do |entries|","role":"trigger"}
- {"file":"lib/hive/tui/state_source.rb","line":659,"snippet":"$stdout = StringIO.new","role":"root_cause"}
- {"file":"lib/hive/tui/state_source.rb","line":663,"snippet":"$stdout = orig_out","role":"impact"}
- {"file":"lib/hive/tui/bubble_model.rb","line":2929,"snippet":"$stdout = orig_out","role":"root_cause"}

### Independent review

The exact-head patch correctly coordinates the two overlapping TUI IO suppressors and restores the original process bindings for both exit orders. Patch-specific and affected-suite validation passes. The broad test failure is isolated to unchanged agent-cli-runtime code and is not caused by this patch.

- HEAD is 13075ab964e8919be607073acaeb8c1346c1005e with a clean worktree, and the diff from base b07b869635e47d986370b19d0dfe583d54143e79 is limited to the two TUI callers, the new IoCapture module, its regression test, and the wiki log.
- Independent io_capture regression run passed: 5 runs, 9 assertions, 0 failures, 0 errors, 0 skips.
- Independent affected-suite run passed: state_source_test.rb and bubble_model_test.rb completed 67 runs and 264 assertions with 0 failures, 0 errors, and 0 skips.
- A forced two-thread probe held the second capture open until the first exited, then verified suppression remained active until the last exit and both original bindings were restored; exception restoration also passed.
- The broad failure reproduces in components/agent-cli-runtime/test/runtime_test.rb alone; that component has no diff from the fix base, and its tested source and test files have identical SHA-256 digests at base and HEAD.

### Validation

Verdict: failed
- ordinary:test: exit 1
- agent:regression-tests-io-capture-race: exit 0
- agent:focused-tui-suites-state-source-and-bubble-model: exit 0

<!-- hive-publication:v1 id=pub-4f22b4ec32b9d9f1448a5ff4b05ebe58 base=b07b869635e47d986370b19d0dfe583d54143e79 -->
