### PR TITLE
fix(closure): accept task ancestors of merged PR heads

### DIFF
--- a/lib/hive/task_closure.rb
+++ b/lib/hive/task_closure.rb
@@ -871,8 +871,13 @@ module Hive
       return [ blocker("unique_worktree_changes", "owned worktree has uncommitted changes") ] unless status.empty?
 
       head = local_git(path, "rev-parse", "HEAD").strip.downcase
-      verified_heads = Array(delivered_heads).map { |oid| oid.to_s.downcase }
-      return [] if head.match?(FULL_OID_RE) && verified_heads.include?(head)
+      verified_heads = Array(delivered_heads).filter_map do |oid|
+        oid = oid.to_s.downcase
+        oid if oid.match?(FULL_OID_RE)
+      end
+      return [] if head.match?(FULL_OID_RE) && verified_heads.any? do |delivered_head|
+        worktree_head_delivered?(path, head, delivered_head)
+      end
 
       config = Hive::Config.load(task.project_root)
       branch = config["default_branch"].to_s.strip
@@ -895,6 +900,15 @@ module Hive
       unique ? [ blocker("unique_worktree_changes", "owned worktree has unique commits") ] : []
     rescue Hive::Error, KeyError, SystemCallError, IOError => e
       [ blocker("worktree_unverifiable", e.message) ]
+    end
+
+    def worktree_head_delivered?(path, head, delivered_head)
+      return true if head == delivered_head
+
+      _out, _err, status = local_git_capture(
+        path, "merge-base", "--is-ancestor", head, delivered_head
+      )
+      status.success?
     end
 
     def local_git(path, *args)

--- a/test/fixtures/runtime_control_plane/affected_production.yml
+++ b/test/fixtures/runtime_control_plane/affected_production.yml
@@ -7,8 +7,8 @@ counting_rule: physical_source_lines
 includes_new_production_files: true
 maximum_final_lines: 7960
 final_inventory_lines: 9220
-outside_inventory_net_lines: -2717
-final_lines: 6503
+outside_inventory_net_lines: -2703
+final_lines: 6517
 final_paths:
 - path: lib/hive/attempts/capacity_snapshot.rb
   lines: 104

--- a/test/unit/task_closure_test.rb
+++ b/test/unit/task_closure_test.rb
@@ -743,6 +743,32 @@ class TaskClosureTest < Minitest::Test
     end
   end
 
+  def test_owned_worktree_head_ancestor_of_verified_pr_head_allows_closure
+    with_closure_project do |task, project|
+      root = Hive::Worktree.canonical_root(task.project_root)
+      worktree = Hive::Worktree.new(task.project_root, task.slug, worktree_root: root)
+      worktree.create!(task.slug, default_branch: "main")
+      worktree.write_pointer!(task.folder, task.slug)
+
+      File.write(File.join(worktree.path, "task-change.txt"), "task work\n")
+      run!("git", "-C", worktree.path, "add", "task-change.txt")
+      run!("git", "-C", worktree.path, "commit", "-m", "task change", "--quiet")
+      task_head = Hive::GitOps.new(worktree.path).head_sha
+
+      File.write(File.join(worktree.path, "review-fix.txt"), "later PR fix\n")
+      run!("git", "-C", worktree.path, "add", "review-fix.txt")
+      run!("git", "-C", worktree.path, "commit", "-m", "review fix", "--quiet")
+      delivered_head = Hive::GitOps.new(worktree.path).head_sha
+      run!("git", "-C", worktree.path, "reset", "--hard", task_head)
+
+      preview = service_for(gh: FakeGh.new(head_oid: delivered_head)).preview(
+        task: task, project: project, input: input_for("acme/app#42")
+      )
+
+      assert preview.valid?, preview.to_h.inspect
+    end
+  end
+
   def test_public_helpers_and_fallbacks_fail_closed
     with_closure_project do |task, project|
       input = input_for("acme/app#42")

--- a/wiki/commands/stage_action.md
+++ b/wiki/commands/stage_action.md
@@ -51,6 +51,10 @@ Confirmation re-reads every mutable fact before writing `closure.json`.
 
 `already_delivered` requires at least one same-repository merged PR or full
 commit OID that is reachable from the repository default branch.
