### PR TITLE
fix(daemon): pace failed markerless advances

### DIFF
--- a/lib/hive/attempts/api.rb
+++ b/lib/hive/attempts/api.rb
@@ -28,10 +28,11 @@ module Hive
       end
 
       def dispatch_request(request, interactive: false, now: Time.now.utc,
-                           admission_view: nil)
+                           admission_view: nil, replay_semantic_terminal: false)
         daemon.dispatch_request(
           request, interactive: interactive, now: now,
-          admission_view: admission_view
+          admission_view: admission_view,
+          replay_semantic_terminal: replay_semantic_terminal
         )
       end
 

--- a/lib/hive/attempts/configured_dispatcher.rb
+++ b/lib/hive/attempts/configured_dispatcher.rb
@@ -24,13 +24,14 @@ module Hive
       end
 
       def dispatch_request(request, interactive: false, now: Time.now.utc,
-                           admission_view: nil)
+                           admission_view: nil, replay_semantic_terminal: false)
         task = Hive::TaskResolver.new(
           request.slug, project_filter: request.project
         ).resolve
         dispatcher_for(task, argv: request.argv).dispatch_request(
           request, interactive: interactive, now: now,
-          admission_view: admission_view
+          admission_view: admission_view,
+          replay_semantic_terminal: replay_semantic_terminal
         )
       end
 

--- a/lib/hive/attempts/dispatcher.rb
+++ b/lib/hive/attempts/dispatcher.rb
@@ -58,7 +58,8 @@ module Hive
       def dispatch(task:, project:, intended_stage:, argv:, request_id:, provider:,
                    interactive: false, generation: nil, predecessor_attempt_id: nil,
                    inherited_outputs: [], retry_charge: 0, now: @clock.call,
-                   admission_view: nil, routing_policy: nil, cohort_release: false)
+                   admission_view: nil, routing_policy: nil, cohort_release: false,
+                   replay_semantic_terminal: false)
         @launcher.preflight!
         generation = normalize_generation(
           generation, task: task, project: project, intended_stage: intended_stage,
@@ -71,7 +72,8 @@ module Hive
           predecessor_attempt_id: predecessor_attempt_id,
           inherited_outputs: inherited_outputs, retry_charge: retry_charge,
           successor_of: nil, now: now, admission_view: admission_view,
-          routing_policy: policy, cohort_release: cohort_release
+          routing_policy: policy, cohort_release: cohort_release,
+          replay_semantic_terminal: replay_semantic_terminal
         )
         return result unless superseding_loss?(result)
 
@@ -147,7 +149,7 @@ module Hive
       end
 
       def dispatch_request(request, interactive: false, now: @clock.call,
-                           admission_view: nil)
+                           admission_view: nil, replay_semantic_terminal: false)
         task = @task_resolver.call(request)
         intended_stage = intended_stage_for(request.argv, task)
         generation = Generation.resolve(
@@ -173,7 +175,8 @@ module Hive
           interactive: interactive, generation: generation,
           inherited_outputs: request.respond_to?(:inherited_outputs) ? request.inherited_outputs : [],
           now: now, admission_view: admission_view,
-          cohort_release: explicit_cohort_release?(request)
+          cohort_release: explicit_cohort_release?(request),
+          replay_semantic_terminal: replay_semantic_terminal
         )
       end
 
@@ -181,7 +184,8 @@ module Hive
 
       def admit(task:, generation:, argv:, request_id:, provider:, interactive:,
                 predecessor_attempt_id:, inherited_outputs:, retry_charge:, successor_of:, now:,
-                subject: nil, admission_view: nil, routing_policy:, cohort_release: false)
+                subject: nil, admission_view: nil, routing_policy:, cohort_release: false,
+                replay_semantic_terminal: false)
         result = nil
         created = nil
         claim_capability = nil
@@ -213,7 +217,8 @@ module Hive
             terminal = if successor_of.nil?
               replayable_terminal(
                 exact, request_id, task: task, admission_view: view,
-                generation: generation, subject: subject
+                generation: generation, subject: subject,
+                replay_semantic_terminal: replay_semantic_terminal
               )
             end
             if terminal
@@ -498,15 +503,25 @@ module Hive
 
       # Request IDs own delivery idempotency: replaying the same request must
       # keep returning its original receipt, including a failure. A different
