### PR TITLE
Fix Patrol finding: post-commit-journal-failure-rolls-the-pointer-ba-c6d2e65ab08c

### DIFF
--- a/lib/hive/workflow_package/transaction.rb
+++ b/lib/hive/workflow_package/transaction.rb
@@ -53,6 +53,7 @@ module Hive
       private
 
       def run(old_bytes, new_bytes, commit)
+        committed = false
         @journal.write("schema_version" => 1, "phase" => "prepared", "lock_path" => @lock_path,
                        "old_lock" => old_bytes, "new_lock" => new_bytes)
         write_pointer(new_bytes)
@@ -62,14 +63,20 @@ module Hive
           @journal.write("schema_version" => 1, "phase" => "commit_started", "lock_path" => @lock_path,
                          "old_lock" => old_bytes, "new_lock" => new_bytes)
           commit.call
+          committed = true
           @journal.write("schema_version" => 1, "phase" => "commit_completed", "lock_path" => @lock_path,
                          "old_lock" => old_bytes, "new_lock" => new_bytes)
         end
         @journal.clear
         true
       rescue StandardError
-        restore(old_bytes)
-        @journal.clear
+        # Once commit.call has succeeded the change is irreversible: rolling
+        # the pointer back would contradict HEAD. Leave the surviving
+        # commit_started journal for reconcile! to resolve against git.
+        unless committed
+          restore(old_bytes)
+          @journal.clear
+        end
         raise
       end
 

--- a/test/unit/workflow_package/transaction_test.rb
+++ b/test/unit/workflow_package/transaction_test.rb
@@ -26,6 +26,49 @@ class WorkflowPackageTransactionTest < Minitest::Test
     end
   end
 
+  def test_post_commit_journal_failure_keeps_new_pointer_and_surviving_journal
+    with_transaction_repo do |root, workflows, lock|
+      old = "{\"old\":true}\n"
+      new_bytes = "{\"new\":true}\n"
+      journal_class = Hive::WorkflowPackage::TransactionJournal
+      original_write = journal_class.instance_method(:write)
+      journal_class.define_method(:write) do |data|
+        raise "injected journal failure" if data["phase"] == "commit_completed"
+
+        original_write.bind_call(self, data)
+      end
+
+      begin
+        Hive::WorkflowPackage::Transaction.activate(
+          lock_path: lock, workflows_dir: workflows, new_lock: { "new" => true },
+          commit: lambda {
+            File.write(lock, new_bytes)
+            run!("git", "-C", root, "add", "workflows/demo/honeycomb.lock.json")
+            run!("git", "-C", root, "commit", "-m", "activate", "--quiet")
+          }
+        )
+        flunk "expected the injected journal failure to propagate"
+      rescue RuntimeError => e
+        assert_equal "injected journal failure", e.message
+      ensure
+        journal_class.class_eval { remove_method :write }
+        journal_class.class_eval { define_method(:write) { |data| original_write.bind_call(self, data) } }
+      end
+
+      # The commit is irreversible, so the working pointer must match HEAD
+      # and the commit_started journal must survive for reconciliation.
+      assert_equal new_bytes, File.read(lock)
+      journal = Hive::WorkflowPackage::TransactionJournal.new(workflows)
+      data = journal.read
+      assert_equal "commit_started", data.fetch("phase")
+      assert_equal old, data.fetch("old_lock")
+
+      assert Hive::WorkflowPackage::Transaction.new(lock_path: lock, workflows_dir: workflows).reconcile!
+      assert_equal new_bytes, File.read(lock)
+      refute File.exist?(journal.path)
+    end
+  end
+
   def test_reconcile_restores_old_pointer_after_interrupted_activation
     with_tmp_dir do |dir|
       lock = File.join(dir, "demo", "honeycomb.lock.json")

