### PR TITLE
refactor(status): share envelope compatibility handling

### DIFF
--- a/lib/hive/bot/status_watcher.rb
+++ b/lib/hive/bot/status_watcher.rb
@@ -1,6 +1,7 @@
 require "json"
 require "open3"
 require "time"
+require "hive/status_envelope"
 
 module Hive
   module Bot
@@ -138,8 +139,8 @@ module Hive
         # message must ALWAYS surface, even on a newer-schema doc. Folding
         # it into the skew degrade would relabel a genuine "ok=false:
         # <reason>" as a misleading "restart to pick up the new version".
-        validate_envelope!(doc)
-        skew = schema_skew(doc)
+        status_envelope.validate!(doc) { doc["message"] }
+        skew = status_envelope.schema_skew(doc)
         # An OLDER payload (a stale `hive` on PATH than this process
         # expects) cannot be trusted to carry the fields we read, so we
         # do not attempt a best-effort parse — surface a clear, actionable
@@ -147,7 +148,7 @@ module Hive
         # best-effort: hive-status envelopes are additive by contract, so
         # an updated binary's output is still readable by an older
         # long-running process.
-        return failure(older_skew_message(doc)) if skew == :older
+        return failure(status_envelope.older_skew_message(doc)) if skew == :older
 
         begin
           rows = extract_rows(doc, now: now)
@@ -162,7 +163,7 @@ module Hive
           # tolerate: re-raise to the outer rescue (raw "#{e.class}: ...").
           raise unless skew == :newer
 
-          return failure(forward_skew_message(doc, underlying: e), underlying: e)
+          return failure(status_envelope.forward_skew_message(doc, underlying: e), underlying: e)
         end
 
         warn_forward_skew(doc) if skew == :newer
@@ -171,7 +172,7 @@ module Hive
           rows: rows,
           legacy_stage_dirs: legacy_stage_dirs,
           error: nil,
-          warning: (skew == :newer ? forward_skew_warning(doc) : nil)
+          warning: (skew == :newer ? status_envelope.forward_skew_warning(doc) : nil)
         )
       rescue JSON::ParserError => e
         failure("malformed JSON from hive status: #{e.message}")
@@ -198,73 +199,20 @@ module Hive
         Result.new(ok: false, rows: [], legacy_stage_dirs: [], error: message)
       end
 
-      # Envelope-shape validation (hard errors) ONLY. A missing/wrong
-      # `schema` key or `ok=false` is a malformed/failed envelope and must
-      # still raise. Schema VERSION skew is NOT validated here — it is
-      # handled tolerantly via `schema_skew` so a binary/process version
-      # mismatch never hard-crashes a long-running consumer (bot `/status`).
-      def validate_envelope!(doc)
-        unless doc.is_a?(Hash) && doc["schema"] == "hive-status"
-          raise ArgumentError, "missing schema=hive-status in envelope"
-        end
-        raise ArgumentError, "envelope ok=false: #{doc['message']}" unless doc["ok"] == true
-      end
-
-      # Classify the envelope's schema_version against what THIS process
-      # was built for: :match, :newer (payload from an updated binary), or
-      # :older (a stale binary on PATH). Never raises.
-      def schema_skew(doc)
-        got = doc["schema_version"]
-        return :match if got == expected_schema_version
-        return :newer if got.is_a?(Integer) && got > expected_schema_version
-
-        :older
-      end
-
       # The forward-skew advisory is logged under a DISTINCT event name
       # (not :poll_failure) so it isn't conflated with real fetch failures
       # — the success path tolerated a newer schema, it didn't fail.
       def warn_forward_skew(doc)
         @logger&.event(
           :poll_schema_skew, source: "status",
-          message: "#{forward_skew_summary(doc)}; parsing best-effort. " \
-                   "Restart the hive bot to pick up the new schema."
+          message: status_envelope.forward_skew_warning(doc)
         )
       end
 
