### PR TITLE
fix(status): scope direct task projections

### DIFF
--- a/lib/hive/commands/status.rb
+++ b/lib/hive/commands/status.rb
@@ -638,6 +638,22 @@ module Hive
                           admission_context: nil, now: Time.now.utc,
                           workflow_generation: nil,
                           include_archive_index: false, task_slugs: nil)
+        unless @status_attempt_store
+          return with_status_attempt_store do
+            project_payload(
+              project,
+              project_count: project_count,
+              stages: stages,
+              exclude_archived: exclude_archived,
+              admission_context: admission_context,
+              now: now,
+              workflow_generation: workflow_generation,
+              include_archive_index: include_archive_index,
+              task_slugs: task_slugs
+            )
+          end
+        end
+
         path = project["path"]
         hive_state = project["hive_state_path"]
         base = {

--- a/test/unit/commands/status_test.rb
+++ b/test/unit/commands/status_test.rb
@@ -1659,6 +1659,33 @@ class CommandsStatusTest < Minitest::Test
     end
   end
 
+  def test_direct_project_payload_owns_attempt_store_through_action_annotation
+    with_tmp_global_config do
+      with_tmp_dir do |project_root|
+        hive_state = File.join(project_root, ".hive-state")
+        write_status_task(
+          hive_state, "1-inbox", "direct-project-260828-abcd",
+          state_file: "idea.md", marker: "WAITING"
+        )
+        command = Hive::Commands::Status.new(json: true)
+        observed_stores = []
+        command.define_singleton_method(:attempt_diagnostic_for) do |_row|
+          observed_stores << status_attempt_store
+          nil
+        end
+
+        payload = command.project_payload(
+          status_project(project_root, hive_state), project_count: 1
+        )
+
+        assert_equal [ "direct-project-260828-abcd" ],
+                     payload.fetch("tasks").map { |row| row.fetch("slug") }
+        assert_equal 1, observed_stores.uniq.length
+        assert_nil command.instance_variable_get(:@status_attempt_store)
+      end
+    end
+  end
+
   def test_daemon_task_scan_reuses_one_attempt_store_across_projects
     with_tmp_dir do |root|
       slug = "fast-tick-260823-abcd"

--- a/wiki/commands/status.md
+++ b/wiki/commands/status.md
@@ -494,6 +494,11 @@ internal `--daemon-task` fast-tick scan shares one store and one reader the
 same way, across every requested project, so a bounded daemon tick never
 rebuilds them per project.
 
+Direct project projections also establish that same scope when no enclosing
+scan owns it. This keeps bounded consumers such as `hive task` able to resolve
+receipt-bound Patrol diagnostics without reopening the store per task or
+raising outside a fleet scan.
+
 Each task row first reads its bounded projection checkpoint instead of hashing
 and replaying the task's complete journal. A checkpoint is usable for exact
 status only when it is current, its journal identity/size/metadata and bounded

--- a/wiki/commands/task.md
+++ b/wiki/commands/task.md
@@ -3,7 +3,7 @@ title: hive task
 type: command
 source: lib/hive/cli.rb, lib/hive/commands/task.rb, lib/hive/task_workspace/builder.rb, schemas/hive-task-workspace.v2.json
 created: 2026-08-16
-updated: 2026-08-16
+updated: 2026-08-28
 tags: [command, task, semantic, workspace, json, diagnosis]
 ---
 
@@ -28,6 +28,10 @@ task ID. Use `--project` for a bare slug or ID whenever more than one registered
 project could match. The command checks ordinary canonical status first and
 then the archive projection for that exact stage, so a retained archived task
 remains inspectable and is marked read-only.
+
+The exact project projection owns one read-only attempts-store scope through
+action and receipt-bound diagnostic annotation. It does not require a
+fleet-status caller to have opened that scope first.
 
 Without `--json`, the command prints a compact human summary: headline, action,
 primary-result reference, and usage coverage. `--json` is the stable machine

--- a/wiki/log.d/20260828T095513Z-task-status-attempt-scope.md
+++ b/wiki/log.d/20260828T095513Z-task-status-attempt-scope.md
@@ -1,0 +1,19 @@
+---
+date: 2026-08-28
+tags: [status, task, attempts, patrol-fix]
+pages: [commands/status, commands/task]
+---
+
+# Keep bounded task status inside an attempts-store scope
+
+Direct `Status#project_payload` consumers now open one scan-scoped read-only
+attempt store when no outer status scan already owns one. This preserves the
+single-store full-scan optimization while allowing `hive task` to project
+receipt-bound Patrol failure diagnostics instead of raising `status attempt
+store is outside a scan` during action annotation.
+
+Focused status coverage exercises the direct project boundary and proves that
+the store is shared through annotation and released afterward. Live source
+verification also resolved the two previously failing Patrol task workspaces
+to their exact `secret_policy_publish_blocked` and `fix_worktree_dirty`
+diagnostics.


### PR DESCRIPTION
## Summary

- keep direct project status projections inside one read-only attempts-store scope
- preserve the existing one-store full-scan reuse path
- restore bounded `hive task` diagnostics for failed Patrol attempts
- document the projection boundary in the managed wiki

## Verification

- `bundle exec ruby -Itest test/unit/commands/status_test.rb` (138 runs, 583 assertions)
- `bundle exec ruby -Itest test/integration/task_command_test.rb` (7 runs, 32 assertions)
- focused RuboCop (2 files, no offenses)
- source-built `hive task --json` resolved the affected rows to `secret_policy_publish_blocked` and `fix_worktree_dirty`

## Context

The attempts-store scan optimization correctly scopes fleet scans, but `Hive::Commands::Task` calls `Status#project_payload` directly. Failed Patrol rows reach receipt-bound action annotation after row collection, where the temporary store had already closed. The direct projection now acquires the same outer scope only when one is not already present.
