### PR TITLE
Fix outcome-evidence runtime visibility

### DIFF
--- a/lib/hive/artifacts/capture_toolkit.rb
+++ b/lib/hive/artifacts/capture_toolkit.rb
@@ -491,8 +491,26 @@ module Hive
         [
           @hive_executable,
           File.join(root, "lib"),
+          *ruby_runtime_paths,
           *Gem.path.select { |path| File.directory?(path) }
         ].map { |path| File.expand_path(path) }.uniq
+      end
+
+      # RbConfig.ruby is part of every controller-issued browser/terminal
+      # prefix, and a conventional project commonly reaches the same runtime
+      # through an env shebang. Codex's closed filesystem policy must therefore
+      # admit the selected Ruby executable, its sibling binstubs (for example
+      # bundle), and the runtime libraries needed to load it. Gem.path alone is
+      # insufficient: a hidden mise/asdf runtime makes env fall through to a
+      # different system Ruby whose dependency set does not match the project.
+      def ruby_runtime_paths
+        config = RbConfig::CONFIG
+        paths = [
+          RbConfig.ruby,
+          *%w[bindir libdir rubylibdir rubyarchdir sitelibdir sitearchdir
+              vendorlibdir vendorarchdir].filter_map { |key| config[key] }
+        ]
+        paths.select { |path| !path.to_s.empty? && File.exist?(path) }
       end
 
       def run_browser_command(environment, argv)

