### PR TITLE
fix(plan-review): recover checkpoint custody false positives

### DIFF
--- a/lib/hive/plan_review/adapters/ce_doc_review.rb
+++ b/lib/hive/plan_review/adapters/ce_doc_review.rb
@@ -11,6 +11,7 @@ require "hive/agent_skills"
 require "hive/artifact_firewall"
 require "hive/config"
 require "hive/plan_review/adapters/base"
+require "hive/plan_review/checkpoint_custody"
 require "hive/plan_review/disposable_worktree"
 require "hive/plan_review/result_parser"
 require "hive/plan_review/route_resolver"
@@ -136,14 +137,17 @@ module Hive
           # Those writes land in the task's own bookkeeping files, so holding
           # them under the firewall made every review fail with "reviewer
           # modified protected artifacts: task-journal.jsonl,
-          # task-projection.json" for edits the reviewer never made.
+          # task-projection.json, task-projection.checkpoint.json" for edits
+          # the reviewer never made.
           #
           # They stay protected everywhere else (the execute-stage firewall is
           # untouched); here they are excluded because hive is the one writing
           # them during this exact window. What the reviewer must not touch —
           # plan.md, meta.yml, and every existing plan-review record — is still
           # anchored below.
-          ORCHESTRATOR_JOURNALS = %w[task-journal.jsonl task-projection.json].freeze
+          ORCHESTRATOR_JOURNALS = %w[
+            task-journal.jsonl task-projection.json
+          ].push(CheckpointCustody::BASENAME).freeze
 
           # Review history is append-only. Keep every record in one custody
           # transaction so validation failure cannot skip restoration of a

--- a/lib/hive/plan_review/checkpoint_custody.rb
+++ b/lib/hive/plan_review/checkpoint_custody.rb
@@ -1,0 +1,66 @@
+require "hive/plan_review/result_parser"
+
+module Hive
+  module PlanReview
+    module CheckpointCustody
+      CONTRACT_VERSION = 1
+      BASENAME = "task-projection.checkpoint.json".freeze
+      DIAGNOSTIC = "reviewer modified protected artifacts: #{BASENAME}".freeze
+      INITIAL_REVIEW_ROLES = ResultParser::INITIAL_REVIEW_RECOVERY_ROLES
+
+      module_function
+
+      # Recover only exact, runner-authored initial-review failures. A
+      # versioned reset suppresses later replays of the same lineage; malformed
+      # recovery metadata fails closed instead of creating a retry loop.
+      def recoverable_routes(routes)
+        recoverable_by_role(routes).values_at(*INITIAL_REVIEW_ROLES).compact
+      end
+
+      def recoverable?(routes)
+        recoverable_by_role(routes).any?
+      end
+
+      def recoverable_by_role(routes)
+        recoverable = {}
+        recovered_roles = {}
+        attempted_roles = {}
+        Array(routes).reverse_each do |route|
+          role = route["role"]
+          next unless INITIAL_REVIEW_ROLES.include?(role)
+
+          if route["checkpoint_custody_recovery"] == true
+            status = contract_status(route)
+            unless status == :stale
+              recovered_roles[role] = true
+              recoverable.delete(role)
+            end
+            next
+          end
+          next if recovered_roles[role]
+          next if route["attempt_id"].to_s.empty?
+          next if attempted_roles[role]
+
+          attempted_roles[role] = true
+          next unless route["outcome"] == "terminal_failure"
+          next unless route["diagnostic"] == DIAGNOSTIC
+          next unless route["diagnostic_source"] == "runner"
+
+          recoverable[role] = route
+        end
+        recoverable
+      end
+      private_class_method :recoverable_by_role
+
+      def contract_status(route)
+        return :current if
+          Integer(route["checkpoint_custody_contract_version"]) >= CONTRACT_VERSION
+
+        :stale
+      rescue ArgumentError, TypeError
+        :invalid
+      end
+      private_class_method :contract_status
+    end
+  end
+end

--- a/lib/hive/plan_review/orchestrator.rb
+++ b/lib/hive/plan_review/orchestrator.rb
@@ -9,6 +9,7 @@ require "hive/lock"
 require "hive/plan_review/approval_policy"
 require "hive/plan_review/adapters/base"
 require "hive/plan_review/adapters/ce_doc_review"
+require "hive/plan_review/checkpoint_custody"
 require "hive/plan_review/clearance"
 require "hive/plan_review/decision"
 require "hive/plan_review/identity"
@@ -132,6 +133,7 @@ module Hive
         record = refresh_planner_identity_contract(record)
         record, capability_pending = refresh_capability_probes(record)
         return Projection.new(record) if capability_pending
+        record = refresh_checkpoint_custody_contract(record)
         record = refresh_adversarial_identity_contract(record)
         record = refresh_selected_lenses_contract(record)
         record = refresh_residual_evidence_contract(record)
