### PR TITLE
fix(recovery): keep operator retries immediately due

### DIFF
--- a/lib/hive/daemon/recovery_coordinator.rb
+++ b/lib/hive/daemon/recovery_coordinator.rb
@@ -319,7 +319,7 @@ module Hive
             state_home: @state_home
           )
           if existing
-            existing = unpark_deterministic_failure(existing, now:) if operator_request
+            existing = expedite_operator_recovery(existing, now:) if operator_request
             return receipt_for_request(
               existing,
               replay: existing.recovery&.fetch("phase", nil) == "terminal",
@@ -360,7 +360,8 @@ module Hive
           end
           attrs = Hive::Recovery.canonical_marker_attrs(current.attrs)
           marker_id = marker_identity(current)
-          next_eligible_at = assessment[:retry_at].utc.iso8601(6)
+          next_eligible_at =
+            (operator_request ? now : assessment[:retry_at].utc).iso8601(6)
           failure_evidence = failure_evidence_for(
             row, retry_count: retry_count, marker_attrs: attrs
           )
@@ -1668,23 +1669,27 @@ module Hive
         request
       end
 
-      # Evidence parking is inert under daemon replay. Only an explicit,
-      # freshness-bound operator retry releases the same guarded request back
-      # into its admitted -> cleared -> dispatched transition.
-      def unpark_deterministic_failure(request, now:)
+      # Automatic cooldown and evidence parking are inert under daemon replay.
+      # Only an explicit, freshness-bound operator retry makes the same guarded
+      # request immediately due and releases deterministic evidence parking.
+      def expedite_operator_recovery(request, now:)
         recovery = request.recovery || {}
         return request unless recovery["phase"] == "admitted"
-        return request unless recovery["blocked_reason"] == "deterministic_failure"
+        blocked_reason = recovery["blocked_reason"]
+        return request unless blocked_reason.nil? || blocked_reason == "deterministic_failure"
 
-        transitioned = @request_queue.update_recovery!(
-          request.request_id,
-          expected_phase: "admitted",
-          changes: {
-            "next_eligible_at" => now.utc.iso8601(6),
+        changes = { "next_eligible_at" => now.utc.iso8601(6) }
+        if blocked_reason == "deterministic_failure"
+          changes.merge!(
             "blocked_reason" => nil,
             "blocked_remediation" => nil,
             "owner" => "scheduler"
-          },
+          )
+        end
+        transitioned = @request_queue.update_recovery!(
+          request.request_id,
+          expected_phase: "admitted",
+          changes: changes,
           state_home: @state_home
         )
         refreshed = @request_queue.fetch(request.request_id, state_home: @state_home)

--- a/test/unit/daemon/recovery_coordinator_test.rb
+++ b/test/unit/daemon/recovery_coordinator_test.rb
@@ -335,7 +335,34 @@ class HiveDaemonRecoveryCoordinatorTest < Minitest::Test
         refute_equal "cooldown", receipt.status,
                      "#{requestor} must not be held by the automatic cooldown"
         refute_empty Q.pending(state_home: state_home), requestor
+        persisted = Q.pending(state_home: state_home).fetch(0)
+        assert_equal NOW.iso8601(6), persisted.recovery.fetch("next_eligible_at"),
+                     "#{requestor} retry must be immediately due after persistence"
+        assert_equal "queued", coordinator.receipt_for_request(persisted, now: NOW).status,
+                     "#{requestor} retry must remain due when the daemon reloads it"
       end
+    end
+  end
+
+  def test_an_operator_retry_makes_an_existing_admitted_recovery_due
+    with_fixture(mtime: NOW - 6) do |coordinator, row, state_home|
+      admitted = coordinator.request(
+        row: row, requestor: "healer", request_id: "automatic", now: NOW
+      )
+      Q.update_recovery!(
+        admitted.request_id, expected_phase: "admitted",
+        changes: { "next_eligible_at" => (NOW + 60).iso8601(6) },
+        state_home: state_home
+      )
+
+      retried = coordinator.request(
+        row: row, requestor: "action", request_id: "manual", now: NOW
+      )
+
+      assert_equal admitted.request_id, retried.request_id
+      assert_equal "queued", retried.status
+      persisted = Q.fetch(admitted.request_id, state_home: state_home)
+      assert_equal NOW.iso8601(6), persisted.recovery.fetch("next_eligible_at")
     end
   end
 

--- a/wiki/log.d/20260829T085500Z-operator-retry-durable-eligibility.md
+++ b/wiki/log.d/20260829T085500Z-operator-retry-durable-eligibility.md
@@ -1,0 +1,16 @@
+## 2026-08-29 — Operator retries remain due after durable admission
+
+**Action:** Fixed generation-guarded `workflow.retry` actions that returned a
+queued receipt but persisted the automatic marker-age deadline. The daemon
+would reload that admitted request on its next tick and put it back into
+cooldown, despite the explicit operator action.
+
+Operator adapters now persist their action time as `next_eligible_at`. When an
+automatic recovery request already owns the same marker generation, the
+operator action makes that admitted request immediately due while preserving
+its identity and single retry charge. Worktree safety, freshness, capacity,
+quarantine, and every post-clear retry gate remain unchanged.
+
+**Verification:** Recovery coordinator tests cover every operator adapter,
+durable receipt replay, and acceleration of an existing admitted automatic
+request.

--- a/wiki/modules/daemon.md
+++ b/wiki/modules/daemon.md
@@ -3,7 +3,7 @@ title: Hive::Daemon
 type: module
 source: lib/hive/daemon/
 created: 2026-05-06
-updated: 2026-08-27
+updated: 2026-08-29
 tags: [daemon, module, automation, dispatcher, operational-status, snapshots, terminal-outcomes, recovery, plan-review, bounded-storage]
 ---
 
@@ -549,8 +549,12 @@ advances a workflow stage directly:
    marker fails with `recovery_migration_required` and must be upgraded once
    with `hive migrate`; there is no mtime/reason identity fallback. Workflow
    retry argv are derived centrally, including `3-plan`, so clearing can never
-   become an alternate scheduling mechanism. Queue admission, capacity,
-   cooldown, and quarantine gates still apply. A post-clear launch failure
+   become an alternate scheduling mechanism. A freshness-bound operator
+   `workflow.retry` bypasses automatic pacing by persisting the action time as
+   `next_eligible_at`; if the same marker generation already has an admitted
+   automatic request, the action makes that request due instead of creating a
+   competing delivery. Safety, queue admission, capacity, and quarantine gates
+   still apply. A post-clear launch failure
    returns the durable request to scheduler ownership with the same shared
    cooldown instead of creating a per-tick loop.
 


### PR DESCRIPTION
## Summary

An explicit `workflow.retry` now stays immediately eligible after Hive persists and reloads its recovery request. Previously, the action returned `queued` but stored the automatic marker-age deadline, so the daemon put the task back into cooldown on its next tick.

The same action now accelerates an existing admitted automatic request for the marker generation instead of creating a competing delivery. Freshness, worktree safety, capacity, quarantine, and post-clear cooldown gates are unchanged.

## Validation

- `bundle exec rake test` — 13,887 runs, 277,337 assertions, 0 failures, 0 errors, 10 skips
- Recovery coordinator, dispatcher, and action tests — 364 runs, 1,509 assertions, 0 failures, 0 errors
- RuboCop — 2 changed Ruby files, no offenses
