### PR TITLE
fix(patrol): contain repeated failure cohorts

### DIFF
--- a/lib/hive/attempts/capacity_snapshot.rb
+++ b/lib/hive/attempts/capacity_snapshot.rb
@@ -1,4 +1,5 @@
 require "date"
+require "hive/attempts/failure_cohort_reconciler"
 require "hive/attempts/lost_outcome"
 require "hive/attempts/store"
 
@@ -150,6 +151,7 @@ module Hive
       def initialize(store:, hot_scan:)
         @store = store
         @hot_scan = hot_scan
+        @failure_cohort_reconciler = FailureCohortReconciler.new(store: store)
         @records = hot_scan.records.to_h { |record| [ record.attempt_id, record ] }
         @indexed_versions = {}
         synchronize_indexes!(@records.values)
@@ -167,9 +169,10 @@ module Hive
       # another Store instance after that scan.
       def refresh_for_admission
         reservations = mutable_live_reservations
-        merge_observed_reservations!(reservations, @records.values)
+        merge_observed_reservations!(reservations, @records.values, release_final: false)
         refresh_known_records!(unreadable: :forget)
         hydrate_reserved_records!(reservations)
+        reconcile_failure_cohorts!(reservations, @records.values)
         merge_observed_reservations!(reservations, @records.values)
         release_converged_reservations!(reservations)
         decision_index.replace_live_reservations(reservations)
@@ -190,18 +193,32 @@ module Hive
       end
 
       # These mutations share the admission lock held by Dispatcher#admit.
-      def reserve_live(attempt_id:, project:, task_slug:)
+      def reserve_live(attempt_id:, project:, task_slug:, admission: nil)
         decision_index.reserve_live(
-          attempt_id: attempt_id, project: project, task_slug: task_slug
+          attempt_id: attempt_id, project: project, task_slug: task_slug,
+          admission: admission
         )
       end
 
-      def confirm_live(record)
+      def confirm_live(record, admission: nil)
         decision_index.confirm_live(
           attempt_id: record.attempt_id,
           project: record["project"],
-          task_slug: record["task_slug"]
+          task_slug: record["task_slug"],
+          admission: admission
         )
+      end
+
+      def failure_cohort_admission(**attributes)
+        decision_index.failure_cohort_admission(**attributes)
+      end
+
+      def claim_failure_cohort_probe(**attributes)
+        decision_index.claim_failure_cohort_probe(**attributes)
+      end
+
+      def release_failure_cohort_probe(**attributes)
+        decision_index.release_failure_cohort_probe(**attributes)
       end
 
       def record(record)
@@ -302,17 +319,27 @@ module Hive
         decision_index.live_reservations.transform_values(&:dup)
       end
 
-      def merge_observed_reservations!(reservations, records)
+      def merge_observed_reservations!(reservations, records, release_final: true)
         records.each do |record|
           if CapacitySnapshot.reserves_capacity?(record, outcome_store: outcome_store)
