### PR TITLE
fix(plan-review): recover reviewer capability automatically

### DIFF
--- a/lib/hive/plan_review/adapters/ce_doc_review.rb
+++ b/lib/hive/plan_review/adapters/ce_doc_review.rb
@@ -118,7 +118,10 @@ module Hive
             }
             unless served_model.empty?
               actual["model"] = served_model
-              actual.delete("family") unless same_model_identity?(request.reviewer, served_model)
+              actual.delete("family")
+              actual = RouteResolver.attest_observed_identity(
+                requested: request.reviewer, actual:
+              )
             end
             {
               "status" => status,
@@ -126,17 +129,6 @@ module Hive
               "retry_at" => retry_at,
               "actual_route" => actual
             }
-          end
-
-          def same_model_identity?(reviewer, served_model)
-            requested_model = reviewer["model"]
-            return true if served_model == requested_model
-
-            support = Hive::AgentSupport.for(reviewer["provider"])
-            support&.respond_to?(:model_identity_equivalent?) &&
-              support.model_identity_equivalent?(
-                requested_model:, served_model:, family: reviewer["family"]
-              )
           end
 
           # Hive journals the review attempt itself — stage entry, agent
@@ -198,12 +190,36 @@ module Hive
           @capability_resolver = capability_resolver
         end
 
+        # Cheap preflight used by the orchestrator while an unsupported route
+        # is parked. It deliberately avoids disposable-worktree construction,
+        # immutable snapshot copies, and reviewer launch.
+        def probe_capability(kind:, reviewer:, project_root:)
+          return { "status" => "present", "diagnostic" => nil } if
+            kind.to_s == "adversarial"
+
+          provider = reviewer.fetch("provider")
+          support = Hive::AgentSupport.for(provider)
+          return support.plan_review_capability if support&.respond_to?(:plan_review_capability)
+
+          contract = @capability_resolver.call(CAPABILITY, provider)
+          stringify(@capability_probe.call(
+            agent: provider,
+            invocation: contract.invocation,
+            project_root:
+          )).merge("invocation" => contract.invocation)
+        rescue KeyError, Hive::ConfigError => e
+          { "status" => "unsupported", "diagnostic" => e.message }
+        end
+
         def call(request)
           runner_result = nil
           disposable = nil
           disposable_worktree = nil
           validate_snapshot!(request)
