### PR TITLE
Fix Patrol finding: make-one-internal-publisher-boundary-authoritati-f57a6c34829f

### DIFF
--- a/lib/hive/stages/review/github_publisher.rb
+++ b/lib/hive/stages/review/github_publisher.rb
@@ -42,7 +42,7 @@ module Hive
             return :secret
           end
 
-          return :already_posted if already_posted?(pr_url, header)
+          return :already_posted if already_posted?(pr_url, header, cfg: cfg)
 
           with_body_file(body) do |file|
             failures = []
@@ -151,8 +151,11 @@ module Hive
         # does not silently accumulate repeated posts each pass.
         COMMENT_PAGE_CAP = 100
 
-        def already_posted?(pr_url, header)
-          out, _err, status = Hive::Gh.capture3("gh", "pr", "view", pr_url, "--json", "comments")
+        # `cfg` threads the configured GitHub invocation path through the
+        # dedupe probe (notably `gh.network_timeout_sec`) so it honors the
+        # same settings as the adjacent `gh pr comment` call.
+        def already_posted?(pr_url, header, cfg: nil)
+          out, _err, status = Hive::Gh.capture3("gh", "pr", "view", pr_url, "--json", "comments", cfg: cfg)
           return false unless status.success?
 
           parsed = JSON.parse(out)

--- a/test/fixtures/runtime_control_plane/affected_production.yml
+++ b/test/fixtures/runtime_control_plane/affected_production.yml
@@ -7,8 +7,8 @@ counting_rule: physical_source_lines
 includes_new_production_files: true
 maximum_final_lines: 7960
 final_inventory_lines: 9220
-outside_inventory_net_lines: -2936
-final_lines: 6284
+outside_inventory_net_lines: -2933
+final_lines: 6287
 final_paths:
 - path: lib/hive/attempts/capacity_snapshot.rb
   lines: 104

--- a/test/unit/stages/review/github_publisher_test.rb
+++ b/test/unit/stages/review/github_publisher_test.rb
@@ -435,6 +435,26 @@ class ReviewGithubPublisherTest < Minitest::Test
     end
   end
 
+  def test_already_posted_forwards_cfg_to_configured_github_invocation
+    # Patrol regression: the duplicate-prevention `gh pr view` call used to
+    # omit cfg, so it ignored `gh.network_timeout_sec` while the adjacent
+    # `gh pr comment` call honored it. Both must route through the same
+    # configured invocation path.
+    ok = Hive::Gh::CommandStatus.new(exitstatus: 0)
+    observed_kwargs = nil
+    test_cfg = { "gh" => { "network_timeout_sec" => 7 } }
+
+    with_replaced_singleton_method(Hive::Gh, :capture3, lambda { |*_args, **kwargs|
+      observed_kwargs = kwargs
+      [ '{"comments":[]}', "", ok ]
+    }) do
+      assert_equal false, Hive::Stages::Review::GithubPublisher.already_posted?("https://example.com/pr/1", "header", cfg: test_cfg)
+    end
+
+    assert_equal test_cfg, observed_kwargs[:cfg],
+                 "duplicate-prevention lookup must pass cfg through to Hive::Gh.capture3"
+  end
+
   def test_already_posted_returns_false_when_view_fails_or_json_is_unusable
     ok = Hive::Gh::CommandStatus.new(exitstatus: 0)
     failed = Hive::Gh::CommandStatus.new(exitstatus: 1)

--- a/wiki/log.d/20260830T065056Z-publisher-dedupe-configured-gh.md
+++ b/wiki/log.d/20260830T065056Z-publisher-dedupe-configured-gh.md
@@ -1,0 +1,11 @@
+---
+title: Review publisher dedupe probe honors configured GitHub invocation
+date: 2026-08-30
+tags: [review, github, config, timeout]
+---
+
+**Problem:** `Review::GithubPublisher.already_posted?` invoked `Hive::Gh.capture3` without `cfg`, so the duplicate-prevention `gh pr view` probe ignored `gh.network_timeout_sec` while the adjacent `gh pr comment` post honored it — the two halves of one publish decision ran on different invocation paths.
+
+**Action:** Threaded `cfg` from `publish!` into `already_posted?` and onto the `gh pr view --json comments` call. The probe's fail-open behavior on command failure is unchanged (a failed probe still permits one post attempt, which then fails closed through the retry budget).
+
+**Evidence:** `test/unit/stages/review/github_publisher_test.rb#test_already_posted_forwards_cfg_to_configured_github_invocation` asserts the `cfg:` kwarg reaches `Hive::Gh.capture3`; the focused publisher, review-unit, gh, and run-review integration suites pass.

