### PR TITLE
Fix Patrol finding: patrol-hv-symlink-is-never-created-on-faa403c56a

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -930,11 +930,12 @@ if [[ "$hive_link_published" -ne 1 ]] ||
     warn "Hive launchers remain available under ${gem_home}/bin"
   fi
 else
-  # Always refresh hv when we already own it so stale symlinks from
-  # earlier installs don't dangle.
-  if [[ -L "$hv_path" ]] && [[ "$(readlink "$hv_path" 2>/dev/null || true)" == "${gem_home}/bin/hv" ]]; then
-    publish_managed_link "$hv_path" "${gem_home}/bin/hv" "hv"
-  fi
+  # The hive launcher is published and unconflicted, but hv must still exist
+  # as the Apache Hive collision fallback: create it when absent, refresh it
+  # when it is ours (so stale symlinks from earlier installs don't dangle),
+  # and back off only when another program owns the name — matching the qmd
+  # managed-link behavior above.
+  publish_managed_link "$hv_path" "${gem_home}/bin/hv" "hv"
 fi
 
 runtime_preflight

--- a/test/unit/install_script_test.rb
+++ b/test/unit/install_script_test.rb
@@ -156,6 +156,34 @@ class InstallScriptTest < Minitest::Test
     end
   end
 
+  def test_fresh_install_creates_the_hv_collision_fallback_link
+    Dir.mktmpdir("hive-installer-fresh-hv") do |dir|
+      _out, err, status = run_installer(dir, "none")
+
+      assert status.success?, err
+      hv = File.join(dir, "bin", "hv")
+      assert_path_exists hv
+      assert File.symlink?(hv)
+      assert_equal File.realpath(File.join(dir, "prefix", "hive", "gems", "bin", "hv")),
+                   File.realpath(hv)
+    end
+  end
+
+  def test_fresh_install_preserves_an_unowned_hv_when_hive_link_publishes
+    Dir.mktmpdir("hive-installer-unowned-hv") do |dir|
+      bin = File.join(dir, "bin")
+      FileUtils.mkdir_p(bin)
+      unowned = "#!/bin/sh\nprintf 'operator hv\\n'\n"
+      write_file_with_mode(File.join(bin, "hv"), unowned, 0o755)
+
+      _out, err, status = run_installer(dir, "none")
+
+      assert status.success?, err
+      assert_equal unowned, File.binread(File.join(bin, "hv"))
+      assert_includes err, "existing hv"
+    end
+  end
+
   def test_reinstall_does_not_replace_an_existing_managed_user_link
     Dir.mktmpdir("hive-installer-managed-link") do |dir|
       _out, err, status = run_installer(dir, "none")
@@ -168,6 +196,31 @@ class InstallScriptTest < Minitest::Test
       assert status.success?, err
       assert_equal before.ino, File.lstat(link).ino
       assert File.symlink?(link)
+    end
+  end
+
+  def test_reinstall_recreates_a_removed_hv_collision_fallback_link
+    Dir.mktmpdir("hive-installer-reinstall-hv") do |dir|
+      _out, err, status = run_installer(dir, "none")
+
+      assert status.success?, err
+      hv = File.join(dir, "bin", "hv")
+      gem_hive = File.join(dir, "prefix", "hive", "gems", "bin", "hive")
+      assert File.symlink?(hv)
+      FileUtils.rm(hv)
+
+      # Resolve `hive` on PATH to the managed launcher so the reinstall takes
+      # the unconflicted branch instead of the collision-fallback branch.
+      File.symlink(gem_hive, File.join(dir, "fake-bin", "hive"))
+
+      _out, err, status = run_installer(dir, "none")
+
+      assert status.success?, err
+      refute_includes err, "existing hive"
+      assert File.symlink?(hv),
+             "an unconflicted reinstall must recreate a missing managed hv link"
+      assert_equal File.realpath(gem_hive.gsub("/gems/bin/hive", "/gems/bin/hv")),
+                   File.realpath(hv)
     end
   end
 

