### PR TITLE
Rearm traversed stages on workflow rewind

### DIFF
--- a/lib/hive/commands/approve.rb
+++ b/lib/hive/commands/approve.rb
@@ -369,6 +369,7 @@ module Hive
         new_folder = nil
         commit_action = nil
         human_state_snapshot = nil
+        rewind_state_snapshots = []
         completion_snapshot = nil
         begin
           with_optional_commit_lock(task.hive_state_path) do
@@ -386,6 +387,7 @@ module Hive
                 task:, destination: dest_stage, observation: @plan_review_observation,
                 config: @plan_review_config
               )
+              rearm_backward_stages!(task, dest_stage, snapshots: rewind_state_snapshots)
               human_state_snapshot = initialize_human_destination!(task, dest_stage)
               if completion_on_terminal_entry?(task, dest_stage)
                 completion_snapshot = Hive::TaskMeta.snapshot(task.folder)
@@ -402,6 +404,7 @@ module Hive
           end
         rescue StandardError, Interrupt
           restore_human_destination!(task, new_folder, human_state_snapshot)
+          restore_rearmed_stages!(task, new_folder, rewind_state_snapshots)
           raise
         end
         [ new_folder, commit_action ]
@@ -411,6 +414,58 @@ module Hive
         return block.call unless @commit_lock
 
         Hive::Lock.with_commit_lock(hive_state_path, &block)
+      end
+
+      # A backward move is a workflow rewind, not just a folder relocation.
+      # Rearm every stage being revisited so a terminal marker from the prior
+      # visit cannot make the destination (or a later stage on the next
+      # forward pass) short-circuit immediately. State-file names are
+      # de-duplicated because coding intentionally reuses task.md and pr.md.
+      # Files outside the rewound stage interval remain byte-for-byte intact.
+      def rearm_backward_stages!(task, dest_stage, snapshots:)
+        destination = stage_for_dest!(task, dest_stage)
+        return unless destination.index < task.stage_index
+
+        state_files = task.workflow.stages.filter_map do |stage|
+          stage.state_file if stage.index.between?(destination.index, task.stage_index)
+        end.uniq
+
+        state_files.each do |state_file|
+          path = File.join(task.folder, state_file)
+          Hive::Markers.with_markers_lock(path) do
+            snapshot = read_rewind_state_snapshot!(path, state_file)
+            next unless snapshot.fetch(:existed)
+
+            # Record before mutation so a later file validation/write failure
+            # can restore every earlier file from this same rewind attempt.
+            snapshots << snapshot
+            body = snapshot.fetch(:body)
+            rearmed = Hive::Markers.without_markers(body)
+            Hive::AtomicFile.write(path, rearmed) unless rearmed == body
+          end
+        end
+      end
+
+      def read_rewind_state_snapshot!(path, state_file)
+        read_regular_state_snapshot!(
+          path, state_file,
+          invalid: "rewind state file #{state_file.inspect} must be a regular file, not a symlink",
+          changed: "rewind state file #{state_file.inspect} changed while rearming stages"
+        )
+      end
+
+      def restore_rearmed_stages!(task, new_folder, snapshots)
+        return unless snapshots
+
+        folder = File.directory?(task.folder) ? task.folder : new_folder
+        return unless folder && File.directory?(folder)
+
+        snapshots.reverse_each do |snapshot|
+          path = File.join(folder, snapshot.fetch(:state_file))
+          Hive::Markers.with_markers_lock(path) do
+            Hive::AtomicFile.write(path, snapshot.fetch(:body))
+          end
+        end
       end
 
       def initialize_human_destination!(task, dest_stage)
@@ -435,10 +490,17 @@ module Hive
       end
 
       def read_human_state_snapshot!(path, state_file)
+        read_regular_state_snapshot!(
+          path, state_file,
+          invalid: "human stage state file #{state_file.inspect} must be a regular file, not a symlink",
+          changed: "human stage state file #{state_file.inspect} changed while entering the stage"
+        )
+      end
+
+      def read_regular_state_snapshot!(path, state_file, invalid:, changed:)
         stat = File.lstat(path)
         unless stat.file? && !stat.symlink?
-          raise Hive::InvalidTaskPath,
-                "human stage state file #{state_file.inspect} must be a regular file, not a symlink"
+          raise Hive::InvalidTaskPath, invalid
         end
 
         flags = File::RDONLY