-            reservations[record.attempt_id] = {
+            replacement = {
               "project" => record["project"],
               "task_slug" => record["task_slug"],
               "phase" => "active"
             }
-          else
+            admission = reservations.dig(record.attempt_id, "admission")
+            replacement["admission"] = admission if admission
+            reservations[record.attempt_id] = replacement
+          elsif release_final
             reservations.delete(record.attempt_id)
           end
+        end
+      end
+
+      def reconcile_failure_cohorts!(reservations, records)
+        records.each do |record|
+          admission = reservations.dig(record.attempt_id, "admission")
+          @failure_cohort_reconciler.reconcile(record: record, admission: admission)
         end
       end
 

--- a/lib/hive/attempts/decision_index.rb
+++ b/lib/hive/attempts/decision_index.rb
@@ -1,4 +1,5 @@
 require "date"
+require "digest"
 require "json"
 require "time"
 require "hive/attempts/point_storage"
@@ -18,6 +19,10 @@ module Hive
       MAX_DAILY_ATTEMPTS = 10_000
       MAX_LIVE_RESERVATIONS = 1_024
       MAX_ROUTING_PROJECTIONS = 4_096
+      MAX_FAILURE_COHORTS = 512
+      FAILURE_COHORT_THRESHOLD = 3
+      FAILURE_COHORT_COOLDOWN_SEC = 60 * 60
+      FAILURE_COHORT_PROBE_TTL_SEC = 24 * 60 * 60
       TERMINAL_REQUEST = "terminal-request".freeze
       LATEST_TERMINAL = "latest-terminal".freeze
       SUCCESSFUL_OWNER = "successful-owner".freeze
@@ -26,6 +31,7 @@ module Hive
       DAILY_ACCOUNTING = "daily-accounting".freeze
       LIVE_CAPACITY = "live-capacity".freeze
       ROUTING_DECISION = "routing-decision".freeze
+      FAILURE_COHORTS = "failure-cohorts".freeze
       ENTRY_KEYS = %w[kind key schema schema_version value].freeze
 
       attr_reader :root
@@ -244,11 +250,12 @@ module Hive
       # it is not attempt history. Pending-before-create makes a crash
       # conservative, and the next lock holder can remove a pending entry only
       # after observing that no hot record was created.
-      def reserve_live(attempt_id:, project:, task_slug:)
+      def reserve_live(attempt_id:, project:, task_slug:, admission: nil)
         update_live_reservations do |reservations|
           id = StorageKey.string(attempt_id)
           candidate = live_reservation(
-            project: project, task_slug: task_slug, phase: "pending"
+            project: project, task_slug: task_slug, phase: "pending",
+            admission: admission
           )
           existing = reservations[id]
           if existing && existing.except("phase") != candidate.except("phase")
@@ -259,11 +266,12 @@ module Hive
         end
       end
 
-      def confirm_live(attempt_id:, project:, task_slug:)
+      def confirm_live(attempt_id:, project:, task_slug:, admission: nil)
         update_live_reservations do |reservations|
           id = StorageKey.string(attempt_id)
           candidate = live_reservation(
-            project: project, task_slug: task_slug, phase: "active"
+            project: project, task_slug: task_slug, phase: "active",
+            admission: admission
           )
           existing = reservations[id]
           if existing && existing.except("phase") != candidate.except("phase")
@@ -289,12 +297,123 @@ module Hive
         end.freeze
       end
 
+      def record_failure_cohort(attempt_id:, identity:, occurred_at:)
+        normalized_identity = failure_cohort_identity(identity)
+        attempt = StorageKey.string(attempt_id)
+        occurred = time_value(occurred_at)
+        date = occurred.utc.to_date
+        digest = failure_cohort_digest(normalized_identity)
+        update_failure_cohorts(date) do |value|
+          next value if value.fetch("processed_attempts").key?(attempt)
+
+          cohorts = value.fetch("cohorts")
+          cohorts.each do |key, candidate|
+            next unless candidate.fetch("probe_attempt_id") == attempt &&
+                        candidate.fetch("identity") != normalized_identity
+
+            cohorts[key] = refresh_failure_cohort(
+              candidate, occurred: occurred, clear_probe: true
+            )
+          end
+          entry = cohorts[digest] || empty_failure_cohort(normalized_identity)
+          count = entry.fetch("failure_count") + 1
+          probe_finished = entry.fetch("probe_attempt_id") == attempt
+          refreshed = refresh_failure_cohort(
+            entry, occurred: occurred, clear_probe: probe_finished,
+            failure_count: count
+          )
+          cohorts[digest] = refreshed.merge(
+            "failure_count" => count,
+            "retry_at" => count >= FAILURE_COHORT_THRESHOLD ?
+              refreshed.fetch("retry_at") : nil
+          )
+          value.fetch("processed_attempts")[attempt] = digest
+          value
+        end
+      end
+
+      def record_failure_cohort_success(attempt_id:, date:)
+        attempt = StorageKey.string(attempt_id)
+        found = false
+        update_failure_cohorts(date, create: false) do |value|
+          value.fetch("cohorts").delete_if do |_digest, entry|
+            matched = entry.fetch("probe_attempt_id") == attempt
+            found ||= matched
+            matched
+          end
+          value.fetch("processed_attempts")[attempt] = "succeeded" if found
+          value
+        end
+        found
+      end
+
+      def failure_cohort_admission(identity:, date:, now:, explicit_release: false)
+        normalized_identity = failure_cohort_identity(identity)
+        value = read_value(FAILURE_COHORTS, failure_cohorts_key(date))
+        entry = value&.fetch("cohorts", {})&.fetch(
+          failure_cohort_digest(normalized_identity), nil
+        )
+        return open_failure_cohort unless entry
+        return open_failure_cohort if entry.fetch("failure_count") < FAILURE_COHORT_THRESHOLD
+
+        current = expire_failure_cohort_probe(entry, now: time_value(now))
+        return blocked_failure_cohort if current.fetch("probe_attempt_id")
+        retry_at = Time.iso8601(current.fetch("retry_at"))
+        return probe_failure_cohort if explicit_release || time_value(now) >= retry_at
+
+        blocked_failure_cohort(retry_at: current.fetch("retry_at"))
+      end
+
+      def claim_failure_cohort_probe(identity:, date:, attempt_id:, now:,
+                                     explicit_release: false)
+        normalized_identity = failure_cohort_identity(identity)
+        digest = failure_cohort_digest(normalized_identity)
+        claimed = false
+        update_failure_cohorts(date) do |value|
+          entry = value.fetch("cohorts")[digest]
+          next value unless entry && entry.fetch("failure_count") >= FAILURE_COHORT_THRESHOLD
+
+          current = expire_failure_cohort_probe(entry, now: time_value(now))
+          next value if current.fetch("probe_attempt_id")
+          retry_at = Time.iso8601(current.fetch("retry_at"))
+          next value unless explicit_release || time_value(now) >= retry_at
+
+          value.fetch("cohorts")[digest] = current.merge(
+            "probe_attempt_id" => StorageKey.string(attempt_id),
+            "probe_expires_at" =>
+              (time_value(now) + FAILURE_COHORT_PROBE_TTL_SEC).utc.iso8601(6)
+          )
+          claimed = true
+          value
+        end
+        claimed
+      end
+
+      def release_failure_cohort_probe(identity:, date:, attempt_id:)
+        normalized_identity = failure_cohort_identity(identity)
+        digest = failure_cohort_digest(normalized_identity)
+        attempt = StorageKey.string(attempt_id)
+        released = false
+        update_failure_cohorts(date, create: false) do |value|
+          entry = value.fetch("cohorts")[digest]
+          next value unless entry&.fetch("probe_attempt_id") == attempt
+
+          value.fetch("cohorts")[digest] = entry.merge(
+            "probe_attempt_id" => nil, "probe_expires_at" => nil
+          )
+          released = true
+          value
+        end
+        released
+      end
+
       def replace_live_reservations(reservations)
         replacements = reservations.to_h do |attempt_id, reservation|
           value = live_reservation(
             project: reservation.fetch("project"),
             task_slug: reservation.fetch("task_slug"),
-            phase: reservation.fetch("phase")
+            phase: reservation.fetch("phase"),
+            admission: reservation["admission"]
           )
           [ StorageKey.string(attempt_id), value ]
         end
@@ -490,16 +609,20 @@ module Hive
 
           reservations.each do |attempt_id, reservation|
             StorageKey.string(attempt_id)
+            valid_keys = [ %w[phase project task_slug], %w[admission phase project task_slug] ]
             valid = reservation.is_a?(Hash) &&
-              reservation.keys.sort == %w[phase project task_slug] &&
+              valid_keys.include?(reservation.keys.sort) &&
               %w[pending active].include?(reservation["phase"])
             raise StoreError unless valid
 
             StorageKey.string(reservation.fetch("project"))
             StorageKey.string(reservation.fetch("task_slug"))
+            live_admission(reservation["admission"]) if reservation.key?("admission")
           end
         when ROUTING_DECISION
           validate_routing_decision_value!(value, key: key)
+        when FAILURE_COHORTS
+          validate_failure_cohorts_value!(value, key: key)
         end
         true
       rescue StoreError
@@ -623,15 +746,164 @@ module Hive
 
       def live_capacity_key = { "scope" => "host" }
 
-      def live_reservation(project:, task_slug:, phase:)
+      def failure_cohorts_key(date) = { "utc_date" => date_value(date).iso8601 }
+
+      def update_failure_cohorts(date, create: true)
+        update_entry(FAILURE_COHORTS, failure_cohorts_key(date)) do |current|
+          next nil if current.nil? && !create
+
+          existing = current&.fetch("value")
+          value = if existing
+            {
+              "cohorts" => existing.fetch("cohorts").dup,
+              "processed_attempts" => existing.fetch("processed_attempts").dup
+            }
+          else
+            { "cohorts" => {}, "processed_attempts" => {} }
+          end
+          result = yield(value)
+          if result.fetch("cohorts").size > MAX_FAILURE_COHORTS ||
+             result.fetch("processed_attempts").size > MAX_DAILY_ATTEMPTS
+            raise StoreError, "failure cohort index exceeds its bounded UTC shard"
+          end
+          result
+        end
+      end
+
+      def failure_cohort_identity(identity)
+        value = StorageKey.normalize(identity)
+        unless value.keys.sort == %w[code project runtime_digest stage workflow]
+          raise StoreError, "failure cohort identity is invalid"
+        end
+        %w[code project stage workflow].each { |key| StorageKey.string(value.fetch(key)) }
+        digest = value.fetch("runtime_digest")
+        unless digest.is_a?(String) && digest.match?(Record::SHA256_PATTERN)
+          raise StoreError, "failure cohort runtime digest is invalid"
+        end
+        value
+      rescue ArgumentError, TypeError, KeyError
+        raise StoreError, "failure cohort identity is invalid"
+      end
+
+      def failure_cohort_digest(identity)
+        Digest::SHA256.hexdigest(StorageKey.dump(identity))
+      end
+
+      def empty_failure_cohort(identity)
+        {
+          "identity" => identity,
+          "failure_count" => 0,
+          "retry_at" => nil,
+          "probe_attempt_id" => nil,
+          "probe_expires_at" => nil
+        }
+      end
+
+      def expire_failure_cohort_probe(entry, now:)
+        expiry = entry.fetch("probe_expires_at")
+        return entry unless expiry && Time.iso8601(expiry) <= now
+
+        entry.merge("probe_attempt_id" => nil, "probe_expires_at" => nil)
+      end
+
+      def refresh_failure_cohort(entry, occurred:, clear_probe:, failure_count: nil)
+        count = failure_count || entry.fetch("failure_count")
+        retry_at = entry.fetch("retry_at")
+        if count >= FAILURE_COHORT_THRESHOLD
+          candidate = occurred + FAILURE_COHORT_COOLDOWN_SEC
+          retry_at = [ retry_at && Time.iso8601(retry_at), candidate ].compact.max
+            .utc.iso8601(6)
+        end
+        entry.merge(
+          "retry_at" => retry_at,
+          "probe_attempt_id" => clear_probe ? nil : entry.fetch("probe_attempt_id"),
+          "probe_expires_at" => clear_probe ? nil : entry.fetch("probe_expires_at")
+        )
+      end
+
+      def open_failure_cohort = { "status" => "open", "reason" => nil }.freeze
+      def probe_failure_cohort = { "status" => "probe", "reason" => nil }.freeze
+
+      def blocked_failure_cohort(retry_at: nil)
+        {
+          "status" => "blocked",
+          "reason" => "failure_cohort_cooldown",
+          "retry_at" => retry_at
+        }.freeze
+      end
+
+      def validate_failure_cohorts_value!(value, key:)
+        unless value.keys.sort == %w[cohorts processed_attempts] &&
+               value.fetch("cohorts").is_a?(Hash) &&
+               value.fetch("processed_attempts").is_a?(Hash) &&
+               value.fetch("cohorts").size <= MAX_FAILURE_COHORTS &&
+               value.fetch("processed_attempts").size <= MAX_DAILY_ATTEMPTS
+          raise StoreError
+        end
+        date_value(key.fetch("utc_date"))
+        value.fetch("processed_attempts").each do |attempt_id, digest|
+          StorageKey.string(attempt_id)
+          unless digest == "succeeded" ||
+                 (digest.is_a?(String) && digest.match?(Record::SHA256_PATTERN))
+            raise StoreError
+          end
+        end
+        value.fetch("cohorts").each do |digest, entry|
+          raise StoreError unless digest.match?(Record::SHA256_PATTERN)
+          unless entry.is_a?(Hash) && entry.keys.sort == %w[
+            failure_count identity probe_attempt_id probe_expires_at retry_at
+          ]
+            raise StoreError
+          end
+          identity = failure_cohort_identity(entry.fetch("identity"))
+          raise StoreError unless failure_cohort_digest(identity) == digest
+          count = entry.fetch("failure_count")
+          raise StoreError unless count.is_a?(Integer) && count.positive?
+          retry_at = entry.fetch("retry_at")
+          Time.iso8601(retry_at) if retry_at
+          probe = entry.fetch("probe_attempt_id")
+          expiry = entry.fetch("probe_expires_at")
+          unless probe.nil? == expiry.nil?
+            raise StoreError
+          end
+          StorageKey.string(probe) if probe
+          Time.iso8601(expiry) if expiry
+        end
+      end
+
+      def time_value(value)
+        return value if value.is_a?(Time)
+
+        Time.iso8601(value.to_s)
+      rescue ArgumentError, TypeError
+        raise StoreError, "failure cohort time is invalid"
+      end
+
+      def live_reservation(project:, task_slug:, phase:, admission: nil)
         unless %w[pending active].include?(phase)
           raise StoreError, "live capacity reservation phase is invalid"
         end
-        {
+        value = {
           "project" => StorageKey.string(project),
           "task_slug" => StorageKey.string(task_slug),
           "phase" => phase
         }
+        value["admission"] = live_admission(admission) if admission
+        value
+      end
+
+      def live_admission(admission)
+        value = StorageKey.normalize(admission)
+        unless value.keys.sort == %w[runtime_digest stage utc_date workflow] &&
+               value.fetch("workflow") == "patrol_fix" &&
+               value.fetch("runtime_digest").match?(Record::SHA256_PATTERN)
+          raise StoreError, "live capacity admission metadata is invalid"
+        end
+        StorageKey.string(value.fetch("stage"))
+        date_value(value.fetch("utc_date"))
+        value
+      rescue ArgumentError, TypeError, KeyError
+        raise StoreError, "live capacity admission metadata is invalid"
       end
 
       def update_live_reservations

--- a/lib/hive/attempts/dispatcher.rb
+++ b/lib/hive/attempts/dispatcher.rb
@@ -5,6 +5,9 @@ require "hive/attempts/capability"
 require "hive/attempts/capacity_snapshot"
 require "hive/attempts/generation"
 require "hive/attempts/command_progress"
+require "hive/canonical_json"
+require "hive/runtime_identity"
+require "hive/patrol_fix/attempt_diagnostic"
 require "hive/provider_health"
 require "hive/provider_routing"
 require "hive/task_resolver"
@@ -17,6 +20,8 @@ module Hive
     class Dispatcher
       BRAINSTORM_STAGE_DIR = "2-brainstorm".freeze # coding-scoped: coding brainstorm artifact repair
       DEFAULT_LIMITS = { max_global: 3, max_per_project: 3, max_daily: 50 }.freeze
+      OPERATOR_COHORT_RELEASE_REQUESTORS = %w[action bot cli web].freeze
+      RUNTIME_SOURCE_FIELDS = %w[channel release_version build_sha].freeze
 
       def initialize(store:, launcher:, limits: DEFAULT_LIMITS, clock: -> { Time.now.utc },
                      id_generator: -> { SecureRandom.uuid }, task_resolver: nil,
@@ -26,7 +31,7 @@ module Hive
                      router: Hive::ProviderRouting::Router.new,
                      decision_id_generator: -> { SecureRandom.uuid },
                      context_provenance: Hive::ContextProvenance,
-                     transient_retry_backoff_sec: 60)
+                     transient_retry_backoff_sec: 60, runtime_digest: nil)
         @store = store
         @launcher = launcher
         @limits = DEFAULT_LIMITS.merge(limits)
@@ -42,12 +47,21 @@ module Hive
         @decision_id_generator = decision_id_generator
         @context_provenance = context_provenance
         @transient_retry_backoff_sec = transient_retry_backoff_sec.to_i
+        @runtime_digest = runtime_digest || self.class.runtime_source_digest
+        unless @runtime_digest.is_a?(String) &&
+               @runtime_digest.match?(Record::SHA256_PATTERN)
+          raise ArgumentError, "attempt runtime digest is invalid"
+        end
+      end
+
+      def self.runtime_source_digest(identity = Hive::RuntimeIdentity.new.to_h)
+        Hive::CanonicalJSON.digest(identity.slice(*RUNTIME_SOURCE_FIELDS))
       end
 
       def dispatch(task:, project:, intended_stage:, argv:, request_id:, provider:,
                    interactive: false, generation: nil, predecessor_attempt_id: nil,
                    inherited_outputs: [], retry_charge: 0, now: @clock.call,
-                   admission_view: nil, routing_policy: nil)
+                   admission_view: nil, routing_policy: nil, cohort_release: false)
         @launcher.preflight!
         generation = normalize_generation(
           generation, task: task, project: project, intended_stage: intended_stage,
@@ -60,7 +74,7 @@ module Hive
           predecessor_attempt_id: predecessor_attempt_id,
           inherited_outputs: inherited_outputs, retry_charge: retry_charge,
           successor_of: nil, now: now, admission_view: admission_view,
-          routing_policy: policy
+          routing_policy: policy, cohort_release: cohort_release
         )
         return result unless superseding_loss?(result)
 
@@ -75,13 +89,15 @@ module Hive
         dispatch_successor(
           predecessor: result.attempt, task: task, project: project, argv: argv,
           request_id: request_id, provider: provider, interactive: interactive,
-          now: now, admission_view: admission_view, routing_policy: policy
+          now: now, admission_view: admission_view, routing_policy: policy,
+          cohort_release: cohort_release
         )
       end
 
       def dispatch_successor(predecessor:, task:, project:, argv:, request_id:, provider:,
                              inherited_outputs: nil, retry_charge: nil, interactive: false,
-                             now: @clock.call, admission_view: nil, routing_policy: nil)
+                             now: @clock.call, admission_view: nil, routing_policy: nil,
+                             cohort_release: false)
         @launcher.preflight!
         generation = Generation.resolve(
           task: task,
@@ -108,7 +124,8 @@ module Hive
           retry_charge: retry_charge.nil? ? predecessor["retry_charge"] : retry_charge,
           successor_of: predecessor.attempt_id, now: now,
           admission_view: admission_view,
-          routing_policy: routing_policy || resolve_routing_policy(task, predecessor["intended_stage"])
+          routing_policy: routing_policy || resolve_routing_policy(task, predecessor["intended_stage"]),
+          cohort_release: cohort_release
         )
       end
 
