### PR TITLE
Harden StatusChannel Action Cable stream lifecycle ownership

### DIFF
--- a/test/fixtures/runtime_control_plane/affected_production.yml
+++ b/test/fixtures/runtime_control_plane/affected_production.yml
@@ -7,8 +7,8 @@ counting_rule: physical_source_lines
 includes_new_production_files: true
 maximum_final_lines: 7960
 final_inventory_lines: 8464
-outside_inventory_net_lines: -8148
-final_lines: 316
+outside_inventory_net_lines: -8142
+final_lines: 322
 final_paths:
 - path: lib/hive/betterleaks.rb
   lines: 26

--- a/web/app/channels/status_channel.rb
+++ b/web/app/channels/status_channel.rb
@@ -1,7 +1,36 @@
+require "monitor"
+
 class StatusChannel < Turbo::StreamsChannel
+  StatusStreamAttempt = Struct.new(
+    :broadcasting,
+    :handler,
+    :state,
+    :confirmation_pending,
+    :cleanup_claimed,
+    keyword_init: true
+  )
+
+  class StatusStreamHandler
+    attr_reader :attempt
+
+    def initialize(attempt, handler)
+      @attempt = attempt
+      @handler = handler
+    end
+
+    def call(message)
+      @handler.call(message)
+    end
+  end
+
+  private_constant :StatusStreamAttempt, :StatusStreamHandler
+
   def initialize(...)
     super
-    @status_subscription_mutex = Mutex.new
+    @status_subscription_mutex = Monitor.new
+    @status_stream_attempts = {}
+    @status_cancelled_confirmation_count = 0
+    @status_stream_reconnect_requested = false
   end
 
   # The browser calls this only after Action Cable confirms the stream, so no
@@ -24,36 +53,68 @@ class StatusChannel < Turbo::StreamsChannel
     )
   end
 
-  # Action Cable defers adapter registration to its stream executor. A socket
-  # can disappear before that work runs; the framework's first unsubscribe then
-  # precedes the late subscribe and cannot remove it. Fence both sides of the
-  # adapter call, and remove a registration that completes after teardown.
+  # These three overrides are one narrow ownership boundary. Rails 8.1 records
+  # a handler before deferred adapter registration, so its stop methods cannot
+  # distinguish queued work from a real subscription. Keep pending attempts out
+  # of Rails' stream registry until registration succeeds; see the dependency
+  # handoff gate in wiki/dependencies.md before removing this fence.
   def stream_from(broadcasting, callback = nil, coder: nil, &block)
-    return if unsubscribed?
-
     broadcasting = String(broadcasting)
-    defer_subscription_confirmation!
-    handler = worker_pool_stream_handler(broadcasting, callback || block, coder: coder)
-    streams[broadcasting] = handler
+    attempt = nil
+
+    @status_subscription_mutex.synchronize do
+      return if unsubscribed?
+
+      defer_subscription_confirmation!
+      attempt = StatusStreamAttempt.new(
+        broadcasting: broadcasting,
+        state: :queued,
+        confirmation_pending: true,
+        cleanup_claimed: false
+      )
+      worker_handler = status_worker_stream_handler(attempt, callback || block, coder: coder)
+      attempt.handler = StatusStreamHandler.new(attempt, worker_handler)
+
+      if previous = @status_stream_attempts[broadcasting]
+        cancel_pending_status_stream_locked(previous)
+      end
+      @status_stream_attempts[broadcasting] = attempt
+    end
 
     connection.server.event_loop.post do
-      next if unsubscribed?
-
-      begin
-        pubsub.subscribe(broadcasting, handler, lambda do
-          if unsubscribed?
-            # Some adapters invoke this callback while holding their subscriber
-            # mutex. Leave that call before re-entering the adapter for cleanup.
-            connection.server.event_loop.post { pubsub.unsubscribe(broadcasting, handler) }
-          else
-            ensure_confirmation_sent
-            logger.info "#{self.class.name} is streaming from #{broadcasting}"
-          end
-        end)
-      rescue StandardError => e
-        fail_status_stream!(e)
-      end
+      register_status_stream(attempt)
     end
+  end
+
+  def stop_stream_from(broadcasting)
+    broadcasting = String(broadcasting)
+    handler = nil
+
+    @status_subscription_mutex.synchronize do
+      if attempt = @status_stream_attempts.delete(broadcasting)
+        cancel_pending_status_stream_locked(attempt)
+      end
+      handler = streams.delete(broadcasting)
+      close_registered_status_stream_locked(handler) if handler
+    end
+
+    unsubscribe_registered_status_stream(broadcasting, handler) if handler
+  end
+
+  def stop_all_streams
+    handlers = nil
+
+    @status_subscription_mutex.synchronize do
+      @status_stream_attempts.each_value do |attempt|
+        cancel_pending_status_stream_locked(attempt)
+      end
+      @status_stream_attempts.clear
+      handlers = streams.to_a
+      streams.clear
+      handlers.each { |_broadcasting, handler| close_registered_status_stream_locked(handler) }
+    end
+
+    handlers.each { |broadcasting, handler| unsubscribe_registered_status_stream(broadcasting, handler) }
   end
 
   private
@@ -105,9 +166,203 @@ class StatusChannel < Turbo::StreamsChannel
     end
   end
 