@@ -446,8 +508,7 @@ module Hive
         body = File.open(path, flags) do |file|
           opened = file.stat
           unless opened.file? && opened.dev == stat.dev && opened.ino == stat.ino
-            raise Hive::InvalidTaskPath,
-                  "human stage state file #{state_file.inspect} changed while entering the stage"
+            raise Hive::InvalidTaskPath, changed
           end
           file.read
         end
@@ -455,8 +516,7 @@ module Hive
       rescue Errno::ENOENT
         { state_file: state_file, existed: false, body: nil }
       rescue Errno::ELOOP, Errno::EMLINK
-        raise Hive::InvalidTaskPath,
-              "human stage state file #{state_file.inspect} must be a regular file, not a symlink"
+        raise Hive::InvalidTaskPath, invalid
       end
 
       def restore_human_destination!(task, new_folder, snapshot)

--- a/lib/hive/commands/approve.rb
+++ b/lib/hive/commands/approve.rb
@@ -66,7 +66,8 @@ module Hive
       end
 
       def initialize(target, to: nil, from: nil, project: nil, force: false, json: false, quiet: false,
-                     observation_guard: nil, commit_lock: true, clock: DEFAULT_CLOCK)
+                     observation_guard: nil, post_rearm_mutation: nil, commit_lock: true,
+                     clock: DEFAULT_CLOCK)
         @target = target
         @to = to
         @from = from
@@ -78,6 +79,7 @@ module Hive
         # State changes and typed exceptions still propagate normally.
         @quiet = quiet
         @observation_guard = observation_guard
+        @post_rearm_mutation = post_rearm_mutation
         @commit_lock = commit_lock
         @clock = clock
       end
@@ -388,6 +390,7 @@ module Hive
                 config: @plan_review_config
               )
               rearm_backward_stages!(task, dest_stage, snapshots: rewind_state_snapshots)
+              @post_rearm_mutation&.call(task)
               human_state_snapshot = initialize_human_destination!(task, dest_stage)
               if completion_on_terminal_entry?(task, dest_stage)
                 completion_snapshot = Hive::TaskMeta.snapshot(task.folder)
@@ -434,11 +437,11 @@ module Hive
           path = File.join(task.folder, state_file)
           Hive::Markers.with_markers_lock(path) do
             snapshot = read_rewind_state_snapshot!(path, state_file)
+            snapshots << snapshot
             next unless snapshot.fetch(:existed)
 
             # Record before mutation so a later file validation/write failure
             # can restore every earlier file from this same rewind attempt.
-            snapshots << snapshot
             body = snapshot.fetch(:body)
             rearmed = Hive::Markers.without_markers(body)
             Hive::AtomicFile.write(path, rearmed) unless rearmed == body
@@ -463,7 +466,11 @@ module Hive
         snapshots.reverse_each do |snapshot|
           path = File.join(folder, snapshot.fetch(:state_file))
           Hive::Markers.with_markers_lock(path) do
-            Hive::AtomicFile.write(path, snapshot.fetch(:body))
+            if snapshot.fetch(:existed)
+              Hive::AtomicFile.write(path, snapshot.fetch(:body))
+            else
+              File.delete(path) if File.exist?(path) || File.symlink?(path)
+            end
           end
         end
       end

--- a/lib/hive/commands/decide.rb
+++ b/lib/hive/commands/decide.rb
@@ -381,9 +381,11 @@ module Hive
 
         record = decision_record(task, stage, outcome, decision_id)
         snapshot = nil
-        mutation = lambda do |locked|
+        observation = lambda do |locked|
           validate_current_decision!(locked, stage, decision_id)
           snapshot = snapshot_files(locked.folder, [ stage.state_file, target.state_file ])
+        end
+        mutation = lambda do |locked|
           write_decision_record(File.join(locked.folder, stage.state_file), record)
           Hive::Markers.set(File.join(locked.folder, target.state_file), :waiting)
         end
@@ -392,7 +394,8 @@ module Hive
           Hive::Lock.with_commit_lock(task.hive_state_path) do
             Hive::Commands::Approve.new(
               task.slug, to: target.dir, from: stage.dir, project: task.project_name,
-              force: true, quiet: true, observation_guard: mutation, commit_lock: false
+              force: true, quiet: true, observation_guard: observation,
+              post_rearm_mutation: mutation, commit_lock: false
             ).call
           end
         rescue Hive::WrongStage => error

