### PR TITLE
fix(patrol): close externally delivered fixes

### DIFF
--- a/lib/hive/commands/guarded_archive.rb
+++ b/lib/hive/commands/guarded_archive.rb
@@ -51,7 +51,8 @@ module Hive
 
       def resume_at_terminal
         marker = Hive::Markers.current(@task.state_file)
-        return publish_completion(@task) if marker.name == :complete
+        return publish_completion(@task) if marker.name == :complete ||
+                                               inert_controller_terminal?(@task)
 
         run_at(@task.folder)
         resumed = Hive::Task.new(@task.folder)
@@ -76,8 +77,11 @@ module Hive
             @observation_guard&.call(locked_task)
           end
         ).call
-        run_at(new_folder)
         closed = Hive::Task.new(new_folder)
+        unless inert_controller_terminal?(closed)
+          run_at(new_folder)
+          closed = Hive::Task.new(new_folder)
+        end
         publish_completion(closed)
         closed
       end
@@ -92,15 +96,22 @@ module Hive
         ).call
       end
 
-      # Same completion broadcast conditions as StageAction: only a task
-      # sitting in its workflow's terminal stage with a :complete marker
-      # publishes the lifecycle event.
+      # Agent-owned terminal stages prove completion with :complete. A
+      # controller-owned inert terminal has no runner or marker; reaching it
+      # through this guarded protocol is itself the terminal side effect.
       def publish_completion(task)
         stage_dir = "#{task.stage_index}-#{task.stage_name}"
         return unless task.workflow.stages.last.dir == stage_dir
-        return unless Hive::Markers.current(task.state_file).name == :complete
+        return unless Hive::Markers.current(task.state_file).name == :complete ||
+                      inert_controller_terminal?(task)
 
         publisher.task_completed(task)
+      end
+
+      def inert_controller_terminal?(task)
+        terminal = task.workflow.stages.last
+        task.workflow.controller? && terminal.kind == :inert &&
+          terminal.dir == "#{task.stage_index}-#{task.stage_name}"
       end
 
       def publisher

--- a/lib/hive/patrol_fix/projection.rb
+++ b/lib/hive/patrol_fix/projection.rb
@@ -48,11 +48,12 @@ module Hive
         publication = current.reverse.find { |receipt| receipt["kind"] == "publication" }
         outcome = parked_outcome(decision)
         done = stage == "6-done" # not-a-stage-ref: Patrol Fix workflow stage
-        missing_publication = done && publication.nil?
-        state = missing_publication ? "invalid" : "current"
-        diagnostic = if missing_publication
-          { "summary" => "Patrol-fix done requires an exact current pull-request receipt." }
-        else
+        closure = done && publication.nil? && valid_evidence_closure?
+        missing_terminal_authority = done && publication.nil? && !closure
+        state = missing_terminal_authority ? "invalid" : "current"
+        diagnostic = if missing_terminal_authority
+          { "summary" => "Patrol-fix done requires an exact current pull-request receipt or valid evidence-closure receipt." }
+        elsif !closure
           publication_diagnostic
         end
 
@@ -74,7 +75,7 @@ module Hive
           "review" => last_decision && last_decision["stage"] == "review" ? last_decision.fetch("payload") : nil,
           "publication" => publication&.fetch("payload", nil),
           "timing" => timing_projection(receipts, current, decision),
