### PR TITLE
Fix Claude structured quota recovery

### DIFF
--- a/components/agent-cli-runtime/lib/agent_cli_runtime/error_extractors.rb
+++ b/components/agent-cli-runtime/lib/agent_cli_runtime/error_extractors.rb
@@ -23,6 +23,30 @@ module AgentCliRuntime
       end
     end
 
+    # Claude's subscription wall is a dedicated structured event with no
+    # human-readable message. The generic extractor therefore returned nil,
+    # leaving callers to flatten a rejected five-hour/seven-day window into a
+    # generic exit-code failure. Accept only the exact rejected account-window
+    # shapes observed from Claude Code and synthesize bounded provider text for
+    # the normal typed limit path. Other Claude errors retain DEFAULT behavior.
+    CLAUDE_ACCOUNT_LIMIT_TYPES = %w[five_hour seven_day].freeze
+    CLAUDE = lambda do |event|
+      if event.is_a?(Hash) && event["type"] == "rate_limit_event"
+        info = event["rate_limit_info"]
+        if info.is_a?(Hash) && info["status"] == "rejected"
+          limit_type = info["rateLimitType"].to_s
+          if CLAUDE_ACCOUNT_LIMIT_TYPES.include?(limit_type)
+            next ExtractedFailure.new(
+              kind: :provider_limit,
+              message: "Claude account quota reached (#{limit_type})"
+            )
+          end
+        end
+      end
+
+      DEFAULT.call(event)
+    end
+
     # pi keeps the envelope type ("message_start"/"message_end") and moves the
     # terminal state into stopReason. Provider refusals use
     # stopReason=error/errorMessage. A model that consumes its entire output

--- a/components/agent-cli-runtime/lib/agent_cli_runtime/profiles.rb
+++ b/components/agent-cli-runtime/lib/agent_cli_runtime/profiles.rb
@@ -156,6 +156,7 @@ module AgentCliRuntime
       effort_argument_builder: ->(effort) { [ "--effort", effort ] },
       launcher_identity: "claude-code/v1",
       usage_extractor: UsageExtractors::CLAUDE,
+      error_extractor: ErrorExtractors::CLAUDE,
       credential_environment_keys: %w[
         ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN CLAUDE_API_KEY
       ],

--- a/components/agent-cli-runtime/test/error_extractors_test.rb
+++ b/components/agent-cli-runtime/test/error_extractors_test.rb
@@ -87,6 +87,38 @@ class AgentCliRuntimeErrorExtractorsTest < Minitest::Test
     assert_equal "quota exhausted", error[:message]
   end
 
