### PR TITLE
fix: unblock review publication and make artifacts best effort

### DIFF
--- a/lib/hive/stages/artifacts.rb
+++ b/lib/hive/stages/artifacts.rb
@@ -13,6 +13,7 @@ require "hive/artifacts/outcome_evidence/rework"
 require "hive/artifacts/outcome_evidence/store"
 require "hive/atomic_file"
 require "hive/markers"
+require "hive/terminal_outcome"
 require "hive/screenote/credential_store"
 require "hive/screenote/mcp_config"
 require "hive/screenote/oauth_client"
@@ -27,6 +28,7 @@ module Hive
       MAX_INFERENCE_ATTEMPTS = 2
       MAX_REVIEWER_ATTEMPTS = 2
       class RoleOutputError < Hive::Artifacts::OutcomeEvidence::StoreError; end
+      class IntegrityError < Hive::Artifacts::OutcomeEvidence::StoreError; end
       class RoleAgentError < StandardError
         attr_reader :role, :profile, :result
 
@@ -43,6 +45,29 @@ module Hive
       }.freeze
 
       def run!(task, cfg)
+        marker = Hive::Markers.current(task.state_file)
+        return { commit: nil, status: :complete } if
+          marker.name == :complete && marker.attrs["evidence_status"] == "unavailable"
+
+        result = collect!(task, cfg)
+        return result unless result[:status] == :error
+
+        marker = Hive::Markers.current(task.state_file)
+        return result if %w[outcome_evidence_integrity_invalid outcome_evidence_reworks_exhausted].include?(marker.attrs["reason"]) ||
+                         Hive::TerminalOutcome.outcome_evidence_rework?(marker.attrs)
+
+        Hive::Markers.set(
+          task.state_file, :complete,
+          marker.attrs.merge(
+            "reason" => "evidence_best_effort", "evidence_status" => "unavailable",
+            "warning_reason" => marker.attrs["reason"]
+          )
+        )
+        warn "hive: evidence collection unavailable; continuing without accepted evidence (#{marker.attrs['reason']})"
+        { commit: "artifacts_best_effort", status: :complete }
+      end
+
+      def collect!(task, cfg)
         FileUtils.touch(task.state_file) unless File.exist?(task.state_file)
         run_outcome_evidence!(task, cfg || {})
       rescue RoleAgentError => e
@@ -53,7 +78,9 @@ module Hive
              Hive::Artifacts::ManagedWebServer::ServerError,
              Hive::AgentError, Hive::ConfigError, KeyError => e
         Hive::Markers.set(
-          task.state_file, :error, reason: "outcome_evidence_invalid",
+          task.state_file, :error,
+          reason: e.is_a?(IntegrityError) || e.is_a?(Hive::Artifacts::OutcomeEvidence::ResolutionError) ||
+            e.is_a?(Hive::ArtifactFirewall::Error) ? "outcome_evidence_integrity_invalid" : "outcome_evidence_invalid",
           diagnostic: e.message.to_s.byteslice(0, 200).to_s.scrub
         )
         { commit: "error", status: :error }
@@ -462,7 +489,7 @@ module Hive
         rescue Hive::AgentError => e
           report = agent_custody.report
           if report && !report.valid?
-            raise Hive::Artifacts::OutcomeEvidence::StoreError,
+            raise IntegrityError,
                   "#{role} modified protected task state: #{report.diagnostic}"
           end
 
@@ -473,11 +500,11 @@ module Hive
         end
         report = agent_custody.report
         if !report && result.is_a?(Hash) && result[:status] == :ok
-          raise Hive::Artifacts::OutcomeEvidence::StoreError,
+          raise IntegrityError,
                 "#{role} agent custody was not invoked"
         end
         if report && !report.valid?
-          raise Hive::Artifacts::OutcomeEvidence::StoreError,
+          raise IntegrityError,
                 "#{role} modified protected task state: #{report.diagnostic}"
         end
         unless result && result[:status] == :ok
@@ -491,7 +518,7 @@ module Hive
           task: task, project: File.basename(task.project_root)
         ).resolve
         unless resolved == identity