-          "archived" => done && publication && state == "current" ? true : false,
+          "archived" => done && state == "current",
           "diagnostic" => diagnostic,
           "action" => action_for(
             state: state, done: done, outcome: outcome,
@@ -193,6 +194,15 @@ module Hive
 
       def stage_name
         stage.split("-", 2).last
+      end
+
+      def valid_evidence_closure?
+        require "hive/task"
+        require "hive/task_closure"
+        task = Hive::Task.new(task_folder)
+        Hive::TaskClosure.read(task, quarantine: false).valid?
+      rescue Hive::Error, SystemCallError, IOError
+        false
       end
 
       def invalid_projection(message)

--- a/lib/hive/patrol_fix/stage_transition.rb
+++ b/lib/hive/patrol_fix/stage_transition.rb
@@ -38,7 +38,8 @@ module Hive
         projection = Hive::PatrolFix::Projection.new(
           task_folder: @task.folder, stage: "#{@task.stage_index}-#{@task.stage_name}"
         ).to_h
-        unless projection.dig("action", "kind") == "advance"
+        unless projection.dig("action", "kind") == "advance" ||
+               evidence_closure_to_terminal?(destination)
           raise InvalidTransition, "patrol-fix transition requires a current terminal stage receipt"
         end
         pending = pending_record
@@ -71,6 +72,18 @@ module Hive
       end
 
       private
+
+      def evidence_closure_to_terminal?(destination)
+        return false unless destination == @task.workflow.stages.last.dir
+
+        path = File.join(@task.folder, "closure.json")
+        return false unless File.exist?(path) || File.symlink?(path)
+
+        require "hive/task_closure"
+        Hive::TaskClosure.read(@task, quarantine: false).valid?
+      rescue Hive::Error, SystemCallError, IOError
+        false
+      end
 
       def identity
         manifest = Hive::PatrolFix::TaskManifest.new(task_folder: @task.folder).read

--- a/test/unit/commands/guarded_archive_test.rb
+++ b/test/unit/commands/guarded_archive_test.rb
@@ -5,10 +5,13 @@ require "hive/commands/stage_action"
 class GuardedArchiveTest < Minitest::Test
   include HiveTestHelper
 
-  FakeStage = Struct.new(:dir)
-  FakeWorkflow = Struct.new(:stages)
+  FakeStage = Struct.new(:dir, :kind)
+  FakeWorkflow = Struct.new(:stages, :controller) do
+    def controller? = !controller.nil?
+  end
 
-  def fake_task(folder:, state_file:, workflow_stages:, hive_state_path: "/tmp/hive-state")
+  def fake_task(folder:, state_file:, workflow_stages:, hive_state_path: "/tmp/hive-state",
+                workflow_controller: nil)
     Struct.new(
       :folder, :state_file, :slug, :stage_index, :stage_name,
       :workflow, :hive_state_path, keyword_init: true
@@ -18,7 +21,7 @@ class GuardedArchiveTest < Minitest::Test
       slug: "guarded-task",
       stage_index: 4,
       stage_name: "execute",
-      workflow: FakeWorkflow.new(workflow_stages),
+      workflow: FakeWorkflow.new(workflow_stages, workflow_controller),
       hive_state_path: hive_state_path
     )
   end
@@ -79,6 +82,34 @@ class GuardedArchiveTest < Minitest::Test
       end
       assert_equal [ dir ], runs, "resume must run Done in place"
       assert_equal [ task ], guards
+    end
+  end
+
+  def test_markerless_inert_controller_terminal_completes_without_a_runner
+    with_tmp_dir do |dir|
+      state_file = File.join(dir, "patrol-fix-manifest.json")
+      File.write(state_file, "{}")
+      task = fake_task(
+        folder: dir,
+        state_file: state_file,
+        workflow_stages: [ FakeStage.new("4-execute", :inert) ],
+        workflow_controller: :patrol_fix
+      )
+      guards = []
+      protocol = build_protocol(
+        task, current_stage: dir, target_stage: dir, guards: guards, observations: []
+      )
+      protocol.define_singleton_method(:run_at) do |_folder|
+        flunk("an inert controller terminal must not dispatch a runner")
+      end
+      completed = []
+      events = Object.new
+      events.define_singleton_method(:task_completed) { |resolved| completed << resolved; resolved }
+      protocol.define_singleton_method(:publisher) { events }
+
+      assert_same task, protocol.call
+      assert_equal [ task ], guards
+      assert_equal [ task ], completed
     end
   end
 

--- a/test/unit/patrol_fix/stage_transition_test.rb
+++ b/test/unit/patrol_fix/stage_transition_test.rb
@@ -26,6 +26,23 @@ class PatrolFixStageTransitionTest < Minitest::Test
     end
   end
 
+  def test_unreadable_evidence_closure_cannot_authorize_the_terminal_move
+    PatrolFixStageFixture.with_task(stage: "1-inbox") do |task, _root, _manifest|
+      File.write(File.join(task.folder, "closure.json"), "{}")
+      original = Hive::TaskClosure.method(:read)
+      Hive::TaskClosure.define_singleton_method(:read) do |*|
+        raise Hive::TaskClosure::InvalidReceipt, "synthetic unreadable closure"
+      end
+      begin
+        assert_raises(Hive::PatrolFix::StageTransition::InvalidTransition) do
+          Hive::PatrolFix::StageTransition.new(task).begin!("6-done")
+        end
+      ensure
+        Hive::TaskClosure.define_singleton_method(:read, original)
+      end
+    end
+  end
+
   def test_intent_before_move_replays_and_reconciles_after_a_crash
     PatrolFixStageFixture.with_task(stage: "1-inbox") do |task, _root, manifest|
       Hive::PatrolFix::ReceiptStore.new(task_folder: task.folder).append!(

--- a/test/unit/patrol_fix/stage_transition_test.rb
+++ b/test/unit/patrol_fix/stage_transition_test.rb
@@ -1,9 +1,31 @@
 require "test_helper"
 require "hive/commands/approve"
 require "hive/commands/run"
+require "hive/task_closure"
 require_relative "../stages/patrol_fix/fix_test"
 
 class PatrolFixStageTransitionTest < Minitest::Test
+  def test_evidence_closure_authorizes_only_the_workflow_terminal_move
+    PatrolFixStageFixture.with_task(stage: "1-inbox") do |task, _root, _manifest|
+      File.write(File.join(task.folder, "closure.json"), "{}")
+      valid_read = Object.new
+      valid_read.define_singleton_method(:valid?) { true }
+      original = Hive::TaskClosure.method(:read)
+      Hive::TaskClosure.define_singleton_method(:read, ->(*) { valid_read })
+      begin
+        transition = Hive::PatrolFix::StageTransition.new(task)
+        assert_raises(Hive::PatrolFix::StageTransition::InvalidTransition) do
+          transition.begin!("2-fix")
+        end
+
+        intent = transition.begin!("6-done")
+        assert_equal "6-done", intent.fetch("to")
+      ensure
+        Hive::TaskClosure.define_singleton_method(:read, original)
+      end
+    end
+  end
+
   def test_intent_before_move_replays_and_reconciles_after_a_crash
     PatrolFixStageFixture.with_task(stage: "1-inbox") do |task, _root, manifest|
       Hive::PatrolFix::ReceiptStore.new(task_folder: task.folder).append!(

--- a/test/unit/task_closure_test.rb
+++ b/test/unit/task_closure_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 require "hive/task_closure"
 require "hive/task_meta"
+require "hive/patrol_fix/task_manifest"
+require "hive/patrol_fix/projection"
 require "json_schemer"
 
 class TaskClosureTest < Minitest::Test
@@ -130,6 +132,47 @@ class TaskClosureTest < Minitest::Test
 
       assert_equal "6-done", "#{archived.stage_index}-#{archived.stage_name}"
       assert_equal :complete, Hive::Markers.current(archived.state_file).name
+      assert_equal receipt.fetch("receipt_digest"),
+                   JSON.parse(File.read(File.join(archived.folder, "closure.json")))
+                       .fetch("receipt_digest")
+    end
+  end
+
+  def test_verified_merge_closes_patrol_fix_without_a_publication_receipt_or_terminal_runner
+    with_closure_project(
+      workflow: "patrol-fix", stage: "3-validate",
+      state_file: Hive::PatrolFix::TaskManifest::FILENAME
+    ) do |task, project|
+      service = service_for
+      input = input_for("acme/app#42")
+      preview = service.preview(task: task, project: project, input: input)
+
+      assert preview.valid?, preview.to_h.inspect
+
+      receipt = service.confirm!(
+        task: task, project: project, input: input,
+        preview_digest: preview.preview_digest,
+        operator: "tester", channel: "cli", authorized: true
+      )
+      archived = Hive::TaskResolver.new(task.slug, project_filter: project).resolve
+      projection = Hive::PatrolFix::Projection.new(
+        task_folder: archived.folder, stage: "6-done"
+      ).to_h
+      journal = File.join(
+        archived.hive_state_path, "patrol-fix", "transitions", archived.slug,
+        "journal.jsonl"
+      )
+
+      assert_equal "6-done", "#{archived.stage_index}-#{archived.stage_name}"
+      refute_equal :complete, Hive::Markers.current(archived.state_file).name
+      assert_equal "current", projection.fetch("state")
+      assert projection.fetch("archived")
+      assert_equal "done", projection.dig("action", "kind")
+      assert_nil projection.fetch("publication")
+      assert_equal Hive::Schemas::TaskActionKind::ARCHIVED,
+                   Hive::TaskAction.new(archived).key
+      assert_equal %w[intent committed],
+                   File.readlines(journal).map { |line| JSON.parse(line).fetch("event") }
       assert_equal receipt.fetch("receipt_digest"),
                    JSON.parse(File.read(File.join(archived.folder, "closure.json")))
                        .fetch("receipt_digest")
@@ -1296,7 +1339,27 @@ class TaskClosureTest < Minitest::Test
       folder = File.join(hive_state, "stages", stage, "closure-task")
       FileUtils.mkdir_p(folder)
       Hive::TaskMeta.write(folder, id: 1, slug: "closure-task", display_name: "Closure Task")
-      File.write(File.join(folder, state_file), "# Closure task\n")
+      if workflow == "patrol-fix"
+        revision = Hive::GitOps.new(project).head_sha
+        Hive::PatrolFix::TaskManifest.new(task_folder: folder).write!(
+          "schema" => "hive-patrol-fix-task-manifest",
+          "schema_version" => 1,
+          "task" => { "slug" => "closure-task", "generation" => 1 },
+          "evidence_revision" => { "generation" => 1, "digest" => "a" * 64 },
+          "target_revision" => revision,
+          "sources" => [ {
+            "engine" => "ordinary_patrol", "identity" => "finding-1",
+            "target_revision" => revision, "evidence" => [ "reachable" ],
+            "affected_code" => [ "README.md" ],
+            "reproduction_guidance" => "Run the focused test.",
+            "discovery_run" => "run-1", "semantic_lineage" => [ "root-1" ]
+          } ],
+          "aliases" => [],
+          "relations" => { "successor" => nil, "issues" => [] }
+        )
+      else
+        File.write(File.join(folder, state_file), "# Closure task\n")
+      end
       if successor
         successor_folder = File.join(hive_state, "stages", "1-inbox", "successor-task")
         FileUtils.mkdir_p(successor_folder)

--- a/wiki/commands/stage_action.md
+++ b/wiki/commands/stage_action.md
@@ -63,8 +63,11 @@ evidence and cannot weaken the ordinary marker/condition guard. `Hive::TaskClosu
 then drives the one internal guarded-archive protocol, `Hive::Commands::GuardedArchive`,
 which may force the task from any active stage to the terminal stage declared by
 that task's workflow (`9-done` for coding and `6-done` for content or Patrol Fix),
-run that terminal stage with the internal no-rebase override, and retain
-`closure.json`. StageAction
+run an agent-owned terminal stage with the internal no-rebase override, and
+retain `closure.json`. A controller-owned inert terminal such as Patrol Fix
+has no terminal agent: its valid closure receipt authorizes only the move to
+that workflow's terminal stage, and that receipt remains the completion
+authority instead of synthesizing a publication receipt or marker. StageAction
 itself carries no closure branch: it dispatches only ordinary verb transitions,
 while GuardedArchive holds no receipt semantics — the caller injects the
 pre-transition guard (rechecked inside the atomic move lock) and an optional

--- a/wiki/log.d/20260828T114559Z-patrol-evidence-closure.md
+++ b/wiki/log.d/20260828T114559Z-patrol-evidence-closure.md
@@ -1,0 +1,13 @@
+---
+title: Patrol Fix evidence closure reaches its inert terminal
+type: change
+date: 2026-08-28
+tags: [patrol, patrol-fix, closure, workflow]
+---
+
+Verified evidence closure now supplies the alternate terminal authority for a
+Patrol Fix task whose work was already delivered outside its current workflow
+stage. The valid closure receipt authorizes only the move to `6-done`; Patrol
+Fix status archives that terminal task without inventing a publication receipt,
+and guarded archive does not dispatch the inert controller terminal as an
+agent stage.

--- a/wiki/modules/patrol.md
+++ b/wiki/modules/patrol.md
@@ -165,6 +165,13 @@ instead of replaying the stage run forever. The worker mutation fence and
 recovery coordinator resolve that same receipt-aware identity before accepting
 side effects or retrying the task.
 
+Ordinary Patrol Fix completion requires the current publication receipt. The
+separate evidence-closure protocol may instead retire a task whose change was
+already delivered through verified external evidence. Its `closure.json`
+authorizes only the workflow-terminal move, remains the terminal projection's
+completion authority, and does not fabricate a publication receipt or dispatch
+a runner for the controller-owned inert `6-done` stage.
+
 The Fix stage alone owns the authoritative patch checkout. Validate proves that
 checkout is clean and at the fix receipt's exact HEAD both before and after the
 run, but executes operator commands in a separate root-confined detached


### PR DESCRIPTION
## Summary

- allow a valid evidence-closure receipt to authorize only the Patrol Fix terminal transition
- project receipt-closed Patrol Fix tasks as archived without fabricating publication receipts
- skip the nonexistent runner for controller-owned inert terminal stages

## Verification

- `bundle exec ruby -Itest test/unit/task_closure_test.rb`
- `bundle exec ruby -Itest test/unit/commands/guarded_archive_test.rb`
- `bundle exec ruby -Itest test/unit/patrol_fix/stage_transition_test.rb`
- `bundle exec ruby -Itest test/unit/patrol_fix/projection_test.rb`
- `bundle exec ruby -Itest test/unit/commands/approve_test.rb`
- `bundle exec ruby -Itest test/unit/commands/stage_action_test.rb`
- RuboCop on changed Ruby files
- `bundle exec rake test` (13,843 runs, 277,099 assertions, 0 failures, 0 errors, 10 skips)