### PR TITLE
Fix Patrol finding: patrol-zero-padded-numeric-target-is-parsed-f56929987f

### DIFF
--- a/lib/hive/task_resolver.rb
+++ b/lib/hive/task_resolver.rb
@@ -76,7 +76,11 @@ module Hive
     end
 
     def resolve_numeric_id
-      matches = find_id_across_projects(Integer(@target))
+      # Force base 10: bare Integer() treats a leading "0" as an octal prefix,
+      # so TARGET "010" would silently select task 8 and "09" would raise
+      # ArgumentError. The /\A\d+\z/ guard above already proved the string is
+      # all decimal digits.
+      matches = find_id_across_projects(Integer(@target, 10))
       case matches.size
       when 0
         Hive::Workflows.assert_known_stage_filter!(@stage_filter, filtered_projects)

--- a/test/fixtures/runtime_control_plane/affected_production.yml
+++ b/test/fixtures/runtime_control_plane/affected_production.yml
@@ -7,8 +7,8 @@ counting_rule: physical_source_lines
 includes_new_production_files: true
 maximum_final_lines: 7960
 final_inventory_lines: 9220
-outside_inventory_net_lines: -2840
-final_lines: 6380
+outside_inventory_net_lines: -2836
+final_lines: 6384
 final_paths:
 - path: lib/hive/attempts/capacity_snapshot.rb
   lines: 104

--- a/test/integration/drop_command_test.rb
+++ b/test/integration/drop_command_test.rb
@@ -132,40 +132,32 @@ class DropCommandIntegrationTest < Minitest::Test
     end
   end
 
-  # Leading-zero numeric inputs are parsed with Ruby's Integer(), which reads a
-  # leading zero as octal. `010` therefore parses to decimal 8 (octal 010), so
-  # it does NOT resolve to the decimal id 10. Lock the current behavior: the
-  # id-10 task is preserved and drop refuses with invalid_task_path. (If the
-  # parse is ever switched to base-10, this test will flag the contract change.)
-  def test_bin_hive_drop_leading_zero_id_010_does_not_resolve_to_decimal_id_10
+  # Leading-zero numeric inputs are decimal task IDs. `010` must select task 10,
+  # rather than Ruby's legacy octal interpretation (decimal 8).
+  def test_bin_hive_drop_leading_zero_id_010_resolves_to_decimal_id_10
     with_cli_project do |home, dir, project|
       slug = "leading-zero-010-260622-aaaa"
       folder = create_task_with_id(dir, "2-brainstorm", slug, 10)
 
       out, _err, status = run_hive(home, "drop", "010", "--project", project, "--json")
 
-      refute status.success?, "drop 010 must not succeed against a decimal id-10 task"
-      assert_equal Hive::ExitCodes::USAGE, status.exitstatus
-      assert_equal "invalid_task_path", JSON.parse(out)["error_kind"]
-      assert File.directory?(folder), "id-10 task folder must survive `drop 010`"
+      assert status.success?, out
+      assert_equal slug, JSON.parse(out)["slug"]
+      refute File.directory?(folder), "id-10 task folder must be dropped by `drop 010`"
     end
   end
 
-  # `08` is not a valid octal literal, so Integer("08") raises before any
-  # lookup. Lock the current behavior: drop fails with an internal-error
-  # envelope (exit 70) and drops nothing, rather than treating `08` as
-  # decimal id 8.
-  def test_bin_hive_drop_leading_zero_id_08_errors_and_preserves_task
+  # `08` is likewise a decimal task ID, rather than an invalid octal literal.
+  def test_bin_hive_drop_leading_zero_id_08_resolves_to_decimal_id_8
     with_cli_project do |home, dir, project|
       slug = "leading-zero-08-260622-aaaa"
       folder = create_task_with_id(dir, "2-brainstorm", slug, 8)
 
       out, _err, status = run_hive(home, "drop", "08", "--project", project, "--json")
 
