### PR TITLE
fix(workflows): run trusted actors with their ordinary environment

### DIFF
--- a/lib/hive/workflow_package/runtime_policy.rb
+++ b/lib/hive/workflow_package/runtime_policy.rb
@@ -254,6 +254,9 @@ module Hive
           directories = (directories + trusted_actor_read_roots(base_add_dirs)).uniq
         end
         child_environment = actor_environment(environment)
+        # Trusted packages run with the same environment as an ordinary agent.
+        # Keep explicit input bindings, but do not isolate installed tools/auth.
+        child_environment = ENV.to_h.merge(child_environment).freeze if scope.yolo?
         if runtime&.respond_to?(:compile_direct_actor)
           return runtime.compile_direct_actor(
             host: ProviderHost, scope:, task_root:, directories:, profile:,

--- a/test/unit/workflow_package/runtime_policy_test.rb
+++ b/test/unit/workflow_package/runtime_policy_test.rb
@@ -891,6 +891,29 @@ class WorkflowPackageRuntimePolicyTest < Minitest::Test
     end
   end
 
+  def test_trusted_actors_use_normal_environment_and_direct_file_output_for_every_provider
+    with_tmp_dir do |dir|
+      task = File.join(dir, "task")
+      package = File.join(dir, "package")
+      FileUtils.mkdir_p([ task, package ])
+      with_env("TRUSTED_WORKFLOW_TEST_VALUE" => "inherited") do
+        %i[claude codex grok pi opencode].each do |name|
+          policy = Hive::WorkflowPackage::RuntimePolicy.compile_actor(
+            "yolo", task_folder: task, package_root: package,
+            profile: Hive::AgentProfiles.lookup(name),
+            managed_outputs: [ File.join(task, "review.md") ]
+          )
+          assert_equal "inherited", policy.environment["TRUSTED_WORKFLOW_TEST_VALUE"], name
+          assert_empty policy.command_prefix, name
+          assert_empty policy.cli_flags, name
+          assert_nil policy.allowed_tools, name
+          assert_nil policy.disallowed_tools, name
+          refute policy.host_outputs?, name
+        end
+      end
+    end
+  end
+
   def test_yolo_actor_rejects_unavailable_or_non_directory_trusted_caller_roots
     with_tmp_dir do |dir|
       task = File.join(dir, "task")

--- a/wiki/log.d/20260908-trusted-workflow-runtime.md
+++ b/wiki/log.d/20260908-trusted-workflow-runtime.md
@@ -1,0 +1,8 @@
+## Run trusted packages like ordinary agents
+
+Explicit `yolo` managed actors retain their ordinary environment, including
+installed tool and provider configuration, instead of receiving a reduced
+environment. Existing direct execution already avoids the scoped sandbox and
+host-owned JSON output adapter. Regression coverage checks direct execution,
+unrestricted tool selection, and inherited environment for Claude, Codex, Grok,
+Pi, and OpenCode. Restricted package policies remain unchanged.

--- a/wiki/modules/workflow_package.md
+++ b/wiki/modules/workflow_package.md
@@ -143,6 +143,14 @@ built-in or `<id>.yml` authored descriptor, and task metadata rewrites preserve
 all three managed provenance fields.
 
 Honeycomb v2 permission summaries are disclosure data, not executable policy.
+Owner-trusted actors declare `permissions: yolo`. They run directly with the
+ordinary agent environment plus explicit package input bindings, without a
+Hive Bubblewrap wrapper, tool allowlists, private agent home, or JSON-to-file
+adapter. Agents write their stage outputs normally. Package provenance, task
+locks, recovery, and completion validation remain unchanged. Restricted actors
+still use their declared scoped policy; installing from Honeycomb alone is not
+a reason to restrict an explicitly trusted actor.
+
 Managed execution uses each stage/reviewer/reviser descriptor's exact
 `permissions:` block. Install reports explicit `yolo`, scoped shell, and
 unqualified scoped file-write actors without adding a second approval gate; a v2


### PR DESCRIPTION
## Summary

Explicitly trusted Honeycomb actors can use the same installed tools and provider configuration as ordinary agents. Their existing `yolo` policy runs directly without Hive's scoped Bubblewrap and JSON-output adapter; it now also preserves the ordinary environment.

This supports the owner-requested trusted Honeycomb package updates. Restricted package policies, task ownership, recovery, and completion checks are unchanged.

## Validation

60 runtime-policy tests pass, including direct execution and inherited environment checks across Claude, Codex, Grok, Pi, and OpenCode. RuboCop passes. Dedicated external review omitted at the owner's request.

## Post-Deploy Monitoring & Validation

During this rollout, verify task 42618 launches Grok directly, writes its reviewer output, and no longer reports nested Bubblewrap failures. Confirm the active dogfood build and retain the previous deployment for rollback if trusted workflows cannot start.
