### PR TITLE
Fix daemon starvation with task priority aging

### DIFF
--- a/lib/hive/daemon/dispatcher.rb
+++ b/lib/hive/daemon/dispatcher.rb
@@ -56,6 +56,7 @@ module Hive
 
       OperationalQueueState = Data.define(:pending, :claimed, :malformed, :error)
       FastProbe = Data.define(:task_keys, :full_tick)
+      DISPATCH_AGING_STEP_SEC = 30 * 60
       TERMINAL_RECOVERY_PRUNE_INTERVAL_SEC = 60 * 60
       STATE_FILE_PROBE_BATCH_SIZE = 64
 
@@ -458,9 +459,9 @@ module Hive
           dispatch_patrol_with_gates(patrol_dispatch, now: now)
         end
 
-        # 4. Per-row dispatch, later pipeline stages first (see
-        # dispatch_priority_order) so work nearest completion drains
-        # ahead of newer earlier-stage work when slots are scarce.
+        # 4. Per-row dispatch, later pipeline stages first for fresh rows
+        # (see dispatch_priority_order), with aging so old earlier-stage
+        # work cannot starve behind a continuous later-stage stream.
         @priority_capacity_fences = dispatch_rows_in_priority_order(
           result.rows, now: now
         )
@@ -2024,16 +2025,15 @@ module Hive
         []
       end
 
-      # Order rows so tasks closer to the end of the pipeline dispatch
-      # first: a 7-artifacts row before a 6-review row, an 8-finalize
-      # before both. When concurrency slots are scarce this drains work
-      # nearest completion ahead of newer earlier-stage work (a WIP-limit
-      # — don't start a fresh review while finalizes wait on a slot).
-      # Stable within a stage (original status order preserved), and
-      # unranked/unknown stages sort last.
-      def dispatch_priority_order(rows)
+      # Order fresh rows so tasks closer to the end of the pipeline dispatch
+      # first: a 7-artifacts row before a 6-review row, an 8-finalize before
+      # both. Each half-hour waited adds one stage of priority, preventing
+      # old earlier-stage work from starving behind a continuous stream of
+      # newer later-stage work. Equal effective priorities preserve source
+      # order, and unranked/unknown stages start below recognized stages.
+      def dispatch_priority_order(rows, now: Time.now)
         rows.each_with_index
-            .sort_by { |row, idx| [ -stage_rank(row.stage), idx ] }
+            .sort_by { |row, idx| [ -dispatch_priority(row, now: now), idx ] }
             .map(&:first)
       end
 
@@ -2050,7 +2050,7 @@ module Hive
         global_fence = capacity_fences&.fetch(:global, nil)
         project_fences = capacity_fences ? capacity_fences.fetch(:projects, {}).dup : {}
 
-        dispatch_priority_order(rows).each do |row|
+        dispatch_priority_order(rows, now: now).each do |row|
           break unless admission_open?
 
           project_key = row.project.to_s
@@ -2086,6 +2086,17 @@ module Hive
       # coding row under slot scarcity (consistent with the sibling gates).
       def stage_rank(stage)
         Hive::Workflows.all_stage_dirs.index(stage.to_s) || -1
+      end
+
+      def dispatch_priority(row, now:)
+        stage_rank(row.stage) + dispatch_age_steps(row, now: now)
+      end
+
+      def dispatch_age_steps(row, now:)
+        mtime = row.state_file_mtime
+        return 0 unless mtime.is_a?(Time)
+
+        [ (now - mtime).to_i, 0 ].max / DISPATCH_AGING_STEP_SEC
       end
 
       def apply_external_running_counts

--- a/test/unit/daemon/dispatcher_test.rb
+++ b/test/unit/daemon/dispatcher_test.rb
@@ -2855,12 +2855,38 @@ class HiveDaemonDispatcherTest < Minitest::Test
     ]
     dispatcher, = make_dispatcher
 