-      refute status.success?, "drop 08 must not succeed against a decimal id-8 task"
-      assert_equal Hive::ExitCodes::SOFTWARE, status.exitstatus
-      assert_equal "internal", JSON.parse(out)["error_kind"]
-      assert File.directory?(folder), "id-8 task folder must survive `drop 08`"
+      assert status.success?, out
+      assert_equal slug, JSON.parse(out)["slug"]
+      refute File.directory?(folder), "id-8 task folder must be dropped by `drop 08`"
     end
   end
 

--- a/test/unit/task_resolver_test.rb
+++ b/test/unit/task_resolver_test.rb
@@ -33,6 +33,35 @@ class TaskResolverTest < Minitest::Test
     end
   end
 
+  # Regression: Kernel#Integer without an explicit base treats a leading "0"
+  # as an octal prefix, so "010" silently resolved to task 8 and "09" raised
+  # ArgumentError. Numeric targets are decimal digit strings and must parse
+  # strictly as base 10.
+  def test_zero_padded_numeric_target_resolves_decimal_id
+    with_tmp_global_config do |home|
+      project_root = File.join(home, "project-a")
+      eight = task_folder(project_root, "2-brainstorm", "task-eight")
+      ten = task_folder(project_root, "2-brainstorm", "task-ten")
+      Hive::TaskMeta.write(eight, id: 8, slug: "task-eight", display_name: nil)
+      Hive::TaskMeta.write(ten, id: 10, slug: "task-ten", display_name: nil)
+      write_registered_project(home, "project-a", project_root)
+
+      assert_equal ten, Hive::TaskResolver.new("010").resolve.folder
+      assert_equal ten, Hive::TaskResolver.new("0010").resolve.folder
+    end
+  end
+
+  def test_leading_zero_numeric_target_below_octal_eight_resolves_decimal_id
+    with_tmp_global_config do |home|
+      project_root = File.join(home, "project-a")
+      nine = task_folder(project_root, "2-brainstorm", "task-nine")
+      Hive::TaskMeta.write(nine, id: 9, slug: "task-nine", display_name: nil)
+      write_registered_project(home, "project-a", project_root)
+
+      assert_equal nine, Hive::TaskResolver.new("09").resolve.folder
+    end
+  end
+
   def test_numeric_target_respects_stage_filter
     with_tmp_global_config do |home|
       project_root = File.join(home, "project-a")

--- a/wiki/log.d/20260826T090000Z-task-resolver-base10-numeric-ids.md
+++ b/wiki/log.d/20260826T090000Z-task-resolver-base10-numeric-ids.md
@@ -1,0 +1,18 @@
+# TaskResolver numeric ids parse strictly as base 10
+
+**Problem:** A zero-padded numeric TARGET silently resolved to the wrong task.
+`TaskResolver.new("010").resolve` selected the folder whose `meta.yml` id is 8
+(bare `Kernel#Integer` reads the leading `0` as an octal prefix), and
+`TaskResolver.new("09").resolve` raised a raw `ArgumentError: invalid value
+for Integer()` instead of any Hive error type.
+
+**Cause:** `TaskResolver#resolve_numeric_id` passed the digit string straight
+to `Integer(@target)` with no explicit base, even though the
+`/\A\d+\z/` guard already proved the target is all decimal digits.
+
+**Fix:** `lib/hive/task_resolver.rb` now calls `Integer(@target, 10)`, so
+`"010"` resolves to id 10 and `"09"` to id 9 by decimal value. Regression
+tests in `test/unit/task_resolver_test.rb` cover both a zero-padded id above
+the octal range (with an id-8 decoy present) and one below it.
+
+See [[task_resolver]].

--- a/wiki/modules/task_resolver.md
+++ b/wiki/modules/task_resolver.md
@@ -19,7 +19,7 @@ task = Hive::TaskResolver.new(target, project_filter: nil, stage_filter: nil).re
 ## Resolution rules
 
 1. **Path-shaped TARGET** (contains `/` or starts with `~`/`.`): `File.expand_path` then `File.realpath`. The realpath flows into `Hive::Task.new`, whose `PATH_RE` validates that the result still looks like `<root>/.hive-state/stages/<N>-<name>/<slug>`. A slug-named symlink pointing outside the `.hive-state` hierarchy is therefore rejected at the PATH_RE check, not silently followed.
