### PR TITLE
Fix Patrol finding: patrol-discovery-completion-lets-hive-configerror-e-84c5cdda61

### DIFF
--- a/lib/hive/daemon/refactor_patrol_scheduler.rb
+++ b/lib/hive/daemon/refactor_patrol_scheduler.rb
@@ -403,7 +403,11 @@ module Hive
         result
       rescue Hive::RefactorPatrol::JobStore::StaleClaim
         completion_result(:stale, dispatch_token, envelope, aggregate: aggregate)
-      rescue Hive::RefactorPatrol::JobStore::Error, KeyError
+      # Hive::ConfigError belongs here alongside JobStore::Error because the
+      # shared entry_for_token/registry lookup can raise it; without it a
+      # corrupt or unreadable registry would escape complete instead of
+      # settling the claim as retryable work (matching reserve/candidates).
+      rescue Hive::RefactorPatrol::JobStore::Error, Hive::ConfigError, KeyError
         begin
           if entry && store
             release_discovery!(

--- a/test/unit/daemon/refactor_patrol_scheduler_test.rb
+++ b/test/unit/daemon/refactor_patrol_scheduler_test.rb
@@ -399,6 +399,36 @@ class HiveDaemonRefactorPatrolSchedulerTest < Minitest::Test
     end
   end
 
+  def test_completion_returns_retry_when_the_registry_lookup_raises_config_error
+    with_project do |_dir, entry, store|
+      enqueue(store)
+      scheduler = scheduler(entry, store)
+      dispatch = scheduler.reserve(scheduler.candidates(now: T0).first, now: T0)
+      broken_registry = lambda do
+        raise Hive::ConfigError, "corrupt registry"
+      end
+      scheduler.instance_variable_set(:@registry, broken_registry)
+
+      result = scheduler.complete(
+        dispatch_token: dispatch.fetch(:dispatch_token),
+        exit_code: 0,
+        envelope: {},
+        now: T0 + 1
+      )
+
+      assert_equal :retry, result.fetch(:status)
+      assert_equal "job-7", result.fetch(:job_id)
+      assert_equal "analyzing", store.read_job("job-7").fetch("state")
+
+      recovered = scheduler(entry, store)
+      assert_equal :closed, recovered.complete(
+        dispatch_token: dispatch.fetch(:dispatch_token), exit_code: 0,
+        envelope: complete_zero_envelope(entry), now: T0 + 2
+      ).fetch(:status),
+        "a healthy registry must still be able to settle the held claim"
+    end
+  end
+
   def test_reserve_reclaims_expired_discovery_claim_only_when_owner_is_provably_resolved
     with_project do |_dir, entry, store|
       enqueue(store)


### PR DESCRIPTION
## Patrol Fix

This pull request repairs one finding tracked by Hive's Patrol Fix workflow.

### Sources

- ordinary_patrol: architecture-lib-hive-daemon-part-7-20260723T060554Z-7a065944-1

### Finding evidence

- {"file":"lib/hive/daemon/refactor_patrol_scheduler.rb","line":278,"snippet":"entry = entry_for_token(dispatch_token)","role":"trigger"}
- {"file":"lib/hive/daemon/refactor_patrol_scheduler.rb","line":300,"snippet":"rescue Hive::RefactorPatrol::JobStore::Error, KeyError","role":"root_cause"}
- {"file":"lib/hive/daemon/refactor_patrol_scheduler.rb","line":504,"snippet":"rescue Hive::RefactorPatrol::JobStore::Error, Hive::ConfigError, KeyError","role":"root_cause"}
- {"file":"lib/hive/daemon/refactor_patrol_scheduler.rb","line":302,"snippet":"store&.release_discovery!(","role":"impact"}

### Independent review

The patch closes the reported completion-path exception at the exact registry lookup boundary and adds a regression proving retry reporting while preserving the fenced claim. The controller broad-suite failure is independently reproducible in an untouched component and is unrelated to this two-file change.

- HEAD 841210dbd5fea0b51c5bbffd6119efd650981413 exactly matches the controller-selected revision; the commit changes only the scheduler rescue clause and its focused unit test, and git diff --check passes.
- Discovery completion calls entry_for_token, whose registry callback can raise Hive::ConfigError before a completion result; the added rescue returns retry while leaving the generation-fenced claim recoverable.
- Independent focused regression passed: 1 run, 4 assertions, 0 failures.
- Independent full refactor patrol scheduler unit suite passed: 48 runs, 248 assertions, 0 failures.
- The broad-suite failure was independently reproduced in components/agent-cli-runtime/test/runtime_test.rb: it expects a bare grok executable but the environment resolves a mise absolute path; neither that component nor its tests are modified by this patch.

### Validation

Verdict: failed
- ordinary:test: exit 1
- agent:regression-test-config-error-retry: exit 0
- agent:focused-scheduler-suite: exit 0

<!-- hive-publication:v1 id=pub-5955e6087a9351114f38faba102ded4e base=b07b869635e47d986370b19d0dfe583d54143e79 -->
