### PR TITLE
Fix retained task checkpoints after SQLite cutover

### DIFF
--- a/lib/hive/attempts/repository.rb
+++ b/lib/hive/attempts/repository.rb
@@ -290,6 +290,14 @@ module Hive
         }
       end
 
+      def pre_activation_projection?(observed_at)
+        activated_at = database.installation_identity&.fetch(:activated_at)
+        activated_at && RuntimeControlPlane::Codec.load_time(observed_at) <
+          RuntimeControlPlane::Codec.load_time(activated_at)
+      rescue RuntimeControlPlane::Error, KeyError, TypeError
+        false
+      end
+
       def projection_reader = ProjectionReader.new(self)
 
       # Internal seams used only by AdmissionTransition's one SQL transaction.

--- a/lib/hive/task_activity.rb
+++ b/lib/hive/task_activity.rb
@@ -379,7 +379,7 @@ module Hive
 
       Hive::TaskProjection::Store.new(
         task_folder: task_folder, attempt_store: @writer.attempt_store
-      ).rebuild!
+      ).refresh_after_append!
     rescue StandardError => e
       warn "[hive] task workspace checkpoint refresh failed: #{e.class}"
       nil

--- a/lib/hive/task_projection/store.rb
+++ b/lib/hive/task_projection/store.rb
@@ -198,6 +198,37 @@ module Hive
         projection
       end
 
+      # Advance from an authenticated checkpoint prefix after an ordinary
+      # append. Full replay remains the fallback when no trusted checkpoint is
+      # available.
+      def refresh_after_append!(marker: nil,
+                                limits: Hive::TaskWorkspace::Limits.new)
+        with_journal_write_lock do
+          bounded = read_bounded_unlocked(
+            marker: marker, limits: limits, require_checkpoint: true,
+            pristine: false
+          )
+          return rebuild!(marker: marker) unless bounded.current?
+
+          bytes = journal_bytes
+          unless bounded.journal_cursor == bytes.bytesize
+            raise Hive::TaskProjection::InvalidJournal,
+                  "journal changed while advancing its projection checkpoint"
+          end
+          data = bounded.projection.to_h
+          binding = {
+            "cursor" => bytes.bytesize,
+            "hash" => ::Digest::SHA256.hexdigest(bytes),
+            "event_id" => data.dig("journal", "event_id")
+          }
+          data["journal"].merge!(binding)
+          projection = Hive::TaskProjection.from_data(data)
+          publish(projection)
+          publish_checkpoint(binding: binding, bytes: bytes, projection: projection)
+          projection
+        end
+      end
+
       # Canonical task creators publish a zero-history checkpoint before the
       # task becomes visible. This is not a repair path: any pre-existing
       # journal or derived projection is refused, leaving historical tasks to
@@ -1005,9 +1036,12 @@ module Hive
           next binding if Hive::Attempts::Record::FINAL_STATES.include?(binding["state"])
 
           attempt = fetch_attempt_binding(binding["attempt_id"])
-          return nil unless attempt
-
-          current = Hive::TaskProjection.durable_attempt_metadata(attempt)
+          current = if attempt
+            Hive::TaskProjection.durable_attempt_metadata(attempt)
+          elsif pre_activation_projection?(binding["accepted_at"])
+            binding.merge("state" => "lost", "outcome" => nil)
+          end
+          return nil unless current
           return nil unless same_attempt_identity?(binding, current)
 
           current
@@ -1037,6 +1071,11 @@ module Hive
         else
           @attempt_store.fetch(attempt_id)
         end
+      end
+
+      def pre_activation_projection?(observed_at)
+        @attempt_store.respond_to?(:pre_activation_projection?) &&
+          @attempt_store.pre_activation_projection?(observed_at)
       end
 
       def durable_handoff_snapshot?(snapshot)

--- a/test/fixtures/runtime_control_plane/affected_production.yml
+++ b/test/fixtures/runtime_control_plane/affected_production.yml
@@ -6,9 +6,9 @@ baseline_lines: 9951
 counting_rule: physical_source_lines
 includes_new_production_files: true
 maximum_final_lines: 7960
-final_inventory_lines: 9202
-outside_inventory_net_lines: -3001
-final_lines: 6201
+final_inventory_lines: 9210
+outside_inventory_net_lines: -2962
+final_lines: 6248
 final_paths:
 - path: lib/hive/attempts/capacity_snapshot.rb
   lines: 104
@@ -19,7 +19,7 @@ final_paths:
 - path: lib/hive/attempts/publication.rb
   lines: 299
 - path: lib/hive/attempts/repository.rb
-  lines: 685
+  lines: 693
 - path: lib/hive/attempts/storage_status.rb
   lines: 20
 - path: lib/hive/commands/runtime.rb

--- a/test/unit/attempts/store_test.rb
+++ b/test/unit/attempts/store_test.rb
@@ -337,6 +337,20 @@ class AttemptsRepositoryTest < Minitest::Test
     end
   end
 