@@ -415,6 +417,22 @@ module Hive
         )
       end
 
+      # A projection-checkpoint rollout briefly placed Hive's own
+      # review-session write inside reviewer custody. Retry each exact,
+      # runner-authored false positive once after the custody exclusion ships.
+      def refresh_checkpoint_custody_contract(record)
+        routes = CheckpointCustody.recoverable_routes(record["routes"])
+        refresh_route_contract(
+          record, routes:,
+          recovery_attributes: {
+            "checkpoint_custody_recovery" => true,
+            "checkpoint_custody_contract_version" =>
+              CheckpointCustody::CONTRACT_VERSION
+          },
+          diagnostic: "retry reviewer after repairing review-session checkpoint custody"
+        )
+      end
+
       # Older parsers rejected lowercase specialist names such as
       # `product-lens` and persisted the otherwise valid reviewer response as a
       # terminal failure. Re-run that exact legacy diagnostic once under the
@@ -422,7 +440,7 @@ module Hive
       # genuinely malformed result produced by the current parser.
       def refresh_selected_lenses_contract(record)
         routes = ResultParser.recoverable_selected_lenses_routes(record["routes"])
-        refresh_parser_contract(
+        refresh_route_contract(
           record, routes:,
           recovery_attributes: {
             "selected_lenses_contract_recovery" => true,
@@ -439,7 +457,7 @@ module Hive
       # initial role once under the explicit empty-array contract.
       def refresh_residual_evidence_contract(record)
         routes = ResultParser.recoverable_residual_evidence_routes(record["routes"])
-        refresh_parser_contract(
+        refresh_route_contract(
           record, routes:,
           recovery_attributes: {
             "residual_evidence_contract_recovery" => true,
@@ -449,7 +467,7 @@ module Hive
         )
       end
 
-      def refresh_parser_contract(record, routes:, recovery_attributes:, diagnostic:)
+      def refresh_route_contract(record, routes:, recovery_attributes:, diagnostic:)
         return record if routes.empty?
 
         resets = routes.map do |route|

--- a/lib/hive/task_action.rb
+++ b/lib/hive/task_action.rb
@@ -13,6 +13,7 @@ require "hive/markers"
 require "hive/draft_pr_receipt"
 require "hive/terminal_outcome"
 require "hive/plan_review/projection"
+require "hive/plan_review/checkpoint_custody"
 require "hive/plan_review/planner_revision"
 require "hive/plan_review/planner_identity"
 require "hive/plan_review/result_parser"
@@ -748,6 +749,8 @@ module Hive
           ACTIONS.fetch(:plan_reviewing)
         elsif recoverable_adversarial_identity_review?
           ACTIONS.fetch(:plan_reviewing)
+        elsif recoverable_checkpoint_custody_review?
+          ACTIONS.fetch(:plan_reviewing)
         elsif recoverable_selected_lenses_contract_review?
           ACTIONS.fetch(:plan_reviewing)
         elsif recoverable_residual_evidence_contract_review?
@@ -1068,6 +1071,14 @@ module Hive
       !Hive::PlanReview::RouteResolver.recoverable_identity_route(
         routes:, planner_identity:
       ).nil?
+    end
+
+    # Builds that first protected the bounded projection checkpoint included
+    # Hive's own session write in reviewer custody. Surface only the adapter's
+    # exact runner-provenance false positive as runnable until the orchestrator
+    # records its versioned one-time reset.
+    def recoverable_checkpoint_custody_review?
+      Hive::PlanReview::CheckpointCustody.recoverable?(plan_review["routes"])
     end
 
     # The old selected-lens grammar rejected natural lowercase kebab-case

--- a/test/unit/plan_review/ce_doc_review_adapter_test.rb
+++ b/test/unit/plan_review/ce_doc_review_adapter_test.rb
@@ -14,6 +14,7 @@ class PlanReviewCeDocReviewAdapterTest < Minitest::Test
 
     refute_includes anchored, "task-journal.jsonl"
     refute_includes anchored, "task-projection.json"
+    refute_includes anchored, "task-projection.checkpoint.json"
     # The reviewer's actual input must still be protected.
     assert_includes anchored, "plan.md"
   end

--- a/test/unit/plan_review/checkpoint_custody_test.rb
+++ b/test/unit/plan_review/checkpoint_custody_test.rb
@@ -1,0 +1,60 @@
+require "test_helper"
+require "hive/plan_review/checkpoint_custody"
+
+class PlanReviewCheckpointCustodyTest < Minitest::Test
+  def test_recovery_is_exact_versioned_and_initial_only
+    diagnostic = Hive::PlanReview::CheckpointCustody::DIAGNOSTIC
+    recoverable = %w[primary adversarial].map do |role|
+      {
+        "role" => role, "outcome" => "terminal_failure", "attempt_id" => "pra-#{role}",
+        "diagnostic" => diagnostic, "diagnostic_source" => "runner"
+      }
+    end
+    ignored = [
+      recoverable.first.merge("role" => "verification"),
+      recoverable.first.merge("diagnostic_source" => "reviewer"),
+      recoverable.first.merge("diagnostic" => "reviewer modified protected artifacts: plan.md")
+    ]
+
+    routes = Hive::PlanReview::CheckpointCustody.recoverable_routes(recoverable)
+
+    assert Hive::PlanReview::CheckpointCustody.recoverable?(recoverable)
+    assert_equal %w[primary adversarial], routes.map { |route| route.fetch("role") }
+    ignored.each do |route|
+      refute Hive::PlanReview::CheckpointCustody.recoverable?([ route ])
+    end
+
+    recovered = recoverable + [
+      Hive::PlanReview.recovery_reset_route(
+        recoverable.first,
+        "checkpoint_custody_recovery" => true,
+        "checkpoint_custody_contract_version" => 1
+      )
+    ]
+    recovered_roles = Hive::PlanReview::CheckpointCustody.recoverable_routes(recovered)
+      .map { |route| route.fetch("role") }
+    assert_equal [ "adversarial" ], recovered_roles
+
+    malformed = recovered.last.merge("checkpoint_custody_contract_version" => "not-a-version")
+    malformed_routes = recoverable + [ malformed ]
+    malformed_roles = Hive::PlanReview::CheckpointCustody.recoverable_routes(malformed_routes)
+      .map { |route| route.fetch("role") }
+    assert_equal [ "adversarial" ], malformed_roles
+
+    superseded = [
+      recoverable.first,
+      recoverable.first.merge("outcome" => "success", "diagnostic" => nil)
+    ]
+    refute Hive::PlanReview::CheckpointCustody.recoverable?(superseded)
+
+    unrelated_failure = recoverable.first.merge("diagnostic" => "reviewer modified plan.md")
+    refute Hive::PlanReview::CheckpointCustody.recoverable?(
+      [ recoverable.first, unrelated_failure ]
+    )
+
+    repeated_after_reset = recovered + [ recoverable.first ]
+    repeated_roles = Hive::PlanReview::CheckpointCustody.recoverable_routes(repeated_after_reset)
+      .map { |route| route.fetch("role") }
+    assert_equal [ "adversarial" ], repeated_roles
+  end
+end

--- a/test/unit/plan_review/checkpoint_custody_test.rb
+++ b/test/unit/plan_review/checkpoint_custody_test.rb
@@ -41,6 +41,11 @@ class PlanReviewCheckpointCustodyTest < Minitest::Test
       .map { |route| route.fetch("role") }
     assert_equal [ "adversarial" ], malformed_roles
 
+    stale = recovered.last.merge("checkpoint_custody_contract_version" => 0)
+    stale_roles = Hive::PlanReview::CheckpointCustody.recoverable_routes(recoverable + [ stale ])
+      .map { |route| route.fetch("role") }
+    assert_equal %w[primary adversarial], stale_roles
+
     superseded = [
       recoverable.first,
       recoverable.first.merge("outcome" => "success", "diagnostic" => nil)

--- a/test/unit/plan_review/orchestrator_test.rb
+++ b/test/unit/plan_review/orchestrator_test.rb
@@ -834,6 +834,40 @@ class PlanReviewOrchestratorTest < Minitest::Test
     end
   end
 
+  def test_checkpoint_custody_false_positive_recovers_every_affected_role_once
+    with_task(mandatory_plan) do |task, cfg|
+      calls = Hash.new(0)
+      adapter = FakeAdapter.new do |request|
+        calls[request.kind] += 1
+        if %w[primary adversarial].include?(request.kind) && calls.fetch(request.kind) == 1
+          next Hive::PlanReview::Adapters::Base::Result.new(
+            outcome: "terminal_failure",
+            diagnostic: "reviewer modified protected artifacts: task-projection.checkpoint.json",
+            route_receipt: { "diagnostic_source" => "runner" }
+          )
+        end
+
+        successful_result(request)
+      end
+
+      blocked = orchestrator(task, cfg, adapter:).advance!.record
+
+      assert_equal "blocked", blocked.state
+      assert_equal({ "primary" => 1, "adversarial" => 1 }, calls)
+
+      cleared = orchestrator(task, cfg, adapter:).advance!.record
+
+      assert_equal "cleared", cleared.state
+      assert_equal({ "primary" => 2, "adversarial" => 2, "verification" => 1 }, calls)
+      resets = cleared["routes"].select { |route| route["checkpoint_custody_recovery"] }
+      assert_equal %w[adversarial primary], resets.map { |route| route.fetch("role") }.sort
+      assert resets.all? { |route| route.fetch("checkpoint_custody_contract_version") == 1 }
+
+      orchestrator(task, cfg, adapter:).advance!
+      assert_equal({ "primary" => 2, "adversarial" => 2, "verification" => 1 }, calls)
+    end
+  end
+
   # Mandatory capability failures get cheap re-probes, then move to a paced
   # retry instead of growing current.json on every daemon tick or parking
   # forever after the provider becomes available.

--- a/test/unit/task_action_test.rb
+++ b/test/unit/task_action_test.rb
@@ -2292,6 +2292,34 @@ class TaskActionTest < Minitest::Test
     assert_equal "hive plan-review-run demo-260426-aaaa", legacy.command
   end
 
+  def test_plan_review_recovers_a_runner_checkpoint_custody_false_positive
+    task = fake_task(stage_name: "plan", stage_index: 3)
+    false_positive = Hive::TaskAction.for(
+      task, marker(:waiting),
+      plan_review: {
+        "state" => "blocked",
+        "required_action" => "waive named coverage or restore required reviewer capability",
+        "routes" => [
+          {
+            "role" => "adversarial", "outcome" => "terminal_failure",
+            "attempt_id" => "pra-checkpoint", "diagnostic_source" => "runner",
+            "diagnostic" =>
+              "reviewer modified protected artifacts: task-projection.checkpoint.json"
+          }
+        ]
+      }
+    )
+
+    assert_equal "plan_reviewing", false_positive.key
+    assert_equal "hive plan-review-run demo-260426-aaaa", false_positive.command
+
+    reviewer_authored = Marshal.load(Marshal.dump(false_positive.plan_review))
+    reviewer_authored.fetch("routes").first["diagnostic_source"] = "reviewer"
+    terminal = Hive::TaskAction.for(task, marker(:waiting), plan_review: reviewer_authored)
+    assert_equal "plan_review_unsupported", terminal.key
+    assert_nil terminal.command
+  end
+
   def test_stale_loaded_plan_review_blocks_execution_with_a_hive_owned_repair
     Dir.mktmpdir("task-action-stale-plan-review") do |root|
       task = fake_task(stage_name: "plan", stage_index: 3, project_root: root)

--- a/wiki/log.d/20260830T223650Z-plan-review-checkpoint-custody.md
+++ b/wiki/log.d/20260830T223650Z-plan-review-checkpoint-custody.md
@@ -1,0 +1,15 @@
+# 2026-08-30 — Keep derived checkpoints out of reviewer custody
+
+Plan reviewers no longer fail with a false protected-artifact violation when
+Hive refreshes `task-projection.checkpoint.json` during the reviewer session.
+The derived checkpoint now follows the existing exact-window exclusion for the
+task journal and projection; canonical plan, metadata, and plan-review authority
+records remain protected and restorable.
+
+The owning adapter test now pins all three Hive-written bookkeeping files so a
+future projection artifact cannot silently reintroduce the same live-review
+failure.
+
+Existing blocked records automatically retry each exact runner-authored false
+positive once for the primary and adversarial roles. A versioned recovery reset
+prevents persistent or reviewer-authored custody failures from creating a loop.

--- a/wiki/modules/plan_review.md
+++ b/wiki/modules/plan_review.md
@@ -94,6 +94,14 @@ validated output path, and the live plan-review records remain under
 ArtifactFirewall detection and restore. One manifest captures the entire
 authority history; its default bound is 128 and this explicit consumer widens
 it only to the exact inventory, subject to the hard 4096-entry ceiling.
+Hive's review-session journal, derived projection, and bounded projection
+checkpoint are excluded only from this review-time manifest because the
+controller updates all three while the provider is running. Canonical
+`plan.md`, task metadata, and every existing plan-review record remain anchored.
+Reviews blocked by the former checkpoint false positive are re-entered once per
+affected initial-review role when their immutable route carries the exact
+runner diagnostic. A versioned recovery reset prevents repeated retries and
+reviewer-authored or unrelated custody failures remain operator-owned.
 
 The default adversarial request is native Grok Build, model `grok-4.6`, effort
 `high`. Every route records requested and actual provider, model, model family,


### PR DESCRIPTION
## Summary

Plan reviews blocked only because Hive refreshed its own projection checkpoint during a reviewer run can now re-enter review automatically. Canonical task and review artifacts remain protected, while exact runner-authored false positives retry only once per affected initial reviewer role.

## Validation

- Focused owners: 197 runs, 1,262 assertions, 0 failures or errors.
- RuboCop: 8 files, no offenses.
- `git diff --check`: clean.
- The broad local suite completed 14,073 runs and 285,958 assertions. Two unrelated contention failures passed when rerun alone; the patrol progress fixture still misses its synthetic 0.5-second startup window on this host. CI owns the exhaustive gate.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
