### PR TITLE
fix: restore fast status reads for installed workflows

### DIFF
--- a/lib/hive/workflow_package/managed_store.rb
+++ b/lib/hive/workflow_package/managed_store.rb
@@ -193,13 +193,15 @@ module Hive
       end
 
       def verify_generation(name, commit, manifest_digest)
+        # Installed bytes already crossed the security boundary in place_generation.
+        # Reads still verify the pinned manifest, inventory hashes and runtime policy.
         Validator.validate(generation_path(name, commit), expected_name: name,
-                           expected_manifest_digest: manifest_digest)
+                           expected_manifest_digest: manifest_digest, scan_security: false)
       end
 
       def workflow(name, commit, manifest_digest, configuration_digest: nil, cfg: {}, verify_profiles: true)
         result = Validator.validate!(generation_path(name, commit), expected_name: name,
-                                     expected_manifest_digest: manifest_digest)
+                                     expected_manifest_digest: manifest_digest, scan_security: false)
         return result.workflow unless configuration_digest
 
         config = begin
@@ -224,7 +226,7 @@ module Hive
 
       def manifest(name, commit, manifest_digest)
         Validator.validate!(generation_path(name, commit), expected_name: name,
-                            expected_manifest_digest: manifest_digest).manifest
+                            expected_manifest_digest: manifest_digest, scan_security: false).manifest
       end
 
       def task_references(name = nil)
@@ -382,7 +384,7 @@ module Hive
 
         validate_lock!(data, expected_name: name)
         result = Validator.validate!(generation_path(name, data.fetch("source_commit")), expected_name: name,
-                                     expected_manifest_digest: data.fetch("manifest_digest"))
+                                     expected_manifest_digest: data.fetch("manifest_digest"), scan_security: false)
         legacy_configuration_for(
           name: name, commit: data.fetch("source_commit"), manifest_digest: data.fetch("manifest_digest"),
           workflow: result.workflow, manifest: result.manifest, cfg: cfg
@@ -413,7 +415,7 @@ module Hive
       def default_configuration(resolution, cfg: {})
         result = Validator.validate!(generation_path(resolution.name, resolution.source_commit),
                                      expected_name: resolution.name,
-                                     expected_manifest_digest: resolution.manifest_digest)
+                                     expected_manifest_digest: resolution.manifest_digest, scan_security: false)
         Configuration.build(
           result.workflow,
           generation: {

--- a/lib/hive/workflow_package/validator.rb
+++ b/lib/hive/workflow_package/validator.rb
@@ -28,9 +28,9 @@ module Hive
         end
       end
 
-      def self.validate(root, expected_name: nil, expected_manifest_digest: nil, managed: true)
+      def self.validate(root, expected_name: nil, expected_manifest_digest: nil, managed: true, scan_security: true)
         new(root, expected_name: expected_name, expected_manifest_digest: expected_manifest_digest,
-                  managed: managed).validate
+                  managed: managed, scan_security: scan_security).validate
       end
 
       def self.validate!(...)
@@ -40,11 +40,12 @@ module Hive
         result
       end
 
-      def initialize(root, expected_name:, expected_manifest_digest:, managed:)
+      def initialize(root, expected_name:, expected_manifest_digest:, managed:, scan_security: true)
         @root = File.expand_path(root)
         @expected_name = expected_name&.to_s
         @expected_manifest_digest = expected_manifest_digest&.to_s
         @managed = managed
+        @scan_security = scan_security
       end
 
       def validate
@@ -81,7 +82,7 @@ module Hive
           @root,
           paths: expected.map { |entry| entry.fetch("path") },
           permissions: manifest.permissions
-        ))
+        )) if @scan_security
         Result.new(manifest: manifest, workflow: workflow, manifest_digest: digest, diagnostics: diagnostics.freeze)
       rescue PackageError => e
         Result.new(manifest: nil, workflow: nil, manifest_digest: nil, diagnostics: [ e.diagnostic ].freeze)

--- a/test/fixtures/runtime_control_plane/affected_production.yml
+++ b/test/fixtures/runtime_control_plane/affected_production.yml
@@ -7,8 +7,8 @@ counting_rule: physical_source_lines
 includes_new_production_files: true
 maximum_final_lines: 7960
 final_inventory_lines: 8436
-outside_inventory_net_lines: -8151
-final_lines: 285
+outside_inventory_net_lines: -8148
+final_lines: 288
 final_paths:
 - path: lib/hive/betterleaks.rb
   lines: 26

--- a/test/unit/workflow_package/managed_store_test.rb
+++ b/test/unit/workflow_package/managed_store_test.rb
@@ -9,6 +9,45 @@ require "hive/workflows/loader"
 class WorkflowPackageManagedStoreTest < Minitest::Test
   include HiveTestHelper
 
