### PR TITLE
Fix Patrol finding: make-one-profile-level-billing-evidence-contract-f7a0c3957f70

### DIFF
--- a/lib/hive/billing_evidence.rb
+++ b/lib/hive/billing_evidence.rb
@@ -4,13 +4,17 @@ module Hive
     SOURCES = %w[
       provider_account_config agent_profile_contract unavailable
     ].freeze
-    DIRECT_SUBSCRIPTION_ADAPTERS = %w[claude codex grok].freeze
 
     module_function
 
+    # The profile's declared billing_semantics contract is the single
+    # authority for subscription evidence. Billing evidence never re-derives
+    # admission from the adapter name; a profile that declares
+    # `subscription_backed` proves subscription semantics from its own
+    # contract, and every other declaration stays unknown/unavailable
+    # unless an admitted provider-account configuration declares the route.
     def for_profile(profile)
-      if DIRECT_SUBSCRIPTION_ADAPTERS.include?(profile.name.to_s) &&
-         profile.respond_to?(:billing_semantics) &&
+      if profile.respond_to?(:billing_semantics) &&
          profile.billing_semantics.to_s == "subscription_backed"
         [ "subscription", "agent_profile_contract" ]
       else

--- a/lib/hive/provider_routing.rb
+++ b/lib/hive/provider_routing.rb
@@ -23,7 +23,6 @@ module Hive
       circuit_cooldown half_open_probe_owned provider_concurrency_saturated
       health_state_unavailable
     ].freeze
