### PR TITLE
Fix safe draft publication after rework

### DIFF
--- a/lib/hive/github_publication.rb
+++ b/lib/hive/github_publication.rb
@@ -156,6 +156,18 @@ module Hive
         }.freeze
       end
 
+      def ancestor?(worktree_path:, ancestor_oid:, head_oid:)
+        result = Hive::AgentGitGate.read(
+          worktree_path, :ancestor,
+          base_oid: ancestor_oid, head_oid: head_oid
+        )
+        return true if result.success?
+        return false if result.exitstatus == 1 && !result.overflow
+
+        raise Hive::AgentGitGate::PublicationFailed,
+              "publication ancestry could not be verified"
+      end
+
       def push_exact(worktree_path:, branch:, head_oid:, expected_remote_oid:)
         receipt = Hive::AgentGitGate.publish(
           repository_path: worktree_path, oid: head_oid, branch: branch,
@@ -310,6 +322,9 @@ module Hive
           ensure_secret_free!(request)
           authenticate(request)
           state = read_state || initialize_state(request, revalidate)
+          return reconcile_revision(request, state, revalidate) if
+            observed_publication_revision?(state, request)
+
           validate_request!(state, request)
           reconcile(request, state, revalidate)
         end
@@ -365,6 +380,153 @@ module Hive
         end
       end
 
+      # A coding task can legitimately return from review/artifact rework with
+      # new commits while its controller-owned draft PR remains open. Keep the
+      # original state as the immutable ownership anchor, prove the hosted PR
+      # still carries that exact title/body marker, and permit only a local
+      # fast-forward of the same branch. The PR body is refreshed later by the
+      # existing finalize stage; this boundary owns only safe branch custody.
+      def reconcile_revision(request, state, revalidate)
+        record = revision_pull_request(request, state)
+        hosted_state = hosted_state(record)
+        if %w[closed merged].include?(hosted_state)
+          unless record.fetch("head_oid") == request.head_oid
+            blocked!(
+              "revision_hosted_terminal",
+              "pull request became terminal before the publication revision was hosted"
+            )
+          end
+          revalidate!(revalidate, :final)
+          return revision_observation(state, request, record, head_oid: request.head_oid)
+        end
+
+        remote = observe(request)
+        remote_oid = remote.fetch("oid")
+        unless remote_oid == record.fetch("head_oid")
+          blocked!(
+            "revision_remote_conflict",
+            "controller-owned pull-request head does not match the remote branch"
+          )
+        end
+        unless revision_ancestor?(request, state.fetch("head_oid"), remote_oid)
+          blocked!(
+            "revision_history_rewritten",
+            "hosted pull-request head no longer contains the owned publication"
+          )
+        end
+        unless revision_ancestor?(request, remote_oid, request.head_oid)
+          blocked!(
+            "revision_non_fast_forward",
+            "local publication revision does not contain the hosted pull-request head"
+          )
+        end
+
+        if remote_oid != request.head_oid
+          revalidate!(revalidate, :before_push)
+          begin
+            receipt = @git.push_exact(
+              worktree_path: request.worktree_path, branch: request.branch,
+              head_oid: request.head_oid, expected_remote_oid: remote_oid
+            )
+            validate_push_receipt!(
+              receipt, remote_oid, request, code: "revision_push_outcome_unknown"
+            )
+          rescue Blocked
+            raise
+          rescue StandardError
+            after_failure = observe(request)
+            unless after_failure.fetch("oid") == request.head_oid
+              blocked!(
+                "revision_push_outcome_unknown",
+                "publication revision push outcome requires reconciliation"
+              )
+            end
+          end
+          after = observe(request)
+          unless after.fetch("oid") == request.head_oid
+            blocked!(
+              "revision_push_not_observed",
+              "publication revision was not observed at the reviewed head"
+            )
+          end
+        end
+
+        revalidate!(revalidate, :final)
+        revision_observation(state, request, record, head_oid: request.head_oid)
+      end
+
+      def observed_publication_revision?(state, request)
+        return false unless state.fetch("phase") == "pr_observed" && state.fetch("pr")
+
+        expected = identity(request)
+        return false if expected.all? { |key, value| state[key] == value }
+
+        %w[host repository base_branch creation_base_oid branch draft].all? do |key|
+          state[key] == expected[key]
+        end && state.fetch("title_digest") == request.title_digest &&
+          state.fetch("head_oid") != request.head_oid
+      end
+
+      def revision_pull_request(request, state)
+        records = complete_inventory(request)
+        candidates = records.select { |record| record.fetch("head_branch") == request.branch }
+        exact = candidates.select { |record| revision_owned?(record, state, request) }
+        return exact.first if candidates.one? && exact.one?
+
+        blocked!(
+          "revision_identity_conflict",
+          "controller-owned pull-request revision identity requires operator reconciliation"
+        )
+      end
+
+      def revision_owned?(record, state, request)
+        prior = state.fetch("pr")
+        marker = publication_marker(state)
+        prior_body = "#{request.body.rstrip}\n\n#{marker}\n"
+        record.fetch("number") == prior.fetch("number") &&
+          record.fetch("url") == prior.fetch("url") &&
+          record.fetch("head_repository")&.casecmp?(request.repository) &&
+          record.fetch("base_branch") == request.base_branch &&
+          record.fetch("base_repository").casecmp?(request.repository) &&
+          record.fetch("title") == request.title &&
+          record.fetch("body") == prior_body &&
+          Digest::SHA256.hexdigest(record.fetch("title")) == state.fetch("title_digest") &&
+          Digest::SHA256.hexdigest(record.fetch("body")) == state.fetch("body_digest") &&
+          Digest::SHA256.hexdigest(marker) == state.fetch("marker_digest")
+      end
+
+      def publication_marker(state)
+        "<!-- hive-publication:v1 id=#{state.fetch('publication_id')} " \
+          "base=#{state.fetch('creation_base_oid')} -->"
+      end
+
+      def revision_ancestor?(request, ancestor_oid, head_oid)
+        @git.ancestor?(
+          worktree_path: request.worktree_path,
+          ancestor_oid: ancestor_oid, head_oid: head_oid
+        ).equal?(true)
+      rescue StandardError
+        blocked!(
+          "revision_ancestry_unavailable",
+          "publication revision ancestry could not be verified"
+        )
+      end
+
+      def revision_observation(state, request, record, head_oid:)
+        state.fetch("pr").merge(
+          "head_oid" => head_oid,
+          "hosted_state" => hosted_state(record),
+          "observed_at" => timestamp,
+          "diff_digest" => request.diff_digest
+        )
+      end
+
+      def hosted_state(record)
+        return record.fetch("state").downcase unless record.fetch("state") == "OPEN"
+
+        record.fetch("draft") ? "draft" : "open"
+      end
+
       def reconcile_push(request, state, revalidate)
         current = observe(request)
         if current.fetch("oid") == request.head_oid
@@ -405,7 +567,7 @@ module Hive
             head_oid: request.head_oid,
             expected_remote_oid: state.fetch("expected_remote_oid")
           )
