### PR TITLE
fix(bench): bind stage markers to campaign runtime

### DIFF
--- a/templates/builtins/bench/generate.md
+++ b/templates/builtins/bench/generate.md
@@ -48,7 +48,10 @@ write_limits_reached() {
     printf '%s\n\n' "$1"
     printf 'Hive will retry this stage after the provider cooldown at %s.\n\n' "$retry_after"
   } >>"$STATE_FILE"
-  ruby -rhive/markers -e '
+  # Stage agents intentionally run with RubyGems environment scrubbed. Load the
+  # marker implementation from the campaign's immutable source runtime instead
+  # of whichever released hive-cli gem happens to be installed on the host.
+  ruby -I"$SOURCE/lib" -rhive/markers -e '
     Hive::Markers.set(
       ARGV.fetch(0),
       :error,
@@ -114,7 +117,7 @@ ruby -ryaml -rjson -e '
   # with published campaign dirs.
   abort("campaign_id must be a slug matching /\\A[a-z0-9][a-z0-9-]{0,63}\\z/; got #{id.inspect}") unless id.match?(/\A[a-z0-9][a-z0-9-]{0,63}\z/)
   abort("campaign_id v3-example is the unedited example id; pick a real campaign id") if id == "v3-example"
-  # source/corpus_version feed three-line `read` extractions here and in the
+  # source/corpus_version feed fixed-line `read` extractions here and in the
   # judge/publish stages: a multi-line value would silently misalign them.
   source = data["source"]
   abort("source must be a non-empty single-line string; got #{source.inspect}") unless source.is_a?(String) && !source.include?("\n") && !source.strip.empty?
@@ -184,6 +187,7 @@ ruby -ryaml -e '
   runtime = ARGV.fetch(0)
   data = YAML.safe_load_file("campaign.yml")
   puts data.fetch("campaign_id")
+  puts data.fetch("source")
   puts data.fetch("corpus_version")
   require File.join(runtime, "harness/profiles/candidates")
   needs_openrouter = data.dig("judges", "openrouter").is_a?(Hash) ||
@@ -193,7 +197,7 @@ ruby -ryaml -e '
   write_waiting "$(cat .generate-campaign.err .generate-campaign.out)"
   exit 0
 }
-{ read -r CAMPAIGN_ID; read -r CORPUS_VERSION; read -r NEEDS_OPENROUTER; } <.generate-campaign.out
+{ read -r CAMPAIGN_ID; read -r SOURCE; read -r CORPUS_VERSION; read -r NEEDS_OPENROUTER; } <.generate-campaign.out
 
 ruby -ryaml -rshellwords -rjson -e '
   repo = ARGV.fetch(0)

