### PR TITLE
Fix Patrol finding: define-one-authoritative-internal-status-feed-co-2a46237416ac

### DIFF
--- a/lib/hive/web/status_feed.rb
+++ b/lib/hive/web/status_feed.rb
@@ -10,11 +10,39 @@ require "hive/tui/state_source"
 
 module Hive
   module Web
+    # The authoritative internal contract between StatusFeed and the status
+    # producer it polls. Every injected status command implements all three
+    # methods; the feed never probes collaborator shape. `json_payload` is
+    # the bounded scan seam, while the other two members are optional
+    # capabilities with explicit nil defaults: a producer without dependency
+    # context or a recovery overlay returns nil and the feed renders the
+    # plain projection instead of silently branching on what happens to be
+    # defined on the collaborator.
+    module StatusCommand
+      def json_payload(_projects)
+        raise NotImplementedError, "status commands must implement json_payload"
+      end
+
+      # Non-scanning read of the dependency context captured by the last
+      # refresh; nil when the producer owns no dependency context.
+      def dependency_context_snapshot
+        nil
+      end
+
+      # Canonical recovery receipts to join in memory against the supplied
+      # status payload; nil when the producer owns no recovery overlay.
+      def operational_recoveries(_projects, status_payload:)
+        nil
+      end
+    end
+
     # Adapts the bounded status projection source to StatusFeed's existing
     # command seam. Puma requests and the shared Cable poller can enter this
     # object concurrently, while StateSource intentionally has one projection
     # writer; serialize those synchronous refreshes here.
     class CachedStatusCommand
