### PR TITLE
fix(digest): retain delivery ownership across garbage collection

### DIFF
--- a/lib/hive/daily_digest/delivery_ledger.rb
+++ b/lib/hive/daily_digest/delivery_ledger.rb
@@ -35,7 +35,7 @@ module Hive
           [ Process.pid, Hive::Lock.process_start_time(Process.pid) ]
         end
         @process_alive = process_alive || method(:matching_process_alive?)
-        @preparer_ids = ObjectSpace::WeakMap.new
+        @preparer_ids = ObjectSpace::WeakKeyMap.new
       end
 
       def prepare(local_date:, record_id:, amendment_frontier:, payload_hash:,

--- a/test/unit/daily_digest/delivery_ledger_test.rb
+++ b/test/unit/daily_digest/delivery_ledger_test.rb
@@ -13,6 +13,7 @@ class DailyDigestDeliveryLedgerTest < Minitest::Test
 
       assert_equal :send, prepared.action
       assert_equal "prepared", prepared.receipt.fetch("outcome")
+      GC.start(full_mark: true, immediate_sweep: true)
       sending = ledger.mark_sending(DATE, attempt: 1, now: NOW + 1)
       assert_equal "sending", sending.fetch("outcome")
       sent = ledger.mark_sent(DATE, attempt: 1, now: NOW + 2)
@@ -76,6 +77,24 @@ class DailyDigestDeliveryLedgerTest < Minitest::Test
       refute_equal first.receipt.fetch("receipt_id"), resumed.receipt.fetch("receipt_id")
       assert_equal 1, resumed.receipt.fetch("attempt")
       assert_equal 1, resumed.receipt.fetch("history").length
+    end
+  end
+
+  def test_live_fiber_keeps_exclusive_preparation_ownership_across_gc
+    with_tmp_dir do |dir|
+      ledger = Hive::DailyDigest::DeliveryLedger.new(root: File.join(dir, "deliveries"))
+      owner = Fiber.new do
+        Fiber.yield ledger.prepare(**identity, now: NOW)
+        ledger.mark_sending(DATE, attempt: 1, now: NOW + 2)
+      end
+
+      assert_equal :send, owner.resume.action
+      GC.start(full_mark: true, immediate_sweep: true)
+      assert_equal :in_flight, ledger.prepare(**identity, now: NOW + 1).action
+      assert_raises(Hive::DailyDigest::DeliveryLedger::InvalidTransition) do
+        ledger.mark_sending(DATE, attempt: 1, now: NOW + 1)
+      end
+      assert_equal "sending", owner.resume.fetch("outcome")
     end
   end
 

--- a/test/unit/daily_digest/delivery_test.rb
+++ b/test/unit/daily_digest/delivery_test.rb
@@ -200,6 +200,8 @@ class DailyDigestDeliveryTest < Minitest::Test
       assert_equal "prepared", prepared.fetch("outcome")
       assert_equal 1, prepared.fetch("attempt")
 
+      GC.start(full_mark: true, immediate_sweep: true)
+
       resumed, = build_delivery(dir, telegram: telegram, ledger: ledger)
       assert_equal "sent", resumed.deliver(date: DATE).outcome
       assert_equal 1, ledger.read(DATE).fetch("attempt")

--- a/wiki/log.d/20260910T034000Z-digest-preparer-gc.md
+++ b/wiki/log.d/20260910T034000Z-digest-preparer-gc.md
@@ -1,0 +1,9 @@
+---
+title: Preserve digest preparation ownership across garbage collection
+date: 2026-09-10
+---
+
+Digest delivery now retains the preparer token while its owning fiber is alive.
+A weak-key map prevents garbage collection from losing the token between
+preparation and sending or resuming after missing credentials. Forced-GC
+regressions cover both paths. See [[modules/daily-digest]].

--- a/wiki/modules/daily-digest.md
+++ b/wiki/modules/daily-digest.md
@@ -261,7 +261,9 @@ sending, sent, suppressed, failed, and ambiguous unknown outcomes. See
 
 A prepared attempt is owned through the exact payload and amendment frontier
 until that owner starts or suppresses the effect. Competing live preparers
-cannot rewrite it, and a stale owner is fenced. Daemon startup and delivery
+cannot rewrite it, and a stale owner is fenced. Each live fiber retains its
+preparer token across garbage collection; completed fibers can be reclaimed,
+and a fork gets a new process-specific identity. Daemon startup and delivery
 child completion reconcile every dead `sending` receipt, including dates older
 than the next scheduled recap, to terminal `unknown`.
 


### PR DESCRIPTION
## Summary

- Digest delivery can resume after missing credentials even when Ruby runs garbage collection. Previously GC could discard the live preparer token, causing a false “already in flight” error or rejecting the transition to sending.
- Retain the token while its fiber is alive, preserving the existing process and competing-owner checks.

Related: #1407, #1418

## Test plan

- [x] Forced-GC missing-token regression reproduced the error before the fix.
- [x] Delivery and ledger tests: 28 tests, 135 assertions, no failures; includes GC between prepare/send and competing-fiber rejection.
- [x] RuboCop: 3 files, no offenses.
- [x] Hosted CI coverage and dedicated merge gates: pre-merge 34434098335; main 34434802366. Install smoke 34434098348/34434802341 passed.
- [x] All digest unit/integration tests: 197 tests, 955 assertions.

## Notes for reviewer

`ObjectSpace::WeakMap` weakly retains values as well as keys. `WeakKeyMap` retains the token value while allowing unused fibers to be collected. No receipt format or retry policy changes.
