### PR TITLE
Fix Patrol finding: introduce-one-internal-status-projection-boundar-db8ee0f0f08a

### DIFF
--- a/lib/hive/commands/status.rb
+++ b/lib/hive/commands/status.rb
@@ -26,6 +26,7 @@ require "hive/gh"
 require "hive/pr"
 require "hive/process_kill"
 require "hive/pid_file"
+require "hive/status_projection"
 require "hive/operational_action"
 require "hive/operational_status"
 require "hive/daemon/operational_snapshot"
@@ -1865,53 +1866,11 @@ module Hive
         end
       end
 
-      ACTION_LABEL_ORDER = [
-        "Admission error",
-        "Ready to brainstorm",
-        # Generic-workflow actions (non-coding descriptors). Sorted high with
-        # the other actionable "ready"/"needs" rows so generic status rows
-        # don't fall to the bottom (below "Error") as unknown labels would.
-        "Ready to run",
-        "Ready to advance",
-        # Per-stage "needs input" labels (the differentiated NEEDS_INPUT rows
-        # plus the shared generic "Needs your input"). Deliberately ordered
-        # between "Ready to advance" and "Ready to plan" so these actionable
-        # rows sort high alongside the other "ready"/"needs" rows.
-        "Answer questions",
-        "Review plan draft",
-        "Needs your input",
-        "Awaiting human decision",
-        "Needs review decision",
-        "Confirm finalize",
-        "Ready to plan",
-        "Plan review in progress",
-        "Plan review retry ready",
-        "Plan review retry scheduled",
-        "Plan review needs an operator decision",
-        "Plan review cleared with degraded coverage",
-        "Plan reviewer configuration required",
-        "Plan review blocks execution",
-        "Ready to develop",
-        "Needs recovery",
-        "Retry draft PR handoff manually",
-        "Agent running",
-        "Ready to open PR",
-        "Ready for review",
-        "Ready to collect artifacts",
-        # Clean ad-hoc PR review parked at 6-review (REVIEW_PARKED): complete and
-        # non-advancing, so it sorts with the other review-complete rows rather
-        # than falling below "Error" as an unknown label.
-        "Ad-hoc review complete (parked)",
-        "Rejected (parked)",
-        "Blocked (parked)",
-        "Escalated (parked)",
-        "Ready to finalize",
-        "Ready to archive",
-        "Archived",
-        "Manually steered",
-        "Blocked",
-        "Error"
-      ].freeze
+      # Presentation ordering is owned by the internal status projection
+      # boundary (`Hive::StatusProjection`); the command re-exports the
+      # frozen constant so existing label-grouping call sites and tests
+      # keep one shared value.
+      ACTION_LABEL_ORDER = Hive::StatusProjection::ACTION_LABEL_ORDER
 
       # Synthetic Error row for a task folder that exists but won't load — e.g.
       # a typo'd `meta.yml workflow:` / project `default_workflow:` that resolves

