### PR TITLE
fix(attempts): retain typed Patrol failure diagnostics

### DIFF
--- a/config/component-boundaries.yml
+++ b/config/component-boundaries.yml
@@ -249,6 +249,7 @@ components:
         - Hive::PatrolFix::ReviewReceipt
         - Hive::PatrolFix::Transition
         - Hive::PatrolFix::SuccessorMaterializer
+        - Hive::PatrolFix::AttemptDiagnostic
       errors:
         - Hive::PatrolFix::AdmissionStore::Error
         - Hive::PatrolFix::SourceSnapshot::InvalidSnapshot
@@ -262,6 +263,7 @@ components:
         - Hive::PatrolFix::ReviewReceipt::InvalidReport
         - Hive::PatrolFix::Transition::InvalidTransition
         - Hive::PatrolFix::SuccessorMaterializer::InvalidSuccessor
+        - Hive::PatrolFix::AttemptDiagnostic::InvalidDiagnostic
     owned_paths:
       - lib/hive/patrol_fix.rb
       - lib/hive/patrol_fix/task_manifest.rb
@@ -281,11 +283,13 @@ components:
       - lib/hive/patrol_fix/review_receipt.rb
       - lib/hive/patrol_fix/transition.rb
       - lib/hive/patrol_fix/successor_materializer.rb
+      - lib/hive/patrol_fix/attempt_diagnostic.rb
       - schemas/hive-patrol-fix-decision.v1.json
       - schemas/hive-patrol-fix-task-manifest.v1.json
       - schemas/hive-patrol-fix-receipt.v1.json
       - schemas/hive-patrol-fix-projection.v1.json
       - schemas/hive-patrol-fix-dogfood-report.v1.json
+      - schemas/hive-patrol-fix-attempt-diagnostic.v1.json
     state_contracts:
       - "The strict task manifest binds every source revision and one canonical task generation while append-only receipts bind exact evidence generation"
       - "Equivalent evidence may add provenance within a generation; materially changed evidence advances exactly one generation and invalidates old receipts"
@@ -304,6 +308,7 @@ components:
       - "Source provenance includes source engine, identity, target revision, evidence, affected code, reproduction guidance, discovery run, and semantic lineage"
       - "Source snapshots and admission records are canonical, size bounded, digest bound, and reject secret-like material"
       - "Dogfood reports bind one source occurrence through ordered workflow observations to one exact publication receipt and zero-duplicate replay counts"
+      - "Attempt diagnostics are append-only, receipt-bound, secret-redacted typed records with exact attempt, ownership generation, phase, and private log identity"
     lock_contracts:
       - "Manifest replacement is atomic and receipts append under a task-local journal lock"
       - "Patrol-fix moves also hold a stable slug lock outside the moving task folder and journal intent before move plus committed reconciliation afterward"
@@ -315,10 +320,12 @@ components:
       - hive/atomic_file
       - hive/agent_git_gate
       - hive/git_ops
+      - hive/github_publication
       - hive/gh/repository_identity
       - hive/git_ref
       - hive/lock
       - hive/managed_directory
+      - hive/output_reference
       - hive/secret_patterns
       - hive/task
       - hive/task_capture
@@ -363,6 +370,7 @@ components:
       - test/unit/patrol_fix/review_receipt_test.rb
       - test/unit/patrol_fix/transition_test.rb
       - test/unit/patrol_fix/successor_materializer_test.rb
+      - test/unit/attempts/patrol_dispatch_replay_test.rb
       - test/unit/stages/patrol_fix/publish_test.rb
     migration_exceptions: []
 

--- a/lib/hive.rb
+++ b/lib/hive.rb
@@ -79,6 +79,7 @@ module Hive
       "hive-patrol-fix-receipt" => 1,
       "hive-patrol-fix-projection" => 1,
       "hive-patrol-fix-dogfood-report" => 1,
+      "hive-patrol-fix-attempt-diagnostic" => 1,
       "hive-refactor-patrol" => 4,
       "hive-refactor-patrol-jobs" => 2,
       "hive-refactor-patrol-thesis" => 4,

--- a/lib/hive/attempts/context.rb
+++ b/lib/hive/attempts/context.rb
@@ -1,5 +1,6 @@
 require "hive/attempts/capability"
 require "hive/attempts/command_progress"
+require "hive/attempts/diagnostic_channel"
 require "hive/attempts/evidence_channel"
 require "hive/attempts/store"
 require "hive/stringify_keys"
@@ -68,6 +69,9 @@ module Hive
               route: record["routing"].fetch("route")
             )
           end
+          diagnostic_writer = DiagnosticChannel::Writer.for_fd(
+            values["HIVE_ATTEMPT_DIAGNOSTIC_FD"]
+          )
           @installed = new(
             attempt_id: record.attempt_id,
             task_generation: record.task_input_epoch,
@@ -78,7 +82,8 @@ module Hive
             progress_token: record["progress_token"],
             predecessor_attempt_id: record["predecessor_attempt_id"],
             routing: record["routing"],
-            evidence_writer: evidence_writer
+            evidence_writer: evidence_writer,
+            diagnostic_writer: diagnostic_writer
           )
         rescue Hive::Error, SystemCallError, IOError => e
           raise StoreError, "durable attempt context rejected: #{e.message}"
@@ -181,6 +186,7 @@ module Hive
       def initialize(attempt_id:, task_generation:, ownership_generation: nil,
                      project: nil, task_slug: nil, intended_stage: nil,
                      routing: { "mode" => "legacy" }, evidence_writer: nil,
+                     diagnostic_writer: nil,
                      progress_token: nil, predecessor_attempt_id: nil)
         @attempt_id = attempt_id.to_s
         @task_generation, bridged_ownership = numeric_generation_or_legacy(task_generation)
@@ -193,6 +199,7 @@ module Hive
         @predecessor_attempt_id = predecessor_attempt_id&.to_s
         @routing = deep_freeze(Hive::StringifyKeys.call(routing))
         @evidence_writer = evidence_writer
+        @diagnostic_writer = diagnostic_writer
         raise ArgumentError, "attempt context requires an attempt ID" if @attempt_id.empty?
         raise ArgumentError, "attempt context task generation must be non-negative" if @task_generation.negative?
       rescue TypeError
@@ -220,8 +227,15 @@ module Hive
         @evidence_writer.write(signal)
       end
 
+      def publish_attempt_diagnostic(document)
+        return false unless @diagnostic_writer
+
+        @diagnostic_writer.write(document)
+      end
+
       def close
         @evidence_writer&.close
+        @diagnostic_writer&.close
         true
       end
 

--- a/lib/hive/attempts/diagnostic_channel.rb
+++ b/lib/hive/attempts/diagnostic_channel.rb
@@ -1,0 +1,84 @@
+require "json"
+require "hive/patrol_fix/attempt_diagnostic"
+
+module Hive
+  module Attempts
+    # One child-to-supervisor diagnostic frame. The bound stays below POSIX
+    # PIPE_BUF so a managed worker can publish once without a concurrent drain
+    # and without interleaving bytes from any inherited writer.
+    module DiagnosticChannel
+      module_function
+
+      MAX_FRAME_BYTES = 3_584
+      STATUSES = Hive::PatrolFix::AttemptDiagnostic::TRANSPORT_STATUSES
+      ReadResult = Data.define(:document, :status)
+
+      class Writer
+        def self.for_fd(value)
+          io = IO.for_fd(Integer(value), "w", autoclose: true)
+          io.close_on_exec = true
+          new(io)
+        rescue ArgumentError, TypeError, Errno::EBADF
+          nil
+        end
+
+        def initialize(io)
+          @io = io
+          @attempted = false
+        end
+
+        def write(document)
+          raise IOError, "attempt diagnostic frame was already written" if @attempted
+
+          @attempted = true
+
+          Hive::PatrolFix::AttemptDiagnostic.validate!(
+            document, require_log_reference: false
+          )
+          frame = JSON.generate(document) + "\n"
+          if frame.bytesize > MAX_FRAME_BYTES
+            raise IOError, "attempt diagnostic frame exceeds #{MAX_FRAME_BYTES} bytes"
+          end
+
+          written = @io.syswrite(frame)
+          raise IOError, "attempt diagnostic frame write was incomplete" unless written == frame.bytesize
+
+          true
+        ensure
+          close if @attempted
+        end
+
+        def close
+          @io.close unless @io.closed?
+          true
+        rescue IOError
+          false
+        end
+      end
+
+      def read(io)
+        return ReadResult.new(document: nil, status: "missing") unless io
+
+        bytes = io.read(MAX_FRAME_BYTES + 1).to_s
+        return ReadResult.new(document: nil, status: "missing") if bytes.empty?
+        return ReadResult.new(document: nil, status: "oversized") if bytes.bytesize > MAX_FRAME_BYTES
+        return ReadResult.new(document: nil, status: "malformed") unless bytes.end_with?("\n")
+
+        lines = bytes.lines
+        return ReadResult.new(document: nil, status: "duplicate") unless lines.length == 1
+
+        document = JSON.parse(lines.fetch(0))
+        Hive::PatrolFix::AttemptDiagnostic.validate!(
+          document, require_log_reference: false
+        )
+        ReadResult.new(document: document, status: "valid")
+      rescue JSON::ParserError, Hive::PatrolFix::AttemptDiagnostic::InvalidDiagnostic
+        ReadResult.new(document: nil, status: "malformed")
+      rescue IOError, SystemCallError
+        ReadResult.new(document: nil, status: "unavailable")
+      ensure
+        io&.close unless io&.closed?
+      end
+    end
+  end
+end

--- a/lib/hive/attempts/store.rb
+++ b/lib/hive/attempts/store.rb
@@ -4,6 +4,7 @@ require "fileutils"
 require "hive/atomic_file"
 require "hive/attempts/capability"
 require "hive/attempts/record"
+require "hive/output_reference"
 require "hive/point_storage"
 require "hive/stringify_keys"
 require "hive/paths"
@@ -31,6 +32,7 @@ module Hive
         def initialize(store)
           @store = store
           @bindings = {}
+          @terminal_diagnostic_bindings = {}
         end
 
         def fetch_projection_binding(attempt_id)
@@ -38,6 +40,23 @@ module Hive
           return @bindings[key] if @bindings.key?(key)
 
           @bindings[key] = @store.fetch_projection_binding(attempt_id)
+        end
+
+        def fetch_terminal_diagnostic_binding(attempt_id)
+          key = attempt_id.to_s
+          return @terminal_diagnostic_bindings[key] if @terminal_diagnostic_bindings.key?(key)
+
+          record = @store.fetch(key)
+          @terminal_diagnostic_bindings[key] = record&.final? ? {
+            "attempt_id" => record.attempt_id,
+            "stage" => record["intended_stage"],
+            "task_generation" => record.task_generation,
+            "receipt" => record.receipt
+          } : nil
+        end
+
+        def read_output(reference, max_bytes:)
+          @store.read_output(reference, max_bytes: max_bytes)
         end
       end
 
@@ -220,6 +239,12 @@ module Hive
         end
 
         path
+      end
+
+      def read_output(reference, max_bytes:)
+        Hive::OutputReference.read(reference, root: root, max_bytes: max_bytes)
+      rescue Hive::InvalidOutputReference => e
+        raise StoreError, e.message
       end
 
       def create_launching(**attributes)

--- a/lib/hive/attempts/supervisor.rb
+++ b/lib/hive/attempts/supervisor.rb
@@ -1,10 +1,14 @@
 require "json"
 require "rbconfig"
+require "hive/atomic_file"
 require "hive/attempts/capability"
+require "hive/attempts/diagnostic_channel"
 require "hive/attempts/evidence_channel"
+require "hive/attempts/command_progress"
 require "hive/attempts/store"
 require "hive/attempts/stream_log"
 require "hive/lock"
+require "hive/patrol_fix/attempt_diagnostic"
 
 module Hive
   module Attempts
@@ -35,6 +39,8 @@ module Hive
         @install_signal_handlers = install_signal_handlers
         @ready_sent = false
         @cancel_reason = nil
+        @cancel_signal = nil
+        @worker_signal = nil
         @worker_pid = nil
         @worker_pgid = nil
       end
@@ -57,7 +63,7 @@ module Hive
         signal_ready("claimed" => true, "attempt_id" => record.attempt_id, "pid" => Process.pid)
         install_signal_handlers! if @install_signal_handlers
 
-        exit_status, outcome, record, provider_signal = run_worker(record, log)
+        exit_status, outcome, record, provider_signal, diagnostic_frame = run_worker(record, log)
         log.close
         log_reference = OutputReference.build(log.path, root: @store.root)
         if provider_signal
@@ -69,10 +75,17 @@ module Hive
           record: record,
           source_reference: log_reference
         )
+        output_references = record["current_outputs"].dup
+        diagnostic_reference = materialize_attempt_diagnostic(
+          record, diagnostic_frame, log_reference: log_reference,
+          exit_status: exit_status, outcome: outcome,
+          provider_signal: provider_signal
+        )
+        output_references << diagnostic_reference if diagnostic_reference
         terminal = @store.terminalize(
           record, outcome: outcome, exit_status: exit_status,
           final_checkpoint: record.checkpoint,
-          output_references: record["current_outputs"],
+          output_references: output_references,
           log_reference: log_reference, provider_evidence: provider_evidence,
           now: @clock.call
         )
@@ -89,9 +102,15 @@ module Hive
           current = @store.fetch(@attempt_id)
           if current&.state == "running"
             reference = OutputReference.build(log.path, root: @store.root)
+            output_references = current["current_outputs"].dup
+            diagnostic_reference = materialize_attempt_diagnostic(
+              current, nil, log_reference: reference,
+              exit_status: Hive::ExitCodes::SOFTWARE, outcome: "failed"
+            )
+            output_references << diagnostic_reference if diagnostic_reference
             @store.terminalize(
               current, outcome: "failed", exit_status: Hive::ExitCodes::SOFTWARE,
-              final_checkpoint: current.checkpoint, output_references: current["current_outputs"],
+              final_checkpoint: current.checkpoint, output_references: output_references,
               log_reference: reference, now: @clock.call
             )
           end
@@ -120,18 +139,22 @@ module Hive
         if hive_worker?(record)
           gate_r, gate_w = IO.pipe
           context_r, context_w = IO.pipe
+          diagnostic_r, diagnostic_w = IO.pipe
           context_w.write(@claim_capability)
           context_w.close
           gate_r.close_on_exec = false
           context_r.close_on_exec = false
+          diagnostic_w.close_on_exec = false
           env.merge!(
             "HIVE_ATTEMPT_INTERNAL" => "1",
             "HIVE_ATTEMPT_ID" => record.attempt_id,
             "HIVE_ATTEMPT_GATE_FD" => gate_r.fileno.to_s,
-            "HIVE_ATTEMPT_CONTEXT_FD" => context_r.fileno.to_s
+            "HIVE_ATTEMPT_CONTEXT_FD" => context_r.fileno.to_s,
+            "HIVE_ATTEMPT_DIAGNOSTIC_FD" => diagnostic_w.fileno.to_s
           )
           spawn_options[gate_r.fileno] = gate_r.fileno
           spawn_options[context_r.fileno] = context_r.fileno
+          spawn_options[diagnostic_w.fileno] = diagnostic_w.fileno
           if record["routing"]["mode"] == "explicit"
             evidence_r, evidence_w = IO.pipe
             evidence_w.close_on_exec = false
@@ -145,6 +168,7 @@ module Hive
         gate_r&.close unless gate_r&.closed?
         context_r&.close unless context_r&.closed?
         evidence_w&.close unless evidence_w&.closed?
+        diagnostic_w&.close unless diagnostic_w&.closed?
         stdout_w.close
         stderr_w.close
         worker_identity = process_identity(@worker_pid)
@@ -230,19 +254,148 @@ module Hive
         end
 
         exit_status = forced_exit || status_exit(status)
+        @worker_signal = signal_name(status.termsig) if status && !status.exited?
         outcome = @cancel_reason ? "cancelled" : (exit_status.zero? ? "succeeded" : "failed")
         provider_signal = EvidenceChannel.read(
           evidence_r,
           route: record["routing"].fetch("route")
         ) if evidence_r
-        [ exit_status, outcome, record, provider_signal ]
+        diagnostic_frame = DiagnosticChannel.read(diagnostic_r) if diagnostic_r
+        [ exit_status, outcome, record, provider_signal, diagnostic_frame ]
       ensure
         [
           stdout_r, stdout_w, stderr_r, stderr_w, gate_r, gate_w,
-          context_r, context_w, evidence_r, evidence_w
+          context_r, context_w, evidence_r, evidence_w,
+          diagnostic_r, diagnostic_w
         ].compact.each do |io|
           io.close unless io.closed?
         end
+      end
+
+      def materialize_attempt_diagnostic(record, frame, log_reference:, exit_status:, outcome:,
+                                         provider_signal: nil)
+        return nil if outcome == "succeeded"
+        return nil unless patrol_fix_attempt?(record)
+
+        transport_status = frame&.status || "missing"
+        document = finalize_or_synthesize_diagnostic(
+          record, frame, log_reference: log_reference,
+          exit_status: exit_status, outcome: outcome,
+          transport_status: transport_status, provider_signal: provider_signal
+        )
+        path = @store.output_path(
+          record.attempt_id,
+          Hive::PatrolFix::AttemptDiagnostic::FILENAME,
+          create_directory: true
+        )
+        persist_diagnostic_once(path, document)
+        OutputReference.build(path, root: @store.root)
+      end
+
+      def finalize_or_synthesize_diagnostic(record, frame, log_reference:, exit_status:,
+                                            outcome:, transport_status:, provider_signal: nil)
+        if frame&.document
+          begin
+            return Hive::PatrolFix::AttemptDiagnostic.finalize(
+              frame.document,
+              log_reference: log_reference,
+              expected_attempt_id: record.attempt_id,
+              expected_stage: record["intended_stage"],
+              expected_task_generation: record.task_generation,
+              transport_status: transport_status,
+              provider_signal: provider_signal,
+              provider_name: record["provider"]
+            )
+          rescue Hive::PatrolFix::AttemptDiagnostic::InvalidDiagnostic
+            transport_status = "malformed"
+          end
+        end
+
+        envelope = {
+          "phase" => "terminal",
+          "status" => outcome == "cancelled" ? "cancelled" : "error",
+          "exit_code" => exit_status,
+          "timed_out" => @cancel_reason == :timeout,
+          "cancelled" => outcome == "cancelled",
+          "signal" => @worker_signal || @cancel_signal,
+          "report_status" => "unknown",
+          "firewall_status" => "unknown",
+          "custody_status" => "unknown"
+        }
+        if provider_signal
+          envelope.merge!(
+            "provider" => record["provider"],
+            "provider_failure" => provider_signal.fetch("failure_class"),
+            "provider_provenance" => provider_signal.fetch("provenance"),
+            "retry_at" => provider_signal["reset_hint_seconds"]
+          )
+        end
+        Hive::PatrolFix::AttemptDiagnostic.normalize(
+          envelope,
+          stage: record["intended_stage"],
+          task_generation: record.task_generation,
+          attempt_id: record.attempt_id,
+          recorded_at: @clock.call,
+          transport_status: transport_status,
+          log_reference: log_reference
+        )
+      end
+
+      def patrol_fix_attempt?(record)
+        require "hive/task_resolver"
+        target = Array(record["worker_argv"])[2].to_s
+        return false if target.empty?
+
+        task = Hive::TaskResolver.new(target, project_filter: record["project"]).resolve
+        Hive::Attempts::CommandProgress.task_progress?(task)
+      rescue Hive::Error, SystemCallError
+        false
+      end
+
+      def persist_diagnostic_once(path, document)
+        source = JSON.generate(document) + "\n"
+        flags = File::WRONLY | File::CREAT | File::EXCL
+        flags |= File::NOFOLLOW if File.const_defined?(:NOFOLLOW)
+        File.open(path, flags, 0o600) do |file|
+          file.write(source)
+          file.flush
+          file.fsync
+        end
+        Hive::AtomicFile.fsync_directory(File.dirname(path))
+        true
+      rescue Errno::EEXIST
+        existing = read_existing_diagnostic(path)
+        raise Hive::Attempts::StoreError, "attempt diagnostic immutable bytes conflict" unless existing == document
+
+        true
+      rescue JSON::ParserError, SystemCallError, IOError => e
+        raise Hive::Attempts::StoreError, "attempt diagnostic storage failed: #{e.message}"
+      end
+
+      def read_existing_diagnostic(path)
+        flags = File::RDONLY | File::NONBLOCK
+        flags |= File::NOFOLLOW if File.const_defined?(:NOFOLLOW)
+        bytes = File.open(path, flags) do |file|
+          stat = file.stat
+          unless stat.file? && stat.nlink == 1
+            raise Hive::Attempts::StoreError, "attempt diagnostic is not a single regular file"
+          end
+          if stat.size > Hive::PatrolFix::AttemptDiagnostic::MAX_BYTES
+            raise Hive::Attempts::StoreError, "attempt diagnostic exceeds its size limit"
+          end
+
+          file.read(Hive::PatrolFix::AttemptDiagnostic::MAX_BYTES + 1).to_s
+        end
+        if bytes.bytesize > Hive::PatrolFix::AttemptDiagnostic::MAX_BYTES
+          raise Hive::Attempts::StoreError, "attempt diagnostic exceeds its size limit"
+        end
+
+        document = JSON.parse(bytes)
+        Hive::PatrolFix::AttemptDiagnostic.validate!(document)
+        document
+      rescue JSON::ParserError, Hive::PatrolFix::AttemptDiagnostic::InvalidDiagnostic,
+             SystemCallError, IOError => e
+        raise Hive::Attempts::StoreError, "attempt diagnostic storage failed: #{e.message}"
       end
 
       def drain_reader(io, readers, log)
@@ -362,8 +515,15 @@ module Hive
 
       def install_signal_handlers!
         %w[TERM INT].each do |signal|
-          Signal.trap(signal) { @cancel_reason ||= :signal }
+          Signal.trap(signal) do
+            @cancel_signal ||= signal
+            @cancel_reason ||= :signal
+          end
         end
+      end
+
+      def signal_name(number)
+        Signal.list.key(number.to_i) || number.to_s
       end
 
       def signal_ready(payload)

--- a/lib/hive/commands/status.rb
+++ b/lib/hive/commands/status.rb
@@ -1,4 +1,5 @@
 require "json"
+require "digest"
 require "time"
 require "hive/agent_limit"
 require "hive/config"
@@ -17,6 +18,7 @@ require "hive/diagnostic_helpers"
 require "hive/secret_patterns"
 require "hive/task_action"
 require "hive/attempts/store"
+require "hive/patrol_fix/attempt_diagnostic"
 require "hive/task_projection/store"
 require "hive/task_closure"
 require "hive/implementation_identity/resolver"
@@ -2012,7 +2014,7 @@ module Hive
             suggested_command: action.command,
             outcomes: action.allowed_outcomes,
             next_action: action.next_action,
-            diagnostic: with_diagnostic ? action.diagnostic : nil,
+            diagnostic: with_diagnostic ? (attempt_diagnostic_for(row) || action.diagnostic) : nil,
             condition_gate: action.condition_gate&.to_h,
             condition_migration: action.migration_selection.to_h,
             condition_warning: action.condition_warning,
@@ -2021,6 +2023,89 @@ module Hive
             state_label: condition_state_label(row, action)
           )
         end
