### PR TITLE
fix(projection): repair journal-less legacy tasks

### DIFF
--- a/lib/hive/commands/repair_projection.rb
+++ b/lib/hive/commands/repair_projection.rb
@@ -105,7 +105,8 @@ module Hive
               pristine: Hive::TaskProjection::Store.pristine_task?(
                 locked_task, marker,
                 held_task_lock: Hive::Lock.task_lock_held?(locked_task.folder)
-              )
+              ),
+              historical_zero_history: true
             )
           rescue Hive::TaskProjection::InvalidJournal => e
             raise Hive::TaskProjection::InvalidJournal,

--- a/lib/hive/task_projection/store.rb
+++ b/lib/hive/task_projection/store.rb
@@ -212,7 +212,7 @@ module Hive
                   "pristine projection initialization requires empty task projection storage"
           end
 
-          publish_pristine!(marker: marker, limits: limits).projection
+          publish_zero_history!(marker: marker, limits: limits).projection
         end
       end
 
@@ -220,15 +220,20 @@ module Hive
       # The exclusive journal lock prevents a concurrent append from binding
       # the new derived files to two different authoritative cursors.
       def repair!(marker: nil, limits: Hive::TaskWorkspace::Limits.new,
-                  pristine: false)
+                  pristine: false, historical_zero_history: false)
         with_journal_write_lock do
           stat = begin
             File.lstat(journal_path)
           rescue Errno::ENOENT
             nil
           end
-          return publish_pristine!(marker: marker, limits: limits) if
+          return publish_zero_history!(marker: marker, limits: limits) if
             stat.nil? && pristine
+          if stat.nil? && historical_zero_history &&
+             zero_history_storage?("checkpoint_missing")
+            ensure_journal_after_handoff!(snapshot: nil, marker: marker, bytes: "")
+            return publish_zero_history!(marker: marker, limits: limits)
+          end
           unless stat && stat.file? && !stat.symlink? && stat.size.positive?
             raise Hive::TaskProjection::InvalidJournal,
                   "authoritative task journal is missing, empty, or not a regular file"
@@ -298,7 +303,7 @@ module Hive
 
       private
 
-      def publish_pristine!(marker:, limits:)
+      def publish_zero_history!(marker:, limits:)
         binding = journal_binding("")
         projection = replay(binding, marker: marker)
         publish(projection)
@@ -311,7 +316,7 @@ module Hive
           reason = bounded.diagnostics.first&.fetch("reason", bounded.state) ||
                    bounded.state
           raise Hive::TaskProjection::InvalidJournal,
-                "pristine projection initialization did not produce a current checkpoint (#{reason})"
+                "zero-history projection publication did not produce a current checkpoint (#{reason})"
         end
 
         RepairResult.new(projection: projection, bounded: bounded)
@@ -330,7 +335,7 @@ module Hive
         unless checkpoint.fetch("valid")
           if require_checkpoint
             return pristine_bounded_read(marker: marker) if
-              pristine && pristine_storage?(checkpoint.fetch("reason"))
+              pristine && zero_history_storage?(checkpoint.fetch("reason"))
 
             return degraded_bounded_read(
               reason: checkpoint.fetch("reason"), state: "repair_required",
@@ -770,7 +775,7 @@ module Hive
         )
       end
 
-      def pristine_storage?(checkpoint_reason)
+      def zero_history_storage?(checkpoint_reason)
         checkpoint_reason == "checkpoint_missing" &&
           !path_entry?(journal_path) && !path_entry?(snapshot_path) &&
           !path_entry?(checkpoint_path)

--- a/test/integration/repair_projection_command_test.rb
+++ b/test/integration/repair_projection_command_test.rb
@@ -76,6 +76,32 @@ class RepairProjectionCommandTest < Minitest::Test
     end
   end
 
+  def test_historical_zero_history_task_repairs_from_its_current_marker
+    with_project_tasks(1) do |project, tasks|
+      original = tasks.first
+      done_folder = File.join(
+        original.project_root, ".hive-state", "stages", "9-done", original.slug
+      )
+      FileUtils.mkdir_p(File.dirname(done_folder))
+      FileUtils.mv(original.folder, done_folder)
+      File.write(File.join(done_folder, "task.md"), "# Completed task\n\n<!-- COMPLETE -->\n")
+
+      payload = cli_json(
+        "repair-projection", original.slug,
+        "--project", project, "--stage", "9-done", "--json"
+      )
+
+      assert_schema_valid(payload)
+      assert_equal true, payload.fetch("ok")
+      assert_equal "current", payload.fetch("checkpoint_state")
+      assert_equal "9-done", payload.fetch("stage")
+      refute File.exist?(File.join(done_folder, Hive::TaskJournal::JOURNAL_BASENAME)),
+             "historical repair must not invent authoritative journal history"
+      projection = JSON.parse(File.read(File.join(done_folder, "task-projection.json")))
+      assert_equal "complete", projection.dig("compatibility", "marker", "name")
+    end
+  end
+
   def test_corrupt_authority_emits_a_typed_bounded_error
     with_project_tasks(2) do |project, tasks|
       _unused, corrupt = tasks

--- a/test/unit/task_projection/store_test.rb
+++ b/test/unit/task_projection/store_test.rb
@@ -657,6 +657,41 @@ class TaskProjectionStoreTest < Minitest::Test
     end
   end
 
