### PR TITLE
fix(plan-review): prevent avoidable review stalls

### DIFF
--- a/lib/hive/plan_review/orchestrator.rb
+++ b/lib/hive/plan_review/orchestrator.rb
@@ -748,69 +748,76 @@ module Hive
       def ensure_planner_revision(record, plan_bytes, findings)
         role = "planner_revision"
         max_attempts = 1 + Integer(@cfg.dig("plan_review", "attempts", "max_transient"))
-        route = latest_route(record, role)
-        if route && TRANSIENT_OUTCOMES.include?(route["outcome"])
-          if stale_planner_revision_contract?(route)
-            reset = Hive::PlanReview.recovery_reset_route(
-              route,
-              "planner_revision_contract_version" => PlannerRevision::RESULT_CONTRACT_VERSION,
-              "contract_upgrade_recovery" => true,
-              "diagnostic" => "planner result adjudication changed; retrying under the current contract"
-            )
-            record = publish_transition(
-              record, state: "revising",
-              required_action: "retry planner revision under the current result contract",
-              routes: record["routes"] + [ reset ]
-            )
-            route = reset
-          end
-          if attempts_in_current_run(record, role) >= max_attempts
-            exhausted = PlannerRevision::Result.new(
-              outcome: route.fetch("outcome"), candidate_bytes: nil,
-              candidate_digest: nil, route_receipt: route.fetch("actual", {}),
-              diagnostic: "planner revision retry bound exhausted"
-            ).freeze
-            return [ record, exhausted, false ]
-          end
-          return [ record, nil, true ] if retry_in_future?(route["retry_at"])
-        end
+        loop do
+          route = latest_route(record, role)
+          if route && TRANSIENT_OUTCOMES.include?(route["outcome"])
+            if stale_planner_revision_contract?(route)
+              reset = Hive::PlanReview.recovery_reset_route(
+                route,
+                "planner_revision_contract_version" => PlannerRevision::RESULT_CONTRACT_VERSION,
+                "contract_upgrade_recovery" => true,
+                "diagnostic" => "planner result adjudication changed; retrying under the current contract"
+              )
+              record = publish_transition(
+                record, state: "revising",
+                required_action: "retry planner revision under the current result contract",
+                routes: record["routes"] + [ reset ]
+              )
+              route = reset
+            end
+            if attempts_in_current_run(record, role) >= max_attempts
+              record, pending = schedule_transient_series_recovery(record, role, route)
+              return [ record, nil, true ] if pending
 
-        attempt_id = Identity.attempt(record.review_id)
-        revision = @planner_revision.call(
-          review_id: record.review_id, plan_bytes:, findings:,
-          planner_identity: planner_identity(record),
-          timeout_sec: @cfg.dig("plan_review", "attempts", "timeout_sec")
-        )
-        retry_at = if TRANSIENT_OUTCOMES.include?(revision.outcome)
-          default_retry_at(record, role, attempt_id)
+              next
+            end
+            return [ record, nil, true ] if retry_in_future?(route["retry_at"])
+          end
+
+          attempt_id = Identity.attempt(record.review_id)
+          revision = @planner_revision.call(
+            review_id: record.review_id, plan_bytes:, findings:,
+            planner_identity: planner_identity(record),
+            timeout_sec: @cfg.dig("plan_review", "attempts", "timeout_sec")
+          )
+          retry_at = if TRANSIENT_OUTCOMES.include?(revision.outcome)
+            default_retry_at(record, role, attempt_id)
+          end
+          route = planner_revision_route(
+            revision, record, attempt_id:, retry_at:
+          )
+          refs = @store.write_attempt!(
+            review_id: record.review_id, attempt_id:, plan_bytes:,
+            result: revision.to_h, coverage: [], route_receipt: route
+          )
+          artifacts = record["artifacts"].merge(
+            "planner_revision_input" => refs.fetch("input_plan"),
+            "planner_revision_result" => refs.fetch("result"),
+            "planner_revision_coverage" => refs.fetch("coverage"),
+            "planner_revision_route" => refs.fetch("route_receipt")
+          )
+          attempts = attempts_in_current_run(record, role) + 1
+          pending = TRANSIENT_OUTCOMES.include?(revision.outcome) && attempts < max_attempts
+          state = pending ? "retry_scheduled" : "revising"
+          record = publish(
+            record,
+            "state" => state, "outcome" => nil,
+            "attempt_ids" => record["attempt_ids"] + [ attempt_id ],
+            "current_attempt_id" => attempt_id,
+            "routes" => record["routes"] + [ route ], "artifacts" => artifacts,
+            "blockers" => [],
+            "required_action" => pending ? "retry planner revision after #{retry_at}" : nil,
+            "retry_at" => pending ? retry_at : nil, "execution_allowed" => false
+          )
+          if TRANSIENT_OUTCOMES.include?(revision.outcome) && !pending
+            record, pending = schedule_transient_series_recovery(record, role, route)
+            return [ record, nil, true ] if pending
+
+            next
+          end
+
+          return [ record, revision, pending ]
         end