-  def fail_status_stream!(error)
-    release_status_subscription!
+  def status_worker_stream_handler(attempt, user_handler, coder:)
+    if user_handler
+      guarded_handler = lambda do |message|
+        user_handler.call(message) if status_stream_deliverable?(attempt)
+      end
+      worker_pool_stream_handler(attempt.broadcasting, guarded_handler, coder: coder)
+    else
+      guarded_transmitter = lambda do |message|
+        if status_stream_deliverable?(attempt)
+          transmit message, via: "streamed from #{attempt.broadcasting}"
+        end
+      end
+      worker_pool_stream_handler(
+        attempt.broadcasting,
+        guarded_transmitter,
+        coder: coder || ActiveSupport::JSON
+      )
+    end
+  end
+
+  def register_status_stream(attempt)
+    should_register = @status_subscription_mutex.synchronize do
+      current = @status_stream_attempts[attempt.broadcasting]
+      if current.equal?(attempt) && attempt.state == :queued && !unsubscribed?
+        attempt.state = :registering
+        true
+      else
+        false
+      end
+    end
+    return unless should_register
+
+    pubsub.subscribe(attempt.broadcasting, attempt.handler, lambda do
+      complete_status_stream_registration(attempt)
+    rescue StandardError => e
+      schedule_status_stream_failure(attempt, e)
+    end)
+  rescue StandardError => e
+    schedule_status_stream_failure(attempt, e)
+  end
+
+  def complete_status_stream_registration(attempt)
+    cleanup = false
+    registered = false
+    replaced_handler = nil
+
+    @status_subscription_mutex.synchronize do
+      current = @status_stream_attempts[attempt.broadcasting]
+      if current.equal?(attempt) && attempt.state == :registering && !unsubscribed?
+        @status_stream_attempts.delete(attempt.broadcasting)
+        replaced_handler = streams[attempt.broadcasting]
+        streams[attempt.broadcasting] = attempt.handler
+        attempt.state = :registered
+        registered = true
+        if attempt.confirmation_pending
+          attempt.confirmation_pending = false
+          confirmations_to_resolve = @status_cancelled_confirmation_count + 1
+          @status_cancelled_confirmation_count = 0
+          confirmations_to_resolve.times { ensure_confirmation_sent }
+        end
+      else
+        @status_stream_attempts.delete(attempt.broadcasting) if current.equal?(attempt)
+        cleanup = claim_late_status_stream_cleanup_locked(attempt)
+      end
+    end
+
+    schedule_registered_status_stream_unsubscribe(attempt.broadcasting, replaced_handler) if replaced_handler
+    if cleanup
+      schedule_registered_status_stream_unsubscribe(attempt.broadcasting, attempt.handler)
+    elsif registered
+      logger.info "#{self.class.name} is streaming from #{attempt.broadcasting}"
+    end
+  rescue StandardError => e
+    schedule_status_stream_failure(attempt, e)
+  end
+
+  def cancel_pending_status_stream_locked(attempt)
+    return unless [ :queued, :registering ].include?(attempt.state)
+
+    attempt.state = :cancelled
+    if attempt.confirmation_pending
+      attempt.confirmation_pending = false
+      @status_cancelled_confirmation_count += 1 unless unsubscribed?
+    end
+  end
+
+  def claim_late_status_stream_cleanup_locked(attempt)
+    return false if attempt.cleanup_claimed || attempt.state == :failed
+
+    attempt.cleanup_claimed = true
+    attempt.confirmation_pending = false
+    attempt.state = :closing
+    true
+  end
+
+  def close_registered_status_stream_locked(handler)
+    attempt = handler.respond_to?(:attempt) ? handler.attempt : nil
+    return unless attempt
+
+    attempt.confirmation_pending = false
+    attempt.cleanup_claimed = true
+    attempt.state = :closed
+  end
+
+  def status_stream_deliverable?(attempt)
+    @status_subscription_mutex.synchronize do
+      attempt.state == :registered &&
+        !unsubscribed? &&
+        streams[attempt.broadcasting].equal?(attempt.handler)
+    end
+  end
+
+  def unsubscribe_registered_status_stream(broadcasting, handler)
+    pubsub.unsubscribe(broadcasting, handler)
+    logger.info "#{self.class.name} stopped streaming from #{broadcasting}"
+  end
+
+  def schedule_registered_status_stream_unsubscribe(broadcasting, handler)
+    return unless handler
+
+    connection.server.event_loop.post do
+      begin
+        unsubscribe_registered_status_stream(broadcasting, handler)
+      ensure
+        @status_subscription_mutex.synchronize do
+          close_registered_status_stream_locked(handler)
+        end
+      end
+    end
+  end
+
+  def schedule_status_stream_failure(attempt, error)
+    connection.server.event_loop.post { fail_status_stream!(attempt, error) }
+  end
+
+  def fail_status_stream!(attempt, error)
+    handlers = []
+    release_lease = false
+    reconnect = false
+
+    @status_subscription_mutex.synchronize do
+      relevant = @status_stream_attempts[attempt.broadcasting].equal?(attempt) ||
+        streams[attempt.broadcasting].equal?(attempt.handler)
+      return unless relevant
+
+      @status_stream_attempts.each_value do |pending_attempt|
+        pending_attempt.state = pending_attempt.equal?(attempt) ? :failed : :cancelled
+        pending_attempt.confirmation_pending = false
+      end
+      @status_stream_attempts.clear
+      @status_cancelled_confirmation_count = 0
+
+      handlers = streams.to_a
+      streams.clear
+      handlers.each do |_broadcasting, handler|
+        registered_attempt = handler.respond_to?(:attempt) ? handler.attempt : nil
+        next unless registered_attempt
+
+        registered_attempt.cleanup_claimed = true
+        registered_attempt.confirmation_pending = false
+        registered_attempt.state = :closing
+      end
+
+      release_lease = @status_subscription_state == :active
+      @status_subscription_state = :closed
+      unless unsubscribed? || @status_stream_reconnect_requested
+        @status_stream_reconnect_requested = true
+        reconnect = true
+      end
+    end
+
+    handlers.each do |broadcasting, handler|
+      begin
+        unsubscribe_registered_status_stream(broadcasting, handler)
+      rescue StandardError => unsubscribe_error
+        Rails.logger.error(
+          "status channel stream cleanup failed " \
+          "(#{unsubscribe_error.class}: #{unsubscribe_error.message})"
+        )
+      ensure
+        @status_subscription_mutex.synchronize { close_registered_status_stream_locked(handler) }
+      end
+    end
+    if release_lease
+      begin
+        StatusBroadcaster.subscriber_disconnected!
+      rescue StandardError => lease_error
+        Rails.logger.error(
+          "status channel lease cleanup failed " \
+          "(#{lease_error.class}: #{lease_error.message})"
+        )
+      end
+    end
+
     Rails.logger.error("status channel stream registration failed (#{error.class}: #{error.message}); reconnecting")
