### PR TITLE
Preserve successful reviewer evidence across failed retries

### DIFF
--- a/lib/hive/agent_support/codex/reviewer.rb
+++ b/lib/hive/agent_support/codex/reviewer.rb
@@ -165,9 +165,9 @@ module Hive::AgentSupport::Codex
       run = nil
       loop do
         attempts += 1
-        # Clear any partial file from a prior crashed attempt so a stale
-        # file can't satisfy this attempt's format check.
-        delete_output!
+        # Clear any staged file from a prior crashed attempt. The canonical
+        # output remains intact until a complete replacement is published.
+        delete_partial_output!
 
         spawn_timeout = effective_timeout(configured_timeout, deadline)
         if spawn_timeout && spawn_timeout <= 0
@@ -191,6 +191,10 @@ module Hive::AgentSupport::Codex
       end
 
       finalize(run, attempts, max_attempts)
+    end
+
+    def failure_output_path
+      staged_output_path
     end
 
     private
@@ -230,15 +234,17 @@ module Hive::AgentSupport::Codex
     def finalize(run, attempts, max_attempts)
       case review_status(run)
       when :findings
-        @runtime.write(output_path, format_body(findings_markdown(review_body(run.stdout))))
+        @runtime.write(staged_output_path, format_body(findings_markdown(review_body(run.stdout))))
+        promote_staged_output!
         Hive::Reviewers::Result.new(name:, output_path:, status: :ok, error_message: nil)
       when :clean
-        @runtime.write(output_path, clean_findings(review_body(run.stdout)))
+        @runtime.write(staged_output_path, clean_findings(review_body(run.stdout)))
+        promote_staged_output!
         Hive::Reviewers::Result.new(name:, output_path:, status: :ok, error_message: nil)
       else
         # Failure: leave no malformed findings file behind — triage would
         # otherwise treat it as real reviewer output.
-        delete_output!
+        delete_partial_output!
         error_result(base_reason(run), attempts, max_attempts, detail: captured_tail(run))
       end
     end
@@ -319,7 +325,7 @@ module Hive::AgentSupport::Codex
           base_msg
         end
       msg = "#{msg}#{detail}" if detail && !detail.empty?
-      Hive::Reviewers::Result.new(name:, output_path:, status: :error, error_message: msg)
+      Hive::Reviewers::Result.new(name:, output_path: failure_output_path, status: :error, error_message: msg)
     end
 
     def valid_findings?(stdout)
@@ -496,7 +502,7 @@ module Hive::AgentSupport::Codex
           task_folder: ctx.task_folder,
           default_branch: ctx.default_branch,
           pass: ctx.pass,
-          output_path: output_path,
+          output_path: staged_output_path,
           user_supplied_tag: tag,
           plan_context_section: Hive::Reviewers::PlanContext.render(ctx.task_folder, tag)
         )
@@ -511,8 +517,8 @@ module Hive::AgentSupport::Codex
       sleep(seconds)
     end
 
-    def delete_output!
-      @runtime.delete(output_path, label: "reviewer #{name.inspect}")
+    def delete_partial_output!
+      @runtime.delete(staged_output_path, label: "reviewer #{name.inspect}")
     end
   end
 end

--- a/lib/hive/reviewers/agent.rb
+++ b/lib/hive/reviewers/agent.rb
@@ -38,7 +38,7 @@ module Hive
             timeout_sec: spawn_timeout || configured_timeout,
             log_label: build_log_label(attempts),
             profile: profile,
