### PR TITLE
Preserve daemon priority across live capacity changes

### DIFF
--- a/lib/hive/daemon/dispatcher.rb
+++ b/lib/hive/daemon/dispatcher.rb
@@ -456,11 +456,7 @@ module Hive
         # 4. Per-row dispatch, later pipeline stages first (see
         # dispatch_priority_order) so work nearest completion drains
         # ahead of newer earlier-stage work when slots are scarce.
-        dispatch_priority_order(result.rows).each do |row|
-          break unless admission_open?
-
-          handle_row(row, now: now)
-        end
+        dispatch_rows_in_priority_order(result.rows, now: now)
 
         # 5. Bound the persisted dispatch-baseline file to the live task set.
         # Only reached on a SUCCESSFUL status fetch (the `unless result.ok`
@@ -546,11 +542,7 @@ module Hive
                         message: "stale_agent_healer raised: #{e.class}: #{e.message}",
                         keeping_previous: true)
         end
-        dispatch_priority_order(result.rows).each do |row|
-          break unless admission_open?
-
-          handle_row(row, now: now)
-        end
+        dispatch_rows_in_priority_order(result.rows, now: now)
         @logger.event(:tick_end, now: Time.now.utc.iso8601,
                                  action: "incremental",
                                  in_flight: @controller.in_flight_count,
@@ -1396,7 +1388,7 @@ module Hive
         !current_stage.nil? && !prior_stage.to_s.empty? && current_stage != prior_stage.to_s
       end
 
-      def handle_row(row, now:)
+      def handle_row(row, now:, capacity_fence: nil)
         return unless admission_open?
 
         unless project_enabled?(row.project)
@@ -1505,8 +1497,14 @@ module Hive
           else
             "advance"
           end
-          outcome = dispatch_or_block(row, now: now, trigger: trigger)
+          outcome = if capacity_fence
+            log_priority_capacity_fence(row, capacity_fence)
+            capacity_fence
+          else
+            dispatch_or_block(row, now: now, trigger: trigger)
+          end
           observe_dispatch_outcome(row, outcome)
+          outcome
         when :wait_for_debounce
           @logger.event(:debouncing, project: row.project, slug: row.slug,
                                      stage: row.stage, mtime: row.state_file_mtime&.utc&.iso8601)
@@ -2009,6 +2007,45 @@ module Hive
         rows.each_with_index
             .sort_by { |row, idx| [ -stage_rank(row.stage), idx ] }
             .map(&:first)
+      end
+
+      # Preserve the priority order for the entire status frame. Durable
+      # admission reads live capacity, so a higher-priority row can be
+      # deferred and a short-lived worker can finish before a later row is
+      # evaluated. Without a tick-local fence that later row steals the newly
+      # opened slot, while the deferred row is not reconsidered until the next
+      # tick. A global/durable capacity result fences every later dispatch;
+      # project/daily caps fence only that project. Non-dispatch policy rows
+      # still run so the operational snapshot remains complete.
+      def dispatch_rows_in_priority_order(rows, now:)
+        global_fence = nil
+        project_fences = {}
+
+        dispatch_priority_order(rows).each do |row|
+          break unless admission_open?
+
+          project_key = row.project.to_s
+          capacity_fence = global_fence || project_fences[project_key]
+          outcome = handle_row(row, now: now, capacity_fence: capacity_fence)
+          case outcome
+          when :global_cap, :attempt_capacity
+            global_fence ||= outcome
+          when :project_cap, :daily_cap
+            project_fences[project_key] ||= outcome
+          end
+        end
+      end
+
+      def log_priority_capacity_fence(row, outcome)
+        reason = outcome == :attempt_capacity ? "capacity" : outcome.to_s
+        @logger.event(
+          :blocked,
+          project: row.project,
+          slug: row.slug,
+          stage: row.stage,
+          reason: reason,
+          priority_fence: true
+        )
       end
 
       # Pipeline position of a stage dir (higher = closer to done); -1 for

--- a/test/unit/daemon/dispatcher_test.rb
+++ b/test/unit/daemon/dispatcher_test.rb
@@ -3633,6 +3633,63 @@ class HiveDaemonDispatcherTest < Minitest::Test
     assert_equal "global_cap", blocked[1][:reason]
   end
 
+  def test_durable_capacity_deferral_fences_lower_priority_rows_for_the_tick
+    rows = [
+      row(slug: "lower", stage: "2-brainstorm", action: "ready_to_plan",
+          command: "hive plan lower --from 2-brainstorm"),
+      row(slug: "higher", stage: "6-review", action: "ready_to_plan",
+          command: "hive review higher --from 6-review")
+    ]
+    calls = []
+    attempt_dispatcher = Object.new
+    attempt_dispatcher.define_singleton_method(:dispatch_request) do |request, **_options|
+      calls << request.slug
+      Hive::Attempts::DispatchResult.new(
+        status: request.slug == "higher" ? :deferred : :accepted,
+        attempt: nil, receipt: nil, attach_descriptor: nil,
+        reason: request.slug == "higher" ? "capacity" : nil
+      )
+    end
+    dispatcher, _sup, _ctrl, logger = make_dispatcher(
+      rows: rows, attempt_dispatcher: attempt_dispatcher
+    )
+
+    dispatcher.tick(now: T0)
+
+    assert_equal [ "higher" ], calls,
+                 "a lower-priority row must not take capacity that reopens later in the same tick"
+    lower_block = logger.events.find do |name, attrs|
+      name == :blocked && attrs[:slug] == "lower"
+    end
+    assert_equal "capacity", lower_block.last.fetch(:reason)
+    assert_equal true, lower_block.last.fetch(:priority_fence)
+  end
+
+  def test_project_capacity_fence_does_not_block_another_project
+    rows = [
+      row(project: "p1", slug: "first", stage: "6-review", action: "ready_to_plan",
+          command: "hive review first --from 6-review"),
+      row(project: "p1", slug: "second", stage: "2-brainstorm", action: "ready_to_plan",
+          command: "hive plan second --from 2-brainstorm"),
+      row(project: "p2", slug: "other", stage: "2-brainstorm", action: "ready_to_plan",
+          command: "hive plan other --from 2-brainstorm")
+    ]
+    dispatcher, supervisor, controller, logger = make_dispatcher(rows: rows)
+    original_gate = controller.method(:can_dispatch?)
+    controller.define_singleton_method(:can_dispatch?) do |project:, **options|
+      project == "p1" ? :project_cap : original_gate.call(project: project, **options)
+    end
+
+    dispatcher.tick(now: T0)
+
+    assert_equal [ "other" ], supervisor.spawned.map { |spawn| spawn.fetch(:slug) }
+    second_block = logger.events.find do |name, attrs|
+      name == :blocked && attrs[:slug] == "second"
+    end
+    assert_equal "project_cap", second_block.last.fetch(:reason)
+    assert_equal true, second_block.last.fetch(:priority_fence)
+  end
+
   def test_status_active_agent_row_counts_toward_project_cap
     rows = [
       row(slug: "running", stage: "6-review", marker: "review_working",

--- a/wiki/commands/daemon.md
+++ b/wiki/commands/daemon.md
@@ -108,6 +108,15 @@ live recorded Claude PID and rows with `live_task_lock: true` (a verified
 daemon restart during auto-rebase or other pre-agent work from spawning
 extra tasks past `max_concurrent_runs` / `max_concurrent_per_project`.
 
+The status-row scan keeps its later-stage-first ordering for the whole tick,
+not only at each individual admission call. If a higher-priority row reaches a
+global or durable-attempt capacity boundary, later dispatchable rows are
+priority-fenced until the next status frame instead of taking a slot that a
+short-lived worker happens to release after the higher row was evaluated.
+Project and daily caps fence only later rows from that project, so unrelated
+projects can still use available global capacity. Non-dispatch policy rows are
+still classified and published in the operational snapshot.
+
 The closed-default policy means any unknown future `TaskActionKind`
 value falls through to `:skip` until the daemon is taught about it.
 

--- a/wiki/gaps.md
+++ b/wiki/gaps.md
@@ -1310,3 +1310,14 @@ workflows, but no live managed-workflow task has yet been rewound through a
 deployed daemon. Keep this gap open until such a workflow proves that its
 destination reruns and later revisited stages do not consume prior terminal
 markers.
+
+## Durable capacity deferrals do not expose their limiting scope (2026-08-29)
+
+`Hive::Attempts::Dispatcher` currently returns the generic reason `capacity`
+when any global, per-project, or daily attempt limit closes between the
+daemon's controller precheck and durable admission. The daemon therefore
+conservatively treats that result as a global priority fence for the remainder
+of one status-row scan. This prevents lower-priority leapfrogging and is
+bounded to one tick, but a rare project-only race can leave an unrelated slot
+unused until the next frame. Keep this gap open until durable admission emits
+a typed capacity scope that the row scheduler can preserve directly.

--- a/wiki/log.d/20260829T171500Z-capacity-priority-fence.md
+++ b/wiki/log.d/20260829T171500Z-capacity-priority-fence.md
@@ -1,0 +1,22 @@
+---
+title: Daemon capacity deferrals now preserve row priority for the tick
+date: 2026-08-29
+tags: [daemon, scheduler, capacity, fairness, attempts]
+---
+
+**Problem:** Durable capacity is evaluated live for every row. A
+higher-priority task could be deferred, a short-lived worker could finish
+during the same long fleet scan, and a later lower-priority row could then
+claim the reopened slot. Because the earlier row was not revisited until the
+next tick, repeated short attempts after its scan position could starve it.
+
+**Action:** Added a tick-local capacity fence to the shared full and
+changed-task row loop. Global and generic durable capacity deferrals fence all
+later dispatch attempts; project and daily caps fence only that project.
+Non-dispatch policy classification continues so operational evidence remains
+complete.
+
+**Evidence:** Dispatcher regressions reproduce the durable-capacity race,
+prove the lower-priority attempt is not admitted, and prove a project-scoped
+fence still permits another project to dispatch. The full dispatcher unit
+suite remains green.

--- a/wiki/modules/daemon.md
+++ b/wiki/modules/daemon.md
@@ -198,6 +198,16 @@ dispatched this tick is already in-flight in the controller and the row
 scan's per-slug in-flight gate (`controller.running_task?`) keeps the same
 tick from double-spawning.
 
+The per-row scan also carries a tick-local capacity fence. Durable admission
+reads live attempt state, so a high-priority row can be deferred just before a
+short-lived worker finishes; without a fence, a later lower-priority row can
+claim the reopened slot even though the earlier row is not reconsidered until
+the next tick. Global and generic durable-capacity deferrals fence all later
+dispatch attempts in the frame. Project and daily caps fence only that
+project. Rows whose policy does not dispatch still run, preserving a complete
+operational disposition set, and the next fresh status frame starts with no
+fence.
+
 The timestamp captured at tick start is an observation timestamp, not a
 durable-attempt launch timestamp. A full tick can exceed
 `attempt_launch_timeout_sec` while draining recovery work. Immediately before


### PR DESCRIPTION
## Problem

Durable attempt capacity is evaluated live for each status row. A higher-priority task can be deferred, a short-lived worker can finish later in the same fleet scan, and a lower-priority row can then claim the reopened slot. The earlier row is not revisited until the next tick, so repeated short attempts after its scan position can starve it.

## Fix

- Carry a tick-local capacity fence through both full and incremental priority-ordered row scans.
- Treat global and generic durable-capacity deferrals as global fences; keep project and daily fences scoped to that project.
- Continue classifying non-dispatch policy rows so operational evidence stays complete.
- Document the behavior and the remaining generic durable-capacity scope gap.

## Proof

- `bundle exec ruby -Itest test/unit/daemon/dispatcher_test.rb`: 295 runs, 1,067 assertions, 0 failures, 0 errors
- Focused regression failed on the prior implementation and now passes: 3 runs, 9 assertions
- `bundle exec rubocop lib/hive/daemon/dispatcher.rb test/unit/daemon/dispatcher_test.rb`: no offenses
- `git diff --check`: clean