### PR TITLE
fix: keep interrupted tasks retrying without runaway dispatch

### DIFF
--- a/lib/hive/attempts/dispatcher.rb
+++ b/lib/hive/attempts/dispatcher.rb
@@ -242,7 +242,7 @@ module Hive
           return deferred_result("patrol_retry_delay")
         end
 
-        if !interactive && !retry_release &&
+        if task && !interactive && !retry_release &&
            "#{task.stage_index}-#{task.stage_name}" != generation.intended_stage &&
            !CommandProgress.patrol_fix?(task)
           previous = view.latest_terminal_attempt(

--- a/lib/hive/attempts/dispatcher.rb
+++ b/lib/hive/attempts/dispatcher.rb
@@ -11,6 +11,7 @@ require "hive/task_resolver"
 require "hive/workflows"
 require "hive/context_provenance"
 require "hive/plan_review/store"
+require "hive/recovery/retry_policy"
 
 module Hive
   module Attempts
@@ -239,6 +240,22 @@ module Hive
           subject: subject || task_subject(generation), runtime_digest: @runtime_digest, now: now
         )
           return deferred_result("patrol_retry_delay")
+        end
+
+        if !interactive && !retry_release &&
+           "#{task.stage_index}-#{task.stage_name}" != generation.intended_stage &&
+           !CommandProgress.patrol_fix?(task)
+          previous = view.latest_terminal_attempt(
+            task_generation: generation.task_generation,
+            subject: subject || task_subject(generation)
+          )
+          if previous && %w[failed cancelled].include?(previous.outcome)
+            retry_at = Time.iso8601(previous.receipt.fetch("ended_at")) +
+              Hive::Recovery::RetryPolicy.delay_sec(previous["retry_charge"])
+            return deferred_result("transition_retry", attempt: previous, receipt: previous.receipt) if now.utc < retry_at
+
+            retry_charge = [ retry_charge, previous["retry_charge"].to_i + 1 ].max
+          end
         end
 
         launching_attributes = {

--- a/lib/hive/daemon/dispatcher.rb
+++ b/lib/hive/daemon/dispatcher.rb
@@ -1831,7 +1831,7 @@ module Hive
           case result.reason
           when "capacity", "capacity_saturated" then :attempt_capacity
           when "patrol_retry_delay" then :attempt_patrol_retry
-          when "transient_retry" then :attempt_transient_retry
+          when "transient_retry", "transition_retry" then :attempt_transient_retry
           when "attempt_lost" then :attempt_lost
           when "launch_handoff_failed" then :launch_handoff_failed
           else :attempt_deferred
@@ -3796,7 +3796,7 @@ module Hive
           when :terminal_replay then :attempt_terminal_replay
           when :deferred
             case result.reason
-            when "transient_retry" then :attempt_transient_retry
+            when "transient_retry", "transition_retry" then :attempt_transient_retry
             when "patrol_retry_delay" then :attempt_patrol_retry_deferred
             else :attempt_capacity_deferred
             end

--- a/lib/hive/daemon/operational_snapshot.rb
+++ b/lib/hive/daemon/operational_snapshot.rb
@@ -221,7 +221,6 @@ module Hive
             [ [ task.dig("identity", "project"), task.dig("identity", "slug") ], task ]
           end
           holds = provider_holds(rows)
-          overlay_provider_dispositions!(task_index, holds)
           overlay_recovery_dispositions!(task_index, recoveries || {})
           record = base_record(phase: "complete", now: now).merge(
             "reason" => nil,
@@ -418,22 +417,6 @@ module Hive
               "reason" => receipt["reason"] || status.tr("_", " "),
               "recovery" => receipt,
               "routing" => entry["routing"]
-            }
-          end
-        end
-
-        def overlay_provider_dispositions!(task_index, holds)
-          holds.each do |hold|
-            task = find_task(task_index, hold)
-            next unless task && task.dig("disposition", "status") == "available"
-
-            provider = hold["provider"] || "provider"
-            suffix = hold["retry_after"] ? " until #{hold.fetch('retry_after')}" : ""
-            task["disposition"] = {
-              "status" => "available",
-              "decision" => "provider_hold",
-              "owner" => "provider",
-              "reason" => "#{provider} quota hold#{suffix}"
             }
           end
         end

--- a/lib/hive/daemon/recovery_coordinator.rb
+++ b/lib/hive/daemon/recovery_coordinator.rb
@@ -162,7 +162,7 @@ module Hive
       # there is one concept to reason about rather than a provider window
       # and a separate marker window that happened to disagree. Steps climb
       # and then hold; the last step is the ceiling.
-      RETRY_BACKOFF_SEC = [ 5, 10, 60, 300, 900, 3600 ].freeze
+      RETRY_BACKOFF_SEC = Hive::Recovery::RetryPolicy::BACKOFF_SEC
       DETERMINISTIC_FAILURE_THRESHOLD = 3
       FAILURE_HISTORY_LIMIT = 64
       INERT_BLOCK_REASONS = %w[
@@ -176,10 +176,7 @@ module Hive
       OPERATOR_REQUESTORS = %w[action cli bot web].freeze
 
       def retry_delay_sec(retry_count)
-        index = retry_count.to_i
-        return RETRY_BACKOFF_SEC.first if index.negative?
-
-        RETRY_BACKOFF_SEC[[ index, RETRY_BACKOFF_SEC.length - 1 ].min]
+        Hive::Recovery::RetryPolicy.delay_sec(retry_count)
       end
 
       # Requests carry their own charge; a request without one is its first.

--- a/lib/hive/git_index_lock.rb
+++ b/lib/hive/git_index_lock.rb
@@ -1,0 +1,41 @@
+require "open3"
+require "securerandom"
+
+module Hive
+  # Only used while holding Hive's state-repository commit lock. Git may close
+  # an index lock before renaming it, so an open-file probe alone is not enough.
+  module GitIndexLock
+    module_function
+
+    def recover!(root)
+      output, _, status = Open3.capture3("git", "-C", root, "rev-parse", "--path-format=absolute", "--git-path", "index.lock")
+      return unless status.success?
+
+      path = output.strip
+      original = File.lstat(path)
+      return unless original.file? && original.size.zero? && original.uid == Process.uid
+      return unless Time.now - original.mtime > 60
+      return unless no_writers?(path)
+      current = File.lstat(path)
+      return unless [ current.dev, current.ino, current.mtime, current.size ] ==
+                    [ original.dev, original.ino, original.mtime, original.size ]
+
+      # Preserve crash residue for inspection rather than deleting it.
+      File.rename(path, "#{path}.hive-stale-#{SecureRandom.hex(8)}")
+      warn "hive: recovered abandoned Git index lock in #{root}"
+    rescue SystemCallError, IOError
+      # Missing tools, inaccessible process state, or a disappearing lock do
+      # not grant authority to remove anything. The normal Git error survives.
+      nil
+    end
+
+    def no_writers?(path)
+      processes, errors, status = Open3.capture3("ps", "-eo", "comm=")
+      return false unless status.success? && errors.empty?
+      return false if processes.lines.any? { |line| File.basename(line.strip).match?(/\Agit(?:\z|[- ])/) }
+
+      holders, errors, status = Open3.capture3("fuser", "--", path)
+      status.exitstatus == 1 && holders.empty? && errors.empty?
+    end
+  end
+end

--- a/lib/hive/lock.rb
+++ b/lib/hive/lock.rb
@@ -1,5 +1,6 @@
 require "fileutils"
 require "time"
+require "hive/git_index_lock"
 require "hive/attempts/context"
 require "hive/runtime_control_plane/task_lease_repository"
 
@@ -121,6 +122,7 @@ module Hive
         end
         held[lock_key] = Process.pid
         begin
+          Hive::GitIndexLock.recover!(project_hive_state_path)
           return yield
         ensure
           held.delete(lock_key) if held[lock_key] == Process.pid

--- a/lib/hive/recovery/retry_policy.rb
+++ b/lib/hive/recovery/retry_policy.rb
@@ -9,7 +9,12 @@ module Hive
     # adapters. It identifies the ordinary workflow verb that owns a stage;
     # marker mutation, admission, pacing, and dispatch remain coordinator-only.
     module RetryPolicy
+      BACKOFF_SEC = [ 5, 10, 60, 300, 900, 3600 ].freeze
       module_function
+
+      def delay_sec(retry_count)
+        BACKOFF_SEC[retry_count.to_i.clamp(0, BACKOFF_SEC.length - 1)]
+      end
 
       def verb_for(stage, workflow: nil, project: nil)
         stage = stage.to_s

--- a/lib/hive/task_activity.rb
+++ b/lib/hive/task_activity.rb
@@ -466,7 +466,10 @@ module Hive
               unless existing.same_domain_intent?(operation.receipt)
                 raise Conflict, "conflicting operation receipt #{operation.operation_id}"
               end
-              return begin_retry!(activity: activity, receipt: receipt)
+              # Reconciliation proved this operation had no committed effect.
+              # Reuse its stable identity; attempts already retain retry history.
+              operation.send(:persist!)
+              return operation
             else
               unless existing.same_intent?(operation.receipt)
                 raise Conflict, "conflicting operation receipt #{operation.operation_id}"
@@ -476,34 +479,6 @@ module Hive
           end
           operation.persist_new!
           operation
-        end
-
-        def begin_retry!(activity:, receipt:)
-          base = receipt.fetch("operation_id")
-          1.upto(100) do |number|
-            candidate = "#{base}:retry:#{number}"
-            path = File.join(
-              activity.task_folder, OPERATION_DIRECTORY,
-              "#{Digest::SHA256.hexdigest(candidate)}.json"
-            )
-            candidate_receipt = receipt.merge("operation_id" => candidate)
-            unless File.exist?(path)
-              operation = new(activity: activity, receipt: candidate_receipt)
-              operation.persist_new!
-              return operation
-            end
-
-            existing = open!(activity: activity, filename: File.basename(path))
-            if existing.same_intent?(candidate_receipt)
-              return existing unless existing.receipt["state"] == "aborted"
-              next
-            end
-            unless existing.receipt["state"] == "aborted" &&
-                   existing.same_domain_intent?(candidate_receipt)
-              raise Conflict, "conflicting operation receipt #{candidate}"
-            end
-          end
-          raise Conflict, "operation receipt retry limit exhausted"
         end
 
         def open!(activity:, filename:)

--- a/test/unit/attempts/dispatcher_test.rb
+++ b/test/unit/attempts/dispatcher_test.rb
@@ -1343,6 +1343,27 @@ class AttemptsDispatcherTest < Minitest::Test
     end
   end
 
+  def test_failed_transition_uses_shared_backoff_without_changing_completed_source
+    with_dispatcher do |dispatcher, launcher, task, store|
+      dispatcher.instance_variable_set(:@id_generator, -> { SecureRandom.uuid })
+      File.write(task.state_file, "<!-- COMPLETE -->\n")
+      now = NOW
+      7.times do |index|
+        accepted = dispatch(dispatcher, task, request_id: "advance-#{index}", intended_stage: "5-open-pr", now: now)
+        assert_equal :accepted, accepted.status
+        assert_equal index, accepted.attempt["retry_charge"]
+        ended = now + 1
+        terminalize_attempt(store, launcher, accepted, outcome: "failed", exit_status: 1, now: ended)
+        delay = Hive::Recovery::RetryPolicy.delay_sec(index)
+        deferred = dispatch(dispatcher, task, request_id: "early-#{index}", intended_stage: "5-open-pr", now: ended + delay - 1)
+        assert_equal :deferred, deferred.status
+        assert_equal "transition_retry", deferred.reason
+        assert_equal "<!-- COMPLETE -->\n", File.read(task.state_file)
+        now = ended + delay
+      end
+    end
+  end
+
   def test_routing_collaborator_defaults
     with_dispatcher do |dispatcher, _launcher, task, _store|
       assert_match(

--- a/test/unit/daemon/operational_snapshot_test.rb
+++ b/test/unit/daemon/operational_snapshot_test.rb
@@ -777,7 +777,7 @@ class HiveDaemonOperationalSnapshotTest < Minitest::Test
     end
   end
 
-  def test_provider_hold_without_stage_or_reason_still_matches_the_current_task
+  def test_provider_reset_hint_does_not_replace_the_hourly_retry_assessment
     with_tmp_dir do |dir|
       path = File.join(dir, "private", "operational-snapshot.json")
       _store, assembler, reader = build(path)
@@ -790,15 +790,22 @@ class HiveDaemonOperationalSnapshotTest < Minitest::Test
       )
 
       assembler.begin_tick(now: T0)
+      assembler.observe(
+        held, decision: "retry_cooldown", owner: "scheduler",
+        reason: "automatic retry is scheduled", retry_at: (T0 + 60).iso8601,
+        retry_due: false, retry_safe: true
+      )
       assembler.complete(
         rows: [ held ], controller: {}, queue: {},
         recoveries: {}, now: T0 + 1
       )
 
       task = reader.read(now: T0 + 2).fetch("tasks").first
-      assert_equal "provider_hold", task.dig("disposition", "decision")
-      assert_equal "provider", task.dig("disposition", "owner")
-      assert_includes task.dig("disposition", "reason"), "codex quota hold"
+      assert_equal "retry_cooldown", task.dig("disposition", "decision")
+      assert_equal "scheduler", task.dig("disposition", "owner")
+      assert_equal (T0 + 60).iso8601, task.dig("disposition", "retry_at")
+      assert_equal (T0 + 3_600).iso8601,
+                   reader.read(now: T0 + 2).dig("provider_holds", 0, "retry_after")
     end
   end
 

--- a/test/unit/git_index_lock_test.rb
+++ b/test/unit/git_index_lock_test.rb
@@ -1,0 +1,84 @@
+require "test_helper"
+require "hive/git_index_lock"
+require "hive/lock"
+
+class GitIndexLockTest < Minitest::Test
+  include HiveTestHelper
+
+  def test_abandoned_empty_lock_is_quarantined_and_git_can_write_again
+    with_tmp_git_repo do |root|
+      path = File.join(root, ".git", "index.lock")
+      File.write(path, "")
+      File.utime(Time.now - 120, Time.now - 120, path)
+      with_replaced_singleton_method(Hive::GitIndexLock, :no_writers?, ->(_) { true }) do
+        Hive::Lock.with_commit_lock(root) { run!("git", "-C", root, "add", "-A") }
+      end
+      refute File.exist?(path)
+      assert_equal 1, Dir.glob("#{path}.hive-stale-*").length
+      run!("git", "-C", root, "add", "-A")
+    end
+  end
+
+  def test_live_writer_recent_nonempty_and_symlink_locks_are_preserved
+    with_tmp_git_repo do |root|
+      path = File.join(root, ".git", "index.lock")
+      File.write(path, "")
+      with_replaced_singleton_method(Hive::GitIndexLock, :no_writers?, ->(_) { true }) do
+        Hive::GitIndexLock.recover!(root)
+        assert File.exist?(path), "recent lock"
+        File.write(path, "index bytes")
+        File.utime(Time.now - 120, Time.now - 120, path)
+        Hive::GitIndexLock.recover!(root)
+        assert_equal "index bytes", File.read(path)
+      end
+      File.write(path, "")
+      File.utime(Time.now - 120, Time.now - 120, path)
+      with_replaced_singleton_method(Hive::GitIndexLock, :no_writers?, ->(_) { false }) do
+        Hive::GitIndexLock.recover!(root)
+      end
+      assert File.exist?(path), "live writer"
+      File.unlink(path)
+      File.symlink("index", path)
+      Hive::GitIndexLock.recover!(root)
+      assert File.symlink?(path)
+    end
+  end
+
+  def test_writer_probe_fails_closed_for_git_processes_and_probe_errors
+    status = Struct.new(:exitstatus) { def success? = exitstatus.zero? }
+    [ [ "git\n", "", 0 ], [ "", "denied", 1 ] ].each do |out, err, code|
+      with_replaced_singleton_method(Open3, :capture3, ->(*) { [ out, err, status.new(code) ] }) do
+        refute Hive::GitIndexLock.no_writers?("/unused")
+      end
+    end
+    [ [ "", "", 1, true ], [ "123", "", 0, false ], [ "", "denied", 1, false ] ].each do |out, err, code, expected|
+      probe = ->(tool, *) { tool == "ps" ? [ "ruby\n", "", status.new(0) ] : [ out, err, status.new(code) ] }
+      with_replaced_singleton_method(Open3, :capture3, probe) do
+        assert_equal expected, Hive::GitIndexLock.no_writers?("/unused")
+      end
+    end
+  end
+
+  def test_recovery_preserves_a_lock_replaced_during_inspection_and_missing_tools
+    with_tmp_git_repo do |root|
+      path = File.join(root, ".git", "index.lock")
+      File.write(path, "")
+      File.utime(Time.now - 120, Time.now - 120, path)
+      probe = lambda do |_|
+        File.rename(path, "#{path}.original")
+        File.write(path, "new owner")
+        true
+      end
+      with_replaced_singleton_method(Hive::GitIndexLock, :no_writers?, probe) do
+        Hive::GitIndexLock.recover!(root)
+      end
+      assert_equal "new owner", File.read(path)
+      File.write(path, "")
+      File.utime(Time.now - 120, Time.now - 120, path)
+      with_replaced_singleton_method(Hive::GitIndexLock, :no_writers?, ->(_) { raise Errno::ENOENT, "fuser" }) do
+        Hive::GitIndexLock.recover!(root)
+      end
+      assert File.exist?(path)
+    end
+  end
+end

--- a/test/unit/task_activity_coverage_gaps_test.rb
+++ b/test/unit/task_activity_coverage_gaps_test.rb
@@ -252,32 +252,6 @@ class TaskActivityCoverageGapsTest < Minitest::Test
                     Hive::TaskActivity::Operation.begin!(activity: activity, receipt: receipt)
       end
 
-      retry_operation = Object.new
-      retry_operation.define_singleton_method(:receipt) { { "state" => "aborted" } }
-      retry_operation.define_singleton_method(:same_intent?) { |_| true }
-      with_replaced_singleton_method(File, :exist?, ->(*) { true }) do
-        with_replaced_singleton_method(
-          Hive::TaskActivity::Operation, :open!, ->(**) { retry_operation }
-        ) do
-          assert_raises(Hive::TaskActivity::Conflict) do
-            Hive::TaskActivity::Operation.begin_retry!(activity: activity, receipt: receipt)
-          end
-        end
-      end
-
-      conflicting_retry = Object.new
-      conflicting_retry.define_singleton_method(:receipt) { { "state" => "complete" } }
-      conflicting_retry.define_singleton_method(:same_intent?) { |_| false }
-      with_replaced_singleton_method(File, :exist?, ->(*) { true }) do
-        with_replaced_singleton_method(
-          Hive::TaskActivity::Operation, :open!, ->(**) { conflicting_retry }
-        ) do
-          assert_raises(Hive::TaskActivity::Conflict) do
-            Hive::TaskActivity::Operation.begin_retry!(activity: activity, receipt: receipt)
-          end
-        end
-      end
-
       assert_raises(Hive::TaskActivity::InvalidActivity) do
         Hive::TaskActivity::Operation.open!(activity: activity, filename: "bad")
       end

--- a/test/unit/task_activity_test.rb
+++ b/test/unit/task_activity_test.rb
@@ -322,7 +322,7 @@ class TaskActivityTest < Minitest::Test
     end
   end
 
-  def test_aborted_operation_keeps_history_and_retry_gets_a_distinct_identity
+  def test_aborted_operation_reuses_stable_identity_without_a_retry_budget
     with_activity do |activity, dir|
       attributes = {
         kind: "retry_requested", operation_id: "retry:task-1",
@@ -334,8 +334,12 @@ class TaskActivityTest < Minitest::Test
       second = activity.begin_operation(**attributes)
 
       assert_equal "retry:task-1", first.operation_id
-      assert_equal "retry:task-1:retry:1", second.operation_id
-      assert_equal 2, Dir[File.join(dir, Hive::TaskActivity::OPERATION_DIRECTORY, "*.json")].length
+      101.times do
+        second.abort!(reason: "not committed")
+        second = activity.begin_operation(**attributes)
+      end
+      assert_equal "retry:task-1", second.operation_id
+      assert_equal 1, Dir[File.join(dir, Hive::TaskActivity::OPERATION_DIRECTORY, "*.json")].length
       assert_equal "pending", second.receipt.fetch("state")
     end
   end
@@ -362,11 +366,11 @@ class TaskActivityTest < Minitest::Test
       duplicate = retry_activity.begin_operation(**attributes)
 
       assert_empty summary.fetch("diagnostics")
-      assert_equal "approve:3-plan:4-execute:forward:retry:1", retried.operation_id
+      assert_equal "approve:3-plan:4-execute:forward", retried.operation_id
       assert_equal retried.operation_id, duplicate.operation_id,
                    "the same successor attempt must reopen its retry receipt idempotently"
       assert_equal "attempt-2", retried.receipt.fetch("attempt_id")
-      assert_equal "aborted", first_activity_receipt(dir).fetch("state")
+      assert_equal "pending", first_activity_receipt(dir).fetch("state")
     end
   end
 

--- a/wiki/commands/daemon.md
+++ b/wiki/commands/daemon.md
@@ -3,9 +3,13 @@ title: hive daemon
 type: command
 source: lib/hive/commands/daemon.rb, lib/hive/daemon/*
 created: 2026-05-06
-updated: 2026-08-30
+updated: 2026-09-07
 tags: [command, daemon, automation, plan-review, json, dogfood]
 ---
+
+Quota reset estimates are display-only hints. Operational status preserves the
+scheduler's actual hourly cooldown, next retry time, and safety decision rather
+than replacing them with a provider's later estimated reset date.
 
 **TLDR**: `hive daemon SUBCOMMAND` is the operator surface for the
 auto-advancing dispatcher (ADR-024). One long-running process wakes

--- a/wiki/gaps.md
+++ b/wiki/gaps.md
@@ -1403,3 +1403,11 @@ and transaction rollback. It has not been applied to dogfood. Stop all writers
 and take an external SQLite backup before the explicit upgrade described in
 [[modules/attempts]]. Request IDs already cleared by the old foreign key are not
 recovered by this change; retained IDs and future attempts are preserved.
+
+## Conservative Git index-lock recovery (2026-09-07)
+
+Automatic recovery requires successful process and open-file probes (`ps` and
+`fuser`). Missing tools, inaccessible process state, any Git process, and
+nonempty locks deliberately leave recovery to a later retry or operator.
+This is not general recovery of interrupted Git operations; preserved lock
+files may still require inspection on platforms without these probes.

--- a/wiki/log.d/20260907-crash-resilient-transitions.md
+++ b/wiki/log.d/20260907-crash-resilient-transitions.md
@@ -1,0 +1,14 @@
+## Recover interrupted state commits without a dispatch loop
+
+Hive's state commit lock now conservatively quarantines abandoned empty Git
+index locks after process and open-holder checks; uncertain/live locks remain.
+Aborted activity operations reuse their stable identity after reconciliation
+proves no committed effect, removing numbered retries and the 100-slot ceiling.
+Existing historical numbered receipts remain on disk; durable attempts retain
+failure history. Pending and completed operations still enforce intent matching.
+
+Failed automatic advances now use the same backoff ladder as marker recovery,
+derived from terminal attempts and capped at hourly retries. This also covers
+a failed move whose source marker remains complete. The daily safety cap stays.
+Regression tests cover more than 100 aborted operations, repeated failed
+transitions through the hourly ceiling, and preserved live/uncertain index locks.

--- a/wiki/log.d/20260907-quota-retry-display.md
+++ b/wiki/log.d/20260907-quota-retry-display.md
@@ -1,0 +1,7 @@
+## Preserve actual scheduler decisions for quota failures
+
+Operational snapshots no longer replace the scheduler's retry assessment with
+a provider reset estimate. Hourly cooldown, retry time, safety, and ownership
+remain visible even before a recovery request is admitted. Provider reset
+estimates remain informational data; they do not establish a scheduling hold.
+The regression test checks a reset estimate later than the actual retry time.

--- a/wiki/modules/attempts.md
+++ b/wiki/modules/attempts.md
@@ -7,6 +7,13 @@ updated: 2026-09-04
 tags: [attempts, admission, sqlite, recovery, capacity]
 ---
 
+Failed automatic stage transitions now use the shared recovery backoff ladder,
+including when the source stage remains `COMPLETE`. The latest same-generation
+terminal receipt supplies the failure time and retry charge; each admitted
+successor increments that charge. No extra timer table or watcher is involved.
+Explicit operator retries retain their existing bypass of automatic pacing.
+The project daily dispatch cap remains the emergency brake.
+
 **TLDR**: Hive admits task-stage work as independent durable attempts. One
 `attempts` row owns the attempt record plus fixed accounting,
 lost-recovery, and terminal-publication facts. Live rows provide capacity.

--- a/wiki/modules/lock.md
+++ b/wiki/modules/lock.md
@@ -111,6 +111,14 @@ and holds the descriptor while yielding. It is same-thread reentrant but
 process-scoped; forked children must contend normally. The kernel releases it
 on close or process death.
 
+While holding that commit lock, Hive checks for an abandoned Git `index.lock`.
+It only quarantines an unchanged, empty, regular file owned by the current user
+and older than a minute, after `ps` finds no Git process and `fuser` finds no
+open holder. Age alone is never sufficient. Missing/inaccessible inspection
+tools, live writers, nonempty locks, and symlinks are preserved. The quarantined
+file remains beside the index with a `.hive-stale-<nonce>` suffix. This recovery
+is limited to Hive state-repository commit windows, not arbitrary agent Git use.
+
 The commit lock serializes the shared hive-state Git index and brief commit
 window. It does not serialize long agents on different tasks. `.markers-lock`
 and other domain-specific filesystem mutexes remain narrower machine-local


### PR DESCRIPTION
## Summary

- Keep failed task transitions retryable without rapid redispatch or an artificial 100-retry ceiling, and show the scheduler's real retry time instead of a provider's reset estimate.
- Recover abandoned empty Git index locks conservatively. Live, recent, nonempty, foreign-owned, or uncertain locks remain untouched; recovered files are quarantined for inspection.

## Test plan

- [x] Focused tests: operation receipts, lock recovery, attempt dispatch, recovery coordinator, operational snapshot/status, and daemon dispatch.
- [x] Regression exercises more than 100 aborted retries, repeated hourly backoff, and a real Git write after lock recovery.
- [x] RuboCop on all changed Ruby files and `git diff --check`.
- [ ] Broad local `bundle exec rake test` (running).
- [ ] Hosted CI coverage and dedicated merge gates.
- [ ] Deploy to dogfood and verify the affected Webmail task; the existing daily dispatch cap may still defer advancement.

## Notes for reviewer

The incident combined an abandoned Git lock with failed transitions that immediately became eligible again. Numbered operation receipts then ran out, and redispatch continued until the project consumed its daily cap. The fix reuses existing operation identity and durable attempt retry charges; it adds no retry store or maintenance service.

Daily caps remain unchanged. Patrol behavior is excluded from the new transition delay. Lock recovery requires successful `ps` and `fuser` probes; missing tools leave the normal Git failure in place.
