### PR TITLE
test: isolate daemon Patrol source wiring

### DIFF
--- a/test/unit/commands/daemon_test.rb
+++ b/test/unit/commands/daemon_test.rb
@@ -169,7 +169,9 @@ class HiveCommandsDaemonTest < Minitest::Test
                 "immediate watcher and catch-up must share one intake boundary"
     assert_equal true, reconciler.instance_variable_get(:@dry_run)
     admission = captured.fetch(:patrol_fix_admission_scheduler)
-    assert_empty admission.instance_variable_get(:@sources).call
+    with_replaced_singleton_method(Hive::Config, :registered_projects, -> { [] }) do
+      assert_empty admission.instance_variable_get(:@sources).call
+    end
     capacity = admission.instance_variable_get(:@capacity_available)
     refute capacity.call(source: Object.new, now: Time.now.utc)
     assert capacity.call(source: Struct.new(:project).new("demo"), now: Time.now.utc)


### PR DESCRIPTION
## Summary

- isolate the daemon startup wiring assertion from the process-global registered-project fixture
- keep the Patrol runtime production behavior unchanged
- prevent suite ordering from leaking another test's temporary project into the expected-empty source list

## Verification

- targeted daemon startup test passes normally
- targeted test passes with a deliberately registered foreign project
- `test/unit/commands/daemon_test.rb`: 74 runs, 232 assertions
- RuboCop clean; `git diff --check` clean

## Root cause

Final `main` CI at `42520c63bd` failed because this wiring test asserted against the live global registry. A different test had registered a temporary project, so the assertion observed valid production state that was outside this test's ownership.