### PR TITLE
fix(web): preserve current task state and fold kanban clutter

### DIFF
--- a/lib/hive/operational_status.rb
+++ b/lib/hive/operational_status.rb
@@ -582,7 +582,7 @@ module Hive
     end
 
     def material_scheduler_disposition?(disposition)
-      !%w[not_evaluated skip project_disabled].include?(disposition["decision"])
+      !%w[not_evaluated skip project_disabled attempt_terminal_replay].include?(disposition["decision"])
     end
 
     def classify_scheduler_disposition(disposition)
@@ -597,8 +597,6 @@ module Hive
         [ "waiting_on_provider_or_scheduler", "scheduler" ]
       when "retry_in_flight"
         [ "running", "agent" ]
-      when "attempt_terminal_replay"
-        [ "idle", "none" ]
       when "retry_safety_blocked"
         [ "needs_repair", disposition["owner"] || "operator" ]
       when "semantic_terminal_error"

--- a/test/fixtures/runtime_control_plane/affected_production.yml
+++ b/test/fixtures/runtime_control_plane/affected_production.yml
@@ -7,8 +7,8 @@ counting_rule: physical_source_lines
 includes_new_production_files: true
 maximum_final_lines: 7960
 final_inventory_lines: 8260
-outside_inventory_net_lines: -7832
-final_lines: 428
+outside_inventory_net_lines: -7834
+final_lines: 426
 final_paths:
 - path: lib/hive/attempts/capacity_snapshot.rb
   lines: 96

--- a/test/unit/operational_status_test.rb
+++ b/test/unit/operational_status_test.rb
@@ -970,6 +970,30 @@ class OperationalStatusTest < Minitest::Test
     end
   end
 