-      # request is a deliberate retry, so only a successful terminal receipt
-      # remains the semantic owner of the unchanged generation.
+      # request is normally a deliberate retry, so only a successful terminal
+      # receipt remains the semantic owner of the unchanged generation. The
+      # daemon's automatic advance scan is the exception: it creates a fresh
+      # delivery request on every tick, so an unchanged failed generation must
+      # replay instead of spending on the same broken command forever.
       def replayable_terminal(records, request_id, task:, admission_view: nil,
-                              generation: nil, subject: nil)
+                              generation: nil, subject: nil,
+                              replay_semantic_terminal: false)
         terminals = records.select { |record| record.state == "terminal" }
+        semantic_terminal = nil
         if admission_view
           point_subject = subject || task_subject(generation)
+          semantic_terminal = admission_view.latest_terminal_attempt(
+            task_generation: generation.task_generation,
+            subject: point_subject
+          )
           terminals |= [
             admission_view.terminal_attempt(request_id: request_id),
+            semantic_terminal,
             admission_view.successful_attempt(
               task_generation: generation.task_generation,
               subject: point_subject
@@ -526,6 +541,10 @@ module Hive
           newest = same_request.last
           return newest unless newest.outcome == "succeeded"
           return newest if required_artifact_valid?(task, newest)
+        end
+
+        if replay_semantic_terminal && semantic_terminal&.outcome != "succeeded"
+          return semantic_terminal
         end
 
         terminals.reverse.find do |record|

--- a/lib/hive/daemon/dispatcher.rb
+++ b/lib/hive/daemon/dispatcher.rb
@@ -1582,11 +1582,7 @@ module Hive
           # ready_to_run indefinitely. Convert it to the ordinary recoverable
           # ERROR lifecycle under the task lock; the next tick submits it to the
           # sole RecoveryCoordinator. Keep the explicit event for observability.
-          healed = @stale_agent_healer.heal_markerless_stall(row)
-          @logger.event(:markerless_stalled, project: row.project, slug: row.slug,
-                                              stage: row.stage, action: row.action,
-                                              reason: "agent_exited_without_marker",
-                                              healed: healed)
+          record_markerless_stall(row)
           observe_policy_disposition(row, decision)
         when :skip
           @logger.event(:skipped, project: row.project, slug: row.slug,
@@ -1763,10 +1759,15 @@ module Hive
           state_file_mtime: row.state_file_mtime,
           state_file_path: row.state_file,
           now: now,
-          trigger: trigger
+          trigger: trigger,
+          replay_semantic_terminal: trigger == "advance" &&
+            row.marker.to_s == "none" && Policy.advance?(row.action)
         )
         remember_routing_observation(row, dispatch_result)
         outcome = dispatch_outcome(dispatch_result)
+        if failed_automatic_advance_replay?(row, trigger, dispatch_result)
+          return record_markerless_stall(row, attempt: dispatch_result.attempt)
+        end
         if dispatch_result.is_a?(Hive::Attempts::DispatchResult) &&
            (dispatch_result.accepted? || dispatch_result.status == :terminal_replay)
           # Durable attempts never enter ChildSupervisor, so consume their
@@ -1780,6 +1781,28 @@ module Hive
           )
         end
         outcome
+      end
+
+      def failed_automatic_advance_replay?(row, trigger, result)
+        trigger == "advance" && row.marker.to_s == "none" &&
+          Policy.advance?(row.action) &&
+          result.is_a?(Hive::Attempts::DispatchResult) &&
+          result.status == :terminal_replay &&
+          %w[failed cancelled].include?(result.attempt&.outcome)
+      end
+
+      def record_markerless_stall(row, attempt: nil)
+        attributes = {
+          project: row.project, slug: row.slug, stage: row.stage,
+          action: row.action, reason: "agent_exited_without_marker",
+          healed: @stale_agent_healer.heal_markerless_stall(row)
+        }
+        if attempt
+          attributes[:attempt_id] = attempt.attempt_id
+          attributes[:attempt_outcome] = attempt.outcome
+        end
+        @logger.event(:markerless_stalled, **attributes)
+        :markerless_stalled
       end
 
       def dispatch_outcome(result)
@@ -1818,6 +1841,8 @@ module Hive
           [ "agent", "this task already has an in-flight child" ]
         when :attempt_terminal_replay
           [ "hive", "the matching durable attempt already reached a terminal receipt" ]
+        when :markerless_stalled
+          [ "hive", "the automatic advance failed without producing task progress" ]
         when :attempt_capacity
           [ "scheduler", "durable attempt capacity is exhausted" ]
         when :attempt_failure_cohort
@@ -3617,13 +3642,15 @@ module Hive
 
       def dispatch_command(command, project:, slug:, stage:, state_file_mtime:,
                            state_file_path:, now:, trigger: "advance",
-                           request_id: nil, kind: :task, dispatch_token: nil)
+                           request_id: nil, kind: :task, dispatch_token: nil,
+                           replay_semantic_terminal: false)
         return :shutdown unless admission_open?
 
         if kind == :task && @attempt_dispatcher && !@dry_run
           return dispatch_durable_command(
             command, project: project, slug: slug, stage: stage,
-            now: now, trigger: trigger, request_id: request_id
+            now: now, trigger: trigger, request_id: request_id,
+            replay_semantic_terminal: replay_semantic_terminal
           )
         end
 