@@ -149,7 +166,8 @@ module Hive
           request_id: request.request_id, provider: provider_for(task),
           inherited_outputs: request.inherited_outputs,
           retry_charge: recovery_retry_charge(request), interactive: interactive,
-          now: now, admission_view: admission_view
+          now: now, admission_view: admission_view,
+          cohort_release: explicit_cohort_release?(request)
         ) if successor_predecessor?(predecessor)
 
         dispatch(
@@ -157,7 +175,8 @@ module Hive
           argv: request.argv, request_id: request.request_id, provider: provider_for(task),
           interactive: interactive, generation: generation,
           inherited_outputs: request.respond_to?(:inherited_outputs) ? request.inherited_outputs : [],
-          now: now, admission_view: admission_view
+          now: now, admission_view: admission_view,
+          cohort_release: explicit_cohort_release?(request)
         )
       end
 
@@ -165,11 +184,13 @@ module Hive
 
       def admit(task:, generation:, argv:, request_id:, provider:, interactive:,
                 predecessor_attempt_id:, inherited_outputs:, retry_charge:, successor_of:, now:,
-                subject: nil, admission_view: nil, routing_policy:)
+                subject: nil, admission_view: nil, routing_policy:, cohort_release: false)
         result = nil
         created = nil
         claim_capability = nil
         route_decision = nil
+        cohort_identity = nil
+        cohort_admission = nil
         view = admission_view
         # Fixed lock order: global admission, then task generation. The outer
         # lock makes the capacity snapshot and reservation one host-wide
@@ -248,13 +269,6 @@ module Hive
               next
             end
 
-            durable_subject = subject || task_subject(generation)
-            frozen_policy = @store.routing_policies.fetch_or_store(
-              ownership_generation: generation.ownership_generation,
-              subject: durable_subject,
-              policy: routing_policy
-            )
-
             snapshot = view.capacity(now: now, records: records)
             utc_date = now.utc.to_date
             if snapshot.at_limit?(
@@ -269,6 +283,30 @@ module Hive
               )
               next
             end
+
+            cohort_identity = failure_cohort_identity(
+              view: view, task: task, generation: generation,
+              subject: subject || task_subject(generation)
+            )
+            cohort_admission = cohort_identity && view.failure_cohort_admission(
+              identity: cohort_identity, date: now.utc.to_date, now: now,
+              explicit_release: cohort_release
+            )
+            if cohort_admission&.fetch("status") == "blocked"
+              result = DispatchResult.new(
+                status: :deferred, attempt: nil, receipt: nil,
+                attach_descriptor: nil,
+                reason: cohort_admission.fetch("reason")
+              )
+              next
+            end
+
+            durable_subject = subject || task_subject(generation)
+            frozen_policy = @store.routing_policies.fetch_or_store(
+              ownership_generation: generation.ownership_generation,
+              subject: durable_subject,
+              policy: routing_policy
+            )
 
             if frozen_policy.explicit?
               health, health_available = resolve_provider_health
@@ -333,7 +371,13 @@ module Hive
                     retry_charge: retry_charge,
                     inherited_outputs: inherited_outputs,
                     subject: subject,
-                    now: now
+                    now: now,
+                    admission: patrol_admission_metadata(
+                      task: task, generation: generation, now: now
+                    ),
+                    cohort_identity: cohort_identity,
+                    cohort_admission: cohort_admission,
+                    cohort_release: cohort_release
                   )
                 end
                 view.record_routing_decision(
@@ -370,7 +414,13 @@ module Hive
                 retry_charge: retry_charge,
                 inherited_outputs: inherited_outputs,
                 subject: subject,
-                now: now
+                now: now,
+                admission: patrol_admission_metadata(
+                  task: task, generation: generation, now: now
+                ),
+                cohort_identity: cohort_identity,
+                cohort_admission: cohort_admission,
+                cohort_release: cohort_release
               )
             end
           end
@@ -388,14 +438,16 @@ module Hive
         resolve_failed_handoff(
           created, interactive: interactive,
           error: handoff.is_a?(Hash) ? handoff["error"] : nil,
-          admission_view: view
+          admission_view: view, cohort_identity: cohort_identity,
+          cohort_date: now.utc.to_date
         )
       rescue StandardError => e
         raise unless created
 
         resolve_failed_handoff(
           created, interactive: interactive, error: "#{e.class}: #{e.message}",
-          admission_view: view
+          admission_view: view, cohort_identity: cohort_identity,
+          cohort_date: now.utc.to_date
         )
       end
 
@@ -595,12 +647,18 @@ module Hive
       end
 
       def resolve_failed_handoff(created, interactive:, error: nil,
-                                 admission_view: nil)
+                                 admission_view: nil, cohort_identity: nil,
+                                 cohort_date: nil)
         current = @store.fetch_hot(created.attempt_id)
         admission_view&.record(current) if current
         adopted = result_for_adopted_handoff(current, interactive: interactive)
         return adopted if adopted
-        return deferred_handoff_result(current) if current&.state == "lost"
+        if current&.state == "lost"
+          release_failed_handoff_probe(
+            current, cohort_identity: cohort_identity, cohort_date: cohort_date
+          )
+          return deferred_handoff_result(current)
+        end
 
         diagnostics = {}
         diagnostics["launch_handoff_error"] = error.to_s[0, 1_000] unless error.to_s.empty?
@@ -611,11 +669,28 @@ module Hive
           now: @clock.call
         )
         admission_view&.record(lost)
+        release_failed_handoff_probe(
+          lost, cohort_identity: cohort_identity, cohort_date: cohort_date
+        )
         deferred_handoff_result(lost)
       rescue CompareAndSwapFailed
         current = @store.fetch_hot(created.attempt_id)
         admission_view&.record(current) if current
+        release_failed_handoff_probe(
+          current, cohort_identity: cohort_identity, cohort_date: cohort_date
+        ) if current&.state == "lost"
         result_for_adopted_handoff(current, interactive: interactive) || deferred_handoff_result(current)
+      end
+
+      def release_failed_handoff_probe(record, cohort_identity:, cohort_date:)
+        return false unless record&.state == "lost" && cohort_identity && cohort_date
+
+        @store.with_admission_lock do
+          @store.decision_index.release_failure_cohort_probe(
+            identity: cohort_identity, date: cohort_date,
+            attempt_id: record.attempt_id
+          )
+        end
       end
 
       def result_for_adopted_handoff(record, interactive:)
@@ -797,11 +872,24 @@ module Hive
       def persist_launching_attempt(view:, attempt_id:, request_id:, predecessor_attempt_id:,
                                     task:, generation:, argv:, provider:, routing:,
                                     claim_capability:, retry_charge:, inherited_outputs:,
-                                    subject:, now:)
+                                    subject:, now:, admission:, cohort_identity:,
+                                    cohort_admission:, cohort_release:)
+        probe_claimed = false
+        if cohort_admission&.fetch("status") == "probe"
+          claimed = view.claim_failure_cohort_probe(
+            identity: cohort_identity, date: now.utc.to_date,
+            attempt_id: attempt_id, now: now,
+            explicit_release: cohort_release
+          )
+          raise StoreError, "failure cohort probe claim became stale" unless claimed
+
+          probe_claimed = true
+        end
         view.reserve_live(
           attempt_id: attempt_id,
           project: generation.project,
-          task_slug: generation.task_slug
+          task_slug: generation.task_slug,
+          admission: admission
         )
         record = @store.create_launching(
           attempt_id: attempt_id,
@@ -826,8 +914,71 @@ module Hive
           launch_timeout_sec: @launch_timeout_sec,
           now: now
         )
-        view.confirm_live(record)
+        view.confirm_live(record, admission: admission)
         view.record(record)
+      rescue StandardError
+        release_unpersisted_failure_probe(
+          view: view, identity: cohort_identity, date: now.utc.to_date,
+          attempt_id: attempt_id
+        ) if probe_claimed
+        raise
+      end
+
+      def release_unpersisted_failure_probe(view:, identity:, date:, attempt_id:)
+        return false if @store.fetch_hot(attempt_id)
+
+        view.release_failure_cohort_probe(
+          identity: identity, date: date, attempt_id: attempt_id
+        )
+      rescue StoreError
+        false
+      end
+
+      def patrol_admission_metadata(task:, generation:, now:)
+        return nil unless CommandProgress.patrol_fix?(task)
+
+        {
+          "workflow" => "patrol_fix",
+          "stage" => generation.intended_stage,
+          "runtime_digest" => @runtime_digest,
+          "utc_date" => now.utc.to_date.iso8601
+        }
+      end
+
+      def failure_cohort_identity(view:, task:, generation:, subject:)
+        return nil unless CommandProgress.patrol_fix?(task)
+
+        terminal = view.latest_terminal_attempt(
+          task_generation: generation.task_generation, subject: subject
+        )
+        return nil unless terminal&.state == "terminal" &&
+                          %w[failed cancelled].include?(terminal.outcome)
+
+        bound = Hive::PatrolFix::AttemptDiagnostic.read_bound(
+          store: @store,
+          binding: {
+            "attempt_id" => terminal.attempt_id,
+            "stage" => terminal["intended_stage"],
+            "task_generation" => terminal.task_generation,
+            "receipt" => terminal.receipt
+          }
+        )
+        return nil unless bound
+
+        {
+          "runtime_digest" => @runtime_digest,
+          "project" => generation.project,
+          "workflow" => "patrol_fix",
+          "stage" => generation.intended_stage,
+          "code" => bound.dig("document", "code")
+        }
+      end
+
+      def explicit_cohort_release?(request)
+        request.respond_to?(:recovery) && request.recovery.is_a?(Hash) &&
+          request.respond_to?(:requestor) &&
+          OPERATOR_COHORT_RELEASE_REQUESTORS.include?(request.requestor.to_s) &&
+          request.respond_to?(:trigger) && request.trigger.to_s == "recovery"
       end
 
       def explicit_routing(decision, probe_bindings)

--- a/lib/hive/attempts/failure_cohort_reconciler.rb
+++ b/lib/hive/attempts/failure_cohort_reconciler.rb
@@ -1,0 +1,62 @@
+require "hive/patrol_fix/attempt_diagnostic"
+
+module Hive
+  module Attempts
+    # Consumes one terminal Patrol attempt while both its immutable receipt and
+    # live admission metadata are still available. DecisionIndex makes this
+    # idempotent when admission refresh and finalization observe the same row.
+    class FailureCohortReconciler
+      def initialize(store:)
+        @store = store
+      end
+
+      def reconcile(record:, admission:)
+        return false unless eligible?(record, admission)
+
+        date = admission.fetch("utc_date")
+        if record.outcome == "succeeded"
+          return decision_index.record_failure_cohort_success(
+            attempt_id: record.attempt_id, date: date
+          )
+        end
+        return false unless %w[failed cancelled].include?(record.outcome)
+
+        bound = Hive::PatrolFix::AttemptDiagnostic.read_bound(
+          store: @store,
+          binding: {
+            "attempt_id" => record.attempt_id,
+            "stage" => record["intended_stage"],
+            "task_generation" => record.task_generation,
+            "receipt" => record.receipt
+          }
+        )
+        return false unless bound
+
+        decision_index.record_failure_cohort(
+          attempt_id: record.attempt_id,
+          identity: {
+            "runtime_digest" => admission.fetch("runtime_digest"),
+            "project" => record["project"],
+            "workflow" => "patrol_fix",
+            "stage" => record["intended_stage"],
+            "code" => bound.dig("document", "code")
+          },
+          occurred_at: record["ended_at"]
+        )
+        true
+      end
+
+      private
+
+      def decision_index
+        @store.decision_index
+      end
+
+      def eligible?(record, admission)
+        record.state == "terminal" && admission.is_a?(Hash) &&
+          admission["workflow"] == "patrol_fix" &&
+          admission["stage"] == record["intended_stage"]
+      end
+    end
+  end
+end

