### PR TITLE
fix(status): preserve completed scheduler snapshots

### DIFF
--- a/lib/hive/daemon/operational_snapshot.rb
+++ b/lib/hive/daemon/operational_snapshot.rb
@@ -224,6 +224,7 @@ module Hive
           @observations = {}
           @runtime_ready = false
           @attempt_storage = Hive::Attempts::StorageHealth.unknown_snapshot
+          @last_completed_record = nil
         end
 
         def reconfigure(poll_interval_sec:)
@@ -234,7 +235,11 @@ module Hive
           @tick_sequence += 1
           @started_at = now.utc
           @observations = {}
-          @store.write(base_record(phase: "started", now: now).merge("tasks" => []))
+          if @last_completed_record
+            retain_completed_record
+          else
+            @store.write(base_record(phase: "started", now: now).merge("tasks" => []))
+          end
           tick_sequence
         end
 
@@ -268,6 +273,8 @@ module Hive
         end
 
         def fail(reason:, now: Time.now.utc)
+          return if @last_completed_record
+
           @store.write(
             base_record(phase: "failed", now: now).merge(
               "reason" => reason.to_s,
@@ -311,7 +318,9 @@ module Hive
             "recoveries" => recoveries || {},
             "tasks" => tasks
           )
-          @store.write(record)
+          published = @store.write(record)
+          @last_completed_record = record
+          published
         end
 
         # Written only by Dispatcher after it has stopped admitting work and
@@ -334,6 +343,18 @@ module Hive
         end
 
         private
+
+        def retain_completed_record
+          observed_at = Time.iso8601(@last_completed_record.fetch("observed_at"))
+          prior_deadline = Time.iso8601(@last_completed_record.fetch("valid_until"))
+          deadline = [ prior_deadline, observed_at + @validity_sec ].min
+          deadline_string = deadline.iso8601(6)
+          return if @last_completed_record.fetch("valid_until") == deadline_string
+
+          retained = @last_completed_record.merge("valid_until" => deadline_string)
+          @store.write(retained)
+          @last_completed_record = retained
+        end
 
         def base_record(phase:, now:)
           instant = now.utc

--- a/lib/hive/web/status_feed.rb
+++ b/lib/hive/web/status_feed.rb
@@ -31,7 +31,6 @@ module Hive
         @recovery_status_command = recovery_status_command
         @scheduler_snapshot_reader = scheduler_snapshot_reader
         @clock = clock
-        @last_current_scheduler_snapshot = nil
         @mutex = Mutex.new
       end
 
@@ -52,46 +51,14 @@ module Hive
         @recovery_status_command.operational_recoveries(
           projects,
           status_payload: status_payload,
-          scheduler_snapshot: stable_scheduler_snapshot
+          scheduler_snapshot: scheduler_snapshot
         )
       end
 
       private
 
-      # A daemon tick briefly replaces its completed observation with a
-      # generation-bound `started` record. Keep the still-valid completed
-      # observation through that narrow window so web subscribers do not
-      # morph-refresh twice per tick. Every other unavailable/stale state is
-      # passed through immediately.
-      def stable_scheduler_snapshot
-        now = @clock.call.utc
-        observed = @scheduler_snapshot_reader.read(now: now)
-        @mutex.synchronize do
-          if current_scheduler_snapshot?(observed, now)
-            @last_current_scheduler_snapshot = observed
-          elsif reusable_during_tick?(observed, @last_current_scheduler_snapshot, now)
-            @last_current_scheduler_snapshot
-          else
-            @last_current_scheduler_snapshot = nil
-            observed
-          end
-        end
-      end
-
-      def current_scheduler_snapshot?(snapshot, now)
-        snapshot["status"] == "current" && snapshot["phase"] == "complete" &&
-          Time.parse(snapshot.fetch("valid_until")) >= now
-      rescue ArgumentError, KeyError, TypeError
-        false
-      end
-
-      def reusable_during_tick?(observed, previous, now)
-        return false unless observed["status"] == "unavailable" &&
-                            observed["phase"] == "started" &&
-                            observed["reason"] == "tick_started"
-        return false unless current_scheduler_snapshot?(previous, now)
-
-        observed.dig("daemon", "generation").to_s == previous.dig("daemon", "generation").to_s
+      def scheduler_snapshot
+        @scheduler_snapshot_reader.read(now: @clock.call.utc)
       end
     end
 

--- a/test/unit/daemon/operational_snapshot_test.rb
+++ b/test/unit/daemon/operational_snapshot_test.rb
@@ -160,7 +160,7 @@ class HiveDaemonOperationalSnapshotTest < Minitest::Test
     end
   end
 
-  def test_full_status_cache_is_bound_to_the_completed_tick_and_retained_while_the_next_tick_runs
+  def test_completed_scheduler_and_status_cache_remain_current_while_the_next_tick_runs
     with_tmp_dir do |dir|
       path = File.join(dir, "private", "operational-snapshot.json")
       _store, assembler, reader, cache_reader = build(path)
@@ -184,14 +184,50 @@ class HiveDaemonOperationalSnapshotTest < Minitest::Test
       assert_equal (T0 + 91).iso8601(6), cache.fetch("valid_until")
 
       assembler.begin_tick(now: T0 + 31)
-      started = reader.read(now: T0 + 32)
-      retained = cache_reader.read(snapshot: started, now: T0 + 32)
-      assert_equal "unavailable", started.fetch("status")
-      assert_equal "tick_started", started.fetch("reason")
-      refute started.key?("status_cache")
+      retained_snapshot = reader.read(now: T0 + 32)
+      retained = cache_reader.read(snapshot: retained_snapshot, now: T0 + 32)
+      assert_equal "current", retained_snapshot.fetch("status")
+      assert_equal "complete", retained_snapshot.fetch("phase")
+      refute retained_snapshot.key?("status_cache")
       assert_equal payload, retained.fetch("payload")
       assert_equal 1, retained.fetch("tick_sequence")
-      assert_equal 2, started.fetch("tick_sequence")
+      assert_equal 1, retained_snapshot.fetch("tick_sequence")
+    end
+  end
+
+  def test_failed_later_tick_preserves_the_last_completed_scheduler_snapshot
+    with_tmp_dir do |dir|
+      path = File.join(dir, "private", "operational-snapshot.json")
+      _store, assembler, reader = build(path)
+      observed = row
+
+      assembler.begin_tick(now: T0)
+      assembler.complete(
+        rows: [ observed ], controller: { "in_flight" => 1 },
+        queue: { "pending" => 2 }, recoveries: {}, now: T0 + 1
+      )
+      completed_bytes = File.binread(path)
+
+      assembler.begin_tick(now: T0 + 31)
+      assembler.fail(reason: "status_failure", now: T0 + 32)
+
+      assert_equal completed_bytes, File.binread(path)
+      retained = reader.read(now: T0 + 33)
+      assert_equal "current", retained.fetch("status")
+      assert_equal 1, retained.fetch("tick_sequence")
+      assert_equal 1, retained.dig("capacity", "in_flight")
+      assert_equal 2, retained.dig("queue", "pending")
+
+      assembler.begin_tick(now: T0 + 61)
+      assembler.complete(
+        rows: [ row(slug: "next") ], controller: { "in_flight" => 0 },
+        queue: { "pending" => 0 }, recoveries: {}, now: T0 + 62
+      )
+
+      replacement = reader.read(now: T0 + 63)
+      assert_equal "current", replacement.fetch("status")
+      assert_equal 3, replacement.fetch("tick_sequence")
+      assert_equal "next", replacement.dig("tasks", 0, "identity", "slug")
     end
   end
 
@@ -324,9 +360,9 @@ class HiveDaemonOperationalSnapshotTest < Minitest::Test
       assembler.reconfigure(poll_interval_sec: 30)
       assembler.begin_tick(now: T0 + 61)
 
-      started = reader.read(now: T0 + 92)
-      assert_equal "unavailable", started.fetch("status")
-      assert_nil cache_reader.read(snapshot: started, now: T0 + 92)
+      retained = reader.read(now: T0 + 92)
+      assert_equal "stale", retained.fetch("status")
+      assert_nil cache_reader.read(snapshot: retained, now: T0 + 92)
     end
   end
 
@@ -668,6 +704,29 @@ class HiveDaemonOperationalSnapshotTest < Minitest::Test
       assert_equal "duplicate_task_identity: demo:ship-it", snapshot.fetch("reason")
       assert_empty snapshot.fetch("tasks")
       assert_empty snapshot.fetch("provider_holds")
+    end
+  end
+
+  def test_duplicate_rows_in_a_later_tick_do_not_erase_the_last_completed_snapshot
+    with_tmp_dir do |dir|
+      path = File.join(dir, "private", "operational-snapshot.json")
+      _store, assembler, reader = build(path)
+      original = row
+
+      assembler.begin_tick(now: T0)
+      assembler.complete(
+        rows: [ original ], controller: {}, queue: {}, recoveries: {}, now: T0 + 1
+      )
+      assembler.begin_tick(now: T0 + 31)
+      assembler.complete(
+        rows: [ original, row(stage: "5-open-pr", folder: "/tmp/5-open-pr/ship-it") ],
+        controller: {}, queue: {}, recoveries: {}, now: T0 + 32
+      )
+
+      retained = reader.read(now: T0 + 33)
+      assert_equal "current", retained.fetch("status")
+      assert_equal 1, retained.fetch("tick_sequence")
+      assert_equal [ "ship-it" ], retained.fetch("tasks").map { |task| task.dig("identity", "slug") }
     end
   end
 

--- a/test/unit/web/status_feed_test.rb
+++ b/test/unit/web/status_feed_test.rb
@@ -187,7 +187,7 @@ class StatusFeedTest < Minitest::Test
     assert_equal 1, source.calls
   end
 
-  def test_cached_status_command_retains_current_scheduler_receipts_during_tick_start
+  def test_cached_status_command_reads_the_daemon_owned_scheduler_snapshot_each_time
     now = Time.utc(2026, 8, 7, 14, 30)
     current = {
       "status" => "current",
@@ -214,39 +214,8 @@ class StatusFeedTest < Minitest::Test
     command.operational_recoveries([], status_payload: payload)
     command.operational_recoveries([], status_payload: payload)
 
-    assert_same current, recovery_status.scheduler_snapshot,
-                "an in-progress tick must retain the same generation's still-valid completed snapshot"
-  end
-
-  def test_cached_status_command_does_not_retain_snapshot_across_daemon_generation
-    now = Time.utc(2026, 8, 7, 14, 30)
-    current = {
-      "status" => "current",
-      "phase" => "complete",
-      "valid_until" => (now + 90).iso8601,
-      "daemon" => { "generation" => "daemon-1" }
-    }
-    restarted = {
-      "status" => "unavailable",
-      "reason" => "tick_started",
-      "phase" => "started",
-      "valid_until" => (now + 120).iso8601,
-      "daemon" => { "generation" => "daemon-2" }
-    }
-    recovery_status = RecordingRecoveryStatus.new
-    command = Hive::Web::CachedStatusCommand.new(
-      source: RecordingSource.new,
-      recovery_status_command: recovery_status,
-      scheduler_snapshot_reader: ScriptedSchedulerReader.new(current, restarted),
-      clock: -> { now }
-    )
-    payload = command.json_payload([])
-
-    command.operational_recoveries([], status_payload: payload)
-    command.operational_recoveries([], status_payload: payload)
-
-    assert_same restarted, recovery_status.scheduler_snapshot,
-                "a new daemon generation must never inherit the predecessor's scheduler authority"
+    assert_same started, recovery_status.scheduler_snapshot,
+                "Web must use the producer-owned snapshot instead of retaining local authority"
   end
 
   def test_cached_status_command_passes_through_a_malformed_current_receipt

--- a/wiki/commands/status.md
+++ b/wiki/commands/status.md
@@ -103,10 +103,12 @@ own graph producer cannot consume its cache recursively.
 The cache is a bounded freshness optimization, not a second source of truth.
 When it belongs to the same completed tick as the scheduler record, the shared
 tick sequence proves that it is the graph on which those scheduler decisions
-were made. A retained cache from the previous tick can still provide cheap
-task visibility while a new tick is running, but scheduler completeness
-remains unavailable until that tick completes. Independently supplied status
-graphs still pass the timestamp and per-task scheduler-join fences.
+were made. The daemon preserves that coherent completed pair while a later tick
+is running or fails, so ordinary operational status does not transiently lose
+scheduler ownership. The retained observation keeps its original timestamp and
+deadline; expiry, daemon replacement, and every task-identity join still fail
+closed. Independently supplied status graphs still pass the timestamp and
+per-task scheduler-join fences.
 During a binary/daemon cutover, an older scheduler record has no dedicated
 payload-mtime field. A same-tick cached Patrol Fix controller graph may treat
 only that unavailable timestamp as unknown because the shared tick sequence

--- a/wiki/log.d/20260827T165900Z-stable-scheduler-snapshot.md
+++ b/wiki/log.d/20260827T165900Z-stable-scheduler-snapshot.md
@@ -1,0 +1,16 @@
+# Preserve completed scheduler authority through later ticks
+
+**Change:** After one successful daemon reconciliation, tick start and tick
+failure no longer replace the same generation's still-valid completed
+scheduler snapshot. The next successful tick replaces it atomically. Before
+the first success, `started` and `failed` remain explicit.
+
+**Why:** One malformed or failed scan previously made every operational client
+lose scheduler ownership even though a recent coherent task graph, capacity
+frame, queue projection, and recovery overlay were still valid. Web carried a
+process-local workaround; the producer now owns the rule for CLI, Web, TUI,
+bot, and watch consumers alike.
+
+**Safety:** Retention never changes `observed_at`, tick sequence, daemon
+generation, source window, or task bindings. The original deadline still
+expires, and a shorter reloaded poll interval can only clamp that deadline.

--- a/wiki/modules/daemon.md
+++ b/wiki/modules/daemon.md
@@ -74,7 +74,7 @@ Valid snapshots keep polling cheap. See [[modules/conditions]].
 | `Hive::Daemon::ConcurrencyController` | `lib/hive/daemon/concurrency_controller.rb` | In-memory budget gate: caps (global / per-project / per-day rate plus per-project patrol scans), WRONG_STAGE protective backoff, transient backoff schedule, quarantine, dropped projects, last-dispatched mtime tracking. `Dispatcher#reload_config!` applies reloaded limits through `update_limits` on this same object so SIGHUP changes admission immediately without discarding runtime state. SUCCESS exits do not cool down; the next stage may dispatch immediately. The last-dispatched mtime map is write-through-persisted via an injected `DispatchBaselines` store so it survives restart (see "Persisted dispatch baselines" below); restored keys retain one-process provenance until a real observation or dispatch consumes them. Everything else is intentionally in-memory. |
 | `Hive::Daemon::DispatchBaselines` | `lib/hive/daemon/dispatch_baselines.rb` | Crash-safe JSON store for the `[project, slug] → state_file_mtime` baseline map (`daemon_dispatch_baselines.json` under the state home). Atomic write + fail-closed load; mirrors `Hive::UpdateCheck::State`. Stops answered `needs_input` tasks being re-stranded across a daemon restart. |
 | `Hive::Daemon::StatusConsumer` | `lib/hive/daemon/status_consumer.rb` | Wraps the hidden internal task-graph transport and bounded `--daemon-task project:slug` reads. Both return typed visible rows including `workflow`, canonical `pr_url`, and structured `admission_error`; full results also carry the validated source payload, project information, and the summed `hidden_archived_task_count`. Each row retains the task payload's exact `mtime` separately from the local state file's precise stat: scheduler/status identity uses the former, while edit-resume and recovery policy use the latter. Bounded responses never carry a fleet payload: they must declare `partial: true`, match the requested project/task identities, and contain no project error; a mismatch fails without replacing cached daemon state. Missing or malformed admission state is converted to `dependency_validation_failed`, `blocked: true`, action `admission_error`, and no command. Envelope shape and hidden-count types are hard-validated while forward schema versions remain best-effort. |
-| `Hive::Daemon::OperationalSnapshot` | `lib/hive/daemon/operational_snapshot.rb` | Private daemon-to-status observation channel. `Assembler` first publishes a generation-bound `runtime_ready` acknowledgement after signal installation and inherited-claim recovery, then retains that flag on `started`, `failed`, revalidated `complete`, and shutdown records. Scheduler task records bind to the exact source-payload `mtime`, including controller workflows whose folder and manifest mtimes differ, without changing the precise state-file timestamp used by recovery. Tick completion includes the final aggregate hidden-archive count. The large source `hive-status` graph is published once in a separate `StatusCache` file, so the ordinary scheduler `Reader`, web, and watch never parse or retain it; concise status explicitly reads and generation/tick/deadline-validates the cache. SIGHUP recalculates validity from the reloaded poll interval, and recovery receipts are overlaid only when task, stage, marker identity, and lifecycle still match. Both stores atomically persist owner-private records. |
+| `Hive::Daemon::OperationalSnapshot` | `lib/hive/daemon/operational_snapshot.rb` | Private daemon-to-status observation channel. `Assembler` first publishes a generation-bound `runtime_ready` acknowledgement after signal installation and inherited-claim recovery. Before the first successful reconciliation, `started` and `failed` remain explicit; afterward, an in-progress or failed tick cannot overwrite the same generation's still-valid completed scheduler authority. Scheduler task records bind to the exact source-payload `mtime`, including controller workflows whose folder and manifest mtimes differ, without changing the precise state-file timestamp used by recovery. Tick completion includes the final aggregate hidden-archive count. The large source `hive-status` graph is published once in a separate `StatusCache` file, so the ordinary scheduler `Reader`, web, and watch never parse or retain it; concise status explicitly reads and generation/tick/deadline-validates the cache. SIGHUP can only shorten retained authority to the reloaded poll interval; recovery receipts are overlaid only when task, stage, marker identity, and lifecycle still match. Both stores atomically persist owner-private records. |
 | `Hive::Daemon::PatrolFixCandidateInventory` | `lib/hive/daemon/patrol_fix_candidate_inventory.rb` | Opens only exact `patrol-fix-manifest.json` files under workflow stage/task owners. It binds every owned manifest's canonical bytes into one full inventory count/digest, fails on owned corruption, ignores unrelated task metadata, and selects one deterministic relevance-ranked context of at most 64 rows and 192 KiB. Exact source identity, alias, and semantic-lineage overlap rank before path/lexical fallback; each selected row carries bounded secret-scanned remediation evidence and its own context digest. |
 | `Hive::Daemon::ActivationLock` | `lib/hive/daemon/activation_lock.rb` | Stable, owner-bound, never-unlinked profile flock held by daemon startup through generation-bound runtime readiness. Unsafe paths, replacement inodes, and bounded contention fail closed. |
 | `Hive::Daemon::StatusReport` | `lib/hive/daemon/status_report.rb` | Shared read-only `hive-daemon-status` producer for `hive daemon status --json` and hivebox. Builds the PID/service/binary/update-nudge envelope as a plain hash, exposes `running_state`, `payload`, and web-safe `safe_payload`, suppresses update-state orphan cleanup, bounds `installed_binary --version` probes to 10s, treats a stable service symlink and its current deployment target as the same binary by filesystem identity, and owns `BINARY_DRIFT_STATES` / `BINARY_DRIFT_ACTIONABLE` so the CLI producer and web repair affordance read the same enum source. |
@@ -175,8 +175,12 @@ recovery path rather than permitting overlapping generations. Signal-derived
 nil exits are failures for terminal recovery and ordinary patrol; only an
 explicit success exit clears failure state.
 
-Each full tick first publishes a `started` record, then reconciles durable
-attempts, processes normalized loss, and publishes lease-first capacity. It
+Before the first successful reconciliation, a full tick publishes a `started`
+record. Once one completed scheduler snapshot exists, later tick starts and
+failures leave that completed observation in place until its validity deadline;
+they never refresh its observation time or authority. The tick then
+reconciles durable attempts, processes normalized loss, and publishes
+lease-first capacity. It
 then runs: reap ancillary children -> enforce child
 timeouts -> prune dispatch-result notices -> **tick the digest scheduler** ->
 fetch status -> observe every task-bound PR in
@@ -213,9 +217,10 @@ project identities still match. A matching cache/snapshot tick sequence binds it
 decisions made from that graph; an independently collected graph still has to
 be sampled at or after snapshot completion. The join then rechecks task identity,
 generation, stage, marker/attrs, attempt, state-file mtime, action,
-dependency/admission policy, and blocked state. A cache retained from the
-previous completed tick keeps task visibility cheap during a new `started`
-record, but cannot make that in-progress scheduler frame complete. Invalid,
+dependency/admission policy, and blocked state. The scheduler record and cache
+from the previous completed tick remain a coherent current pair while a later
+tick runs or fails. If either expires, status degrades normally; no in-progress
+work extends the old authority. Invalid,
 generation-mismatched, project-mismatched, or expired cache data falls back to
 a fresh task scan. Cache rejection cannot prevent publication of scheduler
 evidence. Status generation
@@ -237,9 +242,11 @@ Retry dispositions additionally carry the exact marker-age `retry_at`,
 whether the boundary is due, the current safety verdict, and its reason.
 `retry_cooldown` is scheduler-owned, `retry_in_flight` is agent-owned, and
 `retry_safety_blocked` is operator-owned (or Hive-owned when inspection itself
-failed). Failed reconciliation/status publishes `failed`. Snapshot age starts at the actual
-completion sample rather than the tick-start sample, and a SIGHUP poll-interval
-reload immediately reconfigures the assembler's next validity window.
+failed). A failed first reconciliation publishes `failed`; a later failure is
+logged while the last completed snapshot remains authoritative until expiry.
+Snapshot age starts at the actual completion sample rather than the tick-start
+sample, and a SIGHUP poll-interval reload can shorten retained authority but
+never extend it.
 
 SIGHUP reads and validates the daemon, update, digest, and answer-digest
 blocks into locals before replacing live policy or the healer. A failure in


### PR DESCRIPTION
## Summary

- keep the last valid completed scheduler snapshot authoritative while a later daemon tick runs or fails
- retain explicit started and failed records before the first successful reconciliation
- remove the Web process-local scheduler snapshot cache now that the producer owns continuity
- preserve expiry, daemon-generation, source-window, and task-identity fences

## Test plan

- `bundle exec ruby -Itest test/unit/daemon/operational_snapshot_test.rb`
- `bundle exec ruby -Itest test/unit/web/status_feed_test.rb`
- `bundle exec ruby -Itest test/unit/operational_status_test.rb`
- `bundle exec ruby -Itest test/unit/commands/status_operational_test.rb`
- `bundle exec ruby -Itest test/unit/daemon/dispatcher_test.rb`
- RuboCop on changed Ruby files

## Local broad-suite note

`bundle exec rake test` remains blocked by the pre-existing local OpenCode offline wrapper probe (`opencode binary not runnable`). The five change-owned suites pass with 428 runs and 1,610 assertions.