+      end
+
+      def attempt_diagnostic_for(row)
+        return nil unless row[:workflow].to_s == Hive::PatrolFix::WORKFLOW_ID.to_s
+
+        identity = row[:projection_data].is_a?(Hash) ? row[:projection_data]["identity"] : nil
+        attempt_id = identity.is_a?(Hash) ? identity["attempt_id"].to_s : ""
+        return nil if attempt_id.empty? || attempt_id == Hive::TaskJournal::LEGACY_ATTEMPT_ID
+
+        attempt = Array(row.dig(:projection_data, "journal", "attempts")).find do |candidate|
+          candidate.is_a?(Hash) && candidate["attempt_id"] == attempt_id
+        end
+        return nil unless attempt && attempt["state"] == "terminal" &&
+                          %w[failed cancelled].include?(attempt["outcome"])
+
+        binding = status_attempt_store.fetch_terminal_diagnostic_binding(attempt_id)
+        return nil unless binding.is_a?(Hash) && binding["attempt_id"] == attempt_id
+
+        receipt = binding["receipt"]
+        return nil unless receipt.is_a?(Hash)
+
+        diagnostic_path = File.join(
+          "outputs", attempt_id, Hive::PatrolFix::AttemptDiagnostic::FILENAME
+        )
+        reference = Array(receipt["output_references"]).find do |candidate|
+          candidate.is_a?(Hash) && candidate["path"] == diagnostic_path
+        end
+        return nil unless reference
+
+        document = JSON.parse(status_attempt_store.read_output(
+          reference, max_bytes: Hive::PatrolFix::AttemptDiagnostic::MAX_BYTES
+        ))
+        Hive::PatrolFix::AttemptDiagnostic.validate!(document)
+        return nil unless document["attempt_id"] == attempt_id &&
+                          document["correlation_id"] == attempt_id &&
+                          document["stage"] == binding["stage"].to_s &&
+                          document["task_generation"] == binding["task_generation"].to_s &&
+                          document["log_reference"] == receipt["log_reference"]
+
+        diagnostic_projection(document, reference)
+      rescue JSON::ParserError, Hive::Error, SystemCallError, IOError
+        nil
+      end
+
+      def diagnostic_projection(document, reference)
+        paths = [ reference["path"], document.dig("log_reference", "path") ].compact.uniq
+        {
+          "summary" => "#{document.fetch('code')} (#{document.fetch('owner')})".byteslice(0, 120),
+          "detail" => document["detail"] || "No provider-safe detail was emitted.",
+          "source" => "artifact",
+          "source_path" => reference.fetch("path"),
+          "artifact_paths" => paths,
+          "generated_by" => "local",
+          "marker_signature" => Digest::SHA256.hexdigest(JSON.generate(reference)),
+          "suggested_next_action" => nil,
+          "updated_at" => document.fetch("recorded_at"),
+          "code" => document.fetch("code"),
+          "owner" => document.fetch("owner"),
+          "workflow" => document.fetch("workflow"),
+          "stage" => document.fetch("stage"),
+          "phase" => document.fetch("phase"),
+          "status" => document.fetch("status"),
+          "agent_reason" => document.fetch("agent_reason"),
+          "exit_code" => document.fetch("exit_code"),
+          "timed_out" => document.fetch("timed_out"),
+          "cancelled" => document.fetch("cancelled"),
+          "signal" => document.fetch("signal"),
+          "provider" => document.fetch("provider"),
+          "attempt_id" => document.fetch("attempt_id"),
+          "correlation_id" => document.fetch("correlation_id"),
+          "task_generation" => document.fetch("task_generation"),
+          "diagnostic_digest" => reference.fetch("sha256"),
+          "diagnostic_reference" => reference,
+          "log_reference" => document.fetch("log_reference"),
+          "report_status" => document.fetch("report_status"),
+          "report_parser" => document.fetch("report_parser"),
+          "firewall_status" => document.fetch("firewall_status"),
+          "firewall_restoration" => document.fetch("firewall_restoration"),
+          "custody_status" => document.fetch("custody_status"),
+          "transport_status" => document.fetch("transport_status"),
+          "redaction_status" => document.fetch("redaction_status"),
+          "secret_policy_version" => document.fetch("secret_policy_version")
+        }
       end
 
       # Dependency admission reports invalid project configuration on each

--- a/lib/hive/operational_status.rb
+++ b/lib/hive/operational_status.rb
@@ -626,6 +626,11 @@ module Hive
       if PLAN_REVIEW_REPAIR_ACTIONS.include?(row["action"])
         return [ "needs_repair", operational_review_owner(row) ]
       end
+      if (diagnostic = typed_attempt_diagnostic(row))
+        owner = diagnostic.fetch("owner")
+        state = owner == "provider" ? "waiting_on_provider_or_scheduler" : "needs_repair"
+        return [ state, owner ]
+      end
       return [ "waiting_on_provider_or_scheduler", "scheduler" ] if automatic_error_retry?(project, row)
       return [ "needs_repair", "operator" ] if repair?(row)
       return [ "waiting_on_provider_or_scheduler", "provider" ] if row["held"]
@@ -937,6 +942,12 @@ module Hive
       elsif row["admission_error"]
         error = row.fetch("admission_error")
         reasons << reason(error.fetch("reason_code"), error.fetch("safe_correction"), "dependency")
+      elsif (diagnostic = typed_attempt_diagnostic(row))
+        reasons << reason(
+          diagnostic.fetch("code"),
+          diagnostic["detail"] || diagnostic.fetch("summary"),
+          "attempt_diagnostic"
+        )
       elsif automatic_error_retry?(project, row)
         marker = row["marker"].to_s.upcase
         reasons << reason(
@@ -981,6 +992,16 @@ module Hive
         reasons << reason("condition_warning", row.fetch("condition_warning"), "condition")
       end
       reasons
+    end
+
+    def typed_attempt_diagnostic(row)
+      diagnostic = row["diagnostic"]
+      return nil unless diagnostic.is_a?(Hash)
+      return nil unless diagnostic["source"] == "artifact" &&
+                        diagnostic["code"].to_s.match?(Hive::PatrolFix::AttemptDiagnostic::CODE_PATTERN) &&
+                        Hive::PatrolFix::AttemptDiagnostic::OWNER_VALUES.include?(diagnostic["owner"])
+
+      diagnostic
     end
 
     def operational_review_owner(row)

--- a/lib/hive/output_reference.rb
+++ b/lib/hive/output_reference.rb
@@ -1,6 +1,7 @@
 require "digest"
 require "fileutils"
 require "hive"
+require "hive/stringify_keys"
 require "pathname"
 
 module Hive
@@ -61,6 +62,40 @@ module Hive
       ::Digest::SHA256.file(candidate).hexdigest == reference.fetch("sha256")
     rescue InvalidOutputReference, Errno::ENOENT, Errno::EACCES
       false
+    end
+
+    def read(reference, root:, max_bytes:)
+      unless max_bytes.is_a?(Integer) && max_bytes.positive?
+        raise InvalidOutputReference, "attempt output read bound is invalid"
+      end
+
+      value = Hive::StringifyKeys.call(reference)
+      validate_shape!(value)
+      root_path = File.realpath(root)
+      path = File.join(root_path, value.fetch("path"))
+      lexical_parent = File.dirname(path)
+      parent = File.realpath(lexical_parent)
+      raise InvalidOutputReference, "attempt output parent is redirected" unless parent == lexical_parent
+
+      ensure_contained!(parent, root_path) unless parent == root_path
+      flags = File::RDONLY | File::NONBLOCK
+      flags |= File::NOFOLLOW if File.const_defined?(:NOFOLLOW)
+      bytes = File.open(path, flags) do |file|
+        stat = file.stat
+        unless stat.file? && stat.nlink == 1
+          raise InvalidOutputReference, "attempt output is not a single regular file"
+        end
+        raise InvalidOutputReference, "attempt output exceeds read bound" if stat.size > max_bytes
+
+        file.read(max_bytes + 1)
+      end
+      unless bytes.bytesize == value.fetch("size") &&
+             Digest::SHA256.hexdigest(bytes) == value.fetch("sha256")
+        raise InvalidOutputReference, "attempt output reference does not verify"
+      end
+      bytes
+    rescue SystemCallError, IOError => e
+      raise InvalidOutputReference, "attempt output is unavailable: #{e.message}"
     end
 
     def safe_relative_path?(path)

--- a/lib/hive/patrol_fix.rb
+++ b/lib/hive/patrol_fix.rb
@@ -25,6 +25,7 @@ module Hive
     autoload :Transition, "hive/patrol_fix/transition"
     autoload :SuccessorMaterializer, "hive/patrol_fix/successor_materializer"
     autoload :PublicationReceipt, "hive/patrol_fix/publication_receipt"
+    autoload :AttemptDiagnostic, "hive/patrol_fix/attempt_diagnostic"
 
     module_function
 

--- a/lib/hive/patrol_fix/attempt_diagnostic.rb
+++ b/lib/hive/patrol_fix/attempt_diagnostic.rb
@@ -1,0 +1,340 @@
+require "json"
+require "time"
+require "hive/output_reference"
+require "hive/patrol_fix"
+require "hive/secret_patterns"
+require "hive/stringify_keys"
+
+module Hive
+  module PatrolFix
+    # One bounded, provider-neutral explanation of a failed Patrol attempt.
+    # Recovery policy deliberately lives above this value; this class only
+    # normalizes trusted process/custody facts and validates the durable bytes.
+    module AttemptDiagnostic
+      module_function
+
+      SCHEMA = "hive-patrol-fix-attempt-diagnostic".freeze
+      SCHEMA_VERSION = 1
+      FILENAME = "patrol-fix-attempt-diagnostic.v1.json".freeze
+      MAX_BYTES = 16 * 1024
+      MAX_DETAIL_BYTES = 2 * 1024
+      WORKFLOW = "patrol_fix".freeze
+      CODE_PATTERN = /\A[a-z][a-z0-9_]*\z/.freeze
+      ANSI_ESCAPE = /\e(?:\[[0-?]*[ -\/]*[@-~]|\][^\a]*(?:\a|\e\\))/.freeze
+      OWNER_VALUES = %w[agent provider hive operator unknown].freeze
+      REDACTION_VALUES = %w[applied omitted failed].freeze
+      TRANSPORT_STATUSES = %w[valid missing oversized malformed duplicate unavailable].freeze
+      REQUIRED_FIELDS = %w[
+        schema schema_version workflow stage phase task_generation attempt_id
+        correlation_id code owner status agent_reason exit_code timed_out cancelled signal
+        provider report_status report_parser firewall_status firewall_restoration
+        custody_status detail redaction_status secret_policy_version transport_status
+        log_reference recorded_at
+      ].freeze
+
+      class InvalidDiagnostic < Hive::Error; end
+
+      def normalize(envelope, stage:, task_generation:, attempt_id:, recorded_at:, redactor: nil,
+                    transport_status: "valid", log_reference: nil)
+        source = Hive::StringifyKeys.call(envelope)
+        detail, redaction_status = safe_detail(source["detail"], redactor: redactor)
+        document = {
+          "schema" => SCHEMA,
+          "schema_version" => SCHEMA_VERSION,
+          "workflow" => WORKFLOW,
+          "stage" => identifier(stage, "stage"),
+          "phase" => bounded_token(source["phase"] || "terminal", "phase"),
+          "task_generation" => identifier(task_generation, "task generation"),
+          "attempt_id" => identifier(attempt_id, "attempt"),
+          "correlation_id" => identifier(attempt_id, "correlation"),
+          "code" => failure_code(source),
+          "owner" => owner_for(source),
+          "status" => bounded_token(source["status"] || "error", "status"),
+          "agent_reason" => optional_token(source["error_reason"] || source["agent_reason"], "agent reason"),
+          "exit_code" => integer_or_nil(source["exit_code"], "exit code"),
+          "timed_out" => source["timed_out"] == true,
+          "cancelled" => source["cancelled"] == true,
+          "signal" => optional_token(source["signal"], "signal"),
+          "provider" => provider_projection(source),
+          "report_status" => bounded_token(source["report_status"] || "unknown", "report status"),
+          "report_parser" => optional_token(source["report_parser"], "report parser"),
+          "firewall_status" => bounded_token(source["firewall_status"] || "unknown", "firewall status"),
+          "firewall_restoration" => optional_token(source["restore_status"] || source["firewall_restoration"], "firewall restoration"),
+          "custody_status" => bounded_token(source["custody_status"] || "unknown", "custody status"),
+          "detail" => detail,
+          "redaction_status" => redaction_status,
+          "secret_policy_version" => Hive::SecretPatterns::POLICY_VERSION,
+          "transport_status" => transport_status,
+          "log_reference" => log_reference && Hive::StringifyKeys.call(log_reference),
+          "recorded_at" => normalize_time(recorded_at)
+        }
+        validate!(document, require_log_reference: !log_reference.nil?)
+        Hive::PatrolFix.deep_freeze(document)
+      end
+
+      def finalize(document, log_reference:, expected_attempt_id:, expected_stage:,
+                   expected_task_generation:, transport_status: "valid", redactor: nil,
+                   provider_signal: nil, provider_name: nil)
+        source = Hive::StringifyKeys.call(document)
+        validate!(source, require_log_reference: false)
+        unless source.fetch("workflow") == WORKFLOW &&
+               source.fetch("attempt_id") == expected_attempt_id.to_s &&
+               source.fetch("correlation_id") == expected_attempt_id.to_s &&
+               source.fetch("stage") == expected_stage.to_s &&
+               source.fetch("task_generation") == expected_task_generation.to_s
+          raise InvalidDiagnostic, "attempt diagnostic identity does not match its terminal receipt"
+        end
+        detail, redaction_status = safe_detail(source["detail"], redactor: redactor)
+        finalized = source.merge(
+          "detail" => detail,
+          "redaction_status" => redaction_status == "failed" ? "failed" : source.fetch("redaction_status"),
+          "transport_status" => transport_status,
+          "log_reference" => Hive::StringifyKeys.call(log_reference)
+        )
+        finalized = apply_provider_signal(
+          finalized, provider_signal: provider_signal, provider_name: provider_name
+        )
+        validate!(finalized, require_log_reference: true)
+        Hive::PatrolFix.deep_freeze(finalized)
+      end
+
+      def validate!(document, require_log_reference: true)
+        value = Hive::StringifyKeys.call(document)
+        unless value.is_a?(Hash) && value.keys.sort == REQUIRED_FIELDS.sort &&
+               value["schema"] == SCHEMA && value["schema_version"] == SCHEMA_VERSION
+          raise InvalidDiagnostic, "attempt diagnostic has an invalid field set or schema"
+        end
+        %w[workflow stage phase task_generation attempt_id correlation_id status].each do |key|
+          strict_identifier(value[key], key)
+        end
+        unless value["code"].is_a?(String) && value["code"].bytesize.between?(1, 128) &&
+               value["code"].match?(CODE_PATTERN)
+          raise InvalidDiagnostic, "attempt diagnostic code is invalid"
+        end
+        raise InvalidDiagnostic, "attempt diagnostic owner is invalid" unless OWNER_VALUES.include?(value["owner"])
+        unless [ true, false ].include?(value["timed_out"]) &&
+               [ true, false ].include?(value["cancelled"])
+          raise InvalidDiagnostic, "attempt diagnostic process flags are invalid"
+        end
+        integer_or_nil(value["exit_code"], "exit code")
+        strict_optional_token(value["agent_reason"], "agent reason")
+        strict_optional_token(value["signal"], "signal")
+        validate_provider!(value["provider"])
+        %w[report_status firewall_status custody_status].each do |key|
+          strict_identifier(value[key], key)
+        end
+        unless TRANSPORT_STATUSES.include?(value["transport_status"])
+          raise InvalidDiagnostic, "attempt diagnostic transport status is invalid"
+        end
+        strict_optional_token(value["report_parser"], "report parser")
+        strict_optional_token(value["firewall_restoration"], "firewall restoration")
+        unless value["detail"].nil? ||
+               (value["detail"].is_a?(String) && value["detail"].valid_encoding? &&
+                value["detail"].bytesize <= MAX_DETAIL_BYTES)
+          raise InvalidDiagnostic, "attempt diagnostic detail is invalid"
+        end
+        unless REDACTION_VALUES.include?(value["redaction_status"]) &&
+               value["secret_policy_version"] == Hive::SecretPatterns::POLICY_VERSION
+          raise InvalidDiagnostic, "attempt diagnostic secret policy is invalid"
+        end
+        if require_log_reference
+          Hive::OutputReference.validate_shape!(value["log_reference"])
+        elsif value["log_reference"]
+          Hive::OutputReference.validate_shape!(value["log_reference"])
+        end
+        Time.iso8601(value.fetch("recorded_at"))
+        encoded = JSON.generate(value)
+        raise InvalidDiagnostic, "attempt diagnostic exceeds #{MAX_BYTES} bytes" if encoded.bytesize > MAX_BYTES
+        if Hive::SecretPatterns.match?(encoded)
+          raise InvalidDiagnostic, "attempt diagnostic contains secret-pattern text"
+        end
+        true
+      rescue Hive::InvalidOutputReference, ArgumentError, TypeError, KeyError => e
+        raise InvalidDiagnostic, e.message
+      end
+
+      def failure_code(source)
+        provider_class = provider_failure_class(source)
+        return provider_class if provider_class
+        return "state_git_index_lock" if source["write_status"] == "lock_conflict"
+        return "secret_policy_publish_blocked" if source["publication_status"] == "blocked_by_policy"
+        return "validation_mutation" if source["authoritative_state_changed"] == true
+        return "fix_worktree_dirty" if source["worktree_status"] == "dirty"
+        return "worktree_head_custody_mismatch" if source["head_relation"] == "unexpected_movement"
+        if source["protected_git_config_changed"] == true
+          return "protected_git_config_tamper"
+        end
+        return "agent_timeout" if source["timed_out"] == true
+        return "agent_cancelled" if source["cancelled"] == true
+        return "agent_signalled" unless source["signal"].nil?
+        return "agent_exit_nonzero" if source["exit_code"].is_a?(Integer) && source["exit_code"] != 0
+        if source["phase"] == "fix_report_admission" || source["report_parser"] == "fix_report"
+          return "fix_report_invalid"
+        end
+        return "agent_report_invalid" if source["report_status"] == "invalid"
+
+        "agent_terminal_failure"
+      end
+      private_class_method :failure_code
+
+      def owner_for(source)
+        code = failure_code(source)
+        return "provider" if code.start_with?("provider_") || code.start_with?("model_")
+        return "agent" if code.start_with?("agent_")
+
+        "hive"
+      end
+      private_class_method :owner_for
+
+      def provider_failure_class(source)
+        failure = source["provider_failure"]
+        value = failure.is_a?(Hash) ? failure["failure_class"] : failure
+        value = source.dig("provider_error", "failure_class") if value.to_s.empty?
+        value = source.dig("provider_signal", "failure_class") if value.to_s.empty?
+        value = provider_kind_code(source.dig("provider_error", "kind")) if value.to_s.empty?
+        value = value.to_s
+        return nil if value.empty?
+
+        value.start_with?("provider_", "model_") ? value : "provider_#{value}"
+      end
+      private_class_method :provider_failure_class
+
+      def provider_kind_code(kind)
+        case kind.to_s
+        when "rate_limited" then "provider_rate_limited"
+        when "provider_limit" then "provider_limit"
+        when "provider_error" then "provider_error"
+        when "model_output_limit" then "model_output_limit"
+        else kind
+        end
+      end
+      private_class_method :provider_kind_code
+
+      def provider_projection(source)
+        error = source["provider_error"] || {}
+        signal = source["provider_signal"] || {}
+        name = source["provider"] || error["provider"]
+        failure_class = provider_failure_class(source)
+        provenance = signal["provenance"] || error["provenance"] ||
+          source["provider_provenance"]
+        hint = source["retry_at"] || signal["reset_hint_seconds"] ||
+          error["reset_hint_seconds"] || error["retry_after"]
+        return nil if [ name, failure_class, provenance, hint ].all?(&:nil?)
+
+        {
+          "name" => optional_token(name, "provider name"),
+          "failure_class" => optional_token(failure_class, "provider failure class"),
+          "retry_hint" => hint.nil? ? nil : bounded_utf8(hint, 128),
+          "provenance" => optional_token(provenance, "provider provenance")
+        }
+      end
+      private_class_method :provider_projection
+
+      def apply_provider_signal(document, provider_signal:, provider_name:)
+        return document unless provider_signal
+
+        signal = Hive::StringifyKeys.call(provider_signal)
+        code = provider_failure_class("provider_failure" => signal.fetch("failure_class"))
+        document.merge(
+          "code" => code,
+          "owner" => "provider",
+          "provider" => {
+            "name" => optional_token(provider_name, "provider name"),
+            "failure_class" => optional_token(code, "provider failure class"),
+            "retry_hint" => signal["reset_hint_seconds"].nil? ? nil :
+              bounded_utf8(signal.fetch("reset_hint_seconds"), 128),
+            "provenance" => optional_token(signal.fetch("provenance"), "provider provenance")
+          }
+        )
+      rescue KeyError => e
+        raise InvalidDiagnostic, "attempt diagnostic provider signal is invalid: #{e.message}"
+      end
+      private_class_method :apply_provider_signal
+
+      def validate_provider!(provider)
+        return true if provider.nil?
+        fields = %w[failure_class name provenance retry_hint]
+        unless provider.is_a?(Hash) && provider.keys.sort == fields
+          raise InvalidDiagnostic, "attempt diagnostic provider is invalid"
+        end
+        %w[name failure_class provenance].each do |key|
+          strict_optional_token(provider[key], "provider #{key}")
+        end
+        strict_optional_token(provider["retry_hint"], "provider retry hint")
+        true
+      end
+      private_class_method :validate_provider!
+
+      def safe_detail(value, redactor: nil)
+        return [ nil, "omitted" ] if value.nil? || value.to_s.empty?
+
+        callable = redactor || Hive::SecretPatterns.method(:redact)
+        text = value.to_s.dup.force_encoding(Encoding::UTF_8).scrub("?")
+        text.gsub!(ANSI_ESCAPE, "")
+        redacted = callable.call(text).to_s
+        [ bounded_utf8(redacted, MAX_DETAIL_BYTES), "applied" ]
+      rescue StandardError
+        [ nil, "failed" ]
+      end
+      private_class_method :safe_detail
+
+      def bounded_utf8(value, max)
+        text = value.to_s.dup.force_encoding(Encoding::UTF_8).scrub("?")
+        return text if text.bytesize <= max
+
+        text.byteslice(0, max).to_s.dup.force_encoding(Encoding::UTF_8).scrub("")
+      end
+      private_class_method :bounded_utf8
+
+      def identifier(value, label)
+        text = value.to_s
+        unless text.bytesize.between?(1, 128) && text.valid_encoding? &&
+               !text.match?(/[\u0000-\u001f\u007f]/)
+          raise InvalidDiagnostic, "attempt diagnostic #{label} is invalid"
+        end
+        text
+      end
+      private_class_method :identifier
+
+      def bounded_token(value, label)
+        identifier(value, label)
+      end
+      private_class_method :bounded_token
+
+      def optional_token(value, label)
+        value.nil? ? nil : bounded_token(value, label)
+      end
+      private_class_method :optional_token
+
+      def strict_identifier(value, label)
+        unless value.is_a?(String)
+          raise InvalidDiagnostic, "attempt diagnostic #{label} is invalid"
+        end
+
+        identifier(value, label)
+      end
+      private_class_method :strict_identifier
+
+      def strict_optional_token(value, label)
+        value.nil? ? nil : strict_identifier(value, label)
+      end
+      private_class_method :strict_optional_token
+
+      def integer_or_nil(value, label)
+        return nil if value.nil?
+        raise InvalidDiagnostic, "attempt diagnostic #{label} is invalid" unless value.is_a?(Integer)
+
+        value
+      end
+      private_class_method :integer_or_nil
+
+      def normalize_time(value)
+        time = value.respond_to?(:utc) ? value.utc : Time.iso8601(value.to_s).utc
+        time.iso8601(6)
+      rescue ArgumentError
+        raise InvalidDiagnostic, "attempt diagnostic recorded_at is invalid"
+      end
+      private_class_method :normalize_time
+    end
+  end
+end

--- a/lib/hive/secret_patterns.rb
+++ b/lib/hive/secret_patterns.rb
@@ -8,6 +8,8 @@ module Hive
   # New patterns must come with at least one test in
   # test/unit/secret_patterns_test.rb (or the consumer's tests).
   module SecretPatterns
+    POLICY_VERSION = 1
+
     PATTERNS = {
       # AWS access key id (AKIA = long-term, ASIA = temporary session token)
       # and secret access key.

--- a/lib/hive/stages/managed_agent_custody.rb
+++ b/lib/hive/stages/managed_agent_custody.rb
@@ -2,6 +2,8 @@ require "open3"
 require "json"
 require "hive/atomic_file"
 require "hive/artifact_firewall"
+require "hive/attempts/context"
+require "hive/patrol_fix/attempt_diagnostic"
 require "hive/stages/base"
 
 module Hive
@@ -94,12 +96,150 @@ module Hive
         end
         status = result.is_a?(Hash) ? result[:status] : :error
         status = :ok if recovered_provider_retry?(result, report)
-        {
+        response = {
           status: status,
           custody: custody_status,
           diagnostic: report&.diagnostic
         }
+        envelope = diagnostic_envelope(
+          result, report, status: status, custody_status: custody_status,
+          provider: profile.name
+        )
+        if status != :ok || custody_status != :clean
+          diagnostic = publish_attempt_diagnostic(envelope, stage: stage)
+          response[:attempt_diagnostic] = diagnostic if diagnostic
+        end
+        response
       end
+
+      def publish_report_invalid(stage:, parser:, detail:)
+        publish_attempt_diagnostic(
+          {
+            "phase" => "report_admission", "status" => "error", "exit_code" => 0,
+            "timed_out" => false, "cancelled" => false, "signal" => nil,
+            "report_status" => "invalid", "report_parser" => parser,
+            "firewall_status" => "clean", "custody_status" => "clean",
+            "detail" => detail
+          },
+          stage: stage
+        )
+      end
+
+      def publish_controller_failure(stage:, error:)
+        publish_attempt_diagnostic(
+          controller_failure_envelope(stage: stage, error: error),
+          stage: stage
+        )
+      end
+
+      def read_report(stage:, parser:, invalid_report:)
+        yield
+      rescue invalid_report => e
+        publish_report_invalid(stage: stage, parser: parser, detail: e.message)
+        raise
+      end
+
+      def publish_attempt_diagnostic(envelope, stage:)
+        context = Hive::Attempts::Context.current
+        return nil unless context
+
+        diagnostic = Hive::PatrolFix::AttemptDiagnostic.normalize(
+          envelope,
+          stage: context.intended_stage || stage,
+          task_generation: context.ownership_generation,
+          attempt_id: context.attempt_id,
+          recorded_at: Time.now.utc
+        )
+        context.publish_attempt_diagnostic(diagnostic)
+        diagnostic
+      rescue Hive::PatrolFix::AttemptDiagnostic::InvalidDiagnostic, IOError, SystemCallError
+        nil
+      end
+
+      def controller_failure_envelope(stage:, error:)
+        message = error.message.to_s
+        envelope = {
+          "phase" => "controller",
+          "status" => "error",
+          "exit_code" => nil,
+          "timed_out" => false,
+          "cancelled" => false,
+          "signal" => nil,
+          "report_status" => "not_applicable",
+          "firewall_status" => "not_applicable",
+          "custody_status" => "unknown",
+          "detail" => message
+        }
+        if error.respond_to?(:code) && error.code.to_s == "secret_detected"
+          envelope.merge!(
+            "phase" => "publication",
+            "publication_status" => "blocked_by_policy"
+          )
+        elsif message.include?("index.lock")
+          envelope.merge!(
+            "phase" => "state_git_write",
+            "write_status" => "lock_conflict"
+          )
+        elsif stage.to_s == "validate" && message.include?("validation changed")
+          envelope.merge!(
+            "phase" => "validation_custody",
+            "authoritative_state_changed" => true,
+            "custody_status" => "mutation"
+          )
+        elsif message.match?(/worktree (?:is dirty|bytes changed)/i)
+          envelope.merge!(
+            "phase" => "fix_worktree_preflight",
+            "worktree_status" => "dirty",
+            "custody_status" => "dirty"
+          )
+        elsif message.match?(/worktree HEAD changed|HEAD custody/i)
+          envelope.merge!(
+            "phase" => "worktree_custody",
+            "head_relation" => "unexpected_movement",
+            "custody_status" => "head_drift"
+          )
+        end
+        envelope
+      end
+      private_class_method :controller_failure_envelope
+
+      def diagnostic_envelope(result, report, status:, custody_status:, provider:)
+        source = result.is_a?(Hash) ? result : {}
+        restore_status = { true => "restored", false => "failed" }.fetch(
+          report&.restored?, "not_attempted"
+        )
+        provider_failure = source[:provider_error].is_a?(Hash) ||
+          source[:provider_signal].is_a?(Hash)
+        {
+          "phase" => "managed_agent",
+          "status" => status.to_s,
+          "exit_code" => source[:exit_code],
+          "timed_out" => source[:timed_out] == true,
+          "cancelled" => source[:cancelled] == true,
+          "signal" => source[:signal],
+          "error_reason" => source[:error_reason],
+          "provider" => provider.to_s,
+          "provider_error" => source[:provider_error],
+          "provider_signal" => source[:provider_signal],
+          "retry_at" => source[:retry_at],
+          "provider_provenance" => source[:final_message_source],
+          "report_status" => report&.required_outputs_valid? ? "valid" : "invalid",
+          "report_parser" => source[:final_message_source],
+          "firewall_status" => report&.status&.to_s || "unavailable",
+          "restore_status" => restore_status,
+          "custody_status" => custody_status.to_s,
+          "protected_git_config_changed" => protected_git_config_changed?(report),
+          "detail" => provider_failure ? nil : (source[:error_message] || report&.diagnostic)
+        }
+      end
+      private_class_method :diagnostic_envelope
+
+      def protected_git_config_changed?(report)
+        Array(report&.tampered_labels).any? do |label|
+          label.to_s.match?(/(?:git config|repository config|worktree config)/i)
+        end
+      end
+      private_class_method :protected_git_config_changed?
 
       # Pi can emit a failed message_end, retry that provider turn internally,
       # then exit zero after writing the current report. Agent keeps the first

--- a/lib/hive/stages/patrol_fix/fix.rb
+++ b/lib/hive/stages/patrol_fix/fix.rb
@@ -61,7 +61,7 @@ module Hive
             )
           end
           validate_agent_run!(run)
-          report = Hive::PatrolFix::FixReport.read(output)
+          report = read_report!(output)
           raise Hive::StageError, "fix agent parked with partial work; preserving the owned worktree" unless report.status == "fixed"
           payload = custody.capture!(
             generation: manifest.dig("task", "generation"),
@@ -98,6 +98,13 @@ module Hive
             "recorded_at" => Time.now.utc.iso8601, "payload" => payload }
         end
         private_class_method :build_receipt
+        def read_report!(path)
+          Hive::Stages::ManagedAgentCustody.read_report(
+            stage: "fix", parser: "fix_report",
+            invalid_report: Hive::PatrolFix::FixReport::InvalidReport
+          ) { Hive::PatrolFix::FixReport.read(path) }
+        end
+        private_class_method :read_report!
 
         def current(store, manifest, kind, stage)
           store.read_all.find { |r| r["kind"] == kind && r["stage"] == stage && r["task"] == manifest["task"] && r["evidence_revision"] == manifest["evidence_revision"] }
@@ -129,8 +136,14 @@ module Hive
         def complete(receipt) = { status: :complete, commit: "patrol-fix fix complete", receipt: receipt }
         private_class_method :complete
         def validate_agent_run!(run)
-          raise Hive::StageError, "fix agent failed" unless run.is_a?(Hash) && run[:status] == :ok
-          raise Hive::StageError, "fix agent modified controller authority: #{run[:diagnostic]}" unless run[:custody] == :clean
+          unless run.is_a?(Hash) && run[:status] == :ok
+            code = run.is_a?(Hash) && run.dig(:attempt_diagnostic, "code")
+            raise Hive::StageError, [ "fix agent failed", code ].compact.join(": ")
+          end
+          unless run[:custody] == :clean
+            diagnostic = run.dig(:attempt_diagnostic, "code") || run[:diagnostic]
+            raise Hive::StageError, "fix agent modified controller authority: #{diagnostic}"
+          end
         end
         private_class_method :validate_agent_run!
       end

--- a/lib/hive/stages/patrol_fix/inbox.rb
+++ b/lib/hive/stages/patrol_fix/inbox.rb
@@ -54,7 +54,7 @@ module Hive
                   "inbox agent changed the controller-selected repository snapshot; preserving bytes for recovery"
           end
 
-          report = Hive::PatrolFix::InboxReport.read(output_path)
+          report = read_report!(output_path)
           receipt = store.append!(decision_receipt(manifest, report, head))
           finish_route(task, receipt, successor_materializer)
         rescue Hive::AgentGitGate::Error => e
@@ -94,6 +94,14 @@ module Hive
           end
         end
         private_class_method :current_decision
+
+        def read_report!(path)
+          Hive::Stages::ManagedAgentCustody.read_report(
+            stage: "inbox", parser: "inbox_report",
+            invalid_report: Hive::PatrolFix::InboxReport::InvalidReport
+          ) { Hive::PatrolFix::InboxReport.read(path) }
+        end
+        private_class_method :read_report!
 
         def decision_receipt(manifest, report, head)
           payload = {
@@ -139,10 +147,13 @@ module Hive
 
         def validate_agent_run!(run)
           unless run.is_a?(Hash) && run[:status] == :ok
-            raise Hive::StageError, "inbox agent did not produce a successful structured result"
+            code = run.is_a?(Hash) && run.dig(:attempt_diagnostic, "code")
+            suffix = code ? "; diagnostic=#{code}" : ""
+            raise Hive::StageError,
+                  "inbox agent did not produce a successful structured result#{suffix}"
           end
           unless run[:custody] == :clean
-            diagnostic = run[:diagnostic].to_s[0, 256]
+            diagnostic = run.dig(:attempt_diagnostic, "code") || run[:diagnostic].to_s[0, 256]
             raise Hive::StageError,
                   "inbox agent modified controller authority or omitted its report; #{diagnostic}".rstrip
           end

--- a/lib/hive/stages/patrol_fix/review.rb
+++ b/lib/hive/stages/patrol_fix/review.rb
@@ -56,7 +56,7 @@ module Hive
             )
           end
           validate_agent_run!(run)
-          report = Hive::PatrolFix::ReviewReceipt.read(output, allowed_routes: allowed)
+          report = read_report!(output, allowed_routes: allowed)
 
           # The independent agent's runtime is outside workflow authority. Re-read
           # the exact controller snapshot immediately before the receipt becomes
@@ -117,6 +117,15 @@ module Hive
           routes.delete("rework") if reworks >= max_reworks
           routes.freeze
         end
+
+
+        def read_report!(path, allowed_routes:)
+          Hive::Stages::ManagedAgentCustody.read_report(
+            stage: "review", parser: "review_report",
+            invalid_report: Hive::PatrolFix::ReviewReceipt::InvalidReport
+          ) { Hive::PatrolFix::ReviewReceipt.read(path, allowed_routes: allowed_routes) }
+        end
+        private_class_method :read_report!
 
         def review_evidence(store, manifest)
           receipts = store.read_all
@@ -211,12 +220,16 @@ module Hive
 
         def validate_agent_run!(run)
           unless run.is_a?(Hash) && run[:status] == :ok
-            raise Hive::StageError, "independent review agent failed without a semantic decision"
+            code = run.is_a?(Hash) && run.dig(:attempt_diagnostic, "code")
+            suffix = code ? "; diagnostic=#{code}" : ""
+            raise Hive::StageError,
+                  "independent review agent failed without a semantic decision#{suffix}"
           end
           return if run[:custody] == :clean
 
+          diagnostic = run.dig(:attempt_diagnostic, "code") || run[:diagnostic].to_s[0, 256]
           raise Hive::StageError,
-                "review agent modified controller authority: #{run[:diagnostic].to_s[0, 256]}"
+                "review agent modified controller authority: #{diagnostic}"
         end
         private_class_method :validate_agent_run!
       end

--- a/lib/hive/stages/patrol_fix/runner.rb
+++ b/lib/hive/stages/patrol_fix/runner.rb
@@ -1,0 +1,28 @@
+require "hive/patrol_fix/runner"
+require "hive/stages/managed_agent_custody"
+
+module Hive
+  module Stages
+    module PatrolFix
+      # Stage-layer boundary around the Patrol Fix core controller. It keeps
+      # Attempts diagnostic transport out of the workflow core while ensuring
+      # every controller exception has one chance to publish semantic facts.
+      module Runner
+        module_function
+
+        def run!(task, cfg = nil, **kwargs)
+          Hive::PatrolFix::Runner.run!(task, cfg, **kwargs)
+        rescue StandardError => error
+          begin
+            Hive::Stages::ManagedAgentCustody.publish_controller_failure(
+              stage: task.stage_name, error: error
+            )
+          rescue StandardError
+            nil
+          end
+          raise
+        end
+      end
+    end
+  end
+end

--- a/lib/hive/stages/resolver.rb
+++ b/lib/hive/stages/resolver.rb
@@ -46,8 +46,8 @@ module Hive
 
       CONTROLLER_RUNNERS = {
         patrol_fix: lambda {
-          require "hive/patrol_fix/runner"
-          Hive::PatrolFix::Runner.method(:run!)
+          require "hive/stages/patrol_fix/runner"
+          Hive::Stages::PatrolFix::Runner.method(:run!)
         }
       }.freeze
 

--- a/schemas/hive-patrol-fix-attempt-diagnostic.v1.json
+++ b/schemas/hive-patrol-fix-attempt-diagnostic.v1.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:hive:schema:patrol-fix-attempt-diagnostic:v1",
+  "title": "Hive Patrol Fix attempt diagnostic v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema", "schema_version", "workflow", "stage", "phase", "task_generation",
+    "attempt_id", "correlation_id", "code", "owner", "status", "agent_reason", "exit_code",
+    "timed_out", "cancelled", "signal", "provider", "report_status",
+    "report_parser", "firewall_status", "firewall_restoration", "custody_status",
+    "detail", "redaction_status", "secret_policy_version", "transport_status",
+    "log_reference", "recorded_at"
+  ],
+  "properties": {
+    "schema": { "const": "hive-patrol-fix-attempt-diagnostic" },
+    "schema_version": { "const": 1 },
+    "workflow": { "const": "patrol_fix" },
+    "stage": { "$ref": "#/$defs/Identifier" },
+    "phase": { "$ref": "#/$defs/Identifier" },
+    "task_generation": { "$ref": "#/$defs/Identifier" },
+    "attempt_id": { "$ref": "#/$defs/Identifier" },
+    "correlation_id": { "$ref": "#/$defs/Identifier" },
+    "code": { "type": "string", "pattern": "^[a-z][a-z0-9_]*$", "maxLength": 128 },
+    "owner": { "enum": ["agent", "provider", "hive", "operator", "unknown"] },
+    "status": { "$ref": "#/$defs/Identifier" },
+    "agent_reason": { "oneOf": [{ "$ref": "#/$defs/Identifier" }, { "type": "null" }] },
+    "exit_code": { "type": ["integer", "null"] },
+    "timed_out": { "type": "boolean" },
+    "cancelled": { "type": "boolean" },
+    "signal": { "oneOf": [{ "$ref": "#/$defs/Identifier" }, { "type": "null" }] },
+    "provider": {
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "object", "additionalProperties": false,
+          "required": ["name", "failure_class", "retry_hint", "provenance"],
+          "properties": {
+            "name": { "oneOf": [{ "$ref": "#/$defs/Identifier" }, { "type": "null" }] },
+            "failure_class": { "oneOf": [{ "$ref": "#/$defs/Identifier" }, { "type": "null" }] },
+            "retry_hint": { "type": ["string", "null"], "maxLength": 128 },
+            "provenance": { "oneOf": [{ "$ref": "#/$defs/Identifier" }, { "type": "null" }] }
+          }
+        }
+      ]
+    },
+    "report_status": { "$ref": "#/$defs/Identifier" },
+    "report_parser": { "oneOf": [{ "$ref": "#/$defs/Identifier" }, { "type": "null" }] },
+    "firewall_status": { "$ref": "#/$defs/Identifier" },
+    "firewall_restoration": { "oneOf": [{ "$ref": "#/$defs/Identifier" }, { "type": "null" }] },
+    "custody_status": { "$ref": "#/$defs/Identifier" },
+    "detail": { "type": ["string", "null"], "maxLength": 2048 },
+    "redaction_status": { "enum": ["applied", "omitted", "failed"] },
+    "secret_policy_version": { "const": 1 },
+    "transport_status": { "enum": ["valid", "missing", "oversized", "malformed", "duplicate", "unavailable"] },
+    "log_reference": {
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "object", "additionalProperties": false,
+          "required": ["path", "size", "sha256"],
+          "properties": {
+            "path": { "type": "string", "minLength": 1, "maxLength": 512 },
+            "size": { "type": "integer", "minimum": 0 },
+            "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+          }
+        }
+      ]
+    },
+    "recorded_at": { "type": "string", "format": "date-time" }
+  },
+  "$defs": {
+    "Identifier": {
+      "type": "string", "minLength": 1, "maxLength": 128,
+      "pattern": "^[^\\u0000-\\u001f\\u007f]+$"
+    }
+  }
+}

