### PR TITLE
fix: recover abandoned Git locks with PSmisc fuser

### DIFF
--- a/lib/hive/git_index_lock.rb
+++ b/lib/hive/git_index_lock.rb
@@ -34,7 +34,9 @@ module Hive
       return false unless status.success? && errors.empty?
       return false if processes.lines.any? { |line| File.basename(line.strip).match?(/\Agit(?:\z|[- ])/) }
 
-      holders, errors, status = Open3.capture3("fuser", "--", path)
+      # rev-parse supplies an absolute path, so no option delimiter is needed.
+      # PSmisc fuser does not accept the conventional `--` delimiter.
+      holders, errors, status = Open3.capture3("fuser", path)
       status.exitstatus == 1 && holders.empty? && errors.empty?
     end
   end

--- a/test/unit/git_index_lock_test.rb
+++ b/test/unit/git_index_lock_test.rb
@@ -81,4 +81,27 @@ class GitIndexLockTest < Minitest::Test
       assert File.exist?(path)
     end
   end
+
+  def test_real_fuser_distinguishes_an_unowned_lock_from_an_open_file
+    capture = Open3.method(:capture3)
+    available = system("fuser", "-V", out: File::NULL, err: File::NULL)
+    skip "fuser is optional on this platform" unless available
+    success = Struct.new(:success?).new(true)
+    probe = ->(tool, *args) { tool == "ps" ? [ "ruby\n", "", success ] : capture.call(tool, *args) }
+    with_tmp_git_repo do |root|
+      path = File.join(root, ".git", "index.lock")
+      File.write(path, "")
+      File.utime(Time.now - 120, Time.now - 120, path)
+      with_replaced_singleton_method(Open3, :capture3, probe) do
+        File.open(path) do
+          refute Hive::GitIndexLock.no_writers?(path)
+          Hive::GitIndexLock.recover!(root)
+          assert File.exist?(path)
+        end
+        assert Hive::GitIndexLock.no_writers?(path)
+        Hive::Lock.with_commit_lock(root) { run!("git", "-C", root, "add", "-A") }
+        refute File.exist?(path)
+      end
+    end
+  end
 end

--- a/wiki/log.d/20260907-git-lock-probe-portability.md
+++ b/wiki/log.d/20260907-git-lock-probe-portability.md
@@ -1,0 +1,7 @@
+# Exercise the real Git lock-owner probe
+
+Dogfood verification found that PSmisc fuser rejects `--`, so the conservative
+lock probe always declined recovery. Pass the absolute Git-resolved path
+directly. A real-process regression now verifies an open lock is preserved,
+an unowned lock is recovered, and Git can write afterward. Missing probe tools
+still leave locks untouched.


### PR DESCRIPTION
## Summary

- Make abandoned Git lock recovery actually work with PSmisc fuser. Live dogfood verification found that its unsupported `--` separator produced usage text, so the safety check correctly declined recovery every time.

## Test plan

- [x] Five lock-recovery tests, 17 assertions, pass.
- [x] New real-process test preserves an open lock, recovers it after close, and completes a real Git write.
- [x] RuboCop and `git diff --check` pass.
- [ ] CI, merge, and dogfood verification of the original Webmail transition.

## Notes for reviewer

The path comes from Git's absolute-path resolver, so it cannot be parsed as an option. Uncertain probe results still leave the lock untouched. This closes the platform behavior missed by the original mocked probe test.

Related: #1415