--- a/wiki/stages/review.md
+++ b/wiki/stages/review.md
@@ -100,8 +100,11 @@ requires the controller-owned worktree pointer, exact task branch, persisted
 `head_oid`, origin host/repository, and one OPEN PR observation whose
 URL/number/branch/head all match. A forged, stale, cross-repository, or
 head-drifted `pr.md` target is inert and local reviewer files remain
-authoritative. The publisher then skips duplicate headers on retry, scans for
-secrets before posting, and degrades transport failures to a stderr warning.
+authoritative. The publisher then skips duplicate headers on retry (the
+`gh pr view` dedupe probe routes through the same configured GitHub
+invocation path — including `gh.network_timeout_sec` — as the `gh pr comment`
+post), scans for secrets before posting, and degrades transport failures to a
+stderr warning.
 
 Per-reviewer failures retry up to `max_attempts` (default `Hive::Reviewers::DEFAULT_REVIEWER_MAX_ATTEMPTS = 2`; configurable on each reviewer spec) with exponential backoff capped at 8s (1s, 2s, 4s, 8s, 8s, …). `Hive::Reviewers::Base` owns the adapters' shared retry-budget parsing, including the warning and default used when a direct/custom adapter construction bypasses config validation. After retries are exhausted, the failure is recorded as a one-line entry in `reviews/errors-NN.md` (an orchestrator-owned file — see `ORCHESTRATOR_OWNED_PREFIXES`); the reviewer's own per-pass output file stays absent so `discover_reviewer_files` correctly reports "this reviewer produced nothing this pass" instead of triaging an infra-failure stub as a real `[ ]` finding. `errors-NN.md` is unconditionally deleted at the start of every `run_reviewers` invocation and re-created on the first failure within that invocation (append-with-header-on-first-write thereafter), so a marker-clear-and-rerun that succeeds leaves no file behind and one that re-fails shows only the latest pass-NN failures rather than concatenated history. All ordinary reviewer failures produce `REVIEW_ERROR phase=reviewers reason=all_failed`; when every failure is a typed provider limit—including Grok's nested HTTP 402 balance exhaustion—the phase instead writes `reason=limits_reached` with its hourly retry hint and does not spend the per-reviewer transient retry budget. Empty reviewer list → skip directly to the all-clean branch (Phase 5).
 


### PR DESCRIPTION
## Patrol Fix

This pull request repairs one finding tracked by Hive's Patrol Fix workflow.

### Sources

- architecture_patrol: pr-1337-d66c3bf7d565456c:centralize-configured-github-invocation

### Finding evidence

- {"file":"lib/hive/stages/review/github_publisher.rb","snippet":"Hive::Gh.capture3(\"gh\", \"pr\", \"comment\", pr_url, \"--body-file\", file.path, cfg: cfg)","claim":"comment publication explicitly uses the configured GitHub command path"}
- {"file":"lib/hive/stages/review/github_publisher.rb","snippet":"out, _err, status = Hive::Gh.capture3(\"gh\", \"pr\", \"view\", pr_url, \"--json\", \"comments\")\n          return false unless status.success?","claim":"the duplicate-prevention lookup omits cfg and converts any resulting command failure into permission to post"}

### Independent review

The patch correctly threads cfg from publish! through the sole duplicate-prevention probe into Hive::Gh.capture3, aligning the read and comment paths without changing dedupe or failure behavior. The controller's broad failure is unrelated host-environment leakage in unchanged agent-cli-runtime code, not a regression from this patch.

- Worktree HEAD is exactly 8fc7a9dcd9ef0869b472d12b7c53d781b67d67ea, its parent is the recorded base c133790bfef1c66251c8a9899e01f4a791886337, and git diff --check is clean.
- The code path now calls already_posted?(pr_url, header, cfg: cfg), which forwards cfg to Hive::Gh.capture3; capture3 derives its deadline from network_timeout_sec(cfg).
- Independent publisher and GitHub transport suites passed: 19 runs and 55 assertions, then 87 runs and 411 assertions, with zero failures or errors.
- The controller's review integration suite passed 78 runs and 466 assertions; its only broad failure named components/agent-cli-runtime/test/runtime_test.rb, and the patch has no diff under components/agent-cli-runtime.
- The isolated runtime assertion reproduced with inherited HIVE_CODEX_BIN/HIVE_GROK_BIN overrides and passed with those host overrides removed, bounding the validation failure to test environment configuration.

### Validation

Verdict: failed
- architecture:test: exit 1
- agent:regression-cfg-forwarded-to-capture3: exit 0
- agent:publisher-focused-suite: exit 0
- agent:gh-transport-and-review-unit-suites: exit 0
- agent:review-integration-suite: exit 0

<!-- hive-publication:v1 id=pub-80fce746ab3d338626bad7864bf17d38 base=c133790bfef1c66251c8a9899e01f4a791886337 -->