--- a/lib/hive/status_projection.rb
+++ b/lib/hive/status_projection.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+module Hive
+  # Internal status projection boundary shared by the `hive status` command
+  # and its read-only consumers (TUI snapshot/state source, daemon and web
+  # feeds). This module — not any single caller — owns the two decisions
+  # that used to leak across the command/TUI boundary:
+  #
+  # 1. Presentation ordering of action labels (`ACTION_LABEL_ORDER`), which
+  #    `Commands::Status` re-exports for its own label grouping and which
+  #    `Tui::Snapshot` applies when ordering rows at construction time.
+  # 2. Composition of archive-aware payload variants from an ordinary
+  #    Status payload plus a frozen archived-row cache, so callers never
+  #    reinterpret raw task arrays or hidden-archive counts themselves.
+  #
+  # The module is internal: it defines no I/O, holds no state, and is not
+  # part of the public gem surface. Consumers must require it explicitly.
+  module StatusProjection
+    # Canonical presentation order for status action labels. Rows with a
+    # label earlier in this list sort first; unknown labels sort last but
+    # preserve payload order against their unknown peers. See
+    # `.label_position`.
+    ACTION_LABEL_ORDER = [
+      "Admission error",
+      "Ready to brainstorm",
+      # Generic-workflow actions (non-coding descriptors). Sorted high with
+      # the other actionable "ready"/"needs" rows so generic status rows
+      # don't fall to the bottom (below "Error") as unknown labels would.
+      "Ready to run",
+      "Ready to advance",
+      # Per-stage "needs input" labels (the differentiated NEEDS_INPUT rows
+      # plus the shared generic "Needs your input"). Deliberately ordered
+      # between "Ready to advance" and "Ready to plan" so these actionable
+      # rows sort high alongside the other "ready"/"needs" rows.
+      "Answer questions",
+      "Review plan draft",
+      "Needs your input",
+      "Awaiting human decision",
+      "Needs review decision",
+      "Confirm finalize",
+      "Ready to plan",
+      "Plan review in progress",
+      "Plan review retry ready",
+      "Plan review retry scheduled",
+      "Plan review needs an operator decision",
+      "Plan review cleared with degraded coverage",
+      "Plan reviewer configuration required",
+      "Plan review blocks execution",
+      "Ready to develop",
+      "Needs recovery",
+      "Retry draft PR handoff manually",
+      "Agent running",
+      "Ready to open PR",
+      "Ready for review",
+      "Ready to collect artifacts",
+      # Clean ad-hoc PR review parked at 6-review (REVIEW_PARKED): complete and
+      # non-advancing, so it sorts with the other review-complete rows rather
+      # than falling below "Error" as an unknown label.
+      "Ad-hoc review complete (parked)",
+      "Rejected (parked)",
+      "Blocked (parked)",
+      "Escalated (parked)",
+      "Ready to finalize",
+      "Ready to archive",
+      "Archived",
+      "Manually steered",
+      "Blocked",
+      "Error"
+    ].freeze
+
+    # Sort position for one action label: its index in
+    # `ACTION_LABEL_ORDER`, or "last" for unknown labels. Callers tie-break
+    # on their own stable secondary key (e.g. original payload order).
+    def self.label_position(label)
+      ACTION_LABEL_ORDER.index(label) || ACTION_LABEL_ORDER.length
+    end
+
+    # Rebuilds an ordinary Status payload whose per-project task lists are
+    # replaced with the full archived rows from `archived_cache` (an
+    # unfiltered-archive cache built by the TUI state source). Projects in
+    # error degrade to an empty task list; the ordinary payload's hidden
+    # counts are dropped because every cached row is visible here. The
+    # input payloads are treated as immutable: projects are duplicated,
+    # never mutated.
+    def self.archive_payload_from_cache(ordinary_payload, archived_cache)
+      cached_rows_by_path = archived_cache.fetch(:rows_by_path)
+      copy = ordinary_payload.dup
+      copy["projects"] = Array(ordinary_payload["projects"]).map do |project|
+        project_copy = project.dup
+        cached_rows = project["error"] ? [] : cached_rows_by_path.fetch(project["path"], [])
+        project_copy["tasks"] = cached_rows
+        project_copy.delete("hidden_archived_task_count")
+        project_copy
+      end
+      copy
+    end
+
+    # Merges the still-visible archived rows from `archived_cache` into an
+    # active-only Status payload: visible archived rows are appended unless
+    # an active row already occupies the same folder, and each project's
+    # `hidden_archived_task_count` is restated from the cache. Erroring
+    # projects contribute no rows and a zero hidden count. As with
+    # `.archive_payload_from_cache`, inputs are duplicated, never mutated.
+    def self.merge_visible_archived_payload(active_payload, archived_cache)
+      visible_rows_by_path = archived_cache.fetch(:visible_rows_by_path)
+      hidden_counts_by_path = archived_cache.fetch(:hidden_counts_by_path)
+      copy = active_payload.dup
+      copy["projects"] = Array(active_payload["projects"]).map do |project|
+        project_copy = project.dup
+        active_rows = Array(project["tasks"])
+        active_folders = active_rows.to_h { |row| [ row["folder"], true ] }
+        cached_rows =
+          if project["error"]
+            []
+          else
+            visible_rows_by_path.fetch(project["path"], [])
+          end
+        project_copy["tasks"] =
+          active_rows + cached_rows.reject { |row| active_folders.key?(row["folder"]) }
+        project_copy["hidden_archived_task_count"] =
+          project["error"] ? 0 : hidden_counts_by_path.fetch(project["path"], 0)
+        project_copy
+      end
+      copy
+    end
+  end
+end