--- a/test/integration/decide_test.rb
+++ b/test/integration/decide_test.rb
@@ -534,6 +534,7 @@ class DecideTest < Minitest::Test
         fake = Object.new
         fake.define_singleton_method(:call) do
           kwargs.fetch(:observation_guard).call(Hive::Task.new(approval))
+          kwargs.fetch(:post_rearm_mutation).call(Hive::Task.new(approval))
           FileUtils.mkdir_p(File.dirname(destination))
           File.rename(approval, destination)
           raise Hive::GitError, "move failed"
@@ -565,6 +566,7 @@ class DecideTest < Minitest::Test
         fake = Object.new
         fake.define_singleton_method(:call) do
           kwargs.fetch(:observation_guard).call(Hive::Task.new(approval))
+          kwargs.fetch(:post_rearm_mutation).call(Hive::Task.new(approval))
           FileUtils.mkdir_p(File.dirname(destination))
           File.rename(approval, destination)
           raise Interrupt, "stop"
@@ -596,6 +598,7 @@ class DecideTest < Minitest::Test
         fake = Object.new
         fake.define_singleton_method(:call) do
           kwargs.fetch(:observation_guard).call(Hive::Task.new(approval))
+          kwargs.fetch(:post_rearm_mutation).call(Hive::Task.new(approval))
           raise Hive::WrongStage, "another transition won"
         end
         fake

--- a/test/integration/run_approve_test.rb
+++ b/test/integration/run_approve_test.rb
@@ -178,6 +178,38 @@ class RunApproveTest < Minitest::Test
     end
   end
 
+  def test_backward_move_rearms_destination_and_traversed_stages_only
+    with_tmp_global_config do
+      with_tmp_git_repo do |dir|
+        _, inbox, slug = seed_project_with_inbox_task(dir)
+        artifacts = File.join(dir, ".hive-state", "stages", "7-artifacts", slug)
+        review = File.join(dir, ".hive-state", "stages", "6-review", slug)
+        FileUtils.mkdir_p(File.dirname(artifacts))
+        FileUtils.mv(inbox, artifacts)
+
+        task_body = "# implementation\n<!-- REVIEW_COMPLETE pass=2 -->\n"
+        artifact_body = "# evidence\n<!-- ERROR reason=ci_red -->\n"
+        pr_body = "# pull request\n<!-- COMPLETE pr_url=https://example.test/pr/1 -->\n"
+        File.write(File.join(artifacts, "task.md"), task_body)
+        File.write(File.join(artifacts, "artifact.md"), artifact_body)
+        File.write(File.join(artifacts, "pr.md"), pr_body)
+
+        capture_io do
+          Hive::Commands::Approve.new(slug, from: "7-artifacts", to: "6-review").call
+        end
+
+        assert File.directory?(review)
+        assert_equal :none, Hive::Markers.current(File.join(review, "task.md")).name
+        assert_equal :none, Hive::Markers.current(File.join(review, "artifact.md")).name
+        assert_equal :complete, Hive::Markers.current(File.join(review, "pr.md")).name
+        assert_includes File.read(File.join(review, "task.md")), "# implementation"
+        assert_includes File.read(File.join(review, "artifact.md")), "# evidence"
+        assert_equal pr_body, File.read(File.join(review, "pr.md")),
+                     "state owned by a stage outside the rewind interval must stay exact"
+      end
+    end
+  end
+
   def test_to_accepts_short_stage_name
     with_tmp_global_config do
       with_tmp_git_repo do |dir|

--- a/test/unit/commands/approve_test.rb
+++ b/test/unit/commands/approve_test.rb
@@ -218,6 +218,66 @@ class HiveCommandsApproveTest < Minitest::Test
     end
   end
 