--- a/templates/builtins/bench/judge.md
+++ b/templates/builtins/bench/judge.md
@@ -32,13 +32,16 @@ write_waiting() {
 }
 
 write_limits_reached() {
-  retry_after="$(ruby -rhive/agent_limit -e 'puts Hive::AgentLimit.retry_after')"
+  # Stage agents intentionally run with RubyGems environment scrubbed. Load the
+  # cooldown and marker implementations from the campaign's immutable source
+  # runtime instead of whichever released hive-cli gem is installed on the host.
+  retry_after="$(ruby -I"$SOURCE/lib" -rhive/agent_limit -e 'puts Hive::AgentLimit.retry_after')"
   {
     printf '\n## Status\n\n'
     printf '%s\n\n' "$1"
     printf 'Hive will retry this stage after the provider cooldown at %s.\n\n' "$retry_after"
   } >>"$STATE_FILE"
-  ruby -rhive/markers -e '
+  ruby -I"$SOURCE/lib" -rhive/markers -e '
     Hive::Markers.set(
       ARGV.fetch(0),
       :error,

--- a/test/unit/workflows/bench_test.rb
+++ b/test/unit/workflows/bench_test.rb
@@ -1147,18 +1147,17 @@ class WorkflowsBenchTest < Minitest::Test
     Dir.mktmpdir("hive-bench-quota-marker") do |dir|
       state_file = File.join(dir, "generate.md")
       File.write(state_file, "# Generate\n<!-- AGENT_WORKING -->\n")
-      ruby_lib = [ File.expand_path("../../../lib", __dir__), ENV["RUBYLIB"] ].compact
-        .join(File::PATH_SEPARATOR)
       shell = <<~BASH
         set -euo pipefail
         STATE_FILE="$1"
+        SOURCE="$2"
         #{function}
         write_limits_reached "provider limit"
       BASH
 
       _out, err, status = Open3.capture3(
-        { "RUBYLIB" => ruby_lib, "HIVE_LIMITS_RETRY_COOLDOWN_SEC" => "60" },
-        "bash", "-c", shell, "--", state_file
+        { "RUBYLIB" => nil, "HIVE_LIMITS_RETRY_COOLDOWN_SEC" => "60" },
+        "bash", "-c", shell, "--", state_file, File.expand_path("../../..", __dir__)
       )
 
       assert status.success?, err
@@ -1367,18 +1366,17 @@ class WorkflowsBenchTest < Minitest::Test
         "# Judge\n<!-- AGENT_WORKING -->\n" +
           ("x" * (Hive::Markers::MAX_MARKER_SCAN_BYTES + 1))
       )
-      ruby_lib = [ File.expand_path("../../../lib", __dir__), ENV["RUBYLIB"] ].compact
-        .join(File::PATH_SEPARATOR)
       shell = <<~BASH
         set -euo pipefail
         STATE_FILE="$1"
+        SOURCE="$2"
         #{function}
         write_limits_reached "provider limit"
       BASH
 
       _out, err, status = Open3.capture3(
-        { "RUBYLIB" => ruby_lib, "HIVE_LIMITS_RETRY_COOLDOWN_SEC" => "60" },
-        "bash", "-c", shell, "--", state_file
+        { "RUBYLIB" => nil, "HIVE_LIMITS_RETRY_COOLDOWN_SEC" => "60" },
+        "bash", "-c", shell, "--", state_file, File.expand_path("../../..", __dir__)
       )
 
       assert status.success?, err

--- a/wiki/log.d/20260827T184000Z-bench-stage-source-runtime.md
+++ b/wiki/log.d/20260827T184000Z-bench-stage-source-runtime.md
@@ -1,0 +1,17 @@
+---
+title: Bind bench quota markers to the campaign runtime
+type: fix
+date: 2026-08-27
+---
+
+## Action
+
+Generate and judge quota recovery now load Hive marker and cooldown code from
+the campaign's immutable source runtime. This keeps dogfood stage-agent shells
+from falling back to an older installed `hive-cli` gem after RubyGems environment
+variables are scrubbed.
+
+## Proof
+
+Focused workflow tests execute both quota-marker helpers with `RUBYLIB` removed
+and require canonical retry markers from the source checkout.

--- a/wiki/modules/workflows.md
+++ b/wiki/modules/workflows.md
@@ -205,6 +205,10 @@ driver resolves the exact immutable deployment named by
 `HIVE_RUNTIME_BUILD_SHA`. It does not treat the stable wrapper as a source
 runtime or follow the mutable `dogfood-current` pointer after the task starts;
 an explicit `HB_HIVE_BIN` override still takes precedence and fails closed.
+Generate and judge quota markers likewise load `Hive::Markers` (and the judge
+cooldown helper) from the campaign's immutable `source/lib`, so a scrubbed
+stage-agent shell cannot silently fall back to an older installed hive-cli gem
+with a different marker API.
 
 
 `hive workflow new ID` (see [[commands/workflow]]) scaffolds the minimal `inbox -> work -> done` descriptor plus `work.md` instruction and commits those initial files to `hive/state`. After editing, the natural-language creator validates and invokes `hive workflow commit ID`, which commits the populated descriptor/instruction directory under the shared state commit lock before it reports success or creates a task. The only richer shipped scaffold is `--template research`; Architecture and Writing are installed as full reviewed Honeycomb packages so their agent-slot configuration remains operator-owned.


### PR DESCRIPTION
## Summary

- Bind benchmark quota recovery to the campaign's immutable Hive runtime.
- Prevent scrubbed dogfood stage shells from loading an older installed `hive-cli` marker API and exiting without a retry marker.

## Test plan

- [x] `bundle exec ruby -Itest test/unit/workflows/bench_test.rb` — 46 runs, 439 assertions, 0 failures.
- [ ] `bundle exec rake test` — reached 115 runs; the existing OpenCode offline smoke errored because its temporary wrapper was not runnable.
- [ ] Hosted CI and merge gates.

## Notes for reviewer

The source path is already validated as a non-empty single-line campaign value and is the immutable runtime used for the benchmark itself. The regression tests remove `RUBYLIB`, which reproduces the dogfood agent environment that exposed the version mismatch.
