### PR TITLE
fix(runtime): resume retained cutover tasks

### DIFF
--- a/lib/hive/daemon/dispatcher.rb
+++ b/lib/hive/daemon/dispatcher.rb
@@ -59,6 +59,9 @@ module Hive
       DISPATCH_AGING_STEP_SEC = 30 * 60
       TERMINAL_RECOVERY_PRUNE_INTERVAL_SEC = 60 * 60
       STATE_FILE_PROBE_BATCH_SIZE = 64
+      STALE_RECOVERY_BLOCK_REASONS = %w[
+        generation_conflict task_identity_conflict
+      ].freeze
 
       # Stage dir whose `needs_input` rows carry a brainstorm Q&A file the
       # daemon gates auto-resume on (see `brainstorm_answer_state`).
@@ -392,7 +395,9 @@ module Hive
         # consume every newly opened slot before an old direct row is ever
         # considered. Single-writer invariant: only the daemon spawns
         # `hive run`-class verbs.
-        queue_dispatch = process_dispatch_requests(now: now, rows: result.rows)
+        queue_dispatch = process_dispatch_requests(
+          now: now, rows: result.rows, projects: result.projects
+        )
         @priority_capacity_fences = queue_dispatch.fetch(:capacity_fences)
 
         # Accepted-source admission is an independent control lane. It is
@@ -2469,7 +2474,7 @@ module Hive
       #   8. Spawn via `dispatch_command`, threading `request_id`
       #      through the supervisor so `reap_completed` can complete the
       #      row and log `:dispatch_request_completed`.
-      def process_dispatch_requests(now:, rows:)
+      def process_dispatch_requests(now:, rows:, projects: nil)
         pending = dispatch_repository.pending(state_home: dispatch_request_state_home)
         pending = prepare_dispatch_requests(pending, now: now)
         current_request_ids = pending.to_h { |request| [ request.request_id.to_s, true ] }
@@ -2500,6 +2505,9 @@ module Hive
         rows.each do |row|
           key = [ row.project.to_s, row.slug.to_s ]
           rows_by_task[key] ||= row
+        end
+        observed_projects = if projects
+          Array(projects).to_h { |project| [ project.name.to_s, project ] }
         end
         pending_task_keys = pending.to_h do |request|
           [ [ request.project.to_s, request.slug.to_s ], true ]
@@ -2599,7 +2607,8 @@ module Hive
             result = process_dispatch_request_iteration(
               req, now: now, rows: rows,
               row_index: rows_by_task, project_lookup: project_lookup,
-              admission_context_loader: admission_context_loader
+              admission_context_loader: admission_context_loader,
+              project_observation: observed_projects&.[](req.project.to_s)
             )
             outcome = if result.is_a?(Hive::Attempts::DispatchResult)
               dispatch_outcome(result)
@@ -2702,7 +2711,8 @@ module Hive
       # @controller, @logger, and the queue's remove() call.
       def process_dispatch_request_iteration(req, now:, rows:, row_index: nil,
                                              project_lookup: nil,
-                                             admission_context_loader: nil)
+                                             admission_context_loader: nil,
+                                             project_observation: nil)
         return unless admission_open?
 
         unless dispatch_repository.valid_argv?(req.argv)
@@ -2769,14 +2779,10 @@ module Hive
               candidate.slug.to_s == req.slug.to_s
           end
         end
-        if row && projection_repair_row?(row)
-          log_dispatch_request_once(
-            :dispatch_request_blocked,
-            request_id: req.request_id, project: req.project,
-            slug: req.slug, reason: "projection_repair_required",
-            remediation: row.suggested_command ||
-              "repair the exact task projection before admission"
-          )
+        if req.recovery.is_a?(Hash) && stale_recovery_request?(
+          req, row, project_observation: project_observation
+        )
+          reject_request(req, reason: "stale_task_identity")
           return
         end
         if req.recovery.nil? && durable_task_request?(req) && bound_task_request?(req)
@@ -2797,6 +2803,16 @@ module Hive
             reject_request(req, reason: "stale_task_identity")
             return
           end
+        end
+        if row && projection_repair_row?(row)
+          log_dispatch_request_once(
+            :dispatch_request_blocked,
+            request_id: req.request_id, project: req.project,
+            slug: req.slug, reason: "projection_repair_required",
+            remediation: row.suggested_command ||
+              "repair the exact task projection before admission"
+          )
+          return
         end
         if req.recovery.is_a?(Hash)
           unless row
@@ -3090,6 +3106,41 @@ module Hive
       def bound_task_request?(request)
         !request.task_generation.to_s.empty? || !request.task_id.to_s.empty? ||
           !request.expected_stage.to_s.empty?
+      end
+
+      def stale_recovery_request?(request, row, project_observation:)
+        return true if STALE_RECOVERY_BLOCK_REASONS.include?(
+          request.recovery["blocked_reason"].to_s
+        )
+
+        if row
+          identity_changed =
+            (!request.task_id.to_s.empty? && !row.id.to_s.empty? &&
+             request.task_id.to_s != row.id.to_s) ||
+            (!request.expected_stage.to_s.empty? &&
+             request.expected_stage.to_s != row.stage.to_s)
+          return false unless identity_changed
+        else
+          return false unless project_observation
+        end
+        return false if project_observation&.legacy?
+
+        exact_recovery_task_stale?(request)
+      end
+
+      def exact_recovery_task_stale?(request)
+        task = Hive::TaskResolver.new(
+          request.slug, project_filter: request.project
+        ).resolve
+        current_stage = "#{task.stage_index}-#{task.stage_name}"
+        (!request.task_id.to_s.empty? && !task.id.to_s.empty? &&
+         request.task_id.to_s != task.id.to_s) ||
+          (!request.expected_stage.to_s.empty? &&
+           request.expected_stage.to_s != current_stage)
+      rescue Hive::InvalidTaskPath
+        bound_task_request?(request)
+      rescue Hive::Error, SystemCallError, IOError
+        false
       end
 
       def bound_task_request_current?(request, row: nil, admission_context: nil)

--- a/lib/hive/plan_review/checkpoint_custody.rb
+++ b/lib/hive/plan_review/checkpoint_custody.rb
@@ -6,15 +6,15 @@ module Hive
       CONTRACT_VERSION = 1
       BASENAME = "task-projection.checkpoint.json".freeze
       DIAGNOSTIC = "reviewer modified protected artifacts: #{BASENAME}".freeze
-      INITIAL_REVIEW_ROLES = ResultParser::INITIAL_REVIEW_RECOVERY_ROLES
+      RECOVERY_ROLES = Adapters::Base::KINDS
 
       module_function
 
-      # Recover only exact, runner-authored initial-review failures. A
+      # Recover only exact, runner-authored review failures. A
       # versioned reset suppresses later replays of the same lineage; malformed
       # recovery metadata fails closed instead of creating a retry loop.
       def recoverable_routes(routes)
-        recoverable_by_role(routes).values_at(*INITIAL_REVIEW_ROLES).compact
+        recoverable_by_role(routes).values_at(*RECOVERY_ROLES).compact
       end
 
       def recoverable?(routes)
@@ -27,7 +27,7 @@ module Hive
         attempted_roles = {}
         Array(routes).reverse_each do |route|
           role = route["role"]
-          next unless INITIAL_REVIEW_ROLES.include?(role)
+          next unless RECOVERY_ROLES.include?(role)
 
           if route["checkpoint_custody_recovery"] == true
             status = contract_status(route)

--- a/lib/hive/task_projection/store.rb
+++ b/lib/hive/task_projection/store.rb
@@ -365,18 +365,6 @@ module Hive
         snapshot_path
       end
 
