### PR TITLE
Fix Patrol finding: make-one-internal-transition-membership-represen-5c390d8999b7

### DIFF
--- a/lib/hive/conditions/registry.rb
+++ b/lib/hive/conditions/registry.rb
@@ -2,9 +2,12 @@ module Hive
   module Conditions
     class RegistryError < Hive::Error; end
 
+    # Registry owns condition semantics (family, scope, evidence, gate role,
+    # authoritative stages). Condition-to-transition membership lives solely in
+    # Conditions::Policy, so there is exactly one internal representation of it.
     Definition = Data.define(
       :name, :family, :supersession_family, :scope, :allowed_evidence,
-      :gate_role, :authoritative_stages, :default_transitions
+      :gate_role, :authoritative_stages
     ) do
       def authoritative_for?(stage)
         authoritative_stages.include?(stage.to_s)
@@ -18,8 +21,7 @@ module Hive
           "scope" => scope.to_s,
           "allowed_evidence" => allowed_evidence.map(&:to_s),
           "gate_role" => gate_role.to_s,
-          "authoritative_stages" => authoritative_stages,
-          "default_transitions" => default_transitions
+          "authoritative_stages" => authoritative_stages
         }
       end
     end
@@ -33,40 +35,40 @@ module Hive
           registry.register(
             "AgentHealthy", family: "agent_health", supersession_family: "agent_health",
             scope: :attempt, allowed_evidence: %i[attempt_lease journal_event],
-            gate_role: :requirement, authoritative_stages: [ "4-execute" ], # coding-scoped: increment 1 gate
-            default_transitions: [ "execute_active" ]
+            gate_role: :requirement,
+            authoritative_stages: [ "4-execute" ] # coding-scoped: increment 1 gate
           )
           registry.register(
             "ChangesPresent", family: "changes_present", supersession_family: "execute_outcome",
             scope: :commit, allowed_evidence: %i[commit journal_event file],
-            gate_role: :requirement, authoritative_stages: [ "4-execute" ], # coding-scoped: increment 1 gate
-            default_transitions: [ "execute_to_open_pr" ]
+            gate_role: :requirement,
+            authoritative_stages: [ "4-execute" ] # coding-scoped: increment 1 gate
           )
           registry.register(
             "AwaitingHuman", family: "awaiting_human", supersession_family: "execute_outcome",
             scope: :attempt, allowed_evidence: %i[journal_event attempt_lease],
-            gate_role: :inhibitor, authoritative_stages: [ "4-execute" ], # coding-scoped: increment 1 gate
-            default_transitions: [ "execute_to_open_pr" ]
+            gate_role: :inhibitor,
+            authoritative_stages: [ "4-execute" ] # coding-scoped: increment 1 gate
           )
           registry.register(
             "BranchPushed", family: "branch_pushed", supersession_family: "branch_pushed",
             scope: :commit, allowed_evidence: %i[commit journal_event],
-            gate_role: :requirement, default_transitions: [ "open_pr_to_review" ]
+            gate_role: :requirement
           )
           registry.register(
             "ArtifactCurrent", family: "artifact_current", supersession_family: "artifact_current",
             scope: :commit, allowed_evidence: %i[file commit journal_event],
-            gate_role: :requirement, default_transitions: [ "artifacts_to_finalize" ]
+            gate_role: :requirement
           )
           registry.register(
             "BabysitterActive", family: "babysitter_active", supersession_family: "babysitter_active",
             scope: :attempt, allowed_evidence: %i[attempt_lease journal_event],
-            gate_role: :requirement, default_transitions: [ "review_active" ]
+            gate_role: :requirement
           )
           registry.register(
             "Merged", family: "merged", supersession_family: "merged",
             scope: :pull_request, allowed_evidence: %i[pull_request journal_event],
-            gate_role: :requirement, default_transitions: [ "finalize_to_archive" ]
+            gate_role: :requirement
           )
           registry.freeze
         end
@@ -78,7 +80,7 @@ module Hive
       end
 
       def register(name, family:, scope:, allowed_evidence:, gate_role:,
-                   supersession_family: family, authoritative_stages: [], default_transitions: [])
+                   supersession_family: family, authoritative_stages: [])
         name = name.to_s
         family = family.to_s
         raise RegistryError, "condition name must be non-empty" if name.empty?
@@ -92,8 +94,7 @@ module Hive
           scope: scope.to_sym,
           allowed_evidence: Array(allowed_evidence).map(&:to_sym).freeze,
           gate_role: gate_role.to_sym,
-          authoritative_stages: Array(authoritative_stages).map(&:to_s).freeze,
-          default_transitions: Array(default_transitions).map(&:to_s).freeze
+          authoritative_stages: Array(authoritative_stages).map(&:to_s).freeze
         )
         unless %i[attempt commit pull_request task].include?(definition.scope)
           raise RegistryError, "condition #{name} has unknown scope #{scope.inspect}"

--- a/test/fixtures/runtime_control_plane/affected_production.yml
+++ b/test/fixtures/runtime_control_plane/affected_production.yml
@@ -7,8 +7,8 @@ counting_rule: physical_source_lines
 includes_new_production_files: true
 maximum_final_lines: 7960
 final_inventory_lines: 9220
-outside_inventory_net_lines: -2846
-final_lines: 6374
+outside_inventory_net_lines: -2845
+final_lines: 6375
 final_paths:
 - path: lib/hive/attempts/capacity_snapshot.rb
   lines: 104

--- a/test/unit/conditions/policy_test.rb
+++ b/test/unit/conditions/policy_test.rb
@@ -15,6 +15,17 @@ class ConditionsPolicyTest < Minitest::Test
     refute policy.rule_for("finalize_to_archive").authoritative_capable
   end
 