-          raise Hive::Artifacts::OutcomeEvidence::StoreError,
+          raise IntegrityError,
                 "#{role} changed the frozen implementation source"
         end
 

--- a/lib/hive/stages/review/github_publisher.rb
+++ b/lib/hive/stages/review/github_publisher.rb
@@ -106,12 +106,6 @@ module Hive
           )
           worktree_path = pointer.fetch("path")
           branch = pointer.fetch("branch")
-          persisted_head = frontmatter["head_oid"].to_s.downcase
-          unless persisted_head.match?(/\A[a-f0-9]{40,64}\z/)
-            warn "hive: review GitHub publish skipped; pr.md has no exact controller head identity"
-            return nil
-          end
-
           identity = Hive::Gh.repository_identity(worktree_path, cfg: cfg)
           unless parsed.fetch("host") == identity.fetch("host").downcase &&
                  parsed.fetch("repository") == identity.fetch("repository").downcase
@@ -124,7 +118,6 @@ module Hive
           ).one? do |candidate|
             candidate["state"].to_s.upcase == "OPEN" &&
               candidate["headRefName"].to_s == branch &&
-              candidate["headRefOid"].to_s.downcase == persisted_head &&
               candidate["number"].to_i == parsed.fetch("number") &&
               Hive::Gh.parse_pull_request_url(candidate["url"]) == parsed
           end

--- a/lib/hive/task_workspace/publication.rb
+++ b/lib/hive/task_workspace/publication.rb
@@ -50,7 +50,7 @@ module Hive
         end
 
         local = observe_local(pointer, diagnostics)
-        pr = read_pr(pointer, local, diagnostics)
+        pr = read_pr(pointer, diagnostics)
         refresh_identity = refresh_identity(pointer, local, pr, diagnostics)
         remote = if @cache && refresh_identity
           @cache.read(refresh_identity)
@@ -280,7 +280,7 @@ module Hive
         { "state" => "unavailable", "tracking_oid" => nil, "ahead" => nil, "behind" => nil }
       end
 
-      def read_pr(pointer, local, diagnostics)
+      def read_pr(pointer, diagnostics)
         path = File.join(@task.folder.to_s, "pr.md")
         return missing_pr unless File.exist?(path)
 
@@ -307,14 +307,13 @@ module Hive
         conflicts = []
         conflicts << "repository" if repository && pointer["repository"] && repository != pointer["repository"]
         conflicts << "number" if declared_number && number && declared_number != number