--- a/schemas/hive-status-diagnose.v2.json
+++ b/schemas/hive-status-diagnose.v2.json
@@ -165,6 +165,31 @@
         }
       }
     },
+    "OutputReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "size", "sha256"],
+      "properties": {
+        "path": { "type": "string", "minLength": 1, "maxLength": 512 },
+        "size": { "type": "integer", "minimum": 0 },
+        "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+      }
+    },
+    "AttemptDiagnosticProvider": {
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "object", "additionalProperties": false,
+          "required": ["name", "failure_class", "retry_hint", "provenance"],
+          "properties": {
+            "name": { "type": ["string", "null"], "maxLength": 128 },
+            "failure_class": { "type": ["string", "null"], "maxLength": 128 },
+            "retry_hint": { "type": ["string", "null"], "maxLength": 128 },
+            "provenance": { "type": ["string", "null"], "maxLength": 128 }
+          }
+        }
+      ]
+    },
     "Diagnostic": {
       "type": "object",
       "additionalProperties": false,
@@ -259,7 +284,33 @@
         "updated_at": {
           "type": "string",
           "format": "date-time"
-        }
+        },
+        "code": { "type": "string", "pattern": "^[a-z][a-z0-9_]*$", "maxLength": 128 },
+        "owner": { "enum": ["agent", "provider", "hive", "operator", "unknown"] },
+        "workflow": { "const": "patrol_fix" },
+        "stage": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "phase": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "status": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "agent_reason": { "type": ["string", "null"], "maxLength": 128 },
+        "exit_code": { "type": ["integer", "null"] },
+        "timed_out": { "type": "boolean" },
+        "cancelled": { "type": "boolean" },
+        "signal": { "type": ["string", "null"], "maxLength": 128 },
+        "provider": { "$ref": "#/$defs/AttemptDiagnosticProvider" },
+        "attempt_id": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "correlation_id": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "task_generation": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "diagnostic_digest": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+        "diagnostic_reference": { "$ref": "#/$defs/OutputReference" },
+        "log_reference": { "$ref": "#/$defs/OutputReference" },
+        "report_status": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "report_parser": { "type": ["string", "null"], "maxLength": 128 },
+        "firewall_status": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "firewall_restoration": { "type": ["string", "null"], "maxLength": 128 },
+        "custody_status": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "transport_status": { "enum": ["valid", "missing", "oversized", "malformed", "duplicate", "unavailable"] },
+        "redaction_status": { "enum": ["applied", "omitted", "failed"] },
+        "secret_policy_version": { "type": "integer", "minimum": 1 }
       }
     }
   }

--- a/schemas/hive-status.v7.json
+++ b/schemas/hive-status.v7.json
@@ -597,6 +597,31 @@
         }
       ]
     },
+    "OutputReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "size", "sha256"],
+      "properties": {
+        "path": { "type": "string", "minLength": 1, "maxLength": 512 },
+        "size": { "type": "integer", "minimum": 0 },
+        "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+      }
+    },
+    "AttemptDiagnosticProvider": {
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "object", "additionalProperties": false,
+          "required": ["name", "failure_class", "retry_hint", "provenance"],
+          "properties": {
+            "name": { "type": ["string", "null"], "maxLength": 128 },
+            "failure_class": { "type": ["string", "null"], "maxLength": 128 },
+            "retry_hint": { "type": ["string", "null"], "maxLength": 128 },
+            "provenance": { "type": ["string", "null"], "maxLength": 128 }
+          }
+        }
+      ]
+    },
     "Diagnostic": {
       "type": "object",
       "additionalProperties": false,
@@ -626,7 +651,33 @@
             { "type": "null" }
           ]
         },
-        "updated_at": { "type": "string", "format": "date-time" }
+        "updated_at": { "type": "string", "format": "date-time" },
+        "code": { "type": "string", "pattern": "^[a-z][a-z0-9_]*$", "maxLength": 128 },
+        "owner": { "enum": ["agent", "provider", "hive", "operator", "unknown"] },
+        "workflow": { "const": "patrol_fix" },
+        "stage": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "phase": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "status": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "agent_reason": { "type": ["string", "null"], "maxLength": 128 },
+        "exit_code": { "type": ["integer", "null"] },
+        "timed_out": { "type": "boolean" },
+        "cancelled": { "type": "boolean" },
+        "signal": { "type": ["string", "null"], "maxLength": 128 },
+        "provider": { "$ref": "#/$defs/AttemptDiagnosticProvider" },
+        "attempt_id": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "correlation_id": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "task_generation": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "diagnostic_digest": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+        "diagnostic_reference": { "$ref": "#/$defs/OutputReference" },
+        "log_reference": { "$ref": "#/$defs/OutputReference" },
+        "report_status": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "report_parser": { "type": ["string", "null"], "maxLength": 128 },
+        "firewall_status": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "firewall_restoration": { "type": ["string", "null"], "maxLength": 128 },
+        "custody_status": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "transport_status": { "enum": ["valid", "missing", "oversized", "malformed", "duplicate", "unavailable"] },
+        "redaction_status": { "enum": ["applied", "omitted", "failed"] },
+        "secret_policy_version": { "type": "integer", "minimum": 1 }
       }
     }
   }

