### PR TITLE
fix: finalize attempts without queue cleanup changing their identity

### DIFF
--- a/lib/hive/runtime_control_plane/database.rb
+++ b/lib/hive/runtime_control_plane/database.rb
@@ -9,12 +9,13 @@ require "hive/atomic_file"
 
 module Hive
   module RuntimeControlPlane
-    EXPECTED_SCHEMA_SHA256 = "24f43b9a0ac27f015b9a4321b9ff3ac2034cd109f354a30abf50f181a8748935".freeze
+    EXPECTED_SCHEMA_SHA256 = "f237684b17dfd8f7ded175a5e3c7a1b0445c4a7bee109fca4f2f51e498ead0a7".freeze
 
     class Database
       MIGRATE_ACTION = "stop Hive and run hive migrate --all".freeze
       BACKUP_ACTION = "stop Hive and recover from an external backup".freeze
       MIGRATIONS = %w[001_create_runtime_control_plane.rb].freeze
+      REQUEST_FOREIGN_KEY_SCHEMA = "24f43b9a0ac27f015b9a4321b9ff3ac2034cd109f354a30abf50f181a8748935".freeze
       attr_reader :path, :owner_pid
 
       def initialize(path: Hive::Paths.runtime_control_plane_path, migrations_dir: MIGRATIONS_DIR,
@@ -49,6 +50,7 @@ module Hive
           FileUtils.mkdir_p(File.dirname(path))
           prepare_storage!
           connect!
+          upgrade_request_provenance!
           Sequel::IntegerMigrator.new(@connection, @migrations_dir, table: :schema_info,
                                       column: :version, use_transactions: true).run
           ensure_installation_identity!
@@ -262,13 +264,40 @@ module Hive
         true
       end
 
-      def exact_schema?(database)
+      def exact_schema?(database, expected: EXPECTED_SCHEMA_SHA256)
         rows = database[:sqlite_master].where(type: %w[table index])
           .exclude(name: "schema_info").exclude(Sequel.like(:name, "sqlite_%"))
           .order(:type, :name).select_map([ :type, :name, :tbl_name, :sql ])
-        Digest::SHA256.hexdigest(Codec.dump_json(rows)) == EXPECTED_SCHEMA_SHA256
+        Digest::SHA256.hexdigest(Codec.dump_json(rows)) == expected
       rescue Sequel::Error
         false
+      end
+
+      # Explicit migration only: queue retention must not rewrite immutable attempts.
+      # Rebuild from the canonical schema: SQLite's generic ALTER emulation loses
+      # CHECK constraints. Foreign keys are disabled outside the transaction so
+      # dropping the old table cannot cascade into receipts, leases or usage.
+      def upgrade_request_provenance!
+        return unless exact_schema?(@connection, expected: REQUEST_FOREIGN_KEY_SCHEMA)
+
+        template = Sequel.sqlite
+        Sequel::Migrator.run(template, @migrations_dir)
+        definitions = template[:sqlite_master].where(tbl_name: "attempts")
+          .exclude(sql: nil).order(Sequel.desc(:type), :name).select_map(:sql)
+        @connection.run("PRAGMA foreign_keys = OFF")
+        @connection.transaction(mode: :exclusive, rollback: :reraise) do
+          @connection.run("CREATE TEMP TABLE attempt_provenance_upgrade AS SELECT * FROM attempts")
+          @connection.drop_table(:attempts)
+          definitions.each { |sql| @connection.run(sql) }
+          @connection.run("INSERT INTO attempts SELECT * FROM attempt_provenance_upgrade")
+          @connection.run("DROP TABLE temp.attempt_provenance_upgrade")
+          unless exact_schema?(@connection) && pragma_rows(@connection, "foreign_key_check").empty?
+            raise Sequel::Error, "attempt provenance upgrade failed schema or foreign-key validation"
+          end
+        end
+      ensure
+        @connection.run("PRAGMA foreign_keys = ON") if template
+        template&.disconnect
       end
 
       def prepare_storage!

--- a/lib/hive/runtime_control_plane/migrations/001_create_runtime_control_plane.rb
+++ b/lib/hive/runtime_control_plane/migrations/001_create_runtime_control_plane.rb
@@ -97,8 +97,7 @@ Sequel.migration do
 
     create_table(:attempts) do
       String :attempt_id, primary_key: true, null: false
-      foreign_key :request_id, :dispatch_requests, type: String, key: :request_id,
-                  on_delete: :set_null, on_update: :cascade
+      String :request_id # Immutable provenance, not ownership by the disposable queue row.
       foreign_key :project_id, :projects, type: String, key: :project_id,
                   null: false, on_delete: :cascade, on_update: :cascade
       foreign_key :task_id, :task_subjects, type: String, key: :task_id,

--- a/test/fixtures/runtime_control_plane/affected_production.yml
+++ b/test/fixtures/runtime_control_plane/affected_production.yml
@@ -6,9 +6,9 @@ baseline_lines: 9951
 counting_rule: physical_source_lines
 includes_new_production_files: true
 maximum_final_lines: 7960
-final_inventory_lines: 8436
+final_inventory_lines: 8464
 outside_inventory_net_lines: -8148
-final_lines: 288
+final_lines: 316
 final_paths:
 - path: lib/hive/betterleaks.rb
   lines: 26
@@ -49,13 +49,13 @@ final_paths:
 - path: lib/hive/runtime_control_plane/cutover_manifest.rb
   lines: 114
 - path: lib/hive/runtime_control_plane/database.rb
-  lines: 366
+  lines: 395
 - path: lib/hive/runtime_control_plane/dispatch_repository.rb
   lines: 773
 - path: lib/hive/runtime_control_plane/maintenance.rb
   lines: 113
 - path: lib/hive/runtime_control_plane/migrations/001_create_runtime_control_plane.rb
-  lines: 283
+  lines: 282
 - path: lib/hive/runtime_control_plane/operational_repository.rb
   lines: 63
 - path: lib/hive/runtime_control_plane/payload_store.rb

--- a/test/unit/attempts/finalization_maintenance_test.rb
+++ b/test/unit/attempts/finalization_maintenance_test.rb
@@ -9,6 +9,69 @@ class AttemptsFinalizationMaintenanceTest < Minitest::Test
   NOW = Time.utc(2026, 8, 10, 12, 0, 0)
   CAPABILITY = "c" * 64
 
+  def test_explicit_request_provenance_upgrade_preserves_rows_and_finalization
+    with_repository do |store|
+      terminal = terminal_attempt(store)
+      subject = maintenance(store)
+      prepare_all(subject, terminal)
+      database = store.database
+      database.transaction do |db|
+        db[:token_usage].insert(id: "usage-1", attempt_id: terminal.attempt_id,
+                               agent: "codex", started_at: NOW.iso8601(6), input: 123)
+        db[:payload_references].insert(payload_id: "upgrade-proof", attempt_id: terminal.attempt_id,
+                                      kind: "test", relative_path: "proof", state: "open",
+                                      created_at: NOW.iso8601(6))
+      end
+      before = database.read { |db| db.tables.to_h { |table| [ table, db[table].all ] } }
+      path = database.path
+      database.disconnect
+      legacy = Sequel.sqlite(path)
+      # Recreate the exact deployed constraint without changing any stored rows.
+      definition = legacy[:sqlite_master].where(name: "attempts").get(:sql).sub(
+        "`request_id` varchar(255),",
+        "`request_id` varchar(255) REFERENCES `dispatch_requests`(`request_id`) ON DELETE SET NULL ON UPDATE CASCADE,"
+      )
+      indexes = legacy[:sqlite_master].where(type: "index", tbl_name: "attempts").exclude(sql: nil).select_map(:sql)
+      legacy.run("PRAGMA foreign_keys = OFF")
+      legacy.transaction do
+        legacy.run("CREATE TEMP TABLE saved_attempts AS SELECT * FROM attempts")
+        legacy.drop_table(:attempts)
+        legacy.run(definition)
+        indexes.each { |sql| legacy.run(sql) }
+        legacy.run("INSERT INTO attempts SELECT * FROM saved_attempts")
+        legacy.run("DROP TABLE saved_attempts")
+      end
+      assert database.send(:exact_schema?, legacy,
+                           expected: Hive::RuntimeControlPlane::Database::REQUEST_FOREIGN_KEY_SCHEMA)
+      legacy.disconnect
+      assert_raises(Hive::RuntimeControlPlane::MigrationRequired) { database.open! }
+
+      original_verification = database.method(:exact_schema?)
+      rejected_upgrade = lambda do |connection, **options|
+        options.empty? ? false : original_verification.call(connection, **options)
+      end
+      with_replaced_singleton_method(database, :exact_schema?, rejected_upgrade) do
+        assert_raises(Hive::RuntimeControlPlane::IntegrityError) { database.migrate! }
+      end
+      assert database.send(:exact_schema?, legacy,
+                           expected: Hive::RuntimeControlPlane::Database::REQUEST_FOREIGN_KEY_SCHEMA)
+      assert_equal before, legacy.tables.to_h { |table| [ table, legacy[table].all ] }
+      legacy.disconnect
+
+      database.migrate!
+      assert_equal before, database.read { |db| db.tables.to_h { |table| [ table, db[table].all ] } }
+      assert_equal 1, database.read { |db| db.fetch("PRAGMA foreign_keys").first.values.first }
+      assert_equal :ok, database.diagnostics.status
+      database.migrate! # Explicit retries are harmless.
+      assert Hive::RuntimeControlPlane::DispatchRepository.new(database: database).remove(terminal["request_id"])
+      assert_equal terminal.to_h, store.fetch(terminal.attempt_id).to_h
+      assert subject.promote(terminal)
+      assert_nil store.fetch_hot(terminal.attempt_id)
+    ensure
+      legacy&.disconnect
+    end
+  end
+
   def test_partial_acknowledgements_resume_and_publish_terminal_payloads_once
     with_repository do |store|
       terminal = terminal_attempt(store)

--- a/test/unit/attempts/lost_outcome_test.rb
+++ b/test/unit/attempts/lost_outcome_test.rb
@@ -230,6 +230,24 @@ class AttemptsLostOutcomeTest < Minitest::Test
     end
   end
 
+  def test_invalid_lost_recovery_transitions_leave_the_durable_row_unchanged
+    with_tmp_dir do |root|
+      store = Hive::Attempts::Repository.new(root: root, migrate: true)
+      lost = lost_without_worker(store)
+      outcomes = Hive::Attempts::LostOutcomeTransition.new(store: store)
+      pending = outcomes.ensure_for(lost, now: NOW)
+      [ { phase: "unknown" }, { cleanup: "unknown" } ].each do |change|
+        error = assert_raises(Hive::Attempts::RepositoryError) { outcomes.update(lost, **change) }
+        assert_equal "lost recovery transition is invalid", error.message
+        assert_equal pending, outcomes.fetch(lost.attempt_id)
+      end
+      ready = outcomes.update(lost, phase: "ready", request_id: outcomes.recovery_request_id(lost), now: NOW)
+      error = assert_raises(Hive::Attempts::RepositoryError) { outcomes.update(lost, phase: "pending") }
+      assert_equal "lost recovery transition is invalid", error.message
+      assert_equal ready, outcomes.fetch(lost.attempt_id)
+    end
+  end
+
   def test_transition_reads_and_writes_fail_closed_on_storage_errors
     with_tmp_dir do |root|
       store = Hive::Attempts::Repository.new(root: root, migrate: true)

--- a/test/unit/daemon/dispatcher_test.rb
+++ b/test/unit/daemon/dispatcher_test.rb
@@ -6124,10 +6124,18 @@ end
   end
 
   def test_terminal_attempt_receipt_completes_claimed_delivery_without_wait2
+    assert_terminal_attempt_completes_delivery(chat_id: 42)
+  end
+
+  def test_terminal_attempt_is_promoted_in_same_tick_when_request_is_deleted
+    assert_terminal_attempt_completes_delivery(chat_id: nil)
+  end
+
+  def assert_terminal_attempt_completes_delivery(chat_id:)
     Dir.mktmpdir("hive-attempt-delivery") do |state_home|
       request_id = Q.write_request!(
         project: "p1", slug: "demo-task", argv: %w[hive run demo-task],
-        chat_id: 42, request_id: "request-1", task_id: "42",
+        chat_id: chat_id, request_id: "request-1", task_id: "42",
         task_generation: "generation-1", expected_stage: "4-execute",
         state_home: state_home, now: T0
       )
@@ -6188,11 +6196,17 @@ end
       assert_empty supervisor.spawned
       assert_empty Q.claimed(state_home: state_home)
       notice = Q.pending_results(state_home: state_home).first
-      assert_equal "attempt-1", notice.attempt_id
-      assert_equal "terminal", notice.attempt_state
-      assert_equal "succeeded", notice.receipt["outcome"]
+      if chat_id
+        assert_equal "attempt-1", notice.attempt_id
+        assert_equal "terminal", notice.attempt_state
+        assert_equal "succeeded", notice.receipt["outcome"]
+      else
+        assert_nil notice
+        assert_nil Q.repository(state_home).fetch(request_id)
+      end
       assert_nil store.fetch_hot("attempt-1")
       assert_equal "terminal", store.fetch("attempt-1").state
+      assert_equal request_id, store.fetch("attempt-1")["request_id"]
     end
   end
 

--- a/test/unit/runtime_control_plane/schema_test.rb
+++ b/test/unit/runtime_control_plane/schema_test.rb
@@ -128,7 +128,7 @@ class RuntimeControlPlaneSchemaTest < Minitest::Test
           end
         }
       end