+  def test_claude_rejected_subscription_window_is_a_provider_limit
+    error = AgentCliRuntime.extract_provider_error(
+      :claude,
+      {
+        "type" => "rate_limit_event",
+        "rate_limit_info" => {
+          "status" => "rejected",
+          "rateLimitType" => "seven_day",
+          "resetsAt" => 1_788_400_800,
+          "overageDisabledReason" => "out_of_credits"
+        }
+      }
+    )
+
+    assert_equal :provider_limit, error[:kind]
+    assert_equal :claude, error[:provider]
+    assert_nil error[:status_code]
+    assert_equal "Claude account quota reached (seven_day)", error[:message]
+  end
+
+  def test_claude_non_rejected_or_unknown_rate_window_is_not_fabricated
+    [
+      { "status" => "allowed", "rateLimitType" => "seven_day" },
+      { "status" => "rejected", "rateLimitType" => "unknown_window" }
+    ].each do |info|
+      assert_nil AgentCliRuntime.extract_provider_error(
+        :claude,
+        { "type" => "rate_limit_event", "rate_limit_info" => info }
+      )
+    end
+  end
+
   def test_grok_nested_402_error_is_a_provider_limit
     event = {
       "type" => "error",

--- a/test/unit/agent_test.rb
+++ b/test/unit/agent_test.rb
@@ -2445,6 +2445,31 @@ class AgentTest < Minitest::Test
     end
   end
 
+  def test_unknown_claude_rate_window_retains_raw_limit_fallback
+    with_tmp_dir do |dir|
+      task = make_task(dir)
+      File.write(task.state_file, "<!-- WAITING -->\n")
+      ENV["HIVE_FAKE_CLAUDE_OUTPUT"] = JSON.generate(
+        "type" => "rate_limit_event",
+        "rate_limit_info" => {
+          "status" => "rejected",
+          "rateLimitType" => "future_window"
+        },
+        "detail" => "account quota reached"
+      )
+      ENV["HIVE_FAKE_CLAUDE_EXIT"] = "1"
+
+      result = Hive::Agent.new(
+        task: task, prompt: "x", max_budget_usd: 1, timeout_sec: 5
+      ).run!
+
+      assert_match(/account quota reached/i, result[:limit_text])
+      assert_equal :error, result[:status]
+      assert_equal "limits_reached", result[:error_reason]
+      assert_equal "limits_reached", Hive::Markers.current(task.state_file).attrs["reason"]
+    end
+  end
+
   # The profile extractor only speaks JSON events. A CLI that prints its quota
   # wall as a bare line leaves `extract_provider_error` with nothing to read, so
   # the raw-line fallback is what has to catch it — otherwise a plain-text limit

--- a/test/unit/agent_test.rb
+++ b/test/unit/agent_test.rb
@@ -2418,6 +2418,33 @@ class AgentTest < Minitest::Test
     end
   end
 
+  def test_captures_claude_rejected_subscription_window_without_message_text
+    with_tmp_dir do |dir|
+      task = make_task(dir)
+      File.write(task.state_file, "<!-- WAITING -->\n")
+      ENV["HIVE_FAKE_CLAUDE_OUTPUT"] = JSON.generate(
+        "type" => "rate_limit_event",
+        "rate_limit_info" => {
+          "status" => "rejected",
+          "rateLimitType" => "seven_day",
+          "resetsAt" => 1_788_400_800,
+          "overageDisabledReason" => "out_of_credits"
+        }
+      )
+      ENV["HIVE_FAKE_CLAUDE_EXIT"] = "1"
+
+      result = Hive::Agent.new(
+        task: task, prompt: "x", max_budget_usd: 1, timeout_sec: 5
+      ).run!
+
+      assert_equal "Claude account quota reached (seven_day)", result[:limit_text]
+      assert_equal :error, result[:status]
+      assert_equal "limits_reached", result[:error_reason]
+      assert_match(/\Alimits reached for claude:/, result[:error_message])
+      assert_equal "limits_reached", Hive::Markers.current(task.state_file).attrs["reason"]
+    end
+  end
+
   # The profile extractor only speaks JSON events. A CLI that prints its quota
   # wall as a bare line leaves `extract_provider_error` with nothing to read, so
   # the raw-line fallback is what has to catch it — otherwise a plain-text limit

--- a/wiki/log.d/20260830T203316Z-claude-structured-quota.md
+++ b/wiki/log.d/20260830T203316Z-claude-structured-quota.md
@@ -1,0 +1,6 @@
+# 2026-08-30 — Claude structured quota classification
+
+Agent CLI Runtime now types Claude's message-free rejected `rate_limit_event`
+for its known five-hour and seven-day subscription windows as a provider
+limit. Reviewers and triage therefore preserve `limits_reached` recovery
+instead of flattening exhausted Claude quota to `exit_code=1` or `unknown`.

--- a/wiki/modules/agent.md
+++ b/wiki/modules/agent.md
@@ -67,6 +67,11 @@ Hive::Agent.new(
 
 Headless `Hive::Agent#spawn_and_wait` scans each raw stream line for limit text while still preserving the structured final message and bounded plain tail. That raw-stream path catches CLIs that emit usage walls as JSON error events which `MessageExtractor` does not surface as a final assistant message; `handle_exit` then prefers `result[:limit_text]` and falls back to scanning `final_message`. Structured provider status extraction accepts both the generic `code` field and Grok's nested `http_status` field, so an HTTP 402 Grok Build balance exhaustion is typed as `provider_limit` instead of a generic reviewer error. Ordinary successful command output is never scanned into failure, but a profile extractor's typed provider error remains authoritative even when the CLI exits zero. A typed quota error retains `limits_reached`; another provider-side failed turn returns `error_reason=provider_error` with its bounded redacted diagnostic. For `:state_file_marker` spawns Hive stamps the corresponding `ERROR`; for `:exit_code_only` and `:output_file_exists` spawns it returns the error without overwriting the orchestrator-owned marker. `Hive::ClaudeLauncher` uses the same limit classifier while waiting for tmux readiness, terminal markers, and expected-output files, so a visible provider-limit pane wins over readiness timeout, tmux-session-death, and missing-output fallbacks.
 
+Claude's structured `rate_limit_event` has no message field. The runtime accepts
+only rejected `five_hour` and `seven_day` windows and synthesizes bounded quota
+text, allowing output-file review and triage spawns to propagate
+`limit_text` even when Claude exits nonzero before writing an artifact.
+
 Claude's own per-invocation cap has a separate protocol boundary.
 `MessageExtractor.extract_failure` recognizes only a structured terminal
 `type=result`, `subtype=error_max_budget_usd` event. It never infers failure

--- a/wiki/modules/agent_cli_runtime.md
+++ b/wiki/modules/agent_cli_runtime.md
@@ -118,6 +118,12 @@ OpenCode's profile-specific provider-error extractor reads only dedicated
 upstream rate-limit refusal therefore reaches Hive as a typed `rate_limited`
 signal and writes the normal cooldown-retry marker, while identical prose in
 ordinary model output cannot forge a retryable provider wall.
+Claude's extractor also recognizes its exact message-free rejected
+`rate_limit_event` for the known `five_hour` and `seven_day` account windows.
+It synthesizes bounded quota text and a typed `provider_limit`, so review,
+triage, and other output-file spawns retain normal `limits_reached` recovery
+instead of degrading to an exit-code error. Non-rejected and unknown window
+types remain unclassified.
 When OpenCode exits zero with an empty terminal assistant message after writing
 a current terminal stage artifact, Hive trusts that controller-scoped artifact;
 the strict malformed transcript remains a failure whenever the artifact itself


### PR DESCRIPTION
## Summary

- recognize Claude Code rejected five-hour and seven-day `rate_limit_event` envelopes even though they contain no message
- carry the exact structured refusal through the typed provider-limit and `limits_reached` paths used by review and triage
- reject non-rejected and unknown window shapes and document the runtime contract

## Dogfood failure

Screenote review pass 04 received a structured Claude `seven_day` rejection with `overageDisabledReason=out_of_credits`, but the message-free event was flattened to `exit_code=1`; review triage then wrote `reason=unknown` instead of a retryable quota hold.

## Verification

- `bundle exec rake test:agent_cli_runtime` (130 runs, 1279 assertions, 0 failures, 1 skip)
- `bundle exec ruby -Itest test/unit/agent_test.rb` (109 runs, 523 assertions)
- `bundle exec ruby -Itest test/unit/reviewers/agent_test.rb` (36 runs, 187 assertions)
- `bundle exec ruby -Itest test/unit/stages/review/triage_test.rb` (28 runs, 133 assertions)
- `bundle exec ruby -Itest test/unit/wiki_log_test.rb` (7 runs, 27 assertions)
- RuboCop on all changed Ruby files: clean
- `git diff --check`: clean