--- a/lib/hive/attempts/finalization_maintenance.rb
+++ b/lib/hive/attempts/finalization_maintenance.rb
@@ -1,4 +1,5 @@
 require "hive/attempts/lost_outcome"
+require "hive/attempts/failure_cohort_reconciler"
 require "hive/attempts/store"
 require "json"
 require "psych"
@@ -75,6 +76,7 @@ module Hive
         @logger = logger
         @provider_health_observer_factory = provider_health_observer_factory
         @storage_health = store.storage_health
+        @failure_cohort_reconciler = FailureCohortReconciler.new(store: store)
       end
 
       def prepare(record)
@@ -136,6 +138,10 @@ module Hive
             raise StoreError, "hot attempt changed after final proof publication"
           end
 
+          reservation = @store.decision_index.live_reservations[current.attempt_id]
+          @failure_cohort_reconciler.reconcile(
+            record: current, admission: reservation&.fetch("admission", nil)
+          )
           pending.remove_complete(record.attempt_id)
           @store.decision_index.release_live(attempt_id: record.attempt_id)
           @store.remove_hot_final(current)

--- a/lib/hive/commands/status.rb
+++ b/lib/hive/commands/status.rb
@@ -2028,34 +2028,12 @@ module Hive
         binding = status_attempt_store.fetch_terminal_diagnostic_binding(attempt_id)
         return nil unless binding.is_a?(Hash) && binding["attempt_id"] == attempt_id
 
-        receipt = binding["receipt"]
-        return nil unless receipt.is_a?(Hash)
-        # Exit 75 is durable scheduler contention. Its receipt remains
-        # auditable, but presenting the synthesized non-zero-exit artifact as
-        # a Patrol agent failure assigns the incident to the wrong owner.
-        return nil if receipt["exit_status"] == Hive::ExitCodes::TEMPFAIL
-
-        diagnostic_path = File.join(
-          "outputs", attempt_id, Hive::PatrolFix::AttemptDiagnostic::FILENAME
+        bound = Hive::PatrolFix::AttemptDiagnostic.read_bound(
+          store: status_attempt_store, binding: binding
         )
-        reference = Array(receipt["output_references"]).find do |candidate|
-          candidate.is_a?(Hash) && candidate["path"] == diagnostic_path
-        end
-        return nil unless reference
+        return nil unless bound
 
-        document = JSON.parse(status_attempt_store.read_output(
-          reference, max_bytes: Hive::PatrolFix::AttemptDiagnostic::MAX_BYTES
-        ))
-        Hive::PatrolFix::AttemptDiagnostic.validate!(document)
-        return nil unless document["attempt_id"] == attempt_id &&
-                          document["correlation_id"] == attempt_id &&
-                          document["stage"] == binding["stage"].to_s &&
-                          document["task_generation"] == binding["task_generation"].to_s &&
-                          document["log_reference"] == receipt["log_reference"]
-
-        diagnostic_projection(document, reference)
-      rescue JSON::ParserError, Hive::Error, SystemCallError, IOError
-        nil
+        diagnostic_projection(bound.fetch("document"), bound.fetch("reference"))
       end
 
       def diagnostic_projection(document, reference)

--- a/lib/hive/daemon/dispatcher.rb
+++ b/lib/hive/daemon/dispatcher.rb
@@ -1758,6 +1758,7 @@ module Hive
         when :deferred
           case result.reason
           when "capacity", "capacity_saturated" then :attempt_capacity
+          when "failure_cohort_cooldown" then :attempt_failure_cohort
           when "transient_retry" then :attempt_transient_retry
           when "attempt_lost" then :attempt_lost
           when "launch_handoff_failed" then :launch_handoff_failed
@@ -1784,6 +1785,8 @@ module Hive
           [ "hive", "the matching durable attempt already reached a terminal receipt" ]
         when :attempt_capacity
           [ "scheduler", "durable attempt capacity is exhausted" ]
+        when :attempt_failure_cohort
+          [ "scheduler", "this typed Patrol failure cohort is durably paced" ]
         when :attempt_transient_retry
           [ "scheduler", "transient contention is waiting for its retry backoff" ]
         when :attempt_lost
@@ -3498,7 +3501,11 @@ module Hive
           when :existing_live then :attempt_duplicate
           when :terminal_replay then :attempt_terminal_replay
           when :deferred
-            result.reason == "transient_retry" ? :attempt_transient_retry : :attempt_capacity_deferred
+            case result.reason
+            when "transient_retry" then :attempt_transient_retry
+            when "failure_cohort_cooldown" then :attempt_failure_cohort_deferred
+            else :attempt_capacity_deferred
+            end
           when :no_route then :attempt_route_unavailable
           else return
           end

--- a/lib/hive/daemon/logger.rb
+++ b/lib/hive/daemon/logger.rb
@@ -81,6 +81,7 @@ module Hive
         attempt_duplicate
         attempt_terminal_replay
         attempt_transient_retry
+        attempt_failure_cohort_deferred
         attempt_capacity_deferred
         attempt_route_unavailable
         attempt_legacy_backfilled

--- a/lib/hive/patrol_fix/attempt_diagnostic.rb
+++ b/lib/hive/patrol_fix/attempt_diagnostic.rb
@@ -34,6 +34,36 @@ module Hive
 
       class InvalidDiagnostic < Hive::Error; end
 
+      # Read one terminal diagnostic only through its immutable receipt
+      # binding. Callers get no raw-log fallback and no partially trusted
+      # document when any identity or custody check fails.
+      def read_bound(store:, binding:)
+        value = Hive::StringifyKeys.call(binding)
+        attempt_id = value.fetch("attempt_id")
+        receipt = value.fetch("receipt")
+        return nil unless receipt.is_a?(Hash)
+        return nil if receipt["exit_status"] == Hive::ExitCodes::TEMPFAIL
+
+        path = File.join("outputs", attempt_id, FILENAME)
+        reference = Array(receipt["output_references"]).find do |candidate|
+          candidate.is_a?(Hash) && candidate["path"] == path
+        end
+        return nil unless reference
+
+        document = JSON.parse(store.read_output(reference, max_bytes: MAX_BYTES))
+        validate!(document)
+        return nil unless document["attempt_id"] == attempt_id &&
+                          document["correlation_id"] == attempt_id &&
+                          document["stage"] == value.fetch("stage").to_s &&
+                          document["task_generation"] == value.fetch("task_generation").to_s &&
+                          document["log_reference"] == receipt["log_reference"]
+
+        { "document" => document, "reference" => reference }.freeze
+      rescue JSON::ParserError, Hive::Error, SystemCallError, IOError,
+             KeyError, TypeError
+        nil
+      end
+
       def normalize(envelope, stage:, task_generation:, attempt_id:, recorded_at:, redactor: nil,
                     transport_status: "valid", log_reference: nil)
         source = Hive::StringifyKeys.call(envelope)

--- a/test/fixtures/attempts/patrol_dispatch_spree.v1.json
+++ b/test/fixtures/attempts/patrol_dispatch_spree.v1.json
@@ -308,6 +308,6 @@
     "available": false,
     "required_window": "seven complete UTC days preceding 2026-08-26",
     "uncertainty": "Attempts v4 does not durably retain an unambiguous workflow identity for every historical 1-inbox record, so a non-Patrol daily series cannot be reconstructed without inventing classification.",
-    "fallback_policy": "use ten percent of the configured cap until defensible workflow-attributed history exists"
+    "fallback_policy": "retain existing Patrol discovery allowances and task safety caps; pace matching typed Patrol Fix failures without partitioning task capacity"
   }
 }

--- a/test/unit/attempts/decision_index_test.rb
+++ b/test/unit/attempts/decision_index_test.rb
@@ -4,6 +4,8 @@ require "hive/attempts/decision_index"
 require "hive/provider_routing"
 
 class AttemptsDecisionIndexTest < Minitest::Test
+  include HiveTestHelper
+
   NOW = Time.utc(2026, 8, 10, 12)
 
   def setup
@@ -79,6 +81,121 @@ class AttemptsDecisionIndexTest < Minitest::Test
     assert_equal admission, reservation.fetch("admission")
   end
 
+  def test_live_reservation_rejects_invalid_patrol_admission_metadata
+    invalid_digest = {
+      "workflow" => "patrol_fix", "stage" => "2-fix",
+      "runtime_digest" => "invalid", "utc_date" => NOW.to_date.iso8601
+    }
+
+    assert_raises(Hive::Attempts::StoreError) do
+      @index.reserve_live(
+        attempt_id: "attempt-1", project: "demo", task_slug: "task",
+        admission: invalid_digest
+      )
+    end
+    assert_raises(Hive::Attempts::StoreError) do
+      @index.reserve_live(
+        attempt_id: "attempt-2", project: "demo", task_slug: "task",
+        admission: invalid_digest.merge(
+          "runtime_digest" => "a" * 64, "stage" => nil
+        )
+      )
+    end
+  end
+
+  def test_failure_cohort_inputs_and_utc_shard_bounds_fail_closed
+    invalid_identities = [
+      failure_cohort_identity.merge("future" => true),
+      failure_cohort_identity.merge("runtime_digest" => "invalid"),
+      failure_cohort_identity.merge("project" => nil)
+    ]
+    invalid_identities.each do |identity|
+      assert_raises(Hive::Attempts::StoreError) do
+        @index.failure_cohort_admission(
+          identity: identity, date: NOW.to_date, now: NOW
+        )
+      end
+    end
+    3.times do |index|
+      @index.record_failure_cohort(
+        attempt_id: "failure-#{index}", identity: failure_cohort_identity,
+        occurred_at: NOW + index
+      )
+    end
+    assert_raises(Hive::Attempts::StoreError) do
+      @index.failure_cohort_admission(
+        identity: failure_cohort_identity, date: NOW.to_date, now: "invalid"
+      )
+    end
+    assert_raises(Hive::Attempts::StoreError) do
+      @index.send(:update_failure_cohorts, NOW.to_date) do |value|
+        value["processed_attempts"] = Array.new(
+          Hive::Attempts::DecisionIndex::MAX_DAILY_ATTEMPTS + 1
+        ) { |index| [ "attempt-#{index}", "succeeded" ] }.to_h
+        value
+      end
+    end
+  end
+
+  def test_failure_cohort_normalizers_translate_raw_type_errors
+    replacement = ->(*) { raise TypeError, "injected normalization failure" }
+
+    with_replaced_singleton_method(
+      Hive::Attempts::StorageKey, :normalize, replacement
+    ) do
+      assert_raises(Hive::Attempts::StoreError) do
+        @index.failure_cohort_admission(
+          identity: failure_cohort_identity, date: NOW.to_date, now: NOW
+        )
+      end
+      assert_raises(Hive::Attempts::StoreError) do
+        @index.send(
+          :live_admission,
+          {
+            "workflow" => "patrol_fix", "stage" => "2-fix",
+            "runtime_digest" => "a" * 64,
+            "utc_date" => NOW.to_date.iso8601
+          }
+        )
+      end
+    end
+  end
+
+  def test_failure_cohort_schema_rejects_each_corrupt_shape
+    identity = failure_cohort_identity
+    digest = @index.send(:failure_cohort_digest, identity)
+    entry = {
+      "identity" => identity,
+      "failure_count" => 1,
+      "retry_at" => nil,
+      "probe_attempt_id" => nil,
+      "probe_expires_at" => nil
+    }
+    base = {
+      "cohorts" => { digest => entry },
+      "processed_attempts" => { "attempt-1" => digest }
+    }
+    mutations = [
+      ->(value) { value["cohorts"] = [] },
+      ->(value) { value["processed_attempts"]["attempt-1"] = "invalid" },
+      ->(value) { value["cohorts"][digest]["future"] = true },
+      lambda do |value|
+        value["cohorts"][digest]["probe_attempt_id"] = "probe-1"
+      end
+    ]
+
+    mutations.each do |mutation|
+      value = Marshal.load(Marshal.dump(base))
+      mutation.call(value)
+      assert_raises(Hive::Attempts::StoreError) do
+        @index.send(
+          :validate_failure_cohorts_value!, value,
+          key: { "utc_date" => NOW.to_date.iso8601 }
+        )
+      end
+    end
+  end
+
   def test_failure_cohort_opens_durably_and_allows_only_one_probe
     identity = failure_cohort_identity
     3.times do |index|