-          validate_push_receipt!(receipt, state, request)
+          validate_push_receipt!(receipt, state.fetch("expected_remote_oid"), request)
         rescue Blocked
           raise
         rescue StandardError
@@ -572,18 +734,13 @@ module Hive
       end
 
       def observe_pr(state, request, record)
-        hosted = if record.fetch("state") == "OPEN"
-          record.fetch("draft") ? "draft" : "open"
-        else
-          record.fetch("state").downcase
-        end
         pr = identity(request).slice(
           "publication_id", "host", "repository", "base_branch",
           "creation_base_oid", "branch", "head_oid", "diff_digest",
           "title_digest", "body_digest", "marker_digest"
         ).merge(
           "number" => record.fetch("number"), "url" => record.fetch("url"),
-          "hosted_state" => hosted, "observed_at" => timestamp
+          "hosted_state" => hosted_state(record), "observed_at" => timestamp
         )
         write_state(state.merge(
           "phase" => "pr_observed", "pr" => pr, "updated_at" => timestamp
@@ -738,14 +895,14 @@ module Hive
           value["remote_fingerprint"].to_s.match?(DIGEST)
       end
 
-      def validate_push_receipt!(value, state, request)
+      def validate_push_receipt!(value, expected_oid, request, code: "push_outcome_unknown")
         fields = %w[expected_oid before_oid after_oid remote_fingerprint]
         unless value.is_a?(Hash) && value.keys.sort == fields.sort &&
-               value["expected_oid"] == state.fetch("expected_remote_oid") &&
-               value["before_oid"] == state.fetch("expected_remote_oid") &&
+               value["expected_oid"] == expected_oid &&
+               value["before_oid"] == expected_oid &&
                value["after_oid"] == request.head_oid &&
                value["remote_fingerprint"].to_s.match?(DIGEST)
-          blocked!("push_outcome_unknown", "remote push outcome requires reconciliation")
+          blocked!(code, "remote push outcome requires reconciliation")
         end
       end
 

--- a/lib/hive/secret_patterns.rb
+++ b/lib/hive/secret_patterns.rb
@@ -44,7 +44,10 @@ module Hive
       # not mistaken for a credential.
       # Include conventional prefixes (`DB_PASSWORD`, `ADMIN_PASSWORD`) so a
       # dotted unquoted credential cannot hide behind the variable name.
-      password_assignment:   /\b(?:[A-Za-z][A-Za-z0-9]*_)*(?:password|passwd|pwd)\b['"]?\s*[:=]\s*['"]?[^\s'"]{6,}['"]?(?=[\s,;}\]]|$)/i,
+      # A whole shell variable reference is not itself secret material. Exempt
+      # only `$NAME` / `${NAME}` (optionally quoted); mixed reference-plus-
+      # literal values remain fail-closed.
+      password_assignment:   /\b(?:[A-Za-z][A-Za-z0-9]*_)*(?:password|passwd|pwd)\b['"]?\s*[:=]\s*(?!['"]?\$(?:\{[A-Za-z_][A-Za-z0-9_]*\}|[A-Za-z_][A-Za-z0-9_]*)['"]?(?=[\s,;}\]]|$))['"]?[^\s'"]{6,}['"]?(?=[\s,;}\]]|$)/i,
       password_sql:          /\bPASSWORD\s+['"][^\s'"]{6,}['"]/i,
       password_xml:          /<password>\s*[^<\s]{6,}\s*<\/password>/i,
       password_cli:          /--password\s+['"]?[^\s'"]{6,}['"]?(?=\s|$)/i,