-      # Non-fatal advisory carried on the success-path Result#warning so the
-      # supervisor can surface a banner on `/status`.
-      def forward_skew_warning(doc)
-        "#{forward_skew_summary(doc)}; parsing best-effort. " \
-          "Restart the hive bot to pick up the new schema."
-      end
-
-      # `underlying` is the exception that aborted best-effort extraction on
-      # a newer-schema doc. We append its class + message so the genuine
-      # defect stays diagnosable in the surfaced error instead of being
-      # masked by the friendly restart hint.
-      def forward_skew_message(doc, underlying:)
-        "hive status: #{forward_skew_summary(doc)}; " \
-          "restart the hive bot to pick up the new version " \
-          "(underlying error: #{underlying.class}: #{underlying.message})"
-      end
-
-      def forward_skew_summary(doc)
-        "envelope schema v#{doc['schema_version']} is newer than this process (v#{expected_schema_version})"
-      end
-
-      def older_skew_message(doc)
-        "hive status: envelope schema v#{doc['schema_version']} is older than this process " \
-          "(v#{expected_schema_version}); update/reinstall the hive binary on PATH"
-      end
-
-      # Computed once and reused. Uses the non-raising `[]` form (not
-      # `.fetch`) so it never introduces a fresh KeyError inside a
-      # rescue-reachable skew path if the "hive-status" key were ever
-      # absent — Finding 4 from the #416 review. Mirrors the daemon's
-      # StatusConsumer.
-      def expected_schema_version
-        @expected_schema_version ||= Hive::Schemas::SCHEMA_VERSIONS["hive-status"]
+      def status_envelope
+        @status_envelope ||= Hive::StatusEnvelope.new(
+          restart_target: "hive bot"
+        )
       end
 
       def extract_legacy_stage_dirs(doc)

--- a/lib/hive/status_envelope.rb
+++ b/lib/hive/status_envelope.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Hive
+  # Shared compatibility contract for long-running consumers of a versioned
+  # status subprocess. Envelope shape is strict; additive forward versions are
+  # best-effort, and older producers fail closed with an actionable message.
+  class StatusEnvelope
+    SCHEMA = "hive-status"
+    EXPECTED_VERSION = Hive::Schemas::SCHEMA_VERSIONS.fetch(SCHEMA)
+
+    def initialize(restart_target:)
+      @restart_target = restart_target
+    end
+
+    def validate!(document)
+      unless document.is_a?(Hash) && document["schema"] == SCHEMA
+        raise ArgumentError, "missing schema=#{SCHEMA} in envelope"
+      end
+      return if document["ok"] == true
+
+      raise ArgumentError, "envelope ok=false: #{yield}"
+    end
+
+    def schema_skew(document)
+      version = document["schema_version"]
+      return :match if version == EXPECTED_VERSION
+      return :newer if version.is_a?(Integer) && version > EXPECTED_VERSION
+
+      :older
+    end
+
+    def forward_skew_warning(document)
+      "#{forward_skew_summary(document)}; parsing best-effort. " \
+        "Restart the #{@restart_target} to pick up the new schema."
+    end
+
+    def forward_skew_message(document, underlying:)
+      "hive status: #{forward_skew_summary(document)}; " \
+        "restart the #{@restart_target} to pick up the new version " \
+        "(underlying error: #{underlying.class}: #{underlying.message})"
+    end
+
+    def older_skew_message(document)
+      "hive status: envelope schema v#{document['schema_version']} is older than this process " \
+        "(v#{EXPECTED_VERSION}); update/reinstall the hive binary on PATH"
+    end
+
+    private
+
+    def forward_skew_summary(document)
+      "envelope schema v#{document['schema_version']} is newer than this process (v#{EXPECTED_VERSION})"
+    end
+  end
+end