-    DIRECT_SUBSCRIPTION_ADAPTERS = Hive::BillingEvidence::DIRECT_SUBSCRIPTION_ADAPTERS
 
     ACCOUNT_HEALTH_CLASSES = %w[
       authentication

--- a/test/fixtures/runtime_control_plane/affected_production.yml
+++ b/test/fixtures/runtime_control_plane/affected_production.yml
@@ -7,8 +7,8 @@ counting_rule: physical_source_lines
 includes_new_production_files: true
 maximum_final_lines: 7960
 final_inventory_lines: 9220
-outside_inventory_net_lines: -2939
-final_lines: 6281
+outside_inventory_net_lines: -2936
+final_lines: 6284
 final_paths:
 - path: lib/hive/attempts/capacity_snapshot.rb
   lines: 104

--- a/test/unit/billing_evidence_test.rb
+++ b/test/unit/billing_evidence_test.rb
@@ -1,0 +1,40 @@
+require_relative "../test_helper"
+require "hive/agent_profiles"
+require "hive/billing_evidence"
+
+class BillingEvidenceTest < Minitest::Test
+  def test_profile_contract_is_the_single_billing_evidence_authority
+    Hive::AgentProfiles.registered_names.sort.each do |name|
+      profile = Hive::AgentProfiles.lookup(name)
+      route, source = Hive::BillingEvidence.for_profile(profile)
+
+      if profile.billing_semantics == :subscription_backed
+        assert_equal [ "subscription", "agent_profile_contract" ], [ route, source ],
+                     "#{name} declares subscription_backed and must prove it from its contract"
+      else
+        assert_equal [ "unknown", "unavailable" ], [ route, source ],
+                     "#{name} does not declare subscription_backed, so evidence stays unavailable"
+      end
+    end
+  end
+
+  def test_subscription_backed_declaration_is_authoritative_regardless_of_adapter_name
+    profile = Struct.new(:name, :billing_semantics)
+                    .new(:future_adapter, :subscription_backed)
+
+    assert_equal [ "subscription", "agent_profile_contract" ],
+                 Hive::BillingEvidence.for_profile(profile)
+  end
+
+  def test_profiles_without_subscription_semantics_stay_unknown_and_unavailable
+    api_billed = Struct.new(:name, :billing_semantics).new(:claude, :api_billed)
+    anonymous = Struct.new(:billing_semantics).new(:unknown)
+
+    assert_equal [ "unknown", "unavailable" ],
+                 Hive::BillingEvidence.for_profile(api_billed)
+    assert_equal [ "unknown", "unavailable" ],
+                 Hive::BillingEvidence.for_profile(anonymous)
+    assert_equal [ "unknown", "unavailable" ],
+                 Hive::BillingEvidence.for_profile(Object.new)
+  end
+end

--- a/test/unit/provider_routing/configuration_test.rb
+++ b/test/unit/provider_routing/configuration_test.rb
@@ -59,7 +59,7 @@ class ProviderRoutingConfigurationTest < Minitest::Test
                  configuration.routes.map { |candidate| candidate.model_routing.provenance[:effort].kind }
   end
 
-  def test_billing_route_is_closed_and_evidenced_without_inferring_from_ambiguous_harnesses
+  def test_billing_route_is_closed_and_evidenced_from_explicit_or_profile_contract_sources
     normalize = lambda do |id, value|
       Hive::ProviderRouting::Configuration.normalize_accounts(
         { id => value }, source: "global providers"
@@ -77,8 +77,8 @@ class ProviderRoutingConfigurationTest < Minitest::Test
         "codex-subscription",
         account("codex", binding: "default", models: %w[gpt-5.6-terra])
       ),
-      "pi-ambiguous" => normalize.call(
-        "pi-ambiguous",
+      "pi-contract" => normalize.call(
+        "pi-contract",
         account("pi", binding: "default", models: %w[provider/model])
       )
     }
@@ -89,8 +89,9 @@ class ProviderRoutingConfigurationTest < Minitest::Test
     assert_equal "subscription", accounts.fetch("codex-subscription").billing_route
     assert_equal "agent_profile_contract",
                  accounts.fetch("codex-subscription").billing_evidence_source
-    assert_equal "unknown", accounts.fetch("pi-ambiguous").billing_route
-    assert_equal "unavailable", accounts.fetch("pi-ambiguous").billing_evidence_source
+    assert_equal "subscription", accounts.fetch("pi-contract").billing_route
+    assert_equal "agent_profile_contract",
+                 accounts.fetch("pi-contract").billing_evidence_source
 
     cfg = Hive::Config.merge_defaults(
       "execute" => {

--- a/wiki/log.d/20260830T230000Z-profile-contract-billing-evidence.md
+++ b/wiki/log.d/20260830T230000Z-profile-contract-billing-evidence.md
@@ -1,0 +1,35 @@
+# 2026-08-30T23:00:00Z — Billing evidence reads the profile contract only
+
+- **Task**: make-one-profile-level-billing-evidence-contract-f7a0c3957f70 (patrol fix, generation 1)
+- **Thesis**: `pr-1347-f4b12c802fffce76:make-profile-billing-evidence-authoritative`
+
+## What changed
+
+`Hive::BillingEvidence.for_profile` admitted profiles by adapter name
+(`DIRECT_SUBSCRIPTION_ADAPTERS = %w[claude codex grok]`) in addition to the
+profile's declared `billing_semantics`. The Pi profile declares
+`subscription_backed` (it requires a CLI subscription/session artifact, per
+[[modules/agent_profile]]), yet was omitted from the name allowlist, so two
+policy owners disagreed: the profile contract said subscription-backed while
+billing evidence recorded `unknown/unavailable`.
+
+The adapter-name allowlist is removed. A profile that declares
+`subscription_backed` proves subscription semantics from its own contract
+(`subscription` / `agent_profile_contract`); every other declaration stays
+`unknown`/`unavailable` unless an admitted provider-account configuration
+declares the route. The now-unused `DIRECT_SUBSCRIPTION_ADAPTERS` constant and
+its `ProviderRouting` re-export were removed.
+
+## Behavioral impact
+
+- Pi launches without an explicit provider-account `billing_route` now record
+  `subscription` / `agent_profile_contract` instead of `unknown`/`unavailable`.
+- OpenCode and any profile not declaring `subscription_backed` are unchanged.
+- Regression coverage: `test/unit/billing_evidence_test.rb` (contract is the
+  single authority across the registered profile set, plus name-independence
+  and fail-closed cases); `ProviderRoutingConfigurationTest` pi expectations
+  updated accordingly.
+
+## Follow-ups
+
+- `wiki/token-usage.md` updated to describe the contract-authoritative rule.

--- a/wiki/token-usage.md
+++ b/wiki/token-usage.md
@@ -3,7 +3,7 @@ title: Token Usage Stats
 type: observability
 source: lib/hive/agent.rb, lib/hive/usage_db.rb, lib/hive/billing_evidence.rb, lib/hive/model_pricing.rb, lib/hive/task_workspace/resources.rb, lib/hive/task_workspace/usage.rb, config/model-pricing.v1.yml, lib/hive/patrol/launch_budget.rb, lib/hive/agent_profiles/usage_extractors.rb, lib/hive/tui/views/token_stats.rb, lib/hive/tui/bubble_model.rb
 created: 2026-05-24
-updated: 2026-08-29
+updated: 2026-08-30
 tags: [observability, usage, pricing, billing, tui, sqlite, agent]
 ---
 
@@ -93,11 +93,13 @@ failure raises a typed runtime-control-plane error and cannot be acknowledged
 as successful accounting.
 
 Conflicting non-unknown billing routes, attempt/generation ownership, or token
-inclusion flags cannot overwrite an existing exact session. Direct Claude,
-Codex, and Grok profiles can prove subscription semantics from their profile
-contract. Pi and OpenCode remain `unknown` unless an admitted provider-account
-configuration explicitly declares the route. Harness identity is never used as
-the billing provider.
+inclusion flags cannot overwrite an existing exact session. A profile that
+declares `subscription_backed` in its contract (Claude, Codex, Grok, and Pi)
+proves subscription semantics from that profile contract; OpenCode stays
+`unknown` unless an admitted provider-account configuration explicitly
+declares the route. `Hive::BillingEvidence.for_profile` reads only the declared
+profile contract and never re-derives admission from the adapter name. Harness
+identity is never used as the billing provider.
 
 ## Semantic task usage
 


### PR DESCRIPTION
## Patrol Fix

This pull request repairs one finding tracked by Hive's Patrol Fix workflow.

### Sources

- architecture_patrol: pr-1347-f4b12c802fffce76:make-profile-billing-evidence-authoritative

### Finding evidence

- {"file":"lib/hive/billing_evidence.rb","line":7,"snippet":"DIRECT_SUBSCRIPTION_ADAPTERS = %w[claude codex grok].freeze","claim":"billing evidence independently admits profiles by adapter name in addition to checking their declared billing semantics"}
- {"file":"lib/hive/agent_profiles/pi.rb","line":11,"snippet":"billing_semantics: :subscription_backed","claim":"pi declares the same subscription-backed semantics as admitted profiles but is omitted from BillingEvidence's name allowlist, so the two policy owners currently disagree"}

### Independent review

The selected HEAD makes billing_semantics the single profile-level authority, closes the Pi mismatch, preserves explicit provider-account precedence, and adds contract regression coverage. The only broad-suite failure is outside this diff: unchanged agent-cli-runtime code resolves the environment-provided HIVE_CODEX_BIN absolute path while its test expects the bare command.

- Verified clean worktree HEAD 672e05a630467570f4a13f77aba2a973b5fb24d9 with sole parent a73704625491a43cc0d78319b3fc83b8b282d6d9; the six-file diff contains no agent-cli-runtime changes.
- BillingEvidence.for_profile now keys only on subscription_backed; Pi declares subscription_backed, OpenCode remains unknown, and Configuration.billing_evidence still returns explicit provider-account billing before profile evidence.
- Independent focused execution loaded all eight billing-related test files: 168 runs, 802 assertions, 0 failures, 0 errors, 0 skips.
- Independent bundle exec rake test reproduced one failure in AgentCliRuntimeRuntimeTest: expected the bare codex command but HIVE_CODEX_BIN resolved to the installed absolute path; the relevant component test and runtime blobs are identical at base and HEAD.
- Correctness, testing, and project-standards reviewer passes reported no diff-scoped findings.

### Validation

Verdict: failed
- architecture:test: exit 1
- agent:regression-profile-contract-authority: exit 0
- agent:reproduction-now-inverted-contract-authoritative: exit 0
- agent:provider-routing-billing-evidence: exit 0
- agent:billing-consumers-unchanged: exit 0

<!-- hive-publication:v1 id=pub-84bd29c5ebecdb43181b3f43336ab851 base=a73704625491a43cc0d78319b3fc83b8b282d6d9 -->
