### PR TITLE
fix(web): keep open kanban columns a fixed width

### DIFF
--- a/web/app/assets/stylesheets/application.css
+++ b/web/app/assets/stylesheets/application.css
@@ -387,7 +387,7 @@ label { font-size: 0.9rem; color: var(--ink-muted); display: block; margin-botto
   overscroll-behavior-inline: contain;
 }
 .kanban-column {
-  flex: 1 0 270px;
+  flex: 0 0 270px;
   min-width: 270px;
   display: flex;
   flex-direction: column;

--- a/web/test/system/kanban_board_test.rb
+++ b/web/test/system/kanban_board_test.rb
@@ -162,8 +162,16 @@ class KanbanBoardTest < ApplicationSystemTestCase
                     "navigation and page content should share the full-width shell"
     assert_operator metrics.fetch("statusMainWidth"), :>, 3_400,
                     "the project rail must leave the rest of a large screen to task content"
-    assert_operator metrics.fetch("columnWidth"), :>, 310,
-                    "kanban columns should grow after their comfortable minimum instead of staying capped"
+    assert_in_delta 270, metrics.fetch("columnWidth"), 1,
+                    "open columns must keep a fixed width on large screens"
+    within(".kanban-band[data-project-name='#{project}']") do
+      click_button "Expand Plan column"
+      widths = all(".kanban-column:not(.is-folded)").map { |column| column.evaluate_script("this.getBoundingClientRect().width") }
+      assert_equal 2, widths.size
+      widths.each { |width| assert_in_delta 270, width, 1 }
+      click_button "Fold Plan column"
+      assert_in_delta 270, find(".kanban-column:not(.is-folded)").evaluate_script("this.getBoundingClientRect().width"), 1
+    end
   end
 
   test "project filter survives a view switch" do

--- a/wiki/commands/web.md
+++ b/wiki/commands/web.md
@@ -255,9 +255,10 @@ Honeycomb projections.
   through the existing task controllers. The application shell and primary
   navigation use the full viewport width with fluid edge gutters; the project
   rail grows to a bounded desktop width while the status content receives all
-  remaining space. Kanban tracks grow beyond their comfortable minimum when a
-  large screen has room, and each band scrolls horizontally inside the page
-  when it does not. Each column heading is a keyboard-accessible fold toggle.
+  remaining space. Open Kanban columns keep a fixed 270px desktop width; unused space
+  stays empty instead of stretching cards when neighboring columns fold.
+  Mobile columns use `min(78vw, 290px)`, and each band scrolls horizontally
+  inside the page when it does not fit. Each column heading is a keyboard-accessible fold toggle.
   Empty columns and the workflow's final Done column start folded, with the
   count and vertical stage label still visible. Explicit choices persist in
   browser local storage per project/workflow/stage across reloads and live

--- a/wiki/log.d/2026-09-05-fixed-kanban-column-width.md
+++ b/wiki/log.d/2026-09-05-fixed-kanban-column-width.md
@@ -1,0 +1,3 @@
+# Fixed Kanban column width
+
+Open board columns retain a fixed width instead of expanding into space freed by folded columns. Desktop uses 270px; the existing mobile width and horizontal scrolling remain. See `commands/web.md`.


### PR DESCRIPTION
## Summary

Open Kanban columns now stay the same width instead of stretching to fill the screen when neighboring columns fold. Desktop columns remain 270px wide, with the existing responsive mobile sizing.

Related: #1399. [Screenshot feedback](https://seyarabata.com/t/6121016c4c08).

## Test plan

- [x] Desktop and mobile browser tests: 2 tests, 25 assertions; expanding and folding another column preserves open-column widths.
- [x] Ruby lint for the changed browser test.
- [x] Real Hive architecture and Writero boards at desktop/mobile sizes: fixed widths and no page overflow.

## Notes for reviewer

This changes only flex growth; folded columns and task behavior keep their existing rules.

## Screenshots

[Four desktop/mobile captures](https://screenote.ai/projects/16?snapshot_id=32)