--- a/wiki/log.d/20260825T000000Z-installer-hv-link-create-if-absent.md
+++ b/wiki/log.d/20260825T000000Z-installer-hv-link-create-if-absent.md
@@ -1,0 +1,45 @@
+# Fix: bash installer never creates the `hv` collision-fallback link on unconflicted installs
+
+- **Date:** 2026-08-25
+- **Actor:** patrol fix agent (generation 1)
+- **Task:** patrol-hv-symlink-is-never-created-on-faa403c56a
+- **Area:** `install.sh` user-bin launcher publication; [[operating]]
+- **Type:** bugfix
+
+## What happened
+
+Patrol flagged that on a host with no prior `hive`/`hv` in
+`${XDG_BIN_HOME:-~/.local/bin}`, a full `install.sh` run never created the `hv`
+symlink even though `${gem_home}/bin/hv` exists and is executable. The hv
+link logic only handled two cases: a conflicting foreign `hive` on PATH (which
+publishes `hv` as fallback) and refreshing an already Hive-owned `hv` symlink.
+The unconflicted branch (fresh install where `hive` publishes cleanly and no
+foreign `hive` is on PATH) had no create-if-absent arm, unlike the qmd managed
+link logic in `install_qmd`.
+
+## Fix
+
+Replaced the refresh-only guard in the unconflicted `else` branch with an
+unconditional `publish_managed_link "$hv_path" "${gem_home}/bin/hv" "hv"` call.
+`publish_managed_link` already implements exactly the desired ownership
+contract: create when absent, leave an identical owned symlink in place, and
+back off with a warning when another program owns the name.
+
+## Regression coverage
+
+- `test_fresh_install_creates_the_hv_collision_fallback_link` — fresh install
+  must create `${XDG_BIN_HOME}/hv -> ${gem_home}/bin/hv`.
+- `test_reinstall_recreates_a_removed_hv_collision_fallback_link` — resolves
+  `hive` on PATH to the managed launcher via a fake-bin shim so the reinstall
+  deterministically takes the unconflicted branch, then asserts a removed `hv`
+  link is recreated (fails on the pre-fix code regardless of host state).
+- `test_fresh_install_preserves_an_unowned_hv_when_hive_link_publishes` — an
+  unrelated operator-owned `hv` is still preserved unchanged.
+
+## Notes
+
+- Local validation requires invoking the suite without bundler's inherited
+  `RUBYOPT=-rbundler/setup`; otherwise the installer subprocess's Ruby preflight
+  fails because Bundler cannot resolve gems under the test tmp `HOME`.
+- Updated [[operating]] to state that `hv` is exposed whenever the destination
+  is absent, not only under collision/refresh conditions.

--- a/wiki/operating.md
+++ b/wiki/operating.md
@@ -150,8 +150,9 @@ work.
 Apache Hive collision: the Homebrew formula installs an `hv` symlink. The bash
 installer always writes a working `${data_home}/gems/bin/hv` wrapper that
 delegates to its GEM_HOME-aware `hive` wrapper, and exposes it under the user
-bin directory when another `hive` is already earlier on PATH or when it is
-reusing an existing owned symlink. User-bin publication leaves an
+bin directory whenever the destination is absent, another `hive` is already
+earlier on PATH, or an existing `hv` symlink is already Hive-owned. User-bin
+publication leaves an
 already-correct managed symlink in place and never force-replaces a
 destination. A concurrent destination creator makes publication fail closed
 into the fallback path. An unrelated `hive` or `hv` file/symlink is preserved;


### PR DESCRIPTION
## Patrol Fix

This pull request repairs one finding tracked by Hive's Patrol Fix workflow.

### Sources

- ordinary_patrol: architecture-install-sh-20260724T175710Z-60128962-2

### Finding evidence

- {"file":"install.sh","line":624,"snippet":"if [[ -n \"$existing_hive\" ]] && [[ -n \"$existing_canon\" ]]","role":"trigger"}
- {"file":"install.sh","line":630,"snippet":"if [[ -L \"$hv_path\" ]]; then","role":"root_cause"}
- {"file":"install.sh","line":20,"snippet":"\\`hive\\` and \\`hv\\` executables are symlinked into","role":"impact"}

### Independent review

The exact patch fixes the missing unconflicted create-if-absent path through the existing ownership-safe link helper. Focused installer validation is green, and the sole broad-suite failure is bounded to unchanged agent-runtime code and is caused by this host resolving grok to an absolute mise path.

- Worktree HEAD b89a4a99def7b78e2c684dec7ae7bc99d2b9eaaf matches the controller and the checkout is clean.
- The diff changes only install.sh, focused installer tests, and matching Wiki documentation; publish_managed_link creates an absent hv link, accepts the exact managed target, and preserves foreign destinations.
- Independent validation passed test/unit/install_script_test.rb with 45 runs and 276 assertions, the four relevant launcher tests with 4 runs and 19 assertions, bash syntax checking, and git diff whitespace checking.
- The failing AgentCliRuntimeRuntimeTest source is byte-identical to the parent commit and independently fails because grok resolves to /home/asterio/.local/share/mise/installs/npm-xai-official-grok/1.0.4/node_modules/.bin/grok; no agent-runtime file is changed by this patch.

### Validation

Verdict: failed
- ordinary:test: exit 1
- agent:installer-focused-suite-green: exit 0
- agent:regression-fresh-install-creates-hv: exit 0
- agent:regression-unconflicted-reinstall-recreates-hv: exit 0
- agent:regression-operator-hv-preserved: exit 0
- agent:installer-script-syntax: exit 0
- agent:fix-commit-present-on-branch: exit 0

<!-- hive-publication:v1 id=pub-6d0aa4a46ce1845ebfce4593aec817c2 base=b07b869635e47d986370b19d0dfe583d54143e79 -->