-            expected_output: output_path,
+            expected_output: staged_output_path,
             cfg: @cfg,
             **Hive::Stages::Base.model_launch_arguments(
               @cfg || {}, "review_reviewers", profile,
@@ -61,13 +61,20 @@ module Hive
 
           handle.send_and_wait!(
             prompt: prompt,
-            expected_output: output_path,
+            expected_output: staged_output_path,
             timeout_sec: spawn_timeout || configured_timeout,
             status_mode: :output_file_exists,
             log_label: build_log_label(attempts),
             deadline: deadline
           )
         end
+      end
+
+      # Agent reviewers write into a staging path and publish only after a
+      # successful exit. Orchestrator cleanup must therefore target the staging
+      # file, never an earlier successful findings artifact at output_path.
+      def failure_output_path
+        staged_output_path
       end
 
       private
@@ -79,7 +86,7 @@ module Hive
         profile_name = context&.explicit_routing? ? context.adapter : spec.fetch("agent")
         profile = Hive::AgentProfiles.lookup(profile_name, cfg: @cfg)
         skill = spec.fetch("skill")
-        prompt = render_prompt(profile, skill)
+        prompt = render_prompt(profile, skill, reviewer_output_path: staged_output_path)
         max_attempts = max_attempts_from_spec
         configured_timeout = spec["timeout_sec"] || DEFAULT_TIMEOUT_SEC
 
@@ -104,7 +111,7 @@ module Hive
         result = nil
         loop do
           attempts += 1
-          # ce-review P1 #3 (round 2): clear stale output_path before
+          # ce-review P1 #3 (round 2): clear stale staged output before
           # every attempt so a partial file from a prior crashed
           # attempt cannot satisfy the next attempt's
           # :output_file_exists check.
@@ -136,8 +143,16 @@ module Hive
           backoff(sleep_seconds)
         end
 
+        if result[:status] == :ok
+          begin
+            promote_staged_output!
+          rescue Hive::Error => e
+            result = { status: :error, error_message: e.message }
+          end
+        end
+
         # ce-review P1 #3 (final-failure cleanup): the last attempt may
-        # have left a partial output_path file behind. Triage's
+        # have left a staged output file behind. Triage's
         # discover_reviewer_files would otherwise find it and treat it
         # as real reviewer output. Final failures must surface only
         # through reviews/errors-NN.md (written by the orchestrator's
@@ -149,20 +164,20 @@ module Hive
       end
 
       # pr-review-toolkit round-5 M2: TOCTOU-safe wrapper for the two
-      # `File.delete(output_path)` sites in the retry loop. Distinguishes
+      # staging-path deletion sites in the retry loop. Distinguishes
       # ENOENT (file may not exist on first attempt — normal) from
       # other SystemCallError (perms / read-only mount — diagnostic).
       # The `stage` label lets the resulting `errors-NN.md` line name
       # which delete failed (pre-attempt clear vs. final-failure
       # cleanup).
       def clear_partial_output!(stage)
-        File.delete(output_path)
+        File.delete(staged_output_path)
       rescue Errno::ENOENT
         nil
       rescue SystemCallError => e
         raise Hive::Error,
               "reviewer #{name.inspect}: failed to clear partial output_path " \
-              "(#{stage}) #{output_path}: #{e.class}: #{e.message}"
+              "(#{stage}) #{staged_output_path}: #{e.class}: #{e.message}"
       end
 
       def build_log_label(attempt)
@@ -196,7 +211,7 @@ module Hive
           msg = max_attempts > 1 ? "#{base_msg} after #{attempts} attempt(s)" : base_msg
           Result.new(
             name: name,
-            output_path: output_path,
+            output_path: failure_output_path,
             status: :error,
             error_message: msg,
             limit_text: spawn_result[:limit_text]
@@ -204,7 +219,7 @@ module Hive
         end
       end
 
-      def render_prompt(profile, skill)
+      def render_prompt(profile, skill, reviewer_output_path: output_path)
         template_path = Hive::Stages::Base.resolve_template_path(
           spec.fetch("prompt_template"),
           hive_state_dir: Hive::Stages::Base.hive_state_dir_for_task_folder(ctx.task_folder)
@@ -224,7 +239,7 @@ module Hive
             task_folder: ctx.task_folder,
             default_branch: ctx.default_branch,
             pass: ctx.pass,
-            output_path: output_path,
+            output_path: reviewer_output_path,
             skill_invocation: Hive::Stages::Base.format_verified_skill_invocation(
               profile, skill, project_root: ctx.worktree_path
             ),

--- a/lib/hive/reviewers/base.rb
+++ b/lib/hive/reviewers/base.rb
@@ -68,6 +68,14 @@ module Hive
         )
       end
 
+      # Path the orchestrator may delete when this adapter fails. Legacy and
+      # custom adapters write directly to output_path, so that remains the
+      # compatibility default. Adapters that stage output before atomically
+      # publishing it override this to protect an already-successful result.
+      def failure_output_path
+        output_path
+      end
+
       def run!
         raise NotImplementedError, "#{self.class} must implement #run!"
       end
@@ -79,6 +87,18 @@ module Hive
       end
 
       private
+
+      def staged_output_path
+        "#{output_path}.partial"
+      end
+
+      def promote_staged_output!
+        File.rename(staged_output_path, output_path)
+      rescue SystemCallError => e
+        raise Hive::Error,
+              "reviewer #{name.inspect}: failed to publish staged output " \
+              "#{staged_output_path} -> #{output_path}: #{e.class}: #{e.message}"
+      end
 
       # Reviewer specs are validated before adapter construction, but custom
       # integrations can still instantiate an adapter directly. Keep their

--- a/lib/hive/stages/review.rb
+++ b/lib/hive/stages/review.rb
@@ -1896,7 +1896,7 @@ module Hive
 
             Hive::Reviewers::Result.new(
               name: spec["name"],
-              output_path: adapter.output_path,
+              output_path: adapter.failure_output_path,
               status: :error,
               error_message: "#{e.class}: #{e.message}"
             )
@@ -1915,7 +1915,7 @@ module Hive
 
             Hive::Reviewers::Result.new(
               name: spec["name"],
-              output_path: adapter.output_path,
+              output_path: adapter.failure_output_path,
               status: :error,
               error_message: "#{e.class}: #{e.message}"
             )

--- a/lib/hive/stages/review.rb
+++ b/lib/hive/stages/review.rb
@@ -1855,6 +1855,11 @@ module Hive
         end
 
         adapter = Hive::Reviewers.dispatch(spec, ctx, cfg: cfg)
+        failure_output_path = if adapter.respond_to?(:failure_output_path)
+          adapter.failure_output_path
+        else
+          adapter.output_path
+        end
         # Wrap adapter.run! so a single reviewer raising (spawn-time
         # SystemCallError, network timeout in a custom adapter, …)
         # doesn't abort the whole reviewers phase. Treat as :error,
@@ -1896,7 +1901,7 @@ module Hive
 
             Hive::Reviewers::Result.new(
               name: spec["name"],
-              output_path: adapter.failure_output_path,
+              output_path: failure_output_path,
               status: :error,
               error_message: "#{e.class}: #{e.message}"
             )
@@ -1915,7 +1920,7 @@ module Hive
 
             Hive::Reviewers::Result.new(
               name: spec["name"],
-              output_path: adapter.failure_output_path,
+              output_path: failure_output_path,
               status: :error,
               error_message: "#{e.class}: #{e.message}"
             )

--- a/test/unit/reviewers/agent_test.rb
+++ b/test/unit/reviewers/agent_test.rb
@@ -49,7 +49,7 @@ class ReviewersAgentTest < Minitest::Test
       FileUtils.mkdir_p(ctx.task_folder)
       reviewer = Hive::Reviewers::Agent.new(make_spec, ctx)
 
-      ENV["HIVE_FAKE_CLAUDE_WRITE_FILE"] = reviewer.output_path
+      ENV["HIVE_FAKE_CLAUDE_WRITE_FILE"] = reviewer.failure_output_path
       ENV["HIVE_FAKE_CLAUDE_WRITE_CONTENT"] = "## High\n- [ ] finding: justification\n"
 
       result = reviewer.run!
@@ -58,6 +58,7 @@ class ReviewersAgentTest < Minitest::Test
       assert_equal reviewer.output_path, result.output_path
       assert File.exist?(reviewer.output_path)
       assert_includes File.read(reviewer.output_path), "## High"
+      refute File.exist?(reviewer.failure_output_path)
     end
   end
 
@@ -116,6 +117,7 @@ class ReviewersAgentTest < Minitest::Test
       captured = nil
       spawn = lambda do |_task, **options|
         captured = options
+        File.write(options.fetch(:expected_output), "## High\nNo findings.\n")
         { status: :ok }
       end
 
@@ -143,6 +145,7 @@ class ReviewersAgentTest < Minitest::Test
       captured = nil
       spawn = lambda do |_task, **options|
         captured = options
+        File.write(options.fetch(:expected_output), "## High\nNo findings.\n")
         { status: :ok }
       end
 
@@ -175,6 +178,7 @@ class ReviewersAgentTest < Minitest::Test
       captured = nil
       spawn = lambda do |_task, **options|
         captured = options
+        File.write(options.fetch(:expected_output), "## High\nNo findings.\n")
         { status: :ok }
       end
 
@@ -225,7 +229,7 @@ class ReviewersAgentTest < Minitest::Test
       File.write(task_md, "## Implementation\n\n<!-- REVIEW_WORKING phase=reviewers pass=1 -->\n")
 
       reviewer = Hive::Reviewers::Agent.new(make_spec, ctx)
-      ENV["HIVE_FAKE_CLAUDE_WRITE_FILE"] = reviewer.output_path
+      ENV["HIVE_FAKE_CLAUDE_WRITE_FILE"] = reviewer.failure_output_path
       ENV["HIVE_FAKE_CLAUDE_WRITE_CONTENT"] = "## High\n- [ ] f: j\n"
 
       reviewer.run!
@@ -408,6 +412,10 @@ class ReviewersAgentTest < Minitest::Test
       labels << kwargs[:log_label]
       result = results[call_count] || results.last
       call_count += 1
+      if result[:status] == :ok
+        FileUtils.mkdir_p(File.dirname(kwargs.fetch(:expected_output)))
+        File.write(kwargs.fetch(:expected_output), "## High\nNo findings.\n")
+      end
       result
     end
     begin
@@ -442,6 +450,7 @@ class ReviewersAgentTest < Minitest::Test
       original = Hive::Stages::Base.method(:spawn_agent)
       Hive::Stages::Base.define_singleton_method(:spawn_agent) do |_task, **kwargs|
         captured = kwargs
+        File.write(kwargs.fetch(:expected_output), "## High\nNo findings.\n")
         { status: :ok }
       end
       begin
@@ -479,6 +488,7 @@ class ReviewersAgentTest < Minitest::Test
       original = Hive::Stages::Base.method(:spawn_agent)
       Hive::Stages::Base.define_singleton_method(:spawn_agent) do |_task, **kwargs|
         captured = kwargs
+        File.write(kwargs.fetch(:expected_output), "## High\nNo findings.\n")
         { status: :ok }
       end
 
@@ -611,6 +621,7 @@ class ReviewersAgentTest < Minitest::Test
       original = Hive::Stages::Base.method(:spawn_agent)
       Hive::Stages::Base.define_singleton_method(:spawn_agent) do |_task, **kwargs|
         captured_timeouts << kwargs[:timeout_sec]
+        File.write(kwargs.fetch(:expected_output), "## High\nNo findings.\n")
         { status: :ok }
       end
       begin
@@ -634,6 +645,7 @@ class ReviewersAgentTest < Minitest::Test
       handle = Object.new
       handle.define_singleton_method(:send_and_wait!) do |**kwargs|
         calls << kwargs
+        File.write(kwargs.fetch(:expected_output), "## High\nNo findings.\n")
         { status: :ok }
       end
 
@@ -654,6 +666,7 @@ class ReviewersAgentTest < Minitest::Test
       original = Hive::Stages::Base.method(:spawn_agent)
       Hive::Stages::Base.define_singleton_method(:spawn_agent) do |_task, **kwargs|
         captured_timeouts << kwargs[:timeout_sec]
+        File.write(kwargs.fetch(:expected_output), "## High\nNo findings.\n")
         { status: :ok }
       end
       begin
@@ -673,6 +686,7 @@ class ReviewersAgentTest < Minitest::Test
       original = Hive::Stages::Base.method(:spawn_agent)
       Hive::Stages::Base.define_singleton_method(:spawn_agent) do |_task, **kwargs|
         captured_timeouts << kwargs[:timeout_sec]
+        File.write(kwargs.fetch(:expected_output), "## High\nNo findings.\n")
         { status: :ok }
       end
       begin
@@ -686,8 +700,8 @@ class ReviewersAgentTest < Minitest::Test
     end
   end
 
-  def test_run_clears_output_path_on_every_retry_attempt
-    # pr-review-toolkit round-5 pr-test-analyzer #9 — output_path must
+  def test_run_clears_staged_output_path_on_every_retry_attempt
+    # pr-review-toolkit round-5 pr-test-analyzer #9 — staged output must
     # be cleared before EACH attempt, not just the first. A regression
     # that hoists the clear out of the loop would let attempt 2's
     # stale file from attempt 1 satisfy the :output_file_exists check.
@@ -709,7 +723,7 @@ class ReviewersAgentTest < Minitest::Test
         assert_equal 3, observations.size,
                      "expected 3 spawn attempts under max_attempts=3"
         assert observations.none?(true),
-               "every attempt must see output_path absent at spawn-time, not just the first"
+               "every attempt must see staged output absent at spawn-time, not just the first"
       ensure
         Hive::Stages::Base.singleton_class.send(:remove_method, :spawn_agent)
         Hive::Stages::Base.define_singleton_method(:spawn_agent, &original)
@@ -723,7 +737,7 @@ class ReviewersAgentTest < Minitest::Test
       original_delete = File.method(:delete)
 
       File.define_singleton_method(:delete) do |*paths|
-        raise Errno::EACCES, reviewer.output_path if paths.include?(reviewer.output_path)
+        raise Errno::EACCES, reviewer.failure_output_path if paths.include?(reviewer.failure_output_path)
 
         original_delete.call(*paths)
       end
@@ -731,7 +745,7 @@ class ReviewersAgentTest < Minitest::Test
       error = assert_raises(Hive::Error) { reviewer.run! }
       assert_includes error.message, "failed to clear partial output_path"
       assert_includes error.message, "(pre_attempt)"
-      assert_includes error.message, reviewer.output_path
+      assert_includes error.message, reviewer.failure_output_path
     ensure
       File.define_singleton_method(:delete, original_delete)
     end
@@ -750,48 +764,56 @@ class ReviewersAgentTest < Minitest::Test
     end
   end
 
-  def test_run_clears_stale_output_path_before_each_attempt
-    # ce-review P1 #3: a prior crashed attempt may have left a
-    # non-empty file at output_path. spawn_agent's
-    # :output_file_exists check only verifies file-exists + non-empty
-    # + exit-0, so a retry that exits 0 (even with no real findings)
-    # would be accepted on stale content. The adapter must clear
-    # output_path before each spawn attempt.
+  def test_failed_run_preserves_existing_successful_output
     with_tmp_dir do |dir|
-      reviewer, _ = with_stubbed_adapter(dir)
+      reviewer, _ = with_stubbed_adapter(dir, "max_attempts" => 1)
       FileUtils.mkdir_p(File.dirname(reviewer.output_path))
-      File.write(reviewer.output_path, "STALE content from a prior crashed attempt\n")
+      prior = "## High\n- [ ] retained finding: prior successful review\n"
+      File.write(reviewer.output_path, prior)
 
-      cleared_observations = []
-      with_spawn_stub([ ok_result ]) do |count_fn, _labels|
-        # Observe the file state inside the stub. spawn_agent is
-        # replaced by the test stub, so we can inspect what's on disk
-        # at the moment the stub runs.
-        original = Hive::Stages::Base.method(:spawn_agent)
-        Hive::Stages::Base.singleton_class.send(:remove_method, :spawn_agent)
-        Hive::Stages::Base.define_singleton_method(:spawn_agent) do |_task, **kwargs|
-          cleared_observations << File.exist?(kwargs[:expected_output])
-          { status: :ok }
-        end
-        begin
-          reviewer.run!
-        ensure
-          Hive::Stages::Base.singleton_class.send(:remove_method, :spawn_agent)
-          Hive::Stages::Base.define_singleton_method(:spawn_agent, &original)
-        end
-        _ = count_fn # silence unused-block-arg
+      original = Hive::Stages::Base.method(:spawn_agent)
+      Hive::Stages::Base.define_singleton_method(:spawn_agent) do |_task, **kwargs|
+        File.write(kwargs.fetch(:expected_output), "## High\n- [ ] partial\n")
+        { status: :error, error_message: "agent timed out" }
       end
+      result = reviewer.run!
 
-      refute_includes cleared_observations, true,
-                      "stale output_path must be deleted BEFORE spawn_agent runs"
+      assert result.error?
+      assert_equal reviewer.failure_output_path, result.output_path
+      assert_equal prior, File.read(reviewer.output_path)
+      refute File.exist?(reviewer.failure_output_path)
+    ensure
+      Hive::Stages::Base.singleton_class.send(:remove_method, :spawn_agent)
+      Hive::Stages::Base.define_singleton_method(:spawn_agent, &original) if original
     end
   end
 
-  def test_run_deletes_output_path_after_final_failure
+  def test_publish_failure_preserves_existing_successful_output
+    with_tmp_dir do |dir|
+      reviewer, _ = with_stubbed_adapter(dir, "max_attempts" => 1)
+      FileUtils.mkdir_p(File.dirname(reviewer.output_path))
+      File.write(reviewer.output_path, "previous success\n")
+      original = Hive::Stages::Base.method(:spawn_agent)
+      Hive::Stages::Base.define_singleton_method(:spawn_agent) do |_task, **_kwargs|
+        { status: :ok }
+      end
+
+      result = reviewer.run!
+
+      assert result.error?
+      assert_match(/failed to publish staged output/, result.error_message)
+      assert_equal "previous success\n", File.read(reviewer.output_path)
+    ensure
+      Hive::Stages::Base.singleton_class.send(:remove_method, :spawn_agent)
+      Hive::Stages::Base.define_singleton_method(:spawn_agent, &original) if original
+    end
+  end
+
+  def test_run_deletes_staged_output_after_final_failure
     # ce-review P1 #3: even after the retry loop exhausts, a partial
-    # file from the last attempt could be left at output_path. Triage's
-    # discover_reviewer_files would then mistake it for real reviewer
-    # output. Final failures must surface only through errors-NN.md.
+    # file from the last attempt could be left at the staging path.
+    # Final failures must surface only through errors-NN.md; the staging
+    # file must disappear without touching any canonical prior result.
     with_tmp_dir do |dir|
       reviewer, _ = with_stubbed_adapter(dir, "max_attempts" => 1)
       FileUtils.mkdir_p(File.dirname(reviewer.output_path))
@@ -813,8 +835,9 @@ class ReviewersAgentTest < Minitest::Test
         Hive::Stages::Base.define_singleton_method(:spawn_agent, &original)
       end
 
-      refute File.exist?(reviewer.output_path),
-             "final-failure cleanup must delete output_path so triage doesn't see partial content"
+      refute File.exist?(reviewer.output_path)
+      refute File.exist?(reviewer.failure_output_path),
+             "final-failure cleanup must delete staged content so triage doesn't see it"
     end
   end
 
@@ -844,7 +867,7 @@ class ReviewersAgentTest < Minitest::Test
 
       log_dir = Dir.mktmpdir("fake-claude-argv")
       ENV["HIVE_FAKE_CLAUDE_LOG_DIR"] = log_dir
-      ENV["HIVE_FAKE_CLAUDE_WRITE_FILE"] = reviewer.output_path
+      ENV["HIVE_FAKE_CLAUDE_WRITE_FILE"] = reviewer.failure_output_path
       ENV["HIVE_FAKE_CLAUDE_WRITE_CONTENT"] = "## High\n- [ ] f: j\n"
 
       reviewer.run!
@@ -882,7 +905,7 @@ class ReviewersAgentTest < Minitest::Test
 
       log_dir = Dir.mktmpdir("fake-claude-argv")
       ENV["HIVE_FAKE_CLAUDE_LOG_DIR"] = log_dir
-      ENV["HIVE_FAKE_CLAUDE_WRITE_FILE"] = reviewer.output_path
+      ENV["HIVE_FAKE_CLAUDE_WRITE_FILE"] = reviewer.failure_output_path
       ENV["HIVE_FAKE_CLAUDE_WRITE_CONTENT"] = "## High\n- [ ] f: j\n"
 
       reviewer.run!
@@ -909,7 +932,7 @@ class ReviewersAgentTest < Minitest::Test
 
       log_dir = Dir.mktmpdir("fake-claude-argv")
       ENV["HIVE_FAKE_CLAUDE_LOG_DIR"] = log_dir
-      ENV["HIVE_FAKE_CLAUDE_WRITE_FILE"] = reviewer.output_path
+      ENV["HIVE_FAKE_CLAUDE_WRITE_FILE"] = reviewer.failure_output_path
       ENV["HIVE_FAKE_CLAUDE_WRITE_CONTENT"] = "## High\n- [ ] f: j\n"
 
       reviewer.run!

--- a/test/unit/reviewers/codex_review_test.rb
+++ b/test/unit/reviewers/codex_review_test.rb
@@ -299,6 +299,24 @@ class ReviewersCodexReviewTest < Minitest::Test
     end
   end
 
+  def test_failed_run_preserves_existing_successful_output
+    with_tmp_dir do |dir|
+      ENV["HIVE_FAKE_CODEX_STDOUT"] = "OpenAI Codex v0.139.0\nReview was interrupted.\n"
+      reviewer = build_reviewer(dir, "max_attempts" => 1)
+      prior = "## High\n- [ ] retained finding: prior successful review\n"
+      FileUtils.mkdir_p(File.dirname(reviewer.output_path))
+      File.write(reviewer.output_path, prior)
+
+      result = reviewer.run!
+
+      assert result.error?
+      assert_equal reviewer.failure_output_path, result.output_path
+      assert_equal prior, File.read(reviewer.output_path)
+      refute File.exist?(reviewer.failure_output_path),
+             "failed native review must remove only its staged output"
+    end
+  end
+
   def test_empty_stdout_yields_error
     with_tmp_dir do |dir|
       ENV["HIVE_FAKE_CODEX_STDOUT"] = ""
@@ -969,18 +987,17 @@ class ReviewersCodexReviewTest < Minitest::Test
     end
   end
 
-  def test_delete_output_reraises_on_non_enoent_system_call_error
+  def test_delete_partial_output_reraises_on_non_enoent_system_call_error
     with_tmp_dir do |dir|
       reviewer = build_reviewer(dir)
-      # Point output_path at a directory; File.delete raises EISDIR/EPERM
-      # (a non-ENOENT SystemCallError) which must surface as a named
-      # Hive::Error rather than being swallowed like a missing file.
-      a_dir = File.join(dir, "a-directory")
-      FileUtils.mkdir_p(a_dir)
-      reviewer.define_singleton_method(:output_path) { a_dir }
+      # Point the staging path at a directory; File.delete raises EISDIR/EPERM
+      # (a non-ENOENT SystemCallError) which must surface as a named Hive::Error
+      # rather than being swallowed like a missing file.
+      FileUtils.mkdir_p(reviewer.failure_output_path)
 
-      err = assert_raises(Hive::Error) { reviewer.send(:delete_output!) }
+      err = assert_raises(Hive::Error) { reviewer.send(:delete_partial_output!) }
       assert_match(/failed to clear partial output_path/, err.message)
+      assert_includes err.message, reviewer.failure_output_path
     end
   end
 

--- a/test/unit/stages/review/run_reviewers_test.rb
+++ b/test/unit/stages/review/run_reviewers_test.rb
@@ -589,6 +589,18 @@ class RunReviewersTest < Minitest::Test
     end
   end
 
+  class StagedRaisingReviewer < Hive::Reviewers::Base
+    def failure_output_path
+      "#{output_path}.partial"
+    end
+
+    def run!(deadline: nil)
+      ensure_reviews_dir!
+      File.write(failure_output_path, "incomplete replacement\n")
+      raise RuntimeError, "staged boom"
+    end
+  end
+
   # A reviewer whose run! returns :ok. Produces a stub findings file so
   # the test can verify both reviewers actually ran.
   class OkReviewer < Hive::Reviewers::Base
@@ -1211,6 +1223,30 @@ class RunReviewersTest < Minitest::Test
       assert_includes contents, "[raises] reviewer \"raises\" failed"
       assert_includes contents, "RuntimeError"
       assert_includes contents, "boom"
+    end
+  end
+
+  def test_raising_staged_reviewer_preserves_prior_successful_output
+    with_tmp_dir do |dir|
+      spec = { "name" => "staged", "output_basename" => "staged" }
+      adapter = StagedRaisingReviewer.new(spec, make_ctx(dir))
+      FileUtils.mkdir_p(File.dirname(adapter.output_path))
+      prior = "## High\n- [ ] retained finding: prior successful review\n"
+      File.write(adapter.output_path, prior)
+
+      with_stubbed_dispatch([ adapter ]) do
+        result = Hive::Stages::Review.run_reviewers(
+          { "review" => { "reviewers" => [ spec ] } },
+          make_ctx(dir),
+          Task.new(dir, File.join(dir, "task.md"))
+        )
+        assert_equal :all_failed, result
+      end
+
+      assert_equal prior, File.read(adapter.output_path)
+      refute File.exist?(adapter.failure_output_path),
+             "orchestrator cleanup must remove only the staged failure output"
+      assert_includes File.read(File.join(dir, "reviews", "errors-01.md")), "staged boom"
     end
   end
 

--- a/wiki/log.d/20260830T210937Z-reviewer-output-staging.md
+++ b/wiki/log.d/20260830T210937Z-reviewer-output-staging.md
@@ -1,0 +1,14 @@
+## [2026-08-30] Preserve successful reviewer evidence across failed retries
+
+**Action:** Agent-backed and native Codex reviewers now write to a per-pass
+staging path and atomically publish the canonical findings file only after a
+successful run. Failure cleanup targets the staging path, so a crashed or
+quota-rejected retry cannot erase an earlier successful result from the same
+review pass.
+
+**Pages updated:** wiki/modules/reviewers.md,
+wiki/log.d/20260830T210937Z-reviewer-output-staging.md
+
+**Source:** `lib/hive/reviewers/base.rb`, `lib/hive/reviewers/agent.rb`,
+`lib/hive/agent_support/codex/reviewer.rb`, `lib/hive/stages/review.rb`, and
+reviewer/orchestrator regression tests

--- a/wiki/modules/reviewers.md
+++ b/wiki/modules/reviewers.md
@@ -3,11 +3,11 @@ title: Hive::Reviewers
 type: module
 source: lib/hive/reviewers.rb, lib/hive/reviewers/{base,agent,runtime,synthetic_task,plan_context}.rb, lib/hive/agent_support/codex/reviewer.rb
 created: 2026-04-26
-updated: 2026-07-18
+updated: 2026-08-30
 tags: [reviewer, dispatch, agent, codex, patrol, architecture]
 ---
 
-**TLDR**: Reviewer adapter layer for the 6-review stage's Phase 2. `Hive::Reviewers.dispatch(spec, ctx)` returns an adapter keyed by the spec's `kind`: `"agent"` (default → `Reviewers::Agent`, spawns an LLM CLI with the configured CE skill+prompt; the agent writes the findings file itself) or `"codex_review"` (→ `AgentSupport::Codex::Reviewer`, runs codex's native single-pass `codex review` and CAPTURES its stdout into the findings file — the cheap patrol default). Either way findings land in `reviews/<output_basename>-<pass>.md` in the GFM-checkbox format the triage/fix loop consumes. `Reviewers::Context` carries per-spawn fields; `Reviewers::Result` is the return shape; `Reviewers::SyntheticTask` is the task-shaped facade `spawn_agent` requires for headless sub-spawns inside the review stage. `Reviewers::PlanContext` renders the task's `plan.md` into an authoritative-on-scope block embedded in every reviewer system prompt, so reviewers stop flagging plan-deferred scope as defects. Tool-specific linters are NOT a reviewer kind — they belong in `review.ci.command` per ADR-014. References ADR-014 / ADR-015.
+**TLDR**: Reviewer adapter layer for the 6-review stage's Phase 2. `Hive::Reviewers.dispatch(spec, ctx)` returns an adapter keyed by the spec's `kind`: `"agent"` (default → `Reviewers::Agent`, spawns an LLM CLI with the configured CE skill+prompt; the agent writes the findings file itself) or `"codex_review"` (→ `AgentSupport::Codex::Reviewer`, runs codex's native single-pass `codex review` and captures its stdout — the cheap patrol default). Both adapters write `<output_path>.partial` and atomically publish complete findings to `reviews/<output_basename>-<pass>.md`; a failed retry therefore cannot erase an earlier successful result for the same pass. `Reviewers::Context` carries per-spawn fields; `Reviewers::Result` is the return shape; `Reviewers::SyntheticTask` is the task-shaped facade `spawn_agent` requires for headless sub-spawns inside the review stage. `Reviewers::PlanContext` renders the task's `plan.md` into an authoritative-on-scope block embedded in every reviewer system prompt, so reviewers stop flagging plan-deferred scope as defects. Tool-specific linters are NOT a reviewer kind — they belong in `review.ci.command` per ADR-014. References ADR-014 / ADR-015.
 
 ## Public API
 
@@ -17,6 +17,7 @@ Hive::Reviewers.backoff_seconds_for(n)         # → capped retry delay in secon
 Hive::Reviewers::Context.new(worktree_path:, task_folder:, default_branch:, pass:)
 Hive::Reviewers::Result.new(name:, output_path:, status:, error_message:)
 Hive::Reviewers.synthetic_task_for(ctx)        # → SyntheticTask facade
+# adapter.failure_output_path                  # → failure-only cleanup target
 ```
 
 `dispatch`'s `kind` discriminator defaults to `"agent"`; `"codex_review"` lazily selects `AgentSupport::Codex::Reviewer`. An explicit `kind: "linter"` raises `UnknownKindError` (exit code `CONFIG = 78`) with a message pointing the user at `review.ci.command` rather than silently ignoring the request. Any other value also raises `UnknownKindError`.
@@ -29,6 +30,9 @@ Shared shell for adapter classes. Subclasses set:
 
 - `name` — derived from `spec["name"]`.
 - `output_path` — `<task_folder>/reviews/<output_basename>-<pass>.md`.
+- `failure_output_path` — the path orchestration may delete after failure;
+  defaults to `output_path` for legacy/custom adapters and is the staging path
+  for adapters that preserve canonical evidence across retries.
 - `ensure_reviews_dir!` — `FileUtils.mkdir_p(File.dirname(output_path))`.
 - monotonic deadline clamping — preserves an adapter's configured timeout when
   no outer deadline exists and otherwise caps each spawn to the review stage's
@@ -43,10 +47,12 @@ The v1 reviewer adapter. `run!`:
 1. Resolves the agent profile via `AgentProfiles.lookup(spec["agent"])`.
 2. Reads `spec["prompt_template"]`; resolves it via `Stages::Base.resolve_template_path` (path-escape guard).
 3. Renders the prompt with bindings: `project_name`, `worktree_path`, `task_folder`, `default_branch`, `pass`, `output_path`, `skill_invocation` (formatted via `profile.format_skill_invocation`, which honors profile-specific syntax — pi receives `/skill:<name>`), `user_supplied_tag`.
-4. Spawns via `Stages::Base.spawn_agent(synthetic_task, prompt:, add_dirs: [task_folder], cwd: worktree_path, profile:, status_mode: :output_file_exists, expected_output: output_path, max_budget_usd: spec["budget_usd"] || 50, timeout_sec: spec["timeout_sec"] || 3600, log_label: "review-#{name}-pass#{NN}")`.
-5. Returns `Result.new(status: :ok | :error, ...)`.
+4. Spawns via `Stages::Base.spawn_agent(synthetic_task, prompt:, add_dirs: [task_folder], cwd: worktree_path, profile:, status_mode: :output_file_exists, expected_output: "#{output_path}.partial", max_budget_usd: spec["budget_usd"] || 50, timeout_sec: spec["timeout_sec"] || 7200, log_label: "review-#{name}-pass#{NN}")`.
+5. On success, atomically renames the staged file to `output_path`. On failure,
+   deletes only the staged file and returns it as `Result#output_path`, allowing
+   orchestration cleanup without deleting a prior successful canonical file.
 
-When `claude.mode: tmux`, `Stages::Review.run_reviewers` opens one shared `Hive::ClaudeLauncher` session per pass for Claude agent reviewers. `Reviewers::Agent#run_in_session!` sends each Claude reviewer prompt into that same pane sequentially and still waits on that reviewer's own `output_path`. Non-Claude reviewers and all reviewers under `claude.mode: headless` keep the `run!` / `spawn_agent` path.
+When `claude.mode: tmux`, `Stages::Review.run_reviewers` opens one shared `Hive::ClaudeLauncher` session per pass for Claude agent reviewers. `Reviewers::Agent#run_in_session!` sends each Claude reviewer prompt into that same pane sequentially and waits on that reviewer's staging path before publishing it atomically. Non-Claude reviewers and all reviewers under `claude.mode: headless` keep the `run!` / `spawn_agent` path.
 
 `status_mode: :output_file_exists` is critical: reviewer spawns own a per-pass output file, not the task marker — the orchestrator's `REVIEW_WORKING` marker must persist across each reviewer's spawn (per ADR-021).
 
@@ -64,7 +70,7 @@ local to the selected provider.
 1. Resolves the codex profile via `AgentProfiles.lookup(spec["agent"])` and calls `check_version!` (preflight; missing binary → `:error "preflight failed: …"`).
 2. Renders `templates/reviewer_codex_native_review.md.erb` (no `skill_invocation` binding — codex review takes no CE skill).
 3. Spawns `codex review --title <title> <prompt>` with `cwd = worktree_path`, capturing combined stdout+stderr under a wall-clock timeout (`spec["timeout_sec"]`, default 7200; process-group TERM on timeout).
-4. Validates: stdout must contain at least one `## High|Medium|Nit` header AND must NOT be the prompt template echoed back. codex occasionally returns the prompt's own example block (the literal `- [ ] <finding>: <one-line justification>` placeholder under each header) instead of reviewing; that passes the header check but is hollow, so `TEMPLATE_ECHO` rejects it as a failure (it retries rather than recording a fake clean pass — a real `No findings.` review still passes). Valid → trims the codex banner to the first severity header, drops the middle `exec` / `thinking` / `codex` tool-call transcript that `codex review` streams after the findings block, keeps codex's final assistant message when present, and writes the normalized body to `output_path`. Invalid / template-echo / non-zero exit / timeout → deletes any partial file and returns `:error` (so triage never sees a malformed findings file). On failure the captured combined stdout+stderr **tail** (last `FAILURE_TAIL_BYTES = 2000`) is appended to the `:error` message, so it lands in `reviews/errors-NN.md` and a `reviewer all_failed` becomes diagnosable instead of an opaque `exited status=1`; surfacing it also lets `Hive::AgentLimit.limit_reached?` (which only sees the error message) catch a codex usage-limit and route the phase to the cooldown `limits_reached` path instead of `all_failed`. Shares Agent's `max_attempts` retry, `Hive::Reviewers.backoff_seconds_for` delay formula, and monotonic `deadline:` handling.
+4. Validates: stdout must contain at least one `## High|Medium|Nit` header AND must NOT be the prompt template echoed back. codex occasionally returns the prompt's own example block (the literal `- [ ] <finding>: <one-line justification>` placeholder under each header) instead of reviewing; that passes the header check but is hollow, so `TEMPLATE_ECHO` rejects it as a failure (it retries rather than recording a fake clean pass — a real `No findings.` review still passes). Valid → trims the codex banner to the first severity header, drops the middle `exec` / `thinking` / `codex` tool-call transcript that `codex review` streams after the findings block, keeps codex's final assistant message when present, writes the normalized body to `<output_path>.partial`, and atomically promotes it. Invalid / template-echo / non-zero exit / timeout → deletes only the staged file and returns `:error` (so triage never sees malformed findings and any earlier successful canonical result survives). On failure the captured combined stdout+stderr **tail** (last `FAILURE_TAIL_BYTES = 2000`) is appended to the `:error` message, so it lands in `reviews/errors-NN.md` and a `reviewer all_failed` becomes diagnosable instead of an opaque `exited status=1`; surfacing it also lets `Hive::AgentLimit.limit_reached?` (which only sees the error message) catch a codex usage-limit and route the phase to the cooldown `limits_reached` path instead of `all_failed`. Shares Agent's `max_attempts` retry, `Hive::Reviewers.backoff_seconds_for` delay formula, and monotonic `deadline:` handling.
 4. Classifies codex's **real answer** — NOT the raw stdout. `codex review` always echoes the prompt (which carries the template's own `## High/Medium/Nit` headers AND the literal `- [ ] <finding>: <one-line justification>` placeholder) at the top of its session, then streams an `exec`/`thinking`/`codex` tool-call transcript, then a final assistant message. `review_body` strips the echoed prompt (a leading findings block whose only content is the `TEMPLATE_ECHO` placeholder is dropped) and the middle transcript, keeping a *real* leading findings block plus codex's final message. The decision then runs on that answer:
    - **structured findings** (`## High|Medium|Nit` present, no placeholder) → `:findings`, published as-is;
    - **native `codex review` findings** (no `## High|Medium|Nit` header, but ≥1 `[Pn]` priority bullet — the format codex emits when it ignores the prompt's GFM coercion, notably on the "No plan was found" patrol path) → `:findings`, but `findings_markdown` first normalizes them via `normalize_native_findings`: each `- [P1] …` bullet becomes a `## High/Medium/Nit` checkbox (P1→High, P2→Medium, P3+→Nit, per `NATIVE_SEVERITY`), folding the finding's indented justification onto its line and de-duplicating codex's repeated echoes. This is what fixes the second `all_failed` regression — a real codex finding in native format used to fail every retry as "missing High/Medium/Nit headers";
@@ -96,7 +102,7 @@ Reviewers live in `cfg.review.reviewers`. Each entry:
   prompt_template: reviewer_claude_ce_code_review.md.erb  # required
   output_basename: claude-ce-code-review                  # required (validated unique, non-empty)
   budget_usd: 50                     # optional; default 50
-  timeout_sec: 3600                  # optional; default 3600
+  timeout_sec: 7200                  # optional; default 7200
 ```
 
 A `codex_review` entry omits `skill` and `budget_usd`:
@@ -117,8 +123,8 @@ The DEFAULTS `patrol.review.reviewers` is the single `codex-native-review` entry
 ## Tests
 
 - `test/unit/reviewers_test.rb` — dispatch (agent / linter / unknown), Context / Result shape.
-- `test/unit/reviewers/agent_test.rb` — adapter render + spawn integration and retry-loop behavior through the adapter seam.
-- `test/unit/reviewers/codex_review_test.rb` — `codex review` argv (no `--base`), cwd, stdout→findings, banner trim, template-echo rejection, session-transcript drop with and without a trailing codex reply, native `[Pn]`-format normalization (P1→High/P2→Medium checkboxes, indented-justification folding, duplicate de-dup), malformed/empty/non-zero → error + no file, timeout kill, version gate, retry/deadline, dispatch, prompt render. Fakes the codex subprocess via `test/fixtures/fake-codex` + `HIVE_CODEX_BIN`.
+- `test/unit/reviewers/agent_test.rb` — adapter render + spawn integration, retry-loop behavior, atomic publication, and prior-result preservation through the adapter seam.
+- `test/unit/reviewers/codex_review_test.rb` — `codex review` argv (no `--base`), cwd, stdout→findings, atomic publication and prior-result preservation, banner trim, template-echo rejection, session-transcript drop with and without a trailing codex reply, native `[Pn]`-format normalization (P1→High/P2→Medium checkboxes, indented-justification folding, duplicate de-dup), malformed/empty/non-zero → error + no file, timeout kill, version gate, retry/deadline, dispatch, prompt render. Fakes the codex subprocess via `test/fixtures/fake-codex` + `HIVE_CODEX_BIN`.
 - `test/unit/reviewers/synthetic_task_test.rb` — facade shape.
 
 ## Backlinks


### PR DESCRIPTION
## Summary
- write agent and native Codex reviewer output to a staging path
- atomically publish only complete successful findings
- clean up only failed staged output so a later quota or crash cannot erase prior pass evidence
- retain compatibility cleanup behavior for custom reviewer adapters

## Verification
- 205 reviewer/orchestrator tests, 750 assertions, 0 failures
- RuboCop clean on all changed Ruby files
- git diff --check clean

## Dogfood regression
Observed on Screenote task 42619: a successful pass-4 reviewer artifact was erased when another reviewer retry hit a provider quota. These changes preserve the successful canonical artifact while keeping incomplete output invisible to triage.