+  def test_backward_commit_failure_restores_rearmed_state_files_exactly
+    with_tmp_dir do |root|
+      state = File.join(root, ".hive-state")
+      source = File.join(state, "stages", "7-artifacts", "slug-260522-abcd")
+      destination = File.join(state, "stages", "6-review", "slug-260522-abcd")
+      FileUtils.mkdir_p(source)
+      originals = {
+        "task.md" => "implementation\n<!-- REVIEW_COMPLETE pass=2 -->\n",
+        "artifact.md" => "evidence\n<!-- ERROR reason=ci_red -->\n"
+      }
+      originals.each { |name, body| File.binwrite(File.join(source, name), body) }
+      current = task(
+        folder: source, hive_state_path: state, project_root: root,
+        stage_index: 7, stage_name: "artifacts"
+      )
+      cmd = command
+      cmd.define_singleton_method(:record_hive_commit) { |*| raise Hive::GitError, "no commit" }
+      fake_ops = Object.new
+      fake_ops.define_singleton_method(:run_git!) { |*| nil }
+
+      with_replaced_singleton_method(Hive::GitOps, :new, ->(*) { fake_ops }) do
+        assert_raises(Hive::GitError) do
+          cmd.send(:perform_move_and_commit, current, "6-review")
+        end
+      end
+
+      assert File.directory?(source)
+      refute File.exist?(destination)
+      originals.each do |name, body|
+        assert_equal body, File.binread(File.join(source, name))
+      end
+    end
+  end
+
+  def test_backward_rearm_restores_earlier_files_when_a_later_state_file_is_invalid
+    with_tmp_dir do |root|
+      state = File.join(root, ".hive-state")
+      source = File.join(state, "stages", "7-artifacts", "slug-260522-abcd")
+      FileUtils.mkdir_p(source)
+      task_body = "implementation\n<!-- REVIEW_COMPLETE pass=2 -->\n"
+      File.binwrite(File.join(source, "task.md"), task_body)
+      outside = File.join(root, "outside.md")
+      File.write(outside, "external\n")
+      File.symlink(outside, File.join(source, "artifact.md"))
+      current = task(
+        folder: source, hive_state_path: state, project_root: root,
+        stage_index: 7, stage_name: "artifacts"
+      )
+
+      error = assert_raises(Hive::InvalidTaskPath) do
+        command.send(:perform_move_and_commit, current, "6-review")
+      end
+
+      assert_includes error.message, "rewind state file \"artifact.md\" must be a regular file"
+      assert_equal task_body, File.binread(File.join(source, "task.md"))
+      assert_equal "external\n", File.read(outside)
+      assert File.symlink?(File.join(source, "artifact.md"))
+    end
+  end
+
   def test_inert_terminal_entry_writes_completed_at_with_the_move
     with_tmp_dir do |root|
       state = File.join(root, ".hive-state")

--- a/test/unit/commands/approve_test.rb
+++ b/test/unit/commands/approve_test.rb
@@ -233,7 +233,16 @@ class HiveCommandsApproveTest < Minitest::Test
         folder: source, hive_state_path: state, project_root: root,
         stage_index: 7, stage_name: "artifacts"
       )
-      cmd = command
+      callback_markers = nil
+      cmd = command(
+        post_rearm_mutation: lambda do |locked|
+          callback_markers = originals.keys.to_h do |name|
+            [ name, Hive::Markers.current(File.join(locked.folder, name)).name ]
+          end
+          Hive::Markers.set(File.join(locked.folder, "task.md"), :review_waiting)
+          Hive::Markers.set(File.join(locked.folder, "artifact.md"), :waiting)
+        end
+      )
       cmd.define_singleton_method(:record_hive_commit) { |*| raise Hive::GitError, "no commit" }
       fake_ops = Object.new
       fake_ops.define_singleton_method(:run_git!) { |*| nil }
@@ -246,6 +255,7 @@ class HiveCommandsApproveTest < Minitest::Test
 
       assert File.directory?(source)
       refute File.exist?(destination)
+      assert_equal({ "task.md" => :none, "artifact.md" => :none }, callback_markers)
       originals.each do |name, body|
         assert_equal body, File.binread(File.join(source, name))
       end
@@ -275,6 +285,40 @@ class HiveCommandsApproveTest < Minitest::Test
       assert_equal task_body, File.binread(File.join(source, "task.md"))
       assert_equal "external\n", File.read(outside)
       assert File.symlink?(File.join(source, "artifact.md"))
