### PR TITLE
Fix Patrol finding: make-publicationattempt-s-pure-validation-interf-e49154609100

### DIFF
--- a/lib/hive/refactor_patrol/job_record_validator.rb
+++ b/lib/hive/refactor_patrol/job_record_validator.rb
@@ -1035,7 +1035,7 @@ module Hive
               path: path
             )
           end
-          if attempt.key?("pr_create_intent") && !attempt.key?("push_complete")
+          unless PublicationAttempt.well_ordered?(attempt)
             inconsistent!("publication PR-create intent requires durable push completion", path)
           end
           if (superseded = attempt["superseded"])
@@ -1069,27 +1069,14 @@ module Hive
       end
 
       def validate_publication_phase!(phase, payload, descriptor:, patch:, action_id:, repository:, path:)
-        expected_keys = case phase
-        when "push_intent"
-          %w[operation canonical_action_id repository branch commit_sha expected_remote_oid]
-        when "push_complete"
-          %w[operation canonical_action_id repository branch commit_sha remote_oid]
-        when "pr_create_intent"
-          %w[operation canonical_action_id repository branch commit_sha]
-        end
         strict_hash!(
           payload,
-          required: expected_keys,
-          allowed: expected_keys,
+          required: PublicationAttempt.phase_payload_keys(phase),
+          allowed: PublicationAttempt.phase_payload_keys(phase),
           label: "publication #{phase}",
           path: path
         )
-        operation = {
-          "push_intent" => "push_branch",
-          "push_complete" => "push_branch_complete",
-          "pr_create_intent" => "create_pr"
-        }.fetch(phase)
-        unless payload.fetch("operation") == operation &&
+        unless payload.fetch("operation") == PublicationAttempt.phase_operation(phase) &&
                payload.fetch("canonical_action_id") == action_id &&
                payload.fetch("repository") == repository &&
                payload.fetch("branch") == patch["branch"] &&

--- a/lib/hive/refactor_patrol/publication_attempt.rb
+++ b/lib/hive/refactor_patrol/publication_attempt.rb
@@ -11,6 +11,19 @@ module Hive
 
       ATTEMPTS_KEY = "publication_attempts".freeze
       PHASES = %w[push_intent push_complete pr_create_intent].freeze
+      PHASE_OPERATIONS = {
+        "push_intent" => "push_branch",
+        "push_complete" => "push_branch_complete",
+        "pr_create_intent" => "create_pr"
+      }.freeze
+      PHASE_PAYLOAD_KEYS = {
+        "push_intent" =>
+          %w[operation canonical_action_id repository branch commit_sha expected_remote_oid],
+        "push_complete" =>
+          %w[operation canonical_action_id repository branch commit_sha remote_oid],
+        "pr_create_intent" =>
+          %w[operation canonical_action_id repository branch commit_sha]
+      }.freeze
       DESCRIPTOR_KEYS = %w[
         attempt_id patch_receipt_key publication_base_sha commit_sha recorded_at
       ].freeze
@@ -110,14 +123,8 @@ module Hive
         if continuation_only && !(phase_name == "push_complete" && attempt["push_intent"].is_a?(Hash))
           raise Error, "revoked action claim cannot begin a publication phase"
         end
-        if phase_name == "push_intent" && (attempt.key?("push_complete") || attempt.key?("pr_create_intent"))
-          raise Error, "publication push intent cannot be appended after completion"
-        end
-        if phase_name == "push_complete" && attempt.key?("pr_create_intent")
-          raise Error, "publication push completion cannot follow PR-create intent"
-        end
-        if phase_name == "pr_create_intent" && !attempt["push_complete"].is_a?(Hash)
-          raise Error, "publication PR-create intent requires durable push completion"
+        if (violation = phase_order_violation(attempt, phase_name))
+          raise Error, violation
         end
 
         attempt[phase_name] = value
@@ -252,6 +259,51 @@ module Hive
         attempt.is_a?(Hash) && !attempt.key?("superseded")
       end
 