@@ -133,6 +250,28 @@ class AttemptsDecisionIndexTest < Minitest::Test
       identity: identity, date: NOW.to_date, now: NOW + 11,
       explicit_release: true
     ).fetch("status")
+  end
+
+  def test_expired_probe_fence_allows_one_new_probe
+    identity = failure_cohort_identity
+    3.times do |index|
+      @index.record_failure_cohort(
+        attempt_id: "failure-#{index}", identity: identity,
+        occurred_at: NOW + index
+      )
+    end
+    claimed_at = NOW + Hive::Attempts::DecisionIndex::FAILURE_COHORT_COOLDOWN_SEC + 10
+    assert @index.claim_failure_cohort_probe(
+      identity: identity, date: NOW.to_date,
+      attempt_id: "probe-1", now: claimed_at
+    )
+
+    result = @index.failure_cohort_admission(
+      identity: identity, date: NOW.to_date,
+      now: claimed_at + Hive::Attempts::DecisionIndex::FAILURE_COHORT_PROBE_TTL_SEC + 1
+    )
+
+    assert_equal "probe", result.fetch("status")
   end
 
   def test_concurrent_probe_claims_admit_exactly_one_attempt

--- a/test/unit/attempts/decision_index_test.rb
+++ b/test/unit/attempts/decision_index_test.rb
@@ -59,6 +59,253 @@ class AttemptsDecisionIndexTest < Minitest::Test
     assert_predicate acceptances.fetch("attempt-1"), :frozen?
   end
 
+  def test_live_reservation_round_trips_bounded_patrol_admission_metadata
+    admission = {
+      "workflow" => "patrol_fix", "stage" => "2-fix",
+      "runtime_digest" => "a" * 64, "utc_date" => NOW.to_date.iso8601
+    }
+    @index.reserve_live(
+      attempt_id: "attempt-1", project: "demo", task_slug: "task",
+      admission: admission
+    )
+    @index.confirm_live(
+      attempt_id: "attempt-1", project: "demo", task_slug: "task",
+      admission: admission
+    )
+
+    reservation = Hive::Attempts::DecisionIndex.new(root: @root)
+      .live_reservations.fetch("attempt-1")
+    assert_equal "active", reservation.fetch("phase")
+    assert_equal admission, reservation.fetch("admission")
+  end
+
+  def test_failure_cohort_opens_durably_and_allows_only_one_probe
+    identity = failure_cohort_identity
+    3.times do |index|
+      @index.record_failure_cohort(
+        attempt_id: "failure-#{index}", identity: identity,
+        occurred_at: NOW + index
+      )
+    end
+
+    blocked = @index.failure_cohort_admission(
+      identity: identity, date: NOW.to_date, now: NOW + 10
+    )
+    assert_equal "blocked", blocked.fetch("status")
+    assert_equal "failure_cohort_cooldown", blocked.fetch("reason")
+
+    restarted = Hive::Attempts::DecisionIndex.new(root: @root)
+    probe = restarted.failure_cohort_admission(
+      identity: identity, date: NOW.to_date,
+      now: NOW + Hive::Attempts::DecisionIndex::FAILURE_COHORT_COOLDOWN_SEC + 10
+    )
+    assert_equal "probe", probe.fetch("status")
+    assert restarted.claim_failure_cohort_probe(
+      identity: identity, date: NOW.to_date,
+      attempt_id: "probe-1", now: NOW + 4_000
+    )
+    refute restarted.claim_failure_cohort_probe(
+      identity: identity, date: NOW.to_date,
+      attempt_id: "probe-2", now: NOW + 4_000
+    )
+  end
+
+  def test_explicit_release_bypasses_pacing_once_but_not_an_active_probe
+    identity = failure_cohort_identity
+    3.times do |index|
+      @index.record_failure_cohort(
+        attempt_id: "failure-#{index}", identity: identity,
+        occurred_at: NOW + index
+      )
+    end
+
+    release = @index.failure_cohort_admission(
+      identity: identity, date: NOW.to_date, now: NOW + 10,
+      explicit_release: true
+    )
+    assert_equal "probe", release.fetch("status")
+    assert @index.claim_failure_cohort_probe(
+      identity: identity, date: NOW.to_date,
+      attempt_id: "probe-1", now: NOW + 10,
+      explicit_release: true
+    )
+    assert_equal "blocked", @index.failure_cohort_admission(
+      identity: identity, date: NOW.to_date, now: NOW + 11,
+      explicit_release: true
+    ).fetch("status")
+  end
+
+  def test_concurrent_probe_claims_admit_exactly_one_attempt
+    skip "fork is unavailable" unless Process.respond_to?(:fork)
+
+    identity = failure_cohort_identity
+    3.times do |index|
+      @index.record_failure_cohort(
+        attempt_id: "failure-#{index}", identity: identity,
+        occurred_at: NOW + index
+      )
+    end
+    release_read, release_write = IO.pipe
+    children = 2.times.map do |index|
+      result_read, result_write = IO.pipe
+      pid = fork do
+        release_write.close
+        result_read.close
+        release_read.read(1)
+        restarted = Hive::Attempts::DecisionIndex.new(root: @root)
+        Marshal.dump(
+          restarted.claim_failure_cohort_probe(
+            identity: identity, date: NOW.to_date,
+            attempt_id: "probe-#{index}", now: NOW + 4_000
+          ),
+          result_write
+        )
+      ensure
+        result_write.close unless result_write.closed?
+      end
+      result_write.close
+      [ pid, result_read ]
+    end
+    release_read.close
+    release_write.write("11")
+    release_write.close
+
+    claims = children.map do |pid, reader|
+      value = Marshal.load(reader)
+      Process.wait(pid)
+      reader.close
+      value
+    end
+    assert_equal [ false, true ], claims.sort_by { |value| value ? 1 : 0 }
+  end
+
+  def test_failed_probe_reopens_the_same_cohort
+    identity = failure_cohort_identity
+    3.times do |index|
+      @index.record_failure_cohort(
+        attempt_id: "failure-#{index}", identity: identity,
+        occurred_at: NOW + index
+      )
+    end
+    @index.claim_failure_cohort_probe(
+      identity: identity, date: NOW.to_date,
+      attempt_id: "probe-1", now: NOW + 4_000
+    )
+    @index.record_failure_cohort(
+      attempt_id: "probe-1", identity: identity,
+      occurred_at: NOW + 4_010
+    )
+
+    result = Hive::Attempts::DecisionIndex.new(root: @root)
+      .failure_cohort_admission(
+        identity: identity, date: NOW.to_date, now: NOW + 4_011
+      )
+    assert_equal "blocked", result.fetch("status")
+    assert_equal (NOW + 4_010 + 3_600).iso8601(6), result.fetch("retry_at")
+  end
+
+  def test_out_of_order_failure_cannot_shorten_an_open_cooldown
+    identity = failure_cohort_identity
+    [ 100, 200, 300 ].each_with_index do |offset, index|
+      @index.record_failure_cohort(
+        attempt_id: "failure-#{index}", identity: identity,
+        occurred_at: NOW + offset
+      )
+    end
+    @index.record_failure_cohort(
+      attempt_id: "late-observed-old-failure", identity: identity,
+      occurred_at: NOW + 50
+    )
+
+    result = @index.failure_cohort_admission(
+      identity: identity, date: NOW.to_date, now: NOW + 400
+    )
+    assert_equal "blocked", result.fetch("status")
+    assert_equal (NOW + 300 + 3_600).iso8601(6), result.fetch("retry_at")
+  end
+
+  def test_probe_with_a_different_code_preserves_the_original_cohort
+    identity = failure_cohort_identity
+    3.times do |index|
+      @index.record_failure_cohort(
+        attempt_id: "failure-#{index}", identity: identity,
+        occurred_at: NOW + index
+      )
+    end
+    @index.claim_failure_cohort_probe(
+      identity: identity, date: NOW.to_date,
+      attempt_id: "probe-1", now: NOW + 4_000
+    )
+    changed = identity.merge("code" => "provider_timeout")
+    @index.record_failure_cohort(
+      attempt_id: "probe-1", identity: changed,
+      occurred_at: NOW + 4_010
+    )
+
+    original = @index.failure_cohort_admission(
+      identity: identity, date: NOW.to_date, now: NOW + 4_011
+    )
+    assert_equal "blocked", original.fetch("status")
+    assert_equal (NOW + 4_010 + 3_600).iso8601(6), original.fetch("retry_at")
+    assert_equal "open", @index.failure_cohort_admission(
+      identity: changed, date: NOW.to_date, now: NOW + 4_011
+    ).fetch("status")
+  end
+
+  def test_unrelated_failure_does_not_clear_a_live_probe
+    identity = failure_cohort_identity
+    3.times do |index|
+      @index.record_failure_cohort(
+        attempt_id: "failure-#{index}", identity: identity,
+        occurred_at: NOW + index
+      )
+    end
+    @index.claim_failure_cohort_probe(
+      identity: identity, date: NOW.to_date,
+      attempt_id: "probe-1", now: NOW + 4_000
+    )
+
+    @index.record_failure_cohort(
+      attempt_id: "concurrent-failure", identity: identity,
+      occurred_at: NOW + 4_010
+    )
+
+    refute @index.claim_failure_cohort_probe(
+      identity: identity, date: NOW.to_date,
+      attempt_id: "probe-2", now: NOW + 4_011,
+      explicit_release: true
+    )
+  end
+
+  def test_successful_probe_closes_only_its_runtime_cohort_and_utc_rollover_releases
+    identity = failure_cohort_identity
+    3.times do |index|
+      @index.record_failure_cohort(
+        attempt_id: "failure-#{index}", identity: identity,
+        occurred_at: NOW + index
+      )
+    end
+    @index.claim_failure_cohort_probe(
+      identity: identity, date: NOW.to_date,
+      attempt_id: "probe-1", now: NOW + 4_000
+    )
+    @index.record_failure_cohort_success(
+      attempt_id: "probe-1", date: NOW.to_date
+    )
+
+    assert_equal "open", @index.failure_cohort_admission(
+      identity: identity, date: NOW.to_date, now: NOW + 4_001
+    ).fetch("status")
+
+    repaired = identity.merge("runtime_digest" => "b" * 64)
+    assert_equal "open", @index.failure_cohort_admission(
+      identity: repaired, date: NOW.to_date, now: NOW + 10
+    ).fetch("status")
+    assert_equal "open", @index.failure_cohort_admission(
+      identity: identity, date: NOW.to_date + 1, now: NOW + 86_400
+    ).fetch("status")
+  end
+
   def test_new_admission_observation_replaces_the_previous_projection
     @index.record_routing_decision(
       decision: selected_decision("decision-1"),
@@ -261,6 +508,16 @@ class AttemptsDecisionIndexTest < Minitest::Test
       "task_id" => "42",
       "task_slug" => "task",
       "intended_stage" => "4-execute"
+    }
+  end
+
+  def failure_cohort_identity
+    {
+      "runtime_digest" => "a" * 64,
+      "project" => "demo",
+      "workflow" => "patrol_fix",
+      "stage" => "2-fix",
+      "code" => "agent_exit_nonzero"
     }
   end
 

