### PR TITLE
fix(plan-review): recover planner revisions via fallback

### DIFF
--- a/lib/hive/config.rb
+++ b/lib/hive/config.rb
@@ -2072,7 +2072,9 @@ module Hive
       "attempts" => %w[max_transient timeout_sec],
       "coverage" => %w[required optional],
       "reviewers" => %w[primary adversarial verification],
-      "routes" => %w[primary adversarial verification fallbacks]
+      "routes" => %w[
+        primary adversarial verification fallbacks planner_revision_fallback
+      ]
     }.freeze
     PLAN_REVIEW_ADAPTERS = %w[ce_doc_review].freeze
     PLAN_REVIEW_BENCHMARK_OPT_OUT_ENV = "HIVE_BENCH_ALLOW_DISABLED_PLAN_REVIEW"
@@ -2197,6 +2199,19 @@ module Hive
         validate_closed_mapping!(row, route_keys, "plan_review.routes.fallbacks[#{index}]", source_path)
         validate_plan_review_route_row!(row, "plan_review.routes.fallbacks[#{index}]", source_path)
       end
+      planner_fallback = routes["planner_revision_fallback"]
+      return unless routes.key?("planner_revision_fallback")
+
+      unless planner_fallback.is_a?(Hash)
+        raise ConfigError,
+              "plan_review.routes.planner_revision_fallback in #{describe_source(source_path)} must be a Hash"
+      end
+      validate_closed_mapping!(
+        planner_fallback, route_keys, "plan_review.routes.planner_revision_fallback", source_path
+      )
+      validate_plan_review_route_row!(
+        planner_fallback, "plan_review.routes.planner_revision_fallback", source_path
+      )
     end
 
     def validate_plan_review_route_row!(row, label, source_path)

--- a/lib/hive/plan_review/orchestrator.rb
+++ b/lib/hive/plan_review/orchestrator.rb
@@ -775,16 +775,19 @@ module Hive
           end
 
           attempt_id = Identity.attempt(record.review_id)
+          revision_identity, fallback = planner_revision_identity(record)
           revision = @planner_revision.call(
             review_id: record.review_id, plan_bytes:, findings:,
-            planner_identity: planner_identity(record),
+            planner_identity: revision_identity,
+            planner_authority: planner_identity(record),
             timeout_sec: @cfg.dig("plan_review", "attempts", "timeout_sec")
           )
           retry_at = if TRANSIENT_OUTCOMES.include?(revision.outcome)
             default_retry_at(record, role, attempt_id)
           end
           route = planner_revision_route(
-            revision, record, attempt_id:, retry_at:
+            revision, record, requested: revision_identity, fallback:,
+            attempt_id:, retry_at:
           )
           refs = @store.write_attempt!(
             review_id: record.review_id, attempt_id:, plan_bytes:,
@@ -1248,10 +1251,11 @@ module Hive
         }
       end
 