+      # Pure statement of the phase-append ordering policy: which phases may
+      # legally follow an attempt's recorded phases. This is the single owner
+      # of the publication lifecycle grammar; both the mutation boundary
+      # (append_phase) and the record-validation boundary consume it instead
+      # of re-deriving the rules. Returns the violated rule as a message, or
+      # nil when appending the phase is legal.
+      def phase_order_violation(attempt, phase)
+        attempt = {} unless attempt.is_a?(Hash)
+        case phase.to_s
+        when "push_intent"
+          if attempt.key?("push_complete") || attempt.key?("pr_create_intent")
+            "publication push intent cannot be appended after completion"
+          end
+        when "push_complete"
+          if attempt.key?("pr_create_intent")
+            "publication push completion cannot follow PR-create intent"
+          end
+        when "pr_create_intent"
+          unless attempt["push_complete"].is_a?(Hash)
+            "publication PR-create intent requires durable push completion"
+          end
+        end
+      end
+
+      # A stored attempt is well-ordered exactly when every recorded phase
+      # could have been produced by a legal append sequence over PHASES.
+      def well_ordered?(attempt)
+        return false unless attempt.is_a?(Hash)
+
+        PHASES.each_with_object({}) do |phase, prefix|
+          return false if attempt.key?(phase) && phase_order_violation(prefix, phase)
+
+          prefix[phase] = attempt[phase] if attempt.key?(phase)
+        end
+        true
+      end
+
+      def phase_operation(phase)
+        PHASE_OPERATIONS.fetch(phase.to_s)
+      end
+
+      def phase_payload_keys(phase)
+        PHASE_PAYLOAD_KEYS.fetch(phase.to_s)
+      end
+
       def remote_push_evidence?(attempt)
         attempt.is_a?(Hash) && attempt["push_complete"].is_a?(Hash)
       end
@@ -268,11 +320,7 @@ module Hive
       def copy_legacy_phase!(state, payload, commit_sha, expected_phase: nil)
         return unless payload.is_a?(Hash) && payload["commit_sha"] == commit_sha
 
-        phase = case payload["operation"]
-        when "push_branch" then "push_intent"
-        when "push_branch_complete" then "push_complete"
-        when "create_pr" then "pr_create_intent"
-        end
+        phase = PHASE_OPERATIONS.key(payload["operation"])
         return unless phase && (!expected_phase || phase == expected_phase)
 
         state[phase] = payload

--- a/test/unit/refactor_patrol/publication_attempt_test.rb
+++ b/test/unit/refactor_patrol/publication_attempt_test.rb
@@ -229,6 +229,47 @@ class RefactorPatrolPublicationAttemptTest < Minitest::Test
     )
   end
 
+  def test_phase_grammar_accessors_expose_the_single_operation_and_payload_mapping
+    assert_equal "push_branch", Publication.phase_operation("push_intent")
+    assert_equal "push_branch_complete", Publication.phase_operation("push_complete")
+    assert_equal "create_pr", Publication.phase_operation("pr_create_intent")
+    Publication::PHASES.each do |phase|
+      assert_includes Publication.phase_payload_keys(phase), "operation"
+      assert_empty Publication.phase_payload_keys(phase) - %w[
+        operation canonical_action_id repository branch commit_sha expected_remote_oid remote_oid
+      ]
+    end
+    assert_raises(KeyError) { Publication.phase_operation("unknown") }
+    assert_raises(KeyError) { Publication.phase_payload_keys("unknown") }
+  end
+
+  def test_well_ordered_applies_the_append_policy_to_stored_attempts
+    push_complete = { "operation" => "push_branch_complete" }
+    create_intent = { "operation" => "create_pr" }
+    assert Publication.well_ordered?({})
+    assert Publication.well_ordered?({ "push_intent" => phase_payload })
+    assert Publication.well_ordered?(
+      { "push_complete" => push_complete, "pr_create_intent" => create_intent }
+    )
+    assert Publication.well_ordered?(
+      {
+        "push_intent" => phase_payload,
+        "push_complete" => push_complete,
+        "pr_create_intent" => create_intent
+      }
+    )
+
+    refute Publication.well_ordered?(nil)
+    refute Publication.well_ordered?("invalid")
+    refute Publication.well_ordered?(
+      { "pr_create_intent" => create_intent, "push_intent" => phase_payload }
+    )
+    refute Publication.well_ordered?({ "pr_create_intent" => create_intent })
+    refute Publication.well_ordered?(
+      { "push_complete" => "junk", "pr_create_intent" => create_intent }
+    )
+  end
+
   def test_supersede_validates_evidence_attempt_and_descriptor
     [ [ "bad-id", DRIFTED_BASE ], [ attempt_id, "short" ], [ attempt_id, "z" * 40 ] ].each do |id, observed|
       assert_publication_error("publication supersession evidence is invalid") do