-          capability = capability_for(request)
+          capability = probe_capability(
+            kind: request.kind, reviewer: request.reviewer,
+            project_root: request.project_root
+          )
           if capability.fetch("status") != "present"
             return result(
               "unsupported",
@@ -295,22 +311,6 @@ module Hive
         end
 
         private
-
-        def capability_for(request)
-          return { "status" => "present", "diagnostic" => nil } if request.kind == "adversarial"
-          provider = request.reviewer.fetch("provider")
-          support = Hive::AgentSupport.for(provider)
-          return support.plan_review_capability if support&.respond_to?(:plan_review_capability)
-
-          contract = @capability_resolver.call(CAPABILITY, provider)
-          stringify(@capability_probe.call(
-            agent: provider,
-            invocation: contract.invocation,
-            project_root: request.project_root
-          )).merge("invocation" => contract.invocation)
-        rescue KeyError, Hive::ConfigError => e
-          { "status" => "unsupported", "diagnostic" => e.message }
-        end
 
         def default_capability_probe(agent:, invocation:, project_root:)
           profile = Hive::AgentProfiles.lookup(agent)

--- a/lib/hive/plan_review/automation.rb
+++ b/lib/hive/plan_review/automation.rb
@@ -1,5 +1,6 @@
 require "hive/config"
 require "hive/lock"
+require "hive/plan_review/marker_sync"
 require "hive/plan_review/orchestrator"
 require "hive/plan_review/projection"
 require "hive/plan_review/store"
@@ -34,6 +35,7 @@ module Hive
           else
             Orchestrator.run!(task:, cfg:, planner_identity:)
           end
+          MarkerSync.hold_until_cleared!(task:, projection:)
         end
         projection || raise(
           TransitionBlocked.new(

--- a/lib/hive/plan_review/marker_sync.rb
+++ b/lib/hive/plan_review/marker_sync.rb
@@ -1,0 +1,21 @@
+require "hive/markers"
+
+module Hive
+  module PlanReview
+    # The planner can only finish authoring the document; required critique is
+    # part of plan completion. Keep the plan marker non-terminal until the
+    # review projection grants execution, then let PlanApproval perform the
+    # guarded WAITING -> COMPLETE transition immediately before develop.
+    module MarkerSync
+      module_function
+
+      def hold_until_cleared!(task:, projection:)
+        return unless projection && !projection.record.execution_allowed?
+
+        Hive::Markers.set_if_current(
+          task.state_file, expected_name: :complete, name: :waiting
+        )
+      end
+    end
+  end
+end

--- a/lib/hive/plan_review/orchestrator.rb
+++ b/lib/hive/plan_review/orchestrator.rb
@@ -4,6 +4,7 @@ require "json"
 require "time"
 require "tmpdir"
 require "hive/atomic_file"
+require "hive/canonical_json"
 require "hive/lock"
 require "hive/plan_review/approval_policy"
 require "hive/plan_review/adapters/base"
@@ -26,6 +27,8 @@ module Hive
       SUCCESS_OUTCOMES = Adapters::Base::SUCCESS_OUTCOMES
       TERMINAL_OUTCOMES = (Adapters::Base::OUTCOMES - TRANSIENT_OUTCOMES).freeze
       MAX_VERIFICATION_REVISION_ROUNDS = 3
+      CAPABILITY_STABLE_PROBE_LIMIT = 3
+      CAPABILITY_RETRY_COOLDOWN_SEC = 5 * 60
 
       class << self
         def run!(task:, cfg:, planner_identity:, **options)
@@ -123,6 +126,10 @@ module Hive
         return terminal(record, state: "skipped", outcome: "skipped") if
           record.effective_level == "skip"
 
+        record, capability_pending = refresh_capability_probes(record)
+        return Projection.new(record) if capability_pending
+        record = refresh_adversarial_identity_contract(record)
+
         %w[primary adversarial].each do |role|
           record, pending = ensure_leg(record, role, original_plan_bytes)
           return Projection.new(record) if pending
@@ -134,7 +141,8 @@ module Hive
           adapter_outcomes: outcomes
         )
         if record.effective_level == "mandatory" && initial_coverage.blocked?
-          return handle_capability_block(record) if capability_only_block?(outcomes)
+          capability_recovery = handle_capability_block(record)
+          return capability_recovery if capability_recovery
 
           return terminal(
             record, state: "blocked", outcome: "blocked",
@@ -335,69 +343,178 @@ module Hive
       # the stale `blocked` replaying forever and the task parked on "waive
       # named coverage or restore required reviewer capability" — with no way
       # to act on the second half of that sentence.
-      # The test is whether any leg produced a *verdict*, not whether every leg
-      # failed the same way. A run can mix an `unsupported` primary with an
-      # adversarial refused for `same_model_family`: different causes, both
-      # about our configuration rather than the plan, and both fixed by
-      # changing routes. Caching either as "blocked" is caching an answer we
-      # never got.
-      CAPABILITY_STABLE_PROBE_LIMIT = 3
+      # A successful leg is durable evidence and must not be thrown away just
+      # because a different required reviewer was unavailable. Recover every
+      # unsupported initial leg independently, then evaluate any remaining
+      # non-capability blockers after that reviewer returns.
+      def unsupported_initial_routes(record)
+        %w[primary adversarial].filter_map do |role|
+          route = latest_route(record, role)
+          route if route && route["outcome"] == "unsupported"
+        end
+      end
 
-      def capability_only_block?(outcomes)
-        observed = Array(outcomes).map(&:to_s)
-        observed.any? && observed.all? { |outcome| outcome == "unsupported" }
+      # Grok reports the served alias `grok-4.6-build`. Reviews completed
+      # before Hive learned that exact alias were retained as successful
+      # attempts but denied adversarial coverage because their family was
+      # unknown. Re-run one such leg under the current identity contract so
+      # the immutable attempt evidence, not a projection rewrite, earns the
+      # missing coverage. The versioned reset makes this a one-time migration.
+      def refresh_adversarial_identity_contract(record)
+        route = RouteResolver.recoverable_identity_route(
+          routes: record["routes"], planner_identity: planner_identity(record)
+        )
+        return record unless route
+
+        reset = Hive::PlanReview.recovery_reset_route(
+          route,
+          "identity_contract_recovery" => true,
+          "identity_contract_version" => RouteResolver::IDENTITY_CONTRACT_VERSION,
+          "diagnostic" => "retry reviewer under the current served-model identity contract"
+        )
+        publish_transition(
+          record, state: "reviewing",
+          required_action: "retry adversarial review under the current identity contract",
+          routes: record["routes"] + [ reset ]
+        )
       end
 
       # Capability retries are cheap probes, not repeated reviewer launches.
-      # Retry while the observation changes; after three identical failed
-      # probes, park once with a durable diagnosis instead of appending route
-      # rows forever. Timeout/transport exhaustion is deliberately excluded:
-      # those are expensive attempts and must not masquerade as capability.
+      # Probe unchanged failures immediately three times, then continue on a
+      # five-minute schedule. This bounds record growth and daemon churn while
+      # retaining automatic recovery when a binary, skill, or route appears.
+      # Timeout/transport exhaustion is deliberately excluded: those are
+      # expensive attempts and must not masquerade as capability.
       def handle_capability_block(record)
-        routes = record["routes"]
-        latest = %w[primary adversarial].filter_map { |role| latest_route(record, role) }
-        fingerprint = capability_probe_fingerprint(latest)
-        previous = routes.reverse.find { |route| route["capability_probe_fingerprint"] }
+        unsupported_routes = unsupported_initial_routes(record)
+        return if unsupported_routes.empty?
+
+        probes = unsupported_routes.map do |route|
+          previous = latest_capability_probe(record, route.fetch("role"))
+          capability_probe_route(route, previous:)
+        end
+        Projection.new(publish_capability_wait(
+          record, routes: record["routes"] + probes, probes:
+        ))
+      end
+
+      # Re-probe only launcher/skill availability while a capability reset is
+      # current. Repeated unchanged misses replace that one rolling route row;
+      # they do not copy plan.md or create immutable attempt directories. Once
+      # every missing capability is present, the normal attempt path resumes.
+      def refresh_capability_probes(record)
+        routes = record["routes"].dup
+        entries = %w[primary adversarial].filter_map do |role|
+          index = routes.rindex { |route| route["role"] == role }
+          route = routes.fetch(index) if index
+          [ role, index, route ] if route && route["capability_probe_fingerprint"]
+        end
+        return [ record, false ] if entries.empty?
+
+        due = entries.reject { |_role, _index, route| retry_in_future?(route["retry_at"]) }
+        return [ record, true ] if due.empty?
+
+        due.each do |role, index, previous|
+          available, observation = probe_reviewer_capability(record, role)
+          routes[index] = if available
+            Hive::PlanReview.recovery_reset_route(
+              observation, "diagnostic" => "reviewer capability restored"
+            )
+          else
+            capability_probe_route(observation, previous:)
+          end
+        end
+
+        probes = %w[primary adversarial].filter_map do |role|
+          route = routes.reverse.find { |entry| entry["role"] == role }
+          route if route && route["capability_probe_fingerprint"]
+        end
+        if probes.any?
+          return [ publish_capability_wait(record, routes:, probes:), true ]
+        end
+
+        resumed = publish_transition(
+          record, state: "reviewing",
+          required_action: "run restored reviewer capability",
+          routes:, retry_at: nil
+        )
+        [ resumed, false ]
+      end
+
+      def probe_reviewer_capability(record, role)
+        resolution = @route_resolver.call(role:, planner_identity: planner_identity(record))
+        unless resolution.resolved?
+          return [ false, stringify(resolution.receipt).merge(
+            "outcome" => "unsupported",
+            "diagnostic" => "review route is unavailable"
+          ) ]
+        end
+
+        capability = if @adapter.respond_to?(:probe_capability)
+          stringify(@adapter.probe_capability(
+            kind: role, reviewer: resolution.candidate,
+            project_root: @task.project_root
+          ))
+        else
+          { "status" => "present" }
+        end
+        status = capability["status"].to_s
+        status = "unsupported" if status.empty?
+        observation = stringify(resolution.receipt).merge(
+          "capability_result" => status
+        )
+        return [ true, observation ] if status == "present"
+
+        [ false, observation.merge(
+          "outcome" => "unsupported",
+          "diagnostic" => capability["diagnostic"] || "reviewer capability is unavailable"
+        ) ]
+      end
+
+      def capability_probe_route(observation, previous:)
+        fingerprint = capability_probe_fingerprint(observation)
         count = if previous && previous["capability_probe_fingerprint"] == fingerprint
           Integer(previous["capability_probe_count"]) + 1
         else
           1
         end
-        if count >= CAPABILITY_STABLE_PROBE_LIMIT
-          diagnostics = latest.filter_map { |route| route["diagnostic"] }.uniq
-          return terminal(
-            record, state: "blocked", outcome: "blocked",
-            blockers: [ {
-              "owner" => "operator", "reason" => "reviewer_unlaunchable",
-              "fingerprint" => fingerprint,
-              "diagnostic" => diagnostics.join("; ")
-            } ],
-            required_action: "restore reviewer capability, then request a fresh review"
-          )
+        retry_at = if count >= CAPABILITY_STABLE_PROBE_LIMIT
+          (@clock.call + CAPABILITY_RETRY_COOLDOWN_SEC).utc.iso8601(6)
         end
-
-        reset = latest.map do |route|
-          Hive::PlanReview.recovery_reset_route(
-            route,
-            "capability_probe_fingerprint" => fingerprint,
-            "capability_probe_count" => count
-          )
-        end
-        Projection.new(publish_transition(
-          record, state: "reviewing",
-          required_action: "restore reviewer capability; the review retries on its own",
-          routes: routes + reset
-        ))
+        attributes = {
+          "capability_probe_fingerprint" => fingerprint,
+          "capability_probe_count" => count,
+          "retry_at" => retry_at,
+          "diagnostic" => observation["diagnostic"]
+        }
+        attributes["attempts"] = observation["attempts"] if observation["attempts"]
+        Hive::PlanReview.recovery_reset_route(observation, attributes)
       end
 
-      def capability_probe_fingerprint(routes)
-        rows = routes.map do |route|
-          route.slice(
-            "role", "requested", "actual", "capability_result", "outcome",
-            "independence_reason", "diagnostic", "attempts"
-          )
+      def publish_capability_wait(record, routes:, probes:)
+        immediate = probes.any? { |route| route["retry_at"].nil? }
+        retry_at = immediate ? nil : probes.filter_map { |route| route["retry_at"] }.min
+        publish_transition(
+          record, state: retry_at ? "retry_scheduled" : "reviewing",
+          required_action: retry_at ?
+            "restore reviewer capability; the review retries after #{retry_at}" :
+            "restore reviewer capability; the review retries on its own",
+          routes:, retry_at:
+        )
+      end
+
+      def latest_capability_probe(record, role)
+        record["routes"].reverse.find do |route|
+          route["role"] == role && route["capability_probe_fingerprint"]
         end
-        Digest::SHA256.hexdigest(JSON.generate(rows))
+      end
+
+      def capability_probe_fingerprint(route)
+        row = route.slice(
+          "role", "requested", "actual", "capability_result", "outcome",
+          "independence_reason", "diagnostic", "attempts"
+        )
+        Hive::CanonicalJSON.digest(row)
       end
 
       # A verifier can return a valid success result with no contrary finding

--- a/lib/hive/plan_review/route_resolver.rb
+++ b/lib/hive/plan_review/route_resolver.rb
@@ -8,6 +8,7 @@ module Hive
   module PlanReview
     module RouteResolver
       CANDIDATE_KEYS = %w[provider model family effort route].freeze
+      IDENTITY_CONTRACT_VERSION = 1
       ROLE_IDENTITIES = {
         "primary" => "plan_review",
         "adversarial" => "plan_review_adversarial",
@@ -178,6 +179,56 @@ module Hive
 
         [ true, "different_model_family" ]
       end
+
+      # A provider may report a served model alias rather than the configured
+      # model name. Promote the configured family only when provider support
+      # explicitly attests that exact requested/served pair. This keeps the
+      # alias rule in one place for new calls and legacy receipt recovery.
+      def attest_observed_identity(requested:, actual:)
+        requested = normalize_hash(requested)
+        actual = normalize_observed_identity(actual)
+        return actual if actual["family"]
+
+        provider = actual["provider"].to_s
+        requested_model = requested["model"].to_s
+        served_model = actual["model"].to_s
+        family = requested["family"].to_s
+        return actual if provider.empty? || requested_model.empty? || served_model.empty? || family.empty?
+        return actual unless provider == requested["provider"].to_s
+
+        support = Hive::AgentSupport.for(provider)
+        equivalent = served_model == requested_model ||
+                     support&.respond_to?(:model_identity_equivalent?) &&
+                       support.model_identity_equivalent?(
+                         requested_model:, served_model:, family:
+                       )
+        equivalent ? actual.merge("family" => redact(family)).freeze : actual
+      end
+
+      def recoverable_identity_route(routes:, planner_identity:)
+        routes = Array(routes)
+        return if routes.any? { |route| current_identity_contract?(route) }
+
+        route = routes.reverse.find { |entry| entry["role"] == "adversarial" }
+        return unless route && %w[success partial_coverage].include?(route["outcome"])
+        return if route["independence_verified"] == true
+
+        actual = attest_observed_identity(
+          requested: route["requested"], actual: route["actual"]
+        )
+        verified, = independence(planner_identity, actual)
+        route if verified
+      rescue Hive::ConfigError
+        nil
+      end
+
+      def current_identity_contract?(route)
+        route["identity_contract_recovery"] == true &&
+          Integer(route["identity_contract_version"]) >= IDENTITY_CONTRACT_VERSION
+      rescue ArgumentError, TypeError
+        false
+      end
+      private_class_method :current_identity_contract?
 
       def normalize_candidate(value, require_family: true)
         candidate = normalize_hash(value)

--- a/lib/hive/stages/plan.rb
+++ b/lib/hive/stages/plan.rb
@@ -1,5 +1,6 @@
 require "hive/stages/base"
 require "hive/claude_launcher"
+require "hive/plan_review/marker_sync"
 require "hive/plan_review/orchestrator"
 require "hive/plan_frontmatter"
 require "hive/dependencies"
@@ -33,6 +34,8 @@ module Hive
         marker = Hive::Markers.current(task.state_file)
         adopt_plan_dependency!(task, marker)
         review = start_plan_review(task, cfg, profile, result, marker)
+        Hive::PlanReview::MarkerSync.hold_until_cleared!(task:, projection: review)
+        marker = Hive::Markers.current(task.state_file)
         {
           commit: action_for(marker.name), status: marker.name,
           plan_review: review&.summary

--- a/lib/hive/task_action.rb
+++ b/lib/hive/task_action.rb
@@ -14,6 +14,7 @@ require "hive/draft_pr_receipt"
 require "hive/terminal_outcome"
 require "hive/plan_review/projection"
 require "hive/plan_review/planner_revision"
+require "hive/plan_review/route_resolver"
 require "hive/plan_review/transition_guard"
 require "hive/patrol_fix/projection"
 require "hive/plan_review/approval_policy"
@@ -724,6 +725,10 @@ module Hive
       when "blocked"
         if stale_planner_revision_contract?
           ACTIONS.fetch(:plan_reviewing)
+        elsif recoverable_capability_review?
+          ACTIONS.fetch(:plan_reviewing)
+        elsif recoverable_adversarial_identity_review?
+          ACTIONS.fetch(:plan_reviewing)
         elsif unsupported_review?
           ACTIONS.fetch(:plan_review_unsupported)
         else
@@ -963,6 +968,33 @@ module Hive
         Array(plan_review["routes"]).any? do |route|
           route["capability_result"] == "unsupported"
         end
+    end
+
+    # Older Hive builds terminalised missing reviewer binaries and emitted no
+    # command. Re-enter those exact persisted initial legs once so the current
+    # orchestrator can preserve successful coverage and move the missing leg
+    # onto its paced automatic retry schedule. Configuration-only blocks with
+    # no attempted route remain operator-owned.
+    def recoverable_capability_review?
+      %w[primary adversarial].any? do |role|
+        route = Array(plan_review["routes"]).reverse.find do |entry|
+          entry["role"] == role
+        end
+        route && route["outcome"] == "unsupported"
+      end
+    end
+
+    # A successful legacy Grok attempt can still carry the pre-alias-fix
+    # `reviewer_family_unknown` receipt. Re-enter only when current provider
+    # support can now attest the exact requested/served identity pair, and only
+    # until the orchestrator has recorded its versioned one-time retry.
+    def recoverable_adversarial_identity_review?
+      routes = Array(plan_review["routes"])
+      planner = routes.find { |entry| entry["role"] == "planner" }
+      planner_identity = planner&.fetch("actual", nil) || planner&.fetch("requested", nil)
+      !Hive::PlanReview::RouteResolver.recoverable_identity_route(
+        routes:, planner_identity:
+      ).nil?
     end
 
     def legacy_execute_findings?

--- a/test/integration/run_plan_test.rb
+++ b/test/integration/run_plan_test.rb
@@ -61,6 +61,33 @@ class RunPlanTest < Minitest::Test
     end
   end
 
+  class UnavailableAdversarialAdapter
+    attr_reader :calls
+
+    def initialize
+      @calls = []
+    end
+
+    def call(request)
+      @calls << request
+      return Hive::PlanReview::Adapters::Base::Result.new(outcome: "unsupported") if
+        request.kind == "adversarial"
+
+      Hive::PlanReview::Adapters::Base::Result.new(
+        outcome: "success",
+        coverage: request.required_coverage.map do |name|
+          { "name" => name, "required" => true, "status" => "completed" }
+        end,
+        route_receipt: {
+          "role" => request.kind, "requested" => request.reviewer,
+          "actual" => request.reviewer, "capability_result" => "present",
+          "independence_verified" => true,
+          "independence_reason" => "different_model_family"
+        }
+      )
+    end
+  end
+
   def setup
     @prev_bin = ENV["HIVE_CLAUDE_BIN"]
     ENV["HIVE_CLAUDE_BIN"] = FAKE_BIN
@@ -202,6 +229,53 @@ class RunPlanTest < Minitest::Test
           assert_equal 1, revision.calls.length
           assert_equal candidate, File.read(plan_md)
         end
+      end
+    end
+  end
+
+  def test_required_review_keeps_an_agent_complete_plan_at_waiting_until_clearance
+    with_tmp_global_config do
+      with_tmp_git_repo do |dir|
+        capture_io do
+          Hive::Commands::Init.new(dir).call
+          set_project_claude_mode(dir, "headless")
+          Hive::Commands::New.new(File.basename(dir), "required review marker").call
+        end
+        inbox = Dir[File.join(dir, ".hive-state", "stages", "1-inbox", "*")].first
+        slug = File.basename(inbox)
+        plan_dir = File.join(dir, ".hive-state", "stages", "3-plan", slug)
+        FileUtils.mkdir_p(File.dirname(plan_dir))
+        FileUtils.mv(inbox, plan_dir)
+        File.write(File.join(plan_dir, "brainstorm.md"), "## Requirements\n- x\n<!-- COMPLETE -->\n")
+
+        plan_md = File.join(plan_dir, "plan.md")
+        ENV["HIVE_FAKE_CLAUDE_WRITE_FILE"] = plan_md
+        ENV["HIVE_FAKE_CLAUDE_WRITE_CONTENT"] = mandatory_review_plan
+        adapter = UnavailableAdversarialAdapter.new
+        route_resolver = method(:review_route)
+        replacement = lambda do |task:, cfg:, planner_identity:, **|
+          Hive::PlanReview::Orchestrator.new(
+            task:, cfg:, planner_identity:, adapter:,
+            route_resolver:,
+            clock: -> { Time.utc(2026, 8, 12, 12) }
+          ).advance!
+        end
+
+        with_replaced_singleton_method(
+          Hive::PlanReview::Orchestrator, :run!, replacement
+        ) do
+          capture_io { Hive::Commands::Run.new(plan_dir).call }
+        end
+
+        assert_equal :waiting, Hive::Markers.current(plan_md).name
+        review = JSON.parse(File.read(File.join(plan_dir, "plan-review", "current.json")))
+        assert_equal "mandatory", review.fetch("effective_level")
+        assert_equal "reviewing", review.fetch("state")
+        refute review.fetch("execution_allowed")
+        assert_equal %w[primary adversarial], adapter.calls.map(&:kind)
+        events = File.readlines(File.join(plan_dir, "events.jsonl"), chomp: true)
+          .map { |line| JSON.parse(line) }
+        assert_includes events.map { |event| event.fetch("event_type") }, "round_waiting"
       end
     end
   end

--- a/test/unit/plan_review/automation_test.rb
+++ b/test/unit/plan_review/automation_test.rb
@@ -7,13 +7,16 @@ class PlanReviewAutomationTest < Minitest::Test
   Workflow = Struct.new(:id, keyword_init: true)
   Task = Struct.new(
     :folder, :project_root, :hive_state_path, :slug, :id, :workflow,
-    :meta_yml_path, :stage_index, :stage_name,
+    :meta_yml_path, :stage_index, :stage_name, :state_file,
     keyword_init: true
   )
 
+  ReviewRecord = Struct.new(:execution_allowed?)
+  ReviewProjection = Struct.new(:record)
+
   def test_runs_the_orchestrator_under_the_task_lock_without_operator_authority
     with_task do |task|
-      expected = Object.new
+      expected = ReviewProjection.new(ReviewRecord.new(true))
       observed = nil
       orchestrator = lambda do |task:, cfg:, planner_identity:|
         observed = { task:, cfg:, planner_identity: }
@@ -45,7 +48,7 @@ class PlanReviewAutomationTest < Minitest::Test
 
   def test_falls_back_to_the_real_orchestrator_when_none_is_injected
     with_task do |task|
-      expected = Object.new
+      expected = ReviewProjection.new(ReviewRecord.new(true))
       observed = nil
       replacement = lambda do |task:, cfg:, planner_identity:|
         observed = { task:, cfg:, planner_identity: }
@@ -64,6 +67,35 @@ class PlanReviewAutomationTest < Minitest::Test
     end
   end
 
+  def test_holds_a_complete_plan_at_waiting_until_required_review_clears
+    with_task do |task|
+      File.write(task.state_file, "# Plan\n<!-- COMPLETE -->\n")
+      projection = ReviewProjection.new(ReviewRecord.new(false))
+
+      result = Hive::PlanReview::Automation.run!(
+        task:, config: Hive::Config::DEFAULTS,
+        orchestrator: ->(**) { projection }
+      )
+
+      assert_same projection, result
+      assert_equal :waiting, Hive::Markers.current(task.state_file).name
+    end
+  end
+
+  def test_leaves_a_complete_plan_terminal_after_review_clearance
+    with_task do |task|
+      File.write(task.state_file, "# Plan\n<!-- COMPLETE -->\n")
+      projection = ReviewProjection.new(ReviewRecord.new(true))
+
+      Hive::PlanReview::Automation.run!(
+        task:, config: Hive::Config::DEFAULTS,
+        orchestrator: ->(**) { projection }
+      )
+
+      assert_equal :complete, Hive::Markers.current(task.state_file).name
+    end
+  end
+
   private
 
   def with_task(workflow: "coding")
@@ -78,7 +110,7 @@ class PlanReviewAutomationTest < Minitest::Test
         folder:, project_root: root, hive_state_path: File.join(root, ".hive-state"),
         slug: "automation-260812-abcd", id: 7,
         workflow: Workflow.new(id: workflow), meta_yml_path: meta,
-        stage_index: 3, stage_name: "plan"
+        stage_index: 3, stage_name: "plan", state_file: File.join(folder, "plan.md")
       )
       yield task
     end

--- a/test/unit/plan_review/ce_doc_review_adapter_test.rb
+++ b/test/unit/plan_review/ce_doc_review_adapter_test.rb
@@ -74,6 +74,25 @@ class PlanReviewCeDocReviewAdapterTest < Minitest::Test
     assert_includes result.fetch("diagnostic"), "/ce-doc-review is available"
   end
 
+  def test_public_capability_probe_does_not_invoke_the_reviewer
+    runner_calls = 0
+    adapter = Hive::PlanReview::Adapters::CeDocReview.new(
+      runner: ->(**) { runner_calls += 1 },
+      capability_probe: ->(**) do
+        { "status" => "unsupported", "diagnostic" => "missing skill" }
+      end
+    )
+
+    result = adapter.probe_capability(
+      kind: "primary", reviewer: { "provider" => "codex" },
+      project_root: Dir.pwd
+    )
+
+    assert_equal "unsupported", result.fetch("status")
+    assert_equal "missing skill", result.fetch("diagnostic")
+    assert_equal 0, runner_calls
+  end
+
   def test_success_uses_disposable_plan_and_validates_machine_output
     with_request do |request, plan_path|
       original = File.binread(plan_path)

--- a/test/unit/plan_review/orchestrator_test.rb
+++ b/test/unit/plan_review/orchestrator_test.rb
@@ -33,16 +33,25 @@ class PlanReviewOrchestratorTest < Minitest::Test
   )
 
   class FakeAdapter
-    attr_reader :calls
+    attr_reader :calls, :capability_calls
 
-    def initialize(&response)
+    def initialize(capability: nil, &response)
       @response = response
+      @capability = capability
       @calls = []
+      @capability_calls = []
     end
 
     def call(request)
       @calls << request
       @response.call(request)
+    end
+
+    def probe_capability(**arguments)
+      @capability_calls << arguments
+      return { "status" => "present" } unless @capability
+
+      @capability.call(**arguments)
     end
   end
 
@@ -367,12 +376,115 @@ class PlanReviewOrchestratorTest < Minitest::Test
     end
   end
 
-  # Mandatory capability failures get cheap re-probes, but an unchanged probe
-  # eventually parks instead of growing current.json forever.
-  def test_mandatory_total_unavailability_parks_after_three_stable_probes
+  def test_mandatory_mixed_success_and_unavailability_retries_only_the_missing_leg
     with_task(mandatory_plan) do |task, cfg|
-      adapter = FakeAdapter.new do |_request|
-        Hive::PlanReview::Adapters::Base::Result.new(outcome: "unsupported")
+      adversarial_available = false
+      resolver = lambda do |role:, **|
+        if role == "adversarial" && !adversarial_available
+          requested = route_identity("grok", "grok-4.6", "grok", "native_adversarial")
+          Hive::PlanReview::RouteResolver::Resolution.new(
+            status: "unsupported", candidate: nil,
+            receipt: {
+              "role" => role, "requested" => requested, "actual" => {},
+              "capability_result" => "unsupported", "independence_verified" => false,
+              "independence_reason" => "reviewer_family_unavailable",
+              "attempts" => [
+                { "candidate" => requested, "status" => "unsupported" }
+              ]
+            }
+          )
+        else
+          resolve_route(role:)
+        end
+      end
+      adapter = success_adapter
+
+      pending = orchestrator(task, cfg, adapter:, route_resolver: resolver).advance!.record
+
+      assert_equal "reviewing", pending.state
+      assert_equal %w[primary], adapter.calls.map(&:kind)
+      primary_routes = pending["routes"].select { |route| route["role"] == "primary" }
+      adversarial_routes = pending["routes"].select { |route| route["role"] == "adversarial" }
+      assert_equal 1, primary_routes.length
+      assert_equal "success", primary_routes.last.fetch("outcome")
+      assert_equal 2, adversarial_routes.length
+      assert_equal true, adversarial_routes.last.fetch("recovery_reset")
+
+      adversarial_available = true
+      cleared = orchestrator(
+        task, cfg, adapter:, route_resolver: resolver
+      ).advance!.record
+
+      assert_equal "cleared", cleared.state
+      assert_equal 1, adapter.calls.count { |request| request.kind == "primary" }
+      assert_equal 1, adapter.calls.count { |request| request.kind == "adversarial" }
+      assert_equal 1, adapter.calls.count { |request| request.kind == "verification" }
+    end
+  end
+
+  def test_legacy_grok_success_retries_once_under_the_current_identity_contract
+    with_task(mandatory_plan) do |task, cfg|
+      adversarial_calls = 0
+      adapter = FakeAdapter.new do |request|
+        unless request.kind == "adversarial" && (adversarial_calls += 1) == 1
+          next successful_result(request)
+        end
+
+        successful = successful_result(request)
+        Hive::PlanReview::Adapters::Base::Result.new(
+          outcome: successful.outcome,
+          findings: successful.findings,
+          coverage: successful.coverage,
+          residual_evidence: successful.residual_evidence,
+          route_receipt: {
+            "role" => "adversarial", "requested" => request.reviewer,
+            "actual" => {
+              "provider" => "grok", "model" => "grok-4.6-build",
+              "effort" => "high", "route" => "native_grok_build"
+            },
+            "capability_result" => "present", "independence_verified" => false,
+            "independence_reason" => "reviewer_family_unknown"
+          }
+        )
+      end
+
+      blocked = orchestrator(task, cfg, adapter:).advance!.record
+
+      assert_equal "blocked", blocked.state
+      assert_equal [ "coverage_failed" ], blocked["blockers"].map { |row| row.fetch("reason") }
+      assert_equal 1, adapter.calls.count { |request| request.kind == "primary" }
+      assert_equal 1, adapter.calls.count { |request| request.kind == "adversarial" }
+
+      cleared = orchestrator(task, cfg, adapter:).advance!.record
+
+      assert_equal "cleared", cleared.state
+      assert_equal 1, adapter.calls.count { |request| request.kind == "primary" }
+      assert_equal 2, adapter.calls.count { |request| request.kind == "adversarial" }
+      reset = cleared["routes"].find { |route| route["identity_contract_recovery"] }
+      assert_equal true, reset.fetch("recovery_reset")
+      assert_equal Hive::PlanReview::RouteResolver::IDENTITY_CONTRACT_VERSION,
+                   reset.fetch("identity_contract_version")
+    end
+  end
+
+  # Mandatory capability failures get cheap re-probes, then move to a paced
+  # retry instead of growing current.json on every daemon tick or parking
+  # forever after the provider becomes available.
+  def test_mandatory_total_unavailability_schedules_after_three_stable_probes
+    with_task(mandatory_plan) do |task, cfg|
+      available = false
+      capability = lambda do |**|
+        {
+          "status" => available ? "present" : "unsupported",
+          "diagnostic" => available ? nil : "missing reviewer"
+        }
+      end
+      adapter = FakeAdapter.new(capability:) do |request|
+        available ? successful_result(request) :
+          Hive::PlanReview::Adapters::Base::Result.new(
+            outcome: "unsupported", diagnostic: "missing reviewer",
+            route_receipt: { "capability_result" => "unsupported" }
+          )
       end
       first = orchestrator(task, cfg, adapter:).advance!.record
       second = orchestrator(task, cfg, adapter:).advance!.record
@@ -380,15 +492,53 @@ class PlanReviewOrchestratorTest < Minitest::Test
 
       assert_equal "reviewing", first.state
       assert_equal "reviewing", second.state
-      assert_equal "blocked", record.state
+      assert_equal "retry_scheduled", record.state
       refute record.execution_allowed?
-      assert_equal "reviewer_unlaunchable", record["blockers"].first.fetch("reason")
+      assert_empty record["blockers"]
       assert_includes record["required_action"], "restore reviewer capability"
-      assert_equal 6, adapter.calls.length
+      assert_equal "2026-08-12T12:05:00.000000Z", record["retry_at"]
+      assert_equal 2, adapter.calls.length
       counts = record["routes"].filter_map do |route|
         route["capability_probe_count"] if route["role"] == "primary"
       end
-      assert_equal [ 1, 2 ], counts
+      assert_equal [ 3 ], counts
+      route_count = record["routes"].length
+      attempt_count = record["attempt_ids"].length
+      attempt_directories = Dir[
+        File.join(task.folder, "plan-review", "reviews", "*", "attempts", "*")
+      ].length
+
+      available = true
+      held = orchestrator(
+        task, cfg, adapter:, clock: -> { Time.utc(2026, 8, 12, 12, 4, 59) }
+      ).advance!.record
+      assert_equal "retry_scheduled", held.state
+      assert_equal 2, adapter.calls.length
+
+      available = false
+      10.times do
+        due = Time.iso8601(record["retry_at"])
+        record = orchestrator(task, cfg, adapter:, clock: -> { due }).advance!.record
+        assert_equal "retry_scheduled", record.state
+        assert_equal route_count, record["routes"].length
+        assert_equal attempt_count, record["attempt_ids"].length
+        assert_equal attempt_directories, Dir[
+          File.join(task.folder, "plan-review", "reviews", "*", "attempts", "*")
+        ].length
+      end
+      primary_probe = record["routes"].find do |route|
+        route["role"] == "primary" && route["capability_probe_count"]
+      end
+      assert_equal 13, primary_probe.fetch("capability_probe_count")
+      assert_equal 2, adapter.calls.length
+
+      available = true
+      due = Time.iso8601(record["retry_at"])
+      cleared = orchestrator(
+        task, cfg, adapter:, clock: -> { due }
+      ).advance!.record
+      assert_equal "cleared", cleared.state
+      assert_equal 5, adapter.calls.length
     end
   end
 

--- a/test/unit/plan_review/route_resolver_test.rb
+++ b/test/unit/plan_review/route_resolver_test.rb
@@ -24,6 +24,24 @@ class PlanReviewRouteResolverTest < Minitest::Test
     assert resolution.receipt.fetch("independence_verified")
   end
 
+  def test_served_model_alias_attests_the_requested_family
+    requested = candidate("grok", "grok-4.6", "grok")
+    actual = {
+      "provider" => "grok", "model" => "grok-4.6-build",
+      "effort" => "high", "route" => "native_grok_build"
+    }
+
+    attested = Hive::PlanReview::RouteResolver.attest_observed_identity(
+      requested:, actual:
+    )
+    unknown = Hive::PlanReview::RouteResolver.attest_observed_identity(
+      requested:, actual: actual.merge("model" => "grok-4.7-build")
+    )
+
+    assert_equal "grok", attested.fetch("family")
+    refute unknown.key?("family")
+  end
+
   def test_fallback_counts_only_when_attested_family_differs
     same_family = Hive::PlanReview::RouteResolver.resolve(
       role: "adversarial",

--- a/test/unit/plan_review/route_resolver_test.rb
+++ b/test/unit/plan_review/route_resolver_test.rb
@@ -42,6 +42,26 @@ class PlanReviewRouteResolverTest < Minitest::Test
     refute unknown.key?("family")
   end
 
+  def test_recoverable_identity_route_fails_closed_for_malformed_legacy_evidence
+    invalid_contract = {
+      "identity_contract_recovery" => true,
+      "identity_contract_version" => "invalid"
+    }
+    assert_nil Hive::PlanReview::RouteResolver.recoverable_identity_route(
+      routes: [ invalid_contract ], planner_identity: { "family" => "openai" }
+    )
+
+    malformed_identity = {
+      "role" => "adversarial", "outcome" => "success",
+      "independence_verified" => false,
+      "requested" => candidate("grok", "grok-4.6", "grok"),
+      "actual" => { "provider" => 5, "model" => "grok-4.6-build" }
+    }
+    assert_nil Hive::PlanReview::RouteResolver.recoverable_identity_route(
+      routes: [ malformed_identity ], planner_identity: { "family" => "openai" }
+    )
+  end
+
   def test_fallback_counts_only_when_attested_family_differs
     same_family = Hive::PlanReview::RouteResolver.resolve(
       role: "adversarial",

--- a/test/unit/task_action_test.rb
+++ b/test/unit/task_action_test.rb
@@ -2082,6 +2082,23 @@ class TaskActionTest < Minitest::Test
     assert_equal "hive plan-review-run demo-260426-aaaa", unsupported.command
   end
 
+  def test_plan_review_unattempted_unsupported_route_remains_operator_owned
+    task = fake_task(stage_name: "plan", stage_index: 3)
+
+    unsupported = Hive::TaskAction.for(
+      task, marker(:waiting),
+      plan_review: {
+        "state" => "blocked", "required_action" => "inspect route",
+        "routes" => [
+          { "role" => "adversarial", "capability_result" => "unsupported" }
+        ]
+      }
+    )
+
+    assert_equal "plan_review_unsupported", unsupported.key
+    assert_nil unsupported.command
+  end
+
   def test_plan_review_recovers_a_legacy_success_with_a_now_attestable_grok_identity
     task = fake_task(stage_name: "plan", stage_index: 3)
     routes = [

--- a/test/unit/task_action_test.rb
+++ b/test/unit/task_action_test.rb
@@ -171,10 +171,16 @@ class TaskActionTest < Minitest::Test
       task, waiting,
       plan_review: {
         "state" => "blocked", "required_action" => "inspect route",
-        "routes" => [ { "capability_result" => "unsupported" } ]
+        "routes" => [
+          {
+            "role" => "adversarial", "capability_result" => "unsupported",
+            "outcome" => "unsupported"
+          }
+        ]
       }
     )
-    assert_equal "plan_review_unsupported", unsupported_route.key
+    assert_equal "plan_reviewing", unsupported_route.key
+    assert_equal "hive plan-review-run demo-260426-aaaa", unsupported_route.command
 
     blocked = Hive::TaskAction.for(
       task, waiting,
@@ -2055,7 +2061,7 @@ class TaskActionTest < Minitest::Test
     assert_nil malformed.command
   end
 
-  def test_plan_review_unsupported_route_capability_overrides_a_generic_required_action
+  def test_plan_review_unsupported_route_capability_recovers_a_legacy_block
     task = fake_task(stage_name: "plan", stage_index: 3)
 
     unsupported = Hive::TaskAction.for(
@@ -2063,12 +2069,66 @@ class TaskActionTest < Minitest::Test
       plan_review: {
         "state" => "blocked",
         "required_action" => "resolve verification blockers",
-        "routes" => [ { "capability_result" => "unsupported" } ]
+        "routes" => [
+          {
+            "role" => "adversarial", "capability_result" => "unsupported",
+            "outcome" => "unsupported"
+          }
+        ]
       }
     )
 
-    assert_equal "plan_review_unsupported", unsupported.key
-    assert_nil unsupported.command
+    assert_equal "plan_reviewing", unsupported.key
+    assert_equal "hive plan-review-run demo-260426-aaaa", unsupported.command
+  end
+
+  def test_plan_review_recovers_a_legacy_success_with_a_now_attestable_grok_identity
+    task = fake_task(stage_name: "plan", stage_index: 3)
+    routes = [
+      {
+        "role" => "planner",
+        "actual" => { "provider" => "codex", "family" => "openai" }
+      },
+      {
+        "role" => "adversarial", "outcome" => "unsupported",
+        "capability_result" => "unsupported"
+      },
+      {
+        "role" => "adversarial", "outcome" => "success",
+        "requested" => {
+          "provider" => "grok", "model" => "grok-4.6", "family" => "grok",
+          "effort" => "high", "route" => "native_grok_build"
+        },
+        "actual" => {
+          "provider" => "grok", "model" => "grok-4.6-build",
+          "effort" => "high", "route" => "native_grok_build"
+        },
+        "capability_result" => "present", "independence_verified" => false,
+        "independence_reason" => "reviewer_family_unknown"
+      }
+    ]
+    legacy = Hive::TaskAction.for(
+      task, marker(:waiting),
+      plan_review: {
+        "state" => "blocked",
+        "required_action" => "waive named coverage or restore required reviewer capability",
+        "routes" => routes
+      }
+    )
+    unknown_routes = Marshal.load(Marshal.dump(routes))
+    unknown_routes.last["actual"]["model"] = "grok-4.7-build"
+    unknown = Hive::TaskAction.for(
+      task, marker(:waiting),
+      plan_review: {
+        "state" => "blocked", "required_action" => "restore reviewer capability",
+        "routes" => unknown_routes
+      }
+    )
+
+    assert_equal "plan_reviewing", legacy.key
+    assert_equal "hive plan-review-run demo-260426-aaaa", legacy.command
+    assert_equal "plan_review_unsupported", unknown.key
+    assert_nil unknown.command
   end
 
   def test_stale_loaded_plan_review_blocks_execution_with_a_hive_owned_repair

--- a/wiki/log.d/20260828T124747Z-plan-review-capability-auto-recovery.md
+++ b/wiki/log.d/20260828T124747Z-plan-review-capability-auto-recovery.md
@@ -1,0 +1,28 @@
+---
+date: 2026-08-28
+tags: [plan-review, daemon, grok, markers, recovery]
+pages: [modules/plan_review, stages/plan]
+---
+
+# Required plan review now owns completion and capability recovery
+
+A planner-authored `COMPLETE` marker is now reconciled to `WAITING` whenever
+the required review projection still denies execution. The same reconciliation
+runs during daemon review automation, so legacy rows cannot keep advertising a
+complete plan while required coverage is missing. Guarded plan approval still
+owns the final `WAITING` to `COMPLETE` transition immediately before develop.
+
+Mandatory reviews now retain successful reviewer legs and reset only an
+unsupported primary or adversarial leg. After three identical immediate
+capability probes, Hive schedules another probe every five minutes instead of
+terminally parking the review. Identical misses update one rolling compact
+receipt per role without copying `plan.md`, appending routes, or creating full
+attempt artifacts; Hive creates the next immutable attempt only after the
+launcher and adapter capability checks report present. Legacy blocked
+projections with a persisted unsupported initial route are daemon-runnable
+under the new behavior, allowing a repaired Grok binary or reviewer skill to
+heal the existing review lineage without an operator-created review or plan
+generation. A successful Grok attempt recorded before Hive recognized the
+`grok-4.6-build` served-model alias also receives one versioned rerun under the
+current identity contract; the new attempt can earn adversarial coverage while
+the original immutable receipt remains intact.

--- a/wiki/modules/plan_review.md
+++ b/wiki/modules/plan_review.md
@@ -3,7 +3,7 @@ title: Plan review
 type: module
 source: lib/hive/plan_review.rb, lib/hive/plan_review/, lib/hive/commands/plan_review.rb, schemas/hive-plan-review.v1.json
 created: 2026-08-12
-updated: 2026-08-21
+updated: 2026-08-28
 tags: [plan, review, policy, findings, coverage, execution, audit]
 ---
 
@@ -107,10 +107,26 @@ exceptions are normalized into those durable attempt outcomes rather than
 escaping before retry evidence is written. Missing retry hints receive bounded
 exponential delay with deterministic jitter rather than a hot retry loop.
 An unsupported mandatory route is probed cheaply before another expensive
-review. An unchanged failed capability probe is recorded as operational
-evidence; after three identical observations the review parks as
-`reviewer_unlaunchable` instead of spawning forever. A changed probe resets the
-series and permits a new reviewer launch. Review identity includes adapter,
+review. Required legs recover independently: a successful primary receipt is
+retained when the adversarial route is unavailable, and only the unsupported
+leg is reset. Three unchanged capability observations may run immediately;
+after that the projection remains non-terminal as `retry_scheduled` on a
+five-minute cooldown. Repeated misses replace one rolling capability receipt
+per role; they do not copy the plan, create immutable attempt directories, or
+grow the route array. A normal immutable review attempt is materialized only
+after the launcher and adapter capability probes report present. Each due
+daemon pass probes again, so installing a skill, repairing a binary, or changing
+a route heals the same review lineage without an operator request or a new plan
+generation. Legacy `blocked` projections
+whose latest primary or adversarial route is explicitly `unsupported` classify
+as `plan_reviewing` once under the new code and enter the same paced recovery;
+configuration-only blocks without an attempted route remain operator-owned. A
+changed probe resets the stable-observation series and permits a new reviewer
+launch. A legacy successful adversarial receipt whose served-model alias is now
+explicitly attested by provider support receives one versioned rerun under the
+current identity contract. This repairs pre-contract `reviewer_family_unknown`
+coverage without rewriting old immutable attempt evidence or repeatedly
+launching a genuinely non-independent reviewer. Review identity includes adapter,
 reviewer, route configuration, and the effective `models.plan_review`,
 `models.plan_review_adversarial`, and `models.plan_review_verification`
 overrides. Unrelated stage-model changes plus attempt timeout and retry tuning
@@ -250,6 +266,15 @@ will not read.
 status and the daemon. It may initialize review, dispatch/retry reviewers,
 perform an already-authorized revision, verify, and advance an already-cleared
 plan. It has no API for approvals, answers, waivers, or downgrades.
+
+Plan authoring and plan completion are distinct. If the planner writes
+`<!-- COMPLETE -->` but the resulting required review projection does not yet
+authorize execution, both the stage runner and `plan-review-run` atomically
+replace that current marker with `<!-- WAITING -->`. A cleared projection is
+left alone; for an already-waiting row, daemon `PlanApproval` owns the guarded
+`WAITING` to `COMPLETE` transition immediately before develop dispatch. Thus a
+required review that has not completed cannot leave the plan artifact claiming
+terminal completion, including on legacy capability-recovery re-entry.
 
 Authority-bearing actions use:
 

--- a/wiki/stages/plan.md
+++ b/wiki/stages/plan.md
@@ -3,7 +3,7 @@ title: 3-plan stage
 type: stage
 source: lib/hive/stages/plan.rb, templates/plan_prompt.md.erb
 created: 2026-04-25
-updated: 2026-08-12
+updated: 2026-08-28
 tags: [stage, plan, llm-wiki, ce-plan, critique, dependencies]
 ---
 
@@ -79,11 +79,15 @@ write canonical `plan.md`.
 `plan-review/current.json` is the authority projection. Its terminal states are
 `skipped`, `cleared`, standard-only `degraded_cleared`, or `blocked`; open
 gated/manual findings, missing mandatory coverage, stale plan/policy identity,
-or corrupt artifacts keep execution disabled. `<!-- COMPLETE -->` remains a
-coarse workflow signal and may be flipped only after the same current review is
-verified. Use `hive plan-review-run TARGET` for non-authority progress and the
-freshness-bound `hive plan-review TARGET ACTION ...` surface for explicit
-approvals, answers, waivers, raises, retries, or downgrades.
+or corrupt artifacts keep execution disabled. When the planner writes
+`<!-- COMPLETE -->` but required critique has not cleared, the stage runner
+atomically rewrites that current marker to `<!-- WAITING -->`; direct
+`plan-review-run` recovery performs the same reconciliation for older rows.
+After clearance, daemon plan approval owns the guarded `WAITING` to `COMPLETE`
+transition immediately before develop dispatch. Use `hive plan-review-run
+TARGET` for non-authority progress and the freshness-bound `hive plan-review
+TARGET ACTION ...` surface for explicit approvals, answers, waivers, raises,
+retries, or downgrades.
 
 ## Marker → commit action mapping (`Stages::Plan.action_for`)
 


### PR DESCRIPTION
## Summary

Required plan review now stays visibly incomplete until review really clears and automatically resumes when a required reviewer becomes available. Legacy Grok capability and served-model identity failures can heal in their existing review lineage without an operator-created generation or rewritten evidence.

## Design decisions

- Preserve successful reviewer evidence and recover only missing required legs.
- Use compact rolling capability probes: three immediate observations, then a five-minute cooldown. Full immutable attempts begin only after capability returns.
- Re-run legacy Grok served-model identity evidence once under a versioned contract instead of modifying historical artifacts.
- Keep approval authority unchanged: automation may resume review, while guarded plan approval alone completes the marker immediately before development.

## Validation

- Exact coverage gate: 13,854 runs, 277,191 assertions, no failures or errors, 10 skips, and 100.00% line coverage (95,210/95,210).
- Project-wide RuboCop: 1,779 files inspected, no offenses; the two CI coverage follow-up tests are also lint-clean.
- Read-only task projection checks classify all eight parked rows as fresh `plan_reviewing` work under this branch.
