### PR TITLE
Fix Patrol finding: patrol-text-sanitize-raises-argumenterror-on-invali-74496c8b42

### DIFF
--- a/lib/hive/tui/text.rb
+++ b/lib/hive/tui/text.rb
@@ -25,9 +25,13 @@ module Hive
 
       module_function
 
-      # Idempotent: strip ANSI CSI sequences first (so the trailing
-      # bytes do not survive into the second pass), then replace each
-      # remaining control byte with `?` so column-width math stays
+      # Idempotent: scrub invalid byte sequences first (subprocess output
+      # and exception messages frequently arrive tagged UTF-8 while
+      # carrying invalid bytes; Regexp#match validates the receiver's
+      # encoding and would otherwise raise ArgumentError before any
+      # sanitisation happens), then strip ANSI CSI sequences (so the
+      # trailing bytes do not survive into the second pass), then replace
+      # each remaining control byte with `?` so column-width math stays
       # one-cell-per-character. nil/non-string input returns the empty
       # string — every caller is concerned with display safety, not
       # with surfacing a TypeError on a missing field.
@@ -37,7 +41,7 @@ module Hive
       # constraint there). The replace-vs-delete split is deliberate; do
       # not unify the two.
       def sanitize(text)
-        text.to_s.gsub(ANSI_CSI_PATTERN, "").gsub(CONTROL_CHARS_PATTERN, "?")
+        text.to_s.scrub.gsub(ANSI_CSI_PATTERN, "").gsub(CONTROL_CHARS_PATTERN, "?")
       end
     end
   end

--- a/test/unit/tui/text_test.rb
+++ b/test/unit/tui/text_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+require "hive/tui/text"
+
+class HiveTuiTextTest < Minitest::Test
+  def test_sanitize_strips_ansi_and_replaces_control_chars
+    out = Hive::Tui::Text.sanitize("\e[2Jhello\nworld\e[31m!\e[0m")
+
+    assert_equal "hello?world!", out
+  end
+
+  # Regression: Regexp matching validates the receiver's encoding, so a
+  # string tagged UTF-8 while carrying invalid bytes (subprocess stderr,
+  # exception messages) used to raise ArgumentError before any
+  # sanitisation happened. Scrubbing must come first.
+  def test_sanitize_scrubs_invalid_byte_sequences_instead_of_raising
+    input = "stderr: \xFF".dup.force_encoding(Encoding::UTF_8)
+
+    refute input.valid_encoding?, "precondition: input must be invalid UTF-8"
+
+    out = Hive::Tui::Text.sanitize(input)
+
+    assert out.valid_encoding?
+    assert_includes out, "stderr:"
+    refute_includes out, "\xFF"
+  end
+
+  def test_sanitize_is_idempotent
+    once = Hive::Tui::Text.sanitize("a\e[1;2mb\x7fc\u0000d".dup.force_encoding(Encoding::UTF_8))
+
+    assert_equal once, Hive::Tui::Text.sanitize(once)
+  end
+
+  def test_sanitize_returns_empty_string_for_nil_or_non_string_input
+    assert_equal "", Hive::Tui::Text.sanitize(nil)
+    assert_equal "42", Hive::Tui::Text.sanitize(42)
+  end
+end

--- a/wiki/log.d/20260826T070000Z-tui-text-sanitize-scrub-invalid-utf8.md
+++ b/wiki/log.d/20260826T070000Z-tui-text-sanitize-scrub-invalid-utf8.md
@@ -1,0 +1,20 @@
+---
+title: Scrub invalid UTF-8 before TUI text sanitisation
+type: fix
+date: 2026-08-26
+tags: [tui, text, encoding, patrol-fix]
+---
+
+`Hive::Tui::Text.sanitize` gsub'd the ANSI CSI and control-char patterns
+without first validating encoding. Ruby regexp matching validates the
+receiver's encoding, so any subprocess-derived string (captured stderr,
+exception messages) tagged UTF-8 while carrying invalid bytes raised
+`ArgumentError: invalid byte sequence in UTF-8` before sanitisation could
+happen — turning a display-safety guard into a crash path for exactly the
+inputs it exists to protect.
+
+`sanitize` now calls `String#scrub` first: invalid sequences become the
+replacement character, then CSI/control bytes are stripped/replaced as
+before. The method stays idempotent and keeps its nil/non-string → `""`
+contract. Unit regression coverage in `test/unit/tui/text_test.rb` pins
+the invalid-UTF-8 input alongside the existing guarantees.


### PR DESCRIPTION
## Patrol Fix

This pull request repairs one finding tracked by Hive's Patrol Fix workflow.

### Sources

- ordinary_patrol: architecture-lib-hive-tui-part-6-20260815T204901Z-d158c504-1

### Finding evidence

- {"file":"lib/hive/tui/text.rb","line":40,"snippet":"text.to_s.gsub(ANSI_CSI_PATTERN, \"\").gsub(CONTROL_CHARS_PATTERN, \"?\")","role":"root_cause"}
- {"file":"lib/hive/tui/text.rb","line":5,"snippet":"captured stderr, exception messages) into the TUI's status line","role":"trigger"}
- {"file":"lib/hive/tui/bubble_model.rb","line":2865,"snippet":"sanitized = Hive::Tui::Text.sanitize(e.message)","role":"impact"}

### Independent review

The exact HEAD fixes the reported invalid-UTF-8 crash with a minimal scrub-before-regexp change and targeted regression coverage. Independent focused and TUI impact tests pass. The broad-suite failure is confined to an unchanged agent-cli-runtime executable-path expectation, so it is unrelated to this patch.

- HEAD ad6880ca208b0a4bd41511455160eacf57747566 matches the controller selection; the two-commit diff from b07b869635e47d986370b19d0dfe583d54143e79 is limited to lib/hive/tui/text.rb, test/unit/tui/text_test.rb, and the required wiki log.
- The pre-fix regexp operation independently reproduced ArgumentError: invalid byte sequence in UTF-8; the patched sanitizer returned valid, idempotent output for invalid UTF-8, ANSI/control, plain, and frozen inputs.
- Independent sanitizer tests passed: 4 runs, 10 assertions, 0 failures.
- Independent TUI impact suite passed: 308 runs, 1182 assertions, 0 failures.
- components/agent-cli-runtime has no diff from the fix base, and its failing test expectation is unchanged; the controller broad-suite failure is therefore outside patch scope.

### Validation

Verdict: failed
- ordinary:test: exit 1
- agent:repro-invalid-utf8-scrubbed-not-raising: exit 0
- agent:unit-test-text-sanitize-regression: exit 0
- agent:impact-area-bubble-model-suite: exit 0

<!-- hive-publication:v1 id=pub-7b69f890cdd532e860c1dda2d8cb162d base=b07b869635e47d986370b19d0dfe583d54143e79 -->