+    end
+  end
+
+  def test_backward_failure_removes_state_file_created_after_missing_snapshot
+    with_tmp_dir do |root|
+      state = File.join(root, ".hive-state")
+      source = File.join(state, "stages", "7-artifacts", "slug-260522-abcd")
+      destination = File.join(state, "stages", "6-review", "slug-260522-abcd")
+      FileUtils.mkdir_p(source)
+      task_body = "implementation\n<!-- REVIEW_COMPLETE pass=2 -->\n"
+      File.binwrite(File.join(source, "task.md"), task_body)
+      current = task(
+        folder: source, hive_state_path: state, project_root: root,
+        stage_index: 7, stage_name: "artifacts"
+      )
+      cmd = command(
+        post_rearm_mutation: lambda do |locked|
+          Hive::Markers.set(File.join(locked.folder, "artifact.md"), :waiting)
+        end
+      )
+      cmd.define_singleton_method(:record_hive_commit) { |*| raise Hive::GitError, "no commit" }
+      fake_ops = Object.new
+      fake_ops.define_singleton_method(:run_git!) { |*| nil }
+
+      with_replaced_singleton_method(Hive::GitOps, :new, ->(*) { fake_ops }) do
+        assert_raises(Hive::GitError) do
+          cmd.send(:perform_move_and_commit, current, "6-review")
+        end
+      end
+
+      assert File.directory?(source)
+      refute File.exist?(destination)
+      assert_equal task_body, File.binread(File.join(source, "task.md"))
+      refute File.exist?(File.join(source, "artifact.md"))
     end
   end
 

--- a/wiki/commands/approve.md
+++ b/wiki/commands/approve.md
@@ -3,7 +3,7 @@ title: hive approve
 type: command
 source: lib/hive/commands/approve.rb
 created: 2026-04-25
-updated: 2026-07-16
+updated: 2026-08-29
 tags: [command, approval, json, dependencies, admission]
 ---
 
@@ -32,13 +32,20 @@ hive approve <slug> --json                 # machine-readable result (success AN
 5. `resolve_destination`: `--to` (long or short stage name), or auto = the descriptor's next stage (`task.workflow.next_stage_after(task.stage_name)`). At the terminal stage (`9-done` for coding) this raises `FinalStageReached` (also exit 4).
 6. **Same-stage no-op**: if destination resolves to the current stage, emit a `noop: true` payload (or one-line `hive: noop —` text) and return success. No mv, no commit.
 7. `validate_move!`: forward auto-advance requires `:complete`, `:execute_complete`, or `:review_complete` marker. At `4-execute`, effective condition authority is checked first. `--to` (backward direction) bypasses; `--force` bypasses the marker/condition result only after an idempotent `operator_action` audit is durable. Audit failure prevents the move.
-8. **Locking**:
+8. For a backward move, rearm the destination and every traversed stage before
+   the folder move. Hive de-duplicates their descriptor-owned state-file names,
+   removes all recognized markers while preserving surrounding prose, and does
+   not touch state files owned only by stages outside the rewind interval. The
+   rewrite happens under the commit lock, task lock, and each file's marker
+   lock. Exact snapshots are restored if validation, the move, or the Hive
+   state commit fails.
+9. **Locking**:
    - `Hive::Lock.with_commit_lock(hive_state_path)` outermost — serialises hive/state writes and surfaces contention BEFORE any filesystem mutation (a 30-second commit-lock timeout never leaves a half-applied move).
    - `Hive::Lock.with_task_lock(task.folder)` inner — blocks a concurrent `hive run` on the same task during the move.
-9. For a forward move, build a fresh all-project dependency snapshot and enforce admission inside both locks, after the read-only destination collision check and immediately before `File.rename`. A benign dependency wait raises `DependencyWaitError` (exit 75); an admission error raises `DependencyAdmissionError` (exit 78). `--force` bypasses only step 7's marker check. Backward moves skip admission so corrupt metadata can be repaired by moving to an earlier stage.
-10. `move_task!`: direct `File.rename` from source to destination, with a rescue for `Errno::ENOTEMPTY` / `EEXIST` / `EISDIR` that surfaces as `Hive::DestinationCollision`. Cross-device fallback uses `cp_r` + `rm_rf`.
-11. Cleanup the moved `.lock`, record the slug-scoped commit, and roll the move back if commit fails.
-12. Report human prose or one `hive-approve` JSON document.
+10. For a forward move, build a fresh all-project dependency snapshot and enforce admission inside both locks, after the read-only destination collision check and immediately before `File.rename`. A benign dependency wait raises `DependencyWaitError` (exit 75); an admission error raises `DependencyAdmissionError` (exit 78). `--force` bypasses only step 7's marker check. Backward moves skip admission so corrupt metadata can be repaired by moving to an earlier stage.
+11. `move_task!`: direct `File.rename` from source to destination, with a rescue for `Errno::ENOTEMPTY` / `EEXIST` / `EISDIR` that surfaces as `Hive::DestinationCollision`. Cross-device fallback uses `cp_r` + `rm_rf`.
+12. Cleanup the moved `.lock`, record the slug-scoped commit, and roll the move back if commit fails.
+13. Report human prose or one `hive-approve` JSON document.
 
 ## JSON contract (`schema = "hive-approve"`, version 2)
 