--- a/wiki/log.d/20260826T010000Z-post-commit-journal-failure-keeps-pointer.md
+++ b/wiki/log.d/20260826T010000Z-post-commit-journal-failure-keeps-pointer.md
@@ -1,0 +1,31 @@
+# Post-commit journal failure no longer rolls back the workflow pointer
+
+- **Date**: 2026-08-26
+- **Scope**: `lib/hive/workflow_package/transaction.rb`
+- **Trigger**: Patrol finding `architecture-lib-hive-workflow-package-part-4-20260826T000046Z-959eda8b-1`
+
+## What changed
+
+`Transaction#run` previously used one unconditional rescue handler for the
+whole activation. A failure after a successful `commit.call` — for example an
+exception while writing the `commit_completed` journal phase — restored the
+old pointer and cleared the journal even though HEAD already contained the new
+lock. That left HEAD at the new selection while the working lock file held the
+old one, with `.transaction.json` deleted so `reconcile!` could not repair it.
+
+Now a local `committed` flag marks the irreversible boundary: once
+`commit.call` returns, failures re-raise without restoring the old bytes or
+clearing the journal. The surviving `commit_started` phase lets `reconcile!`
+resolve against git via `committed_pointer?`, which keeps the new lock when
+HEAD matches and restores the old one when it does not.
+
+Failures before or during `commit.call` keep the original rollback semantics.
+
+## Tests
+
+- `test/unit/workflow_package/transaction_test.rb`:
+  `test_post_commit_journal_failure_keeps_new_pointer_and_surviving_journal`
+
+## Uncertainty
+
+None recorded.


### PR DESCRIPTION
## Patrol Fix

This pull request repairs one finding tracked by Hive's Patrol Fix workflow.

### Sources

- ordinary_patrol: architecture-lib-hive-workflow-package-part-4-20260826T000046Z-959eda8b-1

### Finding evidence

- {"file":"lib/hive/workflow_package/transaction.rb","line":64,"snippet":"commit.call","role":"trigger"}
- {"file":"lib/hive/workflow_package/transaction.rb","line":65,"snippet":"@journal.write(\"schema_version\" => 1, \"phase\" => \"commit_completed\", \"lock_path\" => @lock_path,","role":"trigger"}
- {"file":"lib/hive/workflow_package/transaction.rb","line":71,"snippet":"restore(old_bytes)","role":"root_cause"}
- {"file":"lib/hive/workflow_package/transaction.rb","line":72,"snippet":"@journal.clear","role":"impact"}

### Independent review

At exact HEAD 67894a0c36e882da721f6a70ea3ba668c4026bce, the bounded patch corrects the reported post-commit journal-write failure: after commit.call returns, later errors preserve the new pointer and durable commit_started evidence, and existing reconciliation checks HEAD. Focused tests pass. The broad checkpoint remains red only in untouched agent-runtime executable probes, so those failures do not justify rework of this patch.

- The clean worktree HEAD matches the controller-selected revision, and the independently computed full binary diff digest is 9665d6c9d9d3eb2bb8d5281cbeedd075b71e5f1cae86362fb0432d49c6fc2e44; the diff is limited to transaction.rb, its unit test, and one wiki log fragment.
- Transaction#run now marks the callback as committed only after commit.call returns and skips restore plus journal clear for subsequent errors; reconcile! already resolves a surviving commit_started journal by comparing the expected pointer with HEAD.
- The new regression test performs a real Git commit, injects failure on the commit_completed journal write, verifies the new pointer and commit_started journal survive, and verifies reconcile! retains the committed pointer and clears the journal.
- Independent focused validation passed: transaction_test.rb completed 11 runs and 26 assertions, and managed_store_test.rb completed 25 runs and 119 assertions, both with zero failures or errors.
- The broad rake checkpoint failed in untouched components/agent-cli-runtime: Grok resolved to an absolute mise executable instead of the test's bare argv, and the OpenCode offline probe rejected its temporary wrapper; both failures reproduced independently and are outside this three-file patch.

### Validation

Verdict: failed
- ordinary:test: exit 1
- agent:architecture-lib-hive-workflow-package-part-4-20260826T000046Z-959eda8b-1: exit 0
- agent:architecture-lib-hive-workflow-package-part-4-20260826T000046Z-959eda8b-1: exit 0

<!-- hive-publication:v1 id=pub-daf618684f12ca08cf5cd3d649f2bb21 base=453ec4c9df9cd39447911f4e1e34111d2ba7a146 -->