+      include StatusCommand
+
       ARCHIVE_REFRESH_FALLBACK_SECONDS = 300.0
 
       def initialize(
@@ -39,9 +67,7 @@ module Hive
       end
 
       def dependency_context_snapshot
-        @mutex.synchronize do
-          @source.dependency_context_snapshot if @source.respond_to?(:dependency_context_snapshot)
-        end
+        @mutex.synchronize { @source.dependency_context_snapshot }
       end
 
       # Keep the daemon-owned recovery receipt overlay available without
@@ -157,8 +183,6 @@ module Hive
       end
 
       def dependency_context_snapshot
-        return unless @status_command.respond_to?(:dependency_context_snapshot)
-
         @status_command.dependency_context_snapshot
       end
 
@@ -297,8 +321,6 @@ module Hive
       # a second fleet scan. The lean projection also avoids building the
       # complete operational envelope on every five-second web poll.
       def overlay_operational_recoveries(payload, projects)
-        return payload unless @status_command.respond_to?(:operational_recoveries)
-
         recovery_rows = @status_command.operational_recoveries(
           projects,
           status_payload: payload

--- a/test/fixtures/runtime_control_plane/affected_production.yml
+++ b/test/fixtures/runtime_control_plane/affected_production.yml
@@ -7,8 +7,8 @@ counting_rule: physical_source_lines
 includes_new_production_files: true
 maximum_final_lines: 7960
 final_inventory_lines: 9220
-outside_inventory_net_lines: -2961
-final_lines: 6259
+outside_inventory_net_lines: -2939
+final_lines: 6281
 final_paths:
 - path: lib/hive/attempts/capacity_snapshot.rb
   lines: 104

--- a/test/integration/archive_visibility_retention_test.rb
+++ b/test/integration/archive_visibility_retention_test.rb
@@ -9,6 +9,8 @@ class ArchiveVisibilityRetentionTest < Minitest::Test
   include HiveTestHelper
 
   FixedStatus = Data.define(:command, :project, :now) do
+    include Hive::Web::StatusCommand
+
     def json_payload(_registered_projects)
       command.json_payload([ project ], now: now)
     end

--- a/test/unit/web/status_feed_test.rb
+++ b/test/unit/web/status_feed_test.rb
@@ -14,6 +14,8 @@ class StatusFeedTest < Minitest::Test
   # which StatusFeed#snapshot reaches the (real, but here counted) status
   # command, so every per-tick filesystem scan flows through `calls`.
   class CountingStatus
+    include Hive::Web::StatusCommand
+
     attr_reader :calls
 
     def initialize(payloads)
@@ -37,6 +39,8 @@ class StatusFeedTest < Minitest::Test
   # `max_active` detects a second poller even if both eventually dedupe to the
   # same published value.
   class ControlledStatus
+    include Hive::Web::StatusCommand
+
     def initialize
       @started = Queue.new
       @releases = Queue.new
@@ -78,6 +82,24 @@ class StatusFeedTest < Minitest::Test
     def token_for(key)
       @token_calls += 1
       super
+    end
+  end
+
+  # Fails any capability discovery: the authoritative StatusCommand contract
+  # must be invoked directly, never probed with respond_to?.
+  class CapabilityProbeDetector
+    def respond_to?(name, include_all = false)
+      raise "capability probed: #{name}" if name == :dependency_context_snapshot
+
+      super
+    end
+
+    def refresh_payload_now
+      { "projects" => [] }
+    end
+
+    def dependency_context_snapshot
+      { fingerprint: "direct" }
     end
   end
 
@@ -147,6 +169,41 @@ class StatusFeedTest < Minitest::Test
     assert_equal 1, first.fetch("call")
     assert_equal 2, second.fetch("call")
     assert_equal 2, source.calls
+  end
+
+  def test_cached_status_command_calls_the_source_contract_without_probing
+    source = CapabilityProbeDetector.new
+    command = Hive::Web::CachedStatusCommand.new(source: source)
+
+    assert_equal "direct", command.dependency_context_snapshot.fetch(:fingerprint)
+  end
+
+  def test_status_commands_declare_the_authoritative_contract
+    assert Hive::Web::CachedStatusCommand.include?(Hive::Web::StatusCommand)
+    feed = Hive::Web::StatusFeed.new
+
+    assert_instance_of Hive::Web::CachedStatusCommand,
+                       feed.instance_variable_get(:@status_command)
+  ensure
+    feed&.stop
+  end
+
+  def test_contract_defaults_keep_minimal_producers_authoritative
+    with_tmp_global_config do
+      feed = Hive::Web::StatusFeed.new(status_command: CountingStatus.new([
+        { "projects" => [ { "name" => "demo", "tasks" => [] } ] }
+      ]))
+
+      payload = nil
+      _out, err = capture_io { payload = feed.snapshot }
+
+      assert_equal [ { "name" => "demo", "tasks" => [] } ], payload.fetch("projects")
+      assert_empty err,
+                   "a conforming producer without optional capabilities must not warn"
+      assert_nil feed.dependency_context_snapshot
+    ensure
+      feed&.stop
+    end
   end
 
   def test_dependency_context_is_a_non_scanning_read_through_feed_and_command
@@ -746,6 +803,8 @@ class StatusFeedTest < Minitest::Test
   # the scan) must not kill the shared poller: a dead poller stops ticks,
   # which silently freezes every subscriber AND the on_idle keep-alive path.
   class FlakyOnceStatus
+    include Hive::Web::StatusCommand
+
     def initialize(payloads)
       @payloads = payloads
       @calls = 0
@@ -791,6 +850,7 @@ class StatusFeedTest < Minitest::Test
   def test_initial_snapshot_failure_is_explicitly_unavailable_and_recovers
     calls = 0
     status = Object.new
+    status.extend(Hive::Web::StatusCommand)
     status.define_singleton_method(:json_payload) do |*|
       calls += 1
       raise "boom" if calls == 1
@@ -863,6 +923,7 @@ class StatusFeedTest < Minitest::Test
     first = { "projects" => [ { "name" => "demo", "tasks" => [] } ] }
     second = { "projects" => [ { "name" => "demo", "tasks" => [ { "slug" => "new" } ] } ] }
     status = Object.new
+    status.extend(Hive::Web::StatusCommand)
     status.define_singleton_method(:json_payload) do |*|
       calls += 1
       raise "mid-edit" if calls == 2

--- a/test/unit/web/status_feed_test.rb
+++ b/test/unit/web/status_feed_test.rb
@@ -188,6 +188,14 @@ class StatusFeedTest < Minitest::Test
     feed&.stop
   end
 
+  def test_status_command_requires_a_payload_implementation
+    command = Object.new.extend(Hive::Web::StatusCommand)
+
+    error = assert_raises(NotImplementedError) { command.json_payload([]) }
+
+    assert_equal "status commands must implement json_payload", error.message
+  end
+
   def test_contract_defaults_keep_minimal_producers_authoritative
     with_tmp_global_config do
       feed = Hive::Web::StatusFeed.new(status_command: CountingStatus.new([

--- a/wiki/architecture.md
+++ b/wiki/architecture.md
@@ -349,7 +349,11 @@ solid_cable. `StatusFeed` serializes concurrent Puma callers through
 `CachedStatusCommand`, which reuses a visible-only `StateSource`: its
 five-second hot path is active-task proportional, its missed-signal backstop is
 five minutes, and the complete archive producer runs only for an explicit
-archive request. Each accepted channel acquires one poller lease and releases it
+archive request. The status producer fulfills the authoritative
+`Hive::Web::StatusCommand` contract (`json_payload`, plus optional
+dependency-context and recovery-overlay members with explicit nil defaults);
+`StatusFeed` invokes the contract directly instead of probing collaborator
+shape with `respond_to?`. Each accepted channel acquires one poller lease and releases it
 exactly once; a per-channel synchronized pending/active/closed transition
 prevents socket teardown from racing stream verification into a leak or double
 release without serializing unrelated browser connections. A failed first

--- a/wiki/log.d/20260830T225156Z-web-status-command-contract.md
+++ b/wiki/log.d/20260830T225156Z-web-status-command-contract.md
@@ -1,0 +1,16 @@
+# Authoritative web status command contract
+
+- Introduced `Hive::Web::StatusCommand`, the single authoritative internal
+  contract between `Web::StatusFeed` and the status producer it polls:
+  `json_payload` (the bounded scan seam) plus optional
+  `dependency_context_snapshot` and `operational_recoveries` members whose
+  contract defaults return nil.
+- `CachedStatusCommand` includes the contract and calls its `StateSource`
+  dependency directly (the source always defines the snapshot reader).
+- `StatusFeed#dependency_context_snapshot` and the recovery overlay no longer
+  branch on collaborator shape with `respond_to?`; a producer without an
+  optional capability returns nil and the feed renders the plain projection.
+  The overlay's existing failure fallback (warn + base status) is unchanged.
+- Test doubles injected as `status_command` (including the archive-retention
+  `FixedStatus`) now declare the contract; regression tests pin no-probing
+  behavior and the nil-default degradation path.


### PR DESCRIPTION
## Patrol Fix

This pull request repairs one finding tracked by Hive's Patrol Fix workflow.

### Sources

- architecture_patrol: pr-1347-f4b12c802fffce76:make-web-status-collaborator-contract-authoritative

### Finding evidence

- {"file":"lib/hive/web/status_feed.rb","line":159,"snippet":"return unless @status_command.respond_to?(:dependency_context_snapshot)","claim":"the feed branches on its injected collaborator's shape before exposing dependency context"}
- {"file":"lib/hive/web/status_feed.rb","line":299,"snippet":"return payload unless @status_command.respond_to?(:operational_recoveries)","claim":"the feed independently branches on another optional capability, causing recovery-overlay behavior to depend silently on collaborator shape"}
- {"file":"lib/hive/web/status_feed.rb","line":41,"snippet":"@source.dependency_context_snapshot if @source.respond_to?(:dependency_context_snapshot)","claim":"the adapter repeats capability discovery against its own dependency instead of presenting an authoritative internal contract"}

### Independent review

The patch satisfies the selected architecture finding by defining one explicit StatusCommand protocol, making the feed and cached adapter invoke it directly, and providing nil defaults that preserve minimal producers. The failed controller validations do not implicate this diff: affected behavior passes independently, while the failures are in an unchanged semantic-token subprocess environment and an unrelated agent-runtime executable-path assertion.

- The clean worktree HEAD is 74ec32444eef2e924aba87c38f34d5067af978d2 and its parent is the declared base a73704625491a43cc0d78319b3fc83b8b282d6d9.
- Repository inspection confirms the three targeted capability probes were replaced by direct calls; CachedStatusCommand includes StatusCommand, StateSource defines dependency_context_snapshot, and the contract's nil recovery default leaves the base payload unchanged.
- Independent StatusFeed validation excluding only the unchanged Bundler-sensitive semantic-token subprocess test passed 36 runs and 124 assertions with no failures, errors, or skips.
- Independent contract-focused validation passed 7 runs and 16 assertions; archive visibility integration passed 2 runs and 41 assertions; RuboCop reported no offenses in the three changed Ruby files.
- The controller's architecture:test failure is an unrelated components/agent-cli-runtime expectation about basename versus absolute Codex executable path, and its remaining unit failure is an unchanged fresh-process Bundler gem-availability error; neither failing area is modified by this patch.

### Validation

Verdict: failed
- architecture:test: exit 1
- agent:pr-1347-f4b12c802fffce76:make-web-status-collaborator-contract-authoritative:status-feed-contract-unit-regressions: exit 1
- agent:pr-1347-f4b12c802fffce76:make-web-status-collaborator-contract-authoritative:archive-retention-contract-doubles: exit 0
- agent:pr-1347-f4b12c802fffce76:make-web-status-collaborator-contract-authoritative:lint-changed-files: exit 0

<!-- hive-publication:v1 id=pub-de3aa062350dc890be19bf9ca8c3cba2 base=a73704625491a43cc0d78319b3fc83b8b282d6d9 -->
