### PR TITLE
Fix Patrol finding: patrol-zero-byte-worktree-yml-crashes-pointer-5ce9e9da2d

### DIFF
--- a/lib/hive/worktree.rb
+++ b/lib/hive/worktree.rb
@@ -459,7 +459,10 @@ module Hive
       source = File.open(pointer_path, File::RDONLY | File::NOFOLLOW) do |file|
         raise WorktreeError, "worktree.yml must be a regular file" unless file.stat.file?
 
-        value = file.read(STRICT_POINTER_MAX_BYTES + 1)
+        # IO#read(length) returns nil (not "") at EOF, e.g. for a zero-byte
+        # pointer file; normalize so the size check and YAML parse below see
+        # an empty String and fail as WorktreeError instead of NoMethodError.
+        value = file.read(STRICT_POINTER_MAX_BYTES + 1) || ""
         if value.bytesize > STRICT_POINTER_MAX_BYTES
           raise WorktreeError, "worktree.yml exceeds #{STRICT_POINTER_MAX_BYTES} bytes"
         end
@@ -516,7 +519,8 @@ module Hive
       source = File.open(pointer_path, File::RDONLY | File::NOFOLLOW) do |file|
         raise WorktreeError, "worktree.yml must be a regular file" unless file.stat.file?
 
-        value = file.read(STRICT_POINTER_MAX_BYTES + 1)
+        # See read_strict_pointer: read(2) at EOF yields nil, not "".
+        value = file.read(STRICT_POINTER_MAX_BYTES + 1) || ""
         raise WorktreeError, "worktree.yml exceeds #{STRICT_POINTER_MAX_BYTES} bytes" if value.bytesize > STRICT_POINTER_MAX_BYTES
 
         value

--- a/test/unit/worktree_test.rb
+++ b/test/unit/worktree_test.rb
@@ -1518,6 +1518,35 @@ class WorktreeTest < Minitest::Test
     end
   end
 
+  def test_strict_pointer_rejects_zero_byte_file_as_worktree_error
+    Dir.mktmpdir do |folder|
+      File.open(File.join(folder, "worktree.yml"), "w") {}
+
+      error = assert_raises(Hive::WorktreeError) do
+        Hive::Worktree.read_strict_pointer(folder, expected_root: folder)
+      end
+      assert_includes error.message, "must be a hash"
+    end
+  end
+
+  def test_owned_pointer_rejects_zero_byte_file_as_worktree_error
+    with_tmp_dir do |root|
+      folder = File.join(root, "task")
+      FileUtils.mkdir_p(folder)
+      File.open(File.join(folder, "worktree.yml"), "w") {}
+
+      error = assert_raises(Hive::WorktreeError) do
+        Hive::Worktree.read_owned_pointer(
+          folder,
+          project_root: root,
+          slug: "owned-task",
+          expected_root: root
+        )
+      end
+      assert_includes error.message, "must be a hash"
+    end
+  end
+
   def test_strict_pointer_rejects_missing_symlink_malformed_and_identity_mismatch
     with_tmp_dir do |root|
       folder = File.join(root, "task")

--- a/wiki/log.d/20260824T000000Z-zero-byte-worktree-yml-nil-read.md
+++ b/wiki/log.d/20260824T000000Z-zero-byte-worktree-yml-nil-read.md
@@ -1,0 +1,20 @@
+# 2026-08-24 — Zero-byte `worktree.yml` raised NoMethodError instead of WorktreeError
+
+## What changed
+
+`Hive::Worktree.read_strict_pointer` and `read_owned_pointer` crashed with
+`NoMethodError: undefined method 'bytesize' for nil` when `<task_folder>/worktree.yml`
+was zero bytes. `IO#read(length)` returns `nil` (not `""`) at EOF, so the
+`value.bytesize` size check blew up before YAML parsing could reject the empty
+content. Both readers now normalize the read result with `|| ""`, so an empty
+pointer fails as `WorktreeError` ("worktree.yml must be a hash") like any other
+invalid content.
+
+- `lib/hive/worktree.rb`: coerce `file.read(...)` nil → `""` in both strict/owned readers.
+- `test/unit/worktree_test.rb`: regression tests for zero-byte files against both readers.
+
+## Impact
+
+Callers rescuing `WorktreeError` around pointer reads (stages, task closure,
+web, auto-retry safety) now handle truncated/empty pointer files instead of
+crashing on an unhandled `NoMethodError`. Public contracts unchanged.


### PR DESCRIPTION
## Patrol Fix

This pull request repairs one finding tracked by Hive's Patrol Fix workflow.

### Sources

- ordinary_patrol: architecture-lib-hive-part-20-20260815T163727Z-f7d41d76-2

### Finding evidence

- {"file":"lib/hive/worktree.rb","line":389,"snippet":"File.open(pointer_path, File::RDONLY | File::NOFOLLOW)","role":"trigger"}
- {"file":"lib/hive/worktree.rb","line":392,"snippet":"value = file.read(STRICT_POINTER_MAX_BYTES + 1)","role":"root_cause"}
- {"file":"lib/hive/worktree.rb","line":449,"snippet":"value = file.read(STRICT_POINTER_MAX_BYTES + 1)","role":"root_cause"}
- {"file":"lib/hive/worktree.rb","line":393,"snippet":"if value.bytesize > STRICT_POINTER_MAX_BYTES","role":"impact"}
- {"file":"lib/hive/worktree.rb","line":450,"snippet":"if value.bytesize > STRICT_POINTER_MAX_BYTES","role":"impact"}

### Independent review

At the pinned HEAD, the minimal nil-to-empty normalization closes both affected pointer-reader crashes while preserving the existing size, YAML, and ownership validation order. The controller's broad-suite failure is an unrelated environment-sensitive Grok executable-path assertion in untouched agent-runtime code; the changed Worktree behavior is fully green.

- git rev-parse verified HEAD 7d2799f87f1bb9b334665816645b5aee1cca0509; its single-parent diff is clean and changes only Worktree implementation, regression tests, and the required wiki log fragment.
- A direct Ruby bounded read of a zero-byte regular file returned nil, confirming the root cause; both readers now normalize the only two STRICT_POINTER_MAX_BYTES reads before bytesize and YAML parsing.
- Independent zero-byte regression validation passed: 2 runs, 6 assertions, 0 failures and 0 errors. The full Worktree unit suite also passed: 74 runs, 249 assertions, 0 failures and 0 errors.
- The broad-suite failure reproduced alone in AgentCliRuntimeRuntimeTest as bare grok versus an absolute mise-installed Grok path; no agent-cli-runtime source or test is present in this patch.

### Validation

Verdict: failed
- ordinary:test: exit 1
- agent:reproduction-zero-byte-pointer-base: exit 1
- agent:regression-tests-zero-byte-pointer: exit 0
- agent:focused-unit-worktree-suite: exit 0

<!-- hive-publication:v1 id=pub-200d1c82c51182d6f32125a3d19ae98b base=b07b869635e47d986370b19d0dfe583d54143e79 -->
