### PR TITLE
fix(patrol): archive rejected and handed-off findings

### DIFF
--- a/lib/hive/commands/approve.rb
+++ b/lib/hive/commands/approve.rb
@@ -272,6 +272,13 @@ module Hive
 
       def resolve_destination(task)
         return resolve_explicit_to(task, @to) if @to
+        if task.workflow.controller?
+          projection = Hive::PatrolFix::Projection.new(
+            task_folder: task.folder, stage: "#{task.stage_index}-#{task.stage_name}"
+          ).to_h
+          return task.workflow.stages.last.dir if
+            Hive::PatrolFix::Projection::TERMINAL_OUTCOMES.include?(projection.dig("outcome", "kind"))
+        end
 
         task.workflow.next_stage_after(task.stage_name)&.dir ||
           raise(Hive::FinalStageReached.new(

--- a/lib/hive/patrol_fix/projection.rb
+++ b/lib/hive/patrol_fix/projection.rb
@@ -12,6 +12,7 @@ module Hive
       MAX_DIAGNOSTIC_BYTES = 512
       STAGE_DIRS = %w[1-inbox 2-fix 3-validate 4-review 5-publish 6-done].freeze # not-a-stage-ref: Patrol Fix workflow stages
       PARKED_ROUTES = %w[reject blocked escalate].freeze
+      TERMINAL_OUTCOMES = %w[rejected escalated].freeze
 
       attr_reader :task_folder, :stage
 
@@ -49,10 +50,12 @@ module Hive
         outcome = parked_outcome(decision)
         done = stage == "6-done" # not-a-stage-ref: Patrol Fix workflow stage
         closure = done && publication.nil? && valid_evidence_closure?
-        missing_terminal_authority = done && publication.nil? && !closure
+        terminal_outcome = outcome && (outcome["kind"] == "rejected" ||
+          (outcome["kind"] == "escalated" && manifest.dig("relations", "successor")))
+        missing_terminal_authority = done && publication.nil? && !closure && !terminal_outcome
         state = missing_terminal_authority ? "invalid" : "current"
         diagnostic = if missing_terminal_authority
-          { "summary" => "Patrol-fix done requires an exact current pull-request receipt or valid evidence-closure receipt." }
+          { "summary" => "Patrol-fix done requires an exact current pull-request receipt, rejection, linked escalation, or valid evidence-closure receipt." }
         elsif !closure
           publication_diagnostic
         end
@@ -95,7 +98,8 @@ module Hive
       def current_decision(receipts)
         relevant_stage = stage_name
         decisions = receipts.select do |receipt|
-          receipt["stage"] == relevant_stage && %w[decision reopen].include?(receipt["kind"])
+          (relevant_stage == "done" || receipt["stage"] == relevant_stage) &&
+            %w[decision reopen].include?(receipt["kind"])
         end
         decisions.reduce(nil) do |current, receipt|
           if receipt["kind"] == "decision"
@@ -144,7 +148,7 @@ module Hive
             parked_seconds += elapsed_seconds(opened, receipt.fetch("recorded_at")) if opened
           end
         end
-        if current_decision && PARKED_ROUTES.include?(current_decision.dig("payload", "route"))
+        if stage_name != "done" && current_decision && PARKED_ROUTES.include?(current_decision.dig("payload", "route"))
           parked_since = current_decision.fetch("recorded_at")
         end
         {
@@ -176,6 +180,7 @@ module Hive
       def action_for(state:, done:, outcome:, decision:, fix:, validation:, publication:)
         return action("invalid", runnable: false) if state == "invalid"
         return action("done", runnable: false) if done
+        return action("advance", runnable: true) if TERMINAL_OUTCOMES.include?(outcome&.fetch("kind"))
         return action("parked", runnable: false) if outcome
         ready = case stage
         when "1-inbox" then decision&.dig("payload", "route") == "fix" # not-a-stage-ref: Patrol Fix workflow stage

--- a/lib/hive/patrol_fix/stage_transition.rb
+++ b/lib/hive/patrol_fix/stage_transition.rb
@@ -42,6 +42,19 @@ module Hive
                evidence_closure_to_terminal?(destination)
           raise InvalidTransition, "patrol-fix transition requires a current terminal stage receipt"
         end
+        outcome = projection.dig("outcome", "kind")
+        if Projection::TERMINAL_OUTCOMES.include?(outcome)
+          unless destination == @task.workflow.stages.last.dir
+            raise InvalidTransition, "rejected and escalated Patrol-fix tasks must move to archive"
+          end
+          if outcome == "escalated"
+            require "hive/patrol_fix/successor_materializer"
+            decision = ReceiptStore.new(task_folder: @task.folder).read_all.find do |receipt|
+              receipt["receipt_id"] == projection.dig("outcome", "receipt_id")
+            end
+            SuccessorMaterializer.new(@task).call(decision)
+          end
+        end
         pending = pending_record
         values = identity.merge("event" => "intent", "from" => "#{@task.stage_index}-#{@task.stage_name}", "to" => destination)
         if pending

--- a/lib/hive/task_action.rb
+++ b/lib/hive/task_action.rb
@@ -428,16 +428,17 @@ module Hive
 
     def patrol_fix_action
       return ACTIONS.fetch(:error) if patrol_fix["state"] == "invalid"
-      return ACTIONS.fetch(:done) if patrol_fix["archived"] == true
-
-      case patrol_fix.dig("outcome", "kind")
-      when "rejected" then ACTIONS.fetch(:patrol_fix_rejected)
-      when "blocked" then ACTIONS.fetch(:patrol_fix_blocked)
-      when "escalated" then ACTIONS.fetch(:patrol_fix_escalated)
-      else
-        return ACTIONS.fetch(:ready_to_advance) if patrol_fix.dig("action", "kind") == "advance"
-        ACTIONS.fetch(:generic_ready_to_run)
+      outcome = patrol_fix.dig("outcome", "kind")
+      if patrol_fix["archived"] == true
+        return ACTIONS.fetch(:done).merge(label: outcome.capitalize) if
+          Hive::PatrolFix::Projection::TERMINAL_OUTCOMES.include?(outcome)
+        return ACTIONS.fetch(:done)
       end
+      return ACTIONS.fetch(:ready_to_advance) if patrol_fix.dig("action", "kind") == "advance"
+
+      return ACTIONS.fetch(:patrol_fix_blocked) if outcome == "blocked"
+
+      ACTIONS.fetch(:generic_ready_to_run)
     end
 
     def universal_action

--- a/test/fixtures/runtime_control_plane/affected_production.yml
+++ b/test/fixtures/runtime_control_plane/affected_production.yml
@@ -7,8 +7,8 @@ counting_rule: physical_source_lines
 includes_new_production_files: true
 maximum_final_lines: 7960
 final_inventory_lines: 8260
-outside_inventory_net_lines: -7834
-final_lines: 426
+outside_inventory_net_lines: -7808
+final_lines: 452
 final_paths:
 - path: lib/hive/attempts/capacity_snapshot.rb
   lines: 96

--- a/test/integration/patrol_fix_lifecycle_test.rb
+++ b/test/integration/patrol_fix_lifecycle_test.rb
@@ -77,7 +77,7 @@ class PatrolFixLifecycleIntegrationTest < Minitest::Test
     end
   end
 
-  def test_both_sources_converge_rework_and_publish_while_escalation_stays_parked
+  def test_both_sources_converge_rework_publish_and_archive_handed_off_escalation
     with_tmp_global_config do
       with_tmp_git_repo do |project|
         capture_io { Hive::Commands::Init.new(project, agent_skill_preflight: false).call }
@@ -178,6 +178,15 @@ class PatrolFixLifecycleIntegrationTest < Minitest::Test
         assert_equal 1, Dir.glob(File.join(hive_state, "stages", "*", successor_slug)).size
         assert_equal "1-inbox", File.basename(File.dirname(escalation_task.folder))
         refute File.exist?(File.join(escalation_task.folder, "pr.md"))
+        original_folder = escalation_task.folder
+        capture_io { Hive::Commands::Approve.new(original_folder, quiet: true).call }
+        refute File.exist?(original_folder)
+        archived_folder = File.join(hive_state, "stages", "6-done", escalation_task.slug)
+        archived = Hive::PatrolFix::Projection.new(task_folder: archived_folder, stage: "6-done").to_h
+        assert archived.fetch("archived")
+        assert_equal "escalated", archived.dig("outcome", "kind")
+        assert_equal successor_slug, archived.dig("successor", "slug")
+        assert_equal 1, Dir.glob(File.join(hive_state, "stages", "*", successor_slug)).size
       end
     end
   end

--- a/test/unit/patrol_fix/projection_test.rb
+++ b/test/unit/patrol_fix/projection_test.rb
@@ -5,7 +5,7 @@ require "pathname"
 require "hive/patrol_fix/projection"
 
 class PatrolFixProjectionTest < Minitest::Test
-  def test_rejected_inbox_is_parked_and_non_runnable
+  def test_rejected_inbox_is_ready_to_archive
     with_task do |dir, manifest, receipts|
       receipts.append!(decision_receipt(route: "reject", stage: "inbox"))
 
@@ -14,11 +14,40 @@ class PatrolFixProjectionTest < Minitest::Test
       assert_equal "current", projected.fetch("state")
       assert_equal "rejected", projected.dig("outcome", "kind")
       assert_equal "inbox_gate", projected.fetch("blocker_owner")
-      assert_equal "parked", projected.dig("action", "kind")
-      refute projected.dig("action", "runnable")
+      assert_equal "advance", projected.dig("action", "kind")
+      assert projected.dig("action", "runnable")
       assert JSONSchemer.schema(
         Pathname.new(Hive::Schemas.schema_path("hive-patrol-fix-projection"))
       ).valid?(projected)
+    end
+  end
+
+  def test_archived_rejection_retains_its_outcome_without_publication
+    %w[inbox review].each do |stage|
+      with_task do |dir, _manifest, receipts|
+        receipts.append!(decision_receipt(route: "reject", stage: stage))
+        projected = Hive::PatrolFix::Projection.new(task_folder: dir, stage: "6-done").to_h
+        assert projected.fetch("archived")
+        assert_equal "rejected", projected.dig("outcome", "kind")
+        assert_nil projected.fetch("publication")
+        assert_nil projected.dig("timing", "parked_since")
+      end
+    end
+  end
+
+  def test_archived_escalation_requires_a_successor
+    [ nil, { "project" => "demo", "slug" => "coding-successor-260820-abcd" } ].each do |successor|
+      with_task(successor: successor) do |dir, _manifest, receipts|
+        receipts.append!(decision_receipt(route: "escalate", stage: "inbox"))
+        projected = Hive::PatrolFix::Projection.new(task_folder: dir, stage: "6-done").to_h
+        assert_equal !successor.nil?, projected.fetch("archived")
+        assert_equal "escalated", projected.dig("outcome", "kind")
+        unless successor
+          assert_equal "invalid", projected.fetch("state")
+          refute projected.dig("action", "runnable")
+          assert_includes projected.dig("diagnostic", "summary"), "linked escalation"
+        end
+      end
     end
   end
 

--- a/test/unit/patrol_fix/stage_transition_test.rb
+++ b/test/unit/patrol_fix/stage_transition_test.rb
@@ -5,6 +5,82 @@ require "hive/task_closure"
 require_relative "../stages/patrol_fix/fix_test"
 
 class PatrolFixStageTransitionTest < Minitest::Test
+  def test_rejected_task_moves_directly_to_archive_and_keeps_rejected_status
+    PatrolFixStageFixture.with_task(stage: "1-inbox") do |task, _root, manifest|
+      Hive::PatrolFix::ReceiptStore.new(task_folder: task.folder).append!(
+        PatrolFixStageFixture.decision_receipt(manifest, "reject")
+      )
+      assert_raises(Hive::PatrolFix::StageTransition::InvalidTransition) do
+        Hive::PatrolFix::StageTransition.new(task).begin!("2-fix")
+      end
+      approve_without_enrollment(task)
+      destination = File.join(task.hive_state_path, "stages", "6-done", task.slug)
+      refute File.exist?(task.folder)
+      assert File.directory?(destination)
+      action = Hive::TaskAction.for(Hive::Task.new(destination), Hive::Markers.current(File.join(destination, "state.md")))
+      assert_equal "archived", action.key
+      assert_equal "Rejected", action.label
+      assert_equal "rejected", action.patrol_fix.dig("outcome", "kind")
+    end
+  end
+
+  def test_failed_escalation_handoff_does_not_archive_and_retries_without_an_agent
+    PatrolFixStageFixture.with_task(stage: "1-inbox") do |task, _root, manifest|
+      Hive::PatrolFix::ReceiptStore.new(task_folder: task.folder).append!(
+        PatrolFixStageFixture.decision_receipt(manifest, "escalate")
+      )
+      require "hive/patrol_fix/successor_materializer"
+      failing = Object.new
+      failing.define_singleton_method(:call) { |_| raise Hive::PatrolFix::SuccessorMaterializer::InvalidSuccessor, "handoff failed" }
+      original = Hive::PatrolFix::SuccessorMaterializer.method(:new)
+      Hive::PatrolFix::SuccessorMaterializer.define_singleton_method(:new) { |*| failing }
+      begin
+        assert_raises(Hive::PatrolFix::SuccessorMaterializer::InvalidSuccessor) do
+          Hive::Commands::Approve.new(task.folder, quiet: true).call
+        end
+      ensure
+        Hive::PatrolFix::SuccessorMaterializer.define_singleton_method(:new, original)
+      end
+      assert File.directory?(task.folder)
+      destination = File.join(task.hive_state_path, "stages", "6-done", task.slug)
+      refute File.exist?(destination)
+
+      approve_without_enrollment(task)
+      refute File.exist?(task.folder)
+      action = Hive::TaskAction.for(Hive::Task.new(destination), Hive::Markers.current(File.join(destination, "state.md")))
+      assert_equal "archived", action.key
+      assert_equal "Escalated", action.label
+      successor = action.patrol_fix.fetch("successor")
+      assert_equal 1, Dir.glob(File.join(task.hive_state_path, "stages", "*", successor.fetch("slug"))).length
+    end
+  end
+
+  def approve_without_enrollment(task)
+    original = Hive::DependencySnapshot.method(:enforce_admission!)
+    Hive::DependencySnapshot.define_singleton_method(:enforce_admission!) { |*| true }
+    Hive::Commands::Approve.new(task.folder, quiet: true).call
+  ensure
+    Hive::DependencySnapshot.define_singleton_method(:enforce_admission!, original)
+  end
+
+  def test_crash_after_handoff_before_archive_intent_reuses_the_successor
+    PatrolFixStageFixture.with_task(stage: "1-inbox") do |task, _root, manifest|
+      Hive::PatrolFix::ReceiptStore.new(task_folder: task.folder).append!(
+        PatrolFixStageFixture.decision_receipt(manifest, "escalate")
+      )
+      transition = Hive::PatrolFix::StageTransition.new(task)
+      transition.define_singleton_method(:append) { |_| raise "crash before intent" }
+      assert_raises(RuntimeError) { transition.begin!("6-done") }
+      successor = Hive::PatrolFix::TaskManifest.new(task_folder: task.folder).read.dig("relations", "successor")
+      assert File.directory?(task.folder)
+      approve_without_enrollment(task)
+      refute File.exist?(task.folder)
+      destination = File.join(task.hive_state_path, "stages", "6-done", task.slug)
+      assert Hive::PatrolFix::Projection.new(task_folder: destination, stage: "6-done").to_h.fetch("archived")
+      assert_equal 1, Dir.glob(File.join(task.hive_state_path, "stages", "*", successor.fetch("slug"))).length
+    end
+  end
+
   def test_evidence_closure_authorizes_only_the_workflow_terminal_move
     PatrolFixStageFixture.with_task(stage: "1-inbox") do |task, _root, _manifest|
       File.write(File.join(task.folder, "closure.json"), "{}")
@@ -65,13 +141,7 @@ class PatrolFixStageTransitionTest < Minitest::Test
       Hive::PatrolFix::ReceiptStore.new(task_folder: task.folder).append!(
         PatrolFixStageFixture.decision_receipt(manifest, "fix")
       )
-      original = Hive::DependencySnapshot.method(:enforce_admission!)
-      Hive::DependencySnapshot.define_singleton_method(:enforce_admission!) { |*| true }
-      begin
-        Hive::Commands::Approve.new(task.folder, quiet: true).call
-      ensure
-        Hive::DependencySnapshot.define_singleton_method(:enforce_admission!, original)
-      end
+      approve_without_enrollment(task)
 
       destination = File.join(task.hive_state_path, "stages", "2-fix", task.slug)
       assert File.directory?(destination)

--- a/test/unit/patrol_fix/task_action_test.rb
+++ b/test/unit/patrol_fix/task_action_test.rb
@@ -18,17 +18,16 @@ class PatrolFixTaskActionTest < Minitest::Test
   SLUG = "repair-login-260820-abcd"
   Marker = Hive::Markers::State
 
-  def test_rejected_and_blocked_outcomes_are_visible_non_runnable_and_never_dispatch
+  def test_rejection_advances_to_archive_while_blocked_remains_parked
     with_task("inbox") do |task, receipts|
       receipts.append!(decision_receipt(route: "reject", stage: "inbox"))
 
       action = Hive::TaskAction.for(task, marker)
 
-      assert_equal Hive::Schemas::TaskActionKind::PATROL_FIX_REJECTED, action.key
-      assert_equal "Rejected (parked)", action.label
-      assert_nil action.command
+      assert_equal Hive::Schemas::TaskActionKind::READY_TO_ADVANCE, action.key
+      assert_includes action.command, "hive approve"
       assert_equal "rejected", action.patrol_fix.dig("outcome", "kind")
-      assert_equal :skip, policy_decision(action)
+      assert_equal :dispatch, policy_decision(action)
     end
 
     with_task("review") do |task, receipts|
@@ -43,17 +42,17 @@ class PatrolFixTaskActionTest < Minitest::Test
     end
   end
 
-  def test_escalation_exposes_the_successor_without_archiving_the_origin
+  def test_escalation_dispatches_the_archive_transition
     with_task("inbox", successor: { "project" => "demo", "slug" => "coding-successor-260820-abcd" }) do |task, receipts|
       receipts.append!(decision_receipt(route: "escalate", stage: "inbox"))
 
       action = Hive::TaskAction.for(task, marker)
 
-      assert_equal Hive::Schemas::TaskActionKind::PATROL_FIX_ESCALATED, action.key
+      assert_equal Hive::Schemas::TaskActionKind::READY_TO_ADVANCE, action.key
       assert_equal({ "project" => "demo", "slug" => "coding-successor-260820-abcd" },
                    action.patrol_fix.fetch("successor"))
       refute action.patrol_fix.fetch("archived")
-      assert_equal :skip, policy_decision(action)
+      assert_equal :dispatch, policy_decision(action)
     end
   end
 

--- a/wiki/log.d/20260905-archive-patrol-terminal-outcomes.md
+++ b/wiki/log.d/20260905-archive-patrol-terminal-outcomes.md
@@ -1,0 +1,11 @@
+# Archive rejected and handed-off Patrol Fix tasks
+
+Rejected findings advance directly to the workflow archive, retaining their
+rejected outcome. Escalations complete the existing idempotent coding-task
+handoff before the same archive move, retaining their successor link and
+escalated outcome. Failed handoffs leave the original active and retryable.
+Blocked findings remain parked. Existing terminal decisions use the normal
+scheduler advance path; no new cleanup service or stored lifecycle state.
+
+Validation: projection, task-action/policy, and real archive-transition tests,
+including handoff failure and retry without a new agent decision.

--- a/wiki/state-model.md
+++ b/wiki/state-model.md
@@ -606,13 +606,20 @@ its referenced Fix receipt as the progress baseline. An unchanged diff and
 unchanged validation-command plan cannot produce a new Fix receipt, while a
 patch change or validation-plan correction can. A completed route intent remains
 replayable so a crash after the folder move is reconciled from either the old
-caller path or the new location. Parked outcomes expose no custom operational
+caller path or the new location. Blocked outcomes expose no custom operational
 action; they remain visible through the standard `needs_input` task contract.
 
-`reject`, `blocked`, and `escalate` are parked non-terminal outcomes. Escalation
+`blocked` remains parked and non-terminal. `reject` and `escalate` dispatch the
+normal receipt-gated `approve` transition directly to `6-done`, retaining
+`rejected` or `escalated` as the archived outcome rather than implying publication.
+Existing parked rejections and escalations become eligible on the next status
+scan; no fresh agent decision or separate cleanup queue is needed. Escalation
 uses a stable source fingerprint to capture one ordinary coding task and stores
 reciprocal controller-owned relations on both tasks. A crash after capture but
-before either link is repaired reuses the same successor. No issue record or
+before either link is repaired reuses the same successor. Before archiving, the
+transition completes that idempotent handoff for the exact current decision;
+handoff failure leaves the origin active for retry. Only the successor remains
+active after the move. No issue record or
 GitHub mutation is part of this state machine.
 
 Publish is a deterministic stage after an exact current Review `publish`
@@ -638,8 +645,10 @@ branch advancement does not rewrite the immutable creation-base commit.
 
 The stage writes `pr.md` and one strict canonical publication receipt before
 `StageTransition` may move the task from `5-publish` to `6-done`. Done projects
-as current and archived only when that receipt matches the current task and
-evidence generation. Worktree cleanup follows receipt durability; failure is a
+as current and archived when that receipt matches the current task and
+evidence generation, or an exact current rejection, linked escalation, or valid
+evidence closure authorizes terminal entry. Worktree cleanup follows publication
+receipt durability; failure is a
 bounded diagnostic and cannot revoke completion. Publication performs no LLM,
 issue, edit, close, ready, or merge operation.
 


### PR DESCRIPTION
## Summary

Rejected and handed-off Patrol Fix findings leave the active queue instead of remaining parked indefinitely. Archive preserves the rejected or escalated outcome; only the coding successor remains active after escalation.

## Test plan

- [x] 46 focused tests, 380 assertions: projection, scheduler actions, real archive moves, handoff failure and crash retry, lifecycle integration, and refreshed inventory check.
- [x] Broad local run: 13,971 tests, no behavioral failures; its sole exact-line-count failure is corrected and covered by the focused rerun.
- [x] RuboCop clean on all touched Ruby files.
- [x] Local review completed with no actionable findings; no external-model review.
- [ ] Hosted coverage and dedicated merge gates.
- [ ] Dogfood: compare the recorded 120 rejected and 42 escalated active findings with post-deploy native status and archived task identities.

## Notes for reviewer

Uses the existing receipt-gated approve transition and idempotent successor handoff. The successor is durably linked before the predecessor can move; interruption retains retryable work. Blocked findings are unchanged. The existing line-count gate remains intact with refreshed expected counts.

## Post-Deploy Monitoring & Validation

Owner: this deployment session. Over the first scheduler ticks, compare native operational status against the 162 recorded terminal Patrol identities. Confirm archived outcomes and successor links with native task reads, not disappearance alone. Watch for handoff errors, duplicate successors, or active terminal rows that fail to advance. If these occur, stop further cleanup and diagnose the named task before changing runtime state again.