@@ -132,7 +139,7 @@ Pinned by `Hive::Schemas::SCHEMA_VERSIONS["hive-approve"]` and the command/schem
 | Backward via `--to`      | none                            | n/a      |
 | Same stage (no-op)       | none                            | n/a      |
 
-`:error`, `:waiting`, `:execute_waiting`, `:execute_stale`, `:review_waiting`, `:review_ci_stale`, `:review_stale`, `:review_error` are all non-terminal: they leave the task in place. The error message includes `marker is :<name>` so an agent can branch deterministically. Backward `--to` is the recovery lever for an intentional stage rewind. Recoverable error markers use the fresh `workflow.retry` action from `hive status --operational --json`; `EXECUTE_STALE` remains manual because findings must be inspected first. `hive markers clear` remains a low-level maintenance command, not the standard agent recovery recipe.
+`:error`, `:waiting`, `:execute_waiting`, `:execute_stale`, `:review_waiting`, `:review_ci_stale`, `:review_stale`, `:review_error` are all non-terminal: they leave the task in place. The error message includes `marker is :<name>` so an agent can branch deterministically. Backward `--to` is the recovery lever for an intentional stage rewind: it clears recognized markers from state files belonging to the destination-through-source interval, so the destination and its next forward visits actually run again instead of consuming terminal output from the previous visit. State files belonging only to earlier or later stages stay exact. Recoverable error markers that do not require a stage rewind use the fresh `workflow.retry` action from `hive status --operational --json`; `EXECUTE_STALE` remains manual because findings must be inspected first. `hive markers clear` remains a low-level maintenance command, not the standard agent recovery recipe.
 
 ## Idempotency: `--from`
 

--- a/wiki/commands/approve.md
+++ b/wiki/commands/approve.md
@@ -38,7 +38,9 @@ hive approve <slug> --json                 # machine-readable result (success AN
    not touch state files owned only by stages outside the rewind interval. The
    rewrite happens under the commit lock, task lock, and each file's marker
    lock. Exact snapshots are restored if validation, the move, or the Hive
-   state commit fails.
+   state commit fails. Composing commands apply their new transition state
+   after this cleanup, so a decision-created `WAITING` marker is not mistaken
+   for stale state and removed with the old markers.
 9. **Locking**:
    - `Hive::Lock.with_commit_lock(hive_state_path)` outermost — serialises hive/state writes and surfaces contention BEFORE any filesystem mutation (a 30-second commit-lock timeout never leaves a half-applied move).
    - `Hive::Lock.with_task_lock(task.folder)` inner — blocks a concurrent `hive run` on the same task during the move.