+  def test_projection_cutover_boundary_accepts_only_pre_activation_history
+    with_repository do |repository|
+      activated_at = "2026-07-16T12:00:00.000000Z"
+      repository.database.transaction do |db|
+        db[:installations].update(activated_at: activated_at)
+      end
+
+      assert repository.pre_activation_projection?("2026-07-16T11:59:59.999999Z")
+      refute repository.pre_activation_projection?(activated_at)
+      refute repository.pre_activation_projection?("2026-07-16T12:00:00.000001Z")
+      refute repository.pre_activation_projection?("invalid")
+    end
+  end
+
   private
 
   def with_repository

--- a/test/unit/task_activity_test.rb
+++ b/test/unit/task_activity_test.rb
@@ -36,7 +36,9 @@ class TaskActivityTest < Minitest::Test
   def test_checkpoint_refresh_failure_does_not_reject_a_durable_activity
     with_activity do |activity, dir|
       broken_store = Object.new
-      broken_store.define_singleton_method(:rebuild!) { raise "checkpoint unavailable" }
+      broken_store.define_singleton_method(:refresh_after_append!) do
+        raise "checkpoint unavailable"
+      end
       original_new = Hive::TaskProjection::Store.method(:new)
       Hive::TaskProjection::Store.define_singleton_method(:new) { |**| broken_store }
       begin

--- a/test/unit/task_projection/store_test.rb
+++ b/test/unit/task_projection/store_test.rb
@@ -314,6 +314,85 @@ class TaskProjectionStoreTest < Minitest::Test
     end
   end
 
+  def test_rebuild_classifies_a_missing_pre_activation_attempt_as_lost
+    with_tmp_dir do |dir|
+      legacy = durable_attempt
+      attempts = { "attempt-1" => legacy }
+      attempt_store = Object.new
+      attempt_store.define_singleton_method(:fetch) { |attempt_id| attempts[attempt_id] }
+      attempt_store.define_singleton_method(:fetch_projection_binding) do |attempt_id|
+        attempts[attempt_id]
+      end
+      activation = Time.iso8601("2026-07-17T12:01:00Z")
+      attempt_store.define_singleton_method(:pre_activation_projection?) do |observed_at|
+        Time.iso8601(observed_at) < activation
+      end
+      store = Hive::TaskProjection::Store.new(
+        task_folder: dir, attempt_store: attempt_store
+      )
+      write_journal(dir, [ condition_event("event-1") ])
+      store.rebuild!
+
+      current = durable_attempt.merge(
+        "attempt_id" => "attempt-2", "ownership_generation" => "owner-2",
+        "state" => "terminal", "outcome" => "failed", "lease_version" => 2
+      )
+      attempts = { "attempt-2" => current }
+      event = condition_event("event-2", state: "unsatisfied")
+      event["attempt_id"] = "attempt-2"
+      event["ownership_generation"] = "owner-2"
+      event["occurred_at"] = "2026-07-17T12:02:00.000000Z"
+      event["observed_at"] = "2026-07-17T12:02:00.000000Z"
+      event.dig("evidence", 0)["attempt_id"] = "attempt-2"
+      File.open(store.journal_path, "a") { |journal| journal.puts(JSON.generate(event)) }
+
+      strict = assert_raises(Hive::TaskProjection::InvalidJournal) { store.rebuild! }
+      assert_includes strict.message, "unknown durable attempt attempt-1"
+      projection = store.refresh_after_append!
+      bounded = store.read_routine
+
+      assert_equal "event-2", projection.to_h.dig("journal", "event_id")
+      assert_equal Digest::SHA256.file(store.journal_path).hexdigest,
+                   projection.to_h.dig("journal", "hash")
+      assert_equal "current", bounded.state
+      assert_equal projection.to_h, bounded.projection.to_h
+    end
+  end
+
+  def test_missing_post_activation_attempt_still_fails_closed
+    with_tmp_dir do |dir|
+      legacy = durable_attempt
+      attempts = { "attempt-1" => legacy }
+      attempt_store = Object.new
+      attempt_store.define_singleton_method(:fetch) { |attempt_id| attempts[attempt_id] }
+      attempt_store.define_singleton_method(:fetch_projection_binding) do |attempt_id|
+        attempts[attempt_id]
+      end
+      activation = Time.iso8601("2026-07-17T12:01:00Z")
+      attempt_store.define_singleton_method(:pre_activation_projection?) do |observed_at|
+        Time.iso8601(observed_at) < activation
+      end
+      write_journal(dir, [ condition_event("event-1") ])
+      store = Hive::TaskProjection::Store.new(
+        task_folder: dir, attempt_store: attempt_store
+      )
+      store.rebuild!
+      attempts = {}
+      event = condition_event("event-2")
+      event["attempt_id"] = "missing-current-attempt"
+      event["occurred_at"] = "2026-07-17T12:02:00.000000Z"
+      event["observed_at"] = "2026-07-17T12:02:00.000000Z"
+      event.dig("evidence", 0)["attempt_id"] = "missing-current-attempt"
+      File.open(store.journal_path, "a") { |journal| journal.puts(JSON.generate(event)) }
+
+      error = assert_raises(Hive::TaskProjection::InvalidJournal) do
+        store.refresh_after_append!
+      end
+
+      assert_includes error.message, "unknown durable attempt missing-current-attempt"
+    end
+  end
+
   def test_routine_read_does_not_charge_terminal_checkpoint_history_to_attempt_budget
     with_tmp_dir do |dir|
       attempts = 101.times.to_h do |index|