--- a/test/unit/github_publication_test.rb
+++ b/test/unit/github_publication_test.rb
@@ -4,6 +4,8 @@ require "open3"
 require "hive/github_publication"
 
 class GithubPublicationTest < Minitest::Test
+  include HiveTestHelper
+
   class FakeGithub
     attr_reader :creates
     attr_accessor :records, :crash_after_create, :fail_before_create,
@@ -97,6 +99,7 @@ class GithubPublicationTest < Minitest::Test
       end
       gateway = Hive::GithubPublication::GithubGateway.new(transport: transport)
 
+      assert gateway.authenticate!(host: request.host)
       records = gateway.list_pull_requests(
         repository: request.repository, host: request.host,
         branch: request.branch
@@ -117,6 +120,35 @@ class GithubPublicationTest < Minitest::Test
       assert_includes create_args, "github.com/acme/demo"
       assert_includes create_args, request.branch
       assert_includes create_args, request.base_branch
+    end
+  end
+
+  def test_git_gateway_reports_false_and_unverifiable_ancestry
+    with_local_remote do |repo, remote, head|
+      gateway = Hive::GithubPublication::GitGateway.new(
+        remote: remote, allow_local_transport: true
+      )
+      base = capture("git", "-C", repo, "rev-parse", "HEAD~1").strip
+
+      refute gateway.ancestor?(
+        worktree_path: repo, ancestor_oid: head, head_oid: base
+      )
+      assert_raises(Hive::AgentGitGate::PublicationFailed) do
+        gateway.ancestor?(
+          worktree_path: repo, ancestor_oid: "f" * 40, head_oid: head
+        )
+      end
+
+      expected = { "host" => "github.com", "repository" => "acme/demo" }
+      calls = []
+      resolver = lambda do |path, cfg:, managed:|
+        calls << [ path, cfg, managed ]
+        expected
+      end
+      with_replaced_singleton_method(Hive::Gh, :repository_identity, resolver) do
+        assert_equal expected, gateway.repository_identity(worktree_path: repo)
+      end
+      assert_equal [ [ repo, nil, true ] ], calls
     end
   end
 
@@ -305,6 +337,150 @@ class GithubPublicationTest < Minitest::Test
         assert_equal 0, git.pushes
         assert_equal 0, github.creates
       end
+    end
+  end
+
+  def test_controller_owned_draft_accepts_only_a_fast_forward_revision
+    with_local_remote do |repo, remote, head|
+      github = FakeGithub.new
+      git = CountingGit.new(remote)
+      controller = controller_for(repo, remote, github, git_gateway: git)
+      original = request_for(repo, head)
+
+      published = controller.publish!(original, revalidate: ->(_phase) { true })
+      original_state = File.binread(state_path(repo))
+      assert_equal head, published.fetch("head_oid")
+
+      revised_head = commit(repo, "follow-up.txt", "follow-up\n", "follow-up")
+      revised = revised_request(repo, original, revised_head)
+      publication = controller.publish!(revised, revalidate: ->(_phase) { true })
+
+      assert_equal revised_head, publication.fetch("head_oid")
+      assert_equal original.publication_id, publication.fetch("publication_id")
+      assert_equal revised_head, remote_oid(remote, revised.branch)
+      assert_equal 2, git.pushes
+      assert_equal 1, github.creates
+      assert_equal original_state, File.binread(state_path(repo)),
+                   "the first exact publication remains the immutable ownership anchor"
+
+      github.records.first["head_oid"] = revised_head
+      replay = controller.publish!(revised, revalidate: ->(_phase) { true })
+      assert_equal revised_head, replay.fetch("head_oid")
+      assert_equal 2, git.pushes
+      assert_equal 1, github.creates
+
+      phases = []
+      github.records.first["state"] = "MERGED"
+      merged = controller.publish!(revised, revalidate: ->(phase) { phases << phase; true })
+      assert_equal "merged", merged.fetch("hosted_state")
+      assert_equal revised_head, merged.fetch("head_oid")
+      assert_equal [ :final ], phases
+    end
+  end
+
+  def test_controller_owned_draft_refuses_a_non_fast_forward_revision
+    with_local_remote do |repo, remote, head|
+      github = FakeGithub.new
+      controller = controller_for(repo, remote, github)
+      original = request_for(repo, head)
+      controller.publish!(original, revalidate: ->(_phase) { true })
+
+      revised_head = commit(repo, "follow-up.txt", "follow-up\n", "follow-up")
+      revised = revised_request(repo, original, revised_head)
+      git = CountingGit.new(remote)
+      ancestry = [ true, false ]
+      git.define_singleton_method(:ancestor?) { |**| ancestry.shift }
+
+      error = assert_raises(Hive::GithubPublication::Blocked) do
+        controller_for(repo, remote, github, git_gateway: git)
+          .publish!(revised, revalidate: ->(_phase) { true })
+      end
+      assert_equal "revision_non_fast_forward", error.code
+      assert_equal head, remote_oid(remote, revised.branch)
+      assert_equal 0, git.pushes
+      assert_equal 1, github.creates
+    end
+  end
+
+  def test_revision_reconciliation_fails_closed_for_identity_remote_terminal_and_ancestry_conflicts
+    with_published_revision do |_repo, _remote, original, revised, controller, github|
+      github.records.first["body"] = "edited by somebody else"
+      assert_revision_error("revision_identity_conflict", controller, revised)
+    end
+
+    with_published_revision do |_repo, _remote, _original, revised, controller, _github|
+      controller.instance_variable_set(
+        :@git, sequence_git([ remote_observation("f" * 40) ])
+      )
+      assert_revision_error("revision_remote_conflict", controller, revised)
+    end
+
+    with_published_revision do |_repo, _remote, _original, revised, controller, github|
+      github.records.first["head_oid"] = "f" * 40
+      controller.instance_variable_set(
+        :@git, sequence_git([ remote_observation("f" * 40) ], ancestor: false)
+      )
+      assert_revision_error("revision_history_rewritten", controller, revised)
+    end
+
+    with_published_revision do |_repo, _remote, _original, revised, controller, github|
+      github.records.first["state"] = "MERGED"
+      assert_revision_error("revision_hosted_terminal", controller, revised)
+    end
+
+    with_published_revision do |_repo, _remote, original, revised, controller, _github|
+      controller.instance_variable_set(
+        :@git,
+        sequence_git([ remote_observation(original.head_oid) ], ancestor: :error)
+      )
+      assert_revision_error("revision_ancestry_unavailable", controller, revised)
+    end
+  end
+
+  def test_revision_push_reconciles_lost_responses_and_blocks_unknown_outcomes
+    with_published_revision do |_repo, _remote, original, revised, controller, _github|
+      controller.instance_variable_set(
+        :@git, sequence_git([ remote_observation(original.head_oid) ], push: {})
+      )
+      assert_revision_error("revision_push_outcome_unknown", controller, revised)
+    end
+
+    with_published_revision do |_repo, _remote, original, revised, controller, _github|
+      controller.instance_variable_set(
+        :@git,
+        sequence_git(
+          [ remote_observation(original.head_oid), remote_observation(original.head_oid) ],
+          push_error: true
+        )
+      )
+      assert_revision_error("revision_push_outcome_unknown", controller, revised)
+    end
+
+    with_published_revision do |_repo, _remote, original, revised, controller, _github|
+      controller.instance_variable_set(
+        :@git,
+        sequence_git(
+          [ remote_observation(original.head_oid), remote_observation(original.head_oid) ],
+          push: revision_push_observation(original, revised)
+        )
+      )
+      assert_revision_error("revision_push_not_observed", controller, revised)
+    end
+
+    with_published_revision do |_repo, _remote, original, revised, controller, _github|
+      controller.instance_variable_set(
+        :@git,
+        sequence_git(
+          [
+            remote_observation(original.head_oid),
+            remote_observation(revised.head_oid),
+            remote_observation(revised.head_oid)
+          ],
+          push_error: true
+        )
+      )
+      publication = controller.publish!(revised, revalidate: ->(*) { true })
+      assert_equal revised.head_oid, publication.fetch("head_oid")
     end
   end
 
@@ -583,7 +759,7 @@ class GithubPublicationTest < Minitest::Test
       assert_raises(Hive::GithubPublication::Blocked) { controller.send(:observe, request) }
 
       assert_raises(Hive::GithubPublication::Blocked) do
-        controller.send(:validate_push_receipt!, {}, base, request)
+        controller.send(:validate_push_receipt!, {}, nil, request)
       end
       bad_pr = pr.merge("observed_at" => "bad")
       refute controller.send(:valid_pr_observation?, bad_pr, base.merge("phase" => "pr_observed"))
@@ -691,6 +867,11 @@ class GithubPublicationTest < Minitest::Test
         controller.send(:reconcile, request, { "phase" => "unknown" }, ->(*) { true })
       end
       assert_equal "invalid_phase", error.code
+
+      error = assert_raises(Hive::GithubPublication::Blocked) do
+        controller.send(:revalidate!, ->(*) { raise "failed" }, :final)
+      end
+      assert_equal "stale_authority", error.code
     end
   end
 
@@ -707,6 +888,7 @@ class GithubPublicationTest < Minitest::Test
     end
 
     def observe(**values) = @delegate.observe(**values)
+    def ancestor?(**values) = @delegate.ancestor?(**values)
 
     def push_exact(**values)
       @pushes += 1
@@ -739,6 +921,19 @@ class GithubPublicationTest < Minitest::Test
       branch: "hive/patrol-fix/repair-one/g1", head_oid: head,
       diff_digest: Digest::SHA256.hexdigest(diff), title: "Fix the patrol finding",
       body: "## Fix\n\nValidated exact patch.\n", diff: diff, draft: true
+    )
+  end
+
+  def revised_request(repo, original, head)
+    diff = capture(
+      "git", "-C", repo, "diff", "#{original.creation_base_oid}..#{head}"
+    )
+    Hive::GithubPublication::Request.new(
+      **original.to_h.merge(
+        head_oid: head,
+        diff: diff,
+        diff_digest: Digest::SHA256.hexdigest(diff)
+      )
     )
   end
 