--- a/test/unit/attempts/dispatcher_test.rb
+++ b/test/unit/attempts/dispatcher_test.rb
@@ -17,6 +17,7 @@ class AttemptsDispatcherTest < Minitest::Test
   FakeRequest = Struct.new(
     :slug, :project, :argv, :request_id, :task_generation,
     :predecessor_attempt_id, :inherited_outputs, :recovery,
+    :requestor, :trigger,
     keyword_init: true
   )
 
@@ -458,6 +459,179 @@ class AttemptsDispatcherTest < Minitest::Test
       assert_empty launcher.launched
       assert_empty store.scan.records
     end
+  end
+
+  def test_patrol_failure_cohort_survives_restart_and_runtime_change_releases_it
+    with_tmp_dir do |root|
+      store = Hive::Attempts::Store.new(root: File.join(root, "attempts"))
+      launcher = FakeLauncher.new
+      ids = (1..8).map { |index| "attempt-#{index}" }.each
+      runtime_digest = "a" * 64
+      dispatcher = Hive::Attempts::Dispatcher.new(
+        store: store, launcher: launcher,
+        limits: { max_global: 6, max_per_project: 6, max_daily: 50 },
+        clock: -> { NOW }, id_generator: -> { ids.next },
+        capability_generator: -> { CLAIM_CAPABILITY },
+        runtime_digest: runtime_digest
+      )
+      tasks = 3.times.map do |index|
+        task_fixture(root, id: index + 1, slug: "patrol-#{index}").tap do |task|
+          task.workflow = Hive::Workflows::PatrolFix::DESCRIPTOR
+          task.stage_index = 2
+          task.stage_name = "fix"
+          task.folder = File.dirname(task.state_file)
+        end
+      end
+      failures = tasks.each_with_index.map do |task, index|
+        result = dispatch(
+          dispatcher, task, request_id: "failure-#{index}", intended_stage: "2-fix",
+          now: NOW + (index * 10)
+        )
+        terminalize_attempt(
+          store, launcher, result, outcome: "failed", exit_status: 7,
+          now: NOW + (index * 10) + 3, diagnostic: true
+        )
+        result
+      end
+
+      capped = Hive::Attempts::Dispatcher.new(
+        store: Hive::Attempts::Store.new(root: store.root), launcher: launcher,
+        limits: { max_global: 6, max_per_project: 6, max_daily: 3 },
+        clock: -> { NOW + 40 }, id_generator: -> { ids.next },
+        capability_generator: -> { CLAIM_CAPABILITY },
+        runtime_digest: runtime_digest
+      )
+      hard_capped = dispatch(
+        capped, tasks.first, request_id: "hard-cap-precedence",
+        intended_stage: "2-fix", now: NOW + 40
+      )
+      assert_equal :deferred, hard_capped.status
+      assert_equal "capacity", hard_capped.reason
+
+      restarted = Hive::Attempts::Dispatcher.new(
+        store: Hive::Attempts::Store.new(root: store.root), launcher: launcher,
+        limits: { max_global: 6, max_per_project: 6, max_daily: 50 },
+        clock: -> { NOW + 40 }, id_generator: -> { ids.next },
+        capability_generator: -> { CLAIM_CAPABILITY },
+        runtime_digest: runtime_digest
+      )
+      blocked = dispatch(
+        restarted, tasks.first, request_id: "blocked-retry",
+        intended_stage: "2-fix", now: NOW + 40
+      )
+      assert_equal :deferred, blocked.status
+      assert_equal "failure_cohort_cooldown", blocked.reason
+
+      restarted.instance_variable_set(:@task_resolver, ->(_request) { tasks[1] })
+      restarted.define_singleton_method(:provider_for) { |_task| "codex" }
+      automatic = restarted.dispatch_request(
+        FakeRequest.new(
+          slug: tasks[1].slug, project: "demo",
+          argv: [ "hive", "run", tasks[1].slug ],
+          request_id: "automatic-recovery", inherited_outputs: [],
+          recovery: { "phase" => "cleared" }, requestor: "action",
+          trigger: "recovery/admission_failure"
+        ),
+        now: NOW + 40
+      )
+      assert_equal :deferred, automatic.status
+      assert_equal "failure_cohort_cooldown", automatic.reason
+
+      restarted_store = restarted.instance_variable_get(:@store)
+      original_create = restarted_store.method(:create_launching)
+      restarted_store.define_singleton_method(:create_launching) do |**|
+        raise Hive::Attempts::StoreError, "injected create failure"
+      end
+      failed_release = FakeRequest.new(
+        slug: tasks[1].slug, project: "demo",
+        argv: [ "hive", "run", tasks[1].slug ],
+        request_id: "failed-operator-release", inherited_outputs: [],
+        recovery: { "phase" => "cleared" }, requestor: "action",
+        trigger: "recovery"
+      )
+      assert_raises(Hive::Attempts::StoreError) do
+        restarted.dispatch_request(failed_release, now: NOW + 40)
+      end
+      restarted_store.define_singleton_method(:create_launching, original_create)
+
+      launcher.instance_variable_set(
+        :@result, { "claimed" => false, "error" => "wrapper unavailable" }
+      )
+      lost_probe = restarted.dispatch_request(
+        FakeRequest.new(
+          slug: tasks[1].slug, project: "demo",
+          argv: [ "hive", "run", tasks[1].slug ],
+          request_id: "lost-operator-release", inherited_outputs: [],
+          recovery: { "phase" => "cleared" }, requestor: "action",
+          trigger: "recovery"
+        ),
+        now: NOW + 40
+      )
+      assert_equal :deferred, lost_probe.status
+      assert_equal "launch_handoff_failed", lost_probe.reason
+      launcher.instance_variable_set(:@result, { "claimed" => true })
+
+      restarted.instance_variable_set(:@task_resolver, ->(_request) { tasks[2] })
+      released_probe = restarted.dispatch_request(
+        FakeRequest.new(
+          slug: tasks[2].slug, project: "demo",
+          argv: [ "hive", "run", tasks[2].slug ],
+          request_id: "operator-release", inherited_outputs: [],
+          recovery: { "phase" => "cleared" }, requestor: "action",
+          trigger: "recovery"
+        ),
+        now: NOW + 40
+      )
+      assert_equal :accepted, released_probe.status
+
+      restarted.instance_variable_set(:@task_resolver, ->(_request) { tasks[0] })
+      second_release = restarted.dispatch_request(
+        FakeRequest.new(
+          slug: tasks[0].slug, project: "demo",
+          argv: [ "hive", "run", tasks[0].slug ],
+          request_id: "operator-release-two", inherited_outputs: [],
+          recovery: { "phase" => "cleared" }, requestor: "action",
+          trigger: "recovery"
+        ),
+        now: NOW + 40
+      )
+      assert_equal :deferred, second_release.status
+      assert_equal "failure_cohort_cooldown", second_release.reason
+
+      repaired = Hive::Attempts::Dispatcher.new(
+        store: Hive::Attempts::Store.new(root: store.root), launcher: launcher,
+        limits: { max_global: 6, max_per_project: 6, max_daily: 50 },
+        clock: -> { NOW + 41 }, id_generator: -> { ids.next },
+        capability_generator: -> { CLAIM_CAPABILITY },
+        runtime_digest: "b" * 64
+      )
+      released = dispatch(
+        repaired, tasks.first, request_id: "repaired-retry",
+        intended_stage: "2-fix", now: NOW + 41
+      )
+      assert_equal :accepted, released.status
+      refute_includes failures.map { |result| result.attempt.attempt_id },
+                      released.attempt.attempt_id
+    end
+  end
+
+  def test_runtime_source_digest_ignores_deployment_identity_but_tracks_build
+    base = {
+      "channel" => "dogfood", "release_version" => "1.2.3",
+      "display_version" => "1.2.3+dogfood.aaaaaaaaa",
+      "build_sha" => "a" * 40, "deployment_id" => "deploy-a"
+    }
+
+    first = Hive::Attempts::Dispatcher.runtime_source_digest(base)
+    redeployed = Hive::Attempts::Dispatcher.runtime_source_digest(
+      base.merge("deployment_id" => "deploy-b")
+    )
+    repaired = Hive::Attempts::Dispatcher.runtime_source_digest(
+      base.merge("build_sha" => "b" * 40)
+    )
+
+    assert_equal first, redeployed
+    refute_equal first, repaired
   end
 
   def test_distinct_generations_share_one_multiprocess_capacity_transaction
@@ -1307,7 +1481,8 @@ class AttemptsDispatcherTest < Minitest::Test
     )
   end
 
-  def terminalize_attempt(store, launcher, result, outcome:, exit_status:, now:)
+  def terminalize_attempt(store, launcher, result, outcome:, exit_status:, now:,
+                          diagnostic: false)
     capability = launcher.launched.find do |record, _claim_capability|
       record.attempt_id == result.attempt.attempt_id
     end.fetch(1)
@@ -1325,6 +1500,29 @@ class AttemptsDispatcherTest < Minitest::Test
       now: now - 2
     )
     running = store.first_heartbeat(claimed, stale_sec: 30, now: now - 1)
+    log_reference = {
+      "path" => "logs/#{result.attempt.attempt_id}.frames",
+      "size" => 0,
+      "sha256" => "0" * 64
+    }
+    output_references = []
+    if diagnostic
+      document = Hive::PatrolFix::AttemptDiagnostic.normalize(
+        { "exit_code" => exit_status, "status" => "error" },
+        stage: result.attempt["intended_stage"],
+        task_generation: result.attempt.task_generation,
+        attempt_id: result.attempt.attempt_id,
+        recorded_at: now,
+        log_reference: log_reference
+      )
+      path = store.output_path(
+        result.attempt.attempt_id,
+        Hive::PatrolFix::AttemptDiagnostic::FILENAME,
+        create_directory: true
+      )
+      File.write(path, JSON.generate(document))
+      output_references << Hive::OutputReference.build(path, root: store.root)
+    end
     store.terminalize(
       running,
       outcome: outcome,
@@ -1333,12 +1531,8 @@ class AttemptsDispatcherTest < Minitest::Test
         "revision" => "b" * 40,
         "progress_token" => result.attempt["progress_token"]
       },
-      output_references: [],
-      log_reference: {
-        "path" => "logs/#{result.attempt.attempt_id}.frames",
-        "size" => 0,
-        "sha256" => "0" * 64
-      },
+      output_references: output_references,
+      log_reference: log_reference,
       now: now
     )
   end

--- a/test/unit/attempts/dispatcher_test.rb
+++ b/test/unit/attempts/dispatcher_test.rb
@@ -634,6 +634,65 @@ class AttemptsDispatcherTest < Minitest::Test
     refute_equal first, repaired
   end
 
