### PR TITLE
fix(attempts): rearm claim window at handoff

### DIFF
--- a/lib/hive/attempts/dispatcher.rb
+++ b/lib/hive/attempts/dispatcher.rb
@@ -430,6 +430,10 @@ module Hive
 
         record_attempt_admission(task, created, now)
         capture_launch_context(task, created, generation, now)
+        handoff_now = [ now.utc, @clock.call.utc ].max
+        created = @store.arm_launch_handoff(
+          created, launch_timeout_sec: @launch_timeout_sec, now: handoff_now
+        )
         handoff = @launcher.launch(created, claim_capability: claim_capability)
         if handoff.is_a?(Hash) && (handoff["claimed"] == true || handoff["state"] == "launching")
           return accepted_result(created, interactive: interactive, decision: route_decision)

--- a/lib/hive/attempts/store.rb
+++ b/lib/hive/attempts/store.rb
@@ -255,6 +255,18 @@ module Hive
         record
       end
 
+      def arm_launch_handoff(observed, launch_timeout_sec:, now:)
+        mutate(observed, allowed_states: [ "launching" ]) do |data|
+          data.merge(
+            "lease_version" => data.fetch("lease_version") + 1,
+            "claim_deadline" => Record.iso8601(now + launch_timeout_sec),
+            "diagnostics" => data.fetch("diagnostics").merge(
+              "handoff_armed_at" => Record.iso8601(now)
+            )
+          )
+        end
+      end
+
       def fetch(attempt_id)
         hot = fetch_hot(attempt_id)
         return hot if hot

--- a/test/unit/attempts/dispatcher_test.rb
+++ b/test/unit/attempts/dispatcher_test.rb
@@ -61,6 +61,28 @@ class AttemptsDispatcherTest < Minitest::Test
     end
   end
 
+  def test_claim_window_starts_after_prelaunch_context_capture
+    wall_time = NOW
+    context_provenance = Object.new
+    context_provenance.define_singleton_method(:capture_launch) do |**_attributes|
+      wall_time = NOW + 45
+    end
+
+    with_dispatcher(
+      context_provenance: context_provenance,
+      clock: -> { wall_time }
+    ) do |dispatcher, launcher, task|
+      task.folder = File.dirname(task.state_file)
+      task.project_root = task.folder
+      result = dispatch(dispatcher, task, request_id: "request-one")
+      launched = launcher.launched.fetch(0).fetch(0)
+
+      assert_equal :accepted, result.status
+      assert_equal NOW.iso8601(6), launched["accepted_at"]
+      assert_equal (NOW + 75).iso8601(6), launched["claim_deadline"]
+    end
+  end
+
   def test_changed_generation_waits_for_live_stage_owner_instead_of_attaching
     with_dispatcher do |dispatcher, launcher, task|
       first = dispatch(dispatcher, task, request_id: "request-one")
@@ -718,7 +740,13 @@ class AttemptsDispatcherTest < Minitest::Test
           result_r.close
           store = Hive::Attempts::Store.new(root: attempt_root)
           original_generation_lock = store.method(:with_generation_lock)
+          admission_generation_lock = true
           store.define_singleton_method(:with_generation_lock) do |generation, &block|
+            unless admission_generation_lock
+              next original_generation_lock.call(generation, &block)
+            end
+
+            admission_generation_lock = false
             original_generation_lock.call(generation) do
               entered_w.write("1")
               entered_w.close
@@ -1512,7 +1540,8 @@ class AttemptsDispatcherTest < Minitest::Test
 
   def with_dispatcher(limits: { max_global: 3, max_per_project: 2, max_daily: 50 },
                       context_provenance: Hive::ContextProvenance,
-                      transient_retry_backoff_sec: 60)
+                      transient_retry_backoff_sec: 60,
+                      clock: -> { NOW })
     with_tmp_dir do |root|
       state_file = File.join(root, "task.md")
       File.write(state_file, "task\n<!-- WAITING -->\n")
@@ -1522,7 +1551,7 @@ class AttemptsDispatcherTest < Minitest::Test
       launcher = FakeLauncher.new
       ids = %w[attempt-one attempt-two attempt-three].each
       dispatcher = Hive::Attempts::Dispatcher.new(
-        store: store, launcher: launcher, limits: limits, clock: -> { NOW },
+        store: store, launcher: launcher, limits: limits, clock: clock,
         id_generator: -> { ids.next }, capability_generator: -> { CLAIM_CAPABILITY },
         context_provenance: context_provenance,
         transient_retry_backoff_sec: transient_retry_backoff_sec

--- a/wiki/log.d/20260829T104600Z-rearm-attempt-claim-handoff.md
+++ b/wiki/log.d/20260829T104600Z-rearm-attempt-claim-handoff.md
@@ -1,0 +1,13 @@
+# Re-arm durable attempt claims at the wrapper handoff
+
+Durable attempt admission now re-arms the persisted launching record's claim
+deadline immediately before invoking the detached wrapper launcher. Task
+activity and context-provenance capture remain prelaunch so they observe the
+unmodified worktree, but their latency can no longer consume the wrapper's
+claim window.
+
+The re-arm is a lease compare-and-swap on the same launching attempt. It keeps
+the immutable admission timestamp, records `handoff_armed_at`, and refuses a
+record that was concurrently claimed or reconciled. A focused regression
+advances the wall clock by 45 seconds during context capture and proves the
+30-second claim window begins afterward.

--- a/wiki/modules/daemon.md
+++ b/wiki/modules/daemon.md
@@ -201,10 +201,15 @@ tick from double-spawning.
 The timestamp captured at tick start is an observation timestamp, not a
 durable-attempt launch timestamp. A full tick can exceed
 `attempt_launch_timeout_sec` while draining recovery work. Immediately before
-durable admission, the production dispatcher reads a fresh wall clock for the
-request creation time and attempt claim deadline; otherwise later rows could
-be born with already-expired claim windows and fail every detached handoff as
-`launch_handoff_failed`.
+durable admission, the production daemon dispatcher reads a fresh wall clock
+for the request creation time. Attempt admission can itself spend longer than
+the launch window recording task activity and advisory context, so the attempt
+store separately re-arms the exact launching record's claim deadline from a
+fresh wall clock immediately before the detached wrapper handoff. The guarded
+compare-and-swap refuses to revive a record that another owner already claimed
+or reconciled. Without both boundaries, later or slow-context rows can be born
+with, or reach handoff with, already-expired claim windows and fail every
+detached handoff as `launch_handoff_failed`.
 
 Scheduler decisions are captured in memory as each row is evaluated from the
 tick's one authoritative status frame. The dispatcher publishes that frame at


### PR DESCRIPTION
## Summary

- re-arm each persisted launching attempt from a fresh wall clock after prelaunch activity/context capture
- use the attempt lease CAS so a claimed or reconciled record cannot be revived
- document the two launch-time boundaries and add a 45-second context-delay regression

## Live reproduction

Screenote artifacts attempt `10fcf6f8-ed9b-45d1-a15e-39bb7824a2a7` was admitted at 10:34:02, spent longer than 30 seconds in prelaunch bookkeeping, reached the detached handoff after its claim deadline, and was reconciled as lost without a worker.

## Validation

- `bundle exec ruby -Itest test/unit/attempts/dispatcher_test.rb` (46 runs, 217 assertions)
- all `test/unit/attempts/**/*_test.rb` (348 runs, 1,929 assertions)
- `bundle exec ruby -Itest test/unit/daemon/dispatcher_test.rb` (293 runs, 1,061 assertions)
- RuboCop on the three changed Ruby files
- `git diff --check`