### PR TITLE
Preserve capacity priority across incremental ticks

### DIFF
--- a/lib/hive/daemon/dispatcher.rb
+++ b/lib/hive/daemon/dispatcher.rb
@@ -224,6 +224,10 @@ module Hive
         # they evaluated. The completed operational snapshot consumes these;
         # no selector is rerun for status rendering.
         @routing_observations = {}
+        # A successful full scan replaces this snapshot. Changed-task ticks
+        # inherit it so a freshly completed task cannot reuse its slot before
+        # older capacity-deferred rows are reconsidered by the next full scan.
+        @priority_capacity_fences = { global: nil, projects: {} }
       end
 
       # Single tick: reap, fetch, dispatch. Pure dispatcher — no signal
@@ -456,7 +460,9 @@ module Hive
         # 4. Per-row dispatch, later pipeline stages first (see
         # dispatch_priority_order) so work nearest completion drains
         # ahead of newer earlier-stage work when slots are scarce.
-        dispatch_rows_in_priority_order(result.rows, now: now)
+        @priority_capacity_fences = dispatch_rows_in_priority_order(
+          result.rows, now: now
+        )
 
         # 5. Bound the persisted dispatch-baseline file to the live task set.
         # Only reached on a SUCCESSFUL status fetch (the `unless result.ok`
@@ -542,7 +548,9 @@ module Hive
                         message: "stale_agent_healer raised: #{e.class}: #{e.message}",
                         keeping_previous: true)
         end
