### PR TITLE
Fix durable binding for automatic evidence rework

### DIFF
--- a/lib/hive/attempts/context.rb
+++ b/lib/hive/attempts/context.rb
@@ -133,11 +133,12 @@ module Hive
           require "hive/task_resolver"
           require "hive/workflows"
           verb = argv[1].to_s
-          target = argv[2].to_s
+          evidence_rework = verb == "evidence" && argv[2].to_s == "rework"
+          target = argv[evidence_rework ? 3 : 2].to_s
           raise StoreError, "attempt worker command has no task target" if verb.empty? || target.empty?
 
           task = Hive::TaskResolver.new(target, project_filter: record["project"]).resolve
-          intended_stage = if %w[run approve plan-review-run].include?(verb)
+          intended_stage = if evidence_rework || %w[run approve plan-review-run].include?(verb)
             "#{task.stage_index}-#{task.stage_name}"
           else
             Hive::Workflows.for_verb(verb).fetch(:target)

--- a/test/unit/attempts/context_test.rb
+++ b/test/unit/attempts/context_test.rb
@@ -349,6 +349,28 @@ class AttemptsContextTest < Minitest::Test
     end
   end
 
+  def test_evidence_rework_binds_its_nested_task_target_to_artifacts
+    task = FakeTask.new(id: 42, slug: "task", stage_index: 7, stage_name: "artifacts")
+    resolver = Struct.new(:task) { def resolve = task }.new(task)
+    record = {
+      "project" => "demo", "task_id" => "42", "task_slug" => "task",
+      "intended_stage" => "7-artifacts"
+    }
+    argv = [
+      "hive", "evidence", "rework", "task", "--stage", "7-artifacts",
+      "--generation", "a" * 64, "--recovery-digest", "b" * 64
+    ]
+    test_case = self
+
+    with_replaced_singleton_method(Hive::TaskResolver, :new, lambda { |target, **options|
+      test_case.assert_equal "task", target
+      test_case.assert_equal({ project_filter: "demo" }, options)
+      resolver
+    }) do
+      assert_nil Hive::Attempts::Context.send(:validate_task_binding!, record, argv)
+    end
+  end
+
   def test_module_hook_binding_uses_its_authenticated_subject_without_task_resolution
     subject = {
       "kind" => "module_hook", "project_id" => "project-1", "module" => "patrol",

--- a/wiki/commands/evidence.md
+++ b/wiki/commands/evidence.md
@@ -81,7 +81,9 @@ and the daemon dispatches it as the next ready action. Its queue grammar accepts
 only the explicit target, `7-artifacts`, both 64-hex bindings, an optional safe
 project, and optional `--json`. Because the command launches no model, durable
 attempt admission uses the controller-only route and does not wait for provider
-health or capacity.
+health or capacity. The durable worker authenticates the task from the fourth
+argument in this nested command shape (`hive evidence rework TARGET`), while
+binding the attempt to the task's current `7-artifacts` stage.
 
 ## Guards and effects
 

--- a/wiki/log.d/20260830T145900Z-evidence-rework-attempt-binding.md
+++ b/wiki/log.d/20260830T145900Z-evidence-rework-attempt-binding.md
@@ -1,0 +1,7 @@
+# Authenticate the nested evidence-rework worker target
+
+The durable attempt context now resolves the task from `hive evidence rework
+TARGET`'s fourth argument and binds that controller-only worker to the task's
+current artifacts stage. Automatic implementation rework can therefore cross
+from reviewed outcome evidence back to execute without rejecting `rework` as a
+nonexistent task slug.

--- a/wiki/modules/attempts.md
+++ b/wiki/modules/attempts.md
@@ -498,6 +498,10 @@ Supervisor gives an authenticated explicit Hive worker one additional
 write-only descriptor. `Attempts::Context` installs it only after the ordinary
 claim capability, worker argv, task binding, process identity, and released
 gate all match, then marks it close-on-exec before any provider child starts.
+Task binding understands both ordinary `hive VERB TARGET` workers and the
+controller-only nested `hive evidence rework TARGET` worker; the latter resolves
+the fourth argument and authenticates the current artifacts stage instead of
+mistaking `rework` for a task slug.
 The channel accepts at most one bounded strict safe signal. Empty, malformed,
 oversized, duplicate, broken-pipe, and wrong-route values become no signal;
 stdout and stderr are never parsed by Supervisor as provider evidence.


### PR DESCRIPTION
## Summary

- authenticate `hive evidence rework TARGET` against its nested task argument
- keep the controller-only attempt bound to the current artifacts stage
- document the durable worker grammar and cover the live failure mode

## Root cause

The attempt context treated every worker as `hive VERB TARGET`. For `hive evidence rework TARGET`, it therefore resolved `rework` as the task slug and rejected the authenticated worker before the 7-artifacts to 4-execute transition could run.

## Verification

- `bundle exec ruby -Itest test/unit/attempts/context_test.rb`
- `bundle exec ruby -Itest test/unit/attempts/configured_dispatcher_test.rb`
- `bundle exec ruby -Itest test/unit/daemon/dispatcher_test.rb -n /outcome_evidence_implementation_rework/`
- `bundle exec ruby -Itest test/unit/commands/evidence_test.rb`
- `bundle exec rubocop lib/hive/attempts/context.rb test/unit/attempts/context_test.rb`
- `git diff --check`