--- a/lib/hive/tui/snapshot.rb
+++ b/lib/hive/tui/snapshot.rb
@@ -1,5 +1,5 @@
 require "hive"
-require "hive/commands/status"
+require "hive/status_projection"
 require "time"
 
 module Hive
@@ -199,7 +199,8 @@ module Hive
         )
       end
 
-      # Rows are sorted by `Status::ACTION_LABEL_ORDER` at construction so
+      # Rows are sorted by the status projection boundary's
+      # `ACTION_LABEL_ORDER` at construction so
       # `row_at(cursor)` and the renderer's grouped-row traversal walk the
       # same list. Without this, a project whose tasks span multiple
       # action_labels has the cursor highlight one row while keystrokes
@@ -211,10 +212,8 @@ module Hive
         payload ||= {}
         name = payload["name"]
         indexed = Array(payload["tasks"]).map.with_index { |t, i| [ build_row(t, name), i ] }
-        order = Hive::Commands::Status::ACTION_LABEL_ORDER
         sorted = indexed.sort_by do |row, idx|
-          pos = order.index(row.action_label) || order.length
-          [ pos, idx ]
+          [ Hive::StatusProjection.label_position(row.action_label), idx ]
         end.map(&:first)
         ProjectView.new(
           name: name,

--- a/lib/hive/tui/state_source.rb
+++ b/lib/hive/tui/state_source.rb
@@ -4,6 +4,7 @@ require "set"
 require "hive"
 require "hive/commands/status"
 require "hive/config"
+require "hive/status_projection"
 require "hive/tui/debug"
 require "hive/tui/snapshot"
 
@@ -359,7 +360,7 @@ module Hive
             now: refresh_now
           )
           publish_snapshot(
-            merge_visible_archived_payload(active_payload, cache),
+            Hive::StatusProjection.merge_visible_archived_payload(active_payload, cache),
             archived_cache: cache,
             next_retention_boundary: cache[:next_retention_boundary]
           )
@@ -571,7 +572,8 @@ module Hive
       def publish_snapshot(payload, archived_cache:, next_retention_boundary: nil)
         snapshot = Snapshot.from_payload(
           payload,
-          archive_payload: archive_payload_from_cache(payload, archived_cache)
+          archive_payload:
+            Hive::StatusProjection.archive_payload_from_cache(payload, archived_cache)
         )
         next_mtime_fingerprint = mtime_fingerprint_for(snapshot)
         next_policy_fingerprint = policy_fingerprint_for(snapshot)
@@ -599,42 +601,10 @@ module Hive
         }.freeze
       end
 
