### PR TITLE
fix(cutover): accept hardlinked task artifacts

### DIFF
--- a/lib/hive/runtime_control_plane/cutover.rb
+++ b/lib/hive/runtime_control_plane/cutover.rb
@@ -91,11 +91,11 @@ module Hive
           raise Error.new("task authority contains a symlink", code: :task_authority_unsafe) if entry.symlink?
           if entry.directory?
             Dir.children(path).sort.reverse_each { |name| pending << File.join(path, name) }
-          elsif entry.file? && entry.nlink == 1 && entry.size <= MAX_FILE_BYTES
+          elsif entry.file? && entry.size <= MAX_FILE_BYTES
             digest << "f\0#{relative}\0#{entry.mode & 0o7777}\0#{entry.size}\0"
             File.open(path, "rb") { |file| digest << file.read(64 * 1024) until file.eof? }
           else
-            raise Error.new("task authority contains an unsafe entry", code: :task_authority_unsafe)
+            raise Error.new("task authority contains an unsafe entry: #{path}", code: :task_authority_unsafe)
           end
         end
         digest.hexdigest

--- a/test/unit/runtime_control_plane/cutover_test.rb
+++ b/test/unit/runtime_control_plane/cutover_test.rb
@@ -647,15 +647,25 @@ class RuntimeControlPlaneCutoverTest < Minitest::Test
       babysitter = File.join(root, "babysitter", "worktrees", "58", "node_modules", ".bin")
       FileUtils.mkdir_p(babysitter)
       File.symlink("../package/bin.js", File.join(babysitter, "package"))
-      Hive::RuntimeControlPlane::Cutover.task_authority(projects)
+      baseline = Hive::RuntimeControlPlane::Cutover.task_authority(projects)
 
       hardlink = File.join(File.dirname(task), "hardlink.md")
       File.link(task, hardlink)
+      authority = Hive::RuntimeControlPlane::Cutover.task_authority(projects)
+      assert_match(/\A[0-9a-f]{64}\z/, authority.first.fetch("sha256"))
+      refute_equal baseline.first.fetch("sha256"), authority.first.fetch("sha256")
+      File.unlink(hardlink)
+
+      oversized = File.join(File.dirname(task), "oversized.bin")
+      File.open(oversized, "wb") do |file|
+        file.truncate(Hive::RuntimeControlPlane::Cutover::MAX_FILE_BYTES + 1)
+      end
       error = assert_raises(Hive::RuntimeControlPlane::Cutover::Error) do
         Hive::RuntimeControlPlane::Cutover.task_authority(projects)
       end
       assert_equal :task_authority_unsafe, error.code
-      File.unlink(hardlink)
+      assert_includes error.message, oversized
+      File.unlink(oversized)
 
       symlink = File.join(File.dirname(task), "linked.md")
       File.symlink(task, symlink)

--- a/wiki/commands/migrate.md
+++ b/wiki/commands/migrate.md
@@ -28,8 +28,10 @@ without the flag fails with the exact `hive migrate --all --yes` action. Missing
 Corrupt reachable projects, live owners, changing task authority, or missing
 task ids stop activation. The task-authority fingerprint covers each project's
 canonical `stages/` tree; project-local babysitter worktrees are disposable
-runtime and are not interpreted as task authority. Project task files remain
-byte-identical before the activation-intent manifest.
+runtime and are not interpreted as task authority. Regular task files remain
+part of the fingerprint when they are hardlinked (for example, tool outputs in
+an archived task); symlinks and non-regular entries still fail closed. Project
+task files remain byte-identical before the activation-intent manifest.
 
 The package manager publishes the candidate normally; Hive never renames a
 package-owned launcher or preserves the previous executable tree. Before any

--- a/wiki/log.d/20260831T171627Z-cutover-hardlink-authority.md
+++ b/wiki/log.d/20260831T171627Z-cutover-hardlink-authority.md
@@ -1,0 +1,12 @@
+---
+title: Cutover accepts hardlinked task artifacts
+type: fix
+date: 2026-08-31
+---
+
+The irreversible fleet cutover now fingerprints regular task files even when
+they have multiple hardlinks. Archived tasks can legitimately retain build or
+capture outputs produced this way; cutover reads and preserves those bytes and
+does not need exclusive inode ownership. Symlinks, oversized files, and
+non-regular entries remain fail-closed, and unsafe-entry errors now identify
+the exact path.

--- a/wiki/state-model.md
+++ b/wiki/state-model.md
@@ -460,8 +460,10 @@ canonical `stages/` task-authority fingerprints, a validated immutable
 token-usage snapshot, and
 every path-shape fence. Before candidate startup mutation an early read-only
 gate refuses ordinary commands. Services stop and live owners are rejected
-before task identity is rebuilt from file authority. All other machine-local
-runtime domains start empty. Every retry converges forward from the manifest;
+before task identity is rebuilt from file authority. Fingerprinting preserves
+regular hardlinked task artifacts while rejecting symlinks and non-regular
+entries. All other machine-local runtime domains start empty. Every retry
+converges forward from the manifest;
 `active` is published only after the services recorded as running at cutover
 start again. There is no general legacy decoder, attempts-v4 migration state
 machine, dual reader/writer, reverse hydration, implicit database creation,


### PR DESCRIPTION
## Summary

- Let the irreversible fleet cutover fingerprint legitimate hardlinked task artifacts instead of refusing the whole fleet.
- Keep symlinks, oversized files, and non-regular entries fail-closed, with the exact unsafe path in the error.

## Test plan

- [x] `bundle exec ruby -Itest test/unit/runtime_control_plane/cutover_test.rb` — 44 runs, 219 assertions
- [x] `bundle exec ruby -Itest test/unit/runtime_control_plane/deletion_contract_test.rb` — 5 runs, 159 assertions
- [x] `bundle exec rubocop lib/hive/runtime_control_plane/cutover.rb test/unit/runtime_control_plane/cutover_test.rb`
- [x] `git diff --check`
- [x] Real read-only task-authority scan across all 20 registered projects, including the archived Honeycomb capture tree

## Notes for reviewer

This is the live-cutover follow-up to #1376. It preserves and hashes every regular task/artifact path; it does not delete evidence or add cache-name exclusions.