@@ -3655,7 +3682,8 @@ module Hive
         pid
       end
 
-      def dispatch_durable_command(command, project:, slug:, stage:, now:, trigger:, request_id:)
+      def dispatch_durable_command(command, project:, slug:, stage:, now:, trigger:, request_id:,
+                                   replay_semantic_terminal: false)
         return :shutdown unless admission_open?
 
         # A full daemon tick can take longer than the attempt launch window
@@ -3687,7 +3715,8 @@ module Hive
 
         result = @attempt_dispatcher.dispatch_request(
           request, interactive: false, now: now,
-          admission_view: @attempt_snapshot&.admission_view
+          admission_view: @attempt_snapshot&.admission_view,
+          replay_semantic_terminal: replay_semantic_terminal
         )
         log_attempt_admission(result)
         if result.status == :accepted

--- a/test/unit/attempts/api_test.rb
+++ b/test/unit/attempts/api_test.rb
@@ -58,7 +58,8 @@ class AttemptsAPITest < Minitest::Test
     api = Hive::Attempts::API.new(foreground: Object.new, daemon: daemon)
 
     result = api.dispatch_request(
-      :request, interactive: false, now: Time.at(1).utc, admission_view: :tick
+      :request, interactive: false, now: Time.at(1).utc, admission_view: :tick,
+      replay_semantic_terminal: true
     )
 
     assert_equal :accepted, result
@@ -66,6 +67,7 @@ class AttemptsAPITest < Minitest::Test
     assert_equal false, call.last.fetch(:interactive)
     assert_equal Time.at(1).utc, call.last.fetch(:now)
     assert_equal :tick, call.last.fetch(:admission_view)
+    assert_equal true, call.last.fetch(:replay_semantic_terminal)
   end
 
   def test_dispatch_successor_delegates_recovery_admission

--- a/test/unit/attempts/configured_dispatcher_test.rb
+++ b/test/unit/attempts/configured_dispatcher_test.rb
@@ -13,8 +13,9 @@ class AttemptsConfiguredDispatcherTest < Minitest::Test
     launcher_options = nil
     dispatcher_options = nil
     downstream = Object.new
-    downstream.define_singleton_method(:dispatch_request) do |_request, interactive:, now:, admission_view:|
-      [ interactive, now, admission_view ]
+    downstream.define_singleton_method(:dispatch_request) do |_request, interactive:, now:, admission_view:,
+                                                              replay_semantic_terminal:|
+      [ interactive, now, admission_view, replay_semantic_terminal ]
     end
     launcher_class = Class.new
     launcher_class.define_singleton_method(:new) do |**options|
@@ -49,10 +50,11 @@ class AttemptsConfiguredDispatcherTest < Minitest::Test
     )
 
     with_replaced_singleton_method(Hive::TaskResolver, :new, ->(*_args, **_kwargs) { resolver }) do
-      assert_equal [ false, Time.at(0), :tick ],
+      assert_equal [ false, Time.at(0), :tick, true ],
                    adapter.dispatch_request(
                      FakeRequest.new(slug: "task", project: "demo", argv: %w[hive review task]),
-                     now: Time.at(0), admission_view: :tick
+                     now: Time.at(0), admission_view: :tick,
+                     replay_semantic_terminal: true
                    )
     end
 

