### PR TITLE
fix(patrol): restore periodic architecture sweeps

### DIFF
--- a/lib/hive/cli.rb
+++ b/lib/hive/cli.rb
@@ -1167,6 +1167,17 @@ module Hive
       ).call
     end
 
+    desc "refactor-patrol-scheduled PROJECT",
+         "Review one periodic current-main architecture slice (daemon/internal)", hide: true
+    option :result_file, type: :string, required: true
+    def refactor_patrol_scheduled(project)
+      require "hive/commands/refactor_patrol_scheduled"
+      result = Hive::Commands::RefactorPatrolScheduled.new(
+        project, result_file: options[:result_file]
+      ).call
+      exit 1 unless result.fetch("ok")
+    end
+
     desc "refactor-patrol-classify PROJECT",
          "Run one queued merge classifier (daemon/internal)", hide: true
     option :occurrence_id, type: :string, required: true

--- a/lib/hive/commands/daemon.rb
+++ b/lib/hive/commands/daemon.rb
@@ -16,6 +16,7 @@ require "hive/daemon/operational_snapshot"
 require "hive/daemon/pr_merge_watcher"
 require "hive/daemon/refactor_patrol_merge_reconciler"
 require "hive/daemon/patrol_scheduler"
+require "hive/daemon/scheduled_architecture_scheduler"
 require "hive/daemon/answer_digest_scheduler"
 require "hive/daemon/logger"
 require "hive/runtime_control_plane/dispatch_repository"
@@ -242,6 +243,7 @@ module Hive
         )
         patrol_scheduler = Hive::Daemon::PatrolScheduler.new
         refactor_patrol_scheduler = Hive::Daemon::RefactorPatrolScheduler.new(
+          scheduled_scheduler: Hive::Daemon::ScheduledArchitectureScheduler.new(dry_run: @dry_run),
           dry_run: @dry_run
         )
         patrol_fix_runtime = Hive::Daemon::PatrolFixRuntime.new

--- a/lib/hive/commands/refactor_patrol.rb
+++ b/lib/hive/commands/refactor_patrol.rb
@@ -60,8 +60,9 @@ module Hive
                      heartbeat_clock: -> { Time.now },
                      heartbeat_resolver: Hive::RefactorPatrol::ClaimLivenessResolver.new,
                      project_entry: nil, capability_context: nil,
-                     scheduled_slice: nil,
+                     scheduled_slice: nil, output: nil,
                      config_loader: ->(path) { Hive::Config.load(path) })
+        @output = output
         @project = project
         @json = json
         @dry_run = dry_run
@@ -1061,7 +1062,7 @@ module Hive
           )
         end
         if @json
-          puts JSON.generate(payload)
+          (@output || $stdout).puts JSON.generate(payload)
         else
           puts query.text(payload)
         end
@@ -1086,7 +1087,7 @@ module Hive
           job: result.fetch(:job)
         )
         if @json
-          puts JSON.generate(payload)
+          (@output || $stdout).puts JSON.generate(payload)
         else
           puts "hive refactor-patrol archive: #{result.fetch(:status)} " \
                "archived_actions=#{result.fetch(:archived_actions)}"
@@ -1222,9 +1223,9 @@ module Hive
       def emit(payload, theses)
         write_result_file(payload)
         if @json
-          puts JSON.generate(payload)
+          (@output || $stdout).puts JSON.generate(payload)
         else
-          puts @reporter.text(payload, theses)
+          (@output || $stdout).puts @reporter.text(payload, theses)
         end
         payload
       end
@@ -1255,7 +1256,7 @@ module Hive
         rescue StandardError
           nil
         end
-        puts JSON.generate(payload)
+        (@output || $stdout).puts JSON.generate(payload)
       end
 
       def validate_result_file!(entry, project_root = nil)

--- a/lib/hive/commands/refactor_patrol_scheduled.rb
+++ b/lib/hive/commands/refactor_patrol_scheduled.rb
@@ -1,0 +1,82 @@
+require "json"
+require "stringio"
+require "hive/atomic_file"
+require "hive/commands/refactor_patrol"
+require "hive/refactor_patrol/scheduled_slice_producer"
+
+module Hive
+  module Commands
+    # One supervised current-main slice. Durable completion precedes the receipt.
+    class RefactorPatrolScheduled
+      def initialize(project, result_file:, config_loader: ->(path) { Hive::Config.load(path) },
+                     producer_factory: nil, command_factory: nil, budget_factory: nil)
+        @project = project
+        @result_file = result_file
+        @config_loader = config_loader
+        @producer_factory = producer_factory || ->(entry, cfg) {
+          Hive::RefactorPatrol::ScheduledSliceProducer.new(entry: entry, cfg: cfg)
+        }
+        @command_factory = command_factory || ->(project, **options) { RefactorPatrol.new(project, **options) }
+        @budget_factory = budget_factory || ->(entry, cfg) {
+          Hive::Patrol::LaunchBudget.new(
+            entry.fetch("path"), cfg: cfg, project_id: entry.fetch("project_id"),
+            project_name: entry.fetch("name"), engine: :architecture
+          )
+        }
+      end
+
+      def call
+        entry = Hive::Config.find_project(@project)
+        raise Hive::ConfigError, "unknown project #{@project.inspect}" unless entry
+        path = validate_result_path!(entry)
+        cfg = @config_loader.call(entry.fetch("path"))
+        unless cfg.dig("daemon", "enabled") == true && cfg.dig("refactor_patrol", "enabled") == true &&
+               Hive::Workflows.coding_id?(cfg["default_workflow"])
+          raise Hive::ConfigError, "scheduled Architecture Patrol is disabled"
+        end
+        budget = @budget_factory.call(entry, cfg)
+        return emit(path, ok: true, reason: "discovery_allowance_exhausted") unless
+          budget.remaining_launches.positive?
+
+        producer = @producer_factory.call(entry, cfg)
+        claim = producer.claim
+        return emit(path, ok: true, reason: "no_available_slice") unless claim
+
+        report = @command_factory.call(
+          entry.fetch("name"), json: true, output: StringIO.new, project_entry: entry,
+          config_loader: ->(_path) { cfg }, scheduled_slice: claim
+        ).call
+        complete = report.is_a?(Hash) && report["ok"] == true &&
+                   report["review_complete"] == true && Array(report["review_errors"]).empty? &&
+                   report["last_scanned_sha"] == claim.fetch("analysis_sha")
+        if complete
+          complete = producer.complete(claim_id: claim.fetch("id"), result: report)
+          claim = nil if complete
+        end
+        emit(path, ok: !!complete, reason: complete ? "completed" : "incomplete", report: report)
+      ensure
+        producer.release(claim_id: claim.fetch("id")) if producer && claim
+      end
+
+      private
+
+      def validate_result_path!(entry)
+        root = File.expand_path(File.join(entry.fetch("hive_state_path"), "refactor_patrol", "v2", "results"))
+        path = File.expand_path(@result_file)
+        unless File.dirname(path) == root && File.basename(path).match?(/\Ascheduled-[0-9a-f]{32}\.json\z/)
+          raise Hive::ConfigError, "scheduled Architecture Patrol result path is outside its fenced root"
+        end
+        path
+      end
+
+      def emit(path, ok:, reason:, report: nil)
+        payload = { "schema" => "hive-refactor-patrol-scheduled-run", "schema_version" => 1,
+                    "ok" => ok, "reason" => reason, "report" => report || {} }
+        FileUtils.mkdir_p(File.dirname(path))
+        Hive::AtomicFile.write(path, "#{JSON.generate(payload)}\n", mode: 0o600)
+        puts JSON.generate(payload)
+        payload
+      end
+    end
+  end
+end