-      def valid?(snapshot, binding = journal_binding)
-        return false unless snapshot.is_a?(Hash)
-        return false unless snapshot["schema"] == Hive::TaskProjection::SCHEMA
-        return false unless snapshot["schema_version"] == Hive::TaskProjection::SCHEMA_VERSION
-
-        journal = snapshot["journal"]
-        journal.is_a?(Hash) &&
-          journal["cursor"] == binding.fetch("cursor") &&
-          journal["hash"] == binding.fetch("hash") &&
-          journal["event_id"] == binding.fetch("event_id")
-      end
-
       private
 
       def publish_zero_history!(marker:, limits:)

--- a/lib/hive/task_projection/store.rb
+++ b/lib/hive/task_projection/store.rb
@@ -145,6 +145,46 @@ module Hive
       end
       private_constant :BoundedAttemptStore
 
+      class SnapshotAttemptStore
+        def initialize(store:, bindings:, records:)
+          @store = store
+          @bindings = bindings.to_h { |binding| [ binding["attempt_id"].to_s, binding ] }
+          @pre_activation_attempt_ids = records.each_with_object({}) do |record, index|
+            observed_at = record["observed_at"] || record["occurred_at"]
+            if observed_at && @store.respond_to?(:pre_activation_projection?) &&
+               @store.pre_activation_projection?(observed_at)
+              index[record["attempt_id"].to_s] = true
+            end
+          end
+        end
+
+        def fetch_projection_binding(attempt_id)
+          current = @store.fetch_projection_binding(attempt_id)
+          return current if current
+
+          binding = @bindings[attempt_id.to_s]
+          return unless binding && @pre_activation_attempt_ids[attempt_id.to_s] &&
+                        @store.respond_to?(:pre_activation_projection?) &&
+                        @store.pre_activation_projection?(binding["accepted_at"])
+
+          task = binding["task"]
+          return unless task.is_a?(Hash)
+
+          {
+            "attempt_id" => binding["attempt_id"], "task_id" => task["id"],
+            "task_slug" => task["slug"], "intended_stage" => binding["stage"],
+            "task_input_epoch" => binding["task_generation"],
+            "ownership_generation" => binding["ownership_generation"],
+            "accepted_at" => binding["accepted_at"],
+            "predecessor_attempt_id" => binding["predecessor_attempt_id"],
+            "state" => binding["state"], "outcome" => binding["outcome"],
+            "lease_version" => binding["lease_version"],
+            "receipt" => { "exit_status" => binding["exit_status"] }
+          }
+        end
+      end
+      private_constant :SnapshotAttemptStore
+
       attr_reader :task_folder, :journal_path, :snapshot_path, :checkpoint_path, :attempt_store
 
       def initialize(task_folder:, projector: Hive::TaskProjection, attempt_store: default_attempt_store)
@@ -157,19 +197,12 @@ module Hive
       end
 
       def read(marker: nil)
+        checkpoint = read_bounded(marker: marker, require_checkpoint: true)
+        return checkpoint.projection if checkpoint.current?
+
         snapshot = read_snapshot
         bytes = journal_bytes
         ensure_journal_after_handoff!(snapshot: snapshot, marker: marker, bytes: bytes)
-        quick_binding = {
-          "cursor" => bytes.bytesize,
-          "hash" => ::Digest::SHA256.hexdigest(bytes),
-          "event_id" => snapshot&.dig("journal", "event_id")
-        }
-        if valid?(snapshot, quick_binding) && attempt_bindings_valid?(snapshot)
-          projection = Hive::TaskProjection.from_data(snapshot)
-          return marker ? projection.with_marker(marker) : projection
-        end
-
         replay(journal_binding(bytes), marker: marker)
       end
 
@@ -249,6 +282,9 @@ module Hive
       end
 
       # Explicit exact-task repair owns the only routine-external full replay.
