### PR TITLE
Fix empty attempt payload finalization

### DIFF
--- a/lib/hive/runtime_control_plane/payload_store.rb
+++ b/lib/hive/runtime_control_plane/payload_store.rb
@@ -196,7 +196,7 @@ module Hive
         File.open(path, flags) do |file|
           before = file.stat
           same_inode!(before, path_status, path)
-          bytes = file.read(size + 1)
+          bytes = file.read(size + 1) || "".b
           after = file.stat
           after_path = File.lstat(path)
           unless same_snapshot?(before, after) && same_snapshot?(before, after_path)

--- a/test/unit/runtime_control_plane/payload_store_test.rb
+++ b/test/unit/runtime_control_plane/payload_store_test.rb
@@ -21,6 +21,22 @@ class RuntimeControlPlanePayloadStoreTest < Minitest::Test
     end
   end
 
+  def test_empty_payload_seals_reuses_and_round_trips
+    with_tmp_dir do |root|
+      subject = store(root)
+      first = subject.write_open(attempt_id: "attempt-1", name: "worker.frames", bytes: "")
+      reference = subject.seal(first)
+
+      assert_equal Digest::SHA256.hexdigest(""), reference.fetch("sha256")
+      assert_equal 0, reference.fetch("size")
+      assert_equal "", subject.read_sealed(reference)
+
+      second = subject.write_open(attempt_id: "attempt-2", name: "worker.frames", bytes: "")
+      assert_equal reference, subject.seal(second)
+      assert_equal "", subject.read_sealed(reference)
+    end
+  end
+
   def test_traversal_symlinks_and_hardlinks_are_rejected
     with_tmp_dir do |root|
       store = store(root)

--- a/wiki/log.d/20260831T235100Z-empty-attempt-payloads.md
+++ b/wiki/log.d/20260831T235100Z-empty-attempt-payloads.md
@@ -1,0 +1,14 @@
+---
+title: Preserve empty payloads during attempt finalization
+tags: [attempts, runtime-control-plane, payload-store, daemon]
+---
+
+Attempt finalization can legitimately seal a zero-byte log or output. Reusing
+the shared empty content address previously asked `IO#read` at EOF for one byte
+and then called `bytesize` on its `nil` result, interrupting the daemon's loss
+healer and leaving final attempts hot.
+
+Sealed-payload verification now normalizes that EOF result to a binary empty
+string before applying the existing size and SHA-256 checks. A regression test
+proves the first empty seal, readback, and a second seal that reuses the same
+content address.

--- a/wiki/modules/attempts.md
+++ b/wiki/modules/attempts.md
@@ -160,7 +160,9 @@ repaired indexes, answer admission queries.
 Finalization seals every receipt log and output through `PayloadStore#seal`
 with the receipt's expected size and SHA-256. `payload_references` stores the
 canonical content address; repeated publication verifies and reuses it, and a
-missing or corrupt sealed object fails closed. Original receipt references
+missing or corrupt sealed object fails closed. Empty logs and outputs are valid
+payloads: their shared empty content address verifies, reuses, and reads back as
+zero bytes without interrupting finalization. Original receipt references
 remain API-stable: repository and correlated-log readers resolve their digest
 to the canonical row. A SQL keyset cursor examines at most 512 retained logs
 per maintenance pass, and expiry removes shared content only after no sealed or


### PR DESCRIPTION
## Summary

- preserve valid zero-byte attempt logs and outputs during sealed-payload verification
- cover first seal, readback, and repeated content-address reuse
- document the empty-payload finalization contract

## Root cause

IO#read returns nil at EOF for an empty sealed object. Reuse verification called bytesize on that nil value, aborting the daemon loss-finalization pass.

## Verification

- payload store: 11 runs, 51 assertions
- finalization maintenance: 18 runs, 96 assertions
- log archive: 10 runs, 75 assertions
- RuboCop: 2 files, no offenses
- copied live-state replay: 23 lost attempts examined, 17 promoted, completed without error
- git diff --check: clean