+    return unless reconnect
+
     connection.close(
       reason: ActionCable::INTERNAL[:disconnect_reasons][:server_restart],
       reconnect: true

--- a/web/config/database.yml
+++ b/web/config/database.yml
@@ -18,8 +18,14 @@ development:
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  <<: *default
-  database: storage/test.sqlite3
+  primary:
+    <<: *default
+    database: storage/test.sqlite3
+  cable:
+    <<: *default
+    database: ":memory:"
+    migrations_paths: db/cable_migrate
+    schema_dump: false
 
 # SQLite3 write its data on the local filesystem, as such it requires
 # persistent disks. If you are deploying to a managed service, you should

--- a/web/test/channels/status_channel_solid_cable_test.rb
+++ b/web/test/channels/status_channel_solid_cable_test.rb
@@ -1,0 +1,91 @@
+require "test_helper"
+require "active_record/tasks/database_tasks"
+require "support/status_channel_stream_lifecycle_contract"
+
+class StatusChannelSolidCableTest < ActiveSupport::TestCase
+  include ActionCableStreamLifecycleContract
+  self.use_transactional_tests = false
+
+  setup do
+    @solid_cable_directory = Dir.mktmpdir("hive-status-channel-solid-cable")
+    @solid_cable_database = File.join(@solid_cable_directory, "cable.sqlite3")
+    template = ActiveRecord::Base.configurations.configs_for(env_name: "test", name: "cable")
+    configuration = template.configuration_hash.merge(database: @solid_cable_database)
+    @solid_cable_config = ActiveRecord::DatabaseConfigurations::HashConfig.new(
+      "test",
+      "cable",
+      configuration
+    )
+    @solid_cable_listener_threads = solid_cable_listener_threads
+
+    SolidCable::Record.establish_connection(@solid_cable_config)
+    pool = SolidCable::Record.connection_pool
+    pool.with_connection do |connection|
+      migration_verbose = ActiveRecord::Migration.verbose
+      ActiveRecord::Migration.verbose = false
+      begin
+        with_replaced_singleton_method(
+          ActiveRecord::Tasks::DatabaseTasks,
+          :migration_connection_pool,
+          -> { pool }
+        ) do
+          with_replaced_singleton_method(
+            ActiveRecord::Tasks::DatabaseTasks,
+            :migration_connection,
+            -> { connection }
+          ) do
+            load Rails.root.join("db/cable_schema.rb")
+          end
+        end
+      ensure
+        ActiveRecord::Migration.verbose = migration_verbose
+      end
+    end
+  end
+
+  teardown do
+    begin
+      if SolidCable::Record.connected? && SolidCable::Message.table_exists?
+        SolidCable::Message.delete_all
+        assert_equal 0, SolidCable::Message.count
+      end
+    ensure
+      begin
+        SolidCable::Record.connection_pool.disconnect! if SolidCable::Record.connected?
+      ensure
+        begin
+          SolidCable::Record.remove_connection
+        ensure
+          FileUtils.remove_entry(@solid_cable_directory) if File.exist?(@solid_cable_directory)
+        end
+      end
+    end
+
+    leaked_threads = solid_cable_listener_threads - @solid_cable_listener_threads
+    assert_empty leaked_threads, "Solid Cable listener threads must be joined after every contract case"
+  end
+
+  private
+
+  def stream_lifecycle_channel_class
+    StatusChannel
+  end
+
+  def build_stream_lifecycle_environment
+    assert_equal @solid_cable_database, SolidCable::Record.connection_db_config.database
+    assert SolidCable::Message.table_exists?, "isolated Solid Cable schema must be loaded before the contract"
+    super
+  end
+
+  def stream_lifecycle_adapter_name
+    "solid_cable"
+  end
+
+  def stream_lifecycle_pending_entries(channel)
+    channel.instance_variable_get(:@status_stream_attempts).to_a
+  end
+
+  def solid_cable_listener_threads
+    Thread.list.select { |thread| thread.alive? && thread.name == "solid_cable_listener" }
+  end
+end

--- a/web/test/channels/status_channel_test.rb
+++ b/web/test/channels/status_channel_test.rb
@@ -111,6 +111,10 @@ class StatusChannelAsyncStreamLifecycleTest < ActiveSupport::TestCase
   def stream_lifecycle_adapter_name
     "async"
   end
+
+  def stream_lifecycle_pending_entries(channel)
+    channel.instance_variable_get(:@status_stream_attempts).to_a
+  end
 end
 
 class StatusChannelTest < ActionCable::Channel::TestCase
@@ -271,6 +275,9 @@ class StatusChannelTest < ActionCable::Channel::TestCase
     assert_predicate fenced, :unsubscribed?
     assert_empty fenced_fixture.registrations
     assert_empty fenced_fixture.confirmations
+    assert_empty fenced_fixture.raw_unsubscribes,
+                 "queued cancellation must not issue an ineffective adapter unsubscribe"
+    assert_empty pending_stream_attempts(fenced)
   end
 
   test "the application fence removes registration completed after teardown" do
@@ -287,11 +294,138 @@ class StatusChannelTest < ActionCable::Channel::TestCase
     assert_predicate fenced, :unsubscribed?
     assert_empty fenced_fixture.registrations
     assert_empty fenced_fixture.confirmations
+    assert_equal 1, fenced_fixture.raw_unsubscribes.length,
+                 "a handler that registered after teardown must have one cleanup owner"
+    assert_empty pending_stream_attempts(fenced)
+  end
+
+  test "targeted stop cancels queued work without raw unsubscribe" do
+    fixture = ControlledStreamLifecycleFixture.new
+    channel = StatusChannel.new(fixture.connection, "targeted-queued", {})
+    channel.stream_from("targeted-queued")
+    channel.send(:ensure_confirmation_sent)
+
+    channel.stop_stream_from("targeted-queued")
+    channel.stop_stream_from("targeted-queued")
+    fixture.run_next_posted
+
+    assert_empty fixture.registrations
+    assert_empty fixture.raw_unsubscribes
+    assert_empty channel.send(:streams)
+    assert_empty pending_stream_attempts(channel)
+  end
+
+  test "targeted stop during registration waits to unsubscribe the real handler once" do
+    fixture = ControlledStreamLifecycleFixture.new(pause_subscribe: true)
+    channel = StatusChannel.new(fixture.connection, "targeted-registering", {})
+    channel.stream_from("targeted-registering")
+    channel.send(:ensure_confirmation_sent)
+    worker = Thread.new { fixture.run_next_posted }
+    fixture.await_subscribe
+
+    channel.stop_stream_from("targeted-registering")
+    channel.stop_stream_from("targeted-registering")
+    assert_empty fixture.raw_unsubscribes
+
+    fixture.release_subscribe
+    worker.value
+    fixture.drain_posted
+
+    assert_empty fixture.registrations
+    assert_equal 1, fixture.raw_unsubscribes.length
+    assert_empty fixture.confirmations
+    assert_empty channel.send(:streams)
+    assert_empty pending_stream_attempts(channel)
+  ensure
+    fixture&.release_subscribe if worker&.alive?
+    worker&.join(1)
+  end
+
+  test "global stop cancels every queued attempt without raw unsubscribe" do
+    fixture = ControlledStreamLifecycleFixture.new
+    channel = StatusChannel.new(fixture.connection, "global-queued", {})
+    channel.stream_from("global-one")
+    channel.stream_from("global-two")
+    channel.send(:ensure_confirmation_sent)
+
+    channel.stop_all_streams
+    channel.stop_all_streams
+    2.times { fixture.run_next_posted }
+
+    assert_empty fixture.registrations
+    assert_empty fixture.raw_unsubscribes
+    assert_empty channel.send(:streams)
+    assert_empty pending_stream_attempts(channel)
+  end
+
+  test "a later registered stream resolves confirmation after targeted pending cancellation" do
+    fixture = ControlledStreamLifecycleFixture.new
+    channel = StatusChannel.new(fixture.connection, "targeted-recovery", {})
+    channel.stream_from("cancelled-stream")
+    channel.send(:ensure_confirmation_sent)
+    channel.stop_stream_from("cancelled-stream")
+    channel.stream_from("replacement-stream")
+
+    2.times { fixture.run_next_posted }
+
+    assert_equal [ "replacement-stream" ], fixture.registrations.map(&:first)
+    assert_empty fixture.raw_unsubscribes
+    assert_equal 1, fixture.confirmations.length
+    assert_equal [ "replacement-stream" ], channel.send(:streams).keys
+    assert_empty pending_stream_attempts(channel)
+  ensure
+    channel&.unsubscribe_from_channel
+  end
+
+  test "targeted stop winning an adapter failure suppresses reconnect" do
+    posted = Queue.new
+    entered_subscribe = Queue.new
+    release_subscribe = Queue.new
+    raw_unsubscribes = []
+    close_calls = []
+    confirmations = []
+    event_loop = Object.new
+    event_loop.define_singleton_method(:post) { |task = nil, &block| posted << (task || block) }
+    pubsub = Object.new
+    pubsub.define_singleton_method(:subscribe) do |*_args|
+      entered_subscribe << true
+      release_subscribe.pop
+      raise ActiveRecord::ConnectionNotEstablished, "adapter stopped with the stream"
+    end
+    pubsub.define_singleton_method(:unsubscribe) { |*args| raw_unsubscribes << args }
+    server = Struct.new(:event_loop).new(event_loop)
+    connection = Object.new
+    connection.define_singleton_method(:server) { server }
+    connection.define_singleton_method(:pubsub) { pubsub }
+    connection.define_singleton_method(:identifiers) { [] }
+    connection.define_singleton_method(:logger) { Rails.logger }
+    connection.define_singleton_method(:close) { |**options| close_calls << options }
+    connection.define_singleton_method(:transmit) { |frame| confirmations << frame }
+    channel = StatusChannel.new(connection, "stopped-failure", {})
+    channel.stream_from("stopped-failure")
+    channel.send(:ensure_confirmation_sent)
+    worker = Thread.new { Timeout.timeout(5) { posted.pop.call } }
+    Timeout.timeout(5) { entered_subscribe.pop }
+
+    channel.stop_stream_from("stopped-failure")
+    release_subscribe << true
+    worker.value
+    Timeout.timeout(5) { posted.pop.call }
+
+    assert_empty raw_unsubscribes
+    assert_empty close_calls
+    assert_empty confirmations
+    assert_empty channel.send(:streams)
+    assert_empty pending_stream_attempts(channel)
+  ensure
+    release_subscribe << true if worker&.alive?
+    worker&.join(1)
   end
 
   test "a deferred adapter failure releases its lease and reconnects the transport" do
     posted = Queue.new
     close_calls = []
+    raw_unsubscribes = []
     connected = 0
     disconnected = 0
     event_loop = Object.new
@@ -300,7 +434,7 @@ class StatusChannelTest < ActionCable::Channel::TestCase
     pubsub.define_singleton_method(:subscribe) do |*_args|
       raise ActiveRecord::ConnectionNotEstablished, "cable database unavailable"
     end
-    pubsub.define_singleton_method(:unsubscribe) { |*_args| }
+    pubsub.define_singleton_method(:unsubscribe) { |*args| raw_unsubscribes << args }
     server = Struct.new(:event_loop).new(event_loop)
     connection = Object.new
     connection.define_singleton_method(:server) { server }
@@ -315,6 +449,7 @@ class StatusChannelTest < ActionCable::Channel::TestCase
         channel.send(:begin_status_subscription!)
         channel.send(:activate_status_subscription!, StatusBroadcaster::CHANNEL)
         Timeout.timeout(5) { posted.pop.call }
+        Timeout.timeout(5) { posted.pop.call }
         channel.unsubscribe_from_channel
       end
     end
@@ -325,6 +460,36 @@ class StatusChannelTest < ActionCable::Channel::TestCase
       reason: ActionCable::INTERNAL[:disconnect_reasons][:server_restart],
       reconnect: true
     } ], close_calls
+    assert_empty raw_unsubscribes
+    assert_empty channel.send(:streams)
+    assert_empty pending_stream_attempts(channel)
+    assert_equal :closed, channel.instance_variable_get(:@status_subscription_state)
+  end
+
+  test "the lifecycle fence private Action Cable dependencies retain their call shape" do
+    required_private_methods = %i[
+      worker_pool_stream_handler
+      defer_subscription_confirmation!
+      ensure_confirmation_sent
+      streams
+    ]
+    required_private_methods.each do |method_name|
+      assert StatusChannel.private_method_defined?(method_name),
+             "Action Cable private API changed: StatusChannel requires ##{method_name}"
+    end
+
+    [
+      ActionCable::SubscriptionAdapter::Async,
+      ActionCable::SubscriptionAdapter::SolidCable
+    ].each do |adapter_class|
+      subscribe = adapter_class.instance_method(:subscribe)
+      minimum_arity = subscribe.arity.negative? ? -subscribe.arity - 1 : subscribe.arity
+      accepts_success_callback = minimum_arity <= 3 && subscribe.arity != 2
+
+      assert accepts_success_callback,
+             "Action Cable adapter API changed: #{adapter_class}#subscribe must accept " \
+             "(broadcasting, handler, success_callback)"
+    end
   end
 
   test "repeated concurrent teardown releases each channel lease exactly once" do
