### PR TITLE
Preserve plan clearance for reviewed rework

### DIFF
--- a/lib/hive/plan_review/transition_guard.rb
+++ b/lib/hive/plan_review/transition_guard.rb
@@ -102,7 +102,8 @@ module Hive
       # task carrying review state must prove current clearance. A task with no
       # review root is treated as an explicitly receipted pre-feature task so
       # upgrades do not retroactively strand work already in execute.
-      def validate_execute_entry!(task:, config: nil, clock: -> { Time.now.utc })
+      def validate_execute_entry!(task:, config: nil, clock: -> { Time.now.utc },
+                                  reviewed_rework: false)
         return true unless execute_applicable?(task)
 
         cfg = config || Hive::Config.load(task.project_root)
@@ -121,7 +122,10 @@ module Hive
         end
         return true if legacy_adoption_valid?(task, root)
 
-        authorize!(task, Projection.load(task_folder: task.folder), cfg:)
+        authorize!(
+          task, Projection.load(task_folder: task.folder), cfg:,
+          allow_policy_drift: reviewed_rework
+        )
         true
       rescue InvalidRecord, StaleObservation, Hive::ConfigError,
              Hive::TaskMeta::InvalidMetadata => error
@@ -143,7 +147,7 @@ module Hive
         cfg.dig("plan_review", "enabled") != false
       end
 