+  def test_historical_zero_history_repair_rejects_a_missing_durable_handoff_journal
+    with_tmp_dir do |dir|
+      marker = Hive::Markers::State.new(
+        name: :execute_complete,
+        attrs: { "attempt_id" => "attempt-1" },
+        raw: nil
+      )
+      store = projection_store(dir)
+
+      error = assert_raises(Hive::TaskProjection::InvalidJournal) do
+        store.repair!(marker: marker, historical_zero_history: true)
+      end
+
+      assert_match(/missing or empty after durable handoff/, error.message)
+      refute File.exist?(store.snapshot_path)
+      refute File.exist?(store.checkpoint_path)
+    end
+  end
+
+  def test_historical_zero_history_repair_refuses_partial_projection_authority
+    with_tmp_dir do |dir|
+      marker = Hive::Markers::State.new(name: :complete, attrs: {}, raw: nil)
+      store = projection_store(dir)
+      original = "existing projection authority\n"
+      File.binwrite(store.snapshot_path, original)
+
+      assert_raises(Hive::TaskProjection::InvalidJournal) do
+        store.repair!(marker: marker, historical_zero_history: true)
+      end
+
+      assert_equal original, File.binread(store.snapshot_path)
+      refute File.exist?(store.checkpoint_path)
+    end
+  end
+
   def test_routine_read_degrades_immediately_while_exact_repair_holds_the_lock
     with_tmp_dir do |dir|
       write_journal(dir, [ condition_event("event-1") ])

--- a/wiki/commands/repair-projection.md
+++ b/wiki/commands/repair-projection.md
@@ -26,9 +26,9 @@ hive repair-projection TASK-SLUG --project PROJECT --stage 4-execute
 
 The command resolves one task in the registered project set, takes its existing
 task lock, resolves it again under that lock, and excludes concurrent journal
-appends while rebuilding. It reads that task's complete authoritative journal
-and only the exact attempt proofs referenced by it; it does not enumerate the
-proof root or inspect other tasks.
+appends while rebuilding. When a journal exists, it reads that complete
+authoritative journal and only the exact attempt proofs referenced by it; it
+does not enumerate the proof root or inspect other tasks.
 
 The journal, attempt proofs, marker, stage, and worktree remain authority and
 are not changed. Repair atomically replaces each derived file—
@@ -40,7 +40,11 @@ For a task that still proves the canonical initial zero-history state, repair
 may republish those two derived files without creating an authoritative
 journal. The same shared pristine predicate used by status must prove that
 exception; only the task lock already owned by the command is ignored while
-making that decision. An arbitrary journal-less task is still rejected.
+making that decision. A pre-projection historical task may also establish the
+same marker-derived zero-history baseline, but only when the journal, snapshot,
+and checkpoint are all absent and the current marker does not prove a durable
+execute handoff. Existing or malformed authority is never replaced, and this
+compatibility baseline does not invent journal events.
 
 On success, human output names the task and journal cursor; `--json` emits
 `hive-repair-projection.v1` with `outcome: repaired` and the next action

--- a/wiki/log.d/20260830T165035Z-historical-projection-repair.md
+++ b/wiki/log.d/20260830T165035Z-historical-projection-repair.md
@@ -1,0 +1,12 @@
+---
+title: Repair journal-less historical task projections
+date: 2026-08-30
+---
+
+- Fixed `hive repair-projection` so the exact command advertised for a
+  pre-projection historical task can establish a bounded marker-derived
+  checkpoint when the journal, snapshot, and checkpoint are all absent.
+- Kept durable execute handoffs and any partial or malformed projection
+  authority fail-closed; repair does not invent an authoritative journal.
+- Added integration coverage for a historical `9-done` task and a regression
+  proving that a missing durable-handoff journal remains unrecoverable.

--- a/wiki/modules/conditions.md
+++ b/wiki/modules/conditions.md
@@ -109,8 +109,12 @@ initial-stage zero-state may project as pristine without a checkpoint. The
 explicit [[commands/repair-projection]] command owns full replay for one exact
 task. It changes derived snapshot/checkpoint files only; it is neither a
 workflow retry nor a migration or watcher. The repair command may also restore
-missing derived files for a journal-less task only when the same shared
-creation-state predicate proves the canonical initial zero-history state.
+missing derived files for a journal-less task when either the shared
+creation-state predicate proves the canonical initial zero-history state or all
+three projection authority files are absent on a historical task whose marker
+does not prove a durable execute handoff. The latter publishes a marker-derived
+compatibility baseline without fabricating journal history; any partial,
+malformed, or post-handoff authority still fails closed.
 
 Selection proceeds by current task generation, then latest compatible attempt
 within each registry family, then exact commit generation/HEAD for branch facts.


### PR DESCRIPTION
## Summary

- let the exact `hive repair-projection` command establish a marker-derived zero-history checkpoint for pre-projection historical tasks
- require journal, snapshot, and checkpoint to all be absent
- keep missing durable-handoff journals and partial or malformed authority fail-closed
- document and test the compatibility repair path

## Why

Bounded status advertised exact repair commands for legacy tasks whose projection files predate the task journal. The commands then failed with `invalid_projection_authority`, so the advertised recovery path could not heal those rows.

## Verification

- `bundle exec ruby -Itest test/integration/repair_projection_command_test.rb`
- `bundle exec ruby -Itest test/unit/task_projection/store_test.rb`
- `bundle exec ruby -Itest test/unit/commands/status_test.rb`
- focused RuboCop: 4 files, no offenses
- `git diff --check`