--- a/lib/hive/daemon/dispatcher.rb
+++ b/lib/hive/daemon/dispatcher.rb
@@ -927,6 +927,8 @@ module Hive
             event = case result && result[:status]
             when :closed
               :architecture_patrol_closed
+            when :skipped
+              :architecture_patrol_skipped
             when :classified, :action_pending
               :architecture_patrol_progress
             else

--- a/lib/hive/daemon/refactor_patrol_scheduler.rb
+++ b/lib/hive/daemon/refactor_patrol_scheduler.rb
@@ -68,7 +68,8 @@ module Hive
                      lease_sec: 7200, dry_run: false,
                      classifier_factory: nil, manifest_resolver_factory: nil,
                      post_merge_batch_store_factory: nil,
-                     post_merge_slice_mapper: nil)
+                     post_merge_slice_mapper: nil, scheduled_scheduler: nil)
+        @scheduled_scheduler = scheduled_scheduler
         @registry = registry
         @config_loader = config_loader
         @job_store_factory = job_store_factory
@@ -115,6 +116,7 @@ module Hive
 
       def candidates(now: Time.now)
         @events.clear
+        scheduled = @scheduled_scheduler ? @scheduled_scheduler.candidates(now: now) : []
         managed = managed_entries
         stores_by_project = {}
         block_configuration_errors(now)
@@ -150,7 +152,7 @@ module Hive
                  discovery.map { |job| { aggregate: job, phase: :discovery } }
           [ entry.fetch("name"), work ]
         end
-        return [] if due_by_project.values.all?(&:empty?)
+        return scheduled if due_by_project.values.all?(&:empty?)
 
         ownership_snapshot = if @repository_ownership.respond_to?(:snapshot)
           @repository_ownership.snapshot
@@ -158,7 +160,7 @@ module Hive
           @repository_ownership
         end
 
-        managed.flat_map do |entry|
+        scheduled + managed.flat_map do |entry|
           project = entry.fetch("name")
           work = due_by_project.fetch(project)
           next [] if work.empty?
@@ -192,12 +194,13 @@ module Hive
       end
 
       def drain_events
-        drained = @events.dup
+        drained = @events.dup + (@scheduled_scheduler ? @scheduled_scheduler.drain_events : [])
         @events.clear
         drained
       end
 
       def reserve(candidate, now: Time.now)
+        return @scheduled_scheduler.reserve(candidate, now: now) if candidate[:action_phase] == :scheduled
         entry = candidate.fetch(:entry)
         phase = candidate.fetch(:action_phase, :discovery).to_sym
         store = %i[classification post_merge].include?(phase) ? nil : store_for(entry)
@@ -330,7 +333,7 @@ module Hive
       end
 
       def spawned(dispatch, pid:, process_start_time:, pgid:, now: Time.now)
-        return dispatch if @dry_run
+        return dispatch if @dry_run || dispatch.dig(:dispatch_token, :phase) == :scheduled
         return dispatch if dispatch.dig(:dispatch_token, :phase) == :classification
 
         @claim_maintenance_transitions.attach_discovery(
@@ -345,6 +348,8 @@ module Hive
       end
 
       def cancel(dispatch, reason:, now: Time.now)
+        return @scheduled_scheduler.cancel(dispatch, reason: reason, now: now) if
+          dispatch.dig(:dispatch_token, :phase) == :scheduled
         token = dispatch[:dispatch_token]
         return unless token
         return dispatch if @dry_run || token[:dry_run]
@@ -368,6 +373,11 @@ module Hive
       end
 
       def complete(dispatch_token:, exit_code:, envelope:, now: Time.now)
+        if dispatch_token[:phase] == :scheduled
+          return @scheduled_scheduler.complete(
+            dispatch_token: dispatch_token, exit_code: exit_code, envelope: envelope, now: now
+          )
+        end
         return completion_result(:dry_run, dispatch_token, envelope) if @dry_run || dispatch_token[:dry_run]
         return complete_classification(dispatch_token, exit_code, now) if
           dispatch_token[:phase] == :classification

--- a/lib/hive/daemon/scheduled_architecture_scheduler.rb
+++ b/lib/hive/daemon/scheduled_architecture_scheduler.rb
@@ -71,7 +71,8 @@ module Hive
                    "--result-file #{Shellwords.escape(path)} --json",
           state_file_path: nil, state_file_mtime: nil,
           dispatch_token: { kind: :architecture_patrol, phase: :scheduled,
-                            registration: project, job_id: "scheduled-#{run_id}", result_path: path }
+                            registration: project, job_id: "scheduled-#{run_id}", result_path: path,
+                            poll_interval_sec: cfg.dig("patrol", "poll_interval_sec") || 600 }
         )
       end
 
@@ -83,9 +84,17 @@ module Hive
         project = dispatch_token.fetch(:registration)
         @pending.delete(project)
         success = exit_code == 0 && envelope.is_a?(Hash) && envelope["ok"] == true
-        @next_check[project] = now + 600 unless success
+        @next_check[project] = now + dispatch_token.fetch(:poll_interval_sec, 600)
         report = envelope.is_a?(Hash) ? envelope.fetch("report", {}) : {}