-      assert_equal :set_null, foreign_keys.dig(:attempt, :on_delete)
+      assert_nil foreign_keys[:attempt], "queue cleanup must not mutate attempt provenance"
 
       database.transaction do |connection|
         request = {

--- a/wiki/gaps.md
+++ b/wiki/gaps.md
@@ -1385,3 +1385,11 @@ prevents lower-priority leapfrogging, but a rare project-only race can leave an
 unrelated slot unused for the full-scan interval plus scan time. Keep this gap
 open until durable admission emits a typed capacity scope that the row
 scheduler can preserve directly.
+## Attempt request-provenance upgrade awaits deployment (2026-09-06)
+
+The exact-schema upgrade removing the dispatch-request foreign key is tested
+against a reconstructed copy of the preceding schema, including row preservation
+and transaction rollback. It has not been applied to dogfood. Stop all writers
+and take an external SQLite backup before the explicit upgrade described in
+[[modules/attempts]]. Request IDs already cleared by the old foreign key are not
+recovered by this change; retained IDs and future attempts are preserved.

--- a/wiki/log.d/20260906-attempt-request-provenance.md
+++ b/wiki/log.d/20260906-attempt-request-provenance.md
@@ -1,0 +1,20 @@
+# Preserve attempt identity across dispatch cleanup
+
+The dispatch queue deleted completed requests without a result delivery. Its
+foreign key silently nulled attempts.request_id, breaking immutable record
+comparison in the same reconciliation tick. Request IDs are now plain immutable
+provenance; the unique index and full finalization comparison remain.
+
+Explicit Database#migrate! supports the exact preceding schema, retaining every
+row and all constraints in one transaction. Startup never upgrades storage.
+With all Hive writers stopped and an external backup taken, run from the new
+checkout using the explicit database path:
+
+```sh
+bundle exec ruby -Ilib -rhive -rhive/runtime_control_plane -e 'Hive::RuntimeControlPlane::Database.new(path: ARGV.fetch(0)).migrate!.disconnect' /absolute/path/to/runtime-control-plane.sqlite3
+```
+
+This is the existing Ruby migration boundary, not hive migrate --all's legacy
+filesystem cutover. Tests cover no-chat and chat delivery, same-tick promotion,
+preservation of all table rows including token history, migration rollback,
+idempotent retry, and refusal to upgrade through ordinary open.

--- a/wiki/modules/attempts.md
+++ b/wiki/modules/attempts.md
@@ -43,6 +43,21 @@ attempt delays automatic retry by `AgentLimit.retry_cooldown_sec`; success or
 changed inputs/runtime clears that delay. Explicit retry bypasses pacing, not
 live capacity or unresolved-loss recovery. There are no cohort counters or probes.
 
+`request_id` is immutable provenance, not a foreign key to the disposable
+dispatch queue. Completing or pruning a request must not change an attempt
+snapshot or prevent same-tick finalization. The unique request index still
+prevents duplicate admission. Finalization retains its full-record equality
+checks; mismatches are not ignored or retried inside the tick.
+
+For the preceding SQLite layout only, explicit `Database#migrate!` recognizes
+the exact old schema fingerprint and atomically rebuilds the attempts table
+without that foreign key. It preserves rows, indexes and CHECK constraints,
+validates the new schema and foreign keys before committing, and rolls back
+on failure. Other tables, token history and payload references are retained.
+Normal open/startup rejects the old schema and does not upgrade it. Stop all
+writers and take an external SQLite backup before invoking the migration.
+Previously nulled request IDs cannot be reconstructed by this schema change.
+
 SQL columns own lifecycle and identity values. `details_json` contains only
 execution details absent from those columns; `subject_json` holds the structured
 subject and `terminal_receipt_json` holds the receipt once. `Record.from_row`


### PR DESCRIPTION
## Summary

- Completed dispatch requests can now be deleted without changing the final attempt record or aborting that reconciliation tick. The originating request ID remains immutable provenance; full-record finalization checks and the unique request index remain intact.
- Existing databases have an explicit, transactional upgrade for the exact preceding schema. It preserves table rows, CHECK constraints, indexes, token usage and payload references without adding a schema version, persistent table, or startup migration.

## Test plan

- [x] Reproduced failure in the real dispatcher test's no-chat request-deletion path; both no-chat and chat paths now promote in the same tick.
- [x] Dispatcher, finalization, database, schema, dispatch repository and deletion-contract tests: 405 tests, 1,726 assertions.
- [x] Upgrade test verifies all-table row preservation, rollback on failed validation, idempotent retry, retained request identity after deletion, and normal-open refusal of the old schema.
- [x] Real subprocess `incident_provider_limit_retry` scenario passed in 10.038 seconds; retained evidence has no proof-mismatch/reconciliation-failure error.
- [x] RuboCop on changed Ruby files and `git diff --check`.
- [ ] Hosted CI coverage and dedicated merge gates.

## Notes for reviewer

Before deploying, stop all Hive database writers and take an external SQLite backup. Invoke the new checkout's explicit `Database#migrate!` boundary using the command in `wiki/log.d/20260906-attempt-request-provenance.md`, then restart services. `hive migrate --all` is the legacy filesystem cutover, not this upgrade. This PR has not modified live storage or dogfood.

The upgrade recreates only `attempts` from the canonical fresh schema in one exclusive transaction, with foreign-key actions disabled for the rebuild and checked before commit. Sequel's generic SQLite drop-foreign-key emulation was rejected because the local experiment dropped CHECK constraints. Existing request IDs already nulled by queue deletion remain unknown; this change preserves retained and future IDs rather than inventing history.

The earlier test used `chat_id: 42`, which retains the completed request for result delivery and never exercises deletion. External review was skipped per operator preference; targeted self-review completed. No full local coverage run or deployment was performed.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