@@ -407,6 +572,10 @@ class StatusChannelTest < ActionCable::Channel::TestCase
   end
 
   private
+
+  def pending_stream_attempts(channel)
+    channel.instance_variable_get(:@status_stream_attempts) || {}
+  end
 
   def exercise_teardown_before_deferred_start(channel_class)
     fixture = ControlledStreamLifecycleFixture.new

--- a/web/test/channels/status_channel_test.rb
+++ b/web/test/channels/status_channel_test.rb
@@ -1,4 +1,117 @@
 require "test_helper"
+require "support/status_channel_stream_lifecycle_contract"
+
+class UnfencedStreamLifecycleChannel < Turbo::StreamsChannel
+  def stream_from(broadcasting, callback = nil, coder: nil, &block)
+    ActionCable::Channel::Streams.instance_method(:stream_from).bind_call(
+      self,
+      broadcasting,
+      callback,
+      coder: coder,
+      &block
+    )
+  end
+end
+
+class ControlledStreamLifecycleFixture
+  attr_reader :connection, :confirmations, :raw_unsubscribes
+
+  def initialize(pause_subscribe: false)
+    @posted = Queue.new
+    @entered_subscribe = Queue.new
+    @release_subscribe = Queue.new
+    @pause_subscribe = pause_subscribe
+    @registrations = []
+    @raw_unsubscribes = []
+    @mutex = Mutex.new
+    @confirmations = []
+
+    event_loop = Object.new
+    event_loop.define_singleton_method(:post) { |task = nil, &block| @posted << (task || block) }
+    event_loop.instance_variable_set(:@posted, @posted)
+
+    pubsub = Object.new
+    fixture = self
+    pubsub.define_singleton_method(:subscribe) do |broadcasting, handler, callback|
+      fixture.enter_subscribe
+      fixture.wait_for_subscribe_release if fixture.pause_subscribe?
+      fixture.register(broadcasting, handler)
+      callback.call
+    end
+    pubsub.define_singleton_method(:unsubscribe) do |broadcasting, handler|
+      fixture.unregister(broadcasting, handler)
+    end
+
+    server = Struct.new(:event_loop).new(event_loop)
+    @connection = Object.new
+    @connection.define_singleton_method(:server) { server }
+    @connection.define_singleton_method(:pubsub) { pubsub }
+    @connection.define_singleton_method(:identifiers) { [] }
+    @connection.define_singleton_method(:logger) { Rails.logger }
+    @connection.define_singleton_method(:transmit) { |frame| fixture.record_confirmation(frame) }
+  end
+
+  def pause_subscribe?
+    @pause_subscribe
+  end
+
+  def enter_subscribe
+    @entered_subscribe << true
+  end
+
+  def wait_for_subscribe_release
+    @release_subscribe.pop
+  end
+
+  def await_subscribe
+    Timeout.timeout(5) { @entered_subscribe.pop }
+  end
+
+  def release_subscribe
+    @release_subscribe << true
+  end
+
+  def run_next_posted
+    Timeout.timeout(5) { @posted.pop.call }
+  end
+
+  def drain_posted
+    @posted.pop(true).call until @posted.empty?
+  end
+
+  def register(broadcasting, handler)
+    @mutex.synchronize { @registrations << [ broadcasting, handler ] }
+  end
+
+  def unregister(broadcasting, handler)
+    @mutex.synchronize do
+      @raw_unsubscribes << [ broadcasting, handler ]
+      @registrations.delete([ broadcasting, handler ])
+    end
+  end
+
+  def registrations
+    @mutex.synchronize { @registrations.dup }
+  end
+
+  def record_confirmation(frame)
+    @confirmations << frame if frame[:type] == ActionCable::INTERNAL[:message_types][:confirmation]
+  end
+end
+
+class StatusChannelAsyncStreamLifecycleTest < ActiveSupport::TestCase
+  include ActionCableStreamLifecycleContract
+
+  private
+
+  def stream_lifecycle_channel_class
+    StatusChannel
+  end
+
+  def stream_lifecycle_adapter_name
+    "async"
+  end
+end
 
 class StatusChannelTest < ActionCable::Channel::TestCase
   test "a verified stream owns one broadcaster subscription for its lifetime" do
@@ -144,6 +257,38 @@ class StatusChannelTest < ActionCable::Channel::TestCase
     worker&.join(1)
   end
 
+  test "the application fence prevents registration after teardown before deferred start" do
+    unfenced, unfenced_fixture = exercise_teardown_before_deferred_start(UnfencedStreamLifecycleChannel)
+
+    assert_predicate unfenced, :unsubscribed?
+    assert_equal 1, unfenced_fixture.registrations.length,
+                 "negative control must expose the framework's late registration"
+    assert_equal 1, unfenced_fixture.confirmations.length,
+                 "negative control must expose confirmation after teardown"
+
+    fenced, fenced_fixture = exercise_teardown_before_deferred_start(StatusChannel)
+
+    assert_predicate fenced, :unsubscribed?
+    assert_empty fenced_fixture.registrations
+    assert_empty fenced_fixture.confirmations
+  end
+
+  test "the application fence removes registration completed after teardown" do
+    unfenced, unfenced_fixture = exercise_teardown_during_registration(UnfencedStreamLifecycleChannel)
+
+    assert_predicate unfenced, :unsubscribed?
+    assert_equal 1, unfenced_fixture.registrations.length,
+                 "negative control must expose the framework's stranded registration"
+    assert_equal 1, unfenced_fixture.confirmations.length,
+                 "negative control must expose confirmation after teardown"
+
+    fenced, fenced_fixture = exercise_teardown_during_registration(StatusChannel)
+
+    assert_predicate fenced, :unsubscribed?
+    assert_empty fenced_fixture.registrations
+    assert_empty fenced_fixture.confirmations
+  end
+
   test "a deferred adapter failure releases its lease and reconnects the transport" do
     posted = Queue.new
     close_calls = []
@@ -262,6 +407,34 @@ class StatusChannelTest < ActionCable::Channel::TestCase
   end
 
   private
+
+  def exercise_teardown_before_deferred_start(channel_class)
+    fixture = ControlledStreamLifecycleFixture.new
+    channel = channel_class.new(fixture.connection, "before-deferred-start", {})
+    channel.stream_from(StatusBroadcaster::CHANNEL)
+    channel.send(:ensure_confirmation_sent)
+    channel.unsubscribe_from_channel
+    fixture.run_next_posted
+    fixture.drain_posted
+    [ channel, fixture ]
+  end
+
+  def exercise_teardown_during_registration(channel_class)
+    fixture = ControlledStreamLifecycleFixture.new(pause_subscribe: true)
+    channel = channel_class.new(fixture.connection, "during-registration", {})
+    channel.stream_from(StatusBroadcaster::CHANNEL)
+    channel.send(:ensure_confirmation_sent)
+    worker = Thread.new { fixture.run_next_posted }
+    fixture.await_subscribe
+    channel.unsubscribe_from_channel
+    fixture.release_subscribe
+    worker.value
+    fixture.drain_posted
+    [ channel, fixture ]
+  ensure
+    fixture&.release_subscribe if worker&.alive?
+    worker&.join(1)
+  end
 
   def with_replaced_instance_method(receiver, name, replacement)
     original = receiver.instance_method(name)

--- a/web/test/channels/status_channel_test.rb
+++ b/web/test/channels/status_channel_test.rb
@@ -118,6 +118,11 @@ class StatusChannelAsyncStreamLifecycleTest < ActiveSupport::TestCase
 end
 
 class StatusChannelTest < ActionCable::Channel::TestCase
