### PR TITLE
Fix markerless recovery retries

### DIFF
--- a/lib/hive/daemon/dispatch_request_queue.rb
+++ b/lib/hive/daemon/dispatch_request_queue.rb
@@ -735,18 +735,14 @@ module Hive
       # retried, move it back to the pending filename before changing its
       # phase. A crash between those operations therefore leaves a safe,
       # invisible terminal receipt instead of an admitted claimed split.
-      def requeue_recovery!(request_id, expected_phase:, changes:,
-                            state_home: Hive::Paths.state_home, known_path: nil)
+      def requeue_recovery!(request_id, expected_phase:, changes:, known_path:,
+                            state_home: Hive::Paths.state_home)
         with_request_lock(request_id, state_home: state_home) do |dir|
-          paths = if known_path
-            expanded = File.expand_path(known_path)
-            next false unless File.dirname(expanded) == File.expand_path(dir)
-            next false unless expanded.end_with?(CLAIMED_SUFFIX)
+          expanded = File.expand_path(known_path)
+          next false unless File.dirname(expanded) == File.expand_path(dir)
+          next false unless expanded.end_with?(CLAIMED_SUFFIX)
 
-            [ expanded, expanded.delete_suffix(CLAIMED_SUFFIX) ]
-          else
-            request_files(dir)
-          end
+          paths = [ expanded, expanded.delete_suffix(CLAIMED_SUFFIX) ]
           matches = paths.filter_map do |path|
             data = parse_json_hash(path)
             [ path, data ] if data && data["request_id"].to_s == request_id.to_s

--- a/lib/hive/daemon/recovery_coordinator.rb
+++ b/lib/hive/daemon/recovery_coordinator.rb
@@ -1217,11 +1217,27 @@ module Hive
           "terminal_outcome" => nil,
           "terminal_at" => nil
         }
-        @request_queue.requeue_recovery!(
-          request.request_id, expected_phase: "terminal", changes: changes,
-          state_home: @state_home
+        retry_request_id = deterministic_markerless_retry_request_id(
+          request, retry_count: changes.fetch("retry_count")
         )
-        @request_queue.fetch(request.request_id, state_home: @state_home) || request
+        @request_queue.write_request!(
+          project: request.project, slug: request.slug, argv: request.argv,
+          requestor: request.requestor, chat_id: request.chat_id,
+          update_id: request.update_id, trigger: request.trigger,
+          request_id: retry_request_id, task_generation: request.task_generation,
+          predecessor_attempt_id: request.predecessor_attempt_id,
+          inherited_outputs: request.inherited_outputs || [], task_id: request.task_id,
+          expected_stage: request.expected_stage,
+          expected_marker_name: request.expected_marker_name,
+          expected_marker_id: request.expected_marker_id,
+          recovery: recovery.merge(changes), state_home: @state_home, now: now
+        )
+        @request_queue.remove_terminal_recoveries(
+          project: request.project, slug: request.slug,
+          expected_stage: request.expected_stage,
+          except_request_id: retry_request_id, state_home: @state_home
+        )
+        @request_queue.fetch(retry_request_id, state_home: @state_home) || request
       end
 
       def source_receipt_for(marker:, task:, project:)
@@ -1631,6 +1647,15 @@ module Hive
           [
             "hive-markerless-recovery-v1", value(row, :project), task.id || task.slug,
             value(row, :stage), reason, dispatch_generation
+          ].join("\0")
+        )[0, 32]
+      end
+
+      def deterministic_markerless_retry_request_id(request, retry_count:)
+        ::Digest::SHA256.hexdigest(
+          [
+            "hive-markerless-recovery-retry-v1", request.request_id,
+            retry_count
           ].join("\0")
         )[0, 32]
       end

--- a/test/unit/daemon/dispatch_request_queue_test.rb
+++ b/test/unit/daemon/dispatch_request_queue_test.rb
@@ -1858,7 +1858,8 @@ class HiveDaemonDispatchRequestQueueTest < Minitest::Test
       assert_nil Q.update_claim("missing", pid: 123, state_home: "/tmp/missing")
       refute Q.release_claim("missing", state_home: "/tmp/missing")
       refute Q.requeue_recovery!(
-        "missing", expected_phase: "terminal", changes: {}, state_home: "/tmp/missing"
+        "missing", expected_phase: "terminal", changes: {},
+        known_path: "/tmp/missing/request.json.claimed", state_home: "/tmp/missing"
       )
       refute Q.discard_sequence("missing-seq", state_home: "/tmp/missing")
     end

--- a/test/unit/daemon/recovery_coordinator_test.rb
+++ b/test/unit/daemon/recovery_coordinator_test.rb
@@ -1464,7 +1464,7 @@ class HiveDaemonRecoveryCoordinatorTest < Minitest::Test
     end
   end
 