-      def planner_revision_route(revision, record, attempt_id: nil, retry_at: nil)
-        actual = revision.route_receipt.empty? ? planner_identity(record) : revision.route_receipt
-        {
-          "role" => "planner_revision", "requested" => planner_identity(record),
+      def planner_revision_route(revision, record, requested:, fallback:,
+                                 attempt_id: nil, retry_at: nil)
+        actual = revision.route_receipt.empty? ? requested : revision.route_receipt
+        route = {
+          "role" => "planner_revision", "requested" => requested,
           "actual" => actual, "capability_result" => "present",
           "independence_verified" => false, "independence_reason" => "same_plan_authority",
           "outcome" => revision.outcome, "attempt_id" => attempt_id,
@@ -1259,6 +1263,38 @@ module Hive
           "diagnostic" => revision.diagnostic,
           "planner_revision_contract_version" => PlannerRevision::RESULT_CONTRACT_VERSION
         }.compact
+        return route unless fallback
+
+        route.merge(
+          "planner_revision_fallback" => true,
+          "planner_authority" => planner_identity(record),
+          "fallback_reason" => "captured_planner_transient_failure"
+        )
+      end
+
+      def planner_revision_identity(record)
+        authority = planner_identity(record)
+        row = @cfg.dig("plan_review", "routes", "planner_revision_fallback")
+        return [ authority, false ] unless row.is_a?(Hash)
+
+        fallback = {
+          "provider" => row.fetch("agent"), "model" => row.fetch("model"),
+          "family" => row.fetch("family"), "effort" => row.fetch("effort"),
+          "route" => row.fetch("route")
+        }
+        previous = latest_route(record, "planner_revision")
+        return [ authority, false ] unless previous
+
+        fallback_used = previous["planner_revision_fallback"] == true ||
+          identity_matches?(previous["requested"], fallback)
+        fallback_due = TRANSIENT_OUTCOMES.include?(previous["outcome"])
+        (fallback_used || fallback_due) ? [ fallback, true ] : [ authority, false ]
+      end
+
+      def identity_matches?(observed, expected)
+        observed.is_a?(Hash) && expected.all? do |key, value|
+          observed[key].to_s == value.to_s
+        end
       end
 
       def stale_planner_revision_contract?(route)

--- a/lib/hive/plan_review/planner_revision.rb
+++ b/lib/hive/plan_review/planner_revision.rb
@@ -149,7 +149,8 @@ module Hive
         @runner = runner
       end
 
-      def call(review_id:, plan_bytes:, findings:, planner_identity:, timeout_sec:)
+      def call(review_id:, plan_bytes:, findings:, planner_identity:, timeout_sec:,
+               planner_authority: planner_identity)
         DisposableWorktree.open(
           project_root: @task.project_root,
           prefix: "hive-plan-revision-worktree-"
@@ -159,7 +160,8 @@ module Hive
           File.binwrite(input_path, Hive::SecretPatterns.redact(plan_bytes.to_s))
           File.chmod(0o600, input_path)
           prompt = render_prompt(
-            input_path:, output_path:, findings:, review_id:, planner_identity:
+            input_path:, output_path:, findings:, review_id:, planner_identity:,
+            planner_authority:
           )
           observed = stringify(@runner.call(
             prompt:, workspace:, output_path:, planner_identity:, timeout_sec:
@@ -177,14 +179,16 @@ module Hive
 
       private
 
-      def render_prompt(input_path:, output_path:, findings:, review_id:, planner_identity:)
+      def render_prompt(input_path:, output_path:, findings:, review_id:, planner_identity:,
+                        planner_authority:)
         source = File.read(File.expand_path("../../../templates/plan_revision_prompt.md.erb", __dir__))
         ERB.new(source, trim_mode: "-").result_with_hash(
           nonce: SecureRandom.hex(24), input_path:, output_path:, review_id:,
           findings_json: JSON.pretty_generate(Array(findings).map do |finding|
             finding.respond_to?(:to_h) ? finding.to_h : finding
           end),
-          planner_identity_json: JSON.generate(planner_identity)
+          planner_identity_json: JSON.generate(planner_identity),
+          planner_authority_json: JSON.generate(planner_authority)
         )
       end
 

--- a/lib/hive/plan_review/policy.rb
+++ b/lib/hive/plan_review/policy.rb
@@ -113,6 +113,16 @@ module Hive
         ].to_h do |key|
           [ key, settings[key] ]
         end
+        # Planner-revision fallback is an operational recovery route, not a
+        # reviewer or verdict change. Keeping it outside the fingerprint lets
+        # an operator recover a provider-limited revision without discarding
+        # the findings and decisions already bound to this review lineage.
+        routes = configured["routes"]
+        if routes.is_a?(Hash)
+          configured["routes"] = routes.reject do |key, _value|
+            key.to_s == "planner_revision_fallback"
+          end
+        end
         return configured if model_routing.empty?
 
         configured.merge("model_routing" => model_routing)

--- a/templates/plan_revision_prompt.md.erb
+++ b/templates/plan_revision_prompt.md.erb
@@ -1,7 +1,9 @@
-You are the original planner revising one executable Hive coding plan.
+You are revising one executable Hive coding plan on behalf of its captured
+planner authority.
 
 Review lineage: <%= review_id %>
-Captured planner route: <%= planner_identity_json %>
+Captured planner authority: <%= planner_authority_json %>
+Effective revision route: <%= planner_identity_json %>
 Immutable input plan: <%= input_path %>
 Required output: <%= output_path %>
 

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -94,6 +94,7 @@ class ConfigTest < Minitest::Test
         "plan_review:\n  routes:\n    primary: nope\n" => /routes\.primary.*must be a Hash/i,
         "plan_review:\n  routes:\n    fallbacks: nope\n" => /fallbacks.*must be an Array/i,
         "plan_review:\n  routes:\n    fallbacks: [nope]\n" => /fallbacks\[0\].*must be a Hash/i,
+        "plan_review:\n  routes:\n    planner_revision_fallback: nope\n" => /planner_revision_fallback.*must be a Hash/i,
         "plan_review:\n  routes:\n    primary:\n      model: ''\n" => /primary\.model.*must be non-empty/i,
         "plan_review:\n  routes:\n    primary:\n      effort: impossible\n" => /primary\.effort.*must be one of/i,
         "plan_review:\n  approval_policies: nope\n" => /approval_policies.*must be an Array/i,
@@ -116,6 +117,21 @@ class ConfigTest < Minitest::Test
       YAML
       assert_equal "fallback-codex",
                    Hive::Config.load(dir).dig("plan_review", "routes", "fallbacks", 0, "route")
+
+      File.write(config_path, <<~YAML)
+        plan_review:
+          routes:
+            planner_revision_fallback:
+              agent: codex
+              model: gpt-5.6-sol
+              family: openai
+              effort: high
+              route: native_codex
+      YAML
+      assert_equal "gpt-5.6-sol",
+                   Hive::Config.load(dir).dig(
+                     "plan_review", "routes", "planner_revision_fallback", "model"
+                   )
 
       policy = {
         "id" => "bounded_policy", "version" => 1, "action" => "approve_finding",

--- a/test/unit/plan_review/orchestrator_test.rb
+++ b/test/unit/plan_review/orchestrator_test.rb
@@ -179,6 +179,47 @@ class PlanReviewOrchestratorTest < Minitest::Test
     end
   end
 
+  def test_planner_revision_falls_back_after_a_transient_failure_without_rekeying
+    revised = standard_plan.sub("# Plan", "# Revised plan")
+    with_task(standard_plan) do |task, cfg|
+      cfg["plan_review"]["routes"]["planner_revision_fallback"] = {
+        "agent" => "codex", "model" => "gpt-5.6-sol", "family" => "openai",
+        "effort" => "high", "route" => "native_codex"
+      }
+      revision = TransientRevision.new(revised, failures: 2)
+      adapter = success_adapter(primary_findings: [ finding("safe_auto", "Clarify tests") ])
+
+      first = orchestrator(task, cfg, adapter:, planner_revision: revision).advance!.record
+      second = orchestrator(
+        task, cfg, adapter:, planner_revision: revision,
+        clock: -> { Time.utc(2026, 8, 12, 13) }
+      ).advance!.record
+      cleared = orchestrator(
+        task, cfg, adapter:, planner_revision: revision,
+        clock: -> { Time.utc(2026, 8, 12, 14) }
+      ).advance!.record
+
+      assert_equal first.review_id, second.review_id
+      assert_equal first.review_id, cleared.review_id
+      providers = revision.calls.map do |call|
+        call.fetch(:planner_identity).fetch("provider")
+      end
+      assert_equal %w[claude codex codex], providers
+      assert revision.calls.all? do |call|
+        call.fetch(:planner_authority).fetch("provider") == "claude"
+      end
+      fallback_routes = cleared["routes"].select do |route|
+        route["role"] == "planner_revision" && route["planner_revision_fallback"] == true
+      end
+      assert_equal 2, fallback_routes.length
+      assert fallback_routes.all? do |route|
+        route.dig("planner_authority", "provider") == "claude" &&
+          route.fetch("fallback_reason") == "captured_planner_transient_failure"
+      end
+      assert_equal "cleared", cleared.state
+    end
+  end
+
   def test_planner_revision_opens_cooled_retry_series_until_provider_recovers
     revised = standard_plan.sub("# Plan", "# Revised plan")
     with_task(standard_plan) do |task, cfg|

--- a/test/unit/plan_review/planner_revision_test.rb
+++ b/test/unit/plan_review/planner_revision_test.rb
@@ -355,6 +355,8 @@ class PlanReviewPlannerRevisionTest < Minitest::Test
     service = Hive::PlanReview::PlannerRevision.new(
       task:, cfg: {}, runner: lambda do |prompt:, output_path:, **|
         assert_includes prompt, "Review me"
+        assert_includes prompt, "Captured planner authority:"
+        assert_includes prompt, "Effective revision route:"
         File.write(output_path, "# Revised\n<!-- COMPLETE -->\n")
         { "status" => "success" }
       end

--- a/test/unit/plan_review/policy_test.rb
+++ b/test/unit/plan_review/policy_test.rb
@@ -132,6 +132,29 @@ class PlanReviewPolicyTest < Minitest::Test
     assert_equal first.policy_fingerprint, second.policy_fingerprint
   end
 
+  def test_planner_revision_fallback_does_not_discard_the_current_review
+    review_route = {
+      "agent" => "codex", "model" => "gpt-5.6-sol", "family" => "openai",
+      "effort" => "high", "route" => "native_codex"
+    }
+    routes = { "primary" => review_route }
+    recovered = routes.merge(
+      "planner_revision_fallback" => review_route.merge("route" => "recovery_codex")
+    )
+    first = config.merge("routes" => routes)
+    second = config.merge("routes" => recovered)
+
+    fingerprint = ->(cfg) do
+      Hive::PlanReview::Policy.evaluate(
+        workflow_id: "coding", signals: signals(skip: false), config: cfg
+      ).policy_fingerprint
+    end
+
+    assert_equal fingerprint.call(first), fingerprint.call(second)
+    assert_equal Hive::PlanReview::Policy.configuration_fingerprint(first),
+                 Hive::PlanReview::Policy.configuration_fingerprint(second)
+  end
+
   def test_reviewer_or_adapter_change_rekeys_a_review
     base = config.merge(
       "adapter" => "ce_doc_review",

--- a/wiki/log.d/20260830T185521Z-planner-revision-provider-fallback.md
+++ b/wiki/log.d/20260830T185521Z-planner-revision-provider-fallback.md
@@ -1,0 +1,8 @@
+# 2026-08-30 — Planner revision provider fallback
+
+Plan review now supports an optional, operator-configured planner-revision
+fallback route. Hive first tries the captured planner, then moves transient
+revision failures to the fallback without changing the logical review or
+discarding its findings and decisions. Receipts preserve both identities and
+the original failure; bounded attempt series and widening cooldown recovery
+remain unchanged.

--- a/wiki/modules/config.md
+++ b/wiki/modules/config.md
@@ -216,6 +216,9 @@ plan_review:
     adversarial: {agent: grok, model: grok-4.6, family: grok, effort: high, route: native_grok_build}
     verification: {agent: codex, model: gpt-5.6-sol, family: openai, effort: high, route: native_codex}
     fallbacks: []
+    # Optional operational recovery route, used only after the captured
+    # planner produces a transient revision failure:
+    # planner_revision_fallback: {agent: codex, model: gpt-5.6-sol, family: openai, effort: high, route: native_codex}
   approval_policies: []
 ```
 
@@ -225,6 +228,16 @@ protected globs must be safe relative patterns, coverage names are unique
 lowercase identifiers, and required/optional coverage cannot overlap. Every
 route is a closed provider/model/family/effort/route receipt and every reviewer
 name must exist in the model-routing registry.
+
+`routes.planner_revision_fallback` is optional. It is an operational liveness
+control rather than a reviewer-policy input, so adding or changing it does not
+rekey the current logical review or discard accepted findings and decisions.
+The captured planner always receives the first revision attempt. After a
+transient failure, later attempts use the configured fallback and retain it for
+the rest of that review. Immutable attempt receipts record the captured
+planner authority, effective fallback, failure, and selection reason. Reviewer
+and verification route changes remain policy changes and still create a linked
+review.
 
 Ordinary project loads still reject `enabled: false`. A benchmark runtime that
 must reproduce pre-plan-review generation may set the process-local

--- a/wiki/modules/plan_review.md
+++ b/wiki/modules/plan_review.md
@@ -227,6 +227,17 @@ exact planner-owned transient blocks written by older builds as
 Stale-contract records retain their versioned adjudication reset. Invalid
 candidate results and other terminal planner outcomes remain blocked and
 operator-owned.
+
+Projects may configure the optional operational
+`plan_review.routes.planner_revision_fallback` route. Hive still tries the
+captured planner first; after a transient revision failure it uses the fallback
+for subsequent attempts in the same lineage, including later cooled series.
+The fallback is deliberately excluded from the reviewer-policy fingerprint so
+recovery preserves all finding decisions. It has no authority to change review
+routes or verdicts: each revision receipt names both the original planner
+authority and the effective fallback route, while reviewer-route changes still
+rekey the review.
+
 Each accepted finding
 requires explicit fingerprint-bound verification evidence; absence from a
 generic critique does not verify it. A


### PR DESCRIPTION
## Summary

- add an optional operational `plan_review.routes.planner_revision_fallback`
- preserve the current logical review, accepted findings, and operator decisions when the captured planner route hits a transient provider failure
- record both captured planner authority and effective fallback in immutable revision receipts
- keep bounded attempt series and widening cooldown recovery unchanged
- document the configuration and recovery contract

## Tests

- `test/unit/config_test.rb`: 305 runs, 1731 assertions
- `test/unit/plan_review/policy_test.rb`: 12 runs, 35 assertions
- `test/unit/plan_review/orchestrator_test.rb`: 50 runs, 318 assertions
- `test/unit/plan_review/planner_revision_test.rb`: 11 runs, 78 assertions
- post-rebase orchestrator rerun: green
- broad `bundle exec rake test`: 14,054 runs, 285,811 assertions; one unrelated saturated-run timing failure in `HivePatrolValidatorTest#test_stderr_output_also_counts_as_activity`
- isolated timing-test rerun: passed 5/5