### PR TITLE
fix(daemon): prune stale recovery before capacity

### DIFF
--- a/lib/hive/daemon/dispatcher.rb
+++ b/lib/hive/daemon/dispatcher.rb
@@ -2449,7 +2449,7 @@ module Hive
       # row = one would-be `hive run`-class spawn. The daemon is the single
       # dispatcher; the bot is a producer only.
       #
-      # The first three cleanup checks run across every pending request before
+      # The first four cleanup checks run across every pending request before
       # admission arbitration. Capacity fences must not leave an expired or
       # invalid row resident forever. Eligible requests then continue from
       # step 4 in FIFO order:
@@ -2459,19 +2459,21 @@ module Hive
       #      validates) → remove + `:dispatch_request_rejected`.
       #   3. Expiry (10 min default) → remove +
       #      `:dispatch_request_expired`.
-      #   4. Unknown project → remove + `:dispatch_request_rejected`, except a
+      #   4. Immutable recovery conflict → remove +
+      #      `:dispatch_request_rejected reason=stale_task_identity`.
+      #   5. Unknown project → remove + `:dispatch_request_rejected`, except a
       #      healer-owned ERROR retry remains queued because config
       #      may be restored or reloaded later.
-      #   5. Current status-row dependency/admission gate for every
+      #   6. Current status-row dependency/admission gate for every
       #      task-advancing request; marker repair is exempt → leave
       #      the row queued, `:dispatch_request_blocked`.
-      #   6. Per-slug in-flight gate (controller's running_task?) →
+      #   7. Per-slug in-flight gate (controller's running_task?) →
       #      leave the row queued, `:dispatch_request_blocked
       #      reason=in_flight`. Picked up next tick.
-      #   7. Concurrency gate (caps / cooldown / quarantine) → leave
+      #   8. Concurrency gate (caps / cooldown / quarantine) → leave
       #      the row queued, `:dispatch_request_blocked
       #      reason=<gate>`. Picked up next tick.
-      #   8. Spawn via `dispatch_command`, threading `request_id`
+      #   9. Spawn via `dispatch_command`, threading `request_id`
       #      through the supervisor so `reap_completed` can complete the
       #      row and log `:dispatch_request_completed`.
       def process_dispatch_requests(now:, rows:, projects: nil)
@@ -2650,6 +2652,10 @@ module Hive
           elsif dispatch_repository.expired?(request, now: now)
             observe_dispatch_request(request)
             expire_request(request)
+            next
+          elsif classified_stale_recovery_request?(request)
+            observe_dispatch_request(request)
+            reject_request(request, reason: "stale_task_identity")
             next
           end
 
@@ -3109,9 +3115,7 @@ module Hive
       end
 
       def stale_recovery_request?(request, row, project_observation:)
-        return true if STALE_RECOVERY_BLOCK_REASONS.include?(
-          request.recovery["blocked_reason"].to_s
-        )
+        return true if classified_stale_recovery_request?(request)
 
         if row
           identity_changed =
@@ -3127,6 +3131,9 @@ module Hive
 
         exact_recovery_task_stale?(request)
       end
