### PR TITLE
fix(cutover): scope task authority to stages

### DIFF
--- a/lib/hive/runtime_control_plane/cutover.rb
+++ b/lib/hive/runtime_control_plane/cutover.rb
@@ -70,16 +70,17 @@ module Hive
         Array(projects).sort_by { |project| project.fetch("project_id") }.map do |project|
           root = File.expand_path(project.fetch("hive_state_path", project.fetch("path")))
           { "project_id" => project.fetch("project_id"), "name" => project.fetch("name"),
-            "state_path" => root, "sha256" => tree_digest(root) }
+            "state_path" => root, "sha256" => tree_digest(root, scope: "stages") }
         end.freeze
       end
 
-      def self.tree_digest(root)
-        status = File.lstat(root)
-        raise Errno::ENOTDIR, root unless status.directory? && !status.symlink?
+      def self.tree_digest(root, scope: nil)
+        scan_root = scope ? File.join(root, scope) : root
+        status = File.lstat(scan_root)
+        raise Errno::ENOTDIR, scan_root unless status.directory? && !status.symlink?
 
         digest = Digest::SHA256.new
-        pending = Dir.children(root).sort.reverse.map { |name| File.join(root, name) }
+        pending = Dir.children(scan_root).sort.reverse.map { |name| File.join(scan_root, name) }
         until pending.empty?
           path = pending.pop
           relative = path.delete_prefix("#{root}#{File::SEPARATOR}")

--- a/test/fixtures/runtime_control_plane/affected_production.yml
+++ b/test/fixtures/runtime_control_plane/affected_production.yml
@@ -6,9 +6,9 @@ baseline_lines: 9951
 counting_rule: physical_source_lines
 includes_new_production_files: true
 maximum_final_lines: 7960
-final_inventory_lines: 9201
+final_inventory_lines: 9202
 outside_inventory_net_lines: -3001
-final_lines: 6200
+final_lines: 6201
 final_paths:
 - path: lib/hive/attempts/capacity_snapshot.rb
   lines: 104
@@ -49,7 +49,7 @@ final_paths:
 - path: lib/hive/runtime_control_plane/codec.rb
   lines: 92
 - path: lib/hive/runtime_control_plane/cutover.rb
-  lines: 840
+  lines: 841
 - path: lib/hive/runtime_control_plane/cutover_manifest.rb
   lines: 114
 - path: lib/hive/runtime_control_plane/database.rb

--- a/test/unit/runtime_control_plane/cutover_test.rb
+++ b/test/unit/runtime_control_plane/cutover_test.rb
@@ -644,6 +644,11 @@ class RuntimeControlPlaneCutoverTest < Minitest::Test
     with_home do |_state, _data, projects|
       root = projects.first.fetch("hive_state_path")
       task = task_path(projects, "idea.md")
+      babysitter = File.join(root, "babysitter", "worktrees", "58", "node_modules", ".bin")
+      FileUtils.mkdir_p(babysitter)
+      File.symlink("../package/bin.js", File.join(babysitter, "package"))
+      Hive::RuntimeControlPlane::Cutover.task_authority(projects)
+
       hardlink = File.join(File.dirname(task), "hardlink.md")
       File.link(task, hardlink)
       error = assert_raises(Hive::RuntimeControlPlane::Cutover::Error) do
@@ -651,6 +656,14 @@ class RuntimeControlPlaneCutoverTest < Minitest::Test
       end
       assert_equal :task_authority_unsafe, error.code
       File.unlink(hardlink)
+
+      symlink = File.join(File.dirname(task), "linked.md")
+      File.symlink(task, symlink)
+      error = assert_raises(Hive::RuntimeControlPlane::Cutover::Error) do
+        Hive::RuntimeControlPlane::Cutover.task_authority(projects)
+      end
+      assert_equal :task_authority_unsafe, error.code
+      File.unlink(symlink)
 
       original = File.method(:lstat)
       failing = lambda do |path|

--- a/wiki/commands/migrate.md
+++ b/wiki/commands/migrate.md
@@ -26,8 +26,10 @@ and requires explicit confirmation. On a TTY it prompts for `yes`; non-TTY use
 without the flag fails with the exact `hive migrate --all --yes` action. Missing registered projects must be repaired or named with
 `--exclude-project`; exclusions and their reason are durable manifest evidence.
 Corrupt reachable projects, live owners, changing task authority, or missing
-task ids stop activation. Project task files remain byte-identical before the
-activation-intent manifest.
+task ids stop activation. The task-authority fingerprint covers each project's
+canonical `stages/` tree; project-local babysitter worktrees are disposable
+runtime and are not interpreted as task authority. Project task files remain
+byte-identical before the activation-intent manifest.
 
 The package manager publishes the candidate normally; Hive never renames a
 package-owned launcher or preserves the previous executable tree. Before any

--- a/wiki/log.d/20260831T170000Z-cutover-task-authority-scope.md
+++ b/wiki/log.d/20260831T170000Z-cutover-task-authority-scope.md
@@ -1,0 +1,16 @@
+---
+date: 2026-08-31
+slug: cutover-task-authority-scope
+tags: [runtime-control-plane, cutover, babysitter, migration]
+---
+
+# Keep disposable babysitter worktrees outside cutover task authority
+
+The fleet cutover now fingerprints each registered project's canonical
+`.hive-state/stages/` tree instead of the complete `.hive-state` root. This
+retains the fail-closed digest over every task file while avoiding
+project-local babysitter worktrees, whose checked-out dependencies may contain
+ordinary symlinks and are not imported into the runtime control plane.
+
+Focused coverage proves a babysitter worktree symlink is ignored while unsafe
+entries inside a task still stop activation.

--- a/wiki/state-model.md
+++ b/wiki/state-model.md
@@ -456,7 +456,8 @@ retention does not delete the terminal attempt row or still-referenced payloads.
 
 The one-way installation cutover is offline and fleet-atomic. A durable
 `ready → intended → active` manifest binds the registered projects,
-task-authority fingerprints, a validated immutable token-usage snapshot, and
+canonical `stages/` task-authority fingerprints, a validated immutable
+token-usage snapshot, and
 every path-shape fence. Before candidate startup mutation an early read-only
 gate refuses ordinary commands. Services stop and live owners are rejected
 before task identity is rebuilt from file authority. All other machine-local


### PR DESCRIPTION
## Summary

- fingerprint only the canonical `.hive-state/stages/` task tree during the SQLite fleet cutover
- keep project-local babysitter worktrees outside task authority while retaining fail-closed checks inside task folders
- document the cutover boundary and add regression coverage for both cases

## Why

The first real dogfood cutover correctly stopped before intent because Toderos disposable babysitter worktrees contain normal `node_modules/.bin` symlinks. Those worktrees are not imported into the runtime control plane, while the complete stages tree is. Scoping the digest to that exact authority avoids rejecting or hashing unrelated runtime worktrees and does not touch Patrol worktrees.

## Verification

- `bundle exec ruby -Itest test/unit/runtime_control_plane/cutover_test.rb` (44 runs, 214 assertions)
- `bundle exec rubocop lib/hive/runtime_control_plane/cutover.rb test/unit/runtime_control_plane/cutover_test.rb`
- `git diff --check`

Dogfood cutover remains paused before any manifest/database activation; services are quiesced and an external cold backup exists.