-        dispatch_rows_in_priority_order(result.rows, now: now)
+        @priority_capacity_fences = dispatch_rows_in_priority_order(
+          result.rows, now: now, capacity_fences: @priority_capacity_fences
+        )
         @logger.event(:tick_end, now: Time.now.utc.iso8601,
                                  action: "incremental",
                                  in_flight: @controller.in_flight_count,
@@ -2009,17 +2017,18 @@ module Hive
             .map(&:first)
       end
 
-      # Preserve the priority order for the entire status frame. Durable
-      # admission reads live capacity, so a higher-priority row can be
-      # deferred and a short-lived worker can finish before a later row is
-      # evaluated. Without a tick-local fence that later row steals the newly
-      # opened slot, while the deferred row is not reconsidered until the next
-      # tick. A global/durable capacity result fences every later dispatch;
+      # Preserve priority across the full status frame and any changed-task
+      # ticks before the next full scan. Durable admission reads live capacity,
+      # so a higher-priority row can be deferred and a short-lived worker can
+      # finish before a later row or incremental successor is evaluated.
+      # Without a remembered fence that row steals the newly opened slot,
+      # while the deferred row is not reconsidered until the next full scan. A
+      # global/durable capacity result fences every later dispatch;
       # project/daily caps fence only that project. Non-dispatch policy rows
       # still run so the operational snapshot remains complete.
-      def dispatch_rows_in_priority_order(rows, now:)
-        global_fence = nil
-        project_fences = {}
+      def dispatch_rows_in_priority_order(rows, now:, capacity_fences: nil)
+        global_fence = capacity_fences&.fetch(:global, nil)
+        project_fences = capacity_fences ? capacity_fences.fetch(:projects, {}).dup : {}
 
         dispatch_priority_order(rows).each do |row|
           break unless admission_open?
@@ -2034,6 +2043,8 @@ module Hive
             project_fences[project_key] ||= outcome
           end
         end
+
+        { global: global_fence, projects: project_fences }
       end
 
       def log_priority_capacity_fence(row, outcome)

--- a/test/unit/daemon/dispatcher_test.rb
+++ b/test/unit/daemon/dispatcher_test.rb
@@ -3690,6 +3690,99 @@ class HiveDaemonDispatcherTest < Minitest::Test
     assert_equal true, second_block.last.fetch(:priority_fence)
   end
 
+  def test_full_tick_capacity_fence_blocks_incremental_successor_until_next_full_scan
+    waiting = row(
+      slug: "waiting", stage: "6-review", action: "ready_to_plan",
+      command: "hive review waiting --from 6-review"
+    )
+    calls = []
+    capacity_blocked = true
+    attempt_dispatcher = Object.new
+    attempt_dispatcher.define_singleton_method(:dispatch_request) do |request, **_options|
+      calls << request.slug
+      deferred = request.slug == "waiting" && capacity_blocked
+      Hive::Attempts::DispatchResult.new(
+        status: deferred ? :deferred : :accepted,
+        attempt: nil, receipt: nil, attach_descriptor: nil,
+        reason: deferred ? "capacity" : nil
+      )
+    end
+    dispatcher, _supervisor, _controller, logger = make_dispatcher(
+      rows: [ waiting ], attempt_dispatcher: attempt_dispatcher
+    )
+
+    dispatcher.tick(now: T0)
+    status = dispatcher.instance_variable_get(:@status_consumer)
+    status.next_task_result = Hive::Daemon::StatusConsumer::Result.new(
+      ok: true,
+      rows: [ row(
+        slug: "successor", stage: "3-plan", action: "ready_to_plan",
+        command: "hive plan successor --from 3-plan"
+      ) ]
+    )
+
+    assert dispatcher.tick_changed(
+      task_keys: [ [ "p1", "successor" ] ], now: T0 + 1
+    )
+
+    assert_equal [ "waiting" ], calls,
+                 "an incremental successor must not bypass the older full-scan queue"
+    successor_block = logger.events.find do |name, attrs|
+      name == :blocked && attrs[:slug] == "successor"
+    end
+    assert_equal "capacity", successor_block.last.fetch(:reason)
+    assert_equal true, successor_block.last.fetch(:priority_fence)
+
+    capacity_blocked = false
+    dispatcher.tick(now: T0 + 30)
+    assert_equal [ "waiting", "waiting" ], calls,
+                 "the next full scan must reconsider the older fenced row"
+  end
+
+  def test_full_tick_project_fence_persists_across_incremental_ticks_only_for_that_project
+    waiting = row(
+      project: "p1", slug: "waiting", stage: "6-review", action: "ready_to_plan",
+      command: "hive review waiting --from 6-review"
+    )
+    dispatcher, supervisor, controller = make_dispatcher(rows: [ waiting ])
+    original_gate = controller.method(:can_dispatch?)
+    project_blocked = true
+    controller.define_singleton_method(:can_dispatch?) do |project:, **options|
+      if project == "p1" && project_blocked
+        :project_cap
+      else
+        original_gate.call(project: project, **options)
+      end
+    end
+
+    dispatcher.tick(now: T0)
+    project_blocked = false
+    status = dispatcher.instance_variable_get(:@status_consumer)
+    status.next_task_result = Hive::Daemon::StatusConsumer::Result.new(
+      ok: true,
+      rows: [ row(
+        project: "p2", slug: "other", stage: "3-plan", action: "ready_to_plan",
+        command: "hive plan other --from 3-plan"
+      ) ]
+    )
+    assert dispatcher.tick_changed(
+      task_keys: [ [ "p2", "other" ] ], now: T0 + 1
+    )
+
+    status.next_task_result = Hive::Daemon::StatusConsumer::Result.new(
+      ok: true,
+      rows: [ row(
+        project: "p1", slug: "successor", stage: "3-plan", action: "ready_to_plan",
+        command: "hive plan successor --from 3-plan"
+      ) ]
+    )
+    assert dispatcher.tick_changed(
+      task_keys: [ [ "p1", "successor" ] ], now: T0 + 2
+    )
+
+    assert_equal [ "other" ], supervisor.spawned.map { |spawn| spawn.fetch(:slug) }
+  end
+
   def test_status_active_agent_row_counts_toward_project_cap
     rows = [
       row(slug: "running", stage: "6-review", marker: "review_working",

--- a/wiki/commands/daemon.md
+++ b/wiki/commands/daemon.md
@@ -108,14 +108,16 @@ live recorded Claude PID and rows with `live_task_lock: true` (a verified
 daemon restart during auto-rebase or other pre-agent work from spawning
 extra tasks past `max_concurrent_runs` / `max_concurrent_per_project`.
 
-The status-row scan keeps its later-stage-first ordering for the whole tick,
-not only at each individual admission call. If a higher-priority row reaches a
-global or durable-attempt capacity boundary, later dispatchable rows are
-priority-fenced until the next status frame instead of taking a slot that a
-short-lived worker happens to release after the higher row was evaluated.
-Project and daily caps fence only later rows from that project, so unrelated
-projects can still use available global capacity. Non-dispatch policy rows are
-still classified and published in the operational snapshot.
+The status-row scan keeps its later-stage-first ordering until the next
+authoritative full scan, not only at each individual admission call. If a
+higher-priority row reaches a global or durable-attempt capacity boundary,
+later dispatchable rows in that frame and in intervening changed-task ticks are
+priority-fenced instead of taking a slot that happens to reopen after the
+higher row was evaluated. The next full scan starts with no inherited fence
+and reconsiders the whole queue. Project and daily caps fence only later rows
+from that project, so unrelated projects can still use available global
+capacity. Non-dispatch policy rows are still classified and published in the
+operational snapshot.
 
 The closed-default policy means any unknown future `TaskActionKind`
 value falls through to `:skip` until the daemon is taught about it.

--- a/wiki/gaps.md
+++ b/wiki/gaps.md
@@ -1316,8 +1316,9 @@ markers.
 `Hive::Attempts::Dispatcher` currently returns the generic reason `capacity`
 when any global, per-project, or daily attempt limit closes between the
 daemon's controller precheck and durable admission. The daemon therefore
-conservatively treats that result as a global priority fence for the remainder
-of one status-row scan. This prevents lower-priority leapfrogging and is
-bounded to one tick, but a rare project-only race can leave an unrelated slot
-unused until the next frame. Keep this gap open until durable admission emits
-a typed capacity scope that the row scheduler can preserve directly.
+conservatively treats that result as a global priority fence through the next
+authoritative full scan, including intervening changed-task ticks. This
+prevents lower-priority leapfrogging, but a rare project-only race can leave an
+unrelated slot unused for the full-scan interval plus scan time. Keep this gap
+open until durable admission emits a typed capacity scope that the row
+scheduler can preserve directly.

--- a/wiki/log.d/20260829T174617Z-incremental-capacity-priority.md
+++ b/wiki/log.d/20260829T174617Z-incremental-capacity-priority.md
@@ -1,0 +1,21 @@
+---
+title: Changed-task ticks now honor the full-scan capacity queue
+date: 2026-08-29
+tags: [daemon, scheduler, capacity, fairness, incremental]
+---
+
+**Problem:** The full status-row scan correctly fenced later rows after a
+higher-priority capacity deferral, but a worker completion could trigger a
+changed-task tick before the next full scan. That bounded delta contained only
+the completed task's successor, so it could immediately reuse the slot without
+reconsidering older capacity-deferred rows.
+
+**Action:** Persist the full scan's global and per-project capacity-fence
+snapshot across intervening changed-task ticks. A successful full scan replaces
+the snapshot from a clean starting point; delta ticks inherit and extend it.
+Project-scoped fences continue to permit unrelated projects to dispatch.
+
+**Evidence:** Regressions reproduce both the global successor bypass and the
+project-scoped variant against the prior implementation. The global successor
+now remains fenced until a full rescan, while another project still dispatches
+through a project-only fence.

--- a/wiki/modules/daemon.md
+++ b/wiki/modules/daemon.md
@@ -198,15 +198,17 @@ dispatched this tick is already in-flight in the controller and the row
 scan's per-slug in-flight gate (`controller.running_task?`) keeps the same
 tick from double-spawning.
 
-The per-row scan also carries a tick-local capacity fence. Durable admission
+The per-row scan also carries a full-scan capacity fence. Durable admission
 reads live attempt state, so a high-priority row can be deferred just before a
 short-lived worker finishes; without a fence, a later lower-priority row can
 claim the reopened slot even though the earlier row is not reconsidered until
-the next tick. Global and generic durable-capacity deferrals fence all later
-dispatch attempts in the frame. Project and daily caps fence only that
-project. Rows whose policy does not dispatch still run, preserving a complete
-operational disposition set, and the next fresh status frame starts with no
-fence.
+the next full scan. The daemon remembers the resulting fence across bounded
+changed-task ticks, preventing a just-completed task's successor from reusing
+the slot ahead of that older queue. Global and generic durable-capacity
+deferrals fence all intervening dispatch attempts. Project and daily caps
+fence only that project. Rows whose policy does not dispatch still run,
+preserving a complete operational disposition set, and the next authoritative
+full scan starts with no inherited fence and replaces the snapshot.
 
 The timestamp captured at tick start is an observation timestamp, not a
 durable-attempt launch timestamp. A full tick can exceed


### PR DESCRIPTION
## Problem

The full status-row scan now fences later rows after a higher-priority capacity deferral, but a worker completion can trigger a changed-task tick before the next full scan. That delta contains only the completed task successor, so it can immediately reuse the slot without reconsidering the older capacity-deferred queue. Live dogfood reproduced this after #1339.

## Fix

- Persist the successful full scan capacity-fence snapshot across intervening changed-task ticks.
- Keep global and generic durable-capacity fences global; preserve project and daily fences per project.
- Start each authoritative full scan without inherited fences so it reconsiders the whole queue.
- Document the cross-frame contract and remaining generic durable-capacity scope gap.

## Proof

- Regression tests fail on main with incremental successors bypassing both global and project fences.
- `bundle exec ruby -Itest test/unit/daemon/dispatcher_test.rb`: 297 runs, 1,075 assertions, 0 failures, 0 errors
- `bundle exec rubocop lib/hive/daemon/dispatcher.rb test/unit/daemon/dispatcher_test.rb`: no offenses
- `git diff --check`: clean