--- a/test/unit/bot/status_watcher_test.rb
+++ b/test/unit/bot/status_watcher_test.rb
@@ -192,6 +192,7 @@ class HiveBotStatusWatcherTest < Minitest::Test
     # failures. Schema-VERSION skew is handled tolerantly and is covered
     # by the dedicated skew tests below, not here.
     cases = {
+      "top-level array" => [ [], /missing schema=hive-status/ ],
       "wrong schema" => [ { "schema" => "other", "ok" => true, "schema_version" => expected_version }, /missing schema/ ],
       "not ok" => [ { "schema" => "hive-status", "ok" => false, "schema_version" => expected_version,
                        "message" => "registry unavailable" }, /envelope ok=false: registry unavailable/ ]

--- a/wiki/log.d/20260827T220435Z-shared-status-envelope.md
+++ b/wiki/log.d/20260827T220435Z-shared-status-envelope.md
@@ -1,0 +1,12 @@
+# 2026-08-27 — Extract bot status envelope compatibility
+
+**Why:** The Telegram bot's long-running status subprocess consumer needs a
+single strict envelope-shape, forward-version tolerance, older-version refusal,
+and operator-guidance policy.
+
+**Change:** Added `Hive::StatusEnvelope` and routed `StatusWatcher` through it
+without changing row projection or warning delivery. The daemon retains its
+in-process status producer, where subprocess schema skew is not a boundary.
+
+**Verification:** The focused bot status-watcher suite covers exact, newer,
+older, malformed, and `ok=false` envelopes.

--- a/wiki/modules/bot.md
+++ b/wiki/modules/bot.md
@@ -1,7 +1,7 @@
 ---
 title: Hive::Bot
 type: module
-source: lib/hive/bot/
+source: lib/hive/bot/, lib/hive/status_envelope.rb
 created: 2026-05-14
 updated: 2026-08-29
 tags: [bot, telegram, module, mobile]
@@ -138,8 +138,8 @@ Legacy stage-directory warnings are proactive as project-level notifications. `S
 
 `StatusWatcher#fetch` is forward-tolerant of a newer `hive-status`
 `schema_version` than this long-running bot was built for — the shared
-mechanism is documented under [[modules/daemon]] § *Forward-tolerant
-schema-version skew*. Bot-specific behaviour (fix-forward on #416):
+`Hive::StatusEnvelope` centralizes the bot's strict envelope validation and
+version-skew guidance. Bot-specific behaviour (fix-forward on #416):
 
 - On a `:newer` best-effort SUCCESS the `Result` carries a non-fatal
   `warning`. `Supervisor#execute_dispatch` prepends a one-line plain-text
@@ -151,7 +151,7 @@ schema-version skew*. Bot-specific behaviour (fix-forward on #416):
   `:poll_schema_skew` event (not the overloaded `:poll_failure`), so it
   isn't conflated with real fetch failures. `:poll_schema_skew` is in
   `Hive::Bot::Logger::EVENTS` and the `hive-bot-log.v3` schema enum.
-- `validate_envelope!` (shape / `ok=false`) runs OUTSIDE the best-effort
+- `Hive::StatusEnvelope#validate!` (shape / `ok=false`) runs OUTSIDE the best-effort
   extraction rescue: a `:newer` envelope that ALSO has `ok=false` surfaces
   its real `envelope ok=false: <reason>`, never the skew hint. A throw
   inside extraction on a `:newer` doc degrades to the restart message but


### PR DESCRIPTION
## Summary

`Hive::Bot::StatusWatcher` now delegates strict `hive-status` envelope validation and version-skew messaging to `Hive::StatusEnvelope`. The daemon keeps main's in-process status producer, where subprocess schema skew is not a boundary.

## Validation

- `bundle exec ruby -Itest test/unit/bot/status_watcher_test.rb` — 16 runs, 93 assertions.
- `bundle exec ruby -Itest test/unit/daemon/status_consumer_test.rb` — 29 runs, 185 assertions.
- `bundle exec rubocop lib/hive/bot/status_watcher.rb lib/hive/status_envelope.rb test/unit/bot/status_watcher_test.rb` — no offenses.