+An owned worktree may still contain commits after a squash merge: closure
+accepts it when the clean worktree HEAD is exactly the verified merged PR head
+or a local Git ancestor of that head. A different or unverifiable unique HEAD
+continues to block closure.
 `superseded` additionally requires exactly one registered `project:slug`
 successor and a non-empty operator attestation; cross-repository evidence is
 recorded under `operator_attestation` authority. Equal refs, a clean branch,

--- a/wiki/log.d/20260901T095925Z-closure-pr-head-ancestry.md
+++ b/wiki/log.d/20260901T095925Z-closure-pr-head-ancestry.md
@@ -1,0 +1,13 @@
+---
+title: Accept delivered task ancestors during evidence closure
+type: bugfix
+source: lib/hive/task_closure.rb, test/unit/task_closure_test.rb
+created: 2026-09-01
+tags: [closure, worktree, pull-request, squash-merge]
+---
+
+Evidence-bound closure now treats a clean task worktree as delivered when its
+HEAD is an ancestor of the verified same-repository merged PR head. This covers
+review and CI fixes appended to the same PR branch before a squash merge while
+preserving the unique-work blocker for unrelated commits and unavailable
+ancestry evidence.

--- a/wiki/log.d/20260901T095925Z-closure-pr-head-ancestry.md
+++ b/wiki/log.d/20260901T095925Z-closure-pr-head-ancestry.md
@@ -1,7 +1,7 @@
 ---
 title: Accept delivered task ancestors during evidence closure
 type: bugfix
-source: lib/hive/task_closure.rb, test/unit/task_closure_test.rb
+source: lib/hive/task_closure.rb, test/unit/task_closure_test.rb, test/fixtures/runtime_control_plane/affected_production.yml
 created: 2026-09-01
 tags: [closure, worktree, pull-request, squash-merge]
 ---
@@ -10,4 +10,6 @@ Evidence-bound closure now treats a clean task worktree as delivered when its
 HEAD is an ancestor of the verified same-repository merged PR head. This covers
 review and CI fixes appended to the same PR branch before a squash merge while
 preserving the unique-work blocker for unrelated commits and unavailable
-ancestry evidence.
+ancestry evidence. The runtime control-plane deletion inventory now includes
+the 14 production lines added by this validation while remaining comfortably
+below its required shrinkage ceiling.

--- a/wiki/state-model.md
+++ b/wiki/state-model.md
@@ -156,6 +156,12 @@ strictly owned canonical worktree when one exists and otherwise uses the
 controller-observed head in current `pr.md` metadata. For tasks created before
 that field existed, only the owned worktree can supply the binding; an
 arbitrary path, missing worktree, or different HEAD remains unverifiable.
+For operator closure, a clean owned worktree is considered delivered when its
+HEAD either equals a verified same-repository merged PR head or is an ancestor
+of that head. This admits review-fix commits added later on the same PR branch,
+including squash merges where the task commits are not ancestors of the
+default branch; unrelated unique work remains blocked. If the verified PR head
+object is unavailable locally, the ancestry check fails closed.
 That channel is not accepted by the public confirmation API and
 cannot take over an operator receipt. `closure.json` is mode 0600 and is
 written/fsynced before the centralized move to `9-done`; a restart resumes the


### PR DESCRIPTION
## Summary

- Tasks can now close after later review or CI commits land on the same PR branch and the PR is squash-merged; closure no longer mistakes the task's older owned HEAD for undelivered work.
- Unrelated unique commits and unavailable ancestry evidence remain blocked.

## Test plan

- [x] `bundle exec ruby -Itest test/unit/task_closure_test.rb` — 32 runs, 212 assertions
- [x] `bundle exec rubocop lib/hive/task_closure.rb test/unit/task_closure_test.rb`
- [x] `bundle exec ruby -Itest test/unit/runtime_control_plane/deletion_contract_test.rb -n /final_affected_inventory/` — 1 run, 81 assertions
- [x] `bundle exec ruby -Itest test/unit/daemon/dispatcher_test.rb` — 331 runs, 1,201 assertions after merging current `main`
- [x] Live preview against Screenote task 42619 and merged PR `ivankuznetsov/screenote#67` — zero blockers; canceled before mutation
- [x] Hosted CI and exact coverage gates on `dd6bbb2a9c`

## Notes for reviewer

The ancestry proof is local and fail-closed. If the verified PR head object is unavailable, closure retains the existing unique-work blocker.
