### PR TITLE
fix(config): default plan reviews to 30 minutes

### DIFF
--- a/templates/project_config.yml.erb
+++ b/templates/project_config.yml.erb
@@ -142,7 +142,7 @@ plan_review:
     - install.sh
   attempts:
     max_transient: 2
-    timeout_sec: 900
+    timeout_sec: 1800
 execute:
   agent: <%= development_agent %>
   # Provider routing is a separate explicit opt-in from `models:`. Accounts

--- a/test/integration/init_test.rb
+++ b/test/integration/init_test.rb
@@ -129,8 +129,10 @@ class InitTest < Minitest::Test
         assert File.directory?(File.join(dir, ".hive-state", "stages", "1-inbox"))
         assert File.exist?(File.join(dir, ".hive-state", "config.yml"))
         refute_includes File.read(File.join(dir, ".hive-state", "config.yml")), "default_workflow:"
-        assert_equal 60, Hive::Config.load(dir).dig("gh", "network_timeout_sec"),
+        config = Hive::Config.load(dir)
+        assert_equal 60, config.dig("gh", "network_timeout_sec"),
                      "fresh generated config, including its no-default gh section, must load immediately"
+        assert_equal 1800, config.dig("plan_review", "attempts", "timeout_sec")
 
         log = `git -C #{dir} log --format=%s hive/state`.strip
         assert_includes log, "hive: bootstrap"

--- a/test/unit/commands/init_test.rb
+++ b/test/unit/commands/init_test.rb
@@ -301,6 +301,12 @@ class HiveCommandsInitTest < Minitest::Test
                  "fresh-render and rebind paths must emit byte-identical default_workflow quoting"
   end
 
+  def test_fresh_render_uses_the_plan_review_timeout_default
+    rendered = YAML.safe_load(render_fresh_config("coding"), aliases: true)
+
+    assert_equal 1800, rendered.dig("plan_review", "attempts", "timeout_sec")
+  end
+
   def render_fresh_config(default_workflow, answers: project_config_answers)
     require "erb"
     template = File.read(File.expand_path("../../../templates/project_config.yml.erb", __dir__))

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -12,6 +12,7 @@ class ConfigTest < Minitest::Test
       assert_equal "skip", review.dig("coding", "minimum_level")
       assert_equal 5, review.dig("skip", "max_files")
       assert_equal 2, review.dig("attempts", "max_transient")
+      assert_equal 1800, review.dig("attempts", "timeout_sec")
       assert_equal "ce_doc_review", review.fetch("adapter")
       assert_equal "grok-4.6", review.dig("routes", "adversarial", "model")
       assert_equal "native_grok_build", review.dig("routes", "adversarial", "route")

--- a/wiki/log.d/20260828T174106Z-plan-review-timeout-default.md
+++ b/wiki/log.d/20260828T174106Z-plan-review-timeout-default.md
@@ -1,0 +1,12 @@
+---
+date: 2026-08-28
+tags: [plan-review, config, init, timeout]
+pages: [modules/config]
+---
+
+# New projects keep the 30-minute plan-review timeout
+
+The generated project configuration now matches Hive's built-in plan-review
+attempt timeout of 1,800 seconds. Existing projects that omit the setting keep
+inheriting the same default instead of diverging from newly initialized
+projects.

--- a/wiki/modules/config.md
+++ b/wiki/modules/config.md
@@ -204,7 +204,7 @@ plan_review:
     - Gemfile.lock
     - hive.gemspec
     - install.sh
-  attempts: {max_transient: 2, timeout_sec: 900}
+  attempts: {max_transient: 2, timeout_sec: 1800}
   coverage: {required: [whole_document, adversarial], optional: []}
   adapter: ce_doc_review
   reviewers:


### PR DESCRIPTION
New Hive projects now allow plan-review attempts to run for 30 minutes, matching the built-in runtime default. Previously, generated configuration forced 900 seconds and overrode the 1,800-second fallback, so legitimate long reviews could still be terminated early.

Validation covered the runtime default, template rendering, and real project initialization. The full suite passed with 13,860 runs and 277,217 assertions; RuboCop inspected 1,779 files with no offenses. The registered fleet was normalized separately, and all 20 projects now resolve the 1,800-second timeout.