--- a/test/unit/task_projection/store_test.rb
+++ b/test/unit/task_projection/store_test.rb
@@ -393,6 +393,24 @@ class TaskProjectionStoreTest < Minitest::Test
     end
   end
 
+  def test_append_refresh_refuses_a_journal_change_after_bounded_validation
+    with_tmp_dir do |dir|
+      write_journal(dir, [ condition_event("event-1") ])
+      store = projection_store(dir)
+      store.rebuild!
+      store.define_singleton_method(:journal_bytes) do
+        "#{File.binread(journal_path)}changed"
+      end
+
+      error = assert_raises(Hive::TaskProjection::InvalidJournal) do
+        store.refresh_after_append!
+      end
+
+      assert_includes error.message,
+                      "journal changed while advancing its projection checkpoint"
+    end
+  end
+
   def test_routine_read_does_not_charge_terminal_checkpoint_history_to_attempt_budget
     with_tmp_dir do |dir|
       attempts = 101.times.to_h do |index|

--- a/wiki/commands/migrate.md
+++ b/wiki/commands/migrate.md
@@ -48,6 +48,14 @@ payload files remain untouched. An interruption after fencing leaves evidence
 and tombstones in place; `hive runtime resume` only converges forward. Normal
 runtime never creates or migrates the database and has no legacy fallback.
 
+The installation's durable activation timestamp is also the boundary between
+discarded legacy attempts and new SQLite attempts. A valid projection
+checkpoint can retain its authenticated pre-activation prefix as lost legacy
+execution while validating every appended record against SQLite. Missing
+post-activation attempts and unknown attempts during strict full replay remain
+integrity failures; Hive inserts no fabricated legacy row and does not rewrite
+the journal.
+
 ## Task-folder renames
 
 `Hive::Commands::Migrate::STAGE_RENAMES` maps the pre-open-pr stage layout onto the current `Hive::Stages::DIRS` list:

--- a/wiki/log.d/20260831T181500Z-cutover-projection-checkpoint.md
+++ b/wiki/log.d/20260831T181500Z-cutover-projection-checkpoint.md
@@ -1,0 +1,16 @@
+---
+title: Advance retained task checkpoints after the SQLite cutover
+tags: [runtime-control-plane, cutover, task-journal, projection, attempts]
+---
+
+The all-in SQLite cutover intentionally resets legacy attempt rows while
+preserving task journals and validated projection checkpoints. A post-cutover
+activity append previously tried to rebuild the complete journal and rejected
+its historical attempt IDs as unknown.
+
+Checkpoint advancement now uses the installation's durable activation timestamp
+as the boundary. A prefix that still passes its cursor, inode, and anchor checks
+may classify a missing pre-activation binding as lost before validating the
+suffix against SQLite. Strict full replay and missing post-activation attempts
+still fail closed; the journal remains immutable and SQLite receives no
+synthetic legacy row.

--- a/wiki/state-model.md
+++ b/wiki/state-model.md
@@ -469,6 +469,13 @@ start again. There is no general legacy decoder, attempts-v4 migration state
 machine, dual reader/writer, reverse hydration, implicit database creation,
 rollback, or downgrade.
 
+The cutover deliberately retains task journals and their validated projection
+checkpoints while resetting legacy attempt rows. A checkpoint prefix whose
+attempt was accepted before the durable installation activation boundary may
+classify that missing legacy attempt as lost; the prefix must still pass its
+cursor, inode, and anchor checks. The appended suffix is validated against
+SQLite, and strict full replay still rejects every unknown attempt.
+
 The package manager publishes the candidate normally; Hive never renames
 package-owned launcher entries or retains the previous executable tree.
 `hive runtime` exposes only bounded status and forward resume. The external


### PR DESCRIPTION
## Summary
- advance post-cutover task projection checkpoints from their authenticated prefix
- classify only missing pre-activation checkpoint bindings as lost legacy execution
- keep suffix validation and strict full replay fail-closed for current SQLite attempts

## Why
The all-in cutover intentionally resets legacy attempt rows but preserves task journals and projections. A later activity append used strict full replay, so historical attempt references could no longer refresh the checkpoint even though the durable append succeeded.

## Verification
- exact live 1.13 MB journal reproduced the failure and advances successfully in an inode-adjusted temporary copy
- task projection store: 44 runs, 172 assertions
- task activity: 18 runs, 78 assertions
- attempt repository: 14 runs, 59 assertions
- task journal: 17 runs, 67 assertions
- status command: 141 runs, 609 assertions
- cutover: 44 runs, 219 assertions
- deletion contract: 5 runs, 159 assertions
- RuboCop and git diff check clean