-        route = planner_revision_route(
-          revision, record, attempt_id:, retry_at:
-        )
-        refs = @store.write_attempt!(
-          review_id: record.review_id, attempt_id:, plan_bytes:,
-          result: revision.to_h, coverage: [], route_receipt: route
-        )
-        artifacts = record["artifacts"].merge(
-          "planner_revision_input" => refs.fetch("input_plan"),
-          "planner_revision_result" => refs.fetch("result"),
-          "planner_revision_coverage" => refs.fetch("coverage"),
-          "planner_revision_route" => refs.fetch("route_receipt")
-        )
-        attempts = attempts_in_current_run(record, role) + 1
-        pending = TRANSIENT_OUTCOMES.include?(revision.outcome) && attempts < max_attempts
-        state = pending ? "retry_scheduled" : "revising"
-        record = publish(
-          record,
-          "state" => state, "outcome" => nil,
-          "attempt_ids" => record["attempt_ids"] + [ attempt_id ],
-          "current_attempt_id" => attempt_id,
-          "routes" => record["routes"] + [ route ], "artifacts" => artifacts,
-          "blockers" => [],
-          "required_action" => pending ? "retry planner revision after #{retry_at}" : nil,
-          "retry_at" => pending ? retry_at : nil, "execution_allowed" => false
-        )
-        [ record, revision, pending ]
       end
 
       def terminal(record, state:, outcome:, findings: record["findings"], blockers: [],
@@ -1121,8 +1128,9 @@ module Hive
       # Mandatory initial coverage is a liveness requirement, not an operator
       # waiver prompt. The per-series max still bounds one invocation, while a
       # persisted recovery reset lets later daemon ticks try again after a
-      # widening cooldown. Standard reviews retain their existing degraded
-      # fallback and verification/revision loops retain their own hard caps.
+      # widening cooldown. Standard reviews retain their degraded fallback;
+      # verification retries and successful planner-revision rounds retain
+      # their separate caps.
       def automatic_transient_series_recovery?(record, role, route)
         record.effective_level == "mandatory" &&
           %w[primary adversarial].include?(role) &&
@@ -1131,22 +1139,38 @@ module Hive
       end
 
       def schedule_transient_series_recovery(record, role, route)
-        series = record["routes"].count do |entry|
-          entry["role"] == role && entry["transient_series_recovery"] == true
+        role_routes = record["routes"].select { |entry| entry["role"] == role }
+        last_success = role_routes.rindex { |entry| SUCCESS_OUTCOMES.include?(entry["outcome"]) }
+        role_routes = role_routes.drop(last_success + 1) if last_success
+        series = role_routes.count do |entry|
+          entry["transient_series_recovery"] == true
         end + 1
         retry_at = transient_series_retry_at(record, role, route, series)
         pending = retry_in_future?(retry_at)
-        reset = Hive::PlanReview.recovery_reset_route(
-          route,
+        diagnostic = if role == "planner_revision"
+          "transient planner revision attempt series exhausted; retrying automatically"
+        else
+          "transient reviewer attempt series exhausted; retrying automatically"
+        end
+        attributes = {
           "transient_series_recovery" => true,
           "transient_series" => series,
           "retry_at" => retry_at,
-          "diagnostic" => "transient reviewer attempt series exhausted; retrying automatically"
+          "diagnostic" => diagnostic
+        }
+        if role == "planner_revision"
+          attributes["planner_revision_contract_version"] =
+            PlannerRevision::RESULT_CONTRACT_VERSION
+        end
+        reset = Hive::PlanReview.recovery_reset_route(
+          route, attributes
         )
-        state = pending ? "retry_scheduled" : "reviewing"
+        state = pending ? "retry_scheduled" :
+          (role == "planner_revision" ? "revising" : "reviewing")
+        label = role == "planner_revision" ? "planner revision" : "#{role} review"
         required_action = pending ?
-          "retry #{role} review automatically after #{retry_at}" :
-          "retry #{role} review automatically"
+          "retry #{label} automatically after #{retry_at}" :
+          "retry #{label} automatically"
         resumed = publish_transition(
           record, state:, required_action:,
           routes: record["routes"] + [ reset ], retry_at: pending ? retry_at : nil

--- a/lib/hive/plan_review/plan_signals.rb
+++ b/lib/hive/plan_review/plan_signals.rb
@@ -138,7 +138,7 @@ module Hive
           return {}
         end
 
-        value = YAML.safe_load(raw, permitted_classes: [], permitted_symbols: [], aliases: false) || {}
+        value = YAML.safe_load(raw, permitted_classes: [ Date ], permitted_symbols: [], aliases: false) || {}
         unless value.is_a?(Hash)
           uncertainties << "malformed_frontmatter"
           return {}
@@ -170,7 +170,7 @@ module Hive
 
       def test_scenarios(text, metadata)
         values = Array(metadata["test_scenarios"]).map(&:to_s)
-        values.concat(section(text, "test scenarios").scan(/^\s*[-*]\s+(.+)$/).flatten)
+        values.concat(section(text, "test scenarios").scan(/^\s*(?:[-*]|\d+[.)])\s+(.+)$/).flatten)
         values.map(&:strip).reject(&:empty?).uniq
       end
 
@@ -183,8 +183,8 @@ module Hive
 
       def section(text, name)
         label = Regexp.escape(name)
-        boundary = '(?=^#{1,6}\s+|^\*\*[^*\n]+:?\*\*\s*$|\z)'
-        pattern = /(?:^\#{1,6}\s+#{label}\s*$|^\*\*#{label}:?\*\*\s*$)\n(.*?)#{boundary}/im
+        boundary = '(?=^#{1,6}[ \t]+|^[ \t]*(?:[-*][ \t]+)?\*\*[^*\n]+:?\*\*(?=[ \t]|\r?$)|\z)'
+        pattern = /(?:^\#{1,6}[ \t]+#{label}[ \t]*\r?$\n|^[ \t]*(?:[-*][ \t]+)?\*\*#{label}:?\*\*[ \t]*)(.*?)#{boundary}/im
         text.scan(pattern).flatten.join("\n")
       end
 

--- a/lib/hive/task_action.rb
+++ b/lib/hive/task_action.rb
@@ -740,6 +740,8 @@ module Hive
       when "blocked"
         if recoverable_planner_identity_review?
           ACTIONS.fetch(:plan_reviewing)
+        elsif recoverable_transient_planner_revision?
+          ACTIONS.fetch(:plan_reviewing)
         elsif stale_planner_revision_contract?
           ACTIONS.fetch(:plan_reviewing)
         elsif recoverable_capability_review?
@@ -979,6 +981,25 @@ module Hive
         Hive::PlanReview::PlannerRevision::RESULT_CONTRACT_VERSION
     rescue ArgumentError, TypeError
       true
+    end
+
+    # Older builds terminalized an exhausted transient planner-revision series.
+    # The orchestrator now owns opening cooled attempt series until that route
+    # recovers, so expose only the exact old planner-owned transient block as
+    # runnable. Invalid candidates and other terminal planner verdicts stay
+    # operator-owned.
+    def recoverable_transient_planner_revision?
+      route = Array(plan_review["routes"]).reverse.find do |entry|
+        entry["role"] == "planner_revision"
+      end
+      return false unless route
+      return false if route["attempt_id"].to_s.empty?
+      return false unless PLAN_REVIEW_TRANSIENT_OUTCOMES.include?(route["outcome"])
+
+      expected_reason = "planner_revision_#{route.fetch('outcome')}"
+      Array(plan_review["blockers"]).any? do |blocker|
+        blocker["owner"] == "planner" && blocker["reason"] == expected_reason
+      end
     end
 
     def recoverable_planner_identity_review?

--- a/templates/plan_review_adversarial_prompt.md.erb
+++ b/templates/plan_review_adversarial_prompt.md.erb
@@ -29,6 +29,30 @@ Use only typed findings and named coverage. Free-form stdout is diagnostic,
 not clearance authority. Every newly emitted finding must use
 `"lifecycle": "open"`; Hive alone owns later lifecycle transitions, so never
 emit `closed` or another inferred disposition.
+
+Classify findings by decision authority:
+
+For the final JSON written to Hive, this rubric is authoritative and overrides
+any classification, autofix, or routing rubric from an invoked skill.
+
+- `safe_auto`: one concrete, low-risk, reversible technical correction follows
+  from the plan, product contract, or established repository patterns.
+- `gated_auto`: the preferred technical correction is clear, but applying it
+  materially changes architecture, external behavior, compatibility,
+  security/privacy posture, or operational risk and therefore needs approval.
+- `manual`: a human must supply a choice because the existing contract and
+  repository patterns do not determine a safe answer, and the alternatives
+  materially change product scope, authority/trust, privacy/compliance, risk
+  acceptance, irreversible external effects, or an architectural direction.
+- `fyi`: useful information that requires no plan change.
+
+Classification is about decision authority, not severity. Prefer `safe_auto`
+for routine technical corrections, and use `gated_auto` only when the
+correction itself crosses a material approval boundary. Do not use `manual`
+merely because the plan must choose, decide, specify, or add details. If you can
+state a concrete correction grounded in the plan or repository, classify it as
+`safe_auto` or `gated_auto` and include that disposition.
+
 This is an initial review, not disposition verification, so
 `residual_evidence` must be exactly an empty array.
 `selected_lenses` names may use lowercase letters, digits, hyphens, and underscores;

--- a/templates/plan_review_prompt.md.erb
+++ b/templates/plan_review_prompt.md.erb
@@ -38,6 +38,30 @@ evidence, and one terminal adapter outcome. Free-form stdout is diagnostic
 only. Every newly emitted finding must use `"lifecycle": "open"`; Hive alone
 owns later lifecycle transitions, so never emit `closed` or another inferred
 disposition.
+
+Classify findings by decision authority:
+
+For the final JSON written to Hive, this rubric is authoritative and overrides
+any classification, autofix, or routing rubric from an invoked skill.
+
+- `safe_auto`: one concrete, low-risk, reversible technical correction follows
+  from the plan, product contract, or established repository patterns.
+- `gated_auto`: the preferred technical correction is clear, but applying it
+  materially changes architecture, external behavior, compatibility,
+  security/privacy posture, or operational risk and therefore needs approval.
+- `manual`: a human must supply a choice because the existing contract and
+  repository patterns do not determine a safe answer, and the alternatives
+  materially change product scope, authority/trust, privacy/compliance, risk
+  acceptance, irreversible external effects, or an architectural direction.
+- `fyi`: useful information that requires no plan change.
+
+Classification is about decision authority, not severity. Prefer `safe_auto`
+for routine technical corrections, and use `gated_auto` only when the
+correction itself crosses a material approval boundary. Do not use `manual`
+merely because the plan must choose, decide, specify, or add details. If you can
+state a concrete correction grounded in the plan or repository, classify it as
+`safe_auto` or `gated_auto` and include that disposition.
+
 This is an initial review, not disposition verification, so
 `residual_evidence` must be exactly an empty array.
 `selected_lenses` names may use lowercase letters, digits, hyphens, and underscores;

--- a/test/unit/plan_review/ce_doc_review_adapter_test.rb
+++ b/test/unit/plan_review/ce_doc_review_adapter_test.rb
@@ -778,6 +778,24 @@ class PlanReviewCeDocReviewAdapterTest < Minitest::Test
           /Every newly emitted finding must use\s+`"lifecycle": "open"`/,
           observed
         )
+        unless kind == "verification"
+          rubric_patterns = [
+            /`safe_auto`: one concrete, low-risk, reversible technical correction follows\s+from the plan, product contract, or established repository patterns/,
+            /`gated_auto`: the preferred technical correction is clear, but applying it\s+materially changes architecture, external behavior, compatibility/,
+            /`manual`: a human must supply a choice because the existing contract and\s+repository patterns do not determine a safe answer/,
+            /`fyi`: useful information that requires no plan change/
+          ]
+          rubric_patterns.each { |pattern| assert_match pattern, observed }
+          assert_match(
+            /For the final JSON written to Hive, this rubric is authoritative and overrides\s+any classification, autofix, or routing rubric from an invoked skill/,
+            observed
+          )
+          assert_includes observed, "Classification is about decision authority, not severity."
+          assert_match(
+            /Do not use `manual`\s+merely because the plan must choose/,
+            observed
+          )
+        end
       end
     end
   end

--- a/test/unit/plan_review/orchestrator_test.rb
+++ b/test/unit/plan_review/orchestrator_test.rb
@@ -76,8 +76,9 @@ class PlanReviewOrchestratorTest < Minitest::Test
   class TransientRevision
     attr_reader :calls
 
-    def initialize(candidate)
+    def initialize(candidate, failures: 1)
       @candidate = candidate
+      @failures = failures
       @calls = []
     end
 
@@ -86,7 +87,7 @@ class PlanReviewOrchestratorTest < Minitest::Test
       return Hive::PlanReview::PlannerRevision::Result.new(
         outcome: "retryable_failure", candidate_bytes: nil, candidate_digest: nil,
         route_receipt: arguments.fetch(:planner_identity), diagnostic: "route failed"
-      ) if @calls.length == 1
+      ) if @calls.length <= @failures
 
       Hive::PlanReview::PlannerRevision::Result.new(
         outcome: "success", candidate_bytes: @candidate,
@@ -174,6 +175,39 @@ class PlanReviewOrchestratorTest < Minitest::Test
     end
   end
 
+  def test_planner_revision_opens_cooled_retry_series_until_provider_recovers
+    revised = standard_plan.sub("# Plan", "# Revised plan")
+    with_task(standard_plan) do |task, cfg|
+      cfg["plan_review"]["attempts"]["max_transient"] = 0
+      revision = TransientRevision.new(revised, failures: 2)
+      adapter = success_adapter(primary_findings: [ finding("safe_auto", "Clarify tests") ])
+
+      first = orchestrator(task, cfg, adapter:, planner_revision: revision).advance!.record
+
+      assert_equal "retry_scheduled", first.state
+      first_due = Time.iso8601(first["retry_at"])
+
+      second = orchestrator(
+        task, cfg, adapter:, planner_revision: revision, clock: -> { first_due }
+      ).advance!.record
+
+      assert_equal "retry_scheduled", second.state
+      second_due = Time.iso8601(second["retry_at"])
+      assert_operator second_due - first_due, :>=, 10 * 60
+
+      cleared = orchestrator(
+        task, cfg, adapter:, planner_revision: revision, clock: -> { second_due }
+      ).advance!.record
+
+      assert_equal "cleared", cleared.state
+      assert_equal 3, revision.calls.length
+      recoveries = cleared["routes"].select do |route|
+        route["role"] == "planner_revision" && route["transient_series_recovery"]
+      end
+      assert_equal [ 1, 2 ], recoveries.map { |route| route.fetch("transient_series") }
+    end
+  end
+
   def test_legacy_cross_provider_planner_model_recovers_once_with_the_same_provider
     revised = standard_plan.sub("# Plan", "# Revised plan")
     with_task(standard_plan) do |task, cfg|
@@ -216,20 +250,28 @@ class PlanReviewOrchestratorTest < Minitest::Test
       adapter = success_adapter(primary_findings: [ finding("safe_auto", "Clarify tests") ])
       runner = orchestrator(task, cfg, adapter:, planner_revision: revision)
 
-      blocked = runner.advance!
-      assert_equal "blocked", blocked.record.state
+      scheduled = runner.advance!
+      assert_equal "retry_scheduled", scheduled.record.state
 
-      routes = blocked.record["routes"].map(&:dup)
+      routes = scheduled.record["routes"].reject do |route|
+        route["transient_series_recovery"]
+      end.map(&:dup)
       routes.last.delete("planner_revision_contract_version")
       legacy = Hive::PlanReview::Record.new(
-        blocked.record.to_h.merge(
-          "version" => blocked.record.version + 1,
+        scheduled.record.to_h.merge(
+          "version" => scheduled.record.version + 1,
+          "state" => "blocked", "outcome" => "blocked",
           "routes" => routes,
+          "blockers" => [
+            { "owner" => "planner", "reason" => "planner_revision_retryable_failure" }
+          ],
+          "required_action" => "repair the planner route and start a linked plan generation",
+          "retry_at" => nil,
           "updated_at" => "2026-08-12T12:01:00.000000Z"
         )
       )
       store = runner.instance_variable_get(:@store)
-      store.publish_current!(legacy, expected_version: blocked.record.version)
+      store.publish_current!(legacy, expected_version: scheduled.record.version)
 
       cleared = runner.advance!
 
@@ -237,6 +279,42 @@ class PlanReviewOrchestratorTest < Minitest::Test
       assert_equal 2, revision.calls.length
       reset = cleared.record["routes"].find { |route| route["contract_upgrade_recovery"] }
       assert_equal true, reset.fetch("recovery_reset")
+      assert_equal Hive::PlanReview::PlannerRevision::RESULT_CONTRACT_VERSION,
+                   reset.fetch("planner_revision_contract_version")
+    end
+  end
+
+  def test_current_contract_blocked_planner_revision_enters_cooled_recovery
+    revised = standard_plan.sub("# Plan", "# Revised plan")
+    with_task(standard_plan) do |task, cfg|
+      cfg["plan_review"]["attempts"]["max_transient"] = 0
+      revision = TransientRevision.new(revised)
+      adapter = success_adapter(primary_findings: [ finding("safe_auto", "Clarify tests") ])
+      runner = orchestrator(task, cfg, adapter:, planner_revision: revision)
+      scheduled = runner.advance!.record
+      routes = scheduled["routes"].reject { |route| route["transient_series_recovery"] }
+      legacy = Hive::PlanReview::Record.new(
+        scheduled.to_h.merge(
+          "version" => scheduled.version + 1,
+          "state" => "blocked", "outcome" => "blocked", "routes" => routes,
+          "blockers" => [
+            { "owner" => "planner", "reason" => "planner_revision_retryable_failure" }
+          ],
+          "required_action" => "repair the planner route and start a linked plan generation",
+          "retry_at" => nil,
+          "updated_at" => "2026-08-12T12:01:00.000000Z"
+        )
+      )
+      store = runner.instance_variable_get(:@store)
+      store.publish_current!(legacy, expected_version: scheduled.version)
+
+      recovered = runner.advance!.record
+
+      assert_equal "retry_scheduled", recovered.state
+      assert_equal 1, revision.calls.length
+      reset = recovered["routes"].last
+      assert_equal "planner_revision", reset.fetch("role")
+      assert_equal true, reset.fetch("transient_series_recovery")
       assert_equal Hive::PlanReview::PlannerRevision::RESULT_CONTRACT_VERSION,
                    reset.fetch("planner_revision_contract_version")
     end
@@ -1252,8 +1330,8 @@ class PlanReviewOrchestratorTest < Minitest::Test
         adapter: success_adapter(primary_findings: [ finding("safe_auto", "Clarify tests") ]),
         planner_revision: revision
       )
-      assert_equal "blocked", runner.advance!.record.state
-      assert_equal "blocked", runner.advance!.record.state
+      assert_equal "retry_scheduled", runner.advance!.record.state
+      assert_equal "retry_scheduled", runner.advance!.record.state
       assert_equal 1, revision.calls.length
     end
   end

--- a/test/unit/plan_review/orchestrator_test.rb
+++ b/test/unit/plan_review/orchestrator_test.rb
@@ -76,18 +76,22 @@ class PlanReviewOrchestratorTest < Minitest::Test
   class TransientRevision
     attr_reader :calls
 
-    def initialize(candidate, failures: 1)
+    def initialize(candidate, failures: 1, after_failure: nil)
       @candidate = candidate
       @failures = failures
+      @after_failure = after_failure
       @calls = []
     end
 
     def call(**arguments)
       @calls << arguments
-      return Hive::PlanReview::PlannerRevision::Result.new(
-        outcome: "retryable_failure", candidate_bytes: nil, candidate_digest: nil,
-        route_receipt: arguments.fetch(:planner_identity), diagnostic: "route failed"
-      ) if @calls.length <= @failures
+      if @calls.length <= @failures
+        @after_failure&.call
+        return Hive::PlanReview::PlannerRevision::Result.new(
+          outcome: "retryable_failure", candidate_bytes: nil, candidate_digest: nil,
+          route_receipt: arguments.fetch(:planner_identity), diagnostic: "route failed"
+        )
+      end
 
       Hive::PlanReview::PlannerRevision::Result.new(
         outcome: "success", candidate_bytes: @candidate,
@@ -205,6 +209,66 @@ class PlanReviewOrchestratorTest < Minitest::Test
         route["role"] == "planner_revision" && route["transient_series_recovery"]
       end
       assert_equal [ 1, 2 ], recoveries.map { |route| route.fetch("transient_series") }
+    end
+  end
+
+  def test_newly_exhausted_past_due_planner_revision_retries_in_the_same_advance
+    revised = standard_plan.sub("# Plan", "# Revised plan")
+    with_task(standard_plan) do |task, cfg|
+      cfg["plan_review"]["attempts"]["max_transient"] = 0
+      base = Time.utc(2026, 8, 12, 12)
+      failed = false
+      anchored = false
+      clock = lambda do
+        next base unless failed
+        next base + (24 * 60 * 60) if anchored
+
+        anchored = true
+        base
+      end
+      revision = TransientRevision.new(
+        revised, after_failure: -> { failed = true }
+      )
+      adapter = success_adapter(primary_findings: [ finding("safe_auto", "Clarify tests") ])
+
+      cleared = orchestrator(
+        task, cfg, adapter:, planner_revision: revision, clock:
+      ).advance!.record
+
+      assert_equal "cleared", cleared.state
+      assert_equal 2, revision.calls.length
+      assert cleared["routes"].any? { |route| route["transient_series_recovery"] }
+    end
+  end
+
+  def test_legacy_exhausted_past_due_planner_revision_retries_in_the_same_advance
+    revised = standard_plan.sub("# Plan", "# Revised plan")
+    with_task(standard_plan) do |task, cfg|
+      cfg["plan_review"]["attempts"]["max_transient"] = 0
+      revision = TransientRevision.new(revised)
+      adapter = success_adapter(primary_findings: [ finding("safe_auto", "Clarify tests") ])
+      runner = orchestrator(task, cfg, adapter:, planner_revision: revision)
+      scheduled = runner.advance!.record
+      routes = scheduled["routes"].reject { |route| route["transient_series_recovery"] }
+      legacy = Hive::PlanReview::Record.new(
+        scheduled.to_h.merge(
+          "version" => scheduled.version + 1,
+          "routes" => routes,
+          "retry_at" => routes.last.fetch("retry_at"),
+          "updated_at" => "2026-08-12T12:01:00.000000Z"
+        )
+      )
+      store = runner.instance_variable_get(:@store)
+      store.publish_current!(legacy, expected_version: scheduled.version)
+
+      cleared = orchestrator(
+        task, cfg, adapter:, planner_revision: revision,
+        clock: -> { Time.utc(2026, 8, 13, 12) }
+      ).advance!.record
+
+      assert_equal "cleared", cleared.state
+      assert_equal 2, revision.calls.length
+      assert cleared["routes"].any? { |route| route["transient_series_recovery"] }
     end
   end
 

--- a/test/unit/plan_review/plan_signals_test.rb
+++ b/test/unit/plan_review/plan_signals_test.rb
@@ -181,6 +181,48 @@ class PlanReviewPlanSignalsTest < Minitest::Test
     end
   end
 
+  def test_unquoted_frontmatter_date_and_list_prefixed_evidence_are_parsed
+    with_plan(<<~PLAN) do |path, task_folder|
+      ---
+      date: 2026-08-30
+      ---
+      # Local parser guard
+
+      - **Files:**
+        - `lib/hive/parser.rb`
+        - `test/unit/parser_test.rb`
+      - **Test scenarios:**
+        1. accepts a valid input
+      - **Rollback:** Revert the commit.
+    PLAN
+      result = Hive::PlanReview::PlanSignals.analyze(plan_path: path, task_folder:)
+
+      assert_equal %w[lib/hive/parser.rb test/unit/parser_test.rb], result.declared_files
+      assert_equal [ "accepts a valid input" ], result.test_scenarios
+      assert result.rollback_explicit
+      assert result.skip_eligible?
+      refute_includes result.uncertainties, "malformed_frontmatter"
+    end
+  end
+
+  def test_inline_bold_files_label_is_parsed
+    with_plan(<<~PLAN) do |path, task_folder|
+      # Local parser guard
+
+      **Files:** `lib/hive/parser.rb`, `test/unit/parser_test.rb`
+
+      **Test scenarios:**
+      - accepts a valid input
+
+      **Rollback:** Revert the commit.
+    PLAN
+      result = Hive::PlanReview::PlanSignals.analyze(plan_path: path, task_folder:)
+
+      assert_equal %w[lib/hive/parser.rb test/unit/parser_test.rb], result.declared_files
+      assert result.skip_eligible?
+    end
+  end
+
   def test_oversized_frontmatter_is_uncertain_even_with_complete_markdown_evidence
     oversized = "note: #{'x' * (64 * 1024)}"
     with_plan(<<~PLAN) do |path, task_folder|

--- a/test/unit/task_action_test.rb
+++ b/test/unit/task_action_test.rb
@@ -2198,6 +2198,31 @@ class TaskActionTest < Minitest::Test
     assert_nil standard.command
   end
 
+  def test_plan_review_recovers_a_blocked_transient_planner_revision
+    task = fake_task(stage_name: "plan", stage_index: 3)
+    exhausted = Hive::TaskAction.for(
+      task, marker(:waiting),
+      plan_review: {
+        "state" => "blocked", "outcome" => "blocked",
+        "required_action" => "repair the planner route and start a linked plan generation",
+        "blockers" => [
+          { "owner" => "planner", "reason" => "planner_revision_retryable_failure" }
+        ],
+        "routes" => [
+          {
+            "role" => "planner_revision", "outcome" => "retryable_failure",
+            "attempt_id" => "pra-legacy",
+            "planner_revision_contract_version" =>
+              Hive::PlanReview::PlannerRevision::RESULT_CONTRACT_VERSION
+          }
+        ]
+      }
+    )
+
+    assert_equal "plan_reviewing", exhausted.key
+    assert_equal "hive plan-review-run demo-260426-aaaa", exhausted.command
+  end
+
   def test_plan_review_recovers_a_legacy_success_with_a_now_attestable_grok_identity
     task = fake_task(stage_name: "plan", stage_index: 3)
     routes = [

--- a/wiki/log.d/20260830T103825Z-plan-review-classification-rubric.md
+++ b/wiki/log.d/20260830T103825Z-plan-review-classification-rubric.md
@@ -1,0 +1,9 @@
+# 2026-08-30 — Plan-review classification rubric
+
+Primary and adversarial plan-review prompts now define `safe_auto`,
+`gated_auto`, `manual`, and `fyi` by decision authority. Routine technical
+corrections with a repository-grounded disposition no longer become manual
+operator questions merely because the plan must make a choice; manual is
+reserved for consequential choices that the existing contract cannot safely
+determine. The Hive prompt rubric is authoritative for the final JSON even when
+an invoked review skill has a different internal routing rubric.

--- a/wiki/log.d/20260830T133454Z-planner-revision-transient-recovery.md
+++ b/wiki/log.d/20260830T133454Z-planner-revision-transient-recovery.md
@@ -1,0 +1,9 @@
+# 2026-08-30 — Planner revision transient recovery
+
+Planner revisions now keep provider failures recoverable without raising the
+global attempt limit. Each invocation still has the configured bounded attempt
+series, but exhaustion persists a deterministic cooled recovery reset and the
+daemon opens later series until the original planner route succeeds. Exact
+transient planner blocks left by older builds are runnable after upgrade;
+invalid or terminal planner results remain blocked. The independent cap on
+successful verification-driven revision rounds is unchanged.

--- a/wiki/log.d/20260830T141317Z-plan-signal-markdown-normalization.md
+++ b/wiki/log.d/20260830T141317Z-plan-signal-markdown-normalization.md
@@ -1,0 +1,15 @@
+## 2026-08-30 — Plan signal Markdown normalization
+
+`Hive::PlanReview::PlanSignals` now accepts the planning syntax emitted by the
+current plan workflow: unquoted YAML dates, list-prefixed or inline bold field
+labels, and numbered as well as bulleted test scenarios. This removes false
+`malformed_frontmatter`, `files_not_declared`, and `tests_not_explicit`
+uncertainties without weakening the requirement for an explicit implementation
+rollback section.
+
+Focused regression tests cover both list-prefixed unified-plan fields and
+inline file declarations. Re-analysis of the four plans that exposed the issue
+finds all declared files and test scenarios; their remaining rollback warning
+is accurate because none contains a dedicated implementation rollback section.
+
+See [[modules/plan_review]] and [[testing]].

--- a/wiki/modules/plan_review.md
+++ b/wiki/modules/plan_review.md
@@ -40,10 +40,12 @@ rollback/reversibility text, file count/locality, protected-path matches, and
 bounded risk text. It never executes project code and rejects symlinks,
 traversal, invalid UTF-8, oversized input, and malformed evidence.
 Declared-file and test evidence may use repeated Markdown headings or repeated
-bold labels such as `**Files:**` and `**Test scenarios:**`. Oversized YAML
-frontmatter remains explicit uncertainty rather than disappearing, and a
-recognized literal credential pattern always selects mandatory review even
-when nearby prose never says "secret" or "credential".
+bold labels such as `**Files:**` and `**Test scenarios:**`. Bold labels may be
+list-prefixed or carry their first value inline, and test scenarios may use
+ordered or unordered Markdown lists. An unquoted YAML date is valid
+frontmatter. Oversized YAML frontmatter remains explicit uncertainty rather
+than disappearing, and a recognized literal credential pattern always selects
+mandatory review even when nearby prose never says "secret" or "credential".
 
 | Level | Rule | Availability behavior |
 |---|---|---|

--- a/wiki/modules/plan_review.md
+++ b/wiki/modules/plan_review.md
@@ -123,13 +123,14 @@ diagnostic receives the same bounded, versioned, daemon-runnable recovery.
 timeouts, and retryable failures preserve retry metadata and use at most one
 initial attempt plus `plan_review.attempts.max_transient` retries in one
 attempt series for primary, adversarial, verification, and original-planner
-revision legs. Exhausting a mandatory primary or adversarial series persists a
-recovery reset instead of converting missing required coverage into an
-operator waiver prompt. The daemon opens the next series after a deterministic
-five-minute exponential cooldown capped at 24 hours; a legacy blocked record
-whose latest required initial leg is an attempted transient outcome enters the
-same recovery path. Standard review degradation and the separately bounded
-verification and planner-revision loops are unchanged. Provider-route
+revision legs. Exhausting a mandatory primary or adversarial series, or any
+transient planner-revision series, persists a recovery reset instead of
+terminalizing the provider outage. The daemon opens the next series after a
+deterministic five-minute exponential cooldown capped at 24 hours; exact legacy
+blocked records produced by the old exhaustion behavior enter the same recovery
+path. Standard review degradation and the verification transient bound are
+unchanged. The separate cap on successful planner-revision rounds still fences
+plans whose defects survive repeated revisions. Provider-route
 exceptions are normalized into those durable attempt outcomes rather than
 escaping before retry evidence is written. Missing retry hints receive bounded
 exponential delay with deterministic jitter rather than a hot retry loop.
@@ -181,6 +182,18 @@ of four classes:
 - `manual`: requires an answer, then planner incorporation and verification;
 - `fyi`: retained as non-blocking evidence.
 
+The primary and adversarial prompts classify by decision authority rather than
+severity. That prompt-level taxonomy is authoritative for the final Hive JSON,
+even when primary review invokes a skill with a different internal routing
+rubric. A routine, repository-grounded technical correction is `safe_auto`;
+`gated_auto` is reserved for a clear correction that itself crosses a material
+approval boundary. `manual` is reserved for a choice the existing contract and
+repository patterns cannot safely determine when the alternatives materially
+change product scope, authority or trust, privacy or compliance, risk
+acceptance, irreversible external effects, or architectural direction. Merely
+needing to choose, decide, specify, or add detail does not make a finding
+manual.
+
 The fingerprint binds classification, risk, source, and exact plan evidence,
 but deliberately excludes model-authored title, description, and excerpt
 prose. The adapter verifies each `plan.md` line range and its normalized
@@ -203,12 +216,15 @@ ending in the exact `COMPLETE` marker remains authoritative completion evidence
 when a provider's terminal telemetry is malformed or truncated. Missing,
 non-terminal, oversized, invalid, or tampered candidates still fail closed.
 Planner-revision attempt receipts carry the result-adjudication contract
-version. When an exhausted transient series predates the running contract,
-Hive opens one new bounded attempt series automatically; a fixed harness can
-therefore recover without an operator manufacturing a linked plan generation.
-The task-action classifier exposes only this stale-contract blocked state as
-`plan_reviewing`, allowing the daemon to enter the recovery path while current
-blocked verdicts remain terminal and operator-owned.
+version. Every exhausted transient series opens another bounded series after
+the shared widening cooldown, so a recovered planner route resumes the same
+review lineage without an operator manufacturing a linked plan generation or
+raising global attempt capacity. The task-action classifier also exposes the
+exact planner-owned transient blocks written by older builds as
+`plan_reviewing`, allowing the daemon to migrate them into paced recovery.
+Stale-contract records retain their versioned adjudication reset. Invalid
+candidate results and other terminal planner outcomes remain blocked and
+operator-owned.
 Each accepted finding
 requires explicit fingerprint-bound verification evidence; absence from a
 generic critique does not verify it. A


### PR DESCRIPTION
## Summary

Plan reviews no longer stop for routine technical corrections, exhausted transient planner failures, or plan syntax that Hive itself emits.

## Behavior

- Findings are classified by decision authority, so only underdetermined product, authority, privacy, risk, or architecture choices require a human answer.
- Planner-provider failures keep each configured attempt series bounded, then open a new series after a widening cooldown until the route recovers. Global attempt capacity and successful-revision caps are unchanged.
- Policy signals recognize unquoted YAML dates, list-prefixed or inline field labels, and numbered test scenarios. Explicit implementation rollback evidence remains required.

Terminal planner outcomes and invalid candidates still fail closed.

## Validation

- Plan-review and task-action unit slice: 384 runs, 2,456 assertions, 0 failures.
- Wiki log tests: 7 runs, 27 assertions, 0 failures.
- RuboCop: 7 affected Ruby files, no offenses.
- Broad checkpoint: 13,952 runs with one TUI startup timing threshold failure; the isolated test then passed in 1.047 seconds.