-      def archive_payload_from_cache(ordinary_payload, archived_cache)
-        cached_rows_by_path = archived_cache.fetch(:rows_by_path)
-        copy = ordinary_payload.dup
-        copy["projects"] = Array(ordinary_payload["projects"]).map do |project|
-          project_copy = project.dup
-          cached_rows = project["error"] ? [] : cached_rows_by_path.fetch(project["path"], [])
-          project_copy["tasks"] = cached_rows
-          project_copy.delete("hidden_archived_task_count")
-          project_copy
-        end
-        copy
-      end
-
-      def merge_visible_archived_payload(active_payload, archived_cache)
-        visible_rows_by_path = archived_cache.fetch(:visible_rows_by_path)
-        hidden_counts_by_path = archived_cache.fetch(:hidden_counts_by_path)
-        copy = active_payload.dup
-        copy["projects"] = Array(active_payload["projects"]).map do |project|
-          project_copy = project.dup
-          active_rows = Array(project["tasks"])
-          active_folders = active_rows.to_h { |row| [ row["folder"], true ] }
-          cached_rows =
-            if project["error"]
-              []
-            else
-              visible_rows_by_path.fetch(project["path"], [])
-            end
-          project_copy["tasks"] =
-            active_rows + cached_rows.reject { |row| active_folders.key?(row["folder"]) }
-          project_copy["hidden_archived_task_count"] =
-            project["error"] ? 0 : hidden_counts_by_path.fetch(project["path"], 0)
-          project_copy
-        end
-        copy
-      end
-
+      # Payload interpretation for archive composition lives on the
+      # internal status projection boundary (`Hive::StatusProjection`);
+      # the state source only supplies the authoritative ordinary payload
+      # and its cached archived rows.
       def empty_archived_cache
         {
           rows_by_path: {}.freeze,

--- a/lib/hive/tui/views/tasks_pane.rb
+++ b/lib/hive/tui/views/tasks_pane.rb
@@ -19,7 +19,7 @@ module Hive
       # context now lives in the left pane (Views::ProjectsPane).
       #
       # Columns: icon · id · PR · display name · stage · status · age. Within each
-      # project, rows are sorted by `Hive::Commands::Status::ACTION_LABEL_ORDER`
+      # project, rows are sorted by `Hive::StatusProjection::ACTION_LABEL_ORDER`
       # at Snapshot construction time, so "Ready to plan" appears above
       # "Agent running" within the same project. At ★ All projects
       # scope, projects are interleaved in `Hive::Config.registered_projects`

--- a/test/unit/status_projection_test.rb
+++ b/test/unit/status_projection_test.rb
@@ -1,0 +1,168 @@
+require "test_helper"
+require "hive/commands/status"
+require "hive/status_projection"
+require "hive/tui/state_source"
+
+class StatusProjectionTest < Minitest::Test
+  ROOT = File.expand_path("../..", __dir__)
+
+  def test_action_label_order_is_frozen_and_terminates_with_error
+    order = Hive::StatusProjection::ACTION_LABEL_ORDER
+
+    refute_empty order
+    assert order.frozen?
+    assert_equal "Error", order.last
+  end
+
+  def test_label_position_ranks_known_labels_by_order_and_unknown_last
+    order = Hive::StatusProjection::ACTION_LABEL_ORDER
+
+    assert_equal 0, Hive::StatusProjection.label_position(order.first)
+    assert_operator(
+      Hive::StatusProjection.label_position("Ready to brainstorm"), :<,
+      Hive::StatusProjection.label_position("Agent running")
+    )
+    assert_equal order.length,
+                 Hive::StatusProjection.label_position("Totally unknown label")
+  end
+
+  # The command boundary re-exports the projection-owned constant so label
+  # grouping and the TUI can never drift onto two different orders.
+  def test_commands_status_reexports_the_projection_owned_order
+    assert_same(
+      Hive::StatusProjection::ACTION_LABEL_ORDER,
+      Hive::Commands::Status::ACTION_LABEL_ORDER
+    )
+  end
+
+  def test_archive_payload_from_cache_swaps_tasks_for_cached_rows
+    ordinary = payload_with_projects([
+                                       project("alpha", "/tmp/alpha",
+                                               tasks: [ row("active-1") ],
+                                               hidden: 3),
+                                       project("beta", "/tmp/beta",
+                                               tasks: [ row("active-2") ], hidden: 0)
+                                     ])
+    cache = { rows_by_path: {
+      "/tmp/alpha" => [ row("archived-1") ].freeze,
+      "/tmp/beta" => [].freeze
+    }.freeze }
+
+    merged = Hive::StatusProjection.archive_payload_from_cache(ordinary, cache)
+
+    assert_equal [ "archived-1" ], slugs_for(merged, "/tmp/alpha")
+    assert_equal [], slugs_for(merged, "/tmp/beta")
+    merged["projects"].each do |project|
+      refute project.key?("hidden_archived_task_count")
+    end
+  end
+
+  def test_archive_payload_from_cache_degrades_error_projects_to_no_rows
+    ordinary = payload_with_projects([ project("broken", "/tmp/broken", error: true) ])
+    cache = { rows_by_path: { "/tmp/broken" => [ row("archived-1") ].freeze }.freeze }
+
+    merged = Hive::StatusProjection.archive_payload_from_cache(ordinary, cache)
+
+    assert_equal [], slugs_for(merged, "/tmp/broken")
+  end
+
+  def test_merge_visible_archived_payload_appends_rows_outside_active_folders
+    ordinary = payload_with_projects([
+                                       project("alpha", "/tmp/alpha",
+                                               tasks: [ row("active-1", folder: "/a/one") ],
+                                               hidden: 0)
+                                     ])
+    cache = {
+      visible_rows_by_path: {
+        "/tmp/alpha" => [
+          row("archived-1", folder: "/a/one"),
+          row("archived-2", folder: "/a/two")
+        ].freeze
+      }.freeze,
+      hidden_counts_by_path: { "/tmp/alpha" => 4 }.freeze
+    }
+
+    merged = Hive::StatusProjection.merge_visible_archived_payload(ordinary, cache)
+    project = merged.fetch("projects").fetch(0)
+
+    assert_equal %w[active-1 archived-2], project.fetch("tasks").map { |r| r.fetch("slug") }
+    assert_equal 4, project.fetch("hidden_archived_task_count")
+  end
+
+  def test_merge_visible_archived_payload_degrades_error_projects
+    ordinary = payload_with_projects([ project("broken", "/tmp/broken", error: true) ])
+    cache = {
+      visible_rows_by_path: { "/tmp/broken" => [ row("archived-1") ].freeze }.freeze,
+      hidden_counts_by_path: { "/tmp/broken" => 9 }.freeze
+    }
+
+    merged = Hive::StatusProjection.merge_visible_archived_payload(ordinary, cache)
+    project = merged.fetch("projects").fetch(0)
+
+    assert_equal [], project.fetch("tasks")
+    assert_equal 0, project.fetch("hidden_archived_task_count")
+  end
+
+  # Composition helpers treat Status payloads as immutable inputs: the
+  # caller's hashes must survive an archival merge untouched.
+  def test_composition_helpers_do_not_mutate_their_inputs
+    ordinary = payload_with_projects(
+      [ project("alpha", "/tmp/alpha", tasks: [ row("active-1") ], hidden: 2) ]
+    )
+    ordinary_before = Marshal.dump(ordinary)
+    cache = {
+      rows_by_path: { "/tmp/alpha" => [ row("archived-1") ].freeze }.freeze,
+      visible_rows_by_path: { "/tmp/alpha" => [ row("archived-1") ].freeze }.freeze,
+      hidden_counts_by_path: { "/tmp/alpha" => 5 }.freeze
+    }
+
+    Hive::StatusProjection.archive_payload_from_cache(ordinary, cache)
+    Hive::StatusProjection.merge_visible_archived_payload(ordinary, cache)
+
+    assert_equal ordinary_before, Marshal.dump(ordinary)
+  end
+
+  # Regression: the TUI data boundary must not reach into the command
+  # boundary for presentation ordering or re-implement archive payload
+  # composition. Both decisions live on the internal status projection
+  # boundary (`Hive::StatusProjection`).
+  def test_tui_consumes_the_projection_boundary_instead_of_the_command_boundary
+    snapshot_source = File.read(File.join(ROOT, "lib", "hive", "tui", "snapshot.rb"))
+    state_source_code = File.read(File.join(ROOT, "lib", "hive", "tui", "state_source.rb"))
+
+    refute_includes snapshot_source, "Commands::Status::"
+    assert_includes snapshot_source, "Hive::StatusProjection"
+    refute_match(/def (archive_payload_from_cache|merge_visible_archived_payload)/,
+                 state_source_code)
+    assert_includes state_source_code, "Hive::StatusProjection."
+  end
+
+  private
+
+  def payload_with_projects(projects)
+    { "generated_at" => "2026-07-24T12:00:00Z", "projects" => projects }
+  end
+
+  def project(name, path, tasks: [], hidden: nil, error: nil)
+    project = {
+      "name" => name,
+      "path" => path,
+      "hive_state_path" => "#{path}/.hive-state",
+      "error" => error,
+      "tasks" => tasks
+    }
+    project["hidden_archived_task_count"] = hidden unless hidden.nil?
+    project
+  end
+
+  def row(slug, folder: "/a/#{slug}")
+    { "slug" => slug, "folder" => folder, "action_label" => "Agent running" }
+  end
+
+  def slugs_for(payload, path)
+    payload.fetch("projects")
+           .find { |p| p.fetch("path") == path }
+           .fetch("tasks")
+           .map { |r| r.fetch("slug") }
+  end
+end

--- a/test/unit/tui/state_source_test.rb
+++ b/test/unit/tui/state_source_test.rb
@@ -1423,7 +1423,6 @@ class TuiStateSourceTest < Minitest::Test
   # The archive payload guard drops cached rows when the ordinary parse flags
   # a project with an explicit error (missing_project_path / not_initialised).
   def test_archive_payload_drops_cached_rows_for_errored_ordinary_project
-    source = Hive::Tui::StateSource.new(poll_interval_seconds: 60)
     archived_cache = {
       rows_by_path: {
         "/p" => [ { "slug" => "done-260626-abcd", "id" => 1, "stage" => "9-done" }.freeze ].freeze
@@ -1433,8 +1432,8 @@ class TuiStateSourceTest < Minitest::Test
       "projects" => [ { "path" => "/p", "error" => "missing_project_path", "tasks" => [] } ]
     }
 
-    archive_payload = source.send(
-      :archive_payload_from_cache, active_payload, archived_cache
+    archive_payload = Hive::StatusProjection.archive_payload_from_cache(
+      active_payload, archived_cache
     )
 
     assert_empty archive_payload["projects"].first["tasks"],
@@ -1444,7 +1443,6 @@ class TuiStateSourceTest < Minitest::Test
   # A healthy project with no ordinary tasks keeps the dedicated cached
   # archive rows without merging them into the ordinary payload.
   def test_archive_payload_keeps_cached_rows_separate_for_healthy_project
-    source = Hive::Tui::StateSource.new(poll_interval_seconds: 60)
     archived_cache = {
       rows_by_path: {
         "/p" => [ { "slug" => "done-260626-abcd", "id" => 1, "stage" => "9-done" }.freeze ].freeze
@@ -1452,8 +1450,8 @@ class TuiStateSourceTest < Minitest::Test
     }.freeze
     active_payload = { "projects" => [ { "path" => "/p", "tasks" => [] } ] }
 
-    archive_payload = source.send(
-      :archive_payload_from_cache, active_payload, archived_cache
+    archive_payload = Hive::StatusProjection.archive_payload_from_cache(
+      active_payload, archived_cache
     )
 
     assert_empty active_payload["projects"].first["tasks"]
@@ -1941,7 +1939,7 @@ class TuiStateSourceTest < Minitest::Test
       hidden_counts_by_path: { "/project" => 3 }
     }
 
-    merged = source.send(:merge_visible_archived_payload, active, cache)
+    merged = Hive::StatusProjection.merge_visible_archived_payload(active, cache)
       .fetch("projects").fetch(0)
 
     assert_equal [ "active" ], merged.fetch("tasks").map { |row| row["slug"] }

--- a/wiki/log.d/20260826T091438Z-status-projection-boundary.md
+++ b/wiki/log.d/20260826T091438Z-status-projection-boundary.md
@@ -1,0 +1,42 @@
+# 2026-08-26 — One internal status projection boundary
+
+## Summary
+
+Introduced `Hive::StatusProjection` (`lib/hive/status_projection.rb`) as the
+single internal boundary that owns status presentation ordering and
+archive-aware payload composition. `Commands::Status` re-exports the frozen
+`ACTION_LABEL_ORDER` from the boundary instead of defining it inline;
+`Tui::Snapshot` orders rows via `Hive::StatusProjection.label_position`
+instead of reaching into `Hive::Commands::Status::ACTION_LABEL_ORDER`; and
+`Tui::StateSource` no longer implements its own second layer of payload
+interpretation — `archive_payload_from_cache` and
+`merge_visible_archived_payload` moved verbatim onto the projection boundary.
+
+## Details
+
+- Patrol finding: make-status-projection-boundary-authoritative
+  (TUI data boundary reached into the command boundary for presentation
+  ordering and rebuilt/merged archive payloads outside both Status and
+  Snapshot).
+- Behavior is unchanged: same frozen label order (unknown labels last,
+  payload order preserved as tie-break), same error-project degradation and
+  hidden-count restating in both archive cache modes, inputs still never
+  mutated.
+- Regression coverage: new `test/unit/status_projection_test.rb` pins the
+  ordering semantics, both composition helpers, input immutability, the
+  command's re-export identity (`assert_same`), and a source-level check
+  that `Tui::Snapshot` no longer references `Commands::Status::` and that
+  StateSource defines no local reconstruction methods. Existing
+  state_source tests now call the boundary directly.
+
+## Validation
+
+- `bundle exec ruby -Itest test/unit/status_projection_test.rb`
+- `bundle exec ruby -Itest test/unit/tui/snapshot_test.rb`
+- `bundle exec ruby -Itest test/unit/tui/state_source_test.rb`
+- `bundle exec ruby -Itest test/unit/tui/schema_correspondence_test.rb`
+- `bundle exec ruby -Itest test/unit/tui/views/tasks_pane_test.rb`
+- `bundle exec ruby -Itest test/unit/commands/status_test.rb`
+- `bundle exec ruby -Itest test/integration/archive_visibility_retention_test.rb`
+- `bundle exec ruby -Itest test/integration/status_test.rb`
+- Rubocop clean on all touched files.


### PR DESCRIPTION
## Patrol Fix

This pull request repairs one finding tracked by Hive's Patrol Fix workflow.

### Sources

- architecture_patrol: pr-1166-86c364158108491b:make-status-projection-boundary-authoritative

### Finding evidence

- {"file":"lib/hive/tui/snapshot.rb","line":143,"snippet":"order = Hive::Commands::Status::ACTION_LABEL_ORDER","claim":"the TUI data boundary reaches into the command boundary for a presentation-ordering decision while independently rebuilding every status row"}
- {"file":"lib/hive/tui/state_source.rb","line":602,"snippet":"def archive_payload_from_cache(ordinary_payload, archived_cache)","claim":"the status caller owns a second layer of payload interpretation and reconstruction for archive composition"}
- {"file":"lib/hive/tui/state_source.rb","line":615,"snippet":"def merge_visible_archived_payload(active_payload, archived_cache)","claim":"caller branching caused by the leaked projection boundary merges raw task arrays and writes hidden-archive counts outside both Status and Snapshot"}
- {"file":"test/integration/archive_visibility_retention_test.rb","line":73,"snippet":"tui = Hive::Tui::Snapshot.from_payload(ordinary, archive_payload: archive)","claim":"the integration contract explicitly passes two Status-shaped hashes into Snapshot and verifies their combined visibility behavior"}

### Independent review

At the exact controller HEAD, the patch centralizes action-label ordering and both archive-composition transforms in Hive::StatusProjection without changing established semantics. TUI snapshot and state consumers now depend on that boundary, while the command keeps an identity-preserving compatibility re-export. Independent focused, integration, load-order, and lint checks pass. The remaining broad-check failures are confined to unchanged agent-cli-runtime and host gem configuration, so they do not implicate this patch.

- Verified clean worktree HEAD a930c87cc2255811cdeb2086968684309f048528; the base-to-head diff contains only the eight stated status, TUI, test, and wiki paths, and git diff --check passed.
- Independent reruns of the six controller-listed suites passed: 303 runs and 1,177 assertions with zero failures or errors.
- Additional schema-correspondence and status-integration checks passed: 18 runs and 307 assertions; a direct load-order check proved hive/tui/snapshot no longer loads Hive::Commands::Status and the command re-export is the same frozen object owned by Hive::StatusProjection.
- RuboCop 1.89.0 inspected all seven touched Ruby files with no offenses.
- Repository-wide verification remains environment-degraded only in unchanged code: the controller failure came from host HIVE_GROK_BIN argv resolution, and independent retries next stopped in unchanged agent-cli-runtime or clean-load fixture gem setup; no components/agent-cli-runtime path differs between base and HEAD.

### Validation

Verdict: failed
- architecture:test: exit 1
- agent:status-projection-boundary-regression: exit 0
- agent:tui-snapshot-ordering-regression: exit 0
- agent:tui-state-source-delegation: exit 0
- agent:status-command-label-grouping: exit 0
- agent:archive-visibility-integration-contract: exit 0
- agent:tui-tasks-pane-rendering: exit 0

<!-- hive-publication:v1 id=pub-c8c5a91531a16e5760fd245d28311630 base=453ec4c9df9cd39447911f4e1e34111d2ba7a146 -->