--- a/test/unit/attempts/dispatcher_test.rb
+++ b/test/unit/attempts/dispatcher_test.rb
@@ -322,6 +322,42 @@ class AttemptsDispatcherTest < Minitest::Test
     end
   end
 
+  def test_automatic_advance_replays_failed_generation_but_recovery_retries
+    with_dispatcher do |dispatcher, launcher, task, store|
+      dispatcher.instance_variable_set(:@task_resolver, ->(_request) { task })
+      dispatcher.define_singleton_method(:provider_for) { |_task| "codex" }
+      request = lambda do |request_id, requestor:, trigger:|
+        FakeRequest.new(
+          slug: task.slug, project: "demo",
+          argv: [ "hive", "run", task.slug ], request_id: request_id,
+          inherited_outputs: [], requestor: requestor, trigger: trigger
+        )
+      end
+
+      first = dispatcher.dispatch_request(
+        request.call("advance-one", requestor: "daemon", trigger: "advance"),
+        now: NOW
+      )
+      failed = terminalize_attempt(
+        store, launcher, first, outcome: "failed", exit_status: 1, now: NOW + 3
+      )
+      replay = dispatcher.dispatch_request(
+        request.call("advance-two", requestor: "daemon", trigger: "advance"),
+        now: NOW + 4, replay_semantic_terminal: true
+      )
+      recovery = dispatcher.dispatch_request(
+        request.call("recovery-one", requestor: "healer", trigger: "recovery"),
+        now: NOW + 5
+      )
+
+      assert_equal :terminal_replay, replay.status
+      assert_equal failed.attempt_id, replay.attempt.attempt_id
+      assert_equal :accepted, recovery.status
+      refute_equal failed.attempt_id, recovery.attempt.attempt_id
+      assert_equal 2, launcher.launched.size
+    end
+  end
+
   def test_successful_retry_replays_for_new_requests_without_changing_old_request_result
     with_dispatcher do |dispatcher, launcher, task, store|
       first = dispatch(dispatcher, task, request_id: "request-one")

--- a/test/unit/daemon/dispatcher_test.rb
+++ b/test/unit/daemon/dispatcher_test.rb
@@ -2237,6 +2237,78 @@ class HiveDaemonDispatcherTest < Minitest::Test
     assert events_include?(logger, :dispatched)
   end
 
+  def test_failed_automatic_advance_replay_enters_markerless_recovery_without_respawning
+    attempt = Struct.new(:attempt_id, :task_generation, :state, :outcome)
+    accepted_attempt = attempt.new("attempt-1", "generation-1", "running", nil)
+    failed_attempt = attempt.new("attempt-1", "generation-1", "terminal", "failed")
+    results = [
+      Hive::Attempts::DispatchResult.new(
+        status: :accepted, attempt: accepted_attempt, receipt: nil,
+        attach_descriptor: nil, reason: nil
+      ),
+      Hive::Attempts::DispatchResult.new(
+        status: :terminal_replay, attempt: failed_attempt,
+        receipt: { "outcome" => "failed", "exit_status" => 1 },
+        attach_descriptor: nil, reason: nil
+      )
+    ]
+    replay_modes = []
+    attempt_dispatcher = Object.new
+    attempt_dispatcher.define_singleton_method(:dispatch_request) do |*_args, **options|
+      replay_modes << options.fetch(:replay_semantic_terminal)
+      results.shift || raise("unexpected third automatic admission")
+    end
+    observed = row(
+      stage: "6-review", marker: "none", action: "ready_for_review",
+      command: "hive review s1 --from 6-review"
+    )
+    File.write(observed.state_file, "# review\n")
+    dispatcher, supervisor, _controller, logger = make_dispatcher(
+      rows: [ observed ], attempt_dispatcher: attempt_dispatcher
+    )
+
+    dispatcher.tick(now: T0)
+    dispatcher.tick(now: T0 + 30)
+
+    assert_empty supervisor.spawned
+    marker = Hive::Markers.current(observed.state_file)
+    assert_equal :error, marker.name
+    assert_equal "agent_exited_without_terminal_marker", marker.attrs.fetch("reason")
+    stalled = logger.events.find { |name, _attributes| name == :markerless_stalled }
+    refute_nil stalled
+    assert_equal "attempt-1", stalled.last.fetch(:attempt_id)
+    assert_equal "failed", stalled.last.fetch(:attempt_outcome)
+    assert stalled.last.fetch(:healed)
+    assert_equal [ true, true ], replay_modes
+    assert_equal 1, logger.events.count { |name, _attributes| name == :dispatched }
+  end
+
+  def test_marked_advance_keeps_fresh_retry_semantics
+    attempt = Struct.new(:attempt_id, :task_generation, :state, :outcome)
+                    .new("attempt-1", "generation-1", "running", nil)
+    result = Hive::Attempts::DispatchResult.new(
+      status: :accepted, attempt: attempt, receipt: nil,
+      attach_descriptor: nil, reason: nil
+    )
+    replay_modes = []
+    attempt_dispatcher = Object.new
+    attempt_dispatcher.define_singleton_method(:dispatch_request) do |*_args, **options|
+      replay_modes << options.fetch(:replay_semantic_terminal)
+      result
+    end
+    observed = row(
+      stage: "6-review", marker: "review_complete", action: "ready_to_artifacts",
+      command: "hive artifacts s1 --from 6-review"
+    )
+    dispatcher, = make_dispatcher(
+      rows: [ observed ], attempt_dispatcher: attempt_dispatcher
+    )
+
+    dispatcher.tick(now: T0)
+
+    assert_equal [ false ], replay_modes
+  end
+
   # A generic-workflow row (`workflow: "research"`, `action: "ready_to_run"`)
   # must dispatch `hive run` on first sight through the real tick loop — the
   # generic dispatch path was previously only asserted via direct CLI calls,