--- a/wiki/log.d/20260825T000000Z-centralize-publication-lifecycle-policy.md
+++ b/wiki/log.d/20260825T000000Z-centralize-publication-lifecycle-policy.md
@@ -1,0 +1,16 @@
+---
+title: Centralize publication attempt lifecycle policy in PublicationAttempt
+date: 2026-08-26
+---
+
+- `Hive::RefactorPatrol::PublicationAttempt` is now the single owner of the
+  publication phase-append lifecycle grammar. New pure interface:
+  `phase_order_violation`, `well_ordered?`, `phase_operation`, and
+  `phase_payload_keys` backed by the `PHASE_OPERATIONS` and
+  `PHASE_PAYLOAD_KEYS` constants; legacy operation-to-phase mapping is derived
+  from `PHASE_OPERATIONS`.
+- `JobRecordValidator.validate_publication_phase!` and
+  `validate_publication_receipts!` consume that interface instead of
+  maintaining a second phase grammar, operation mapping, and an independent
+  copy of the "PR-create intent requires durable push completion" rule.
+  Validation behavior is unchanged; stored attempts must remain well ordered.


### PR DESCRIPTION
## Patrol Fix

This pull request repairs one finding tracked by Hive's Patrol Fix workflow.

### Sources

- architecture_patrol: pr-1113-300dbd75b27d0024:centralize-publication-attempt-lifecycle-policy

### Finding evidence

- {"file":"lib/hive/refactor_patrol/publication_attempt.rb","line":119,"snippet":"if phase_name == \"pr_create_intent\" && !attempt[\"push_complete\"].is_a?(Hash)","claim":"the publication mutation boundary owns the rule that PR creation requires durable push completion"}
- {"file":"lib/hive/refactor_patrol/job_record_validator.rb","line":912,"snippet":"if attempt.key?(\"pr_create_intent\") && !attempt.key?(\"push_complete\")","claim":"the record-validation boundary independently repeats the same lifecycle decision"}
- {"file":"lib/hive/refactor_patrol/job_record_validator.rb","line":945,"snippet":"def validate_publication_phase!(phase, payload, descriptor:, patch:, action_id:, repository:, path:)","claim":"the validator branches over PublicationAttempt's phase internals and maintains a second phase grammar and operation mapping"}

### Independent review

The patch correctly centralizes publication phase ordering, operation mapping, and payload-key mapping in PublicationAttempt without changing validated behavior. The sole broad-suite failure is an unrelated environment-sensitive Grok executable-path expectation outside the patch.

- Exact worktree HEAD is 6aabdbd68792d3a19fca024656f53641bc46c9e7 with a clean status; its four-file diff is based on b07b869635e47d986370b19d0dfe583d54143e79 and passes git diff --check.
- Fresh independent runs passed publication_attempt_test.rb (18 runs, 148 assertions), job_store_test.rb (98 runs, 480 assertions), and job_store_collaborators_test.rb (13 runs, 101 assertions), with zero failures or errors.
- An exhaustive matrix over all eight hash-valued phase-presence combinations confirmed PublicationAttempt.well_ordered? preserves the validator's prior acceptance rule.
- The refactor keeps append_phase's three prior error rules and derives validation keys, operations, and legacy operation lookup from the shared PublicationAttempt mappings.
- The controller broad failure is confined to components/agent-cli-runtime/test/runtime_test.rb expecting argv[0] to be grok while this host resolves the installed Grok binary to an absolute path; the patch changes no agent-cli-runtime file.

### Validation

Verdict: failed
- architecture:test: exit 1
- agent:publication_attempt_pure_validation_interface_unit_tests: exit 0
- agent:job_store_record_validator_lifecycle_integration_tests: exit 0
- agent:job_store_collaborator_tests: exit 0

<!-- hive-publication:v1 id=pub-0daf2ef704f847c581172b34083de5bb base=b07b869635e47d986370b19d0dfe583d54143e79 -->
