### PR TITLE
fix(closure): follow workflow terminal stage

### DIFF
--- a/lib/hive/task_closure.rb
+++ b/lib/hive/task_closure.rb
@@ -1218,11 +1218,7 @@ module Hive
 
     def transition!(task, project, receipt)
       require "hive/commands/guarded_archive"
-      target_stage = Hive::Workflows.for_verb("archive").fetch(:target)
-      unless target_stage == Hive::Stages::DIRS.last
-        raise InvalidReceipt,
-              "closure receipts can authorize only the archive transition"
-      end
+      target_stage = task.workflow.stages.last.dir
       digest = receipt.fetch("receipt_digest")
       Hive::Commands::GuardedArchive.call(
         task,

--- a/test/unit/commands/stage_action_test.rb
+++ b/test/unit/commands/stage_action_test.rb
@@ -329,18 +329,4 @@ class CommandsStageActionTest < Minitest::Test
     end
     assert_empty out
   end
-
-  def test_closure_transition_is_authorized_only_for_the_terminal_archive_target
-    task = Struct.new(:stage_index, :stage_name).new(4, "execute")
-    service = Hive::TaskClosure.new
-
-    with_replaced_singleton_method(
-      Hive::Workflows, :for_verb, ->(*) { { target: "3-plan" } }
-    ) do
-      error = assert_raises(Hive::TaskClosure::InvalidReceipt) do
-        service.send(:transition!, task, nil, "receipt_digest" => "a" * 64)
-      end
-      assert_match(/only the archive transition/, error.message)
-    end
-  end
 end

--- a/test/unit/task_closure_test.rb
+++ b/test/unit/task_closure_test.rb
@@ -109,6 +109,33 @@ class TaskClosureTest < Minitest::Test
     end
   end
 
+  def test_verified_merge_closes_into_the_task_workflow_terminal_stage
+    with_closure_project(
+      workflow: "content", stage: "4-draft", state_file: "draft.md"
+    ) do |task, project|
+      service = service_for
+      input = input_for("acme/app#42")
+      preview = service.preview(task: task, project: project, input: input)
+
+      assert preview.valid?, preview.to_h.inspect
+
+      receipt = with_deterministic_content_agent do
+        service.confirm!(
+          task: task, project: project, input: input,
+          preview_digest: preview.preview_digest,
+          operator: "tester", channel: "cli", authorized: true
+        )
+      end
+      archived = Hive::TaskResolver.new(task.slug, project_filter: project).resolve
+
+      assert_equal "6-done", "#{archived.stage_index}-#{archived.stage_name}"
+      assert_equal :complete, Hive::Markers.current(archived.state_file).name
+      assert_equal receipt.fetch("receipt_digest"),
+                   JSON.parse(File.read(File.join(archived.folder, "closure.json")))
+                       .fetch("receipt_digest")
+    end
+  end
+
   def test_daemon_reconciles_same_repository_merge_and_replays_idempotently
     with_closure_project do |task, project|
       File.write(
@@ -1244,7 +1271,8 @@ class TaskClosureTest < Minitest::Test
     Hive::TaskClosure.new(gh: gh, attempt_store: attempt_store)
   end
 
-  def with_closure_project(successor: false)
+  def with_closure_project(successor: false, workflow: "coding",
+                           stage: "4-execute", state_file: "task.md")
     with_tmp_global_config do |home|
       project = File.join(home, "app")
       FileUtils.mkdir_p(project)
@@ -1261,14 +1289,14 @@ class TaskClosureTest < Minitest::Test
         File.join(hive_state, "config.yml"),
         {
           "default_branch" => "main",
-          "default_workflow" => "coding",
+          "default_workflow" => workflow,
           "worktree_root" => File.join(home, "worktrees")
         }.to_yaml
       )
-      folder = File.join(hive_state, "stages", "4-execute", "closure-task")
+      folder = File.join(hive_state, "stages", stage, "closure-task")
       FileUtils.mkdir_p(folder)
       Hive::TaskMeta.write(folder, id: 1, slug: "closure-task", display_name: "Closure Task")
-      File.write(File.join(folder, "task.md"), "# Closure task\n")
+      File.write(File.join(folder, state_file), "# Closure task\n")
       if successor
         successor_folder = File.join(hive_state, "stages", "1-inbox", "successor-task")
         FileUtils.mkdir_p(successor_folder)

--- a/wiki/commands/stage_action.md
+++ b/wiki/commands/stage_action.md
@@ -3,11 +3,11 @@ title: Workflow verbs
 type: command
 source: lib/hive/cli.rb, lib/hive/commands/stage_action.rb, lib/hive/task_closure.rb, lib/hive/commands/adhoc_review.rb, lib/hive/workflows.rb, lib/hive/gh.rb
 created: 2026-04-26
-updated: 2026-07-25
+updated: 2026-08-28
 tags: [command, workflow, verbs, stage_action, json, closure, evidence]
 ---
 
-**TLDR**: Eight Thor commands wrap promote-or-run for the stage transitions defined in `Hive::Workflows::VERBS`: `brainstorm`, `plan`, `develop`, `open-pr`, `review`, `artifacts`, `finalize`, and `archive <target>`. The CLI also gives `hive archive` a no-target listing mode and an interactive, evidence-bound `already_delivered` / `superseded` closure mode. Ordinary archive safety is unchanged: only `Hive::TaskClosure` can invoke the internal guarded-archive protocol (`Hive::Commands::GuardedArchive`) that retires an active task from outside `8-finalize`. Automatic same-repository merge closure uses that same protocol; there is no marker-reason archive bypass.
+**TLDR**: Eight Thor commands wrap promote-or-run for the stage transitions defined in `Hive::Workflows::VERBS`: `brainstorm`, `plan`, `develop`, `open-pr`, `review`, `artifacts`, `finalize`, and `archive <target>`. The CLI also gives `hive archive` a no-target listing mode and an interactive, evidence-bound `already_delivered` / `superseded` closure mode. Ordinary archive safety is unchanged: only `Hive::TaskClosure` can invoke the internal guarded-archive protocol (`Hive::Commands::GuardedArchive`) that retires an active task from outside its workflow's ordinary terminal transition. Automatic same-repository merge closure uses that same protocol; there is no marker-reason archive bypass.
 
 ## Usage
 
@@ -61,8 +61,10 @@ The receipt is written atomically before transition. Its exact digest enters a
 separate `TransitionGuard.validate_closure!` path; it is not attempt success
 evidence and cannot weaken the ordinary marker/condition guard. `Hive::TaskClosure`
 then drives the one internal guarded-archive protocol, `Hive::Commands::GuardedArchive`,
-which may force the task from any active stage to `9-done`, run the Done stage
-with the internal no-rebase override, and retain `closure.json`. StageAction
+which may force the task from any active stage to the terminal stage declared by
+that task's workflow (`9-done` for coding and `6-done` for content or Patrol Fix),
+run that terminal stage with the internal no-rebase override, and retain
+`closure.json`. StageAction
 itself carries no closure branch: it dispatches only ordinary verb transitions,
 while GuardedArchive holds no receipt semantics — the caller injects the
 pre-transition guard (rechecked inside the atomic move lock) and an optional

--- a/wiki/log.d/20260828T110032Z-workflow-aware-evidence-closure.md
+++ b/wiki/log.d/20260828T110032Z-workflow-aware-evidence-closure.md
@@ -1,0 +1,12 @@
+---
+title: Evidence closure follows each workflow terminal stage
+type: change
+date: 2026-08-28
+tags: [task-closure, workflows, patrol-fix, archive]
+---
+
+Evidence-bound task closure now derives its destination from the task's workflow
+descriptor instead of coding's global `9-done` archive verb. Coding tasks still
+close to `9-done`; workflows such as content and Patrol Fix close to their own
+`6-done` terminal stage while retaining the same receipt validation, guarded
+move, terminal run, and replay behavior.


### PR DESCRIPTION
## Summary

- derive evidence-closure destinations from each task workflow descriptor
- preserve coding closure at 9-done while allowing Patrol Fix and content closure at 6-done
- cover the non-coding closure path end to end and document the contract

## Verification

- bundle exec ruby -Itest test/unit/task_closure_test.rb
- bundle exec ruby -Itest test/unit/commands/guarded_archive_test.rb
- mise exec ruby@3.4.10 -- bundle exec rubocop lib/hive/task_closure.rb test/unit/task_closure_test.rb
- git diff --check