--- a/test/fixtures/attempts/patrol_dispatch_spree.v1.json
+++ b/test/fixtures/attempts/patrol_dispatch_spree.v1.json
@@ -1,0 +1,313 @@
+{
+  "schema": "hive-patrol-dispatch-incident-replay",
+  "schema_version": 1,
+  "incident": {
+    "date_utc": "2026-08-26",
+    "source": "sanitized durable Attempts v4 accounting projection",
+    "selection": "first 600 charged project attempts in the incident accounting window",
+    "observed_window_utc": {
+      "start": "2026-08-26T00:00:35Z",
+      "end": "2026-08-26T11:51:13Z"
+    }
+  },
+  "sanitization": {
+    "synthetic_identities": true,
+    "prompts_included": false,
+    "secret_material_included": false,
+    "credentials_included": false,
+    "raw_output_included": false,
+    "absolute_paths_included": false,
+    "stage_failure_pairing": "deterministic synthetic allocation preserving each observed aggregate margin"
+  },
+  "expected_metrics": {
+    "accepted_attempts": 600,
+    "charged_attempts": 600,
+    "patrol_fix_attempts": 598,
+    "coding_attempts": 2,
+    "failed_attempts": 153,
+    "succeeded_attempts": 447,
+    "repeat_launches": 141,
+    "unique_generation_stage_identities": 459,
+    "repeated_generation_stage_identities": 88,
+    "max_attempts_for_identity": 5
+  },
+  "identity_multiplicity": [
+    { "attempts": 1, "identities": 371 },
+    { "attempts": 2, "identities": 44 },
+    { "attempts": 3, "identities": 36 },
+    { "attempts": 4, "identities": 7 },
+    { "attempts": 5, "identities": 1 }
+  ],
+  "stage_outcomes": [
+    { "stage": "1-inbox", "failed": 0, "succeeded": 5 },
+    { "stage": "2-brainstorm", "failed": 0, "succeeded": 2 },
+    { "stage": "2-fix", "failed": 58, "succeeded": 179 },
+    { "stage": "3-validate", "failed": 35, "succeeded": 147 },
+    { "stage": "4-review", "failed": 55, "succeeded": 86 },
+    { "stage": "5-publish", "failed": 5, "succeeded": 28 }
+  ],
+  "failure_cohorts": [
+    {
+      "cohort": "worktree_head_custody_mismatch",
+      "count": 59,
+      "terminal_envelope": {
+        "phase": "post_agent_custody",
+        "status": "error",
+        "exit_code": 0,
+        "timed_out": false,
+        "cancelled": false,
+        "signal": null,
+        "provider": "sanitized_managed_profile",
+        "provider_failure": null,
+        "report_status": "valid",
+        "firewall_status": "clean",
+        "custody_status": "head_drift",
+        "head_relation": "unexpected_movement",
+        "custody_proven": false
+      },
+      "expected_normalized_code": "worktree_head_custody_mismatch"
+    },
+    {
+      "cohort": "agent_result_generic",
+      "count": 53,
+      "terminal_envelope": {
+        "phase": "managed_agent",
+        "status": "error",
+        "exit_code": 1,
+        "timed_out": false,
+        "cancelled": false,
+        "signal": null,
+        "provider": "sanitized_managed_profile",
+        "provider_failure": null,
+        "report_status": "unknown",
+        "firewall_status": "clean",
+        "custody_status": "clean",
+        "stage_family": "fix_or_review",
+        "typed_detail_present": false
+      },
+      "expected_normalized_code": "agent_result_generic"
+    },
+    {
+      "cohort": "diagnostic_missing",
+      "count": 18,
+      "terminal_envelope": {
+        "phase": "terminal_receipt",
+        "status": "error",
+        "exit_code": 1,
+        "timed_out": false,
+        "cancelled": false,
+        "signal": null,
+        "provider": "sanitized_managed_profile",
+        "provider_failure": null,
+        "report_status": "unknown",
+        "firewall_status": "unknown",
+        "custody_status": "unknown",
+        "diagnostic_present": false
+      },
+      "expected_normalized_code": "diagnostic_missing"
+    },
+    {
+      "cohort": "protected_git_config_mutation",
+      "count": 11,
+      "terminal_envelope": {
+        "phase": "protected_anchor_restore",
+        "status": "error",
+        "exit_code": 0,
+        "timed_out": false,
+        "cancelled": false,
+        "signal": null,
+        "provider": "sanitized_managed_profile",
+        "provider_failure": null,
+        "report_status": "valid",
+        "firewall_status": "tampered_restored",
+        "custody_status": "tampered",
+        "protected_git_config_changed": true,
+        "restore_status": "restored"
+      },
+      "expected_normalized_code": "protected_git_config_mutation"
+    },
+    {
+      "cohort": "state_git_index_lock",
+      "count": 4,
+      "terminal_envelope": {
+        "phase": "state_git_write",
+        "status": "error",
+        "exit_code": null,
+        "timed_out": false,
+        "cancelled": false,
+        "signal": null,
+        "provider": null,
+        "provider_failure": null,
+        "report_status": "not_applicable",
+        "firewall_status": "not_applicable",
+        "custody_status": "not_applicable",
+        "relative_lock": ".hive-state/index.lock",
+        "write_status": "lock_conflict"
+      },
+      "expected_normalized_code": "state_git_index_lock"
+    },
+    {
+      "cohort": "secret_policy_publish_blocked",
+      "count": 3,
+      "terminal_envelope": {
+        "phase": "publication",
+        "status": "error",
+        "exit_code": null,
+        "timed_out": false,
+        "cancelled": false,
+        "signal": null,
+        "provider": null,
+        "provider_failure": null,
+        "report_status": "valid",
+        "firewall_status": "clean",
+        "custody_status": "clean",
+        "publication_status": "blocked_by_policy",
+        "matched_bytes_retained": false
+      },
+      "expected_normalized_code": "secret_policy_publish_blocked"
+    },
+    {
+      "cohort": "fix_report_invalid",
+      "count": 2,
+      "terminal_envelope": {
+        "phase": "fix_report_admission",
+        "status": "error",
+        "exit_code": 0,
+        "timed_out": false,
+        "cancelled": false,
+        "signal": null,
+        "provider": "sanitized_managed_profile",
+        "provider_failure": null,
+        "report_status": "invalid",
+        "firewall_status": "clean",
+        "custody_status": "invalid_output"
+      },
+      "expected_normalized_code": "fix_report_invalid"
+    },
+    {
+      "cohort": "fix_worktree_dirty",
+      "count": 2,
+      "terminal_envelope": {
+        "phase": "fix_worktree_preflight",
+        "status": "error",
+        "exit_code": null,
+        "timed_out": false,
+        "cancelled": false,
+        "signal": null,
+        "provider": null,
+        "provider_failure": null,
+        "report_status": "not_applicable",
+        "firewall_status": "not_applicable",
+        "custody_status": "dirty",
+        "worktree_status": "dirty"
+      },
+      "expected_normalized_code": "fix_worktree_dirty"
+    },
+    {
+      "cohort": "validation_mutation",
+      "count": 1,
+      "terminal_envelope": {
+        "phase": "validation_custody",
+        "status": "error",
+        "exit_code": 0,
+        "timed_out": false,
+        "cancelled": false,
+        "signal": null,
+        "provider": null,
+        "provider_failure": null,
+        "report_status": "not_applicable",
+        "firewall_status": "clean",
+        "custody_status": "mutation",
+        "authoritative_state_changed": true
+      },
+      "expected_normalized_code": "validation_mutation"
+    }
+  ],
+  "accounting_cases": [
+    {
+      "name": "started_failure",
+      "accepted": true,
+      "state": "terminal",
+      "started_at": "2026-08-26T00:00:01Z",
+      "exit_status": 1,
+      "expected_charged": true
+    },
+    {
+      "name": "started_success",
+      "accepted": true,
+      "state": "terminal",
+      "started_at": "2026-08-26T00:00:01Z",
+      "exit_status": 0,
+      "expected_charged": true
+    },
+    {
+      "name": "unstarted_loss",
+      "accepted": true,
+      "state": "lost",
+      "started_at": null,
+      "exit_status": null,
+      "expected_charged": false
+    },
+    {
+      "name": "started_tempfail",
+      "accepted": true,
+      "state": "terminal",
+      "started_at": "2026-08-26T00:00:01Z",
+      "exit_status": 75,
+      "expected_charged": false
+    }
+  ],
+  "pending_candidates": [
+    {
+      "class": "patrol_progress_later_stage",
+      "workflow": "patrol_fix",
+      "stage": "4-review",
+      "current_priority": 1
+    },
+    {
+      "class": "patrol_progress_first_attempt",
+      "workflow": "patrol_fix",
+      "stage": "2-fix",
+      "current_priority": 2
+    },
+    {
+      "class": "non_patrol_first_attempt",
+      "workflow": "coding",
+      "stage": "4-execute",
+      "current_priority": 3
+    },
+    {
+      "class": "patrol_retry",
+      "workflow": "patrol_fix",
+      "stage": "2-fix",
+      "current_priority": 4
+    }
+  ],
+  "operational": {
+    "temporary_daily_cap": 1000,
+    "rollback_daily_cap": 600,
+    "portable_fields": [
+      "configured_daily_cap",
+      "accepted_attempt_count",
+      "charged_attempt_count",
+      "utc_accounting_date",
+      "deployed_revision",
+      "runtime_deployment_id"
+    ],
+    "exit_gate": {
+      "requires": "stable_24_hour_final_soak",
+      "then": "restore_cap_and_observe_one_complete_utc_accounting_window"
+    },
+    "rollback": {
+      "preserve_accepted_attempts": true,
+      "block_new_admission_when_usage_is_at_or_above_600": true,
+      "cancel_running_attempts": false
+    }
+  },
+  "non_patrol_demand": {
+    "available": false,
+    "required_window": "seven complete UTC days preceding 2026-08-26",
+    "uncertainty": "Attempts v4 does not durably retain an unambiguous workflow identity for every historical 1-inbox record, so a non-Patrol daily series cannot be reconstructed without inventing classification.",
+    "fallback_policy": "use ten percent of the configured cap until defensible workflow-attributed history exists"
+  }
+}

--- a/test/fixtures/attempts/patrol_dispatch_spree.v1.json
+++ b/test/fixtures/attempts/patrol_dispatch_spree.v1.json
@@ -85,7 +85,7 @@
         "stage_family": "fix_or_review",
         "typed_detail_present": false
       },
-      "expected_normalized_code": "agent_result_generic"
+      "expected_normalized_code": "agent_exit_nonzero"
     },
     {
       "cohort": "diagnostic_missing",
@@ -104,7 +104,7 @@
         "custody_status": "unknown",
         "diagnostic_present": false
       },
-      "expected_normalized_code": "diagnostic_missing"
+      "expected_normalized_code": "agent_exit_nonzero"
     },
     {
       "cohort": "protected_git_config_mutation",
@@ -124,7 +124,7 @@
         "protected_git_config_changed": true,
         "restore_status": "restored"
       },
-      "expected_normalized_code": "protected_git_config_mutation"
+      "expected_normalized_code": "protected_git_config_tamper"
     },
     {
       "cohort": "state_git_index_lock",

--- a/test/support/patrol_dispatch_replay.rb
+++ b/test/support/patrol_dispatch_replay.rb
@@ -3,6 +3,7 @@ require "digest"
 require "json"
 require "time"
 require "hive/errors"
+require "hive/patrol_fix/attempt_diagnostic"
 require "hive/secret_patterns"
 
 module HiveTestSupport
@@ -48,19 +49,22 @@ module HiveTestSupport
 
       failure_counts = attempts.filter_map { |attempt| attempt["failure_code"] }
                                .tally.sort.to_h.freeze
-      expected_failures = failure_cohorts.to_h do |cohort|
-        [ cohort.fetch("expected_normalized_code"), cohort.fetch("count") ]
-      end.sort.to_h
+      expected_failures = failure_cohorts.group_by do |cohort|
+        cohort.fetch("expected_normalized_code")
+      end.transform_values { |cohorts| cohorts.sum { |cohort| cohort.fetch("count") } }
+        .sort.to_h
       unless failure_counts == expected_failures
         raise InvalidFixture, "replayed failure counts differ from expected cohorts"
       end
 
-      canonical = canonicalize("attempts" => attempts, "metrics" => metrics)
+      canonical = Hive::PatrolFix.canonical_json(
+        "attempts" => attempts, "metrics" => metrics
+      ).delete_suffix("\n")
       Result.new(
         attempts: attempts,
         metrics: metrics,
         failure_counts: failure_counts,
-        digest: Digest::SHA256.hexdigest(JSON.generate(canonical))
+        digest: Digest::SHA256.hexdigest(canonical)
       )
     end
 
@@ -208,8 +212,15 @@ module HiveTestSupport
       failed_remaining = document.fetch("stage_outcomes").to_h do |entry|
         [ entry.fetch("stage"), entry.fetch("failed") ]
       end
-      failure_codes = failure_cohorts.flat_map do |cohort|
-        [ cohort.fetch("expected_normalized_code") ] * cohort.fetch("count")
+      failure_codes = failure_cohorts.each_with_index.flat_map do |cohort, index|
+        diagnostic = Hive::PatrolFix::AttemptDiagnostic.normalize(
+          cohort.fetch("terminal_envelope"),
+          stage: "incident-replay",
+          task_generation: "incident-generation",
+          attempt_id: format("incident-attempt-%03d", index + 1),
+          recorded_at: Time.utc(2026, 8, 26)
+        )
+        [ diagnostic.fetch("code") ] * cohort.fetch("count")
       end
       sequence = 0
       groups.flat_map do |group|
@@ -248,17 +259,6 @@ module HiveTestSupport
         "repeated_generation_stage_identities" => identities.count { |_, entries| entries.length > 1 },
         "max_attempts_for_identity" => identities.values.map(&:length).max
       }
-    end
-
-    def canonicalize(value)
-      case value
-      when Hash
-        value.keys.sort.to_h { |key| [ key, canonicalize(value.fetch(key)) ] }
-      when Array
-        value.map { |entry| canonicalize(entry) }
-      else
-        value
-      end
     end
   end
 end