--- a/wiki/commands/daemon.md
+++ b/wiki/commands/daemon.md
@@ -108,6 +108,14 @@ they never claim a later daemon tick will allocate the id.
 | `archived`            | Skip — terminal. |
 | `error`               | Keep durable `ERROR` / `REVIEW_ERROR` rows scheduler-owned while the universal healer waits for its shared cooldown and temporary safety gates. Task-bound merge reconciliation runs first, so already merged work closes without another provider attempt when every closure guard passes. |
 
+Markerless automatic advance actions also stop at one failed durable attempt
+per unchanged task generation. A later daemon tick replays that terminal
+receipt and enters the same `markerless_stalled` recovery path instead of
+launching the broken command again. The resulting error or controller recovery
+request observes the shared cooldown; an explicit recovery delivery remains
+authorized to create a fresh attempt after the cause is fixed. Advance rows
+that still carry a terminal marker retain their existing transition semantics.
+
 `agent_running` rows also feed daemon capacity accounting when status
 has positive liveness evidence. The dispatcher counts both rows with a
 live recorded Claude PID and rows with `live_task_lock: true` (a verified

--- a/wiki/log.d/20260831T024500Z-markerless-advance-terminal-recovery.md
+++ b/wiki/log.d/20260831T024500Z-markerless-advance-terminal-recovery.md
@@ -1,0 +1,24 @@
+---
+title: Failed automatic advances converge through markerless recovery
+date: 2026-08-31
+tags: [daemon, attempts, recovery, idempotency, capacity]
+---
+
+**Problem:** The daemon assigned a fresh request id to every direct advance
+scan. When a markerless stage command failed before changing task state, each
+tick treated the new id as an explicit retry. An old broken row could therefore
+consume every available attempt slot indefinitely and starve queued recovery
+work.
+
+**Action:** A daemon-owned advance for a row that still has no marker now
+replays the latest failed terminal attempt for the unchanged semantic
+generation. The dispatcher turns that replay into the existing locked
+`markerless_stalled` repair: marker-driven tasks receive the ordinary
+recoverable error marker and controller workflows receive a generation-bound
+recovery request. Marked advances and explicit recovery requests retain fresh
+retry semantics.
+
+**Evidence:** Attempts tests prove a second automatic request replays one failed
+attempt while a healer recovery request launches a successor. Daemon tests prove
+the terminal replay writes the recoverable error, records the attempt-bound
+stall event, and does not spawn a second worker.

--- a/wiki/log.d/20260831T024500Z-markerless-advance-terminal-recovery.md
+++ b/wiki/log.d/20260831T024500Z-markerless-advance-terminal-recovery.md
@@ -19,6 +19,7 @@ recovery request. Marked advances and explicit recovery requests retain fresh
 retry semantics.
 
 **Evidence:** Attempts tests prove a second automatic request replays one failed
-attempt while a healer recovery request launches a successor. Daemon tests prove
-the terminal replay writes the recoverable error, records the attempt-bound
-stall event, and does not spawn a second worker.
+attempt while a healer recovery request launches a successor, and the public
+attempts API test pins forwarding of the semantic-replay control. Daemon tests
+prove the terminal replay writes the recoverable error, records the
+attempt-bound stall event, and does not spawn a second worker.

--- a/wiki/log.d/20260831T024500Z-markerless-advance-terminal-recovery.md
+++ b/wiki/log.d/20260831T024500Z-markerless-advance-terminal-recovery.md
@@ -20,6 +20,7 @@ retry semantics.
 
 **Evidence:** Attempts tests prove a second automatic request replays one failed
 attempt while a healer recovery request launches a successor, and the public
-attempts API test pins forwarding of the semantic-replay control. Daemon tests
+attempts API tests pin forwarding of the semantic-replay control through the
+configured per-project adapter to the durable dispatcher. Daemon tests
 prove the terminal replay writes the recoverable error, records the
 attempt-bound stall event, and does not spawn a second worker.

--- a/wiki/modules/attempts.md
+++ b/wiki/modules/attempts.md
@@ -442,6 +442,15 @@ false/malformed handoff or launcher exception marks the unclaimed reservation
 `lost` and returns a retryable deferral; if the wrapper won the claim race, the
 dispatcher re-reads and adopts it instead of creating an overlapping owner.
 
+Request IDs normally distinguish an explicit retry from a duplicate delivery:
+the same request replays any terminal receipt, while a new request may retry a
+failed generation. Daemon-owned markerless advance deliveries are narrower.
+Because the row scan mints a new delivery request on every tick, the daemon asks
+admission to replay the latest failed terminal attempt for the unchanged
+generation. This prevents an invalid markerless workflow command from consuming
+a new slot forever. Marked advance rows and recovery requests retain ordinary
+fresh retry semantics.
+
 An explicit-policy initial admission that returns no route has no attempt to
 attach. The foreground adapter therefore hands that markerless result directly
 to `RecoveryCoordinator`, which creates the same single pending request and

--- a/wiki/modules/daemon.md
+++ b/wiki/modules/daemon.md
@@ -718,6 +718,19 @@ configured caps. Rows with no live Claude PID and no live task lock do
 not consume capacity; if they are stale `AGENT_WORKING` rows, the healer
 will rewrite them on the same tick or a later retry.
 
+Markerless pure-advance rows need terminal evidence rather than the generic
+mtime brake. Each daemon scan creates a fresh delivery request, but for a row
+that still has no marker the dispatcher asks the attempts layer to treat that
+request as the same automatic action when its semantic task generation is
+unchanged. If the latest attempt failed or was cancelled, admission returns its
+terminal receipt. The dispatcher records
+`markerless_stalled` with the attempt identity and calls
+`StaleAgentHealer#heal_markerless_stall`: marker-driven workflows atomically
+enter `ERROR reason=agent_exited_without_terminal_marker`, while controller
+workflows enter the generation-bound recovery queue. Explicit recovery requests
+remain eligible for a new attempt after cooldown. Marked advance rows do not use
+this replay mode.
+
 TERM and INT close daemon admission as soon as the dispatcher observes the
 shutdown flag. One `admission_open?` predicate is rechecked after durable
 attempt reconciliation and other blocking work, between lost-attempt


### PR DESCRIPTION
## Summary

- replay a failed durable terminal receipt when a daemon-owned markerless advance has the same semantic task generation
- route that replay through the existing markerless-stall healer instead of consuming another worker slot
- preserve fresh retry semantics for marked transitions and explicit recovery deliveries
- forward the replay control through both Attempts API adapters used by the production daemon

## Why

A markerless stage command that failed before changing its task artifact received a new request ID on every daemon scan. Each scan therefore looked like an explicit retry and the broken row could monopolize global capacity indefinitely.

## Verification

- Attempts dispatcher — 47 runs, 222 assertions
- Daemon dispatcher — 324 runs, 1,156 assertions
- Attempts API — 6 runs, 41 assertions
- Configured dispatcher — 5 runs, 29 assertions
- Incident harness focus — 2 runs, 11 assertions
- `bundle exec rake test` — 14,098 runs, 286,050 assertions, 0 failures/errors
- RuboCop on changed Ruby files — clean
- wiki log test — 7 runs, 27 assertions
- `git diff --check` — clean