-      def authorize!(task, projection, cfg:)
+      def authorize!(task, projection, cfg:, allow_policy_drift: false)
         unless projection.is_a?(Projection)
           raise blocked_error(
             task, nil, "plan review has not produced a current resolution",
@@ -152,7 +156,9 @@ module Hive
         end
 
         record = projection.record
-        current_freshness = freshness(task:, projection:, config: cfg)
+        current_freshness = freshness(
+          task:, projection:, config: cfg, allow_policy_drift:
+        )
         fresh = current_freshness.fetch("status") == "current"
         executable = record.execution_allowed? && record["blockers"].empty?
         return projection if fresh && executable
@@ -162,15 +168,16 @@ module Hive
         raise blocked_error(task, projection, reason)
       end
 
-      def freshness(task:, projection:, config:)
+      def freshness(task:, projection:, config:, allow_policy_drift: false)
         record = projection.record
         required_digest = record["candidate_plan_digest"] || record.plan_digest
         return stale("task generation changed after plan review") unless
           record.task_generation.to_s == Identity.task_generation(task).to_s
         return stale("canonical plan changed after plan review") unless
           required_digest == current_plan_digest(task)
-        return stale("plan review policy changed after resolution") unless
-          policy_configuration_matches?(record, task, config)
+        unless allow_policy_drift || policy_configuration_matches?(record, task, config)
+          return stale("plan review policy changed after resolution")
+        end
 
         { "status" => "current", "reason" => nil }.freeze
       rescue InvalidPlan, InvalidRecord, SystemCallError, IOError => error

--- a/lib/hive/stages/execute.rb
+++ b/lib/hive/stages/execute.rb
@@ -51,7 +51,17 @@ module Hive
       UNRESOLVED_IDENTITY = Object.new.freeze
 
       def run!(task, cfg)
-        Hive::PlanReview::TransitionGuard.validate_execute_entry!(task:, config: cfg)
+        rework_context = nil
+        begin
+          Hive::PlanReview::TransitionGuard.validate_execute_entry!(task:, config: cfg)
+        rescue Hive::PlanReview::TransitionBlocked
+          rework_context = outcome_evidence_rework_context(task, require_receipt: true)
+          raise unless rework_context&.fetch("feedback")
+
+          Hive::PlanReview::TransitionGuard.validate_execute_entry!(
+            task:, config: cfg, reviewed_rework: true
+          )
+        end
         plan_path = File.join(task.folder, "plan.md")
         unless File.exist?(plan_path)
           warn "hive: plan.md missing; this task did not pass through 3-plan"
@@ -68,7 +78,7 @@ module Hive
         end
 
         identity = capture_implementation_identity(task, cfg)
-        rework_context = outcome_evidence_rework_context(task)
+        rework_context ||= outcome_evidence_rework_context(task)
         FileUtils.mkdir_p(task.reviews_dir)
 
         if File.exist?(task.worktree_yml_path)
@@ -633,12 +643,14 @@ module Hive
         merged
       end
 
-      def outcome_evidence_rework_context(task)
+      def outcome_evidence_rework_context(task, require_receipt: false)
         project = File.basename(task.project_root)
         tracker = Hive::Artifacts::OutcomeEvidence::Rework.new(
           task: task, project: project
         )
         records = tracker.records
+        return nil if require_receipt && records.empty?
+
         package = unless records.empty?
           Hive::Artifacts::OutcomeEvidence::Store.new(
             task: task, project: project

--- a/test/unit/plan_review/transition_guard_test.rb
+++ b/test/unit/plan_review/transition_guard_test.rb
@@ -185,6 +185,42 @@ class PlanReviewTransitionGuardTest < Minitest::Test
     end
   end
 
+  def test_reviewed_implementation_rework_keeps_clearance_across_policy_drift
+    with_task(stage_index: 4, stage_name: "execute") do |task, cfg|
+      publish_projection(task, cfg, state: "cleared")
+      changed_cfg = Marshal.load(Marshal.dump(cfg))
+      changed_cfg["plan_review"]["adapter"] = "replacement-review-adapter"
+
+      error = assert_raises(Hive::PlanReview::TransitionBlocked) do
+        Hive::PlanReview::TransitionGuard.validate_execute_entry!(
+          task:, config: changed_cfg
+        )
+      end
+      assert_includes error.message, "policy changed"
+
+      assert Hive::PlanReview::TransitionGuard.validate_execute_entry!(
+        task:, config: changed_cfg, reviewed_rework: true
+      )
+
+      task.id = 43
+      changed_generation = assert_raises(Hive::PlanReview::TransitionBlocked) do
+        Hive::PlanReview::TransitionGuard.validate_execute_entry!(
+          task:, config: changed_cfg, reviewed_rework: true
+        )
+      end
+      assert_includes changed_generation.message, "task generation changed"
+      task.id = 42
+
+      File.write(File.join(task.folder, "plan.md"), "# changed after review\n")
+      changed_plan = assert_raises(Hive::PlanReview::TransitionBlocked) do
+        Hive::PlanReview::TransitionGuard.validate_execute_entry!(
+          task:, config: changed_cfg, reviewed_rework: true
+        )
+      end
+      assert_includes changed_plan.message, "canonical plan changed"
+    end
+  end
+
   def test_invalid_review_inputs_are_normalized_to_blocked_or_invalid_results
     with_task do |task, cfg|
       error = assert_raises(Hive::PlanReview::TransitionBlocked) do

--- a/test/unit/stages/execute_test.rb
+++ b/test/unit/stages/execute_test.rb
@@ -90,6 +90,66 @@ class HiveStagesExecuteTest < Minitest::Test
     end
   end
 
+  def test_run_reuses_clearance_only_after_validated_reviewed_rework
+    with_tmp_dir do |dir|
+      task = build_task(dir)
+      write_plan(task)
+      calls = []
+      guard = lambda do |**kwargs|
+        calls << kwargs
+        raise Hive::PlanReview::TransitionBlocked, "policy changed" if calls.one?
+
+        true
+      end
+      package = {
+        "current" => {
+          "status" => "rework", "reason" => "implementation_rework",
+          "generation" => "a" * 64, "recovery_digest" => "b" * 64,
+          "failed_targets" => [ "claim-interface" ],
+          "reviewer_reasons" => [ "Repair and recapture the interface." ],
+          "attempts" => []
+        },
+        "requirement" => {
+          "generation" => "a" * 64,
+          "implementation" => {
+            "implementation_base" => "a" * 40,
+            "implementation_head" => "b" * 40
+          }
+        },
+        "attempts" => []
+      }
+      Hive::Artifacts::OutcomeEvidence::Rework.new(
+        task:, project: File.basename(task.project_root)
+      ).record!(
+        package:, expected_generation: "a" * 64, expected_digest: "b" * 64
+      )
+      store = Object.new
+      store.define_singleton_method(:package_metadata) do
+        package
+      end
+
+      result = with_replaced_singleton_method(
+        Hive::PlanReview::TransitionGuard, :validate_execute_entry!, guard
+      ) do
+        with_replaced_singleton_method(
+          Hive::Artifacts::OutcomeEvidence::Store, :new, ->(**) { store }
+        ) do
+          with_replaced_singleton_method(
+            Hive::Stages::Execute, :task_state, ->(*) { :complete }
+          ) do
+            captured = nil
+            capture_io { captured = Hive::Stages::Execute.run!(task, {}) }
+            captured
+          end
+        end
+      end
+
+      assert_equal({ commit: nil, status: :execute_complete }, result)
+      assert_nil calls.fetch(0)[:reviewed_rework]
+      assert_equal true, calls.fetch(1).fetch(:reviewed_rework)
+    end
+  end
+
   def test_apply_execute_outcome_publishes_projection_before_compatibility_marker
     with_tmp_git_repo do |worktree|
       with_tmp_dir do |dir|
@@ -1592,6 +1652,15 @@ class HiveStagesExecuteTest < Minitest::Test
       assert_equal expected, context
 
       tracker.define_singleton_method(:records) { [] }
+      required = with_replaced_singleton_method(
+        Hive::Artifacts::OutcomeEvidence::Rework, :new, ->(**) { tracker }
+      ) do
+        Hive::Stages::Execute.outcome_evidence_rework_context(
+          task, require_receipt: true
+        )
+      end
+      assert_nil required
+
       empty = with_replaced_singleton_method(
         Hive::Artifacts::OutcomeEvidence::Rework, :new, ->(**) { tracker }
       ) do

--- a/wiki/log.d/20260830T231500Z-plan-review-rework-policy-drift.md
+++ b/wiki/log.d/20260830T231500Z-plan-review-rework-policy-drift.md
@@ -1,0 +1,16 @@
+---
+title: Preserve plan clearance during reviewed implementation rework
+module: plan-review
+tags: [plan-review, outcome-evidence, rework, recovery]
+problem_type: workflow_recovery
+---
+
+An outcome-evidence reviewer can return an implementation from `7-artifacts` to
+`4-execute` after the plan has already passed its gate. A later reviewer-route
+change previously made the execute backstop reject that native rework, even
+though the reviewed plan and task generation were unchanged.
+
+Execute now validates the exact outcome-evidence rework context before allowing
+the existing clearance to survive policy-only drift. Plan changes, generation
+changes, blocked review resolutions, malformed rework evidence, and ordinary
+first-time transitions continue to fail closed.

--- a/wiki/modules/plan_review.md
+++ b/wiki/modules/plan_review.md
@@ -16,6 +16,13 @@ resolution can authorize `3-plan` to `4-execute`. Markers, generic approval,
 `--force`, daemon automation, Web forms, and direct execute entry cannot replace
 that authority.
 
+An implementation returned from `7-artifacts` by the native outcome-evidence
+rework command retains that already-used clearance when reviewer routing changes
+later. The exact rework receipt and current evidence package must validate first;
+the reviewed plan digest, task generation, executable resolution, and empty
+blocker set remain mandatory. Raw moves and first-time plan transitions still
+require the current review policy fingerprint.
+
 ## Applicability and boundary
 
 The first release applies only when all of these are true:


### PR DESCRIPTION
## Summary

- keep an already-used plan-review clearance valid when an exact native outcome-evidence rework receipt returns implementation from artifacts to execute
- ignore only reviewer-routing policy drift; still fail closed on plan digest, task generation, blockers, malformed evidence, and ordinary first-time transitions
- document the recovery boundary in the managed wiki

## Test plan

- [x] `test/unit/plan_review/transition_guard_test.rb`: 9 runs, 61 assertions
- [x] `test/unit/stages/execute_test.rb`: 56 runs, 219 assertions
- [x] RuboCop: 4 changed Ruby files, no offenses
- [x] broad checkpoint: 14,069 runs, 285,907 assertions, 0 failures, 2 unrelated Web capture deadline errors; both failing tests passed alone (2 runs, 6 assertions)
- [x] validated the real Webmail task rework receipt and current evidence package against this branch

## Notes for reviewer

This does not rewrite old review records or relax initial plan-review entry. Execute first applies the normal guard; only a validated outcome-evidence implementation-rework receipt enables a second check that tolerates policy-only drift.