-2. **Numeric id** (`/\A\d+\z/`): searched across registered projects by reading each candidate task's `meta.yml` via `Hive::TaskMeta.read(folder)[:id]`. `--project` and `stage_filter` narrow the scan the same way slug lookup does. A missing match raises `Hive::InvalidTaskPath` with `"no task folder for id <id>"`.
+2. **Numeric id** (`/\A\d+\z/`): parsed strictly as base 10 (`Integer(@target, 10)`) — bare `Integer()` treats a leading `0` as an octal prefix, which would make TARGET `"010"` select task 8 and `"09"` raise `ArgumentError`. The parsed id is searched across registered projects by reading each candidate task's `meta.yml` via `Hive::TaskMeta.read(folder)[:id]`. `--project` and `stage_filter` narrow the scan the same way slug lookup does. A missing match raises `Hive::InvalidTaskPath` with `"no task folder for id <id>"`.
 3. **Bare slug**: searched across registered projects (filtered by `--project` if given) for an unambiguous match. The search walks every stage directory under each project's `.hive-state/stages/`, or only `stage_filter` when one is provided.
 4. **Ambiguity**:
    - **0 hits** → `Hive::InvalidTaskPath` (exit 64). Message includes the optional `--project <name>` hint when `--project` was set.


### PR DESCRIPTION
## Patrol Fix

This pull request repairs one finding tracked by Hive's Patrol Fix workflow.

### Sources

- ordinary_patrol: architecture-lib-hive-part-17-20260815T141613Z-4d4d5297-1

### Finding evidence

- {"file":"lib/hive/task_resolver.rb","line":75,"snippet":"@target.to_s.match?(/\\A\\d+\\z/)","role":"trigger"}
- {"file":"lib/hive/task_resolver.rb","line":79,"snippet":"matches = find_id_across_projects(Integer(@target))","role":"root_cause"}
- {"file":"lib/hive/task_resolver.rb","line":157,"snippet":"next unless Hive::TaskMeta.read(folder)[:id] == id","role":"impact"}

### Independent review

The exact controller-selected two-commit patch parses already-validated digit targets explicitly in base 10, adds direct decoy and invalid-octal regression cases, and updates the managed wiki. Focused validation is green; the broad checkpoint failures are confined to unchanged agent-cli-runtime host/tooling behavior, so they are unrelated and bounded.

- HEAD remained 1a4e7fb61d1dedafccbae4410eb09fe5d32ee826 on a clean worktree; the independently derived patch base is 2bcba3195aa6f87e3e195d64d288a693e99d11b5 and git diff --check passed across the four changed files.
- lib/hive/task_resolver.rb:75 limits the numeric route to all-digit strings, and line 83 passes that string to Integer(@target, 10), which independently reproduced 010=>10 and 09=>9 while bare Integer reproduced 010=>8 and ArgumentError for 09.
- test/unit/task_resolver_test.rb:40-62 covers 010 and 0010 with an id-8 decoy plus 09; bundle exec ruby -Itest test/unit/task_resolver_test.rb passed 9 runs and 28 assertions.
- bundle exec rake test failed only in components/agent-cli-runtime on OpenCode binary availability and an environment-resolved absolute Grok binary path; git diff confirms that component is unchanged from 2bcba3195aa6f87e3e195d64d288a693e99d11b5 to HEAD.
- Independent correctness, project-standards, and testing reviews reported no actionable findings.

### Validation

Verdict: failed
- ordinary:test: exit 1
- agent:task-resolver-focused-unit-regression: exit 0
- agent:base10-parse-root-cause-check: exit 0
- agent:resolver-source-uses-explicit-base: exit 0

<!-- hive-publication:v1 id=pub-f0bd8f5db7e93cf747366a9bc9a5a542 base=2bcba3195aa6f87e3e195d64d288a693e99d11b5 -->