+  def test_installed_workflow_reads_check_integrity_without_launching_secret_scans
+    with_tmp_dir do |dir|
+      package = File.join(dir, "package")
+      resolution = write_package(package, "a" * 40)
+      store = Hive::WorkflowPackage::ManagedStore.new(File.join(dir, ".hive-state"))
+      generation = store.place_generation(package, resolution)
+      store.activate(resolution)
+      unexpected_scan = ->(*) { raise Minitest::Assertion, "installed workflow reads must not launch secret scans" }
+
+      with_replaced_singleton_method(Hive::SecretScanner, :scan, unexpected_scan) do
+        assert_equal :demo, Hive::Workflows::Loader.load_dir(store.workflows_dir).fetch(:demo).id
+        assert_equal :demo, store.workflow("demo", resolution.source_commit, resolution.manifest_digest).id
+        assert store.manifest("demo", resolution.source_commit, resolution.manifest_digest)
+        assert store.verify_generation("demo", resolution.source_commit, resolution.manifest_digest).valid?
+
+        readme = File.join(generation, "README.md")
+        File.chmod(0o644, readme)
+        File.write(readme, "tampered\n")
+        refute store.verify_generation("demo", resolution.source_commit, resolution.manifest_digest).valid?
+        assert_raises(Hive::WorkflowPackage::PackageError) do
+          store.workflow("demo", resolution.source_commit, resolution.manifest_digest)
+        end
+      end
+    end
+  end
+
+  def test_installation_still_requires_secret_scanning
+    with_tmp_dir do |dir|
+      package = File.join(dir, "package")
+      resolution = write_package(package, "a" * 40)
+      store = Hive::WorkflowPackage::ManagedStore.new(File.join(dir, ".hive-state"))
+      unavailable = ->(*) { raise Hive::SecretScanner::Unavailable, "scanner unavailable" }
+      with_replaced_singleton_method(Hive::SecretScanner, :scan, unavailable) do
+        assert_raises(Hive::SecretScanner::Unavailable) { store.place_generation(package, resolution) }
+      end
+      refute File.exist?(store.generation_path("demo", resolution.source_commit))
+    end
+  end
+
   def test_places_activates_and_verifies_immutable_generation
     with_tmp_dir do |dir|
       hive_state = File.join(dir, ".hive-state")

--- a/wiki/log.d/20260906-workflow-read-scanning.md
+++ b/wiki/log.d/20260906-workflow-read-scanning.md
@@ -1,0 +1,12 @@
+# Keep package security scans at admission boundaries
+
+Installed workflow reads now retain manifest/inventory integrity and runtime
+validation without repeating package security scans. Incoming package placement,
+registry validation and publication retain full scanning by default.
+
+The real-project status profile before this change took 103.2 seconds with 254
+Betterleaks launches. The first fixed profile took 16.4 seconds with two launches
+outside installed-package validation (20 projects, 366 rows in both profiles).
+These are local observations, not timing guarantees. Regression tests require
+scanner-free installed reads, continued tamper rejection, and fail-closed
+installation when the scanner cannot run.

--- a/wiki/modules/workflow_package.md
+++ b/wiki/modules/workflow_package.md
@@ -13,6 +13,14 @@ tags: [module, workflow-package, honeycomb, registry, permissions, disclosure, m
 
 ## Managed Honeycomb boundary
 
+Package installation and publication run full security scanning. Reads of an
+already installed generation (workflow loading, manifest inspection, integrity
+verification, and configuration reconstruction) do not launch Betterleaks or
+repeat package security lint. They still check the pinned manifest digest, file
+inventory and hashes, filesystem shape, descriptor, and runtime policy. Changed
+installed bytes fail integrity verification rather than being silently rescanned
+and accepted. This keeps package admission work out of routine status scans.
+
 An unchanged `honeycomb-manifest/v1` package normalizes to a one-workflow,
 hook-free `Hive::ModulePackage` with the same immutable identity, mappings,
 inputs, and disclosure. That compatibility relationship does not make this


### PR DESCRIPTION
## Summary

- Routine status scans no longer repeat security scanning of installed workflow packages. Installation and publication retain full scanning; installed reads retain pinned manifest, file-hash, filesystem and runtime-policy validation.
- Corrects the scan regression following the Betterleaks integration without adding a cache or another persisted state.

| Local real-project profile | Before | After |
|---|---:|---:|
| Full scan, 20 projects / 366 rows | 103.2 s | 16.4 s |
| Betterleaks launches | 254 | 2 |

These are individual local measurements, not timing guarantees. A second run took 22.0 s with four Patrol diagnostic scans as live task state changed. Installed-package validation made no scanner calls. Patrol diagnostic text screening is intentionally retained.

## Test plan

- [x] Regression reproduced before the fix: installed workflow loading unexpectedly invoked the scanner.
- [x] Managed-store tests: 27 tests, 127 assertions; installed reads do not scan, tampered bytes are rejected, and installation fails closed if scanning is unavailable.
- [x] Validator, security scanner, publisher and registry-manifest tests: 59 tests, 348 assertions; incoming secrets remain blocked.
- [x] RuboCop on all three changed Ruby files; git diff --check.
- [x] Real-project read-only status profiling using the same StatusConsumer entrypoint before and after.
- [ ] Hosted CI coverage and dedicated merge gates.

## Notes for reviewer

Incoming validation scans by default. Only already installed generation reads opt out of repeated security lint. No daemon restart, deployment, live task mutation, or change to the separate attempt-proof mismatch is included. External review and babysitting were skipped per operator preference; fix-scoped self-review completed.

Related: #1403

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