+  def test_every_policy_condition_is_registered_vocabulary
+    policy = Hive::Conditions::Policy.default
+    registry = Hive::Conditions::Registry.default
+
+    policy.instance_variable_get(:@rules).each_value do |rule|
+      (rule.required + rule.inhibitors).each do |name|
+        assert registry.key?(name), "policy references unregistered condition #{name}"
+      end
+    end
+  end
+
   def test_descriptor_rule_accepts_registered_semantics_and_research_option
     rule = Hive::Conditions::Policy.rule_from_descriptor({
       "version" => 1,

--- a/test/unit/conditions/registry_test.rb
+++ b/test/unit/conditions/registry_test.rb
@@ -46,6 +46,12 @@ class ConditionsRegistryTest < Minitest::Test
     definition = Hive::Conditions::Registry.default.fetch("Merged")
     assert_equal "pull_request", definition.to_h.fetch("scope")
     assert_equal [ "pull_request", "journal_event" ], definition.to_h.fetch("allowed_evidence")
-    assert_equal [ "finalize_to_archive" ], definition.to_h.fetch("default_transitions")
+    refute definition.to_h.key?("default_transitions")
+  end
+
+  def test_registry_does_not_own_transition_membership
+    # Transition membership has exactly one internal representation: the gate
+    # rules in Conditions::Policy. The registry must not carry a parallel copy.
+    refute_respond_to Hive::Conditions::Registry.default.fetch("AgentHealthy"), :default_transitions
   end
 end

--- a/wiki/log.d/20260825T124123Z-consolidate-condition-transition-membership.md
+++ b/wiki/log.d/20260825T124123Z-consolidate-condition-transition-membership.md
@@ -1,0 +1,12 @@
+## Consolidate condition-transition membership into Policy
+
+- Removed `default_transitions` from `Hive::Conditions::Registry` and
+  `Definition`. It was a second, unused owner of condition-to-transition
+  membership and had already drifted (`AgentHealthy` pointed at the
+  non-existent `execute_active` gate instead of `execute_to_open_pr`).
+- `Conditions::Policy.default` is now the single internal representation of
+  transition membership; the registry keeps only condition semantics
+  (family, scope, evidence, gate role, authoritative stages).
+- Regression coverage: registry definitions no longer expose
+  `default_transitions`, and every condition named by a policy rule must be
+  registered vocabulary.

--- a/wiki/modules/conditions.md
+++ b/wiki/modules/conditions.md
@@ -21,6 +21,14 @@ for `4-execute`. `BranchPushed`, `ArtifactCurrent`, `BabysitterActive`, and
 stages yet. Observations use `pending`, `satisfied`, `unsatisfied`, or
 `unverifiable`; the projector alone adds `superseded` history.
 
+Transition membership has exactly one internal representation: the gate
+rules registered in `Conditions::Policy.default`. The registry owns only
+condition semantics (family, supersession family, scope, allowed evidence,
+gate role, authoritative stages) and carries no condition-to-transition
+membership; `Definition` exposes no `default_transitions` field. Policy
+descriptors are validated against registered vocabulary, so an unknown or
+wrong-role condition in a gate rule raises `InvalidPolicy`.
+
 Every condition observation has a durable attempt ID, numeric task input
 epoch, optional commit generation, explicit reason/time, typed evidence, and
 provenance. The numeric epoch is distinct from the opaque attempt ownership


### PR DESCRIPTION
## Patrol Fix

This pull request repairs one finding tracked by Hive's Patrol Fix workflow.

### Sources

- architecture_patrol: pr-1148-29a3b5c29236f8c9:consolidate-condition-transition-membership

### Finding evidence

- {"file":"lib/hive/conditions/policy.rb","line":31,"snippet":"required: %w[AgentHealthy ChangesPresent], inhibitors: [ \"AwaitingHuman\" ]","claim":"the executable default policy assigns AgentHealthy to execute_to_open_pr"}
- {"file":"lib/hive/conditions/registry.rb","line":37,"snippet":"default_transitions: [ \"execute_active\" ]","claim":"the registry independently assigns AgentHealthy to a different default transition, demonstrating current divergence between the two ownership sources"}
- {"file":"test/unit/conditions/policy_test.rb","line":8,"snippet":"assert_equal %w[AgentHealthy ChangesPresent], execute.required","claim":"the existing policy contract characterizes the behavior that consolidation must preserve"}

### Independent review

Exact-head inspection confirms the patch removes the unused duplicate transition-membership field without changing Policy gate behavior. Focused validation is green; the broad checkpoint failures are confined to unchanged agent-cli-runtime environment behavior, and independent review found no patch-caused blocker.

- HEAD 3ff3146d7cba0c4967d7e52f54281a5925a8ca5c matches the controller binding; base b07b869635e47d986370b19d0dfe583d54143e79 and the diff is limited to the registry, two focused tests, and two wiki files.
- Current production search finds no default_transitions occurrence; Conditions::Policy.default contains all five transition rules and Policy#add validates every condition through Registry#fetch.
- Independent focused validation passed: 65 runs, 309 assertions, 0 failures, 0 errors; git diff --check also passed.
- Independent broad validation failures are confined to unchanged agent-cli-runtime behavior: an absolute Grok path expectation and an unrunnable OpenCode offline wrapper.
- Correctness and project-standards reviews found no defect; testing, maintainability, and independent cross-model observations were non-blocking hardening suggestions with no runtime consequence.

### Validation

Verdict: failed
- architecture:test: exit 1
- agent:conditions-focused-suite-includes-membership-regressions: exit 0
- agent:no-default_transitions-membership-field-remains-in-production-code: exit 0

<!-- hive-publication:v1 id=pub-b95ceee083f84af37be09f66571327ce base=b07b869635e47d986370b19d0dfe583d54143e79 -->