+
+      def classified_stale_recovery_request?(request) =
+        request.recovery.is_a?(Hash) && STALE_RECOVERY_BLOCK_REASONS.include?(request.recovery["blocked_reason"].to_s)
 
       def exact_recovery_task_stale?(request)
         task = Hive::TaskResolver.new(

--- a/test/fixtures/runtime_control_plane/affected_production.yml
+++ b/test/fixtures/runtime_control_plane/affected_production.yml
@@ -7,8 +7,8 @@ counting_rule: physical_source_lines
 includes_new_production_files: true
 maximum_final_lines: 7960
 final_inventory_lines: 9220
-outside_inventory_net_lines: -2717
-final_lines: 6503
+outside_inventory_net_lines: -2710
+final_lines: 6510
 final_paths:
 - path: lib/hive/attempts/capacity_snapshot.rb
   lines: 104

--- a/test/unit/daemon/dispatcher_test.rb
+++ b/test/unit/daemon/dispatcher_test.rb
@@ -8131,6 +8131,53 @@ end
     end
   end
 
+  def test_dispatcher_removes_stale_recovery_conflict_behind_project_capacity_fence
+    Dir.mktmpdir("hive-dispatch-queue") do |state_home|
+      coordinator = FakeRecoveryCoordinator.new(status: "queued")
+      dispatcher, sup, controller, logger, = make_dispatcher(
+        rows: [
+          row(id: 42, slug: "current", stage: "4-review", action: "blocked"),
+          row(id: 43, slug: "stale", stage: "4-review", action: "blocked")
+        ],
+        dispatch_request_state_home: state_home,
+        recovery_coordinator: coordinator
+      )
+      controller.define_singleton_method(:can_dispatch?) { |**| :daily_cap }
+      Q.write_request!(
+        project: "p1", slug: "current", argv: %w[hive run current --json],
+        requestor: "healer", request_id: "CAP-FENCE", task_id: 42,
+        expected_stage: "4-review", task_generation: "current-generation",
+        recovery: dispatcher_recovery(phase: "cleared"),
+        state_home: state_home, now: T0
+      )
+      Q.write_request!(
+        project: "p1", slug: "stale", argv: %w[hive run stale --json],
+        requestor: "healer", request_id: "STALE-BEHIND-FENCE", task_id: 43,
+        expected_stage: "4-review", task_generation: "stale-generation",
+        recovery: dispatcher_recovery(phase: "cleared").merge(
+          "owner" => "operator", "blocked_reason" => "generation_conflict"
+        ),
+        state_home: state_home, now: T0 + 1
+      )
+      stub_find_project!(dispatcher, "p1")
+      begin
+        dispatcher.tick(now: T0 + 2)
+      ensure
+        restore_find_project!
+      end
+
+      assert_equal [ "CAP-FENCE" ], Q.pending(state_home: state_home).map(&:request_id)
+      rejected = logger.events.find do |name, attrs|
+        name == :dispatch_request_rejected &&
+          attrs[:request_id] == "STALE-BEHIND-FENCE"
+      end
+      refute_nil rejected
+      assert_equal "stale_task_identity", rejected.last.fetch(:reason)
+      assert_equal [ "CAP-FENCE" ], coordinator.resumes.map { |entry| entry[:request].request_id }
+      assert_empty sup.spawned
+    end
+  end
+
   def test_dispatcher_removes_a_recovery_request_after_the_task_is_archived
     Dir.mktmpdir("hive-dispatch-queue") do |state_home|
       coordinator = FakeRecoveryCoordinator.new(status: "blocked")

--- a/wiki/log.d/20260901T095704Z-retire-stale-recovery-before-capacity.md
+++ b/wiki/log.d/20260901T095704Z-retire-stale-recovery-before-capacity.md
@@ -1,0 +1,15 @@
+---
+title: Retire stale recovery before capacity arbitration
+module: daemon
+problem_type: bug_fix
+tags: [dispatch, recovery, capacity, sqlite]
+---
+
+Already-classified `generation_conflict` and `task_identity_conflict` recovery
+requests are now retired in the queue cleanup pass. Project and global capacity
+fences apply only to runnable work, so an exhausted daily cap can no longer
+leave immutable stale recovery receipts resident behind an older request.
+
+The current-task identity checks that depend on a fresh status observation
+remain in normal admission. Only conflicts already proven immutable by the
+recovery coordinator bypass capacity arbitration.

--- a/wiki/modules/daemon.md
+++ b/wiki/modules/daemon.md
@@ -642,8 +642,9 @@ advances a workflow stage directly:
    recovery receipt, not runnable backlog. Already-classified
    `generation_conflict` and `task_identity_conflict` requests are different:
    those receipts prove that their bound recovery transition can never resume,
-   so the dispatcher retires them instead of leaving inert operator rows in
-   the queue forever.
+   so the dispatcher's capacity-independent cleanup pass retires them before
+   project or global admission fences can leave inert operator rows in the
+   queue forever.
 
    `StaleAgentHealer` is the automatic scheduler for those durable errors and
    for `REVIEW_STALE` whose pass-completion receipt is newer than its escalation


### PR DESCRIPTION
## Summary

Immutable recovery conflicts no longer remain queued when an older request exhausts a project or global capacity fence. Hive now retires already-classified conflicts during capacity-independent queue cleanup, while identity checks that require a fresh task observation remain in normal admission.

## Validation

- Full dispatcher suite: 331 runs, 1,201 assertions, 0 failures.
- Runtime-control-plane deletion contract: 5 runs, 159 assertions, 0 failures.
- Wiki log validation: 7 runs, 27 assertions, 0 failures.
- RuboCop: 2 files inspected, 0 offenses.
- Dogfood diagnosis reproduced two `generation_conflict` rows retained behind Hive's exhausted daily cap.

## Related

Related: #1384