+  def test_invalid_runtime_digest_is_rejected_before_dispatch
+    with_tmp_dir do |root|
+      assert_raises(ArgumentError) do
+        Hive::Attempts::Dispatcher.new(
+          store: Hive::Attempts::Store.new(root: File.join(root, "attempts")),
+          launcher: FakeLauncher.new,
+          runtime_digest: "invalid"
+        )
+      end
+    end
+  end
+
+  def test_already_lost_handoff_defers_and_releases_matching_probe
+    with_dispatcher do |dispatcher, _launcher, task, store|
+      created = dispatch(dispatcher, task, request_id: "lost-handoff").attempt
+      lost = store.mark_lost(created, reason: "owner_gone", now: NOW + 1)
+      3.times do |index|
+        store.decision_index.record_failure_cohort(
+          attempt_id: "failure-#{index}", identity: failure_cohort_identity,
+          occurred_at: NOW + index
+        )
+      end
+      assert store.decision_index.claim_failure_cohort_probe(
+        identity: failure_cohort_identity, date: NOW.to_date,
+        attempt_id: lost.attempt_id, now: NOW + 4_000
+      )
+      view = Object.new
+      view.define_singleton_method(:record) { |_record| true }
+
+      result = dispatcher.send(
+        :resolve_failed_handoff, lost, interactive: false,
+        admission_view: view, cohort_identity: failure_cohort_identity,
+        cohort_date: NOW.to_date
+      )
+
+      assert_equal :deferred, result.status
+      assert_equal "launch_handoff_failed", result.reason
+      assert store.decision_index.claim_failure_cohort_probe(
+        identity: failure_cohort_identity, date: NOW.to_date,
+        attempt_id: "probe-2", now: NOW + 4_001, explicit_release: true
+      )
+    end
+  end
+
+  def test_unpersisted_probe_release_fails_closed_on_store_error
+    with_dispatcher do |dispatcher|
+      view = Object.new
+      view.define_singleton_method(:release_failure_cohort_probe) do |**|
+        raise Hive::Attempts::StoreError, "injected release failure"
+      end
+
+      refute dispatcher.send(
+        :release_unpersisted_failure_probe,
+        view: view, identity: failure_cohort_identity,
+        date: NOW.to_date, attempt_id: "missing-attempt"
+      )
+    end
+  end
+
   def test_distinct_generations_share_one_multiprocess_capacity_transaction
     skip "fork is unavailable" unless Process.respond_to?(:fork)
 
@@ -1440,6 +1499,16 @@ class AttemptsDispatcherTest < Minitest::Test
   end
 
   private
+
+  def failure_cohort_identity
+    {
+      "runtime_digest" => "a" * 64,
+      "project" => "demo",
+      "workflow" => "patrol_fix",
+      "stage" => "2-fix",
+      "code" => "agent_exit_nonzero"
+    }
+  end
 
   def with_dispatcher(limits: { max_global: 3, max_per_project: 2, max_daily: 50 },
                       context_provenance: Hive::ContextProvenance,

--- a/test/unit/attempts/finalization_maintenance_test.rb
+++ b/test/unit/attempts/finalization_maintenance_test.rb
@@ -54,6 +54,47 @@ class AttemptsFinalizationMaintenanceTest < Minitest::Test
     end
   end
 
+  def test_promotion_accounts_patrol_failure_before_removing_hot_evidence
+    with_store do |store|
+      admission = {
+        "workflow" => "patrol_fix", "stage" => "2-fix",
+        "runtime_digest" => "a" * 64, "utc_date" => NOW.to_date.iso8601
+      }
+      service = maintenance(store)
+
+      3.times do |index|
+        attempt_id = "patrol-failure-#{index}"
+        store.decision_index.reserve_live(
+          attempt_id: attempt_id, project: "demo", task_slug: "task",
+          admission: admission
+        )
+        terminal = terminal_attempt(
+          store, attempt_id: attempt_id, request_id: "request-#{index}",
+          now: NOW + (index * 10), exit_status: 7,
+          intended_stage: "2-fix", diagnostic: true
+        )
+        store.decision_index.confirm_live(
+          attempt_id: attempt_id, project: "demo", task_slug: "task",
+          admission: admission
+        )
+        assert service.prepare(terminal)
+        service.acknowledge(terminal, :journal)
+        service.acknowledge(terminal, :request_delivery)
+        assert service.promote(terminal)
+      end
+
+      result = store.decision_index.failure_cohort_admission(
+        identity: {
+          "runtime_digest" => "a" * 64, "project" => "demo",
+          "workflow" => "patrol_fix", "stage" => "2-fix",
+          "code" => "agent_exit_nonzero"
+        },
+        date: NOW.to_date, now: NOW + 40
+      )
+      assert_equal "blocked", result.fetch("status")
+    end
+  end
+
   def test_unresolved_loss_stays_hot_and_resolved_loss_promotes
     with_store do |store|
       lost = store.mark_lost(
@@ -600,12 +641,13 @@ class AttemptsFinalizationMaintenanceTest < Minitest::Test
   end
 
   def create_attempt(store, attempt_id: "attempt-1", request_id: "request-1",
-                     predecessor_attempt_id: nil, now: NOW)
+                     predecessor_attempt_id: nil, now: NOW,
+                     intended_stage: "4-execute")
     store.create_launching(
       attempt_id: attempt_id, request_id: request_id,
       predecessor_attempt_id: predecessor_attempt_id,
       task_id: "42", project: "demo", task_slug: "task",
-      intended_stage: "4-execute", task_generation: "generation-1",
+      intended_stage: intended_stage, task_generation: "generation-1",
       ownership_generation: "generation-1", task_input_epoch: 1,
       progress_token: "progress", provider: "codex",
       worker_argv: [ "hive", "run", "task" ],
@@ -616,9 +658,11 @@ class AttemptsFinalizationMaintenanceTest < Minitest::Test
   end
 
   def terminal_attempt(store, attempt_id: "attempt-1", request_id: "request-1",
-                       now: NOW, write_log: false, exit_status: 0)
+                       now: NOW, write_log: false, exit_status: 0,
+                       intended_stage: "4-execute", diagnostic: false)
     launching = create_attempt(
-      store, attempt_id: attempt_id, request_id: request_id, now: now
+      store, attempt_id: attempt_id, request_id: request_id, now: now,
+      intended_stage: intended_stage
     )
     if write_log
       writer = store.log_archive.open_writer(attempt_id, clock: -> { now })
@@ -631,14 +675,31 @@ class AttemptsFinalizationMaintenanceTest < Minitest::Test
       now: now + 1
     )
     running = store.first_heartbeat(claimed, stale_sec: 30, now: now + 2)
+    log_reference = {
+      "path" => "logs/#{attempt_id}.frames", "size" => 0,
+      "sha256" => Digest::SHA256.hexdigest("")
+    }
+    output_references = []
+    if diagnostic
+      document = Hive::PatrolFix::AttemptDiagnostic.normalize(
+        { "exit_code" => exit_status, "status" => "error" },
+        stage: intended_stage, task_generation: running.task_generation,
+        attempt_id: attempt_id, recorded_at: now + 3,
+        log_reference: log_reference
+      )
+      path = store.output_path(
+        attempt_id, Hive::PatrolFix::AttemptDiagnostic::FILENAME,
+        create_directory: true
+      )
+      File.write(path, JSON.generate(document))
+      output_references << Hive::OutputReference.build(path, root: store.root)
+    end
     store.terminalize(
       running, outcome: exit_status.zero? ? "succeeded" : "failed",
       exit_status: exit_status,
-      final_checkpoint: running.checkpoint, output_references: [],
-      log_reference: {
-        "path" => "logs/#{attempt_id}.frames", "size" => 0,
-        "sha256" => Digest::SHA256.hexdigest("")
-      },
+      final_checkpoint: running.checkpoint,
+      output_references: output_references,
+      log_reference: log_reference,
       now: now + 3
     )
   end

--- a/test/unit/daemon/dispatcher_test.rb
+++ b/test/unit/daemon/dispatcher_test.rb
@@ -1457,6 +1457,7 @@ class HiveDaemonDispatcherTest < Minitest::Test
       [ :terminal_replay, nil, :attempt_terminal_replay, "hive" ],
       [ :deferred, "capacity", :attempt_capacity, "scheduler" ],
       [ :deferred, "capacity_saturated", :attempt_capacity, "scheduler" ],
+      [ :deferred, "failure_cohort_cooldown", :attempt_failure_cohort, "scheduler" ],
       [ :deferred, "transient_retry", :attempt_transient_retry, "scheduler" ],
       [ :deferred, "attempt_lost", :attempt_lost, "hive" ],
       [ :deferred, "launch_handoff_failed", :launch_handoff_failed, "hive" ],
@@ -6764,21 +6765,27 @@ end
   def test_durable_auto_dispatch_logs_all_admission_outcomes_and_charges_only_new_starts
     attempt = Struct.new(:attempt_id, :task_generation, :state)
                     .new("attempt-1", "generation-1", "launching")
-    statuses = [ :accepted, :existing_live, :terminal_replay, :deferred ]
+    outcomes = [
+      [ :accepted, nil ],
+      [ :existing_live, nil ],
+      [ :terminal_replay, nil ],
+      [ :deferred, "capacity" ],
+      [ :deferred, "failure_cohort_cooldown" ]
+    ]
     calls = []
     attempt_dispatcher = Object.new
     attempt_dispatcher.define_singleton_method(:dispatch_request) do |request, **options|
-      status = statuses.shift
+      status, reason = outcomes.shift
       calls << [ request, options ]
       Hive::Attempts::DispatchResult.new(
         status: status, attempt: (status == :deferred ? nil : attempt), receipt: nil,
-        attach_descriptor: nil, reason: (status == :deferred ? "capacity" : nil)
+        attach_descriptor: nil, reason: reason
       )
     end
     dispatcher, supervisor, _controller, logger = make_dispatcher(
       rows: [], attempt_dispatcher: attempt_dispatcher
     )
-    results = 4.times.map do |index|
+    results = 5.times.map do |index|
       dispatcher.send(
         :dispatch_command, "hive run demo-task", project: "p1", slug: "demo-task",
         stage: "4-execute", state_file_mtime: nil, state_file_path: nil,
@@ -6786,11 +6793,15 @@ end
       )
     end
 
-    assert_equal %i[accepted existing_live terminal_replay deferred], results.map(&:status)
-    assert_equal 4, calls.size
+    assert_equal %i[accepted existing_live terminal_replay deferred deferred],
+                 results.map(&:status)
+    assert_equal 5, calls.size
     assert_empty supervisor.spawned
     assert_equal 1, dispatcher.instance_variable_get(:@dispatched_today)
-    assert_equal %i[attempt_accepted attempt_duplicate attempt_terminal_replay attempt_capacity_deferred],
+    assert_equal %i[
+      attempt_accepted attempt_duplicate attempt_terminal_replay
+      attempt_capacity_deferred attempt_failure_cohort_deferred
+    ],
                  logger.events.map(&:first).grep(/attempt_/)
     dispatched = logger.events.select { |name, _attrs| name == :dispatched }
     assert_equal 1, dispatched.size

--- a/wiki/gaps.md
+++ b/wiki/gaps.md
@@ -66,18 +66,22 @@ and reach one focused hosted PR.
 The sanitized 600-charge incident replay pins the Patrol/coding, outcome,
 generation-stage repeat, stage, and failure-class aggregates without retaining
 task identities, provider output, secret material, credentials, or host paths.