@@ -786,14 +981,47 @@ class GithubPublicationTest < Minitest::Test
     )
   end
 
-  def sequence_git(observations, push: nil, push_error: false)
+  def sequence_git(observations, push: nil, push_error: false, ancestor: true)
     Object.new.tap do |git|
       git.define_singleton_method(:observe) { |**| observations.shift || raise("unexpected observation") }
+      git.define_singleton_method(:ancestor?) do |**|
+        raise "ancestry failed" if ancestor == :error
+
+        ancestor
+      end
       git.define_singleton_method(:push_exact) do |**|
         raise "push failed" if push_error
         push
       end
     end
+  end
+
+  def revision_push_observation(original, revised)
+    {
+      "expected_oid" => original.head_oid,
+      "before_oid" => original.head_oid,
+      "after_oid" => revised.head_oid,
+      "remote_fingerprint" => "9" * 64
+    }
+  end
+
+  def with_published_revision
+    with_local_remote do |repo, remote, head|
+      github = FakeGithub.new
+      controller = controller_for(repo, remote, github)
+      original = request_for(repo, head)
+      controller.publish!(original, revalidate: ->(*) { true })
+      revised_head = commit(repo, "follow-up.txt", "follow-up\n", "follow-up")
+      revised = revised_request(repo, original, revised_head)
+      yield repo, remote, original, revised, controller, github
+    end
+  end
+
+  def assert_revision_error(code, controller, request)
+    error = assert_raises(Hive::GithubPublication::Blocked) do
+      controller.publish!(request, revalidate: ->(*) { true })
+    end
+    assert_equal code, error.code
   end
 
   def with_local_remote