--- a/lib/hive/artifacts/terminal_recorder.rb
+++ b/lib/hive/artifacts/terminal_recorder.rb
@@ -75,7 +75,7 @@ module Hive
         deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + @timeout_seconds + 1
         load_paths = [
           File.expand_path("../..", __dir__),
-          *Gem.loaded_specs.fetch("agent-cli-runtime").full_require_paths
+          *agent_runtime_require_paths
         ].uniq
         worker_environment = {
           "PATH" => ENV.fetch("PATH", "/usr/local/bin:/usr/bin:/bin")
@@ -105,6 +105,27 @@ module Hive
         end
 
         JSON.parse(result.fetch("stdout"))
+      end
+
+      # Source checkouts load agent-cli-runtime by placing the component on
+      # $LOAD_PATH before requiring Hive; that valid launch does not activate a
+      # RubyGems specification. The terminal custody worker still needs the
+      # exact already-loaded runtime path after its environment is scrubbed, so
+      # prefer the activated spec and fall back to the loaded feature itself.
+      def agent_runtime_require_paths
+        paths = Gem.loaded_specs["agent-cli-runtime"]&.full_require_paths.to_a
+        if paths.empty?
+          feature = $LOADED_FEATURES.find do |path|
+            File.basename(path) == "agent_cli_runtime.rb"
+          end
+          paths << File.dirname(File.realpath(feature)) if feature
+        end
+        paths.select! { |path| File.directory?(path) }
+        return paths.uniq unless paths.empty?
+
+        raise CaptureError, "terminal capture runtime is unavailable"
+      rescue Errno::ENOENT, Errno::EACCES
+        raise CaptureError, "terminal capture runtime is unavailable"
       end
 
       def worker_request

--- a/templates/artifacts_producer_prompt.md.erb
+++ b/templates/artifacts_producer_prompt.md.erb
@@ -63,6 +63,11 @@ controller-owned proxy maps that
 one random browser origin to the exact `web.app_endpoint`. When `web.server.status`
 is `ready`, the controller has already started the app: do not install
 dependencies or start, restart, replace, or detach another application server.
+For a conventional project, use its already-installed locked dependencies and
+the runtime visible on the issued `PATH`; do not run a package installer or
+contact a package registry from the evidence producer. If a locked dependency
+is genuinely unavailable, report that exact capability failure rather than
+substituting source commentary for requested runtime proof.
 For Hive Web fixtures, seed only disposable product state with the frozen Hive
 CLI and `HIVE_HOME=$HIVE_EVIDENCE_WEB_HIVE_HOME`; keep all other disposable
 fixture/project state below the evidence-write root. Hive closes the named

--- a/test/unit/artifacts/capture_toolkit_test.rb
+++ b/test/unit/artifacts/capture_toolkit_test.rb
@@ -147,6 +147,9 @@ class ArtifactsCaptureToolkitTest < Minitest::Test
     assert_includes filesystem_policy, "/managed/codex-runtime"
     assert_includes filesystem_policy, "/opt/hive/bin/hive"
     assert_includes filesystem_policy, "/opt/hive/lib"
+    assert_includes filesystem_policy, RbConfig.ruby
+    assert_includes filesystem_policy, RbConfig::CONFIG.fetch("bindir")
+    assert_includes filesystem_policy, RbConfig::CONFIG.fetch("libdir")
     domain = URI.parse(receipt.dig("web", "origin")).host
     browser_environment, browser_argv = browser_commands.first
     assert_includes browser_argv, domain

--- a/test/unit/artifacts/terminal_recorder_test.rb
+++ b/test/unit/artifacts/terminal_recorder_test.rb
@@ -169,19 +169,25 @@ class ArtifactsTerminalRecorderTest < Minitest::Test
         result
       end
 
+      source_runtime = $LOADED_FEATURES.find do |path|
+        File.basename(path) == "agent_cli_runtime.rb"
+      end
+      refute_nil source_runtime
       with_env("HIVE_COVERAGE" => nil, "RUBYOPT" => "-r/untrusted") do
-        with_replaced_singleton_method(
-          Hive::Web::ProjectCaptureProvider, :capture_command_with_custody, fake
-        ) do
-          Hive::Artifacts::TerminalRecorder.new(
-            argv: [ RbConfig.ruby, "-e", "exit" ], cwd: root,
-            cast_path: File.join(root, "proof.cast"),
-            review_path: File.join(root, "proof.txt")
-          ).record!
+        with_replaced_singleton_method(Gem, :loaded_specs, -> { {} }) do
+          with_replaced_singleton_method(
+            Hive::Web::ProjectCaptureProvider, :capture_command_with_custody, fake
+          ) do
+            Hive::Artifacts::TerminalRecorder.new(
+              argv: [ RbConfig.ruby, "-e", "exit" ], cwd: root,
+              cast_path: File.join(root, "proof.cast"),
+              review_path: File.join(root, "proof.txt")
+            ).record!
+          end
         end
       end
 
-      runtime_path = Gem.loaded_specs.fetch("agent-cli-runtime").full_require_paths.first
+      runtime_path = File.dirname(File.realpath(source_runtime))
       assert_includes captured.fetch(:argv), runtime_path
       assert_equal [ "PATH" ], captured.fetch(:environment).keys
     end

--- a/test/unit/artifacts/terminal_recorder_test.rb
+++ b/test/unit/artifacts/terminal_recorder_test.rb
@@ -193,6 +193,35 @@ class ArtifactsTerminalRecorderTest < Minitest::Test
     end
   end
 
+  def test_worker_rejects_missing_or_unreadable_runtime_paths
+    Dir.mktmpdir("hive-terminal-recorder-runtime-errors") do |root|
+      build = lambda do
+        Hive::Artifacts::TerminalRecorder.new(
+          argv: [ RbConfig.ruby, "-e", "exit" ], cwd: root,
+          cast_path: File.join(root, "proof.cast"),
+          review_path: File.join(root, "proof.txt")
+        )
+      end
+
+      missing_runtime = Struct.new(:full_require_paths).new([ File.join(root, "missing") ])
+      with_replaced_singleton_method(
+        Gem, :loaded_specs, -> { { "agent-cli-runtime" => missing_runtime } }
+      ) do
+        error = assert_raises(Hive::Artifacts::TerminalRecorder::CaptureError) { build.call.record! }
+        assert_equal "terminal capture runtime is unavailable", error.message
+      end
+
+      unreadable_runtime = Object.new
+      unreadable_runtime.define_singleton_method(:full_require_paths) { raise Errno::EACCES }
+      with_replaced_singleton_method(
+        Gem, :loaded_specs, -> { { "agent-cli-runtime" => unreadable_runtime } }
+      ) do
+        error = assert_raises(Hive::Artifacts::TerminalRecorder::CaptureError) { build.call.record! }
+        assert_equal "terminal capture runtime is unavailable", error.message
+      end
+    end
+  end
+
   def test_record_normalizes_empty_worker_provider_json_and_configuration_failures
     Dir.mktmpdir("hive-terminal-recorder-normalize") do |root|
       build = lambda do

--- a/wiki/commands/evidence.md
+++ b/wiki/commands/evidence.md
@@ -45,6 +45,9 @@ recorded in both the receipt and text rather than erasing the evidence. On Linux
 the recorder runs inside Hive's child-subreaper custody boundary; timeout,
 overflow, success, and failure all terminate and reap the complete descendant
 tree, and any detached child makes the capture invalid.
+The worker carries the exact already-loaded `agent-cli-runtime` require path;
+this works for both a packaged gem and a source checkout whose `bin/hive`
+loaded the monorepo component without activating a RubyGems specification.
 
 Both internal forms send bounded JSON through a controller-owned filesystem
 mailbox; the producer does not execute the PTY recorder or browser gateway.

--- a/wiki/log.d/20260829T113000Z-outcome-evidence-runtime-visibility.md
+++ b/wiki/log.d/20260829T113000Z-outcome-evidence-runtime-visibility.md
@@ -1,0 +1,16 @@
+# Outcome evidence keeps its issued Ruby runtime visible
+
+**Why:** A Codex evidence producer could receive an exact `RbConfig.ruby`
+capture prefix while the closed filesystem policy hid that executable. Env
+shebangs then fell through to the system Ruby, project dependencies appeared
+missing, and raw source-checkout terminal capture failed because the
+source-loaded `agent-cli-runtime` had no activated RubyGems specification.
+
+**Change:** Admit the controller's exact Ruby executable, binstubs, runtime
+libraries, and active gem paths to the producer's read-only policy. Terminal
+custody now resolves `agent-cli-runtime` from the activated gem or the exact
+loaded feature path. The producer prompt keeps package installation and package
+registries outside the evidence boundary.
+
+**Verification:** Focused capture-toolkit and terminal-recorder tests cover the
+runtime policy and the no-activated-spec source-checkout path.

--- a/wiki/stages/artifacts.md
+++ b/wiki/stages/artifacts.md
@@ -66,7 +66,11 @@ completion authority.
    controller-private browser state, and media staging stay outside its sandbox.
    Codex's managed network proxy runs in limited mode with no admitted domains
    and local binding enabled, so a producer may start the issued application
-   port but cannot connect directly to arbitrary loopback services. The
+   port but cannot connect directly to arbitrary loopback services. The closed
+   filesystem policy admits the controller's exact Ruby executable, sibling
+   binstubs, runtime libraries, and active gem paths; an env shebang therefore
+   cannot silently fall through to a different system Ruby. Producers use
+   already-installed locked dependencies and cannot contact package registries. The
    controller executes admitted browser/terminal operations, records exact
    file receipts, and exclusively publishes basename-only PNG/WebM media into
    the evidence root.
@@ -121,6 +125,9 @@ configuration may reduce recaptures to zero or one, but cannot exceed two.
   under Linux subreaper custody, without asciinema, VHS, a shell, or terminal-GIF
   conversion. Success, nonzero exit, timeout, and output overflow all reap the
   complete descendant tree; a detached child invalidates the capture.
+  Source checkouts that load `agent-cli-runtime` directly from the monorepo
+  component remain supported: the custody worker carries the exact loaded
+  feature path even when no RubyGems specification was activated.
 - Use `document` for invisible/refactoring outcomes, using safe text, Markdown,
   JSON, or static image material that explains the resulting contract, schema,
   or architecture. Active HTML, SVG, and PDF are not admitted. Static images


### PR DESCRIPTION
## Summary

- admit the controller-selected Ruby runtime and binstubs to the closed Codex evidence sandbox
- let terminal custody resolve source-loaded agent-cli-runtime without an activated gem spec
- keep package installation and registry access outside evidence production

## Root cause

The capture receipt named an exact Ruby executable that the filesystem policy hid. Env shebangs fell through to system Ruby, making installed project gems appear missing. Raw source-checkout Hive startup also loaded agent-cli-runtime from the monorepo without registering a RubyGems spec, while terminal custody required that spec.

## Verification

- 12 capture toolkit and terminal recorder tests, 134 assertions
- 4 prompt, command, and coverage-gap tests, 104 assertions
- 51 artifacts-stage tests, 283 assertions
- RuboCop clean on four changed Ruby files
- git diff --check clean