-It also characterizes the current undifferentiated daily pool: once Patrol has
+It also characterizes the former undifferentiated daily pool: once Patrol had
 used all 600 charges, later-stage Patrol progress, first-attempt Patrol work,
-and non-Patrol work are all starved even though later-stage ordering remains
-stable. This is expected-failure evidence for the later containment units, not
-a scheduling-policy change.
+and non-Patrol work were all starved even though later-stage ordering remained
+stable. Source and focused tests now pace three matching receipt-bound typed
+Patrol failures with one durable probe across restart while leaving task
+capacity as the shared safety boundary. The remaining gap is installed-daemon load
+and UTC-rollover proof over a live representative backlog; the sanitized replay
+is deterministic local evidence, not that operational soak.
 
 The preceding seven complete UTC days cannot be reconstructed into a
 defensible non-Patrol demand series from the retained Attempts v4 records.
 Historical `1-inbox` attempts do not all carry an unambiguous durable workflow
-identity, so classifying them as Patrol or coding would invent evidence. Until
-workflow-attributed history exists, reserve calibration must use the documented
-10% fail-safe rather than a fabricated p95.
+identity, so classifying them as Patrol or coding would invent evidence. No
+task-capacity partition is inferred from that missing history: Patrol discovery
+already has separate scan concurrency and per-engine daily allowances, while
+Attempts capacity remains a shared safety boundary.
 
 **TLDR**: The wiki has broad domain coverage for the current `lib/`, command, stage, TUI, daemon, bot, native Hive web, Hivebox container, testing/static-analysis, template/prompt, and release surfaces, but the source-file map below is representative rather than an automatically verified one-file-per-source audit. Remaining gaps are mainly live behavioral verification and a few deeper reference pages.
 

--- a/wiki/log.d/20260827T201712Z-patrol-failure-cohort-pacing.md
+++ b/wiki/log.d/20260827T201712Z-patrol-failure-cohort-pacing.md
@@ -1,0 +1,27 @@
+---
+title: Durable Patrol failure-cohort pacing
+module: attempts
+tags: [attempts, patrol-fix, daemon, recovery]
+---
+
+Patrol attempt admission now records receipt-bound typed failures in a bounded
+UTC decision shard keyed by project, stage, failure code, and runtime digest.
+Three matching failures open a one-hour circuit; only one fenced probe can run,
+including an early probe claimed by an explicit operator recovery. Success
+closes the cohort, while a changed runtime build digest or UTC rollover starts
+open. Finalization consumes terminal evidence before removing the hot record;
+failed pre-persistence and definitively unstarted handoffs release only their
+matching probe fence.
+
+Attempts capacity remains the shared daemon safety boundary. Patrol scheduling
+continues to use its separate scan concurrency and per-engine discovery
+allowances; this change does not reserve or partition task capacity. Circuit
+pacing reports `failure_cohort_cooldown`. Focused tests cover restart
+persistence, concurrent single-probe claiming, explicit release, repair and
+rollover release, failed probe reopening, daemon admission reasons, and the
+sanitized 600-charge incident fixture. The runtime digest excludes
+deployment-only identity, and hard-cap reasons retain precedence over cohort
+pacing.
+
+The installed-daemon representative-load and complete UTC-window proof remains
+an explicit follow-up in [[gaps]].

--- a/wiki/modules/attempts.md
+++ b/wiki/modules/attempts.md
@@ -23,7 +23,8 @@ task agents.
 | `Record`, `Store` | Read and write schema-v4 records in the physical v4 layout, scan only hot records, point-fetch hot or permanent proof, perform locked guarded transitions with atomic write/fsync/rename persistence, and copy nested record/checkpoint/receipt values through `Hive::StringifyKeys`. `Store::ProjectionReader` is a read-only scan-scoped view that caches each immutable projection binding once without making the long-lived runtime store stale. The default store opens only v4 and contains no migration trigger or legacy-layout monitor. |
 | `Capability`, `Context` | Generate one-time launch authority, authenticate the exact worker process/task/stage, revalidate generation at the mutation boundary, expose the immutable admitted route, and provide one inherited bounded diagnostic writer after transport variables are scrubbed. |
 | `Generation` | Bind stable task identity, intended stage, and a workflow progress token into the semantic ownership key. |
-| `Dispatcher` | Resolve receipt replay, live duplicate attachment, durable transient-contention pacing, loss deferral, capacity, deterministic explicit-provider routing, fresh admission, and explicit successors. |
+| `Dispatcher` | Resolve receipt replay, live duplicate attachment, durable transient-contention and typed Patrol-cohort pacing, loss deferral, capacity, deterministic explicit-provider routing, fresh admission, and explicit successors. |
+| `FailureCohortReconciler` | Consume a terminal Patrol diagnostic idempotently while its receipt and live admission metadata are still bound, including immediately before finalization removes hot evidence. |
 | `DetachedLauncher` | Reject unsupported platforms before handoff, create a POSIX session, and start the private supervisor route. |
 | `Supervisor` | Claim, first-heartbeat, spawn the existing Hive command, heartbeat, frame output, enforce timeout/cancellation, validate one child diagnostic frame, bind its exact private log reference, and terminalize only after appending the diagnostic output reference. |
 | `Client` | Tail frames read-only and replay a terminal result. It performs one final drain after observing a terminal or lost record so frames published during the decisive record fetch are not dropped. Interrupt means detach; it never signals the owner group. |
@@ -138,7 +139,7 @@ attempt subject.
 $HIVE_HOME/attempts/v4/
 ├── records/<attempt-id>.json              # live and finalization-pending hot set
 ├── proof/...                              # permanent point-addressed receipts
-├── decision-indexes/...                   # semantic/request/latest-terminal/successor and routed-decision indexes
+├── decision-indexes/...                   # ownership, accounting, routing, capacity, and Patrol cohort indexes
 ├── pending-finalization/...               # consumer acknowledgements
 ├── logs/<attempt-id>.frames               # active raw stream
 ├── cold-logs/<digest-shard>/...           # finalized raw stream awaiting expiry
@@ -201,6 +202,33 @@ Patrol stage directory names are not workflow identity. Output reads used by pro
 share the `OutputReference` custody primitive: they open the validated lexical
 path with `O_NOFOLLOW`, bound bytes, and verify the receipt size and SHA-256
 from the same descriptor. Raw log bytes are never a status fallback.
+
+Status and admission use the same `AttemptDiagnostic.read_bound` contract.
+It accepts a diagnostic only when the terminal receipt names the exact output
+reference and its attempt, generation, stage, correlation, log reference,
+size, and SHA-256 all agree. Admission never fingerprints a shared log tail or
+an unbound diagnostic.
+
+Patrol failure pacing is a bounded UTC-sharded decision index under the
+host-wide admission lock. A live Patrol reservation temporarily carries the
+workflow, stage, runtime digest, and admission date needed to attribute its
+terminal diagnostic; terminal reconciliation consumes that metadata before
+releasing the reservation, and finalization repeats the idempotent consume
+inside its admission-locked promotion boundary before removing hot evidence.
+Three matching failures for the same project,
+Patrol workflow, stage, typed diagnostic code, and runtime digest open a
+one-hour circuit. Once eligible, exactly one 24-hour-fenced probe may run. An
+explicit operator recovery request may claim that probe early, but cannot
+bypass global, project, task, or daily limits, and a second
+release cannot overlap it. A successful probe closes the cohort; a failed
+probe reopens it, and a failed pre-persistence or definitively unstarted
+handoff releases only its matching probe fence. The runtime digest uses the
+validated channel, release version, and dogfood build SHA; deployment identity
+alone cannot reset pacing. A different validated runtime build digest or the
+next UTC shard starts open, so repaired deployed code and daily rollover do not
+inherit stale pacing.
+Only a retry with its own receipt-bound matching failure identity is held;
+unrelated Patrol codes and healthy stages continue.
 
 For an explicit pool, admission freezes the task-generation policy before the
 first decision, including no-route and provider-capacity results. Under the

--- a/wiki/modules/daemon.md
+++ b/wiki/modules/daemon.md
@@ -258,6 +258,8 @@ Durable admission results retain their real scheduler meaning in this record:
 only an accepted attempt is `dispatched`; an already-live attempt is
 `in_flight`, while capacity deferral, terminal replay, lost attempts, invalid
 predecessors, and launch handoff failures keep distinct owner/reason evidence.
+Durable typed failure-cohort pacing retains the distinct
+`failure_cohort_cooldown` reason instead of collapsing into generic capacity.
 Recovery retries do not exhaust. A terminal coordinator receipt remains visible
 only while no fresh recoverable marker or different live attempt has replaced
 the completed generation.
@@ -266,7 +268,10 @@ Operational task capacity uses the same accounting as dispatch admission:
 task-kind internal runs plus reconciled external task runs. Patrol scans and
 the global digest remain visible in the diagnostic `running` list but do not
 consume the global/per-project task slots or create phantom capacity projects;
-both have separate scheduler budgets.
+both have separate scheduler budgets. Attempts capacity remains the shared
+fail-safe accounting boundary for task dispatch; Patrol policy stays in its
+separate scan concurrency, per-engine discovery allowances, and typed failure
+cohort pacing rather than partitioning task capacity.
 
 The reader treats incomplete phases, a stopped/replaced daemon, generation
 mismatch, expiry, malformed content, unsafe symlink/hard-link/permissions, and


### PR DESCRIPTION
## Summary

- Stop repeated Patrol Fix failures from consuming unbounded attempts by opening a durable circuit after three matching receipt-bound failures.
- Permit one fenced probe after a one-hour cooldown, or through an explicit recovery action; successful probes close the cohort and repaired runtime builds start open.
- Preserve Attempts as a shared safety boundary. Existing Patrol scan concurrency and per-engine discovery allowances remain the scheduling policy; this change does not partition task capacity.

This is U7 of the dispatch-containment program. Earlier units established commit serialization, immutable controller checkouts, typed attempt diagnostics, Git metadata isolation, and deterministic secret-failure parking. Installed-daemon replay, UTC rollover, and temporary-cap rollback remain the final operational proof after this PR lands.

## Test plan

- [x] Failure-cohort dispatcher, decision-index, finalization, daemon, replay, capacity, and status owner suites pass.
- [x] 654 focused runs and 3,156 assertions pass with no failures or errors.
- [x] Component boundaries, wiki validation, RuboCop, Ruby syntax, and `git diff --check` pass.
- [x] Broad Hive checkpoint completed with 13,698 runs, 276,532 assertions, and no failures before the final removal of the proposed capacity partition; all affected suites were rerun afterward.
- [x] CI repair owner suites pass 66 runs / 285 assertions, and targeted stdlib coverage executes all 16 lines the first hosted coverage report identified.
- [x] Hosted CI coverage and dedicated merge gates pass.

## Notes for reviewer

The circuit identity is project, Patrol workflow, stage, typed diagnostic code, and runtime source digest. Finalization consumes the terminal outcome before removing live admission metadata. Failed persistence or a definitively unstarted handoff releases only its matching probe fence.

The daily/global/per-project attempt limits remain unchanged. Patrol discovery scans continue to use their separate concurrency and per-engine daily allowances.

## New concepts

### Receipt-bound failure cohorts

A failure cohort groups retries only when immutable attempt evidence proves they failed for the same typed reason under the same runtime build. Hive derives that identity from a diagnostic already bound into the terminal receipt, not from a shared log tail.

This keeps the circuit narrow: one broken stage is paced without pausing unrelated Patrol work or changing task-capacity policy. It is unsuitable for provider-wide outages, which remain owned by the existing provider-health circuits.