-        { status: success ? :closed : :retry, job_id: dispatch_token[:job_id],
+        reason = envelope.is_a?(Hash) ? envelope["reason"] : nil
+        status = if !success
+          :retry
+        elsif %w[no_available_slice discovery_allowance_exhausted].include?(reason)
+          :skipped
+        else
+          :closed
+        end
+        { status: status, reason: reason, job_id: dispatch_token[:job_id],
           lane: "scheduled", fix_count: Array(report["fix"]).size,
           discuss_count: Array(report["discuss"]).size, dismiss_count: Array(report["dismiss"]).size }
       end

--- a/lib/hive/daemon/scheduled_architecture_scheduler.rb
+++ b/lib/hive/daemon/scheduled_architecture_scheduler.rb
@@ -1,0 +1,109 @@
+require "shellwords"
+require "securerandom"
+require "hive/config"
+require "hive/workflows"
+require "hive/patrol/launch_budget"
+require "hive/refactor_patrol/state_store"
+
+module Hive
+  module Daemon
+    # The child owns the durable slice claim; the daemon owns dispatch cadence.
+    class ScheduledArchitectureScheduler
+      def initialize(registry: -> { Hive::Config.registered_projects },
+                     config_loader: ->(path) { Hive::Config.load(path) }, dry_run: false)
+        @dry_run = dry_run
+        @registry = registry
+        @config_loader = config_loader
+        @events = []
+        @pending = {}
+        @next_check = {}
+      end
+
+      def candidates(now: Time.now)
+        @events.clear
+        @registry.call.filter_map do |entry|
+          project = entry.fetch("name")
+          next if @pending[project] || (@next_check[project] && now < @next_check[project])
+
+          cfg = @config_loader.call(entry.fetch("path"))
+          next unless enabled?(cfg)
+          interval = cfg.dig("patrol", "poll_interval_sec") || 600
+          @next_check[project] = now + interval
+          last_run = Hive::RefactorPatrol::StateStore.new(
+            entry.fetch("path"), hive_state_path: entry.fetch("hive_state_path")
+          ).state["last_run_at"]
+          next if last_run && now < Time.iso8601(last_run) + interval
+          next unless budget(entry, cfg, now).remaining_launches.positive?
+
+          @next_check.delete(project)
+          {
+            project: project, entry: entry, patrol_kind: :architecture,
+            action_phase: :scheduled, job_id: "scheduled", merged_at: nil,
+            slug: "refactor-patrol-scheduled", stage: "refactor-patrol"
+          }
+        rescue StandardError => error
+          @events << { status: :blocked, project: project, lane: "scheduled",
+                       reason: "scheduled_discovery_unavailable", error: error.message[0, 2_000] }
+          nil
+        end
+      end
+
+      def drain_events
+        events = @events
+        @events = []
+        events
+      end
+
+      def reserve(candidate, now: Time.now)
+        entry = candidate.fetch(:entry)
+        project = entry.fetch("name")
+        cfg = @config_loader.call(entry.fetch("path"))
+        return if @pending[project] || !enabled?(cfg)
+        return unless budget(entry, cfg, now).remaining_launches.positive?
+
+        run_id = SecureRandom.hex(16)
+        path = File.join(entry.fetch("hive_state_path"), "refactor_patrol", "v2", "results",
+                         "scheduled-#{run_id}.json")
+        @pending[project] = true unless @dry_run
+        @next_check[project] = now + (cfg.dig("patrol", "poll_interval_sec") || 600)
+        candidate.merge(
+          command: "hive refactor-patrol-scheduled #{Shellwords.escape(project)} " \
+                   "--result-file #{Shellwords.escape(path)} --json",
+          state_file_path: nil, state_file_mtime: nil,
+          dispatch_token: { kind: :architecture_patrol, phase: :scheduled,
+                            registration: project, job_id: "scheduled-#{run_id}", result_path: path }
+        )
+      end
+
+      def cancel(dispatch, reason:, now: Time.now)
+        @pending.delete(dispatch.fetch(:project))
+      end
+
+      def complete(dispatch_token:, exit_code:, envelope:, now: Time.now)
+        project = dispatch_token.fetch(:registration)
+        @pending.delete(project)
+        success = exit_code == 0 && envelope.is_a?(Hash) && envelope["ok"] == true
+        @next_check[project] = now + 600 unless success
+        report = envelope.is_a?(Hash) ? envelope.fetch("report", {}) : {}
+        { status: success ? :closed : :retry, job_id: dispatch_token[:job_id],
+          lane: "scheduled", fix_count: Array(report["fix"]).size,
+          discuss_count: Array(report["discuss"]).size, dismiss_count: Array(report["dismiss"]).size }
+      end
+
+      private
+
+      def enabled?(cfg)
+        cfg.dig("daemon", "enabled") == true &&
+          Hive::Workflows.coding_id?(cfg["default_workflow"]) &&
+          cfg.dig("refactor_patrol", "enabled") == true
+      end
+
+      def budget(entry, cfg, now)
+        Hive::Patrol::LaunchBudget.new(
+          entry.fetch("path"), cfg: cfg, project_id: entry.fetch("project_id"),
+          project_name: entry.fetch("name"), engine: :architecture, clock: -> { now }
+        )
+      end
+    end
+  end
+end

--- a/lib/hive/refactor_patrol/fix_admission_adapter.rb
+++ b/lib/hive/refactor_patrol/fix_admission_adapter.rb
@@ -1,4 +1,5 @@
 require "json"
+require "digest"
 require "hive/patrol_fix/admission_store"
 
 module Hive
@@ -91,7 +92,8 @@ module Hive
       end
 
       def occurrence_id(aggregate, disposition, snapshot)
-        "architecture:#{aggregate.fetch('job_id')}:#{disposition.fetch('id')}:#{snapshot.evidence_digest[0, 24]}"
+        identity = "architecture:#{aggregate.fetch('job_id')}:#{disposition.fetch('id')}:#{snapshot.evidence_digest[0, 24]}"
+        identity.bytesize <= 128 ? identity : "architecture:#{Digest::SHA256.hexdigest(identity)}"
       end
 
       def bounded_json_text(value)

--- a/lib/hive/refactor_patrol/scheduled_slice_producer.rb
+++ b/lib/hive/refactor_patrol/scheduled_slice_producer.rb
@@ -68,7 +68,8 @@ module Hive
 
       def claim(now: Time.now.utc)
         @directory.prepare!
-        @directory.with_lock(LOCK_FILE) { replay_unconsumed_results(now) }
+        available = @directory.with_lock(LOCK_FILE) { replay_unconsumed_results(now) }
+        return nil unless available
 
         snapshot = @snapshotter.call(entry: @entry, cfg: @cfg)
         validate_snapshot!(snapshot)
@@ -138,12 +139,28 @@ module Hive
       end
 
       def replay_unconsumed_results(now)
-        result_records.each do |record|
+        state = load_state
+        return false if live_claim?(state["claim"])
+
+        records = result_records
+        records.each do |record|
           next if record["consumed_at"]
 
           publish_admission(record)
           mark_result_consumed(record, now)
         end
+        # Results precede admission and cursor persistence. Recover even when
+        # the owner died after marking a result consumed, or released its claim
+        # after admission failed. Sweep generation and feature order only grow.
+        latest = records.max_by { |record| [ record.fetch("sweep_generation"), record.fetch("feature_id") ] }
+        if latest && ([ latest.fetch("sweep_generation"), latest.fetch("feature_id") ] <=>
+                      [ state.fetch("sweep_generation"), state["cursor"].to_s ]).positive?
+          state["cursor"] = latest.fetch("feature_id")
+          state["sweep_generation"] = latest.fetch("sweep_generation")
+          state["updated_at"] = normalize_time(now).iso8601(6)
+          persist(state)
+        end
+        true
       end
 
       def mutate_claim(claim_id, now:)

--- a/test/integration/refactor_patrol_command_test.rb
+++ b/test/integration/refactor_patrol_command_test.rb
@@ -5,6 +5,7 @@ require "yaml"
 require "digest"
 require "hive/cli"
 require "hive/commands/refactor_patrol"
+require "hive/commands/refactor_patrol_scheduled"
 require "hive/config"
 require "hive/patrol/feature"
 require "hive/refactor_patrol/thesis"
@@ -1415,6 +1416,62 @@ class RefactorPatrolCommandTest < Minitest::Test
         assert_equal [ "checkout" ], payload.fetch("feature_results").map { |item| item.fetch("feature_id") }
         refute_equal repo, observed.fetch(0).fetch(0)
         assert_equal sha, observed.fetch(0).fetch(1)
+      end
+    end
+  end
+
+  def test_periodic_child_completes_a_real_slice_and_advances_the_durable_cursor
+    with_refactor_patrol_project do |repo|
+      with_tmp_dir do |worktree_root|
+        entry = Hive::Config.find_project("demo")
+        sha = IO.popen([ "git", "-C", repo, "rev-parse", "HEAD" ], &:read).strip
+        cfg = Hive::Config.load(repo).merge("worktree_root" => worktree_root, "daemon" => { "enabled" => true })
+        producer = Hive::RefactorPatrol::ScheduledSliceProducer.new(
+          entry: entry, cfg: cfg, snapshotter: ->(**) {
+            Hive::RefactorPatrol::ScheduledSliceProducer::Snapshot.new(
+              analysis_sha: sha, feature_ids: %w[billing checkout]
+            )
+          }
+        )
+        reviewer = FakeReviewer.new(
+          { "billing" => [ thesis("billing-boundary", feature_id: "billing", fingerprint: "fp-billing") ] }
+        )
+        budget = Object.new
+        budget.define_singleton_method(:remaining_launches) { 1 }
+        path = File.join(entry.fetch("hive_state_path"), "refactor_patrol", "v2", "results",
+                         "scheduled-#{'a' * 32}.json")
+        command = Hive::Commands::RefactorPatrolScheduled.new(
+          "demo", result_file: path, config_loader: ->(*) { cfg },
+          producer_factory: ->(*) { producer }, budget_factory: ->(*) { budget },
+          command_factory: ->(project, **options) {
+            Hive::Commands::RefactorPatrol.new(
+              project, **options,
+              mapper_factory: ->(*) { FakeMapper.new([ feature("billing"), feature("checkout") ]) },
+              reviewer_factory: ->(*) { reviewer }
+            )
+          }
+        )
+        payload = nil
+        output, = capture_io { payload = command.call }
+        assert payload.fetch("ok")
+        assert_equal payload, JSON.parse(output), "supervised child must emit one final JSON receipt"
+        assert_equal payload, JSON.parse(File.read(path))
+        assert_equal [ "billing" ], reviewer.seen_feature_ids
+        assert_equal sha, payload.dig("report", "last_scanned_sha")
+        records = producer.each_result.to_a
+        assert_equal 1, records.size
+        assert_equal [ "billing-boundary" ], records.first.dig("dispositions", "fix").map { |item| item.fetch("id") }
+        admissions = Hive::RefactorPatrol::FixAdmissionAdapter.for_project(
+          project_root: repo, hive_state_path: entry.fetch("hive_state_path")
+        ).store.pending
+        assert_equal 1, admissions.size, "completed findings must reach durable fix admission"
+        source = admissions.first.fetch("source")
+        assert_equal "architecture_patrol", source.fetch("engine")
+        assert_equal sha, source.fetch("target_revision")
+        assert_equal "#{records.first.fetch('job_id')}:billing-boundary", source.fetch("identity")
+        next_claim = producer.claim
+        assert_equal "checkout", next_claim.fetch("feature_id")
+        producer.release(claim_id: next_claim.fetch("id"))
       end
     end
   end

--- a/test/integration/refactor_patrol_command_test.rb
+++ b/test/integration/refactor_patrol_command_test.rb
@@ -1476,6 +1476,69 @@ class RefactorPatrolCommandTest < Minitest::Test
     end
   end
 
+  def test_periodic_child_charges_real_architecture_allowance_and_stops_at_the_daily_limit
+    with_refactor_patrol_project do |repo|
+      with_tmp_dir do |worktree_root|
+        entry = Hive::Config.find_project("demo")
+        sha = IO.popen([ "git", "-C", repo, "rev-parse", "HEAD" ], &:read).strip
+        cfg = Hive::Config.deep_merge(
+          Hive::Config.load(repo),
+          "worktree_root" => worktree_root, "daemon" => { "enabled" => true },
+          "patrol" => { "scheduled_discovery_launches_per_engine_per_day" => 1 }
+        )
+        producer = Hive::RefactorPatrol::ScheduledSliceProducer.new(
+          entry: entry, cfg: cfg, snapshotter: ->(**) {
+            Hive::RefactorPatrol::ScheduledSliceProducer::Snapshot.new(
+              analysis_sha: sha, feature_ids: %w[billing checkout]
+            )
+          }
+        )
+        command = Hive::Commands::RefactorPatrolScheduled.new(
+          "demo", config_loader: ->(*) { cfg }, producer_factory: ->(*) { producer },
+          result_file: File.join(entry.fetch("hive_state_path"), "refactor_patrol", "v2", "results",
+                                 "scheduled-#{'b' * 32}.json"),
+          command_factory: ->(project, **options) {
+            Hive::Commands::RefactorPatrol.new(
+              project, **options,
+              mapper_factory: ->(*) { FakeMapper.new([ feature("billing"), feature("checkout") ]) }
+            )
+          }
+        )
+        budget = Hive::Patrol::LaunchBudget.new(
+          repo, cfg: cfg, project_id: entry.fetch("project_id"), project_name: "demo", engine: :architecture
+        )
+        assert_equal 1, budget.remaining_launches
+        launches = 0
+        fake_agent_factory = lambda do |**options|
+          agent = Object.new
+          agent.define_singleton_method(:run!) do
+            launches += 1
+            File.write(options.fetch(:expected_output), JSON.generate("theses" => []))
+            { status: :ok, usage: { input: 10, output: 5, cached: 0 } }
+          end
+          agent
+        end
+        with_replaced_singleton_method(Hive::Agent, :new, fake_agent_factory) do
+          capture_io do
+            first = command.call
+            assert first.fetch("ok"), first.inspect
+            assert_equal "completed", first.fetch("reason")
+            assert_equal 0, budget.remaining_launches
+            assert_equal 1, budget.allowance_snapshot.fetch(:used)
+            assert_equal 1, budget.remaining_launches(engine: :ordinary), "Architecture must not charge ordinary Patrol"
+            second = command.call
+            assert_equal "discovery_allowance_exhausted", second.fetch("reason")
+          end
+        end
+        assert_equal 1, launches, "exhausted allowance must prevent a second provider launch"
+        assert_equal [ "billing" ], producer.each_result.map { |record| record.fetch("feature_id") }
+        next_claim = producer.claim
+        assert_equal "checkout", next_claim.fetch("feature_id"), "blocked launch must not advance the slice cursor"
+        producer.release(claim_id: next_claim.fetch("id"))
+      end
+    end
+  end
+
   def test_scheduled_slice_rejects_malformed_or_incomplete_identity
     entry = { "project_id" => "project-1" }
     valid = {

--- a/test/unit/cli_test.rb
+++ b/test/unit/cli_test.rb
@@ -1029,6 +1029,18 @@ class HiveCliTest < Minitest::Test
   end
 
   def test_internal_patrol_commands_forward_fenced_identifiers
+    require "hive/commands/refactor_patrol_scheduled"
+    with_command_new_stub(Hive::Commands::RefactorPatrolScheduled, return_value: { "ok" => true }) do |calls|
+      Hive::CLI.start([ "refactor-patrol-scheduled", "proj", "--result-file", "/tmp/result.json", "--json" ])
+      assert_equal [ "proj" ], calls.first.fetch(:args)
+      assert_equal({ result_file: "/tmp/result.json" }, calls.first.fetch(:kwargs))
+    end
+    with_command_new_stub(Hive::Commands::RefactorPatrolScheduled, return_value: { "ok" => false }) do
+      _out, _err, status = with_captured_exit do
+        Hive::CLI.start([ "refactor-patrol-scheduled", "proj", "--result-file", "/tmp/result.json" ])
+      end
+      assert_equal 1, status
+    end
     require "hive/commands/refactor_patrol_classify"
     with_command_new_stub(Hive::Commands::RefactorPatrolClassify) do |calls|
       Hive::CLI.start([

--- a/test/unit/commands/daemon_test.rb
+++ b/test/unit/commands/daemon_test.rb
@@ -123,6 +123,37 @@ class HiveCommandsDaemonTest < Minitest::Test
   end
 
 
+  def test_daemon_composition_offers_a_periodic_architecture_scan_without_merged_jobs
+    captured = nil
+    with_global_start_config(daemon_config) do
+      with_replaced_singleton_method(Hive::Daemon::Dispatcher, :new, lambda { |**kwargs|
+        captured = kwargs
+        FakeDispatcher.new([])
+      }) { daemon("start", dry_run: true).call }
+    end
+    entry = { "name" => "demo", "path" => @home, "project_id" => "demo-id",
+              "hive_state_path" => File.join(@home, ".hive-state") }
+    cfg = Hive::Config.merge_defaults(
+      "daemon" => { "enabled" => true }, "patrol" => { "enabled" => false },
+      "refactor_patrol" => { "enabled" => true }
+    )
+    budget = Object.new
+    budget.define_singleton_method(:remaining_launches) { 1 }
+    with_replaced_singleton_method(Hive::Config, :registered_projects, -> { [ entry ] }) do
+      with_replaced_singleton_method(Hive::Config, :load, ->(*) { cfg }) do
+        with_replaced_singleton_method(Hive::Patrol::LaunchBudget, :new, ->(*) { budget }) do
+          candidate = captured.fetch(:patrol_arbiter).candidates(now: Time.now).find do |item|
+            item[:action_phase] == :scheduled
+          end
+          refute_nil candidate, "daemon must schedule current-main sweeps without any merged-PR jobs"
+          dispatch = captured.fetch(:refactor_patrol_scheduler).reserve(candidate, now: Time.now)
+          assert_includes dispatch.fetch(:command), "refactor-patrol-scheduled"
+          assert_equal :architecture_patrol, dispatch.dig(:dispatch_token, :kind)
+        end
+      end
+    end
+  end
+
   def test_start_daemon_writes_pid_loads_global_config_runs_dispatcher_and_cleans_pid
     command = daemon("start", dry_run: true)
     dispatcher = FakeDispatcher.new([])

--- a/test/unit/commands/refactor_patrol_scheduled_test.rb
+++ b/test/unit/commands/refactor_patrol_scheduled_test.rb
@@ -1,0 +1,115 @@
+require "test_helper"
+require "hive/commands/refactor_patrol_scheduled"
+
+class HiveCommandsRefactorPatrolScheduledTest < Minitest::Test
+  include HiveTestHelper
+
+  def with_command(remaining: 1, report: nil, error: nil)
+    with_tmp_dir do |root|
+      entry = { "name" => "demo", "path" => root, "project_id" => "demo-id",
+                "hive_state_path" => File.join(root, ".hive-state") }
+      cfg = { "default_workflow" => "coding", "daemon" => { "enabled" => true },
+              "refactor_patrol" => { "enabled" => true } }
+      calls = []
+      producer = Object.new
+      producer.define_singleton_method(:claim) do
+        calls << :claim
+        { "id" => "claim", "analysis_sha" => "a" * 40 }
+      end
+      producer.define_singleton_method(:release) { |claim_id:| calls << [ :release, claim_id ] }
+      producer.define_singleton_method(:complete) { |**| calls << :complete; true }
+      budget = Object.new
+      budget.define_singleton_method(:remaining_launches) { remaining }
+      review = Object.new
+      review.define_singleton_method(:call) do
+        raise error if error
+        report
+      end
+      path = File.join(entry.fetch("hive_state_path"), "refactor_patrol", "v2", "results",
+                       "scheduled-#{'a' * 32}.json")
+      command = Hive::Commands::RefactorPatrolScheduled.new(
+        "demo", result_file: path, config_loader: ->(*) { cfg },
+        producer_factory: ->(*) { producer }, budget_factory: ->(*) { budget },
+        command_factory: ->(*) { review }
+      )
+      with_replaced_singleton_method(Hive::Config, :find_project, ->(*) { entry }) do
+        yield command, calls, path, entry, cfg, producer, budget, review
+      end
+    end
+  end
+
+  def test_exhausted_allowance_does_not_claim_or_review
+    with_command(remaining: 0) do |command, calls, path|
+      capture_io { assert command.call.fetch("ok") }
+      assert_empty calls
+      assert_equal "discovery_allowance_exhausted", JSON.parse(File.read(path)).fetch("reason")
+    end
+  end
+
+  def test_incomplete_review_releases_slice_without_advancing_cursor
+    with_command(report: { "ok" => true, "review_complete" => false }) do |command, calls, path|
+      capture_io { refute command.call.fetch("ok") }
+      assert_equal [ :claim, [ :release, "claim" ] ], calls
+      refute JSON.parse(File.read(path)).fetch("ok")
+    end
+  end
+
+  def test_provider_start_failure_releases_slice_for_the_next_attempt
+    with_command(error: Errno::ENOENT.new("missing provider")) do |command, calls, _path|
+      assert_raises(Errno::ENOENT) { command.call }
+      assert_equal [ :claim, [ :release, "claim" ] ], calls
+    end
+  end
+
+  def test_result_path_is_rejected_before_claiming
+    with_command do |command, calls, path|
+      command.instance_variable_set(:@result_file, File.join(File.dirname(path), "other.json"))
+      assert_raises(Hive::ConfigError) { command.call }
+      assert_empty calls
+    end
+  end
+
+  def test_default_composition_publishes_a_completed_review
+    report = { "ok" => true, "review_complete" => true, "last_scanned_sha" => "a" * 40 }
+    with_command(report: report) do |_command, calls, path, _entry, cfg, producer, budget, review|
+      with_replaced_singleton_method(Hive::Config, :load, ->(*) { cfg }) do
+        with_replaced_singleton_method(Hive::Patrol::LaunchBudget, :new, ->(*) { budget }) do
+          with_replaced_singleton_method(Hive::RefactorPatrol::ScheduledSliceProducer, :new, ->(*) { producer }) do
+            with_replaced_singleton_method(Hive::Commands::RefactorPatrol, :new, ->(*) { review }) do
+              capture_io do
+                result = Hive::Commands::RefactorPatrolScheduled.new("demo", result_file: path).call
+                assert_equal "completed", result.fetch("reason")
+              end
+            end
+          end
+        end
+      end
+      assert_equal [ :claim, :complete ], calls
+      assert_equal report, JSON.parse(File.read(path)).fetch("report")
+    end
+  end
+
+  def test_no_available_slice_emits_success_without_reviewing
+    with_command do |command, calls, path, _entry, _cfg, producer|
+      producer.define_singleton_method(:claim) { calls << :claim; nil }
+      capture_io { assert command.call.fetch("ok") }
+      assert_equal [ :claim ], calls
+      assert_equal "no_available_slice", JSON.parse(File.read(path)).fetch("reason")
+    end
+  end
+
+  def test_disabled_project_is_rejected_before_claiming
+    with_command do |command, calls, _path, _entry, cfg|
+      cfg["refactor_patrol"]["enabled"] = false
+      assert_raises(Hive::ConfigError) { command.call }
+      assert_empty calls
+    end
+  end
+
+  def test_unknown_project_is_rejected
+    with_replaced_singleton_method(Hive::Config, :find_project, ->(*) { nil }) do
+      command = Hive::Commands::RefactorPatrolScheduled.new("missing", result_file: "/tmp/result.json")
+      assert_raises(Hive::ConfigError) { command.call }
+    end
+  end
+end

--- a/test/unit/daemon/dispatcher_test.rb
+++ b/test/unit/daemon/dispatcher_test.rb
@@ -1164,9 +1164,21 @@ class HiveDaemonDispatcherTest < Minitest::Test
         ) ]
         dispatcher.tick(now: T0 + 3602)
         assert_equal 2, logger.events.count { |name, attrs| name == :architecture_patrol_closed && attrs[:lane] == "scheduled" }
-        remaining = 0
         dispatcher.tick(now: T0 + 7200)
-        assert_equal 2, supervisor.spawned.size, "exhausted discovery allowance must block another launch"
+        third_child = supervisor.spawned.last
+        assert_equal 3, supervisor.spawned.size
+        supervisor.next_exits = [ ChildExit.new(
+          pid: third_child.fetch(:pid), exit_code: 0, project: "p1", slug: "refactor-patrol-scheduled",
+          stage: "refactor-patrol", command: third_child.fetch(:command), started_at: T0 + 7200,
+          finished_at: T0 + 7202, json_envelope: { "ok" => true, "reason" => "no_available_slice" },
+          dispatch_token: third_child.fetch(:dispatch_token)
+        ) ]
+        dispatcher.tick(now: T0 + 7202)
+        assert logger.events.any? { |name, attrs| name == :architecture_patrol_skipped && attrs[:reason] == "no_available_slice" }
+        assert_equal 2, logger.events.count { |name, attrs| name == :architecture_patrol_closed && attrs[:lane] == "scheduled" }
+        remaining = 0
+        dispatcher.tick(now: T0 + 10800)
+        assert_equal 3, supervisor.spawned.size, "exhausted discovery allowance must block another launch"
       end
     end
   end

--- a/test/unit/daemon/dispatcher_test.rb
+++ b/test/unit/daemon/dispatcher_test.rb
@@ -9,6 +9,7 @@ require "hive/daemon/dispatcher"
 require "hive/daemon/concurrency_controller"
 require "hive/daemon/dispatch_baselines"
 require "hive/daemon/logger"
+require "hive/daemon/scheduled_architecture_scheduler"
 
 # Pin Dispatcher#tick logic with mocked collaborators. The point of
 # these tests is the routing decisions: which Policy outcome maps to
@@ -1109,6 +1110,66 @@ class HiveDaemonDispatcherTest < Minitest::Test
     assert_equal 1, supervisor.spawned.size
   end
 
+
+  def test_periodic_architecture_scan_dispatches_and_reaps_through_real_schedulers
+    with_tmp_dir do |root|
+      entry = { "name" => "p1", "path" => root, "project_id" => "p1-id",
+                "hive_state_path" => File.join(root, ".hive-state") }
+      cfg = Hive::Config.merge_defaults(
+        "daemon" => { "enabled" => true }, "refactor_patrol" => { "enabled" => true }
+      )
+      scheduled = Hive::Daemon::ScheduledArchitectureScheduler.new(
+        registry: -> { [ entry ] }, config_loader: ->(*) { cfg }
+      )
+      architecture = Hive::Daemon::RefactorPatrolScheduler.new(
+        registry: -> { [ entry ] }, config_loader: ->(*) { cfg }, scheduled_scheduler: scheduled
+      )
+      arbiter = Hive::Daemon::PatrolArbiter.new(
+        ordinary_scheduler: nil, architecture_scheduler: architecture,
+        state_path: File.join(root, "arbiter.json")
+      )
+      dispatcher, supervisor, _controller, logger = make_dispatcher(
+        refactor_patrol_scheduler: architecture, patrol_arbiter: arbiter
+      )
+      remaining = 1
+      budget = Object.new
+      budget.define_singleton_method(:remaining_launches) { remaining }
+      with_replaced_singleton_method(Hive::Patrol::LaunchBudget, :new, ->(*) { budget }) do
+        dispatcher.tick(now: T0)
+        assert_equal 1, supervisor.spawned.size
+        child = supervisor.spawned.first
+        assert_includes child.fetch(:command), "refactor-patrol-scheduled"
+        token = child.fetch(:dispatch_token)
+        assert_equal :scheduled, token.fetch(:phase)
+        dispatcher.tick(now: T0 + 1)
+        assert_equal 1, supervisor.spawned.size, "live slice must not launch twice"
+        supervisor.next_exits = [ ChildExit.new(
+          pid: child.fetch(:pid), exit_code: 0, project: "p1", slug: "refactor-patrol-scheduled",
+          stage: "refactor-patrol", command: child.fetch(:command), started_at: T0,
+          finished_at: T0 + 2, json_envelope: { "ok" => true }, dispatch_token: token
+        ) ]
+        dispatcher.tick(now: T0 + 2)
+        assert logger.events.any? { |name, attrs| name == :architecture_patrol_closed && attrs[:lane] == "scheduled" }
+        assert_equal 1, supervisor.spawned.size, "completion must preserve cadence"
+        dispatcher.tick(now: T0 + 3600)
+        assert_equal 2, supervisor.spawned.size, "completed sweep must permit the next periodic dispatch"
+        second_child = supervisor.spawned.last
+        second_token = second_child.fetch(:dispatch_token)
+        assert_equal :scheduled, second_token.fetch(:phase)
+        refute_equal token.fetch(:job_id), second_token.fetch(:job_id)
+        supervisor.next_exits = [ ChildExit.new(
+          pid: second_child.fetch(:pid), exit_code: 0, project: "p1", slug: "refactor-patrol-scheduled",
+          stage: "refactor-patrol", command: second_child.fetch(:command), started_at: T0 + 3600,
+          finished_at: T0 + 3602, json_envelope: { "ok" => true }, dispatch_token: second_token
+        ) ]
+        dispatcher.tick(now: T0 + 3602)
+        assert_equal 2, logger.events.count { |name, attrs| name == :architecture_patrol_closed && attrs[:lane] == "scheduled" }
+        remaining = 0
+        dispatcher.tick(now: T0 + 7200)
+        assert_equal 2, supervisor.spawned.size, "exhausted discovery allowance must block another launch"
+      end
+    end
+  end
 
   def test_architecture_patrol_spawn_attaches_fence_then_commits_arbiter_and_routes_completion
     architecture = FakeRefactorPatrolScheduler.new

--- a/test/unit/daemon/scheduled_architecture_scheduler_test.rb
+++ b/test/unit/daemon/scheduled_architecture_scheduler_test.rb
@@ -44,8 +44,8 @@ class HiveDaemonScheduledArchitectureSchedulerTest < Minitest::Test
       result = subject.complete(dispatch_token: dispatch.fetch(:dispatch_token),
                                 exit_code: 1, envelope: nil, now: NOW + 101)
       assert_equal :retry, result.fetch(:status)
-      assert_empty subject.candidates(now: NOW + 700)
-      assert_equal 1, subject.candidates(now: NOW + 701).size
+      assert_empty subject.candidates(now: NOW + 160)
+      assert_equal 1, subject.candidates(now: NOW + 161).size
     end
   end
 
@@ -74,6 +74,18 @@ class HiveDaemonScheduledArchitectureSchedulerTest < Minitest::Test
       assert_empty subject.candidates(now: NOW)
       assert_equal "scheduled_discovery_unavailable", subject.drain_events.fetch(0).fetch(:reason)
       assert_empty subject.drain_events
+    end
+  end
+
+  def test_empty_child_is_skipped_and_waits_a_full_interval_after_completion
+    with_scheduler do |subject, _entry, _cfg, _budget|
+      dispatch = subject.reserve(subject.candidates(now: NOW).fetch(0), now: NOW)
+      result = subject.complete(dispatch_token: dispatch.fetch(:dispatch_token), exit_code: 0,
+                                envelope: { "ok" => true, "reason" => "no_available_slice" }, now: NOW + 120)
+      assert_equal :skipped, result.fetch(:status)
+      assert_equal "no_available_slice", result.fetch(:reason)
+      assert_empty subject.candidates(now: NOW + 179)
+      assert_equal 1, subject.candidates(now: NOW + 180).size
     end
   end
 end

--- a/test/unit/daemon/scheduled_architecture_scheduler_test.rb
+++ b/test/unit/daemon/scheduled_architecture_scheduler_test.rb
@@ -1,0 +1,79 @@
+require "test_helper"
+require "hive/daemon/scheduled_architecture_scheduler"
+
+class HiveDaemonScheduledArchitectureSchedulerTest < Minitest::Test
+  include HiveTestHelper
+  NOW = Time.utc(2026, 9, 9, 12)
+
+  def with_scheduler(dry_run: false)
+    with_tmp_dir do |root|
+      entry = { "name" => "demo", "path" => root, "project_id" => "demo-id",
+                "hive_state_path" => File.join(root, ".hive-state") }
+      cfg = Hive::Config.merge_defaults("daemon" => { "enabled" => true },
+                                        "refactor_patrol" => { "enabled" => true },
+                                        "patrol" => { "poll_interval_sec" => 60 })
+      budget = Object.new
+      budget.define_singleton_method(:remaining_launches) { 1 }
+      subject = Hive::Daemon::ScheduledArchitectureScheduler.new(
+        registry: -> { [ entry ] }, config_loader: ->(*) { cfg }, dry_run: dry_run
+      )
+      with_replaced_singleton_method(Hive::Patrol::LaunchBudget, :new, ->(*) { budget }) do
+        yield subject, entry, cfg, budget
+      end
+    end
+  end
+
+  def test_dry_run_remains_eligible_after_cadence_without_child_completion
+    with_scheduler(dry_run: true) do |subject, _entry, _cfg, _budget|
+      candidate = subject.candidates(now: NOW).fetch(0)
+      subject.reserve(candidate, now: NOW)
+      assert_empty subject.candidates(now: NOW + 59)
+      assert_equal 1, subject.candidates(now: NOW + 60).size
+    end
+  end
+
+  def test_cancel_releases_pending_and_failure_backs_off_before_retry
+    with_scheduler do |subject, _entry, _cfg, _budget|
+      candidate = subject.candidates(now: NOW).fetch(0)
+      dispatch = subject.reserve(candidate, now: NOW)
+      assert_nil subject.reserve(candidate, now: NOW)
+      assert_empty subject.candidates(now: NOW + 100)
+      subject.cancel(dispatch, reason: "spawn_failed", now: NOW + 100)
+      retry_candidate = subject.candidates(now: NOW + 100).fetch(0)
+      dispatch = subject.reserve(retry_candidate, now: NOW + 100)
+      result = subject.complete(dispatch_token: dispatch.fetch(:dispatch_token),
+                                exit_code: 1, envelope: nil, now: NOW + 101)
+      assert_equal :retry, result.fetch(:status)
+      assert_empty subject.candidates(now: NOW + 700)
+      assert_equal 1, subject.candidates(now: NOW + 701).size
+    end
+  end
+
+  def test_restart_observes_last_run_and_reservation_rechecks_enabled_and_allowance
+    with_scheduler do |subject, entry, cfg, budget|
+      Hive::RefactorPatrol::StateStore.new(
+        entry.fetch("path"), hive_state_path: entry.fetch("hive_state_path")
+      ).update_state("last_run_at" => NOW.iso8601)
+      assert_empty subject.candidates(now: NOW + 1)
+      candidate = subject.candidates(now: NOW + 61).fetch(0)
+      cfg["refactor_patrol"]["enabled"] = false
+      assert_nil subject.reserve(candidate, now: NOW + 61)
+      assert_empty subject.candidates(now: NOW + 61)
+      cfg["refactor_patrol"]["enabled"] = true
+      budget.define_singleton_method(:remaining_launches) { 0 }
+      assert_nil subject.reserve(candidate, now: NOW + 61)
+      assert_empty subject.candidates(now: NOW + 61)
+    end
+  end
+
+  def test_invalid_state_reports_a_block_without_crashing_other_scheduler_work
+    with_scheduler do |subject, entry, _cfg, _budget|
+      Hive::RefactorPatrol::StateStore.new(
+        entry.fetch("path"), hive_state_path: entry.fetch("hive_state_path")
+      ).update_state("last_run_at" => "invalid")
+      assert_empty subject.candidates(now: NOW)
+      assert_equal "scheduled_discovery_unavailable", subject.drain_events.fetch(0).fetch(:reason)
+      assert_empty subject.drain_events
+    end
+  end
+end

--- a/test/unit/daemon/scheduled_architecture_scheduler_test.rb
+++ b/test/unit/daemon/scheduled_architecture_scheduler_test.rb
@@ -88,4 +88,29 @@ class HiveDaemonScheduledArchitectureSchedulerTest < Minitest::Test
       assert_equal 1, subject.candidates(now: NOW + 180).size
     end
   end
+
+  def test_real_daily_allowance_uses_tick_time_and_recovers_on_the_next_utc_day
+    with_tmp_global_config do
+      with_tmp_git_repo do |root|
+        cfg = Hive::Config.merge_defaults(
+          "daemon" => { "enabled" => true }, "refactor_patrol" => { "enabled" => true },
+          "patrol" => { "mode" => "low" }
+        )
+        FileUtils.mkdir_p(File.join(root, ".hive-state"))
+        File.write(File.join(root, ".hive-state", "config.yml"), cfg.to_yaml)
+        Hive::Config.register_project(name: "demo", path: root)
+        subject = Hive::Daemon::ScheduledArchitectureScheduler.new
+        assert_equal [ "demo" ], subject.candidates(now: NOW).map { |item| item.fetch(:project) }
+        limit = Hive::Config.load(root).dig("patrol", "scheduled_discovery_launches_per_engine_per_day")
+        limit.times do |index|
+          Hive::UsageDb.reserve_patrol_discovery!(
+            session_id: "daily-architecture-#{index}", agent: "codex", project_slug: "demo",
+            stage: "refactor-patrol-review", started_at: NOW, limit: limit
+          )
+        end
+        assert_empty subject.candidates(now: NOW + 1)
+        assert_equal [ "demo" ], subject.candidates(now: NOW + 86_400).map { |item| item.fetch(:project) }
+      end
+    end
+  end
 end

--- a/test/unit/refactor_patrol/fix_admission_adapter_test.rb
+++ b/test/unit/refactor_patrol/fix_admission_adapter_test.rb
@@ -76,6 +76,23 @@ class RefactorPatrolFixAdmissionAdapterTest < Minitest::Test
     end
   end
 
+  def test_long_scheduled_identities_are_bounded_and_replay_idempotently
+    Dir.mktmpdir do |dir|
+      adapter = Hive::RefactorPatrol::FixAdmissionAdapter.new(root: dir)
+      source = aggregate.merge("job_id" => "scheduled-#{'a' * 64}")
+      item = disposition.merge("id" => "billing-boundary")
+
+      first = adapter.publish_disposition!(source, item, accepted_at: NOW)
+      replay = adapter.publish_disposition!(source, item, accepted_at: NOW)
+      assert_equal first, replay
+      assert_equal 1, adapter.store.pending.length
+      assert_equal "#{source.fetch('job_id')}:billing-boundary", first.dig("source", "identity")
+      different = adapter.publish_disposition!(source, item.merge("id" => "checkout-boundary"), accepted_at: NOW)
+      refute_equal first, different
+      assert_equal 2, adapter.store.pending.length
+    end
+  end
+
   private
 
   def aggregate

--- a/test/unit/refactor_patrol/scheduled_slice_producer_test.rb
+++ b/test/unit/refactor_patrol/scheduled_slice_producer_test.rb
@@ -234,6 +234,59 @@ class RefactorPatrolScheduledSliceProducerTest < Minitest::Test
     end
   end
 
+  def test_admission_retry_advances_cursor_without_reviewing_the_same_revision_again
+    with_tmp_dir do |dir|
+      admission = FlakyAdmissionAdapter.new
+      subject, = producer(
+        dir, snapshots: Snapshots.new(snapshot(SHA1, %w[a b])), admission: admission
+      )
+      claim = subject.claim(now: NOW)
+      assert_raises(RuntimeError) do
+        subject.complete(claim_id: claim.fetch("id"), result: result(claim), now: NOW)
+      end
+      assert subject.release(claim_id: claim.fetch("id"), now: NOW + 1)
+
+      next_claim = subject.claim(now: NOW + 60)
+      assert_equal [ SHA1, "b", 0 ],
+                   next_claim.values_at("analysis_sha", "feature_id", "sweep_generation")
+      assert_equal [ "thesis-a" ], admission.published.map { |_aggregate, item| item.fetch("id") }
+      assert subject.complete(
+        claim_id: next_claim.fetch("id"), result: result(next_claim, route: "discuss"), now: NOW + 60
+      )
+      assert_equal 2, subject.each_result.to_a.size
+    end
+  end
+
+  def test_consumed_result_recovers_cursor_after_owner_dies_before_state_persistence
+    with_tmp_dir do |dir|
+      subject, admission = producer(dir, snapshots: Snapshots.new(snapshot(SHA1, %w[a b])))
+      claim = subject.claim(now: NOW)
+      persist = subject.method(:persist)
+      subject.define_singleton_method(:persist) do |state|
+        raise "cursor persistence interrupted" if state["cursor"] == "a"
+        persist.call(state)
+      end
+      assert_raises(RuntimeError) do
+        subject.complete(claim_id: claim.fetch("id"), result: result(claim), now: NOW)
+      end
+      refute_nil subject.each_result.first.fetch("consumed_at")
+      # The original owner is still live: another claim must not steal or
+      # complete its position, even though its durable result already exists.
+      refute subject.claim(now: NOW + 1)
+
+      recovered, = producer(
+        dir, snapshots: Snapshots.new(snapshot(SHA1, %w[a b])), admission: admission, pid: 202
+      )
+      next_claim = recovered.claim(now: NOW + 60)
+      assert_equal [ SHA1, "b", 0 ],
+                   next_claim.values_at("analysis_sha", "feature_id", "sweep_generation")
+      assert_equal 1, admission.published.size, "consumed admission must not be published again"
+      assert recovered.complete(
+        claim_id: next_claim.fetch("id"), result: result(next_claim), now: NOW + 60
+      )
+    end
+  end
+
   def test_dead_owner_claim_is_recovered_against_fresh_main
     with_tmp_dir do |dir|
       live = { 101 => "start-101", 202 => "start-202" }

--- a/wiki/commands/refactor-patrol.md
+++ b/wiki/commands/refactor-patrol.md
@@ -83,8 +83,20 @@ classification, discovery, checkpointing, retries, and post-merge bookkeeping.
 Those manifests carry path/status/rename metadata rather than GitHub patch
 bodies; the pinned merge worktree is the source of code truth, and patch size
 does not gate reconciliation.
-Scheduled current-main scans use the Architecture Patrol launch lane and
-reserve their completed dispositions through the same source adapter.
+Scheduled current-main scans are wired into the daemon through
+`ScheduledArchitectureScheduler` and the shared Patrol arbiter. They become due
+independently of merged-PR jobs, using `patrol.poll_interval_sec` and the
+Architecture engine's daily discovery allowance. They use the existing patrol
+scan concurrency budget. The internal `refactor-patrol-scheduled` child claims
+one mapped slice at a frozen revision, runs the review, and durably admits the
+result before advancing its cursor. Failed or incomplete reviews release the
+slice for retry. Successful dispositions use the same source adapter as
+post-merge discovery.
+
+Daemon composition and dispatcher regression tests require a periodic launch
+when no merged-PR jobs exist. Command integration tests exercise the real slice
+producer through review and durable cursor advancement; provider failures must
+leave that cursor retryable.
 
 The runtime has no action candidate selection, action reservation, fixer,
 issue filer, branch creator, PR opener, or review handoff. Historical action

--- a/wiki/commands/refactor-patrol.md
+++ b/wiki/commands/refactor-patrol.md
@@ -122,3 +122,7 @@ projection after its guarded transition.
 ## Backlinks
 
 - [[modules/patrol]] · [[modules/daemon]] · [[commands/patrol]]
+
+Scheduled completion waits a full configured poll interval before the next attempt,
+including failures and empty slices. Empty or allowance-exhausted children emit
+`architecture_patrol_skipped` with a reason, rather than claiming a review closed.

--- a/wiki/log.d/20260909-restore-periodic-architecture-sweeps.md
+++ b/wiki/log.d/20260909-restore-periodic-architecture-sweeps.md
@@ -17,3 +17,7 @@ failure, including a crash after admission is marked consumed. Live claims retai
 ownership. Long admission occurrence IDs use a stable digest while preserving
 existing short IDs. Regression tests cover nonempty durable admission, repeated
 periodic launches, interrupted completion, and dry-run cadence.
+
+Scheduled completion waits a full configured poll interval before the next attempt,
+including failures and empty slices. Empty or allowance-exhausted children emit
+`architecture_patrol_skipped` with a reason, rather than claiming a review closed.

--- a/wiki/log.d/20260909-restore-periodic-architecture-sweeps.md
+++ b/wiki/log.d/20260909-restore-periodic-architecture-sweeps.md
@@ -1,0 +1,19 @@
+# Restore periodic Architecture Patrol dispatch
+
+The unified Patrol cleanup deleted the module adapter that called
+`ScheduledSliceProducer`, without connecting a replacement to the native daemon.
+Producer unit tests and direct scheduled-command tests still passed; daemon
+routing tests injected fake Architecture schedulers and never required periodic
+work with an empty merged-PR queue.
+
+Restored native daemon composition, bounded periodic candidates, a supervised
+slice command, completion routing, cadence, and Architecture discovery allowance
+checks. Regression coverage now includes daemon composition without merged jobs,
+real schedulers through dispatcher launch/reap, and real producer/command cursor
+advancement. Incomplete reviews and provider start failures release the slice.
+
+Recovery now advances the cursor from retained completed results after an admission
+failure, including a crash after admission is marked consumed. Live claims retain
+ownership. Long admission occurrence IDs use a stable digest while preserving
+existing short IDs. Regression tests cover nonempty durable admission, repeated
+periodic launches, interrupted completion, and dry-run cadence.

--- a/wiki/modules/daemon.md
+++ b/wiki/modules/daemon.md
@@ -1348,3 +1348,13 @@ code is not part of the daemon scan path.
 - [[decisions]] (ADR-024)
 - [[architecture]]
 - [[cli]]
+
+## Periodic Architecture Patrol wiring
+
+`Commands::Daemon` composes `ScheduledArchitectureScheduler` into
+`RefactorPatrolScheduler`, which offers both periodic and post-merge candidates
+to `PatrolArbiter`. The dispatcher supervises `refactor-patrol-scheduled` with
+an Architecture token whose phase is `scheduled`; completion returns through
+the same scheduler. Periodic work does not require a merged-PR job. Its child
+owns the durable `ScheduledSliceProducer` claim and only advances the cursor
+after successful review and finding admission.


### PR DESCRIPTION
Periodic Architecture Patrol stopped running when the old module adapter was removed: the native daemon never called the surviving scheduled-slice producer. Restore supervised current-main sweeps through the existing scan arbiter, respecting cadence and Architecture discovery allowance.

Completed findings reach durable fix admission; interrupted admission recovers the cursor; long scheduled finding IDs fit the admission store. Empty sweeps are reported as skipped. Regression tests exercise actual daemon composition, repeated dispatch/reap, nonempty admission, recovery, dry-run behavior, and the real usage ledger across UTC days.

Validation: all hosted checks passed on `dd70f7a369`, including the exact 100% coverage gate. Focused regression suites passed. The broad local run completed 14,145 tests with 12 skips and one checkout-SHA comparison failure caused by HEAD changing during the run; the affected release-candidate file passed all 7 tests when rerun on a stable checkout.