+  STRESS_ITERATIONS = Integer(ENV.fetch("STATUS_CHANNEL_STRESS_ITERATIONS", "0"), 10)
+  STRESS_SEED = Integer(ENV.fetch("STATUS_CHANNEL_STRESS_SEED", Random.new_seed.to_s), 10)
+
+  raise ArgumentError, "STATUS_CHANNEL_STRESS_ITERATIONS must not be negative" if STRESS_ITERATIONS.negative?
+
   test "a verified stream owns one broadcaster subscription for its lifetime" do
     connected = 0
     disconnected = 0
@@ -489,6 +494,36 @@ class StatusChannelTest < ActionCable::Channel::TestCase
       assert accepts_success_callback,
              "Action Cable adapter API changed: #{adapter_class}#subscribe must accept " \
              "(broadcasting, handler, success_callback)"
+    end
+  end
+
+  if STRESS_ITERATIONS.positive?
+    test "bounded stress repeats both teardown windows" do
+      windows = {
+        before_deferred_start: -> { exercise_teardown_before_deferred_start(StatusChannel) },
+        during_registration: -> { exercise_teardown_during_registration(StatusChannel) }
+      }
+      windows.each_key do |window|
+        puts "StatusChannel stress adapter=controlled window=#{window} " \
+          "iterations=#{STRESS_ITERATIONS} seed=#{STRESS_SEED}"
+      end
+      random = Random.new(STRESS_SEED)
+
+      STRESS_ITERATIONS.times do |iteration|
+        windows.keys.shuffle(random: random).each do |window|
+          channel, fixture = windows.fetch(window).call
+          assert_empty fixture.registrations
+          assert_empty fixture.confirmations
+          assert_empty channel.send(:streams)
+          assert_empty pending_stream_attempts(channel)
+          expected_unsubscribes = window == :during_registration ? 1 : 0
+          assert_equal expected_unsubscribes, fixture.raw_unsubscribes.length
+        rescue Exception
+          warn "StatusChannel stress failed adapter=controlled window=#{window} " \
+            "iteration=#{iteration + 1}/#{STRESS_ITERATIONS} seed=#{STRESS_SEED}"
+          raise
+        end
+      end
     end
   end
 

--- a/web/test/support/status_channel_stream_lifecycle_contract.rb
+++ b/web/test/support/status_channel_stream_lifecycle_contract.rb
@@ -1,0 +1,262 @@
+require "set"
+require "stringio"
+require "timeout"
+
+# Shared behavior for any channel class that owns Action Cable stream lifecycle.
+# The including test supplies the channel class and adapter name; this contract
+# deliberately observes public stream behavior rather than a scheduling mechanism.
+module ActionCableStreamLifecycleContract
+  extend ActiveSupport::Concern
+
+  WAIT_TIMEOUT = 5
+
+  class ObservedAdapter
+    attr_reader :events
+
+    def initialize(adapter)
+      @adapter = adapter
+      @events = Queue.new
+      @recorded_events = []
+      @mutex = Mutex.new
+    end
+
+    def broadcast(...)
+      @adapter.broadcast(...)
+    end
+
+    def subscribe(broadcasting, handler, success_callback = nil)
+      @adapter.subscribe(broadcasting, handler, lambda do
+        success_callback&.call
+        record([ :registered, broadcasting, handler ])
+      end)
+    end
+
+    def unsubscribe(broadcasting, handler)
+      record([ :unsubscribed, broadcasting, handler ])
+      @adapter.unsubscribe(broadcasting, handler)
+    end
+
+    def shutdown
+      @adapter.shutdown
+    end
+
+    def recorded_events
+      @mutex.synchronize { @recorded_events.dup }
+    end
+
+    private
+
+    def record(event)
+      @mutex.synchronize { @recorded_events << event }
+      @events << event
+    end
+  end
+
+  Environment = Struct.new(
+    :server,
+    :connection,
+    :adapter,
+    :frames,
+    :frame_events,
+    :close_calls,
+    :close_events,
+    :channels,
+    :initialized_channels,
+    keyword_init: true
+  )
+
+  included do
+    test "real adapter confirms registration and preserves the default transmit path" do
+      with_stream_lifecycle_environment do |environment|
+        channel = build_stream_lifecycle_channel(environment)
+        start_stream(environment, channel, "contract-default")
+
+        confirmation = await_frame(environment, channel) { |frame| frame[:type] == confirmation_type }
+        assert_equal channel.identifier, confirmation[:identifier]
+
+        environment.server.broadcast("contract-default", { "kind" => "default" })
+        payload = await_frame(environment, channel) { |frame| frame[:message] == { "kind" => "default" } }
+        assert_equal({ "kind" => "default" }, payload[:message])
+      end
+    end
+
+    test "real adapter preserves explicit callbacks, blocks, and coders" do
+      with_stream_lifecycle_environment do |environment|
+        channel = build_stream_lifecycle_channel(environment)
+        callback_payloads = Queue.new
+        block_payloads = Queue.new
+        decoder = Object.new
+        decoder.define_singleton_method(:decode) { |payload| "decoded:#{payload}" }
+
+        start_stream(environment, channel, "contract-callback", ->(payload) { callback_payloads << payload })
+        start_stream(environment, channel, "contract-coded", coder: decoder) { |payload| block_payloads << payload }
+
+        environment.server.broadcast("contract-callback", "callback-payload", coder: nil)
+        environment.server.broadcast("contract-coded", "coded-payload", coder: nil)
+
+        assert_equal "callback-payload", await_queue(callback_payloads, environment, channel, "explicit callback")
+        assert_equal "decoded:coded-payload", await_queue(block_payloads, environment, channel, "coded block")
+      end
+    end
+
+    test "real adapter targeted and global stops unsubscribe registered handlers once" do
+      with_stream_lifecycle_environment do |environment|
+        channel = build_stream_lifecycle_channel(environment)
+        start_stream(environment, channel, "contract-targeted")
+        start_stream(environment, channel, "contract-global")
+
+        channel.stop_stream_from("contract-targeted")
+        channel.stop_stream_from("contract-targeted")
+        assert_equal 1, unsubscribe_count(environment, "contract-targeted")
+
+        channel.stop_all_streams
+        channel.stop_all_streams
+        assert_equal 1, unsubscribe_count(environment, "contract-global")
+        assert_empty channel.send(:streams)
+      end
+    end
+
+    test "real adapter teardown removes the handler and suppresses later payloads" do
+      with_stream_lifecycle_environment do |environment|
+        channel = build_stream_lifecycle_channel(environment)
+        control = build_stream_lifecycle_channel(environment)
+        start_stream(environment, channel, "contract-teardown")
+        start_stream(environment, control, "contract-control")
+
+        channel.unsubscribe_from_channel
+        environment.server.broadcast("contract-teardown", { "kind" => "forbidden" })
+        environment.server.broadcast("contract-control", { "kind" => "control" })
+        await_frame(environment, control) { |frame| frame[:message] == { "kind" => "control" } }
+
+        assert_equal 1, unsubscribe_count(environment, "contract-teardown")
+        assert_empty channel.send(:streams)
+        refute environment.frames.any? { |frame| frame[:message] == { "kind" => "forbidden" } }
+      end
+    end
+  end
+
+  private
+
+  def with_stream_lifecycle_environment
+    environment = build_stream_lifecycle_environment
+    yield environment
+  ensure
+    shutdown_stream_lifecycle_environment(environment) if environment
+  end
+
+  def build_stream_lifecycle_environment
+    logger = ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new(StringIO.new))
+    configuration = ActionCable::Server::Configuration.new
+    configuration.logger = logger
+    configuration.cable = { "adapter" => stream_lifecycle_adapter_name }
+    configuration.filter_parameters = []
+    configuration.worker_pool_size = 1
+
+    server = ActionCable::Server::Base.new(config: configuration)
+    real_adapter = server.pubsub
+    observed_adapter = ObservedAdapter.new(real_adapter)
+    server.instance_variable_set(:@pubsub, observed_adapter)
+
+    frames = []
+    frame_events = Queue.new
+    close_calls = []
+    close_events = Queue.new
+    connection = ActionCable::Connection::Base.new(server, {})
+    connection.define_singleton_method(:transmit) do |frame|
+      recorded = frame.with_indifferent_access
+      frames << recorded
+      frame_events << recorded
+    end
+    connection.define_singleton_method(:close) do |**options|
+      close_calls << options
+      close_events << options
+    end
+
+    Environment.new(
+      server: server,
+      connection: connection,
+      adapter: observed_adapter,
+      frames: frames,
+      frame_events: frame_events,
+      close_calls: close_calls,
+      close_events: close_events,
+      channels: [],
+      initialized_channels: Set.new
+    )
+  end
+
+  def build_stream_lifecycle_channel(environment)
+    stream_lifecycle_channel_class.new(
+      environment.connection,
+      "lifecycle-contract-#{environment.channels.length}",
+      {}
+    ).tap { |channel| environment.channels << channel }
+  end
+
+  def start_stream(environment, channel, broadcasting, callback = nil, coder: nil, &block)
+    channel.stream_from(broadcasting, callback, coder: coder, &block)
+    unless environment.initialized_channels.include?(channel.object_id)
+      environment.initialized_channels << channel.object_id
+      channel.send(:ensure_confirmation_sent)
+    end
+    await_adapter_event(environment, channel, :registered, broadcasting)
+  end
+
+  def await_adapter_event(environment, channel, kind, broadcasting)
+    Timeout.timeout(WAIT_TIMEOUT) do
+      loop do
+        event = environment.adapter.events.pop
+        return event if event.first == kind && event[1] == broadcasting
+      end
+    end
+  rescue Timeout::Error
+    flunk lifecycle_timeout_message(environment, channel, "adapter #{kind} for #{broadcasting.inspect}")
+  end
+
+  def await_frame(environment, channel)
+    Timeout.timeout(WAIT_TIMEOUT) do
+      loop do
+        frame = environment.frame_events.pop
+        return frame if yield(frame)
+      end
+    end
+  rescue Timeout::Error
+    flunk lifecycle_timeout_message(environment, channel, "matching Action Cable frame")
+  end
+
+  def await_queue(queue, environment, channel, label)
+    Timeout.timeout(WAIT_TIMEOUT) { queue.pop }
+  rescue Timeout::Error
+    flunk lifecycle_timeout_message(environment, channel, label)
+  end
+
+  def unsubscribe_count(environment, broadcasting)
+    environment.adapter.recorded_events.count do |kind, name, _handler|
+      kind == :unsubscribed && name == broadcasting
+    end
+  end
+
+  def confirmation_type
+    ActionCable::INTERNAL[:message_types][:confirmation]
+  end
+
+  def lifecycle_timeout_message(environment, channel, awaited)
+    "timed out waiting for #{awaited}; streams=#{channel.send(:streams).keys.inspect} " \
+      "adapter_events=#{environment.adapter.recorded_events.inspect} " \
+      "frames=#{environment.frames.inspect} closes=#{environment.close_calls.inspect}"
+  end
+
+  def shutdown_stream_lifecycle_environment(environment)
+    environment.channels.reverse_each do |channel|
+      channel.unsubscribe_from_channel unless channel.unsubscribed?
+    rescue StandardError
+      # Preserve the original assertion while still shutting down adapter threads.
+    end
+    environment.adapter.shutdown
+    environment.server.worker_pool.halt
+    environment.server.worker_pool.executor.wait_for_termination(WAIT_TIMEOUT)
+    event_loop = environment.server.event_loop
+    event_loop.stop
+    event_loop.instance_variable_get(:@thread)&.join(WAIT_TIMEOUT)
+  end
+end

