### PR TITLE
fix: allow read-only shell inspection during brainstorm

### DIFF
--- a/templates/brainstorm_prompt.md.erb
+++ b/templates/brainstorm_prompt.md.erb
@@ -39,7 +39,9 @@ Behavior:
 
 Constraints:
 - Do not modify any file other than brainstorm.md.
-- Do not invoke shell, network, or any tool that mutates the working tree
-  outside this folder.
+- Read-only shell commands are allowed to inspect local task artifacts, project
+  files, and skill instructions (for example, `cat`, `rg`, and `git diff`).
+- Do not make network requests or run commands that modify files other than
+  brainstorm.md, including commands that change Git state.
 - The trailing marker must be exactly one of `<!-- WAITING -->` or
   `<!-- COMPLETE -->` — no other line follows it.

--- a/test/integration/prompt_injection_test.rb
+++ b/test/integration/prompt_injection_test.rb
@@ -330,6 +330,10 @@ class PromptInjectionTest < Minitest::Test
       assert_includes prompt, "/ce-brainstorm",
         "default skill must be the CE brainstorm skill"
       refute_match(/<%=/, prompt, "no unrendered ERB should leak through")
+      assert_includes prompt, "Read-only shell commands are allowed"
+      assert_includes prompt, "Do not modify any file other than brainstorm.md."
+      assert_includes prompt, "Do not make network requests"
+      refute_includes prompt, "Do not invoke shell"
     end
   end
 

--- a/wiki/log.d/20260910T200000Z-brainstorm-read-only-shell.md
+++ b/wiki/log.d/20260910T200000Z-brainstorm-read-only-shell.md
@@ -1,0 +1,10 @@
+---
+title: Allow local shell inspection during brainstorm
+---
+
+The brainstorm prompt now explicitly allows read-only shell commands while
+restricting edits to `brainstorm.md` and retaining the network and Git-state
+restrictions. The previous blanket shell ban caused Writero task 43131 to stop
+without writing its brainstorm because Codex needed shell tools to read local
+context. The rendered-prompt regression covers the allowed reads and retained
+write and network boundaries.

--- a/wiki/stages/brainstorm.md
+++ b/wiki/stages/brainstorm.md
@@ -3,7 +3,7 @@ title: 2-brainstorm stage
 type: stage
 source: lib/hive/stages/brainstorm.rb, lib/hive/claude_launcher.rb, lib/hive/attempts/dispatcher.rb, lib/hive/tmux_runner.rb, templates/brainstorm_prompt.md.erb
 created: 2026-04-25
-updated: 2026-09-09
+updated: 2026-09-10
 tags: [stage, brainstorm, qa, tmux]
 ---
 
@@ -13,6 +13,7 @@ tags: [stage, brainstorm, qa, tmux]
 
 - **State file**: `brainstorm.md` (touched empty if absent so the marker write has a target).
 - **Prompt**: `templates/brainstorm_prompt.md.erb`, rendered with `project_name`, `task_folder`, `idea_text`. Idea text is wrapped in `<user_supplied content_type="idea_text">…</user_supplied>` per the prompt-injection boundary policy.
+- **Inspection and writes**: The prompt permits read-only shell inspection of local task artifacts, project files, and skill instructions. Only `brainstorm.md` may be modified; network requests and commands that change other files or Git state remain forbidden. This lets shell-based agents inspect context without expanding the brainstorm write boundary.
 - **Agent invocation**: `cwd = task.folder`, `--add-dir <task.folder>`, `log_label = "brainstorm"`. For `claude.mode: tmux`, `Hive::ClaudeLauncher` starts Claude through `interactive_claude_wrapper.sh`, unsets API-key env vars, maps `claude.permission_mode` (default `bypassPermissions`) to the same flags the headless path uses (`bypassPermissions` → `--dangerously-skip-permissions`, otherwise `--permission-mode <mode>`) plus `--allowedTools Read,Write,Edit,LS`, waits for the TUI prompt, and then asks `Hive::TmuxRunner` to paste the rendered prompt and submit only after the pane tail has settled.
 - **Tmux readiness env vars**: `Hive::ClaudeLauncher` owns `HIVE_CLAUDE_TMUX_*` readiness settings. `SESSION_READY`, `PID_READY`, and `CLAUDE_READY` inherit `HIVE_CLAUDE_TMUX_READY_WAIT_TIMEOUT_SEC` when their specific env var is unset; `CLAUDE_READY` otherwise keeps a 120s bare default for slow Claude TUI startup. Legacy `HIVE_BRAINSTORM_TMUX_*` names remain fallback inputs during the migration window.
 - **Claude TUI readiness predicates**: Trust, permission, banner, footer, and prompt-chrome strings are named constants in `Hive::ClaudeLauncher`, with observed coverage for Claude Code 2.1.133, the later line-end-caret footer shape, and Claude Code 2.1.179's separator/caret/separator/footer shape. `claude_ready_prompt?` accepts an idle `❯` caret at the start or end of the current input line, including Unicode separator spaces around the caret and the patrol-observed case where the captured pane tail has scrolled the `Claude Code` banner out but still shows `... PR #N ... for agents`. It classifies trust and permission prompts from the current prompt block instead of stale scrollback, rejects numbered menu options as non-ready, and only treats `⏵⏵` footer lines as prompt chrome when they carry the real bypass-permissions footer copy.


### PR DESCRIPTION
## Summary

- Let brainstorm agents inspect local files through read-only shell commands. Writero task 43131 stopped without producing questions because Codex interpreted the previous blanket shell ban literally.
- Keep writes limited to `brainstorm.md`; network requests and changes to Git state remain prohibited.

## Test plan

- [x] The rendered-prompt regression failed before the fix.
- [x] Prompt integration tests: 15 tests, 130 assertions, zero failures/errors.
- [x] Brainstorm runtime tests: 11 tests, 24 assertions, zero failures/errors.
- [x] RuboCop on the changed test file and `git diff --check` passed.
- [ ] Hosted CI.

## Notes for reviewer

This changes prompt wording, not runtime sandbox settings. The installed dogfood runtime and the blocked Writero task have not been updated or retried.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
