### PR TITLE
fix(execute): tolerate nil agent spawn result

### DIFF
--- a/lib/hive/stages/execute.rb
+++ b/lib/hive/stages/execute.rb
@@ -669,7 +669,7 @@ module Hive
       end
 
       def append_implementation_output(task, result)
-        final_message = result && result[:final_message].to_s.strip
+        final_message = result&.fetch(:final_message, nil).to_s.strip
         return if final_message.empty?
 
         output = final_message.byteslice(0, 64 * 1024).scrub

--- a/test/unit/stages/execute_test.rb
+++ b/test/unit/stages/execute_test.rb
@@ -1172,6 +1172,17 @@ class HiveStagesExecuteTest < Minitest::Test
     end
   end
 
+  def test_append_implementation_output_tolerates_nil_spawn_result
+    with_tmp_dir do |dir|
+      task = build_task(dir)
+      File.write(task.state_file, "# Task\n\n<!-- AGENT_WORKING -->\n")
+
+      Hive::Stages::Execute.append_implementation_output(task, nil)
+
+      assert_match(/<!-- AGENT_WORKING -->\n\z/, File.read(task.state_file))
+    end
+  end
+
   def test_research_execution_returns_false_for_malformed_frontmatter
     with_tmp_dir do |dir|
       task = build_task(dir)

--- a/wiki/log.d/20260828T101853Z-execute-nil-spawn-output.md
+++ b/wiki/log.d/20260828T101853Z-execute-nil-spawn-output.md
@@ -1,0 +1,15 @@
+---
+date: 2026-08-28
+tags: [execute, patrol-fix, recovery, agent]
+pages: [stages/execute]
+---
+
+# Keep nil implementation results on the normal failure path
+
+`Stages::Execute.append_implementation_output` now treats a nil implementation
+spawn result as empty output instead of calling `empty?` on nil. The state file
+remains unchanged, allowing the existing implementation-failure classifier and
+recovery lifecycle to own the attempt.
+
+A focused regression test passes nil directly and proves the working marker is
+preserved without an exception.

--- a/wiki/stages/execute.md
+++ b/wiki/stages/execute.md
@@ -3,7 +3,7 @@ title: 4-execute stage
 type: stage
 source: lib/hive/stages/execute.rb, templates/execute_prompt.md.erb
 created: 2026-04-25
-updated: 2026-08-20
+updated: 2026-08-28
 tags: [stage, execute, worktree, plan-review]
 ---
 
@@ -85,7 +85,7 @@ signing, ownership, branch, ancestry, and cleanliness gates.
 - **`--add-dir <task folder>`**: lets the agent read plan.md and append to `task.md` ("## Implementation" section).
 - **Budgets**: `cfg["budget_usd"]["execute_implementation"]` (100), `cfg["timeout_sec"]["execute_implementation"]` (2700).
 - **Log label**: `execute-impl`.
-- **Final message capture**: `Hive::Agent` records the last `result`, `item.completed agent_message`, `assistant` stream-json message, or plain stdout tail. `Stages::Execute` writes it to `task.md` before the terminal marker so investigation work is not trapped only in raw logs. Only structured final messages count as research-mode output; plain stdout/stderr progress is preserved but does not complete research mode.
+- **Final message capture**: `Hive::Agent` records the last `result`, `item.completed agent_message`, `assistant` stream-json message, or plain stdout tail. `Stages::Execute` writes it to `task.md` before the terminal marker so investigation work is not trapped only in raw logs. A nil spawn result is treated as no final message, leaving the state file unchanged so the normal implementation-failure path can classify and recover the attempt. Only structured final messages count as research-mode output; plain stdout/stderr progress is preserved but does not complete research mode.
 - Agent must commit each logical unit in the worktree and run lint/tests as it goes. May only edit `task.md` inside the task folder; must not touch `plan.md` or `worktree.yml` (SHA-256 protected, ADR-013).
 - The firewall also protects the task journal/projection and every promoted
   `context-receipts` and `activity-operations` record. Because those immutable
@@ -102,7 +102,7 @@ signing, ownership, branch, ancestry, and cleanliness gates.
 ## Tests
 
 - `test/unit/agent_test.rb` — captures final messages from stream-json result lines.
-- `test/unit/stages/execute_test.rb` — pins execute's provider-limit classification via both `error_message` and raw `limit_text`, typed and exceptional `implementer_failed` markers, tamper precedence, and bounded custody of growing controller-receipt history.
+- `test/unit/stages/execute_test.rb` — pins execute's provider-limit classification via both `error_message` and raw `limit_text`, typed and exceptional `implementer_failed` markers, nil spawn-result output capture, tamper precedence, and bounded custody of growing controller-receipt history.
 - `test/integration/run_execute_test.rb` — init pass produces `EXECUTE_COMPLETE`; no-change exits preserve `## Execute Output` and pause; research-mode no-change runs can complete with output; research-mode without output pauses; re-run announces 5-open-pr; tampering → `:error`; impl failure → `:error`; missing plan.md exits 1; no review files written.
 
 ## Backlinks


### PR DESCRIPTION
## Summary

- treat a nil implementation spawn result as empty output
- preserve the working marker so the normal implementation-failure recovery path owns the attempt
- add focused regression coverage and managed-wiki documentation

## Verification

- `bundle exec ruby -Itest test/unit/stages/execute_test.rb -n /append_implementation_output/` (2 runs, 4 assertions)
- focused RuboCop (2 files, no offenses)

## Patrol recovery

This salvages the exact fix produced for Patrol task `patrol-nil-agent-spawn-result-crashes-run-043971ba37` from its clean cutover backup commit. Its original task worktree was contaminated by a repository-global `git stash pop` under the historical validator; current main already isolates validation in a disposable exact-HEAD checkout.