--- a/web/test/support/status_channel_stream_lifecycle_contract.rb
+++ b/web/test/support/status_channel_stream_lifecycle_contract.rb
@@ -18,6 +18,7 @@ module ActionCableStreamLifecycleContract
       @events = Queue.new
       @recorded_events = []
       @mutex = Mutex.new
+      @fail_next_subscribe = false
     end
 
     def broadcast(...)
@@ -25,6 +26,17 @@ module ActionCableStreamLifecycleContract
     end
 
     def subscribe(broadcasting, handler, success_callback = nil)
+      failure = @mutex.synchronize do
+        next false unless @fail_next_subscribe
+
+        @fail_next_subscribe = false
+        true
+      end
+      if failure
+        record([ :subscribe_failed, broadcasting, handler ])
+        raise ActiveRecord::ConnectionNotEstablished, "injected adapter subscription failure"
+      end
+
       @adapter.subscribe(broadcasting, handler, lambda do
         success_callback&.call
         record([ :registered, broadcasting, handler ])
@@ -38,6 +50,10 @@ module ActionCableStreamLifecycleContract
 
     def shutdown
       @adapter.shutdown
+    end
+
+    def fail_next_subscribe!
+      @mutex.synchronize { @fail_next_subscribe = true }
     end
 
     def recorded_events
@@ -133,6 +149,30 @@ module ActionCableStreamLifecycleContract
         refute environment.frames.any? { |frame| frame[:message] == { "kind" => "forbidden" } }
       end
     end
+
+    test "real adapter subscription failure leaves clean state and later recovers" do
+      with_stream_lifecycle_environment do |environment|
+        environment.adapter.fail_next_subscribe!
+        failed_channel = build_stream_lifecycle_channel(environment)
+        begin_stream(environment, failed_channel, "contract-failure")
+
+        close = await_close(environment, failed_channel)
+        assert_equal true, close[:reconnect]
+        assert_equal ActionCable::INTERNAL[:disconnect_reasons][:server_restart], close[:reason]
+        assert_empty failed_channel.send(:streams)
+        assert_empty stream_lifecycle_pending_entries(failed_channel)
+        assert_empty environment.frames.select { |frame| frame[:type] == confirmation_type }
+        assert_equal 1, environment.close_calls.length
+
+        recovered_channel = build_stream_lifecycle_channel(environment)
+        start_stream(environment, recovered_channel, "contract-recovery")
+        environment.server.broadcast("contract-recovery", { "kind" => "recovered" })
+        recovered = await_frame(environment, recovered_channel) do |frame|
+          frame[:message] == { "kind" => "recovered" }
+        end
+        assert_equal({ "kind" => "recovered" }, recovered[:message])
+      end
+    end
   end
 
   private
@@ -194,12 +234,16 @@ module ActionCableStreamLifecycleContract
   end
 
   def start_stream(environment, channel, broadcasting, callback = nil, coder: nil, &block)
+    begin_stream(environment, channel, broadcasting, callback, coder: coder, &block)
+    await_adapter_event(environment, channel, :registered, broadcasting)
+  end
+
+  def begin_stream(environment, channel, broadcasting, callback = nil, coder: nil, &block)
     channel.stream_from(broadcasting, callback, coder: coder, &block)
     unless environment.initialized_channels.include?(channel.object_id)
       environment.initialized_channels << channel.object_id
       channel.send(:ensure_confirmation_sent)
     end
-    await_adapter_event(environment, channel, :registered, broadcasting)
   end
 
   def await_adapter_event(environment, channel, kind, broadcasting)
@@ -228,6 +272,12 @@ module ActionCableStreamLifecycleContract
     Timeout.timeout(WAIT_TIMEOUT) { queue.pop }
   rescue Timeout::Error
     flunk lifecycle_timeout_message(environment, channel, label)
+  end
+
+  def await_close(environment, channel)
+    Timeout.timeout(WAIT_TIMEOUT) { environment.close_events.pop }
+  rescue Timeout::Error
+    flunk lifecycle_timeout_message(environment, channel, "transport reconnect")
   end
 
   def unsubscribe_count(environment, broadcasting)

--- a/web/test/system/kanban_board_test.rb
+++ b/web/test/system/kanban_board_test.rb
@@ -871,6 +871,8 @@ class KanbanBoardTest < ApplicationSystemTestCase
     release_subscription = Queue.new
     connected = Queue.new
     disconnected = Queue.new
+    lifecycle_events = []
+    lifecycle_mutex = Mutex.new
     released = false
     signed_name = Turbo::StreamsChannel.signed_stream_name([ StatusBroadcaster::CHANNEL ])
     original_verifier = StatusChannel.instance_method(:verified_stream_name_from_params)
@@ -879,35 +881,54 @@ class KanbanBoardTest < ApplicationSystemTestCase
       release_subscription.pop
       original_verifier.bind_call(self)
     end
+    confirmation_subscription = ActiveSupport::Notifications.subscribe(
+      "transmit_subscription_confirmation.action_cable"
+    ) do |*args|
+      payload = args.last
+      if payload[:channel_class] == "StatusChannel"
+        lifecycle_mutex.synchronize { lifecycle_events << :confirmation }
+      end
+    end
+    disconnect = lambda do
+      lifecycle_mutex.synchronize { lifecycle_events << :teardown }
+      disconnected << true
+    end
 
     with_replaced_singleton_method(StatusBroadcaster, :subscriber_connected!, -> { connected << true }) do
-      with_replaced_singleton_method(StatusBroadcaster, :subscriber_disconnected!, -> { disconnected << true }) do
-        with_replaced_instance_method(StatusChannel, :verified_stream_name_from_params, blocked_verifier) do
-          execute_script(<<~JS, signed_name)
-            const owner = document.createElement("div")
-            owner.id = "pending-status-owner"
-            owner.dataset.statusVersion = "pending-token"
-            const source = document.createElement("hive-status-stream-source")
-            source.setAttribute("channel", "StatusChannel")
-            source.setAttribute("signed-stream-name", arguments[0])
-            owner.appendChild(source)
-            document.body.appendChild(owner)
-          JS
-          Timeout.timeout(10) { entered_subscription.pop }
+      with_replaced_singleton_method(StatusBroadcaster, :subscriber_disconnected!, disconnect) do
+        with_status_catch_up_observer do |catch_ups|
+          with_replaced_instance_method(StatusChannel, :verified_stream_name_from_params, blocked_verifier) do
+            execute_script(<<~JS, signed_name)
+              const owner = document.createElement("div")
+              owner.id = "pending-status-owner"
+              owner.dataset.statusVersion = "pending-token"
+              const source = document.createElement("hive-status-stream-source")
+              source.setAttribute("channel", "StatusChannel")
+              source.setAttribute("signed-stream-name", arguments[0])
+              owner.appendChild(source)
+              document.body.appendChild(owner)
+            JS
+            Timeout.timeout(10) { entered_subscription.pop }
 
-          execute_script("document.querySelector('#pending-status-owner').remove()")
-          release_subscription << true
-          released = true
+            execute_script("document.querySelector('#pending-status-owner').remove()")
+            release_subscription << true
+            released = true
 
-          Timeout.timeout(10) { connected.pop }
-          Timeout.timeout(10) { disconnected.pop }
+            Timeout.timeout(10) { connected.pop }
+            Timeout.timeout(10) { disconnected.pop }
+          end
+
+          assert catch_ups.empty?, "a disposed source must not send catch-up after late confirmation"
         end
       end
     end
 
     assert connected.empty?
     assert disconnected.empty?
+    assert_equal [ :confirmation, :teardown ], lifecycle_mutex.synchronize { lifecycle_events.dup },
+                 "confirmation may release a disposed handle, but none may arrive after server teardown"
   ensure
+    ActiveSupport::Notifications.unsubscribe(confirmation_subscription) if confirmation_subscription
     release_subscription << true if release_subscription && !released
     execute_script("document.querySelector('#pending-status-owner')?.remove()") if page&.current_url
   end

--- a/wiki/commands/web.md
+++ b/wiki/commands/web.md
@@ -768,6 +768,38 @@ rendered while a plan review applies, and task mutations independently invoke
 
 ## Tests
 
+### Status stream lifecycle checks and rollback
+
+The application fence is checked separately through real Async, real Solid
+Cable with an isolated temporary database, and the browser boundary:
+
+```bash
+cd web
+bin/rails test test/channels/status_channel_test.rb
+bin/rails test test/channels/status_channel_solid_cable_test.rb
+bin/rails test test/system/kanban_board_test.rb
+STATUS_CHANNEL_STRESS_ITERATIONS=100 STATUS_CHANNEL_STRESS_SEED=42837 \
+  bin/rails test test/channels/status_channel_test.rb
+```
+
+Production warning signals are a `StatusBroadcaster` subscriber lease count
+that drifts from connected pages and the never-confirmed cleanup path leaving a
+board that never becomes live. If the application coordination deadlocks,
+leaks, or suppresses a legitimate confirmation after merge, stop the rollout
+and revert the production lifecycle coordination in `StatusChannel` while
+retaining the owner-neutral contract, negative controls, and documentation.
+Before a repaired change is deployed, rerun the focused Async and Solid Cable
+suites plus the affected never-confirmed/disposed-source system case (and the
+full system file when the boundary is not isolated).
+
+A future Rails-owned handoff has a different, atomic rollback: restore the last
+verified released Rails declaration and complete lockfile together with the
+application fence, then rerun the focused lifecycle suite and whichever outer
+gate failed. Do not accept framework ownership until the exact upstream
+PR/merge/release provenance and every applicable verification row pass. A
+dependency bump, fence deletion, deployment, or version choice is not part of
+the current lifecycle repair.
+
 `web/test/integration/` drives the real GithubAuth through the device-flow
 routes via the `http:` DI seam (no API stubbing), including ownerless
 first-login claim, persisted `web.github.owner`, request-time owner-change

--- a/wiki/dependencies.md
+++ b/wiki/dependencies.md
@@ -3,7 +3,7 @@ title: Dependencies
 type: dependencies
 source: Gemfile, hive.gemspec, Gemfile.lock, web/Gemfile, web/Gemfile.lock, .github/workflows, install.sh, components/agent-cli-runtime/mirror, .llm-wiki/post-commit-refresh.sh
 created: 2026-04-25
-updated: 2026-08-29
+updated: 2026-08-30
 tags: [dependencies, gems, runtime, sequel, sqlite]
 ---
 
@@ -147,6 +147,36 @@ Rails 8.1.3.1 is the minimum locked web release for the
 CVE-2026-66066 Active Storage/libvips security fix. Production images install
 the distribution `libvips` package, which must remain at libvips 8.13 or newer
 for the patched Active Storage safety checks.
+
+### Action Cable status-stream ownership
+
+The web lock resolves Rails and Action Cable `8.1.3.1` and Solid Cable
+`4.0.0`. For [issue #1143](https://github.com/ivankuznetsov/hive/issues/1143),
+`StatusChannel` remains the application-level owner of the subscription
+lifecycle race: no exact upstream merge plus first official released Rails gem
+containing the full Hive lifecycle contract has been established. The current
+dependency therefore remains a released gem; Hive does not use a Rails Git or
+prerelease pin, vendored framework file, monkey patch, or broad backport for
+this fix.
+
+The fence deliberately relies on the private Action Cable methods
+`worker_pool_stream_handler`, `defer_subscription_confirmation!`,
+`ensure_confirmation_sent`, and `streams`, plus the adapter call shape
+`pubsub.subscribe(broadcasting, handler, success_callback)`. The private-API
+guard in `web/test/channels/status_channel_test.rb` names any missing method or
+changed three-argument adapter shape, making an ordinary Rails update fail
+before runtime.
+
+A future ownership transfer is fail closed. Its provenance packet must name
+the upstream PR, merge commit, official Rails tag/release, first gem version,
+Hive lock resolution, and comparison with that released source. One atomic
+change must then raise the Rails floor, update every Rails lock component,
+remove only the obsolete application fence/helpers, and pass the unchanged
+mechanism-neutral Async/Solid Cable contract, deterministic/stress cases,
+browser/system suites, broad Web suite, golden path, and style checks. Any
+failure restores the prior released Rails declaration and lockfile together
+with the application fence; an issue, unreleased branch, or adjacent fix is
+not transfer evidence.
 
 The `curses` gem was removed in U11 of plan #003 alongside the legacy curses TUI backend. `HIVE_TUI_BACKEND=curses` now raises a typed error pointing at the removal instead of routing to the deleted code.
 

--- a/wiki/gaps.md
+++ b/wiki/gaps.md
@@ -617,6 +617,22 @@ and channel-test pinned as well. Channel coverage also forces adapter
 registration to finish after teardown and proves the late handler removes
 itself, then forces deferred registration to raise and proves the lease releases
 before the transport reconnects.
+The application fence now owns pending cancellation and registered cleanup
+across `stream_from`, `stop_stream_from`, and `stop_all_streams`, with the same
+real-channel contract passing on Async and Solid Cable. Framework handoff is
+still an explicit gap: no exact upstream PR, merge commit, official release,
+first containing gem, lock resolution, and released-source comparison has been
+recorded. Until that complete provenance packet exists and the unchanged
+verification matrix passes without the fence, the released Rails gem is not
+accepted as lifecycle owner.
+
+The Web golden-path E2E is not fully agent-isolated on the current baseline.
+Its stage fixture puts only a fake `claude` on `PATH`, while mandatory plan
+review defaults to the real Codex route. Two 2026-08-30 acceptance attempts
+therefore remained live in `3-plan` beyond the test's 90-second transition
+bound. The fixture and route are unchanged from `origin/main`; a separate
+harness repair must fake or otherwise deterministically contain plan review
+before this gate can be treated as reproducible local Action Cable evidence.
 An isolated four-tab profile against the real 15-project registry confirms one
 shared poller and no idle DOM/HTTP loop. Real multi-worker Puma convergence and
 live-Docker evidence remain open; last-subscriber shutdown also retains an

--- a/wiki/log.d/20260830T184156Z-action-cable-stream-lifecycle.md
+++ b/wiki/log.d/20260830T184156Z-action-cable-stream-lifecycle.md
@@ -1,0 +1,39 @@
+---
+title: Action Cable stream lifecycle ownership
+date: 2026-08-30
+tags: [web, action-cable, solid-cable, concurrency, testing]
+---
+
+`StatusChannel` now owns one coordinated boundary across `stream_from`,
+`stop_stream_from`, and `stop_all_streams`. Pending attempts remain outside
+Rails' stream registry, queued cancellation makes no raw adapter unsubscribe,
+registration completed after stop receives one event-loop cleanup, and only a
+live successful registration can confirm or deliver. Failure clears stream and
+pending state before releasing the broadcaster lease and requesting one
+reconnect.
+
+Deterministic barriers prove both teardown windows against an explicit
+unfenced Rails negative-control channel. A mechanism-neutral contract uses a
+real `ActionCable::Connection::Base` and channel for default transmit,
+callbacks/blocks, coders, stop APIs, teardown, injected failure, recovery, and
+empty final state. It passed with the real Async adapter and with Solid Cable
+`4.0.0` against a temporary SQLite database loaded from `db/cable_schema.rb`;
+the Solid suite also proved listener, connection, row, and database cleanup.
+The focused browser file passed 30 cases / 222 assertions and records the
+disposed-source confirmation before server teardown with no catch-up action or
+later confirmation.
+
+One-time acceptance ran both controlled race windows 100 times with
+`STATUS_CHANNEL_STRESS_SEED=42837`: 25 tests / 1,935 assertions completed with
+no failures, errors, or skips. Normal focused execution leaves stress disabled.
+The current dependency remains released Rails/Action Cable `8.1.3.1`; no
+Gemfile or lockfile changed. The dependency page records the private API guard,
+current coordination rollback, and exact provenance plus atomic rollback
+required before any future framework handoff.
+
+Release-default broad verification passed 344 Web tests / 2,055 assertions and
+63 system tests / 636 assertions; RuboCop was clean. The standalone golden path
+did not reach its PR gate in two attempts because its unchanged baseline
+fixture fakes Claude but routes mandatory plan review to a real Codex process,
+which remained active past the E2E's 90-second bound. That non-isolated
+baseline gate is recorded in `wiki/gaps.md` rather than reported as passing.

--- a/wiki/state-model.md
+++ b/wiki/state-model.md
@@ -574,7 +574,17 @@ authoritative before local release. `StatusChannel` fences the deferred adapter
 subscribe before it begins and in its completion callback, removing a handler
 that finishes after teardown. An adapter exception after deferral releases the
 lease and reconnects the transport instead of stranding an active unconfirmed
-channel. A rejected server subscription is forgotten
+channel. Queued and registering attempts live only in a synchronized
+application registry; a handler enters Rails' `streams` registry only after
+the adapter success callback. A named or global stop cancels pending attempts
+without a raw unsubscribe, while each registered handler has exactly one raw
+unsubscribe owner. If stop wins while registration completes, the callback
+suppresses confirmation and delivery and posts one late unsubscribe back to
+the event loop, outside adapter subscriber locks. Repeated stops are
+idempotent. Adapter failure clears both registries before releasing the
+independent broadcaster lease and requesting one reconnect, so teardown and
+failure cannot double-release another page's lease or retain an unconfirmed
+stream. A rejected server subscription is forgotten
 and retried. A rejected asynchronous consumer setup
 clears turbo-rails' rejected cached consumer promise before retrying at a
 bounded five-second cadence. A synchronous subscription-creation failure drops

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -867,6 +867,48 @@ confirmation callback ever arrives, retry after a real server-side startup
 rejection, and reconnect after deferred adapter registration fails. Unit barriers
 bound every wait and assert the exact shared scan count and first-poller lease
 rollback rather than relying on scheduler timing.
+
+`web/test/channels/status_channel_test.rb` now pairs those application-specific
+barriers with an explicit channel that binds directly to Rails' unfenced
+`ActionCable::Channel::Streams` implementation. Each negative control must
+expose the forbidden late registration/confirmation before `StatusChannel`
+proves queued cancellation, in-registration teardown, targeted/global and
+repeated stops, exact raw unsubscribe counts, failure/recovery, empty state,
+callback/coder/default-transmit compatibility, and private-API drift guards.
+The reusable assertions in
+`web/test/support/status_channel_stream_lifecycle_contract.rb` construct a real
+`ActionCable::Connection::Base` and channel without the Rails `ChannelStub` or
+a deferred-start assumption. The same contract runs against real Async and,
+unconditionally in `status_channel_solid_cable_test.rb`, real Solid Cable. The
+Solid suite loads `db/cable_schema.rb` into a per-example temporary SQLite
+database, leaves `config/cable.yml` test delivery on Async, and asserts row,
+connection, listener-thread, and database cleanup.
+
+```bash
+cd web
+bin/rails test test/channels/status_channel_test.rb
+bin/rails test test/channels/status_channel_solid_cable_test.rb
+bin/rails test test/system/kanban_board_test.rb
+STATUS_CHANNEL_STRESS_ITERATIONS=100 STATUS_CHANNEL_STRESS_SEED=42837 \
+  bin/rails test test/channels/status_channel_test.rb
+```
+
+Stress is not a default test or CI path: `STATUS_CHANNEL_STRESS_ITERATIONS`
+defaults to zero, and an enabled run prints its generated or supplied seed,
+adapter/window, and count before executing. The 2026-08-30 acceptance run used
+seed `42837`, completed 100 bounded iterations for each teardown window, and
+reported 1,935 assertions with no failures, errors, or skips. The disposed-DOM
+browser case also records confirmation before server teardown and proves no
+catch-up action or later confirmation crosses that boundary.
+
+The same acceptance run completed the release-default Web suite at 344 tests /
+2,055 assertions and the full system suite at 63 tests / 636 assertions, with
+no failures, errors, or skips; RuboCop was clean. The standalone golden-path
+gate remains unproven for this change: two runs reached `3-plan`, where the
+unchanged E2E fixture invoked the real mandatory Codex plan reviewer and
+exceeded its 90-second browser transition bound. The fixture and default route
+are unchanged from `origin/main`; the Action Cable change does not claim that
+baseline isolation gap as a passing result.
 Before submitting the
 brainstorm answer, it waits for the daemon to classify the
 `needs_input` row and for the current `brainstorm.md` mtime second to pass, so


### PR DESCRIPTION
## Summary

Keeps Hive's application-owned `StatusChannel` lifecycle fence in place and extends it across start, targeted stop, and global stop. Adds deterministic race regressions, a reusable real-channel lifecycle contract, Solid Cable coverage, browser checks, stress controls, and rollback/provenance documentation.

## Why

Rails 8.1.3.1 does not yet provide the required teardown fencing, so late registration, confirmation, duplicate cleanup, and lease leaks must remain guarded locally until a released upstream fix is proven.

## Validation

- Focused channel: 24 tests, 135 assertions
- Solid Cable: 5 tests, 47 assertions
- Stress: seed `42837`, 100 iterations per race window (25 tests, 1,935 assertions)
- Focused browser: 30 tests, 222 assertions
- Full Web: 344 tests, 2,055 assertions; full system: 63 tests, 636 assertions
- RuboCop clean; Gemfile, lockfile, and `cable.yml` unchanged

The unchanged golden-path fixture remains non-green because mandatory plan review launches a real Codex process beyond its 90-second bound; this isolation gap is documented in `wiki/gaps.md`.

<!-- hive-publication:v1 id=pub-81972f1f07965e79871b05cec9c48da3 base=5de0be0ab160806b5596244b1ce3a41ba77e00ef -->