-    ordered = dispatcher.send(:dispatch_priority_order, rows)
+    ordered = dispatcher.send(:dispatch_priority_order, rows, now: T0)
 
     assert_equal %w[9-done 7-artifacts 7-artifacts 6-review 2-brainstorm],
                  ordered.map(&:stage), "later stages first"
     assert_equal %w[b d], ordered.select { |r| r.stage == "7-artifacts" }.map(&:slug),
                  "stable within a stage — original status order preserved"
+  end
+
+  def test_dispatch_priority_ages_waiting_rows_past_fresh_later_stage_work
+    rows = [
+      row(slug: "fresh-finalize", stage: "8-finalize", mtime: T0 - 60),
+      row(slug: "old-plan", stage: "3-plan", mtime: T0 - (6 * 60 * 60))
+    ]
+    dispatcher, = make_dispatcher
+
+    ordered = dispatcher.send(:dispatch_priority_order, rows, now: T0)
+
+    assert_equal %w[old-plan fresh-finalize], ordered.map(&:slug),
+                 "aging must prevent a stream of fresh later-stage work from starving old retries"
+  end
+
+  def test_dispatch_priority_does_not_age_missing_or_future_mtimes
+    rows = [
+      row(slug: "future-plan", stage: "3-plan", mtime: T0 + 60),
+      row(slug: "missing-review", stage: "6-review", mtime: nil),
+      row(slug: "fresh-finalize", stage: "8-finalize", mtime: T0 - 60)
+    ]
+    dispatcher, = make_dispatcher
+
+    ordered = dispatcher.send(:dispatch_priority_order, rows, now: T0)
+
+    assert_equal %w[fresh-finalize missing-review future-plan], ordered.map(&:slug)
   end
 
   def test_advance_action_skips_when_task_folder_vanished_after_snapshot

--- a/wiki/log.d/20260830T220000Z-daemon-dispatch-aging.md
+++ b/wiki/log.d/20260830T220000Z-daemon-dispatch-aging.md
@@ -1,0 +1,13 @@
+---
+title: Daemon dispatch aging prevents early-stage starvation
+date: 2026-08-30
+tags: [daemon, scheduler, fairness, capacity]
+---
+
+- Kept later-workflow-stage-first dispatch for fresh rows while adding one
+  priority step per 30 minutes since the task state file changed.
+- Old eligible plan and retry rows now rise above a continuous stream of newer
+  review, artifact, and publication work instead of remaining behind the
+  capacity priority fence indefinitely.
+- Missing and future mtimes receive no boost; equal effective priorities keep
+  the internal status graph's stable order.

--- a/wiki/modules/daemon.md
+++ b/wiki/modules/daemon.md
@@ -247,6 +247,13 @@ fence only that project. Rows whose policy does not dispatch still run,
 preserving a complete operational disposition set, and the next authoritative
 full scan starts with no inherited fence and replaces the snapshot.
 
+Task-row priority still favors work closer to the end of its workflow, but it
+adds one priority step for every 30 minutes since the row's state-file mtime.
+Fresh rows therefore preserve the pipeline WIP limit, while an old eligible
+plan, retry, or generic-stage row eventually outranks a continuous stream of
+newer later-stage work instead of starving indefinitely. Rows with missing or
+future mtimes receive no aging boost, and equal scores retain source order.
+
 Chronological dispatch-request consumption applies the same rule within each
 queue scan. Once an older request observes the controller's global cap or a
 generic durable-attempt capacity deferral, the scan stops before a later


### PR DESCRIPTION
## Summary

- Preserve later-stage-first scheduling for fresh task rows.
- Add deterministic priority aging so old eligible rows cannot starve behind continuous newer downstream work.
- Document the scheduler contract and cover old, missing, and future mtimes.

## Evidence

- Dispatcher unit suite: 311 runs, 1,111 assertions.
- Daemon auto-retry integration: 4 runs, 13 assertions.
- Status consumer unit suite: 31 runs, 157 assertions.
- RuboCop: 2 files, no offenses.
- Live read-only replay places the 13-day-old Screenote plan-review retry at eligible priority #2 rather than behind fresh review/open-PR rows.