--- a/test/support/patrol_dispatch_replay.rb
+++ b/test/support/patrol_dispatch_replay.rb
@@ -1,0 +1,264 @@
+require "date"
+require "digest"
+require "json"
+require "time"
+require "hive/errors"
+require "hive/secret_patterns"
+
+module HiveTestSupport
+  class PatrolDispatchReplay
+    SCHEMA = "hive-patrol-dispatch-incident-replay".freeze
+    SCHEMA_VERSION = 1
+    MAX_BYTES = 256 * 1024
+    FORBIDDEN_KEYS = %w[
+      credential credentials host_path prompt prompts provider_output
+      raw_provider_output secret_bytes
+    ].freeze
+
+    class InvalidFixture < StandardError; end
+
+    Result = Data.define(:attempts, :metrics, :failure_counts, :digest)
+
+    attr_reader :document
+
+    def initialize(path)
+      bytes = File.binread(path)
+      raise InvalidFixture, "fixture exceeds #{MAX_BYTES} bytes" if bytes.bytesize > MAX_BYTES
+
+      utf8 = bytes.dup.force_encoding(Encoding::UTF_8)
+      raise InvalidFixture, "fixture must be valid UTF-8" unless utf8.valid_encoding?
+      raise InvalidFixture, "fixture is secret-bearing" if Hive::SecretPatterns.match?(utf8)
+      if %r{(?:\A|["'\s])/(?:home|Users)/|[A-Za-z]:\\\\}.match?(utf8)
+        raise InvalidFixture, "fixture contains a host-specific path"
+      end
+
+      @document = JSON.parse(utf8)
+      validate!
+    rescue JSON::ParserError => e
+      raise InvalidFixture, "fixture contains malformed JSON: #{e.message}"
+    end
+
+    def replay
+      attempts = build_attempts.freeze
+      metrics = metrics_for(attempts).freeze
+      expected = document.fetch("expected_metrics")
+      unless metrics == expected
+        raise InvalidFixture, "replayed metrics differ from expected metrics"
+      end
+
+      failure_counts = attempts.filter_map { |attempt| attempt["failure_code"] }
+                               .tally.sort.to_h.freeze
+      expected_failures = failure_cohorts.to_h do |cohort|
+        [ cohort.fetch("expected_normalized_code"), cohort.fetch("count") ]
+      end.sort.to_h
+      unless failure_counts == expected_failures
+        raise InvalidFixture, "replayed failure counts differ from expected cohorts"
+      end
+
+      canonical = canonicalize("attempts" => attempts, "metrics" => metrics)
+      Result.new(
+        attempts: attempts,
+        metrics: metrics,
+        failure_counts: failure_counts,
+        digest: Digest::SHA256.hexdigest(JSON.generate(canonical))
+      )
+    end
+
+    def failure_cohorts = document.fetch("failure_cohorts")
+    def operational = document.fetch("operational")
+    def non_patrol_demand = document.fetch("non_patrol_demand")
+
+    def accounting_results
+      document.fetch("accounting_cases").to_h do |entry|
+        charged = entry.fetch("accepted") &&
+                  !(entry.fetch("state") == "lost" && entry["started_at"].nil?) &&
+                  entry["exit_status"] != Hive::ExitCodes::TEMPFAIL
+        unless charged == entry.fetch("expected_charged")
+          raise InvalidFixture, "accounting case #{entry.fetch('name')} differs from its expected charge"
+        end
+        [ entry.fetch("name"), charged ]
+      end
+    end
+
+    def current_pool_at(cap:)
+      remaining = [ Integer(cap) - document.dig("expected_metrics", "charged_attempts"), 0 ].max
+      candidates = document.fetch("pending_candidates").sort_by do |candidate|
+        candidate.fetch("current_priority")
+      end.each_with_index.map do |candidate, index|
+        candidate.merge("admitted" => index < remaining)
+      end
+      {
+        "cap" => cap,
+        "remaining" => remaining,
+        "candidates" => candidates,
+        "starved_classes" => candidates.reject { |candidate| candidate.fetch("admitted") }
+                                       .map { |candidate| candidate.fetch("class") }
+      }
+    end
+
+    def future_containment_violations(cap:)
+      starved = current_pool_at(cap: cap).fetch("starved_classes")
+      violations = []
+      if starved.include?("non_patrol_first_attempt")
+        violations << "non-Patrol work is starved by the current undifferentiated pool"
+      end
+      if starved.any? { |entry| entry.start_with?("patrol_progress") }
+        violations << "healthy Patrol progress is starved by the current undifferentiated pool"
+      end
+      violations
+    end
+
+    private
+
+    def validate!
+      unless document.is_a?(Hash) && document["schema"] == SCHEMA &&
+             document["schema_version"] == SCHEMA_VERSION
+        raise InvalidFixture, "fixture schema identity must be #{SCHEMA} v#{SCHEMA_VERSION}"
+      end
+      %w[
+        incident sanitization expected_metrics identity_multiplicity stage_outcomes
+        failure_cohorts accounting_cases pending_candidates operational non_patrol_demand
+      ].each do |key|
+        raise InvalidFixture, "fixture missing #{key}" unless document.key?(key)
+      end
+      reject_forbidden_keys!(document)
+      validate_aggregate_contract!
+      validate_envelopes!
+      true
+    end
+
+    def validate_aggregate_contract!
+      expected = document.fetch("expected_metrics")
+      raise InvalidFixture, "accepted and charged totals differ" unless
+        expected.fetch("accepted_attempts") == 600 && expected.fetch("charged_attempts") == 600
+      raise InvalidFixture, "workflow totals differ" unless
+        expected.fetch("patrol_fix_attempts") + expected.fetch("coding_attempts") == 600
+      raise InvalidFixture, "outcome totals differ" unless
+        expected.fetch("failed_attempts") + expected.fetch("succeeded_attempts") == 600
+
+      identity = document.fetch("identity_multiplicity")
+      identities = identity.sum { |entry| entry.fetch("identities") }
+      attempts = identity.sum { |entry| entry.fetch("attempts") * entry.fetch("identities") }
+      repeated = identity.sum { |entry| entry.fetch("attempts") > 1 ? entry.fetch("identities") : 0 }
+      repeat_launches = identity.sum do |entry|
+        (entry.fetch("attempts") - 1) * entry.fetch("identities")
+      end
+      unless identities == expected.fetch("unique_generation_stage_identities") &&
+             attempts == 600 && repeated == expected.fetch("repeated_generation_stage_identities") &&
+             repeat_launches == expected.fetch("repeat_launches") &&
+             identity.map { |entry| entry.fetch("attempts") }.max == expected.fetch("max_attempts_for_identity")
+        raise InvalidFixture, "identity multiplicity differs from expected metrics"
+      end
+
+      stage_attempts = document.fetch("stage_outcomes").sum do |entry|
+        entry.fetch("failed") + entry.fetch("succeeded")
+      end
+      failures = failure_cohorts.sum { |cohort| cohort.fetch("count") }
+      unless stage_attempts == 600 && failures == expected.fetch("failed_attempts")
+        raise InvalidFixture, "stage or failure cohort totals differ"
+      end
+      demand = non_patrol_demand
+      unless demand["available"] == false && !demand.fetch("uncertainty").to_s.empty?
+        raise InvalidFixture, "unavailable non-Patrol demand must retain its uncertainty"
+      end
+    end
+
+    def validate_envelopes!
+      failure_cohorts.each do |cohort|
+        envelope = cohort.fetch("terminal_envelope")
+        unless envelope.is_a?(Hash) && !envelope.empty? &&
+               !envelope.key?("failure_code") && !envelope.key?("expected_normalized_code")
+          raise InvalidFixture, "terminal envelope must remain pre-normalization"
+        end
+        code = cohort.fetch("expected_normalized_code")
+        unless /\A[a-z][a-z0-9_]*\z/.match?(code)
+          raise InvalidFixture, "invalid expected normalized code"
+        end
+      end
+    end
+
+    def reject_forbidden_keys!(value)
+      case value
+      when Hash
+        forbidden = value.keys & FORBIDDEN_KEYS
+        raise InvalidFixture, "fixture contains forbidden evidence key #{forbidden.first}" unless forbidden.empty?
+        value.each_value { |child| reject_forbidden_keys!(child) }
+      when Array
+        value.each { |child| reject_forbidden_keys!(child) }
+      end
+    end
+
+    def build_attempts
+      stage_remaining = document.fetch("stage_outcomes").to_h do |entry|
+        [ entry.fetch("stage"), entry.fetch("failed") + entry.fetch("succeeded") ]
+      end
+      multiplicities = document.fetch("identity_multiplicity").flat_map do |entry|
+        [ entry.fetch("attempts") ] * entry.fetch("identities")
+      end.sort.reverse
+      groups = multiplicities.each_with_index.map do |count, index|
+        stage = stage_remaining.select { |_, remaining| remaining >= count }
+                               .max_by { |name, remaining| [ remaining, name ] }&.first
+        raise InvalidFixture, "identity multiplicity cannot fit stage totals" unless stage
+
+        stage_remaining[stage] -= count
+        { "identity" => format("generation-%03d:%s", index + 1, stage), "stage" => stage, "count" => count }
+      end
+      raise InvalidFixture, "identity allocation left stage attempts" unless stage_remaining.values.all?(&:zero?)
+
+      failed_remaining = document.fetch("stage_outcomes").to_h do |entry|
+        [ entry.fetch("stage"), entry.fetch("failed") ]
+      end
+      failure_codes = failure_cohorts.flat_map do |cohort|
+        [ cohort.fetch("expected_normalized_code") ] * cohort.fetch("count")
+      end
+      sequence = 0
+      groups.flat_map do |group|
+        group.fetch("count").times.map do |launch_index|
+          sequence += 1
+          stage = group.fetch("stage")
+          failed = failed_remaining.fetch(stage).positive?
+          failed_remaining[stage] -= 1 if failed
+          {
+            "attempt_id" => format("attempt-%03d", sequence),
+            "generation_stage_identity" => group.fetch("identity"),
+            "launch_index" => launch_index + 1,
+            "repeat_launch" => launch_index.positive?,
+            "workflow" => stage == "2-brainstorm" ? "coding" : "patrol_fix",
+            "stage" => stage,
+            "outcome" => failed ? "failed" : "succeeded",
+            "failure_code" => failed ? failure_codes.shift : nil,
+            "charged" => true,
+            "accepted_at" => (Time.utc(2026, 8, 26) + sequence).iso8601
+          }
+        end
+      end
+    end
+
+    def metrics_for(attempts)
+      identities = attempts.group_by { |attempt| attempt.fetch("generation_stage_identity") }
+      {
+        "accepted_attempts" => attempts.length,
+        "charged_attempts" => attempts.count { |attempt| attempt.fetch("charged") },
+        "patrol_fix_attempts" => attempts.count { |attempt| attempt.fetch("workflow") == "patrol_fix" },
+        "coding_attempts" => attempts.count { |attempt| attempt.fetch("workflow") == "coding" },
+        "failed_attempts" => attempts.count { |attempt| attempt.fetch("outcome") == "failed" },
+        "succeeded_attempts" => attempts.count { |attempt| attempt.fetch("outcome") == "succeeded" },
+        "repeat_launches" => attempts.count { |attempt| attempt.fetch("repeat_launch") },
+        "unique_generation_stage_identities" => identities.length,
+        "repeated_generation_stage_identities" => identities.count { |_, entries| entries.length > 1 },
+        "max_attempts_for_identity" => identities.values.map(&:length).max
+      }
+    end
+
+    def canonicalize(value)
+      case value
+      when Hash
+        value.keys.sort.to_h { |key| [ key, canonicalize(value.fetch(key)) ] }
+      when Array
+        value.map { |entry| canonicalize(entry) }
+      else
+        value
+      end
+    end
+  end
+end

--- a/test/unit/attempts/context_test.rb
+++ b/test/unit/attempts/context_test.rb
@@ -2,6 +2,7 @@ require "test_helper"
 require "hive/attempts/context"
 require "hive/attempts/generation"
 require "hive/lock"
+require "hive/patrol_fix/attempt_diagnostic"
 require "hive/task_resolver"
 
 class AttemptsContextTest < Minitest::Test
@@ -91,6 +92,44 @@ class AttemptsContextTest < Minitest::Test
           assert_equal "4-execute", context.intended_stage
           assert_empty ENV.keys.grep(/\AHIVE_ATTEMPT_/)
         end
+      end
+    end
+  end
+
+  def test_environment_context_publishes_opaque_ownership_generation
+    with_running_attempt do |store, _record|
+      resolver = Struct.new(:task) { def resolve = task }.new(
+        FakeTask.new(id: 42, slug: "task", stage_index: 4, stage_name: "execute")
+      )
+      diagnostic_reader, diagnostic_writer = IO.pipe
+      with_replaced_singleton_method(
+        Hive::TaskResolver, :new, ->(*_args, **_kwargs) { resolver }
+      ) do
+        with_env("HIVE_ATTEMPT_DIAGNOSTIC_FD" => diagnostic_writer.fileno.to_s) do
+          with_context_environment(store, capability: CLAIM_CAPABILITY) do
+            context = Hive::Attempts::Context.install_from_env!(argv: WORKER_ARGV)
+            installed_writer = context.instance_variable_get(:@diagnostic_writer)
+            assert installed_writer.instance_variable_get(:@io).close_on_exec?
+            draft = Hive::PatrolFix::AttemptDiagnostic.normalize(
+              { "status" => "error", "exit_code" => 7 },
+              stage: context.intended_stage,
+              task_generation: context.ownership_generation,
+              attempt_id: context.attempt_id,
+              recorded_at: Time.now.utc
+            )
+            assert context.publish_attempt_diagnostic(draft)
+            frame = Hive::Attempts::DiagnosticChannel.read(diagnostic_reader)
+            assert_equal "valid", frame.status
+            assert_equal "generation-env", frame.document.fetch("task_generation")
+            refute_equal context.task_generation.to_s, frame.document.fetch("task_generation")
+          end
+        end
+      end
+    ensure
+      [ diagnostic_reader, diagnostic_writer ].compact.each do |io|
+        io.close unless io.closed?
+      rescue Errno::EBADF
+        nil
       end
     end
   end

--- a/test/unit/attempts/output_reference_test.rb
+++ b/test/unit/attempts/output_reference_test.rb
@@ -1,5 +1,6 @@
 require "test_helper"
 require "hive/attempts/output_reference"
+require "hive/attempts/store"
 
 class AttemptsOutputReferenceTest < Minitest::Test
   include HiveTestHelper
@@ -56,6 +57,51 @@ class AttemptsOutputReferenceTest < Minitest::Test
         Hive::Attempts::OutputReference.validate_shape!(base.merge("sha256" => "BAD"))
       end
       refute Hive::Attempts::OutputReference.verify(base.merge("path" => "../escape"), root: root)
+    end
+  end
+
+  def test_projection_reader_reads_only_verified_bounded_output_bytes
+    with_tmp_dir do |root|
+      store = Hive::Attempts::Store.new(root: root)
+      path = store.output_path("attempt-1", "diagnostic.json", create_directory: true)
+      File.binwrite(path, "typed diagnostic")
+      reference = Hive::Attempts::OutputReference.build(path, root: root)
+      reader = store.projection_reader
+
+      assert_equal "typed diagnostic", reader.read_output(reference, max_bytes: 64)
+      assert_raises(Hive::Attempts::StoreError) do
+        reader.read_output(reference, max_bytes: 4)
+      end
+
+      File.binwrite(path, "tampered bytes")
+      assert_raises(Hive::Attempts::StoreError) do
+        reader.read_output(reference, max_bytes: 64)
+      end
+      assert_raises(Hive::Attempts::StoreError) do
+        reader.read_output(reference.merge("path" => "../private.log"), max_bytes: 64)
+      end
+
+
+      target = store.output_path("attempt-1", "target.json")
+      File.binwrite(target, "typed diagnostic")
+      File.unlink(path)
+      File.symlink(target, path)
+      assert_raises(Hive::Attempts::StoreError) do
+        reader.read_output(reference, max_bytes: 64)
+      end
+
+      real_parent = store.output_directory("attempt-real", create: true)
+      redirected_path = File.join(real_parent, "diagnostic.json")
+      File.binwrite(redirected_path, "typed diagnostic")
+      File.symlink(real_parent, File.join(store.outputs_root, "attempt-link"))
+      redirected_reference = {
+        "path" => "outputs/attempt-link/diagnostic.json",
+        "size" => 16,
+        "sha256" => Digest::SHA256.hexdigest("typed diagnostic")
+      }
+      assert_raises(Hive::Attempts::StoreError) do
+        reader.read_output(redirected_reference, max_bytes: 64)
+      end
     end
   end
 end

--- a/test/unit/attempts/output_reference_test.rb
+++ b/test/unit/attempts/output_reference_test.rb
@@ -70,6 +70,9 @@ class AttemptsOutputReferenceTest < Minitest::Test
 
       assert_equal "typed diagnostic", reader.read_output(reference, max_bytes: 64)
       assert_raises(Hive::Attempts::StoreError) do
+        reader.read_output(reference, max_bytes: 0)
+      end
+      assert_raises(Hive::Attempts::StoreError) do
         reader.read_output(reference, max_bytes: 4)
       end
 
@@ -101,6 +104,15 @@ class AttemptsOutputReferenceTest < Minitest::Test
       }
       assert_raises(Hive::Attempts::StoreError) do
         reader.read_output(redirected_reference, max_bytes: 64)
+      end
+
+      linked_target = store.output_path("attempt-real", "linked-target.json")
+      File.binwrite(linked_target, "linked diagnostic")
+      linked_path = store.output_path("attempt-real", "linked-diagnostic.json")
+      File.link(linked_target, linked_path)
+      linked_reference = Hive::Attempts::OutputReference.build(linked_path, root: root)
+      assert_raises(Hive::Attempts::StoreError) do
+        reader.read_output(linked_reference, max_bytes: 64)
       end
     end
   end

--- a/test/unit/attempts/patrol_dispatch_replay_test.rb
+++ b/test/unit/attempts/patrol_dispatch_replay_test.rb
@@ -1,0 +1,170 @@
+require "test_helper"
+require "support/patrol_dispatch_replay"
+
+class PatrolDispatchReplayTest < Minitest::Test
+  include HiveTestHelper
+
+  FIXTURE = File.expand_path(
+    "../../fixtures/attempts/patrol_dispatch_spree.v1.json",
+    __dir__
+  ).freeze
+
+  def test_replay_preserves_incident_totals_and_failure_classes
+    result = replay.replay
+
+    assert_equal 600, result.metrics.fetch("accepted_attempts")
+    assert_equal 600, result.metrics.fetch("charged_attempts")
+    assert_equal 598, result.metrics.fetch("patrol_fix_attempts")
+    assert_equal 2, result.metrics.fetch("coding_attempts")
+    assert_equal 153, result.metrics.fetch("failed_attempts")
+    assert_equal 447, result.metrics.fetch("succeeded_attempts")
+    assert_equal(
+      {
+        [ "1-inbox", "succeeded" ] => 5,
+        [ "2-brainstorm", "succeeded" ] => 2,
+        [ "2-fix", "failed" ] => 58,
+        [ "2-fix", "succeeded" ] => 179,
+        [ "3-validate", "failed" ] => 35,
+        [ "3-validate", "succeeded" ] => 147,
+        [ "4-review", "failed" ] => 55,
+        [ "4-review", "succeeded" ] => 86,
+        [ "5-publish", "failed" ] => 5,
+        [ "5-publish", "succeeded" ] => 28
+      },
+      result.attempts.group_by { |attempt| [ attempt.fetch("stage"), attempt.fetch("outcome") ] }
+            .transform_values(&:length)
+    )
+    assert_equal(
+      {
+        "agent_result_generic" => 53,
+        "diagnostic_missing" => 18,
+        "fix_report_invalid" => 2,
+        "fix_worktree_dirty" => 2,
+        "protected_git_config_mutation" => 11,
+        "secret_policy_publish_blocked" => 3,
+        "state_git_index_lock" => 4,
+        "validation_mutation" => 1,
+        "worktree_head_custody_mismatch" => 59
+      },
+      result.failure_counts
+    )
+  end
+
+  def test_replay_preserves_generation_stage_repeat_cohort
+    result = replay.replay
+
+    assert_equal 459, result.metrics.fetch("unique_generation_stage_identities")
+    assert_equal 88, result.metrics.fetch("repeated_generation_stage_identities")
+    assert_equal 141, result.metrics.fetch("repeat_launches")
+    assert_equal 5, result.metrics.fetch("max_attempts_for_identity")
+    assert_equal(
+      { 1 => 371, 2 => 44, 3 => 36, 4 => 7, 5 => 1 },
+      result.attempts.group_by { |attempt| attempt.fetch("generation_stage_identity") }
+            .transform_values(&:length).values.tally.sort.to_h
+    )
+  end
+
+  def test_terminal_envelopes_are_separate_from_expected_normalized_codes
+    replay.failure_cohorts.each do |cohort|
+      envelope = cohort.fetch("terminal_envelope")
+
+      refute envelope.key?("failure_code")
+      refute envelope.key?("expected_normalized_code")
+      %w[
+        status exit_code timed_out cancelled signal provider provider_failure
+        report_status firewall_status custody_status
+      ].each { |key| assert envelope.key?(key), "#{cohort.fetch("cohort")} missing #{key}" }
+      assert_match(/\A[a-z][a-z0-9_]*\z/, cohort.fetch("expected_normalized_code"))
+    end
+  end
+
+  def test_current_accounting_charges_started_failures_and_refunds_only_existing_cases
+    assert_equal(
+      {
+        "started_failure" => true,
+        "started_success" => true,
+        "unstarted_loss" => false,
+        "started_tempfail" => false
+      },
+      replay.accounting_results
+    )
+  end
+
+  def test_current_pool_keeps_later_stage_order_but_starves_healthy_and_non_patrol_work
+    projection = replay.current_pool_at(cap: 600)
+
+    assert_equal "patrol_progress_later_stage", projection.fetch("candidates").first.fetch("class")
+    assert projection.fetch("candidates").all? { |candidate| candidate.fetch("admitted") == false }
+    assert_includes projection.fetch("starved_classes"), "patrol_progress_later_stage"
+    assert_includes projection.fetch("starved_classes"), "patrol_progress_first_attempt"
+    assert_includes projection.fetch("starved_classes"), "non_patrol_first_attempt"
+
+    temporary = replay.current_pool_at(cap: 1_000)
+    assert_equal 400, temporary.fetch("remaining")
+    assert temporary.fetch("candidates").all? { |candidate| candidate.fetch("admitted") }
+  end
+
+  def test_operational_metadata_keeps_temporary_cap_and_rollback_portable
+    operational = replay.operational
+
+    assert_equal 1_000, operational.fetch("temporary_daily_cap")
+    assert_equal 600, operational.fetch("rollback_daily_cap")
+    assert_equal "stable_24_hour_final_soak", operational.dig("exit_gate", "requires")
+    assert_equal true, operational.dig("rollback", "preserve_accepted_attempts")
+    assert_equal false, replay.non_patrol_demand.fetch("available")
+    assert_match(/workflow identity/i, replay.non_patrol_demand.fetch("uncertainty"))
+  end
+
+  def test_replay_is_byte_deterministic
+    first = replay.replay
+    second = replay.replay
+
+    assert_equal first.digest, second.digest
+    assert_equal first.attempts, second.attempts
+  end
+
+  def test_malformed_and_oversized_fixtures_are_rejected
+    error = fixture_error("{")
+    assert_match(/malformed JSON/, error.message)
+
+    oversized = "{" + ("x" * HiveTestSupport::PatrolDispatchReplay::MAX_BYTES)
+    error = fixture_error(oversized)
+    assert_match(/exceeds/, error.message)
+  end
+
+  def test_secret_bearing_non_utf8_and_host_specific_fixtures_are_rejected
+    token = "github" + "_pat_" + ("A" * 24)
+    error = fixture_error(JSON.generate("diagnostic" => token))
+    assert_match(/secret-bearing/, error.message)
+
+    error = fixture_error("{\"diagnostic\":\"\xFF\"}".b)
+    assert_match(/UTF-8/, error.message)
+
+    error = fixture_error(JSON.generate("evidence_path" => "/home/operator/private.log"))
+    assert_match(/host-specific path/, error.message)
+  end
+
+  def test_future_lane_containment_assertion_is_an_expected_failure
+    error = assert_raises(Minitest::Assertion) do
+      assert_empty replay.future_containment_violations(cap: 600)
+    end
+
+    assert_match(/non-Patrol work is starved/, error.message)
+  end
+
+  private
+
+  def replay
+    HiveTestSupport::PatrolDispatchReplay.new(FIXTURE)
+  end
+
+  def fixture_error(bytes)
+    with_tmp_dir do |dir|
+      path = File.join(dir, "incident.json")
+      File.binwrite(path, bytes)
+      return assert_raises(HiveTestSupport::PatrolDispatchReplay::InvalidFixture) do
+        HiveTestSupport::PatrolDispatchReplay.new(path)
+      end
+    end
+  end
+end

--- a/test/unit/attempts/patrol_dispatch_replay_test.rb
+++ b/test/unit/attempts/patrol_dispatch_replay_test.rb
@@ -210,6 +210,113 @@ class PatrolDispatchReplayTest < Minitest::Test
     end
   end
 
+  def test_finalizer_binds_identity_and_applies_authoritative_provider_signal
+    draft = Hive::PatrolFix::AttemptDiagnostic.normalize(
+      { "status" => "error", "exit_code" => 1, "detail" => "safe detail" },
+      stage: "2-fix", task_generation: "generation-1",
+      attempt_id: "attempt-1", recorded_at: Time.utc(2026, 8, 26)
+    )
+    log_reference = {
+      "path" => "logs/attempt-1.frames", "size" => 12, "sha256" => "a" * 64
+    }
+    provider_signal = {
+      "failure_class" => "model_capacity", "reset_hint_seconds" => 30,
+      "provenance" => "codex_jsonl_transport"
+    }
+
+    finalized = Hive::PatrolFix::AttemptDiagnostic.finalize(
+      draft, log_reference: log_reference,
+      expected_attempt_id: "attempt-1", expected_stage: "2-fix",
+      expected_task_generation: "generation-1", provider_signal: provider_signal,
+      provider_name: "codex", redactor: ->(_text) { raise "redactor unavailable" }
+    )
+
+    assert_equal "model_capacity", finalized.fetch("code")
+    assert_equal "provider", finalized.fetch("owner")
+    assert_equal "codex", finalized.dig("provider", "name")
+    assert_equal "30", finalized.dig("provider", "retry_hint")
+    assert_equal "failed", finalized.fetch("redaction_status")
+    assert_equal log_reference, finalized.fetch("log_reference")
+
+    assert_raises(Hive::PatrolFix::AttemptDiagnostic::InvalidDiagnostic) do
+      Hive::PatrolFix::AttemptDiagnostic.finalize(
+        draft, log_reference: log_reference,
+        expected_attempt_id: "other-attempt", expected_stage: "2-fix",
+        expected_task_generation: "generation-1"
+      )
+    end
+    assert_raises(Hive::PatrolFix::AttemptDiagnostic::InvalidDiagnostic) do
+      Hive::PatrolFix::AttemptDiagnostic.finalize(
+        draft, log_reference: log_reference,
+        expected_attempt_id: "attempt-1", expected_stage: "2-fix",
+        expected_task_generation: "generation-1",
+        provider_signal: { "failure_class" => "provider_error" }, provider_name: "codex"
+      )
+    end
+  end
+
+  def test_validator_rejects_each_fail_closed_document_shape
+    base = Hive::PatrolFix::AttemptDiagnostic.normalize(
+      { "status" => "error", "exit_code" => 1 },
+      stage: "2-fix", task_generation: "generation-1",
+      attempt_id: "attempt-1", recorded_at: Time.utc(2026, 8, 26)
+    )
+    invalid_mutations = [
+      ->(row) { row.delete("owner") },
+      ->(row) { row["timed_out"] = nil },
+      ->(row) { row["detail"] = [] },
+      ->(row) { row["redaction_status"] = "future" },
+      ->(row) { row["provider"] = { "unexpected" => nil } },
+      ->(row) { row["stage"] = "" }
+    ]
+
+    invalid_mutations.each do |mutate|
+      candidate = JSON.parse(JSON.generate(base))
+      mutate.call(candidate)
+      assert_raises(Hive::PatrolFix::AttemptDiagnostic::InvalidDiagnostic) do
+        Hive::PatrolFix::AttemptDiagnostic.validate!(candidate, require_log_reference: false)
+      end
+    end
+
+    candidate = JSON.parse(JSON.generate(base))
+    candidate["log_reference"] = {
+      "path" => "logs/attempt-1.frames", "size" => 12, "sha256" => "a" * 64
+    }
+    assert Hive::PatrolFix::AttemptDiagnostic.validate!(candidate, require_log_reference: false)
+
+    candidate["log_reference"]["size"] = -1
+    assert_raises(Hive::PatrolFix::AttemptDiagnostic::InvalidDiagnostic) do
+      Hive::PatrolFix::AttemptDiagnostic.validate!(candidate, require_log_reference: false)
+    end
+    assert_raises(Hive::PatrolFix::AttemptDiagnostic::InvalidDiagnostic) do
+      Hive::PatrolFix::AttemptDiagnostic.normalize(
+        { "status" => "error" }, stage: "2-fix", task_generation: "generation-1",
+        attempt_id: "attempt-1", recorded_at: "not-a-time"
+      )
+    end
+  end
+
+  def test_normalizer_maps_remaining_provider_kinds_and_terminal_fallback
+    {
+      "provider_limit" => "provider_limit",
+      "provider_error" => "provider_error",
+      "model_output_limit" => "model_output_limit"
+    }.each_with_index do |(kind, code), index|
+      diagnostic = Hive::PatrolFix::AttemptDiagnostic.normalize(
+        { "status" => "error", "provider_error" => { "kind" => kind } },
+        stage: "2-fix", task_generation: "generation-1",
+        attempt_id: "attempt-provider-#{index}", recorded_at: Time.utc(2026, 8, 26)
+      )
+      assert_equal code, diagnostic.fetch("code")
+    end
+
+    terminal = Hive::PatrolFix::AttemptDiagnostic.normalize(
+      { "status" => "error" }, stage: "2-fix", task_generation: "generation-1",
+      attempt_id: "attempt-terminal", recorded_at: Time.utc(2026, 8, 26)
+    )
+    assert_equal "agent_terminal_failure", terminal.fetch("code")
+  end
+
   def test_terminal_process_states_normalize_to_distinct_codes
     cases = {
       "agent_timeout" => { "timed_out" => true, "cancelled" => true, "exit_code" => 124 },

--- a/test/unit/attempts/patrol_dispatch_replay_test.rb
+++ b/test/unit/attempts/patrol_dispatch_replay_test.rb
@@ -1,5 +1,7 @@
 require "test_helper"
+require "json_schemer"
 require "support/patrol_dispatch_replay"
+require "hive/patrol_fix/attempt_diagnostic"
 
 class PatrolDispatchReplayTest < Minitest::Test
   include HiveTestHelper
@@ -36,11 +38,10 @@ class PatrolDispatchReplayTest < Minitest::Test
     )
     assert_equal(
       {
-        "agent_result_generic" => 53,
-        "diagnostic_missing" => 18,
+        "agent_exit_nonzero" => 71,
         "fix_report_invalid" => 2,
         "fix_worktree_dirty" => 2,
-        "protected_git_config_mutation" => 11,
+        "protected_git_config_tamper" => 11,
         "secret_policy_publish_blocked" => 3,
         "state_git_index_lock" => 4,
         "validation_mutation" => 1,
@@ -65,7 +66,7 @@ class PatrolDispatchReplayTest < Minitest::Test
   end
 
   def test_terminal_envelopes_are_separate_from_expected_normalized_codes
-    replay.failure_cohorts.each do |cohort|
+    replay.failure_cohorts.each_with_index do |cohort, index|
       envelope = cohort.fetch("terminal_envelope")
 
       refute envelope.key?("failure_code")
@@ -75,6 +76,156 @@ class PatrolDispatchReplayTest < Minitest::Test
         report_status firewall_status custody_status
       ].each { |key| assert envelope.key?(key), "#{cohort.fetch("cohort")} missing #{key}" }
       assert_match(/\A[a-z][a-z0-9_]*\z/, cohort.fetch("expected_normalized_code"))
+      diagnostic = Hive::PatrolFix::AttemptDiagnostic.normalize(
+        envelope,
+        stage: "incident-replay",
+        task_generation: "incident-generation",
+        attempt_id: format("incident-attempt-%03d", index + 1),
+        recorded_at: Time.utc(2026, 8, 26)
+      )
+      assert_equal cohort.fetch("expected_normalized_code"), diagnostic.fetch("code")
+    end
+  end
+
+  def test_normalizer_bounds_and_redacts_detail_and_omits_it_when_redaction_fails
+    token = "github" + "_pat_" + ("A" * 24)
+    detail = "\e[31mprovider failed #{token} \xFF".b + ("x" * 8_000)
+    diagnostic = Hive::PatrolFix::AttemptDiagnostic.normalize(
+      {
+        "status" => "error", "exit_code" => 1, "timed_out" => false,
+        "cancelled" => false, "signal" => nil, "detail" => detail
+      },
+      stage: "2-fix", task_generation: "generation-1",
+      attempt_id: "attempt-1",
+      recorded_at: Time.utc(2026, 8, 26)
+    )
+
+    assert_equal "agent_exit_nonzero", diagnostic.fetch("code")
+    assert_operator diagnostic.fetch("detail").bytesize, :<=,
+                    Hive::PatrolFix::AttemptDiagnostic::MAX_DETAIL_BYTES
+    assert diagnostic.fetch("detail").valid_encoding?
+    refute_includes diagnostic.fetch("detail"), "\e[31m"
+    refute_includes diagnostic.fetch("detail"), token
+    assert_includes diagnostic.fetch("detail"), "[REDACTED:github_fine_grained_pat]"
+
+    failed = Hive::PatrolFix::AttemptDiagnostic.normalize(
+      {
+        "status" => "error", "exit_code" => 1, "timed_out" => false,
+        "cancelled" => false, "signal" => nil, "detail" => "private detail"
+      },
+      stage: "2-fix", task_generation: "generation-1",
+      attempt_id: "attempt-2",
+      recorded_at: Time.utc(2026, 8, 26),
+      redactor: ->(_text) { raise "redactor unavailable" }
+    )
+    assert_equal "agent_exit_nonzero", failed.fetch("code")
+    assert_nil failed.fetch("detail")
+    assert_equal "failed", failed.fetch("redaction_status")
+  end
+
+  def test_failure_code_must_be_snake_case
+    assert_raises(Hive::PatrolFix::AttemptDiagnostic::InvalidDiagnostic) do
+      Hive::PatrolFix::AttemptDiagnostic.normalize(
+        { "status" => "error", "provider_failure" => "Capacity.Exhausted" },
+        stage: "2-fix", task_generation: "generation-1",
+        attempt_id: "attempt-1",
+        recorded_at: Time.utc(2026, 8, 26)
+      )
+    end
+  end
+
+  def test_transport_status_must_be_from_the_closed_protocol
+    assert_raises(Hive::PatrolFix::AttemptDiagnostic::InvalidDiagnostic) do
+      Hive::PatrolFix::AttemptDiagnostic.normalize(
+        { "status" => "error", "exit_code" => 1 },
+        stage: "2-fix", task_generation: "generation-1",
+        attempt_id: "attempt-1", recorded_at: Time.utc(2026, 8, 26),
+        transport_status: "future_state"
+      )
+    end
+  end
+
+  def test_secret_shaped_metadata_invalidates_the_entire_diagnostic
+    secret = "github" + "_pat_" + ("A" * 24)
+    base = Hive::PatrolFix::AttemptDiagnostic.normalize(
+      {
+        "phase" => "managed_agent", "status" => "error", "exit_code" => 1,
+        "provider" => "codex", "provider_failure" => "provider_error",
+        "provider_provenance" => "codex_jsonl_transport",
+        "retry_at" => 30, "report_parser" => "fix_report"
+      },
+      stage: "2-fix", task_generation: "generation-1",
+      attempt_id: "attempt-1", recorded_at: Time.utc(2026, 8, 26)
+    )
+    mutations = [
+      ->(row) { row.fetch("provider")["name"] = secret },
+      ->(row) { row.fetch("provider")["failure_class"] = secret },
+      ->(row) { row.fetch("provider")["retry_hint"] = secret },
+      ->(row) { row.fetch("provider")["provenance"] = secret },
+      ->(row) { row["agent_reason"] = secret },
+      ->(row) { row["report_parser"] = secret },
+      ->(row) { row["status"] = secret }
+    ]
+
+    mutations.each do |mutate|
+      candidate = JSON.parse(JSON.generate(base))
+      mutate.call(candidate)
+      error = assert_raises(Hive::PatrolFix::AttemptDiagnostic::InvalidDiagnostic) do
+        Hive::PatrolFix::AttemptDiagnostic.validate!(
+          candidate, require_log_reference: false
+        )
+      end
+      assert_match(/secret-pattern text/, error.message)
+    end
+  end
+
+  def test_validator_rejects_wrong_scalar_types_that_the_schema_rejects
+    base = Hive::PatrolFix::AttemptDiagnostic.normalize(
+      {
+        "status" => "error", "exit_code" => 1, "provider" => "codex",
+        "provider_failure" => "provider_error"
+      },
+      stage: "2-fix", task_generation: "generation-1",
+      attempt_id: "attempt-1", recorded_at: Time.utc(2026, 8, 26)
+    )
+    mutations = [
+      ->(row) { row["status"] = 7 },
+      ->(row) { row["agent_reason"] = 7 },
+      ->(row) { row.fetch("provider")["name"] = 7 },
+      ->(row) { row.fetch("provider")["retry_hint"] = 7 }
+    ]
+    schema = JSONSchemer.schema(JSON.parse(File.read(File.expand_path(
+      "../../../schemas/hive-patrol-fix-attempt-diagnostic.v1.json", __dir__
+    ))))
+
+    mutations.each do |mutate|
+      candidate = JSON.parse(JSON.generate(base))
+      mutate.call(candidate)
+      refute schema.valid?(candidate)
+      assert_raises(Hive::PatrolFix::AttemptDiagnostic::InvalidDiagnostic) do
+        Hive::PatrolFix::AttemptDiagnostic.validate!(
+          candidate, require_log_reference: false
+        )
+      end
+    end
+  end
+
+  def test_terminal_process_states_normalize_to_distinct_codes
+    cases = {
+      "agent_timeout" => { "timed_out" => true, "cancelled" => true, "exit_code" => 124 },
+      "agent_cancelled" => { "cancelled" => true, "exit_code" => 143 },
+      "agent_signalled" => { "signal" => "KILL", "exit_code" => 137 },
+      "agent_exit_nonzero" => { "exit_code" => 23 }
+    }
+
+    cases.each_with_index do |(code, fields), index|
+      diagnostic = Hive::PatrolFix::AttemptDiagnostic.normalize(
+        { "status" => "error", **fields },
+        stage: "2-fix", task_generation: "generation-1",
+        attempt_id: "attempt-#{index}",
+        recorded_at: Time.utc(2026, 8, 26)
+      )
+      assert_equal code, diagnostic.fetch("code")
     end
   end
 

--- a/test/unit/attempts/store_test.rb
+++ b/test/unit/attempts/store_test.rb
@@ -38,6 +38,42 @@ class AttemptsStoreTest < Minitest::Test
     end
   end
 
+  def test_projection_reader_caches_terminal_diagnostic_bindings_including_absence
+    terminal = Object.new
+    terminal.define_singleton_method(:final?) { true }
+    terminal.define_singleton_method(:attempt_id) { "attempt-1" }
+    terminal.define_singleton_method(:task_generation) { "generation-1" }
+    terminal.define_singleton_method(:receipt) { { "outcome" => "failed" } }
+    terminal.define_singleton_method(:[]) do |key|
+      raise KeyError, key unless key == "intended_stage"
+
+      "4-review"
+    end
+    store = Struct.new(:record, :fetches) do
+      def fetch(_attempt_id)
+        self.fetches += 1
+        record
+      end
+    end.new(terminal, 0)
+    reader = Hive::Attempts::Store::ProjectionReader.new(store)
+
+    expected = {
+      "attempt_id" => "attempt-1", "stage" => "4-review",
+      "task_generation" => "generation-1", "receipt" => { "outcome" => "failed" }
+    }
+    assert_equal expected, reader.fetch_terminal_diagnostic_binding("attempt-1")
+    assert_equal expected, reader.fetch_terminal_diagnostic_binding("attempt-1")
+    assert_equal 1, store.fetches
+
+    nonterminal = Object.new
+    nonterminal.define_singleton_method(:final?) { false }
+    store.record = nonterminal
+    missing_reader = Hive::Attempts::Store::ProjectionReader.new(store)
+    assert_nil missing_reader.fetch_terminal_diagnostic_binding("attempt-2")
+    assert_nil missing_reader.fetch_terminal_diagnostic_binding("attempt-2")
+    assert_equal 2, store.fetches
+  end
+
   def test_stale_version_wrong_generation_and_wrong_deadline_do_not_mutate
     with_store do |store|
       launching = store.create_launching(**identity, launch_timeout_sec: 30, now: NOW)

--- a/test/unit/attempts/supervisor_test.rb
+++ b/test/unit/attempts/supervisor_test.rb
@@ -308,6 +308,72 @@ class AttemptsSupervisorTest < Minitest::Test
     assert_equal "oversized", oversized.status
   end
 
+  def test_diagnostic_channel_contains_writer_and_reader_io_failures
+    writer = Hive::Attempts::DiagnosticChannel::Writer.new(StringIO.new)
+    with_replaced_singleton_method(
+      Hive::PatrolFix::AttemptDiagnostic, :validate!, ->(*, **) { true }
+    ) do
+      assert_raises(IOError) do
+        writer.write("detail" => "x" * Hive::Attempts::DiagnosticChannel::MAX_FRAME_BYTES)
+      end
+    end
+
+    broken_close = Object.new
+    broken_close.define_singleton_method(:closed?) { false }
+    broken_close.define_singleton_method(:close) { raise IOError }
+    refute Hive::Attempts::DiagnosticChannel::Writer.new(broken_close).close
+
+    unavailable = Object.new
+    unavailable.define_singleton_method(:read) { |_limit| raise IOError }
+    unavailable.define_singleton_method(:closed?) { false }
+    unavailable.define_singleton_method(:close) { @closed = true }
+    result = Hive::Attempts::DiagnosticChannel.read(unavailable)
+    assert_equal "unavailable", result.status
+    assert_nil result.document
+  end
+
+  def test_supervisor_finalizes_valid_frames_and_synthesizes_identity_mismatches
+    with_attempt(
+      worker_argv: [ "hive", "run", "durable-task" ], intended_stage: "4-review",
+      workflow_controller: :patrol_fix
+    ) do |_store, attempt|
+      supervisor = Hive::Attempts::Supervisor.new(
+        store: Object.new, attempt_id: attempt.attempt_id,
+        claim_io: StringIO.new(CLAIM_CAPABILITY), clock: -> { NOW }
+      )
+      log_reference = {
+        "path" => "logs/attempt-1.frames", "size" => 12, "sha256" => "a" * 64
+      }
+      draft = Hive::PatrolFix::AttemptDiagnostic.normalize(
+        { "status" => "error", "exit_code" => 7 },
+        stage: "4-review", task_generation: attempt.task_generation,
+        attempt_id: attempt.attempt_id, recorded_at: NOW
+      )
+      frame = Hive::Attempts::DiagnosticChannel::ReadResult.new(
+        document: draft, status: "valid"
+      )
+
+      finalized = supervisor.send(
+        :finalize_or_synthesize_diagnostic, attempt, frame,
+        log_reference: log_reference, exit_status: 7, outcome: "failed",
+        transport_status: "valid"
+      )
+      assert_equal "valid", finalized.fetch("transport_status")
+      assert_equal log_reference, finalized.fetch("log_reference")
+
+      mismatched = frame.with(document: draft.merge(
+        "attempt_id" => "other-attempt", "correlation_id" => "other-attempt"
+      ))
+      fallback = supervisor.send(
+        :finalize_or_synthesize_diagnostic, attempt, mismatched,
+        log_reference: log_reference, exit_status: 7, outcome: "failed",
+        transport_status: "valid"
+      )
+      assert_equal "malformed", fallback.fetch("transport_status")
+      assert_equal attempt.attempt_id, fallback.fetch("attempt_id")
+    end
+  end
+
   def test_existing_diagnostic_collision_is_read_with_a_strict_bound_and_no_symlinks
     with_tmp_dir do |root|
       path = File.join(root, Hive::PatrolFix::AttemptDiagnostic::FILENAME)
@@ -329,6 +395,60 @@ class AttemptsSupervisorTest < Minitest::Test
       File.symlink(target, path)
       assert_raises(Hive::Attempts::StoreError) do
         supervisor.send(:persist_diagnostic_once, path, {})
+      end
+    end
+  end
+
+  def test_existing_diagnostic_reconciliation_accepts_exact_bytes_and_rejects_other_shapes
+    with_tmp_dir do |root|
+      supervisor = Hive::Attempts::Supervisor.new(
+        store: Object.new, attempt_id: "attempt-1",
+        claim_io: StringIO.new(CLAIM_CAPABILITY)
+      )
+      log_reference = {
+        "path" => "logs/attempt-1.frames", "size" => 12, "sha256" => "a" * 64
+      }
+      document = Hive::PatrolFix::AttemptDiagnostic.normalize(
+        { "status" => "error", "exit_code" => 1 },
+        stage: "4-review", task_generation: "generation-1",
+        attempt_id: "attempt-1", recorded_at: NOW, log_reference: log_reference
+      )
+      path = File.join(root, Hive::PatrolFix::AttemptDiagnostic::FILENAME)
+
+      assert supervisor.send(:persist_diagnostic_once, path, document)
+      assert supervisor.send(:persist_diagnostic_once, path, document)
+      conflict = document.merge("recorded_at" => (NOW + 1).iso8601(6))
+      assert_raises(Hive::Attempts::StoreError) do
+        supervisor.send(:persist_diagnostic_once, path, conflict)
+      end
+      assert_raises(Hive::Attempts::StoreError) do
+        supervisor.send(:persist_diagnostic_once, File.join(root, "missing", "diagnostic"), document)
+      end
+
+      fake_status = Object.new
+      fake_status.define_singleton_method(:file?) { false }
+      fake_status.define_singleton_method(:nlink) { 1 }
+      fake_status.define_singleton_method(:size) { 0 }
+      fake_file = Object.new
+      fake_file.define_singleton_method(:stat) { fake_status }
+      with_replaced_singleton_method(File, :open, ->(*_args, &block) { block.call(fake_file) }) do
+        assert_raises(Hive::Attempts::StoreError) do
+          supervisor.send(:read_existing_diagnostic, path)
+        end
+      end
+
+      fake_status.define_singleton_method(:file?) { true }
+      fake_status.define_singleton_method(:size) do
+        Hive::PatrolFix::AttemptDiagnostic::MAX_BYTES
+      end
+      fake_file.define_singleton_method(:read) do |_limit|
+        "x" * (Hive::PatrolFix::AttemptDiagnostic::MAX_BYTES + 1)
+      end
+      with_replaced_singleton_method(File, :open, ->(*_args, &block) { block.call(fake_file) }) do
+        error = assert_raises(Hive::Attempts::StoreError) do
+          supervisor.send(:read_existing_diagnostic, path)
+        end
+        assert_match(/size limit/, error.message)
       end
     end
   end
@@ -677,11 +797,14 @@ class AttemptsSupervisorTest < Minitest::Test
       assert_nil supervisor.send(:terminate_worker_group)
     end
 
-    trapped = []
-    with_replaced_singleton_method(Signal, :trap, ->(signal, &_block) { trapped << signal }) do
+    trapped = {}
+    with_replaced_singleton_method(Signal, :trap, ->(signal, &block) { trapped[signal] = block }) do
       supervisor.send(:install_signal_handlers!)
     end
-    assert_equal %w[TERM INT], trapped
+    assert_equal %w[INT TERM], trapped.keys.sort
+    trapped.fetch("TERM").call
+    assert_equal "TERM", supervisor.instance_variable_get(:@cancel_signal)
+    assert_equal :signal, supervisor.instance_variable_get(:@cancel_reason)
 
     ready = Object.new
     ready.define_singleton_method(:closed?) { false }

--- a/test/unit/attempts/supervisor_test.rb
+++ b/test/unit/attempts/supervisor_test.rb
@@ -1,6 +1,9 @@
 require "test_helper"
 require "timeout"
+require "hive/attempts/diagnostic_channel"
 require "hive/attempts/supervisor"
+require "hive/patrol_fix/attempt_diagnostic"
+require "hive/task_resolver"
 
 class AttemptsSupervisorTest < Minitest::Test
   include HiveTestHelper
@@ -146,6 +149,344 @@ class AttemptsSupervisorTest < Minitest::Test
     end
   end
 
+  def test_provider_signal_owns_missing_frame_patrol_diagnostic
+    worker_argv = [ "hive", "run", "durable-task" ]
+    with_attempt(
+      worker_argv: worker_argv, routing: explicit_routing,
+      intended_stage: "2-fix", workflow_controller: :patrol_fix
+    ) do |store, attempt|
+      signal = {
+        "failure_class" => "model_capacity",
+        "scope" => {
+          "kind" => "model", "provider_account_id" => "account-a", "model" => "model-a"
+        },
+        "provenance" => "codex_jsonl_transport",
+        "reset_hint_seconds" => 30
+      }
+      worker = <<~RUBY
+        evidence = IO.for_fd(Integer(ENV.fetch("HIVE_ATTEMPT_EVIDENCE_FD")), "w")
+        evidence.write(#{JSON.generate("#{JSON.generate(signal)}\n")})
+        evidence.close
+        exit 0
+      RUBY
+      supervisor = Hive::Attempts::Supervisor.new(
+        store: store, attempt_id: attempt.attempt_id,
+        claim_io: StringIO.new(CLAIM_CAPABILITY),
+        heartbeat_sec: 0.01, stale_sec: 1, first_heartbeat_timeout_sec: 1
+      )
+      supervisor.define_singleton_method(:resolved_worker_argv) do |_record|
+        [ RbConfig.ruby, "-e", worker ]
+      end
+
+      assert_equal Hive::ExitCodes::SOFTWARE, Timeout.timeout(2) { supervisor.run }
+      diagnostic = diagnostic_from_terminal(store, store.fetch(attempt.attempt_id))
+      assert_equal "model_capacity", diagnostic.fetch("code")
+      assert_equal "provider", diagnostic.fetch("owner")
+      assert_equal "codex", diagnostic.dig("provider", "name")
+      assert_equal "model_capacity", diagnostic.dig("provider", "failure_class")
+      assert_equal "codex_jsonl_transport", diagnostic.dig("provider", "provenance")
+      assert_equal "30", diagnostic.dig("provider", "retry_hint")
+      assert_equal "missing", diagnostic.fetch("transport_status")
+    end
+  end
+
+  def test_failed_bench_publish_does_not_receive_a_patrol_diagnostic
+    worker_argv = [ "hive", "run", "durable-task" ]
+    with_attempt(
+      worker_argv: worker_argv, intended_stage: "5-publish",
+      workflow_controller: :benchmark
+    ) do |store, attempt|
+      supervisor = Hive::Attempts::Supervisor.new(
+        store: store, attempt_id: attempt.attempt_id,
+        claim_io: StringIO.new(CLAIM_CAPABILITY),
+        heartbeat_sec: 0.01, stale_sec: 1, first_heartbeat_timeout_sec: 1
+      )
+      supervisor.define_singleton_method(:resolved_worker_argv) do |_record|
+        [ RbConfig.ruby, "-e", "exit 7" ]
+      end
+
+      assert_equal 7, Timeout.timeout(2) { supervisor.run }
+      assert_empty store.fetch(attempt.attempt_id).receipt.fetch("output_references")
+    end
+  end
+
+  def test_failed_patrol_inbox_receives_a_bound_diagnostic
+    worker_argv = [ "hive", "run", "durable-task" ]
+    with_attempt(
+      worker_argv: worker_argv, intended_stage: "1-inbox",
+      workflow_controller: :patrol_fix
+    ) do |store, attempt|
+      supervisor = Hive::Attempts::Supervisor.new(
+        store: store, attempt_id: attempt.attempt_id,
+        claim_io: StringIO.new(CLAIM_CAPABILITY),
+        heartbeat_sec: 0.01, stale_sec: 1, first_heartbeat_timeout_sec: 1
+      )
+      supervisor.define_singleton_method(:resolved_worker_argv) do |_record|
+        [ RbConfig.ruby, "-e", "exit 8" ]
+      end
+
+      assert_equal 8, Timeout.timeout(2) { supervisor.run }
+      diagnostic = diagnostic_from_terminal(store, store.fetch(attempt.attempt_id))
+      assert_equal "agent_exit_nonzero", diagnostic.fetch("code")
+      assert_equal "1-inbox", diagnostic.fetch("stage")
+    end
+  end
+
+  def test_patrol_diagnostic_pipe_binds_one_artifact_and_exact_log_to_terminal_receipt
+    worker_argv = [ "hive", "run", "durable-task" ]
+    with_attempt(
+      worker_argv: worker_argv, intended_stage: "4-review",
+      workflow_controller: :patrol_fix
+    ) do |store, attempt|
+      draft = Hive::PatrolFix::AttemptDiagnostic.normalize(
+        {
+          "status" => "error", "exit_code" => 7, "timed_out" => false,
+          "cancelled" => false, "signal" => nil,
+          "report_status" => "unknown", "firewall_status" => "clean",
+          "custody_status" => "clean", "detail" => "agent exited without a report"
+        },
+        stage: "4-review",
+        task_generation: attempt.task_generation,
+        attempt_id: attempt.attempt_id,
+        recorded_at: NOW
+      )
+      secret = "github" + "_pat_" + ("A" * 24)
+      draft = draft.merge("detail" => "\e[31magent failed #{secret}")
+      worker = <<~RUBY
+        diagnostic = IO.for_fd(Integer(ENV.fetch("HIVE_ATTEMPT_DIAGNOSTIC_FD")), "w")
+        diagnostic.write(#{JSON.generate("#{JSON.generate(draft)}\n")})
+        diagnostic.close
+        warn "private provider body"
+        exit 7
+      RUBY
+      supervisor = Hive::Attempts::Supervisor.new(
+        store: store, attempt_id: attempt.attempt_id,
+        claim_io: StringIO.new(CLAIM_CAPABILITY),
+        heartbeat_sec: 0.01, stale_sec: 1, first_heartbeat_timeout_sec: 1
+      )
+      supervisor.define_singleton_method(:resolved_worker_argv) do |_record|
+        [ RbConfig.ruby, "-e", worker ]
+      end
+
+      assert_equal 7, Timeout.timeout(2) { supervisor.run }
+      terminal = store.fetch(attempt.attempt_id)
+      references = terminal.receipt.fetch("output_references")
+      assert_equal 1, references.length
+      reference = references.fetch(0)
+      assert Hive::Attempts::OutputReference.verify(reference, root: store.root)
+      diagnostic = JSON.parse(File.binread(File.join(store.root, reference.fetch("path"))))
+      assert_equal "agent_exit_nonzero", diagnostic.fetch("code")
+      assert_equal attempt.attempt_id, diagnostic.fetch("correlation_id")
+      assert_equal terminal.receipt.fetch("log_reference"), diagnostic.fetch("log_reference")
+      assert_equal "malformed", diagnostic.fetch("transport_status")
+      assert_nil diagnostic.fetch("detail")
+      refute_includes JSON.generate(diagnostic), secret
+      refute_includes JSON.generate(diagnostic), "\e[31m"
+      refute_includes JSON.generate(diagnostic), "private provider body"
+    end
+  end
+
+  def test_diagnostic_pipe_is_single_frame_bounded_and_fails_closed
+    assert_operator Hive::Attempts::DiagnosticChannel::MAX_FRAME_BYTES, :<, 4_096
+
+    missing = Hive::Attempts::DiagnosticChannel.read(StringIO.new(""))
+    assert_nil missing.document
+    assert_equal "missing", missing.status
+
+    malformed = Hive::Attempts::DiagnosticChannel.read(StringIO.new("{\n"))
+    assert_nil malformed.document
+    assert_equal "malformed", malformed.status
+
+    duplicate = Hive::Attempts::DiagnosticChannel.read(StringIO.new("{}\n{}\n"))
+    assert_nil duplicate.document
+    assert_equal "duplicate", duplicate.status
+
+    oversized = Hive::Attempts::DiagnosticChannel.read(
+      StringIO.new("x" * (Hive::Attempts::DiagnosticChannel::MAX_FRAME_BYTES + 1))
+    )
+    assert_nil oversized.document
+    assert_equal "oversized", oversized.status
+  end
+
+  def test_existing_diagnostic_collision_is_read_with_a_strict_bound_and_no_symlinks
+    with_tmp_dir do |root|
+      path = File.join(root, Hive::PatrolFix::AttemptDiagnostic::FILENAME)
+      supervisor = Hive::Attempts::Supervisor.new(
+        store: Object.new, attempt_id: "attempt-1",
+        claim_io: StringIO.new(CLAIM_CAPABILITY)
+      )
+      File.binwrite(
+        path, "x" * (Hive::PatrolFix::AttemptDiagnostic::MAX_BYTES + 1)
+      )
+      error = assert_raises(Hive::Attempts::StoreError) do
+        supervisor.send(:persist_diagnostic_once, path, {})
+      end
+      assert_match(/size limit/, error.message)
+
+      target = File.join(root, "target")
+      File.binwrite(target, "{}")
+      File.unlink(path)
+      File.symlink(target, path)
+      assert_raises(Hive::Attempts::StoreError) do
+        supervisor.send(:persist_diagnostic_once, path, {})
+      end
+    end
+  end
+
+  def test_failed_patrol_attempt_synthesizes_bound_diagnostic_when_frame_is_malformed
+    worker_argv = [ "hive", "run", "durable-task" ]
+    with_attempt(
+      worker_argv: worker_argv, intended_stage: "4-review",
+      workflow_controller: :patrol_fix
+    ) do |store, attempt|
+      worker = <<~'RUBY'
+        diagnostic = IO.for_fd(Integer(ENV.fetch("HIVE_ATTEMPT_DIAGNOSTIC_FD")), "w")
+        diagnostic.write("{malformed\n")
+        diagnostic.close
+        exit 9
+      RUBY
+      supervisor = Hive::Attempts::Supervisor.new(
+        store: store, attempt_id: attempt.attempt_id,
+        claim_io: StringIO.new(CLAIM_CAPABILITY),
+        heartbeat_sec: 0.01, stale_sec: 1, first_heartbeat_timeout_sec: 1
+      )
+      supervisor.define_singleton_method(:resolved_worker_argv) do |_record|
+        [ RbConfig.ruby, "-e", worker ]
+      end
+
+      assert_equal 9, Timeout.timeout(2) { supervisor.run }
+      terminal = store.fetch(attempt.attempt_id)
+      references = terminal.receipt.fetch("output_references")
+      assert_equal 1, references.length
+      diagnostic = JSON.parse(File.binread(File.join(store.root, references.fetch(0).fetch("path"))))
+      assert_equal "agent_exit_nonzero", diagnostic.fetch("code")
+      assert_equal "malformed", diagnostic.fetch("transport_status")
+      assert_equal attempt.task_generation, diagnostic.fetch("task_generation")
+      assert_equal terminal.receipt.fetch("log_reference"), diagnostic.fetch("log_reference")
+    end
+  end
+
+  def test_secret_bearing_metadata_frame_is_replaced_by_safe_fallback
+    worker_argv = [ "hive", "run", "durable-task" ]
+    with_attempt(
+      worker_argv: worker_argv, intended_stage: "4-review",
+      workflow_controller: :patrol_fix
+    ) do |store, attempt|
+      draft = Hive::PatrolFix::AttemptDiagnostic.normalize(
+        {
+          "status" => "error", "exit_code" => 9,
+          "provider" => "codex", "provider_failure" => "provider_error",
+          "provider_provenance" => "codex_jsonl_transport"
+        },
+        stage: "4-review", task_generation: attempt.task_generation,
+        attempt_id: attempt.attempt_id, recorded_at: NOW
+      )
+      secret = "github" + "_pat_" + ("A" * 24)
+      draft = JSON.parse(JSON.generate(draft))
+      draft.fetch("provider")["provenance"] = secret
+      worker = <<~RUBY
+        diagnostic = IO.for_fd(Integer(ENV.fetch("HIVE_ATTEMPT_DIAGNOSTIC_FD")), "w")
+        diagnostic.write(#{JSON.generate("#{JSON.generate(draft)}\n")})
+        diagnostic.close
+        exit 9
+      RUBY
+      supervisor = Hive::Attempts::Supervisor.new(
+        store: store, attempt_id: attempt.attempt_id,
+        claim_io: StringIO.new(CLAIM_CAPABILITY),
+        heartbeat_sec: 0.01, stale_sec: 1, first_heartbeat_timeout_sec: 1
+      )
+      supervisor.define_singleton_method(:resolved_worker_argv) do |_record|
+        [ RbConfig.ruby, "-e", worker ]
+      end
+
+      assert_equal 9, Timeout.timeout(2) { supervisor.run }
+      diagnostic = diagnostic_from_terminal(store, store.fetch(attempt.attempt_id))
+      assert_equal "malformed", diagnostic.fetch("transport_status")
+      assert_nil diagnostic.fetch("provider")
+      refute_includes JSON.generate(diagnostic), secret
+    end
+  end
+
+  def test_cancelled_patrol_attempt_synthesizes_diagnostic_when_frame_is_missing
+    worker_argv = [ "hive", "run", "durable-task" ]
+    with_attempt(
+      worker_argv: worker_argv, intended_stage: "4-review",
+      workflow_controller: :patrol_fix
+    ) do |store, attempt|
+      supervisor = Hive::Attempts::Supervisor.new(
+        store: store, attempt_id: attempt.attempt_id,
+        claim_io: StringIO.new(CLAIM_CAPABILITY),
+        heartbeat_sec: 0.01, stale_sec: 1, first_heartbeat_timeout_sec: 1,
+        timeout_sec: 0.03, kill_grace_sec: 0.03
+      )
+      supervisor.define_singleton_method(:resolved_worker_argv) do |_record|
+        [ RbConfig.ruby, "-e", "sleep 10" ]
+      end
+
+      assert_equal 124, Timeout.timeout(2) { supervisor.run }
+      terminal = store.fetch(attempt.attempt_id)
+      references = terminal.receipt.fetch("output_references")
+      assert_equal 1, references.length
+      diagnostic = JSON.parse(File.binread(File.join(store.root, references.fetch(0).fetch("path"))))
+      assert_equal "agent_timeout", diagnostic.fetch("code")
+      assert_equal true, diagnostic.fetch("timed_out")
+      assert_equal true, diagnostic.fetch("cancelled")
+      assert_equal "missing", diagnostic.fetch("transport_status")
+      assert_equal terminal.receipt.fetch("log_reference"), diagnostic.fetch("log_reference")
+    end
+  end
+
+  def test_signalled_patrol_attempt_synthesizes_artifact_and_log_reference
+    worker_argv = [ "hive", "run", "durable-task" ]
+    with_attempt(
+      worker_argv: worker_argv, intended_stage: "2-fix",
+      workflow_controller: :patrol_fix
+    ) do |store, attempt|
+      supervisor = Hive::Attempts::Supervisor.new(
+        store: store, attempt_id: attempt.attempt_id,
+        claim_io: StringIO.new(CLAIM_CAPABILITY), heartbeat_sec: 0.01,
+        stale_sec: 1, first_heartbeat_timeout_sec: 1
+      )
+      supervisor.define_singleton_method(:resolved_worker_argv) do |_record|
+        [ RbConfig.ruby, "-e", 'Process.kill("KILL", Process.pid)' ]
+      end
+
+      assert_equal 137, Timeout.timeout(2) { supervisor.run }
+      terminal = store.fetch(attempt.attempt_id)
+      diagnostic = diagnostic_from_terminal(store, terminal)
+      assert_equal "agent_signalled", diagnostic.fetch("code")
+      assert_equal "KILL", diagnostic.fetch("signal")
+      assert_equal terminal.receipt.fetch("log_reference"), diagnostic.fetch("log_reference")
+    end
+  end
+
+  def test_cancel_signal_synthesizes_cancelled_artifact_and_log_reference
+    worker_argv = [ "hive", "run", "durable-task" ]
+    with_attempt(
+      worker_argv: worker_argv, intended_stage: "2-fix",
+      workflow_controller: :patrol_fix
+    ) do |store, attempt|
+      supervisor = Hive::Attempts::Supervisor.new(
+        store: store, attempt_id: attempt.attempt_id,
+        claim_io: StringIO.new(CLAIM_CAPABILITY), heartbeat_sec: 0.01,
+        stale_sec: 1, first_heartbeat_timeout_sec: 1, kill_grace_sec: 0.03
+      )
+      supervisor.define_singleton_method(:resolved_worker_argv) do |_record|
+        [ RbConfig.ruby, "-e", "sleep 10" ]
+      end
+      supervisor.instance_variable_set(:@cancel_reason, :signal)
+      supervisor.instance_variable_set(:@cancel_signal, "TERM")
+
+      assert_equal 143, Timeout.timeout(2) { supervisor.run }
+      terminal = store.fetch(attempt.attempt_id)
+      diagnostic = diagnostic_from_terminal(store, terminal)
+      assert_equal "agent_cancelled", diagnostic.fetch("code")
+      assert_equal true, diagnostic.fetch("cancelled")
+      assert_equal "TERM", diagnostic.fetch("signal")
+      assert_equal terminal.receipt.fetch("log_reference"), diagnostic.fetch("log_reference")
+    end
+  end
+
   def test_timeout_and_heartbeat_continue_while_descendant_holds_output_pipe
     worker_argv = [
       "/bin/sh", "-c",
@@ -236,6 +577,27 @@ class AttemptsSupervisorTest < Minitest::Test
       assert_equal "terminal", terminal.state
       assert_equal "failed", terminal.outcome
       assert_includes ready.string, '"claimed":true'
+    end
+  end
+
+  def test_unexpected_patrol_supervisor_failure_still_binds_synthetic_diagnostic
+    with_attempt(
+      worker_argv: [ "hive", "run", "durable-task" ], intended_stage: "4-review",
+      workflow_controller: :patrol_fix
+    ) do |store, attempt|
+      supervisor = Hive::Attempts::Supervisor.new(
+        store: store, attempt_id: attempt.attempt_id,
+        claim_io: StringIO.new(CLAIM_CAPABILITY)
+      )
+      supervisor.define_singleton_method(:run_worker) { |_record, _log| raise "boom" }
+
+      assert_equal Hive::ExitCodes::SOFTWARE, supervisor.run
+      terminal = store.fetch(attempt.attempt_id)
+      reference = terminal.receipt.fetch("output_references").fetch(0)
+      diagnostic = JSON.parse(File.binread(File.join(store.root, reference.fetch("path"))))
+      assert_equal "agent_exit_nonzero", diagnostic.fetch("code")
+      assert_equal "missing", diagnostic.fetch("transport_status")
+      assert_equal terminal.receipt.fetch("log_reference"), diagnostic.fetch("log_reference")
     end
   end
 
@@ -351,19 +713,38 @@ class AttemptsSupervisorTest < Minitest::Test
 
   private
 
-  def with_attempt(worker_argv:, routing: { "mode" => "legacy" })
+  def diagnostic_from_terminal(store, terminal)
+    reference = terminal.receipt.fetch("output_references").find do |candidate|
+      File.basename(candidate.fetch("path")) == Hive::PatrolFix::AttemptDiagnostic::FILENAME
+    end
+    JSON.parse(File.binread(File.join(store.root, reference.fetch("path"))))
+  end
+
+  def with_attempt(worker_argv:, routing: { "mode" => "legacy" }, intended_stage: "4-execute",
+                   workflow_controller: nil)
     with_tmp_dir do |root|
       store = Hive::Attempts::Store.new(root: root)
       attempt = store.create_launching(
         attempt_id: "attempt-1", request_id: "request-1", predecessor_attempt_id: nil,
         task_id: "42", project: "demo", task_slug: "durable-task",
-        intended_stage: "4-execute", task_generation: "generation-1",
+        intended_stage: intended_stage, task_generation: "generation-1",
         progress_token: "progress-1", provider: "codex", worker_argv: worker_argv,
         claim_capability_digest: Hive::Attempts::Capability.digest(CLAIM_CAPABILITY), starting_revision: nil,
         retry_charge: 0, inherited_outputs: [], routing: routing,
         launch_timeout_sec: 30, now: Time.now.utc
       )
-      yield store, attempt
+      unless workflow_controller
+        yield store, attempt
+        next
+      end
+
+      workflow = Struct.new(:controller).new(workflow_controller)
+      task = Struct.new(:workflow).new(workflow)
+      resolver = Object.new
+      resolver.define_singleton_method(:resolve) { task }
+      with_replaced_singleton_method(
+        Hive::TaskResolver, :new, ->(*_args, **_kwargs) { resolver }
+      ) { yield store, attempt }
     end
   end
 

--- a/test/unit/commands/status_test.rb
+++ b/test/unit/commands/status_test.rb
@@ -84,6 +84,8 @@ class CommandsStatusTest < Minitest::Test
     reader.binding = binding
     reader.bytes = JSON.generate(diagnostic.merge("log_reference" => log_reference.merge("size" => 99)))
     assert_nil command.send(:attempt_diagnostic_for, row)
+    reader.bytes = "{"
+    assert_nil command.send(:attempt_diagnostic_for, row)
 
     running = Marshal.load(Marshal.dump(row))
     running[:projection_data]["journal"]["attempts"][0]["state"] = "running"

--- a/test/unit/commands/status_test.rb
+++ b/test/unit/commands/status_test.rb
@@ -6,6 +6,92 @@ require "hive/task_action"
 class CommandsStatusTest < Minitest::Test
   include HiveTestHelper
 
+  def test_patrol_attempt_diagnostic_projection_is_receipt_bound_and_rejects_stale_identity
+    log_reference = {
+      "path" => "logs/attempt-1.frames", "size" => 12, "sha256" => "a" * 64
+    }
+    diagnostic = Hive::PatrolFix::AttemptDiagnostic.normalize(
+      {
+        "phase" => "managed_agent", "status" => "error",
+        "error_reason" => "agent_exit", "exit_code" => 7,
+        "report_status" => "invalid", "report_parser" => "review_report",
+        "firewall_status" => "clean", "custody_status" => "clean"
+      },
+      stage: "4-review", task_generation: "generation-1",
+      attempt_id: "attempt-1", recorded_at: Time.now.utc,
+      log_reference: log_reference
+    )
+    reference = {
+      "path" => "outputs/attempt-1/patrol-fix-attempt-diagnostic.v1.json",
+      "size" => JSON.generate(diagnostic).bytesize, "sha256" => "b" * 64
+    }
+    receipt = {
+      "output_references" => [ reference ], "log_reference" => log_reference
+    }
+    binding = {
+      "attempt_id" => "attempt-1", "stage" => "4-review",
+      "task_generation" => "generation-1", "receipt" => receipt
+    }
+    reader = Struct.new(:binding, :bytes, :fetches) do
+      def fetch_terminal_diagnostic_binding(_attempt_id)
+        self.fetches += 1
+        binding
+      end
+      def read_output(_reference, max_bytes:)
+        raise "unbounded read" unless max_bytes == Hive::PatrolFix::AttemptDiagnostic::MAX_BYTES
+        bytes
+      end
+    end.new(binding, JSON.generate(diagnostic), 0)
+    command = Hive::Commands::Status.new(json: true)
+    command.instance_variable_set(:@status_attempt_store, reader)
+    task_projection = Hive::TaskProjection.from_data(
+      "schema" => Hive::TaskProjection::SCHEMA,
+      "schema_version" => Hive::TaskProjection::SCHEMA_VERSION,
+      "identity" => { "attempt_id" => "attempt-1", "task_generation" => 9 },
+      "journal" => {
+        "attempts" => [
+          { "attempt_id" => "attempt-1", "state" => "terminal", "outcome" => "failed" }
+        ]
+      }
+    )
+    row = {
+      workflow: "patrol-fix", stage: "4-review",
+      projection_data: task_projection.to_h
+    }
+
+    projected = command.send(:attempt_diagnostic_for, row)
+    assert_equal "agent_exit_nonzero", projected.fetch("code")
+    assert_equal "agent", projected.fetch("owner")
+    assert_equal "managed_agent", projected.fetch("phase")
+    assert_equal "error", projected.fetch("status")
+    assert_equal "agent_exit", projected.fetch("agent_reason")
+    assert_equal 7, projected.fetch("exit_code")
+    assert_equal false, projected.fetch("timed_out")
+    assert_equal false, projected.fetch("cancelled")
+    assert_nil projected.fetch("signal")
+    assert_nil projected.fetch("provider")
+    assert_equal "review_report", projected.fetch("report_parser")
+    assert_nil projected.fetch("firewall_restoration")
+    assert_equal reference.fetch("sha256"), projected.fetch("diagnostic_digest")
+    assert_equal reference, projected.fetch("diagnostic_reference")
+    assert_equal log_reference, projected.fetch("log_reference")
+
+    stale = Marshal.load(Marshal.dump(row))
+    stale[:projection_data]["identity"]["attempt_id"] = "attempt-stale"
+    assert_nil command.send(:attempt_diagnostic_for, stale)
+    reader.binding = binding.merge("task_generation" => "generation-2")
+    assert_nil command.send(:attempt_diagnostic_for, row)
+    reader.binding = binding
+    reader.bytes = JSON.generate(diagnostic.merge("log_reference" => log_reference.merge("size" => 99)))
+    assert_nil command.send(:attempt_diagnostic_for, row)
+
+    running = Marshal.load(Marshal.dump(row))
+    running[:projection_data]["journal"]["attempts"][0]["state"] = "running"
+    reader.fetches = 0
+    assert_nil command.send(:attempt_diagnostic_for, running)
+    assert_equal 0, reader.fetches
+  end
+
   def test_default_json_call_uses_compact_producer_without_building_full_graph
     with_tmp_dir do |project_root|
       hive_state = File.join(project_root, ".hive-state")

--- a/test/unit/component_boundaries_test.rb
+++ b/test/unit/component_boundaries_test.rb
@@ -163,6 +163,7 @@ class ComponentBoundariesTest < Minitest::Test
     assert_equal "Hive::PatrolFix", patrol_fix.dig("entrypoint", "constant")
     assert_equal %w[
       Hive::PatrolFix::AdmissionStore
+      Hive::PatrolFix::AttemptDiagnostic
       Hive::PatrolFix::FixReport
       Hive::PatrolFix::InboxReport
       Hive::PatrolFix::Projection

--- a/test/unit/operational_status_test.rb
+++ b/test/unit/operational_status_test.rb
@@ -39,6 +39,33 @@ class OperationalStatusTest < Minitest::Test
     refute result.fetch("tasks").any? { |row| row.dig("identity", "slug") == "archived" }
   end
 
+  def test_typed_attempt_diagnostic_owner_and_digest_are_preserved_before_retry_projection
+    diagnostic = {
+      "summary" => "provider_rate_limited (provider)",
+      "detail" => "No provider-safe detail was emitted.",
+      "source" => "artifact", "source_path" => "outputs/attempt-1/diagnostic.json",
+      "artifact_paths" => [ "outputs/attempt-1/diagnostic.json", "logs/attempt-1.frames" ],
+      "generated_by" => "local", "marker_signature" => "c" * 64,
+      "suggested_next_action" => nil, "updated_at" => "2026-07-20T10:00:00Z",
+      "code" => "provider_rate_limited", "owner" => "provider",
+      "diagnostic_digest" => "d" * 64
+    }
+    row = task(action: "error", slug: "patrol", marker: "error").merge(
+      "workflow" => "patrol-fix", "diagnostic" => diagnostic
+    )
+
+    projected = project(
+      status_payload(row),
+      project_context: { "demo" => { "daemon_enabled" => true } }
+    ).fetch("tasks").first
+
+    assert_equal "waiting_on_provider_or_scheduler", projected.fetch("state")
+    assert_equal "provider", projected.fetch("blocker_owner")
+    assert_equal "provider_rate_limited", projected.dig("reasons", 0, "code")
+    assert_equal "attempt_diagnostic", projected.dig("reasons", 0, "source")
+    assert_equal diagnostic, projected.dig("evidence", "diagnostic")
+  end
+
   def test_operational_snapshot_identifies_the_active_dogfood_build
     sha = "0864de726d9a75f7bc46610a89db851c90b402ee"
     result = Hive::OperationalStatus.new(

--- a/test/unit/patrol_fix/runner_test.rb
+++ b/test/unit/patrol_fix/runner_test.rb
@@ -1,6 +1,10 @@
 require "test_helper"
 require "hive/patrol_fix/runner"
 require "hive/stages/patrol_fix/inbox"
+require "hive/stages/patrol_fix/runner"
+require "hive/attempts/context"
+require "hive/attempts/diagnostic_channel"
+require "hive/github_publication"
 
 class PatrolFixRunnerTest < Minitest::Test
   include HiveTestHelper
@@ -65,5 +69,73 @@ class PatrolFixRunnerTest < Minitest::Test
     end
 
     assert_includes error.message, "controller for stage done is not available"
+  end
+
+  def test_controller_failures_publish_semantic_attempt_diagnostics_before_reraising
+    cases = [
+      [ "validate", Hive::StageError.new("validation changed the worktree bytes"),
+        "validation_mutation" ],
+      [ "publish", Hive::StageError.new("reviewed worktree is dirty before publication"),
+        "fix_worktree_dirty" ],
+      [ "publish", Hive::StageError.new("reviewed worktree HEAD changed before publication"),
+        "worktree_head_custody_mismatch" ],
+      [ "fix", Hive::StageError.new("fatal: unable to create .hive-state/index.lock"),
+        "state_git_index_lock" ],
+      [ "publish", Hive::GithubPublication::Blocked.new(
+        "secret_detected", "publication secret policy blocked body bytes"
+      ), "secret_policy_publish_blocked" ]
+    ]
+
+    cases.each do |stage, failure, expected_code|
+      raised, frame = capture_controller_failure(stage: stage, failure: failure)
+
+      assert_same failure, raised
+      assert_equal "valid", frame.status
+      assert_equal expected_code, frame.document.fetch("code")
+      assert_equal "hive", frame.document.fetch("owner")
+    end
+  end
+
+  private
+
+  def capture_controller_failure(stage:, failure:)
+    reader, writer = IO.pipe
+    context = Hive::Attempts::Context.send(
+      :new,
+      attempt_id: "attempt-controller", task_generation: 4,
+      ownership_generation: "opaque-generation", intended_stage: stage_dir(stage),
+      diagnostic_writer: Hive::Attempts::DiagnosticChannel::Writer.new(writer)
+    )
+    task = Struct.new(:stage_name).new(stage)
+    transition = Object.new
+    transition.define_singleton_method(:reconcile!) { nil }
+    handler = ->(*) { raise failure }
+    raised = nil
+
+    with_replaced_singleton_method(Hive::Attempts::Context, :current, -> { context }) do
+      with_replaced_singleton_method(Hive::PatrolFix::Transition, :new, ->(*) { transition }) do
+        with_replaced_singleton_method(Hive::PatrolFix::Runner, :load_handler, ->(*) { handler }) do
+          raised = assert_raises(failure.class) do
+            Hive::Stages::PatrolFix::Runner.run!(task)
+          end
+        end
+      end
+    end
+    context.close
+    [ raised, Hive::Attempts::DiagnosticChannel.read(reader) ]
+  ensure
+    context&.close
+    [ reader, writer ].compact.each do |io|
+      io.close unless io.closed?
+    rescue Errno::EBADF
+      nil
+    end
+  end
+
+  def stage_dir(stage)
+    {
+      "fix" => "2-fix", "validate" => "3-validate",
+      "review" => "4-review", "publish" => "5-publish"
+    }.fetch(stage)
   end
 end

--- a/test/unit/patrol_fix/runner_test.rb
+++ b/test/unit/patrol_fix/runner_test.rb
@@ -96,6 +96,26 @@ class PatrolFixRunnerTest < Minitest::Test
     end
   end
 
+  def test_controller_failure_remains_authoritative_when_diagnostic_publication_also_fails
+    failure = Hive::StageError.new("controller failed")
+
+    raised = with_replaced_singleton_method(
+      Hive::PatrolFix::Runner, :run!, ->(*) { raise failure }
+    ) do
+      with_replaced_singleton_method(
+        Hive::Stages::ManagedAgentCustody,
+        :publish_controller_failure,
+        ->(**) { raise IOError, "diagnostic pipe closed" }
+      ) do
+        assert_raises(Hive::StageError) do
+          Hive::Stages::PatrolFix::Runner.run!(Struct.new(:stage_name).new("fix"))
+        end
+      end
+    end
+
+    assert_same failure, raised
+  end
+
   private
 
   def capture_controller_failure(stage:, failure:)

--- a/test/unit/stages/managed_agent_custody_test.rb
+++ b/test/unit/stages/managed_agent_custody_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 require "open3"
 require "hive/task"
+require "hive/attempts/context"
+require "hive/attempts/diagnostic_channel"
 require "hive/stages/managed_agent_custody"
 
 class ManagedAgentCustodyTest < Minitest::Test
@@ -177,6 +179,109 @@ class ManagedAgentCustodyTest < Minitest::Test
     end
   end
 
+  def test_failed_agent_publishes_typed_process_diagnostic_through_attempt_context
+    with_task do |task|
+      output = File.join(task.folder, "patrol-fix-inbox-report.json")
+      spawn = lambda do |_task, agent_custody:, **|
+        agent_custody.call do
+          {
+            status: :error, exit_code: 17, timed_out: false,
+            cancelled: false, signal: nil, error_reason: "agent_exit"
+          }
+        end
+      end
+
+      result, frame = capture_diagnostic(stage: "1-inbox") do
+        with_replaced_singleton_method(Hive::Stages::Base, :spawn_agent, spawn) do
+          launch(task, output)
+        end
+      end
+
+      assert_equal :error, result.fetch(:status)
+      assert_equal "valid", frame.status
+      assert_equal "agent_exit_nonzero", frame.document.fetch("code")
+      assert_equal 17, frame.document.fetch("exit_code")
+      assert_equal "opaque-generation", frame.document.fetch("task_generation")
+      assert_nil frame.document.fetch("log_reference")
+    end
+  end
+
+  def test_provider_failure_keeps_class_hint_and_provenance_without_raw_message
+    with_task do |task|
+      output = File.join(task.folder, "patrol-fix-inbox-report.json")
+      secret = "provider raw token github" + "_pat_" + ("A" * 24)
+      spawn = lambda do |_task, agent_custody:, **|
+        agent_custody.call do
+          {
+            status: :error, exit_code: 1, timed_out: false,
+            provider_error: {
+              kind: :rate_limited, provider: :pi, retry_after: 45,
+              provenance: "pi_jsonl", message: secret
+            }
+          }
+        end
+      end
+
+      _result, frame = capture_diagnostic(stage: "1-inbox") do
+        with_replaced_singleton_method(Hive::Stages::Base, :spawn_agent, spawn) do
+          launch(task, output)
+        end
+      end
+
+      assert_equal "provider_rate_limited", frame.document.fetch("code")
+      assert_equal "provider", frame.document.fetch("owner")
+      assert_equal "45", frame.document.dig("provider", "retry_hint")
+      assert_equal "pi_jsonl", frame.document.dig("provider", "provenance")
+      refute_includes JSON.generate(frame.document), secret
+    end
+  end
+
+  def test_invalid_fix_and_review_parser_results_publish_typed_report_diagnostics
+    {
+      "2-fix" => [ "fix_report", "fix_report_invalid" ],
+      "4-review" => [ "review_report", "agent_report_invalid" ]
+    }.each do |stage, (parser, code)|
+      _result, frame = capture_diagnostic(stage: stage) do
+        Hive::Stages::ManagedAgentCustody.publish_report_invalid(
+          stage: stage, parser: parser, detail: "malformed report"
+        )
+      end
+
+      assert_equal code, frame.document.fetch("code")
+      assert_equal "invalid", frame.document.fetch("report_status")
+      assert_equal parser, frame.document.fetch("report_parser")
+    end
+  end
+
+  def test_git_config_firewall_tamper_normalizes_restoration_state
+    restoration = Hive::ArtifactFirewall::Restoration.new(
+      attempted: true, succeeded: true, diagnostic: "restored"
+    )
+    violation = Hive::ArtifactFirewall::Violation.new(
+      kind: :protected_changed, label: "repository config",
+      path: "/private/repository/config", diagnostic: "changed"
+    )
+    report = Hive::ArtifactFirewall::Report.new(
+      snapshot_id: "snapshot", status: :tampered_restored,
+      violations: [ violation ], restoration: restoration,
+      diagnostic: "repository config restored"
+    )
+    envelope = Hive::Stages::ManagedAgentCustody.send(
+      :diagnostic_envelope,
+      { status: :ok, exit_code: 0, timed_out: false }, report,
+      status: :ok, custody_status: :tampered, provider: :pi
+    )
+    diagnostic = Hive::PatrolFix::AttemptDiagnostic.normalize(
+      envelope,
+      stage: "2-fix", task_generation: "generation-1",
+      attempt_id: "attempt-1", recorded_at: Time.now.utc
+    )
+
+    assert_equal "protected_git_config_tamper", diagnostic.fetch("code")
+    assert_equal "tampered_restored", diagnostic.fetch("firewall_status")
+    assert_equal "restored", diagnostic.fetch("firewall_restoration")
+  end
+
   def test_launch_agent_does_not_recover_rate_limits_without_a_clean_process_exit
     [
       { exit_code: 1, timed_out: false },
@@ -344,6 +449,28 @@ class ManagedAgentCustodyTest < Minitest::Test
   end
 
   private
+
+  def capture_diagnostic(stage:)
+    reader, writer = IO.pipe
+    diagnostic_writer = Hive::Attempts::DiagnosticChannel::Writer.new(writer)
+    context = Hive::Attempts::Context.send(
+      :new,
+      attempt_id: "attempt-managed", task_generation: 9,
+      ownership_generation: "opaque-generation", intended_stage: stage,
+      diagnostic_writer: diagnostic_writer
+    )
+    result = with_replaced_singleton_method(
+      Hive::Attempts::Context, :current, -> { context }
+    ) { yield }
+    [ result, Hive::Attempts::DiagnosticChannel.read(reader) ]
+  ensure
+    context&.close
+    [ reader, writer ].compact.each do |io|
+      io.close unless io.closed?
+    rescue Errno::EBADF
+      nil
+    end
+  end
 
   def launch(task, output, cfg: {}, actor: "patrol_review", stage: "inbox",
              log_label: "patrol-fix-inbox")

--- a/test/unit/stages/managed_agent_custody_test.rb
+++ b/test/unit/stages/managed_agent_custody_test.rb
@@ -253,6 +253,24 @@ class ManagedAgentCustodyTest < Minitest::Test
     end
   end
 
+  def test_attempt_diagnostic_publication_fails_closed_when_transport_is_unavailable
+    context = Struct.new(:intended_stage, :ownership_generation, :attempt_id) do
+      def publish_attempt_diagnostic(_diagnostic)
+        raise IOError, "diagnostic pipe closed"
+      end
+    end.new("2-fix", "opaque-generation", "attempt-1")
+
+    result = with_replaced_singleton_method(
+      Hive::Attempts::Context, :current, -> { context }
+    ) do
+      Hive::Stages::ManagedAgentCustody.publish_attempt_diagnostic(
+        { "status" => "error", "exit_code" => 1 }, stage: "fix"
+      )
+    end
+
+    assert_nil result
+  end
+
   def test_git_config_firewall_tamper_normalizes_restoration_state
     restoration = Hive::ArtifactFirewall::Restoration.new(
       attempted: true, succeeded: true, diagnostic: "restored"

--- a/test/unit/stages/patrol_fix/fix_test.rb
+++ b/test/unit/stages/patrol_fix/fix_test.rb
@@ -165,6 +165,30 @@ class PatrolFixFixStageTest < Minitest::Test
     end
   end
 
+  def test_agent_run_validation_surfaces_typed_failure_and_custody_codes
+    failure = assert_raises(Hive::StageError) do
+      Hive::Stages::PatrolFix::Fix.send(
+        :validate_agent_run!,
+        { status: :error, attempt_diagnostic: { "code" => "agent_exit_nonzero" } }
+      )
+    end
+    assert_equal "fix agent failed: agent_exit_nonzero", failure.message
+
+    custody = assert_raises(Hive::StageError) do
+      Hive::Stages::PatrolFix::Fix.send(
+        :validate_agent_run!,
+        {
+          status: :ok, custody: :tampered,
+          attempt_diagnostic: { "code" => "protected_git_config_tamper" }
+        }
+      )
+    end
+    assert_equal(
+      "fix agent modified controller authority: protected_git_config_tamper",
+      custody.message
+    )
+  end
+
   private
 
   def with_fix_task

--- a/test/unit/stages/resolver_test.rb
+++ b/test/unit/stages/resolver_test.rb
@@ -117,7 +117,7 @@ class StagesResolverTest < Minitest::Test
         task(stage.name, workflow: descriptor), descriptor: descriptor
       )
 
-      assert_equal Hive::PatrolFix::Runner.method(:run!), runner
+      assert_equal Hive::Stages::PatrolFix::Runner.method(:run!), runner
     end
   end
 

--- a/wiki/commands/status.md
+++ b/wiki/commands/status.md
@@ -3,7 +3,7 @@ title: hive status
 type: command
 source: lib/hive/commands/status.rb, lib/hive/running_status.rb, lib/hive/task_projection/store.rb, lib/hive/task_closure.rb, lib/hive/operational_status.rb, lib/hive/runtime_identity.rb, lib/hive/operational_action.rb, lib/hive/daemon/operational_snapshot.rb, lib/hive/diagnostic_evidence.rb
 created: 2026-04-25
-updated: 2026-08-25
+updated: 2026-08-26
 tags: [command, status, operational, agents, observability, json, diagnostics, archive, closure, blocked, plan-review, terminal-outcomes, dependencies, scheduler]
 ---
 
@@ -145,6 +145,20 @@ The hidden compatibility graph continues to expose their action as
 (`marker: none`, no suggested command) and reports `completion_ready` with
 `blocker_owner: none`. Rejected, blocked, and escalated findings therefore
 remain visible for audit without inflating the operator-decision count.
+
+A current failed Patrol attempt may project a receipt-bound typed diagnostic
+through the existing task `diagnostic` field. Status resolves only the
+diagnostic output reference named by the validated terminal Record, verifies
+its bounded bytes and digest, and requires its attempt, stage, opaque ownership
+generation, and log reference to match that Record. The task and operational
+documents expose the same diagnostic digest, owner, process/provider/parser/
+firewall fields, and safe references. Stale identity, tampered bytes, symlinks,
+or a mismatched log reference omit the projection; status never opens the raw
+log as a substitute. The task journal must first identify the current attempt
+as terminal and failed or cancelled, so running and successful rows do not
+point-fetch diagnostic receipts on the status hot path. A provider-owned typed
+failure is provider-waiting, while other typed failures are repair-owned.
+Durable recovery disposition and pacing remain separate policy.
 
 For a daemon-enrolled project with global automatic retry enabled, a real
 `ERROR` or `REVIEW_ERROR` defaults to

--- a/wiki/gaps.md
+++ b/wiki/gaps.md
@@ -61,6 +61,24 @@ New first generations now fail closed onto exact `origin/<default>` OIDs; the
 remaining live-delivery proof must come from a task admitted after that cutover
 and reach one focused hosted PR.
 
+## Patrol dispatch incident demand baseline (2026-08-26)
+
+The sanitized 600-charge incident replay pins the Patrol/coding, outcome,
+generation-stage repeat, stage, and failure-class aggregates without retaining
+task identities, provider output, secret material, credentials, or host paths.
+It also characterizes the current undifferentiated daily pool: once Patrol has
+used all 600 charges, later-stage Patrol progress, first-attempt Patrol work,
+and non-Patrol work are all starved even though later-stage ordering remains
+stable. This is expected-failure evidence for the later containment units, not
+a scheduling-policy change.
+
+The preceding seven complete UTC days cannot be reconstructed into a
+defensible non-Patrol demand series from the retained Attempts v4 records.
+Historical `1-inbox` attempts do not all carry an unambiguous durable workflow
+identity, so classifying them as Patrol or coding would invent evidence. Until
+workflow-attributed history exists, reserve calibration must use the documented
+10% fail-safe rather than a fabricated p95.
+
 **TLDR**: The wiki has broad domain coverage for the current `lib/`, command, stage, TUI, daemon, bot, native Hive web, Hivebox container, testing/static-analysis, template/prompt, and release surfaces, but the source-file map below is representative rather than an automatically verified one-file-per-source audit. Remaining gaps are mainly live behavioral verification and a few deeper reference pages.
 
 ## OpenCode live validation (updated 2026-08-21)

--- a/wiki/log.d/2026-08-26-2300-patrol-attempt-diagnostics.md
+++ b/wiki/log.d/2026-08-26-2300-patrol-attempt-diagnostics.md
@@ -1,0 +1,22 @@
+---
+date: 2026-08-26
+title: Patrol Fix attempts retain typed private diagnostics
+tags: [patrol-fix, attempts, diagnostics, status, security]
+---
+
+- Managed Patrol agents now normalize process, provider, parser, and Artifact
+  Firewall failure facts into one bounded, versioned diagnostic frame.
+- The Attempts supervisor validates or synthesizes the diagnostic, rejects
+  secret-bearing metadata, injects the exact private log reference, and
+  appends the immutable output reference before the terminal receipt. Trusted
+  provider evidence owns attribution when present.
+- Task and operational status verify the receipt-bound artifact and project
+  the same safe typed fields, digest, owner, and references without reading raw
+  provider output or raw logs.
+- Status point-fetches that artifact only after the journal identifies the
+  current attempt as terminal and failed or cancelled. Invalid Fix reports
+  retain the specific `fix_report_invalid` cohort code.
+- Workflow classification resolves the task controller rather than inferring
+  it from overlapping stage directory names. Patrol controller exceptions
+  preserve semantic worktree, validation, publication-policy, and state-Git
+  failure cohorts before they reach the supervisor.

--- a/wiki/log.d/20260826T172453Z-patrol-dispatch-incident-baseline.md
+++ b/wiki/log.d/20260826T172453Z-patrol-dispatch-incident-baseline.md
@@ -1,0 +1,25 @@
+---
+title: Freeze the Patrol dispatch incident baseline
+type: testing
+date: 2026-08-26
+tags: [patrol-fix, attempts, incident-replay, capacity]
+---
+
+Added a sanitized, deterministic replay of the August 26 daily-cap incident.
+The fixture preserves all 600 charged attempts, 598 Patrol Fix and two coding
+attempts, 153 failures and 447 successes, the 459 generation-stage identities
+and their repeat distribution, and all nine observed failure cohorts. Raw
+provider output, task identities, prompts, secret material, credentials, and
+host paths are excluded.
+
+The replay separately stores pre-normalization terminal envelopes and expected
+normalized codes, pins existing unstarted and TEMPFAIL refunds, preserves
+later-stage ordering, and records current starvation at cap 600 as an expected
+future-containment failure. Portable metadata retains the temporary 1,000 cap,
+the 600 rollback target, and the final soak/UTC-window exit gate. No production
+scheduling or recovery behavior changes in this characterization unit.
+
+Seven-day non-Patrol demand remains unknown because retained historical
+attempts do not unambiguously identify the workflow for every `1-inbox`
+record. The fixture records that uncertainty and the 10% fail-safe instead of
+inventing a demand series.

--- a/wiki/modules/attempts.md
+++ b/wiki/modules/attempts.md
@@ -3,8 +3,8 @@ title: Durable task attempts
 type: module
 source: lib/hive/attempts/
 created: 2026-07-16
-updated: 2026-08-22
-tags: [attempts, ownership, leases, daemon, recovery, bounded-storage]
+updated: 2026-08-26
+tags: [attempts, ownership, leases, daemon, recovery, bounded-storage, diagnostics]
 ---
 
 **TLDR**: Every accepted task-stage launch has one immutable attempt ID and
@@ -21,11 +21,11 @@ task agents.
 | `API` | Provide Hive commands, bot delivery, daemon recovery, and module-hook delivery with the stable admission operations `dispatch`, `dispatch_request`, `dispatch_successor`, and `dispatch_module_hook`, while keeping one injected store shared by its foreground and daemon adapters. |
 | `Contracts` | Define the public `ClientResult`, `DispatchResult`, and `UnsupportedDetachment` values independently of the internal client, dispatcher, and launcher implementations. |
 | `Record`, `Store` | Read and write schema-v4 records in the physical v4 layout, scan only hot records, point-fetch hot or permanent proof, perform locked guarded transitions with atomic write/fsync/rename persistence, and copy nested record/checkpoint/receipt values through `Hive::StringifyKeys`. `Store::ProjectionReader` is a read-only scan-scoped view that caches each immutable projection binding once without making the long-lived runtime store stale. The default store opens only v4 and contains no migration trigger or legacy-layout monitor. |
-| `Capability`, `Context` | Generate one-time launch authority, authenticate the exact worker process/task/stage, revalidate generation at the mutation boundary, and expose the immutable admitted route plus process-local compatibility projections after transport variables are scrubbed. |
+| `Capability`, `Context` | Generate one-time launch authority, authenticate the exact worker process/task/stage, revalidate generation at the mutation boundary, expose the immutable admitted route, and provide one inherited bounded diagnostic writer after transport variables are scrubbed. |
 | `Generation` | Bind stable task identity, intended stage, and a workflow progress token into the semantic ownership key. |
 | `Dispatcher` | Resolve receipt replay, live duplicate attachment, loss deferral, capacity, deterministic explicit-provider routing, fresh admission, and explicit successors. |
 | `DetachedLauncher` | Reject unsupported platforms before handoff, create a POSIX session, and start the private supervisor route. |
-| `Supervisor` | Claim, first-heartbeat, spawn the existing Hive command, heartbeat, frame output, enforce timeout/cancellation, and terminalize. |
+| `Supervisor` | Claim, first-heartbeat, spawn the existing Hive command, heartbeat, frame output, enforce timeout/cancellation, validate one child diagnostic frame, bind its exact private log reference, and terminalize only after appending the diagnostic output reference. |
 | `Client` | Tail frames read-only and replay a terminal result. It performs one final drain after observing a terminal or lost record so frames published during the decisive record fetch are not dropped. Interrupt means detach; it never signals the owner group. |
 | `CommandDispatch` | Give `hive run` and workflow stage commands one attach-result policy: shared durable dispatch, lost-attempt translation, receipt exit propagation, and single-document JSON fallback when a failed worker emitted no stdout. |
 | `Reconciler`, `ProcessIdentity` | Adopt without `wait2`, detect PID/start/session/group mismatch, preserve suspects, expire launches, normalize loss, and publish current hot counts beside cached storage-maintenance health without scanning historical proof or cold logs. |
@@ -183,6 +183,24 @@ deadlines, checkpoint, integrity references, diagnostics, and loss or receipt
 fields. The capability itself is never persisted. Large payloads remain
 owner-private referenced files with canonical relative path, byte size, and
 SHA-256.
+
+Failed Patrol Fix attempts add exactly one
+`outputs/<attempt-id>/patrol-fix-attempt-diagnostic.v1.json`. The child may
+send one bounded schema-valid frame; EOF, duplicate, malformed, and oversized
+frames are closed transport states rather than trusted evidence. The
+supervisor revalidates identity and scans the complete document for secret
+patterns, injects the exact
+per-spawn log reference, and synthesizes a minimal typed terminal diagnostic
+from authoritative exit, timeout, cancellation, and signal state whenever a
+failed Patrol attempt has no usable frame. Secret-bearing metadata invalidates
+the child frame rather than being persisted. A trusted provider-evidence signal
+overrides child attribution and supplies the provider-owned failure class on
+both finalized and synthesized diagnostics. The supervisor resolves the task's
+current workflow controller before writing the artifact; overlapping Bench and
+Patrol stage directory names are not workflow identity. Output reads used by projections
+share the `OutputReference` custody primitive: they open the validated lexical
+path with `O_NOFOLLOW`, bound bytes, and verify the receipt size and SHA-256
+from the same descriptor. Raw log bytes are never a status fallback.
 
 For an explicit pool, admission freezes the task-generation policy before the
 first decision, including no-route and provider-capacity results. Under the

--- a/wiki/modules/patrol.md
+++ b/wiki/modules/patrol.md
@@ -3,7 +3,7 @@ title: Hive::Patrol
 type: module
 source: lib/hive/patrol/, lib/hive/refactor_patrol/, lib/hive/patrol_fix/, script/migrate_patrol_findings.rb
 created: 2026-05-28
-updated: 2026-08-25
+updated: 2026-08-26
 tags: [module, patrol, architecture, workflow]
 ---
 
@@ -179,6 +179,22 @@ the controller may materialize only that exact, untruncated JSON object before
 Artifact Firewall validation. Prose, arrays, truncated output, and any existing
 path are not accepted; in particular, a dangling report symlink remains a
 custody violation rather than being replaced by the fallback.
+
+Managed Inbox, Fix, and Review failures normalize the existing agent process,
+provider, parser, and Artifact Firewall facts into the versioned Patrol Fix
+attempt-diagnostic schema before custody returns. The artifact records the
+opaque attempt ownership generation (not the numeric task input epoch), a
+snake-case failure code and owner, process termination state, provider class
+and retry hint without provider response text, report/parser state, firewall
+restoration, and bounded publication-policy-redacted detail. A clean report
+after Pi's recovered internal provider retry remains successful and emits no
+failure frame. Invalid Fix reports emit `fix_report_invalid`; invalid reports
+from the other managed stages emit `agent_report_invalid`. Silent failures
+receive a supervisor-authored terminal diagnostic. The first-party controller
+also publishes semantic failure facts before reraising known worktree head
+drift, dirty worktrees, validation mutation, publication secret blocks, and
+Hive-state Git index-lock conflicts, so those failures retain their typed
+cohort codes even when no managed agent seam ran.
 
 Independent review hashes the bounded Git diff as raw bytes, then validates and
 labels a copy as UTF-8 before placing it in the canonical prompt context. Valid


### PR DESCRIPTION
## Summary

- Failed Patrol attempts now retain one bounded, secret-safe diagnostic that is bound to the exact terminal receipt and private per-attempt log.
- Status can distinguish provider, agent, controller, worktree, validation, publication-policy, and state-Git failures without parsing raw output. A sanitized replay freezes the 600-launch incident as the baseline for later containment work.

This is the first implementation slice of the wider Patrol dispatch-failure containment program. Later slices will address commit serialization, checkout isolation, pre-spend Git-config isolation, deterministic publication parking, and durable cohort pacing.

## Test plan

- [x] Focused attempt, Patrol stage, status, schema, workflow resolver, and component-boundary tests pass.
- [x] `bundle exec rake test` passes: 13,669 runs, 276,353 assertions, 0 failures, 0 errors, 10 skips.
- [x] Full RuboCop gate passes with the bundled RuboCop 1.89 executable.
- [x] Structured code review completed across correctness, security, reliability, performance, API contract, project standards, testing, maintainability, agent-native parity, and documented learnings; all six findings were fixed and rechecked.
- [x] Hosted CI coverage and dedicated merge gates are green.
- [ ] Dogfood observation completed after a separately authorized deployment.

## Notes for reviewer

- Child diagnostics are treated as untrusted. Missing, malformed, duplicate, oversized, secret-bearing, or schema-invalid frames become a minimal supervisor-authored diagnostic.
- Trusted provider evidence overrides child attribution. Workflow identity is resolved from the task controller, so a Bench `5-publish` failure cannot acquire a Patrol artifact.
- Projection accepts only an exact terminal-record binding and a verified no-follow output reference. It never falls back to raw or latest logs.
- The incident fixture contains sanitized aggregate envelopes, not production logs or provider output.

## Deployment monitoring

- Reviewed head: `93253ea65611fae34ff026134a3035d431329f52`.
- After deployment, observe the next 10 failed Patrol attempts and include at least one daemon restart.
- Each failed attempt must expose one `patrol-fix-attempt-diagnostic` with a non-empty typed code, `secret_policy_version`, exact diagnostic reference, and resolvable log reference.
- Watch `transport_status`, `redaction_status`, missing or malformed frames, and provider-owner consistency. Do not inspect or publish raw provider output.
- Mitigate by rolling back this PR if any failed Patrol attempt lacks its artifact or receipt binding, if status cannot resolve the reference, or if secret-shaped text reaches the artifact or status projection.
- Owner: operator. Observation window ends after 10 failed attempts and one restart.

No dogfood configuration, deployment, benchmark state, or release artifact is changed by this PR.