+  def test_terminal_recovery_history_preserves_current_workflow_state_and_reason
+    rows = [ "Escalated (parked)", "Rejected (parked)" ].map.with_index do |label, index|
+      task(action: "needs_input", slug: "writero-parked-#{index}", stage: "4-review", marker: "none").merge(
+        "workflow" => "patrol-fix", "action_label" => label, "suggested_command" => nil
+      )
+    end
+    rows << task(action: "needs_input", slug: "question", stage: "2-brainstorm",
+                 marker: "waiting", unanswered_questions: 2)
+    rows.each do |row|
+      expected = project(status_payload(row)).fetch("tasks").first
+      snapshot = scheduler_snapshot_for(row, decision: "attempt_terminal_replay", reason: "terminal")
+      snapshot.dig("tasks", 0, "disposition")["recovery"] = {
+        "status" => "terminal", "phase" => "terminal", "request_id" => "old-request",
+        "attempt_id" => "old-attempt", "terminal_outcome" => "succeeded"
+      }
+      actual = project(status_payload(row), project_context: { "demo" => { "daemon_enabled" => true } },
+                       scheduler_snapshot: snapshot).fetch("tasks").first
+      %w[state blocker_owner reason].each { |key| assert_equal expected[key], actual[key], "#{row['slug']}: #{key}" }
+      assert_equal expected.fetch("reasons").first.fetch("code"), actual.fetch("reasons").first.fetch("code")
+      assert_equal "terminal", actual.dig("recovery", "status")
+      assert_equal "succeeded", actual.dig("recovery", "terminal_outcome")
+    end
+  end
+
   def test_recovery_projection_derives_running_terminal_and_provider_hint_without_a_receipt
     row = task(
       action: "error", slug: "derived-recovery", stage: "4-execute",

--- a/web/app/assets/stylesheets/application.css
+++ b/web/app/assets/stylesheets/application.css
@@ -378,9 +378,7 @@ label { font-size: 0.9rem; color: var(--ink-muted); display: block; margin-botto
 .kanban-workflow { color: var(--ink-faint); font-size: 0.82rem; overflow-wrap: anywhere; }
 .kanban-band-warning { margin: 0 0 12px; }
 .kanban-columns {
-  display: grid;
-  grid-auto-flow: column;
-  grid-auto-columns: minmax(270px, 1fr);
+  display: flex;
   gap: 12px;
   max-width: 100%;
   overflow-x: auto;
@@ -389,6 +387,8 @@ label { font-size: 0.9rem; color: var(--ink-muted); display: block; margin-botto
   overscroll-behavior-inline: contain;
 }
 .kanban-column {
+  flex: 1 0 270px;
+  min-width: 270px;
   display: flex;
   flex-direction: column;
   min-height: 170px;
@@ -1411,7 +1411,7 @@ pre {
   .task-row { grid-template-columns: 1fr; gap: 8px; }
   .status-view-toolbar { align-items: start; }
   .kanban-band-header { align-items: start; }
-  .kanban-columns { grid-auto-columns: minmax(78vw, 290px); }
+  .kanban-column { flex-basis: min(78vw, 290px); min-width: min(78vw, 290px); }
   .task-meta { flex-wrap: wrap; white-space: normal; }
   .workflow-row { grid-template-columns: 1fr; }
   .workflow-actions { justify-content: flex-start; }

--- a/web/app/assets/stylesheets/kanban_folding.css
+++ b/web/app/assets/stylesheets/kanban_folding.css
@@ -1,0 +1,13 @@
+.kanban-column-header h3 { width: 100%; }
+.kanban-column-toggle { display: flex; align-items: center; gap: 10px; width: 100%; padding: 0; border: 0; background: transparent; color: inherit; font: inherit; text-align: left; cursor: pointer; }
+.kanban-column-toggle:hover { background: transparent; color: var(--accent); }
+.kanban-column-toggle:focus-visible { outline: 2px solid var(--accent); outline-offset: 4px; }
+.kanban-column-label { flex: 1; }
+.kanban-fold-icon { font-size: 1.3rem; line-height: 1; }
+.kanban-cards[hidden] { display: none; }
+.kanban-column.is-folded { flex: 0 0 52px; min-width: 52px; padding: 12px 8px; }
+.kanban-column.is-folded .kanban-column-header { margin: 0; }
+.kanban-column.is-folded .kanban-column-toggle { flex-direction: column; min-height: 145px; gap: 16px; }
+.kanban-column.is-folded .kanban-count { order: -1; }
+.kanban-column.is-folded .kanban-column-label { writing-mode: vertical-rl; white-space: nowrap; flex: 0; }
+.kanban-column.is-folded .kanban-fold-icon { transform: rotate(180deg); }

--- a/web/app/javascript/controllers/kanban_column_controller.js
+++ b/web/app/javascript/controllers/kanban_column_controller.js
@@ -1,0 +1,32 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["toggle", "cards"]
+  static values = { defaultFolded: Boolean, label: String }
+
+  connect() { this.restore() }
+  defaultFoldedValueChanged() { this.restore() }
+
+  restore(event) {
+    if (event && event.target !== this.element) return
+    if (!this.hasToggleTarget || !this.hasCardsTarget) return
+    let choice = null
+    try { choice = localStorage.getItem(this.storageKey) } catch { /* Storage can be disabled. */ }
+    this.render(choice === null ? this.defaultFoldedValue : choice === "true")
+  }
+
+  toggle() {
+    const folded = !this.element.classList.contains("is-folded")
+    try { localStorage.setItem(this.storageKey, String(folded)) } catch { /* Folding still works. */ }
+    this.render(folded)
+  }
+
+  render(folded) {
+    this.element.classList.toggle("is-folded", folded)
+    this.cardsTarget.hidden = folded
+    this.toggleTarget.setAttribute("aria-expanded", String(!folded))
+    this.toggleTarget.setAttribute("aria-label", `${folded ? "Expand" : "Fold"} ${this.labelValue} column`)
+  }
+
+  get storageKey() { return `hive:kanban-fold:${this.element.id}` }
+}

--- a/web/app/models/board.rb
+++ b/web/app/models/board.rb
@@ -3,7 +3,9 @@ require "hive/stage_label"
 class Board
   DEFAULT_WORKFLOW = Hive::Config::DEFAULTS.fetch("default_workflow")
 
-  Column = Data.define(:stage, :label, :tasks)
+  Column = Data.define(:stage, :label, :tasks, :terminal) do
+    def folded_by_default? = tasks.empty? || terminal
+  end
 
   Band = Data.define(
     :project, :workflow_id, :columns, :daemon_enabled, :error,
@@ -68,12 +70,13 @@ class Board
     configured_dirs = configured_stages.map(&:dir)
 
     columns = configured_stages.map do |stage|
-      Column.new(stage: stage.dir, label: Hive::StageLabel.format(stage.name), tasks: tasks_by_stage.fetch(stage.dir, []))
+      Column.new(stage: stage.dir, label: Hive::StageLabel.format(stage.name), tasks: tasks_by_stage.fetch(stage.dir, []),
+                 terminal: stage == configured_stages.last)
     end
     (tasks_by_stage.keys - configured_dirs).sort_by { |stage| stage_sort_key(stage) }.each do |stage|
-      columns << Column.new(stage:, label: Hive::StageLabel.format(stage), tasks: tasks_by_stage.fetch(stage))
+      columns << Column.new(stage:, label: Hive::StageLabel.format(stage), tasks: tasks_by_stage.fetch(stage), terminal: false)
     end
-    columns.presence || [ Column.new(stage: "unavailable", label: "Workflow unavailable", tasks:) ]
+    columns.presence || [ Column.new(stage: "unavailable", label: "Workflow unavailable", tasks:, terminal: false) ]
   end
 
   def workflows_for(project, workflow_ids)

--- a/web/app/views/status/_board.html.erb
+++ b/web/app/views/status/_board.html.erb
@@ -35,13 +35,25 @@
           <% band.columns.each do |column| %>
             <% column_id = stable_dom_id("kanban-column", band.project.name, band.workflow_id, column.stage) %>
             <% heading_id = "#{column_id}-heading" %>
-            <section id="<%= column_id %>" class="kanban-column" data-stage="<%= column.stage %>" aria-labelledby="<%= heading_id %>">
+            <section id="<%= column_id %>" class="kanban-column <%= "is-folded" if column.folded_by_default? %>"
+                     data-stage="<%= column.stage %>" aria-labelledby="<%= heading_id %>"
+                     data-controller="kanban-column" data-action="turbo:morph-element->kanban-column#restore"
+                     data-kanban-column-default-folded-value="<%= column.folded_by_default? %>"
+                     data-kanban-column-label-value="<%= column.label %>">
               <header class="kanban-column-header">
-                <h3 id="<%= heading_id %>"><%= column.label %></h3>
-                <span class="kanban-count" aria-label="<%= pluralize(column.tasks.size, "task") %>"><%= column.tasks.size %></span>
+                <h3 id="<%= heading_id %>">
+                  <button type="button" class="kanban-column-toggle" data-kanban-column-target="toggle"
+                          data-action="kanban-column#toggle" aria-controls="<%= column_id %>-cards"
+                          aria-expanded="<%= !column.folded_by_default? %>"
+                          aria-label="<%= column.folded_by_default? ? "Expand" : "Fold" %> <%= column.label %> column">
+                    <span class="kanban-column-label"><%= column.label %></span>
+                    <span class="kanban-count" aria-label="<%= pluralize(column.tasks.size, "task") %>"><%= column.tasks.size %></span>
+                    <span class="kanban-fold-icon" aria-hidden="true">‹</span>
+                  </button>
+                </h3>
               </header>
 
-              <div class="kanban-cards">
+              <div id="<%= column_id %>-cards" class="kanban-cards" data-kanban-column-target="cards" <%= "hidden" if column.folded_by_default? %>>
                 <% if column.tasks.empty? %>
                   <p class="kanban-empty">No tasks</p>
                 <% else %>

--- a/web/test/models/board_test.rb
+++ b/web/test/models/board_test.rb
@@ -63,6 +63,7 @@ class BoardTest < ActiveSupport::TestCase
 
     assert_equal "99-future", band.columns.last.stage
     assert_equal [ "future-task" ], band.columns.last.tasks.map(&:slug)
+    refute band.columns.last.folded_by_default?
   end
 
   test "renders an empty project through its configured default workflow" do
@@ -167,6 +168,9 @@ class BoardTest < ActiveSupport::TestCase
     assert_nil empty_band.error
     assert_equal [ "custom-task" ], task_band.columns.fetch(1).tasks.map(&:slug)
     assert_nil task_band.error
+    refute task_band.columns.fetch(1).folded_by_default?
+    assert task_band.columns.last.terminal
+    assert task_band.columns.last.folded_by_default?
   ensure
     Hive::Workflows::Project.reset!
   end

--- a/web/test/system/kanban_board_test.rb
+++ b/web/test/system/kanban_board_test.rb
@@ -68,6 +68,43 @@ class KanbanBoardTest < ApplicationSystemTestCase
     assert_selector "#status-board .kanban-card", text: slug
   end
 
+  test "columns fold empty and done stages by default and retain operator choices" do
+    project = create_hive_project!("kanban-fold-app")
+    create_task!(project, "Active card")
+    done = create_task!(project, "Completed card")
+    FileUtils.mv(stage_dir(project, "1-inbox").join(done), stage_dir(project, "9-done").join(done))
+    stage_dir(project, "9-done").join(done, "task.md").write("<!-- COMPLETE -->\n")
+    sign_in!
+
+    band = ".kanban-band[data-project-name='#{project}']"
+    assert_selector "#{band} [data-stage='1-inbox']:not(.is-folded) .kanban-card", text: "Active card"
+    assert_selector "#{band} [data-stage='3-plan'].is-folded"
+    assert_selector "#{band} [data-stage='9-done'].is-folded"
+    assert_no_selector "#{band} [data-stage='9-done'] .kanban-card"
+    within("#{band} [data-stage='9-done']") do
+      assert_selector "button[aria-expanded='false']"
+      find_button("Expand Done column").send_keys(:enter)
+      assert_selector "button[aria-expanded='true'][aria-label='Fold Done column']"
+    end
+    assert_selector "#{band} [data-stage='9-done'] .kanban-card", text: "Completed card"
+    find("#{band} [data-stage='1-inbox'] button.kanban-column-toggle").click
+    assert_no_selector "#{band} [data-stage='1-inbox'] .kanban-card"
+
+    # A pushed update must update counts and keep the operator's fold choices.
+    create_task!(project, "New incoming card")
+    assert_selector "#{band} [data-stage='1-inbox'] .kanban-count", text: "2", wait: 10
+    assert_selector "#{band} [data-stage='1-inbox'].is-folded"
+    assert_selector "#{band} [data-stage='9-done']:not(.is-folded)"
+    visit board_path(project: project)
+    assert_selector "#{band} [data-stage='1-inbox'].is-folded"
+    assert_selector "#{band} [data-stage='9-done']:not(.is-folded) .kanban-card"
+
+    # An untouched empty column opens when a live task arrives.
+    new_slug = create_task!(project, "New brainstorm card")
+    FileUtils.mv(stage_dir(project, "1-inbox").join(new_slug), stage_dir(project, "2-brainstorm").join(new_slug))
+    assert_selector "#{band} [data-stage='2-brainstorm']:not(.is-folded) .kanban-card", text: "New brainstorm card", wait: 10
+  end
+
   test "board remains contained at a mobile viewport" do
     project = create_hive_project!("kanban-#{"unbroken" * 8}")
     create_task!(project, "A deliberately long kanban task title that must stay inside the mobile viewport")
@@ -181,6 +218,9 @@ class KanbanBoardTest < ApplicationSystemTestCase
     disable_daemon!(focused_project)
     sign_in!
 
+    within(".kanban-band[data-project-name='#{focused_project}']") do
+      all(".kanban-column.is-folded .kanban-column-toggle").each(&:click)
+    end
     focused_card = find(".kanban-card[data-task-slug='#{focused_slug}']")
     focused_card.find_button("Run brainstorm")
     expected_action = evaluate_script(<<~JS)

--- a/wiki/commands/status.md
+++ b/wiki/commands/status.md
@@ -658,3 +658,12 @@ task/commit locks and committed before the clock can hide a row.
 
 - [[cli]] · [[commands/run]] · [[commands/approve]] · [[commands/watch]]
 - [[modules/markers]] · [[modules/task]] · [[modules/task_action]] · [[modules/task_dependencies]] · [[modules/config]] · [[modules/plan_review]]
+
+## Historical terminal recovery
+
+The operational projection retains terminal recovery receipts for diagnostics,
+but `attempt_terminal_replay` does not override the current task state, blocker
+owner, or reason. For example, a Patrol fix now parked in review keeps its
+`Escalated (parked)` reason instead of becoming idle with reason `terminal`
+because an earlier recovery succeeded. Active recovery dispositions still
+participate in scheduling classification.

--- a/wiki/commands/web.md
+++ b/wiki/commands/web.md
@@ -257,7 +257,11 @@ Honeycomb projections.
   rail grows to a bounded desktop width while the status content receives all
   remaining space. Kanban tracks grow beyond their comfortable minimum when a
   large screen has room, and each band scrolls horizontally inside the page
-  when it does not. `Grid` retains the compact per-project task rows and gains
+  when it does not. Each column heading is a keyboard-accessible fold toggle.
+  Empty columns and the workflow's final Done column start folded, with the
+  count and vertical stage label still visible. Explicit choices persist in
+  browser local storage per project/workflow/stage across reloads and live
+  morphs. An untouched empty column opens when a task arrives. `Grid` retains the compact per-project task rows and gains
   the same fluid content area. Both ordinary views consume status's
   workflow-aware archive projection:
   expired archived rows are absent, and a positive project count renders

--- a/wiki/log.d/2026-09-05-writero-state-kanban-folding.md
+++ b/wiki/log.d/2026-09-05-writero-state-kanban-folding.md
@@ -1,0 +1,5 @@
+# Writero state and Kanban folding
+
+- Keep terminal recovery history from overriding current operational state and reason.
+- Add accessible per-column folding to the web board: empty and final columns fold by default; explicit browser choices survive live updates and reloads.
+- Documented in `commands/status.md` and `commands/web.md`.


### PR DESCRIPTION
## Summary

Hive keeps current task states visible and makes room for occupied Kanban stages. Writero's parked review tasks no longer become idle with reason `terminal` after an earlier recovery; empty and Done columns fold by default, with names and counts still visible.

Column headings let users expand or fold any stage. Explicit choices survive live updates and reloads; an untouched empty column opens when a task arrives.

Related: Screenote project 16, annotation 106 and its Done-column reply. Related: #1397 (the separate task-card clarity changes).

## Test plan

- [x] 103 operational status and daemon snapshot tests: current parked/input state survives terminal recovery history, and recovery evidence remains available.
- [x] 52 board model, status integration, and browser tests: default folding, explicit choices, live task arrival, reload, focus, scroll, and responsive layout. Additional Enter-key/ARIA check passed (17 assertions).
- [x] Ruby lint for the core and Rails app.
- [x] Real Writero desktop/mobile browser captures, including expanded Done; no page overflow.
- [ ] Hosted CI coverage and dedicated merge gates.

## Notes for reviewer

The recovery change affects status projection only. Saved fold choices require browser local storage; if it is unavailable, folding works but may reset on refresh. Screenshots come from the candidate worktree using the existing local task data; this PR does not deploy the candidate. The board partial also changes in #1397 and may need reconciliation if that PR lands first.

## Screenshots

[Writero Kanban: six desktop/mobile images, snapshot 30](https://screenote.ai/projects/16?snapshot_id=30)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