-  def test_terminal_markerless_controller_failure_rearms_same_request
+  def test_terminal_markerless_controller_failure_rearms_with_fresh_delivery
     with_markerless_fixture do |coordinator, row, dir, original|
       admitted = coordinator.request_markerless_failure(
         row: row, requestor: "healer",
@@ -1493,15 +1493,21 @@ class HiveDaemonRecoveryCoordinatorTest < Minitest::Test
         row: row.with(attempt_id: "attempt-2"), requestor: "healer",
         reason: "agent_exited_without_terminal_marker", now: NOW + 8
       )
+      replay = coordinator.request_markerless_failure(
+        row: row.with(attempt_id: "attempt-2"), requestor: "healer",
+        reason: "agent_exited_without_terminal_marker", now: NOW + 9
+      )
 
-      assert_equal admitted.request_id, rearmed.request_id
+      refute_equal admitted.request_id, rearmed.request_id
+      assert_equal rearmed.request_id, replay.request_id
       assert_equal "cooldown", rearmed.status
       assert_equal "admitted", rearmed.phase
       assert_equal 2, rearmed.retry_count
       assert_empty Q.claimed(state_home: dir)
-      assert_equal [ admitted.request_id ], Q.pending(state_home: dir).map(&:request_id)
+      assert_equal [ rearmed.request_id ], Q.pending(state_home: dir).map(&:request_id)
       refute File.exist?("#{claimed_path}#{Q::CLAIM_META_SUFFIX}")
-      persisted = Q.fetch(admitted.request_id, state_home: dir)
+      assert_nil Q.fetch(admitted.request_id, state_home: dir)
+      persisted = Q.fetch(rearmed.request_id, state_home: dir)
       assert_nil persisted.recovery.fetch("attempt_id")
       assert_nil persisted.recovery.fetch("terminal_outcome")
       assert_equal original, File.binread(row.state_file)

--- a/wiki/commands/daemon.md
+++ b/wiki/commands/daemon.md
@@ -113,7 +113,10 @@ per unchanged task generation. A later daemon tick replays that terminal
 receipt and enters the same `markerless_stalled` recovery path instead of
 launching the broken command again. The resulting error or controller recovery
 request observes the shared cooldown; an explicit recovery delivery remains
-authorized to create a fresh attempt after the cause is fixed. Advance rows
+authorized to create a fresh attempt after the cause is fixed. Each terminal
+controller-recovery retry receives a deterministic new delivery id, so the
+original request remains idempotent without trapping later retries behind its
+failed receipt. Advance rows
 that still carry a terminal marker retain their existing transition semantics.
 
 `agent_running` rows also feed daemon capacity accounting when status

--- a/wiki/log.d/20260831T104441Z-markerless-recovery-fresh-delivery.md
+++ b/wiki/log.d/20260831T104441Z-markerless-recovery-fresh-delivery.md
@@ -16,10 +16,13 @@ delivery request for the next retry count, copies its bounded recovery ledger,
 and removes the superseded terminal queue receipt. The immutable attempt proof
 is retained. Duplicate observation before terminalization still returns the
 same request, and repeated failures still stop at the existing deterministic
-failure ceiling.
+failure ceiling. The obsolete whole-queue fallback in the startup-only claimed
+receipt repair was removed; that repair now requires its already-known claimed
+path and remains directory-bound.
 
 **Evidence:** Recovery coordinator tests prove a terminal controller failure
 rearms as one new pending delivery, removes the old claimed receipt and claim
 sidecar, preserves the retry count, and never mutates the controller manifest.
 Attempts tests continue to prove that a new recovery request can launch a fresh
-attempt while replaying the same request remains idempotent.
+attempt while replaying the same request remains idempotent. Queue tests cover
+the path-bound repair and its missing-directory failure mode.

--- a/wiki/log.d/20260831T104441Z-markerless-recovery-fresh-delivery.md
+++ b/wiki/log.d/20260831T104441Z-markerless-recovery-fresh-delivery.md
@@ -1,0 +1,25 @@
+---
+title: Markerless controller retries use fresh delivery identities
+date: 2026-08-31
+tags: [daemon, recovery, attempts, idempotency]
+---
+
+**Problem:** A controller workflow keeps the same task generation when a
+worker exits without changing its structured state. The recovery coordinator
+rearmed the same dispatch request after cooldown, but attempt admission treats
+a request id as immutable delivery identity and correctly replayed its first
+failed receipt. Every scheduled retry therefore replayed old evidence and no
+new worker could heal the task.
+
+**Action:** A terminal markerless recovery now writes a deterministic fresh
+delivery request for the next retry count, copies its bounded recovery ledger,
+and removes the superseded terminal queue receipt. The immutable attempt proof
+is retained. Duplicate observation before terminalization still returns the
+same request, and repeated failures still stop at the existing deterministic
+failure ceiling.
+
+**Evidence:** Recovery coordinator tests prove a terminal controller failure
+rearms as one new pending delivery, removes the old claimed receipt and claim
+sidecar, preserves the retry count, and never mutates the controller manifest.
+Attempts tests continue to prove that a new recovery request can launch a fresh
+attempt while replaying the same request remains idempotent.