--- a/test/unit/secret_patterns_test.rb
+++ b/test/unit/secret_patterns_test.rb
@@ -158,6 +158,13 @@ class SecretPatternsTest < Minitest::Test
     assert_match_name("password: s3cretpassphrase42", :password_assignment)
   end
 
+  def test_password_assignment_shell_variable_indirection_is_not_a_secret
+    refute_match_any("MINIO_ROOT_PASSWORD=${SECRET_ACCESS_KEY}")
+    refute_match_any('DATABASE_PASSWORD="$DATABASE_PASSWORD"')
+    assert_match_name("DATABASE_PASSWORD=${DATABASE_PASSWORD}-literal", :password_assignment)
+    assert_match_name('DATABASE_PASSWORD="$DATABASE_PASSWORD-suffix"', :password_assignment)
+  end
+
   def test_password_before_json_delimiter_is_detected
     assert_match_name(
       '{"password":"s3cretpassphrase42"}',

--- a/wiki/log.d/20260830T180741Z-open-pr-rework-publication.md
+++ b/wiki/log.d/20260830T180741Z-open-pr-rework-publication.md
@@ -1,0 +1,16 @@
+# 2026-08-30 — Reconcile reworked draft publications
+
+Open-PR re-entry now fast-forwards an existing controller-owned draft after
+review or artifact rework. Hive retains the original durable publication as the
+ownership anchor, revalidates the exact hosted PR and remote head, requires the
+hosted history to retain that anchor and the new local head to retain the hosted
+head, then pushes with an expected-OID lease. Lost push responses converge from
+remote observation; identity changes, rewritten history, divergence, remote
+conflicts, and terminal PRs missing the revision remain fail-closed.
+
+The shared password-assignment scanner now distinguishes whole shell variable
+references such as `MINIO_ROOT_PASSWORD=${SECRET_ACCESS_KEY}` from embedded
+literal credential material. This prevents safe environment indirection in an
+exact diff from blocking publication without weakening mixed-value detection.
+
+See [[stages/open-pr]] and [[modules/secret_patterns]].

--- a/wiki/modules/secret_patterns.md
+++ b/wiki/modules/secret_patterns.md
@@ -3,7 +3,7 @@ title: Hive::SecretPatterns
 type: module
 source: lib/hive/secret_patterns.rb
 created: 2026-04-26
-updated: 2026-08-21
+updated: 2026-08-30
 tags: [security, secrets, regex, secret-scan, redact]
 ---
 
@@ -36,7 +36,7 @@ record for every hit. `redact` coerces binary input to UTF-8 with invalid bytes 
 | `github_fine_grained_pat` | `github_pat_[A-Za-z0-9_]{20,}` | Current fine-grained GitHub personal access tokens. |
 | `generic_api_key` | `\bapi[_-]?key\b[\s:=]{0,3}['"]?…20+ chars` | Quoted or unquoted assignments. |
 | `pem_private_key` | `-----BEGIN … PRIVATE KEY-----…-----END … PRIVATE KEY-----` (`/m`) | Block form — redacts the base64 body, not just the BEGIN header. PR #84 #3. |
-| `password_assignment` | conventional names ending in `password`, `passwd`, or `pwd`, followed by `:` or `=` and 6+ chars | Catches shell / env / YAML assignment shapes such as `DB_PASSWORD=...` as well as bare `password: ...`. |
+| `password_assignment` | conventional names ending in `password`, `passwd`, or `pwd`, followed by `:` or `=` and 6+ chars | Catches shell / env / YAML assignment shapes such as `DB_PASSWORD=...` as well as bare `password: ...`. A whole `$NAME` or `${NAME}` reference, optionally quoted, is indirection rather than secret material; mixed reference-plus-literal values remain findings. |
 | `bearer_token` | `\bauthorization\s*[:=]\s*['"]?(Bearer|Basic|Token)\s+…8+ chars` | HTTP `Authorization:` headers across curl / log / framework formats. |
 | `session_cookie` | `(Set-)?Cookie:\s*…(session(id)?|sid|auth)…=…8+` | Cookie / Set-Cookie values containing a session-like key. |
 | `openai_api_key` | `\bsk-[A-Za-z0-9]{20,}` | OpenAI API key prefix. |

--- a/wiki/stages/open-pr.md
+++ b/wiki/stages/open-pr.md
@@ -3,7 +3,7 @@ title: 5-open-pr stage
 type: stage
 source: lib/hive/stages/open_pr.rb, lib/hive/github_publication.rb, templates/open_pr_prompt.md.erb
 created: 2026-05-13
-updated: 2026-08-21
+updated: 2026-08-30
 tags: [stage, pr, github]
 ---
 
@@ -41,11 +41,19 @@ outside `pr-draft.json`. The agent never writes `pr.md` or a completion marker.
 - push only with an expected-absence lease and verify the remote OID;
 - create the PR only after intent is durable and exact local/remote evidence is
   revalidated;
+- after review or artifact rework, fast-forward the same controller-owned draft
+  only when its original number, URL, title, body marker, repository, base, and
+  branch are unchanged, the hosted head still equals the remote branch, and
+  that head is an ancestor of the new local commit;
 - safely retry a failed absent-branch push or a definite `gh pr create`
   failure; unknown attempted outcomes remain reconciliation-only.
 
 The durable controller state stores identities and digests, never raw title,
-body, or diff bytes.
+body, or diff bytes. A rework fast-forward keeps the first observed publication
+state as its immutable ownership anchor. Its expected-remote-OID push is safe to
+reconcile after a lost response, while a changed/ambiguous PR, non-fast-forward
+head, rewritten hosted history, remote mismatch, or terminal PR missing the new
+revision fails closed.
 
 ## Outcomes
 


### PR DESCRIPTION
## Summary

- allow a controller-owned draft PR to fast-forward after review or artifact rework
- retain the original publication as the immutable ownership anchor and reject rewritten, divergent, ambiguous, or terminal-missing revisions
- stop treating whole shell variable password references as literal secrets while keeping mixed values blocked
- document the publication and scanner contracts

## Verification

- focused open-PR and scanner suite: 78 runs, 443 assertions, 0 failures
- changed-source coverage: exact coverage for both modified production files
- full coverage collection: 100.00% lines, 96,674 of 96,674
- full local suite: 14,058 runs and 285,761 assertions; its sole failure was caused by the original isolated worktree path containing the fixture-forbidden substring secret-, and the exact owner passed from the neutral worktree with 1 run and 148 assertions
- read-only Screenote rehearsal proved PR 67 ownership, hosted/remote equality, retained anchor ancestry, and local fast-forward ancestry