+      # A retained pre-activation snapshot may supply attempt bindings that the
+      # all-in cutover intentionally discarded, but only when its complete
+      # projection still matches the exact journal under the current projector.
       # The exclusive journal lock prevents a concurrent append from binding
       # the new derived files to two different authoritative cursors.
       def repair!(marker: nil, limits: Hive::TaskWorkspace::Limits.new,
@@ -270,6 +306,11 @@ module Hive
             raise Hive::TaskProjection::InvalidJournal,
                   "authoritative task journal is missing, empty, or not a regular file"
           end
+          cutover_repair = repair_from_pre_activation_snapshot(
+            marker: marker, limits: limits, bytes: journal_bytes
+          )
+          return cutover_repair if cutover_repair
+
           projection = rebuild!(marker: marker)
           bounded = read_bounded_unlocked(
             marker: marker, limits: limits, require_checkpoint: true, pristine: false
@@ -278,9 +319,11 @@ module Hive
         end
       end
 
-      # Workspace reads use a separately bounded checkpoint and only replay
-      # the append-only suffix. The lifecycle-facing #read and #rebuild!
-      # methods intentionally retain their historical behavior.
+      # Bounded reads use a separately validated checkpoint and only replay
+      # the append-only suffix. Lifecycle reads prefer that path but retain
+      # strict full replay as their fallback. Explicit rebuild stays strict;
+      # repair has the narrow pre-activation compatibility path documented
+      # above before it falls back to that same strict replay.
       def read_bounded(marker: nil, limits: Hive::TaskWorkspace::Limits.new,
                        snapshot_max_bytes: nil, journal_suffix_max_bytes: nil,
                        journal_event_limit: nil, require_checkpoint: false,
@@ -306,6 +349,7 @@ module Hive
           snapshot_limit: snapshot_limit
         )
       rescue Hive::TaskProjection::Error, Hive::TaskJournal::Error,
+             Hive::Conditions::InvalidCondition,
              JSON::ParserError, KeyError, TypeError, ArgumentError,
              SystemCallError, IOError => e
         degraded_bounded_read(
@@ -382,7 +426,8 @@ module Hive
         end
 
         read_from_checkpoint(
-          checkpoint.fetch("document"), marker: marker,
+          checkpoint.fetch("document"), base_projection: checkpoint.fetch("projection"),
+          marker: marker,
           suffix_limit: suffix_limit, event_limit: event_limit,
           attempt_limit: attempt_limit, predecessor_limit: predecessor_limit
         )
@@ -443,8 +488,8 @@ module Hive
           return { "valid" => false, "reason" => "checkpoint_invalid" }
         end
 
-        Hive::TaskProjection.from_data(document.fetch("snapshot"))
-        { "valid" => true, "document" => document }
+        projection = Hive::TaskProjection.from_data(document.fetch("snapshot"))
+        { "valid" => true, "document" => document, "projection" => projection }
       rescue Errno::ENOENT
         { "valid" => false, "reason" => "checkpoint_missing" }
       rescue JSON::ParserError, KeyError, TypeError, ArgumentError,
@@ -452,12 +497,11 @@ module Hive
         { "valid" => false, "reason" => "checkpoint_invalid" }
       end
 
-      def read_from_checkpoint(checkpoint, marker:, suffix_limit:, event_limit:,
-                               attempt_limit:, predecessor_limit:)
+      def read_from_checkpoint(checkpoint, base_projection:, marker:, suffix_limit:,
+                               event_limit:, attempt_limit:, predecessor_limit:)
         journal = checkpoint.fetch("journal")
         cursor = Integer(journal.fetch("cursor"))
         snapshot = checkpoint.fetch("snapshot")
-        base_projection = Hive::TaskProjection.from_data(snapshot)
         return degraded_from_projection(
           base_projection, reason: "checkpoint_prefix_changed", state: "stale", cursor: cursor
         ) unless checkpoint_prefix_valid?(journal, cursor)
@@ -985,7 +1029,54 @@ module Hive
         )
       end
 
-      def journal_binding(bytes = journal_bytes)
+      def repair_from_pre_activation_snapshot(marker:, limits:, bytes:)
+        snapshot = read_snapshot
+        bindings = snapshot&.dig("journal", "attempts")
+        return unless bindings.is_a?(Array) &&
+                      @attempt_store.respond_to?(:fetch_projection_binding)
+
+        records = Hive::TaskProjection.replay_journal(bytes).records
+        binding = journal_binding(
+          bytes,
+          attempt_store: SnapshotAttemptStore.new(
+            store: @attempt_store, bindings: bindings, records: records
+          )
+        )
+        derived = replay(binding, marker: nil).to_h
+        expected = Hive::TaskProjection.from_data(snapshot).to_h
+        [ derived, expected ].each do |value|
+          value.delete("marker")
+          value.delete("closure")
+          if (compatibility = value["compatibility"])
+            compatibility["marker"] = nil
+            compatibility["marker_fallback"] = nil
+          end
+          value.dig("implementation_identity")&.delete("stages")
+          Array(value.dig("journal", "attempts")).each do |attempt|
+            attempt["exit_status"] = nil unless attempt.key?("exit_status")
+          end
+        end
+        return unless Hive::TaskProjection.canonical_json(derived) ==
+                      Hive::TaskProjection.canonical_json(expected)
+
+        projection = replay(binding, marker: marker)
+        publish_checkpoint(binding: binding, bytes: bytes, projection: projection)
+        bounded = read_bounded_unlocked(
+          marker: marker, limits: limits, require_checkpoint: true, pristine: false
+        )
+        unless bounded.current?
+          raise Hive::TaskProjection::InvalidJournal,
+                "pre-activation snapshot did not produce a current checkpoint"
+        end
+        publish(bounded.projection)
+        publish_checkpoint(binding: binding, bytes: bytes, projection: bounded.projection)
+        RepairResult.new(projection: bounded.projection, bounded: bounded)
+      rescue Hive::TaskProjection::Error, Hive::TaskJournal::Error,
+             JSON::ParserError, KeyError, TypeError, ArgumentError
+        nil
+      end
+
+      def journal_binding(bytes = journal_bytes, attempt_store: @attempt_store)
         if bytes.empty? && !File.exist?(journal_path)
           return {
             "cursor" => 0, "hash" => ::Digest::SHA256.hexdigest(""),
@@ -993,7 +1084,7 @@ module Hive
           }
         end
 
-        replay = Hive::TaskProjection.replay_journal(bytes, attempt_store: @attempt_store)
+        replay = Hive::TaskProjection.replay_journal(bytes, attempt_store: attempt_store)
         {
           "cursor" => replay.cursor,
           "hash" => replay.ledger_hash,
@@ -1012,17 +1103,6 @@ module Hive
         File.binread(journal_path)
       rescue Errno::ENOENT
         ""
-      end
-
-      def attempt_bindings_valid?(snapshot)
-        bindings = snapshot.dig("journal", "attempts")
-        return false unless bindings.is_a?(Array)
-
-        refreshed = refreshed_attempt_bindings(snapshot)
-        refreshed && bindings.zip(refreshed).all? do |expected, current|
-          expected.values_at("state", "outcome", "lease_version") ==
-            current.values_at("state", "outcome", "lease_version")
-        end
       end
 
       def refreshed_attempt_bindings(snapshot)

--- a/test/fixtures/runtime_control_plane/affected_production.yml
+++ b/test/fixtures/runtime_control_plane/affected_production.yml
@@ -7,8 +7,8 @@ counting_rule: physical_source_lines
 includes_new_production_files: true
 maximum_final_lines: 7960
 final_inventory_lines: 9220
-outside_inventory_net_lines: -2836
-final_lines: 6384
+outside_inventory_net_lines: -2705
+final_lines: 6515
 final_paths:
 - path: lib/hive/attempts/capacity_snapshot.rb
   lines: 104

--- a/test/fixtures/runtime_control_plane/affected_production.yml
+++ b/test/fixtures/runtime_control_plane/affected_production.yml
@@ -7,8 +7,8 @@ counting_rule: physical_source_lines
 includes_new_production_files: true
 maximum_final_lines: 7960
 final_inventory_lines: 9220
-outside_inventory_net_lines: -2705
-final_lines: 6515
+outside_inventory_net_lines: -2717
+final_lines: 6503
 final_paths:
 - path: lib/hive/attempts/capacity_snapshot.rb
   lines: 104

--- a/test/unit/attempts/supervisor_test.rb
+++ b/test/unit/attempts/supervisor_test.rb
@@ -618,7 +618,7 @@ class AttemptsSupervisorTest < Minitest::Test
       supervisor = Hive::Attempts::Supervisor.new(
         store: store, attempt_id: attempt.attempt_id,
         claim_io: StringIO.new(CLAIM_CAPABILITY), heartbeat_sec: 0.01,
-        stale_sec: 1, first_heartbeat_timeout_sec: 1, kill_grace_sec: 0.03
+        stale_sec: 1, first_heartbeat_timeout_sec: 1, kill_grace_sec: 1
       )
       supervisor.define_singleton_method(:resolved_worker_argv) do |_record|
         [ RbConfig.ruby, "-e", "sleep 10" ]
@@ -626,7 +626,7 @@ class AttemptsSupervisorTest < Minitest::Test
       supervisor.instance_variable_set(:@cancel_reason, :signal)
       supervisor.instance_variable_set(:@cancel_signal, "TERM")
 
-      assert_equal 143, Timeout.timeout(2) { supervisor.run }
+      assert_equal 143, Timeout.timeout(3) { supervisor.run }
       terminal = store.fetch(attempt.attempt_id)
       diagnostic = diagnostic_from_terminal(store, terminal)
       assert_equal "agent_cancelled", diagnostic.fetch("code")

--- a/test/unit/daemon/dispatcher_test.rb
+++ b/test/unit/daemon/dispatcher_test.rb
@@ -8010,9 +8010,6 @@ end
         expected_stage: "4-execute", task_generation: "old-generation",
         state_home: state_home, now: T0
       )
-      dispatcher.define_singleton_method(:bound_task_request_current?) do |_request, row: nil, **|
-        false
-      end
       stub_find_project!(dispatcher, "p1")
       begin
         dispatcher.tick(now: T0)
@@ -8027,6 +8024,293 @@ end
       assert_equal "stale_task_identity", rejected.last.fetch(:reason)
       assert_empty sup.spawned
       assert_nil Q.fetch("STALE", state_home: state_home)
+    end
+  end
+
+  def test_dispatcher_removes_a_recovery_request_after_the_task_advances
+    Dir.mktmpdir("hive-dispatch-queue") do |state_home|
+      coordinator = FakeRecoveryCoordinator.new(status: "blocked")
+      dispatcher, sup, _ctrl, logger, = make_dispatcher(
+        rows: [ row(id: 42, slug: "s1", stage: "6-done", action: "archived") ],
+        dispatch_request_state_home: state_home,
+        recovery_coordinator: coordinator
+      )
+      Q.write_request!(
+        project: "p1", slug: "s1", argv: %w[hive run s1 --json],
+        requestor: "healer", request_id: "STALE-RECOVERY", task_id: 42,
+        expected_stage: "4-review", task_generation: "old-generation",
+        recovery: dispatcher_recovery(phase: "dispatched"),
+        state_home: state_home, now: T0
+      )
+      stub_find_project!(dispatcher, "p1")
+      begin
+        dispatcher.tick(now: T0)
+      ensure
+        restore_find_project!
+      end
+
+      rejected = logger.events.find do |name, attrs|
+        name == :dispatch_request_rejected && attrs[:request_id] == "STALE-RECOVERY"
+      end
+      refute_nil rejected
+      assert_equal "stale_task_identity", rejected.last.fetch(:reason)
+      assert_empty coordinator.resumes
+      assert_empty sup.spawned
+      assert_nil Q.fetch("STALE-RECOVERY", state_home: state_home)
+    end
+  end
+
+  def test_dispatcher_removes_a_recovery_request_after_the_task_identity_changes
+    Dir.mktmpdir("hive-dispatch-queue") do |state_home|
+      coordinator = FakeRecoveryCoordinator.new(status: "blocked")
+      dispatcher, sup, _ctrl, logger, = make_dispatcher(
+        rows: [ row(id: 43, slug: "s1", stage: "4-review", action: "blocked") ],
+        dispatch_request_state_home: state_home,
+        recovery_coordinator: coordinator
+      )
+      Q.write_request!(
+        project: "p1", slug: "s1", argv: %w[hive run s1 --json],
+        requestor: "healer", request_id: "REPLACED-RECOVERY", task_id: 42,
+        expected_stage: "4-review", task_generation: "old-generation",
+        recovery: dispatcher_recovery(phase: "dispatched"),
+        state_home: state_home, now: T0
+      )
+      stub_find_project!(dispatcher, "p1")
+      begin
+        dispatcher.tick(now: T0)
+      ensure
+        restore_find_project!
+      end
+
+      rejected = logger.events.find do |name, attrs|
+        name == :dispatch_request_rejected && attrs[:request_id] == "REPLACED-RECOVERY"
+      end
+      refute_nil rejected
+      assert_equal "stale_task_identity", rejected.last.fetch(:reason)
+      assert_empty coordinator.resumes
+      assert_empty sup.spawned
+      assert_nil Q.fetch("REPLACED-RECOVERY", state_home: state_home)
+    end
+  end
+
+  def test_dispatcher_removes_inert_stale_recovery_conflicts
+    Hive::Daemon::Dispatcher::STALE_RECOVERY_BLOCK_REASONS.each do |reason|
+      Dir.mktmpdir("hive-dispatch-queue") do |state_home|
+        coordinator = FakeRecoveryCoordinator.new(status: "blocked")
+        request_id = "STALE-#{reason.upcase}"
+        dispatcher, sup, _ctrl, logger, = make_dispatcher(
+          rows: [ row(id: 42, slug: "s1", stage: "4-review", action: "blocked") ],
+          dispatch_request_state_home: state_home,
+          recovery_coordinator: coordinator
+        )
+        recovery = dispatcher_recovery(phase: "cleared").merge(
+          "owner" => "operator", "blocked_reason" => reason
+        )
+        Q.write_request!(
+          project: "p1", slug: "s1", argv: %w[hive run s1 --json],
+          requestor: "healer", request_id: request_id, task_id: 42,
+          expected_stage: "4-review", task_generation: "old-generation",
+          recovery: recovery, state_home: state_home, now: T0
+        )
+        stub_find_project!(dispatcher, "p1")
+        begin
+          dispatcher.tick(now: T0)
+        ensure
+          restore_find_project!
+        end
+
+        rejected = logger.events.find do |name, attrs|
+          name == :dispatch_request_rejected && attrs[:request_id] == request_id
+        end
+        refute_nil rejected
+        assert_equal "stale_task_identity", rejected.last.fetch(:reason)
+        assert_empty coordinator.resumes
+        assert_empty sup.spawned
+        assert_nil Q.fetch(request_id, state_home: state_home)
+      end
+    end
+  end
+
+  def test_dispatcher_removes_a_recovery_request_after_the_task_is_archived
+    Dir.mktmpdir("hive-dispatch-queue") do |state_home|
+      coordinator = FakeRecoveryCoordinator.new(status: "blocked")
+      observed_project = Hive::Daemon::StatusConsumer::ProjectInfo.new(
+        name: "p1", legacy_stage_dirs: []
+      )
+      status_result = Hive::Daemon::StatusConsumer::Result.new(
+        ok: true, rows: [], projects: [ observed_project ], error: nil
+      )
+      dispatcher, sup, _ctrl, logger, = make_dispatcher(
+        rows: [], status_result: status_result,
+        dispatch_request_state_home: state_home, recovery_coordinator: coordinator
+      )
+      Q.write_request!(
+        project: "p1", slug: "s1", argv: %w[hive run s1 --json],
+        requestor: "healer", request_id: "ARCHIVED-RECOVERY", task_id: 42,
+        expected_stage: "4-review", task_generation: "old-generation",
+        recovery: dispatcher_recovery(phase: "dispatched"),
+        state_home: state_home, now: T0
+      )
+      stub_find_project!(dispatcher, "p1")
+      begin
+        dispatcher.tick(now: T0)
+      ensure
+        restore_find_project!
+      end
+
+      rejected = logger.events.find do |name, attrs|
+        name == :dispatch_request_rejected && attrs[:request_id] == "ARCHIVED-RECOVERY"
+      end
+      refute_nil rejected
+      assert_equal "stale_task_identity", rejected.last.fetch(:reason)
+      assert_empty coordinator.resumes
+      assert_empty sup.spawned
+      assert_nil Q.fetch("ARCHIVED-RECOVERY", state_home: state_home)
+    end
+  end
+
+  def test_dispatcher_preserves_a_recovery_request_when_the_project_observation_degrades
+    Dir.mktmpdir("hive-dispatch-queue") do |state_home|
+      coordinator = FakeRecoveryCoordinator.new(status: "blocked")
+      dispatcher, sup, _ctrl, logger, = make_dispatcher(
+        rows: [], dispatch_request_state_home: state_home,
+        recovery_coordinator: coordinator
+      )
+      Q.write_request!(
+        project: "p1", slug: "s1", argv: %w[hive run s1 --json],
+        requestor: "healer", request_id: "DEGRADED-RECOVERY", task_id: 42,
+        expected_stage: "4-review", task_generation: "old-generation",
+        recovery: dispatcher_recovery(phase: "dispatched"),
+        state_home: state_home, now: T0
+      )
+      stub_find_project!(dispatcher, "p1")
+      begin
+        dispatcher.tick(now: T0)
+      ensure
+        restore_find_project!
+      end
+
+      blocked = logger.events.find do |name, attrs|
+        name == :dispatch_request_blocked && attrs[:request_id] == "DEGRADED-RECOVERY"
+      end
+      refute_nil blocked
+      assert_equal "recovery_observation_unavailable", blocked.last.fetch(:reason)
+      assert_empty coordinator.resumes
+      assert_empty sup.spawned
+      refute_nil Q.fetch("DEGRADED-RECOVERY", state_home: state_home)
+    end
+  end
+
+  def test_dispatcher_preserves_a_recovery_request_for_a_legacy_project_observation
+    Dir.mktmpdir("hive-dispatch-queue") do |state_home|
+      coordinator = FakeRecoveryCoordinator.new(status: "blocked")
+      legacy_project = Hive::Daemon::StatusConsumer::ProjectInfo.new(
+        name: "p1", legacy_stage_dirs: [ "/tmp/p1/legacy" ]
+      )
+      status_result = Hive::Daemon::StatusConsumer::Result.new(
+        ok: true, rows: [], projects: [ legacy_project ], error: nil
+      )
+      dispatcher, sup, _ctrl, logger, = make_dispatcher(
+        rows: [], status_result: status_result,
+        dispatch_request_state_home: state_home, recovery_coordinator: coordinator
+      )
+      Q.write_request!(
+        project: "p1", slug: "s1", argv: %w[hive run s1 --json],
+        requestor: "healer", request_id: "LEGACY-RECOVERY", task_id: 42,
+        expected_stage: "4-review", task_generation: "old-generation",
+        recovery: dispatcher_recovery(phase: "dispatched"),
+        state_home: state_home, now: T0
+      )
+      stub_find_project!(dispatcher, "p1")
+      begin
+        dispatcher.tick(now: T0)
+      ensure
+        restore_find_project!
+      end
+
+      blocked = logger.events.find do |name, attrs|
+        name == :dispatch_request_blocked && attrs[:request_id] == "LEGACY-RECOVERY"
+      end
+      refute_nil blocked
+      assert_equal "recovery_observation_unavailable", blocked.last.fetch(:reason)
+      assert_empty coordinator.resumes
+      assert_empty sup.spawned
+      refute_nil Q.fetch("LEGACY-RECOVERY", state_home: state_home)
+    end
+  end
+
+  def test_dispatcher_preserves_a_recovery_request_when_the_status_row_is_stale
+    Dir.mktmpdir("hive-dispatch-project") do |project_root|
+      state_home = Dir.mktmpdir("hive-dispatch-queue")
+      state_path = File.join(project_root, ".hive-state")
+      folder = File.join(state_path, "stages", "4-execute", "s1")
+      Hive::TaskMeta.write(
+        folder, id: 42, slug: "s1", display_name: nil, workflow: "coding"
+      )
+      project = {
+        "name" => "p1", "path" => project_root, "hive_state_path" => state_path
+      }
+      old_row = row(id: 42, slug: "s1", stage: "3-plan", action: "blocked")
+      coordinator = FakeRecoveryCoordinator.new(status: "blocked")
+      dispatcher, sup, _ctrl, logger, = make_dispatcher(
+        rows: [ old_row ], dispatch_request_state_home: state_home,
+        recovery_coordinator: coordinator
+      )
+      Q.write_request!(
+        project: "p1", slug: "s1", argv: %w[hive run s1 --json],
+        requestor: "healer", request_id: "RACING-RECOVERY", task_id: 42,
+        expected_stage: "4-execute", task_generation: "current-generation",
+        recovery: dispatcher_recovery(phase: "dispatched"),
+        state_home: state_home, now: T0
+      )
+
+      with_replaced_singleton_method(Hive::Config, :registered_projects, -> { [ project ] }) do
+        with_replaced_singleton_method(Hive::Config, :find_project, ->(_name) { project }) do
+          dispatcher.tick(now: T0)
+        end
+      end
+
+      refute logger.events.any? { |name, attrs|
+        name == :dispatch_request_rejected && attrs[:request_id] == "RACING-RECOVERY"
+      }
+      assert_equal 1, coordinator.resumes.size
+      assert_empty sup.spawned
+      refute_nil Q.fetch("RACING-RECOVERY", state_home: state_home)
+    ensure
+      FileUtils.remove_entry(state_home) if state_home && File.exist?(state_home)
+    end
+  end
+
+  def test_dispatcher_preserves_a_stale_candidate_when_exact_resolution_fails
+    Dir.mktmpdir("hive-dispatch-queue") do |state_home|
+      old_row = row(id: 42, slug: "s1", stage: "3-plan", action: "blocked")
+      coordinator = FakeRecoveryCoordinator.new(status: "blocked")
+      dispatcher, sup, _ctrl, logger, = make_dispatcher(
+        rows: [ old_row ], dispatch_request_state_home: state_home,
+        recovery_coordinator: coordinator
+      )
+      Q.write_request!(
+        project: "p1", slug: "s1", argv: %w[hive run s1 --json],
+        requestor: "healer", request_id: "UNAVAILABLE-RECOVERY", task_id: 42,
+        expected_stage: "4-execute", task_generation: "current-generation",
+        recovery: dispatcher_recovery(phase: "dispatched"),
+        state_home: state_home, now: T0
+      )
+      stub_find_project!(dispatcher, "p1")
+      begin
+        with_replaced_singleton_method(
+          Hive::TaskResolver, :new, ->(*, **) { raise IOError, "transient task read" }
+        ) { dispatcher.tick(now: T0) }
+      ensure
+        restore_find_project!
+      end
+
+      refute logger.events.any? { |name, attrs|
+        name == :dispatch_request_rejected && attrs[:request_id] == "UNAVAILABLE-RECOVERY"
+      }
+      assert_equal 1, coordinator.resumes.size
+      assert_empty sup.spawned
+      refute_nil Q.fetch("UNAVAILABLE-RECOVERY", state_home: state_home)
     end
   end
 

--- a/test/unit/plan_review/checkpoint_custody_test.rb
+++ b/test/unit/plan_review/checkpoint_custody_test.rb
@@ -2,16 +2,15 @@ require "test_helper"
 require "hive/plan_review/checkpoint_custody"
 
 class PlanReviewCheckpointCustodyTest < Minitest::Test
-  def test_recovery_is_exact_versioned_and_initial_only
+  def test_recovery_is_exact_versioned_and_covers_every_review_role
     diagnostic = Hive::PlanReview::CheckpointCustody::DIAGNOSTIC
-    recoverable = %w[primary adversarial].map do |role|
+    recoverable = %w[primary adversarial verification].map do |role|
       {
         "role" => role, "outcome" => "terminal_failure", "attempt_id" => "pra-#{role}",
         "diagnostic" => diagnostic, "diagnostic_source" => "runner"
       }
     end
     ignored = [
-      recoverable.first.merge("role" => "verification"),
       recoverable.first.merge("diagnostic_source" => "reviewer"),
       recoverable.first.merge("diagnostic" => "reviewer modified protected artifacts: plan.md")
     ]
@@ -19,7 +18,7 @@ class PlanReviewCheckpointCustodyTest < Minitest::Test
     routes = Hive::PlanReview::CheckpointCustody.recoverable_routes(recoverable)
 
     assert Hive::PlanReview::CheckpointCustody.recoverable?(recoverable)
-    assert_equal %w[primary adversarial], routes.map { |route| route.fetch("role") }
+    assert_equal %w[primary adversarial verification], routes.map { |route| route.fetch("role") }
     ignored.each do |route|
       refute Hive::PlanReview::CheckpointCustody.recoverable?([ route ])
     end
@@ -33,18 +32,18 @@ class PlanReviewCheckpointCustodyTest < Minitest::Test
     ]
     recovered_roles = Hive::PlanReview::CheckpointCustody.recoverable_routes(recovered)
       .map { |route| route.fetch("role") }
-    assert_equal [ "adversarial" ], recovered_roles
+    assert_equal %w[adversarial verification], recovered_roles
 
     malformed = recovered.last.merge("checkpoint_custody_contract_version" => "not-a-version")
     malformed_routes = recoverable + [ malformed ]
     malformed_roles = Hive::PlanReview::CheckpointCustody.recoverable_routes(malformed_routes)
       .map { |route| route.fetch("role") }
-    assert_equal [ "adversarial" ], malformed_roles
+    assert_equal %w[adversarial verification], malformed_roles
 
     stale = recovered.last.merge("checkpoint_custody_contract_version" => 0)
     stale_roles = Hive::PlanReview::CheckpointCustody.recoverable_routes(recoverable + [ stale ])
       .map { |route| route.fetch("role") }
-    assert_equal %w[primary adversarial], stale_roles
+    assert_equal %w[primary adversarial verification], stale_roles
 
     superseded = [
       recoverable.first,
@@ -60,6 +59,6 @@ class PlanReviewCheckpointCustodyTest < Minitest::Test
     repeated_after_reset = recovered + [ recoverable.first ]
     repeated_roles = Hive::PlanReview::CheckpointCustody.recoverable_routes(repeated_after_reset)
       .map { |route| route.fetch("role") }
-    assert_equal [ "adversarial" ], repeated_roles
+    assert_equal %w[adversarial verification], repeated_roles
   end
 end

--- a/test/unit/plan_review/orchestrator_test.rb
+++ b/test/unit/plan_review/orchestrator_test.rb
@@ -839,9 +839,10 @@ class PlanReviewOrchestratorTest < Minitest::Test
   def test_checkpoint_custody_false_positive_recovers_every_affected_role_once
     with_task(mandatory_plan) do |task, cfg|
       calls = Hash.new(0)
+      revision = FakeRevision.new(mandatory_plan.sub("# Plan", "# Revised"))
       adapter = FakeAdapter.new do |request|
         calls[request.kind] += 1
-        if %w[primary adversarial].include?(request.kind) && calls.fetch(request.kind) == 1
+        if calls.fetch(request.kind) == 1
           next Hive::PlanReview::Adapters::Base::Result.new(
             outcome: "terminal_failure",
             diagnostic: "reviewer modified protected artifacts: task-projection.checkpoint.json",
@@ -849,24 +850,33 @@ class PlanReviewOrchestratorTest < Minitest::Test
           )
         end
 
-        successful_result(request)
+        successful_result(
+          request,
+          findings: request.kind == "primary" ? [ finding("safe_auto", "Clarify tests") ] : []
+        )
       end
+      runner = -> { orchestrator(task, cfg, adapter:, planner_revision: revision) }
 
-      blocked = orchestrator(task, cfg, adapter:).advance!.record
+      blocked = runner.call.advance!.record
 
       assert_equal "blocked", blocked.state
       assert_equal({ "primary" => 1, "adversarial" => 1 }, calls)
 
-      cleared = orchestrator(task, cfg, adapter:).advance!.record
+      verification_blocked = runner.call.advance!.record
+
+      assert_equal "blocked", verification_blocked.state
+      assert_equal({ "primary" => 2, "adversarial" => 2, "verification" => 1 }, calls)
+      cleared = runner.call.advance!.record
 
       assert_equal "cleared", cleared.state
-      assert_equal({ "primary" => 2, "adversarial" => 2, "verification" => 1 }, calls)
+      assert_equal({ "primary" => 2, "adversarial" => 2, "verification" => 2 }, calls)
       resets = cleared["routes"].select { |route| route["checkpoint_custody_recovery"] }
-      assert_equal %w[adversarial primary], resets.map { |route| route.fetch("role") }.sort
+      assert_equal %w[adversarial primary verification],
+                   resets.map { |route| route.fetch("role") }.sort
       assert resets.all? { |route| route.fetch("checkpoint_custody_contract_version") == 1 }
 
-      orchestrator(task, cfg, adapter:).advance!
-      assert_equal({ "primary" => 2, "adversarial" => 2, "verification" => 1 }, calls)
+      runner.call.advance!
+      assert_equal({ "primary" => 2, "adversarial" => 2, "verification" => 2 }, calls)
     end
   end
 

--- a/test/unit/task_projection/store_test.rb
+++ b/test/unit/task_projection/store_test.rb
@@ -359,6 +359,130 @@ class TaskProjectionStoreTest < Minitest::Test
     end
   end
 
+  def test_lifecycle_read_resumes_from_checkpoint_when_pre_activation_attempt_is_missing
+    with_tmp_dir do |dir|
+      attempt_store, attempts = pre_activation_attempt_store
+      store = Hive::TaskProjection::Store.new(
+        task_folder: dir, attempt_store: attempt_store
+      )
+      write_journal(dir, [ condition_event("event-1") ])
+      store.rebuild!
+      attempts.clear
+
+      projection = store.read
+
+      assert_equal "event-1", projection.to_h.dig("journal", "event_id")
+      assert_equal "attempt_lost",
+                   projection.current_condition("AgentHealthy").fetch("reason")
+      strict = assert_raises(Hive::TaskProjection::InvalidJournal) { store.rebuild! }
+      assert_includes strict.message, "unknown durable attempt attempt-1"
+      FileUtils.rm(store.checkpoint_path)
+      uncheckpointed = assert_raises(Hive::TaskProjection::InvalidJournal) { store.read }
+      assert_includes uncheckpointed.message, "unknown durable attempt attempt-1"
+    end
+  end
+
+  def test_repair_rebuilds_a_checkpoint_from_exact_pre_activation_snapshot_bindings
+    with_tmp_dir do |dir|
+      attempt_store, attempts = pre_activation_attempt_store
+      store = Hive::TaskProjection::Store.new(
+        task_folder: dir, attempt_store: attempt_store
+      )
+      write_journal(dir, [ condition_event("event-1") ])
+      store.rebuild!
+      attempts.clear
+      FileUtils.rm(store.checkpoint_path)
+      snapshot = JSON.parse(File.binread(store.snapshot_path))
+      snapshot.dig("journal", "attempts", 0).delete("exit_status")
+      snapshot["compatibility"]["marker"] = {
+        "name" => "execute_waiting", "attrs" => { "reason" => "legacy_wait" }
+      }
+      snapshot["compatibility"]["marker_fallback"] =
+        snapshot.dig("compatibility", "marker")
+      snapshot["implementation_identity"]["stages"] = {
+        "execute" => { "event_id" => "legacy-projector-choice" }
+      }
+      File.binwrite(store.snapshot_path, JSON.generate(snapshot))
+
+      repaired = store.repair!
+
+      assert_equal "current", repaired.bounded.state
+      assert_equal "attempt_lost",
+                   repaired.projection.current_condition("AgentHealthy").fetch("reason")
+      assert_equal repaired.projection.to_h, store.read_routine.projection.to_h
+    end
+  end
+
+  def test_repair_refuses_post_activation_or_journal_divergent_snapshot_bindings
+    with_tmp_dir do |dir|
+      attempt_store, attempts = pre_activation_attempt_store
+      store = Hive::TaskProjection::Store.new(
+        task_folder: dir, attempt_store: attempt_store
+      )
+      write_journal(dir, [ condition_event("event-1") ])
+      store.rebuild!
+      snapshot = JSON.parse(File.binread(store.snapshot_path))
+      journal = File.binread(store.journal_path)
+      FileUtils.rm(store.checkpoint_path)
+      attempts.clear
+
+      post_activation = JSON.parse(JSON.generate(snapshot))
+      post_activation.dig("journal", "attempts", 0)["accepted_at"] =
+        "2026-07-17T12:02:00.000000Z"
+      File.binwrite(store.snapshot_path, JSON.generate(post_activation))
+      assert_raises(Hive::TaskProjection::InvalidJournal) { store.repair! }
+      refute_path_exists store.checkpoint_path
+
+      File.binwrite(store.snapshot_path, JSON.generate(snapshot))
+      File.open(store.journal_path, "a") { |file| file.puts(JSON.generate(condition_event("event-2"))) }
+      assert_raises(Hive::TaskProjection::InvalidJournal) { store.repair! }
+      refute_path_exists store.checkpoint_path
+      File.binwrite(store.journal_path, journal)
+    end
+  end
+
+  def test_repair_never_replaces_a_conflicting_current_attempt_with_snapshot_evidence
+    with_tmp_dir do |dir|
+      attempt_store, attempts = pre_activation_attempt_store
+      store = Hive::TaskProjection::Store.new(
+        task_folder: dir, attempt_store: attempt_store
+      )
+      write_journal(dir, [ condition_event("event-1") ])
+      store.rebuild!
+      FileUtils.rm(store.checkpoint_path)
+      attempts["attempt-1"] = durable_attempt.tap { |attempt| attempt["task_id"] = "99" }
+
+      assert_raises(Hive::TaskProjection::InvalidJournal) { store.repair! }
+      refute_path_exists store.checkpoint_path
+    end
+  end
+
+  def test_repair_rejects_a_backdated_snapshot_without_pre_activation_journal_evidence
+    with_tmp_dir do |dir|
+      post_activation_attempt = durable_attempt.tap do |attempt|
+        attempt["accepted_at"] = "2026-07-17T12:02:00.000000Z"
+      end
+      attempt_store, attempts = pre_activation_attempt_store(attempt: post_activation_attempt)
+      store = Hive::TaskProjection::Store.new(
+        task_folder: dir, attempt_store: attempt_store
+      )
+      event = condition_event("event-1")
+      event["occurred_at"] = "2026-07-17T12:03:00.000000Z"
+      event["observed_at"] = "2026-07-17T12:03:00.000000Z"
+      write_journal(dir, [ event ])
+      store.rebuild!
+      snapshot = JSON.parse(File.binread(store.snapshot_path))
+      snapshot.dig("journal", "attempts", 0)["accepted_at"] =
+        "2026-07-17T11:59:00.000000Z"
+      File.binwrite(store.snapshot_path, JSON.generate(snapshot))
+      FileUtils.rm(store.checkpoint_path)
+      attempts.clear
+
+      assert_raises(Hive::TaskProjection::InvalidJournal) { store.repair! }
+      refute_path_exists store.checkpoint_path
+    end
+  end
+
   def test_missing_post_activation_attempt_still_fails_closed
     with_tmp_dir do |dir|
       legacy = durable_attempt
@@ -1058,6 +1182,20 @@ class TaskProjectionStoreTest < Minitest::Test
     Object.new.tap do |store|
       store.define_singleton_method(:fetch) { |attempt_id| attempt if attempt_id == "attempt-1" }
     end
+  end
+
+  def pre_activation_attempt_store(attempt: durable_attempt)
+    attempts = { "attempt-1" => attempt }
+    activation = Time.iso8601("2026-07-17T12:01:00Z")
+    store = Object.new
+    store.define_singleton_method(:fetch) { |attempt_id| attempts[attempt_id] }
+    store.define_singleton_method(:fetch_projection_binding) do |attempt_id|
+      attempts[attempt_id]
+    end
+    store.define_singleton_method(:pre_activation_projection?) do |observed_at|
+      Time.iso8601(observed_at) < activation
+    end
+    [ store, attempts ]
   end
 
   def durable_attempt

--- a/test/unit/task_projection/store_test.rb
+++ b/test/unit/task_projection/store_test.rb
@@ -483,6 +483,42 @@ class TaskProjectionStoreTest < Minitest::Test
     end
   end
 
+  def test_snapshot_validity_rejects_noncanonical_or_mismatched_snapshots
+    with_tmp_dir do |dir|
+      store = projection_store(dir)
+      binding = { "cursor" => 1, "hash" => "hash", "event_id" => "event-1" }
+      snapshot = {
+        "schema" => Hive::TaskProjection::SCHEMA,
+        "schema_version" => Hive::TaskProjection::SCHEMA_VERSION,
+        "journal" => binding
+      }
+
+      refute store.send(:valid?, nil, binding)
+      refute store.send(:valid?, snapshot.merge("schema" => "other"), binding)
+      refute store.send(:valid?, snapshot.merge("schema_version" => -1), binding)
+      refute store.send(:valid?, snapshot.merge("journal" => nil), binding)
+      refute store.send(:valid?, snapshot.merge("journal" => binding.merge("hash" => "other")), binding)
+    end
+  end
+
+  def test_repair_falls_back_when_compatibility_checkpoint_is_not_current
+    with_tmp_dir do |dir|
+      attempt_store, attempts = pre_activation_attempt_store
+      store = Hive::TaskProjection::Store.new(task_folder: dir, attempt_store: attempt_store)
+      write_journal(dir, [ condition_event("event-1") ])
+      store.rebuild!
+      attempts.clear
+      FileUtils.rm(store.checkpoint_path)
+      store.define_singleton_method(:read_bounded_unlocked) do |**|
+        Object.new.tap { |result| result.define_singleton_method(:current?) { false } }
+      end
+
+      error = assert_raises(Hive::TaskProjection::InvalidJournal) { store.repair! }
+
+      assert_includes error.message, "unknown durable attempt attempt-1"
+    end
+  end
+
   def test_missing_post_activation_attempt_still_fails_closed
     with_tmp_dir do |dir|
       legacy = durable_attempt

--- a/test/unit/task_projection/store_test.rb
+++ b/test/unit/task_projection/store_test.rb
@@ -413,6 +413,31 @@ class TaskProjectionStoreTest < Minitest::Test
     end
   end
 
+  def test_repair_falls_back_when_pre_activation_checkpoint_is_not_current
+    with_tmp_dir do |dir|
+      attempt_store, attempts = pre_activation_attempt_store
+      store = Hive::TaskProjection::Store.new(
+        task_folder: dir, attempt_store: attempt_store
+      )
+      write_journal(dir, [ condition_event("event-1") ])
+      store.rebuild!
+      projection = store.read_routine.projection
+      attempts.clear
+      FileUtils.rm(store.checkpoint_path)
+      store.define_singleton_method(:read_bounded_unlocked) do |**|
+        Hive::TaskProjection::Store::BoundedRead.new(
+          projection: projection, state: "partial",
+          diagnostics: [ { "reason" => "checkpoint_invalid" } ],
+          truncated: false, journal_cursor: File.size(journal_path)
+        )
+      end
+
+      error = assert_raises(Hive::TaskProjection::InvalidJournal) { store.repair! }
+
+      assert_includes error.message, "unknown durable attempt attempt-1"
+    end
+  end
+
   def test_repair_refuses_post_activation_or_journal_divergent_snapshot_bindings
     with_tmp_dir do |dir|
       attempt_store, attempts = pre_activation_attempt_store
@@ -480,42 +505,6 @@ class TaskProjectionStoreTest < Minitest::Test
 
       assert_raises(Hive::TaskProjection::InvalidJournal) { store.repair! }
       refute_path_exists store.checkpoint_path
-    end
-  end
-
-  def test_snapshot_validity_rejects_noncanonical_or_mismatched_snapshots
-    with_tmp_dir do |dir|
-      store = projection_store(dir)
-      binding = { "cursor" => 1, "hash" => "hash", "event_id" => "event-1" }
-      snapshot = {
-        "schema" => Hive::TaskProjection::SCHEMA,
-        "schema_version" => Hive::TaskProjection::SCHEMA_VERSION,
-        "journal" => binding
-      }
-
-      refute store.send(:valid?, nil, binding)
-      refute store.send(:valid?, snapshot.merge("schema" => "other"), binding)
-      refute store.send(:valid?, snapshot.merge("schema_version" => -1), binding)
-      refute store.send(:valid?, snapshot.merge("journal" => nil), binding)
-      refute store.send(:valid?, snapshot.merge("journal" => binding.merge("hash" => "other")), binding)
-    end
-  end
-
-  def test_repair_falls_back_when_compatibility_checkpoint_is_not_current
-    with_tmp_dir do |dir|
-      attempt_store, attempts = pre_activation_attempt_store
-      store = Hive::TaskProjection::Store.new(task_folder: dir, attempt_store: attempt_store)
-      write_journal(dir, [ condition_event("event-1") ])
-      store.rebuild!
-      attempts.clear
-      FileUtils.rm(store.checkpoint_path)
-      store.define_singleton_method(:read_bounded_unlocked) do |**|
-        Object.new.tap { |result| result.define_singleton_method(:current?) { false } }
-      end
-
-      error = assert_raises(Hive::TaskProjection::InvalidJournal) { store.repair! }
-
-      assert_includes error.message, "unknown durable attempt attempt-1"
     end
   end
 

--- a/wiki/log.d/20260831T214218Z-resume-retained-task-journals.md
+++ b/wiki/log.d/20260831T214218Z-resume-retained-task-journals.md
@@ -1,0 +1,19 @@
+---
+title: Resume retained tasks through their cutover checkpoint
+tags: [runtime-control-plane, cutover, task-journal, projection, lifecycle]
+---
+
+Ordinary lifecycle projection reads previously ignored the retained cutover
+checkpoint and replayed the complete journal. Because the all-in cutover
+intentionally reset legacy attempt rows, a resumed task could complete its
+stage action and then fail while computing the next action on the journal's
+first historical attempt.
+
+Lifecycle reads now prefer the authenticated checkpoint prefix and validate
+only its bounded append-only suffix against SQLite. If that path is unavailable
+or invalid, Hive falls back to the original strict full replay. Explicit
+rebuild remains strict. Exact-task repair may reconstruct a missing checkpoint
+from a retained snapshot only for pre-activation attempt bindings, after a
+pre-activation observation for that attempt is also present in the journal and
+after a complete journal replay and projection match. A changed journal, unrelated
+projection drift, or missing post-activation attempt still fails closed.

--- a/wiki/log.d/20260831T221656Z-recover-verification-checkpoint-custody.md
+++ b/wiki/log.d/20260831T221656Z-recover-verification-checkpoint-custody.md
@@ -1,0 +1,14 @@
+---
+title: Recover verification checkpoint-custody false positives
+tags: [plan-review, verification, recovery, task-projection]
+---
+
+The plan-review checkpoint-custody rollout recovery covered primary and
+adversarial reviewers but omitted disposition verification. Historical
+verification rows carrying the same exact runner-authored false positive could
+therefore retry forever even though the current firewall already excluded the
+orchestrator checkpoint.
+
+The versioned recovery contract now covers verification as well. It resets
+only the exact historical diagnostic once; malformed metadata, unrelated
+custody failures, and failures after the current reset still fail closed.

--- a/wiki/log.d/20260831T224204Z-retire-stale-recovery-requests.md
+++ b/wiki/log.d/20260831T224204Z-retire-stale-recovery-requests.md
@@ -1,0 +1,24 @@
+---
+title: Retire stale recovery dispatch requests
+tags: [daemon, dispatch, recovery, queue, archive]
+---
+
+Recovery requests previously remained queued when their task advanced to a
+different stage or disappeared from the active graph after archive. The daemon
+reported those superseded rows as pending indefinitely and retried their
+recovery observation even though the bound task identity could no longer be
+current.
+
+Dispatch now rejects a recovery request as `stale_task_identity` before
+coordinator resume when its task ID/stage no longer matches, or when its row is
+absent from a project whose status graph was successfully observed. A
+project-level status failure or a legacy-layout scan is not proof of archive,
+so Hive preserves that request as `recovery_observation_unavailable`. A healthy
+canonical scan confirms the exact task identity before removing an absent row.
+The same exact resolution protects against a task advancing after the status
+snapshot but before queue processing. Current operator-owned
+deterministic-failure receipts remain durable and are not mistaken for stale
+work. Requests already parked as `generation_conflict` or
+`task_identity_conflict` are also retired: the coordinator classified their
+bound transition as immutable, so preserving them only creates an inert queue
+row and cannot make the task runnable again.

--- a/wiki/modules/daemon.md
+++ b/wiki/modules/daemon.md
@@ -628,6 +628,23 @@ advances a workflow stage directly:
    This keeps a historical recovery queue from turning each daemon tick into
    one full task reconstruction per parked request.
 
+   Before resuming a recovery request, the dispatcher compares its bound task
+   ID and expected stage with the current authoritative status row. A task that
+   advanced, was archived, or was otherwise removed from a successfully
+   observed project graph makes the old request stale; Hive rejects and removes
+   that request instead of retaining it forever as
+   `recovery_observation_unavailable`. If the project-level status observation
+   failed or the project still has legacy stage directories, absence is not
+   authoritative and Hive preserves the request. For a healthy canonical
+   project, Hive resolves the exact task identity before treating the missing
+   row or an ID/stage-mismatched status row as stale. A current
+   deterministic-failure request remains durable because it is the operator's
+   recovery receipt, not runnable backlog. Already-classified
+   `generation_conflict` and `task_identity_conflict` requests are different:
+   those receipts prove that their bound recovery transition can never resume,
+   so the dispatcher retires them instead of leaving inert operator rows in
+   the queue forever.
+
    `StaleAgentHealer` is the automatic scheduler for those durable errors and
    for `REVIEW_STALE` whose pass-completion receipt is newer than its escalation
    input. A newer escalation is operator input and remains parked.

--- a/wiki/modules/plan_review.md
+++ b/wiki/modules/plan_review.md
@@ -384,6 +384,13 @@ required route from the sanctioned recovery action. Its semantic target binds
 the current terminal attempt IDs, so a later failed attempt can receive a new
 recovery decision while an exact replay remains a no-op.
 
+A projection-checkpoint rollout briefly included Hive's own
+`task-projection.checkpoint.json` write in reviewer custody. The current
+reviewer firewall excludes that orchestrator-owned file. Exact historical
+runner diagnostics for this false positive receive one versioned recovery
+reset for primary, adversarial, or verification; unrelated diagnostics and a
+second failure under the current contract remain terminal.
+
 Under ADR-008's local same-user trust model, direct CLI invocation is the
 operator boundary; Web actions use the authenticated access predicate. An
 agent with unrestricted same-user shell access therefore has CLI authority.

--- a/wiki/state-model.md
+++ b/wiki/state-model.md
@@ -474,7 +474,18 @@ checkpoints while resetting legacy attempt rows. A checkpoint prefix whose
 attempt was accepted before the durable installation activation boundary may
 classify that missing legacy attempt as lost; the prefix must still pass its
 cursor, inode, and anchor checks. The appended suffix is validated against
-SQLite, and strict full replay still rejects every unknown attempt.
+SQLite. Ordinary lifecycle reads prefer this validated checkpoint and bounded
+suffix so retained tasks can resume after cutover. Strict full replay remains
+the fallback when no trusted checkpoint exists and remains mandatory for an
+explicit rebuild. Exact-task repair has one cutover-only compatibility route:
+it may use a retained snapshot binding for an unknown pre-activation attempt,
+but only when the journal itself also contains a pre-activation observation for
+that attempt. Hive then replays the complete journal under the task lock and
+publishes only when the ledger and complete projection match. The comparison ignores only recomputed
+marker overlays, an omitted optional null exit status, and the historical
+per-stage implementation-identity summary; its underlying identity events and
+history must still match. Post-activation unknown attempts, changed journals,
+and every other projection mismatch remain strict failures.
 
 The package manager publishes the candidate normally; Hive never renames
 package-owned launcher entries or retains the previous executable tree.


### PR DESCRIPTION
## Summary

This restores task progress after the all-in SQLite cutover while keeping current attempts fail-closed. Retained tasks can resume from authenticated checkpoints, exact pre-cutover evidence can repair a missing checkpoint, verification-review custody false positives recover once, and stale recovery receipts no longer remain as fake runnable backlog.

## Safety boundaries

- A retained snapshot can supply a missing attempt binding only when the journal independently proves that the attempt predates activation and the complete projection still matches.
- Current SQLite attempt identity always wins. Changed journals, post-activation attempts, and projection mismatches still fail strict replay.
- Recovery cleanup re-resolves exact task identity and preserves requests when project status, a legacy layout, or task resolution is unavailable.
- `deterministic_failure` remains durable operator evidence. Only immutable generation and task-identity conflicts self-retire.

## Operational evidence

- The local repair sweep cleared 116 non-Patrol projection-repair rows; Patrol and Architecture tasks were excluded.
- The live recovery queue exposed 5 inert identity/generation conflicts covered by this cleanup. Its 16 deterministic-failure receipts remain intentional.

## Validation

- Dispatcher: 330 runs, 1,195 assertions
- Projection store: 50 runs, 194 assertions
- Plan-review orchestrator and custody: 52 runs, 337 assertions
- Runtime deletion contract: 5 runs, 159 assertions
- Broad checkpoint: 130 runs, 1,279 assertions, 1 documented skip
- RuboCop, Ruby syntax, and diff checks clean