--- a/wiki/modules/attempts.md
+++ b/wiki/modules/attempts.md
@@ -449,7 +449,10 @@ Because the row scan mints a new delivery request on every tick, the daemon asks
 admission to replay the latest failed terminal attempt for the unchanged
 generation. This prevents an invalid markerless workflow command from consuming
 a new slot forever. Marked advance rows and recovery requests retain ordinary
-fresh retry semantics.
+fresh retry semantics. A terminal controller-markerless recovery therefore
+rearms with a deterministic new delivery request id after its cooldown; it
+never asks admission to reinterpret the failed receipt owned by the previous
+request id as a fresh attempt.
 
 An explicit-policy initial admission that returns no route has no attempt to
 attach. The foreground adapter therefore hands that markerless result directly

--- a/wiki/modules/daemon.md
+++ b/wiki/modules/daemon.md
@@ -955,24 +955,28 @@ The dispatcher materializes pending and claimed rows once per tick and reuses
 that immutable queue state for both operational counters and recovery
 receipts. A `retry_pending` projection is `queued` only when a matching
 canonical request has a request ID; malformed or absent queue evidence leaves
-the ordinary retry action available instead of inventing a request. Terminal
-recovery receipts remain durable for history, while filesystem pruning is
-throttled to one pass per hour so a five-second dispatcher loop does not
-rescan and rewrite retention state continuously.
+the ordinary retry action available instead of inventing a request. The latest
+terminal recovery receipt remains durable until it is superseded or reaches
+bounded retention, while filesystem pruning is throttled to one pass per hour
+so a five-second dispatcher loop does not rescan and rewrite retention state
+continuously.
 
-Retrying a terminal markerless recovery is one queue transaction: the queue
-moves any `<id>.json.claimed` receipt back to `<id>.json`, removes its claim
-sidecar, and only then changes `terminal` to `admitted`. The ordering is
-crash-safe because interruption before the phase rewrite leaves a terminal
-pending receipt, which remains invisible to dispatch. Startup claim recovery
-also recognizes the older invalid `admitted` + claimed combination and
-requeues it without following or deleting the stale terminal attempt. Its
-targeted queue lookup accepts only the claimed receipt path; pending or
-out-of-directory hints fail closed instead of synthesizing a sibling claim
-path. During terminal delivery reconciliation, a rejected durable phase
-transition emits `dispatch_request_reconciliation_failed`; it is not
-acknowledged, written as a result, or reported as
-`dispatch_request_completed`.
+Retrying a terminal markerless recovery creates a deterministic fresh delivery
+request from the prior request id and next retry count, copies the bounded
+recovery ledger into it, and removes the superseded terminal queue receipt.
+The attempt proof remains immutable. This preserves ordinary request
+idempotency—replaying one request still returns its first receipt—while an
+authorized cooled retry can launch a new worker for the unchanged controller
+generation. Writing the replacement before pruning the old receipt is
+restart-safe: after an interruption, the same deterministic replacement is
+rediscovered and duplicate writes are idempotent. Startup claim recovery still
+recognizes the older invalid `admitted` + claimed combination and requeues it
+without following or deleting the stale terminal attempt. Its targeted queue
+lookup accepts only the claimed receipt path; pending or out-of-directory hints
+fail closed instead of synthesizing a sibling claim path. During terminal
+delivery reconciliation, a rejected durable phase transition emits
+`dispatch_request_reconciliation_failed`; it is not acknowledged, written as a
+result, or reported as `dispatch_request_completed`.
 
 Recovery generation checks also share one immutable dependency-admission
 context per queue scan. The dispatcher creates it lazily only when a recovery


### PR DESCRIPTION
## Summary

- give each cooled terminal markerless recovery a deterministic fresh delivery identity
- preserve the bounded retry ledger while pruning the superseded terminal queue receipt
- keep immutable attempt receipts, request idempotency, controller state, and provider routing unchanged
- document the recovery identity boundary in the managed wiki

## Root cause

The recovery coordinator rearmed the same request ID after a controller task failed without changing its structured state. Attempt admission correctly treats a request ID as immutable delivery identity, so every scheduled retry replayed the first failed receipt and never launched another worker.

## Verification

- bundle exec ruby -Itest test/unit/daemon/recovery_coordinator_test.rb
- bundle exec ruby -Itest test/unit/attempts/dispatcher_test.rb -n /automatic_advance_replays_failed_generation_but_recovery_retries/
- bundle exec ruby -Itest test/unit/daemon/stale_agent_healer_test.rb -n /markerless_stall/
- bundle exec ruby -Itest test/unit/wiki_log_test.rb
- bundle exec rubocop lib/hive/daemon/recovery_coordinator.rb test/unit/daemon/recovery_coordinator_test.rb
- bundle exec rake test: 14,098 runs, 286,053 assertions, 0 failures, 0 errors, 10 skips
- git diff --check