### PR TITLE
Fix Patrol finding: patrol-timeout-kill-escalation-keyed-on-shell-468b5688ab

### DIFF
--- a/lib/hive/patrol/validator.rb
+++ b/lib/hive/patrol/validator.rb
@@ -231,10 +231,15 @@ module Hive
         [ "", false ]
       end
 
+      # Escalation is keyed on the timed-out decision, never on liveness of
+      # the process-group leader: a shell whose wait builtin is interrupted
+      # by TERM can exit while group members that trap TERM survive, so an
+      # early return on waiter.join would leak them. After the grace period
+      # we always attempt the group KILL; Errno::ESRCH then reports that no
+      # group member (leader included) remains.
       def terminate(waiter)
         Process.kill("TERM", -waiter.pid)
-        return if waiter.join(TERM_GRACE_SEC)
-
+        waiter.join(TERM_GRACE_SEC)
         Process.kill("KILL", -waiter.pid)
         waiter.join(TERM_GRACE_SEC)
       rescue Errno::ESRCH, Errno::ECHILD

--- a/test/fixtures/runtime_control_plane/affected_production.yml
+++ b/test/fixtures/runtime_control_plane/affected_production.yml
@@ -7,8 +7,8 @@ counting_rule: physical_source_lines
 includes_new_production_files: true
 maximum_final_lines: 7960
 final_inventory_lines: 9220
-outside_inventory_net_lines: -2845
-final_lines: 6375
+outside_inventory_net_lines: -2840
+final_lines: 6380
 final_paths:
 - path: lib/hive/attempts/capacity_snapshot.rb
   lines: 104

--- a/test/unit/patrol/validator_test.rb
+++ b/test/unit/patrol/validator_test.rb
@@ -274,6 +274,43 @@ class HivePatrolValidatorTest < Minitest::Test
     assert_equal [ [ "TERM", -12_345 ], [ "KILL", -12_345 ] ], signals
   end
 
+  # Leader liveness is not proof of an empty process group: a shell whose
+  # wait builtin is interrupted by TERM can exit while members that trap
+  # TERM survive, so the grace-period join must not suppress escalation.
+  def test_termination_still_escalates_to_kill_when_the_leader_exits_during_grace
+    waiter = Struct.new(:pid) do
+      def join(*) = true
+    end.new(12_345)
+    signals = []
+
+    with_replaced_singleton_method(Process, :kill, ->(signal, pid) { signals << [ signal, pid ] }) do
+      Hive::Patrol::Validator.new.send(:terminate, waiter)
+    end
+
+    assert_equal [ [ "TERM", -12_345 ], [ "KILL", -12_345 ] ], signals
+  end
+
+  def test_timeout_kill_reaches_group_members_that_outlive_the_shell
+    with_tmp_dir do |dir|
+      # The group leader (outer shell) has no TERM trap, so its wait is
+      # interrupted and it exits during the grace period; the inner member
+      # ignores TERM and can only die through the KILL escalation.
+      validator = Hive::Patrol::Validator.new(
+        { "test" => "bash -c 'echo $$ > pid; trap \"\" TERM; sleep 300' & wait" },
+        timeout_sec: 0.5
+      )
+
+      result = validator.validate(dir)
+      command = result["commands"].first
+
+      assert_equal true, command["timed_out"]
+      child_pid = File.read(File.join(dir, "pid")).to_i
+      refute_equal 0, child_pid
+      sleep 0.1
+      assert_raises(Errno::ESRCH) { Process.kill(0, child_pid) }
+    end
+  end
+
   def test_termination_tolerates_process_disappearing
     waiter = Struct.new(:pid).new(12_345)
 

--- a/wiki/log.d/20260822T120000Z-patrol-validator-timeout-kill-escalation.md
+++ b/wiki/log.d/20260822T120000Z-patrol-validator-timeout-kill-escalation.md
@@ -1,0 +1,21 @@
+# Patrol validator timeout kills now escalate even when the shell leader exits
+
+**Change:** `Hive::Patrol::Validator#terminate`
+(`lib/hive/patrol/validator.rb`) no longer returns early when the
+process-group leader survives the `TERM_GRACE_SEC` join. After sending
+group TERM and waiting one grace period, it always attempts the group
+KILL; `Errno::ESRCH`/`ECHILD` still report that nothing remains.
+
+**Why:** leader liveness was used as a proxy for group liveness. A shell
+whose `wait` builtin is interrupted by TERM exits during the grace
+period, so the KILL escalation never fired while group members that
+trapped TERM (e.g. test-suite children) survived the timeout and kept
+running after `validate` returned.
+
+**Tests:** `test/unit/patrol/validator_test.rb` adds
+`test_termination_still_escalates_to_kill_when_the_leader_exits_during_grace`
+(fake waiter whose join succeeds) and
+`test_timeout_kill_reaches_group_members_that_outlive_the_shell` (real
+process group where an inner member ignores TERM; asserts it is gone via
+`Process.kill(0, pid)` raising `Errno::ESRCH`). Both fail on the previous
+implementation.


### PR DESCRIPTION
## Patrol Fix

This pull request repairs one finding tracked by Hive's Patrol Fix workflow.

### Sources

- ordinary_patrol: architecture-lib-hive-patrol-part-6-20260815T174925Z-d84aa4e9-1

### Finding evidence

- {"file":"lib/hive/patrol/validator.rb","line":97,"snippet":"\"bash\", \"-lc\", command, chdir: worktree_path, pgroup: true","role":"trigger"}
- {"file":"lib/hive/patrol/validator.rb","line":103,"snippet":"terminate(waiter) if timed_out","role":"trigger"}
- {"file":"lib/hive/patrol/validator.rb","line":161,"snippet":"return if waiter.join(TERM_GRACE_SEC)","role":"root_cause"}
- {"file":"lib/hive/patrol/validator.rb","line":163,"snippet":"Process.kill(\"KILL\", -waiter.pid)","role":"impact"}

### Independent review

Publish. The patch fixes the exact process-group leak without widening controller behavior: a timed-out validation always attempts KILL on the original group after TERM, regardless of shell-leader exit, while vanished groups remain benign. Focused behavior and repeated real-process evidence pass; all observed nonfocused failures are outside the changed files and environment-dependent.

- Trusted checkout HEAD 098066f5c44fcd21211b2b95151e4a749c519ee4 is clean; its parent diff changes only lib/hive/patrol/validator.rb, focused validator tests, and the required wiki log fragment, with git diff --check clean.
- Static review confirms terminate now sends group TERM, joins the leader for up to TERM_GRACE_SEC, then attempts group KILL even if the leader exited; Errno::ESRCH and Errno::ECHILD still make already-vanished groups benign.
- The focused timeout selection completed 4 runs and 6 assertions with zero failures, errors, or skips; the real descendant-survivor regression also passed eight consecutive independent repetitions.
- The full validator-file failures were three unchanged tests whose nested Ruby commands hit Bundler::GemNotFound, and the controller broad-suite failures were confined to unchanged AgentCliRuntime executable-path and local OpenCode-inventory setup; none intersects this three-file patch.

### Validation

Verdict: failed
- ordinary:test: exit 1
- agent:regression-tests-patrol-validator-timeout-kill-escalation: exit 0

<!-- hive-publication:v1 id=pub-4a564ad274f5c0f29c8c2cdb73eaccaa base=2bcba3195aa6f87e3e195d64d288a693e99d11b5 -->
