### PR TITLE
Expose the cutover boundary to routine status reads

### DIFF
--- a/lib/hive/attempts/repository.rb
+++ b/lib/hive/attempts/repository.rb
@@ -58,6 +58,9 @@ module Hive
         def read_output(reference, max_bytes:)
           @repository.read_output(reference, max_bytes: max_bytes)
         end
+
+        def pre_activation_projection?(observed_at) =
+          @repository.pre_activation_projection?(observed_at)
       end
 
       attr_reader :database

--- a/test/fixtures/runtime_control_plane/affected_production.yml
+++ b/test/fixtures/runtime_control_plane/affected_production.yml
@@ -6,9 +6,9 @@ baseline_lines: 9951
 counting_rule: physical_source_lines
 includes_new_production_files: true
 maximum_final_lines: 7960
-final_inventory_lines: 9210
+final_inventory_lines: 9213
 outside_inventory_net_lines: -2962
-final_lines: 6248
+final_lines: 6251
 final_paths:
 - path: lib/hive/attempts/capacity_snapshot.rb
   lines: 104
@@ -19,7 +19,7 @@ final_paths:
 - path: lib/hive/attempts/publication.rb
   lines: 299
 - path: lib/hive/attempts/repository.rb
-  lines: 693
+  lines: 696
 - path: lib/hive/attempts/storage_status.rb
   lines: 20
 - path: lib/hive/commands/runtime.rb

--- a/test/unit/attempts/store_test.rb
+++ b/test/unit/attempts/store_test.rb
@@ -345,6 +345,9 @@ class AttemptsRepositoryTest < Minitest::Test
       end
 
       assert repository.pre_activation_projection?("2026-07-16T11:59:59.999999Z")
+      assert repository.projection_reader.pre_activation_projection?(
+        "2026-07-16T11:59:59.999999Z"
+      )
       refute repository.pre_activation_projection?(activated_at)
       refute repository.pre_activation_projection?("2026-07-16T12:00:00.000001Z")
       refute repository.pre_activation_projection?("invalid")

--- a/wiki/log.d/20260831T185100Z-cutover-projection-reader.md
+++ b/wiki/log.d/20260831T185100Z-cutover-projection-reader.md
@@ -1,0 +1,9 @@
+---
+title: Carry the cutover boundary through routine projection reads
+tags: [runtime-control-plane, cutover, task-projection, status]
+---
+
+Routine status scans use the attempt repository's bounded projection reader,
+not the full repository facade. That reader now delegates the durable
+pre-activation boundary check, so daemon and Web snapshots advance retained
+cutover checkpoints under the same rules as direct task projection reads.


### PR DESCRIPTION
## Summary
- delegate the durable pre-activation projection boundary through `ProjectionReader`
- cover the real bounded-reader adapter used by daemon and Web status scans

## Why
PR #1378 fixed direct task-projection reads, but routine status intentionally uses the repository read-only adapter. Without this delegation, daemon snapshots continued to classify otherwise valid retained checkpoints as repair-required.

## Verification
- exact live routine-reader path returns `current` with no diagnostics
- attempt repository: 14 runs, 60 assertions
- task projection store: 45 runs, 175 assertions
- deletion contract: 5 runs, 159 assertions
- RuboCop and diff check clean