--- a/wiki/gaps.md
+++ b/wiki/gaps.md
@@ -3,7 +3,7 @@ title: Gaps
 type: gaps
 source: wiki/* vs lib/, templates/, test/, bin/
 created: 2026-04-25
-updated: 2026-08-28
+updated: 2026-08-29
 tags: [gap, todo, release-proof, agent-skills, plan-review, opencode]
 ---
 
@@ -1299,3 +1299,14 @@ not stored in this repository, so this remains unproven as an end-to-end
 installed flow until a later authorized dogfood cutover supplies all three
 `HIVE_RUNTIME_*` values, restarts the single existing daemon/web units, and an
 unchanged installed plugin observes the matching status identity.
+
+## Generic rewind rearming lacks managed-workflow live proof (2026-08-29)
+
+Backward `hive approve --to` now rearms descriptor-owned state files across the
+destination-through-source interval and has focused coding-workflow integration
+coverage, including exact rollback and shared-file scoping. The algorithm is
+descriptor-driven and therefore also applies to project-authored and managed
+workflows, but no live managed-workflow task has yet been rewound through a
+deployed daemon. Keep this gap open until such a workflow proves that its
+destination reruns and later revisited stages do not consume prior terminal
+markers.

--- a/wiki/log.d/20260829T122500Z-backward-rewind-rearms-stages.md
+++ b/wiki/log.d/20260829T122500Z-backward-rewind-rearms-stages.md
@@ -9,6 +9,11 @@ restores exact bytes if validation or commit fails. Added coding integration
 coverage for `7-artifacts` to `6-review`, commit-failure rollback, partial
 multi-file failure rollback, and symlink refusal.
 
+Composed human decisions validate and snapshot their observation before the
+rewind, then write the decision record and new `WAITING` marker after stale
+markers have been removed. This preserves the newly selected workflow state
+without weakening exact rollback.
+
 **Why:** A task moved back from artifacts to review retained
 `REVIEW_COMPLETE` in `task.md` and `ERROR` in `artifact.md`. Review therefore
 reported itself already complete and the next artifacts visit immediately

--- a/wiki/log.d/20260829T122500Z-backward-rewind-rearms-stages.md
+++ b/wiki/log.d/20260829T122500Z-backward-rewind-rearms-stages.md
@@ -1,0 +1,20 @@
+# Backward workflow rewinds now rearm traversed stages
+
+**Action:** Changed the supported backward `hive approve --to` recovery path
+from a folder-only move into a controller-owned workflow rewind. Under the
+existing commit and task locks, Hive now snapshots and clears every recognized
+marker from descriptor state files in the destination-through-source interval,
+de-duplicates shared files, preserves prose and files outside the interval, and
+restores exact bytes if validation or commit fails. Added coding integration
+coverage for `7-artifacts` to `6-review`, commit-failure rollback, partial
+multi-file failure rollback, and symlink refusal.
+
+**Why:** A task moved back from artifacts to review retained
+`REVIEW_COMPLETE` in `task.md` and `ERROR` in `artifact.md`. Review therefore
+reported itself already complete and the next artifacts visit immediately
+returned the old error, even though the documented recovery command succeeded.
+
+**Verification:** `test/unit/commands/approve_test.rb` and
+`test/integration/run_approve_test.rb` pass; RuboCop is clean for the changed
+Ruby files. Live managed-workflow rewind evidence remains tracked in
+[[gaps]].

--- a/wiki/modules/markers.md
+++ b/wiki/modules/markers.md
@@ -3,7 +3,7 @@ title: Hive::Markers
 type: module
 source: lib/hive/markers.rb
 created: 2026-04-25
-updated: 2026-08-25
+updated: 2026-08-29
 tags: [marker, protocol, flock, recovery, migration, binary, filesystem-safety]
 ---
 
@@ -58,6 +58,15 @@ operator repair primitive and performs the same history purge after its
 current-name and optional attribute guards pass. Both paths remove every
 recognized marker comment while preserving surrounding prose, so a successful
 retry cannot expose an older shadowed marker.
+
+An intentional workflow rewind is a separate controller-owned transition.
+`hive approve --to <earlier-stage>` resolves the closed destination-through-
+source stage interval, de-duplicates those stages' descriptor-owned state
+files, and applies the same all-marker removal while holding the commit, task,
+and marker locks. Exact file snapshots are restored if the rewind cannot be
+committed. A file referenced only by a stage outside that interval is not
+rewritten; for example, coding's `7-artifacts` to `6-review` rewind rearms
+`task.md` and `artifact.md` but preserves `pr.md` exactly.
 
 Marker scans retain their binary encoding so malformed surrounding artifact
 bytes remain readable. `Hive::Recovery` is the shared compatibility boundary


### PR DESCRIPTION
## Summary

- make backward `hive approve --to` invalidate recognized markers for destination-through-source state files
- preserve prose and out-of-interval files while de-duplicating shared descriptor state files
- restore exact snapshots when validation or the Hive state commit fails

## Why

A documented artifacts-to-review rewind moved the folder but retained `REVIEW_COMPLETE` and the artifacts `ERROR`, so both revisited stages immediately consumed stale terminal outcomes.

## Verification

- `bundle exec ruby -Itest test/unit/commands/approve_test.rb`
- `bundle exec ruby -Itest test/integration/run_approve_test.rb`
- focused coverage: 88 runs, 376 assertions; every newly added production line covered
- RuboCop clean on all changed Ruby files
- `git diff --check`