-        conflicts << "head" if head && local["head_oid"] && head != local["head_oid"]
         diagnostics.concat(conflicts.map { |field| diagnostic("pr_#{field}_mismatch") })
         title = frontmatter["title"].to_s.strip
         title = body[/^#\s+(.+)$/, 1].to_s.strip if title.empty?
         state = if conflicts.any?
           "conflicting"
         elsif parsed
-          result.truncated || head.nil? ? "partial" : "current"
+          result.truncated ? "partial" : "current"
         else
           "partial"
         end

--- a/test/unit/stages/artifacts_test.rb
+++ b/test/unit/stages/artifacts_test.rb
@@ -4,9 +4,73 @@ require "hive/config"
 require "hive/markers"
 require "hive/stages/artifacts"
 require "hive/task"
+require "hive/task_action"
 
 class StagesArtifactsTest < Minitest::Test
   include HiveTestHelper
+
+  def test_best_effort_capture_failure_completes_without_claiming_accepted_evidence
+    Dir.mktmpdir("hive-artifacts-best-effort") do |dir|
+      task = make_artifacts_task(dir)
+      File.write(task.state_file, "Existing evidence notes\n")
+      calls = 0
+      collector = lambda do |*_|
+        calls += 1
+        raise Hive::Artifacts::OutcomeEvidence::StoreError, "screenshot has no matching controller capture receipt"
+      end
+      with_replaced_singleton_method(Hive::Stages::Artifacts, :run_outcome_evidence!, collector) do
+        result = Hive::Stages::Artifacts.run!(task, {})
+        assert_equal :complete, result.fetch(:status)
+        marker = Hive::Markers.current(task.state_file)
+        assert_equal "unavailable", marker.attrs.fetch("evidence_status")
+        assert_equal "outcome_evidence_invalid", marker.attrs.fetch("warning_reason")
+        assert_includes marker.attrs.fetch("diagnostic"), "capture receipt"
+        assert_includes File.read(task.state_file), "Existing evidence notes"
+        assert_equal "ready_to_finalize", Hive::TaskAction.for(task, marker).key
+        assert_equal :complete, Hive::Stages::Artifacts.run!(task, {}).fetch(:status)
+        assert_equal 1, calls
+      end
+    end
+  end
+
+  def test_best_effort_does_not_hide_source_integrity_failures_or_implementation_rework
+    Dir.mktmpdir("hive-artifacts-best-effort") do |dir|
+      task = make_artifacts_task(dir)
+      [ Hive::Stages::Artifacts::IntegrityError,
+        Hive::Artifacts::OutcomeEvidence::ResolutionError ].each do |error_class|
+        with_replaced_singleton_method(Hive::Stages::Artifacts, :run_outcome_evidence!, ->(*_) { raise error_class, "source changed" }) do
+          assert_equal :error, Hive::Stages::Artifacts.run!(task, {}).fetch(:status)
+          assert_equal "outcome_evidence_integrity_invalid", Hive::Markers.current(task.state_file).attrs.fetch("reason")
+        end
+      end
+      %w[outcome_evidence_implementation_rework outcome_evidence_reworks_exhausted].each do |reason|
+        rework = lambda do |*_|
+          Hive::Markers.set(task.state_file, :error, reason: reason)
+          { status: :error, commit: "rework" }
+        end
+        with_replaced_singleton_method(Hive::Stages::Artifacts, :run_outcome_evidence!, rework) do
+          assert_equal :error, Hive::Stages::Artifacts.run!(task, {}).fetch(:status)
+        end
+      end
+    end
+  end
+
+  def test_best_effort_continues_after_capture_quota_or_a_blocked_capture
+    Dir.mktmpdir("hive-artifacts-best-effort") do |dir|
+      %w[limits_reached outcome_evidence_capability_blocked outcome_evidence_recaptures_exhausted].each do |reason|
+        task = make_artifacts_task(dir)
+        File.write(task.state_file, "")
+        failed = lambda do |*_|
+          Hive::Markers.set(task.state_file, :error, reason: reason)
+          { status: :error, commit: "error" }
+        end
+        with_replaced_singleton_method(Hive::Stages::Artifacts, :run_outcome_evidence!, failed) do
+          assert_equal :complete, Hive::Stages::Artifacts.run!(task, {}).fetch(:status)
+          assert_equal reason, Hive::Markers.current(task.state_file).attrs.fetch("warning_reason")
+        end
+      end
+    end
+  end
 
   def test_markerless_artifacts_stage_spawns_agent_and_returns_complete_marker
     Dir.mktmpdir("hive-artifacts-stage") do |dir|
@@ -1329,7 +1393,7 @@ class StagesArtifactsTest < Minitest::Test
     end
   end
 
-  def test_run_touches_state_and_translates_controller_errors_to_a_durable_marker
+  def test_collection_touches_state_and_translates_controller_errors_to_a_durable_marker
     Dir.mktmpdir("hive-artifacts-stage") do |dir|
       task = make_artifacts_task(dir)
       FileUtils.rm_f(task.state_file)
@@ -1337,7 +1401,7 @@ class StagesArtifactsTest < Minitest::Test
       result = with_replaced_singleton_method(
         Hive::Stages::Artifacts, :run_outcome_evidence!, replacement
       ) do
-        Hive::Stages::Artifacts.run!(task, nil)
+        Hive::Stages::Artifacts.collect!(task, nil)
       end
       assert_equal({ commit: "done", status: :complete }, result)
       assert File.exist?(task.state_file)
@@ -1348,7 +1412,7 @@ class StagesArtifactsTest < Minitest::Test
       result = with_replaced_singleton_method(
         Hive::Stages::Artifacts, :run_outcome_evidence!, replacement
       ) do
-        Hive::Stages::Artifacts.run!(task, {})
+        Hive::Stages::Artifacts.collect!(task, {})
       end
       assert_equal({ commit: "error", status: :error }, result)
       marker = Hive::Markers.current(task.state_file)
@@ -1357,7 +1421,7 @@ class StagesArtifactsTest < Minitest::Test
     end
   end
 
-  def test_run_preserves_role_provider_limits_as_a_cooldown_marker
+  def test_collection_preserves_role_provider_limits_as_a_cooldown_marker
     Dir.mktmpdir("hive-artifacts-stage") do |dir|
       task = make_artifacts_task(dir)
       retry_at = "2026-08-21T10:15:00Z"
@@ -1379,7 +1443,7 @@ class StagesArtifactsTest < Minitest::Test
       result = with_replaced_singleton_method(
         Hive::Stages::Artifacts, :run_outcome_evidence!, replacement
       ) do
-        Hive::Stages::Artifacts.run!(task, {})
+        Hive::Stages::Artifacts.collect!(task, {})
       end
 
       assert_equal({ commit: "limits_reached", status: :error }, result)
@@ -1392,7 +1456,7 @@ class StagesArtifactsTest < Minitest::Test
     end
   end
 
-  def test_run_preserves_non_limit_role_provider_errors
+  def test_collection_preserves_non_limit_role_provider_errors
     Dir.mktmpdir("hive-artifacts-stage") do |dir|
       task = make_artifacts_task(dir)
       failure = Hive::Stages::Artifacts::RoleAgentError.new(
@@ -1410,7 +1474,7 @@ class StagesArtifactsTest < Minitest::Test
       result = with_replaced_singleton_method(
         Hive::Stages::Artifacts, :run_outcome_evidence!, replacement
       ) do
-        Hive::Stages::Artifacts.run!(task, {})
+        Hive::Stages::Artifacts.collect!(task, {})
       end
 
       assert_equal({ commit: "error", status: :error }, result)

--- a/test/unit/stages/review/github_publisher_test.rb
+++ b/test/unit/stages/review/github_publisher_test.rb
@@ -138,23 +138,6 @@ class ReviewGithubPublisherTest < Minitest::Test
     end
   end
 
-  def test_validated_pr_url_requires_an_exact_persisted_head
-    with_tmp_dir do |dir|
-      task = make_task(dir)
-
-      with_replaced_singleton_method(
-        Hive::Worktree, :canonical_root, ->(_root) { "/owned" }
-      ) do
-        with_replaced_singleton_method(
-          Hive::Worktree, :read_owned_pointer,
-          ->(*_args, **_kwargs) { { "path" => "/owned/task", "branch" => task.slug } }
-        ) do
-          assert_nil Hive::Stages::Review::GithubPublisher.validated_pr_url(task, cfg)
-        end
-      end
-    end
-  end
-
   def test_validated_pr_url_fails_closed_when_repository_identity_cannot_be_read
     with_tmp_dir do |dir|
       task = make_task(dir)
@@ -173,7 +156,7 @@ class ReviewGithubPublisherTest < Minitest::Test
     end
   end
 
-  def test_validated_pr_url_binds_task_branch_and_persisted_head
+  def test_validated_pr_url_binds_the_live_pr_not_a_saved_commit
     with_tmp_dir do |dir|
       task = make_task(dir)
       head = "a" * 40
@@ -219,8 +202,17 @@ class ReviewGithubPublisherTest < Minitest::Test
                 Hive::Stages::Review::GithubPublisher.validated_pr_url(task, cfg)
               )
               candidates = [ observed.merge("headRefOid" => "b" * 40) ]
-              assert_nil Hive::Stages::Review::GithubPublisher.validated_pr_url(task, cfg)
-              candidates = [ observed.merge("headRefName" => "other-branch") ]
+              assert_equal observed.fetch("url"),
+                           Hive::Stages::Review::GithubPublisher.validated_pr_url(task, cfg)
+              File.write(File.join(task.folder, "pr.md"), "---\npr_url: #{observed.fetch('url')}\n---\n")
+              assert_equal observed.fetch("url"),
+                           Hive::Stages::Review::GithubPublisher.validated_pr_url(task, cfg)
+              [ { "headRefName" => "other-branch" }, { "number" => 43 },
+                { "state" => "CLOSED" }, { "url" => "https://github.com/acme/app/pull/43" } ].each do |change|
+                candidates = [ observed.merge(change) ]
+                assert_nil Hive::Stages::Review::GithubPublisher.validated_pr_url(task, cfg)
+              end
+              candidates = [ observed, observed ]
               assert_nil Hive::Stages::Review::GithubPublisher.validated_pr_url(task, cfg)
             end
           end

--- a/test/unit/task_workspace/publication_coverage_gaps_test.rb
+++ b/test/unit/task_workspace/publication_coverage_gaps_test.rb
@@ -128,14 +128,13 @@ class TaskWorkspacePublicationCoverageGapsTest < Minitest::Test
   def test_pr_reader_and_frontmatter_failures_are_bounded
     with_service do |subject, folder, worktrees|
       pointer = strict_pointer(worktrees)
-      local = { "head_oid" => "d" * 40 }
       diagnostics = []
 
       File.binwrite(File.join(folder, "pr.md"), "\0binary")
-      assert_equal "unavailable", subject.send(:read_pr, pointer, local, diagnostics).fetch("state")
+      assert_equal "unavailable", subject.send(:read_pr, pointer, diagnostics).fetch("state")
 
       File.write(File.join(folder, "pr.md"), "# No identity\n")
-      assert_equal "partial", subject.send(:read_pr, pointer, local, diagnostics).fetch("state")
+      assert_equal "partial", subject.send(:read_pr, pointer, diagnostics).fetch("state")
 
       duplicate = "---\npr_url: a\npr_url: b\n---\nbody\n"
       assert_equal({}, subject.send(:parse_pr_document, duplicate, diagnostics).first)
@@ -147,7 +146,7 @@ class TaskWorkspacePublicationCoverageGapsTest < Minitest::Test
       FileUtils.rm_f(File.join(folder, "pr.md"))
       File.write(File.join(folder, "linked-pr"), "body")
       File.symlink(File.join(folder, "linked-pr"), File.join(folder, "pr.md"))
-      assert_equal "unavailable", subject.send(:read_pr, pointer, local, diagnostics).fetch("state")
+      assert_equal "unavailable", subject.send(:read_pr, pointer, diagnostics).fetch("state")
     end
   end
 

--- a/test/unit/task_workspace/publication_test.rb
+++ b/test/unit/task_workspace/publication_test.rb
@@ -141,7 +141,7 @@ class TaskWorkspacePublicationTest < Minitest::Test
     end
   end
 
-  def test_foreign_pr_and_declared_head_mismatch_remain_conflicting
+  def test_foreign_pr_remains_conflicting
     with_task do |task|
       write_pr(
         task.folder,
@@ -154,9 +154,24 @@ class TaskWorkspacePublicationTest < Minitest::Test
 
       assert_equal "conflicting", panel.fetch("state")
       assert_equal "identity_conflicting", panel.fetch("publication_state")
-      assert_equal %w[head repository], panel.dig("pull_request", "conflicts").sort
+      assert_equal %w[repository], panel.dig("pull_request", "conflicts")
       refute panel.dig("refresh", "eligible")
       assert_empty cache.reads
+    end
+  end
+
+  def test_old_or_missing_declared_head_does_not_block_live_pr_refresh
+    with_task do |task|
+      [ "a" * 40, nil ].each do |old_head|
+        write_pr(task.folder, head: old_head)
+        cache = FakeCache.new(remote_result)
+        panel = service(task, runner: GitRunner.new, cache: cache).call
+
+        assert_equal "current", panel.fetch("state")
+        assert_empty panel.dig("pull_request", "conflicts")
+        assert panel.dig("refresh", "eligible")
+        assert_equal "d" * 40, cache.reads.first.fetch("expected_head")
+      end
     end
   end
 

--- a/wiki/gaps.md
+++ b/wiki/gaps.md
@@ -7,6 +7,16 @@ updated: 2026-09-01
 tags: [gap, todo, release-proof, agent-skills, plan-review, opencode]
 ---
 
+## Automatic outcome capture remains unreliable (2026-09-06)
+
+Dogfood producers can still fail to obtain controller screenshot receipts or
+start the target application. The artifact stage now treats these as best-effort
+warnings, not task-completion blockers, without labelling missing or rejected
+proof accepted. Rebuilding capture and the Screenote integration is deferred;
+this change makes workflow progress independent of that larger project, not
+the evidence pipeline reliable. Real implementation rework and source-integrity
+failures retain their blocking behavior.
+
 ## Betterleaks distribution and recovery verification
 
 Betterleaks 1.8.1 binaries are checksum-pinned for Linux/macOS x64/arm64.

--- a/wiki/log.d/20260906-best-effort-artifacts.md
+++ b/wiki/log.d/20260906-best-effort-artifacts.md
@@ -1,0 +1,10 @@
+## Best-effort automatic artifact collection
+
+`Stages::Artifacts.run!` keeps trying the existing collector, but records an
+explicit completion warning when capture, provider, capability, or evidence
+validation fails. It preserves diagnostics and files, never fabricates an
+accepted package, and does not repeat failed collection after completion.
+Source identity/custody failures and implementation-rework findings still
+block. Focused regressions cover missing capture receipts, provider limits,
+blocked capture, idempotent resume, and retained integrity/rework failures.
+The larger capture/Screenote redesign remains deferred in `wiki/gaps.md`.

--- a/wiki/log.d/20260906-publication-panel-live-head.md
+++ b/wiki/log.d/20260906-publication-panel-live-head.md
@@ -1,0 +1,12 @@
+---
+title: Publication refresh follows current local HEAD
+date: 2026-09-06
+---
+
+- SHA audit found the same obsolete saved-head veto in the task publication
+  panel. Removed its old/missing `pr.md` head conflict so live refresh remains
+  available after review commits.
+- The remote cache already keys on the actual local HEAD; remote divergence,
+  repository mismatches, and PR-number contradictions remain visible.
+- Regression covers both old and missing saved heads, plus the existing remote
+  divergence and foreign-repository cases.

--- a/wiki/log.d/20260906-review-comment-live-identity.md
+++ b/wiki/log.d/20260906-review-comment-live-identity.md
@@ -1,0 +1,12 @@
+---
+title: Review comments follow the live PR identity
+date: 2026-09-06
+---
+
+- Removed the saved-commit veto from review comment publication. TopGreenDeals
+  PR 402 had advanced while its saved head remained at the original commit,
+  so comment publication silently skipped the correct open PR.
+- Retained live repository, owned branch, PR number/URL, open-state, and
+  uniqueness checks. Code push and CI exact-head checks are unchanged.
+- Regression tests cover changed/missing saved heads and reject wrong branches,
+  numbers, URLs, closed PRs, duplicate observations, and foreign repositories.

--- a/wiki/modules/task_workspace.md
+++ b/wiki/modules/task_workspace.md
@@ -288,6 +288,11 @@ the visual layer is ignored.
 
 ## Publication and artifacts
 
+The saved `pr.md` head is descriptive, not a refresh gate: an old or absent
+saved SHA does not make an otherwise verified PR identity conflicting or partial.
+Refresh uses the current owned worktree HEAD and still exposes a genuinely
+different remote head. Repository and PR-number contradictions remain blocked.
+
 The publication panel is advisory and read-only. Local facts come from the
 strict owned `worktree.yml`, bounded argv-form Git observations including
 untracked files, an independently observed current base ref, at most 50 commit

--- a/wiki/stages/artifacts.md
+++ b/wiki/stages/artifacts.md
@@ -3,18 +3,24 @@ title: 7-artifacts stage
 type: stage
 source: lib/hive/stages/artifacts.rb
 created: 2026-05-22
-updated: 2026-08-30
+updated: 2026-09-06
 tags: [stage, artifacts, evidence, review]
 ---
 
-**TLDR**: `7-artifacts` now completes only after Hive publishes a strict,
-identity-bound outcome-evidence package. A fresh read-only inference agent maps
+**TLDR**: `7-artifacts` attempts automatic outcome evidence on a best-effort
+basis. Capture, provider, capability, or evidence-validation failures complete
+the stage with `evidence_status=unavailable`, preserving the original reason
+and diagnostic instead of parking otherwise reviewed implementation work.
+This does not publish accepted evidence: packages still require strict,
+identity-bound validation. Source-integrity failures and findings requiring
+implementation rework still block. A fresh read-only inference agent maps
 the task, plan, and exact committed diff into user-meaningful claims; a separate
 producer makes the required proof; and a third fresh read-only reviewer accepts,
 targets evidence for recapture, returns repository defects for implementation
 rework, or blocks every claim and supported exclusion. Legacy
 Hivebox screenshots and recordings remain visible diagnostics but never establish
-completion authority.
+accepted-evidence authority. A best-effort completion is idempotent on resume;
+the existing notes, captures, and rejected packages remain available.
 
 Codex capture resolves its filesystem runtime root through the shared managed
 executable provenance probe, not by scanning PATH for native-looking binaries.
@@ -86,9 +92,8 @@ capture or an approval request.
    controller executes admitted browser/terminal operations, records exact
    file receipts, and exclusively publishes basename-only PNG/WebM media into
    the evidence root.
-   Missing capabilities publish a durable blocker before the producer starts.
-   A paced daemon retry rechecks that blocker against the same immutable
-   requirement; it does not replay a stale capability verdict.
+   Missing capabilities retain a durable blocked package before the producer
+   starts; the stage wrapper reports evidence unavailable and continues.
 6. Launch a distinct **producer** context with one writable root under the active
    evidence attempt. Source and controller metadata remain read-only. Every proof
    names one retained original, one bounded reviewer representation, and the
@@ -132,7 +137,9 @@ capture or an approval request.
    environment, or decision that repository work cannot solve. Invalid
    exclusions, missing capability, exhausted recaptures, or exhausted
    implementation reworks publish an operator-visible blocked pointer and
-   semantic `ERROR`.
+   semantic `ERROR` inside the collector. The stage wrapper converts capture
+   and evidence-only failures to best-effort completion; implementation rework
+   and exhausted implementation reworks remain blocking.
 
 The default is one initial attempt plus at most two targeted recaptures. Project
 configuration may reduce recaptures to zero or one, but cannot exceed two.
@@ -219,11 +226,10 @@ revalidates that selected file's exact size and digest before streaming it.
 Write admission and publication remain responsible for complete media decoding,
 OCR, retained-proof validation, and independent review.
 
-Reviewer and recapture-exhaustion blockers suppress ordinary daemon retry.
-Capability blockers preserve the same audit package but are re-probed on a
-paced ordinary retry, so restored controller tools do not require an operator
-acknowledgement. The task page, status diagnostic, and run output still expose
-an exact command containing the blocked generation and recovery digest:
+Blocked packages retain their audit history even when best-effort collection
+lets the workflow continue. Legacy tasks already parked on a semantic blocker
+can still expose a guarded recovery command containing the blocked generation
+and recovery digest:
 
 ```sh
 hive evidence recover PROJECT:SLUG \
@@ -263,25 +269,20 @@ and reviewer capability. Legacy media follows in a visibly labelled
 
 - A valid accepted pointer is projected as `COMPLETE` and surfaces
   `ready_to_finalize`.
+- A capture/evidence failure is also `COMPLETE`, but explicitly carries
+  `reason=evidence_best_effort evidence_status=unavailable`, the original
+  `warning_reason`, and diagnostic attributes. It surfaces `ready_to_finalize`
+  without claiming an accepted package, and is idempotent on resume.
 - An implementation-rework pointer is a semantic `ERROR` that surfaces the
   exact digest-bound `hive evidence rework` command. The daemon dispatches it
   automatically without provider-route admission, returning the task to
   `4-execute`; it is not handled by the same-stage stale-error healer.
-- Capability, review, and recapture-exhaustion blockers are durable `ERROR`
-  rows with the exact `hive evidence recover` command. Paced automated recovery
-  re-probes capability blockers in the same generation. It does not clear an
-  independent review block or exhausted recapture decision.
-- Integrity, role-launch, source-drift, or malformed-output failures use
-  `ERROR reason=outcome_evidence_invalid` and retain their bounded diagnostic;
-  they remain ordinary recoverable stage errors.
-- A role process that returns a typed provider failure keeps that envelope at
-  the controller boundary. Quota and credit failures publish
-  `ERROR reason=limits_reached provider=<profile> retry_after=<iso8601>` and
-  return `commit=limits_reached`, so daemon recovery observes the normal
-  provider cooldown instead of immediately replaying an expensive inference,
-  producer, or reviewer prompt. Other typed provider failures retain
-  `reason=provider_error`, the provider, status code when supplied, and a
-  bounded message rather than being mislabeled as invalid evidence.
+- Source identity/custody failures retain
+  `ERROR reason=outcome_evidence_integrity_invalid`; exhausted implementation
+  reworks retain their semantic blocker. Neither becomes unavailable evidence.
+- Typed provider failures retain the provider, status code, message, and retry
+  time in the warning. They no longer park a reviewed task merely because an
+  optional capture role exhausted its provider allowance.
 
 ## Backlinks
 

--- a/wiki/stages/review.md
+++ b/wiki/stages/review.md
@@ -158,6 +158,12 @@ Escalations land in `reviews/escalations-<NN>.md` — every line that triage lef
 
 The escalations digest is mirrored to the PR with the same publisher path and duplicate-header guard.
 
+Comment publication validates the live open PR against the owned task branch,
+repository, URL, and number. It does not require the PR head to equal the old
+`pr.md` head: review fixes legitimately advance that commit. Exact-head guards
+remain on code publication and CI settlement. This avoids a separate metadata
+repair loop for ordinary PR comments.
+
 ## Branching after triage
 
 - `accepted.empty? && escalations.zero?` with `reviews/errors-NN.md` present — at least one reviewer failed while surviving reviewers found nothing; write `REVIEW_ERROR phase=reviewers reason=reviewer_partial_failure pass=NN` so the task is recoverable/retryable rather than a user-input gate.


### PR DESCRIPTION
## Summary

- Review comments follow the verified open PR even when review fixes have advanced its head since `pr.md` was written. This removes the stale-SHA veto rather than adding a healer or metadata-repair loop.
- The target must still match the owned task branch, repository, PR number, and URL, with exactly one open match. Code-push, CI, and approval commit checks are unchanged.
- The web publication panel also stops treating an old or missing saved SHA as an identity conflict. Refresh compares GitHub with the actual worktree HEAD, not an old snapshot.
- Automatic artifact collection is best effort: missing screenshots, capture capability failures, provider limits, and rejected evidence finish with an explicit `evidence_status=unavailable` warning. Existing diagnostics remain intact, and no accepted package is fabricated. Source-integrity failures and actual implementation-rework findings still block.

## Test plan

- [x] Regression reproduced the stale-head failure before the change.
- [x] Publisher and publication-panel/cache suites: 45 tests, 242 assertions, all passing.
- [x] Artifact suite: 56 tests, 320 assertions, all passing, including warning-to-finalize routing and idempotent resume.
- [x] Changed/missing saved heads work; wrong branch, number, URL, closed PR, duplicate observations, and foreign repositories remain rejected.
- [x] RuboCop and diff whitespace checks clean.
- [ ] Hosted CI.
- [ ] Dogfood deployment and affected-task recovery.

## Notes for reviewer

TopGreenDeals PR 402 remained open on the correct branch, but its saved head was 5013fa64 while GitHub had f71a5279. The publisher returned `invalid_pr` and skipped comments without creating a healer condition. A PR comment does not require equality with that old snapshot. Exact-head checks still protect CI results and Git writes.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
